### PR TITLE
PIM-2521: Avoid to load all attributes in grid column configuration 

### DIFF
--- a/features/Context/FixturesContext.php
+++ b/features/Context/FixturesContext.php
@@ -74,6 +74,8 @@ class FixturesContext extends RawMinkContext
 
     private $placeholderValues = array();
 
+    private $username;
+
     /**
      * @BeforeScenario
      */
@@ -1086,6 +1088,14 @@ class FixturesContext extends RawMinkContext
     }
 
     /**
+     * @param $username
+     */
+    public function setUsername($username)
+    {
+        $this->username = $username;
+    }
+
+    /**
      * @param string $columns
      *
      * @Given /^I\'ve displayed the columns (.*)$/
@@ -1093,7 +1103,7 @@ class FixturesContext extends RawMinkContext
     public function iVeDisplayedTheColumns($columns)
     {
         $alias = 'product-grid';
-        $user  = $this->getUser('Julia');
+        $user  = $this->getUser($this->username);
 
         $view = $this->getRepository('PimDataGridBundle:DatagridView')->findOneBy(
             [

--- a/features/Context/NavigationContext.php
+++ b/features/Context/NavigationContext.php
@@ -100,6 +100,8 @@ class NavigationContext extends RawMinkContext implements PageObjectAwareInterfa
     {
         $this->username = $username;
         $this->password = $username;
+
+        $this->getMainContext()->getSubcontext('fixtures')->setUsername($username);
     }
 
     /**

--- a/features/product/browse_products_by_locale_and_scope.feature
+++ b/features/product/browse_products_by_locale_and_scope.feature
@@ -17,7 +17,8 @@ Feature: Browse products by locale and scope
     And the following product:
       | sku    | family    | name-en_US | name-fr_FR | description-en_US-ecommerce | description-fr_FR-ecommerce | description-fr_FR-mobile | image-ecommerce | image-mobile |
       | postit | furniture | Post it    | Etiquette  | My ecommerce description    | Ma description ecommerce    | Ma description mobile    | large.jpeg      | small.jpeg   |
-    And I am logged in as "admin"
+    And I am logged in as "Julia"
+    And I've displayed the columns sku, name, image, description and family
     And I am on the products page
 
   Scenario: Successfully display english data on products page
@@ -26,7 +27,7 @@ Feature: Browse products by locale and scope
     When I filter by "Channel" with value "E-Commerce"
     Then the row "postit" should contain:
       | column      | value                    |
-      | sku         | postit                   |
+      | SKU         | postit                   |
       | name        | Post it                  |
       | image       | large.jpeg               |
       | description | My ecommerce description |

--- a/features/product/choose_and_order_products_grid_columns.feature
+++ b/features/product/choose_and_order_products_grid_columns.feature
@@ -12,21 +12,21 @@ Feature: Choose and order product grids columns
       | basket  |
     And I am logged in as "Julia"
 
-  Scenario: Succesfully display all columns by default
+  Scenario: Succesfully display default columns
     Given I am on the products page
-    Then I should see the columns Sku, Label, Family, Status, Complete, Created At, Updated At, Groups, Color, Name, Price, Rating and Size
+    Then I should see the columns Sku, Label, Family, Status, Complete, Created At, Updated At, Groups
 
   @skip
   Scenario: Succesfully hide some columns
     Given I am on the products page
-    When I hide the "Color" column
-    Then I should see the columns Sku, Label, Family, Status, Complete, Created At, Updated At, Groups, Name, Price, Rating and Size
+    When I hide the "Label" column
+    Then I should see the columns Sku, Family, Status, Complete, Created At, Updated At, Groups
 
   @skip
   Scenario: Succesfully order some columns
     Given I am on the products page
-    When I put the "Color" column before the "Complete" one
-    Then I should see the columns Sku, Label, Family, Status, Color, Complete, Created At, Updated At, Groups, Name, Price, Rating and Size
+    When I put the "Complete" column before the "Sku" one
+    Then I should see the columns Sku, Family, Status, Complete, Created At, Updated At, Groups
 
   Scenario: Succesfully hide removed attribute column that was previously selected to be displayed
     Given I've displayed the columns sku, family and name

--- a/features/product/edit_product_and_action.feature
+++ b/features/product/edit_product_and_action.feature
@@ -6,7 +6,8 @@ Feature: Product edition clicking on another action
 
   Background:
     Given a "footwear" catalog configuration
-    And I am logged in as "admin"
+    And I am logged in as "Julia"
+    And I've displayed the columns sku, name, image, description and family
     And the following products:
       | sku    | family  |
       | sandal | sandals |

--- a/spec/Pim/Bundle/DataGridBundle/Datagrid/Product/ColumnsConfiguratorSpec.php
+++ b/spec/Pim/Bundle/DataGridBundle/Datagrid/Product/ColumnsConfiguratorSpec.php
@@ -30,8 +30,6 @@ class ColumnsConfiguratorSpec extends ObjectBehavior
 
     function it_configures_datagrid_columns($configuration, $registry)
     {
-        $columnConfPath = sprintf('[%s]', FormatterConfiguration::COLUMNS_KEY);
-
         $attributes = [
             'sku' => [
                 'code'  => 'sku',
@@ -58,7 +56,7 @@ class ColumnsConfiguratorSpec extends ObjectBehavior
         $displayColumnPath = sprintf(ContextConfigurator::SOURCE_PATH, ContextConfigurator::DISPLAYED_COLUMNS_KEY);
         $configuration->offsetGetByPath($displayColumnPath)->shouldBeCalled();
 
-        $columns = [
+        $availableColumns = [
             'sku' => [
                 'identifier_config',
                 'label' => 'Sku'
@@ -71,10 +69,15 @@ class ColumnsConfiguratorSpec extends ObjectBehavior
                 'label' => 'Name'
             ]
         ];
-        $configuration->offsetSetByPath($columnConfPath, $columns)->shouldBeCalled();
+
+        $displayedColumns = $availableColumns;
+        array_pop($displayedColumns);
+
+        $columnConfPath = sprintf('[%s]', FormatterConfiguration::COLUMNS_KEY);
+        $configuration->offsetSetByPath($columnConfPath, $displayedColumns)->shouldBeCalled();
 
         $availableColumnPath = sprintf(ContextConfigurator::SOURCE_PATH, ContextConfigurator::AVAILABLE_COLUMNS_KEY);
-        $configuration->offsetSetByPath($availableColumnPath, $columns)->shouldBeCalled();
+        $configuration->offsetSetByPath($availableColumnPath, $availableColumns)->shouldBeCalled();
 
         $this->configure();
     }

--- a/src/Pim/Bundle/DataGridBundle/Datagrid/Product/ColumnsConfigurator.php
+++ b/src/Pim/Bundle/DataGridBundle/Datagrid/Product/ColumnsConfigurator.php
@@ -178,7 +178,8 @@ class ColumnsConfigurator implements ConfiguratorInterface
             }
 
         } else {
-            $this->displayedColumns = $this->availableColumns;
+            $this->displayedColumns = $this->editableColumns + $this->primaryColumns + $this->identifierColumn
+                + $this->propertiesColumns;
         }
     }
 

--- a/src/Pim/Bundle/DataGridBundle/Manager/DatagridViewManager.php
+++ b/src/Pim/Bundle/DataGridBundle/Manager/DatagridViewManager.php
@@ -7,6 +7,7 @@ use Oro\Bundle\UserBundle\Entity\User;
 use Pim\Bundle\DataGridBundle\Datagrid\Product\ContextConfigurator;
 use Pim\Bundle\DataGridBundle\Entity\DatagridView;
 use Oro\Bundle\DataGridBundle\Datagrid\Manager as DatagridManager;
+use Oro\Bundle\DataGridBundle\Extension\Formatter\Configuration as FormatterConfiguration;
 
 /**
  * Datagrid view manager
@@ -59,20 +60,25 @@ class DatagridViewManager
     /**
      * Get datagrid column choices for the provided datagrid alias
      *
-     * @param string $alias
+     * @param string  $alias
+     * @param boolean $displayedColumns
      *
      * @return array
      */
