### PR TITLE
PIM-3069: Fix image file prefixes not well generated on product creation...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,9 +84,11 @@
 - Remove ObjectManager first argument of `Pim\Bundle\EnrichBundle\Builder\ProductBuilder` constructor and delete method removeAttributeFromProduct
 - Change of constructor of `Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\CompletenessGenerator` to accept `Pim\Bundle\CatalogBundle\Entity\Repository\ChannelRepository` as third argument to replace `Pim\Bundle\CatalogBundle\Manager\ChannelManager` argument
 - Method `Pim\Bundle\CatalogBundle\Entity\Category::addProduct()`, `Pim\Bundle\CatalogBundle\Entity\Category::removeProduct()`, `Pim\Bundle\CatalogBundle\Entity\Category::setProducts()` have been removed.
+- We now use uniqid() to generate filename prefix (on media attributes)
 
 ## Bug fixes
 - PIM-3332: Fix incompatibility with overriden category due to usage of ParamConverter in ProductController
+- PIM-3069: Fix image file prefixes not well generated on product creation (import and fixtures)
 
 # 1.2.x
 

--- a/src/Pim/Bundle/CatalogBundle/Manager/MediaManager.php
+++ b/src/Pim/Bundle/CatalogBundle/Manager/MediaManager.php
@@ -149,7 +149,7 @@ class MediaManager
     {
         return sprintf(
             '%s-%s-%s-%s-%s-%s',
-            $product->getId(),
+            uniqid(),
             Urlizer::urlize($product->getIdentifier(), '_'),
             $value->getAttribute()->getCode(),
             $value->getLocale(),


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | Y |
| New feature? | N |
| BC breaks? | Y |
| CI currently passes? | Y |
| Tests pass? | Y |
| Scenarios pass? | ? |
| Checkstyle issues?* | N |
| PMD issues?** | N |
| Changelog updated? | Y |
| Fixed tickets | PIM-3069 |
| DB schema updated? | N |
| Migration script? | N |
| Doc PR | N |

Use $product->getId() on creation (import and fixtures for example) returns null. We now use uniqid() to generate the "uniq" part of the file name.
