### PR TITLE
[TR] PIM-5150: Grid is very slow to load with a lot of attributes

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -4,6 +4,7 @@
 - PIM-5127: Improve products export memory usage
 - PIM-5148: IE11 wrong display on multiple select attributes
 - PIM-5161: Fix the is_associated sort on MongoDB association grid
+- PIM-5150: Improve the product grid loading performance when a lot of attribute filters are available
 
 # 1.4.8 (2015-11-09)
 

--- a/spec/Pim/Bundle/DataGridBundle/Datagrid/Configuration/Product/FiltersConfiguratorSpec.php
+++ b/spec/Pim/Bundle/DataGridBundle/Datagrid/Configuration/Product/FiltersConfiguratorSpec.php
@@ -42,34 +42,38 @@ class FiltersConfiguratorSpec extends ObjectBehavior
                 'groupOrder'          => 1
             ]
         ];
-        $path = sprintf('[source][%s]', ContextConfigurator::USEABLE_ATTRIBUTES_KEY);
-        $configuration->offsetGetByPath($path)->willReturn($attributes);
+
+        $attributesConf = [ContextConfigurator::USEABLE_ATTRIBUTES_KEY => $attributes];
+        $configuration->offsetGet(ContextConfigurator::SOURCE_KEY)->willReturn($attributesConf);
+        $configuration->offsetGet(FilterConfiguration::FILTERS_KEY)->willReturn([]);
 
         $registry->getConfiguration('pim_catalog_identifier')->willReturn(['filter' => ['identifier_config']]);
         $registry->getConfiguration('pim_catalog_text')->willReturn(['filter' => ['text_config']]);
 
-        $columnConfPath = sprintf('%s[%s]', FilterConfiguration::COLUMNS_PATH, 'sku');
         $expectedConf = [
-            0            => 'identifier_config',
-            'data_name'  => 'sku',
-            'label'      => 'Sku',
-            'enabled'    => true,
-            'order'      => 1,
-            'group'      => 'General',
-            'groupOrder' => 1
+            'sku' => [
+                0            => 'identifier_config',
+                'data_name'  => 'sku',
+                'label'      => 'Sku',
+                'enabled'    => true,
+                'order'      => 1,
+                'group'      => 'General',
+                'groupOrder' => 1
+            ],
+            'name' => [
+                0            => 'text_config',
+                'data_name'  => 'name',
+                'label'      => 'Name',
+                'enabled'    => false,
+                'order'      => 2,
+                'group'      => 'General',
+                'groupOrder' => 1
+            ]
         ];
-        $configuration->offsetSetByPath($columnConfPath, $expectedConf)->willReturn($configuration);
-        $columnConfPath = sprintf('%s[%s]', FilterConfiguration::COLUMNS_PATH, 'name');
-        $expectedConf = [
-            0            => 'text_config',
-            'data_name'  => 'name',
-            'label'      => 'Name',
-            'enabled'    => false,
-            'order'      => 2,
-            'group'      => 'General',
-            'groupOrder' => 1
-        ];
-        $configuration->offsetSetByPath($columnConfPath, $expectedConf)->willReturn($configuration);
+
+        $configuration->offsetSet(FilterConfiguration::FILTERS_KEY, [
+            'columns' => $expectedConf
+        ])->shouldBeCalled();
 
         $this->configure($configuration);
     }
@@ -96,8 +100,9 @@ class FiltersConfiguratorSpec extends ObjectBehavior
                 'groupOrder'          => 5
             ]
         ];
-        $path = sprintf('[source][%s]', ContextConfigurator::USEABLE_ATTRIBUTES_KEY);
-        $configuration->offsetGetByPath($path)->willReturn($attributes);
+
+        $attributesConf = [ContextConfigurator::USEABLE_ATTRIBUTES_KEY => $attributes];
+        $configuration->offsetGet(ContextConfigurator::SOURCE_KEY)->willReturn($attributesConf);
 
         $registry->getConfiguration('pim_catalog_identifier')->willReturn(['filter' => ['identifier_config']]);
         $registry->getConfiguration('pim_catalog_text')->willReturn([]);

