### PR TITLE
Adding base64 encode function to media manager

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Manager/MediaManager.php
+++ b/src/Pim/Bundle/CatalogBundle/Manager/MediaManager.php
@@ -220,8 +220,8 @@ class MediaManager
 
     /**
      * Get the media, base64 encoded
+     * @param Media $media
      *
-     * @param  Media  $media
      * @return string
      */
     public function getBase64(Media $media)


### PR DESCRIPTION
Encode media files in base64 could be useful for connector export purpose.

Bug fix: [no]
Feature addition: [yes]
Backwards compatibility break: [no]
Unit test passes: [yes|no]
Behat scenarios passes: [yes|no]
Checkstyle issues: [no]*
ChangeLog updated: [no]
