### PR TITLE
PIM-3282: fix the grid filters that can be set as json in the request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@
 - Update CsvProductWriter::copyMedia argument to replace AbstractProductMedia by an array
 - Change constructor of `Pim\Bundle\BaseConnectorBundle\Processor\TransformerProcessor`. `Doctrine\Common\Persistence\ManagerRegistry` is used as fourth argument and is mandatory now. The data class is the fifth argument.
 
-# 1.2.x
+# 1.2.9 (2014-10-17)
 
 ## Bug fixes
 - PIM-3254: Fix issue with inactive locales in exports
@@ -56,6 +56,7 @@
 - PIM-3248: Fix completeness not being correctly calculated after removing a required attribute from a family
 - PIM-3279: Fix performance issue with big group sets
 - PIM-3266: Fix the flush of skipped items during an import that uses the `Pim\Bundle\BaseConnectorBundle\Processor\TransformerProcessor`. All your custom processors that uses the `TransformmerProcessor` should now inject the `Pim\Bundle\CatalogBundle\Doctrine\SmartManagerRegistry` to fix this issue too.
+- PIM-3282: Fix the grid filters that can be set as json in the request
 
 ## BC breaks
 - Two new arguments have been added to Pim\Bundle\FilterBundle\Filter\Product\GroupsFilter: `userContext` and `groupClass`

--- a/features/mass-action/edit_common_attributes.feature
+++ b/features/mass-action/edit_common_attributes.feature
@@ -221,3 +221,26 @@ Feature: Edit common attributes of many products at once
       | amount | currency |
       | 100    | USD      |
       | 150    | EUR      |
+
+  @jira https://akeneo.atlassian.net/browse/PIM-3282
+  Scenario: Successfully mass edit products on the non default channel
+    Given the following product values:
+      | product   | attribute                | value                   |
+      | boots     | description-en_US-tablet | A beautiful description |
+      | boots     | weight                   | 500 GRAM                |
+      | sneakers  | description-en_US-tablet | A beautiful description |
+      | sneakers  | weight                   | 500 GRAM                |
+      | sandals   | weight                   | 500 GRAM                |
+      | pump      | weight                   | 500 GRAM                |
+      | highheels | weight                   | 500 GRAM                |
+    When I show the filter "Description"
+    And I filter by "Channel" with value "Tablet"
+    And I filter by "Description" with value "A beautiful description"
+    And I select all products
+    And I press mass-edit button
+    And I choose the "Edit attributes" operation
+    And I display the Weight attribute
+    And I change the "Weight" to "600"
+    And I move on to the next step
+    Then the metric "Weight" of products boots and sneakers should be "600"
+    And the metric "Weight" of products sandals, pump and highheels should be "500"

--- a/src/Pim/Bundle/DataGridBundle/EventListener/AddParametersToProductGridListener.php
+++ b/src/Pim/Bundle/DataGridBundle/EventListener/AddParametersToProductGridListener.php
@@ -109,6 +109,12 @@ class AddParametersToProductGridListener extends AddParametersToGridListener
         $filterValues = $this->requestParams->get('_filter');
         if (empty($filterValues)) {
             $filterValues = $this->request->get('filters');
+            if (is_string($filterValues)) {
+                $filterValues = json_decode($filterValues, true);
+            }
+            if (!$filterValues) {
+                $filterValues = [];
+            }
         }
 
         if (isset($filterValues['scope']['value']) && $filterValues['scope']['value'] !== null) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | Y |
| New feature? | N |
| BC breaks? | N |
| CI currently passes? | Y |
| Tests pass? | Y |
| Scenarios pass? | running |
| Checkstyle issues?* | N |
| PMD issues?** | N |
| Changelog updated? | Y |
| Fixed tickets | PIM-3282 |
| DB schema updated? | N |
| Migration script? | - |
| Doc PR | - |
