### PR TITLE
PIM-3733: rename parameter akeneo_storage_utils_storage_driver 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,7 +131,7 @@
 - The following constants have been moved:
   * `DOCTRINE_ORM` and `DOCTRINE_MONGODB_ODM` from `Pim\Bundle\CatalogBundle\DependencyInjection\PimCatalogExtension` are now located in `Akeneo\Bundle\StorageUtilsBundle\DependencyInjection\AkeneoStorageUtilsExtension`
   * `DOCTRINE_MONGODB`, `ODM_ENTITIES_TYPE` and `ODM_ENTITY_TYPE` from `Pim\Bundle\CatalogBundle\PimCatalogBundle` are now located in `Akeneo\Bundle\StorageUtilsBundle\AkeneoStorageUtilsBundle`
-- The container parameter `pim_catalog.storage_driver` has been renamed to `akeneo_storage_utils.storage_driver`
+- The container parameter `pim_catalog.storage_driver` has been deleted
 - The following services have been renamed:
   * `pim_catalog.event_subscriber.resolve_target_repository` has been renamed to `akeneo_storage_utils.event_subscriber.resolve_target_repository`
   * `pim_catalog.doctrine.smart_manager_registry` has been renamed to `akeneo_storage_utils.doctrine.smart_manager_registry`

--- a/UPGRADE-1.3.md
+++ b/UPGRADE-1.3.md
@@ -42,13 +42,13 @@ The ProductPersister has been replaced by ProductSaver.
 
 All classes related to Akeneo dual storage (ORM and/or MongoDB) have been moved in a dedicated bundle called *AkeneoStorageUtilsBundle*.
 
-Normally you should not much be impacted by this internal change. The main change concerns the parameter `pim_catalog_storage_driver` that has been deprecated. You are encouraged to replace the parameter `pim_catalog_storage_driver` by `akeneo_storage_utils_storage_driver` in your `app/config/pim_parameters.yml` or `app/config/parameters.yml` configuration file. Please note that the parameter `pim_catalog_storage_driver` is still supported until version 1.4.
+Normally you should not much be impacted by this internal change. The main change concerns the parameter `pim_catalog_storage_driver` that has been renamed. You have to replace the parameter `pim_catalog_storage_driver` by `pim_catalog_product_storage_driver` in your `app/config/pim_parameters.yml` or `app/config/parameters.yml` configuration file.
 
 Here are the other changes:
  * the following constants have been moved:
   * `DOCTRINE_ORM` and `DOCTRINE_MONGODB_ODM` from `Pim\Bundle\CatalogBundle\DependencyInjection\PimCatalogExtension` are now located in `Akeneo\Bundle\StorageUtilsBundle\DependencyInjection\AkeneoStorageUtilsExtension`
   * `DOCTRINE_MONGODB`, `ODM_ENTITIES_TYPE` and `ODM_ENTITY_TYPE` from `Pim\Bundle\CatalogBundle\PimCatalogBundle` are now located in `Akeneo\Bundle\StorageUtilsBundle\AkeneoStorageUtilsBundle`
- * the container parameter `pim_catalog.storage_driver` has been renamed to `akeneo_storage_utils.storage_driver`
+ * the container parameter `pim_catalog.storage_driver` has been deleted
  * the following services have been renamed:
   * `pim_catalog.event_subscriber.resolve_target_repository` has been renamed to `akeneo_storage_utils.event_subscriber.resolve_target_repository`
   * `pim_catalog.doctrine.smart_manager_registry` has been renamed to `akeneo_storage_utils.doctrine.smart_manager_registry`
@@ -72,7 +72,7 @@ Here are the other changes:
   * `Pim\Bundle\CatalogBundle\EventSubscriber\MongoDBODM\EntityTypeSubscriber` becomes `Akeneo\Bundle\StorageUtilsBundle\EventSubscriber\MongoDBODM\EntityTypeSubscriber`
   * `Pim\Bundle\CatalogBundle\EventSubscriber\ResolveTargetRepositorySubscriber` becomes `Akeneo\Bundle\StorageUtilsBundle\EventSubscriber\ResolveTargetRepositorySubscriber`
 
-Please note that former services, and containter parameter `pim_catalog.storage_driver` are still supported thanks to aliases until version 1.4.
+Please note that former services are still supported thanks to aliases until version 1.4.
 
 In case you used one the classes or services listed above, you can easily update your code by doing the following:
 

