### PR TITLE
[TR] Clean behat grid context

### DIFF
--- a/features/Context/DataGridContext.php
+++ b/features/Context/DataGridContext.php
@@ -519,7 +519,14 @@ class DataGridContext extends RawMinkContext implements PageObjectAwareInterface
     public function iSortByValue($columnName, $order = 'ascending')
     {
         $this->datagrid->sortBy($columnName, $order);
-        $this->wait();
+
+        $loadlingMask = $this->datagrid
+            ->getElement('Grid container')
+            ->find('css', '.loading-mask .loading-mask');
+
+        $this->spin(function () use ($loadlingMask) {
+            return !$loadlingMask->isVisible();
+        });
     }
 
     /**

--- a/features/Context/DataGridContext.php
+++ b/features/Context/DataGridContext.php
@@ -370,7 +370,7 @@ class DataGridContext extends RawMinkContext implements PageObjectAwareInterface
 
         $expectedPosition = 0;
         foreach ($columns as $column) {
-            $position = $this->datagrid->getColumnPosition($column);
+            $position = $this->datagrid->getColumnPosition($column, false, false);
             if ($expectedPosition++ !== $position) {
                 throw $this->createExpectationException(
                     sprintf(
@@ -518,7 +518,6 @@ class DataGridContext extends RawMinkContext implements PageObjectAwareInterface
      */
     public function iSortByValue($columnName, $order = 'ascending')
     {
-        $this->wait(10000, sprintf('$("a:contains(\'%s\')").length > 0', ucfirst($columnName)));
         $this->datagrid->sortBy($columnName, $order);
         $this->wait();
     }

