### PR TITLE
PIM-2975: Fix normalization of decimal attributes for MongoDB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fixed category order in the categories tab of products
 - Incomplete archives no longer appear as downloadable in the export execution details page
 - Fixed Cascade delete on associations for MongoDB impl
+- Fixed a bug on normalization of decimal attributes for MongoDB impl
 
 ## BC breaks
 - Replace ACLs `pim_enrich_family_add_atribute` and `pim_enrich_family_remove_atribute` with `pim_enrich_family_edit_attributes`. This ACL also enforces rights to edit attribute requirements.

--- a/spec/Pim/Bundle/CatalogBundle/MongoDB/Normalizer/ProductValueNormalizerSpec.php
+++ b/spec/Pim/Bundle/CatalogBundle/MongoDB/Normalizer/ProductValueNormalizerSpec.php
@@ -18,8 +18,10 @@ class ProductValueNormalizerSpec extends ObjectBehavior
         $this->shouldImplement('Symfony\Component\Serializer\Normalizer\NormalizerInterface');
     }
 
-    function it_supports_normalization_in_mongodb_json_of_value(ProductValueInterface $value)
+    function it_supports_normalization_in_mongodb_json_of_value(ProductValueInterface $value, AbstractAttribute $attribute)
     {
+        $attribute->getBackendType()->willReturn('foo');
+
         $this->supportsNormalization($value, 'mongodb_json')->shouldBe(true);
         $this->supportsNormalization($value, 'json')->shouldBe(false);
         $this->supportsNormalization($value, 'xml')->shouldBe(false);
@@ -34,6 +36,7 @@ class ProductValueNormalizerSpec extends ObjectBehavior
         $this->setSerializer($serializer);
 
         $attribute->getCode()->willReturn('code');
+        $attribute->getBackendType()->willReturn('foo');
         $attribute->isLocalizable()->willReturn(false);
         $attribute->isScopable()->willReturn(false);
 
@@ -86,4 +89,21 @@ class ProductValueNormalizerSpec extends ObjectBehavior
 
         $this->normalize($value, 'mongodb_json', [])->shouldReturn(null);
     }
+
+    function it_normalizes_value_with_decimal_support_backend(
+        ProductValueInterface $value,
+        AbstractAttribute $attribute
+    ) {
+        $attribute->getCode()->willReturn('code');
+        $attribute->getBackendType()->willReturn('decimal');
+        $attribute->isLocalizable()->willReturn(false);
+        $attribute->isScopable()->willReturn(false);
+
+        $value->getData()->willReturn('42.42');
+        $value->getAttribute()->willReturn($attribute);
+
+        $this->normalize($value, 'mongodb_json', [])->shouldReturn(['code' => 42.42]);
+    }
+
+
 }


### PR DESCRIPTION
Decimal product values where normalized as strings.

| Q | A |
| --- | --- |
| Bug fix? | Y |
| New feature? | N |
| BC breaks? | N |
| CI currently passes? | Y |
| Tests pass? | Y |
| Scenarios pass? | Y |
| Checkstyle issues?* | N |
| PMD issues?** | N |
| Changelog updated? | Y |
| Fixed tickets | - |
| Doc PR | - |
