### PR TITLE
PIM-5071 : refactor spin method

### DIFF
--- a/app/Resources/jenkins/behat/run_behat.sh
+++ b/app/Resources/jenkins/behat/run_behat.sh
@@ -158,7 +158,7 @@ for FEATURE in $FEATURES; do
                     export SYMFONY__MONGODB__DATABASE=$DB_PREFIX$PROC
                     DATE=`date +'%F %T̀'`
                     echo "[$DATE] Executing feature $FEATURE_NAME with proc $PROC" | tee -a $OUTPUT
-                    ($BEHAT_CMD --profile=$PROFILE_PREFIX$PROC $FEATURE_NAME 2>&1 | tee -a $OUTPUT) &
+                    ($BEHAT_CMD -v --profile=$PROFILE_PREFIX$PROC $FEATURE_NAME 2>&1 | tee -a $OUTPUT) &
                     RESULT=$!
                     eval PID_$PROC=$RESULT
                     FEATURE_NAME=""

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -5,7 +5,7 @@ default:
         class:  Context\FeatureContext
         parameters:
             base_url: http://akeneo-pim-behat.local/
-            timeout: 20000
+            timeout: 30000
             window_width: 1280
             window_height: 1024
     extensions:
@@ -25,7 +25,7 @@ jenkins-1:
     context:
         parameters:
             base_url: http://pim-behat-1.ci/
-            timeout: 20000
+            timeout: 30000
     extensions:
         Behat\MinkExtension\Extension:
             base_url: http://pim-behat-1.ci/
@@ -43,7 +43,7 @@ jenkins-2:
     context:
         parameters:
             base_url: http://pim-behat-2.ci/
-            timeout: 20000
+            timeout: 30000
     extensions:
         Behat\MinkExtension\Extension:
             base_url: http://pim-behat-2.ci/
@@ -61,7 +61,7 @@ jenkins-3:
     context:
         parameters:
             base_url: http://pim-behat-3.ci/
-            timeout: 20000
+            timeout: 30000
     extensions:
         Behat\MinkExtension\Extension:
             base_url: http://pim-behat-3.ci/
@@ -79,7 +79,7 @@ jenkins-4:
     context:
         parameters:
             base_url: http://pim-behat-4.ci/
-            timeout: 20000
+            timeout: 30000
     extensions:
         Behat\MinkExtension\Extension:
             base_url: http://pim-behat-4.ci/

--- a/features/Context/FeatureContext.php
+++ b/features/Context/FeatureContext.php
@@ -23,8 +23,6 @@ use Symfony\Component\Yaml\Parser;
  */
 class FeatureContext extends MinkContext implements KernelAwareInterface
 {
-    const DEFAULT_TIMEOUT = 10000;
-
     use SpinCapableTrait;
 
     /** @var KernelInterface */
@@ -34,7 +32,7 @@ class FeatureContext extends MinkContext implements KernelAwareInterface
     protected static $errorMessages = [];
 
     /** @var int */
-    protected $timeout;
+    protected static $timeout;
 
     /**
      * Path of the yaml file containing tables that should be excluded from database purge
@@ -50,12 +48,6 @@ class FeatureContext extends MinkContext implements KernelAwareInterface
      */
     public function __construct(array $parameters)
     {
-        if (isset($parameters['timeout']) && '' !== $parameters['timeout']) {
-            $this->timeout = $parameters['timeout'];
-        } else {
-            $this->timeout = self::DEFAULT_TIMEOUT;
-        }
-
         $this->useContext('fixtures', new FixturesContext());
         $this->useContext('catalogConfiguration', new CatalogConfigurationContext());
         $this->useContext('webUser', new WebUser($parameters['window_width'], $parameters['window_height']));
@@ -66,14 +58,16 @@ class FeatureContext extends MinkContext implements KernelAwareInterface
         $this->useContext('transformations', new TransformationContext());
         $this->useContext('assertions', new AssertionContext());
         $this->useContext('technical', new TechnicalContext());
+
+        $this->setTimeout($parameters);
     }
 
     /**
      * @return int the timeout in milliseconds
      */
-    public function getTimeout()
+    public static function getTimeout()
     {
-        return $this->timeout;
+        return static::$timeout;
     }
 
     /**
@@ -336,7 +330,8 @@ class FeatureContext extends MinkContext implements KernelAwareInterface
                 "typeof $ != 'undefined'",                     // jQuery is loaded
                 "!$.active",                                   // No ajax request is active
                 "$('#page').css('display') == 'block'",        // Page is displayed (no progress bar)
-                "$('.loading-mask').css('display') == 'none'", // Page is not loading (no black mask loading page)
+                // Page is not loading (no black mask loading page)
+                "($('.loading-mask').length == 0 || $('.loading-mask').css('display') == 'none')",
                 "$('.jstree-loading').length == 0",            // Jstree has finished loading
             ];
 
@@ -431,5 +426,15 @@ class FeatureContext extends MinkContext implements KernelAwareInterface
     public function getMailRecorder()
     {
         return $this->getContainer()->get('pim_enrich.mailer.mail_recorder');
+    }
+
+    /**
+     * Set the waiting timeout
+     *
+     * @param $parameters
+     */
+    protected function setTimeout($parameters)
+    {
+        static::$timeout = $parameters['timeout'];
     }
 }

