### PR TITLE
PIM-2786 : create a dedicated getChildren method in the category tree controller

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Controller/CategoryTreeController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/CategoryTreeController.php
@@ -354,7 +354,7 @@ class CategoryTreeController extends AbstractDoctrineController
 
     /**
      * @param integer $parentId
-     * @param boolean $selectNodeId
+     * @param mixed   $selectNodeId
      *
      * @return CategoryInterface[]
      */


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | N (extensibility point) |
| New feature? | N |
| BC breaks? | N |
| CI currently passes? | Y |
| Tests pass? | Y |
| Scenarios pass? | Y |
| Checkstyle issues? | N |
| Changelog updated? | N |
| Fixed tickets | PIM-2786 (partially) |
| Doc PR |  |
