### PR TITLE
PIM-4047: Missing translation key for a number value which should not be decimal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 - PIM-4045: Fix completeness computation with behat
+- PIM-4047: Missing translation key for a number value which should not be decimal in edit form
 
 # 1.3.7 (2015-04-03)
 

--- a/src/Pim/Bundle/CatalogBundle/Resources/translations/validators.en.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/translations/validators.en.yml
@@ -10,3 +10,4 @@ This value should be Yes or No:                                  This value shou
 This value should not be blank:                                  This value should not be blank
 Option code may contain only letters, numbers and underscores:   Option code may contain only letters, numbers and underscores
 This color is already used by another channel:                   This color is already used by another channel
+This value should not be a decimal.:                             This value should not be a decimal.


### PR DESCRIPTION
| Q                    | A
| -------------------- | ---
| Bug fix?             | y
| New feature?         | n
| BC breaks?           | n
| CI currently passes? | /
| Tests pass?          | y
| Scenarios pass?      | y
| Checkstyle issues?*  | n
| PMD issues?**        | n
| Changelog updated?   | y
| Fixed tickets        | PIM-4047
| DB schema updated?   | n
| Migration script?    |
| Doc PR               |