### PR TITLE
PIM-2458: handle variant group in mass edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 - Base template has been moved from `app/Resources/views` to `PimEnrichBundle/Resources/views`
 - Make classes of `Pim\Bundle\CatalogBundle\Model` consistent with the interfaces
 - Move filter transformation to CatalogBundle
-- Re-work `Pim\Bundle\ImportExportBundle\Controller\JobProfileController` to make it more readable 
+- Re-work `Pim\Bundle\ImportExportBundle\Controller\JobProfileController` to make it more readable
 - Re-work the `Pim\Bundle\CatalogBundle\Doctrine\Query\ProductQueryBuilder` to provide a clear and extensible API to query products
 - Normalize the managers by introducing 4 interfaces, `Akeneo\Component\Persistence\SaverInterface`, `Akeneo\Component\Persistence\BulkSaverInterface`, `Akeneo\Component\Persistence\RemoverInterface` and `Pim\Component\Persistence\BulkRemoverInterface`
 - Add a view manager to help integrators to override and add elements to the UI (tabs, buttons, etc)
@@ -167,6 +167,7 @@
 - constructor of `Pim\Bundle\EnrichBundle\Controller\ProductController` has been updated and now receives `Akeneo\Component\Persistence\SaverInterface`, `Pim\Bundle\CatalogBundle\Manager\MediaManager` and `Pim\Bundle\EnrichBundle\Manager\SequentialEditManager` as extra arguments
 - constructor of `Pim\Bundle\EnrichBundle\Form\View\ProductFormView` has been updated and now receives `Pim\Bundle\EnrichBundle\Form\View\ViewUpdater\ViewUpdaterRegistry`
 - constructor of `Pim\Bundle\TransformBundle\Transformer\ProductTransformer` has been updated and now receives `Pim\Bundle\CatalogBundle\Updater\ProductTemplateUpdaterInterface`
+- You cannot add product to multiple variant group anymore
 
 ## Bug fixes
 - PIM-3332: Fix incompatibility with overriden category due to usage of ParamConverter in ProductController
@@ -182,7 +183,7 @@
 
 ## Bug fixes
 - PIM-3556: Fix memory leak on versionning
-- PIM-3548: Do not rely on the absolute file path of a media 
+- PIM-3548: Do not rely on the absolute file path of a media
 
 # 1.2.18 (2014-12-23)
 

--- a/spec/Pim/Bundle/BaseConnectorBundle/Validator/Import/ProductImportValidatorSpec.php
+++ b/spec/Pim/Bundle/BaseConnectorBundle/Validator/Import/ProductImportValidatorSpec.php
@@ -96,9 +96,8 @@ class ProductImportValidatorSpec extends ObjectBehavior
         $productValue3->__toString()->willReturn("17727158");
         $productValue4->__toString()->willReturn("1200000011a");
 
-        $validator->validateValue('17727158', Argument::any())->shouldBeCalled()->willReturn($constraint);
-        $validator->validateValue('1200000011a', Argument::any())->shouldBeCalled()->willReturn($constraint);
-        $validator->validateValue('AKNTS_BPXL', Argument::any())->shouldBeCalled()->willReturn($constraint);
+        $validator->validate($product1, Argument::any())->shouldBeCalled()->willReturn($constraint);
+        $validator->validate($product2, Argument::any())->shouldBeCalled()->willReturn($constraint);
         $constraint->count()->willReturn(0);
 
         $errors = [

--- a/spec/Pim/Bundle/BaseConnectorBundle/Validator/Import/ProductImportValidatorSpec.php
+++ b/spec/Pim/Bundle/BaseConnectorBundle/Validator/Import/ProductImportValidatorSpec.php
@@ -96,6 +96,10 @@ class ProductImportValidatorSpec extends ObjectBehavior
         $productValue3->__toString()->willReturn("17727158");
         $productValue4->__toString()->willReturn("1200000011a");
 
+        $validator->validateValue('17727158', Argument::any())->shouldBeCalled()->willReturn($constraint);
+        $validator->validateValue('1200000011a', Argument::any())->shouldBeCalled()->willReturn($constraint);
+        $validator->validateValue('AKNTS_BPXL', Argument::any())->shouldBeCalled()->willReturn($constraint);
+
         $validator->validate($product1, Argument::any())->shouldBeCalled()->willReturn($constraint);
         $validator->validate($product2, Argument::any())->shouldBeCalled()->willReturn($constraint);
         $constraint->count()->willReturn(0);

--- a/spec/Pim/Bundle/EnrichBundle/MassEditAction/Operation/AddToGroupsSpec.php
+++ b/spec/Pim/Bundle/EnrichBundle/MassEditAction/Operation/AddToGroupsSpec.php
@@ -48,7 +48,7 @@ class AddToGroupsSpec extends ObjectBehavior
 
     function it_provides_form_options($groupRepository, $shirts, $pants)
     {
-        $groupRepository->findAll()->willReturn([$shirts, $pants]);
+        $groupRepository->getAllGroupsExceptVariant()->willReturn([$shirts, $pants]);
 
         $this->getFormOptions()->shouldReturn(['groups' => [$shirts, $pants]]);
     }

--- a/src/Pim/Bundle/BaseConnectorBundle/Validator/Import/ProductImportValidator.php
+++ b/src/Pim/Bundle/BaseConnectorBundle/Validator/Import/ProductImportValidator.php
@@ -77,16 +77,10 @@ class ProductImportValidator extends ImportValidator
             $errors[$data['sku']] = [[$e->getMessage()]];
         }
 
