### PR TITLE
PIM-3298 : fix CI

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Form/Subscriber/FilterLocaleSpecificValueSubscriber.php
+++ b/src/Pim/Bundle/EnrichBundle/Form/Subscriber/FilterLocaleSpecificValueSubscriber.php
@@ -52,7 +52,6 @@ class FilterLocaleSpecificValueSubscriber implements EventSubscriberInterface
 
         foreach ($data as $name => $value) {
             if ($this->currentLocale && $value->getAttribute()->getAvailableLocales()) {
-                // TODO : should be provided by Attribute itself, we'll do in 1.3 to avoid BC Break
                 $availableCodes = $value->getAttribute()->getAvailableLocales()->map(
                     function ($locale) {
                         return $locale->getCode();


### PR DESCRIPTION
fail due to the use of Attribute in a TODO which is understood as a use of concret object in the check interfaces script
