### PR TITLE
[TR] PIM-5161: fix the is_associated sort on MongoDB association grid

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 - PIM-5127: Improve products export memory usage
 - PIM-5148: IE11 wrong display on multiple select attributes
+- PIM-5161: Fix the is_associated sort on MongoDB association grid
 
 # 1.4.8 (2015-11-09)
 

--- a/features/product/associate_product.feature
+++ b/features/product/associate_product.feature
@@ -130,3 +130,40 @@ Feature: Associate a product
     # Wait for the fade-out of the message
     And I wait 1 seconds
     Then I should not see the text "There are unsaved changes."
+
+  @jira https://akeneo.atlassian.net/browse/PIM-5161
+  Scenario: Grid is sorted by default by "is associated"
+    Given the following products:
+      | sku          |
+      | red-boots    |
+      | purple-boots |
+      | yellow-boots |
+      | orange-boots |
+      | white-boots  |
+    And the following associations for the product "red-boots":
+      | type   | product     |
+      | X_SELL | black-boots |
+      | X_SELL | gray-boots  |
+    And I edit the "red-boots" product
+    When I visit the "Associations" tab
+    Then I should see the text "black-boots"
+    And I should see the text "gray-boots"
+    And the rows "black-boots and gray-boots" should be checked
+    And the rows should be sorted descending by Is associated
+
+  @jira https://akeneo.atlassian.net/browse/PIM-5161
+  Scenario: Grid is sortable by "is associated"
+    Given the following products:
+      | sku          |
+      | red-boots    |
+      | purple-boots |
+      | yellow-boots |
+      | orange-boots |
+      | white-boots  |
+    And the following associations for the product "red-boots":
+      | type   | product     |
+      | X_SELL | black-boots |
+      | X_SELL | gray-boots  |
+    And I edit the "red-boots" product
+    When I visit the "Associations" tab
+    Then I should be able to sort the rows by Is associated

--- a/spec/Pim/Bundle/DataGridBundle/Datasource/ResultRecord/MongoDbOdm/AssociatedProductHydratorSpec.php
+++ b/spec/Pim/Bundle/DataGridBundle/Datasource/ResultRecord/MongoDbOdm/AssociatedProductHydratorSpec.php
@@ -62,6 +62,8 @@ class AssociatedProductHydratorSpec extends ObjectBehavior
             'current_product'          => $product,
         ];
 
+        $builder->find()->willReturn($builder);
+        $builder->count()->willReturn($builder);
         $builder->getQuery()->willReturn($query);
         $builder->hydrate(false)->willReturn($builder);
         $builder->setQueryArray(Argument::any())->willReturn($builder);

--- a/src/Pim/Bundle/DataGridBundle/Datasource/ResultRecord/MongoDbOdm/AssociatedProductHydrator.php
+++ b/src/Pim/Bundle/DataGridBundle/Datasource/ResultRecord/MongoDbOdm/AssociatedProductHydrator.php
@@ -42,7 +42,7 @@ class AssociatedProductHydrator implements HydratorInterface
         $scope             = $options['scope_code'];
         $config            = $options['attributes_configuration'];
         $groupId           = $options['current_group_id'];
-        $associationTypeId = (int)$options['association_type_id'];
+        $associationTypeId = (int) $options['association_type_id'];
         $currentProduct    = $options['current_product'];
 
         $query           = $queryBuilder->hydrate(false)->getQuery();