--- a/app/config/pim_parameters.yml
+++ b/app/config/pim_parameters.yml
@@ -27,8 +27,8 @@ parameters:
     uservoice_key:        ~
     mass_edit_limit:      1000
 
-    # Storage driver can be doctrine/orm or doctrine/mongodb-odm
-    akeneo_storage_utils_storage_driver: doctrine/orm
+    # Product storage driver can be doctrine/orm or doctrine/mongodb-odm
+    pim_catalog_product_storage_driver: doctrine/orm
 
     ## Uncomment to configure mongodb
     # mongodb_server: 'mongodb://localhost:27017'

--- a/build.xml
+++ b/build.xml
@@ -365,7 +365,7 @@
             </fileset>
         </replaceregexp>
 
-        <replaceregexp match="akeneo_storage_utils_storage_driver: doctrine/orm" replace="akeneo_storage_utils_storage_driver: doctrine/mongodb-odm" byline="true">
+        <replaceregexp match="pim_catalog_product_storage_driver: doctrine/orm" replace="pim_catalog_product_storage_driver: doctrine/mongodb-odm" byline="true">
             <fileset dir="${basedir}/app/config/">
                 <include name="pim_parameters*" />
             </fileset>

--- a/features/Context/FeatureContext.php
+++ b/features/Context/FeatureContext.php
@@ -237,7 +237,7 @@ class FeatureContext extends MinkContext implements KernelAwareInterface
      */
     public function getStorageDriver()
     {
-        return $this->getContainer()->getParameter('akeneo_storage_utils.storage_driver');
+        return $this->getContainer()->getParameter('pim_catalog_product_storage_driver');
     }
 
     /**

--- a/src/Akeneo/Bundle/StorageUtilsBundle/AkeneoStorageUtilsBundle.php
+++ b/src/Akeneo/Bundle/StorageUtilsBundle/AkeneoStorageUtilsBundle.php
@@ -2,8 +2,6 @@
 
 namespace Akeneo\Bundle\StorageUtilsBundle;
 
-//TODO: should be trashed
-use Oro\Bundle\EntityBundle\DependencyInjection\Compiler\DoctrineOrmMappingsPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -56,32 +54,6 @@ class AkeneoStorageUtilsBundle extends Bundle
                 'Doctrine\ODM\MongoDB\Tools\ResolveTargetDocumentListener'
             );
             $definition->addTag('doctrine_mongodb.odm.event_listener', array('event' => 'loadClassMetadata'));
-        }
-    }
-
-    /**
-     * @param ContainerBuilder $container
-     * @param array            $mappings
-     */
-    protected function registerDoctrineMappingDriver(ContainerBuilder $container, array $mappings)
-    {
-        $container->addCompilerPass(
-            DoctrineOrmMappingsPass::createYamlMappingDriver(
-                $mappings,
-                array('doctrine.orm.entity_manager'),
-                'akeneo_storage_utils.storage_driver.doctrine/orm'
-            )
-        );
-
-        if (class_exists(self::DOCTRINE_MONGODB)) {
-            $mongoDBClass = self::DOCTRINE_MONGODB;
-            $container->addCompilerPass(
-                $mongoDBClass::createYamlMappingDriver(
-                    $mappings,
-                    array('doctrine.odm.mongodb.document_manager'),
-                    'akeneo_storage_utils.storage_driver.doctrine/mongodb-odm'
-                )
-            );
         }
     }
 }

--- a/src/Akeneo/Bundle/StorageUtilsBundle/DependencyInjection/AkeneoStorageUtilsExtension.php
+++ b/src/Akeneo/Bundle/StorageUtilsBundle/DependencyInjection/AkeneoStorageUtilsExtension.php
@@ -33,23 +33,15 @@ class AkeneoStorageUtilsExtension extends Extension
         $config = $this->processConfiguration(new Configuration(), $configs);
         self::$storageDriver = $config['storage_driver'];
 
-        $container->setParameter($this->getAlias() . '.storage_driver', $this->getStorageDriver());
+        $container->setParameter($this->getAlias() . '.storage_driver', self::$storageDriver);
         // Parameter defining if the mapping driver must be enabled or not
