### PR TITLE
PIM-3217 Fix grid filter selector with duplicate group order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 - Fix issue with inactive locales in exports
+- Fix missing filter groups in grid filter selector when two attribute groups have the same sort orders
 
 # 1.2.8 (2014-10-10)
 

--- a/src/Pim/Bundle/FilterBundle/Resources/public/js/datafilter/filters-manager.js
+++ b/src/Pim/Bundle/FilterBundle/Resources/public/js/datafilter/filters-manager.js
@@ -6,17 +6,20 @@ define(
         return FiltersManager.extend({
             addButtonTemplate: _.template(
                 '<select id="add-filter-select" multiple>' +
-                    '<%  var groups = {};' +
+                    '<%  var groups = [_.__("system_filter_group")];' +
                         '_.each(filters, function(filter) {' +
                             'if (filter.group) {' +
-                                'groups[filter.groupOrder !== null ? filter.groupOrder : "last"] = filter.group;' +
+                                'var key = filter.groupOrder !== null ? filter.groupOrder : "last";' +
+                                'if (_.isUndefined(groups[key])) {' +
+                                    'groups[key] = filter.group;' +
+                                '} else if (!_.contains(groups, filter.group)) {' +
+                                    'groups.push(filter.group);' +
+                                '}' +
                             '} else {' +
                                 'filter.group = _.__("system_filter_group");' +
-                                'groups[-1] = filter.group;' +
-                            '}' +
+                            '} ' +
                        '});' +
                     '%>' +
-                    '<% var groups = _.sortBy(groups, function(group, index) {return index;}); %>' +
                     '<% _.each(groups, function (group) { %>' +
                         '<optgroup label="<%= group %>">' +
                             '<% _.each(filters, function (filter, name) { %>' +


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | Y |
| New feature? | N |
| BC breaks? | N |
| CI currently passes? | ? |
| Tests pass? | Y |
| Scenarios pass? | ? |
| Checkstyle issues?* | N |
| PMD issues?** | N |
| Changelog updated? | Y |
| Fixed tickets | PIM-3217 |
| Doc PR | ~ |