-    public function getColumnChoices($alias)
+    public function getColumnChoices($alias, $displayedColumns = false)
     {
         $choices = array();
+
+        $path = (true === $displayedColumns) ?
+            sprintf('[%s]', FormatterConfiguration::COLUMNS_KEY) :
+            sprintf(ContextConfigurator::SOURCE_PATH, ContextConfigurator::AVAILABLE_COLUMNS_KEY);
 
         $columnsConfig = $this
             ->datagridManager
             ->getDatagrid($alias)
             ->getAcceptor()
             ->getConfig()
-            ->offsetGetByPath(sprintf(ContextConfigurator::SOURCE_PATH, ContextConfigurator::AVAILABLE_COLUMNS_KEY));
+            ->offsetGetByPath($path);
 
         if ($columnsConfig) {
             foreach ($columnsConfig as $code => $meta) {
@@ -107,7 +113,7 @@ class DatagridViewManager
                 ->setType(DatagridView::TYPE_DEFAULT)
                 ->setOwner($user)
                 ->setDatagridAlias($alias)
-                ->setColumns(array_keys($this->getColumnChoices($alias)));
+                ->setColumns(array_keys($this->getColumnChoices($alias, true)));
 
             $this->entityManager->persist($view);
             $this->entityManager->flush();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | N |
| New feature? | N |
| BC breaks? | N |
| Tests pass? | Y |
| Scenarios pass? | Y |
| Checkstyle issues? | - |
| Changelog updated? | - |
| Fixed tickets | PIM-2521 |
| Doc PR | - |
