### PR TITLE
PIM-4017: Fix bug with variant group when saving an empty media attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - PIM-3956: Fix user can add an attribute in a group even if he does not have the permission
 - PIM-3965: Fix groups without labels are not displayed in the product grid cell
 - PIM-3971: Cache results for Select2 on product edit form
+- PIM-4017: Fix save an empty media attribute with variant group
 
 ## BC breaks
 - Change the constructor of `Pim\Bundle\EnrichBundle\Form\Subscriber\AddAttributeTypeRelatedFieldsSubscriber` to include `Oro\Bundle\SecurityBundle\SecurityFacade`and `Pim\Bundle\CatalogBundle\Repository\AttributeGroupRepositoryInterface`

--- a/src/Pim/Bundle/CatalogBundle/Manager/MediaManager.php
+++ b/src/Pim/Bundle/CatalogBundle/Manager/MediaManager.php
@@ -218,8 +218,12 @@ class MediaManager
      */
     public function createFromFilePath($filePath)
     {
-        $media = $this->factory->createMedia();
-        $media->setFilename(pathinfo($filePath, PATHINFO_BASENAME));
+        $media    = $this->factory->createMedia();
+        $fileName = pathinfo($filePath, PATHINFO_BASENAME);
+
+        if ('' !== $fileName) {
+            $media->setFilename(pathinfo($filePath, PATHINFO_BASENAME));
+        }
 
         return $media;
     }


### PR DESCRIPTION
| Q                    | A
| -------------------- | ---
| Bug fix?             | YES
| New feature?         | n
| BC breaks?           | n
| CI currently passes? | 
| Tests pass?          | y
| Scenarios pass?      | 
| Checkstyle issues?*  | n
| PMD issues?**        | n
| Changelog updated?   | y
| Fixed tickets        | PIM-4017
| DB schema updated?   | n
| Migration script?    | n
| Doc PR               |