### PR TITLE
[TR] PIM-5071: CI stabilization

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -5,6 +5,7 @@ default:
         class:  Context\FeatureContext
         parameters:
             base_url: http://akeneo-pim-behat.local/
+            timeout: 10000
             window_width: 1280
             window_height: 1024
     extensions:
@@ -24,6 +25,7 @@ jenkins-1:
     context:
         parameters:
             base_url: http://pim-behat-1.ci/
+            timeout: 10000
     extensions:
         Behat\MinkExtension\Extension:
             base_url: http://pim-behat-1.ci/
@@ -41,6 +43,7 @@ jenkins-2:
     context:
         parameters:
             base_url: http://pim-behat-2.ci/
+            timeout: 10000
     extensions:
         Behat\MinkExtension\Extension:
             base_url: http://pim-behat-2.ci/
@@ -58,6 +61,7 @@ jenkins-3:
     context:
         parameters:
             base_url: http://pim-behat-3.ci/
+            timeout: 10000
     extensions:
         Behat\MinkExtension\Extension:
             base_url: http://pim-behat-3.ci/
@@ -75,6 +79,7 @@ jenkins-4:
     context:
         parameters:
             base_url: http://pim-behat-4.ci/
+            timeout: 10000
     extensions:
         Behat\MinkExtension\Extension:
             base_url: http://pim-behat-4.ci/

--- a/features/Context/AssertionContext.php
+++ b/features/Context/AssertionContext.php
@@ -51,7 +51,7 @@ class AssertionContext extends RawMinkContext
             $this->assertSession()->pageTextNotContains($text);
 
             return true;
-        }, 5);
+        });
     }
 
     /**

--- a/features/Context/AssertionContext.php
+++ b/features/Context/AssertionContext.php
@@ -242,7 +242,7 @@ class AssertionContext extends RawMinkContext
     {
         // TODO Flash messages tests temporarily disabled because unstable on CI
         return true;
-//        $this->getMainContext()->wait(10000, '$(".flash-messages-holder").length > 0');
+//        $this->getMainContext()->wait('$(".flash-messages-holder").length > 0');
 //        if (!$this->getCurrentPage()->findFlashMessage($text)) {
 //            throw $this->createExpectationException(sprintf('No flash messages containing "%s" were found.', $text));
 //        }

--- a/features/Context/DataGridContext.php
+++ b/features/Context/DataGridContext.php
@@ -318,7 +318,7 @@ class DataGridContext extends RawMinkContext implements PageObjectAwareInterface
     public function iShowTheFilter($filterName)
     {
         if (false === strpos(strtolower($filterName), 'category')) {
-            $this->wait(30000, '$("div.filter-box").length > 0;');
+            $this->wait('$("div.filter-box").length > 0;');
             $this->datagrid->showFilter($filterName);
             $this->wait();
             $this->datagrid->assertFilterVisible($filterName);
@@ -370,7 +370,7 @@ class DataGridContext extends RawMinkContext implements PageObjectAwareInterface
 
         $expectedColumns = count($columns);
 
-        $this->wait(30000, '$("table.grid").length > 0');
+        $this->wait('$("table.grid").length > 0');
 
         $countColumns = $this->datagrid->countColumns();
         if ($expectedColumns !== $countColumns) {
@@ -529,7 +529,7 @@ class DataGridContext extends RawMinkContext implements PageObjectAwareInterface
      */
     public function iSortByValue($columnName, $order = 'ascending')
     {
-        $this->wait(10000, sprintf('$("a:contains(\'%s\')").length > 0', ucfirst($columnName)));
+        $this->wait(sprintf('$("a:contains(\'%s\')").length > 0', ucfirst($columnName)));
         $this->datagrid->sortBy($columnName, $order);
         $this->wait();
     }
@@ -910,7 +910,7 @@ class DataGridContext extends RawMinkContext implements PageObjectAwareInterface
     public function iPressSequentialEditButton()
     {
         $this->getCurrentPage()->sequentialEdit();
-        $this->wait(20000);
+        $this->wait();
         $this->getNavigationContext()->currentPage = 'Product edit';
     }
 
@@ -997,12 +997,11 @@ class DataGridContext extends RawMinkContext implements PageObjectAwareInterface
     /**
      * Wait
      *
-     * @param int    $time
      * @param string $condition
      */
