### PR TITLE
[WIP] PIM-5118: csv product export is now creating multiple csv files

### DIFF
--- a/src/Pim/Bundle/BaseConnectorBundle/Writer/File/CsvProductWriter.php
+++ b/src/Pim/Bundle/BaseConnectorBundle/Writer/File/CsvProductWriter.php
@@ -18,6 +18,9 @@ class CsvProductWriter extends ContextableCsvWriter
     /** @var FileExporterInterface */
     protected $fileExporter;
 
+    /** @const int */
+    const NB_ENTRY_PER_FILE = 1000;
+
     /**
      * @param FileExporterInterface $fileExporter
      */
@@ -50,6 +53,19 @@ class CsvProductWriter extends ContextableCsvWriter
         }
 
         $this->items = array_merge($this->items, $products);
+
+        if (count($this->items) > self::NB_ENTRY_PER_FILE) {
+            $this->nextFile();
+        }
+    }
+
+    /**
+     * Writes current CSV file content.
+     */
+    public function nextFile()
+    {
+        $this->flush();
+        $this->incrementFileNumber();
     }
 
     /**


### PR DESCRIPTION
Native CSV export now writes CSv files by chuck of 1 000 products per file. This is to avoid memory leak and keep memory usage reasonable.

By default, output will be like : 
 `/tmp/product-YYYY-MM-DD_HH:MM:SS-X.csv` where X is the number of the file.

It can be changed by using `%filenumber%` in the filename pattern.

| Q                 | A
| ----------------- | ---
| Added Specs       | No
| Added Behats      | No
| Travis CI is ok   | N/A
| Changelog updated | No