### PR TITLE
[TR] PIM-5197: Improve products export memory usage (backport PIM-5127 into 1.3)

### DIFF
--- a/features/Context/WebUser.php
+++ b/features/Context/WebUser.php
@@ -1757,6 +1757,7 @@ class WebUser extends RawMinkContext
         unset($expectedLines[0]);
 
         foreach ($expectedLines as $expectedLine) {
+            $originalExpectedLine = $expectedLine;
             $found = false;
             foreach ($actualLines as $index => $actualLine) {
                 // Order of columns is not ensured
@@ -1782,7 +1783,7 @@ class WebUser extends RawMinkContext
                 throw new \Exception(
                     sprintf(
                         'Could not find a line containing "%s" in %s',
-                        implode(' | ', $expectedLine),
+                        implode(' | ', $originalExpectedLine),
                         $path
                     )
                 );

--- a/spec/Pim/Bundle/BaseConnectorBundle/Writer/File/CsvProductWriterSpec.php
+++ b/spec/Pim/Bundle/BaseConnectorBundle/Writer/File/CsvProductWriterSpec.php
@@ -17,7 +17,7 @@ class CsvProductWriterSpec extends ObjectBehavior
         $file = new \SplFileInfo(realpath(__DIR__.'/../../../../../../features/Context/fixtures/product_export_with_non_utf8_characters.csv'));
         $media = ['filePath' => $file->getPathname(), 'exportPath' => 'test.csv'];
 
-        $this->write([['product' => 'my-product', 'media' => [$media]]]);
+        $this->write([['product' => ['sku' => 'my-product'], 'media' => [$media]]]);
         $this->getWrittenFiles()->shouldReturn(['/tmp/test.csv' => 'test.csv']);
         $stepExecution->addWarning()->shouldNotBeCalled();
     }
@@ -26,7 +26,7 @@ class CsvProductWriterSpec extends ObjectBehavior
     {
         $media = ['filePath' => 'not-found.csv', 'exportPath' => 'test.csv'];
 
-        $this->write([['product' => 'my-product', 'media' => [$media]]]);
+        $this->write([['product' =>  ['sku' => 'my-product'], 'media' => [$media]]]);
         $this->getWrittenFiles()->shouldReturn([]);
         $stepExecution->addWarning('csv_product_writer', 'The media has not been found or is not currently available', [], $media)
             ->shouldBeCalled();
@@ -40,7 +40,7 @@ class CsvProductWriterSpec extends ObjectBehavior
         $previousReporting = error_reporting();
         error_reporting(0);
 
-        $this->write([['product' => 'my-product', 'media' => [$media]]]);
+        $this->write([['product' =>  ['sku' => 'my-product'], 'media' => [$media]]]);
         $this->getWrittenFiles()->shouldReturn([]);
         $stepExecution->addWarning('csv_product_writer', 'The media has not been copied', [], $media)
             ->shouldBeCalled();

--- a/src/Pim/Bundle/BaseConnectorBundle/Writer/File/CsvProductWriter.php
+++ b/src/Pim/Bundle/BaseConnectorBundle/Writer/File/CsvProductWriter.php
@@ -2,6 +2,8 @@
 
 namespace Pim\Bundle\BaseConnectorBundle\Writer\File;
 
+use Akeneo\Bundle\BatchBundle\Job\RuntimeErrorException;
+
 /**
  * Write product data into a csv file on the filesystem
  *
@@ -11,33 +13,77 @@ namespace Pim\Bundle\BaseConnectorBundle\Writer\File;
  */
 class CsvProductWriter extends CsvWriter
 {
+    /** @var string */
+    protected $bufferFile;
+
+    /** @var array */
+    protected $headers = [];
+
     /**
      * {@inheritdoc}
      */
     public function write(array $items)
     {
-        $products = [];
-
         if (!is_dir(dirname($this->getPath()))) {
             mkdir(dirname($this->getPath()), 0777, true);
         }
 
         foreach ($items as $item) {
-            $products[] = $item['product'];
+            $this->writeProductToBuffer($item['product']);
+
             foreach ($item['media'] as $media) {
                 if ($media && isset($media['filePath']) && $media['filePath']) {
                     $this->copyMedia($media);
                 }
             }
         }
+    }
 
-        $this->items = array_merge($this->items, $products);
+    /**
+     * {@inheritdoc}
+     *
+     * Override of CsvWriter flush method to use the file buffer
+     */
+    public function flush()
+    {
+        if (!is_file($this->bufferFile)) {
+            return;
+        }
+
+        $exportDirectory = dirname($this->getPath());
+        if (!is_dir($exportDirectory)) {
+            mkdir(dirname($exportDirectory), 0777, true);
+        }
+
+        $this->writtenFiles[$this->getPath()] = basename($this->getPath());
+
+        if (false === $csvFile = fopen($this->getPath(), 'w')) {
+            throw new RuntimeErrorException('Failed to open file %path%', ['%path%' => $this->getPath()]);
+        }
+
+        $header = $this->isWithHeader() ? $this->headers : [];
+        if (false === fputcsv($csvFile, $header, $this->delimiter)) {
+            throw new RuntimeErrorException('Failed to write to file %path%', ['%path%' => $this->getPath()]);
+        }
+
+        $bufferHandle = fopen($this->bufferFile, 'r');
+        $hollowProduct = array_fill_keys($this->headers, '');
+        while (null !== $bufferedProduct = $this->readProductFromBuffer($bufferHandle)) {
+            $fullProduct = array_replace($hollowProduct, $bufferedProduct);
+            if (false === fputcsv($csvFile, $fullProduct, $this->delimiter, $this->enclosure)) {
+                throw new RuntimeErrorException('Failed to write to file %path%', ['%path%' => $this->getPath()]);
+            } elseif (null !== $this->stepExecution) {
+                $this->stepExecution->incrementSummaryInfo('write');
+            }
+        }
+
+        fclose($bufferHandle);
+        unlink($this->bufferFile);
+        fclose($csvFile);
     }
 
     /**
      * @param array $media
-     *
-     * @return void
      */
     protected function copyMedia(array $media)
     {
@@ -74,5 +120,38 @@ class CsvProductWriter extends CsvWriter
                 $media
             );
         }
+    }
+
+    /**
+     * Write the product data to the file buffer, and collect the headers
+     *
+     * @param array $product
+     */
+    protected function writeProductToBuffer(array $product)
+    {
+        if (!is_file($this->bufferFile)) {
+            $this->bufferFile = tempnam(sys_get_temp_dir(), 'pim_products_buffer_');
+        }
+
+        file_put_contents($this->bufferFile, json_encode($product) . "\n", FILE_APPEND);
+
+        $this->headers = $this->getAllKeys([
+            array_flip($this->headers),
+            $product
+        ]);
+    }
+
+    /**
+     * Read the next line from the products buffer
+     *
+     * @param resource $bufferHandle
+     *
+     * @return array|null
+     */
+    protected function readProductFromBuffer($bufferHandle)
+    {
+        $rawLine = fgets($bufferHandle);
+
+        return false !== $rawLine ? json_decode($rawLine, true) : null;
     }
 }


### PR DESCRIPTION
Tested with 10K products. Memory stays stable at 88MB.

| Q                 | A
| ----------------- | ---
| Specs             | Y
| Behats            | -
| Blue CI           | running
| Changelog updated | Y
| Review and 2 GTM  |