### PR TITLE
PIM-2205 Prevent product values from being unintentionnaly removed

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Form/Type/ProductType.php
+++ b/src/Pim/Bundle/EnrichBundle/Form/Type/ProductType.php
@@ -44,8 +44,8 @@ class ProductType extends AbstractType
             'pim_enrich_localized_collection',
             array(
                 'type'               => 'pim_product_value',
-                'allow_add'          => true,
-                'allow_delete'       => true,
+                'allow_add'          => false,
+                'allow_delete'       => false,
                 'by_reference'       => false,
                 'cascade_validation' => true,
                 'currentLocale'      => $options['currentLocale'],


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Tests pass? | no |
| Scenarios pass? | 741 |
| Checkstyle issues? | ? |
| Changelog updated? | no |
| Fixed tickets | PIM-2205 |
| Doc PR |  |

Because the product edit form only contains values in a given language,
the odm adapter removes values from db that are not present in the collection.
This does not happen when using the orm.

Anyway, it makes sense to prevent the form from adding/removing values
as it will never happen currently (values are created on server side, so
extra value fields should be safely ignored).
