### PR TITLE
PIM-5163: Fix the VersionRepository on MongoDB to take the most recent entry for product resources

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -1,3 +1,8 @@
+# 1.4.x
+
+## Bug fixes
+- PIM-5163: Fix the VersionRepository on MongoDB to take the most recent entry for product resources
+
 # 1.4.9 (2015-11-12)
 
 ## Bug fixes

--- a/src/Pim/Bundle/VersioningBundle/Doctrine/MongoDBODM/VersionRepository.php
+++ b/src/Pim/Bundle/VersioningBundle/Doctrine/MongoDBODM/VersionRepository.php
@@ -46,7 +46,9 @@ class VersionRepository extends DocumentRepository implements VersionRepositoryI
      */
     public function getNewestLogEntryForRessources($resourceNames)
     {
-        return $this->findOneBy(['resourceName' => ['$in' => $resourceNames]], ['loggedAt' => 'desc'], 1);
+        $entries = $this->findBy(['resourceName' => ['$in' => $resourceNames]], ['loggedAt' => 'desc'], 1);
+
+        return empty($entries) ? null : current($entries);
     }
 
     /**


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Specs             | Y
| Behats            | N
| Blue CI           | Y
| Changelog updated | Y
| Review and 2 GTM  | Y

This fix **can't be tested by behat scenarios**, as they reload pages each time.
This bug is only reproducible with the normal navigation (single page application).