### PR TITLE
Fix for undescore.js :

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/tab/attributes/validation-error.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/tab/attributes/validation-error.html
@@ -1,7 +1,7 @@
 <% _.each(errors, function(error) { %>
     <span>
         <i class="icon-warning-sign"></i>
-        <% if (error.locale || error.scope) { %>
+        <% if (error.locale || error.scope) { %>
             <span class="field-context change-context" data-locale="<%- error.locale %>" data-scope="<%- error.scope %>">
                 <% if (error.scope) { %> <span><%- error.scope %></span> <% } %>
                 <% if (error.locale) { %> <span><%= i18n.getFlag(error.locale) %></span> <% } %>


### PR DESCRIPTION
In some systems, underscore.js throw an "Uncaught SyntaxError: Unexpected identifier" in product view.

Issue : Underscore.js bug on product view #3383
URL : https://github.com/akeneo/pim-community-dev/issues/3383