### PR TITLE
[TR] Fix reference data repository

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Repository/ChannelRepositoryInterface.php
+++ b/src/Pim/Bundle/CatalogBundle/Repository/ChannelRepositoryInterface.php
@@ -46,7 +46,7 @@ interface ChannelRepositoryInterface extends IdentifiableObjectRepositoryInterfa
     /**
      * Get full channels with locales and currencies
      *
-     * @return array
+     * @return ChannelInterface[]
      */
     public function getFullChannels();
 }

--- a/src/Pim/Bundle/ReferenceDataBundle/Doctrine/ORM/Repository/ReferenceDataRepository.php
+++ b/src/Pim/Bundle/ReferenceDataBundle/Doctrine/ORM/Repository/ReferenceDataRepository.php
@@ -44,10 +44,14 @@ class ReferenceDataRepository extends EntityRepository implements
         }
 
         $qb = $this->createQueryBuilder($this->getAlias());
-        $qb
-            ->select($selectDql)
-            ->orderBy(sprintf('%s.sortOrder', $this->getAlias()), 'DESC')
-            ->addOrderBy(sprintf('%s.code', $this->getAlias()));
+        $qb->select($selectDql);
+
+        if ($this->getClassMetadata()->hasField('sortOrder')) {
+            $qb->orderBy(sprintf('%s.sortOrder', $this->getAlias()), 'DESC');
+            $qb->addOrderBy(sprintf('%s.code', $this->getAlias()));
+        } else {
+            $qb->orderBy(sprintf('%s.code', $this->getAlias()));
+        }
 
         if (null !== $search) {
             $searchDql = sprintf('%s.code LIKE :search', $this->getAlias());

--- a/src/Pim/Bundle/ReferenceDataBundle/Resources/config/datagrid/sorters.yml
+++ b/src/Pim/Bundle/ReferenceDataBundle/Resources/config/datagrid/sorters.yml
@@ -8,10 +8,3 @@ services:
             - '@oro_datagrid.datagrid.request_params'
         tags:
             - { name: pim_datagrid.extension.sorter, type: product_value_reference_data }
-
-    pim_reference_data.doctrine.query.sorter.reference_data:
-        class: %pim_reference_data.doctrine.query.sorter.reference_data.class%
-        arguments:
-            - '@pim_reference_data.registry'
-        tags:
-            - { name: 'pim_catalog.doctrine.query.sorter', priority: 30 }


### PR DESCRIPTION
Only the *code* field is required for a *reference data* entity. The purpose of this fix is to sort reference data only if they have a field *sortOrder* (like what we have for custom entities)

| Q                    | A
| -------------------- | ---
| Bug fix?             | Y (on master only)
| New feature?         | N
| BC breaks?           | N
| CI currently passes? | Y 
| Tests pass?          | Y
| Scenarios pass?      | running
| Checkstyle issues?*  | N
| PMD issues?**        | N
| Changelog updated?   |
| Fixed tickets        |
| DB schema updated?   |
| Migration script?    |
| Doc PR               |