### PR TITLE
Update family repo for a bug in products export

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Entity/Repository/FamilyRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Entity/Repository/FamilyRepository.php
@@ -5,6 +5,7 @@ namespace Pim\Bundle\CatalogBundle\Entity\Repository;
 use Pim\Bundle\CatalogBundle\Entity\Family;
 use Pim\Bundle\CatalogBundle\Doctrine\ReferableEntityRepository;
 use Pim\Bundle\EnrichBundle\Form\DataTransformer\ChoicesProviderInterface;
+use Pim\Bundle\CatalogBundle\Entity\Channel;
 
 /**
  * Repository


### PR DESCRIPTION
Generating this error for product export : 
Argument 2 passed to Pim\Bundle\CatalogBundle\Entity\Repository\FamilyRepository::getFullFamilies() must be an instance of Pim\Bundle\CatalogBundle\Entity\Repository\Channel, instance of Pim\Bundle\CatalogBundle\Entity\Channel given, called in vendor/akeneo/pim-community-dev/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/CompletenessGenerator.php
