### PR TITLE
[TR] PIM-4113: initialize cursors on first item during creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.3.x
+
+## Bug fixes
+- PIM-4113: Initialize cursors on first item during creation
+
 # 1.3.9 (2015-04-21)
 
 ## Bug fixes

--- a/spec/Akeneo/Bundle/StorageUtilsBundle/Doctrine/MongoDBODM/Cursor/CursorFactorySpec.php
+++ b/spec/Akeneo/Bundle/StorageUtilsBundle/Doctrine/MongoDBODM/Cursor/CursorFactorySpec.php
@@ -4,6 +4,8 @@ namespace spec\Akeneo\Bundle\StorageUtilsBundle\Doctrine\MongoDBODM\Cursor;
 
 use PhpSpec\ObjectBehavior;
 use Doctrine\ODM\MongoDB\Query\Builder;
+use Doctrine\MongoDB\Query\Query;
+use Doctrine\ODM\MongoDB\Cursor;
 
 /**
  * @require Doctrine\ODM\MongoDB\Query\Builder
@@ -26,8 +28,11 @@ class CursorFactorySpec extends ObjectBehavior
         $this->shouldImplement('Akeneo\Component\StorageUtils\Cursor\CursorFactoryInterface');
     }
 
-    function it_create_a_cursor(Builder $queryBuilder)
+    function it_creates_a_cursor(Builder $queryBuilder, Query $query, Cursor $cursor)
     {
+        $queryBuilder->getQuery()->shouldBeCalled()->willReturn($query);
+        $query->execute()->shouldBeCalled()->willReturn($cursor);
+
         $cursor = $this->createCursor($queryBuilder);
         $cursor->shouldBeAnInstanceOf('Akeneo\Component\StorageUtils\Cursor\CursorInterface');
     }

--- a/spec/Akeneo/Bundle/StorageUtilsBundle/Doctrine/MongoDBODM/Cursor/CursorSpec.php
+++ b/spec/Akeneo/Bundle/StorageUtilsBundle/Doctrine/MongoDBODM/Cursor/CursorSpec.php
@@ -12,9 +12,11 @@ use Doctrine\ODM\MongoDB\Cursor;
  */
 class CursorSpec extends ObjectBehavior
 {
-    function let(
-        Builder $queryBuilder
-    ) {
+    function let(Builder $queryBuilder, Query $query, Cursor $cursor)
+    {
+        $queryBuilder->getQuery()->willReturn($query);
+        $query->execute()->willReturn($cursor);
+
         $this->beConstructedWith($queryBuilder);
     }
 
@@ -24,19 +26,19 @@ class CursorSpec extends ObjectBehavior
         $this->shouldImplement('Akeneo\Component\StorageUtils\Cursor\CursorInterface');
     }
 
-    function it_is_countable($queryBuilder, Query $query, Cursor $cursor)
+    function it_is_countable($queryBuilder, $query, $cursor)
     {
         $this->shouldImplement('\Countable');
 
-        $queryBuilder->getQuery()->shouldBeCalled()->willReturn($query);
-        $query->execute()->shouldBeCalled()->willReturn($cursor);
-        $cursor->count()->shouldBeCalled()->willReturn(13);
-        $cursor->getNext()->shouldBeCalled()->willReturn(null);
+        $queryBuilder->getQuery()->willReturn($query);
+        $query->execute()->willReturn($cursor);
+        $cursor->count()->willReturn(13);
+        $cursor->getNext()->willReturn(null);
 
         $this->shouldHaveCount(13);
     }
 
-    function it_is_iterable($queryBuilder, Query $query, Cursor $mongodbCursor)
+    function it_is_iterable($cursor)
     {
         $this->shouldImplement('\Iterator');
 
@@ -48,19 +50,16 @@ class CursorSpec extends ObjectBehavior
 
         $data = array_merge([], $initialData);
 
-        $queryBuilder->getQuery()->shouldBeCalled()->willReturn($query);
-        $query->execute()->shouldBeCalled()->willReturn($mongodbCursor);
-
-        $mongodbCursor->getNext()->shouldBeCalled()->will(function () use ($mongodbCursor, &$data) {
+        $cursor->getNext()->will(function () use ($cursor, &$data) {
             $stepData = array_shift($data);
-            $mongodbCursor->current()->willReturn($stepData);
+            $cursor->current()->willReturn($stepData);
             return $stepData;
         });
-        $mongodbCursor->reset()->shouldBeCalled()->will(function () use ($mongodbCursor, &$data, $initialData) {
+        $cursor->reset()->will(function () use ($cursor, &$data, $initialData) {
             $data = array_merge([], $initialData);
         });
 
-        $mongodbCursor->count()->shouldBeCalled()->willReturn(3);
+        $cursor->count()->willReturn(3);
 
         // methods that not iterate can be called twice
         $this->rewind()->shouldReturn(null);

--- a/spec/Akeneo/Bundle/StorageUtilsBundle/Doctrine/ORM/Cursor/CursorFactorySpec.php
+++ b/spec/Akeneo/Bundle/StorageUtilsBundle/Doctrine/ORM/Cursor/CursorFactorySpec.php
@@ -2,9 +2,12 @@
 
 namespace spec\Akeneo\Bundle\StorageUtilsBundle\Doctrine\ORM\Cursor;
 
-use PhpSpec\ObjectBehavior;
-use Doctrine\ORM\QueryBuilder;
+use Doctrine\ORM\AbstractQuery;
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Query\Expr\From;
+use Doctrine\ORM\QueryBuilder;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
 
 class CursorFactorySpec extends ObjectBehavior
 {
@@ -25,8 +28,17 @@ class CursorFactorySpec extends ObjectBehavior
         $this->shouldImplement('Akeneo\Component\StorageUtils\Cursor\CursorFactoryInterface');
     }
 
-    function it_create_a_cursor(QueryBuilder $queryBuilder)
+    function it_creates_a_cursor(QueryBuilder $queryBuilder, AbstractQuery $query, From $from)
     {
+        $queryBuilder->getRootAliases()->willReturn(['a']);
+        $queryBuilder->getDQLPart('from')->willReturn([$from]);
+        $queryBuilder->select('a.id')->willReturn($queryBuilder);
+        $queryBuilder->resetDQLPart('from')->willReturn($queryBuilder);
+        $queryBuilder->from(Argument::any(), Argument::any(), 'a.id')->willReturn($queryBuilder);
+        $queryBuilder->groupBy('a.id')->willReturn($queryBuilder);
+        $queryBuilder->getQuery()->willReturn($query);
+        $query->getArrayResult()->willReturn([]);
+
         $cursor = $this->createCursor($queryBuilder);
         $cursor->shouldBeAnInstanceOf('Akeneo\Component\StorageUtils\Cursor\CursorInterface');
     }

--- a/src/Akeneo/Bundle/StorageUtilsBundle/Doctrine/MongoDBODM/Cursor/Cursor.php
+++ b/src/Akeneo/Bundle/StorageUtilsBundle/Doctrine/MongoDBODM/Cursor/Cursor.php
@@ -38,6 +38,7 @@ class Cursor extends AbstractCursor
     {
         $this->queryBuilder = $queryBuilder;
         $this->batchSize = $batchSize;
+        $this->rewind();
     }
 
     /**

--- a/src/Akeneo/Bundle/StorageUtilsBundle/Doctrine/ORM/Cursor/Cursor.php
+++ b/src/Akeneo/Bundle/StorageUtilsBundle/Doctrine/ORM/Cursor/Cursor.php
@@ -2,11 +2,11 @@
 
 namespace Akeneo\Bundle\StorageUtilsBundle\Doctrine\ORM\Cursor;
 
+use Akeneo\Bundle\StorageUtilsBundle\Doctrine\ORM\Repository\CursorableRepositoryInterface;
 use Akeneo\Component\StorageUtils\Cursor\AbstractCursor;
 use ArrayIterator;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\QueryBuilder;
-use Akeneo\Bundle\StorageUtilsBundle\Doctrine\ORM\Repository\CursorableRepositoryInterface;
 use LogicException;
 
 /**
@@ -61,6 +61,7 @@ class Cursor extends AbstractCursor
         $this->queryBuilder = clone $queryBuilder;
         $this->entityManager = $entityManager;
         $this->pageSize = $pageSize;
+        $this->rewind();
     }
 
     /**


### PR DESCRIPTION
| Q                    | A
| -------------------- | ---
| Bug fix?             | Y
| New feature?         | N
| BC breaks?           | N
| CI currently passes? | Y
| Tests pass?          | Y
| Scenarios pass?      | running
| Checkstyle issues?*  | N
| PMD issues?**        | N
| Changelog updated?   | Y
| Fixed tickets        | PIM-4113
| DB schema updated?   |
| Migration script?    |
| Doc PR               |


Imagine the following code:

```php
$products = $pqb->execute(); // returns the products 12468511, 13675186, 13851841

$first = $products->current();
if (null !== $first) {
    echo "FIRST=" . $first->getIdentifier()  . "\n";
} else {
    echo "FIRST IS NULL\n";
}

$i = 1;
foreach ($products as $product) {
    echo "$i    " .  $product->getIdentifier() . "\n";
    $i++;
}
```

Result before:
```
FIRST IS NULL
1    12468511
2    13675186
3    13851841
```

Result now:
```
FIRST=12468511
1    12468511
2    13675186
3    13851841
```