-        $container->setParameter($this->getAlias() . '.storage_driver.' . $this->getStorageDriver(), true);
+        $container->setParameter($this->getAlias() . '.storage_driver.' . self::$storageDriver, true);
 
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('doctrine.yml');
         $loader->load('factories.yml');
 
         $this->loadStorageDriver($container, __DIR__);
-    }
-
-    /**
-     * @return string
-     */
-    public static function getStorageDriver()
-    {
-        return self::$storageDriver;
     }
 
     /**
@@ -72,16 +64,16 @@ class AkeneoStorageUtilsExtension extends Extension
      */
     protected function loadStorageDriver(ContainerBuilder $container, $path)
     {
-        if (!in_array($this->getStorageDriver(), $this->getSupportedStorageDrivers())) {
+        if (!in_array(self::$storageDriver, $this->getSupportedStorageDrivers())) {
             throw new \RuntimeException(
                 sprintf(
                     'The storage driver "%s" is not supported.',
-                    $this->getStorageDriver()
+                    self::$storageDriver
                 )
             );
         }
 
         $loader = new YamlFileLoader($container, new FileLocator($path . '/../Resources/config'));
-        $loader->load(sprintf('storage_driver/%s.yml', $this->getStorageDriver()));
+        $loader->load(sprintf('storage_driver/%s.yml', self::$storageDriver));
     }
 }

--- a/src/Akeneo/Bundle/StorageUtilsBundle/DependencyInjection/AkeneoStorageUtilsExtension.php
+++ b/src/Akeneo/Bundle/StorageUtilsBundle/DependencyInjection/AkeneoStorageUtilsExtension.php
@@ -54,9 +54,10 @@ class AkeneoStorageUtilsExtension extends Extension
 
     /**
      * Provides the supported driver for application storage
+     *
      * @return string[]
      */
-    protected function getSupportedStorageDrivers()
+    public static function getSupportedStorageDrivers()
     {
         return array(self::DOCTRINE_ORM, self::DOCTRINE_MONGODB_ODM);
     }

--- a/src/Akeneo/Bundle/StorageUtilsBundle/DependencyInjection/Configuration.php
+++ b/src/Akeneo/Bundle/StorageUtilsBundle/DependencyInjection/Configuration.php
@@ -24,7 +24,10 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
             ->children()
-                ->scalarNode('storage_driver')->defaultValue('doctrine/orm')->end()
+                ->enumNode('storage_driver')
+                    ->values(AkeneoStorageUtilsExtension::getSupportedStorageDrivers())
+                    ->defaultValue(AkeneoStorageUtilsExtension::DOCTRINE_ORM)
+                ->end()
             ->end()
         ->end();
 

--- a/src/Pim/Bundle/BaseConnectorBundle/DependencyInjection/PimBaseConnectorExtension.php
+++ b/src/Pim/Bundle/BaseConnectorBundle/DependencyInjection/PimBaseConnectorExtension.php
@@ -29,7 +29,7 @@ class PimBaseConnectorExtension extends Extension
         $loader->load('validators.yml');
         $loader->load('steps.yml');
 
