### PR TITLE
PIM-2905 Removed mimetype validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@
 - Attribute Options code validation now more precise on uniqueness (equality instead of similarity)
 - Fixed a bug with repository resolver on ODM implementation
 - Fixed a bug on mass edit when we use a completeness filter to select products
+- Removed the import CSV mimetype validation which is unreliable
 
 ## BC breaks
 - Remove FlexibleEntityBundle

--- a/src/Pim/Bundle/BaseConnectorBundle/Reader/File/CsvReader.php
+++ b/src/Pim/Bundle/BaseConnectorBundle/Reader/File/CsvReader.php
@@ -29,14 +29,7 @@ class CsvReader extends FileReader implements
      * @Assert\NotBlank(groups={"Execution"})
      * @AssertFile(
      *     groups={"Execution"},
-     *     allowedExtensions={"csv", "zip"},
-     *     mimeTypes={
-     *         "text/csv",
-     *         "text/comma-separated-values",
-     *         "text/plain",
-     *         "application/csv",
-     *         "application/zip"
-     *     }
+     *     allowedExtensions={"csv", "zip"}
      * )
      */
     protected $filePath;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| CI currently passes? | yes |
| Tests pass? | yes |
| Scenarios pass? | yes |
| Checkstyle issues? | no |
| Changelog updated? | yes |
| Fixed tickets | PIM-2905 |
| Doc PR |  |