-    protected function wait($time = 10000, $condition = null)
+    protected function wait($condition = null)
     {
-        $this->getMainContext()->wait($time, $condition);
+        $this->getMainContext()->wait($condition);
     }
 
     /**

--- a/features/Context/FeatureContext.php
+++ b/features/Context/FeatureContext.php
@@ -347,7 +347,6 @@ class FeatureContext extends MinkContext implements KernelAwareInterface
         }
 
         // Make sure the AJAX calls are fired up before checking the condition
-        //TODO: change thie one?
         $this->getSession()->wait(100, false);
 
         $this->getSession()->wait($timeout, $condition);

--- a/features/Context/FeatureContext.php
+++ b/features/Context/FeatureContext.php
@@ -23,6 +23,8 @@ use Symfony\Component\Yaml\Parser;
  */
 class FeatureContext extends MinkContext implements KernelAwareInterface
 {
+    const DEFAULT_TIMEOUT = 10000;
+
     use SpinCapableTrait;
 
     /** @var KernelInterface */
@@ -30,6 +32,9 @@ class FeatureContext extends MinkContext implements KernelAwareInterface
 
     /** @var string[] */
     protected static $errorMessages = [];
+
+    /** @var int */
+    protected $timeout;
 
     /**
      * Path of the yaml file containing tables that should be excluded from database purge
@@ -45,6 +50,12 @@ class FeatureContext extends MinkContext implements KernelAwareInterface
      */
     public function __construct(array $parameters)
     {
+        if (isset($parameters['timeout']) && '' !== $parameters['timeout']) {
+            $this->timeout = $parameters['timeout'];
+        } else {
+            $this->timeout = self::DEFAULT_TIMEOUT;
+        }
+
         $this->useContext('fixtures', new FixturesContext());
         $this->useContext('catalogConfiguration', new CatalogConfigurationContext());
         $this->useContext('webUser', new WebUser($parameters['window_width'], $parameters['window_height']));
@@ -55,6 +66,14 @@ class FeatureContext extends MinkContext implements KernelAwareInterface
         $this->useContext('transformations', new TransformationContext());
         $this->useContext('assertions', new AssertionContext());
         $this->useContext('technical', new TechnicalContext());
+    }
+
+    /**
+     * @return int the timeout in milliseconds
+     */
+    public function getTimeout()
+    {
+        return $this->timeout;
     }
 
     /**
@@ -295,19 +314,20 @@ class FeatureContext extends MinkContext implements KernelAwareInterface
     /**
      * Wait
      *
-     * @param int    $time
      * @param string $condition
      *
-     * @throws BehaviorException If timeout is reached
+     * @throws BehaviorException
      */
-    public function wait($time = 30000, $condition = null)
+    public function wait($condition = null)
     {
         if (!($this->getSession()->getDriver() instanceof Selenium2Driver)) {
             return;
         }
 
+        $timeout = $this->getTimeout();
+
         $start = microtime(true);
-        $end   = $start + $time / 1000.0;
+        $end   = $start + $timeout / 1000.0;
 
         if ($condition === null) {
             $defaultCondition = true;
@@ -327,9 +347,10 @@ class FeatureContext extends MinkContext implements KernelAwareInterface
         }
 
         // Make sure the AJAX calls are fired up before checking the condition
+        //TODO: change thie one?
         $this->getSession()->wait(100, false);
 
-        $this->getSession()->wait($time, $condition);
+        $this->getSession()->wait($timeout, $condition);
 
         // Check if we reached the timeout unless the condition is false to explicitly wait the specified time
         if ($condition !== false && microtime(true) > $end) {
@@ -340,14 +361,14 @@ class FeatureContext extends MinkContext implements KernelAwareInterface
                         throw new BehaviorException(
                             sprintf(
                                 'Timeout of %d reached when checking on "%s"',
-                                $time,
+                                $timeout,
                                 $condition
                             )
                         );
                     }
                 }
             } else {
-                throw new BehaviorException(sprintf('Timeout of %d reached when checking on %s', $time, $condition));
+                throw new BehaviorException(sprintf('Timeout of %d reached when checking on %s', $timeout, $condition));
             }
         }
     }

--- a/features/Context/NavigationContext.php
+++ b/features/Context/NavigationContext.php
@@ -718,7 +718,7 @@ class NavigationContext extends RawMinkContext implements PageObjectAwareInterfa
     {
         $pinButton = $this->spin(function () {
             return $this->getCurrentPage()->find('css', '.minimize-button');
-        }, 10);
+        });
 
         $pinButton->click();
     }
@@ -732,7 +732,7 @@ class NavigationContext extends RawMinkContext implements PageObjectAwareInterfa
     {
         $pinnedItem = $this->spin(function () use ($label) {
             return $this->getCurrentPage()->find('css', sprintf('.pin-bar a[title="%s"]', $label));
-        }, 10);
+        });
 
         $pinnedItem->click();
     }

--- a/features/Context/NavigationContext.php
+++ b/features/Context/NavigationContext.php
@@ -845,12 +845,11 @@ class NavigationContext extends RawMinkContext implements PageObjectAwareInterfa
     }
 
     /**
-     * @param int    $time
      * @param string $condition
      */
