### PR TITLE
Added classes to manage progress bars in commands

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Event/ProgressEvent.php
+++ b/src/Pim/Bundle/CatalogBundle/Event/ProgressEvent.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Represents a progress event for a task
+ *
+ * @author    Antoine Guigan <antoine@akeneo.com>
+ * @copyright 2013 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ProgressEvent extends Event
+{
+    /**
+     * @var string
+     */
+    protected $section;
+
+    /**
+     * @var int
+     */
+    protected $totalItems;
+
+    /**
+     * @var int
+     */
+    protected $treatedItems;
+
+    /**
+     * Constructor
+     *
+     * @param int    $totalItems
+     * @param int    $treatedItems
+     * @param string $section
+     */
+    public function __construct($totalItems, $treatedItems, $section = '')
+    {
+        $this->totalItems = $totalItems;
+        $this->treatedItems = $treatedItems;
+        $this->section = $section;
+    }
+
+    /**
+     * Returns the section name
+     *
+     * @return string
+     */
+    public function getsection()
+    {
+        return $this->section;
+    }
+
+    /**
+     * Returns the number of items for the task
+     *
+     * @return int
+     */
+    public function getTotalItems()
+    {
+        return $this->totalItems;
+    }
+
+    /**
+     * Returns the number of treated items for the task
+     *
+     * @return int
+     */
+    public function getTreatedItems()
+    {
+        return $this->treatedItems;
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/EventListener/ProgressListener.php
+++ b/src/Pim/Bundle/CatalogBundle/EventListener/ProgressListener.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\EventListener;
+
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Pim\Bundle\CatalogBundle\Event\ProgressEvent;
+use Symfony\Component\Console\Helper\ProgressHelper;
+
+/**
+ * Progress listener for commands
+ *
+ * @author    Antoine Guigan <antoine@akeneo.com>
+ * @copyright 2013 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ProgressListener
+{
+    /**
+     * @var EventDispatcherInterface
+     */
+    protected $eventDispatcher;
+
+    /**
+     * Constructor
+     *
+     * @param EventDispatcherInterface $eventDispatcher
+     */
+    public function __construct(EventDispatcherInterface $eventDispatcher)
+    {
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
+    /**
+     * Creates progress bars for a specified event
+     *
+     * @param OutputInterface $output
+     * @param string          $eventName
+     * @param string          $message
+     */
+    public function bind(OutputInterface $output, $eventName, $message = '')
+    {
+        $progress = null;
+
+        $this->eventDispatcher->addListener(
+            $eventName,
+            function (ProgressEvent $event) use ($output, &$progress, $message) {
+                if (0 == $event->getTreatedItems()) {
+                    if (null !== $progress) {
+                       $progress->finish() ;
+                    }
+                    if ($message) {
+                        $output->writeln(sprintf($message, $event->getSection()));
+                    }
+                    $progress = new ProgressHelper;
+                    $progress->start($output, $event->getTotalItems());
+                } else {
+                    $progress->advance();
+                    if ($event->getTotalItems() == $event->getTreatedItems()) {
+                        $progress->finish();
+                        $progress = null;
+                    }
+                }
+            }
+        );
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/services.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/services.yml
@@ -1,5 +1,6 @@
 parameters:
     pim_catalog.imagine.local_dir_resolver.class:    Pim\Bundle\CatalogBundle\Imagine\Cache\Resolver\LocalDirResolver
+    pim_catalog.event_listener.progress.class:       Pim\Bundle\CatalogBundle\EventListener\ProgressListener
 
 services:
     # Attribute property types
@@ -36,6 +37,11 @@ services:
             - [ setContainer, [ '@service_container' ] ]
         tags:
             - { name: doctrine.event_subscriber }
+
+    pim_catalog.event_listener.progress:
+        class: %pim_catalog.event_listener.progress.class%
+        arguments:
+            - '@event_dispatcher'
 
     pim_catalog.event_listener.update_completeness:
         class: %pim_catalog.event_listener.update_completeness.class%


### PR DESCRIPTION
Bug fix: [no]
Feature addition: [no]
Backwards compatibility break: [no]
Unit test passes: [N/A]
Behat scenarios passes: [N/A]
Checkstyle issues: [no]*
ChangeLog updated: [no]
Documentation PR: 
Fixes the following jira:

This PR adds two more classes to easily manage progress bars in commands without having to add business logic inside command classes.

To add a progress bar inside a command, proceed like this :

```
    $this->getContainer()->get('pim_catalog.event_listener.progress')->bind(
        $output,
        'event_name',
        '<info>Treating section %s</info>'
    );
```

The command bar will be updated each time a ProgressEvent with the name 'event_name' is fired. To fire these events inside a service, the following code can be used :

```
    $this->eventDispatcher->dispatch(
        'event',
        new ProgressEvent($treatedItems, $totalItems, 'section')
    );
```

(The event dispatcher has to be injected inside your service)
