### PR TITLE
Extend REST API to return all products

### DIFF
--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -3,6 +3,7 @@
 ## Technical improvements
 
 - PIM-4964: Use enable / disable import parameter only to create the product
+- Enhance REST API to return all products when calling /products without a product SKU.
 
 ## Bug fixes
 

--- a/app/SymfonyRequirements.php
+++ b/app/SymfonyRequirements.php
@@ -447,6 +447,12 @@ class SymfonyRequirements extends RequirementCollection
         }
 
         $this->addRequirement(
+            function_exists('iconv'),
+            'iconv() must be available',
+            'Install and enable the <strong>iconv</strong> extension.'
+        );
+
+        $this->addRequirement(
             function_exists('json_encode'),
             'json_encode() must be available',
             'Install and enable the <strong>JSON</strong> extension.'

--- a/features/Context/WebApiContext.php
+++ b/features/Context/WebApiContext.php
@@ -58,6 +58,19 @@ class WebApiContext extends BehatWebApiContext
     }
 
     /**
+     * @param string $sku
+     *
+     * @return array:Step
+     * @Given /^I request information for all products$/
+     */
+    public function iRequestInformationForAllProducts()
+    {
+        $this->setPlaceHolder('{baseUrl}', $this->url);
+
+        return array(new Step\Given("I send a GET request to \"api/rest/products\""));
+    }
+
+    /**
      * @Given /^(?:the )?response should be valid json$/
      */
     public function theResponseShouldBeValidJson()

--- a/features/rest/get-products.feature
+++ b/features/rest/get-products.feature
@@ -1,0 +1,83 @@
+Feature: Expose all product data via a REST API
+  In order to provide access to product data to an external application
+  As a developer
+  I need to expose all product data via a REST API
+
+  Background:
+    Given a "footwear" catalog configuration
+    And the following product:
+      | sku     | name-en_US | description-en_US-mobile | description-en_US-tablet | price-EUR | price-USD | categories      |
+      | sandals | My sandals | My great sandals         | My great new sandals     | 20        | 30        | 2014_collection |
+      | shirt   | My shirt   | My great shirt           | My great new shirt       | 10        | 20        | 2014_collection |
+
+  Scenario: Fail to authenticate an anonymous user
+    Given I send a GET request to "api/rest/products"
+    Then the response code should be 401
+
+  Scenario: Successfully authenticate a user
+    Given I am authenticating as "admin" with "admin_api_key" api key
+    And I send a GET request to "api/rest/products"
+    Then the response code should be 200
+
+  Scenario: Successfully retrieve a product
+    Given I am authenticating as "admin" with "admin_api_key" api key
+    And I request information for all products
+    Then the response code should be 200
+    And the response should be valid json
+    And the response should contain json:
+    """
+    [{
+      "family":null,
+      "groups":[],
+      "variant_group":null,
+      "categories":["2014_collection"],
+      "enabled":true,
+      "associations":[],
+      "values": {
+        "sku":[
+          {"locale":null,"scope":null,"data":"sandals"}
+        ],
+        "name":[
+          {"locale":"en_US","scope":null,"data":"My sandals"}
+        ],
+        "description":[
+          {"locale":"en_US","scope":"mobile","data":"My great sandals"},
+          {"locale":"en_US","scope":"tablet","data":"My great new sandals"}
+        ],
+        "price":[
+          {"locale":null,"scope":null,"data":[
+            {"data":"20.00","currency":"EUR"},
+            {"data":"30.00","currency":"USD"}
+          ]}
+        ]
+      },
+      "resource":"{baseUrl}/api/rest/products/sandals"
+    },
+        {
+      "family":null,
+      "groups":[],
+      "variant_group":null,
+      "categories":["2014_collection"],
+      "enabled":true,
+      "associations":[],
+      "values": {
+        "sku":[
+          {"locale":null,"scope":null,"data":"shirt"}
+        ],
+        "name":[
+          {"locale":"en_US","scope":null,"data":"My shirt"}
+        ],
+        "description":[
+          {"locale":"en_US","scope":"mobile","data":"My great shirt"},
+          {"locale":"en_US","scope":"tablet","data":"My great new shirt"}
+        ],
+        "price":[
+          {"locale":null,"scope":null,"data":[
+            {"data":"10.00","currency":"EUR"},
+            {"data":"20.00","currency":"USD"}
+          ]}
+        ]
+      },
+      "resource":"{baseUrl}/api/rest/products/shirt"
+    }]
+    """

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Repository/ProductRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Repository/ProductRepository.php
@@ -106,6 +106,23 @@ class ProductRepository extends DocumentRepository implements
     /**
      * {@inheritdoc}
      */
