### PR TITLE
[TR][PAM]PIM-4690: Changed interfaces

### DIFF
--- a/spec/Pim/Bundle/TransformBundle/Normalizer/Flat/CategoryNormalizerSpec.php
+++ b/spec/Pim/Bundle/TransformBundle/Normalizer/Flat/CategoryNormalizerSpec.php
@@ -3,7 +3,7 @@
 namespace spec\Pim\Bundle\TransformBundle\Normalizer\Flat;
 
 use PhpSpec\ObjectBehavior;
-use Pim\Bundle\CatalogBundle\Model\CategoryInterface;
+use Pim\Component\Classification\Model\CategoryInterface;
 use Pim\Bundle\TransformBundle\Normalizer\Flat\TranslationNormalizer;
 use Prophecy\Argument;
 

--- a/spec/Pim/Bundle/TransformBundle/Normalizer/Structured/CategoryNormalizerSpec.php
+++ b/spec/Pim/Bundle/TransformBundle/Normalizer/Structured/CategoryNormalizerSpec.php
@@ -3,7 +3,7 @@
 namespace spec\Pim\Bundle\TransformBundle\Normalizer\Structured;
 
 use PhpSpec\ObjectBehavior;
-use Pim\Bundle\CatalogBundle\Model\CategoryInterface;
+use Pim\Component\Classification\Model\CategoryInterface;
 use Pim\Bundle\TransformBundle\Normalizer\Flat\TranslationNormalizer;
 use Prophecy\Argument;
 

--- a/src/Pim/Bundle/TransformBundle/Normalizer/Structured/CategoryNormalizer.php
+++ b/src/Pim/Bundle/TransformBundle/Normalizer/Structured/CategoryNormalizer.php
@@ -2,7 +2,7 @@
 
 namespace Pim\Bundle\TransformBundle\Normalizer\Structured;
 
-use Pim\Bundle\CatalogBundle\Model\CategoryInterface;
+use Pim\Component\Classification\Model\CategoryInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**


### PR DESCRIPTION
Interfaces has changed in order to also use the assets categories

| Q                  | A
| ------------------ | ---
| Migration script?  | n
| Behats             | yes
| Specs & Static     | yes
| Changelog updated  | yes

http://core-ci.akeneo.com/job/pim-pr-behat/3042/console