--- a/spec/Pim/Bundle/FilterBundle/Filter/ProductValue/BooleanFilterSpec.php
+++ b/spec/Pim/Bundle/FilterBundle/Filter/ProductValue/BooleanFilterSpec.php
@@ -8,6 +8,7 @@ use Pim\Bundle\FilterBundle\Filter\ProductFilterUtility;
 use Pim\Bundle\FilterBundle\Form\Type\Filter\BooleanFilterType;
 use Prophecy\Argument;
 use Symfony\Component\Form\ChoiceList\View\ChoiceView;
+use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
@@ -48,7 +49,7 @@ class BooleanFilterSpec extends ObjectBehavior
     ) {
         $utility->applyFilter($datasource, 'bar', '=', true)->shouldBeCalled();
 
-        $this->apply($datasource, array('value' => BooleanFilterType::TYPE_YES))->shouldReturn(true);
+        $this->apply($datasource, ['value' => BooleanFilterType::TYPE_YES])->shouldReturn(true);
     }
 
     function it_does_not_apply_boolean_flexible_filter_on_unparsable_data(
@@ -57,9 +58,9 @@ class BooleanFilterSpec extends ObjectBehavior
     ) {
         $utility->applyFilter(Argument::cetera())->shouldNotBeCalled();
 
-        $this->apply($datasource, array('value' => 'foo'))->shouldReturn(false);
-        $this->apply($datasource, array('value' => null))->shouldReturn(false);
-        $this->apply($datasource, array())->shouldReturn(false);
+        $this->apply($datasource, ['value' => 'foo'])->shouldReturn(false);
+        $this->apply($datasource, ['value' => null])->shouldReturn(false);
+        $this->apply($datasource, [])->shouldReturn(false);
         $this->apply($datasource, BooleanFilterType::TYPE_NO)->shouldReturn(false);
     }
 
@@ -71,6 +72,8 @@ class BooleanFilterSpec extends ObjectBehavior
     }
 
     function it_generates_choices_metadata(
+        FormBuilderInterface $formBuilder,
+        FormBuilderInterface $typeFormBuilder,
         FormInterface $form,
         FormView $formView,
         FormView $fieldView,
@@ -84,8 +87,11 @@ class BooleanFilterSpec extends ObjectBehavior
         $utility->getParamMap()->willReturn([]);
         $utility->getExcludeParams()->willReturn([]);
         $factory->create(BooleanFilterType::NAME, [], ['csrf_protection' => false])->willReturn($form);
+        $factory->createBuilder(BooleanFilterType::NAME, [], ['csrf_protection' => false])->willReturn($formBuilder);
         $form->createView()->willReturn($formView);
 
+        $formBuilder->get('type')->willReturn($typeFormBuilder);
+        $typeFormBuilder->getOption('choices')->willReturn([$noChoice, $yesChoice]);
         $formView->children = array('value' => $fieldView, 'type' => $typeView);
         $formView->vars     = array('populate_default' => true);
         $fieldView->vars    = array('multiple' => true, 'choices' => array($yesChoice, $noChoice));

--- a/spec/Pim/Bundle/FilterBundle/Filter/ProductValue/DateRangeFilterSpec.php
+++ b/spec/Pim/Bundle/FilterBundle/Filter/ProductValue/DateRangeFilterSpec.php
@@ -7,7 +7,9 @@ use Oro\Bundle\FilterBundle\Form\Type\Filter\DateRangeFilterType;
 use PhpSpec\ObjectBehavior;
 use Pim\Bundle\FilterBundle\Filter\ProductFilterUtility;
 use Prophecy\Argument;
+use Symfony\Component\Form\ChoiceList\View\ChoiceView;
 use Symfony\Component\Form\Form;
+use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormView;
 
@@ -50,7 +52,7 @@ class DateRangeFilterSpec extends ObjectBehavior
                 'start' => $start,
                 'end'   => $end,
             ],
