### PR TITLE
PIM-4911: fix escaping of property with locale and scope

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 - PIM-4887: Fixed locales active status when removed from channels
+- PIM-4911: Fix escaping of property with locale and scope
 
 # 1.4.1 (2015-09-24)
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/panel/history.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/panel/history.html
@@ -60,7 +60,7 @@
                                 <tbody>
                                     <% _.each(version.changeset, function(value) { %>
                                         <tr>
-                                            <td class="property"><%- value.label %></td>
+                                            <td class="property"><%= value.label %></td>
                                             <td class="old-values"><%- value.old %></td>
                                             <td class="onew-values"><%- value.new %></td>
                                         </tr>


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Migration script?  | N
| Behats             | N (this PR fix existing behats)
| Specs & Static     | N
| Changelog updated  | Y