--- a/features/Context/NavigationContext.php
+++ b/features/Context/NavigationContext.php
@@ -167,7 +167,7 @@ class NavigationContext extends RawMinkContext implements PageObjectAwareInterfa
     public function iAmOnTheRelativePath($path, $referer)
     {
         $basePath = parse_url($this->baseUrl)['path'];
-        $uri = sprintf('%s%s/#url=%s%s', $this->baseUrl, $referer, $basePath, $path);
+        $uri      = sprintf('%s%s/#url=%s%s', $this->baseUrl, $referer, $basePath, $path);
 
         $this->getSession()->visit($uri);
     }
@@ -758,7 +758,7 @@ class NavigationContext extends RawMinkContext implements PageObjectAwareInterfa
             }
 
             return $page->verifyAfterLogin();
-        });
+        }, 'Trying to open page ' . $this->currentPage);
         $this->wait();
 
         return $page;

--- a/features/Context/Page/Base/Base.php
+++ b/features/Context/Page/Base/Base.php
@@ -394,7 +394,6 @@ class Base extends Page
      */
     protected function getTimeout()
     {
-        // no way to retrieve the timeout from behat.yml at the moment
-        return FeatureContext::DEFAULT_TIMEOUT;
+        return FeatureContext::getTimeout();
     }
 }

--- a/features/Context/Page/Base/Form.php
+++ b/features/Context/Page/Base/Form.php
@@ -715,10 +715,6 @@ class Form extends Base
             }
         }
 
