### PR TITLE
[TR] PIM-4774: validate any data imported via behat

### DIFF
--- a/features/Context/FixturesContext.php
+++ b/features/Context/FixturesContext.php
@@ -2214,13 +2214,21 @@ class FixturesContext extends RawMinkContext
         if ($object instanceof ProductInterface) {
             $validator = $this->getContainer()->get('pim_catalog.validator.product');
             // TODO: check validation constraint on localizable/scopable value
+            // TODO: fix validation constraint to forbid to add product with empty option in variant group
+            // TODO: fix validation constraint to forbid to add products with same options in variant group (add in same time, then save)
         } else {
             $validator = $this->getContainer()->get('validator');
         }
         $violations = $validator->validate($object);
         if (0 < $violations->count()) {
+
+            $messages = [];
+            foreach ($violations as $violation) {
+                $messages[] = $violation->getMessage();
+            }
+
             throw new \InvalidArgumentException(
-                sprintf('Object "%s" is not valid', ClassUtils::getClass($object))
+                sprintf('Object "%s" is not valid "%s"', ClassUtils::getClass($object), implode(', ', $messages))
             );
         }
     }

--- a/features/export/view_an_export_detail_page.feature
+++ b/features/export/view_an_export_detail_page.feature
@@ -21,10 +21,3 @@ Feature: View an export detail page
       | Akeneo CSV Connector | csv_product_export | acme_product_export | Product export for Acme.com | export |
     When I am on the "acme_product_export" export job page
     Then I should see "This value should not be blank." next to the channel
-
-  Scenario: Fail to show a job instance for which the job does not exist anymore
-    Given the following job:
-      | connector            | alias          | code                        | label                       | type   |
-      | Akeneo CSV Connector | removed_export | removed_acme_product_export | Product export for Acme.com | export |
-    When I am on the "removed_acme_product_export" export job page
-    Then I should see "The following export does not exist anymore."

--- a/features/import/product/import_products.feature
+++ b/features/import/product/import_products.feature
@@ -7,8 +7,8 @@ Feature: Execute a job
   Background:
     Given the "footwear" catalog configuration
     And the following product groups:
-      | code  | label     | axis | type    |
-      | CROSS | Bag Cross |      | VARIANT |
+      | code  | label     | type    |
+      | CROSS | Bag Cross | RELATED |
     And I am logged in as "Julia"
 
   Scenario: Successfully import a csv file of products

--- a/features/import/product/import_products_with_associations.feature
+++ b/features/import/product/import_products_with_associations.feature
@@ -7,8 +7,8 @@ Feature: Execute a job
   Background:
     Given the "footwear" catalog configuration
     And the following product groups:
-      | code  | label     | axis | type    |
-      | CROSS | Bag Cross |      | VARIANT |
+      | code  | label     | type    |
+      | CROSS | Bag Cross | RELATED |
     And I am logged in as "Julia"
 
   Scenario: Successfully import a csv file of products with associations

--- a/features/import/product/import_products_with_invalid_data.feature
+++ b/features/import/product/import_products_with_invalid_data.feature
@@ -7,8 +7,8 @@ Feature: Execute a job
   Background:
     Given the "footwear" catalog configuration
     And the following product groups:
-      | code  | label     | axis | type    |
-      | CROSS | Bag Cross |      | VARIANT |
+      | code  | label     | type    |
+      | CROSS | Bag Cross | RELATED |
     And I am logged in as "Julia"
 
   @jira https://akeneo.atlassian.net/browse/PIM-3266

--- a/features/import/product_variant_group/import_variant_group_with_invalid_properties.feature
+++ b/features/import/product_variant_group/import_variant_group_with_invalid_properties.feature
@@ -9,7 +9,7 @@ Feature: Execute an import
     And the following product groups:
       | code   | label  | axis        | type    |
       | SANDAL | Sandal | size, color | VARIANT |
-      | NOT_VG | Not VG | color, size | RELATED |
+      | NOT_VG | Not VG |             | RELATED |
     And I am logged in as "Julia"
 
   Scenario: Stop the import if variant group code column is not provided

--- a/features/import/product_variant_group/import_variant_group_with_valid_properties.feature
+++ b/features/import/product_variant_group/import_variant_group_with_valid_properties.feature
@@ -9,7 +9,7 @@ Feature: Execute an import
     And the following product groups:
       | code   | label  | axis        | type    |
       | SANDAL | Sandal | color, size | VARIANT |
-      | NOT_VG | Not VG | color, size | RELATED |
+      | NOT_VG | Not VG |             | RELATED |
     And I am logged in as "Julia"
 
   Scenario: Successfully import a csv file of variant group to create a new one

--- a/features/import/view_an_import_detail_page.feature
+++ b/features/import/view_an_import_detail_page.feature
@@ -13,10 +13,3 @@ Feature: View an import detail page
     When I click on the "footwear_product_import" row
     Then I should be on the "footwear_product_import" export job page
     And I should see "Import profile - Footwear product"
-
-  Scenario: Fail to show a job for which job definition does not exist anymore
-    Given the following job:
-      | connector            | alias          | code                        | label                       | type   |
-      | Akeneo CSV Connector | removed_import | removed_acme_product_import | Product import for Acme.com | import |
-    And I am on the "removed_acme_product_import" import job page
-    Then I should see "The following import does not exist anymore."

--- a/features/product/filtering/filter_products_per_group.feature
+++ b/features/product/filtering/filter_products_per_group.feature
@@ -15,11 +15,11 @@ Feature: Filter products
       | color | Color | simpleselect |
     And the following "color" attribute options: Black and White
     And the following products:
-      | sku    | family    |
-      | BOOK   | library   |
-      | MUG-1  | furniture |
-      | MUG-2  | furniture |
-      | POSTIT | furniture |
+      | sku    | family    | color |
+      | BOOK   | library   |       |
+      | MUG-1  | furniture | white |
+      | MUG-2  | furniture | black |
+      | POSTIT | furniture |       |
     And the following product groups:
       | code   | label  | axis  | type    | products     |
       | MUG    | Mug    | color | VARIANT | MUG-1, MUG-2 |

--- a/features/product/filtering/filter_products_per_with_multiple_dates.feature
+++ b/features/product/filtering/filter_products_per_with_multiple_dates.feature
@@ -14,8 +14,6 @@ Feature: Filter products
       | code     | label    | type | useable_as_grid_filter |
       | delivery | Delivery | date | yes                    |
       | supply   | Supply   | date | yes                    |
-    And the following "delivery" attribute options: Black and Green
-    And the following "supply" attribute options: Black and White and Red
     And the following products:
       | sku    | family    | supply     | delivery   |
       | BOOK   | library   |            |            |
@@ -27,11 +25,6 @@ Feature: Filter products
       | POST-1 | furniture | 2014-08-01 |            |
       | POST-2 | furniture | 2014-08-01 |            |
       | POST-3 | furniture | 2014-09-01 |            |
-    And the following product groups:
-      | code   | label  | axis             | type    | products                          |
-      | MUG    | Mug    | delivery, supply | VARIANT | MUG-1, MUG-2, MUG-3, MUG-4, MUG-5 |
-      | POSTIT | Postit | supply           | X_SELL  | POST-1, POST-2, POST-3            |
-      | EMPTY  | Empty  |                  | X_SELL  |                                   |
     And I am logged in as "Mary"
 
   Scenario: Successfully filter products with the sames attributes

--- a/features/product/filtering/filter_products_per_with_multiple_metrics.feature
+++ b/features/product/filtering/filter_products_per_with_multiple_metrics.feature
@@ -14,8 +14,6 @@ Feature: Filter products with multiples metrics filters
       | code      | label     | type   | useable_as_grid_filter | metric_family | default_metric_unit | decimals_allowed |
       | weight    | Weight    | metric | yes                    | Weight        | GRAM                | yes              |
       | packaging | Packaging | metric | yes                    | Weight        | GRAM                | yes              |
-    And the following "weight" attribute options: Black and Green
-    And the following "packaging" attribute options: Black and White and Red
     And the following products:
       | sku    | family    | packaging | weight   |
       | BOOK   | library   |           |          |
@@ -27,11 +25,6 @@ Feature: Filter products with multiples metrics filters
       | POST-1 | furniture | 50 GRAM   |          |
       | POST-2 | furniture | 50 GRAM   |          |
       | POST-3 | furniture | 20 GRAM   |          |
