### PR TITLE
PIM-4518: Restore removed translation keys

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Resources/translations/validators.en.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/translations/validators.en.yml
@@ -16,3 +16,4 @@ This value should not be a decimal.:                                            
 The file extension is not allowed (allowed extensions: %extensions%).:                    The file extension is not allowed (allowed extensions: %extensions%).
 The value %value% is already set on another product for the unique attribute %attribute%: The value %value% is already set on another product for the unique attribute %attribute%
 regex.comma_or_semicolon.message:                                                         This field should not contain any comma or semicolon.
+file.extensions.message:                                                                  'The file extension is not allowed (allowed extensions: %extensions%).'

--- a/src/Pim/Bundle/UIBundle/Resources/translations/jsmessages.en.yml
+++ b/src/Pim/Bundle/UIBundle/Resources/translations/jsmessages.en.yml
@@ -43,6 +43,8 @@ Unit:     Unit
 Currency: Currency
 
 jstree:
+    all:          All products
+    unclassified: Unclassified products
     product:
         all:          All products
         unclassified: Unclassified products


### PR DESCRIPTION
restore these keys to avoid regression on 1.2 and 1.3