### PR TITLE
[WIP] PIM-3207: Apply the user channel in the edit product page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - PIM-3298: Fix issue with locale specific property of an attribute when edit and mass edit
 - PIM-3229: Fix values for simple and multi select attributes with missing translations not being displayed in the grid
 - PIM-3309: Fix check on product value uniqueness
+- PIM-3207: Apply the user channel in the edit product page
 
 # 1.2.11 (2014-10-31)
 

--- a/features/product/edit_product.feature
+++ b/features/product/edit_product.feature
@@ -27,3 +27,18 @@ Feature: Edit a product
     When I am on the "sandal" product page
     Then I should not see "Attributes"
     And I reset the "Administrator" rights
+
+  Scenario Outline: Edit a product with my default channel
+    Given I am logged in as "<user>"
+    And the following product values:
+      | product | attribute   | value                  | locale | scope  |
+      | sandal  | description | description for tablet | en_US  | tablet |
+      | sandal  | description | description for mobile | en_US  | mobile |
+    And I am on the "sandal" product page
+    Then I should see "<see>"
+    And I should not see "<not_see>"
+
+    Examples:
+      | user   | see                    | not_see                |
+      | Julia  | description for tablet | description for mobile |
+      | Sandra | description for mobile | description for tablet |

--- a/spec/Pim/Bundle/DataGridBundle/Datasource/ResultRecord/MongoDbOdm/Product/FieldsTransformerSpec.php
+++ b/spec/Pim/Bundle/DataGridBundle/Datasource/ResultRecord/MongoDbOdm/Product/FieldsTransformerSpec.php
@@ -26,7 +26,8 @@ class FieldsTransformerSpec extends ObjectBehavior
             'updated' => null,
             'enabled' => false,
             'id'      => 42,
-            'dataLocale' => 'fr_FR'
+            'dataLocale' => 'fr_FR',
+            'dataScope' => null,
         ];
 
         $this->transform($result, $locale)->shouldReturn($expected);

--- a/src/Pim/Bundle/DataGridBundle/Datasource/ResultRecord/MongoDbOdm/Product/FieldsTransformer.php
+++ b/src/Pim/Bundle/DataGridBundle/Datasource/ResultRecord/MongoDbOdm/Product/FieldsTransformer.php
@@ -14,14 +14,16 @@ class FieldsTransformer
     /**
      * @param array  $result
      * @param string $locale
+     * @param string $scope
      *
      * @return array
      */
