### PR TITLE
[SLA][TR] PIM-5208: patch for grid performance with large amount of attributes

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -1,9 +1,10 @@
 # 1.4.x
 
 ## Bug fixes
-- PIM-5238: fix scroll on multiselect for mass edit
-- PIM-5177: fix login redirection
+- PIM-5238: Fix scroll on multiselect for mass edit
+- PIM-5177: Fix login redirection
 - PIM-5235: Fix empty reference data name on attributes import
+- PIM-5208: Fix the datagrid performance issue related to large number of attributes, only attribute usable in grid will be available
 
 # 1.4.11 (2015-11-27)
 

--- a/features/Context/DataGridContext.php
+++ b/features/Context/DataGridContext.php
@@ -261,6 +261,27 @@ class DataGridContext extends RawMinkContext implements PageObjectAwareInterface
     }
 
     /**
+     * @Given /^I should( not)? see the available filters (.*)$/
+     */
+    public function iShouldSeeTheAvailableFilters($not, $filters)
+    {
+        $available = !(bool)$not;
+
+        $filters = $this->getMainContext()->listToArray($filters);
+        foreach ($filters as $filter) {
+            if ($available && !$this->datagrid->isFilterAvailable($filter)) {
+                throw $this->createExpectationException(
+                    sprintf('Filter "%s" should be available.', $filter)
+                );
+            } elseif (!$available && $this->datagrid->isFilterAvailable($filter)) {
+                throw $this->createExpectationException(
+                    sprintf('Filter "%s" should not be available.', $filter)
+                );
+            }
+        }
+    }
+
+    /**
      * @param string $filters
      *
      * @Then /^I should not see the filters? (.*)$/

--- a/features/Context/Page/Base/Grid.php
+++ b/features/Context/Page/Base/Grid.php
@@ -557,6 +557,22 @@ class Grid extends Index
     }
 
     /**
+     * @param string $filterName
+     *
+     * @return bool
+     */
+    public function isFilterAvailable($filterName)
+    {
+        $this->clickFiltersList();
+
+        $filterElement = $this
+            ->getElement('Manage filters')
+            ->find('css', sprintf('label:contains("%s")', $filterName));
+
+        return null !== $filterElement;
+    }
+
+    /**
      * Show a filter from the management list
      *
      * @param string $filterName

--- a/features/attribute/edit_identifier_attribute.feature
+++ b/features/attribute/edit_identifier_attribute.feature
@@ -10,7 +10,7 @@ Feature: Edit an identifier attribute
   Scenario: Successfully display the identifier related fields
     Given I am on the "SKU" attribute page
     Then I should see the Max characters and Validation rule fields
-    And the fields Unique, Scope and Usable as grid filter should be disabled
+    And the fields Unique, Scope and Usable in grid should be disabled
 
   @javascript
   Scenario: Fail to create a second identifier attribute

--- a/features/product/date.feature
+++ b/features/product/date.feature
@@ -8,8 +8,8 @@ Feature: Check that imported date is properly displayed
     Given the "default" catalog configuration
     And I am logged in as "Julia"
     And the following attributes:
-      | label   | type | localizable | scopable |
-      | release | date | no          | no       |
+      | label   | type | localizable | scopable | useable_as_grid_filter |
+      | release | date | no          | no       | yes                    |
     And the following products:
       | sku    | release    |
       | postit | 2014-05-01 |

--- a/features/product/display_attributes_in_the_grid.feature
+++ b/features/product/display_attributes_in_the_grid.feature
@@ -7,9 +7,9 @@ Feature: Display product attributes in the grid
   Scenario: Successfully display values for simple and multi select attributes
     Given the "default" catalog configuration
     And the following attributes:
-      | code               | type         | label-en_US        | group |
-      | manufacturer       | simpleselect | Manufacturer       | other |
-      | weather_conditions | multiselect  | Weather conditions | other |
+      | code               | type         | label-en_US        | group | useable_as_grid_filter |
+      | manufacturer       | simpleselect | Manufacturer       | other | yes                    |
+      | weather_conditions | multiselect  | Weather conditions | other | yes                    |
     And the following "manufacturer" attribute options: Converse, adidas and lacoste
     And the following "weather_conditions" attribute options: dry, hot, cloudy and stormy
     And the following products:
@@ -34,7 +34,11 @@ Feature: Display product attributes in the grid
       | Weather conditions | [cloudy]  |
 
   Scenario: Successfully display image attributes
-    Given the "footwear" catalog configuration
+    Given the "default" catalog configuration
+    And the following attributes:
+      | code      | type  | label-en_US | allowed_extensions | useable_as_grid_filter |
+      | side_view | image | Side view   | gif,png,jpeg,jpg   | yes                    |
+      | top_view  | image | Top view    | gif,png,jpeg,jpg   | yes                    |
     And the following products:
       | sku      | side_view             | top_view               |
       | sneakers | %fixtures%/akeneo.jpg |                        |

--- a/features/product/filtering/filter_products.feature
+++ b/features/product/filtering/filter_products.feature
@@ -11,10 +11,11 @@ Feature: Filter products
       | furniture |
       | library   |
     And the following attributes:
-      | label | localizable | scopable | useable_as_grid_filter |
-      | Name  | yes         | no       | yes                    |
-      | Image | no          | yes      | yes                    |
-      | Info  | yes         | yes      | yes                    |
+      | label       | localizable | scopable | useable_as_grid_filter |
+      | Name        | yes         | no       | yes                    |
+      | Image       | no          | yes      | yes                    |
+      | Info        | yes         | yes      | yes                    |
+      | Description | no          | no       | no                     |
     And the following products:
       | sku    | family    | enabled | name-en_US  | name-fr_FR   | info-en_US-ecommerce    | info-fr_FR-ecommerce     | info-fr_FR-mobile     | image-ecommerce  | image-mobile     |
       | postit | furniture | yes     | Post it     | Etiquette    | My ecommerce info       | Ma info ecommerce        | Ma info mobile        | large.jpeg       | small.jpeg       |
@@ -75,3 +76,10 @@ Feature: Filter products
     And the grid should contain 5 elements
     When I refresh the grid
     Then the grid should contain 5 elements
+
+  @jira https://akeneo.atlassian.net/browse/PIM-5208
+  Scenario: View only attribute filters that are usable as grid filters
+    Given I am on the products page
+    Then I should see the available filters SKU, Family, Status
+    And I should see the available filters Name, Image, Info
+    And I should not see the available filters Description

--- a/features/variant-group/add_attributes_to_a_variant_group.feature
+++ b/features/variant-group/add_attributes_to_a_variant_group.feature
@@ -83,3 +83,28 @@ Feature: Add attributes to a variant group
     And I visit the "Attributes" tab
     When I add available attributes Price
     And I should see "EUR, USD" currencies on the Price price field
+
+  @javascript @jira https://akeneo.atlassian.net/browse/PIM-5208
+  Scenario: View only attribute filters that are usable as grid filters and view varient axes in columns
+    Given the following attributes:
+      | code                       | label-en_US                | type         | group  | useable_as_grid_filter |
+      | high_heel_main_color       | High heel main color       | simpleselect | colors | yes                    |
+      | high_heel_main_fabric      | High heel main fabric      | simpleselect | other  | no                     |
+      | high_heel_secondary_color  | High heel secondary color  | simpleselect | colors | no                     |
+      | high_heel_secondary_fabric | High heel secondary fabric | simpleselect | other  | yes                    |
+    And the following "high_heel_main_color" attribute options: Red, Blue
+    And the following "high_heel_main_fabric" attribute options: Leather, Silk
+    And the following family:
+      | code       | requirements-mobile                              | requirements-tablet |
+      | high_heels | sku, high_heel_main_color, high_heel_main_fabric | sku                 |
+    And the following product groups:
+      | code       | label      | axis                                        | type    |
+      | high_heels | High heels | high_heel_main_color, high_heel_main_fabric | VARIANT |
+    And the following product:
+      | sku     | family     | high_heel_main_color | high_heel_main_fabric |
+      | heel001 | high_heels | Red                  | Silk                  |
+    When I am on the "high_heels" variant group page
+    Then I should see the available filters High heel main color and High heel secondary fabric
+    And I should not see the available filters High heel main fabric and High heel secondary color
+    And I should see the columns In group, Sku, High heel main color, High heel main fabric, Label, Family, Status, Complete, Created at and Updated at
+

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/AttributeRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/AttributeRepository.php
@@ -334,6 +334,9 @@ class AttributeRepository extends EntityRepository implements
             return [];
         }
 
+        $qb->andWhere('att.useableAsGridFilter = :useableInGrid');
+        $qb->setParameter('useableInGrid', 1);
+
         $result = $qb->getQuery()->execute([], AbstractQuery::HYDRATE_ARRAY);
 
         return array_keys($result);

--- a/src/Pim/Bundle/DataGridBundle/Resources/config/configurators.yml
+++ b/src/Pim/Bundle/DataGridBundle/Resources/config/configurators.yml
@@ -14,6 +14,7 @@ services:
             - '@oro_datagrid.datagrid.request_params'
             - '@pim_user.context.user'
             - '@pim_datagrid.repository.datagrid_view'
+            - '@pim_catalog.repository.group'
         calls:
             - [setRequest, ['@?request=']]
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/messages.en.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/messages.en.yml
@@ -594,7 +594,7 @@ Defaultvalue:                        Default value
 Variant:                             Variant
 Smart:                               Smart
 Useable as grid column:              Usable as grid column
-Useable as grid filter:              Usable as grid filter
+Useable as grid filter:              Usable in grid
 Family:                              Family
 Available locales:                   Available locales
 Locale specific:                     Locale specific


### PR DESCRIPTION
TEST PROTOCOL:
* no xdebug, done on local machine
* database with 10k attributes
* 1 variant group,  1 product that belongs to that variant group
* calculate mean time of  25 curl calls

BEFORE PATCH:
* refresh product grid: 9.278s
* refresh variant product grid: 9.235s

AFTER PATCH:
* refresh product grid: 0.439s
* refresh variant product grid: 0.453s

| Q                 | A
| ----------------- | ---
| Specs             | -
| Behats            | Y
| Blue CI           | CE Y, EE running
| Changelog updated | Y
| Review and 2 GTM  |

- [x] Update translation in attribute configuration to 'Useable in grid'
- [x] Add chapter in the http://docs.akeneo.com/latest/reference/performances_guide/index.html. PR here https://github.com/akeneo/pim-docs/pull/169/files
- [x] Add custom logic for variant group products grid to allow to display attribue axis values and filter by attribute axis (add a specific context configurator for group grid to always append axis attributes?)