-            'type' => 1
+            'type'  => 1
         ])->shouldReturn([
             'date_start' => '1987-05-14',
             'date_end'   => '2014-01-23',
@@ -69,7 +71,7 @@ class DateRangeFilterSpec extends ObjectBehavior
             'value' => [
                 'start' => $start,
             ],
-            'type' => 1
+            'type'  => 1
         ])->shouldReturn([
             'date_start' => '1987-05-14',
             'date_end'   => null,
@@ -86,9 +88,9 @@ class DateRangeFilterSpec extends ObjectBehavior
 
         $this->parseData([
             'value' => [
-                'end'   => $end,
+                'end' => $end,
             ],
-            'type' => 1
+            'type'  => 1
         ])->shouldReturn([
             'date_start' => null,
             'date_end'   => '2014-01-23',
@@ -112,7 +114,7 @@ class DateRangeFilterSpec extends ObjectBehavior
                 'start' => $start,
                 'end'   => $end,
             ],
-            'type' => DateRangeFilterType::TYPE_BETWEEN,
+            'type'  => DateRangeFilterType::TYPE_BETWEEN,
         ])->shouldReturn([
             'date_start' => '1987-05-14',
             'date_end'   => '2014-01-23',
@@ -136,7 +138,7 @@ class DateRangeFilterSpec extends ObjectBehavior
                 'start' => $start,
                 'end'   => $end,
             ],
-            'type' => DateRangeFilterType::TYPE_NOT_BETWEEN,
+            'type'  => DateRangeFilterType::TYPE_NOT_BETWEEN,
         ])->shouldReturn([
             'date_start' => '1987-05-14',
             'date_end'   => '2014-01-23',
@@ -160,7 +162,7 @@ class DateRangeFilterSpec extends ObjectBehavior
                 'start' => $start,
                 'end'   => $end,
             ],
-            'type' => DateRangeFilterType::TYPE_MORE_THAN,
+            'type'  => DateRangeFilterType::TYPE_MORE_THAN,
         ])->shouldReturn([
             'date_start' => '1987-05-14',
             'date_end'   => null,
@@ -184,7 +186,7 @@ class DateRangeFilterSpec extends ObjectBehavior
                 'start' => $start,
                 'end'   => $end,
             ],
-            'type' => DateRangeFilterType::TYPE_LESS_THAN,
+            'type'  => DateRangeFilterType::TYPE_LESS_THAN,
         ])->shouldReturn([
             'date_start' => null,
             'date_end'   => '2014-01-23',
@@ -208,7 +210,7 @@ class DateRangeFilterSpec extends ObjectBehavior
                 'start' => $start,
                 'end'   => $end,
             ],
-            'type' => 'unknown',
+            'type'  => 'unknown',
         ])->shouldReturn([
             'date_start' => '1987-05-14',
             'date_end'   => '2014-01-23',
@@ -270,7 +272,7 @@ class DateRangeFilterSpec extends ObjectBehavior
         $end->format('Y-m-d')->willReturn('2014-01-23');
 
         $utility
-            ->applyFilter($datasource, 'data_name_key', 'BETWEEN', array('1987-05-14', '2014-01-23'))
+            ->applyFilter($datasource, 'data_name_key', 'BETWEEN', ['1987-05-14', '2014-01-23'])
             ->shouldBeCalled();
 
         $this->apply(
@@ -280,7 +282,7 @@ class DateRangeFilterSpec extends ObjectBehavior
                     'start' => $start,
                     'end'   => $end,
                 ],
-                'type' => DateRangeFilterType::TYPE_BETWEEN,
+                'type'  => DateRangeFilterType::TYPE_BETWEEN,
             ]
         );
     }
@@ -316,7 +318,7 @@ class DateRangeFilterSpec extends ObjectBehavior
                     'start' => $start,
                     'end'   => $end,
                 ],
-                'type' => DateRangeFilterType::TYPE_NOT_BETWEEN,
+                'type'  => DateRangeFilterType::TYPE_NOT_BETWEEN,
             ]
         );
     }
@@ -345,7 +347,7 @@ class DateRangeFilterSpec extends ObjectBehavior
                     'start' => $start,
                     'end'   => $end,
                 ],
-                'type' => DateRangeFilterType::TYPE_LESS_THAN,
+                'type'  => DateRangeFilterType::TYPE_LESS_THAN,
             ]
         );
     }
@@ -374,7 +376,7 @@ class DateRangeFilterSpec extends ObjectBehavior
                     'start' => $start,
                     'end'   => $end,
                 ],
