### PR TITLE
PIM-3229 Display choice attribute values with missing translations in the grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 - PIM-3298 : Fix issue with locale specific property of an attribute when edit and mass edit
+- PIM-3229: Fix values for simple and multi select attributes with missing translations not being displayed in the grid
 
 # 1.2.11 (2014-10-31)
 

--- a/features/product/display_attributes_in_the_grid.feature
+++ b/features/product/display_attributes_in_the_grid.feature
@@ -1,0 +1,30 @@
+@javascript
+Feature: Display product attributes in the grid
+  In order to easily see product data in the grid
+  As a regular user
+  I need to be able to display values for different attributes in the grid
+
+  Scenario: Successfully display values for simple and multi select attributes
+    Given a "footwear" catalog configuration
+    And the following "manufacturer" attribute options: adidas and lacoste
+    And the following "weather_conditions" attribute options: cloudy and stormy
+    And the following products:
+      | sku      | manufacturer | weather_conditions  |
+      | sneakers | Converse     | dry, cloudy, stormy |
+      | sandals  | adidas       | hot, dry            |
+      | boots    | lacoste      | cloudy              |
+    And I am logged in as "Mary"
+    And I am on the products page
+    When I display the columns sku, manufacturer and weather_conditions
+    Then the row "sneakers" should contain:
+      | column             | value                   |
+      | Manufacturer       | Converse                |
+      | Weather conditions | Dry, [cloudy], [stormy] |
+    And the row "sandals" should contain:
+      | column             | value    |
+      | Manufacturer       | [adidas] |
+      | Weather conditions | Dry, Hot |
+    And the row "boots" should contain:
+      | column             | value     |
+      | Manufacturer       | [lacoste] |
+      | Weather conditions | [cloudy]  |

--- a/src/Pim/Bundle/DataGridBundle/Extension/Formatter/Property/ProductValue/AttributeOptionProperty.php
+++ b/src/Pim/Bundle/DataGridBundle/Extension/Formatter/Property/ProductValue/AttributeOptionProperty.php
@@ -21,7 +21,9 @@ class AttributeOptionProperty extends FieldProperty
         if (isset($data['optionValues']) && count($data['optionValues']) === 1) {
             $optionValue = current($data['optionValues']);
 
-            return $optionValue['value'];
+            if (null !== $optionValue['value']) {
+                return $optionValue['value'];
+            }
         }
 
         return isset($data['code']) ? sprintf('[%s]', $data['code']) : null;

--- a/src/Pim/Bundle/DataGridBundle/Extension/Formatter/Property/ProductValue/AttributeOptionsProperty.php
+++ b/src/Pim/Bundle/DataGridBundle/Extension/Formatter/Property/ProductValue/AttributeOptionsProperty.php
@@ -22,7 +22,12 @@ class AttributeOptionsProperty extends FieldProperty
         foreach ($data as $option) {
             if (isset($option['optionValues']) && count($option['optionValues']) === 1) {
                 $optionValue = current($option['optionValues']);
-                $optionValues[] = $optionValue['value'];
+                $value = $optionValue['value'];
+                if (null === $value) {
+                    $value = '['.$option['code'].']';
+                }
+                $optionValues[] = $value;
+
             } else {
                 $optionValues[] = '['.$option['code'].']';
             }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | Y |
| New feature? | N |
| BC breaks? | N |
| CI currently passes? | N |
| Tests pass? | Y |
| Scenarios pass? | Y |
| Checkstyle issues?* | N |
| PMD issues?** | N |
| Changelog updated? | Y |
| Fixed tickets | PIM-3229 |
| DB schema updated? | N |
| Migration script? | N |
| Doc PR | ~ |
