### PR TITLE
Use default phpspec formatter

### DIFF
--- a/phpspec.yml
+++ b/phpspec.yml
@@ -1,3 +1,2 @@
-formatter.name: pretty
 extensions:
     - Akeneo\SkipExampleExtension


### PR DESCRIPTION
We have too many specs now. Displaying all of them is useless...