-    And the following product groups:
-      | code   | label  | axis              | type    | products                          |
-      | MUG    | Mug    | weight, packaging | VARIANT | MUG-1, MUG-2, MUG-3, MUG-4, MUG-5 |
-      | POSTIT | Postit | packaging         | X_SELL  | POST-1, POST-2, POST-3            |
-      | EMPTY  | Empty  |                   | X_SELL  |                                   |
     And I am logged in as "Mary"
     And I am on the products page
     And I show the filter "Packaging"

--- a/features/product/filtering/filter_products_per_with_multiple_multiselect.feature
+++ b/features/product/filtering/filter_products_per_with_multiple_multiselect.feature
@@ -27,24 +27,19 @@ Feature: Filter products with multiples multiselect filters
       | POST-1 | furniture | red     |       |
       | POST-2 | furniture | red     |       |
       | POST-3 | furniture | black   |       |
-    And the following product groups:
-      | code   | label  | axis           | type    | products                          |
-      | MUG    | Mug    | color, company | VARIANT | MUG-1, MUG-2, MUG-3, MUG-4, MUG-5 |
-      | POSTIT | Postit | company        | X_SELL  | POST-1, POST-2, POST-3            |
-      | EMPTY  | Empty  |                | X_SELL  |                                   |
     And I am logged in as "Mary"
     And I am on the products page
     And I show the filter "Company"
     And I show the filter "Color"
 
-  # Scenario: Successfully filter products with the sames attributes
-  #   Given I filter by "Company" with value "Red"
-  #   And I should be able to use the following filters:
-  #     | filter | value    | result                 |
-  #     | Color  | green    | MUG-2, MUG-3 and MUG-4 |
-  #     | Color  | is empty | POST-1 and POST-2      |
-  #   And I hide the filter "Company"
-  #   And I hide the filter "Color"
+  Scenario: Successfully filter products with the sames attributes
+    Given I filter by "Company" with value "Red"
+    And I should be able to use the following filters:
+      | filter | value    | result                 |
+      | Color  | green    | MUG-2, MUG-3 and MUG-4 |
+      | Color  | is empty | POST-1 and POST-2      |
+    And I hide the filter "Company"
+    And I hide the filter "Color"
 
   Scenario: Successfully filter product without commons attributes
     Given I filter by "Color" with value "Green"

--- a/features/product/filtering/filter_products_per_with_multiple_number_fields.feature
+++ b/features/product/filtering/filter_products_per_with_multiple_number_fields.feature
@@ -14,8 +14,6 @@ Feature: Filter products with multiples number fields filters
       | code      | label     | type   | useable_as_grid_filter |
       | component | Component | number | yes                    |
       | supplier  | Supplier  | number | yes                    |
-    And the following "component" attribute options: Black and Green
-    And the following "supplier" attribute options: Black and White and Red
     And the following products:
       | sku    | family    | supplier | component |
       | BOOK   | library   |          |           |
@@ -27,11 +25,6 @@ Feature: Filter products with multiples number fields filters
       | POST-1 | furniture | 03       |           |
       | POST-2 | furniture | 03       |           |
       | POST-3 | furniture | 01       |           |
-    And the following product groups:
-      | code   | label  | axis                | type    | products                          |
-      | MUG    | Mug    | component, supplier | VARIANT | MUG-1, MUG-2, MUG-3, MUG-4, MUG-5 |
-      | POSTIT | Postit | supplier            | X_SELL  | POST-1, POST-2, POST-3            |
-      | EMPTY  | Empty  |                     | X_SELL  |                                   |
     And I am logged in as "Mary"
     And I am on the products page
     And I show the filter "Supplier"

--- a/features/product/filtering/filter_products_per_with_multiple_prices.feature
+++ b/features/product/filtering/filter_products_per_with_multiple_prices.feature
@@ -14,8 +14,6 @@ Feature: Filter products with multiples prices filters
       | code      | label     | type   | useable_as_grid_filter |
       | margin    | Margin    | prices | yes                    |
       | transport | Transport | prices | yes                    |
-    And the following "margin" attribute options: Black and Green
-    And the following "transport" attribute options: Black and White and Red
     And the following products:
       | sku    | family    | transport | margin |
       | BOOK   | library   |           |        |
@@ -27,11 +25,6 @@ Feature: Filter products with multiples prices filters
       | POST-1 | furniture | 15 EUR    |        |
       | POST-2 | furniture | 15 EUR    |        |
       | POST-3 | furniture | 30 EUR    |        |
-    And the following product groups:
-      | code   | label  | axis              | type    | products                          |
-      | MUG    | Mug    | margin, transport | VARIANT | MUG-1, MUG-2, MUG-3, MUG-4, MUG-5 |
-      | POSTIT | Postit | transport         | X_SELL  | POST-1, POST-2, POST-3            |
-      | EMPTY  | Empty  |                   | X_SELL  |                                   |
     And I am logged in as "Mary"
     And I am on the products page
     And I show the filter "Transport"

--- a/features/product/filtering/filter_products_per_with_multiple_text_fields.feature
+++ b/features/product/filtering/filter_products_per_with_multiple_text_fields.feature
@@ -14,8 +14,6 @@ Feature: Filter products with multiples text fields filters
       | code        | label       | type | useable_as_grid_filter |
       | name        | Name        | text | yes                    |
       | description | Description | text | yes                    |
-    And the following "name" attribute options: Black and Green
-    And the following "description" attribute options: Black and White and Red
     And the following products:
       | sku    | family    | description    | name   |
       | BOOK   | library   |                |        |
@@ -27,11 +25,6 @@ Feature: Filter products with multiples text fields filters
       | POST-1 | furniture | red color      |        |
       | POST-2 | furniture | red color      |        |
       | POST-3 | furniture | black color    | indigo |
-    And the following product groups:
-      | code   | label  | axis              | type    | products                          |
-      | MUG    | Mug    | name, description | VARIANT | MUG-1, MUG-2, MUG-3, MUG-4, MUG-5 |
-      | POSTIT | Postit | description       | X_SELL  | POST-1, POST-2, POST-3            |
-      | EMPTY  | Empty  |                   | X_SELL  |                                   |
     And I am logged in as "Mary"
     And I am on the products page
     And I show the filter "Description"

--- a/features/product/filtering/filter_products_with_multiple_simpleselect.feature
+++ b/features/product/filtering/filter_products_with_multiple_simpleselect.feature
@@ -21,16 +21,16 @@ Feature: Filter products with multiples simpleselect filters
       | BOOK   | library   |         |       |
       | MUG-1  | furniture | white   | green |
       | MUG-2  | furniture | red     | green |
-      | MUG-3  | furniture | red     | green |
-      | MUG-4  | furniture | red     | green |
-      | MUG-5  | furniture |         | green |
+      | MUG-3  | furniture | black   | green |
+      | MUG-4  | furniture | white   | black |
+      | MUG-5  | furniture | red     | black |
       | POST-1 | furniture | red     |       |
-      | POST-2 | furniture | red     |       |
+      | POST-2 | furniture | white   |       |
       | POST-3 | furniture | black   |       |
     And the following product groups:
       | code   | label  | axis           | type    | products                          |
       | MUG    | Mug    | color, company | VARIANT | MUG-1, MUG-2, MUG-3, MUG-4, MUG-5 |
-      | POSTIT | Postit | company        | X_SELL  | POST-1, POST-2, POST-3            |
+      | POSTIT | Postit | company        | VARIANT | POST-1, POST-2, POST-3            |
       | EMPTY  | Empty  |                | X_SELL  |                                   |
     And I am logged in as "Mary"
 
@@ -40,8 +40,8 @@ Feature: Filter products with multiples simpleselect filters
     And I filter by "Company" with value "Red"
     And I show the filter "Color"
     And I filter by "Color" with value "Green"
-    Then the grid should contain 3 elements
-    And I should see entities "MUG-2" and "MUG-3" and "MUG-4"
+    Then the grid should contain 1 elements
+    And I should see entities "MUG-2"
     And I hide the filter "Company"
     And I hide the filter "Color"
 
@@ -50,7 +50,7 @@ Feature: Filter products with multiples simpleselect filters
     And I show the filter "Company"
     And I filter by "Company" with value "Black"
     And I show the filter "Color"
-    And I filter by "Color" with value "Green"
+    And I filter by "Color" with value "Black"
     Then the grid should contain 0 elements
     And I hide the filter "Company"
     And I hide the filter "Color"

