### PR TITLE
Revert "[SLA][TR]PIM-5194: fix perf on json family generation"

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -3,7 +3,6 @@
 ## Bug fixes
 - PIM-5163: Fix the VersionRepository on MongoDB to take the most recent entry for product resources
 - PIM-5169: Fix mass edit attribute selection while using a small screen resolution
-- PIM-5194: Fix performance issue on family json generation
 
 # 1.4.9 (2015-11-12)
 

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/FamilyRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/FamilyRepository.php
@@ -229,41 +229,4 @@ class FamilyRepository extends EntityRepository implements FamilyRepositoryInter
 
         return $count;
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getFamiliesTranslationsAsArray()
-    {
-        $queryBuilder = $this->createQueryBuilder('f')
-            ->select('f.code AS code, ft.label, ft.locale')
-            ->join('f.translations', 'ft');
-
-        return $queryBuilder->getQuery()->getArrayResult();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getFamiliesAttributeCodesAsArray()
-    {
-        $sql = 'SELECT f.code AS code, GROUP_CONCAT(a.code) AS attributes ' .
-               'FROM %s f ' .
-               'INNER JOIN pim_catalog_family_attribute fa ON f.id = fa.family_id ' .
-               'INNER JOIN pim_catalog_attribute a ON a.id = fa.attribute_id ' .
-               'GROUP BY f.id';
-
-        $metadata = $this->_em->getClassMetadata($this->_entityName);
-        $tableName = $metadata->getTableName();
-
-        $sql = sprintf($sql, $tableName);
-
-        $query = $this->getEntityManager()
-            ->getConnection()
-            ->prepare($sql);
-
-        $query->execute();
-
-        return $query->fetchAll();
-    }
 }

--- a/src/Pim/Bundle/CatalogBundle/Repository/FamilyRepositoryInterface.php
+++ b/src/Pim/Bundle/CatalogBundle/Repository/FamilyRepositoryInterface.php
@@ -79,18 +79,4 @@ interface FamilyRepositoryInterface extends
      * @return int
      */
     public function countAll();
-
-    /**
-     * Returns an array of families with code and label
-     *
-     * @return array
-     */
-    public function getFamiliesTranslationsAsArray();
-
-    /**
-     * Returns an array of families with concatenated attributes code
-     *
-     * @return array
-     */
-    public function getFamiliesAttributeCodesAsArray();
 }

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/FamilyController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/FamilyController.php
@@ -3,7 +3,6 @@
 namespace Pim\Bundle\EnrichBundle\Controller\Rest;
 
 use Doctrine\ORM\EntityRepository;
-use Pim\Bundle\CatalogBundle\Repository\FamilyRepositoryInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
@@ -16,7 +15,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
  */
 class FamilyController
 {
-    /** @var FamilyRepositoryInterface */
+    /** @var EntityRepository */
     protected $familyRepository;
 
     /** @var NormalizerInterface */
@@ -39,29 +38,11 @@ class FamilyController
      */
     public function indexAction()
     {
-        $rawFamiliesTrans = $this->familyRepository->getFamiliesTranslationsAsArray();
-        $rawFamiliesAttr  = $this->familyRepository->getFamiliesAttributeCodesAsArray();
+        $families = $this->familyRepository->findAll();
 
         $normalizedFamilies = [];
-        foreach ($rawFamiliesTrans as $familyTranslation) {
-            $normalizedFamilies[$familyTranslation['code']]['label'][$familyTranslation['locale']] =
-                $familyTranslation['label'];
-            $normalizedFamilies[$familyTranslation['code']]['code'] = $familyTranslation['code'];
-        }
-
-        foreach ($rawFamiliesAttr as $familyAttributes) {
-            $normalizedFamilies[$familyAttributes['code']]['attributes'] = explode(
-                ',',
-                $familyAttributes['attributes']
-            );
-
-            if (!isset($normalizedFamilies[$familyAttributes['code']]['label'])) {
-                $normalizedFamilies[$familyAttributes['code']]['label'] = [];
-            }
-
-            if (!isset($normalizedFamilies[$familyAttributes['code']]['code'])) {
-                $normalizedFamilies[$familyAttributes['code']]['code'] = $familyAttributes['code'];
-            }
+        foreach ($families as $family) {
+            $normalizedFamilies[$family->getCode()] = $this->normalizer->normalize($family, 'json');
         }
 
         return new JsonResponse($normalizedFamilies);


### PR DESCRIPTION
Reverts akeneo/pim-community-dev#3583

We have identifiied a new bug with this patch. The permissions are not applied correctly on Enterprise Edition (ie: attributes are not filtered by permissions). 

The Behat _Compare and copy localized fields from different sources // Successfully copy value from my draft_ fails.