-    protected function wait($time = 10000, $condition = null)
+    protected function wait($condition = null)
     {
-        $this->getMainContext()->wait($time, $condition);
+        $this->getMainContext()->wait($condition);
     }
 
     /**

--- a/features/Context/Page/Attribute/Creation.php
+++ b/features/Context/Page/Attribute/Creation.php
@@ -21,17 +21,17 @@ class Creation extends Form
     /**
      * {@inheritdoc}
      */
-    public function __construct($session, $pageFactory, $parameters = array())
+    public function __construct($session, $pageFactory, $parameters = [])
     {
         parent::__construct($session, $pageFactory, $parameters);
 
         $this->elements = array_merge(
             $this->elements,
-            array(
-                'attribute_option_table' => array('css' => '#attribute-option-grid table'),
-                'attribute_options'      => array('css' => '#attribute-option-grid tbody tr'),
-                'add_option_button'      => array('css' => '#attribute-option-grid .btn.option-add'),
-            )
+            [
+                'attribute_option_table' => ['css' => '#attribute-option-grid table'],
+                'attribute_options'      => ['css' => '#attribute-option-grid tbody tr'],
+                'add_option_button'      => ['css' => '#attribute-option-grid .btn.option-add'],
+            ]
         );
     }
 
@@ -57,7 +57,7 @@ class Creation extends Form
     {
         if (!$this->getElement('attribute_option_table')->find('css', '.attribute_option_code')) {
             $this->getElement('add_option_button')->click();
-            $this->getSession()->wait(10000);
+            $this->getSession()->wait($this->getTimeout());
         }
 
         $rows = $this->getOptionsElement();

--- a/features/Context/Page/AttributeGroup/Edit.php
+++ b/features/Context/Page/AttributeGroup/Edit.php
@@ -16,15 +16,15 @@ class Edit extends Creation
     /**
      * {@inheritdoc}
      */
-    public function __construct($session, $pageFactory, $parameters = array())
+    public function __construct($session, $pageFactory, $parameters = [])
     {
         parent::__construct($session, $pageFactory, $parameters);
 
         $this->elements = array_merge(
             $this->elements,
-            array(
-                'Attribute list' => array('css' => '#attributes-sortable'),
-            )
+            [
+                'Attribute list' => ['css' => '#attributes-sortable'],
+            ]
         );
     }
 

--- a/features/Context/Page/Base/Base.php
+++ b/features/Context/Page/Base/Base.php
@@ -35,11 +35,11 @@ class Base extends Page
     /**
      * {@inheritdoc}
      */
-    public function getElement($name, $timeout = 20, $message = 'no message')
+    public function getElement($name, $message = 'no message')
     {
         return $this->spin(function () use ($name) {
             return parent::getElement($name);
-        }, $timeout, $message);
+        }, $message);
     }
 
     /**

--- a/features/Context/Page/Base/Base.php
+++ b/features/Context/Page/Base/Base.php
@@ -5,6 +5,7 @@ namespace Context\Page\Base;
 use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Exception\ElementNotFoundException;
 use Behat\Mink\Exception\UnsupportedDriverActionException;
+use Context\FeatureContext;
 use Context\Spin\SpinCapableTrait;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Element;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Page;
@@ -391,5 +392,14 @@ class Base extends Page
         }
 
         return true;
+    }
+
+    /**
+     * @return int timeout in millisecond
+     */
+    protected function getTimeout()
+    {
+        // no way to retrieve the timeout from behat.yml at the moment
+        return FeatureContext::DEFAULT_TIMEOUT;
     }
 }

--- a/features/Context/Page/Base/Form.php
+++ b/features/Context/Page/Base/Form.php
@@ -143,7 +143,7 @@ class Form extends Base
         try {
             $node = $this->spin(function () use ($tab) {
                 return $this->getElement('Form tabs')->find('css', sprintf('a:contains("%s")', $tab));
-            }, 5);
+            });
         } catch (\Exception $e) {
             $node = null;
         }
@@ -507,7 +507,7 @@ class Form extends Base
 
                 return $choices;
             }
