### PR TITLE
PIM-4660 : missing translation key for pim_enrich.acl.job_tracker.index

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/messages.en.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/messages.en.yml
@@ -261,6 +261,9 @@ pim_enrich:
             edit: Edit an association type
             remove: Remove an association type
             history: View association type history
+        job_tracker:
+            index: View process tracker
+
     acl_group:
         association_type: Association types
         attribute: Attributes


### PR DESCRIPTION
 Q                  | A
| ------------------ | ---
| Migration script?  |n
| Behats             |y
| Specs & Static     |y
| Changelog updated  |n