### PR TITLE
[TR] PIM-5224: Fix first matching option on selects during filtering via the pqb

### DIFF
--- a/CHANGELOG-1.3.md
+++ b/CHANGELOG-1.3.md
@@ -1,3 +1,9 @@
+# 1.3.x
+
+## Bug fixes
+
+- PIM-5224: Fix first matching option on selects during filtering via the pqb
+
 # 1.3.32 (2015-11-19)
 
 ## Technical improvements

--- a/features/filter/option.feature
+++ b/features/filter/option.feature
@@ -16,3 +16,21 @@ Feature: Filter on select attributes
       | [{"field":"size.code", "operator":"IN",    "value": ["44"] }]       | ["BOOTBS"]            |
       | [{"field":"size.code", "operator":"IN",    "value": ["44", "38"] }] | ["BOOTBS", "BOOTWXS"] |
       | [{"field":"size.code", "operator":"EMPTY", "value": null }]         | ["BOOTRXS"]           |
+
+  @jira https://akeneo.atlassian.net/browse/PIM-5224
+  Scenario: Successfully filter on select attributes that have the same option codes
+    Given a "footwear" catalog configuration
+    And the following attributes:
+      | code            | label           | type         |
+      | main_color      | Main color      | simpleselect |
+      | secondary_color | Secondary color | simpleselect |
+    And the following "main_color" attribute options: purple
+    And the following "secondary_color" attribute options: purple
+    And the following products:
+      | sku        | main_color | secondary_color |
+      | high-heels | purple     |                 |
+      | rangers    |            | purple          |
+    Then I should get the following results for the given filters:
+      | filter                                                                    | result         |
+      | [{"field":"main_color.code", "operator":"IN", "value": ["purple"] }]      | ["high-heels"] |
+      | [{"field":"secondary_color.code", "operator":"IN", "value": ["purple"] }] | ["rangers"]    |

--- a/features/filter/options.feature
+++ b/features/filter/options.feature
@@ -18,3 +18,21 @@ Feature: Filter on multi select attributes
       | [{"field":"weather_conditions.code", "operator":"IN",    "value": ["wet", "hot"] }]                                                                | ["BOOTBS", "BOOTBL", "BOOTBXS"] |
       | [{"field":"weather_conditions.code", "operator":"IN", "value": ["wet"] }, {"field":"weather_conditions.code", "operator":"IN", "value": ["hot"] }] | ["BOOTBL"]                      |
       | [{"field":"weather_conditions.code", "operator":"EMPTY", "value": null }]                                                                          | ["BOOTRXS"]                     |
+
+  @jira https://akeneo.atlassian.net/browse/PIM-5224
+  Scenario: Successfully filter on multi select attributes that have the same option codes
+    Given a "footwear" catalog configuration
+    And the following attributes:
+      | code            | label           | type        |
+      | main_color      | Main color      | multiselect |
+      | secondary_color | Secondary color | multiselect |
+    And the following "main_color" attribute options: purple and red
+    And the following "secondary_color" attribute options: purple and red
+    And the following products:
+      | sku        | main_color  | secondary_color |
+      | high-heels | purple, red |                 |
+      | rangers    |             | purple,red      |
+    Then I should get the following results for the given filters:
+      | filter                                                                           | result         |
+      | [{"field":"main_color.code", "operator":"IN", "value": ["purple", "red"] }]      | ["high-heels"] |
+      | [{"field":"secondary_color.code", "operator":"IN", "value": ["purple", "red"] }] | ["rangers"]    |

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Filter/ObjectIdResolver.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Filter/ObjectIdResolver.php
@@ -4,6 +4,7 @@ namespace Pim\Bundle\CatalogBundle\Doctrine\Common\Filter;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Pim\Bundle\CatalogBundle\Exception\ObjectNotFoundException;
+use Pim\Bundle\CatalogBundle\Model\AttributeInterface;
 
 /**
  * Object id resolver
@@ -31,7 +32,7 @@ class ObjectIdResolver implements ObjectIdResolverInterface
     /**
      * {@inheritdoc}
      */