-        }, 10);
+        });
 
         if ($isExpected) {
             foreach ($choices as $choice) {

--- a/features/Context/Page/Base/Form.php
+++ b/features/Context/Page/Base/Form.php
@@ -54,7 +54,7 @@ class Form extends Base
     {
         $this->pressButton('Save');
         if ($this->getSession()->getDriver() instanceof Selenium2Driver) {
-            $this->getSession()->wait(10000, '!$.active');
+            $this->getSession()->wait($this->getTimeout(), '!$.active');
         }
     }
 
@@ -717,7 +717,7 @@ class Form extends Base
 
         // Removing tags in MultiSelect2 drops an "animation" with opacity, we must
         // wait for it to completly vanish in order to reopen select list
-        $this->getSession()->wait(2000);
+        $this->getSession()->wait($this->getTimeout());
 
         $allValues = array_filter($allValues);
 
@@ -732,7 +732,7 @@ class Form extends Base
         foreach ($remainingValues as $value) {
             if (trim($value)) {
                 $label->getParent()->find('css', 'input[type="text"]')->click();
-                $this->getSession()->wait(100000, "$('div:contains(\"Searching\")').length == 0");
+                $this->getSession()->wait($this->getTimeout(), "$('div:contains(\"Searching\")').length == 0");
                 $option = $this->find(
                     'css',
                     sprintf('.select2-result:not(.select2-selected) .select2-result-label:contains("%s")', trim($value))
@@ -763,7 +763,7 @@ class Form extends Base
             if (null !== $link = $label->getParent()->find('css', 'a.select2-choice')) {
                 $link->click();
 
-                $this->getSession()->wait(5000, '!$.active');
+                $this->getSession()->wait($this->getTimeout(), '!$.active');
 
                 $field = $this->spin(function () use ($value) {
                     return $this->find('css', sprintf('#select2-drop li:contains("%s")', $value));

--- a/features/Context/Page/Batch/Classify.php
+++ b/features/Context/Page/Batch/Classify.php
@@ -16,16 +16,16 @@ class Classify extends Wizard
     /**
      * {@inheritdoc}
      */
-    public function __construct($session, $pageFactory, $parameters = array())
+    public function __construct($session, $pageFactory, $parameters = [])
     {
         parent::__construct($session, $pageFactory, $parameters);
 
         $this->elements = array_merge(
             $this->elements,
-            array(
-                'Trees list'    => array('css' => '#trees-list'),
-                'Category tree' => array('css' => '#trees'),
-            )
+            [
+                'Trees list'    => ['css' => '#trees-list'],
+                'Category tree' => ['css' => '#trees'],
+            ]
         );
     }
 

--- a/features/Context/Page/Category/CategoryView.php
+++ b/features/Context/Page/Category/CategoryView.php
@@ -44,7 +44,7 @@ abstract class CategoryView extends Form
     {
         $elt = $this->spin(function () use ($category) {
             return $this->getElement('Category tree')->find('css', sprintf('li a:contains("%s")', $category));
-        }, 10, sprintf('Unable to find category "%s" in the tree', $category));
+        }, sprintf('Unable to find category "%s" in the tree', $category));
 
         return $elt;
     }

--- a/features/Context/Page/Family/Edit.php
+++ b/features/Context/Page/Family/Edit.php
@@ -21,16 +21,16 @@ class Edit extends Form
     /**
      * {@inheritdoc}
      */
-    public function __construct($session, $pageFactory, $parameters = array())
+    public function __construct($session, $pageFactory, $parameters = [])
     {
         parent::__construct($session, $pageFactory, $parameters);
 
         $this->elements = array_merge(
             $this->elements,
-            array(
-                'Attributes'                 => array('css' => '.tab-pane.tab-attribute table'),
-                'Attribute as label choices' => array('css' => '#pim_enrich_family_form_attributeAsLabel'),
-            )
+            [
+                'Attributes'                 => ['css' => '.tab-pane.tab-attribute table'],
+                'Attribute as label choices' => ['css' => '#pim_enrich_family_form_attributeAsLabel'],
+            ]
         );
     }
 

--- a/features/Context/Page/Product/Edit.php
+++ b/features/Context/Page/Product/Edit.php
@@ -151,7 +151,6 @@ class Edit extends Form
     {
         $dropdown = $this->getElement(
             $copy ? 'Copy locales dropdown' : 'Locales dropdown',
-            20,
             'Could not find locale switcher'
         );
 
@@ -162,7 +161,7 @@ class Edit extends Form
 
         $option = $this->spin(function () use ($dropdown, $localeCode) {
             return $dropdown->find('css', sprintf('a[data-locale="%s"]', $localeCode));
-        }, 20, sprintf('Could not find locale "%s" in switcher', $localeCode));
+        }, sprintf('Could not find locale "%s" in switcher', $localeCode));
         $option->click();
     }
 
@@ -176,7 +175,6 @@ class Edit extends Form
     {
         $dropdown = $this->getElement(
             $copy ? 'Copy channel dropdown' : 'Channel dropdown',
-            20,
             'Could not find scope switcher'
         );
 
@@ -187,7 +185,7 @@ class Edit extends Form
 
         $option = $this->spin(function () use ($dropdown, $scopeCode) {
             return $dropdown->find('css', sprintf('a[data-scope="%s"]', $scopeCode));
-        }, 20, sprintf('Could not find scope "%s" in switcher', $scopeCode));
+        }, sprintf('Could not find scope "%s" in switcher', $scopeCode));
         $option->click();
     }
 
@@ -201,12 +199,12 @@ class Edit extends Form
         $dropdown = $this->getElement('Copy source dropdown');
         $toggle   = $this->spin(function () use ($dropdown) {
             return $dropdown->find('css', '.dropdown-toggle');
-        }, 20, 'Could not find copy source switcher.');
+        }, 'Could not find copy source switcher.');
         $toggle->click();
 
         $option = $this->spin(function () use ($dropdown, $source) {
             return $dropdown->find('css', sprintf('a[data-source="%s"]', $source));
-        }, 20, sprintf('Could not find source "%s" in switcher', $source));
+        }, sprintf('Could not find source "%s" in switcher', $source));
         $option->click();
     }
 