--- a/features/Context/Page/Base/Grid.php
+++ b/features/Context/Page/Base/Grid.php
@@ -49,14 +49,12 @@ class Grid extends Index
     /**
      * Returns the currently visible grid, if there is one
      *
-     * @throws \InvalidArgumentException
-     *
      * @return NodeElement
      */
     public function getGrid()
     {
-        try {
-            $grid = $this->spin(function () {
+        return $this->spin(
+            function () {
                 $grids = $this->getElement('Container')->findAll('css', $this->elements['Grid']['css']) +
                     $this->getElement('Dialog')->findAll('css', $this->elements['Grid']['css']);
 
@@ -67,18 +65,16 @@ class Grid extends Index
                 }
 
                 return false;
-            });
-
-            return $grid;
-        } catch (\Exception $e) {
-            throw new \InvalidArgumentException('No visible grids found');
-        }
+            },
+            20,
+            'No visible grid found'
+        );
     }
 
     /**
      * Returns the grid body
      *
-     * @return NodeElement
+     * @return NodeElement|null
      */
     public function getGridContent()
     {
@@ -99,7 +95,7 @@ class Grid extends Index
         $value   = str_replace('"', '', $value);
         $gridRow = $this->getGridContent()->find('css', sprintf('tr td:contains("%s")', $value));
 
-        if (!$gridRow) {
+        if (null === $gridRow) {
             throw new \InvalidArgumentException(
                 sprintf('Couldn\'t find a row for value "%s"', $value)
             );
@@ -145,7 +141,7 @@ class Grid extends Index
      * @param string $element
      * @param string $actionName
      *
-     * @return NodeElement|mixed|null
+     * @return NodeElement|null
      */
     public function findAction($element, $actionName)
     {
@@ -161,7 +157,7 @@ class Grid extends Index
      * @param bool|string          $operator   If false, no operator will be selected
      * @param DriverInterface|null $driver     Required to filter by multiple choices
      *
-     * @throws \Behat\Mink\Exception\ElementNotFoundException
+     * @throws \InvalidArgumentException
      */
     public function filterBy($filterName, $value, $operator = false, DriverInterface $driver = null)
     {
@@ -360,26 +356,29 @@ class Grid extends Index
      */
     public function getColumnNode($column, $row)
     {
-        return $this->getRowCell($this->getRow($row), $this->getColumnPosition($column, true));
+        return $this->getRowCell(
+            $this->getRow($row),
+            $this->getColumnPosition($column, true, true)
+        );
     }
 
     /**
      * Get an array of values in the specified column
      *
-     * @param string $column
+     * @param string $columnName
      *
      * @return array
      */
-    public function getValuesInColumn($column)
+    public function getValuesInColumn($columnName)
     {
-        $column = $this->getColumnPosition($column, true);
-        $rows   = $this->getRows();
-        $values = [];
+        $position = $this->getColumnPosition($columnName, true, true);
+        $rows     = $this->getRows();
+        $values   = [];
 
         foreach ($rows as $row) {
-            $cell = $this->getRowCell($row, $column);
+            $cell = $this->getRowCell($row, $position);
             if ($span = $cell->find('css', 'span')) {
-                $values[] = (string) strpos($span->getAttribute('class'), 'success') !== false;
+                $values[] = (string) (strpos($span->getAttribute('class'), 'success') !== false);
             } else {
                 $values[] = $cell->getText();
             }
@@ -400,7 +399,7 @@ class Grid extends Index
      */
     public function getCellImage($column, $row)
     {
-        $cell = $this->getColumnNode($column, $row);
+        $cell  = $this->getColumnNode($column, $row);
         $image = $cell->find('css', 'img');
         if (null === $image) {
             throw new \InvalidArgumentException(
@@ -412,34 +411,37 @@ class Grid extends Index
     }
 
     /**
-     * @param string $column
+     * @param string $columnName
+     * @param bool   $withHidden
      * @param bool   $withActions
+     *
+     * @throws \InvalidArgumentException
      *
      * @return int
      */
-    public function getColumnPosition($column, $withActions = false)
+    public function getColumnPosition($columnName, $withHidden, $withActions)
     {
-        $headers = $this->getColumnHeaders(false, $withActions);
+        $headers = $this->getColumnHeaders($withHidden, $withActions);
         foreach ($headers as $position => $header) {
-            if (strtolower($column) === strtolower($header->getText())) {
+            if (strtolower($columnName) === strtolower($header->getText())) {
                 return $position;
             }
         }
 
         throw new \InvalidArgumentException(
-            sprintf('Couldn\'t find a column "%s"', $column)
+            sprintf('Could not find a column header "%s"', $columnName)
         );
     }
 
     /**
      * Sort rows by a column in the specified order
      *
-     * @param string $column
+     * @param string $columnName
      * @param string $order
      */
-    public function sortBy($column, $order = 'ascending')
+    public function sortBy($columnName, $order = 'ascending')
     {
-        $sorter = $this->getColumnSorter($column);
+        $sorter = $this->getColumnSorter($columnName);
         if ($sorter->getParent()->getAttribute('class') !== strtolower($order)) {
             $sorter->click();
         }
@@ -448,20 +450,19 @@ class Grid extends Index
     /**
      * Predicate to know if a column is sorted and ordered as we want
      *
-     * @param string $column
+     * @param string $columnName
      * @param string $order
      *
      * @return bool
      */
-    public function isSortedAndOrdered($column, $order)
+    public function isSortedAndOrdered($columnName, $order)
     {
-        $column = strtoupper($column);
-        $order  = strtolower($order);
-        if ($this->getColumn($column)->getAttribute('class') !== $order) {
+        $order = strtolower($order);
+        if ($this->getColumnHeader($columnName)->getAttribute('class') !== $order) {
             return false;
         }
 
-        $values = $this->getValuesInColumn($column);
+        $values = $this->getValuesInColumn($columnName);
         $values = $this->formatColumnValues($values);
 
         $sortedValues = $values;
@@ -486,48 +487,23 @@ class Grid extends Index
     }
 
     /**
-     * Get column
-     *
-     * @param string $columnName
-     *
-     * @throws \InvalidArgumentException
-     *
-     * @return \Behat\Mink\Element\Element
-     */
-    public function getColumn($columnName)
-    {
-        $columnName    = strtoupper($columnName);
-        $columnHeaders = $this->getColumnHeaders();
-
-        foreach ($columnHeaders as $columnHeader) {
-            if ($columnHeader->getText() === $columnName) {
-                return $columnHeader;
-            }
-        }
-
-        throw new \InvalidArgumentException(
-            sprintf('Couldn\'t find column "%s"', $columnName)
-        );
-    }
-
-    /**
      * Get column sorter
      *
      * @param string $columnName
      *
-     * @return \Behat\Mink\Element\Element
+     * @return NodeElement
      */
     public function getColumnSorter($columnName)
     {
-        $sorter = $this->getColumn($columnName)->find('css', 'a');
+        $header = $this->getColumnHeader($columnName);
 
-        if (!$sorter) {
-            throw new \InvalidArgumentException(
-                sprintf('Column %s is not sortable', $columnName)
-            );
-        }
-
-        return $sorter;
+        return $this->spin(
+            function () use ($header) {
+                return $header->find('css', 'a');
+            },
+            20,
+            sprintf('Column %s is not sortable', $columnName)
+        );
     }
 
     /**
@@ -547,7 +523,7 @@ class Grid extends Index
             $filter = $this->getElement('Filters')->find('css', sprintf('div.filter-item:contains("%s")', $filterName));
         }
 
-        if (!$filter) {
+        if (null === $filter) {
             throw new \InvalidArgumentException(
                 sprintf('Couldn\'t find a filter with name "%s"', $filterName)
             );
@@ -612,48 +588,48 @@ class Grid extends Index
 
     /**
      * Click on the reset button of the datagrid toolbar
-     *
-     * @throws \InvalidArgumentException
      */
     public function clickOnResetButton()
     {
-        try {
-            $this->spin(function () {
+        $this->spin(
+            function () {
                 $resetBtn = $this
                     ->getElement('Grid toolbar')
                     ->find('css', sprintf('a:contains("%s")', 'Reset'));
-                if ($resetBtn) {
+                if (null !== $resetBtn) {
                     $resetBtn->click();
 
                     return true;
                 }
 
                 return false;
-            });
-        } catch (\Exception $e) {
-            throw new \InvalidArgumentException('Reset button not found');
-        }
+            },
+            20,
+            'Reset button not found'
+        );
     }
 
     /**
      * Click on the refresh button of the datagrid toolbar
-     *
-     * @throws \InvalidArgumentException
      */
     public function clickOnRefreshButton()
     {
-        try {
-            $this->spin(function () {
+        $this->spin(
+            function () {
                 $refreshBtn = $this
                     ->getElement('Grid toolbar')
                     ->find('css', sprintf('a:contains("%s")', 'Refresh'));
-                $refreshBtn->click();
+                if (null !== $refreshBtn) {
+                    $refreshBtn->click();
 
-                return true;
-            });
-        } catch (\Exception $e) {
-            throw new \InvalidArgumentException('Refresh button not found');
-        }
+                    return true;
+                }
+
+                return false;
+            },
+            20,
+            'Refresh button not found'
+        );
     }
 
     /**
@@ -679,7 +655,7 @@ class Grid extends Index
      *
      * @param string $viewLabel
      *
-     * @return NodeElement|mixed|null
+     * @return NodeElement|null
      */
     public function findView($viewLabel)
     {
@@ -720,8 +696,6 @@ class Grid extends Index
      * Activate a filter
      *
      * @param string $filterName
-     *
-     * @throws \InvalidArgumentException
      */
     protected function activateFilter($filterName)
     {
@@ -758,28 +732,25 @@ class Grid extends Index
      * Click on a filter in filter management list
      *
      * @param string $filterName
-     *
-     * @throws \InvalidArgumentException
      */
     protected function clickOnFilterToManage($filterName)
     {
-        try {
-            $this->spin(function () use ($filterName) {
+        $this->spin(
+            function () use ($filterName) {
                 $filterElement = $this
                     ->getElement('Manage filters')
                     ->find('css', sprintf('label:contains("%s")', $filterName));
-
-                if ($filterElement) {
+                if (null !== $filterElement) {
                     $filterElement->click();
 
                     return true;
                 }
-            });
-        } catch (\Exception $e) {
-            throw new \InvalidArgumentException(
-                sprintf('Impossible to activate filter "%s"', $filterName)
-            );
-        }
+
+                return false;
+            },
+            20,
+            sprintf('Impossible to activate filter "%s"', $filterName)
+        );
     }
 
     /**
@@ -787,18 +758,22 @@ class Grid extends Index
      */
     protected function clickFiltersList()
     {
-        try {
-            $this->spin(function () {
+        $this->spin(
+            function () {
                 $filterList = $this
                     ->getElement('Filters')
                     ->find('css', 'a#add-filter-button');
-                $filterList->click();
+                if (null !== $filterList) {
+                    $filterList->click();
 
-                return true;
-            });
-        } catch (\Exception $e) {
-            throw new \InvalidArgumentException('Impossible to find filter list');
-        }
+                    return true;
+                }
+
+                return false;
+            },
+            20,
+            'Impossible to find filter list'
+        );
     }
 
     /**
@@ -807,44 +782,25 @@ class Grid extends Index
      * @param string $value
      * @param bool   $check
      *
-     * @throws \InvalidArgumentException
-     *
-     * @return \Behat\Mink\Element\NodeElement|null
+     * @return NodeElement|null
      */
     public function selectRow($value, $check = true)
     {
-        try {
-            /** @var NodeElement $checkbox */
-            $checkbox = $this->spin(function () use ($value, $check) {
-                $row = $this->getRow($value);
+        $row      = $this->getRow($value);
+        $checkbox = $this->spin(
+            function () use ($row) {
+                return $row->find('css', 'input[type="checkbox"]');
+            },
+            20,
+            sprintf('Couldn\'t find a checkbox for row "%s"', $value)
+        );
 
-                if (!$row) {
-                    throw new \InvalidArgumentException(
-                        sprintf('Couldn\'t find row for "%s"', $value)
-                    );
-                }
-
-                $checkbox = $row->find('css', 'input[type="checkbox"]');
-
-                if (!$checkbox) {
-                    throw new \InvalidArgumentException(
-                        sprintf('Couldn\'t find a checkbox for row "%s"', $value)
-                    );
-                }
-
-                if ($check) {
-                    $checkbox->check();
-                } else {
-                    $checkbox->uncheck();
-                }
-
-                return $checkbox;
-            });
-        } catch (\Exception $e) {
-            throw new \InvalidArgumentException(
-                sprintf('Couldn\'t find a checkbox for row "%s"', $value)
-            );
+        if ($check) {
+            $checkbox->check();
+        } else {
+            $checkbox->uncheck();
         }
+
 
         return $checkbox;
     }
@@ -853,22 +809,13 @@ class Grid extends Index
      * @param NodeElement $row
      * @param int         $position
      *
+     * @throws \InvalidArgumentException
+     *
      * @return NodeElement
      */
     protected function getRowCell($row, $position)
     {
         $cells = $row->findAll('css', 'td');
-
-        $visibleCells = [];
-        foreach ($cells as $cell) {
-            $style = $cell->getAttribute('style');
-            if (!$style || !preg_match('/display: ?none;/', $style)) {
-                $visibleCells[] = $cell;
-            }
-        }
-
-        $cells = $visibleCells;
-
         if (!isset($cells[$position])) {
             throw new \InvalidArgumentException(
                 sprintf(
@@ -891,7 +838,7 @@ class Grid extends Index
      */
     public function openFilter(NodeElement $filter)
     {
-        if ($element = $filter->find('css', 'button')) {
+        if (null !== $element = $filter->find('css', 'button')) {
             $element->click();
         } else {
             throw new \InvalidArgumentException(
@@ -906,7 +853,7 @@ class Grid extends Index
      * @param bool $withHidden
      * @param bool $withActions
      *
-     * @return \Behat\Mink\Element\Element
+     * @return NodeElement[]
      */
     protected function getColumnHeaders($withHidden = false, $withActions = true)
     {
@@ -927,21 +874,41 @@ class Grid extends Index
             return $headers;
         }
 
-        $visibleHeaders = [];
-        foreach ($headers as $header) {
-            $style = $header->getAttribute('style');
-            if (!$style || !preg_match('/display: ?none;/', $style)) {
-                $visibleHeaders[] = $header;
-            }
-        }
+        $visibleHeaders = array_filter($headers, function ($header) {
+            return $header->isVisible();
+        });
+        $visibleHeaders = array_values($visibleHeaders);
 
         return $visibleHeaders;
     }
 
     /**
+     * Get column header
+     *
+     * @param string $columnName
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @return NodeElement
+     */
+    public function getColumnHeader($columnName)
+    {
+        $headers = $this->getColumnHeaders(true);
+        foreach ($headers as $header) {
+            if (strtolower($columnName) === strtolower($header->getText())) {
+                return $header;
+            }
+        }
+
+        throw new \InvalidArgumentException(
+            sprintf('Could not find column header "%s"', $columnName)
+        );
+    }
+
+    /**
      * Get rows
      *
-     * @return \Behat\Mink\Element\Element
+     * @return NodeElement[]
      */
     protected function getRows()
     {
@@ -953,17 +920,10 @@ class Grid extends Index
      * @param string $action     Type of filtering (>, >=, etc.)
      * @param number $value      Value to filter
      * @param string $currency   Currency on which to filter
-     *
-     * @throws \Behat\Mink\Exception\ElementNotFoundException
-     * @throws \Exception
      */
     public function filterPerPrice($filterName, $action, $value, $currency)
     {
         $filter = $this->getFilter($filterName);
-        if (!$filter) {
-            throw new \Exception("Could not find filter for $filterName.");
-        }
-
         $this->openFilter($filter);
 
         if (null !== $value) {
@@ -995,10 +955,6 @@ class Grid extends Index
     public function filterPerMetric($filterName, $action, $value, $unit)
     {
         $filter = $this->getFilter($filterName);
-        if (!$filter) {
-            throw new \InvalidArgumentException("Could not find filter for $filterName.");
-        }
-
         $this->openFilter($filter);
 
         $criteriaElt = $filter->find('css', 'div.filter-criteria');
@@ -1027,10 +983,6 @@ class Grid extends Index
     public function filterPerNumber($filterName, $action, $value)
     {
         $filter = $this->getFilter($filterName);
-        if (!$filter) {
-            throw new \InvalidArgumentException("Could not find filter for $filterName.");
-        }
-
         $this->openFilter($filter);
 
         $criteriaElt = $filter->find('css', 'div.filter-criteria');
@@ -1105,14 +1057,16 @@ class Grid extends Index
 
     /**
      * Select all rows
-     *
-     * @throws \InvalidArgumentException
      */
     public function selectAll()
     {
-        if (!$allBtn = $this->getDropdownSelector()->find('css', 'button:contains("All")')) {
-            throw new \InvalidArgumentException('"All" button on dropdown row selector not found');
-        }
+        $allBtn = $this->spin(
+            function () {
+                return $this->getDropdownSelector()->find('css', 'button:contains("All")');
+            },
+            20,
+            '"All" button on dropdown row selector not found'
+        );
 
         $allBtn->click();
     }
@@ -1136,37 +1090,42 @@ class Grid extends Index
     /**
      * Get the dropdown row selector
      *
-     * @throws \InvalidArgumentException
-     *
-     * @return \Behat\Mink\Element\NodeElement
+     * @return NodeElement
      */
     protected function getDropdownSelector()
     {
-        if (!$dropdown = $this->getElement('Grid')->find('css', 'th div.btn-group')) {
-            throw new \InvalidArgumentException('Grid dropdown row selector not found');
-        }
-
-        return $dropdown;
+        return $this->spin(
+            function () {
+                return $this->getElement('Grid')->find('css', 'th .btn-group');
+            },
+            20,
+            'Grid dropdown row selector not found'
+        );
     }
 
     /**
      * Click on an item of the dropdown selector
      *
      * @param string $item
-     *
-     * @throws \InvalidArgumentException
      */
     protected function clickOnDropdownSelector($item)
     {
-        if (!$dropdown = $this->getDropdownSelector()->find('css', 'button.dropdown-toggle')) {
-            throw new \InvalidArgumentException('Dropdown row selector not found');
-        }
-
+        $dropdown = $this->spin(
+            function () {
+                return $this->getDropdownSelector()->find('css', 'button.dropdown-toggle');
+            },
+            20,
+            'Dropdown row selector not found'
+        );
         $dropdown->click();
-        if (!$listItem = $dropdown->getParent()->find('css', sprintf('li:contains("%s") a', $item))) {
-            throw new \InvalidArgumentException(sprintf('Item "%s" of dropdown row selector not found', $item));
-        }
 
+        $listItem = $this->spin(
+            function () use ($dropdown, $item) {
+                return $dropdown->getParent()->find('css', sprintf('li:contains("%s") a', $item));
+            },
+            20,
+            sprintf('Item "%s" of dropdown row selector not found', $item)
+        );
         $listItem->click();
     }
 

--- a/features/Context/Page/Base/Grid.php
+++ b/features/Context/Page/Base/Grid.php
@@ -32,6 +32,7 @@ class Grid extends Index
 
         $this->elements = array_merge(
             [
+                'Grid container'    => ['css' => '.grid-container'],
                 'Grid'              => ['css' => 'table.grid'],
                 'Grid content'      => ['css' => 'table.grid tbody'],
                 'Filters'           => ['css' => 'div.filter-box'],
@@ -39,7 +40,7 @@ class Grid extends Index
                 'Manage filters'    => ['css' => 'div.filter-list'],
                 'Configure columns' => ['css' => 'a:contains("Columns")'],
                 'View selector'     => ['css' => '#view-selector'],
-                'Views list'        => ['css' => 'div.ui-multiselect-menu.highlight-hover'],
+                'Views list'        => ['css' => '.ui-multiselect-menu.highlight-hover'],
                 'Select2 results'   => ['css' => '#select2-drop .select2-results'],
             ],
             $this->elements
@@ -591,22 +592,13 @@ class Grid extends Index
      */
     public function clickOnResetButton()
     {
-        $this->spin(
-            function () {
-                $resetBtn = $this
-                    ->getElement('Grid toolbar')
-                    ->find('css', sprintf('a:contains("%s")', 'Reset'));
-                if (null !== $resetBtn) {
-                    $resetBtn->click();
+        $resetBtn = $this->spin(function () {
+            return $this
+                ->getElement('Grid toolbar')
+                ->find('css', sprintf('a:contains("%s")', 'Reset'));
+        }, 20, 'Reset button not found');
 
-                    return true;
-                }
-
-                return false;
-            },
-            20,
-            'Reset button not found'
-        );
+        $resetBtn->click();
     }
 
     /**
@@ -614,22 +606,13 @@ class Grid extends Index
      */
     public function clickOnRefreshButton()
     {
-        $this->spin(
-            function () {
-                $refreshBtn = $this
-                    ->getElement('Grid toolbar')
-                    ->find('css', sprintf('a:contains("%s")', 'Refresh'));
-                if (null !== $refreshBtn) {
-                    $refreshBtn->click();
+        $refreshBtn = $this->spin(function () {
+            return $this
+                ->getElement('Grid toolbar')
+                ->find('css', sprintf('a:contains("%s")', 'Refresh'));
+        }, 20, 'Refresh button not found');
 
-                    return true;
-                }
-
-                return false;
-            },
-            20,
-            'Refresh button not found'
-        );
+        $refreshBtn->click();
     }
 
     /**
@@ -735,22 +718,13 @@ class Grid extends Index
      */
     protected function clickOnFilterToManage($filterName)
     {
-        $this->spin(
-            function () use ($filterName) {
-                $filterElement = $this
-                    ->getElement('Manage filters')
-                    ->find('css', sprintf('label:contains("%s")', $filterName));
-                if (null !== $filterElement) {
-                    $filterElement->click();
+        $filterElement = $this->spin(function () use ($filterName) {
+            return $this
+                ->getElement('Manage filters')
+                ->find('css', sprintf('label:contains("%s")', $filterName));
+        }, 20, sprintf('Impossible to activate filter "%s"', $filterName));
 
-                    return true;
-                }
-
-                return false;
-            },
-            20,
-            sprintf('Impossible to activate filter "%s"', $filterName)
-        );
+        $filterElement->click();
     }
 
     /**
@@ -758,22 +732,13 @@ class Grid extends Index
      */
     protected function clickFiltersList()
     {
-        $this->spin(
-            function () {
-                $filterList = $this
-                    ->getElement('Filters')
-                    ->find('css', 'a#add-filter-button');
-                if (null !== $filterList) {
-                    $filterList->click();
+        $filterList = $this->spin(function () {
+            return $this
+                ->getElement('Filters')
+                ->find('css', '#add-filter-button');
+        }, 20, 'Impossible to find filter list');
 
-                    return true;
-                }
-
-                return false;
-            },
-            20,
-            'Impossible to find filter list'
-        );
+        $filterList->click();
     }
 
     /**
@@ -787,20 +752,15 @@ class Grid extends Index
     public function selectRow($value, $check = true)
     {
         $row      = $this->getRow($value);
-        $checkbox = $this->spin(
-            function () use ($row) {
-                return $row->find('css', 'input[type="checkbox"]');
-            },
-            20,
-            sprintf('Couldn\'t find a checkbox for row "%s"', $value)
-        );
+        $checkbox = $this->spin(function () use ($row) {
+            return $row->find('css', 'input[type="checkbox"]');
+        }, 20, sprintf('Couldn\'t find a checkbox for row "%s"', $value));
 
         if ($check) {
             $checkbox->check();
         } else {
             $checkbox->uncheck();
         }
-
 
         return $checkbox;
     }
@@ -860,14 +820,11 @@ class Grid extends Index
         $headers = $this->getGrid()->findAll('css', 'thead th');
 
         if (!$withActions) {
-            foreach ($headers as $key => $header) {
-                if ($header->getAttribute('class') === 'action-column'
-                    || $header->getAttribute('class') === 'select-all-header-cell'
-                    || $header->find('css', 'input[type="checkbox"]')
-                ) {
-                    unset($headers[$key]);
-                }
-            }
+            $headers = array_filter($headers, function ($header) {
+                return false === strpos($header->getAttribute('class'), 'action-column') &&
+                    false === strpos($header->getAttribute('class'), 'select-all-header-cell') &&
+                    null === $header->find('css', 'input[type="checkbox"]');
+            });
         }
 
         if ($withHidden) {
@@ -1060,13 +1017,11 @@ class Grid extends Index
      */
     public function selectAll()
     {
-        $allBtn = $this->spin(
-            function () {
-                return $this->getDropdownSelector()->find('css', 'button:contains("All")');
-            },
-            20,
-            '"All" button on dropdown row selector not found'
-        );
+        $selector = $this->getDropdownSelector();
+
+        $allBtn = $this->spin(function () use ($selector) {
+            return $selector->find('css', 'button:contains("All")');
+        }, 20, '"All" button on dropdown row selector not found');
 
         $allBtn->click();
     }
@@ -1094,13 +1049,9 @@ class Grid extends Index
      */
     protected function getDropdownSelector()
     {
-        return $this->spin(
-            function () {
-                return $this->getElement('Grid')->find('css', 'th .btn-group');
-            },
-            20,
-            'Grid dropdown row selector not found'
-        );
+        return $this->spin(function () {
+            return $this->getElement('Grid')->find('css', 'th .btn-group');
+        }, 20, 'Grid dropdown row selector not found');
     }
 
     /**
@@ -1110,22 +1061,18 @@ class Grid extends Index
      */
     protected function clickOnDropdownSelector($item)
     {
-        $dropdown = $this->spin(
-            function () {
-                return $this->getDropdownSelector()->find('css', 'button.dropdown-toggle');
-            },
-            20,
-            'Dropdown row selector not found'
-        );
+        $selector = $this->getDropdownSelector();
+
+        $dropdown = $this->spin(function () use ($selector) {
+            return $selector->find('css', 'button.dropdown-toggle');
+        }, 20, 'Dropdown row selector not found');
+
         $dropdown->click();
 
-        $listItem = $this->spin(
-            function () use ($dropdown, $item) {
-                return $dropdown->getParent()->find('css', sprintf('li:contains("%s") a', $item));
-            },
-            20,
-            sprintf('Item "%s" of dropdown row selector not found', $item)
-        );
+        $listItem = $this->spin(function () use ($dropdown, $item) {
+            return $dropdown->getParent()->find('css', sprintf('li:contains("%s") a', $item));
+        }, 20, sprintf('Item "%s" of dropdown row selector not found', $item));
+
         $listItem->click();
     }
 


### PR DESCRIPTION
The goal of this PR is to improve the way the grid is tested in our behats by :
- reworking the methods that fetch information inside the grid (speed improvement)
- adding more spins (stability improvement)
- removing lots of `catch (\Exception $e)` (debuggability improvement)
- fixing a false positive case when sorting by a boolean column
- cleaning phpdoc

For example, the sorting steps ("I should be able to sort the rows by...") are around 4x faster with this implementation. Although the gain is significant on a local machine, it does not really speed up the builds on the CI (don't know why : / ).

CI is blue.