### PR TITLE
Urlizer::urlize works with a string

### DIFF
--- a/spec/Pim/Bundle/CatalogBundle/Manager/MediaManagerSpec.php
+++ b/spec/Pim/Bundle/CatalogBundle/Manager/MediaManagerSpec.php
@@ -137,9 +137,14 @@ class MediaManagerSpec extends ObjectBehavior
         $this->getExportPath($media, 'custom-sku')->shouldReturn('files/custom-sku/thumbnail/en_US/mobile/akeneo.jpg');
     }
 
-    function it_generates_filename_prefix(ProductInterface $product, ProductValueInterface $value, AttributeInterface $attribute)
-    {
-        $product->getIdentifier()->shouldBeCalled();
+    function it_generates_filename_prefix(
+        ProductInterface $product,
+        ProductValueInterface $value,
+        ProductValueInterface $identifier,
+        AttributeInterface $attribute
+    ) {
+        $identifier->getData()->shouldBeCalled();
+        $product->getIdentifier()->willReturn($identifier);
         $value->getAttribute()->willReturn($attribute);
         $attribute->getCode()->shouldBeCalled();
         $value->getLocale()->shouldBeCalled();

--- a/src/Pim/Bundle/CatalogBundle/Manager/MediaManager.php
+++ b/src/Pim/Bundle/CatalogBundle/Manager/MediaManager.php
@@ -275,7 +275,7 @@ class MediaManager
         return sprintf(
             '%s-%s-%s-%s-%s-%s',
             uniqid(),
-            Urlizer::urlize($product->getIdentifier(), '_'),
+            Urlizer::urlize($product->getIdentifier()->getData(), '_'),
             $value->getAttribute()->getCode(),
             $value->getLocale(),
             $value->getScope(),


### PR DESCRIPTION
| Q                    | A
| -------------------- | ---
| Bug fix?             |  yes
| New feature?         | 
| BC breaks?           |
| CI currently passes? |
| Tests pass?          |  yes
| Scenarios pass?      |
| Checkstyle issues?*  |
| PMD issues?**        |
| Changelog updated?   |
| Fixed tickets        |
| DB schema updated?   |
| Migration script?    |
| Doc PR               |

It prevents error like `ProductValue` can not be used like an array when your identifier has special characters.