### PR TITLE
PIM-3632 : Correctly show scopable attribute icons on scope change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,6 +193,7 @@
 - PIM-3069: Fix image file prefixes not well generated on product creation (import and fixtures)
 - PIM-3548: Do not use the absolute file path of a media
 - PIM-3730: Fix variant group link on product edit page
+- PIM-3632: Correctly show scopable attribute icons on scope change
 
 # 1.2.*
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/pim-init.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/pim-init.js
@@ -27,7 +27,7 @@ define(
                 // Place code that we need to run on every page load here
 
                 $target.find('.remove-attribute').each(function () {
-                    var target = $(this).parent().find('.icons-container').first();
+                    var target = $(this).parent().find('.icons-container');
                     if (target.length) {
                         $(this).appendTo(target).attr('tabIndex', -1);
                     }
@@ -47,9 +47,9 @@ define(
                     }
                 });
                 $target.find('.attribute-field.localizable').each(function () {
-                    var $iconsContainer = $(this).find('div.controls').find('.icons-container').eq(0);
-                    if (!$iconsContainer.find('i.icon-globe').length) {
-                        $iconsContainer.prepend($localizableIcon.clone());
+                    var $iconsContainers = $(this).find('div.controls').find('.icons-container');
+                    if (!$iconsContainers.find('i.icon-globe').length) {
+                        $iconsContainers.prepend($localizableIcon.clone());
                     }
                 });
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/pim-scopable.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/pim-scopable.js
@@ -299,12 +299,17 @@ define(
             },
 
             _showField: function (field, first) {
+                var $icons = $(field).find('.icons-container i:not(".validation-tooltip")');
+
                 if (first) {
                     $(field).addClass('first');
+                    $icons.attr('style', 'display: inline !important');
                     this._setFieldFirst(field);
                 } else {
                     $(field).removeClass('first');
+                    $icons.attr('style', 'display: none !important');
                 }
+
                 $(field).show();
             },
 


### PR DESCRIPTION
| Q                    | A
| -------------------- | ---
| Bug fix?             | Y
| New feature?         | N
| BC breaks?           | N
| CI currently passes? | Y
| Tests pass?          | Y
| Scenarios pass?      | Y (Build 1867)
| Checkstyle issues?*  | N
| PMD issues?**        | N
| Changelog updated?   | Y
| Fixed tickets        | PIM-3632
| DB schema updated?   | N
| Migration script?    | -
| Doc PR               | -