### PR TITLE
PIM-3825: Use the new --no-log batch option

### DIFF
--- a/src/Pim/Bundle/InstallerBundle/DataFixtures/AbstractLoadFixturesData.php
+++ b/src/Pim/Bundle/InstallerBundle/DataFixtures/AbstractLoadFixturesData.php
@@ -94,6 +94,7 @@ abstract class AbstractLoadFixturesData extends AbstractFixture implements
                     'command'     => 'akeneo:batch:job',
                     'code'        => $job->getCode(),
                     '--no-debug'  => true,
+                    '--no-log'    => true,
                     '-v'          => true
                 ]
             ),


### PR DESCRIPTION
With the `0.4` version of the BatchBundle, we should use  the `--no-log` option to hide all logs during installation.