### PR TITLE
PIM-3458 Automatically set next sort order when creating an attribute group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - PIM-3369: Check on import if the couple channel/local exist
 - PIM-3368: Add association type check on association import
 - PIM-3377: Add a check if the specific locale exists on imports, and skip unused attribute column for locale specific on exports
+- PIM-3458: When creating an attribute group, automatically set the sort order to the last one
 
 ## BC breaks
 - PIM-3368: Add AssociationType class argument to the `Pim\Bundle\TransformBundle\Transformer\AssociationTransformer` constructor

--- a/spec/Pim/Bundle/EnrichBundle/Form/Subscriber/SetAttributeGroupSortOrderSubscriberSpec.php
+++ b/spec/Pim/Bundle/EnrichBundle/Form/Subscriber/SetAttributeGroupSortOrderSubscriberSpec.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace spec\Pim\Bundle\EnrichBundle\Form\Subscriber;
+
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\CatalogBundle\Entity\AttributeGroup;
+use Pim\Bundle\CatalogBundle\Entity\Repository\AttributeGroupRepository;
+use Prophecy\Argument;
+use Symfony\Component\Form\FormEvent;
+
+class SetAttributeGroupSortOrderSubscriberSpec extends ObjectBehavior
+{
+    function let(AttributeGroupRepository $repository)
+    {
+        $this->beConstructedWith($repository);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Pim\Bundle\EnrichBundle\Form\Subscriber\SetAttributeGroupSortOrderSubscriber');
+    }
+
+    function it_is_an_event_subscriber()
+    {
+        $this->shouldImplement('Symfony\Component\EventDispatcher\EventSubscriberInterface');
+    }
+
+    function it_subscribes_to_the_pre_set_data_form_event()
+    {
+        $this->getSubscribedEvents()->shouldReturn(
+            [
+                'form.pre_set_data' => 'preSetData'
+            ]
+        );
+    }
+
+    function it_sets_the_sort_order_when_creating_an_attribute_group($repository, FormEvent $event, AttributeGroup $group)
+    {
+        $event->getData()->willReturn($group);
+        $group->getId()->willReturn(null);
+
+        $repository->getMaxSortOrder()->willReturn(3);
+        $group->setSortOrder(4)->shouldBeCalled();
+
+        $this->preSetData($event);
+    }
+
+    function it_does_nothing_if_a_new_group_is_not_being_created($repository, FormEvent $event, AttributeGroup $group)
+    {
+        $event->getData()->willReturn($group);
+        $group->getId()->willReturn(5);
+
+        $repository->getMaxSortOrder()->shouldNotBeCalled();
+        $group->setSortOrder(Argument::any())->shouldNotBeCalled();
+
+        $this->preSetData($event);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Entity/Repository/AttributeGroupRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Entity/Repository/AttributeGroupRepository.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Bundle\CatalogBundle\Entity\Repository;
 
+use Doctrine\ORM\AbstractQuery;
 use Pim\Bundle\CatalogBundle\Doctrine\ReferableEntityRepository;
 use Pim\Bundle\CatalogBundle\Entity\AttributeGroup;
 
@@ -86,9 +87,21 @@ class AttributeGroupRepository extends ReferableEntityRepository
             ->innerJoin('ga.attributes', 'a')
             ->where($qb->expr()->in('a.code', ':codes'))
             ->setParameter(':codes', $codes)
-            ->getQuery()
-        ;
+            ->getQuery();
 
         return $query->getResult();
+    }
+
+    /**
+     * Find the largest attribute group sort order present in the database
+     *
+     * @return int
+     */
+    public function getMaxSortOrder()
+    {
+        return (int) $this->createQueryBuilder('ag')
+            ->select('MAX(ag.sortOrder)')
+            ->getQuery()
+            ->execute([], AbstractQuery::HYDRATE_SINGLE_SCALAR);
     }
 }

--- a/src/Pim/Bundle/EnrichBundle/Form/Subscriber/SetAttributeGroupSortOrderSubscriber.php
+++ b/src/Pim/Bundle/EnrichBundle/Form/Subscriber/SetAttributeGroupSortOrderSubscriber.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Pim\Bundle\EnrichBundle\Form\Subscriber;
+
+use Pim\Bundle\CatalogBundle\Entity\Repository\AttributeGroupRepository;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+
+/**
+ * A subscriber that sets the attribute group sort order
+ * when creating a new attribute group
+ *
+ * @author    Filips Alpe <filips@akeneo.com>
+ * @copyright 2014 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class SetAttributeGroupSortOrderSubscriber implements EventSubscriberInterface
+{
+    /** @var AttributeGroupRepository */
+    protected $repository;
+
+    /**
+     * @param AttributeGroupRepository $repository
+     */
+    public function __construct(AttributeGroupRepository $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            FormEvents::PRE_SET_DATA => 'preSetData',
+        ];
+    }
+
+    /**
+     * @param FormEvent $event
+     */
+    public function preSetData(FormEvent $event)
+    {
+        $data = $event->getData();
+
+        if (null === $data || null !== $data->getId()) {
+            return;
+        }
+
+        $data->setSortOrder($this->repository->getMaxSortOrder() + 1);
+    }
+}

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_subscribers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_subscribers.yml
@@ -4,6 +4,7 @@ parameters:
     pim_enrich.form.subscriber.add_value_field_subscriber.class: Pim\Bundle\EnrichBundle\Form\Subscriber\AddProductValueFieldSubscriber
     pim_enrich.form.subscriber.family_disable_fields_subscriber.class: Pim\Bundle\EnrichBundle\Form\Subscriber\DisableFamilyFieldsSubscriber
     pim_enrich.form.subscriber.family_attribute_label_subscriber.class: Pim\Bundle\EnrichBundle\Form\Subscriber\AddAttributeAsLabelSubscriber
+    pim_enrich.form.subscriber.set_attribute_group_sort_order.class: Pim\Bundle\EnrichBundle\Form\Subscriber\SetAttributeGroupSortOrderSubscriber
 
 services:
     # Subscribers
@@ -33,3 +34,8 @@ services:
             - %pim_catalog.entity.attribute.class%
             - '@form.factory'
             - '@oro_security.security_facade'
+
+    pim_enrich.form.subscriber.set_attribute_group_sort_order:
+        class: %pim_enrich.form.subscriber.set_attribute_group_sort_order.class%
+        arguments:
+            - '@pim_catalog.repository.attribute_group'

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_types.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_types.yml
@@ -105,6 +105,8 @@ services:
         class: %pim_enrich.form.type.attribute_group.class%
         tags:
             - { name: form.type, alias: pim_enrich_attribute_group }
+        calls:
+            - [addEventSubscriber, ['@pim_enrich.form.subscriber.set_attribute_group_sort_order']]
 
     pim_enrich.form.type.family:
         class: %pim_enrich.form.type.family.class%


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | Y |
| New feature? | N |
| BC breaks? | N |
| CI currently passes? | ? |
| Tests pass? | Y |
| Scenarios pass? | Y |
| Checkstyle issues?* | N |
| PMD issues?** | N |
| Changelog updated? | Y |
| Fixed tickets | PIM-3458 |
| DB schema updated? | N |
| Migration script? | N |
| Doc PR | ~ |
