### PR TITLE
[TR] PIM-5190: Fix calculation error for MongoDB completeness with empty media attributes

### DIFF
--- a/CHANGELOG-1.3.md
+++ b/CHANGELOG-1.3.md
@@ -3,6 +3,9 @@
 ## Technical improvements
 - Introduction of a command to purge completenesses: `pim:completeness:purge`
 
+## Bug fixes
+- PIM-5190: Fix calculation error for MongoDB completeness with empty media attributes
+
 # 1.3.31 (2015-11-12)
 
 ## Technical improvements

--- a/CHANGELOG-1.3.md
+++ b/CHANGELOG-1.3.md
@@ -1,3 +1,8 @@
+# 1.3.x
+
+## Technical improvements
+- Introduction of a command to purge completenesses: `pim:completeness:purge`
+
 # 1.3.31 (2015-11-12)
 
 ## Technical improvements

--- a/features/product/completeness.feature
+++ b/features/product/completeness.feature
@@ -42,6 +42,28 @@ Feature: Display the completeness of a product
       | tablet  | English (United States) | warning | 6 missing values | 25%   |
       | tablet  | French (France)         | warning | 4 missing values | 50%   |
 
+  @jira https://akeneo.atlassian.net/browse/PIM-5190
+  Scenario: Successfully display the completeness of the products with medias after a save
+    Given I am on the "sneakers" product page
+    And I save the product
+    When I visit the "Completeness" tab
+    Then I should see the completeness summary
+    And I should see the completeness:
+      | channel | locale                  | state   | message          | ratio |
+      | mobile  | English (United States) | success | Complete         | 100%  |
+      | mobile  | French (France)         | success | Complete         | 100%  |
+      | tablet  | English (United States) | warning | 1 missing value  | 89%   |
+      | tablet  | French (France)         | warning | 2 missing values | 78%   |
+    When I am on the "sandals" product page
+    And I visit the "Completeness" tab
+    Then I should see the completeness summary
+    And I should see the completeness:
+      | channel | locale                  | state   | message          | ratio |
+      | mobile  | English (United States) | warning | 3 missing values | 40%   |
+      | mobile  | French (France)         | warning | 2 missing values | 60%   |
+      | tablet  | English (United States) | warning | 6 missing values | 25%   |
+      | tablet  | French (France)         | warning | 4 missing values | 50%   |
+
   Scenario: Successfully display the completeness of the products in the grid
     Given I am on the products page
     And I switch the locale to "English (United States)"

--- a/src/Pim/Bundle/CatalogBundle/Command/PurgeCompletenessCommand.php
+++ b/src/Pim/Bundle/CatalogBundle/Command/PurgeCompletenessCommand.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\Command;
+
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\QueryBuilder;
+use Doctrine\ORM\Tools\Pagination\Paginator;
+use Pim\Bundle\CatalogBundle\Manager\CompletenessManager;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Purge the completeness of the products family by family:
+ *  - for products stored with ORM: rows from the table "pim_catalog_completeness" will be deleted
+ *  - for products stored with MongoDB: will drop the keys "completenesses" and
+ *    "normalizedData.completenesses" from the product's documents
+ *
+ * @author    Julien Janvier <jjanvier@akeneo.com>
+ * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class PurgeCompletenessCommand extends ContainerAwareCommand
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('pim:completeness:purge')
+            ->setDescription('Purge the product completenesses');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $qb = $this->getFamilyQueryBuilder();
+        $paginator = new Paginator($qb);
+
+        foreach ($paginator as $family) {
+            $output->writeln(sprintf('Purging completenesses of the family "%s"...', $family->getCode()));
+            $this->getCompletenessManager()->scheduleForFamily($family);
+        }
+
+        $output->writeln('<info>Completenesses purged.</info>');
+    }
+
+    /**
+     * @return CompletenessManager
+     */
+    protected function getCompletenessManager()
+    {
+        return $this
+            ->getContainer()
+            ->get('pim_catalog.manager.completeness');
+    }
+
+    /**
+     * @return QueryBuilder
+     */
+    protected function getFamilyQueryBuilder()
+    {
+        $em = $this->getEntityManager();
+
+        return $em->createQueryBuilder()
+            ->select('f')
+            ->from($this->getFamilyClass(), 'f');
+    }
+
+    /**
+     * @return EntityManager
+     */
+    protected function getEntityManager()
+    {
+        return $this->getContainer()->get('doctrine.orm.entity_manager');
+    }
+
+    /**
+     * @return string
+     */
+    protected function getFamilyClass()
+    {
+        return $this->getContainer()->getParameter('pim_catalog.entity.family.class');
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/CompletenessGenerator.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/CompletenessGenerator.php
@@ -42,10 +42,10 @@ class CompletenessGenerator implements CompletenessGeneratorInterface
     /**
      * Constructor
      *
-     * @param DocumentManager           $documentManager
-     * @param string                    $productClass
-     * @param ChannelManager            $channelRepository
-     * @param FamilyRepositoryInterface $familyRepository
+     * @param DocumentManager            $documentManager
+     * @param string                     $productClass
+     * @param ChannelRepositoryInterface $channelRepository
+     * @param FamilyRepositoryInterface  $familyRepository
      */
     public function __construct(
         DocumentManager $documentManager,
@@ -139,7 +139,10 @@ class CompletenessGenerator implements CompletenessGeneratorInterface
         $normalizedData = array_filter(
             $normalizedData,
             function ($value) {
-                return (null !== $value);
+                //TODO: should be dropped on master as we don't normalize anymore empty medias in the normalized data
+                $nullNormalizedMedia = ['filename' => null, 'originalFilename' => null];
+
+                return (null !== $value && $nullNormalizedMedia !== $value);
             }
         );
 

--- a/src/Pim/Bundle/CatalogBundle/MongoDB/Normalizer/MediaNormalizer.php
+++ b/src/Pim/Bundle/CatalogBundle/MongoDB/Normalizer/MediaNormalizer.php
@@ -19,6 +19,10 @@ class MediaNormalizer implements NormalizerInterface
      */
     public function normalize($object, $format = null, array $context = array())
     {
+        if (null === $object->getFilename() && null === $object->getOriginalFilename()) {
+            return null;
+        }
+
         return ['filename' => $object->getFilename(), 'originalFilename' => $object->getOriginalFilename()];
     }
 


### PR DESCRIPTION
Imagine a family `F` with a media attribute `M` which is required for a channel.
When you create a product with this family `F`, the normalized data contains the empty media (it's an array with the keys `filename` and `originalFilename`) .
During the completeness calculation, as the media normalzed data exists, the generator thinks the media is filled in, so the calculation is wrong.

To fix this:
* for new products, we don't normalize the empty medias anymore in the normalized data
* for old products: we don't take into account empty medias in the calculation and we'll ask customers to purge their completeness with the new command `pim:completeness:purge` and to recalculate it  with`pim:completeness:calculate`

| Q                 | A
| ----------------- | ---
| Specs             | Y
| Behats            | Y
| Blue CI           | running
| Changelog updated | Y
| Review and 2 GTM  | 