### PR TITLE
PIM-3446: limit the warning display to 100 in import/export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 - PIM-3443: Fix prices not exported in quick export 
+- PIM-3446: Fix import export history with large amount of errors
 
 # 1.2.13 (2014-11-26)
 

--- a/src/Pim/Bundle/ImportExportBundle/Controller/JobExecutionController.php
+++ b/src/Pim/Bundle/ImportExportBundle/Controller/JobExecutionController.php
@@ -143,9 +143,12 @@ class JobExecutionController extends AbstractDoctrineController
                 $this->jobExecutionManager->markAsFailed($jobExecution);
             }
 
+            // limit the number of step execution returned to avoid memory overflow
+            $context = ['limit_warnings' => 100];
+
             return new JsonResponse(
                 [
-                    'jobExecution' => $this->serializer->normalize($jobExecution, 'json'),
+                    'jobExecution' => $this->serializer->normalize($jobExecution, 'json', $context),
                     'hasLog'       => file_exists($jobExecution->getLogFile()),
                     'archives'     => $archives,
                 ]

--- a/src/Pim/Bundle/ImportExportBundle/Resources/translations/messages.en.yml
+++ b/src/Pim/Bundle/ImportExportBundle/Resources/translations/messages.en.yml
@@ -146,6 +146,7 @@ job_execution.summary:
     skip:   skipped
     create: created
     update: updated
+    displayed: first warnings displayed
     charset_validator:
         title: File encoding:
         skipped: skipped, extension in white list


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | Y |
| New feature? | N |
| BC breaks? | N |
| CI currently passes? | Y |
| Tests pass? | Y |
| Scenarios pass? | Y |
| Checkstyle issues?* | N |
| PMD issues?** | N |
| Changelog updated? | Y |
| Fixed tickets | PIM-3446 |
| DB schema updated? | N |
| Migration script? | N |
| Doc PR | N |

The limit displayed in the results
http://dl.dropbox.com/u/41163683/S%C3%A9lection_005.png
