### PR TITLE
[TR] PIM-5209: Optimized AttributeGroupNormalizer in order to serialize attributes codes in one request.

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -1,5 +1,11 @@
 # 1.4.x
 
+## BC Breaks
+- Changed constructor of `Pim\Bundle\VersioningBundle\EventSubscriber\AddVersionSubscriber` in order to avoid circular reference dependency exceptions.
+
+## Performance improvements
+- PIM-5209: Optimize AttributeGroupNormalizer in order to serialize attributes codes in one request.
+
 ## Bug fixes
 - PIM-5170: Fixes memory leak on MongoDB at import time
 - PIM-5176: Fix customisation of columns not saved in "Column Selection"

--- a/features/Context/Page/UserRole/Edit.php
+++ b/features/Context/Page/UserRole/Edit.php
@@ -50,9 +50,9 @@ class Edit extends Form
     /**
      * Select the specified $role
      *
-     * @throws ElementNotFoundException
-     *
      * @param string $role
+     *
+     * @throws ElementNotFoundException
      */
     public function selectRole($role)
     {

--- a/spec/Pim/Bundle/TransformBundle/Normalizer/Flat/AttributeGroupNormalizerSpec.php
+++ b/spec/Pim/Bundle/TransformBundle/Normalizer/Flat/AttributeGroupNormalizerSpec.php
@@ -3,6 +3,7 @@
 namespace spec\Pim\Bundle\TransformBundle\Normalizer\Flat;
 
 use PhpSpec\ObjectBehavior;
+use Pim\Bundle\CatalogBundle\Doctrine\ORM\Repository\AttributeRepository;
 use Pim\Bundle\CatalogBundle\Model\AttributeGroupInterface;
 use Pim\Bundle\CatalogBundle\Model\AttributeInterface;
 use Pim\Bundle\TransformBundle\Normalizer\Structured\TranslationNormalizer;
@@ -10,9 +11,9 @@ use Prophecy\Argument;
 
 class AttributeGroupNormalizerSpec extends ObjectBehavior
 {
-    function let(TranslationNormalizer $normalizer, AttributeGroupInterface $group)
+    function let(TranslationNormalizer $normalizer, AttributeRepository $attributeRepository)
     {
-        $this->beConstructedWith($normalizer);
+        $this->beConstructedWith($normalizer, $attributeRepository);
     }
 
     function it_is_initializable()
@@ -25,20 +26,22 @@ class AttributeGroupNormalizerSpec extends ObjectBehavior
         $this->shouldImplement('Symfony\Component\Serializer\Normalizer\NormalizerInterface');
     }
 
-    function it_supports_attribute_group_normalization_into_csv($group)
+    function it_supports_attribute_group_normalization_into_csv(AttributeGroupInterface $group)
     {
         $this->supportsNormalization($group, 'csv')->shouldBe(true);
         $this->supportsNormalization($group, 'json')->shouldBe(false);
         $this->supportsNormalization($group, 'xml')->shouldBe(false);
     }
 
-    function it_normalizes_attribute_group(
+    function it_normalizes_attribute_group_legacy(
         $normalizer,
-        $group,
+        AttributeGroupInterface $group,
         AttributeInterface $type,
         AttributeInterface $size,
         AttributeInterface $price
     ) {
+        $this->beConstructedWith($normalizer);
+
         $normalizer->normalize(Argument::cetera())->willReturn([]);
         $type->getCode()->willReturn('type');
         $size->getCode()->willReturn('size');
@@ -46,6 +49,24 @@ class AttributeGroupNormalizerSpec extends ObjectBehavior
         $group->getAttributes()->willReturn([$type, $size, $price]);
         $group->getCode()->willReturn('code');
         $group->getSortOrder()->willReturn(1);
+        $this->normalize($group)->shouldReturn([
+            'code'       => 'code',
+            'sortOrder'  => 1,
+            'attributes' => 'type,size,price'
+        ]);
+    }
+
+    function it_normalizes_attribute_group(
+        $normalizer,
+        $attributeRepository,
+        AttributeGroupInterface $group
+    ) {
+        $normalizer->normalize(Argument::cetera())->willReturn([]);
+
+        $attributeRepository->getAttributeCodesByGroup($group)->willReturn(['type', 'size', 'price']);
+        $group->getCode()->willReturn('code');
+        $group->getSortOrder()->willReturn(1);
+
         $this->normalize($group)->shouldReturn([
             'code'       => 'code',
             'sortOrder'  => 1,

--- a/spec/Pim/Bundle/VersioningBundle/EventSubscriber/AddVersionSubscriberSpec.php
+++ b/spec/Pim/Bundle/VersioningBundle/EventSubscriber/AddVersionSubscriberSpec.php
@@ -3,20 +3,13 @@
 namespace spec\Pim\Bundle\VersioningBundle\EventSubscriber;
 
 use PhpSpec\ObjectBehavior;
-use Pim\Bundle\VersioningBundle\Manager\VersionContext;
-use Pim\Bundle\VersioningBundle\Manager\VersionManager;
-use Pim\Bundle\VersioningBundle\UpdateGuesser\ChainedUpdateGuesser;
-use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class AddVersionSubscriberSpec extends ObjectBehavior
 {
-    function let(
-        VersionManager $versionManager,
-        ChainedUpdateGuesser $guesser,
-        NormalizerInterface $normalizer,
-        VersionContext $versionContext
-    ) {
-        $this->beConstructedWith($versionManager, $guesser, $normalizer, $versionContext);
+    function let(ContainerInterface $container)
+    {
+        $this->beConstructedWith($container);
     }
 
     function it_is_a_doctrine_event_listener()

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/AttributeRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/AttributeRepository.php
@@ -8,6 +8,7 @@ use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\QueryBuilder;
 use Pim\Bundle\CatalogBundle\AttributeType\AttributeTypes;
 use Pim\Bundle\CatalogBundle\Entity\AttributeGroup;
+use Pim\Bundle\CatalogBundle\Model\AttributeGroupInterface;
 use Pim\Bundle\CatalogBundle\Model\AttributeInterface;
 use Pim\Bundle\CatalogBundle\Repository\AttributeRepositoryInterface;
 
@@ -457,6 +458,30 @@ class AttributeRepository extends EntityRepository implements
         } else {
             return array_map('current', $qb->getQuery()->getScalarResult());
         }
+    }
+
+    /**
+     * Get attribute codes by attribute group
+     *
+     * @param AttributeGroupInterface $group
+     *
+     * @return string[]
+     */
+    public function getAttributeCodesByGroup(AttributeGroupInterface $group)
+    {
+        $qb = $this->createQueryBuilder('a');
+        $qb
+            ->select('a.code')
+            ->where($qb->expr()->eq('a.group', ':group'))
+            ->setParameter(':group', $group);
+
+        $result = $qb->getQuery()->getScalarResult();
+
+        if (null === $result) {
+            return [];
+        }
+
+        return array_map('current', $qb->getQuery()->getScalarResult());
     }
 
     /**

--- a/src/Pim/Bundle/TransformBundle/Normalizer/Flat/AttributeGroupNormalizer.php
+++ b/src/Pim/Bundle/TransformBundle/Normalizer/Flat/AttributeGroupNormalizer.php
@@ -2,8 +2,7 @@
 
 namespace Pim\Bundle\TransformBundle\Normalizer\Flat;
 
-use Pim\Bundle\CatalogBundle\Model\AttributeGroupInterface;
-use Pim\Bundle\TransformBundle\Normalizer\Structured;
+use Pim\Bundle\TransformBundle\Normalizer\Structured\AttributeGroupNormalizer as BaseAttributeGroupNormalizer;
 
 /**
  * Flat attribute group normalizer
@@ -12,7 +11,7 @@ use Pim\Bundle\TransformBundle\Normalizer\Structured;
  * @copyright 2013 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class AttributeGroupNormalizer extends Structured\AttributeGroupNormalizer
+class AttributeGroupNormalizer extends BaseAttributeGroupNormalizer
 {
     /**
      * @var array
@@ -22,10 +21,12 @@ class AttributeGroupNormalizer extends Structured\AttributeGroupNormalizer
     /**
      * {@inheritdoc}
      */
-    protected function normalizeAttributes(AttributeGroupInterface $group)
+    public function normalize($object, $format = null, array $context = [])
     {
-        $attributes = parent::normalizeAttributes($group);
+        $data = parent::normalize($object, $format, $context);
 
-        return implode(',', $attributes);
+        $data['attributes'] = implode(',', $data['attributes']);
+
+        return $data;
     }
 }

--- a/src/Pim/Bundle/TransformBundle/Normalizer/Structured/AttributeGroupNormalizer.php
+++ b/src/Pim/Bundle/TransformBundle/Normalizer/Structured/AttributeGroupNormalizer.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Bundle\TransformBundle\Normalizer\Structured;
 
+use Pim\Bundle\CatalogBundle\Doctrine\ORM\Repository\AttributeRepository;
 use Pim\Bundle\CatalogBundle\Model\AttributeGroupInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
@@ -14,36 +15,39 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
  */
 class AttributeGroupNormalizer implements NormalizerInterface
 {
-    /**
-     * @var array
-     */
-    protected $supportedFormats = array('json', 'xml');
+    /** @var array */
+    protected $supportedFormats = ['json', 'xml'];
 
-    /**
-     * @var TranslationNormalizer
-     */
+    /** @var NormalizerInterface */
     protected $transNormalizer;
+
+    /** @var AttributeRepository */
+    protected $attributeRepository;
 
     /**
      * Constructor
      *
-     * @param TranslationNormalizer $transNormalizer
+     * @param NormalizerInterface $transNormalizer
+     * @param AttributeRepository $attributeRepository
      */
-    public function __construct(TranslationNormalizer $transNormalizer)
-    {
+    public function __construct(
+        NormalizerInterface $transNormalizer,
+        AttributeRepository $attributeRepository = null
+    ) {
         $this->transNormalizer = $transNormalizer;
+        $this->attributeRepository = $attributeRepository;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function normalize($object, $format = null, array $context = array())
+    public function normalize($object, $format = null, array $context = [])
     {
-        return array(
+        return [
             'code'       => $object->getCode(),
             'sortOrder'  => $object->getSortOrder(),
             'attributes' => $this->normalizeAttributes($object)
-        ) + $this->transNormalizer->normalize($object, $format, $context);
+        ] + $this->transNormalizer->normalize($object, $format, $context);
     }
 
     /**
@@ -63,7 +67,11 @@ class AttributeGroupNormalizer implements NormalizerInterface
      */
     protected function normalizeAttributes(AttributeGroupInterface $group)
     {
-        $attributes = array();
+        if (null !== $this->attributeRepository) {
+            return $this->attributeRepository->getAttributeCodesByGroup($group);
+        }
+
+        $attributes = [];
         foreach ($group->getAttributes() as $attribute) {
             $attributes[] = $attribute->getCode();
         }

--- a/src/Pim/Bundle/TransformBundle/Resources/config/serializer/flat.yml
+++ b/src/Pim/Bundle/TransformBundle/Resources/config/serializer/flat.yml
@@ -80,6 +80,7 @@ services:
         class: %pim_serializer.normalizer.flat.attribute_group.class%
         arguments:
             - '@pim_serializer.normalizer.flat.label_translation'
+            - '@pim_catalog.repository.attribute'
         tags:
             - { name: pim_serializer.normalizer, priority: 90 }
 

--- a/src/Pim/Bundle/TransformBundle/Resources/config/serializer/structured.yml
+++ b/src/Pim/Bundle/TransformBundle/Resources/config/serializer/structured.yml
@@ -102,6 +102,7 @@ services:
         class: %pim_serializer.normalizer.attribute_group.class%
         arguments:
             - '@pim_serializer.normalizer.label_translation'
+            - '@pim_catalog.repository.attribute'
         tags:
             - { name: pim_serializer.normalizer, priority: 90 }
 

--- a/src/Pim/Bundle/VersioningBundle/Resources/config/event_subscribers.yml
+++ b/src/Pim/Bundle/VersioningBundle/Resources/config/event_subscribers.yml
@@ -9,10 +9,7 @@ services:
     pim_versioning.event_subscriber.addversion:
         class: %pim_versioning.event_subscriber.addversion.class%
         arguments:
-            - '@pim_versioning.manager.version'
-            - '@pim_versioning.update_guesser.chained'
-            - '@pim_versioning.serializer'
-            - '@pim_versioning.context.version'
+            - '@service_container'
         tags:
             - { name: doctrine.event_subscriber }
 

--- a/src/Pim/Bundle/VersioningBundle/Resources/config/serializer/flat.yml
+++ b/src/Pim/Bundle/VersioningBundle/Resources/config/serializer/flat.yml
@@ -36,6 +36,7 @@ services:
         class: %pim_serializer.normalizer.flat.attribute_group.class%
         arguments:
             - '@pim_serializer.normalizer.flat.label_translation'
+            - '@pim_catalog.repository.attribute'
         tags:
             - { name: pim_versioning.serializer.normalizer, priority: 90 }
 


### PR DESCRIPTION
The goal of this PR is to reduce the memory footprint and request time of whatever uses the `AttributeGroupNormalizer`. Actually `Rest\AttributegroupController` and `VersionManager` are using this normalizers so it should fix some performance issues in the product edit form ans during the versioning management.

Note: To make this PR 1.4 compatible and avoid BC Break, the injection of AttributeRepository is optional in this version. We will remove this compatibility layer during the merge on master branch.

| Q                 | A
| ----------------- | ---
| Specs             | Y
| Behats            | Running
| Blue CI           | Running
| Changelog updated | Y
| Review and 2 GTM  | todo
| Micro Demo (PO)   | todo
| Migration script  | N/A
| Tech Doc          | N/A