### PR TITLE
PIM-3738: Lazy load some part of product value for better edit performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # 1.3.x
 
+## Improvements
+- PIM-3738: Lazy load some part of product value for better edit performance
+
 ## Bug fixes
 - PIM-1235: Fix information message when trying to delete a category tree used by a channel
 - PIM-3068: Darken navigation arrows in product grid

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/ProductRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/ProductRepository.php
@@ -462,16 +462,8 @@ class ProductRepository extends EntityRepository implements
         $qb = $productQb->getQueryBuilder();
         $rootAlias = current($qb->getRootAliases());
         $this->addJoinToValueTables($qb);
-        $qb->leftJoin('Attribute.translations', 'AttributeTranslations');
-        $qb->leftJoin('Attribute.availableLocales', 'AttributeLocales');
         $qb->addSelect('Value');
         $qb->addSelect('Attribute');
-        $qb->addSelect('AttributeTranslations');
-        $qb->addSelect('AttributeLocales');
-        $qb->leftJoin('Attribute.group', 'AttributeGroup');
-        $qb->addSelect('AttributeGroup');
-        $qb->leftJoin('AttributeGroup.translations', 'AGroupTranslations');
-        $qb->addSelect('AGroupTranslations');
         $qb->andWhere(
             $qb->expr()->eq($rootAlias.'.id', $id)
         );


### PR DESCRIPTION
We see difference only on large dataset, otherwise no differences.

| Q                    | A
| -------------------- | ---
| Bug fix?             | N
| New feature?         | N
| BC breaks?           | N
| behat passes? | running
| phpspec pass?      | Y
| Checkstyle issues?*  | N
| PMD issues?**        | N
| Changelog updated?   | N
| Fixed tickets        | PIM-3738
| DB schema updated?   | N
| Migration script?    | N
| Doc PR               | N