--- a/features/product/filtering/filter_products_with_multiple_simpleselect.feature
+++ b/features/product/filtering/filter_products_with_multiple_simpleselect.feature
@@ -27,11 +27,6 @@ Feature: Filter products with multiples simpleselect filters
       | POST-1 | furniture | red     |       |
       | POST-2 | furniture | white   |       |
       | POST-3 | furniture | black   |       |
-    And the following product groups:
-      | code   | label  | axis           | type    | products                          |
-      | MUG    | Mug    | color, company | VARIANT | MUG-1, MUG-2, MUG-3, MUG-4, MUG-5 |
-      | POSTIT | Postit | company        | VARIANT | POST-1, POST-2, POST-3            |
-      | EMPTY  | Empty  |                | X_SELL  |                                   |
     And I am logged in as "Mary"
 
   Scenario: Successfully filter products with the sames attributes

--- a/features/update/set_variant_group.feature
+++ b/features/update/set_variant_group.feature
@@ -22,7 +22,7 @@ Feature: Update variant group fields
       | tshirt2             | [{"type": "set_data", "field": "variant_group", "data": "TSHIRT1"}, {"type": "set_data", "field": "variant_group", "data": "TSHIRT3"}] | {"variant_group": "TSHIRT3"} |
 
   Scenario: Successfully update the variant group field and the group field
-    Given a "default" catalog configuration
+    Given a "footwear" catalog configuration
     And the following products:
       | sku                              |
       | tshirt1                          |
@@ -33,13 +33,13 @@ Feature: Update variant group fields
       | code |
       | PACK |
     And the following product groups:
-      | code    | label         | type    |
-      | TSHIRT1 | First tshirt  | VARIANT |
-      | TSHIRT2 | Second tshirt | VARIANT |
-      | TSHIRT3 | Third tshirt  | VARIANT |
-      | PACK1   | First pack    | PACK    |
-      | PACK2   | Second pack   | PACK    |
-      | PACK3   | Third pack    | PACK    |
+      | code    | label         | type    | axis |
+      | TSHIRT1 | First tshirt  | VARIANT | size |
+      | TSHIRT2 | Second tshirt | VARIANT | size |
+      | TSHIRT3 | Third tshirt  | VARIANT | size |
+      | PACK1   | First pack    | PACK    |      |
+      | PACK2   | Second pack   | PACK    |      |
+      | PACK3   | Third pack    | PACK    |      |
     Then I should get the following products after apply the following updater to it:
       | product | actions                                                                                                                                  | result                                                     |
       | tshirt1 | [{"type": "set_data", "field": "groups", "data": ["PACK1", "PACK2", "TSHIRT1"]}]                                                         | {"groups": ["PACK1", "PACK2"], "variant_group": "TSHIRT1"} |

--- a/features/update/set_variant_group.feature
+++ b/features/update/set_variant_group.feature
@@ -4,16 +4,16 @@ Feature: Update variant group fields
   I need to be able to update the variant group field of a product
 
   Scenario: Successfully update the variant group field
-    Given a "default" catalog configuration
+    Given a "footwear" catalog configuration
     And the following products:
       | sku                              |
       | tshirt1                          |
       | tshirt2                          |
     And the following product groups:
-      | code    | label         | type    |
-      | TSHIRT1 | First tshirt  | VARIANT |
-      | TSHIRT2 | Second tshirt | VARIANT |
-      | TSHIRT3 | Third tshirt  | VARIANT |
+      | code    | label         | type    | axis |
+      | TSHIRT1 | First tshirt  | VARIANT | size |
+      | TSHIRT2 | Second tshirt | VARIANT | size |
+      | TSHIRT3 | Third tshirt  | VARIANT | size |
     Then I should get the following products after apply the following updater to it:
       | product             | actions                                                                                                                                | result                       |
       | tshirt1             | [{"type": "set_data", "field": "variant_group", "data": "TSHIRT1"}]                                                                    | {"variant_group": "TSHIRT1"} |

--- a/spec/Pim/Bundle/CatalogBundle/Validator/Constraints/AttributeTypeForOptionValidatorSpec.php
+++ b/spec/Pim/Bundle/CatalogBundle/Validator/Constraints/AttributeTypeForOptionValidatorSpec.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace spec\Pim\Bundle\CatalogBundle\Validator\Constraints;
+
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\CatalogBundle\AttributeType\AttributeTypes;
+use Pim\Bundle\CatalogBundle\Model\AttributeInterface;
+use Pim\Bundle\CatalogBundle\Model\AttributeOptionInterface;
+use Pim\Bundle\CatalogBundle\Validator\Constraints\AttributeTypeForOption;
+use Prophecy\Argument;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
+
+class AttributeTypeForOptionValidatorSpec extends ObjectBehavior
+{
+    function let(ExecutionContextInterface $context)
+    {
+        $this->initialize($context);
+    }
+
+    function it_does_not_validate_if_object_is_not_a_product_value(
+        $context,
+        AttributeTypeForOption $constraint
+    ) {
+        $object = new \stdClass();
+        $context->buildViolation(Argument::cetera())->shouldNotBeCalled();
+
+        $this->validate($object, $constraint);
+    }
+
+    function it_does_not_add_violations_if_attribute_has_allowed_type(
+        $context,
+        AttributeOptionInterface $attributeOption,
+        AttributeInterface $allowedAttribute,
+        AttributeTypeForOption $constraint
+    ) {
+        $attributeOption->getAttribute()->willReturn($allowedAttribute);
+        $allowedAttribute->getAttributeType()->willReturn(AttributeTypes::OPTION_SIMPLE_SELECT);
+        $context->buildViolation(Argument::cetera())->shouldNotBeCalled();
+
+        $this->validate($attributeOption, $constraint);
+    }
+
+    function it_does_violations_if_attribute_type_is_not_allowed(
+        $context,
+        AttributeOptionInterface $attributeOption,
+        AttributeInterface $notAllowedAttribute,
+        AttributeTypeForOption $constraint,
+        ConstraintViolationBuilderInterface $violation
+    ) {
+        $attributeOption->getAttribute()->willReturn($notAllowedAttribute);
+        $notAllowedAttribute->getAttributeType()->willReturn(AttributeTypes::TEXT);
+        $notAllowedAttribute->getCode()->willReturn('attributeCode');
+
+        $violationData = [
+            '%attribute%' => 'attributeCode'
+        ];
+        $context->buildViolation($constraint->invalidAttributeMessage, $violationData)
+            ->shouldBeCalled()
+            ->willReturn($violation);
+
+        $this->validate($attributeOption, $constraint);
+    }
+}

