### PR TITLE
PIM-3247: Can't display all variant groups on grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 - Fix memory leak in CSV quick export
+- Cannot display correctly all variant groups on grid
 
 ## Improvements
 - avoid hydrating duplicate categories when applying category filter in product grid

--- a/features/variant-group/browse_variant_groups.feature
+++ b/features/variant-group/browse_variant_groups.feature
@@ -13,20 +13,27 @@ Feature: Browse variant groups
       | size      | Size       | simpleselect |
       | dimension | Dimensions | simpleselect |
     And the following product groups:
-      | code           | label          | attributes  | type    |
-      | tshirt_akeneo  | Akeneo T-Shirt | size, color | VARIANT |
-      | mug            | Mug            | color       | VARIANT |
-      | sticker_akeneo | Akeneo Sticker | dimension   | VARIANT |
-      | cross_sell     | Cross Sell     |             | X_SELL  |
+      | code              | label             | attributes  | type    |
+      | tshirt_akeneo     | Akeneo T-Shirt    | size, color | VARIANT |
+      | mug               | Mug               | color       | VARIANT |
+      | sticker_akeneo    | Akeneo Sticker    | dimension   | VARIANT |
+      | mug_akeneo        | Mug Akeneo        | dimension   | VARIANT |
+      | car_akeneo        | Akeneo Car        | dimension   | VARIANT |
+      | boat_akeneo       | Akeneo Boat       | dimension   | VARIANT |
+      | plane_akeneo      | Akeneo Plane      | dimension   | VARIANT |
+      | helicopter_akeneo | Akeneo Helicopter | dimension   | VARIANT |
+      | watch_akeneo      | Akeneo Watch      | dimension   | VARIANT |
+      | bike_akeneo       | Akeneo Bike       | dimension   | VARIANT |
+      | cross_sell        | Cross Sell        |             | X_SELL  |
     And I am logged in as "Julia"
     And I am on the variant groups page
-    Then the grid should contain 3 elements
+    Then the grid should contain 10 elements
     And I should see the columns Code, Label and Axis
-    And I should see groups tshirt_akeneo, mug and sticker_akeneo
+    And I should see groups bike_akeneo, boat_akeneo, car_akeneo, helicopter_akeneo, mug, mug_akeneo, plane_akeneo, tshirt_akeneo, sticker_akeneo, watch_akeneo
     And the rows should be sorted ascending by code
     And I should be able to sort the rows by code and label
     And I should be able to use the following filters:
-      | filter | value  | result                           |
-      | Code   | mug    | mug                              |
-      | Label  | Akeneo | tshirt_akeneo and sticker_akeneo |
-      | Axis   | Color  | tshirt_akeneo and mug            |
+      | filter | value  | result                                                                                                                            |
+      | Code   | mug    | mug, mug_akeneo                                                                                                                   |
+      | Label  | Akeneo | bike_akeneo, boat_akeneo, car_akeneo, helicopter_akeneo, mug_akeneo, plane_akeneo, tshirt_akeneo, sticker_akeneo and watch_akeneo |
+      | Axis   | Color  | tshirt_akeneo and mug                                                                                                             |

--- a/src/Pim/Bundle/CatalogBundle/Entity/Repository/GroupRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Entity/Repository/GroupRepository.php
@@ -130,6 +130,8 @@ class GroupRepository extends ReferableEntityRepository
             ->leftJoin('g.attributes', 'attribute')
             ->innerJoin('g.type', 'type', 'WITH', $typeExpr);
 
+        $qb->groupBy('g');
+
         return $qb;
     }
 


### PR DESCRIPTION
When you were on the variant group page, you could only see 4 variant groups but there were 6 variant groups in reality. 

| Q | A |
| --- | --- |
| Bug fix? | Yes |
| New feature? | No |
| BC breaks? | No |
| CI currently passes? | Running |
| Tests pass? | Yes |
| Scenarios pass? | Running |
| Checkstyle issues?* | No |
| PMD issues?** | No |
| Changelog updated? | Yes |
| Fixed tickets | PIM-3247 |
| DB schema updated? | No |
| Migration script? | No |
| Doc PR | No |
