### PR TITLE
PIM-3697: Add behat when remove attribute from a variant group

### DIFF
--- a/features/Context/AssertionContext.php
+++ b/features/Context/AssertionContext.php
@@ -491,6 +491,25 @@ class AssertionContext extends RawMinkContext
     }
 
     /**
+     * @param string $attribute
+     *
+     * @return bool
+     * @throws ExpectationException
+     * @Then /^I should see that (.*) is not inherited from variant group attribute$/
+     */
+    public function iShouldSeeThatAttributeIsNotInheritedFromVariantGroup($attribute)
+    {
+        $icons = $this->getCurrentPage()->findFieldIcons($attribute);
+        foreach ($icons as $icon) {
+            if (!$icon->hasClass('icon-lock')) {
+                return true;
+            }
+        }
+
+        throw $this->createExpectationException('Affected by a variant group icon is found and it should not');
+    }
+
+    /**
      * @return Page
      */
     protected function getCurrentPage()

--- a/features/variant-group/remove_attributes_from_variant_group.feature
+++ b/features/variant-group/remove_attributes_from_variant_group.feature
@@ -25,3 +25,19 @@ Feature: Remove an attribute from a variant group
     And I remove the "Comment" attribute
     Then I should see flash message "Attribute successfully removed from the variant group"
     And I should see available attribute Comment in group "Other"
+
+  @jira https://akeneo.atlassian.net/browse/PIM-3697
+  Scenario: Successfully remove an attribute from a variant group and ensure the field is enabled back
+    Given I am on the "caterpillar_boots" variant group page
+    And I visit the "Attributes" tab
+    When I add available attribute Comment
+    And I visit the "Other" group
+    Then I should see the Name field
+    And I am on the "boot" product page
+    And the fields Comment should be disabled
+    And I should see that Comment is inherited from variant group attribute
+    And I am on the "caterpillar_boots" variant group page
+    And I visit the "Attributes" tab
+    When I remove the "Comment" attribute
+    And I am on the "boot" product page
+    And I should see that Comment is not inherited from variant group attribute


### PR DESCRIPTION
| Q                    | A
| -------------------- | ---
| Bug fix?             | No
| New feature?         | No
| BC breaks?           | No
| CI currently passes? | Yes
| Tests pass?          | Running
| Scenarios pass?      | Running
| Checkstyle issues?*  | No
| PMD issues?**        | No
| Changelog updated?   | No
| Fixed tickets        | PIM-3693
| DB schema updated?   | No
| Migration script?    | -
| Doc PR               | -