### PR TITLE
Remove specific routes for JS router component

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Resources/config/bundles/fos_js_routing.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/bundles/fos_js_routing.yml
@@ -1,2 +1,2 @@
 fos_js_routing:
-    routes_to_expose:          [oro_*, pim_*]
+    routes_to_expose: ~


### PR DESCRIPTION
When you want to add new routes on the JS Router component, if they does not start by pim_ or oro_, you need to add them in that's hidden configuration.

Here it will add 5 routes (+ routes in development environment: _profiler, etc.) but it will automatically add your project routes to the JS component.

| Q                 | A
| ----------------- | ---
| Added Specs       | NA
| Added Behats      | NA
| Travis CI is ok   | 
| Changelog updated | Let me know if needed?