### PR TITLE
[POC] PIM-2968 Disabled wysisyg forced root block

### DIFF
--- a/src/Pim/Bundle/UIBundle/Resources/public/js/pim-wysiwyg.js
+++ b/src/Pim/Bundle/UIBundle/Resources/public/js/pim-wysiwyg.js
@@ -13,7 +13,8 @@ define(
                 ed.on('change', function() {
                     $('#' + ed.id).trigger('change');
                 });
-            }
+            },
+            forced_root_block: false
         };
         var destroyEditor = function(id) {
             var instance = tinymce.get(id);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| CI currently passes? | maybe |
| Tests pass? | yes |
| Scenarios pass? | yes |
| Checkstyle issues?* | no |
| PMD issues?** | no |
| Changelog updated? | no |
| Fixed tickets | PIM-2968 (and probably PIM-2965 also) |
| Doc PR |  |

There are several consequences of activating this [TinyMCE option](www.tinymce.com/wiki.php/Configuration:forced_root_block).
## Saving blank value

This doesn't change. Blank value (meaning value not even containing a root tag) will remain blank.
## Saving non html value

Given the value is "Lorem Ipsum", this is what happens when saving:

| Before | After |
| --- | --- |
| `<p>Lorem Ipsum</p>` | `Lorem Ipsum` |
## Saving value containing special characters

Given the value is "Lorem & Ipsum", this is what happens when saving:

| Before | After |
| --- | --- |
| `<p>Lorem &amp; Ipsum</p>` | `Lorem &amp; Ipsum` |
## Saving html value

Given the value is "`<p>Lorem Ipsum</p>`", this is what happens when saving:

| Before | After |
| --- | --- |
| `<p>Lorem Ipsum</p>` | `<p>Lorem Ipsum</p>` |
## Carriage Return

Given the value is "Lorem Ipsum", this is what happens when inserting a carriage return between "Lorem" and "Ipsum":

| Before | After |
| --- | --- |
| `<p>Lorem</p><p>Ipsum</p>` | `Lorem<br /><br />Ipsum` |

With the option deactivated, you have to press Maj+Enter to create paragraphs.
