### PR TITLE
[POC][WIP] Validate a product through validator directly (and not through Form)

### DIFF
--- a/spec/Pim/Bundle/CatalogBundle/Validator/Mapping/DelegatingClassMetadataFactorySpec.php
+++ b/spec/Pim/Bundle/CatalogBundle/Validator/Mapping/DelegatingClassMetadataFactorySpec.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace spec\Pim\Bundle\CatalogBundle\Validator\Mapping;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\Validator\MetadataFactoryInterface;
+use Symfony\Component\Validator\Mapping\ClassMetadata;
+use Symfony\Component\Validator\Exception\NoSuchMetadataException;
+
+class DelegatingClassMetadataFactorySpec extends ObjectBehavior
+{
+    function let(
+        MetadataFactoryInterface $dupond,
+        MetadataFactoryInterface $dupont
+    ) {
+        $this->addMetadataFactory($dupond);
+        $this->addMetadataFactory($dupont);
+    }
+
+    function it_is_a_validator_metadata_factory()
+    {
+        $this->shouldBeAnInstanceOf('Symfony\Component\Validator\MetadataFactoryInterface');
+    }
+
+    function it_delegate_metadata_creation_to_the_first_factory_having_one_for_an_object(
+        $object,
+        $dupond,
+        $dupont,
+        ClassMetadata $metadata
+    ) {
+        $dupond->hasMetadataFor($object)->willReturn(false);
+        $dupont->hasMetadataFor($object)->willReturn(true);
+        $dupont->getMetadataFor($object)->willReturn($metadata);
+
+        $this->getMetadataFor($object)->shouldReturn($metadata);
+    }
+
+   function its_getMetadataFor_method_throws_exception_when_no_factory_has_metadata_for_object(
+        $object,
+        $dupond,
+        $dupont
+    ) {
+        $dupond->hasMetadataFor($object)->willReturn(false);
+        $dupont->hasMetadataFor($object)->willReturn(false);
+
+        $this
+            ->shouldThrow(new NoSuchMetadataException())
+            ->duringGetMetadataFor($object);
+   }
+
+    function it_has_metadata_if_at_least_one_factory_has_one(
+        $object,
+        $dupond,
+        $dupont
+    ) {
+        $dupond->hasMetadataFor($object)->willReturn(false);
+        $dupont->hasMetadataFor($object)->willReturn(true);
+
+        $this->hasMetadataFor($object)->shouldReturn(true);
+    }
+
+    function it_does_not_have_metadata_if_no_factory_has_one(
+        $object,
+        $dupond,
+        $dupont
+    ) {
+        $dupond->hasMetadataFor($object)->willReturn(false);
+        $dupont->hasMetadataFor($object)->willReturn(false);
+
+        $this->hasMetadataFor($object)->shouldReturn(false);
+    }
+}

