### PR TITLE
PIM-3471 Add a warning when we reach the max indexes of a mongo collection

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/IndexCreator.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/IndexCreator.php
@@ -8,6 +8,7 @@ use Pim\Bundle\CatalogBundle\Entity\Channel;
 use Pim\Bundle\CatalogBundle\Entity\Currency;
 use Pim\Bundle\CatalogBundle\Entity\Locale;
 use Pim\Bundle\CatalogBundle\Model\AttributeInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * Create index for different entity requirements
@@ -27,19 +28,25 @@ class IndexCreator
     /** @var string */
     protected $productClass;
 
+    /** @var LoggerInterface */
+    protected $logger;
+
     /**
      * @param ManagerRegistry $managerRegistry
      * @param NamingUtility   $namingUtility
      * @param string          $productClass
+     * @param LoggerInterface $logger
      */
     public function __construct(
         ManagerRegistry $managerRegistry,
         NamingUtility $namingUtility,
-        $productClass
+        $productClass,
+        $logger = null
     ) {
         $this->managerRegistry = $managerRegistry;
         $this->namingUtility   = $namingUtility;
         $this->productClass    = $productClass;
+        $this->logger          = $logger;
     }
 
     /**
@@ -195,6 +202,18 @@ class IndexCreator
     protected function ensureIndexes(array $fields)
     {
         $collection = $this->getCollection();
+        $preNbIndexes = count($collection->getIndexInfo());
+        $postNbIndexes = $preNbIndexes + count($fields);
+        if ($postNbIndexes > 64) {
+            $msg = sprintf('Too many MongoDB indexes (%d), no way to add %s', $preNbIndexes, print_r($fields, true));
+            if (null !== $this->logger) {
+                $this->logger->error($msg);
+            } else {
+                error_log($msg);
+            }
+
+            return;
+        }
 
         $indexOptions = [
             'background' => true,

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/storage_driver/doctrine/mongodb-odm.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/storage_driver/doctrine/mongodb-odm.yml
@@ -84,6 +84,7 @@ services:
             - '@pim_catalog.doctrine.smart_manager_registry'
             - '@pim_catalog.doctrine.naming_utility'
             - %pim_catalog.entity.product.class%
+            - @logger
 
     pim_catalog.doctrine.naming_utility:
         class: %pim_catalog.doctrine.naming_utility.class%


### PR DESCRIPTION
With Mongo 2.6.5, when try to create to much indexes, a MongoResultException is raised.

Idea is to add a notice to prevent the following error when we install the PIM with Mongo and more than 64 indexes for values,

`Error #67 in class MongoResultException: localhost:27017: add index fails, too many indexes for pim_ce_mongo.pim_catalog_product key:{ normalizedData.completenesses.mobile-en_US: 1 }`

The new message is the following, it doesnt stop the install

`Too many MongoDB indexes (64), not way to add Array
(
    [0] => normalizedData.light_metering-de_DE
    [1] => normalizedData.light_metering-en_US
    [2] => normalizedData.light_metering-fr_FR
)`

TODO
- [ ] use monolog to log a warning

| Q | A |
| --- | --- |
| Bug fix? |  |
| New feature? |  |
| BC breaks? |  |
| CI currently passes? |  |
| Tests pass? |  |
| Scenarios pass? |  |
| Checkstyle issues?* |  |
| PMD issues?** |  |
| Changelog updated? |  |
| Fixed tickets |  |
| DB schema updated? |  |
| Migration script? |  |
| Doc PR |  |
