### PR TITLE
Several improvements on behat context

### DIFF
--- a/features/Context/FixturesContext.php
+++ b/features/Context/FixturesContext.php
@@ -299,6 +299,18 @@ class FixturesContext extends RawMinkContext
     }
 
     /**
+     * @param TableNode $table
+     *
+     * @Given /^the product?:$/
+     */
+    public function theProduct(TableNode $table)
+    {
+        $this->createProduct(
+            $table->getRowsHash()
+        );
+    }
+
+    /**
      * @param string $status
      * @param string $sku
      *

--- a/features/Context/Page/Base/Form.php
+++ b/features/Context/Page/Base/Form.php
@@ -409,7 +409,7 @@ class Form extends Base
         $label = $this->find('css', sprintf('label:contains("%s")', $name));
 
         if (!$label) {
-            throw new ElementNotFoundException($this->getSession(), 'form label ', 'value', $name);
+            throw new ElementNotFoundException($this->getSession(), 'form label', 'value', $name);
         }
 
         $labels = $label->getParent()->findAll('css', '.currency-label');
@@ -423,7 +423,7 @@ class Form extends Base
         }
 
         if ($fieldNum === null) {
-            throw new ElementNotFoundException($this->getSession(), 'form field ', 'id|name|label|value', $name);
+            throw new ElementNotFoundException($this->getSession(), 'price field', 'id|name|label|value', $currency);
         }
 
         $fields = $label->getParent()->findAll('css', 'input[type="text"]');

--- a/features/Context/Page/Product/Edit.php
+++ b/features/Context/Page/Product/Edit.php
@@ -182,11 +182,12 @@ class Edit extends Form
      */
     public function findFieldIcons($name)
     {
-        if ($field = $this->findField($name)) {
-            return $field->getParent()->findAll('css', '.icons-container i');
-        }
+        $controls = $this->findField($name);
+        do {
+            $controls = $controls->getParent();
+        } while (null !== $controls && !$controls->hasClass('controls'));
 
-        return [];
+        return $controls->findAll('css', '.icons-container i');
     }
 
     /**

--- a/features/Context/WebUser.php
+++ b/features/Context/WebUser.php
@@ -436,6 +436,7 @@ class WebUser extends RawMinkContext
      *
      * @Then /^the product (.*) should be empty$/
      * @Then /^the product (.*) should be "([^"]*)"$/
+     * @Then /^the field (.*) should contain "([^"]*)"$/
      */
     public function theProductFieldValueShouldBe($fieldName, $expected = '')
     {
@@ -475,6 +476,12 @@ class WebUser extends RawMinkContext
             sort($expected);
             $actual   = implode(', ', $actual);
             $expected = implode(', ', $expected);
+        } elseif ((null !== $parent = $field->getParent()) && $parent->hasClass('upload-zone')) {
+            # We are dealing with an upload field
+            if (null === $filename = $parent->find('css', '.upload-filename')) {
+                throw new \LogicException('Cannot find filename of upload field');
+            }
+            $actual = $filename->getText();
         } else {
             $actual = $field->getValue();
         }
@@ -482,7 +489,7 @@ class WebUser extends RawMinkContext
         if ($expected != $actual) {
             throw $this->createExpectationException(
                 sprintf(
-                    'Expected product %s to be "%s", but got "%s".',
+                    'Expected product field "%s" to contain "%s", but got "%s".',
                     $fieldName,
                     $expected,
                     $actual


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| CI currently passes? | yes |
| Tests pass? | yes |
| Scenarios pass? | yes |
| Checkstyle issues? | no |
| Changelog updated? | no |
| Fixed tickets |  |
| Doc PR |  |
- Be able to create a single product like that:

``` gherkin
Given the following product:
| SKU        | shoe  |
| families   | shoes |
| name-en_US | foo   |
```
- Improve step exceptions
- Improve field icons retrieval
- Check value of a field using `Then the field english Name should contain "foo"`
- Correctly check value of an upload file widget
