### PR TITLE
PIM-1653 Prevent displaying scientific notation when exporting metric

### DIFF
--- a/features/Context/WebUser.php
+++ b/features/Context/WebUser.php
@@ -1357,7 +1357,7 @@ class WebUser extends RawMinkContext
             $actualLine = $actualLines[$index];
             sort($expectedLine);
             sort($actualLine);
-            assertEquals(
+            assertSame(
                 $expectedLine,
                 $actualLine,
                 sprintf(

--- a/features/export/convert_metric_values_during_export.feature
+++ b/features/export/convert_metric_values_during_export.feature
@@ -1,3 +1,4 @@
+@javascript
 Feature: Convert metric values during export
   In order to homogeneize exported metric values
   As Julia
@@ -13,7 +14,6 @@ Feature: Convert metric values during export
       | Washing temperature |
       | Weight              |
 
-  @javascript
   Scenario: Succesfully convert metric values
     Given the following channel "ecommerce" conversion options:
       | weight | GRAM |
@@ -44,5 +44,5 @@ Feature: Convert metric values during export
     Then exported file of "ecommerce_product_export" should contain:
     """
     sku;family;groups;categories;additional_colors;color;cost;country_of_manufacture;customer_rating-ecommerce;customs_tax-de_DE;description-de_DE-ecommerce;description-en_GB-ecommerce;description-en_US-ecommerce;description-fr_FR-ecommerce;handmade;image;manufacturer;material;name-de_DE;name-en_GB;name-en_US;name-fr_FR;number_in_stock-ecommerce;price;release_date-ecommerce;size;thumbnail;washing_temperature;washing_temperature-unit;weight;weight-unit;enabled;legend-de_DE;legend-en_GB;legend-en_US;legend-fr_FR
-    tshirt-white;tshirts;;2014_collection;;white;;;;;"Ein elegantes weißes T-Shirt";"An elegant white t-shirt";"A stylish white t-shirt";"Un T-shirt blanc élégant";;;american_apparel;cotton;"Weißes T-Shirt";"White t-shirt";"White t-shirt";"T-shirt blanc";;"10.00 EUR,9.00 GBP,15.00 USD";;size_M;;60.0000;CELSIUS;5000;GRAM;1;;;;
+    tshirt-white;tshirts;;2014_collection;;white;;;;;"Ein elegantes weißes T-Shirt";"An elegant white t-shirt";"A stylish white t-shirt";"Un T-shirt blanc élégant";;;american_apparel;cotton;"Weißes T-Shirt";"White t-shirt";"White t-shirt";"T-shirt blanc";;"10.00 EUR,9.00 GBP,15.00 USD";;size_M;;60.0000;CELSIUS;5000.0000;GRAM;1;;;;
     """

--- a/src/Pim/Bundle/ImportExportBundle/Normalizer/FlatProductNormalizer.php
+++ b/src/Pim/Bundle/ImportExportBundle/Normalizer/FlatProductNormalizer.php
@@ -168,7 +168,7 @@ class FlatProductNormalizer implements NormalizerInterface
             $fieldName = $this->getFieldValue($value);
 
             return array(
-                $fieldName                     => $data->getData(),
+                $fieldName                     => sprintf('%.4f', $data->getData()),
                 sprintf('%s-unit', $fieldName) => ($data->getData() !== null) ? $data->getUnit() : '',
             );
         }

--- a/src/Pim/Bundle/ImportExportBundle/Tests/Unit/Normalizer/FlatProductNormalizerTest.php
+++ b/src/Pim/Bundle/ImportExportBundle/Tests/Unit/Normalizer/FlatProductNormalizerTest.php
@@ -105,7 +105,7 @@ class FlatProductNormalizerTest extends \PHPUnit_Framework_TestCase
             'name-es_ES'  => 'Carretilla',
             'name-fr_FR'  => 'Brouette',
             'visual'      => 'files/media.jpg',
-            'weight'      => '73',
+            'weight'      => '73.0000',
             'weight-unit' => 'KILOGRAM',
             'enabled'     => (int) true
         );
@@ -280,8 +280,8 @@ class FlatProductNormalizerTest extends \PHPUnit_Framework_TestCase
      */
     protected function assertArrayEquals(array $a, array $b)
     {
-        $this->assertEquals(array_keys($a), array_keys($b));
-        $this->assertEquals($a, $b);
+        $this->assertSame(array_keys($a), array_keys($b));
+        $this->assertSame($a, $b);
     }
 
     /**


### PR DESCRIPTION
```
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Unit test passes: yes
Behat scenarios passes: no
Checkstyle issues: no
ChangeLog updated: no
Documentation PR:
Fixes the following jira:
 - PIM-1653
```

Converting `double(0.00005)` into `string` gives `5E-5`
