### PR TITLE
[WIP] PIM-3905: Add category field copier

### DIFF
--- a/features/update/copy_category.feature
+++ b/features/update/copy_category.feature
@@ -1,0 +1,16 @@
+Feature: Update category fields
+  In order to update products
+  As an internal process or any user
+  I need to be able to copy a category field of a product
+
+  Scenario: Successfully update a text field
+    Given a "apparel" catalog configuration
+    And the following products:
+      | sku                 | categories                                 |
+      | AKN_FROM            | men_2015_spring, men_2015_summer, men_2014 |
+      | AKN_NOT_CATEGORIZED |                                            |
+      | AKN_CATEGORIZED     | men_2013                                   |
+    Then I should get the following products after apply the following updater to it:
+      | product             | actions                                                                                                                                            | result                                                             |
+      | AKN_FROM            | [{"type": "copy_category", "from_product": "AKN_FROM", "to_product": "AKN_NOT_CATEGORIZED", "from_field": "categories", "to_field": "categories"}] | {"categories": ["men_2015_spring", "men_2015_summer", "men_2014"]} |
+      | AKN_FROM            | [{"type": "copy_category", "from_product": "AKN_FROM", "to_product": "AKN_CATEGORIZED", "from_field": "categories", "to_field": "categories"}]     | {"categories": ["men_2015_spring", "men_2015_summer", "men_2014"]} |

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/updaters.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/updaters.yml
@@ -35,6 +35,7 @@ parameters:
     pim_catalog.updater.copier.simpleselect_value.class:     Pim\Bundle\CatalogBundle\Updater\Copier\BaseAttributeCopier
     pim_catalog.updater.copier.multiselect_value.class:      Pim\Bundle\CatalogBundle\Updater\Copier\MultiSelectAttributeCopier
     pim_catalog.updater.copier.price_collection_value.class: Pim\Bundle\CatalogBundle\Updater\Copier\PriceCollectionAttributeCopier
+    pim_catalog.updater.copier.category_field.class:         Pim\Bundle\CatalogBundle\Updater\Copier\CategoryFieldCopier
 
     pim_catalog.updater.adder.registry.class:               Pim\Bundle\CatalogBundle\Updater\Adder\AdderRegistry
     pim_catalog.updater.adder.category_field.class:         Pim\Bundle\CatalogBundle\Updater\Adder\CategoryFieldAdder
@@ -307,6 +308,14 @@ services:
         arguments:
             - ['pim_catalog_price_collection']
             - ['pim_catalog_price_collection']
+        tags:
+            - { name: 'pim_catalog.updater.copier' }
+
+    pim_catalog.updater.copier.category_field:
+        class: %pim_catalog.updater.copier.category_field.class%
+        arguments:
+            - ['categories']
+            - ['categories']
         tags:
             - { name: 'pim_catalog.updater.copier' }
 

--- a/src/Pim/Bundle/CatalogBundle/Updater/Copier/AbstractFieldCopier.php
+++ b/src/Pim/Bundle/CatalogBundle/Updater/Copier/AbstractFieldCopier.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\Updater\Copier;
+
+/**
+ * Abstract field copier
+ *
+ * @author    Willy Mesnage <willy.mesnage@akeneo.com>
+ * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+abstract class AbstractFieldCopier implements FieldCopierInterface
+{
+    /** @var array */
+    protected $supportedFromFields = [];
+
+    /** @var array */
+    protected $supportedToFields = [];
+
+    /**
+     * @param array $supportedFromFields
+     * @param array $supportedToFields
+     */
+    public function __construct(array $supportedFromFields, array $supportedToFields)
+    {
+        $this->supportedFromFields = $supportedFromFields;
+        $this->supportedToFields   = $supportedToFields;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsFields($fromField, $toField)
+    {
+        $supportsFromField = in_array($fromField, $this->supportedFromFields);
+        $supportsToField   = in_array($toField, $this->supportedToFields);
+
+        return $supportsFromField && $supportsToField;
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Updater/Copier/CategoryFieldCopier.php
+++ b/src/Pim/Bundle/CatalogBundle/Updater/Copier/CategoryFieldCopier.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\Updater\Copier;
+
+use Pim\Bundle\CatalogBundle\Model\ProductInterface;
+
+/**
+ * Copies the category field
+ *
+ * @author    Willy Mesnage <willy.mesnage@akeneo.com>
+ * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class CategoryFieldCopier extends AbstractFieldCopier
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function copyFieldData(
+        ProductInterface $fromProduct,
+        ProductInterface $toProduct,
+        $fromField,
+        $toField,
+        array $options = []
+    ) {
+        $categoriesToCopy   = $fromProduct->getCategories();
+        $categoriesToRemove = $toProduct->getCategories();
+
+        foreach ($categoriesToRemove as $categoryToRemove) {
+            $toProduct->removeCategory($categoryToRemove);
+        }
+
+        foreach ($categoriesToCopy as $categoryToCopy) {
+            $toProduct->addCategory($categoryToCopy);
+        }
+    }
+}


### PR DESCRIPTION
| Q                    | A
| -------------------- | ---
| Bug fix?             | n
| New feature?         |
| BC breaks?           | n
| CI currently passes? | 
| Tests pass?          | y
| Scenarios pass?      | n
| Checkstyle issues?*  | n
| PMD issues?**        | n
| Changelog updated?   | n
| Fixed tickets        | PIM-3905
| DB schema updated?   | n
| Migration script?    | n
| Doc PR               |

- [x] Add category field copier
- [ ] Refactor updater command to be able to use it with a "from_product" and a "to_product"
- [ ] Add behat context to be able to use updater command with from and to product