### PR TITLE
PIM-3664: Fix product media stacktrace regression on missing media on filesystem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.2.x
+
+## Bug fixes
+- PIM-3664: Fix product media stacktrace regression on missing media on filesystem during an export
+
 # 1.2.22 (2015-01-21)
 - Crowdin Updated translations
 

--- a/src/Pim/Bundle/BaseConnectorBundle/Writer/File/CsvProductWriter.php
+++ b/src/Pim/Bundle/BaseConnectorBundle/Writer/File/CsvProductWriter.php
@@ -67,7 +67,7 @@ class CsvProductWriter extends CsvWriter
         } else {
             $this->stepExecution->addWarning(
                 $this->getName(),
-                sprintf('Copy of "%s" failed.', $media['filePath']),
+                'The media has not been found or is not currently available',
                 [],
                 $media
             );


### PR DESCRIPTION
Fix product media stacktrace regression on missing media on filesystem during an export

| Q                    | A
| -------------------- | ---
| Bug fix?             | Yes
| New feature?         | No
| BC breaks?           | No
| CI currently passes? | Yes
| Tests pass?          | Yes
| Scenarios pass?      | Yes also green on EE
| Checkstyle issues?*  | No
| PMD issues?**        | No
| Changelog updated?   | Yes
| Fixed tickets        | PIM-3664
| Doc PR               | -