### PR TITLE
PIM-4019: option code is properly displayed during option deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 - PIM-3961: Fix inconsistencies in unique value constraint validator
 - PIM-3416: Fix less / more than date filter
+- PIM-4019: option code is properly displayed during option deletion in attribute edit form
 
 # 1.3.6 (2015-04-01)
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/pim-attributeoptionview.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/pim-attributeoptionview.js
@@ -138,9 +138,15 @@ define(
                 }
             },
             deleteItem: function() {
-                Dialog.confirm(__('pim_enrich.item.delete.confirm.content'), __('pim_enrich.item.delete.confirm.title'), _.bind(function () {
-                    this.parent.deleteItem(this);
-                }, this));
+                var itemCode = this.el.firstChild.innerText;
+
+                Dialog.confirm(
+                    __('pim_enrich.item.delete.confirm.content', {'itemName': itemCode}),
+                    __('pim_enrich.item.delete.confirm.title', {'itemName': itemCode}),
+                    _.bind(function () {
+                            this.parent.deleteItem(this);
+                    }, this)
+                );
             },
             updateItem: function() {
                 this.inLoading(true);


### PR DESCRIPTION
| Q                    | A
| -------------------- | ---
| Bug fix?             | y
| New feature?         | n
| BC breaks?           | n
| CI currently passes? | 
| Tests pass?          | y
| Scenarios pass?      | y
| Checkstyle issues?*  | n
| PMD issues?**        | n
| Changelog updated?   | y
| Fixed tickets        | PIM-4019
| DB schema updated?   | n
| Migration script?    | n
| Doc PR               |