### PR TITLE
default value 0 for sess_lifetime

### DIFF
--- a/src/Pim/Bundle/InstallerBundle/Command/DatabaseCommand.php
+++ b/src/Pim/Bundle/InstallerBundle/Command/DatabaseCommand.php
@@ -126,7 +126,7 @@ class DatabaseCommand extends ContainerAwareCommand
                 `sess_id` VARBINARY(128) NOT NULL PRIMARY KEY,
                 `sess_data` BLOB NOT NULL,
                 `sess_time` INTEGER UNSIGNED NOT NULL,
-                `sess_lifetime` MEDIUMINT NOT NULL
+                `sess_lifetime` MEDIUMINT NOT NULL DEFAULT  '0'
             ) COLLATE utf8_bin, ENGINE = InnoDB";
 
         $db = $this->getContainer()->get('doctrine');


### PR DESCRIPTION
fix an error about sess_lifetime not having a default value.
Reminder : this field is not used before SF 2.6