--- a/spec/Pim/Bundle/CatalogBundle/Validator/Constraints/LocalizableValueValidatorSpec.php
+++ b/spec/Pim/Bundle/CatalogBundle/Validator/Constraints/LocalizableValueValidatorSpec.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace spec\Pim\Bundle\CatalogBundle\Validator\Constraints;
+
+use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\CatalogBundle\Model\AttributeInterface;
+use Pim\Bundle\CatalogBundle\Model\LocaleInterface;
+use Pim\Bundle\CatalogBundle\Model\ProductValueInterface;
+use Pim\Bundle\CatalogBundle\Validator\Constraints\LocalizableValue;
+use Prophecy\Argument;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
+
+class LocalizableValueValidatorSpec extends ObjectBehavior
+{
+    function let(IdentifiableObjectRepositoryInterface $localeRepository, ExecutionContextInterface $context)
+    {
+        $this->beConstructedWith($localeRepository);
+        $this->initialize($context);
+    }
+
+    function it_does_not_validate_if_object_is_not_a_product_value(
+        $context,
+        LocalizableValue $constraint
+    ) {
+        $object = new \stdClass();
+        $context->buildViolation(Argument::cetera())->shouldNotBeCalled();
+
+        $this->validate($object, $constraint);
+    }
+
+    function it_does_not_add_violations_if_value_is_localizable_and_has_an_existing_locale(
+        $context,
+        $localeRepository,
+        ProductValueInterface $value,
+        AttributeInterface $localizableAttribute,
+        LocaleInterface $existingLocale,
+        LocalizableValue $constraint
+    ) {
+        $value->getAttribute()->willReturn($localizableAttribute);
+        $localizableAttribute->isLocalizable()->willReturn(true);
+        $value->getLocale()->willReturn('mobile');
+        $localeRepository->findOneByIdentifier('mobile')->willReturn($existingLocale);
+        $context->buildViolation(Argument::cetera())->shouldNotBeCalled();
+
+        $this->validate($value, $constraint);
+    }
+
+    function it_adds_violations_if_value_is_localizable_and_does_not_have_locale(
+        $context,
+        ProductValueInterface $value,
+        AttributeInterface $localizableAttribute,
+        LocalizableValue $constraint,
+        ConstraintViolationBuilderInterface $violation
+    ) {
+        $value->getAttribute()->willReturn($localizableAttribute);
+        $localizableAttribute->isLocalizable()->willReturn(true);
+        $value->getLocale()->willReturn(null);
+        $localizableAttribute->getCode()->willReturn('attributeCode');
+
+        $violationData = [
+            '%attribute%' => 'attributeCode'
+        ];
+        $context->buildViolation($constraint->expectedLocaleMessage, $violationData)
+            ->shouldBeCalled()
+            ->willReturn($violation);
+
+        $this->validate($value, $constraint);
+    }
+
+    function it_adds_violations_if_value_is_not_localizable_and_a_locale_is_provided(
+        $context,
+        ProductValueInterface $value,
+        AttributeInterface $notLocalizableAttribute,
+        LocalizableValue $constraint,
+        ConstraintViolationBuilderInterface $violation
+    ) {
+        $value->getAttribute()->willReturn($notLocalizableAttribute);
+        $notLocalizableAttribute->isLocalizable()->willReturn(false);
+        $value->getLocale()->willReturn('aLocale');
+        $notLocalizableAttribute->getCode()->willReturn('attributeCode');
+
+        $violationData = [
+            '%attribute%' => 'attributeCode'
+        ];
+        $context->buildViolation($constraint->unexpectedLocaleMessage, $violationData)
+            ->shouldBeCalled()
+            ->willReturn($violation);
+
+        $this->validate($value, $constraint);
+    }
+
+    function it_adds_violations_if_value_is_localizable_and_its_locale_does_not_exist(
+        $context,
+        $localeRepository,
+        ProductValueInterface $value,
+        AttributeInterface $localizableAttribute,
+        LocalizableValue $constraint,
+        ConstraintViolationBuilderInterface $violation
+    ) {
+        $value->getAttribute()->willReturn($localizableAttribute);
+        $localizableAttribute->isLocalizable()->willReturn(true);
+        $value->getLocale()->willReturn('inexistingLocale');
+        $localizableAttribute->getCode()->willReturn('attributeCode');
+        $localeRepository->findOneByIdentifier('inexistingLocale')->willReturn(null);
+
+        $violationData = [
+            '%attribute%' => 'attributeCode',
+            '%locale%'    => 'inexistingLocale'
+        ];
+        $context->buildViolation($constraint->inexistingLocaleMessage, $violationData)
+            ->shouldBeCalled()
+            ->willReturn($violation);
+
+        $this->validate($value, $constraint);
+    }
+}

--- a/spec/Pim/Bundle/CatalogBundle/Validator/Constraints/ScopableValueValidatorSpec.php
+++ b/spec/Pim/Bundle/CatalogBundle/Validator/Constraints/ScopableValueValidatorSpec.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace spec\Pim\Bundle\CatalogBundle\Validator\Constraints;
+
+use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\CatalogBundle\Model\AttributeInterface;
+use Pim\Bundle\CatalogBundle\Model\ChannelInterface;
+use Pim\Bundle\CatalogBundle\Model\ProductValueInterface;
+use Pim\Bundle\CatalogBundle\Validator\Constraints\ScopableValue;
+use Prophecy\Argument;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
+
+class ScopableValueValidatorSpec extends ObjectBehavior
+{
+    function let(IdentifiableObjectRepositoryInterface $channelRepository, ExecutionContextInterface $context)
+    {
+        $this->beConstructedWith($channelRepository);
+        $this->initialize($context);
+    }
+
+    function it_does_not_validate_if_object_is_not_a_product_value(
+        $context,
+        ScopableValue $constraint
+    ) {
+        $object = new \stdClass();
+        $context->buildViolation(Argument::cetera())->shouldNotBeCalled();
+
+        $this->validate($object, $constraint);
+    }
+
+    function it_does_not_add_violations_if_value_is_scopable_and_has_an_existing_scope(
+        $context,
+        $channelRepository,
+        ProductValueInterface $value,
+        AttributeInterface $scopableAttribute,
+        ChannelInterface $existingChannel,
+        ScopableValue $constraint
+    ) {
+        $value->getAttribute()->willReturn($scopableAttribute);
+        $scopableAttribute->isScopable()->willReturn(true);
+        $value->getScope()->willReturn('mobile');
+        $channelRepository->findOneByIdentifier('mobile')->willReturn($existingChannel);
+        $context->buildViolation(Argument::cetera())->shouldNotBeCalled();
+
+        $this->validate($value, $constraint);
+    }
+
+    function it_adds_violations_if_value_is_scopable_and_does_not_have_scope(
+        $context,
+        ProductValueInterface $value,
+        AttributeInterface $scopableAttribute,
+        ScopableValue $constraint,
+        ConstraintViolationBuilderInterface $violation
+    ) {
+        $value->getAttribute()->willReturn($scopableAttribute);
+        $scopableAttribute->isScopable()->willReturn(true);
+        $value->getScope()->willReturn(null);
+        $scopableAttribute->getCode()->willReturn('attributeCode');
+
+        $violationData = [
+            '%attribute%' => 'attributeCode'
+        ];
+        $context->buildViolation($constraint->expectedScopeMessage, $violationData)
+            ->shouldBeCalled()
+            ->willReturn($violation);
+
+        $this->validate($value, $constraint);
+    }
+
+    function it_adds_violations_if_value_is_not_scopable_and_a_scope_is_provided(
+        $context,
+        ProductValueInterface $value,
+        AttributeInterface $notScopableAttribute,
+        ScopableValue $constraint,
+        ConstraintViolationBuilderInterface $violation
+    ) {
+        $value->getAttribute()->willReturn($notScopableAttribute);
+        $notScopableAttribute->isScopable()->willReturn(false);
+        $value->getScope()->willReturn('aScope');
+        $notScopableAttribute->getCode()->willReturn('attributeCode');
+
+        $violationData = [
+            '%attribute%' => 'attributeCode'
+        ];
+        $context->buildViolation($constraint->unexpectedScopeMessage, $violationData)
+            ->shouldBeCalled()
+            ->willReturn($violation);
+
+        $this->validate($value, $constraint);
+    }
+
+    function it_adds_violations_if_value_is_scopable_and_its_scope_does_not_exist(
+        $context,
+        $channelRepository,
+        ProductValueInterface $value,
+        AttributeInterface $scopableAttribute,
+        ScopableValue $constraint,
+        ConstraintViolationBuilderInterface $violation
+    ) {
+        $value->getAttribute()->willReturn($scopableAttribute);
+        $scopableAttribute->isScopable()->willReturn(true);
+        $value->getScope()->willReturn('inexistingChannel');
+        $scopableAttribute->getCode()->willReturn('attributeCode');
+        $channelRepository->findOneByIdentifier('inexistingChannel')->willReturn(null);
+
+        $violationData = [
+            '%attribute%' => 'attributeCode',
+            '%channel%'   => 'inexistingChannel'
+        ];
+        $context->buildViolation($constraint->inexistingScopeMessage, $violationData)
+            ->shouldBeCalled()
+            ->willReturn($violation);
+
+        $this->validate($value, $constraint);
+    }
+}

--- a/spec/Pim/Bundle/CatalogBundle/Validator/Constraints/UniqueVariantAxisValidatorSpec.php
+++ b/spec/Pim/Bundle/CatalogBundle/Validator/Constraints/UniqueVariantAxisValidatorSpec.php
@@ -108,7 +108,6 @@ class UniqueVariantAxisValidatorSpec extends ObjectBehavior
         ProductValueInterface $colorProductValue,
         UniqueVariantAxis $uniqueVariantAxisConstraint,
         ConstraintViolationBuilderInterface $violation
-
     ) {
         $tShirtGroupType->isVariant()->willReturn(true);
 

--- a/src/Pim/Bundle/CatalogBundle/AttributeType/AttributeTypes.php
+++ b/src/Pim/Bundle/CatalogBundle/AttributeType/AttributeTypes.php
@@ -34,4 +34,8 @@ final class AttributeTypes
     const TEXTAREA = 'pim_catalog_textarea';
 
     const TEXT = 'pim_catalog_text';
+
+    const REFERENCE_DATA_MULTI_SELECT = 'pim_reference_data_multiselect';
+
+    const REFERENCE_DATA_SIMPLE_SELECT = 'pim_reference_data_simpleselect';
 }

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/repositories.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/repositories.yml
@@ -150,3 +150,8 @@ services:
         class: %akeneo_storage_utils.repository.base_cached_object.class%
         arguments:
             - '@pim_catalog.repository.channel'