-                'type' => DateRangeFilterType::TYPE_MORE_THAN,
+                'type'  => DateRangeFilterType::TYPE_MORE_THAN,
             ]
         );
     }
@@ -384,30 +386,5 @@ class DateRangeFilterSpec extends ObjectBehavior
         $factory->create(DateRangeFilterType::NAME, [], ['csrf_protection' => false])->willReturn($form);
 
         $this->getForm()->shouldReturn($form);
-    }
-
-    function it_provides_metadata($factory, $utility, Form $form, FormView $formView, FormView $typeView)
-    {
-        $factory->create(DateRangeFilterType::NAME, [], ['csrf_protection' => false])->willReturn($form);
-        $form->createView()->willReturn($formView);
-        $formView->vars = [
-            'type_values'    => ['foo', 'bar'],
-            'widget_options' => ['boo' => 'far'],
-        ];
-        $formView->children = ['type' => $typeView];
-        $typeView->vars     = ['choices' => ['a', 'b', 'c']];
-
-        $utility->getParamMap()->willReturn([]);
-        $utility->getExcludeParams()->willReturn([]);
-
-        $this->getMetadata()->shouldReturn([
-            'name'                  => 'date_filter',
-            'label'                 => 'Date_filter',
-            'choices'               => ['a', 'b', 'c'],
-            'enabled'               => true,
-            'data_name'             => 'data_name_key',
-            'typeValues'            => ['foo', 'bar'],
-            'externalWidgetOptions' => ['boo' => 'far'],
-        ]);
     }
 }

--- a/src/Pim/Bundle/DataGridBundle/Datagrid/Configuration/ConfiguratorInterface.php
+++ b/src/Pim/Bundle/DataGridBundle/Datagrid/Configuration/ConfiguratorInterface.php
@@ -17,6 +17,9 @@ interface ConfiguratorInterface
     const SOURCE_PATH = '[source][%s]';
 
     /** @staticvar string */
+    const SOURCE_KEY = 'source';
+
+    /** @staticvar string */
     const AVAILABLE_COLUMNS_KEY = 'available_columns';
 
     /** @staticvar string */

--- a/src/Pim/Bundle/DataGridBundle/Datagrid/Configuration/Product/FiltersConfigurator.php
+++ b/src/Pim/Bundle/DataGridBundle/Datagrid/Configuration/Product/FiltersConfigurator.php
@@ -33,8 +33,7 @@ class FiltersConfigurator implements ConfiguratorInterface
      */
     public function configure(DatagridConfiguration $configuration)
     {
-        $path       = sprintf(self::SOURCE_PATH, self::USEABLE_ATTRIBUTES_KEY);
-        $attributes = $configuration->offsetGetByPath($path);
+        $attributes = $configuration->offsetGet(self::SOURCE_KEY)[self::USEABLE_ATTRIBUTES_KEY];
         $attributes = ($attributes === null) ? [] : $attributes;
 
         $displayedFilters = [];
@@ -74,13 +73,13 @@ class FiltersConfigurator implements ConfiguratorInterface
         }
 
         $this->sortFilters($displayedFilters);
+        $filters = $configuration->offsetGet(FilterConfiguration::FILTERS_KEY);
 
         foreach ($displayedFilters as $attributeCode => $filterConfig) {
-            $configuration->offsetSetByPath(
-                sprintf('%s[%s]', FilterConfiguration::COLUMNS_PATH, $attributeCode),
-                $filterConfig
-            );
+            $filters['columns'][$attributeCode] = $filterConfig;
         }
+
+        $configuration->offsetSet(FilterConfiguration::FILTERS_KEY, $filters);
     }
 
     /**


### PR DESCRIPTION
> This is a part of improvement for the product grid loading speed. (The main part is in the platform: https://github.com/akeneo/platform/pull/39)

The `configure()` method is called X times when the grid is loaded.
X being the number of attributes usable as grid filter.

`offsetGetByPath` and `offsetSetByPath` are very time consuming (property accessor that handles a lot of cases), but those cases are pretty simple and can be managed by `offsetGet` and `offsetSet`.

| Q                 | A
| ----------------- | ---
| Added Specs       | Y
| Added Behats      | N
| Travis CI is ok   | Y
| Changelog updated | Y