@@ -53,39 +53,31 @@ class AssociatedProductHydrator implements HydratorInterface
         $hasResults           = 0 !== $queryDefinition['limit'];
 
         if ($hasCurrentProduct && $sortedByIsAssociated && $hasResults) {
-            $associatedIds     = $this->getAssociatedProductIds($currentProduct, $associationTypeId);
-            $nbTotalAssociated = count($associatedIds);
+            $associatedIds = $this->getAssociatedProductIds($currentProduct, $associationTypeId);
 
             $limit    = $queryDefinition['limit'];
             $skip     = $queryDefinition['skip'];
             $rawQuery = $queryDefinition['query'];
 
-            $queryDefinition['skip'];
-            $associatedProducts = $this->getAssociatedProducts(
-                $queryBuilder,
-                $associatedIds,
-                $rawQuery,
-                $limit,
-                $skip
-            );
-
-            $nonAssociatedProducts = [];
-            $nbAssociated = count($associatedProducts);
-            if ($limit > $nbAssociated) {
-                $limit -= $nbAssociated;
-                $skip -= $nbTotalAssociated;
-                $skip = ($skip > 0) ? $skip : 0;
-
-                $nonAssociatedProducts = $this->getNonAssociatedProducts(
+            if (-1 === (int) $queryDefinition['sort']['normalizedData.is_associated']) {
+                $results = $this->getProductsSortedByIsAssociatedDesc(
                     $queryBuilder,
                     $associatedIds,
                     $rawQuery,
                     $limit,
-                    $skip
+                    $skip,
+                    count($associatedIds)
+                );
+            } else {
+                $results = $this->getProductsSortedByIsAssociatedAsc(
+                    $queryBuilder,
+                    $associatedIds,
+                    $rawQuery,
+                    $limit,
+                    $skip,
+                    $this->countProducts($queryBuilder, $associatedIds, $rawQuery)
                 );
             }
-
-            $results = $associatedProducts + $nonAssociatedProducts;
         } else {
             $results = $query->execute();
         }
@@ -120,6 +112,100 @@ class AssociatedProductHydrator implements HydratorInterface
     }
 
     /**
+     * Get products sorted by associated_id desc (is associated first)
+     *
+     * @param Builder $queryBuilder      the query builder
+     * @param array   $associatedIds     the ids of the products that are associated
+     * @param array   $rawQuery          the query parameters
+     * @param int     $limit             the limit of products to select for the page
+     * @param int     $skip              the number of products to skip for the page
+     * @param int     $nbTotalAssociated the number total of associated products
+     *
+     * @return array
+     */
+    protected function getProductsSortedByIsAssociatedDesc(
+        Builder $queryBuilder,
+        array $associatedIds,
+        array $rawQuery,
+        $limit,
+        $skip,
+        $nbTotalAssociated
+    ) {
+        $associatedProducts = $this->getAssociatedProducts(
+            $queryBuilder,
+            $associatedIds,
+            $rawQuery,
+            $limit,
+            $skip
+        );
+
+        $nonAssociatedProducts = [];
+        $nbAssociated = count($associatedProducts);
+        if ($limit > $nbAssociated) {
+            $limit -= $nbAssociated;
+            $skip -= $nbTotalAssociated;
+            $skip = max($skip, 0);
+
+            $nonAssociatedProducts = $this->getNonAssociatedProducts(
+                $queryBuilder,
+                $associatedIds,
+                $rawQuery,
+                $limit,
+                $skip
+            );
+        }
+
+        return $associatedProducts + $nonAssociatedProducts;
+    }
+
+    /**
+     * Get products sorted by associated_id asc (is associated last)
+     *
+     * @param Builder $queryBuilder         the query builder
+     * @param array   $associatedIds        the ids of the products that are associated
+     * @param array   $rawQuery             the query parameters
+     * @param int     $limit                the limit of products to select for the page
+     * @param int     $skip                 the number of products to skip for the page
+     * @param int     $nbTotalNonAssociated the number total of non associated products
+     *
+     * @return array
+     */
+    protected function getProductsSortedByIsAssociatedAsc(
+        Builder $queryBuilder,
+        array $associatedIds,
+        array $rawQuery,
+        $limit,
+        $skip,
+        $nbTotalNonAssociated
+    ) {
+        $nonAssociatedProducts = $this->getNonAssociatedProducts(
+            $queryBuilder,
+            $associatedIds,
+            $rawQuery,
+            $limit,
+            $skip
+        );
+
+        $associatedProducts = [];
+        $nbNonAssociated = count($nonAssociatedProducts);
+        if ($limit > $nbNonAssociated) {
+            $limit -= $nbNonAssociated;
+            $skip -= $nbTotalNonAssociated;
+            $skip = max($skip, 0);
+
+            $associatedProducts = $this->getAssociatedProducts(
+                $queryBuilder,
+                $associatedIds,
+                $rawQuery,
+                $limit,
+                $skip
+            );
+        }
+
+        return $nonAssociatedProducts + $associatedProducts;
+    }
+
+    /**
      * Get Mongo Ids of the associated products of the current product
      *
      * @param ProductInterface $product
@@ -145,11 +231,11 @@ class AssociatedProductHydrator implements HydratorInterface
     /**
      * Get the associated products for the current page
      *
-     * @param Builder  $queryBuilder
-     * @param string[] $associatedIds
-     * @param array    $rawQuery
-     * @param int      $limit
-     * @param int      $skip
+     * @param Builder  $queryBuilder  the query builder
+     * @param string[] $associatedIds the ids of the products that are associated
+     * @param array    $rawQuery      the query parameters
+     * @param int      $limit         the limit of products to select for the page
+     * @param int      $skip          the number of products to skip for the page
      *
      * @return array
      */
@@ -169,11 +255,11 @@ class AssociatedProductHydrator implements HydratorInterface
     /**
      * Get the non associated products for the current page
      *
-     * @param Builder  $queryBuilder
-     * @param string[] $associatedIds
-     * @param array    $rawQuery
-     * @param int      $limit
-     * @param int      $skip
+     * @param Builder  $queryBuilder  the query builder
+     * @param string[] $associatedIds the ids of the products that are associated
+     * @param array    $rawQuery      the query parameters
+     * @param int      $limit         the limit of products to select for the page
+     * @param int      $skip          the number of products to skip for the page
      *
      * @return array
      */
@@ -194,22 +280,18 @@ class AssociatedProductHydrator implements HydratorInterface
      * Get products as array according to the query, the limit and the skip. The column "is_associated"
      * is also added.
      *
-     * @param Builder $queryBuilder
-     * @param array   $rawQuery
-     * @param int     $limit
-     * @param int     $skip
-     * @param bool    $isAssociated
+     * @param Builder $queryBuilder the query builder
+     * @param array   $rawQuery     the ids of the products that are associated
+     * @param int     $limit        the query parameters
+     * @param int     $skip         the limit of products to select for the page
+     * @param bool    $isAssociated value of the "is associated" column that will be added
      *
      * @throws \Doctrine\ODM\MongoDB\MongoDBException
      * @return array
      */
-    protected function getProductsAsArray(
-        Builder $queryBuilder,
-        array $rawQuery,
-        $limit,
-        $skip,
-        $isAssociated
-    ) {
+    protected function getProductsAsArray(Builder $queryBuilder, array $rawQuery, $limit, $skip, $isAssociated)
+    {
+        $queryBuilder->find();
         $queryBuilder->setQueryArray($rawQuery);
         $queryBuilder->limit($limit);
         $queryBuilder->skip($skip);
@@ -221,5 +303,26 @@ class AssociatedProductHydrator implements HydratorInterface
         }
 
         return $results;
+    }
+
+    /**
+     * Get the number of products according to the query
+     *
+     * @param Builder $queryBuilder  the query builder
+     * @param array   $associatedIds the ids of the products that are associated
+     * @param array   $rawQuery      the query parameters
+     *
+     * @return int
+     */
+    protected function countProducts(Builder $queryBuilder, array $associatedIds, array $rawQuery)
+    {
+        $queryBuilder->count();
+        $queryBuilder->setQueryArray($rawQuery);
+        $queryBuilder->limit(0);
+        $queryBuilder->skip(0);
+
+        $count = $queryBuilder->getQuery()->execute() - count($associatedIds);
+
+        return max($count, 0);
     }
 }


### PR DESCRIPTION
The is_associated sort does not work anymore on the MongoDB association grid due to https://github.com/akeneo/pim-community-dev/pull/3540...

| Q                 | A
| ----------------- | ---
| Specs             | Y
| Behats            | Y
| Blue CI           | running
| Changelog updated | Y
| Review and 2 GTM  |