-        foreach ($columnsInfo as $columnInfo) {
-            if ($columnInfo->getAttribute()) {
-                $violations = $this->validateProductValue($entity, $columnInfo);
-            } else {
-                $violations = $this->validator->validateProperty($entity, $columnInfo->getPropertyPath());
-            }
+        $violations = $this->validator->validate($entity);
 
-            if ($violations->count()) {
-                $errors[$columnInfo->getLabel()] = $this->getErrorArray($violations);
-            }
+        if ($violations->count() > 0) {
+            $errors['error'] = $this->getErrorArray($violations);
         }
 
         return $errors;
@@ -138,48 +132,6 @@ class ProductImportValidator extends ImportValidator
                 }
             }
         }
-    }
-
-    /**
-     * Validates a ProductValue
-     *
-     * @param ProductInterface    $product
-     * @param ColumnInfoInterface $columnInfo
-     *
-     * @return ConstraintViolationListInterface
-     */
-    protected function validateProductValue(ProductInterface $product, ColumnInfoInterface $columnInfo)
-    {
-        $value = $this->getProductValue($product, $columnInfo);
-        if (!$value) {
-            return new \Symfony\Component\Validator\ConstraintViolationList();
-        }
-
-        return $this->validator->validateValue(
-            $value->getData(),
-            $this->getAttributeConstraints($columnInfo->getAttribute())
-        );
-    }
-
-    /**
-     * Returns an array of constraints for a given attribute
-     *
-     * @param AttributeInterface $attribute
-     *
-     * @return string
-     */
-    protected function getAttributeConstraints(AttributeInterface $attribute)
-    {
-        $code = $attribute->getCode();
-        if (!isset($this->constraints[$code])) {
-            if ($this->constraintGuesser->supportAttribute($attribute)) {
-                $this->constraints[$code] = $this->constraintGuesser->guessConstraints($attribute);
-            } else {
-                $this->constraints[$code] = array();
-            }
-        }
-
-        return $this->constraints[$code];
     }
 
     /**

--- a/src/Pim/Bundle/BaseConnectorBundle/Validator/Import/ProductImportValidator.php
+++ b/src/Pim/Bundle/BaseConnectorBundle/Validator/Import/ProductImportValidator.php
@@ -77,10 +77,16 @@ class ProductImportValidator extends ImportValidator
             $errors[$data['sku']] = [[$e->getMessage()]];
         }
 
-        $violations = $this->validator->validate($entity);
+        foreach ($columnsInfo as $columnInfo) {
+            if ($columnInfo->getAttribute()) {
+                $violations = $this->validateProductValue($entity, $columnInfo);
+            } else {
+                $violations = $this->validator->validateProperty($entity, $columnInfo->getPropertyPath());
+            }
 
-        if ($violations->count() > 0) {
-            $errors['error'] = $this->getErrorArray($violations);
+            if ($violations->count()) {
+                $errors[$columnInfo->getLabel()] = $this->getErrorArray($violations);
+            }
         }
 
         return $errors;
@@ -132,6 +138,48 @@ class ProductImportValidator extends ImportValidator
                 }
             }
         }
+    }
+
+    /**
+     * Validates a ProductValue
+     *
+     * @param ProductInterface    $product
+     * @param ColumnInfoInterface $columnInfo
+     *
+     * @return ConstraintViolationListInterface
+     */
+    protected function validateProductValue(ProductInterface $product, ColumnInfoInterface $columnInfo)
+    {
+        $value = $this->getProductValue($product, $columnInfo);
+        if (!$value) {
+            return new \Symfony\Component\Validator\ConstraintViolationList();
+        }
+
+        return $this->validator->validateValue(
+            $value->getData(),
+            $this->getAttributeConstraints($columnInfo->getAttribute())
+        );
+    }
+
+    /**
+     * Returns an array of constraints for a given attribute
+     *
+     * @param AttributeInterface $attribute
+     *
+     * @return string
+     */
+    protected function getAttributeConstraints(AttributeInterface $attribute)
+    {
+        $code = $attribute->getCode();
+        if (!isset($this->constraints[$code])) {
+            if ($this->constraintGuesser->supportAttribute($attribute)) {
+                $this->constraints[$code] = $this->constraintGuesser->guessConstraints($attribute);
+            } else {
+                $this->constraints[$code] = array();
+            }
+        }
+
+        return $this->constraints[$code];
     }
 
     /**

--- a/src/Pim/Bundle/CatalogBundle/Entity/Repository/GroupRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Entity/Repository/GroupRepository.php
@@ -85,8 +85,8 @@ class GroupRepository extends ReferableEntityRepository
     {
         $qb = $this->createQueryBuilder('grp');
         $qb->innerJoin('grp.type', 'type')
-            ->where($qb->expr()->neq('type.code', ':code'))
-            ->setParameter(':code', 'VARIANT');
+            ->where($qb->expr()->eq('type.variant', ':variant'))
+            ->setParameter(':variant', false);
 
         return $qb->getQuery()->execute();
     }
@@ -100,8 +100,8 @@ class GroupRepository extends ReferableEntityRepository
     {
         $qb = $this->createQueryBuilder('grp');
         $qb->innerJoin('grp.type', 'type')
-            ->where($qb->expr()->eq('type.code', ':code'))
-            ->setParameter(':code', 'VARIANT');
+            ->where($qb->expr()->eq('type.variant', ':variant'))
+            ->setParameter(':variant', true);
 
         return $qb->getQuery()->execute();
     }

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/validation/product.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/validation/product.yml
@@ -1,6 +1,7 @@
 Pim\Bundle\CatalogBundle\Model\Product:
     constraints:
         - Pim\Bundle\CatalogBundle\Validator\Constraints\UniqueVariantAxis: ~
+        - Pim\Bundle\CatalogBundle\Validator\Constraints\UniqueVariantGroup: ~
     properties:
         values:
             - Symfony\Component\Validator\Constraints\Valid:

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/validators.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/validators.yml
@@ -3,6 +3,7 @@ parameters:
     pim_catalog.validator.constraint.valid_metric.class:             Pim\Bundle\CatalogBundle\Validator\Constraints\ValidMetricValidator
     pim_catalog.validator.constraint.single_identifier.class:        Pim\Bundle\CatalogBundle\Validator\Constraints\SingleIdentifierAttributeValidator
     pim_catalog.validator.constraint.unique_variant_axis.class:      Pim\Bundle\CatalogBundle\Validator\Constraints\UniqueVariantAxisValidator
+    pim_catalog.validator.constraint.unique_variant_group.class:     Pim\Bundle\CatalogBundle\Validator\Constraints\UniqueVariantGroupValidator
     pim_catalog.validator.constraint.unique_value.class:             Pim\Bundle\CatalogBundle\Validator\Constraints\UniqueValueValidator
     pim_catalog.validator.constraint.immutable.class:                Pim\Bundle\CatalogBundle\Validator\Constraints\ImmutableValidator
     pim_catalog.validator.constraint.variant_group_values.class:     Pim\Bundle\CatalogBundle\Validator\Constraints\VariantGroupValuesValidator
@@ -55,6 +56,11 @@ services:
             - '@pim_catalog.manager.product'
         tags:
             - { name: validator.constraint_validator, alias: pim_unique_variant_axis_validator }
+
+    pim_catalog.validator.constraint.unique_variant_group:
+        class: %pim_catalog.validator.constraint.unique_variant_group.class%
+        tags:
+            - { name: validator.constraint_validator, alias: pim_unique_variant_group_validator }
 
     pim_catalog.validator.constraint.unique_value:
         class: %pim_catalog.validator.constraint.unique_value.class%

--- a/src/Pim/Bundle/CatalogBundle/Validator/Constraints/UniqueVariantAxisValidator.php
+++ b/src/Pim/Bundle/CatalogBundle/Validator/Constraints/UniqueVariantAxisValidator.php
@@ -78,21 +78,21 @@ class UniqueVariantAxisValidator extends ConstraintValidator
     /**
      * Validate product
      *
-     * @param ProductInterface $entity
+     * @param ProductInterface $product
      * @param Constraint       $constraint
      *
      * @return null
      */
