### PR TITLE
PIM-4308: MongoDB indexes are removed on schema update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 1.4.x
 
 ## Features
+- Create command to index fields in MongoDB
 
 ## Technical improvements
 - In BaseConnector, revamp the Readers, Processors and Writers to import data, make them more simple and re-useable
@@ -117,6 +118,7 @@
 - Remove `Pim\Bundle\EnrichBundle\MassEditAction\Operator\FamilyMassEditOperator`
 - Remove `Pim\Bundle\EnrichBundle\MassEditAction\Operator\MassEditOperatorInterface`
 - Remove `Pim\Bundle\EnrichBundle\MassEditAction\OperatorRegistry`
+- Change constructor of `Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\IndexCreator`, added Attribute class name
 
 # 1.3.x
 

--- a/spec/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/IndexCreatorSpec.php
+++ b/spec/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/IndexCreatorSpec.php
@@ -7,10 +7,12 @@ use Doctrine\MongoDB\Collection;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use PhpSpec\ObjectBehavior;
 use Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\NamingUtility;
+use Pim\Bundle\CatalogBundle\Doctrine\ORM\Repository\AttributeRepository;
 use Pim\Bundle\CatalogBundle\Model\AttributeInterface;
 use Pim\Bundle\CatalogBundle\Model\ChannelInterface;
 use Pim\Bundle\CatalogBundle\Model\CurrencyInterface;
 use Pim\Bundle\CatalogBundle\Model\LocaleInterface;
+use Pim\Bundle\CatalogBundle\Repository\AttributeRepositoryInterface;
 use Prophecy\Argument;
 use Psr\Log\LoggerInterface;
 
@@ -34,7 +36,8 @@ class IndexCreatorSpec extends ObjectBehavior
             $managerRegistry,
             $namingUtility,
             'Product',
-            $logger
+            $logger,
+            'Attribute'
         );
     }
 
@@ -387,6 +390,111 @@ class IndexCreatorSpec extends ObjectBehavior
             );
 
         $this->ensureIndexesFromAttribute($description);
