### PR TITLE
PIM-1401 Fixed displayed conversion unit fields for a given channel

### DIFF
--- a/features/Context/Page/Base/Form.php
+++ b/features/Context/Page/Base/Form.php
@@ -316,7 +316,7 @@ class Form extends Base
 
         if (!$accordionContent->findField($field)) {
             throw new \InvalidArgumentException(
-                sprintf('Could not find a %s field inside the %s accordion group', $field, $groupField)
+                sprintf('Could not find a "%s" field inside the %s accordion group', $field, $groupField)
             );
         }
     }

--- a/features/export/convert_metric_values_during_export.feature
+++ b/features/export/convert_metric_values_during_export.feature
@@ -9,22 +9,14 @@ Feature: Convert metric values during export
 
   Scenario: Succesfully display metric conversion configuration for a channel
     Given I am on the "tablet" channel page
-    Then I should see "Conversion Options" fields:
-      | Area        |
-      | Binary      |
-      | Frequency   |
-      | Length      |
-      | Power       |
-      | Speed       |
-      | Temperature |
-      | Volume      |
-      | Weight      |
+    Then I should see "Pick a conversion unit for each metric attributes that will be used during product export" fields:
+      | Washing temperature |
+      | Weight              |
 
   @javascript
   Scenario: Succesfully convert metric values
     Given I have configured channel "ecommerce" with the following conversion options:
-      | Weight | GRAM  |
-      | Volume | LITER |
+      | weight | GRAM |
     And the following products:
       | sku          | family  | categories      |
       | tshirt-white | tshirts | 2014_collection |

--- a/src/Pim/Bundle/CatalogBundle/Form/Type/ChannelType.php
+++ b/src/Pim/Bundle/CatalogBundle/Form/Type/ChannelType.php
@@ -58,7 +58,7 @@ class ChannelType extends AbstractType
             ->addCurrenciesField($builder)
             ->addLocalesField($builder)
             ->addCategoryField($builder)
-            ->addConversionUnitFields($builder, $options)
+            ->addConversionUnitFields($builder)
             ->addEventSubscribers($builder);
     }
 
@@ -121,15 +121,9 @@ class ChannelType extends AbstractType
      *
      * @return ChannelType
      */
-    protected function addConversionUnitFields(FormBuilderInterface $builder, array $options)
+    protected function addConversionUnitFields(FormBuilderInterface $builder)
     {
-        $builder->add(
-            'conversionUnits',
-            'pim_catalog_conversion_units',
-            array(
-                'units' => $options['units']
-            )
-        );
+        $builder->add('conversionUnits', 'pim_catalog_conversion_units');
 
         return $this;
     }
@@ -238,7 +232,6 @@ class ChannelType extends AbstractType
         $resolver->setDefaults(
             array(
                 'data_class' => 'Pim\Bundle\CatalogBundle\Entity\Channel',
-                'units'      => array()
             )
         );
     }

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/form_types.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/form_types.yml
@@ -138,6 +138,9 @@ services:
 
     pim_catalog.form.type.conversion_units:
         class: %pim_catalog.form.type.conversion_units.class%
+        arguments:
+            - '@oro_measure.manager'
+            - '@doctrine.orm.entity_manager'
         tags:
             - { name: form.type, alias: pim_catalog_conversion_units }
 

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/forms.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/forms.yml
@@ -31,8 +31,6 @@ services:
         arguments:
             - pim_catalog_channel_form
             - pim_catalog_channel
-            - null
-            - {units: %oro_measure.measures_config%}
 
     pim_catalog.form.currency:
         class:           Symfony\Component\Form\Form

--- a/src/Pim/Bundle/CatalogBundle/Resources/translations/messages.en.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/translations/messages.en.yml
@@ -447,7 +447,7 @@ pim_catalog.product:
     no_compared_media: 'No media available for comparison'
 
 # Channel form
-pim_catalog.channel.pick_conversion_unit: 'Pick a conversion unit for each metric family:'
+pim_catalog.channel.pick_conversion_unit: 'Pick a conversion unit for each metric attributes that will be used during product export'
 
 # Product view
 Group: Group

--- a/src/Pim/Bundle/CatalogBundle/Resources/views/Channel/edit.html.twig
+++ b/src/Pim/Bundle/CatalogBundle/Resources/views/Channel/edit.html.twig
@@ -45,15 +45,15 @@
                     {{ form_row(form.locales) }}
                     {{ form_row(form.category) }}
                 {% endset %}
-                {{ elements.accordion({ 'General Properties': generalProperties }) }}
-
                 {% set conversionOptions %}
-                    {{ 'pim_catalog.channel.pick_conversion_unit'|trans }}
                     {% for conversionUnitForm in form.conversionUnits %}
                         {{ form_row(conversionUnitForm) }}
                     {% endfor %}
                 {% endset %}
-                {{ elements.accordion({ 'Conversion Options': conversionOptions }, 2) }}
+                {{ elements.accordion({
+                    'General Properties': generalProperties,
+                    'pim_catalog.channel.pick_conversion_unit': conversionOptions
+                }) }}
             </div>
             {% if form.vars.value.id %}
                 <div class="tab-pane" id="history">

--- a/src/Pim/Bundle/ImportExportBundle/Converter/MetricConverter.php
+++ b/src/Pim/Bundle/ImportExportBundle/Converter/MetricConverter.php
@@ -40,8 +40,9 @@ class MetricConverter
         foreach ($products as $product) {
             foreach ($product->getValues() as $value) {
                 $data = $value->getData();
-                if ($data instanceof Metric && isset($channelUnits[$data->getFamily()])) {
-                    $channelUnit = $channelUnits[$data->getFamily()];
+                $attribute = $value->getAttribute();
+                if ($data instanceof Metric && isset($channelUnits[$attribute->getCode()])) {
+                    $channelUnit = $channelUnits[$attribute->getCode()];
                     $this->converter->setFamily($data->getFamily());
                     $data->setData(
                         $this->converter->convert($data->getUnit(), $channelUnit, $data->getData())


### PR DESCRIPTION
```
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Unit test passes: no
Behat scenarios passes: ?
Checkstyle issues: no
ChangeLog updated: no
Documentation PR:
Fixes the following jira:
 - PIM-1401
```

In fact, one field should be displayed for each metric attributes (and
not one field per metric family). This allows to define two different
conversion units for two metric attributes that are using the same
metric family.
