### PR TITLE
PIM-3929: Categories with circular references are skipped in processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - PIM-3874: clicking a category gives an error with only "list categories" permission
 - PIM-3771: Create version when modifying variant group attribute
 - PIM-3758: Hide the category tree on products grid if user do not have the right to list categories
+- PIM-3929: Categories with circular references are skipped in processor during import
 
 ## BC breaks
 - Change the constructor of `Pim/Bundle/TransformBundle/Denormalizer/Structured/ProductValuesDenormalizer`, removed `Pim\Bundle\CatalogBundle\Repository\AttributeRepositoryInterface`, added `Akeneo\Bundle\StorageUtilsBundle\Doctrine\SmartManagerRegistry` as the second argument and `pim_catalog.entity.attribute.class` as the last argument

--- a/spec/Pim/Bundle/BaseConnectorBundle/Processor/CategoryProcessorSpec.php
+++ b/spec/Pim/Bundle/BaseConnectorBundle/Processor/CategoryProcessorSpec.php
@@ -562,10 +562,6 @@ class CategoryProcessorSpec extends ObjectBehavior
             ->shouldBeCalled();
 
         $this->setStepExecution($stepExecution);
-        $this->process($data)->shouldReturn([
-            'child_category' => $childCategory,
-            'parent_category' => $parentCategory,
-            'grand_parent_category' => $grandParentCategory
-        ]);
+        $this->process($data)->shouldReturn([]);
     }
 }

--- a/src/Pim/Bundle/BaseConnectorBundle/Processor/CategoryProcessor.php
+++ b/src/Pim/Bundle/BaseConnectorBundle/Processor/CategoryProcessor.php
@@ -189,7 +189,7 @@ class CategoryProcessor extends TransformerProcessor
      *
      * @return null
      */
-    private function checkCircularReferences(array $categories, array $items)
+    private function checkCircularReferences(array &$categories, array $items)
     {
         $invalidCodes = array();
         $checkParent = function ($category, $visited = array()) use (&$invalidCodes, &$checkParent) {
@@ -211,8 +211,6 @@ class CategoryProcessor extends TransformerProcessor
             }
         }
 
-        // TODO: Categories which are skipped because of a circular references problem should be detach
-        // or $categories should be passed by reference in checkCircularReferences()
         foreach (array_unique($invalidCodes) as $code) {
             unset($categories[$code]);
             $this->setItemErrors(


### PR DESCRIPTION
| Q                    | A
| -------------------- | ---
| Bug fix?             | y
| New feature?         | n
| BC breaks?           | n
| CI currently passes? | yes
| Tests pass?          | y
| Scenarios pass?      |
| Checkstyle issues?*  | n
| PMD issues?**        | n
| Changelog updated?   | y
| Fixed tickets        | PIM-3929
| DB schema updated?   | n
| Migration script?    | n
| Doc PR               |