### PR TITLE
PIM-2891 : remove the count of products in the manage category tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 - Dispatch events when removing some entities
 - Add method remove in Category, Group, Attribute, Association type and family managers.
 - Call manager's method remove from these entity controllers
+- Remove the count of products by category in the context of the management of the categories (perf)
 
 ## Bug fixes
 - Replaced usage of Symfony process to launch background job with a simple exec, more reliable on a heavily loaded environment

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/tree-manage.jstree.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/tree-manage.jstree.js
@@ -40,7 +40,7 @@ define(
                 },
                 tree_selector: {
                     ajax: {
-                        url: Routing.generate('pim_enrich_categorytree_listtree', { _format: 'json', select_node_id: selectedNodeOrTree, context: 'manage' })
+                        url: Routing.generate('pim_enrich_categorytree_listtree', { _format: 'json', select_node_id: selectedNodeOrTree, context: 'manage', with_products_count: 0 })
                     },
                     auto_open_root: true,
                     node_label_field: 'label',
@@ -66,7 +66,7 @@ define(
                             return {
                                 id: id,
                                 select_node_id: selectedNode,
-                                with_products_count: 1
+                                with_products_count: 0
                             };
                         }
                     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | N |
| New feature? | Y |
| BC breaks? | N |
| CI currently passes? | Y |
| Tests pass? | Y |
| Scenarios pass? | Y |
| Checkstyle issues? | N |
| Changelog updated? | Y |
| Fixed tickets | PIM-2891 |
| Doc PR |  |