@@ -387,7 +385,7 @@ class Edit extends Form
 
         $field = $this->spin(function () use ($subContainer) {
             return $subContainer->find('css', '.field-input input, .field-input textarea');
-        }, 10);
+        });
 
         return $field;
     }
@@ -411,7 +409,7 @@ class Edit extends Form
         try {
             $labelNode = $this->spin(function () use ($label) {
                 return $this->find('css', sprintf('.field-container header label:contains("%s")', $label));
-            }, 10);
+            });
         } catch (\Exception $e) {
             throw new ElementNotFoundException($this->getSession());
         }
@@ -447,11 +445,11 @@ class Edit extends Form
         if ($element) {
             $label = $this->spin(function () use ($element, $labelContent) {
                 return $element->find('css', sprintf('label:contains("%s")', $labelContent));
-            }, 10, sprintf('unable to find label %s in element : %s', $labelContent, $element->getHtml()));
+            }, sprintf('unable to find label %s in element : %s', $labelContent, $element->getHtml()));
         } else {
             $label = $this->spin(function () use ($labelContent) {
                 return $this->find('css', sprintf('label:contains("%s")', $labelContent));
-            }, 10, sprintf('unable to find label %s', $labelContent));
+            }, sprintf('unable to find label %s', $labelContent));
         }
 
         if (!$label) {
@@ -637,7 +635,7 @@ class Edit extends Form
 
         $link = $this->spin(function () use ($fieldContainer) {
             return $fieldContainer->find('css', 'a.select2-choice');
-        }, 20, sprintf('Could not find select2 widget inside %s', $fieldContainer->getParent()->getHtml()));
+        }, sprintf('Could not find select2 widget inside %s', $fieldContainer->getParent()->getHtml()));
 
 
         $link->click();
@@ -666,7 +664,7 @@ class Edit extends Form
     {
         $input = $this->spin(function () use ($subContainer) {
             return $subContainer->find('css', 'input[type="hidden"].select-field');
-        }, 5);
+        });
 
         return $input->getValue();
     }
@@ -703,7 +701,7 @@ class Edit extends Form
                     'css',
                     sprintf('.select2-result:not(.select2-selected) .select2-result-label:contains("%s")', $value)
                 );
-            }, 5);
+            });
 
             // Select the value in the displayed dropdown
             if (null !== $item) {
@@ -731,7 +729,7 @@ class Edit extends Form
     {
         $input = $this->spin(function () use ($subContainer) {
             return $subContainer->find('css', 'input[type="hidden"].select-field');
-        }, 5);
+        });
 
         return '' === $input->getValue() ? [] : explode(',', $input->getValue());
     }
@@ -747,7 +745,7 @@ class Edit extends Form
     {
         $widget = $this->spin(function () use ($subContainer) {
             return $subContainer->find('css', '.field-input .media-uploader');
-        }, 5);
+        });
 
         $filenameNode = $widget->find('css', '.filename');
 
@@ -767,7 +765,7 @@ class Edit extends Form
     {
         $widget = $this->spin(function () use ($fieldContainer) {
             return $fieldContainer->find('css', '.field-input .switch.has-switch');
-        }, 5);
+        });
 
         if ($widget->find('css', '.switch-on')) {
             return true;
@@ -853,7 +851,7 @@ class Edit extends Form
 
                 $item = $this->spin(function () use ($select) {
                     return $this->find('css', sprintf('#select2-drop li:contains("%s")', $select));
-                }, 5);
+                });
             }
 
             if (!$item) {
@@ -880,7 +878,7 @@ class Edit extends Form
         $input  = $subContainer->find('css', '.data');
         $select = $this->spin(function () use ($subContainer) {
             return $subContainer->find('css', '.select2-container');
-        }, 5);
+        });
 
         return sprintf(
             '%s %s',
@@ -974,7 +972,7 @@ class Edit extends Form
         try {
             $button = $this->spin(function () use ($field) {
                 return $this->find('css', sprintf('.field-container:contains("%s") .clear-field', $field));
-            }, 5);
+            });
         } catch (\Exception $e) {
             $button = null;
         }
