### PR TITLE
[TR] PIM-4803: Drag & Drop is too long when I filter on attribute group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 - PIM-4612: Error on Quick Export (MongoDB)
+- PIM-4803: Drag & Drop is too long when I filter on attribute group
 
 # 1.3.21 (2015-08-17)
 

--- a/src/Pim/Bundle/UIBundle/Resources/public/css/form.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/css/form.less
@@ -1454,7 +1454,11 @@ table#progress-table {
         border-top: none;
       }
       &.filtered {
-        display: none;
+        opacity: 0;
+        height: 0;
+        overflow: hidden;
+        padding: 0;
+        border: none;
       }
       i {
         font-size: 15px;


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Migration script?  | Y
| Behats             | No regression
| Specs & Static     | N
| Changelog updated  | Y