### PR TITLE
[TR] PIM-4044 : "Enter" and Product grid filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.3.x
+
+## Bug fixes
+- PIM-4044: Fix pressing Enter on a Product grid filter makes the page "unclickable"
+
 # 1.3.10 (2015-05-05)
 
 ## Bug fixes

--- a/src/Pim/Bundle/FilterBundle/Resources/public/js/datafilter/filter/select2-choice-filter.js
+++ b/src/Pim/Bundle/FilterBundle/Resources/public/js/datafilter/filter/select2-choice-filter.js
@@ -197,6 +197,14 @@ define(
                 }
             },
 
+            _onReadCriteriaInputKey: function(e) {
+                if (e.which == 13) {
+                    this.$(this.criteriaValueSelectors.value).select2('close');
+                    this._hideCriteria();
+                    this.setValue(this._formatRawValue(this._readDOMValue()));
+                }
+            },
+
             _cacheResults: function (results) {
                 _.each(results, function (result) {
                     this.resultCache[result.id] = result.text;


### PR DESCRIPTION
Pressing Enter on a Product grid filter makes the page "unclickable"

| Q                    | A
| -------------------- | ---
| Bug fix?             |y
| New feature?         |n
| BC breaks?           |n
| CI currently passes? |y
| Tests pass?          |y
| Scenarios pass?      |y
| Checkstyle issues?*  |n
| PMD issues?**        |n
| Changelog updated?   |y
| Fixed tickets        |PIM-4044
| DB schema updated?   |
| Migration script?    |
| Doc PR               |