@@ -1036,7 +1034,7 @@ class Edit extends Form
         try {
             $switcher = $this->spin(function () {
                 return $this->find('css', '.status-switcher');
-            }, 5);
+            });
         } catch (\Exception $e) {
             $switcher = null;
         }
@@ -1067,7 +1065,7 @@ class Edit extends Form
      */
     public function findCompletenessContent()
     {
-        return $this->getElement('Completeness', 20, 'Completeness content not found !!!');
+        return $this->getElement('Completeness', 'Completeness content not found !!!');
     }
 
     /**
@@ -1466,7 +1464,7 @@ class Edit extends Form
     {
         $startCopyBtn = $this->spin(function () {
             return $this->getElement('Comparison dropdown')->find('css', 'div.start-copying');
-        }, 5);
+        });
 
         $startCopyBtn->click();
         $this->getSession()->wait($this->getTimeout());
@@ -1487,7 +1485,7 @@ class Edit extends Form
             // Is panel already open?
             $this->spin(function () {
                 return $this->getElement('Copy actions')->find('css', '.stop-copying');
-            }, 20, "Copy panel seems neither open nor closed.");
+            }, "Copy panel seems neither open nor closed.");
         }
 
         $this->switchLocale($localeCode, true);
@@ -1584,7 +1582,7 @@ class Edit extends Form
     {
         $this->spin(function () {
             return $this->getElement('Progress bar');
-        }, 30);
+        });
     }
 
     /**
@@ -1635,7 +1633,7 @@ class Edit extends Form
 
         $groupNode = $this->spin(function () use ($groups, $group) {
             return $groups->find('css', sprintf('.attribute-group-label:contains("%s")', $group));
-        }, 20, sprintf("Can't find attribute group '%s'", $group));
+        }, sprintf("Can't find attribute group '%s'", $group));
 
         return $groupNode->getParent()->getParent();
     }

--- a/features/Context/Page/Product/Edit.php
+++ b/features/Context/Page/Product/Edit.php
@@ -261,7 +261,7 @@ class Edit extends Form
      */
     public function fillField($label, $value, Element $element = null)
     {
-        $this->getSession()->wait(5000);
+        $this->getSession()->wait($this->getTimeout());
         $isLabel = false;
 
         try {
@@ -1469,7 +1469,7 @@ class Edit extends Form
         }, 5);
 
         $startCopyBtn->click();
-        $this->getSession()->wait(500);
+        $this->getSession()->wait($this->getTimeout());
     }
 
     /**

--- a/features/Context/Spin/SpinCapableTrait.php
+++ b/features/Context/Spin/SpinCapableTrait.php
@@ -2,28 +2,29 @@
 
 namespace Context\Spin;
 
+use Context\FeatureContext;
+
 trait SpinCapableTrait
 {
     /**
      * This method executes $callable every second. If its return value is evaluated to true, the spinning stops and the
      * value is returned. If the return value is falsy or if $callable throw an exception, the spinning continues until
-     * the $wait limit (in seconds) is reached, in that case a TimeoutException is thrown.
+     * the loop limit is reached, in that case a TimeoutException is thrown.
      * If another spinning method is used inside $callable and throws a TimeoutException the current spinning stops
      * immediately to avoid waiting uselessly.
      *
      * @param callable $callable
-     * @param int      $wait
      * @param string   $message
      *
      * @throws TimeoutException
      *
      * @return mixed
      */