+
+    pim_catalog.repository.cached_locale:
+        class: %akeneo_storage_utils.repository.base_cached_object.class%
+        arguments:
+            - '@pim_catalog.repository.locale'

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/repositories.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/repositories.yml
@@ -145,3 +145,8 @@ services:
         class: %akeneo_storage_utils.repository.base_cached_object.class%
         arguments:
             - '@pim_catalog.repository.category'
+
+    pim_catalog.repository.cached_channel:
+        class: %akeneo_storage_utils.repository.base_cached_object.class%
+        arguments:
+            - '@pim_catalog.repository.channel'

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/validation/attribute.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/validation/attribute.yml
@@ -159,6 +159,7 @@ Pim\Bundle\CatalogBundle\Entity\AttributeOption:
         - Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity:
             - code
             - attribute
+        - Pim\Bundle\CatalogBundle\Validator\Constraints\AttributeTypeForOption : ~
     properties:
         code:
             - NotBlank: ~

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/validation/productvalue.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/validation/productvalue.yml
@@ -1,0 +1,3 @@
+Pim\Bundle\CatalogBundle\Model\ProductValue:
+    constraints:
+        - Pim\Bundle\CatalogBundle\Validator\Constraints\ScopableValue: ~

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/validation/productvalue.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/validation/productvalue.yml
@@ -1,3 +1,4 @@
 Pim\Bundle\CatalogBundle\Model\ProductValue:
     constraints:
         - Pim\Bundle\CatalogBundle\Validator\Constraints\ScopableValue: ~
+        - Pim\Bundle\CatalogBundle\Validator\Constraints\LocalizableValue: ~

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/validators.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/validators.yml
@@ -15,6 +15,7 @@ parameters:
     pim_catalog.validator.constraint.family_requirements.class:            Pim\Bundle\CatalogBundle\Validator\Constraints\FamilyRequirementsValidator
     pim_catalog.validator.constraint.scopable_value.class:                 Pim\Bundle\CatalogBundle\Validator\Constraints\ScopableValueValidator
     pim_catalog.validator.constraint.localizable_value.class:              Pim\Bundle\CatalogBundle\Validator\Constraints\LocalizableValueValidator
+    pim_catalog.validator.constraint.attribute_type_for_option.class:      Pim\Bundle\CatalogBundle\Validator\Constraints\AttributeTypeForOptionValidator
     pim_catalog.validator.constraint_guesser.chained.class:                Pim\Bundle\CatalogBundle\Validator\ChainedAttributeConstraintGuesser
     pim_catalog.validator.constraint_guesser.email.class:                  Pim\Bundle\CatalogBundle\Validator\ConstraintGuesser\EmailGuesser
     pim_catalog.validator.constraint_guesser.file.class:                   Pim\Bundle\CatalogBundle\Validator\ConstraintGuesser\FileGuesser
@@ -138,6 +139,11 @@ services:
             - '@pim_catalog.repository.cached_locale'
         tags:
             - { name: validator.constraint_validator, alias: pim_localizable_value_validator }
+
+    pim_catalog.validator.constraint.attribute_type_for_option:
+        class: %pim_catalog.validator.constraint.attribute_type_for_option.class%
+        tags:
+            - { name: validator.constraint_validator, alias: pim_attribute_type_for_option_validator }
 
     # Attribute constraint guesser
     pim_catalog.validator.constraint_guesser.chained_attribute:

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/validators.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/validators.yml
@@ -13,6 +13,7 @@ parameters:
     pim_catalog.validator.constraint.variant_group_axis.class:             Pim\Bundle\CatalogBundle\Validator\Constraints\VariantGroupAxisValidator
     pim_catalog.validator.constraint.has_variant_axes.class:               Pim\Bundle\CatalogBundle\Validator\Constraints\HasVariantAxesValidator
     pim_catalog.validator.constraint.family_requirements.class:            Pim\Bundle\CatalogBundle\Validator\Constraints\FamilyRequirementsValidator
+    pim_catalog.validator.constraint.scopable_value.class:                 Pim\Bundle\CatalogBundle\Validator\Constraints\ScopableValueValidator
     pim_catalog.validator.constraint_guesser.chained.class:                Pim\Bundle\CatalogBundle\Validator\ChainedAttributeConstraintGuesser
     pim_catalog.validator.constraint_guesser.email.class:                  Pim\Bundle\CatalogBundle\Validator\ConstraintGuesser\EmailGuesser
     pim_catalog.validator.constraint_guesser.file.class:                   Pim\Bundle\CatalogBundle\Validator\ConstraintGuesser\FileGuesser
@@ -122,6 +123,13 @@ services:
             - '@pim_catalog.repository.channel'
         tags:
             - { name: validator.constraint_validator, alias: pim_family_requirements_validator }
+
+    pim_catalog.validator.constraint.scopable_value:
+        class: %pim_catalog.validator.constraint.scopable_value.class%
+        arguments:
+            - '@pim_catalog.repository.cached_channel'
+        tags:
+            - { name: validator.constraint_validator, alias: pim_scopable_value_validator }
 
     # Attribute constraint guesser
     pim_catalog.validator.constraint_guesser.chained_attribute:

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/validators.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/validators.yml
@@ -14,6 +14,7 @@ parameters:
     pim_catalog.validator.constraint.has_variant_axes.class:               Pim\Bundle\CatalogBundle\Validator\Constraints\HasVariantAxesValidator
     pim_catalog.validator.constraint.family_requirements.class:            Pim\Bundle\CatalogBundle\Validator\Constraints\FamilyRequirementsValidator
     pim_catalog.validator.constraint.scopable_value.class:                 Pim\Bundle\CatalogBundle\Validator\Constraints\ScopableValueValidator
+    pim_catalog.validator.constraint.localizable_value.class:              Pim\Bundle\CatalogBundle\Validator\Constraints\LocalizableValueValidator
     pim_catalog.validator.constraint_guesser.chained.class:                Pim\Bundle\CatalogBundle\Validator\ChainedAttributeConstraintGuesser
     pim_catalog.validator.constraint_guesser.email.class:                  Pim\Bundle\CatalogBundle\Validator\ConstraintGuesser\EmailGuesser
     pim_catalog.validator.constraint_guesser.file.class:                   Pim\Bundle\CatalogBundle\Validator\ConstraintGuesser\FileGuesser
@@ -130,6 +131,13 @@ services:
             - '@pim_catalog.repository.cached_channel'
         tags:
             - { name: validator.constraint_validator, alias: pim_scopable_value_validator }
+
+    pim_catalog.validator.constraint.localizable_value:
+        class: %pim_catalog.validator.constraint.localizable_value.class%
+        arguments:
+            - '@pim_catalog.repository.cached_locale'
+        tags:
+            - { name: validator.constraint_validator, alias: pim_localizable_value_validator }
 
     # Attribute constraint guesser
     pim_catalog.validator.constraint_guesser.chained_attribute:

