### PR TITLE
[TR] PIM-4347: Moved model initialization from PEF to BaseForm

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/edit-form.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/edit-form.js
@@ -30,11 +30,6 @@ define(
     ) {
         var FormView = BaseForm.extend({
             template: _.template(template),
-            initialize: function () {
-                this.model = new Backbone.Model();
-
-                BaseForm.prototype.initialize.apply(this, arguments);
-            },
             configure: function () {
                 mediator.clear('pim_enrich:form');
                 Backbone.Router.prototype.once('route', this.unbindEvents);

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form.js
@@ -22,15 +22,16 @@ define(
     ) {
         return Backbone.View.extend({
             code: 'form',
+            parent: null,
 
             /**
              * {@inheritdoc}
              */
             initialize: function () {
-                this.extensions   = {};
-                this.zones        = {};
-                this.targetZone   = '';
-                this.configured   = false;
+                this.extensions = {};
+                this.zones      = {};
+                this.targetZone = '';
+                this.configured = false;
             },
 
             /**
@@ -39,6 +40,10 @@ define(
              * @return {Promise}
              */
             configure: function () {
+                if (null === this.parent) {
+                    this.model = new Backbone.Model();
+                }
+
                 var extensionPromises = _.map(this.extensions, function (extension) {
                     return extension.configure();
                 });


### PR DESCRIPTION
Actually in the BaseForm we are trying to reach this.model in the `getFormData` but this.model is not instantiated by the BaseForm. The goal of this PR is to make the BaseForm standealone.

| Q                 | A
| ----------------- | ---
| Added Specs       | N/A
| Added Behats      | N/A
| Changelog updated | N/A