-    public function transform(array $result, $locale)
+    public function transform(array $result, $locale, $scope = null)
     {
         $result['id'] = $result['_id']->__toString();
         unset($result['_id']);
         $result['dataLocale'] = $locale;
+        $result['dataScope'] = $scope;
         $dateTransformer = new DateTimeTransformer();
         $result['created'] = isset($result['created']) ? $dateTransformer->transform($result['created']) : null;
         $result['updated'] = isset($result['updated']) ? $dateTransformer->transform($result['updated']) : null;

--- a/src/Pim/Bundle/DataGridBundle/Datasource/ResultRecord/MongoDbOdm/ProductHydrator.php
+++ b/src/Pim/Bundle/DataGridBundle/Datasource/ResultRecord/MongoDbOdm/ProductHydrator.php
@@ -49,7 +49,7 @@ class ProductHydrator implements HydratorInterface
         $assocTramsformer  = new AssociationTransformer();
 
         foreach ($results as $result) {
-            $result = $fieldsTransformer->transform($result, $locale);
+            $result = $fieldsTransformer->transform($result, $locale, $scope);
             $result = $valuesTransformer->transform($result, $attributes, $locale, $scope);
             $result = $familyTransformer->transform($result, $locale);
             $result = $complTransformer->transform($result, $locale, $scope);

--- a/src/Pim/Bundle/DataGridBundle/Datasource/ResultRecord/Orm/ProductHydrator.php
+++ b/src/Pim/Bundle/DataGridBundle/Datasource/ResultRecord/Orm/ProductHydrator.php
@@ -20,6 +20,7 @@ class ProductHydrator implements HydratorInterface
     public function hydrate($qb, array $options = [])
     {
         $localeCode = $options['locale_code'];
+        $scopeCode = $options['scope_code'];
 
         $query = $qb->getQuery();
         $results = $query->getArrayResult();
@@ -36,6 +37,7 @@ class ProductHydrator implements HydratorInterface
             $result = $this->prepareValues($result);
             $result = $this->prepareGroups($result);
             $result['dataLocale'] = $localeCode;
+            $result['dataScope'] = $scopeCode;
 
             $rows[] = new ResultRecord($result);
         }

--- a/src/Pim/Bundle/EnrichBundle/Controller/ProductController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/ProductController.php
@@ -528,6 +528,18 @@ class ProductController extends AbstractDoctrineController
     }
 
     /**
+     * Get data channel code
+     *
+     * @throws \Exception
+     *
+     * @return string
+     */
+    protected function getDataScopeCode()
+    {
+        return $this->userContext->getCurrentChannelCode();
+    }
+
+    /**
      * Get data locale object
      *
      * @throws \Exception
@@ -641,6 +653,7 @@ class ProductController extends AbstractDoctrineController
         $defaultParameters = array(
             'form'             => $form->createView(),
             'dataLocale'       => $this->getDataLocaleCode(),
+            'dataScope'        => $this->getDataScopeCode(),
             'comparisonLocale' => $this->getComparisonLocale(),
             'channels'         => $channels,
             'attributesForm'   =>

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product.yml
@@ -49,6 +49,7 @@ datagrid:
                 params:
                     - id
                     - dataLocale
+                    - dataScope
             delete_link:
                 type: url
                 route: pim_enrich_product_remove

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/pim-scopable.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/pim-scopable.js
@@ -128,7 +128,7 @@ define(
                 '<%= label %>'
             ),
 
-            initialize: function () {
+            initialize: function (options) {
                 this.fieldViews = [];
                 this.fields     = [];
                 this.expanded   = true;
@@ -166,6 +166,10 @@ define(
                         self._expand();
                     }
                 });
+
+                if (_.has(options, 'initialScope')) {
+                    this._changeDefault(options.initialScope);
+                }
             },
 
             render: function () {

--- a/src/Pim/Bundle/EnrichBundle/Resources/views/MassEditAction/configure/edit-common-attributes.html.twig
+++ b/src/Pim/Bundle/EnrichBundle/Resources/views/MassEditAction/configure/edit-common-attributes.html.twig
@@ -59,6 +59,9 @@
 
                     _.each($('form div.scopable:not(.currency)'), function (field) {
                         new Scopable({ el: $(field) });
+                        {# TODO: inject the scope here too
+                        new Scopable({ el: $(field), initialScope: '{{ dataScope }}' });
+                        #}
                     });
 
                     _.each($('form div.currency'), function (field) {

--- a/src/Pim/Bundle/EnrichBundle/Resources/views/Product/_js-handler.html.twig
+++ b/src/Pim/Bundle/EnrichBundle/Resources/views/Product/_js-handler.html.twig
@@ -10,7 +10,7 @@
                 });
 
                 _.each($('form div.scopable:not(.currency)'), function (field) {
-                    new Scopable({ el: $(field) });
+                    new Scopable({ el: $(field), initialScope: '{{ dataScope }}' });
                 });
 
                 _.each($('form div.currency'), function (field) {

--- a/src/Pim/Bundle/EnrichBundle/Resources/views/Product/edit.html.twig
+++ b/src/Pim/Bundle/EnrichBundle/Resources/views/Product/edit.html.twig
@@ -66,25 +66,4 @@
     <a href="javascript:void(0);"
         id="create-product"
         data-form-url="{{ path('pim_enrich_product_create', { 'dataLocale': dataLocale }) }}"></a>
-
-    <script type="text/javascript">
-        require(
-            ['jquery', 'underscore', 'oro/mediator'],
-            function ($, _, mediator) {
-                'use strict';
-                $(function () {
-                    mediator.on('scopablefield:rendered', function() {
-                        setTimeout(function() {
-                            console.log('{{ dataScope }}');
-                            mediator.trigger('scopablefield:changescope', '{{ dataScope }}');
-                        }, 0);
-                    });
-                    {#setTimeout(_.bind(function() {#}
-                        {#console.log('{{ dataScope }}');#}
-                        {#mediator.trigger('scopablefield:changescope', '{{ dataScope }}');#}
-                    {#}, this), 20);#}
-                });
-            }
-        );
-    </script>
 {% endblock %}

--- a/src/Pim/Bundle/EnrichBundle/Resources/views/Product/edit.html.twig
+++ b/src/Pim/Bundle/EnrichBundle/Resources/views/Product/edit.html.twig
@@ -66,4 +66,25 @@
     <a href="javascript:void(0);"
         id="create-product"
         data-form-url="{{ path('pim_enrich_product_create', { 'dataLocale': dataLocale }) }}"></a>
+
+    <script type="text/javascript">
+        require(
+            ['jquery', 'underscore', 'oro/mediator'],
+            function ($, _, mediator) {
+                'use strict';
+                $(function () {
+                    mediator.on('scopablefield:rendered', function() {
+                        setTimeout(function() {
+                            console.log('{{ dataScope }}');
+                            mediator.trigger('scopablefield:changescope', '{{ dataScope }}');
+                        }, 0);
+                    });
+                    {#setTimeout(_.bind(function() {#}
+                        {#console.log('{{ dataScope }}');#}
+                        {#mediator.trigger('scopablefield:changescope', '{{ dataScope }}');#}
+                    {#}, this), 20);#}
+                });
+            }
+        );
+    </script>
 {% endblock %}

--- a/src/Pim/Bundle/UserBundle/Context/UserContext.php
+++ b/src/Pim/Bundle/UserBundle/Context/UserContext.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Bundle\UserBundle\Context;
 
+use Pim\Bundle\CatalogBundle\Entity\Channel;
 use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Oro\Bundle\UserBundle\Entity\User;
@@ -21,6 +22,9 @@ class UserContext
 {
     /** @staticvar string */
     const REQUEST_LOCALE_PARAM = 'dataLocale';
+
+    /** @staticvar string */
+    const REQUEST_CHANNEL_PARAM = 'dataScope';
 
     /** @var SecurityContextInterface */
     protected $securityContext;
@@ -104,6 +108,26 @@ class UserContext
     }
 
     /**
+     * Returns the current channel from the request or the user's catalog channel
+     *
+     * @return Channel
+     *
+     * @throws \LogicException When there are no channel
+     */
+    public function getCurrentChannel()
+    {
+        if (null !== $channel = $this->getRequestChannel()) {
+            return $channel;
+        }
+
+        if (null !== $channel = $this->getUserChannel()) {
+            return $channel;
+        }
+
+        throw new \LogicException('There are no available channel');
+    }
+
+    /**
      * Returns the current locale code
      *
      * @return string
@@ -111,6 +135,16 @@ class UserContext
     public function getCurrentLocaleCode()
     {
         return $this->getCurrentLocale()->getCode();
+    }
+
+    /**
+     * Returns the current channel code
+     *
+     * @return string
+     */
+    public function getCurrentChannelCode()
+    {
+        return $this->getCurrentChannel()->getCode();
     }
 
     /**
@@ -207,6 +241,23 @@ class UserContext
                 if ($locale && $this->isLocaleAvailable($locale)) {
                     return $locale;
                 }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns the request channel
+     *
+     * @return Channel|null
+     */
+    protected function getRequestChannel()
+    {
+        if ($this->request) {
+            $channelCode = $this->request->get(self::REQUEST_CHANNEL_PARAM);
+            if ($channelCode) {
+                return $this->channelManager->getChannelByCode($channelCode);
             }
         }
 


### PR DESCRIPTION
TODO:
 - [ ] another bug has been raised by this fix. When you add a scopable attribute to a product. The icon which allows to remove it is only available on the first channel. So the scenario "Successfully remove a scopable attribute from a product" is failing right now.
 - [ ] check that it works with mass edit and a  Behat for this

| Q                    | A
| -------------------- | ---
| Bug fix?             | Y
| New feature?         | N
| BC breaks?           | N
| CI currently passes? | Y
| Tests pass?          | Y
| Scenarios pass?      | Y except "Successfully remove a scopable attribute from a product"
| Checkstyle issues?*  | N
| PMD issues?**        | N
| Changelog updated?   | Y
| Fixed tickets        | N
| DB schema updated?   | N
| Migration script?    | -
| Doc PR               | -