--- a/spec/Pim/Bundle/CatalogBundle/Validator/Mapping/ProductValueMetadataFactorySpec.php
+++ b/spec/Pim/Bundle/CatalogBundle/Validator/Mapping/ProductValueMetadataFactorySpec.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace spec\Pim\Bundle\CatalogBundle\Validator\Mapping;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\Validator\Mapping\ClassMetadata;
+use Pim\Bundle\CatalogBundle\Validator\ConstraintGuesserInterface;
+use Pim\Bundle\CatalogBundle\Validator\Mapping\ClassMetadataFactory;
+use Pim\Bundle\CatalogBundle\Model\AbstractProductValue;
+use Pim\Bundle\CatalogBundle\Model\AbstractAttribute;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Exception\NoSuchMetadataException;
+
+class ProductValueMetadataFactorySpec extends ObjectBehavior
+{
+    function it_is_a_validator_metadata_factory()
+    {
+        $this->shouldBeAnInstanceOf('Symfony\Component\Validator\MetadataFactoryInterface');
+    }
+
+    function let(
+        ConstraintGuesserInterface $guesser,
+        ClassMetadataFactory $factory
+    ) {
+        $this->beConstructedWith($guesser, $factory);
+    }
+
+    function it_provides_metadata_for_product_value(
+        $guesser,
+        $factory,
+        ClassMetadata $metadata,
+        AbstractProductValue $value,
+        AbstractAttribute $attribute,
+        Constraint $foo,
+        Constraint $bar
+    ) {
+        $factory->createMetadata(Argument::any())->willReturn($metadata);
+
+        $value->getAttribute()->willReturn($attribute);
+        $attribute->getBackendType()->willReturn('varchar');
+        $guesser->guessConstraints($attribute)->willReturn([$foo, $bar]);
+
+        $metadata->addPropertyConstraint('varchar', $foo)->shouldBeCalled();
+        $metadata->addPropertyConstraint('varchar', $bar)->shouldBeCalled();
+
+        $this->getMetadataFor($value);
+    }
+
+    function its_getMetadataFor_method_throws_exception_when_argument_is_not_an_AbstractProductValue($object)
+    {
+        $this
+            ->shouldThrow(new NoSuchMetadataException())
+            ->duringGetMetadataFor($object);
+    }
+
+    function it_has_metadata_for_AbstractProductValue(AbstractProductValue $value)
+    {
+        $this->hasMetadataFor($value)->shouldBe(true);
+    }
+
+    function it_does_not_have_metadata_for_something_else($object)
+    {
+        $this->hasMetadataFor($object)->shouldBe(false);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/validation/product.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/validation/product.yml
@@ -1,3 +1,7 @@
 Pim\Bundle\CatalogBundle\Model\Product:
     constraints:
         - Pim\Bundle\CatalogBundle\Validator\Constraints\UniqueVariantAxis: ~
+    properties:
+        values:
+            - Symfony\Component\Validator\Constraints\Valid:
+                traverse: true

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/validators.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/validators.yml
@@ -1,23 +1,25 @@
 parameters:
-    pim_catalog.validator.constraint.valid_metric.class:             Pim\Bundle\CatalogBundle\Validator\Constraints\ValidMetricValidator
-    pim_catalog.validator.constraint.single_identifier.class:        Pim\Bundle\CatalogBundle\Validator\Constraints\SingleIdentifierAttributeValidator
-    pim_catalog.validator.constraint.unique_variant_axis.class:      Pim\Bundle\CatalogBundle\Validator\Constraints\UniqueVariantAxisValidator
-    pim_catalog.validator.constraint.unique_value.class:             Pim\Bundle\CatalogBundle\Validator\Constraints\UniqueValueValidator
-    pim_catalog.validator.constraint.immutable.class:                Pim\Bundle\CatalogBundle\Validator\Constraints\ImmutableValidator
-    pim_catalog.validator.constraint_guesser.chained.class:          Pim\Bundle\CatalogBundle\Validator\ChainedAttributeConstraintGuesser
-    pim_catalog.validator.constraint_guesser.email.class:            Pim\Bundle\CatalogBundle\Validator\ConstraintGuesser\EmailGuesser
-    pim_catalog.validator.constraint_guesser.file.class:             Pim\Bundle\CatalogBundle\Validator\ConstraintGuesser\FileGuesser
-    pim_catalog.validator.constraint_guesser.length.class:           Pim\Bundle\CatalogBundle\Validator\ConstraintGuesser\LengthGuesser
-    pim_catalog.validator.constraint_guesser.not_blank.class:        Pim\Bundle\CatalogBundle\Validator\ConstraintGuesser\NotBlankGuesser
-    pim_catalog.validator.constraint_guesser.date.class:             Pim\Bundle\CatalogBundle\Validator\ConstraintGuesser\DateGuesser
-    pim_catalog.validator.constraint_guesser.numeric.class:          Pim\Bundle\CatalogBundle\Validator\ConstraintGuesser\NumericGuesser
-    pim_catalog.validator.constraint_guesser.range.class:            Pim\Bundle\CatalogBundle\Validator\ConstraintGuesser\RangeGuesser
-    pim_catalog.validator.constraint_guesser.regex.class:            Pim\Bundle\CatalogBundle\Validator\ConstraintGuesser\RegexGuesser
-    pim_catalog.validator.constraint_guesser.not_decimal.class:      Pim\Bundle\CatalogBundle\Validator\ConstraintGuesser\NotDecimalGuesser
-    pim_catalog.validator.constraint_guesser.url.class:              Pim\Bundle\CatalogBundle\Validator\ConstraintGuesser\UrlGuesser
-    pim_catalog.validator.constraint_guesser.unique_value.class:     Pim\Bundle\CatalogBundle\Validator\ConstraintGuesser\UniqueValueGuesser
-    pim_catalog.validator.constraint_guesser.price_collection.class: Pim\Bundle\CatalogBundle\Validator\ConstraintGuesser\PriceCollectionGuesser
-    pim_catalog.validator.constraint_guesser.metric.class:           Pim\Bundle\CatalogBundle\Validator\ConstraintGuesser\MetricGuesser
+    pim_catalog.validator.constraint.valid_metric.class:                      Pim\Bundle\CatalogBundle\Validator\Constraints\ValidMetricValidator
+    pim_catalog.validator.constraint.single_identifier.class:                 Pim\Bundle\CatalogBundle\Validator\Constraints\SingleIdentifierAttributeValidator
+    pim_catalog.validator.constraint.unique_variant_axis.class:               Pim\Bundle\CatalogBundle\Validator\Constraints\UniqueVariantAxisValidator
+    pim_catalog.validator.constraint.unique_value.class:                      Pim\Bundle\CatalogBundle\Validator\Constraints\UniqueValueValidator
+    pim_catalog.validator.constraint.immutable.class:                         Pim\Bundle\CatalogBundle\Validator\Constraints\ImmutableValidator
+    pim_catalog.validator.constraint_guesser.chained.class:                   Pim\Bundle\CatalogBundle\Validator\ChainedAttributeConstraintGuesser
+    pim_catalog.validator.constraint_guesser.email.class:                     Pim\Bundle\CatalogBundle\Validator\ConstraintGuesser\EmailGuesser
+    pim_catalog.validator.constraint_guesser.file.class:                      Pim\Bundle\CatalogBundle\Validator\ConstraintGuesser\FileGuesser
+    pim_catalog.validator.constraint_guesser.length.class:                    Pim\Bundle\CatalogBundle\Validator\ConstraintGuesser\LengthGuesser
+    pim_catalog.validator.constraint_guesser.not_blank.class:                 Pim\Bundle\CatalogBundle\Validator\ConstraintGuesser\NotBlankGuesser
+    pim_catalog.validator.constraint_guesser.date.class:                      Pim\Bundle\CatalogBundle\Validator\ConstraintGuesser\DateGuesser
+    pim_catalog.validator.constraint_guesser.numeric.class:                   Pim\Bundle\CatalogBundle\Validator\ConstraintGuesser\NumericGuesser
+    pim_catalog.validator.constraint_guesser.range.class:                     Pim\Bundle\CatalogBundle\Validator\ConstraintGuesser\RangeGuesser
+    pim_catalog.validator.constraint_guesser.regex.class:                     Pim\Bundle\CatalogBundle\Validator\ConstraintGuesser\RegexGuesser
+    pim_catalog.validator.constraint_guesser.not_decimal.class:               Pim\Bundle\CatalogBundle\Validator\ConstraintGuesser\NotDecimalGuesser
+    pim_catalog.validator.constraint_guesser.url.class:                       Pim\Bundle\CatalogBundle\Validator\ConstraintGuesser\UrlGuesser
+    pim_catalog.validator.constraint_guesser.unique_value.class:              Pim\Bundle\CatalogBundle\Validator\ConstraintGuesser\UniqueValueGuesser
+    pim_catalog.validator.constraint_guesser.price_collection.class:          Pim\Bundle\CatalogBundle\Validator\ConstraintGuesser\PriceCollectionGuesser
+    pim_catalog.validator.constraint_guesser.metric.class:                    Pim\Bundle\CatalogBundle\Validator\ConstraintGuesser\MetricGuesser
+    pim_catalog.validator.mapping.delegating_class_metadata_factory.class:    Pim\Bundle\CatalogBundle\Validator\Mapping\DelegatingClassMetadataFactory
+    pim_catalog.validator.mapping.product_value_metadata_factory.class:       Pim\Bundle\CatalogBundle\Validator\Mapping\ProductValueMetadataFactory
 
 services:
     # Validators
@@ -139,3 +141,26 @@ services:
         class: %pim_catalog.validator.constraint_guesser.metric.class%
         tags:
             - { name: pim_catalog.constraint_guesser.attribute }
+
+    # Validator ClassMetadata factory
+    pim_catalog.validator.mapping.product_value_metadata_factory:
+        public: false
+        class: %pim_catalog.validator.mapping.product_value_metadata_factory.class%
+        arguments:
+            - '@pim_catalog.validator.constraint_guesser.chained_attribute'
+
+    pim_catalog.validator.mapping.delegating_class_metadata_factory:
+        public: false
+        class: %pim_catalog.validator.mapping.delegating_class_metadata_factory.class%
+        calls:
+            - [ 'addMetadataFactory', [ '@pim_catalog.validator.mapping.product_value_metadata_factory' ] ]
+            - [ 'addMetadataFactory', [ '@validator.mapping.class_metadata_factory' ] ]
+
+    pim_validator:
+        class: %validator.class%
+        arguments:
+            - '@pim_catalog.validator.mapping.delegating_class_metadata_factory'
+            - '@validator.validator_factory'
+            - '@translator.default'
+            - %validator.translation_domain%
+            - []

--- a/src/Pim/Bundle/CatalogBundle/Validator/Mapping/ClassMetadataFactory.php
+++ b/src/Pim/Bundle/CatalogBundle/Validator/Mapping/ClassMetadataFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\Validator\Mapping;
+
+use Symfony\Component\Validator\Mapping\ClassMetadata;
+
+/**
+ * ClassMetadata object factory
+ *
+ * @author    Gildas Quemener <gildas@akeneo.com>
+ * @copyright 2014 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ClassMetadataFactory
+{
+    /**
+     * Create an instance of ClassMetadata
+     *
+     * @param string $class
+     *
+     * @return ClassMetadata
+     */
+    public function createMetadata($class)
+    {
+        return new ClassMetadata($class);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Validator/Mapping/DelegatingClassMetadataFactory.php
+++ b/src/Pim/Bundle/CatalogBundle/Validator/Mapping/DelegatingClassMetadataFactory.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\Validator\Mapping;
+
+use Symfony\Component\Validator\MetadataFactoryInterface;
+use Symfony\Component\Validator\Exception\NoSuchMetadataException;
+
+/**
+ * Pim\Bundle\CatalogBundle\Validator\Mapping
+ *
+ * @author    Gildas Quemener <gildas@akeneo.com>
+ * @copyright 2014 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class DelegatingClassMetadataFactory implements MetadataFactoryInterface
+{
+    /** @var array */
+    protected $factories = [];
+
+    /**
+     * Register a metadata factory
+     *
+     * @param MetadataFactoryInterface $factory
+     */
+    public function addMetadataFactory(MetadataFactoryInterface $factory)
+    {
+        $this->factories[] = $factory;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMetadataFor($value)
+    {
+        foreach ($this->factories as $factory) {
+            if ($factory->hasMetadataFor($value)) {
+                return $factory->getMetadataFor($value);
+            }
+        }
+
+        throw new NoSuchMetadataException();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasMetadataFor($value)
+    {
+        foreach ($this->factories as $factory) {
+            if ($factory->hasMetadataFor($value)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Validator/Mapping/ProductValueMetadataFactory.php
+++ b/src/Pim/Bundle/CatalogBundle/Validator/Mapping/ProductValueMetadataFactory.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\Validator\Mapping;
+
+use Symfony\Component\Validator\MetadataFactoryInterface;
+use Pim\Bundle\CatalogBundle\Model\AbstractProductValue;
+use Symfony\Component\Validator\Exception\NoSuchMetadataException;
+use Symfony\Component\Validator\Mapping\ClassMetadata;
+use Pim\Bundle\CatalogBundle\Validator\ConstraintGuesserInterface;
+use Doctrine\Common\Util\ClassUtils;
+
+/**
+ * Create a ClassMetadata instance for an AbstractProductValue instance
+ * Constraints are guessed from the value's attribute
+ *
+ * @author    Gildas Quemener <gildas@akeneo.com>
+ * @copyright 2014 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ProductValueMetadataFactory implements MetadataFactoryInterface
+{
+    /** @var ConstraintGuesserInterface */
+    protected $guesser;
+
+    /** @var ClassMetadataFactory */
+    protected $factory;
+
+    /**
+     * Constructor
+     *
+     * @param ConstraintGuesserInterface $guesser
+     * @param ClassMetadataFactory|null  $factory
+     */
+    public function __construct(ConstraintGuesserInterface $guesser, ClassMetadataFactory $factory = null)
+    {
+        $this->guesser = $guesser;
+        $this->factory = $factory ?: new ClassMetadataFactory();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMetadataFor($value)
+    {
+        if (!$value instanceof AbstractProductValue) {
+            throw new NoSuchMetadataException();
+        }
+
+        $class = ClassUtils::getClass($value);
+
+        $metadata = $this->factory->createMetadata($class);
+
+        $attribute = $value->getAttribute();
+        foreach ($this->guesser->guessConstraints($attribute) as $constraint) {
+            $metadata->addPropertyConstraint($attribute->getBackendType(), $constraint);
+        }
+
+        return $metadata;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasMetadataFor($value)
+    {
+        if ($value instanceof AbstractProductValue) {
+            return true;
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
# TL;DR:

This PR allows to validate a product by doing:

``` php
$violations = $this->validator->validate($product);
```

Usage of product_edit_form to validate a product should not be necessary any longer.
# Usage

To avoid breaking the whole PIM, the validator which is able to validate a product is registered under the service id `pim_validator`, be sure to inject it if you want to validate a product.
# Refactoring

IMO, it's no longer necessary to inject the constraints guesser in all of our attribute types.
It's been used to generate a form option "constraints" which contained the constraints to apply on the value data. As this constraints are now part of the property metadata, they should be validated when submitting the form.
