### PR TITLE
PIM-3712: freeze gedmo/doctrine-extensions to v2.3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.2.x
+
+## Bug fixes
+- PIM-3712: Fix installation issue related to the tag of gedmo/doctrine-extensions v2.3.11, we freeze to v2.3.10
+
 # 1.2.23 (2015-01-23)
 
 ## Bug fixes

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "nelmio/api-doc-bundle": "2.4.*",
         "knplabs/knp-menu-bundle":"v2.0.0-alpha2",
         "knplabs/knp-menu":"v2.0.0-alpha2",
-        "gedmo/doctrine-extensions":"2.3.x-dev@dev"
+        "gedmo/doctrine-extensions":"v2.3.10"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*",


### PR DESCRIPTION
| Q                    | A
| -------------------- | ---
| Bug fix?             | Y
| New feature?         | N
| BC breaks?           | N
| CI currently passes? | Y
| Tests pass?          | Y
| Scenarios pass?      | Y
| Checkstyle issues?*  | N
| PMD issues?**        | N
| Changelog updated?   | Y
| Fixed tickets        | PIM-3712
| Doc PR               |