### PR TITLE
PIM-2498 : ProductEditType add extensibility point

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Form/Type/ProductEditType.php
+++ b/src/Pim/Bundle/EnrichBundle/Form/Type/ProductEditType.php
@@ -36,9 +36,9 @@ class ProductEditType extends AbstractType
     /**
      * Constructor
      *
-     * @param ProductFormView          $productFormView
-     * @param FamilyRepository         $repository
-     * @param string                   $categoryClass
+     * @param ProductFormView  $productFormView
+     * @param FamilyRepository $repository
+     * @param string           $categoryClass
      */
     public function __construct(ProductFormView $productFormView, FamilyRepository $repository, $categoryClass)
     {


### PR DESCRIPTION
Be able to add and use many EventSubscriber in ProductEditType (one for now, I'm doing some experiments to validate the case)

| Q | A |
| --- | --- |
| Bug fix? | N |
| New feature? | N |
| BC breaks? | N |
| Tests pass? | Y |
| Scenarios pass? | Y |
| Checkstyle issues? | N |
| Changelog updated? | Y |
| Fixed tickets | PIM-2498 |
| Doc PR |  |