-    public function spin($callable, $wait = 20, $message = 'no message')
+    public function spin($callable, $message = 'no message')
     {
         $lastException = null;
 
-        for ($i = 0; $i < $wait; ++$i) {
+        for ($i = 0; $i < FeatureContext::DEFAULT_TIMEOUT / 1000; ++$i) {
             try {
                 if ($result = $callable($this)) {
                     return $result;

--- a/features/Context/WebUser.php
+++ b/features/Context/WebUser.php
@@ -445,7 +445,7 @@ class WebUser extends RawMinkContext
             $expectedLinkCount = count($table->getHash());
 
             return $linkCount === $expectedLinkCount;
-        }, 20, sprintf('Expected to see %d items in the locale switcher, saw %d', $expectedLinkCount, $linkCount));
+        }, sprintf('Expected to see %d items in the locale switcher, saw %d', $expectedLinkCount, $linkCount));
 
         foreach ($table->getHash() as $data) {
             $this->spin(
@@ -457,7 +457,6 @@ class WebUser extends RawMinkContext
                         $copy
                     );
                 },
-                5,
                 sprintf(
                     'Could not find locale "%s %s" in the locale switcher',
                     $data['locale'],
@@ -1648,7 +1647,7 @@ class WebUser extends RawMinkContext
     {
         $switch = $this->spin(function () {
             return $this->getCurrentPage()->findById('nested_switch_input');
-        }, 5);
+        });
 
         $on = 'en' === $status;
         if ($switch->isChecked() !== $on) {
@@ -2198,7 +2197,7 @@ class WebUser extends RawMinkContext
 
         $link = $this->spin(function () use ($attribute, $cell) {
             return $cell->find('css', sprintf(".missing-attributes [data-attribute='%s']", $attribute));
-        }, 20, sprintf("Can't find missing '%s' value link for %s/%s", $attribute, $locale, $channel));
+        }, sprintf("Can't find missing '%s' value link for %s/%s", $attribute, $locale, $channel));
 
         $link->click();
     }

--- a/features/Context/WebUser.php
+++ b/features/Context/WebUser.php
@@ -226,7 +226,7 @@ class WebUser extends RawMinkContext
     public function iVisitTheTab($tab)
     {
         $tabLocator = sprintf('$("a:contains(\'%s\')").length > 0;', $tab);
-        $this->wait(30000, $tabLocator);
+        $this->wait($tabLocator);
         $this->getCurrentPage()->visitTab($tab);
         $this->wait();
     }
@@ -1154,7 +1154,7 @@ class WebUser extends RawMinkContext
 
         $addButton->click();
 
-        $this->getMainContext()->wait(10000);
+        $this->wait();
     }
 
     /**
@@ -1416,7 +1416,7 @@ class WebUser extends RawMinkContext
         }
 
         $this->getCurrentPage()->attachFileToField($field, $file);
-        $this->getMainContext()->wait();
+        $this->wait();
     }
 
     /**
@@ -1426,14 +1426,14 @@ class WebUser extends RawMinkContext
      */
     public function iRemoveTheFile($field)
     {
-        $this->getMainContext()->wait();
+        $this->wait();
         $script = sprintf("$('label:contains(\"%s\")').parents('.form-field').find('.clear-field').click();", $field);
         if (!$this->getMainContext()->executeScript($script)) {
             $this->getCurrentPage()->removeFileFromField($field);
         }
 
         $this->getSession()->executeScript('$(\'.edit .field-input input[type="file"]\').trigger(\'change\');');
-        $this->getMainContext()->wait();
+        $this->wait();
     }
 
     /**
@@ -1490,7 +1490,7 @@ class WebUser extends RawMinkContext
     {
         foreach ($table->getHash() as $data) {
             $this->getCurrentPage()->addOption($data['Code']);
-            $this->wait(3000);
+            $this->wait();
         }
     }
 
@@ -1503,7 +1503,7 @@ class WebUser extends RawMinkContext
     public function iEditTheFollowingAttributeOptions($oldOptionName, $newOptionName)
     {
         $this->getCurrentPage()->editOption($oldOptionName, $newOptionName);
-        $this->wait(3000);
+        $this->wait();
     }
 
     /**
@@ -1515,7 +1515,7 @@ class WebUser extends RawMinkContext
     public function iEditAndCancelToEditTheFollowingAttributeOptions($oldOptionName, $newOptionName)
     {
         $this->getCurrentPage()->editOptionAndCancel($oldOptionName, $newOptionName);
-        $this->wait(3000);
+        $this->wait();
     }
 
     /**
@@ -1842,7 +1842,7 @@ class WebUser extends RawMinkContext
         $condition = '$("#status").length && /(COMPLETED|STOPPED|FAILED|TERMINÉ|ARRÊTÉ|EN ÉCHEC)$/.test($("#status").text().trim())';
 
         try {
-            $this->wait(120000, $condition);
+            $this->wait($condition);
         } catch (BehaviorException $e) {
             $jobInstance  = $this->getFixturesContext()->getJobInstance($code);
             $jobExecution = $jobInstance->getJobExecutions()->first();
@@ -1881,12 +1881,12 @@ class WebUser extends RawMinkContext
                     $jobExecution->getId()
                 )
             );
-            $this->wait(2000);
+            $this->wait();
             $executionLog = $this->getSession()->evaluateScript("return window.executionLog;");
             $this->getMainContext()->addErrorMessage(sprintf('Job execution: %s', print_r($executionLog, true)));
 
             // Call the wait method again to trigger timeout failure
-            $this->wait(100, $condition);
+            $this->wait($condition);
         }
     }
 
@@ -1935,7 +1935,7 @@ class WebUser extends RawMinkContext
      */
     public function iWaitForTheWidgetsToLoad()
     {
-        $this->wait(2000, false);
+        $this->wait(false);
         $this->wait();
     }
 
