### PR TITLE
Fixed PIM-3194

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
   - Fixtures stop if warnings are encountered
   - Errors and warnings for fixtures are displayed
 
+ ## Bug fixes
+  - Entity collections in MongoDb are now returned in the correct order
+
 # 1.2.4 (2014-09-11)
 
 ## Bug fixes

--- a/spec/Pim/Bundle/CatalogBundle/Doctrine/ReferencedCollectionSpec.php
+++ b/spec/Pim/Bundle/CatalogBundle/Doctrine/ReferencedCollectionSpec.php
@@ -54,8 +54,28 @@ class ReferencedCollectionSpec extends ObjectBehavior
         EntityStub $entity8,
         EntityStub $entity15
     ) {
+        $entity4->getId()->willReturn(4);
+        $entity8->getId()->willReturn(8);
+        $entity15->getId()->willReturn(15);
         $classMetadata->getIdentifier()->willReturn(['id']);
         $repository->findBy(['id' => [4, 8, 15]])->willReturn([$entity4, $entity8, $entity15]);
+
+        $this->toArray()->shouldReturn([$entity4, $entity8, $entity15]);
+    }
+
+
+    function it_keeps_entities_order_when_hydrating_the_collection(
+        ObjectRepository $repository,
+        ClassMetadata $classMetadata,
+        EntityStub $entity4,
+        EntityStub $entity8,
+        EntityStub $entity15
+    ) {
+        $entity4->getId()->willReturn(4);
+        $entity8->getId()->willReturn(8);
+        $entity15->getId()->willReturn(15);
+        $classMetadata->getIdentifier()->willReturn(['id']);
+        $repository->findBy(['id' => [4, 8, 15]])->willReturn([$entity8, $entity15, $entity4]);
 
         $this->toArray()->shouldReturn([$entity4, $entity8, $entity15]);
     }
@@ -85,6 +105,10 @@ class ReferencedCollectionSpec extends ObjectBehavior
         EntityStub $entity15,
         EntityStub $newEntity
     ) {
+        $entity4->getId()->willReturn(4);
+        $entity8->getId()->willReturn(8);
+        $entity15->getId()->willReturn(15);
+        $newEntity->getId()->willReturn(null);
         $classMetadata->getIdentifier()->willReturn(['id']);
         $repository->findBy(['id' => [4, 8, 15]])->willReturn([$entity4, $entity8, $entity15]);
 
@@ -105,6 +129,9 @@ class ReferencedCollectionSpec extends ObjectBehavior
         EntityStub $entity8,
         EntityStub $entity15
     ) {
+        $entity4->getId()->willReturn(4);
+        $entity8->getId()->willReturn(8);
+        $entity15->getId()->willReturn(15);
         $classMetadata->getIdentifier()->willReturn(['id']);
         $repository->findBy(['id' => [4, 8, 15]])->willReturn([$entity4, $entity8, $entity15]);
 
@@ -125,6 +152,9 @@ class ReferencedCollectionSpec extends ObjectBehavior
         EntityStub $entity8,
         EntityStub $entity15
     ) {
+        $entity4->getId()->willReturn(4);
+        $entity8->getId()->willReturn(8);
+        $entity15->getId()->willReturn(15);
         $classMetadata->getIdentifier()->willReturn(['id']);
         $repository->findBy(['id' => [4, 8, 15]])->willReturn([$entity4, $entity8, $entity15]);
 
@@ -146,6 +176,9 @@ class ReferencedCollectionSpec extends ObjectBehavior
         EntityStub $entity15,
         EntityStub $newEntity
     ) {
+        $entity4->getId()->willReturn(4);
+        $entity8->getId()->willReturn(8);
+        $entity15->getId()->willReturn(15);
         $classMetadata->getIdentifier()->willReturn(['id']);
         $repository->findBy(['id' => [4, 8, 15]])->willReturn([$entity4, $entity8, $entity15]);
 
@@ -160,6 +193,9 @@ class ReferencedCollectionSpec extends ObjectBehavior
 
 class EntityStub
 {
+    public function getId()
+    {
+    }
 }
 
 class DocumentStub

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ReferencedCollection.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ReferencedCollection.php
@@ -183,12 +183,24 @@ class ReferencedCollection extends AbstractLazyCollection
             );
         }
 
-        $this->collection = new ArrayCollection(
-            $this
-                ->registry
-                ->getRepository($this->entityClass)
-                ->findBy([$classIdentifier[0] => $this->identifiers])
+        $entities = $this
+            ->registry
+            ->getRepository($this->entityClass)
+            ->findBy([$classIdentifier[0] => $this->identifiers]);
+        $method = sprintf('get%s', ucfirst($classIdentifier[0]));
+        $positions = array_flip(
+            array_map (
+                function ($entity) use ($method) {
+                    return $entity->$method();
+                },
+                $entities
+            )
         );
+        $this->collection = new ArrayCollection();
+        foreach ($this->identifiers as $identifier) {
+            $position = $positions[$identifier];
+            $this->collection->add($entities[$position]);
+        }
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | Yes |
| New feature? | No |
| BC breaks? | No |
| CI currently passes? | ? |
| Tests pass? | Yes |
| Scenarios pass? | Yes |
| Checkstyle issues?* | No |
| PMD issues?** | No |
| Changelog updated? | Yes |
| Fixed tickets | PIM-3194 |
| DB schema updated? | No |
| Migration script? | No |
| Doc PR | No |

This is needed for the FeuVert DAM. It fixes entities collections being reordered on hydration.
