### PR TITLE
PIM-1648: Rename translation switcher label by Translate from

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Resources/views/Product/_attributes.html.twig
+++ b/src/Pim/Bundle/CatalogBundle/Resources/views/Product/_attributes.html.twig
@@ -28,7 +28,7 @@
         <div id="comparison-switcher" class="btn-group">
 
             <button class="btn dropdown-toggle" data-toggle="dropdown">
-                {{ 'Translate'|trans }}{% if comparisonLocale is not null %}: {{ comparisonLocale|flag }}<span class="title">{{ locale_label(comparisonLocale) }}</span>{% endif %}
+                {{ 'Translate from'|trans }}{% if comparisonLocale is not null %}: {{ comparisonLocale|flag }}<span class="title">{{ locale_label(comparisonLocale) }}</span>{% endif %}
                 <span class="caret"></span>
             </button>
 


### PR DESCRIPTION
Bug fix: [no]
Feature addition: [no]
Backwards compatibility break: [no]
Unit test passes: [yes]
Behat scenarios passes: [yes|no]
Checkstyle issues: [no]*
ChangeLog updated: [no]
Fixes the following jira:
- PIM-1648