-    protected function validateProduct(ProductInterface $entity, Constraint $constraint)
+    protected function validateProduct(ProductInterface $product, Constraint $constraint)
     {
-        if (null === $entity->getGroups()) {
+        if (null === $product->getGroups()) {
             return;
         }
 
-        foreach ($entity->getGroups() as $variantGroup) {
+        foreach ($product->getGroups() as $variantGroup) {
             if ($variantGroup->getType()->isVariant()) {
-                $criteria = $this->prepareQueryCriterias($variantGroup, $entity);
-                $matchingProducts = $this->getMatchingProducts($variantGroup, $entity, $criteria);
+                $criteria = $this->prepareQueryCriterias($variantGroup, $product);
+                $matchingProducts = $this->getMatchingProducts($variantGroup, $product, $criteria);
                 if (count($matchingProducts) !== 0) {
                     $values = array();
                     foreach ($criteria as $item) {

--- a/src/Pim/Bundle/CatalogBundle/Validator/Constraints/UniqueVariantGroup.php
+++ b/src/Pim/Bundle/CatalogBundle/Validator/Constraints/UniqueVariantGroup.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Unique variant group constraint
+ *
+ * @author    Julien Sanchez <julien@akeneo.com>
+ * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class UniqueVariantGroup extends Constraint
+{
+    /**
+     * Violation message for already have a variant group
+     *
+     * @var string
+     */
+    public $message = 'The product "%product%" cannot belongs to many variant groups "%group_one%" and "%group_two%"';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validatedBy()
+    {
+        return 'pim_unique_variant_group_validator';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTargets()
+    {
+        return self::CLASS_CONSTRAINT;
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Validator/Constraints/UniqueVariantGroupValidator.php
+++ b/src/Pim/Bundle/CatalogBundle/Validator/Constraints/UniqueVariantGroupValidator.php
@@ -18,18 +18,18 @@ class UniqueVariantGroupValidator extends ConstraintValidator
     /**
      * {@inheritdoc}
      */
-    public function validate($value, Constraint $constraint)
+    public function validate($product, Constraint $constraint)
     {
-        if ($value instanceof ProductInterface) {
+        if ($product instanceof ProductInterface) {
             $productVariantGroup = null;
-            foreach ($value->getGroups() as $group) {
+            foreach ($product->getGroups() as $group) {
                 if ($group->getType()->isVariant() && null !== $productVariantGroup) {
                     $this->context->addViolation(
                         $constraint->message,
                         array(
                             '%group_one%' => $productVariantGroup,
                             '%group_two%' => $group,
-                            '%product%'   => $value->getIdentifier()
+                            '%product%'   => $product->getIdentifier()
                         )
                     );
                 } elseif ($group->getType()->isVariant()) {

--- a/src/Pim/Bundle/CatalogBundle/Validator/Constraints/UniqueVariantGroupValidator.php
+++ b/src/Pim/Bundle/CatalogBundle/Validator/Constraints/UniqueVariantGroupValidator.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\Validator\Constraints;
+
+use Pim\Bundle\CatalogBundle\Model\ProductInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ * Unique variant group validator
+ *
+ * @author    Julien Sanchez <julien@akeneo.com>
+ * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class UniqueVariantGroupValidator extends ConstraintValidator
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function validate($value, Constraint $constraint)
+    {
+        if ($value instanceof ProductInterface) {
+            $productVariantGroup = null;
+            foreach ($value->getGroups() as $group) {
+                if ($group->getType()->isVariant() && null !== $productVariantGroup) {
+                    $this->context->addViolation(
+                        $constraint->message,
+                        array(
+                            '%group_one%' => $productVariantGroup,
+                            '%group_two%' => $group,
+                            '%product%'   => $value->getIdentifier()
+                        )
+                    );
+                } elseif ($group->getType()->isVariant()) {
+                    $productVariantGroup = $group;
+                }
+            }
+        }
+    }
+}

--- a/src/Pim/Bundle/EnrichBundle/DependencyInjection/PimEnrichExtension.php
+++ b/src/Pim/Bundle/EnrichBundle/DependencyInjection/PimEnrichExtension.php
@@ -27,6 +27,7 @@ class PimEnrichExtension extends Extension
         $loader->load('attribute_icons.yml');
         $loader->load('colors.yml');
         $loader->load('controllers.yml');
+        $loader->load('data_transformers.yml');
         $loader->load('datagrid_listeners.yml');
         $loader->load('entities.yml');
         $loader->load('event_listeners.yml');
@@ -43,18 +44,18 @@ class PimEnrichExtension extends Extension
         $loader->load('resolvers.yml');
         $loader->load('serializers.yml');
         $loader->load('twig.yml');
-        $loader->load('view_updaters.yml');
         $loader->load('view_elements.yml');
-
         $loader->load('view_elements/association_type.yml');
         $loader->load('view_elements/attribute.yml');
         $loader->load('view_elements/attribute_group.yml');
+        $loader->load('view_elements/category.yml');
         $loader->load('view_elements/channel.yml');
         $loader->load('view_elements/family.yml');
-        $loader->load('view_elements/group_type.yml');
-        $loader->load('view_elements/product.yml');
-        $loader->load('view_elements/category.yml');
         $loader->load('view_elements/group.yml');
+        $loader->load('view_elements/group_type.yml');
+        $loader->load('view_elements/mass_edit.yml');
+        $loader->load('view_elements/product.yml');
+        $loader->load('view_updaters.yml');
 
         if ($config['record_mails']) {
             $loader->load('mail_recorder.yml');

--- a/src/Pim/Bundle/EnrichBundle/Form/Type/MassEditAction/AddToVariantGroupType.php
+++ b/src/Pim/Bundle/EnrichBundle/Form/Type/MassEditAction/AddToVariantGroupType.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Pim\Bundle\EnrichBundle\Form\Type\MassEditAction;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
+/**
+ * Add to groups mass action form type
+ *
+ * @author    Julien Sanchez <julien@akeneo.com>
+ * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class AddToVariantGroupType extends AbstractType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->add(
+            'group',
+            'entity',
+            array(
+                'class'    => 'Pim\\Bundle\\CatalogBundle\\Entity\\Group',
+                'required' => true,
+                'multiple' => false,
+                'expanded' => true,
+                'choices'  => $options['groups'],
+            )
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $resolver->setDefaults(
+            [
+                'data_class' => 'Pim\\Bundle\\EnrichBundle\\MassEditAction\\Operation\\AddToVariantGroup',
+                'groups' => array()
+            ]
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'pim_enrich_mass_add_to_variant_group';
+    }
+}

--- a/src/Pim/Bundle/EnrichBundle/MassEditAction/Operation/AddToVariantGroup.php
+++ b/src/Pim/Bundle/EnrichBundle/MassEditAction/Operation/AddToVariantGroup.php
@@ -10,7 +10,7 @@ use Pim\Bundle\CatalogBundle\Model\GroupInterface;
 use Pim\Bundle\CatalogBundle\Model\ProductInterface;
 
 /**
- * My class definition
+ * Operation to add products to variant groups
  *
  * @author    Julien Sanchez <julien@akeneo.com>
  * @copyright 2015 Akeneo SAS (http://www.akeneo.com)

--- a/src/Pim/Bundle/EnrichBundle/MassEditAction/Operation/AddToVariantGroup.php
+++ b/src/Pim/Bundle/EnrichBundle/MassEditAction/Operation/AddToVariantGroup.php
@@ -1,29 +1,31 @@
 <?php
 
+
 namespace Pim\Bundle\EnrichBundle\MassEditAction\Operation;
 
 use Akeneo\Component\Persistence\BulkSaverInterface;
 use Doctrine\Common\Collections\ArrayCollection;
 use Pim\Bundle\CatalogBundle\Entity\Repository\GroupRepository;
+use Pim\Bundle\CatalogBundle\Model\GroupInterface;
 use Pim\Bundle\CatalogBundle\Model\ProductInterface;
 
 /**
- * Adds many products to many groups
+ * My class definition
  *
- * @author    Gildas Quemener <gildas@akeneo.com>
- * @copyright 2013 Akeneo SAS (http://www.akeneo.com)
+ * @author    Julien Sanchez <julien@akeneo.com>
+ * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class AddToGroups extends ProductMassEditOperation
+class AddToVariantGroup extends ProductMassEditOperation
 {
     /** @var GroupRepository */
     protected $groupRepository;
 
-    /** @var ArrayCollection */
-    protected $groups;
+    /** @var GroupInterface */
+    protected $group;
 
     /** @var string[] */
-    protected $warningMessages;
+    protected $warningMessages = null;
 
     /**
      * @param GroupRepository    $groupRepository
@@ -34,27 +36,26 @@ class AddToGroups extends ProductMassEditOperation
         parent::__construct($productSaver);
 
         $this->groupRepository = $groupRepository;
-        $this->groups = new ArrayCollection();
     }
 
     /**
-     * Set groups
+     * Set group
      *
-     * @param array $groups
+     * @param GroupInterface $group
      */
-    public function setGroups(array $groups)
+    public function setGroup(GroupInterface $group)
     {
-        $this->groups = new ArrayCollection($groups);
+        $this->group = $group;
     }
 
     /**
-     * Get groups
+     * Get group
      *
      * @return array
      */
-    public function getGroups()
+    public function getGroup()
     {
-        return $this->groups;
+        return $this->group;
     }
 
     /**
@@ -63,7 +64,7 @@ class AddToGroups extends ProductMassEditOperation
     public function getFormOptions()
     {
         return [
-            'groups' => $this->groupRepository->getAllGroupsExceptVariant()
+            'groups' => $this->groupRepository->getAllVariantGroups()
         ];
     }
 
@@ -72,7 +73,17 @@ class AddToGroups extends ProductMassEditOperation
      */
     public function getFormType()
     {
-        return 'pim_enrich_mass_add_to_groups';
+        return 'pim_enrich_mass_add_to_variant_group';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doPerform(ProductInterface $product)
+    {
+        if (null === $product->getVariantGroup()) {
+            $this->group->addProduct($product);
+        }
     }
 
     /**
@@ -99,23 +110,29 @@ class AddToGroups extends ProductMassEditOperation
     {
         $messages = [];
 
-        if (count($this->groupRepository->getAllGroupsExceptVariant()) === 0) {
+        if (count($this->groupRepository->getAllVariantGroups()) === 0) {
             $messages[] = [
-                'key'     => 'pim_enrich.mass_edit_action.add-to-groups.no_group',
+                'key'     => 'pim_enrich.mass_edit_action.add-to-variant-group.no_variant_group',
                 'options' => []
+            ];
+
+            return $messages;
+        }
+
+        $alreadyInVariantGroup = [];
+        foreach ($products as $product) {
+            if (null != $product->getVariantGroup()) {
+                $alreadyInVariantGroup[] = $product->getIdentifier();
+            }
+        }
+
+        if (count($alreadyInVariantGroup) > 1) {
+            $messages[] = [
+                'key'     => 'pim_enrich.mass_edit_action.add-to-variant-group.already_in_variant_group',
+                'options' => ['%products%' => implode(', ', $alreadyInVariantGroup)]
             ];
         }
 
         return $messages;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function doPerform(ProductInterface $product)
-    {
-        foreach ($this->groups as $group) {
-            $group->addProduct($product);
-        }
     }
 }

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/acl.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/acl.yml
@@ -60,6 +60,10 @@ pim_enrich_product_add_to_groups:
     type: action
     label: pim_enrich.acl.product.add_to_groups
     group_name: pim_enrich.acl_group.product
+pim_enrich_product_add_to_variant_group:
+    type: action
+    label: pim_enrich.acl.product.add_to_variant_group
+    group_name: pim_enrich.acl_group.product
 pim_enrich_product_comment:
     type: action
     label: pim_enrich.acl.product.comment

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_types.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_types.yml
@@ -40,6 +40,7 @@ parameters:
 
     pim_enrich.form.type.edit_common_attributes.class:     Pim\Bundle\EnrichBundle\Form\Type\MassEditAction\EditCommonAttributesType
     pim_enrich.form.type.add_to_groups.class:              Pim\Bundle\EnrichBundle\Form\Type\MassEditAction\AddToGroupsType
+    pim_enrich.form.type.add_to_variant_group.class:       Pim\Bundle\EnrichBundle\Form\Type\MassEditAction\AddToVariantGroupType
     pim_enrich.form.type.change_family.class:              Pim\Bundle\EnrichBundle\Form\Type\MassEditAction\ChangeFamilyType
     pim_enrich.form.type.change_status.class:              Pim\Bundle\EnrichBundle\Form\Type\MassEditAction\ChangeStatusType
     pim_enrich.form.type.classify.class:                   Pim\Bundle\EnrichBundle\Form\Type\MassEditAction\ClassifyType
@@ -289,6 +290,11 @@ services:
         class: %pim_enrich.form.type.add_to_groups.class%
         tags:
             - { name: form.type, alias: pim_enrich_mass_add_to_groups }
+
+    pim_enrich.form.type.add_to_variant_group:
+        class: %pim_enrich.form.type.add_to_variant_group.class%
+        tags:
+            - { name: form.type, alias: pim_enrich_mass_add_to_variant_group }
 
     pim_enrich.form.type.change_family:
         class: %pim_enrich.form.type.change_family.class%

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/mass_actions.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/mass_actions.yml
@@ -8,6 +8,7 @@ parameters:
     pim_enrich.mass_edit_action.classify.class: Pim\Bundle\EnrichBundle\MassEditAction\Operation\Classify
     pim_enrich.mass_edit_action.change_family.class: Pim\Bundle\EnrichBundle\MassEditAction\Operation\ChangeFamily
     pim_enrich.mass_edit_action.add_to_groups.class: Pim\Bundle\EnrichBundle\MassEditAction\Operation\AddToGroups
+    pim_enrich.mass_edit_action.add_to_variant_group.class: Pim\Bundle\EnrichBundle\MassEditAction\Operation\AddToVariantGroup
     pim_entich.mass_edit_action.set_attribute_requirements.class: Pim\Bundle\EnrichBundle\MassEditAction\Operation\SetAttributeRequirements
 
 services:
@@ -105,6 +106,18 @@ services:
                 name: pim_enrich.mass_edit_action
                 alias: add-to-groups
                 acl: pim_enrich_product_add_to_groups
+                operator: pim_enrich.mass_edit_action.operator.product
+
+    pim_enrich.mass_edit_action.add_to_variant_group:
+        class: %pim_enrich.mass_edit_action.add_to_variant_group.class%
+        arguments:
+            - '@pim_catalog.repository.group'
+            - '@pim_catalog.saver.product'
+        tags:
+            -
+                name: pim_enrich.mass_edit_action
+                alias: add-to-variant-group
+                acl: pim_enrich_product_add_to_variant_group
                 operator: pim_enrich.mass_edit_action.operator.product
 
     # Family Grid Mass edit actions

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/view_elements/mass_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/view_elements/mass_edit.yml
@@ -1,0 +1,13 @@
+parameters:
+    pim_enrich.view_element.mass_edit.warning.template: 'PimEnrichBundle:MassEditAction:warning.html.twig'
+
+services:
+    pim_enrich.view_element.mass_edit.warning:
+        parent: pim_enrich.view_element.base
+        arguments:
+            - 'pim_enrich.view_element.mass_edit.warning'
+            - %pim_enrich.view_element.mass_edit.warning.template%
+        calls:
+            - [ addVisibilityChecker, ['@pim_enrich.view_element.visibility_checker.non_empty_property', {property: '[form][operation].vars[data].warningMessages'}] ]
+        tags:
+            - { name: pim_enrich.view_element, type: pim_mass_edit.warning, position: 90 }

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/messages.en.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/messages.en.yml
@@ -126,6 +126,14 @@ pim_enrich:
             label:         Add to groups
             description:   Select the groups in which to add the selected products
             success_flash: Products were successfully added to the selected groups
+            no_group:      No group for now. Please start by creating a group.
+
+        add-to-variant-group:
+            label:                    Add to a variant group
+            description:              Select the variant group in which to add the selected products
+            success_flash:            Products were successfully added to the selected variant group
+            already_in_variant_group: You cannot group the following products (%products%) because they are already in a variant group.
+            no_variant_group:         No variant group for now. Please start by creating a variant group.
 
         set-attribute-requirements:
             label:         Set attribute requirements
@@ -157,6 +165,7 @@ pim_enrich:
             change_family: Change product family
             change_state: Change state of product
             add_to_groups: Add product to groups
+            add_to_variant_group: Add product to a variant group
             mass_edit: Product mass edit actions
             comment: Comment products
             download: Download the product as PDF

--- a/src/Pim/Bundle/EnrichBundle/Resources/views/MassEditAction/configure/add-to-variant-group.html.twig
+++ b/src/Pim/Bundle/EnrichBundle/Resources/views/MassEditAction/configure/add-to-variant-group.html.twig
@@ -2,5 +2,5 @@
 
 {% block formContent %}
     {{ view_elements('pim_mass_edit.warning') }}
-    {{ form_row(form.operation.groups) }}
+    {{ form_row(form.operation.group) }}
 {% endblock %}

--- a/src/Pim/Bundle/EnrichBundle/Resources/views/MassEditAction/configure/edit-common-attributes.html.twig
+++ b/src/Pim/Bundle/EnrichBundle/Resources/views/MassEditAction/configure/edit-common-attributes.html.twig
@@ -27,19 +27,7 @@
 {% endblock %}
 
 {% block formContent %}
-    {% set warningMessages = form.operation.vars.data.getWarningMessages %}
-    {% if warningMessages|length > 0 %}
-        <div class="alert alert-info">
-            <div class="message">
-                <ul>
-                {% for message in warningMessages %}
-                    <li>{{ message.key|trans(message.options) }}</li>
-                {% endfor %}
-                </ul>
-            </div>
-        </div>
-    {% endif %}
-
+    {{ view_elements('pim_mass_edit.warning') }}
     {% for groupView in form.operation.vars.groups %}
         <div class="group-container hide">
             <h4>{{ groupView.label }}</h4>

--- a/src/Pim/Bundle/EnrichBundle/Resources/views/MassEditAction/warning.html.twig
+++ b/src/Pim/Bundle/EnrichBundle/Resources/views/MassEditAction/warning.html.twig
@@ -1,0 +1,12 @@
+{% set warningMessages = form.operation.vars.data.getWarningMessages %}
+{% if warningMessages|length > 0 %}
+    <div class="alert alert-info">
+        <div class="message">
+            <ul>
+                {% for message in warningMessages %}
+                    <li>{{ message.key|trans(message.options) }}</li>
+                {% endfor %}
+            </ul>
+        </div>
+    </div>
+{% endif %}


### PR DESCRIPTION
| Q                    | A
| -------------------- | ---
| Bug fix?             | N
| New feature?         | Y
| BC breaks?           | N
| CI currently passes? | Y
| Tests pass?          | Y
| Scenarios pass?      | ?
| Checkstyle issues?*  | N
| PMD issues?**        | N
| Changelog updated?   | Y
| Fixed tickets        | PIM-2458
| DB schema updated?   | N
| Migration script?    |
| Doc PR               |

This pull request intend to remove the ability to add a product to multiple variant groups. I split add to groups and add to variant group in two seperate operations.

Todo : 

- [ ] rework specs to specify the new add to variant operation
- [ ] Add behat for add to variant group
- [ ] Add behat for import
- [ ] Extra : handle properly "no group for now" case