### PR TITLE
[SLA] PIM-5039: Fix missing translation key for boolean attribute switch

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -7,6 +7,7 @@
 - PIM-5084: Fix attribute groups order in product edit form
 - PIM-5008: Optimize product edit form when lots of attributes are used
 - PIM-5041: Add cache warmup for product edit form
+- PIM-5039: Fix missing translation key for boolean attribute switch
 
 # 1.4.6 (2015-10-27)
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/field/boolean.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/field/boolean.html
@@ -1,3 +1,3 @@
-<div class="switch switch-small" data-on-label="<%- _.__('pim_enrich.form.product.switch.yes') %>" data-off-label="<%- _.__('pim_enrich.form.product.switch.no') %>">
+<div class="switch switch-small" data-on-label="<%- _.__('switch_on') %>" data-off-label="<%- _.__('switch_off') %>">
     <input type="checkbox" data-locale="<%- value.locale %>" data-scope="<%- value.scope %>" <%- value.data ? 'checked' : '' %> <%- editMode === 'view' ? 'disabled' : '' %>>
 </div>


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Specs             | Yes
| Behats            | No
| Blue CI           | Running
| Changelog updated | Yes
| Review and 2 GTM  | No