### PR TITLE
Prevented having an orphan option

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Resources/config/doctrine/AttributeOption.orm.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/doctrine/AttributeOption.orm.yml
@@ -26,6 +26,7 @@ Pim\Bundle\CatalogBundle\Entity\AttributeOption:
             inversedBy: options
             joinColumns:
                 attribute_id:
+                    nullable: false
                     referencedColumnName: id
                     onDelete: CASCADE
     oneToMany:


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Tests pass? | yes |
| Scenarios pass? | yes |
| Checkstyle issues? | no |
| Changelog updated? | no |
| Fixed tickets |  |
| Doc PR |  |

We have an issue on test-dev during option import that raises the following error:

```
PHP Fatal error:  Call to a member function getCode() on a non-object in /home/demo/git/pim/src/Pim/Bundle/CatalogBundle/Entity/AttributeOption.php on line 109
```

This PR won't fix it, but we will know where the option creation without attribute happens
