### PR TITLE
Late controller flashes translation

### DIFF
--- a/spec/Pim/Bundle/EnrichBundle/EventListener/TranslateFlashMessagesSubscriberSpec.php
+++ b/spec/Pim/Bundle/EnrichBundle/EventListener/TranslateFlashMessagesSubscriberSpec.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace spec\Pim\Bundle\EnrichBundle\EventListener;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
+use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Pim\Bundle\EnrichBundle\Flash\Message;
+
+class TranslateFlashMessagesSubscriberSpec extends ObjectBehavior
+{
+    function let(TranslatorInterface $translator)
+    {
+        $this->beConstructedWith($translator);
+    }
+
+    function it_is_an_event_subscriber()
+    {
+        $this->shouldBeAnInstanceOf('Symfony\Component\EventDispatcher\EventSubscriberInterface');
+    }
+
+    function it_subscribes_to_the_response_kernel_event_with_a_low_priority()
+    {
+        $this->getSubscribedEvents()->shouldReturn([
+            KernelEvents::RESPONSE => ['translate', -128],
+        ]);
+    }
+
+    function it_translates_flash_messages(
+        $translator,
+        FilterResponseEvent $event,
+        Request $request,
+        Session $session,
+        FlashBagInterface $flashBag,
+        Message $noticeFoo,
+        Message $noticeBar,
+        Message $successFoo
+    ) {
+        $event->getRequest()->willReturn($request);
+        $event->getRequestType()->willReturn(HttpKernelInterface::MASTER_REQUEST);
+        $request->getSession()->willReturn($session);
+        $session->getFlashBag()->willReturn($flashBag);
+
+        $noticeFoo->getTemplate()->willReturn('flash.notice.foo');
+        $noticeBar->getTemplate()->willReturn('flash.notice.bar');
+        $successFoo->getTemplate()->willReturn('flash.success.foo');
+        $noticeFoo->getParameters()->willReturn([]);
+        $noticeBar->getParameters()->willReturn([]);
+        $successFoo->getParameters()->willReturn([]);
+
+        $flashBag->all()->willReturn([
+            'notice' => [$noticeFoo, $noticeBar],
+            'success' => [$successFoo],
+        ]);
+
+        $translator->trans(Argument::type('string'), Argument::type('array'))->will(function ($args) {
+            return ucfirst(strtr($args[0], ['.' => ' ']));
+        });
+
+        $flashBag
+            ->setAll([
+                'notice' => [
+                    'Flash notice foo',
+                    'Flash notice bar',
+                ],
+                'success' => [
+                    'Flash success foo',
+                ]
+            ])
+            ->shouldBeCalled();
+
+        $this->translate($event);
+    }
+}

--- a/src/Pim/Bundle/EnrichBundle/AbstractController/AbstractController.php
+++ b/src/Pim/Bundle/EnrichBundle/AbstractController/AbstractController.php
@@ -14,6 +14,7 @@ use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Validator\ValidatorInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Pim\Bundle\EnrichBundle\Flash\Message;
 
 /**
  * Base abstract controller
@@ -253,7 +254,7 @@ abstract class AbstractController
      */
     protected function addFlash($type, $message, array $parameters = array())
     {
-        $this->request->getSession()->getFlashBag()->add($type, $this->translator->trans($message, $parameters));
+        $this->request->getSession()->getFlashBag()->add($type, new Message($message, $parameters));
     }
 
     /**

--- a/src/Pim/Bundle/EnrichBundle/DependencyInjection/PimEnrichExtension.php
+++ b/src/Pim/Bundle/EnrichBundle/DependencyInjection/PimEnrichExtension.php
@@ -37,6 +37,7 @@ class PimEnrichExtension extends Extension implements PrependExtensionInterface
         $loader->load('attribute_icons.yml');
         $loader->load('mass_actions.yml');
         $loader->load('factories.yml');
+        $loader->load('event_subscribers.yml');
 
         if ($config['record_mails']) {
             $loader->load('mail_recorder.yml');

--- a/src/Pim/Bundle/EnrichBundle/EventListener/TranslateFlashMessagesSubscriber.php
+++ b/src/Pim/Bundle/EnrichBundle/EventListener/TranslateFlashMessagesSubscriber.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Pim\Bundle\EnrichBundle\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Pim\Bundle\EnrichBundle\Flash\Message;
+
+/**
+ * Translate all flash messages
+ *
+ * @author    Gildas Quemener <gildas@akeneo.com>
+ * @copyright 2014 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class TranslateFlashMessagesSubscriber implements EventSubscriberInterface
+{
+    /** @var TranslatorInterface */
+    protected $translator;
+
+    /**
+     * @param TranslatorInterface $translator
+     */
+    public function __construct(TranslatorInterface $translator)
+    {
+        $this->translator = $translator;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * All subscribers to the response event registered with a higher priority will have access to Message instance
+     * inside the flash bag. All others will have access to strings (translated flashes).
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            KernelEvents::RESPONSE => ['translate', -128],
+        ];
+    }
+
+    /**
+     * Replace flash messages with their translation
+     *
+     * @param FilterResponseEvent $event
+     */
+    public function translate(FilterResponseEvent $event)
+    {
+        if (HttpKernelInterface::MASTER_REQUEST !== $event->getRequestType()) {
+            return;
+        }
+
+        $bag = $event->getRequest()->getSession()->getFlashBag();
+        $messages = [];
+        foreach ($bag->all() as $type => $flashes) {
+            foreach ($flashes as $flash) {
+                if ($flash instanceof Message) {
+                    $flash = $this->translator->trans(
+                        $flash->getTemplate(),
+                        $flash->getParameters()
+                    );
+                }
+                $messages[$type][] = $flash;
+            }
+        }
+
+        $bag->setAll($messages);
+    }
+}

