### PR TITLE
PIM-2966 : enforce checks on missing files in installer

### DIFF
--- a/src/Pim/Bundle/InstallerBundle/DataFixtures/ORM/AbstractInstallerFixture.php
+++ b/src/Pim/Bundle/InstallerBundle/DataFixtures/ORM/AbstractInstallerFixture.php
@@ -38,9 +38,20 @@ abstract class AbstractInstallerFixture extends AbstractFixture implements Order
 
     /**
      * @return string
+     *
+     * @throws \Exception
      */
     public function getFilePath()
     {
+        if (!isset($this->files[$this->getEntity()])) {
+            throw new \Exception(
+                sprintf(
+                    'No fixture path for entity "%s", this data set is erroneous',
+                    $this->getEntity()
+                )
+            );
+        }
+
         return $this->files[$this->getEntity()];
     }
 


### PR DESCRIPTION
Check that all expected files are present in a data set fixtures before to import them

 - [ ] add missing files in minimal data set or make them optional
 - [ ] update the EE data sets

| Q                    | A
| -------------------- | ---
| Bug fix?             |
| New feature?         |
| BC breaks?           |
| CI currently passes? |
| Tests pass?          |
| Scenarios pass?      |
| Checkstyle issues?*  |
| PMD issues?**        |
| Changelog updated?   |
| Fixed tickets        |
| DB schema updated?   |
| Migration script?    |
| Doc PR               |
