### PR TITLE
[TR] PIM-4203: fix mass edit of families after sorting by label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 1.3.x
 
 ## Bug fixes
+- PIM-4203: fix mass edit of families after sorting by label
 - PIM-4208: Fix js memory leak on a product edit form with scopable attributes
 
 # 1.3.11 (2015-05-13)

--- a/features/family/mass_edit_families.feature
+++ b/features/family/mass_edit_families.feature
@@ -65,3 +65,12 @@ Feature: Mass Edit Families
     And I am on the families page
     When I mass-edit families first, second, third, fourth, fifth, sixth, seventh, eigth, ninth, tenth and eleventh
     Then I should see "Mass Edit (11 families)"
+
+  @jira https://akeneo.atlassian.net/browse/PIM-4203
+  Scenario: Successfully mass edit families after sorting by label
+    Given the "footwear" catalog configuration
+    And I am logged in as "Julia"
+    And I am on the families page
+    When I sort by "label" value ascending
+    And I mass-edit families boots, sneakers and sandals
+    Then I should see "Mass Edit (3 families)"

--- a/src/Pim/Bundle/CatalogBundle/Entity/Repository/FamilyRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Entity/Repository/FamilyRepository.php
@@ -51,10 +51,6 @@ class FamilyRepository extends ReferableEntityRepository implements FamilyReposi
             )
         );
 
-        // Allows hydration as object.
-        // Family mass edit operation receives an array instead of a Family object
-        $qb->select($qb->getRootAlias());
-
         // remove limit of the query
         $qb->setMaxResults(null);
     }

--- a/src/Pim/Bundle/EnrichBundle/MassEditAction/Operation/AbstractMassEditAction.php
+++ b/src/Pim/Bundle/EnrichBundle/MassEditAction/Operation/AbstractMassEditAction.php
@@ -38,6 +38,12 @@ abstract class AbstractMassEditAction implements MassEditOperationInterface
      */
     public function setObjectsToMassEdit(array $objects)
     {
+        foreach($objects as &$object) {
+            if (is_array($object)) {
+                $object = $object[0];
+            }
+        }
+
         $this->objects = $objects;
 
         return $this;


### PR DESCRIPTION
| Q                    | A
| -------------------- | ---
| Bug fix?             | Y
| New feature?         | N
| BC breaks?           | N
| CI currently passes? | Y
| Tests pass?          | Y
| Scenarios pass?      | Y
| Checkstyle issues?*  | N
| PMD issues?**        | N
| Changelog updated?   | Y
| Fixed tickets        | PIM-4203
| DB schema updated?   | N
| Migration script?    | N
| Doc PR               |

See : http://doctrine-orm.readthedocs.org/en/latest/reference/dql-doctrine-query-language.html#pure-and-mixed-results