### PR TITLE
PIM-2345 : clear the object manager during CSV export to avoid memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 1.2.x
 
 ## Bug fixes
+- Fix memory leak in CSV quick export
 
 ## Improvements
 - avoid hydrating duplicate categories when applying category filter in product grid

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/ProductRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/ProductRepository.php
@@ -767,4 +767,12 @@ class ProductRepository extends DocumentRepository implements
             );
         }
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getObjectManager()
+    {
+        return $this->getDocumentManager();
+    }
 }

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/ProductRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/ProductRepository.php
@@ -644,4 +644,12 @@ class ProductRepository extends EntityRepository implements
 
         return $attributeIds;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getObjectManager()
+    {
+        return $this->getEntityManager();
+    }
 }

--- a/src/Pim/Bundle/CatalogBundle/Repository/ProductRepositoryInterface.php
+++ b/src/Pim/Bundle/CatalogBundle/Repository/ProductRepositoryInterface.php
@@ -2,7 +2,6 @@
 
 namespace Pim\Bundle\CatalogBundle\Repository;
 
-use Doctrine\ORM\QueryBuilder;
 use Pim\Bundle\CatalogBundle\Entity\Channel;
 use Pim\Bundle\CatalogBundle\Entity\Group;
 use Pim\Bundle\CatalogBundle\Model\ProductInterface;
@@ -51,14 +50,14 @@ interface ProductRepositoryInterface
     /**
      * @param string $scope
      *
-     * @return QueryBuilder
+     * @return mixed
      */
     public function buildByScope($scope);
 
     /**
      * @param Channel $channel
      *
-     * @return QueryBuilder
+     * @return mixed
      */
     public function buildByChannelAndCompleteness(Channel $channel);
 

--- a/src/Pim/Bundle/DataGridBundle/Controller/ProductExportController.php
+++ b/src/Pim/Bundle/DataGridBundle/Controller/ProductExportController.php
@@ -97,6 +97,7 @@ class ProductExportController extends ExportController
             echo $this->serializer->serialize($results, $this->getFormat(), $context);
             $offset += $batchSize;
             flush();
+            $this->productRepository->getObjectManager()->clear();
         }
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | Y |
| New feature? | N |
| BC breaks? | Y |
| CI currently passes? | Y |
| Tests pass? | Y |
| Scenarios pass? | Y |
| Checkstyle issues?* | N |
| PMD issues?** | N |
| Changelog updated? | Y |
| Fixed tickets | PIM-3245 |
| DB schema updated? |  |
| Migration script? |  |
| Doc PR |  |