--- a/src/Pim/Bundle/CatalogBundle/Validator/Constraints/AttributeTypeForOption.php
+++ b/src/Pim/Bundle/CatalogBundle/Validator/Constraints/AttributeTypeForOption.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Constraint to check that the attribute used with an option is valid
+ *
+ * @author    Nicolas Dupont <nicolas@akeneo.com>
+ * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class AttributeTypeForOption extends Constraint
+{
+    /** @var string */
+    public $invalidAttributeMessage = 'Invalid type for attribute "%attribute%", it cannot be used with options';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validatedBy()
+    {
+        return 'pim_attribute_type_for_option_validator';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTargets()
+    {
+        return self::CLASS_CONSTRAINT;
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Validator/Constraints/AttributeTypeForOptionValidator.php
+++ b/src/Pim/Bundle/CatalogBundle/Validator/Constraints/AttributeTypeForOptionValidator.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\Validator\Constraints;
+
+use Pim\Bundle\CatalogBundle\AttributeType\AttributeTypes;
+use Pim\Bundle\CatalogBundle\Model\AttributeOptionInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ * Validator for attribute used for an option
+ *
+ * @author    Nicolas Dupont <nicolas@akeneo.com>
+ * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class AttributeTypeForOptionValidator extends ConstraintValidator
+{
+    /**
+     * @param object     $attributeOption
+     * @param Constraint $constraint
+     */
+    public function validate($attributeOption, Constraint $constraint)
+    {
+        /** @var AttributeOptionInterface */
+        if ($attributeOption instanceof AttributeOptionInterface) {
+            $attribute = $attributeOption->getAttribute();
+            $authorizedTypes = [AttributeTypes::OPTION_SIMPLE_SELECT, AttributeTypes::OPTION_MULTI_SELECT];
+            if (!in_array($attribute->getAttributeType(), $authorizedTypes)) {
+                $this->addInvalidAttributeViolation($constraint, $attributeOption);
+            }
+        }
+    }
+
+    /**
+     * @param AttributeTypeForOption   $constraint
+     * @param AttributeOptionInterface $option
+     */
+    protected function addInvalidAttributeViolation(
+        AttributeTypeForOption $constraint,
+        AttributeOptionInterface $option
+    ) {
+        $this->context->buildViolation(
+            $constraint->invalidAttributeMessage,
+            [
+                '%attribute%' => $option->getAttribute()->getCode()
+            ]
+        )->addViolation();
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Validator/Constraints/AttributeTypeForOptionValidator.php
+++ b/src/Pim/Bundle/CatalogBundle/Validator/Constraints/AttributeTypeForOptionValidator.php
@@ -24,7 +24,7 @@ class AttributeTypeForOptionValidator extends ConstraintValidator
     {
         /** @var AttributeOptionInterface */
         if ($attributeOption instanceof AttributeOptionInterface) {
-            $attribute = $attributeOption->getAttribute();
+            $attribute       = $attributeOption->getAttribute();
             $authorizedTypes = [AttributeTypes::OPTION_SIMPLE_SELECT, AttributeTypes::OPTION_MULTI_SELECT];
             if (!in_array($attribute->getAttributeType(), $authorizedTypes)) {
                 $this->addInvalidAttributeViolation($constraint, $attributeOption);

--- a/src/Pim/Bundle/CatalogBundle/Validator/Constraints/LocalizableValue.php
+++ b/src/Pim/Bundle/CatalogBundle/Validator/Constraints/LocalizableValue.php
@@ -5,7 +5,7 @@ namespace Pim\Bundle\CatalogBundle\Validator\Constraints;
 use Symfony\Component\Validator\Constraint;
 
 /**
- * Constraint to check localizable value has existing locale, and not localizable value has no locale
+ * Constraint to check if localizable value has existing locale, and if not localizable value has no locale
  *
  * @author    Nicolas Dupont <nicolas@akeneo.com>
  * @copyright 2015 Akeneo SAS (http://www.akeneo.com)

--- a/src/Pim/Bundle/CatalogBundle/Validator/Constraints/LocalizableValue.php
+++ b/src/Pim/Bundle/CatalogBundle/Validator/Constraints/LocalizableValue.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Constraint to check localizable value has existing locale, and not localizable value has no locale
+ *
+ * @author    Nicolas Dupont <nicolas@akeneo.com>
+ * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class LocalizableValue extends Constraint
+{
+    /** @var string */
+    public $expectedLocaleMessage = 'Product value for attribute "%attribute%" must be defined with a locale';
+
+    /** @var string */
+    public $unexpectedLocaleMessage = 'Product value for attribute "%attribute%" must be defined without a locale';
+
+    /** @var string */
+    public $inexistingLocaleMessage = 'Inexisting locale "%locale%" is used to localize the value "%attribute%"';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validatedBy()
+    {
+        return 'pim_localizable_value_validator';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTargets()
+    {
+        return self::CLASS_CONSTRAINT;
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Validator/Constraints/LocalizableValueValidator.php
+++ b/src/Pim/Bundle/CatalogBundle/Validator/Constraints/LocalizableValueValidator.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\Validator\Constraints;
+
+use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
+use Pim\Bundle\CatalogBundle\Model\ProductValueInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ * Validator for localizable product value
+ *
+ * @author    Nicolas Dupont <nicolas@akeneo.com>
+ * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class LocalizableValueValidator extends ConstraintValidator
+{
+    /** @var IdentifiableObjectRepositoryInterface */
+    protected $localeRepository;
+
+    /**
+     * @param IdentifiableObjectRepositoryInterface $localeRepository
+     */
+    public function __construct(IdentifiableObjectRepositoryInterface $localeRepository)
+    {
+        $this->localeRepository = $localeRepository;
+    }
+
+    /**
+     * @param object     $productValue
+     * @param Constraint $constraint
+     */
+    public function validate($productValue, Constraint $constraint)
+    {
+        /** @var ProductValueInterface */
+        if ($productValue instanceof ProductValueInterface) {
+            $isLocalizable = $productValue->getAttribute()->isLocalizable();
+            $localeCode = $productValue->getLocale();
+
+            if ($isLocalizable && null === $localeCode) {
+                $this->addExpectedLocaleViolation($constraint, $productValue);
+            } elseif ($isLocalizable && !$this->localeExists($localeCode)) {
+                $this->addUnexistingLocaleViolation($constraint, $productValue, $localeCode);
+            } elseif (!$isLocalizable && null !== $localeCode) {
+                $this->addUnexpectedLocaleViolation($constraint, $productValue);
+            }
+        }
+    }
+
+    /**
+     * @param string $localeCode
+     *
+     * @return bool
+     */
+    protected function localeExists($localeCode)
+    {
+        $locale = $this->localeRepository->findOneByIdentifier($localeCode);
+
+        return null !== $locale;
+    }
+
+    /**
+     * @param LocalizableValue      $constraint
+     * @param ProductValueInterface $value
+     */
+    protected function addExpectedLocaleViolation(LocalizableValue $constraint, ProductValueInterface $value)
+    {
+        $this->context->buildViolation(
+            $constraint->expectedLocaleMessage,
+            [
+                '%attribute%' => $value->getAttribute()->getCode()
+            ]
+        )->addViolation();
+    }
+
+    /**
+     * @param LocalizableValue      $constraint
+     * @param ProductValueInterface $value
+     * @param string                $localeCode
+     */
+    protected function addUnexistingLocaleViolation(
+        LocalizableValue $constraint,
+        ProductValueInterface $value,
+        $localeCode
+    ) {
+        $this->context->buildViolation(
+            $constraint->inexistingLocaleMessage,
+            [
+                '%attribute%' => $value->getAttribute()->getCode(),
+                '%locale%'    => $localeCode
+            ]
+        )->addViolation();
+    }
+
+    /**
+     * @param LocalizableValue      $constraint
+     * @param ProductValueInterface $value
+     */
+    protected function addUnexpectedLocaleViolation(LocalizableValue $constraint, ProductValueInterface $value)
+    {
+        $this->context->buildViolation(
+            $constraint->unexpectedLocaleMessage,
+            [
+                '%attribute%' => $value->getAttribute()->getCode()
+            ]
+        )->addViolation();
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Validator/Constraints/LocalizableValueValidator.php
+++ b/src/Pim/Bundle/CatalogBundle/Validator/Constraints/LocalizableValueValidator.php
@@ -36,11 +36,11 @@ class LocalizableValueValidator extends ConstraintValidator
         /** @var ProductValueInterface */
         if ($productValue instanceof ProductValueInterface) {
             $isLocalizable = $productValue->getAttribute()->isLocalizable();
-            $localeCode = $productValue->getLocale();
+            $localeCode    = $productValue->getLocale();
 
             if ($isLocalizable && null === $localeCode) {
                 $this->addExpectedLocaleViolation($constraint, $productValue);
-            } elseif ($isLocalizable && !$this->localeExists($localeCode)) {
+            } elseif ($isLocalizable && !$this->doesLocaleExist($localeCode)) {
                 $this->addUnexistingLocaleViolation($constraint, $productValue, $localeCode);
             } elseif (!$isLocalizable && null !== $localeCode) {
                 $this->addUnexpectedLocaleViolation($constraint, $productValue);
@@ -53,7 +53,7 @@ class LocalizableValueValidator extends ConstraintValidator
      *
      * @return bool
      */
-    protected function localeExists($localeCode)
+    protected function doesLocaleExist($localeCode)
     {
         $locale = $this->localeRepository->findOneByIdentifier($localeCode);
 

--- a/src/Pim/Bundle/CatalogBundle/Validator/Constraints/ScopableValue.php
+++ b/src/Pim/Bundle/CatalogBundle/Validator/Constraints/ScopableValue.php
@@ -5,7 +5,7 @@ namespace Pim\Bundle\CatalogBundle\Validator\Constraints;
 use Symfony\Component\Validator\Constraint;
 
 /**
- * Constraint to check scopable value has existing scope, and not scopable value has no scope
+ * Constraint to check if scopable value has existing scope, and if not scopable value has no scope
  *
  * @author    Nicolas Dupont <nicolas@akeneo.com>
  * @copyright 2015 Akeneo SAS (http://www.akeneo.com)

--- a/src/Pim/Bundle/CatalogBundle/Validator/Constraints/ScopableValue.php
+++ b/src/Pim/Bundle/CatalogBundle/Validator/Constraints/ScopableValue.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Constraint to check scopable value has existing scope, and not scopable value has no scope
+ *
+ * @author    Nicolas Dupont <nicolas@akeneo.com>
+ * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ScopableValue extends Constraint
+{
+    /** @var string */
+    public $expectedScopeMessage = 'Product value for attribute "%attribute%" must be defined with a scope';
+
+    /** @var string */
+    public $unexpectedScopeMessage = 'Product value for attribute "%attribute%" must be defined without a scope';
+
+    /** @var string */
+    public $inexistingScopeMessage = 'Inexisting channel "%channel%" is used to scope the product value "%attribute%"';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validatedBy()
+    {
+        return 'pim_scopable_value_validator';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTargets()
+    {
+        return self::CLASS_CONSTRAINT;
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Validator/Constraints/ScopableValueValidator.php
+++ b/src/Pim/Bundle/CatalogBundle/Validator/Constraints/ScopableValueValidator.php
@@ -40,7 +40,7 @@ class ScopableValueValidator extends ConstraintValidator
 
             if ($isScopable && null === $channelCode) {
                 $this->addExpectedScopeViolation($constraint, $productValue);
-            } elseif ($isScopable && !$this->channelExists($channelCode)) {
+            } elseif ($isScopable && !$this->doesChannelExist($channelCode)) {
                 $this->addUnexistingScopeViolation($constraint, $productValue, $channelCode);
             } elseif (!$isScopable && null !== $channelCode) {
                 $this->addUnexpectedScopeViolation($constraint, $productValue);
@@ -53,7 +53,7 @@ class ScopableValueValidator extends ConstraintValidator
      *
      * @return bool
      */
-    protected function channelExists($channelCode)
+    protected function doesChannelExist($channelCode)
     {
         $channel = $this->channelRepository->findOneByIdentifier($channelCode);
 

--- a/src/Pim/Bundle/CatalogBundle/Validator/Constraints/ScopableValueValidator.php
+++ b/src/Pim/Bundle/CatalogBundle/Validator/Constraints/ScopableValueValidator.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\Validator\Constraints;
+
+use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
+use Pim\Bundle\CatalogBundle\Model\ProductValueInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ * Validator for scopable product value
+ *
+ * @author    Nicolas Dupont <nicolas@akeneo.com>
+ * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ScopableValueValidator extends ConstraintValidator
+{
+    /** @var IdentifiableObjectRepositoryInterface */
+    protected $channelRepository;
+
+    /**
+     * @param IdentifiableObjectRepositoryInterface $channelRepository
+     */
+    public function __construct(IdentifiableObjectRepositoryInterface $channelRepository)
+    {
+        $this->channelRepository = $channelRepository;
+    }
+
+    /**
+     * @param object     $productValue
+     * @param Constraint $constraint
+     */
+    public function validate($productValue, Constraint $constraint)
+    {
+        /** @var ProductValueInterface */
+        if ($productValue instanceof ProductValueInterface) {
+            $isScopable = $productValue->getAttribute()->isScopable();
+            $channelCode = $productValue->getScope();
+
+            if ($isScopable && null === $channelCode) {
+                $this->addExpectedScopeViolation($constraint, $productValue);
+            } elseif ($isScopable && !$this->channelExists($channelCode)) {
+                $this->addUnexistingScopeViolation($constraint, $productValue, $channelCode);
+            } elseif (!$isScopable && null !== $channelCode) {
+                $this->addUnexpectedScopeViolation($constraint, $productValue);
+            }
+        }
+    }
+
+    /**
+     * @param string $channelCode
+     *
+     * @return bool
+     */
+    protected function channelExists($channelCode)
+    {
+        $channel = $this->channelRepository->findOneByIdentifier($channelCode);
+
+        return null !== $channel;
+    }
+
+    /**
+     * @param ScopableValue         $constraint
+     * @param ProductValueInterface $value
+     */
+    protected function addExpectedScopeViolation(ScopableValue $constraint, ProductValueInterface $value)
+    {
+        $this->context->buildViolation(
+            $constraint->expectedScopeMessage,
+            [
+                '%attribute%' => $value->getAttribute()->getCode()
+            ]
+        )->addViolation();
+    }
+
+    /**
+     * @param ScopableValue         $constraint
+     * @param ProductValueInterface $value
+     * @param string                $channelCode
+     */
+    protected function addUnexistingScopeViolation(
+        ScopableValue $constraint,
+        ProductValueInterface $value,
+        $channelCode
+    ) {
+        $this->context->buildViolation(
+            $constraint->inexistingScopeMessage,
+            [
+                '%attribute%' => $value->getAttribute()->getCode(),
+                '%channel%'   => $channelCode
+            ]
+        )->addViolation();
+    }
+
+    /**
+     * @param ScopableValue         $constraint
+     * @param ProductValueInterface $value
+     */
+    protected function addUnexpectedScopeViolation(ScopableValue $constraint, ProductValueInterface $value)
+    {
+        $this->context->buildViolation(
+            $constraint->unexpectedScopeMessage,
+            [
+                '%attribute%' => $value->getAttribute()->getCode()
+            ]
+        )->addViolation();
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Validator/Constraints/UniqueVariantAxis.php
+++ b/src/Pim/Bundle/CatalogBundle/Validator/Constraints/UniqueVariantAxis.php
@@ -21,6 +21,13 @@ class UniqueVariantAxis extends Constraint
     public $message = 'Group "%variant group%" already contains another product with values "%values%"';
 
     /**
+     * Violation message for missing axis value
+     *
+     * @var string
+     */
+    public $missingAxisMessage = 'Product "%product%" should have value for axis "%axis%" of variant group "%group%"';
+
+    /**
      * {@inheritdoc}
      */
     public function validatedBy()

--- a/src/Pim/Bundle/CatalogBundle/Validator/Constraints/UniqueVariantAxisValidator.php
+++ b/src/Pim/Bundle/CatalogBundle/Validator/Constraints/UniqueVariantAxisValidator.php
@@ -65,13 +65,22 @@ class UniqueVariantAxisValidator extends ConstraintValidator
             $values = array();
             foreach ($variantGroup->getAxisAttributes() as $attribute) {
                 $code = $attribute->getCode();
-                $option = $product->getValue($code) ? (string) $product->getValue($code)->getOption() : '';
+                $option = $product->getValue($code) ? (string) $product->getValue($code)->getOption() : null;
+
+                if (null === $option) {
+                    $this->addEmptyAxisViolation(
+                        $constraint,
+                        $variantGroup->getLabel(),
+                        $product->getIdentifier()->getVarchar(),
+                        $attribute->getCode()
+                    );
+                }
                 $values[] = sprintf('%s: %s', $code, $option);
             }
             $combination = implode(', ', $values);
 
             if (in_array($combination, $existingCombinations)) {
-                $this->addViolation($constraint, $variantGroup->getLabel(), $combination);
+                $this->addExistingCombinationViolation($constraint, $variantGroup->getLabel(), $combination);
             } else {
                 $existingCombinations[] = $combination;
             }
@@ -92,14 +101,14 @@ class UniqueVariantAxisValidator extends ConstraintValidator
 
         foreach ($product->getGroups() as $variantGroup) {
             if ($variantGroup->getType()->isVariant()) {
-                $criteria = $this->prepareQueryCriterias($variantGroup, $product);
+                $criteria = $this->prepareQueryCriterias($variantGroup, $product, $constraint);
                 $matchingProducts = $this->getMatchingProducts($variantGroup, $product, $criteria);
                 if (count($matchingProducts) !== 0) {
                     $values = array();
                     foreach ($criteria as $item) {
                         $values[] = sprintf('%s: %s', $item['attribute']->getCode(), (string) $item['option']);
                     }
-                    $this->addViolation(
+                    $this->addExistingCombinationViolation(
                         $constraint,
                         $variantGroup->getLabel(),
                         implode(', ', $values)
@@ -114,11 +123,15 @@ class UniqueVariantAxisValidator extends ConstraintValidator
      *
      * @param GroupInterface   $variantGroup
      * @param ProductInterface $product
+     * @param Constraint       $constraint
      *
      * @return array
      */
-    protected function prepareQueryCriterias(GroupInterface $variantGroup, ProductInterface $product)
-    {
+    protected function prepareQueryCriterias(
+        GroupInterface $variantGroup,
+        ProductInterface $product,
+        Constraint $constraint
+    ) {
         $criteria = array();
         foreach ($variantGroup->getAxisAttributes() as $attribute) {
             $value = $product->getValue($attribute->getCode());
@@ -128,6 +141,13 @@ class UniqueVariantAxisValidator extends ConstraintValidator
                     'attribute' => $attribute,
                     'option'    => $value->getOption(),
                 ];
+            } else {
+                $this->addEmptyAxisViolation(
+                    $constraint,
+                    $variantGroup->getLabel(),
+                    $product->getIdentifier()->getVarchar(),
+                    $attribute->getCode()
+                );
             }
         }
 
@@ -167,19 +187,37 @@ class UniqueVariantAxisValidator extends ConstraintValidator
     }
 
     /**
-     * Add violation to the executioncontext
+     * Add existing combination violation
      *
      * @param Constraint $constraint
      * @param string     $variantLabel
      * @param string     $values
      */
-    protected function addViolation(Constraint $constraint, $variantLabel, $values)
+    protected function addExistingCombinationViolation(Constraint $constraint, $variantLabel, $values)
     {
         $this->context->buildViolation(
             $constraint->message,
             [
                 '%variant group%' => $variantLabel,
                 '%values%'        => $values
+            ]
+        )->addViolation();
+    }
+
+    /**
+     * @param Constraint $constraint
+     * @param string $variantLabel
+     * @param string $productIdentifier
+     * @param string $axisCode
+     */
+    protected function addEmptyAxisViolation(Constraint $constraint, $variantLabel, $productIdentifier, $axisCode)
+    {
+        $this->context->buildViolation(
+            $constraint->missingAxisMessage,
+            [
+                '%group%'   => $variantLabel,
+                '%product%' => $productIdentifier,
+                '%axis%'    => $axisCode
             ]
         )->addViolation();
     }

--- a/src/Pim/Bundle/CatalogBundle/Validator/Constraints/UniqueVariantAxisValidator.php
+++ b/src/Pim/Bundle/CatalogBundle/Validator/Constraints/UniqueVariantAxisValidator.php
@@ -206,9 +206,9 @@ class UniqueVariantAxisValidator extends ConstraintValidator
 
     /**
      * @param Constraint $constraint
-     * @param string $variantLabel
-     * @param string $productIdentifier
-     * @param string $axisCode
+     * @param string     $variantLabel
+     * @param string     $productIdentifier
+     * @param string     $axisCode
      */
     protected function addEmptyAxisViolation(Constraint $constraint, $variantLabel, $productIdentifier, $axisCode)
     {

--- a/src/Pim/Bundle/CatalogBundle/Validator/Constraints/VariantGroupAxis.php
+++ b/src/Pim/Bundle/CatalogBundle/Validator/Constraints/VariantGroupAxis.php
@@ -19,6 +19,9 @@ class VariantGroupAxis extends Constraint
     /** @var string */
     public $unexpectedAxisMessage = 'Group "%group%", which is not variant, can not be defined with axes';
 
+    /** @var string */
+    public $invalidAxisMessage = 'Attribute "%attribute%" cannot be used as axis of variant group "%group%"';
+
     /**
      * {@inheritdoc}
      */

--- a/src/Pim/Bundle/CatalogBundle/Validator/Constraints/VariantGroupAxisValidator.php
+++ b/src/Pim/Bundle/CatalogBundle/Validator/Constraints/VariantGroupAxisValidator.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Bundle\CatalogBundle\Validator\Constraints;
 
+use Pim\Bundle\CatalogBundle\AttributeType\AttributeTypes;
 use Pim\Bundle\CatalogBundle\Model\GroupInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
@@ -29,20 +30,69 @@ class VariantGroupAxisValidator extends ConstraintValidator
             $isVariantGroup = $variantGroup->getType()->isVariant();
             $hasAxis = count($variantGroup->getAxisAttributes()) > 0;
             if ($isNew && $isVariantGroup && !$hasAxis) {
-                $this->context->buildViolation(
-                    $constraint->expectedAxisMessage,
-                    [
-                        '%variant group%' => $variantGroup->getCode()
-                    ]
-                )->addViolation();
+                $this->addExpectedAxisViolation($constraint, $variantGroup->getCode());
+            } elseif ($isVariantGroup && $hasAxis) {
+                $this->validateAttributeAxis($constraint, $variantGroup);
             } elseif (!$isVariantGroup && $hasAxis) {
-                $this->context->buildViolation(
-                    $constraint->unexpectedAxisMessage,
-                    [
-                        '%group%' => $variantGroup->getCode()
-                    ]
-                )->addViolation();
+                $this->addUnexpectedAxisViolation($constraint, $variantGroup->getCode());
             }
         }
+    }
+
+    /**
+     * @param VariantGroupAxis $constraint
+     * @param GroupInterface   $variantGroup
+     */
+    protected function validateAttributeAxis(VariantGroupAxis $constraint, GroupInterface $variantGroup)
+    {
+        foreach ($variantGroup->getAxisAttributes() as $attribute) {
+            if (AttributeTypes::OPTION_SIMPLE_SELECT !== $attribute->getAttributeType()) {
+                $this->addInvalidAxisViolation($constraint, $variantGroup->getCode(), $attribute->getCode());
+            }
+        }
+    }
+
+    /**
+     * @param VariantGroupAxis $constraint
+     * @param string           $groupCode
+     */
+    protected function addExpectedAxisViolation(VariantGroupAxis $constraint, $groupCode)
+    {
+        $this->context->buildViolation(
+            $constraint->expectedAxisMessage,
+            [
+                '%variant group%' => $groupCode
+            ]
+        )->addViolation();
+    }
+
+    /**
+     * @param VariantGroupAxis $constraint
+     * @param string           $groupCode
+     */
+    protected function addUnexpectedAxisViolation(VariantGroupAxis $constraint, $groupCode)
+    {
+        $this->context->buildViolation(
+            $constraint->unexpectedAxisMessage,
+            [
+                '%group%' => $groupCode
+            ]
+        )->addViolation();
+    }
+
+    /**
+     * @param VariantGroupAxis $constraint
+     * @param string           $groupCode
+     * @param string           $attributeCode
+     */
+    protected function addInvalidAxisViolation(VariantGroupAxis $constraint, $groupCode, $attributeCode)
+    {
+        $this->context->buildViolation(
+            $constraint->invalidAxisMessage,
+            [
+                '%group%'     => $groupCode,
+                '%attribute%' => $attributeCode,
+            ]
+        )->addViolation();
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/Validator/Constraints/VariantGroupAxisValidator.php
+++ b/src/Pim/Bundle/CatalogBundle/Validator/Constraints/VariantGroupAxisValidator.php
@@ -45,8 +45,9 @@ class VariantGroupAxisValidator extends ConstraintValidator
      */
     protected function validateAttributeAxis(VariantGroupAxis $constraint, GroupInterface $variantGroup)
     {
+        $allowedTypes = [AttributeTypes::OPTION_SIMPLE_SELECT, AttributeTypes::REFERENCE_DATA_SIMPLE_SELECT];
         foreach ($variantGroup->getAxisAttributes() as $attribute) {
-            if (AttributeTypes::OPTION_SIMPLE_SELECT !== $attribute->getAttributeType()) {
+            if (!in_array($attribute->getAttributeType(), $allowedTypes)) {
                 $this->addInvalidAxisViolation($constraint, $variantGroup->getCode(), $attribute->getCode());
             }
         }


### PR DESCRIPTION
Ensure that every behat scenario uses valid objects (we had issues with previous way to create, update and validate objects, some business validation constraints are missing)

![missing-validation](https://cloud.githubusercontent.com/assets/2104359/9294653/314568f6-4454-11e5-9850-c5ae211c41a8.jpg)

| Q                  | A
| ------------------ | ---
| Migration script?  | N
| Behats             | Y
| Specs & Static     | Y
| Changelog updated  | N