-        $storageDriver = $container->getParameter('akeneo_storage_utils.storage_driver');
+        $storageDriver = $container->getParameter('pim_catalog_product_storage_driver');
         $storageConfig = sprintf('storage_driver/%s.yml', $storageDriver);
         if (file_exists(__DIR__ . '/../Resources/config/' . $storageConfig)) {
             $loader->load($storageConfig);

--- a/src/Pim/Bundle/CatalogBundle/DependencyInjection/PimCatalogExtension.php
+++ b/src/Pim/Bundle/CatalogBundle/DependencyInjection/PimCatalogExtension.php
@@ -2,11 +2,11 @@
 
 namespace Pim\Bundle\CatalogBundle\DependencyInjection;
 
-use Akeneo\Bundle\StorageUtilsBundle\DependencyInjection\AkeneoStorageUtilsExtension;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\Finder\Finder;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
  * This is the class that loads and manages your bundle configuration
@@ -15,7 +15,7 @@ use Symfony\Component\Finder\Finder;
  * @copyright 2013 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
-class PimCatalogExtension extends AkeneoStorageUtilsExtension
+class PimCatalogExtension extends Extension
 {
     /**
      * {@inheritdoc}
@@ -41,7 +41,7 @@ class PimCatalogExtension extends AkeneoStorageUtilsExtension
         $loader->load('models.yml');
 
         $this->loadValidationFiles($container);
-        $this->loadStorageDriver($container, __DIR__);
+        $this->loadStorageDriver($container);
     }
 
     /**
@@ -72,5 +72,20 @@ class PimCatalogExtension extends AkeneoStorageUtilsExtension
                 array_values($mappingFiles)
             )
         );
+    }
+
+    /**
+     * Load the mapping for product and product storage
+     *
+     * @param ContainerBuilder $container
+     */
+    protected function loadStorageDriver(ContainerBuilder $container)
+    {
+        $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $storageDriver = $container->getParameter('pim_catalog_product_storage_driver');
+        $storageConfig = sprintf('storage_driver/%s.yml', $storageDriver);
+        if (file_exists(__DIR__ . '/../Resources/config/' . $storageConfig)) {
+            $loader->load($storageConfig);
+        }
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/PimCatalogBundle.php
+++ b/src/Pim/Bundle/CatalogBundle/PimCatalogBundle.php
@@ -4,6 +4,7 @@ namespace Pim\Bundle\CatalogBundle;
 
 use Akeneo\Bundle\StorageUtilsBundle\AkeneoStorageUtilsBundle;
 use Akeneo\Bundle\StorageUtilsBundle\DependencyInjection\Compiler\ResolveDoctrineTargetRepositoryPass;
+use Oro\Bundle\EntityBundle\DependencyInjection\Compiler\DoctrineOrmMappingsPass;
 use Pim\Bundle\CatalogBundle\DependencyInjection\Compiler\RegisterAttributeConstraintGuessersPass;
 use Pim\Bundle\CatalogBundle\DependencyInjection\Compiler\RegisterAttributeTypePass;
 use Pim\Bundle\CatalogBundle\DependencyInjection\Compiler\RegisterProductQueryFilterPass;
@@ -12,6 +13,7 @@ use Pim\Bundle\CatalogBundle\DependencyInjection\Compiler\RegisterProductUpdater
 use Pim\Bundle\CatalogBundle\DependencyInjection\Compiler\RegisterQueryGeneratorsPass;
 use Pim\Bundle\CatalogBundle\DependencyInjection\Compiler\ResolveDoctrineTargetModelPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
  * Pim Catalog Bundle
@@ -20,7 +22,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  * @copyright 2013 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class PimCatalogBundle extends AkeneoStorageUtilsBundle
+class PimCatalogBundle extends Bundle
 {
     /**
      * {@inheritdoc}
@@ -41,6 +43,23 @@ class PimCatalogBundle extends AkeneoStorageUtilsBundle
             realpath(__DIR__ . '/Resources/config/model/doctrine') => 'Pim\Bundle\CatalogBundle\Model'
         );
 
-        $this->registerDoctrineMappingDriver($container, $productMappings);
+        $container->addCompilerPass(
+            DoctrineOrmMappingsPass::createYamlMappingDriver(
+                $productMappings,
+                ['doctrine.orm.entity_manager'],
+                'akeneo_storage_utils.storage_driver.doctrine/orm'
+            )
+        );
+
+        if (class_exists(AkeneoStorageUtilsBundle::DOCTRINE_MONGODB)) {
+            $mongoDBClass = AkeneoStorageUtilsBundle::DOCTRINE_MONGODB;
+            $container->addCompilerPass(
+                $mongoDBClass::createYamlMappingDriver(
+                    $productMappings,
+                    ['doctrine.odm.mongodb.document_manager'],
+                    'akeneo_storage_utils.storage_driver.doctrine/mongodb-odm'
+                )
+            );
+        }
     }
 }

--- a/src/Pim/Bundle/DataGridBundle/DependencyInjection/Compiler/ResolverPass.php
+++ b/src/Pim/Bundle/DataGridBundle/DependencyInjection/Compiler/ResolverPass.php
@@ -40,7 +40,7 @@ class ResolverPass implements CompilerPassInterface
         $datasourceResolver = $container->getDefinition(self::DATASOURCE_ADAPTER_RESOLVER_ID);
 
         if (AkeneoStorageUtilsExtension::DOCTRINE_MONGODB_ODM ===
-            $container->getParameter('akeneo_storage_utils.storage_driver')
+            $container->getParameter('pim_catalog_product_storage_driver')
         ) {
             $datasourceResolver->addMethodCall(
                 'setMongodbAdapterClass',

--- a/src/Pim/Bundle/DataGridBundle/DependencyInjection/PimDataGridExtension.php
+++ b/src/Pim/Bundle/DataGridBundle/DependencyInjection/PimDataGridExtension.php
@@ -39,7 +39,7 @@ class PimDataGridExtension extends Extension
         $loader->load('repositories.yml');
         $loader->load('configurators.yml');
 
-        $storageDriver = $container->getParameter('akeneo_storage_utils.storage_driver');
+        $storageDriver = $container->getParameter('pim_catalog_product_storage_driver');
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load(sprintf('storage_driver/%s.yml', $storageDriver));
     }

--- a/src/Pim/Bundle/DataGridBundle/Resources/config/data_sources.yml
+++ b/src/Pim/Bundle/DataGridBundle/Resources/config/data_sources.yml
@@ -35,7 +35,7 @@ services:
     pim_datagrid.datasource.support_resolver:
         class: %pim_datagrid.datasource.support_resolver.class%
         arguments:
-            - %akeneo_storage_utils.storage_driver%
+            - %pim_catalog_product_storage_driver%
         calls:
             - [addSmartDatasource, ['pim_datasource_product']]
             - [addSmartDatasource, ['pim_datasource_smart']]

--- a/src/Pim/Bundle/DataGridBundle/Resources/config/extensions.yml
+++ b/src/Pim/Bundle/DataGridBundle/Resources/config/extensions.yml
@@ -32,7 +32,7 @@ services:
     pim_datagrid.extension.selector.orm_selector:
         class: %pim_datagrid.extension.selector.orm_selector.class%
         arguments:
-            - %akeneo_storage_utils.storage_driver%
+            - %pim_catalog_product_storage_driver%
             - '@oro_datagrid.datagrid.request_params'
         calls:
             - [addEligibleDatasource, ['pim_datasource_product']]

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/pim.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/pim.yml
@@ -25,7 +25,7 @@ imports:
     - { resource: '@PimEnrichBundle/Resources/config/bundles/twig.yml' }
 
 akeneo_storage_utils:
-    storage_driver: '%akeneo_storage_utils_storage_driver%'
+    storage_driver: '%pim_catalog_product_storage_driver%'
 
 services:
     oro.cache.abstract:

--- a/src/Pim/Bundle/InstallerBundle/Command/DatabaseCommand.php
+++ b/src/Pim/Bundle/InstallerBundle/Command/DatabaseCommand.php
@@ -205,7 +205,7 @@ class DatabaseCommand extends ContainerAwareCommand
      */
     protected function getStorageDriver()
     {
-        return $this->getContainer()->getParameter('akeneo_storage_utils.storage_driver');
+        return $this->getContainer()->getParameter('pim_catalog_product_storage_driver');
     }
 
     /**

--- a/src/Pim/Bundle/InstallerBundle/DataFixtures/MongoDB/LoadFixturesData.php
+++ b/src/Pim/Bundle/InstallerBundle/DataFixtures/MongoDB/LoadFixturesData.php
@@ -23,7 +23,7 @@ class LoadFixturesData extends AbstractLoadFixturesData
 
         foreach ($jobs as $key => $job) {
             // Do not load products and associations with the ORM fixtures when MongoDB support is activated
-            $storageDriver = $this->container->getParameter('akeneo_storage_utils.storage_driver');
+            $storageDriver = $this->container->getParameter('pim_catalog_product_storage_driver');
             if (AkeneoStorageUtilsExtension::DOCTRINE_MONGODB_ODM === $storageDriver
                 && 0 === preg_match('#^fixtures_(product|association)_(csv|yml)$#', $job->getCode())) {
                 unset($jobs[$key]);

--- a/src/Pim/Bundle/InstallerBundle/DataFixtures/ORM/LoadFixturesData.php
+++ b/src/Pim/Bundle/InstallerBundle/DataFixtures/ORM/LoadFixturesData.php
@@ -23,7 +23,7 @@ class LoadFixturesData extends AbstractLoadFixturesData
 
         foreach ($jobs as $key => $job) {
             // Do not load products and associations with the ORM fixtures when MongoDB support is activated
-            $storageDriver = $this->container->getParameter('akeneo_storage_utils.storage_driver');
+            $storageDriver = $this->container->getParameter('pim_catalog_product_storage_driver');
             if (AkeneoStorageUtilsExtension::DOCTRINE_MONGODB_ODM === $storageDriver
                 && 1 === preg_match('#^fixtures_(product|association)_(csv|yml)$#', $job->getCode())) {
                 unset($jobs[$key]);

--- a/src/Pim/Bundle/TransformBundle/DependencyInjection/PimTransformExtension.php
+++ b/src/Pim/Bundle/TransformBundle/DependencyInjection/PimTransformExtension.php
@@ -28,7 +28,7 @@ class PimTransformExtension extends Extension
         $loader->load('cache.yml');
         $loader->load('builders.yml');
 
-        $storageDriver = $container->getParameter('akeneo_storage_utils.storage_driver');
+        $storageDriver = $container->getParameter('pim_catalog_product_storage_driver');
         $storageConfig = sprintf('storage_driver/%s.yml', $storageDriver);
         if (file_exists(__DIR__ . '/../Resources/config/' . $storageConfig)) {
             $loader->load($storageConfig);

--- a/src/Pim/Bundle/VersioningBundle/DependencyInjection/PimVersioningExtension.php
+++ b/src/Pim/Bundle/VersioningBundle/DependencyInjection/PimVersioningExtension.php
@@ -27,7 +27,7 @@ class PimVersioningExtension extends Extension
         $loader->load('builders.yml');
         $loader->load('event_subscribers.yml');
 
-        $storageDriver = $container->getParameter('akeneo_storage_utils.storage_driver');
+        $storageDriver = $container->getParameter('pim_catalog_product_storage_driver');
         $storageConfig = sprintf('storage_driver/%s.yml', $storageDriver);
         if (file_exists(__DIR__ . '/../Resources/config/' . $storageConfig)) {
             $loader->load($storageConfig);

--- a/src/Pim/Bundle/VersioningBundle/Tests/Unit/DependencyInjection/PimVersioningExtensionTest.php
+++ b/src/Pim/Bundle/VersioningBundle/Tests/Unit/DependencyInjection/PimVersioningExtensionTest.php
@@ -38,7 +38,7 @@ class PimVersioningExtensionTest extends \PHPUnit_Framework_TestCase
 
         $this->extension = new PimVersioningExtension();
         $this->containerBuilder = new ContainerBuilder();
-        $this->containerBuilder->setParameter('akeneo_storage_utils.storage_driver', 'foo');
+        $this->containerBuilder->setParameter('pim_catalog_product_storage_driver', 'foo');
     }
 
     /**

--- a/upgrades/1.2-1.3/common/remove_multiple_variant_groups.php
+++ b/upgrades/1.2-1.3/common/remove_multiple_variant_groups.php
@@ -28,7 +28,7 @@ $kernel->boot();
 $container = $kernel->getContainer();
 $connection = $container->get('doctrine')->getConnection();
 $identifierCode = $container->get('pim_catalog.repository.attribute')->getIdentifier()->getCode();
-$storageDriver = $container->getParameter('akeneo_storage_utils_storage_driver');
+$storageDriver = $container->getParameter('pim_catalog_product_storage_driver');
 
 switch ($storageDriver) {
     case 'doctrine/orm':


### PR DESCRIPTION
This PR is transitional. 

Its aim is to rename the **user parameter** `akeneo_storage_utils_storage_driver` to `pim_catalog_product_storage_driver`. Please also note that the **container parameter** `akeneo_storage_utils.storage_driver` has been deleted.  From 1.2 branch, that means the **container parameter** `pim_catalog.storage_driver` has been deleted. This container parameter should be handled directly by AkeneoStorageUtils, which we are not able to do right now.

| Q                    | A
| -------------------- | ---
| Bug fix?             | N
| New feature?         | N 
| BC breaks?           | Y
| CI currently passes? | Y
| Tests pass?          | Y
| Scenarios pass?      | Y
| Checkstyle issues?*  | N
| PMD issues?**        | N
| Changelog updated?   | Y
| Fixed tickets        |
| DB schema updated?   |
| Migration script?    |
| Doc PR               |