### PR TITLE
PIM-2322 Kept old entity relation value if new value has no id

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/EventListener/MongoDBODM/EntityTypeSubscriber.php
+++ b/src/Pim/Bundle/CatalogBundle/EventListener/MongoDBODM/EntityTypeSubscriber.php
@@ -76,7 +76,14 @@ class EntityTypeSubscriber implements EventSubscriber
             if ('entity' === $mapping['type'] && $args->hasChangedField($field)) {
                 $newValue = $args->getNewValue($field);
                 if (is_object($newValue)) {
-                    $args->setNewValue($field, $newValue->getId());
+                    if (null === $id = $newValue->getId()) {
+                        // For some reason, sometimes a newValue with no id is set as the new value
+                        // In that case, we ignore it and rely on the old value
+                        $id = $args->getOldValue($field);
+                    }
+
+                    // Cast into int is mandatory to prevent storing string id (for data consistency purpose)
+                    $args->setNewValue($field, (int) $id);
                 }
             }
         }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Tests pass? | yes |
| Scenarios pass? | no |
| Checkstyle issues? | no |
| Changelog updated? | no |
| Fixed tickets | PIM-2322 |
| Doc PR |  |

This is a fix for the consequences of a (still) unknown cause.
Here's the consequences:

When saving an attribute of type simple select all the products that actually use this attribute will be updated (for synchronizing normalized version?), together with their values.
Strange behaviour is that the AttributeOption that is present in the ProductValue object (representing the value of the simple select attribute) has **NO ID**.

As current implementation convert any entity into its id (this is how the entity is referenced inside a document), it replaces previous id with null, thus removing the previously selected option.