-    public function getIdsFromCodes($entityName, array $codes)
+    public function getIdsFromCodes($entityName, array $codes, AttributeInterface $attribute = null)
     {
         if (!isset($this->fieldMapping[$entityName])) {
             throw new \InvalidArgumentException(sprintf('The class %s cannot be found', $entityName));
@@ -43,7 +44,12 @@ class ObjectIdResolver implements ObjectIdResolverInterface
 
         $ids = [];
         foreach ($codes as $code) {
-            $entity = $repository->findOneBy(['code' => $code]);
+            $criterias = ['code' => $code];
+            if (null !== $attribute) {
+                $criterias['attribute'] = $attribute->getId();
+            }
+
+            $entity = $repository->findOneBy($criterias);
 
             if (!$entity) {
                 throw new ObjectNotFoundException(

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Filter/ObjectIdResolverInterface.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Filter/ObjectIdResolverInterface.php
@@ -2,6 +2,8 @@
 
 namespace Pim\Bundle\CatalogBundle\Doctrine\Common\Filter;
 
+use Pim\Bundle\CatalogBundle\Model\AttributeInterface;
+
 /**
  * Object id resolver interface
  *
@@ -13,12 +15,13 @@ interface ObjectIdResolverInterface
 {
     /**
      * Get ids for the given codes
-     * @param string $field
-     * @param array  $codes
+     * @param string                  $field
+     * @param array                   $codes
+     * @param AttributeInterface|null $attribute
      *
      * @return int[]
      */
-    public function getIdsFromCodes($field, array $codes);
+    public function getIdsFromCodes($field, array $codes, AttributeInterface $attribute = null);
 
     /**
      * Add a mapping to the field mapping

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/OptionFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/OptionFilter.php
@@ -90,7 +90,7 @@ class OptionFilter extends AbstractAttributeFilter implements AttributeFilterInt
             $this->checkValue($options['field'], $value);
 
             if (FieldFilterHelper::getProperty($options['field']) === FieldFilterHelper::CODE_PROPERTY) {
-                $value = $this->objectIdResolver->getIdsFromCodes('option', $value);
+                $value = $this->objectIdResolver->getIdsFromCodes('option', $value, $attribute);
             }
         }
 

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/OptionsFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/OptionsFilter.php
@@ -89,7 +89,7 @@ class OptionsFilter extends AbstractAttributeFilter implements AttributeFilterIn
             $this->checkValue($options['field'], $value);
 
             if (FieldFilterHelper::getProperty($options['field']) === FieldFilterHelper::CODE_PROPERTY) {
-                $value = $this->objectIdResolver->getIdsFromCodes('option', $value);
+                $value = $this->objectIdResolver->getIdsFromCodes('option', $value, $attribute);
             }
         } else {
             $value = !is_array($value) ? [$value] : $value;

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/OptionFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/OptionFilter.php
@@ -100,7 +100,7 @@ class OptionFilter extends AbstractAttributeFilter implements AttributeFilterInt
             $condition = $this->prepareAttributeJoinCondition($attribute, $joinAlias, $locale, $scope);
 
             if (FieldFilterHelper::getProperty($field) === FieldFilterHelper::CODE_PROPERTY) {
-                $value = $this->objectIdResolver->getIdsFromCodes('option', $value);
+                $value = $this->objectIdResolver->getIdsFromCodes('option', $value, $attribute);
             }
 
             $condition .= ' AND ( ' . $this->qb->expr()->in($optionAlias, $value) . ' ) ';

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/OptionsFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/OptionsFilter.php
@@ -97,7 +97,7 @@ class OptionsFilter extends AbstractAttributeFilter implements AttributeFilterIn
                 ->andWhere($this->qb->expr()->isNull($backendField));
         } else {
             if (FieldFilterHelper::getProperty($options['field']) === FieldFilterHelper::CODE_PROPERTY) {
-                $value = $this->objectIdResolver->getIdsFromCodes('option', $value);
+                $value = $this->objectIdResolver->getIdsFromCodes('option', $value, $attribute);
             }
 
             $this->qb


### PR DESCRIPTION
Imagine you have 2 attributes: `attr1` and `attr2` (multi or simple select). Each attribute has the following options: `red`, `blue`, `purple`.

Let's say you want to filter the products with `attr2 IN purple`. 
Currently, the `purple` option that is returned by the filters is ALWAYS the one that belongs to `attr1` because the attribute is not taken into account.

| Q                 | A
| ----------------- | ---
| Specs             | Y
| Behats            | Y
| Blue CI           | running
| Changelog updated | Y
| Review and 2 GTM  |
