### PR TITLE
[TR] PIM-4032: Wrong error message when deleting used attribute option by a published product

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - PIM-4024: Fix for metric and price denormalizer
 - PIM-4314: Added missing translation keys
 - PIM-4112: Not translated Error message when wrong format import
+- PMI-4032: Fix wrong error message when deleting used attribute option by a published product
 
 ## BC breaks
 - Change the constructor of `Pim\Bundle\VersioningBundle\EventSubscriber\AddUserSubscriber`, removed `Pim\Bundle\VersioningBundle\Manager\VersionManager`

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/pim-attributeoptionview.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/pim-attributeoptionview.js
@@ -435,7 +435,7 @@ define(
                         var message;
 
                         if (response.responseJSON) {
-                            message = response.responseJSON;
+                            message = response.responseJSON.message;
                         } else {
                             message = response.responseText;
                         }


### PR DESCRIPTION
| Q                    | A
| -------------------- | ---
| Bug fix?             | Yes
| New feature?         | No
| BC breaks?           | No
| CI currently passes? | Yes
| Tests pass?          | Yes
| Scenarios pass?      | Yes
| Checkstyle issues?*  | No
| PMD issues?**        | No
| Changelog updated?   | Yes
| Fixed tickets        | PIM-4032
| DB schema updated?   | No
| Migration script?    | No
| Doc PR               | No