+    }
+
+    function it_generates_completeness_indexes(
+        $namingUtility,
+        $collection,
+        ChannelInterface $channelWeb,
+        ChannelInterface $channelPrint,
+        LocaleInterface $localeFr,
+        LocaleInterface $localeEn
+    ) {
+        $indexes = array_fill(0, 10, 'fake_index');
+        $collection->getIndexInfo()->willReturn($indexes);
+        $namingUtility->getChannels()->willReturn([$channelWeb, $channelPrint]);
+
+        $channelWeb->getLocales()->willReturn([$localeEn]);
+        $channelPrint->getLocales()->willReturn([$localeFr, $localeEn]);
+        $channelPrint->getCode()->willReturn('PRINT');
+        $channelWeb->getCode()->willReturn('WEB');
+        $localeEn->getCode()->willReturn('en_US');
+        $localeFr->getCode()->willReturn('fr_FR');
+
+        $indexOptions = [
+            'background' => true,
+            'w'          => 0
+        ];
+
+        $collection
+            ->ensureIndex(['normalizedData.completenesses.PRINT-en_US' => 1], $indexOptions)
+            ->shouldBeCalled();
+        $collection
+            ->ensureIndex(['normalizedData.completenesses.PRINT-fr_FR' => 1], $indexOptions)
+            ->shouldBeCalled();
+        $collection
+            ->ensureIndex(['normalizedData.completenesses.WEB-en_US' => 1], $indexOptions)
+            ->shouldBeCalled();
+
+        $this->ensureCompletenessesIndexes();
+    }
+
+    function it_generates_unique_attribute_indexes(
+        $namingUtility,
+        $collection,
+        $managerRegistry,
+        AttributeRepositoryInterface $attributeRepository,
+        AttributeInterface $sku,
+        AttributeInterface $ean
+    ) {
+        $indexes = array_fill(0, 10, 'fake_index');
+        $collection->getIndexInfo()->willReturn($indexes);
+
+        $managerRegistry->getRepository('Attribute')->willReturn($attributeRepository);
+        $attributeRepository
+            ->findBy(['unique' => true], ['created' => 'ASC'], 64)
+            ->willReturn([$sku, $ean]);
+
+        $namingUtility->getAttributeNormFields($sku)->willReturn(['normalizedData.sku']);
+        $namingUtility->getAttributeNormFields($ean)->willReturn(['normalizedData.ean']);
+
+        $indexOptions = [
+            'background' => true,
+            'w'          => 0
+        ];
+
+        $collection
+            ->ensureIndex(['normalizedData.sku' => 1], $indexOptions)
+            ->shouldBeCalled();
+        $collection
+            ->ensureIndex(['normalizedData.ean' => 1], $indexOptions)
+            ->shouldBeCalled();
+
+        $this->ensureUniqueAttributesIndexes();
+    }
+
+    function it_generates_attribute_indexes(
+        $namingUtility,
+        $collection,
+        $managerRegistry,
+        AttributeRepositoryInterface $attributeRepository,
+        AttributeInterface $name,
+        AttributeInterface $description
+    ) {
+        $indexes = array_fill(0, 10, 'fake_index');
+        $collection->getIndexInfo()->willReturn($indexes);
+
+        $managerRegistry->getRepository('Attribute')->willReturn($attributeRepository);
+        $attributeRepository
+            ->findBy(['useableAsGridFilter' => true], ['created' => 'ASC'], 64)
+            ->willReturn([$name, $description]);
+
+        $namingUtility->getAttributeNormFields($name)->willReturn(['normalizedData.name']);
+        $namingUtility->getAttributeNormFields($description)->willReturn(['normalizedData.description']);
+
+        $indexOptions = [
+            'background' => true,
+            'w'          => 0
+        ];
+
+        $collection
+            ->ensureIndex(['normalizedData.name' => 1], $indexOptions)
+            ->shouldBeCalled();
+        $collection
+            ->ensureIndex(['normalizedData.description' => 1], $indexOptions)
+            ->shouldBeCalled();
+
+        $this->ensureAttributesIndexes();
     }
 
     function it_logs_error_when_the_maximum_number_of_indexes_is_reached(

--- a/src/Pim/Bundle/CatalogBundle/Command/MongoDBIndexCreatorCommand.php
+++ b/src/Pim/Bundle/CatalogBundle/Command/MongoDBIndexCreatorCommand.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Bundle\CatalogBundle\Command;
 
+use Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\IndexCreator;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -10,7 +11,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  * Command creating indexes on MongoDB for Product collection
  *
  * @author    Romain Monceau <romain@akeneo.com>
- * @copyright 2014 Akeneo SAS (http://www.akeneo.com)
+ * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 class MongoDBIndexCreatorCommand extends ContainerAwareCommand
@@ -32,20 +33,22 @@ class MongoDBIndexCreatorCommand extends ContainerAwareCommand
     {
         $storageDriver = $this->getContainer()->getParameter('pim_catalog_product_storage_driver');
 
-        if ($storageDriver !== 'doctrine/mongodb-odm') {
+        if ('doctrine/mongodb-odm' !== $storageDriver) {
             $output->writeln('<error>This command could be only launched on mongodb storage</error>');
 
-            return 1;
+            return -1;
         }
 
         $indexCreator = $this->getIndexCreator();
         $indexCreator->ensureUniqueAttributesIndexes();
         $indexCreator->ensureCompletenessesIndexes();
         $indexCreator->ensureAttributesIndexes();
+
+        return;
     }
 
     /**
-     * @return \Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\IndexCreator
+     * @return IndexCreator
      */
     protected function getIndexCreator()
     {

--- a/src/Pim/Bundle/CatalogBundle/Command/MongoDBIndexCreatorCommand.php
+++ b/src/Pim/Bundle/CatalogBundle/Command/MongoDBIndexCreatorCommand.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\Command;
+
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Command creating indexes on MongoDB for Product collection
+ *
+ * @author    Romain Monceau <romain@akeneo.com>
+ * @copyright 2014 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class MongoDBIndexCreatorCommand extends ContainerAwareCommand
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('pim:mongodb:index-fields')
+            ->setDescription('Create MongoDB indexes');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $storageDriver = $this->getContainer()->getParameter('pim_catalog_product_storage_driver');
+
+        if ($storageDriver !== 'doctrine/mongodb-odm') {
+            $output->writeln('<error>This command could be only launched on mongodb storage</error>');
+
+            return 1;
+        }
+
+        $indexCreator = $this->getIndexCreator();
+        $indexCreator->ensureUniqueAttributesIndexes();
+        $indexCreator->ensureCompletenessesIndexes();
+        $indexCreator->ensureAttributesIndexes();
+    }
+
+    /**
+     * @return \Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\IndexCreator
+     */
+    protected function getIndexCreator()
+    {
+        return $this->getContainer()->get('pim_catalog.doctrine.index_creator');
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/IndexCreator.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/IndexCreator.php
@@ -8,6 +8,7 @@ use Pim\Bundle\CatalogBundle\Model\AttributeInterface;
 use Pim\Bundle\CatalogBundle\Model\ChannelInterface;
 use Pim\Bundle\CatalogBundle\Model\CurrencyInterface;
 use Pim\Bundle\CatalogBundle\Model\LocaleInterface;
+use Pim\Bundle\CatalogBundle\Repository\AttributeRepositoryInterface;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -19,7 +20,7 @@ use Psr\Log\LoggerInterface;
  */
 class IndexCreator
 {
-    /** @const int */
+    /** @staticvar int */
     const MONGODB_INDEXES_LIMIT = 64;
 
     /** @var ManagerRegistry */
@@ -181,7 +182,7 @@ class IndexCreator
     }
 
     /**
-     * @return \Pim\Bundle\CatalogBundle\Repository\AttributeRepositoryInterface
+     * @return AttributeRepositoryInterface
      */
     protected function getAttributeRepository()
     {

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/storage_driver/doctrine/mongodb-odm.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/storage_driver/doctrine/mongodb-odm.yml
@@ -79,10 +79,11 @@ services:
     pim_catalog.doctrine.index_creator:
         class: %pim_catalog.doctrine.index_creator.class%
         arguments:
-            - @pim_catalog.doctrine.smart_manager_registry
-            - @pim_catalog.doctrine.naming_utility
+            - '@pim_catalog.doctrine.smart_manager_registry'
+            - '@pim_catalog.doctrine.naming_utility'
             - %pim_catalog.entity.product.class%
-            - @logger
+            - '@logger'
+            - %pim_catalog.entity.attribute.class%
 
     pim_catalog.doctrine.naming_utility:
         class: %pim_catalog.doctrine.naming_utility.class%


### PR DESCRIPTION
| Q                    | A
| -------------------- | ---
| Bug fix?             | Y
| New feature?         | Y
| BC breaks?           | Y
| CI currently passes? | ?
| Tests pass?          | ?
| Scenarios pass?      | ?
| Checkstyle issues?*  | N (but already broken)
| PMD issues?**        | N (but already broken)
| Changelog updated?   | Y
| Fixed tickets        | PIM-4308
| DB schema updated?   | N
| Migration script?    | N
| Doc PR               | N