### PR TITLE
Grid filter "in list" for text attributes

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
@@ -163,7 +163,7 @@ services:
         arguments:
             - @pim_catalog.validator.helper.attribute
             - ['pim_catalog_text', 'pim_catalog_textarea']
-            - ['STARTS WITH', 'ENDS WITH', 'CONTAINS', 'DOES NOT CONTAIN', '=', 'EMPTY']
+            - ['STARTS WITH', 'ENDS WITH', 'CONTAINS', 'DOES NOT CONTAIN', '=', 'EMPTY', 'IN']
         tags:
             - { name: 'pim_catalog.doctrine.query.filter', priority: 30 }
 

--- a/src/Pim/Bundle/DataGridBundle/Resources/config/attribute_types.yml
+++ b/src/Pim/Bundle/DataGridBundle/Resources/config/attribute_types.yml
@@ -22,6 +22,7 @@ parameters:
                 field_options:
                     attr:
                         empty_choice: true
+                        choice_list: true
         sorter:          product_value
     pim_datagrid.product.attribute_type.pim_catalog_textarea:
         column:


### PR DESCRIPTION
As described in the [Akeneo forum](http://www.akeneo.com/forums/topic/grid-filter-in-list-for-text-attributes/) we have to filter products by a list of Strings.
I think this feature is useful for many users, so I created a pull request for this configuration.

I also think that the "in list"-filter would be useful for the other attribute types like f.ex. numbers, media, prices... 