### PR TITLE
Allow API to receive requests for skus with "."

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - PIM-3874: clicking a category gives an error with only "list categories" permission 
 - PIM-3771: Create version when modifying variant group attribute
 - PIM-3758: Hide the category tree on products grid if user do not have the right to list categories
+- PIM-2187: Allows API to receive requests to skus with "."
 
 ## BC breaks
 - Change the constructor of `Pim/Bundle/TransformBundle/Denormalizer/Structured/ProductValuesDenormalizer`, removed `Pim\Bundle\CatalogBundle\Repository\AttributeRepositoryInterface`, added `Akeneo\Bundle\StorageUtilsBundle\Doctrine\SmartManagerRegistry` as the second argument and `pim_catalog.entity.attribute.class` as the last argument

--- a/src/Pim/Bundle/WebServiceBundle/Controller/Rest/ProductController.php
+++ b/src/Pim/Bundle/WebServiceBundle/Controller/Rest/ProductController.php
@@ -85,7 +85,7 @@ class ProductController extends FOSRestController
 	 * possibility of conflict with a legitimate sku.
 	 */
 	$identifier = str_replace('_0x2E_', '.', $identifier);	
-			
+	
         $manager = $this->get('pim_catalog.manager.product');
         $product = $manager->findByIdentifier($identifier);
 

--- a/src/Pim/Bundle/WebServiceBundle/Controller/Rest/ProductController.php
+++ b/src/Pim/Bundle/WebServiceBundle/Controller/Rest/ProductController.php
@@ -77,14 +77,14 @@ class ProductController extends FOSRestController
      */
     protected function handleGetRequest($identifier, $channels, $locales)
     {
-		/* Handle requests for skus that contain a period
-		 * cURL cannot handle API requests that contain a period
-		 * but we can substitute with hexidecimal in the cURL request
-		 * and then replace it here.
-		 * Using additional leading and trailing underscore to limit the
-		 * possibility of conflict with a legitimate sku.
-		 */
-		$identifier = str_replace('_0x2E_', '.', $identifier);	
+	/* Handle requests for skus that contain a period
+	 * cURL cannot handle API requests that contain a period
+	 * but we can substitute with hexidecimal in the cURL request
+	 * and then replace it here.
+	 * Using additional leading and trailing underscore to limit the
+	 * possibility of conflict with a legitimate sku.
+	 */
+	$identifier = str_replace('_0x2E_', '.', $identifier);	
 			
         $manager = $this->get('pim_catalog.manager.product');
         $product = $manager->findByIdentifier($identifier);

--- a/src/Pim/Bundle/WebServiceBundle/Controller/Rest/ProductController.php
+++ b/src/Pim/Bundle/WebServiceBundle/Controller/Rest/ProductController.php
@@ -77,6 +77,15 @@ class ProductController extends FOSRestController
      */
     protected function handleGetRequest($identifier, $channels, $locales)
     {
+		/* Handle requests for skus that contain a period
+		 * cURL cannot handle API requests that contain a period
+		 * but we can substitute with hexidecimal in the cURL request
+		 * and then replace it here.
+		 * Using additional leading and trailing underscore to limit the
+		 * possibility of conflict with a legitimate sku.
+		 */
+		$identifier = str_replace('_0x2E_', '.', $identifier);	
+			
         $manager = $this->get('pim_catalog.manager.product');
         $product = $manager->findByIdentifier($identifier);
 


### PR DESCRIPTION
| Q                    | A
| -------------------- | ---
| Bug fix?             | Y, For Issue #2187
| New feature?         | N
| BC breaks?           | None
| Tests pass?          | Y
| Scenarios pass?      | Y
| Changelog updated?   | Y
| Fixed tickets        | #2187
| DB schema updated?   | N
| Migration script?    | N/A

*> ./src/Pim/Bundle/WebServiceBundle/Controller/Rest/ProductController.php

Allows API to receive requests to skus with "." by having a string
replace for the code "_0x2E_" to period.