### PR TITLE
[TR] Travis settings : execute CS fixer only for PHP 5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,13 +23,13 @@ before_script:
     - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then composer require --no-update doctrine/mongodb-odm v1.0.0-beta12@dev; fi;'
     - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then composer require --no-update doctrine/mongodb-odm-bundle v3.0.0-BETA6@dev; fi;'
     - composer update --prefer-dist --no-scripts --no-interaction
-    - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then curl http://get.sensiolabs.org/php-cs-fixer.phar -o php-cs-fixer; fi;'
+    - sh -c 'if [ "$TRAVIS_PHP_VERSION" = "5.6" ]; then curl http://get.sensiolabs.org/php-cs-fixer.phar -o php-cs-fixer; fi;'
 
 script:
     - ./bin/phpunit -c app/phpunit.travis.xml --testsuite PIM_Unit_Test
     - ./phpspec-fix
-    - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then php php-cs-fixer fix --dry-run -v --diff --config-file=.php_cs; fi;'
-    - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then php php-cs-fixer fix --dry-run -v --diff --config-file=.php_cs_spec; fi;'
+    - sh -c 'if [ "$TRAVIS_PHP_VERSION" = "5.6" ]; then php php-cs-fixer fix --dry-run -v --diff --config-file=.php_cs; fi;'
+    - sh -c 'if [ "$TRAVIS_PHP_VERSION" = "5.6" ]; then php php-cs-fixer fix --dry-run -v --diff --config-file=.php_cs_spec; fi;'
     - ./app/Resources/jenkins/interface_check.sh src/
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,13 +23,13 @@ before_script:
     - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then composer require --no-update doctrine/mongodb-odm v1.0.0-beta12@dev; fi;'
     - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then composer require --no-update doctrine/mongodb-odm-bundle v3.0.0-BETA6@dev; fi;'
     - composer update --prefer-dist --no-scripts --no-interaction
-    - sh -c 'if [ "$TRAVIS_PHP_VERSION" = "5.6" ]; then curl http://get.sensiolabs.org/php-cs-fixer.phar -o php-cs-fixer; fi;'
+    - sh -c 'if [ "$TRAVIS_PHP_VERSION" = "5.5" ] || [ "$TRAVIS_PHP_VERSION" = "5.6" ]; then curl http://get.sensiolabs.org/php-cs-fixer.phar -o php-cs-fixer; fi;'
 
 script:
     - ./bin/phpunit -c app/phpunit.travis.xml --testsuite PIM_Unit_Test
     - ./phpspec-fix
+    - sh -c 'if [ "$TRAVIS_PHP_VERSION" = "5.5" ]; then php php-cs-fixer fix --dry-run -v --diff --config-file=.php_cs_spec; fi;'
     - sh -c 'if [ "$TRAVIS_PHP_VERSION" = "5.6" ]; then php php-cs-fixer fix --dry-run -v --diff --config-file=.php_cs; fi;'
-    - sh -c 'if [ "$TRAVIS_PHP_VERSION" = "5.6" ]; then php php-cs-fixer fix --dry-run -v --diff --config-file=.php_cs_spec; fi;'
     - ./app/Resources/jenkins/interface_check.sh src/
 
 notifications:


### PR DESCRIPTION
Executing CS fixer only on PHP 5.6 speed up Travis build by a 50%+ ratio