### PR TITLE
attribute label size extended from 100 to 255

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Resources/config/doctrine/AttributeTranslation.orm.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/doctrine/AttributeTranslation.orm.yml
@@ -14,7 +14,7 @@ Pim\Bundle\CatalogBundle\Entity\AttributeTranslation:
                 strategy: AUTO
         label:
             type: string
-            length: 100
+            length: 255
             nullable: true
         locale:
             type: string

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/validation/attribute.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/validation/attribute.yml
@@ -149,7 +149,7 @@ Pim\Bundle\CatalogBundle\Entity\AttributeTranslation:
     properties:
         label:
             - Length:
-                max: 100
+                max: 255
 
 Pim\Bundle\CatalogBundle\Entity\AttributeOption:
     constraints:


### PR DESCRIPTION
Just a suggestion. To allow a user to use a long label to describe an attribute.
It seams to not break the layout and it give more freedom to the user.