### PR TITLE
PIM-3068: Darken navigation arrows in product grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Bug fixes
 - PIM-1235: Fix information message when trying to delete a category tree used by a channel
+- PIM-3068: Darken navigation arrows in product grid
+- PIM-2094: Regroup attributes validation properties in a subpanel
+- PIM-3700: Fix comment display on long words
 - PIM-2103: Display a loading when deleting a category tree
 
 # 1.3.0-RC1 (2015-02-03)
@@ -199,8 +202,6 @@
 - PIM-3730: Fix variant group link on product edit page
 - PIM-3632: Correctly show scopable attribute icons on scope change
 - PIM-3583: Fix the bad parsed filter value with spaces
-- PIM-3700: Fix comment display on long words
-- PIM-2094: Regroup attributes validation properties in a subpanel
 
 # 1.2.25 (2015-02-04)
 

--- a/src/Pim/Bundle/UIBundle/Resources/public/css/pim.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/css/pim.less
@@ -49,8 +49,12 @@ table.grid {
   }
 }
 
-@media all and (max-width: 1600px) {
-  .grid-toolbar {
+.grid-toolbar {
+  .pagination > ul > li .icon-chevron-left:before,
+  .pagination > ul > li .icon-chevron-right:before {
+    color: #666;
+  }
+  @media all and (max-width: 1600px) {
     .pagination-centered, .page-size label {
       width: auto;
     }


### PR DESCRIPTION
| Q                    | A
| -------------------- | ---
| Bug fix?             | yes
| New feature?         | no
| BC breaks?           | no
| CI currently passes? | Yes
| Tests pass?          | yes
| Scenarios pass?      | Yes
| Checkstyle issues?*  | no
| PMD issues?**        | no
| Changelog updated?   | yes
| Fixed tickets        | PIM-3068
| DB schema updated?   | no
| Migration script?    | no
| Doc PR               | no