### PR TITLE
PIM-3812 : add translation message

### DIFF
--- a/src/Pim/Bundle/DataGridBundle/Resources/translations/jsmessages.en.yml
+++ b/src/Pim/Bundle/DataGridBundle/Resources/translations/jsmessages.en.yml
@@ -69,3 +69,5 @@ pim.grid.action.show.title:   Show
 
 Please select view: Please select view
 Loading...: Loading...
+
+View : View


### PR DESCRIPTION
Missing translation message in users grid

| Q                    | A
| -------------------- | ---
| Bug fix?             |n
| New feature?         |n
| BC breaks?           |n
| CI currently passes? |y
| Tests pass?          |y
| Scenarios pass?      |y
| Checkstyle issues?*  |
| PMD issues?**        |
| Changelog updated?   |n
| Fixed tickets        | PIM-3812
| DB schema updated?   |n
| Migration script?    |n
| Doc PR               |n