### PR TITLE
[WIP] Add a script to begin to check bundle coupling in static analysis

### DIFF
--- a/app/Resources/jenkins/coupling_check.sh
+++ b/app/Resources/jenkins/coupling_check.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Check the forbidden use statement to ensure appropriate de-coupling
+OUTPUT=''
+
+# CatalogBundle
+for pattern in Oro EnrichBundle TransformBundle; do
+    OUTPUT=`grep -r 'use.*'$pattern $1Pim/Bundle/CatalogBundle/ | tr "\n" "#"`$OUTPUT
+done
+
+# TransformBundle
+for pattern in Oro EnrichBundle ImportExportBundle BaseConnector; do
+    OUTPUT=`grep -r 'use.*'$pattern $1Pim/Bundle/TransformBundle/ | tr "\n" "#"`$OUTPUT
+done
+
+# BaseConnectorBundle
+for pattern in Oro EnrichBundle ImportExportBundle ; do
+    OUTPUT=`grep -r 'use.*'$pattern $1Pim/Bundle/BaseConnectorBundle/ | tr "\n" "#"`$OUTPUT
+done
+
+if [ -z "$OUTPUT" ]; then
+    exit 0
+else
+    echo -n $OUTPUT | tr "#" "\n"
+    exit 1
+fi

--- a/build.xml
+++ b/build.xml
@@ -12,7 +12,7 @@
 
     <target name="build-behat-mongo" depends="prepare,composer,require-mongo,activate-mongo,vendors,install-all-behat,behat"/>
 
-    <target name="build-code-quality" depends="prepare,check-interfaces,lint,phploc,pdepend,phpmd-ci,phpcs-ci,phpcpd,phpdoc"/>
+    <target name="build-code-quality" depends="prepare,check-interfaces,check-coupling,lint,phploc,pdepend,phpmd-ci,phpcs-ci,phpcpd,phpdoc"/>
 
     <target name="clean" description="Cleanup build artifacts">
         <delete dir="${basedir}/app/build/api"/>
@@ -109,6 +109,12 @@
         </exec>
         <exec executable="${basedir}/app/Resources/jenkins/interface_check.sh" failonerror="false">
             <arg value="${basedir}/spec" />
+        </exec>
+    </target>
+
+    <target name="check-coupling" description="Check the bundles coupling">
+        <exec executable="${basedir}/app/Resources/jenkins/coupling_check.sh" failonerror="true">
+            <arg value="${basedir}/src" />
         </exec>
     </target>
 


### PR DESCRIPTION
Run with `app/Resources/jenkins/coupling_check.sh ./src/`

Unappropriate use statements to fix,
```
./src/Pim/Bundle/BaseConnectorBundle/Writer/File/FileWriter.php:use Pim\Bundle\ImportExportBundle\Validator\Constraints\WritableDirectory;
./src/Pim/Bundle/TransformBundle/Transformer/ProductTransformer.php:use Pim\Bundle\BaseConnectorBundle\Reader\CachedReader;
./src/Pim/Bundle/CatalogBundle/MongoDB/Normalizer/GroupNormalizer.php:use Pim\Bundle\TransformBundle\Normalizer\Structured\TranslationNormalizer;
./src/Pim/Bundle/CatalogBundle/MongoDB/Normalizer/FamilyNormalizer.php:use Pim\Bundle\TransformBundle\Normalizer\Structured\TranslationNormalizer;
./src/Pim/Bundle/CatalogBundle/Entity/Repository/FamilyRepository.php:use Pim\Bundle\EnrichBundle\Form\DataTransformer\ChoicesProviderInterface;
./src/Pim/Bundle/CatalogBundle/Entity/Repository/AttributeRepository.php:use Pim\Bundle\EnrichBundle\Form\DataTransformer\ChoicesProviderInterface;
./src/Pim/Bundle/CatalogBundle/PimCatalogBundle.php:use Oro\Bundle\EntityBundle\DependencyInjection\Compiler\DoctrineOrmMappingsPass;
```

Could be enhanced by checking other bundles and used services aliases