### PR TITLE
PIM-2575: Add a popover to display a long textarea in product datagrid

### DIFF
--- a/src/Pim/Bundle/DataGridBundle/Resources/config/attribute_types.yml
+++ b/src/Pim/Bundle/DataGridBundle/Resources/config/attribute_types.yml
@@ -25,8 +25,9 @@ parameters:
         sorter:          product_value
     pim_datagrid.product.attribute_type.pim_catalog_textarea:
         column:
-            type:        product_value_field
-            selector:    product_value_base
+            type:          product_value_field
+            frontend_type: textarea
+            selector:      product_value_base
         filter:
             type:        product_value_string
             ftype:       string

--- a/src/Pim/Bundle/DataGridBundle/Resources/config/formatters.yml
+++ b/src/Pim/Bundle/DataGridBundle/Resources/config/formatters.yml
@@ -22,6 +22,13 @@ services:
         tags:
             - { name: oro_datagrid.extension.formatter.property, type: product_value_field }
 
+    pim_datagrid.extension.formatter.property.product_value.textarea_property:
+        class: %pim_datagrid.extension.formatter.property.product_value.field_property.class%
+        arguments:
+            - '@translator'
+        tags:
+            - { name: oro_datagrid.extension.formatter.property, type: product_value_textarea }
+
     pim_datagrid.extension.formatter.property.product_value.attribute_options_property:
         class: %pim_datagrid.extension.formatter.property.product_value.attribute_options_property.class%
         arguments:

--- a/src/Pim/Bundle/DataGridBundle/Resources/config/requirejs.yml
+++ b/src/Pim/Bundle/DataGridBundle/Resources/config/requirejs.yml
@@ -93,6 +93,7 @@ config:
         oro/datafilter/filters-manager:             pimdatagrid/js/datafilter/filters-manager
         oro/datafilter/collection-filters-manager:  pimdatagrid/js/datafilter/collection-filters-manager
         oro/datafilter-builder:                     pimdatagrid/js/datafilter-builder
+        oro/datagrid/textarea-cell:                 pimdatagrid/js/datagrid/cell/textarea-cell
 
         pim/template/datagrid/action-launcher-button:           pimdatagrid/templates/datagrid/action-launcher-button.html
         pim/template/datagrid/action-launcher-list-item:        pimdatagrid/templates/datagrid/action-launcher-list-item.html
@@ -100,3 +101,4 @@ config:
         pim/template/datagrid/configure-columns-action:         pimdatagrid/templates/configure-columns-action.html
         pim/template/datagrid/filter/select2-choice-filter:     pimdatagrid/templates/filter/select2-choice-filter.html
         pim/template/datagrid/filter/date-filter:               pimdatagrid/templates/filter/date-filter.html
+        pim/template/datagrid/cell/textarea-cell:               pimdatagrid/templates/datagrid/cell/textarea-cell.html

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/cell/textarea-cell.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/cell/textarea-cell.js
@@ -1,0 +1,99 @@
+/* global define */
+
+'use strict';
+
+define(
+    [
+        'underscore',
+        'oro/datagrid/string-cell',
+        'text!pim/template/datagrid/cell/textarea-cell',
+        'bootstrap'
+    ],
+    function(
+        _,
+        StringCell,
+        template
+    ) {
+        return StringCell.extend({
+            /** @property {Integer} Max length the content should have in the grid before being truncated */
+            datagridMaxLength: 40,
+
+            /** @property {Integer} Max length the content should have in the popover before being truncated */
+            popoverMaxLength: 300,
+
+            template: _.template(template),
+
+            /**
+             * {@inheritdoc}
+             */
+            render: function() {
+                var content = this.formatter.fromRaw(this.model.get(this.column.get('name')));
+
+                if (content.length <= this.datagridMaxLength) {
+                    StringCell.prototype.render.call(this);
+
+                    return this;
+                }
+
+                this.$el.html(
+                    this.template({
+                        id: this.getPopoverID(this.model),
+                        content: this.truncateContent(content, this.datagridMaxLength)
+                    })
+                );
+
+                this.delegateEvents();
+
+                this.$el.popover({
+                    title: this.formatter.fromRaw(this.column.get('label')),
+                    html: true,
+                    content: this.truncateContent(content, this.popoverMaxLength),
+                    delay: {
+                        show: 500,
+                        hide: 100
+                    },
+                    container: '#' + this.getPopoverID(this.model),
+                    trigger: 'hover',
+                    // Automatic placement for popover
+                    // Source: https://github.com/twbs/bootstrap/issues/1833#issuecomment-4102195
+                    placement: function (tip, element) {
+                        var offset = $(element).offset();
+                        var width = $(document).outerWidth();
+                        var horiz = 0.5 * width - offset.left;
+
+                        return horiz > 0 ? 'right' : 'left';
+                    }
+                });
+
+                return this;
+            },
+
+            /**
+             * Return the unique popover DOM ID with the given model
+             *
+             * @param {Object} model
+             *
+             * @returns {String}
+             */
+            getPopoverID: function (model) {
+                return 'textarea-popover-' + model.get('id');
+            },
+
+            /**
+             * Truncate the given content depending on the given max length.
+             *
+             * @param {String}  content
+             * @param {Integer} maxLength
+             *
+             * @returns {String}
+             */
+            truncateContent: function (content, maxLength) {
+                if (content.length > maxLength) {
+                    return content.substring(0, maxLength) + ' ...';
+                }
+
+                return content;
+            }
+        });
+    }
+);

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/templates/datagrid/cell/textarea-cell.html
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/templates/datagrid/cell/textarea-cell.html
@@ -1,0 +1,3 @@
+<span id="<%- id %>">
+    <%- content %>
+</span>

--- a/src/Pim/Bundle/UIBundle/Resources/public/css/pim.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/css/pim.less
@@ -177,6 +177,17 @@ a.back-link i {
   padding-left: 5px;
 }
 
+.popover {
+  -webkit-hyphens: auto;
+  -moz-hyphens: auto;
+  -ms-hyphens: auto;
+  -o-hyphens: auto;
+  hyphens: auto;
+  word-wrap: break-word;
+  width: 400px;
+  max-width: none;
+}
+
 /** Dashboard ********************************************************************************************************/
 .dashboard {
   background-color: white;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Added Specs | N |
| Added Behats | N |
| Changelog updated | N |
| Review and 2 GTM |  |
| Micro Demo to the PO (Story only) | Y |
| Migration script | N |
| Tech Doc | N |

This PR displays a popover on long textarea fields when displayed in the datagrid:

![products](https://cloud.githubusercontent.com/assets/301169/13530518/052c554c-e222-11e5-80e1-b0caa78371b0.png)
