### PR TITLE
PIM-3051 : update knp menu and wsse-authentication to stable versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,11 +23,8 @@
         "symfony/icu": "1.1.0",
         "akeneo/measure-bundle": "0.2.0",
         "akeneo/batch-bundle": "0.2.*@stable",
-        "oro/platform": "1.0.0-beta10",
-        "apy/jsfv-bundle": "2.1.x-dev#c7bcd7bbd52af55cfd7f6e9097e284d964ce0200",
-        "knplabs/knp-menu": "2.0.x-dev#de645e813ddca4a1243db48bce5eaee8adb346a2",
-        "knplabs/knp-menu-bundle": "2.0.x-dev#d7da4383a20e725a2df99fd9913a076b463c1670",
-        "escapestudios/wsse-authentication-bundle": "2.3.x-dev#f1bd591f4a3be8b21288d967ddb3b723db70fee3"
+        "oro/platform": "1.0.0-beta11",
+        "apy/jsfv-bundle": "2.1.x-dev#c7bcd7bbd52af55cfd7f6e9097e284d964ce0200"
     },
     "require-dev": {
         "behat/behat":  "2.5.*@stable",


### PR DESCRIPTION
Use very last stable releases of knp menu and knp menu bundle -> BC Break in UriVoter used by OroPlatform

Alpha2 should be ok
