### PR TITLE
[TR] PIM-5127: Improve products export memory usage

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -1,3 +1,8 @@
+# 1.4.x
+
+## Bug fixes
+- PIM-5127: Improve products export memory usage
+
 # 1.4.8 (2015-11-09)
 
 ## Bug fixes

--- a/features/Context/WebUser.php
+++ b/features/Context/WebUser.php
@@ -2408,6 +2408,7 @@ class WebUser extends RawMinkContext
         unset($expectedLines[0]);
 
         foreach ($expectedLines as $expectedLine) {
+            $originalExpectedLine = $expectedLine;
             $found = false;
             foreach ($actualLines as $index => $actualLine) {
                 // Order of columns is not ensured
@@ -2433,7 +2434,7 @@ class WebUser extends RawMinkContext
                 throw new \Exception(
                     sprintf(
                         'Could not find a line containing "%s" in %s',
-                        implode(' | ', $expectedLine),
+                        implode(' | ', $originalExpectedLine),
                         $path
                     )
                 );

--- a/spec/Pim/Bundle/BaseConnectorBundle/Writer/File/CsvProductWriterSpec.php
+++ b/spec/Pim/Bundle/BaseConnectorBundle/Writer/File/CsvProductWriterSpec.php
@@ -94,7 +94,17 @@ class CsvProductWriterSpec extends ObjectBehavior
         $fileExporter->export('1/2/3/4/1234-the-file.csv', '/tmp/test.csv', FileStorage::CATALOG_STORAGE_ALIAS)->shouldBeCalled();
 
         $this->getPath();
-        $this->write([['product' => 'my-product', 'media' => [$media]]]);
+        $this->write(
+            [
+                [
+                    'product' => [
+                        'sku'  => '001',
+                        'name' => 'Michel'
+                    ],
+                    'media'   => [$media]
+                ]
+            ]
+        );
         $this->getWrittenFiles()->shouldReturn(['/tmp/test.csv' => 'test.csv']);
         $stepExecution->addWarning()->shouldNotBeCalled();
     }
@@ -104,7 +114,17 @@ class CsvProductWriterSpec extends ObjectBehavior
         $media = ['filePath' => 'not-found.jpg', 'exportPath' => 'test.jpg', 'storageAlias' => FileStorage::CATALOG_STORAGE_ALIAS];
         $fileExporter->export('not-found.jpg', '/tmp/test.jpg', FileStorage::CATALOG_STORAGE_ALIAS)->willThrow(new FileTransferException());
 
-        $this->write([['product' => 'my-product', 'media' => [$media]]]);
+        $this->write(
+            [
+                [
+                    'product' => [
+                        'sku'  => '002',
+                        'name' => 'Mireille'
+                    ],
+                    'media'   => [$media]
+                ]
+            ]
+        );
         $this->getWrittenFiles()->shouldReturn([]);
         $stepExecution->addWarning('csv_product_writer', 'The media has not been found or is not currently available', [], $media)
             ->shouldBeCalled();
@@ -115,7 +135,17 @@ class CsvProductWriterSpec extends ObjectBehavior
         $media = ['filePath' => 'copy-error.jpg', 'exportPath' => 'test.jpg', 'storageAlias' => FileStorage::CATALOG_STORAGE_ALIAS];
         $fileExporter->export('copy-error.jpg', '/tmp/test.jpg', FileStorage::CATALOG_STORAGE_ALIAS)->willThrow(new \LogicException('Copy error.'));
 
-        $this->write([['product' => 'my-product', 'media' => [$media]]]);
+        $this->write(
+            [
+                [
+                    'product' => [
+                        'sku'  => '003',
+                        'name' => 'Monique'
+                    ],
+                    'media'   => [$media]
+                ]
+            ]
+        );
         $this->getWrittenFiles()->shouldReturn([]);
         $stepExecution->addWarning('csv_product_writer', 'The media has not been copied. Copy error.', [], $media)
             ->shouldBeCalled();

--- a/src/Pim/Bundle/BaseConnectorBundle/Writer/File/CsvProductWriter.php
+++ b/src/Pim/Bundle/BaseConnectorBundle/Writer/File/CsvProductWriter.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Bundle\BaseConnectorBundle\Writer\File;
 
+use Akeneo\Bundle\BatchBundle\Job\RuntimeErrorException;
 use Akeneo\Component\FileStorage\Exception\FileTransferException;
 use Pim\Bundle\ConnectorBundle\Writer\File\ContextableCsvWriter;
 use Pim\Component\Connector\Writer\File\FileExporterInterface;
@@ -18,6 +19,12 @@ class CsvProductWriter extends ContextableCsvWriter
     /** @var FileExporterInterface */
     protected $fileExporter;
 
+    /** @var string */
+    protected $bufferFile;
+
+    /** @var array */
+    protected $headers = [];
+
     /**
      * @param FileExporterInterface $fileExporter
      */
@@ -33,23 +40,59 @@ class CsvProductWriter extends ContextableCsvWriter
      */
     public function write(array $items)
     {
-        $products = [];
-
         $exportDirectory = dirname($this->getPath());
         if (!is_dir($exportDirectory)) {
             $this->localFs->mkdir($exportDirectory);
         }
 
         foreach ($items as $item) {
-            $products[] = $item['product'];
+            $this->writeProductToBuffer($item['product']);
+
             foreach ($item['media'] as $media) {
                 if ($media && isset($media['filePath']) && $media['filePath']) {
                     $this->copyMedia($media);
                 }
             }
         }
+    }
 
-        $this->items = array_merge($this->items, $products);
+    /**
+     * {@inheritdoc}
+     *
+     * Override of CsvWriter flush method to use the file buffer
+     */
+    public function flush()
+    {
+        $exportDirectory = dirname($this->getPath());
+        if (!is_dir($exportDirectory)) {
+            $this->localFs->mkdir($exportDirectory);
+        }
+
+        $this->writtenFiles[$this->getPath()] = basename($this->getPath());
+
+        if (false === $csvFile = fopen($this->getPath(), 'w')) {
+            throw new RuntimeErrorException('Failed to open file %path%', ['%path%' => $this->getPath()]);
+        }
+
+        $header = $this->isWithHeader() ? $this->headers : [];
+        if (false === fputcsv($csvFile, $header, $this->delimiter)) {
+            throw new RuntimeErrorException('Failed to write to file %path%', ['%path%' => $this->getPath()]);
+        }
+
+        $bufferHandle = fopen($this->bufferFile, 'r');
+        $hollowProduct = array_fill_keys($this->headers, '');
+        while (null !== $bufferedProduct = $this->readProductFromBuffer($bufferHandle)) {
+            $fullProduct = array_replace($hollowProduct, $bufferedProduct);
+            if (false === fputcsv($csvFile, $fullProduct, $this->delimiter, $this->enclosure)) {
+                throw new RuntimeErrorException('Failed to write to file %path%', ['%path%' => $this->getPath()]);
+            } elseif (null !== $this->stepExecution) {
+                $this->stepExecution->incrementSummaryInfo('write');
+            }
+        }
+
+        fclose($bufferHandle);
+        unlink($this->bufferFile);
+        fclose($csvFile);
     }
 
     /**
@@ -81,5 +124,38 @@ class CsvProductWriter extends ContextableCsvWriter
                 $media
             );
         }
+    }
+
+    /**
+     * Write the product data to the file buffer, and collect the headers
+     *
+     * @param array $product
+     */
+    protected function writeProductToBuffer(array $product)
+    {
+        if (!$this->bufferFile) {
+            $this->bufferFile = tempnam(sys_get_temp_dir(), 'pim_products_buffer_');
+        }
+
+        file_put_contents($this->bufferFile, json_encode($product) . "\n", FILE_APPEND);
+
+        $this->headers = $this->getAllKeys([
+            array_flip($this->headers),
+            $product
+        ]);
+    }
+
+    /**
+     * Read the next line from the products buffer
+     *
+     * @param resource $bufferHandle
+     *
+     * @return array|null
+     */
+    protected function readProductFromBuffer($bufferHandle)
+    {
+        $rawLine = fgets($bufferHandle);
+
+        return false !== $rawLine ? json_decode($rawLine, true) : null;
     }
 }


### PR DESCRIPTION
https://akeneo.atlassian.net/browse/PIM-5127

| Q                 | A
| ----------------- | ---
| Specs             | no regression
| Behats            | n/a
| Blue CI           | yes
| Changelog updated | yes
| Review and 2 GTM  |

Overrides `flush()` of CsvWriter to be able to read products from a buffer.
To be reworked on master.