### PR TITLE
PIM-3758: hide the caterory tree on products grid if user do not have the right to list categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 - PIM-3771: Create version when modifying variant group attribute
+- PIM-3758: Hide the category tree on products grid if user do not have the right to list categories
 
 ## BC breaks
 - Change the constructor of `Pim/Bundle/TransformBundle/Denormalizer/Structured/ProductValuesDenormalizer`, removed `Pim\Bundle\CatalogBundle\Repository\AttributeRepositoryInterface`, added `Akeneo\Bundle\StorageUtilsBundle\Doctrine\SmartManagerRegistry` as the second argument and `pim_catalog.entity.attribute.class` as the last argument

--- a/features/acl/assert_acl.feature
+++ b/features/acl/assert_acl.feature
@@ -47,3 +47,16 @@ Feature: Define user rights
       | Remove an attribute         | "color" attribute                        | Delete                  |                          |
       | Remove an export profile    | "footwear_option_export" export job edit | Delete                  |                          |
       | Remove an import profile    | "footwear_group_import" import job edit  | Delete                  |                          |
+
+  @jira https://akeneo.atlassian.net/browse/PIM-3758
+  Scenario: Successfully remove and add the List categories right
+    Given I am on the "Administrator" role page
+    When I remove rights to List categories
+    And I save the role
+    And I wait 10 seconds
+    Then I am on the products page
+    And I should not see "2014 Collection"
+    Then I reset the "Administrator" rights
+    And I wait 10 seconds
+    And I am on the products page
+    And I should see "2014 Collection"

--- a/src/Pim/Bundle/EnrichBundle/Resources/views/Product/index.html.twig
+++ b/src/Pim/Bundle/EnrichBundle/Resources/views/Product/index.html.twig
@@ -50,8 +50,11 @@
 
     {{ elements.page_header(title, buttons, subtitle) }}
 
-    <div class="row-fluid has-sidebar">
-        <div id="tree" data-datalocale="{{ dataLocale.code }}" data-relatedentity="product"></div>
+    {% set categoriesGranted = resource_granted('pim_enrich_category_list') %}
+    <div class="row-fluid {{ categoriesGranted ? 'has-sidebar': '' }}">
+        {% if categoriesGranted %}
+            <div id="tree" data-datalocale="{{ dataLocale.code }}" data-relatedentity="product"></div>
+        {% endif %}
         <div id="product-grid">
             {{ dataGrid.renderStatefulGrid('product-grid', { dataLocale: dataLocale.code }) }}
         </div>


### PR DESCRIPTION
| Q                    | A
| -------------------- | ---
| Bug fix?             | Yes
| New feature?         | No
| BC breaks?           | No
| CI currently passes? | Yes
| Tests pass?          | Yes
| Scenarios pass?      | Yes
| Checkstyle issues?*  | No
| PMD issues?**        | No
| Changelog updated?   | Yes
| Fixed tickets        | PIM-3758
| DB schema updated?   | No
| Migration script?    | -
| Doc PR               | -