### PR TITLE
PIM-2115 : add missing group by in selector extension

### DIFF
--- a/src/Pim/Bundle/DataGridBundle/Extension/Selector/OrmSelectorExtension.php
+++ b/src/Pim/Bundle/DataGridBundle/Extension/Selector/OrmSelectorExtension.php
@@ -130,6 +130,7 @@ class OrmSelectorExtension extends AbstractExtension
         $rootAlias  = $getIdsQb->getRootAlias();
         $rootField  = $rootAlias.'.id';
         $getIdsQb->add('from', new From($rootEntity, $rootAlias, $rootField), false);
+        $getIdsQb->groupBy($rootField);
         $results = $getIdsQb->getQuery()->getResult(AbstractQuery::HYDRATE_ARRAY);
 
         return array_keys($results);


### PR DESCRIPTION
To fix wrong number of lines in product grid

| Q | A |
| --- | --- |
| Bug fix? | Y |
| New feature? | N |
| BC breaks? | N |
| Tests pass? | Y |
| Scenarios pass? | Y |
| Checkstyle issues? | N |
| Changelog updated? | N |
| Fixed tickets | PIM-2115 |
| Doc PR |  |
