### PR TITLE
PIM-4146: add missing translation keys

### DIFF
--- a/src/Pim/Bundle/DataGridBundle/Resources/translations/jsmessages.en.yml
+++ b/src/Pim/Bundle/DataGridBundle/Resources/translations/jsmessages.en.yml
@@ -59,6 +59,11 @@ pim_datagrid:
         apply:             Apply
         cancel:            Cancel
         remove_column:     Remove
+    mass_action:
+        delete:
+            confirm_title:   Delete confirmation.
+            confirm_ok:      OK
+            empty_selection: No product selected.
 
 # Quick export
 pim.grid.mass_action.quick_export.title: Quick Export

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
@@ -15,6 +15,13 @@ confirmation:
         user:             Are you sure you want to delete this user?
         role:             Are you sure you want to delete this role?
 
+pim_datagrid:
+    mass_action:
+        delete:
+            confirm_content: Are you sure you want to delete selected products?
+            success:         Selected products successfully deleted.
+            error:           Error ocurred when trying to delete selected products, please try again.
+
 flash:
     item:
         removed: Item successfully removed


### PR DESCRIPTION
To prepare the 1.3 tagging (keys are synchronized from master)