### PR TITLE
[TR] Fix jasmine spec by giving the .bind() polyfill as vendor

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -54,6 +54,7 @@ module.exports = function (grunt) {
                 src: '/bundles/ororequirejs/lib/require.js',
                 options: {
                     specs: 'src/**/spec/**/*Spec.js',
+                    vendor: ['.grunt/grunt-contrib-jasmine/es5-shim.js'],
                     template: require('grunt-template-jasmine-requirejs'),
                     templateOptions: {
                         requireConfigFile: 'web/js/require-config.js',


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Migration script?  | N
| Behats             | Y
| Specs & Static     | Y
| Changelog updated  | N

Thanks to @filipsalpe and based on the solution given here https://github.com/cloudchen/grunt-template-jasmine-requirejs/issues/72 