### PR TITLE
PIM-3407: Fix text filter with special characters and 'is equal to' operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - PIM-3786: Attribute type should not be blank for import
 - PIM-3437: Fix applying datagrid views and columns when not using hash navigation
 - PIM-3844: Create popin keeps state in memory
+- PIM-3407: Fix text filter with special characters and 'is equal to' operator
 
 # 1.2.31 (2015-03-06)
 

--- a/features/product/filtering/filter_products_per_text_fields.feature
+++ b/features/product/filtering/filter_products_per_text_fields.feature
@@ -23,10 +23,11 @@ Feature: Filter products by text field
     Then the grid should contain 4 elements
     And I should see products "HP LA2206xc + WF722A", "Canon 5D + EF 24-105 F4L IS", "Canon 5D + EF 24-105mm f/4L IS" and "Canon 5D + EF 24-105 F5L IS"
     And I should be able to use the following filters:
-      | filter | value                | result                                                                                      |
-      | name   | HP LA2206xc + WF722A | HP LA2206xc + WF722A                                                                        |
-      | name   | Canon 5D + EF 24-105 | Canon 5D + EF 24-105 F4L IS, Canon 5D + EF 24-105mm f/4L IS and Canon 5D + EF 24-105 F5L IS |
-      | name   | f/4L                 | Canon 5D + EF 24-105mm f/4L IS                                                              |
+      | filter | value                                   | result                                                                                      |
+      | name   | HP LA2206xc + WF722A                    | HP LA2206xc + WF722A                                                                        |
+      | name   | Canon 5D + EF 24-105                    | Canon 5D + EF 24-105 F4L IS, Canon 5D + EF 24-105mm f/4L IS and Canon 5D + EF 24-105 F5L IS |
+      | name   | f/4L                                    | Canon 5D + EF 24-105mm f/4L IS                                                              |
+      | name   | is equal to Canon 5D + EF 24-105 F5L IS | 13572541
 
   Scenario: Successfully filter products by empty value for text and textarea attributes
     Given the following attributes:
@@ -99,3 +100,23 @@ Feature: Filter products by text field
     And I should be able to use the following filters:
       | filter | value | result       |
       | name   | empty | book and mug |
+
+  Scenario: Successfully filter products with special characters value for sku
+    Given the following attribute:
+      | label | type | useable as grid filter | useable as grid column |
+      | name  | text | yes                    | yes                    |
+    And the following products:
+      | sku            | name-en_US            |
+      | elves.it       | Christmas elves       |
+      | *candle^p      | Candle High-longevity |
+      | elves.mac      | Macarons kit          |
+      | AC{1256}-[10]  | Aromatherapy Diffuser |
+    When I am on the products page
+    Then I should be able to use the following filters:
+      | filter | value                     | result                  |
+      | SKU    | is equal to elves.it      | elves.it                |
+      | SKU    | is equal to AC{1256}-[10] | AC{1256}-[10]           |
+      | SKU    | is equal to elves.        |                         |
+      | SKU    | is equal to *candle^p     | *candle^p               |
+      | SKU    | is equal to elves%        | elves.it and elves.mac  |
+

--- a/src/Pim/Bundle/FilterBundle/Filter/ProductValue/StringFilter.php
+++ b/src/Pim/Bundle/FilterBundle/Filter/ProductValue/StringFilter.php
@@ -6,6 +6,7 @@ use Oro\Bundle\FilterBundle\Form\Type\Filter\FilterType;
 use Oro\Bundle\FilterBundle\Filter\StringFilter as OroStringFilter;
 use Oro\Bundle\FilterBundle\Datasource\FilterDatasourceAdapterInterface;
 use Pim\Bundle\FilterBundle\Filter\ProductFilterUtility;
+use Oro\Bundle\FilterBundle\Form\Type\Filter\TextFilterType;
 
 /**
  * String filter
@@ -64,5 +65,27 @@ class StringFilter extends OroStringFilter
         }
 
         return $data;
+    }
+
+    /**
+     * Get operator string
+     *
+     * @param int $type
+     *
+     * @return string
+     */
+    protected function getOperator($type)
+    {
+        $operatorTypes = array(
+            TextFilterType::TYPE_CONTAINS     => 'LIKE',
+            TextFilterType::TYPE_NOT_CONTAINS => 'NOT LIKE',
+            TextFilterType::TYPE_EQUAL        => 'LIKE',
+            TextFilterType::TYPE_STARTS_WITH  => 'LIKE',
+            TextFilterType::TYPE_ENDS_WITH    => 'LIKE',
+            FilterType::TYPE_EMPTY            => 'EMPTY',
+            FilterType::TYPE_IN_LIST          => 'IN',
+        );
+
+        return isset($operatorTypes[$type]) ? $operatorTypes[$type] : 'LIKE';
     }
 }

--- a/src/Pim/Bundle/FilterBundle/Filter/ProductValue/StringFilter.php
+++ b/src/Pim/Bundle/FilterBundle/Filter/ProductValue/StringFilter.php
@@ -76,7 +76,7 @@ class StringFilter extends OroStringFilter
      */
     protected function getOperator($type)
     {
-        $operatorTypes = array(
+        $operatorTypes = [
             TextFilterType::TYPE_CONTAINS     => 'LIKE',
             TextFilterType::TYPE_NOT_CONTAINS => 'NOT LIKE',
             TextFilterType::TYPE_EQUAL        => 'LIKE',
@@ -84,7 +84,7 @@ class StringFilter extends OroStringFilter
             TextFilterType::TYPE_ENDS_WITH    => 'LIKE',
             FilterType::TYPE_EMPTY            => 'EMPTY',
             FilterType::TYPE_IN_LIST          => 'IN',
-        );
+        ];
 
         return isset($operatorTypes[$type]) ? $operatorTypes[$type] : 'LIKE';
     }


### PR DESCRIPTION
| Q                    | A
| -------------------- | ---
| Bug fix?             | Y
| New feature?         | N
| BC breaks?           | N
| CI currently passes? | Y
| Tests pass?          | Y
| Scenarios pass?      | Y
| Checkstyle issues?*  | N
| PMD issues?**        | N
| Changelog updated?   | Y
| Fixed tickets        | PIM-3407
| DB schema updated?   | N
| Migration script?    | N
| Doc PR               | N