@@ -1944,7 +1944,7 @@ class WebUser extends RawMinkContext
      */
     public function iWaitForTheOptionsToLoad()
     {
-        $this->wait(2000, false);
+        $this->wait(false);
         $this->wait();
     }
 
@@ -2033,7 +2033,7 @@ class WebUser extends RawMinkContext
         $maxTime = 10000;
 
         while ($maxTime > 0) {
-            $this->wait(2000, false);
+            $this->wait(false);
             $maxTime -= 1000;
             if ($this->getPage('Product edit')->getImagePreview()) {
                 return;
@@ -2243,7 +2243,7 @@ class WebUser extends RawMinkContext
      */
     public function iWaitSeconds($seconds)
     {
-        $this->wait($seconds * 1000, false);
+        $this->wait(false);
     }
 
     /**
@@ -2278,7 +2278,7 @@ class WebUser extends RawMinkContext
     public function iMoveOnToTheNextStep()
     {
         $this->scrollContainerTo(900);
-        $this->wait(10000, '$(".btn:contains(\'Next\')").length > 0');
+        $this->wait('$(".btn:contains(\'Next\')").length > 0');
         $this->getCurrentPage()->next();
         $this->scrollContainerTo(900);
         $this->getCurrentPage()->confirm();
@@ -2856,12 +2856,11 @@ class WebUser extends RawMinkContext
     }
 
     /**
-     * @param int    $time
      * @param string $condition
      */
-    protected function wait($time = 20000, $condition = null)
+    protected function wait($condition = null)
     {
-        $this->getMainContext()->wait($time, $condition);
+        $this->getMainContext()->wait($condition);
     }
 
     /**

--- a/features/datagrid/datagrid_views.feature
+++ b/features/datagrid/datagrid_views.feature
@@ -22,7 +22,7 @@ Feature: Datagrid views
     And I create the view:
       | label | Sneakers only |
     Then I should be on the products page
-    And I should see "Datagrid view successfully created"
+    And I should see a flash message "Datagrid view successfully created"
     And I should see "Views Sneakers only"
     And I should see products purple-sneakers and black-sneakers
     But I should not see product black-boots
@@ -39,7 +39,7 @@ Feature: Datagrid views
     And I create the view:
       | label | Some shoes |
     Then I should be on the products page
-    And I should see "Datagrid view successfully created"
+    And I should see a flash message "Datagrid view successfully created"
     And I should see "Views Some shoes"
     And I should see product black-boots
     But I should not see products purple-sneakers and black-sneakers
@@ -58,7 +58,7 @@ Feature: Datagrid views
     And I create the view:
       | label | Boots only |
     Then I should be on the products page
-    And I should see "Datagrid view successfully created"
+    And I should see a flash message "Datagrid view successfully created"
     And I should see "Views Boots only"
     And I should see product black-boots
     But I should not see products purple-sneakers and black-sneakers

--- a/features/user/edit_my_account.feature
+++ b/features/user/edit_my_account.feature
@@ -13,5 +13,5 @@ Feature: Change my profile picture
     Given I edit the "admin" user
     When I attach file "akeneo.jpg" to "Avatar"
     And I save the user
-    Then I should see "User saved"
+    Then I should see a flash message "User saved"
     And I should not see the default avatar

--- a/features/user/edit_user_group_and_role_assignations.feature
+++ b/features/user/edit_user_group_and_role_assignations.feature
@@ -13,7 +13,7 @@ Feature: Edit a user groups and roles
     And I visit the "Groups and Roles" tab
     And I check "Redactor"
     And I save the user
-    Then I should see "User saved"
+    Then I should see a flash message "User saved"
     And the user "admin" should be in 3 groups
     And the user "admin" should be in the "Redactor" group
     Given I edit the "admin" user


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Specs             | -
| Behats            | Y
| Blue CI           | Y
| Changelog updated | -
| Review and 2 GTM  | -

The aim of this PR is to make a first step on the stabilization on our CI. Our first tests on the new CI system reveal a lot of unstable Behat due to timeouts. Our current CI is super fast thanks to RAMFS and we will not have this on our future CI; ie: **each Behat will surely be slower and more subject to timeouts on the future CI than what we have currently**.

We'll test this branch on the new CI to find which timeout suit the best.

What's done here?
- [x] use flash message when relevant (instead of searching for a normal text)
- [x] standardize all timeouts to be able to rework them easily later and to fine tune the timeout we really need
- [ ] replace *wait* by *spin* [FOR ANOTHER PR]