-        // Removing tags in MultiSelect2 drops an "animation" with opacity, we must
-        // wait for it to completly vanish in order to reopen select list
-        $this->getSession()->wait($this->getTimeout());
-
         $allValues = array_filter($allValues);
 
         if (1 === count($allValues) && null !== $label->getParent()->find('css', 'select')) {

--- a/features/Context/Spin/SpinCapableTrait.php
+++ b/features/Context/Spin/SpinCapableTrait.php
@@ -7,11 +7,10 @@ use Context\FeatureContext;
 trait SpinCapableTrait
 {
     /**
-     * This method executes $callable every second. If its return value is evaluated to true, the spinning stops and the
-     * value is returned. If the return value is falsy or if $callable throw an exception, the spinning continues until
-     * the loop limit is reached, in that case a TimeoutException is thrown.
-     * If another spinning method is used inside $callable and throws a TimeoutException the current spinning stops
-     * immediately to avoid waiting uselessly.
+     * This method executes $callable every second.
+     * If its return value is evaluated to true, the spinning stops and the value is returned.
+     * If the return value is falsy, the spinning continues until the loop limit is reached,
+     * In that case a TimeoutException is thrown.
      *
      * @param callable $callable
      * @param string   $message
@@ -22,36 +21,37 @@ trait SpinCapableTrait
      */
     public function spin($callable, $message = 'no message')
     {
-        $lastException = null;
+        $start   = microtime(true);
+        $timeout = FeatureContext::getTimeout();
+        $end     = $start + ($timeout / 1000.0);
 
-        for ($i = 0; $i < FeatureContext::DEFAULT_TIMEOUT / 1000; ++$i) {
+        $logThreshold      = (int) $timeout * 0.8;
+        $previousException = null;
+        $result            = null;
+
+        do {
             try {
-                if ($result = $callable($this)) {
-                    return $result;
-                }
-            } catch (TimeoutException $e) {
-                throw $e;
+                $result = $callable($this);
+                sleep(1);
             } catch (\Exception $e) {
-                $lastException = $e;
+                $previousException = $e;
             }
+        } while (
+            microtime(true) < $end &&
+            !$result &&
+            !$previousException instanceof TimeoutException
+        );
 
-            sleep(1);
+        if (!$result) {
+            $infos = sprintf('Spin : timeout of %d excedeed, with message : %s', $timeout, $message);
+            throw new TimeoutException($infos, 0, $previousException);
         }
 
-        $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2);
-
-        $infos = sprintf('Timeout thrown by %s::%s()', $backtrace[0]['class'], $backtrace[0]['function']);
-
-        if (isset($backtrace[0]['file']) && isset($backtrace[0]['line'])) {
-            $infos .= PHP_EOL . sprintf('file %s, line %d', $backtrace[0]['file'], $backtrace[0]['line']);
-            $infos .= PHP_EOL . sprintf('message : %s', $message);
+        $elapsed = microtime(true) - $start;
+        if ($elapsed >= $logThreshold) {
+            printf('[%s] Long spin detected with message : %s', date('y-md H:i:s'), $message);
         }
 
-        if (null !== $lastException) {
-            $infos .= PHP_EOL . sprintf('last exception : %s', $lastException->getMessage());
-            $infos .= PHP_EOL . sprintf('file %s, line %d', $lastException->getFile(), $lastException->getLine());
-        }
-
-        throw new TimeoutException($infos);
+        return $result;
     }
 }

--- a/features/Context/WebUser.php
+++ b/features/Context/WebUser.php
@@ -1941,7 +1941,7 @@ class WebUser extends RawMinkContext
      */
     public function iWaitForTheWidgetsToLoad()
     {
-        $this->wait(false);
+        $this->iWaitSeconds(10);
         $this->wait();
     }
 
@@ -1950,7 +1950,7 @@ class WebUser extends RawMinkContext
      */
     public function iWaitForTheOptionsToLoad()
     {
-        $this->wait(false);
+        $this->iWaitSeconds(10);
         $this->wait();
     }
 
@@ -2039,7 +2039,7 @@ class WebUser extends RawMinkContext
         $maxTime = 10000;
 
         while ($maxTime > 0) {
-            $this->wait(false);
+            $this->iWaitSeconds(10);
             $maxTime -= 1000;
             if ($this->getPage('Product edit')->getImagePreview()) {
                 return;
@@ -2249,7 +2249,7 @@ class WebUser extends RawMinkContext
      */
     public function iWaitSeconds($seconds)
     {
-        $this->wait(false);
+        sleep($seconds);
     }
 
     /**


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Specs             |n
| Behats            |y
| Blue CI           |
| Changelog updated |n
| Review and 2 GTM  |y
| Micro Demo (PO)   |n
| Migration script  |n
| Tech Doc          |n

What's new : 
- timeout is only fixed in behat config file and accessed statically to avoid the redundant constant
- spinning is now "time based" and no more based on a number of iterations. Necessary because we are not really able to catch Timeout exceptions in nested spins