+
++    public function findAll()
++    {
++        $pqb = $this->queryBuilderFactory->create();
++        $qb = $pqb->getQueryBuilder();
++        $result = $qb->getQuery()->execute();
++
++        if (empty($result)) {
++            return null;
++        }
++
++        return $result;
++    }
++
++    /**
++     * {@inheritdoc}
++     */
     public function findOneById($id)
     {
         $pqb = $this->queryBuilderFactory->create();

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/ProductRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/ProductRepository.php
@@ -487,6 +487,22 @@ class ProductRepository extends EntityRepository implements
     /**
      * {@inheritdoc}
      */
+    public function findAll()
+    {
+        $pqb = $this->queryBuilderFactory->create();
+        $qb = $pqb->getQueryBuilder();
+        $result = $qb->getQuery()->execute();
+
+        if (empty($result)) {
+            return null;
+        }
+
+        return $result;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function findOneById($id)
     {
         $pqb = $this->queryBuilderFactory->create();

--- a/src/Pim/Bundle/CatalogBundle/Repository/ProductRepositoryInterface.php
+++ b/src/Pim/Bundle/CatalogBundle/Repository/ProductRepositoryInterface.php
@@ -84,7 +84,7 @@ interface ProductRepositoryInterface
     public function getFullProduct($id);
 
     /**
-     * Returns true if a ProductValue with the provided value alread exists,
+     * Returns true if a ProductValue with the provided value already exists,
      * false otherwise.
      *
      * @param ProductValueInterface $value
@@ -132,9 +132,15 @@ interface ProductRepositoryInterface
     public function findOneByIdentifier($identifier);
 
     /**
-     * @param string|int $id
      *
      * @return ProductInterface|null
+     */
+    public function findAll();
+
+    /**
+     * @param string|int $id
+     *
+     * @return array ProductInterface|null
      */
     public function findOneById($id);
 

--- a/src/Pim/Bundle/WebServiceBundle/Controller/Rest/ProductsController.php
+++ b/src/Pim/Bundle/WebServiceBundle/Controller/Rest/ProductsController.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Pim\Bundle\WebServiceBundle\Controller\Rest;
+
+use FOS\RestBundle\Controller\Annotations\NamePrefix;
+use FOS\RestBundle\Controller\Annotations\RouteResource;
+use FOS\RestBundle\Controller\FOSRestController;
+use Nelmio\ApiDocBundle\Annotation\ApiDoc;
+use Pim\Bundle\CatalogBundle\Model\ProductInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+/**
+ * Product API controller
+ *
+ * @author    Filips Alpe <filips@akeneo.com>
+ * @copyright 2013 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *
+ * @RouteResource("products")
+ * @NamePrefix("oro_api_")
+ */
+class ProductsController extends FOSRestController
+{
+    /**
+     * Get products
+     *
+     * @param Request $request
+     *
+     * @ApiDoc(
+     *      description="Get a single product",
+     *      resource=true
+     * )
+     *
+     * @return Response
+     */
+    public function getAction(Request $request)
+    {
+        $userContext       = $this->get('pim_user.context.user');
+        $availableChannels = array_keys($userContext->getChannelChoicesWithUserChannel());
+        $availableLocales  = $userContext->getUserLocaleCodes();
+
+        $channels = $request->get('channels', $request->get('channel', null));
+        if ($channels !== null) {
+            $channels = explode(',', $channels);
+
+            foreach ($channels as $channel) {
+                if (!in_array($channel, $availableChannels)) {
+                    return new Response(sprintf('Channel "%s" does not exist or is not available', $channel), 403);
+                }
+            }
+        }
+
+        $locales = $request->get('locales', $request->get('locale', null));
+        if ($locales !== null) {
+            $locales = explode(',', $locales);
+
+            foreach ($locales as $locale) {
+                if (!in_array($locale, $availableLocales)) {
+                    return new Response(sprintf('Locale "%s" does not exist or is not available', $locale), 403);
+                }
+            }
+        }
+
+        return $this->handleGetRequest($channels, $locales);
+    }
+
+    /**
+     * Return a single product
+     *
+     * @param string[] $channels
+     * @param string[] $locales
+     *
+     * @return Response
+     */
+    protected function handleGetRequest($channels, $locales)
+    {
+        $productRepository = $this->container->get('pim_catalog.repository.product');
+        $products = $productRepository->findAll();
+
+        try {
+            $serializedData = $this->serializeProducts($products, $channels, $locales);
+        } catch (AccessDeniedException $exception) {
+            return new Response(sprintf('Access denied to the products'), 403);
+        }
+
+        return new Response($serializedData);
+    }
+
+    /**
+     * Serialize many products
+     *
+     * @param array            $products
+     * @param string[]         $channels
+     * @param string[]         $locales
+     *
+     * @return array
+     */
+    protected function serializeProducts(array $products, $channels, $locales)
+    {
+        $handler = $this->container->get('pim_webservice.handler.rest.product');
+        $data = array();
+
+        foreach($products as &$product) {
+
+            $url = $this->generateUrl(
+                'oro_api_get_product',
+                array(
+                    'identifier' => $product->getIdentifier()->getData()
+                ),
+                true
+            );
+
+            array_push($data, $handler->get($product, $channels, $locales, $url));
+        }
+        return "[" . implode(",", $data) . "]";
+    }
+}

--- a/src/Pim/Bundle/WebServiceBundle/Resources/config/routing.yml
+++ b/src/Pim/Bundle/WebServiceBundle/Resources/config/routing.yml
@@ -1,4 +1,9 @@
-api:
+product_api:
     resource: '@PimWebServiceBundle/Controller/Rest/ProductController.php'
+    type:   rest
+    prefix: api/rest/
+
+products_api:
+    resource: '@PimWebServiceBundle/Controller/Rest/ProductsController.php'
     type:   rest
     prefix: api/rest/


### PR DESCRIPTION
I have extended the REST API to support Get Products. In addition to http://pim-dev.local/api/rest/products/sku-000.json you can now hit http://pim-dev.local/api/rest/products to return an array of all products.

| Q                 | A
| ----------------- | ---
| Added Specs       | Y
| Added Behats      | Y
| Travis CI is ok   | not yet
| Changelog updated | Y

Disclaimer: I'm not a PHP Developer (.NET is my home!) so please forgive any novice PHP mistakes. Any advice would be appreciated!

Thanks