### PR TITLE
PIM-5240: Fix Mongo normalization that creates a nullable family field

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -11,6 +11,7 @@
 - PIM-5201: Fix permission System/Edit a Role
 - PIM-5172: Fix PDF export for text area attribute
 - PIM-5171: Apply ACLs on mass edit actions
+- PIM-5240: Fix Mongo normalization that creates a nullable family field
 
 # 1.4.10 (2015-11-20)
 

--- a/spec/Pim/Bundle/TransformBundle/Normalizer/MongoDB/ProductNormalizerSpec.php
+++ b/spec/Pim/Bundle/TransformBundle/Normalizer/MongoDB/ProductNormalizerSpec.php
@@ -105,6 +105,63 @@ class ProductNormalizerSpec extends ObjectBehavior
         ]);
     }
 
+    function it_normalizes_a_new_product_without_family_into_mongodb_document(
+        $mongoFactory,
+        $serializer,
+        ProductInterface $product,
+        \MongoId $mongoId,
+        \MongoDate $mongoDate,
+        Association $assoc1,
+        Association $assoc2,
+        CategoryInterface $category1,
+        CategoryInterface $category2,
+        GroupInterface $group1,
+        GroupInterface $group2,
+        ProductValueInterface $value1,
+        ProductValueInterface $value2
+    ) {
+        $mongoFactory->createMongoId()->willReturn($mongoId);
+        $mongoFactory->createMongoDate()->willReturn($mongoDate);
+
+        $category1->getId()->willReturn(12);
+        $category2->getId()->willReturn(34);
+
+        $group1->getId()->willReturn(56);
+        $group2->getId()->willReturn(78);
+
+        $product->getId()->willReturn(null);
+        $product->getCreated()->willReturn(null);
+        $product->getFamily()->willReturn(null);
+        $product->isEnabled()->willReturn(true);
+        $product->getGroups()->willReturn([$group1, $group2]);
+        $product->getCategories()->willReturn([$category1, $category2]);
+        $product->getAssociations()->willReturn([$assoc1, $assoc2]);
+        $product->getValues()->willReturn([$value1, $value2]);
+
+        $context = ['_id' => $mongoId];
+
+        $serializer
+            ->normalize($product, 'mongodb_json')
+            ->willReturn(['data' => 'data', 'completenesses' => 'completenesses']);
+        $serializer->normalize($value1, 'mongodb_document', $context)->willReturn('my_value_1');
+        $serializer->normalize($value2, 'mongodb_document', $context)->willReturn('my_value_2');
+        $serializer->normalize($assoc1, 'mongodb_document', $context)->willReturn('my_assoc_1');
+        $serializer->normalize($assoc2, 'mongodb_document', $context)->willReturn('my_assoc_2');
+
+        $this->normalize($product, 'mongodb_document')->shouldReturn([
+            '_id'            => $mongoId,
+            'created'        => $mongoDate,
+            'updated'        => $mongoDate,
+            'enabled'        => true,
+            'groupIds'       => [56, 78],
+            'categoryIds'    => [12, 34],
+            'associations'   => ['my_assoc_1', 'my_assoc_2'],
+            'values'         => ['my_value_1', 'my_value_2'],
+            'normalizedData' => ['data' => 'data'],
+            'completenesses' => []
+        ]);
+    }
+
     function it_normalizes_an_existing_product_into_mongodb_document(
         $mongoFactory,
         $serializer,
@@ -156,6 +213,63 @@ class ProductNormalizerSpec extends ObjectBehavior
             'created'        => $mongoDate,
             'updated'        => $mongoDate,
             'family'         => 36,
+            'enabled'        => true,
+            'groupIds'       => [56, 78],
+            'categoryIds'    => [12, 34],
+            'associations'   => ['my_assoc_1', 'my_assoc_2'],
+            'values'         => ['my_value_1', 'my_value_2'],
+            'normalizedData' => ['data' => 'data'],
+            'completenesses' => []
+        ]);
+    }
+
+    function it_normalizes_an_existing_product_without_family_into_mongodb_document(
+        $mongoFactory,
+        $serializer,
+        ProductInterface $product,
+        \MongoId $mongoId,
+        \MongoDate $mongoDate,
+        Association $assoc1,
+        Association $assoc2,
+        CategoryInterface $category1,
+        CategoryInterface $category2,
+        GroupInterface $group1,
+        GroupInterface $group2,
+        ProductValueInterface $value1,
+        ProductValueInterface $value2
+    ) {
+        $mongoFactory->createMongoId('product1')->willReturn($mongoId);
+        $mongoFactory->createMongoDate()->willReturn($mongoDate);
+
+        $category1->getId()->willReturn(12);
+        $category2->getId()->willReturn(34);
+
+        $group1->getId()->willReturn(56);
+        $group2->getId()->willReturn(78);
+
+        $product->getId()->willReturn('product1');
+        $product->getCreated()->willReturn(null);
+        $product->getFamily()->willReturn(null);
+        $product->isEnabled()->willReturn(true);
+        $product->getGroups()->willReturn([$group1, $group2]);
+        $product->getCategories()->willReturn([$category1, $category2]);
+        $product->getAssociations()->willReturn([$assoc1, $assoc2]);
+        $product->getValues()->willReturn([$value1, $value2]);
+
+        $context = ['_id' => $mongoId];
+
+        $serializer
+            ->normalize($product, 'mongodb_json')
+            ->willReturn(['data' => 'data', 'completenesses' => 'completenesses']);
+        $serializer->normalize($value1, 'mongodb_document', $context)->willReturn('my_value_1');
+        $serializer->normalize($value2, 'mongodb_document', $context)->willReturn('my_value_2');
+        $serializer->normalize($assoc1, 'mongodb_document', $context)->willReturn('my_assoc_1');
+        $serializer->normalize($assoc2, 'mongodb_document', $context)->willReturn('my_assoc_2');
+
+        $this->normalize($product, 'mongodb_document')->shouldReturn([
+            '_id'            => $mongoId,
+            'created'        => $mongoDate,
+            'updated'        => $mongoDate,
             'enabled'        => true,
             'groupIds'       => [56, 78],
             'categoryIds'    => [12, 34],

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/FamilyFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/FamilyFilter.php
@@ -73,10 +73,13 @@ class FamilyFilter extends AbstractFilter implements FieldFilterInterface
                 $this->qb->field($fieldCode)->notIn($value);
                 break;
             case Operators::IS_EMPTY:
+                $exists = new Expr();
+                $equals = new Expr();
                 $expr = new Expr();
-                $this->qb->addAnd(
-                    $expr->field($fieldCode)->exists(false)
-                );
+                $exists->field($fieldCode)->exists(false);
+                $equals->field($fieldCode)->equals(null);
+                $expr->addOr($exists)->addOr($equals);
+                $this->qb->addAnd($expr);
                 break;
         }
 

--- a/src/Pim/Bundle/TransformBundle/Normalizer/MongoDB/ProductNormalizer.php
+++ b/src/Pim/Bundle/TransformBundle/Normalizer/MongoDB/ProductNormalizer.php
@@ -86,8 +86,11 @@ class ProductNormalizer implements NormalizerInterface, SerializerAwareInterface
 
         $data['updated'] = $this->mongoFactory->createMongoDate();
 
-        $data['family']         = $product->getFamily() ? $product->getFamily()->getId() : null;
-        $data['enabled']        = $product->isEnabled();
+        if (null !== $product->getFamily()) {
+            $data['family'] = $product->getFamily()->getId();
+        }
+
+        $data['enabled'] = $product->isEnabled();
 
         $data['groupIds']       = $this->normalizeGroups($product->getGroups());
         $data['categoryIds']    = $this->normalizeCategories($product->getCategories());


### PR DESCRIPTION
Impossible to create a behat as this wrong normalization is only used by the DirectToDb Mongo writer.

| Q                 | A
| ----------------- | ---
| Specs             | Y
| Behats            | -
| Blue CI           | CE Y, EE running
| Changelog updated | Y
| Review and 2 GTM  |