--- a/src/Pim/Bundle/EnrichBundle/Flash/Message.php
+++ b/src/Pim/Bundle/EnrichBundle/Flash/Message.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Pim\Bundle\EnrichBundle\Flash;
+
+/**
+ * A flash message
+ *
+ * @author    Gildas Quemener <gildas@akeneo.com>
+ * @copyright 2014 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class Message
+{
+    /** @var string */
+    protected $template;
+
+    /** @var array */
+    protected $parameters;
+
+    /**
+     * @param string $template
+     * @param array  $parameters
+     */
+    public function __construct($template, array $parameters = [])
+    {
+        $this->template = $template;
+        $this->parameters = $parameters;
+    }
+
+    /**
+     * Set the template
+     *
+     * @param string $template
+     */
+    public function setTemplate($template)
+    {
+        $this->template = $template;
+    }
+
+    /**
+     * Get the template
+     *
+     * @return string
+     */
+    public function getTemplate()
+    {
+        return $this->template;
+    }
+
+    /**
+     * Set the parameters
+     *
+     * @param array $parameters
+     */
+    public function setParameters(array $parameters)
+    {
+        $this->parameters = $parameters;
+    }
+
+    /**
+     * Get the parameters
+     *
+     * @return array
+     */
+    public function getParameters()
+    {
+        return $this->parameters;
+    }
+}

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/event_subscribers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/event_subscribers.yml
@@ -1,0 +1,9 @@
+parameters: ~
+
+services:
+    pim_enrich.event_subscriber.translate_flash_messages:
+        class: %pim_enrich.event_subscriber.translate_flash_messages.class%
+        arguments:
+            - '@translator'
+        tags:
+            - { name: kernel.event_subscriber }

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/services.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/services.yml
@@ -1,14 +1,15 @@
 parameters:
-    pim_enrich.imagine.local_dir_resolver.class:  Pim\Bundle\EnrichBundle\Imagine\Cache\Resolver\LocalDirResolver
+    pim_enrich.imagine.local_dir_resolver.class: Pim\Bundle\EnrichBundle\Imagine\Cache\Resolver\LocalDirResolver
     pim_enrich.event_listener.user_context.class: Pim\Bundle\EnrichBundle\EventListener\UserContextListener
-    pim_enrich.provider.colors.class:             Pim\Bundle\EnrichBundle\Provider\ColorsProvider
-    pim_enrich.twig.locale_extension.class:       Pim\Bundle\EnrichBundle\Twig\LocaleExtension
-    pim_enrich.twig.category_extension.class:     Pim\Bundle\EnrichBundle\Twig\CategoryExtension
-    pim_enrich.twig.channel_extension.class:      Pim\Bundle\EnrichBundle\Twig\ChannelExtension
-    pim_enrich.twig.attribute_extension.class:    Pim\Bundle\EnrichBundle\Twig\AttributeExtension
+    pim_enrich.provider.colors.class: Pim\Bundle\EnrichBundle\Provider\ColorsProvider
+    pim_enrich.twig.locale_extension.class: Pim\Bundle\EnrichBundle\Twig\LocaleExtension
+    pim_enrich.twig.category_extension.class: Pim\Bundle\EnrichBundle\Twig\CategoryExtension
+    pim_enrich.twig.channel_extension.class: Pim\Bundle\EnrichBundle\Twig\ChannelExtension
+    pim_enrich.twig.attribute_extension.class: Pim\Bundle\EnrichBundle\Twig\AttributeExtension
     pim_enrich.twig.object_class_extension.class: Pim\Bundle\EnrichBundle\Twig\ObjectClassExtension
-    pim_enrich.twig.version_extension.class:      Pim\Bundle\EnrichBundle\Twig\VersionExtension
-    pim_enrich.event_listener.request.class:      Pim\Bundle\EnrichBundle\EventListener\RequestListener
+    pim_enrich.twig.version_extension.class: Pim\Bundle\EnrichBundle\Twig\VersionExtension
+    pim_enrich.event_listener.request.class: Pim\Bundle\EnrichBundle\EventListener\RequestListener
+    pim_enrich.event_subscriber.translate_flash_messages.class: Pim\Bundle\EnrichBundle\EventListener\TranslateFlashMessagesSubscriber
 
 services:
     # Media management


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| CI currently passed? | no |
| Tests pass? | yes |
| Scenarios pass? | yes |
| Checkstyle issues? | no |
| Changelog updated? | no |
| Fixed tickets |  |
| Doc PR |  |

AbstractController could be lighten by removing the dependency on translator, but it would break BC.
