### PR TITLE
[TR] PIM-5008: Optimize PEF when dealing with lots of attributes

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -4,6 +4,7 @@
 - PIM-4925: Fix dashboard patch available information
 - PIM-5082: Fix variant group modal display in product edit form (in mongo storage)
 - PIM-5084: Fix attribute groups order in product edit form
+- PIM-5008: Optimize product edit form when lots of attributes are used
 
 # 1.4.6 (2015-10-27)
 

--- a/features/Context/Page/Base/Form.php
+++ b/features/Context/Page/Base/Form.php
@@ -257,25 +257,22 @@ class Form extends Base
      * Add available attributes
      *
      * @param array $attributes
-     *
-     * @throws \Exception
      */
     public function addAvailableAttributes(array $attributes = [])
     {
         $this->openAvailableAttributesMenu();
 
         $search = $this->getElement('Available attributes search');
-        foreach ($attributes as $attribute) {
-            $search->setValue($attribute);
-            if (!$search->isVisible()) {
-                $this->openAvailableAttributesMenu();
-            }
-            $label = $this->getElement('Available attributes list')
-                    ->find('css', sprintf('li:contains("%s") label', $attribute));
-
-            if (!$label) {
-                throw new \Exception(sprintf('Could not find available attribute "%s".', $attribute));
-            }
+        foreach ($attributes as $attributeLabel) {
+            $search->setValue($attributeLabel);
+            $list  = $this->getElement('Available attributes list');
+            $label = $this->spin(
+                function () use ($list, $attributeLabel) {
+                    return $list->find('css', sprintf('li label:contains("%s")', $attributeLabel));
+                },
+                20,
+                sprintf('Could not find available attribute "%s".', $attributeLabel)
+            );
 
             $label->click();
         }

--- a/features/Context/Page/Product/Edit.php
+++ b/features/Context/Page/Product/Edit.php
@@ -214,18 +214,35 @@ class Edit extends Form
      * @param string $attribute
      * @param string $group
      *
-     * @return NodeElement
+     * @return NodeElement|null
      */
     public function findAvailableAttributeInGroup($attribute, $group)
     {
-        return $this->find(
-            'css',
-            sprintf(
-                'optgroup[label="%s"] option:contains("%s")',
-                $group,
-                $attribute
-            )
-        );
+        $list = $this->getElement('Available attributes list');
+        if (!$list->isVisible()) {
+            $this->openAvailableAttributesMenu();
+        }
+
+        $options = $this->spin(function () use ($list) {
+            return $list->findAll('css', 'li');
+        }, 20, 'No attributes found in available attributes list');
+
+        $groupedAttributes = [];
+        $currentOptgroup   = '';
+        foreach ($options as $option) {
+            if ($option->hasClass('ui-multiselect-optgroup-label')) {
+                $currentOptgroup = strtolower($option->getText());
+            } else {
+                $groupedAttributes[$currentOptgroup][$option->getText()] = $option;
+            }
+        }
+
+        $group = strtolower($group);
+        if (isset($groupedAttributes[$group]) && isset($groupedAttributes[$group][$attribute])) {
+            return $groupedAttributes[$group][$attribute];
+        }
+
+        return null;
     }
 
     /**

--- a/src/Pim/Bundle/DataGridBundle/Extension/Filter/FilterExtension.php
+++ b/src/Pim/Bundle/DataGridBundle/Extension/Filter/FilterExtension.php
@@ -119,7 +119,7 @@ class FilterExtension extends AbstractExtension
     public function visitMetadata(DatagridConfiguration $config, MetadataObject $data)
     {
         $filtersState    = $data->offsetGetByPath('[state][filters]', []);
-        $filtersConfig = $config->offsetGetByPath(Configuration::COLUMNS_PATH);
+        $filtersConfig   = $config->offsetGetByPath(Configuration::COLUMNS_PATH);
         $filtersMetaData = [];
 
         $filters = $this->getFiltersToApply($config);
@@ -128,7 +128,7 @@ class FilterExtension extends AbstractExtension
         foreach ($filters as $filter) {
             $value = isset($values[$filter->getName()]) ? $values[$filter->getName()] : false;
 
-            if ($value !== false) {
+            if (false !== $value) {
                 $form = $filter->getForm();
                 if (!$form->isSubmitted()) {
                     $form->submit($value);

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
@@ -38,6 +38,7 @@ config:
                 attribute:
                     module: pim/attribute-fetcher
                     options:
+                        identifier_type: pim_catalog_identifier
                         urls:
                             list: pim_enrich_attribute_rest_index
                 family:

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/fetcher/attribute-fetcher.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/fetcher/attribute-fetcher.js
@@ -1,11 +1,53 @@
 'use strict';
 
-define(['underscore', 'pim/base-fetcher'], function (_, BaseFetcher) {
+define(['jquery', 'underscore', 'pim/base-fetcher', 'routing'], function ($, _, BaseFetcher, Routing) {
     return BaseFetcher.extend({
-        getIdentifierField: function () {
-            return this.fetchAll().then(function (attributes) {
-                return _.findWhere(attributes, { type: 'pim_catalog_identifier' });
-            }).promise();
+        identifierPromise: null,
+
+        /**
+         * Return the identifier attribute
+         *
+         * @return {Promise}
+         */
+        getIdentifierAttribute: function () {
+            if (null === this.identifierPromise) {
+                return this.fetchByTypes([this.options.identifier_type])
+                    .then(function (attributes) {
+                        if (attributes.length > 0) {
+                            this.identifierPromise = $.Deferred().resolve(attributes[0]);
+
+                            return this.identifierPromise;
+                        }
+
+                        return $.Deferred()
+                            .reject()
+                            .promise();
+                    }.bind(this));
+            }
+
+            return this.identifierPromise;
+        },
+
+        /**
+         * Fetch attributes by types
+         *
+         * @param {Array} attributeTypes
+         *
+         * @return {Promise}
+         */
+        fetchByTypes: function (attributeTypes) {
+            return $.getJSON(Routing.generate(this.options.urls.list, { types: attributeTypes.join(',') }))
+                .then(_.identity)
+                .promise();
+        },
+
+        /**
+         * {@inheritdoc}
+         */
+        clear: function () {
+            BaseFetcher.prototype.clear.apply(this, arguments);
+
+            this.identifierPromise = null;
         }
     });
 });

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/fetcher/base-fetcher.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/fetcher/base-fetcher.js
@@ -13,12 +13,12 @@ define(['jquery', 'underscore', 'backbone', 'routing'], function ($, _, Backbone
         entityPromises: {},
 
         /**
-         * @param {Array} options
+         * @param {Object} options
          */
         initialize: function (options) {
             this.entityListPromise = null;
-            this.entityPromises = {};
-            this.options = options || {};
+            this.entityPromises    = {};
+            this.options           = options || {};
         },
 
         /**
@@ -40,6 +40,7 @@ define(['jquery', 'underscore', 'backbone', 'routing'], function ($, _, Backbone
          * Fetch an element based on its identifier
          *
          * @param {string} identifier
+         * @param {Object} options
          *
          * @return {Promise}
          */
@@ -118,7 +119,7 @@ define(['jquery', 'underscore', 'backbone', 'routing'], function ($, _, Backbone
         /**
          * Clear cache of the fetcher
          *
-         * @param {string}|{null} identifier
+         * @param {string|null} identifier
          */
         clear: function (identifier) {
             if (identifier) {

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/manager/attribute-manager.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/manager/attribute-manager.js
@@ -12,9 +12,10 @@ define([
         return {
             /**
              * Get the attributes of the given product
-             * @param  Object product
              *
-             * @return Array
+             * @param  {Object} product
+             *
+             * @return {Array}
              */
             getAttributesForProduct: function (product) {
                 if (!product.family) {
@@ -30,9 +31,10 @@ define([
 
             /**
              * Get all optional attributes available for a product
-             * @param Object product
              *
-             * @return Array
+             * @param {Object} product
+             *
+             * @return {Array}
              */
             getAvailableOptionalAttributes: function (product) {
                 return $.when(
@@ -42,7 +44,7 @@ define([
                     var optionalAttributes = _.map(
                         _.difference(_.pluck(attributes, 'code'), productAttributes),
                         function (attributeCode) {
-                            return _.findWhere(attributes, {code: attributeCode});
+                            return _.findWhere(attributes, { code: attributeCode });
                         }
                     );
 
@@ -52,11 +54,12 @@ define([
 
             /**
              * Check if an attribute is optional
-             * @param Object attribute
-             * @param Object product
-             * @param Array  families
              *
-             * @return boolean
+             * @param {Object} attribute
+             * @param {Object} product
+             * @param {Array}  families
+             *
+             * @return {boolean}
              */
             isOptional: function (attribute, product, families) {
                 return 'pim_catalog_identifier' !== attribute.type &&
@@ -65,27 +68,29 @@ define([
 
             /**
              * Get the value in the given collection for the given locale and scope
-             * @param Array  values
-             * @param Object attribute
-             * @param String locale
-             * @param String scope
              *
-             * @return {*}
+             * @param {Array}  values
+             * @param {Object} attribute
+             * @param {string} locale
+             * @param {string} scope
+             *
+             * @return {Object}
              */
             getValue: function (values, attribute, locale, scope) {
                 locale = attribute.localizable ? locale : null;
                 scope  = attribute.scopable ? scope : null;
 
-                return _.findWhere(values, {scope: scope, locale: locale});
+                return _.findWhere(values, { scope: scope, locale: locale });
             },
 
             /**
              * Generate a single value for the given attribute, scope and lcoale
-             * @param Object attribute
-             * @param String locale
-             * @param String scope
              *
-             * @return {*}
+             * @param {Object} attribute
+             * @param {string} locale
+             * @param {string} scope
+             *
+             * @return {Object}
              */
             generateValue: function (attribute, locale, scope) {
                 locale = attribute.localizable ? locale : null;
@@ -100,13 +105,14 @@ define([
 
             /**
              * Generate all missing values for an attribute
-             * @param values
-             * @param attribute
-             * @param locales
-             * @param channels
-             * @param currencies
              *
-             * @return {*}
+             * @param {Array}  values
+             * @param {Object} attribute
+             * @param {Array}  locales
+             * @param {Array}  channels
+             * @param {Array}  currencies
+             *
+             * @return {Array}
              */
             generateMissingValues: function (values, attribute, locales, channels, currencies) {
                 _.each(locales, function (locale) {
@@ -134,18 +140,19 @@ define([
 
             /**
              * Generate missing prices in the given collection for the given currencies
-             * @param Array prices
-             * @param Array currencies
              *
-             * @return Array
+             * @param {Array} prices
+             * @param {Array} currencies
+             *
+             * @return {Array}
              */
             generateMissingPrices: function (prices, currencies) {
                 prices = prices || [];
                 _.each(currencies, function (currency) {
-                    var price = _.findWhere(prices, {currency: currency.code});
+                    var price = _.findWhere(prices, { currency: currency.code });
 
                     if (!price) {
-                        price = {data: null, currency: currency.code};
+                        price = { data: null, currency: currency.code };
                         prices.push(price);
                     }
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/associations.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/associations.js
@@ -114,13 +114,13 @@ define(
                 return BaseForm.prototype.configure.apply(this, arguments);
             },
             render: function () {
-                if (!this.configured) {
+                if (!this.configured || this.code !== this.getParent().getCurrentTab()) {
                     return;
                 }
 
                 $.when(
                     this.loadAssociationTypes(),
-                    FetcherRegistry.getFetcher('attribute').getIdentifierField()
+                    FetcherRegistry.getFetcher('attribute').getIdentifierAttribute()
                 ).then(function (associationTypes, identifierAttribute) {
                     this.state.set(
                         'currentAssociationType',

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/form-tabs.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/form-tabs.js
@@ -63,7 +63,7 @@ define(
             },
 
             /**
-             * {ainheritdoc}
+             * {@inheritdoc}
              */
             render: function () {
                 if (!this.configured || _.isEmpty(this.tabs)) {

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/meta/groups.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/meta/groups.js
@@ -114,8 +114,8 @@ define(
 
                     $.when(
                         this.getProductList(group.code),
-                        FetcherRegistry.getFetcher('attribute').getIdentifierField()
-                    ).done(function (productList, identifier) {
+                        FetcherRegistry.getFetcher('attribute').getIdentifierAttribute()
+                    ).done(function (productList, identifierAttribute) {
                         var groupModal = new Backbone.BootstrapModal({
                             allowCancel: true,
                             okText: _.__('pim_enrich.entity.product.meta.groups.modal.view_group'),
@@ -127,7 +127,7 @@ define(
                             content: this.modalTemplate({
                                 products:     productList.products,
                                 productCount: productList.productCount,
-                                identifier:   identifier,
+                                identifier:   identifierAttribute,
                                 locale:       UserContext.get('catalogLocale')
                             })
                         });

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/tab/attributes/add-attribute.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/tab/attributes/add-attribute.html
@@ -1,11 +1,9 @@
-<select multiple="multiple">
-    <% _.each(groupedAttributes, function (group) { %>
-        <optgroup label="<%- group.label[locale] ? group.label[locale] : '[' + group.code + ']' %>">
-            <% _.each(group.attributes, function (attribute) { %>
-                <option value="<%- attribute.code %>">
-                    <%- attribute.label[locale] ? attribute.label[locale] : '[' + attribute.code + ']' %>
-                </option>
-            <% }); %>
-        </optgroup>
-    <% }); %>
-</select>
+<% _.each(groupedAttributes, function (group) { %>
+    <optgroup label="<%- group.label[locale] ? group.label[locale] : '[' + group.code + ']' %>">
+        <% _.each(group.attributes, function (attribute) { %>
+            <option value="<%- attribute.code %>">
+                <%- attribute.label[locale] ? attribute.label[locale] : '[' + attribute.code + ']' %>
+            </option>
+        <% }); %>
+    </optgroup>
+<% }); %>


### PR DESCRIPTION
https://akeneo.atlassian.net/browse/PIM-5008

| Q                 | A
| ----------------- | ---
| Specs             | no regression
| Behats            | n/a
| Blue CI           | yes
| Changelog updated | yes
| Review and 2 GTM  |

What this PR does ?
- Each time we used to fetch all attributes, fetch only needed attributes by codes instead.
- Rework the "add attributes" extension (the last one that really needs all attributes) so that the attributes choices are fetched only when the user opens the multiselect.
- Load the associations grid only when the user opens the associations tab.
- Fix the way identifier attribute is fetched.