### PR TITLE
Changed default_locale to be en_US

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -18,7 +18,7 @@ parameters:
     session_handler:   ~
 
     locale:            en_US
-    default_locale:    default
+    default_locale:    en_US
     secret:            ThisTokenIsNotSoSecretChangeIt
 
     upload_dir:        %kernel.root_dir%/uploads/product


### PR DESCRIPTION
This was needed to be able to run `cache:clear` and then login (I use pim-community-standard v1.0.0-BETA4). This was the error message:

```
[ReflectionException]                                                            
Property Oro\Bundle\UserBundle\Entity\User::$field_catalogLocale does not exist
```
