### PR TITLE
[DISCUSS] CommentBundle de-coupling

### DIFF
--- a/src/Pim/Bundle/CommentBundle/Entity/Comment.php
+++ b/src/Pim/Bundle/CommentBundle/Entity/Comment.php
@@ -3,7 +3,6 @@
 namespace Pim\Bundle\CommentBundle\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
-use Oro\Bundle\UserBundle\Entity\User;
 use Pim\Bundle\CommentBundle\Model\CommentInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 
@@ -26,7 +25,7 @@ class Comment implements CommentInterface
     /** @var string */
     protected $resourceId;
 
-    /** @var User */
+    /** @var UserInterface */
     protected $author;
 
     /** @var string */

--- a/src/Pim/Bundle/CommentBundle/Repository/CommentRepository.php
+++ b/src/Pim/Bundle/CommentBundle/Repository/CommentRepository.php
@@ -2,7 +2,7 @@
 
 namespace Pim\Bundle\CommentBundle\Repository;
 
-use Pim\Bundle\CatalogBundle\Doctrine\EntityRepository;
+use Doctrine\ORM\EntityRepository;
 
 /**
  * Comment repository

--- a/src/Pim/Bundle/CommentBundle/Resources/config/controllers.yml
+++ b/src/Pim/Bundle/CommentBundle/Resources/config/controllers.yml
@@ -5,7 +5,15 @@ services:
     pim_comment.controller.comment:
         scope: request
         class: %pim_comment.controller.comment.class%
-        parent: pim_enrich.controller.abstract_doctrine
         arguments:
+            - '@request'
+            - '@templating'
+            - '@router'
+            - '@security.context'
+            - '@form.factory'
+            - '@validator'
+            - '@translator'
+            - '@event_dispatcher'
+            - '@pim_catalog.doctrine.smart_manager_registry'
             - '@pim_comment.builder.comment'
             - %pim_comment.entity.comment.class%


### PR DESCRIPTION
A PR to discuss about coupling by using the CommentBundle use case :dancer: 

Let's imagine we would use it in other application to add comments on others entities than products.

This PR removes deps to other Oro and Pim bundles, here the CommentBundle classes only rely on Symfony and Doctrine.

We can notice that the controller duplicates some logic from the base enrich controller (I copy/pasted deps we could remove useless ones and replace smart registry by classic doctrine one), it could also use symfony base controller but it means become container aware (another topic), it could also use other services from other bundle to use shortcuts.

Other open question is the templating which depends on twig macros (page_elements) from UIBundle.
