### PR TITLE
[TR] PIM-4535: Fix font problems on pdf generation: you can now set a custom font by setting the %pim_pdf_font% parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 - PIM-4528: Fix attribute field display on error during mass edit
+- PIM-4535: Fix font problems on pdf generation: you can now set a custom font by setting the %pim_pdf_generator_font% parameter.
 
 # 1.3.17 (2015-07-07)
 

--- a/app/config/pim_parameters.yml
+++ b/app/config/pim_parameters.yml
@@ -35,4 +35,3 @@ parameters:
     # mongodb_database: akeneo_pim
 
     doctrine_migrations_dir: %kernel.root_dir%/../upgrades/schema
-

--- a/spec/Pim/Bundle/PdfGeneratorBundle/Renderer/ProductPdfRendererSpec.php
+++ b/spec/Pim/Bundle/PdfGeneratorBundle/Renderer/ProductPdfRendererSpec.php
@@ -53,6 +53,7 @@ class ProductPdfRendererSpec extends ObjectBehavior
             'groupedAttributes' => ['Design' => ['color' => $color]],
             'imageAttributes'   => [],
             'uploadDir'         => $path . DIRECTORY_SEPARATOR,
+            'customFont'        => null
         ])->shouldBeCalled();
 
         $this->render(
@@ -86,6 +87,7 @@ class ProductPdfRendererSpec extends ObjectBehavior
                 'groupedAttributes' => ['Media' => ['main_image' => $mainImage]],
                 'imageAttributes'   => ['main_image' => $mainImage],
                 'uploadDir'         => $path . DIRECTORY_SEPARATOR,
+                'customFont'        => null
             ]
         )->shouldBeCalled();
 

--- a/src/Pim/Bundle/PdfGeneratorBundle/DependencyInjection/PimPdfGeneratorExtension.php
+++ b/src/Pim/Bundle/PdfGeneratorBundle/DependencyInjection/PimPdfGeneratorExtension.php
@@ -25,5 +25,9 @@ class PimPdfGeneratorExtension extends Extension
         $loader->load('controllers.yml');
         $loader->load('renderers.yml');
         $loader->load('builders.yml');
+
+        if (!$container->hasParameter('pim_pdf_generator_font')) {
+            $container->setParameter('pim_pdf_generator_font', null);
+        }
     }
 }

--- a/src/Pim/Bundle/PdfGeneratorBundle/Renderer/ProductPdfRenderer.php
+++ b/src/Pim/Bundle/PdfGeneratorBundle/Renderer/ProductPdfRenderer.php
@@ -5,6 +5,7 @@ namespace Pim\Bundle\PdfGeneratorBundle\Renderer;
 use Pim\Bundle\CatalogBundle\Model\ProductInterface;
 use Pim\Bundle\PdfGeneratorBundle\Builder\PdfBuilderInterface;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
@@ -37,17 +38,20 @@ class ProductPdfRenderer implements RendererInterface
      * @param string              $template
      * @param PdfBuilderInterface $pdfBuilder
      * @param string              $uploadDirectory
+     * @param ContainerInterface  $customFont
      */
     public function __construct(
         EngineInterface $templating,
         $template,
         PdfBuilderInterface $pdfBuilder,
-        $uploadDirectory
+        $uploadDirectory,
+        $customFont = null
     ) {
         $this->templating      = $templating;
         $this->template        = $template;
         $this->pdfBuilder      = $pdfBuilder;
         $this->uploadDirectory = $uploadDirectory;
+        $this->customFont      = $customFont;
     }
 
     /**
@@ -64,6 +68,7 @@ class ProductPdfRenderer implements RendererInterface
                 'product'           => $object,
                 'groupedAttributes' => $this->getGroupedAttributes($object, $context['locale']),
                 'imageAttributes'   => $this->getImageAttributes($object, $context['locale']),
+                'customFont'        => $this->customFont
             ]
         );
 
@@ -149,8 +154,9 @@ class ProductPdfRenderer implements RendererInterface
         $resolver->setDefaults(
             [
                 'groupedAttributes' => [],
-                'imageAttributes' => [],
-                'renderingDate' => new \DateTime()
+                'imageAttributes'   => [],
+                'renderingDate'     => new \DateTime(),
+                'customFont'        => null
             ]
         );
     }

--- a/src/Pim/Bundle/PdfGeneratorBundle/Resources/config/renderers.yml
+++ b/src/Pim/Bundle/PdfGeneratorBundle/Resources/config/renderers.yml
@@ -10,6 +10,7 @@ services:
             - 'PimPdfGeneratorBundle:Product:renderPdf.html.twig'
             - '@pim_pdf_generator.builder.dompdf'
             - %upload_dir%
+            - %pim_pdf_generator_font%
         tags:
             - { name: pim_pdf_generator.renderer, priority: 80 }
 

--- a/src/Pim/Bundle/PdfGeneratorBundle/Resources/views/Product/renderPdf.html.twig
+++ b/src/Pim/Bundle/PdfGeneratorBundle/Resources/views/Product/renderPdf.html.twig
@@ -4,9 +4,18 @@
         <title>{{ product.identifier }} - {{ renderingDate|date }}</title>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
         <style type="text/css">
+            {% if (null != customFont) %}
+                @font-face {
+                    font-family: 'Custom font';
+                    font-style: normal;
+                    font-weight: 400;
+                    src: url({{ customFont }}) format('truetype');
+                }
+            {% endif %}
+
             * {
-                font-family: Helvetica;
-                font-weight: 100;
+                font-family: 'Custom font', Helvetica;
+                font-weight: 400 !important;
             }
 
             .header {


### PR DESCRIPTION
| Q                    | A
| -------------------- | ---
| Bug fix?             | Y
| New feature?         | N
| BC breaks?           | N
| CI currently passes? | Y
| Tests pass?          | Y
| Scenarios pass?      | ?
| Checkstyle issues?*  | N
| PMD issues?**        | N
| Changelog updated?   | Y
| Fixed tickets        | PIM-4535
| DB schema updated?   |
| Migration script?    |
| Doc PR               |