### PR TITLE
PIM-1439 : Redirect to channel edit form after creating/editing a channel

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Controller/ChannelController.php
+++ b/src/Pim/Bundle/CatalogBundle/Controller/ChannelController.php
@@ -146,7 +146,7 @@ class ChannelController extends AbstractDoctrineController
             $this->addFlash('success', 'flash.channel.saved');
 
             return $this->redirect(
-                $this->generateUrl('pim_catalog_channel_index')
+                $this->generateUrl('pim_catalog_channel_edit', array('id' => $channel->getId()))
             );
         }
 


### PR DESCRIPTION
Bug fix: [no]
Feature addition: [yes]
Backwards compatibility break: [no]
Unit test passes: [yes]
Behat scenarios passes: [yes]
Checkstyle issues: [no]*
ChangeLog updated: [no]
Fixes the following jira:
- PIM-1439
