### PR TITLE
[TR] PIM-5218: Use DirectToMongoDB saver natively

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -7,6 +7,13 @@
 - PIM-5208: Fix the datagrid performance issue related to large number of attributes, only attribute usable in grid will be available
 - PIM-5215: Create empty product values for new family attributes after product import with family change
 
+## BC Breaks
+- Changed constructor of `Pim\Bundle\TransformBundle\Normalizer\MongoDB\ProductValueNormalizer`to add a `Doctrine\Common\Persistence\ManagerRegistry` (instead of a DocumentManager to avoid circular references)
+  It is required because normalization of reference data in product values is based on Doctrine metadata.
+
+## Performance improvements
+- PIM-5218: Use DirectToMongoDB bulk product saver natively. This considerably speeds up all bulk actions on a MongoDB storage install (imports, mass edit, rules application, etc.).
+
 # 1.4.11 (2015-11-27)
 
 ## BC Breaks

--- a/spec/Akeneo/Bundle/StorageUtilsBundle/Doctrine/Common/Saver/BaseSaverSpec.php
+++ b/spec/Akeneo/Bundle/StorageUtilsBundle/Doctrine/Common/Saver/BaseSaverSpec.php
@@ -96,8 +96,12 @@ class BaseSaverSpec extends ObjectBehavior
         $this->saveAll([$type1, $type2], ['flush' => false]);
     }
 
-    function it_throws_exception_when_save_anything_else_than_the_expected_class()
+    function it_throws_exception_when_save_anything_else_than_the_expected_class($optionsResolver)
     {
+        $optionsResolver->resolveSaveAllOptions(Argument::any())
+            ->shouldBeCalled()
+            ->willReturn(['flush' => false]);
+
         $anythingElse = new \stdClass();
         $exception = new \InvalidArgumentException(
             sprintf(

--- a/spec/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Saver/ProductSaverSpec.php
+++ b/spec/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Saver/ProductSaverSpec.php
@@ -10,7 +10,7 @@ use Doctrine\ODM\MongoDB\DocumentManager;
 use PhpSpec\ObjectBehavior;
 use Pim\Bundle\CatalogBundle\Manager\CompletenessManager;
 use Pim\Bundle\CatalogBundle\Model\ProductInterface;
-use Pim\Bundle\VersioningBundle\Doctrine\MongoDBODM\BulkVersionSaver;
+use Pim\Bundle\VersioningBundle\Doctrine\MongoDBODM\Saver\BulkVersionSaver;
 use Prophecy\Argument;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;

--- a/spec/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Saver/ProductSaverSpec.php
+++ b/spec/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Saver/ProductSaverSpec.php
@@ -10,6 +10,7 @@ use Doctrine\ODM\MongoDB\DocumentManager;
 use PhpSpec\ObjectBehavior;
 use Pim\Bundle\CatalogBundle\Manager\CompletenessManager;
 use Pim\Bundle\CatalogBundle\Model\ProductInterface;
+use Pim\Bundle\VersioningBundle\Doctrine\MongoDBODM\BulkVersionBuilder;
 use Pim\Bundle\VersioningBundle\Doctrine\MongoDBODM\Saver\BulkVersionSaver;
 use Prophecy\Argument;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -22,6 +23,7 @@ class ProductSaverSpec extends ObjectBehavior
         CompletenessManager $completenessManager,
         SavingOptionsResolverInterface $optionsResolver,
         EventDispatcherInterface $eventDispatcher,
+        BulkVersionBuilder $bulkVersionBuilder,
         BulkVersionSaver $versionSaver,
         NormalizerInterface $normalizer,
         MongoObjectsFactory $mongoFactory,
@@ -32,6 +34,7 @@ class ProductSaverSpec extends ObjectBehavior
             $completenessManager,
             $optionsResolver,
             $eventDispatcher,
+            $bulkVersionBuilder,
             $versionSaver,
             $normalizer,
             $mongoFactory,
@@ -41,6 +44,8 @@ class ProductSaverSpec extends ObjectBehavior
 
         $documentManager->getDocumentCollection('Pim\Bundle\CatalogBundle\Model\Product')->willReturn($collection);
         $collection->getName()->willReturn('pim_catalog_product');
+
+        $bulkVersionBuilder->buildVersions(Argument::any())->willReturn([]);
 
         $optionsResolver
             ->resolveSaveAllOptions(Argument::any())
@@ -97,7 +102,7 @@ class ProductSaverSpec extends ObjectBehavior
         $collection->update(['_id' => 'id_a'], ['_id' => 'id_a', 'key_a' => 'data_a'])->shouldBeCalled();
         $collection->update(['_id' => 'id_b'], ['_id' => 'id_b', 'key_b' => 'data_b'])->shouldBeCalled();
 
-        $versionSaver->bulkSave($products)->shouldBeCalled();
+        $versionSaver->saveAll(Argument::any())->shouldBeCalled();
 
         $this->saveAll($products);
     }

--- a/spec/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Saver/ProductSaverSpec.php
+++ b/spec/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Saver/ProductSaverSpec.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace spec\Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Saver;
+
+use Akeneo\Bundle\StorageUtilsBundle\MongoDB\MongoObjectsFactory;
+use Akeneo\Component\StorageUtils\Saver\SavingOptionsResolverInterface;
+use Akeneo\Component\StorageUtils\StorageEvents;
+use Doctrine\MongoDB\Collection;
+use Doctrine\ODM\MongoDB\DocumentManager;
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\CatalogBundle\Manager\CompletenessManager;
+use Pim\Bundle\CatalogBundle\Model\ProductInterface;
+use Pim\Bundle\VersioningBundle\Doctrine\MongoDBODM\BulkVersionSaver;
+use Prophecy\Argument;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+class ProductSaverSpec extends ObjectBehavior
+{
+    function let(
+        DocumentManager $documentManager,
+        CompletenessManager $completenessManager,
+        SavingOptionsResolverInterface $optionsResolver,
+        EventDispatcherInterface $eventDispatcher,
+        BulkVersionSaver $versionSaver,
+        NormalizerInterface $normalizer,
+        MongoObjectsFactory $mongoFactory,
+        Collection $collection
+    ) {
+        $this->beConstructedWith(
+            $documentManager,
+            $completenessManager,
+            $optionsResolver,
+            $eventDispatcher,
+            $versionSaver,
+            $normalizer,
+            $mongoFactory,
+            'Pim\Bundle\CatalogBundle\Model\Product',
+            'my_db'
+        );
+
+        $documentManager->getDocumentCollection('Pim\Bundle\CatalogBundle\Model\Product')->willReturn($collection);
+        $collection->getName()->willReturn('pim_catalog_product');
+
+        $optionsResolver
+            ->resolveSaveAllOptions(Argument::any())
+            ->willReturn(
+                [
+                    'flush'       => true,
+                    'recalculate' => false,
+                    'schedule'    => true
+                ]
+            );
+    }
+
+    function it_is_a_saver()
+    {
+        $this->shouldImplement('Akeneo\Component\StorageUtils\Saver\SaverInterface');
+    }
+
+    function it_is_a_bulk_saver()
+    {
+        $this->shouldImplement('Akeneo\Component\StorageUtils\Saver\BulkSaverInterface');
+    }
+
+    function it_inserts_or_updates_several_products(
+        $versionSaver,
+        $normalizer,
+        $collection,
+        ProductInterface $product_a,
+        ProductInterface $product_b,
+        ProductInterface $product_c,
+        ProductInterface $product_d
+    ) {
+        $products = [$product_a, $product_b, $product_c, $product_d];
+
+        $product_a->getId()->willReturn('id_a');
+        $product_b->getId()->willReturn('id_b');
+        $product_c->getId()->willReturn(null);
+        $product_d->getId()->willReturn(null);
+
+        $product_c->setId(Argument::any())->shouldBeCalled();
+        $product_d->setId(Argument::any())->shouldBeCalled();
+
+        $normalizer->normalize($product_a, Argument::cetera())->willReturn(['_id' => 'id_a', 'key_a' => 'data_a']);
+        $normalizer->normalize($product_b, Argument::cetera())->willReturn(['_id' => 'id_b', 'key_b' => 'data_b']);
+        $normalizer->normalize($product_c, Argument::cetera())->willReturn(['_id' => 'id_c', 'key_c' => 'data_c']);
+        $normalizer->normalize($product_d, Argument::cetera())->willReturn(['_id' => 'id_d', 'key_d' => 'data_d']);
+
+        $collection->batchInsert(
+            [
+                ['_id' => 'id_c', 'key_c' => 'data_c'],
+                ['_id' => 'id_d', 'key_d' => 'data_d']
+            ]
+        )->shouldBeCalled();
+
+        $collection->update(['_id' => 'id_a'], ['_id' => 'id_a', 'key_a' => 'data_a'])->shouldBeCalled();
+        $collection->update(['_id' => 'id_b'], ['_id' => 'id_b', 'key_b' => 'data_b'])->shouldBeCalled();
+
+        $versionSaver->bulkSave($products)->shouldBeCalled();
+
+        $this->saveAll($products);
+    }
+
+    function it_dispatches_events_on_save(
+        $eventDispatcher,
+        $collection,
+        ProductInterface $product_a,
+        ProductInterface $product_b
+    ) {
+        $eventDispatcher->dispatch(StorageEvents::PRE_SAVE_ALL, Argument::cetera())->shouldBeCalled();
+        $eventDispatcher->dispatch(StorageEvents::POST_SAVE_ALL, Argument::cetera())->shouldBeCalled();
+        $collection->batchInsert(Argument::any())->willReturn(null);
+
+        $this->saveAll([$product_a, $product_b]);
+    }
+}

--- a/spec/Pim/Bundle/ReferenceDataBundle/Normalizer/MongoDB/ReferenceDataNormalizerSpec.php
+++ b/spec/Pim/Bundle/ReferenceDataBundle/Normalizer/MongoDB/ReferenceDataNormalizerSpec.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace spec\Pim\Bundle\ReferenceDataBundle\Normalizer\MongoDB;
+
+use PhpSpec\ObjectBehavior;
+use Pim\Component\ReferenceData\Model\ReferenceDataInterface;
+
+class ReferenceDataNormalizerSpec extends ObjectBehavior
+{
+    function it_is_a_normalizer()
+    {
+        $this->shouldImplement('Symfony\Component\Serializer\Normalizer\NormalizerInterface');
+    }
+
+    function it_supports_normalization_of_reference_data_in_mongodb_document(ReferenceDataInterface $refData)
+    {
+        $this->supportsNormalization($refData, 'mongodb_document')->shouldReturn(true);
+    }
+
+    function it_does_not_support_normalization_of_other_entities(\stdClass $object)
+    {
+        $this->supportsNormalization($object, 'mongodb_document')->shouldReturn(false);
+    }
+
+    function it_does_not_support_normalization_of_reference_data_into_other_format(ReferenceDataInterface $refData)
+    {
+        $this->supportsNormalization($refData, 'json')->shouldReturn(false);
+    }
+
+    function it_normalizes_a_reference_data_into_mongodb_document(ReferenceDataInterface $refData) {
+        $refData->getId()->willReturn('ref_id');
+        $this->normalize($refData, 'mongodb_document')->shouldReturn('ref_id');
+    }
+}

--- a/spec/Pim/Bundle/ReferenceDataBundle/Normalizer/MongoDB/ReferenceDataNormalizerSpec.php
+++ b/spec/Pim/Bundle/ReferenceDataBundle/Normalizer/MongoDB/ReferenceDataNormalizerSpec.php
@@ -27,7 +27,8 @@ class ReferenceDataNormalizerSpec extends ObjectBehavior
         $this->supportsNormalization($refData, 'json')->shouldReturn(false);
     }
 
-    function it_normalizes_a_reference_data_into_mongodb_document(ReferenceDataInterface $refData) {
+    function it_normalizes_a_reference_data_into_mongodb_document(ReferenceDataInterface $refData)
+    {
         $refData->getId()->willReturn('ref_id');
         $this->normalize($refData, 'mongodb_document')->shouldReturn('ref_id');
     }

--- a/spec/Pim/Bundle/TransformBundle/Normalizer/MongoDB/MetricNormalizerSpec.php
+++ b/spec/Pim/Bundle/TransformBundle/Normalizer/MongoDB/MetricNormalizerSpec.php
@@ -63,11 +63,11 @@ class MetricNormalizerSpec extends ObjectBehavior
 
         $this->normalize($metric, 'mongodb_document')->shouldReturn([
             '_id'      => $mongoId,
+            'family'   => 'weight',
             'unit'     => 'Kg',
             'data'     => 85,
             'baseUnit' => 'g',
-            'baseData' => 8500,
-            'family'   => 'weight'
+            'baseData' => 8500
         ]);
     }
 }

--- a/spec/Pim/Bundle/TransformBundle/Normalizer/MongoDB/ProductValueNormalizerSpec.php
+++ b/spec/Pim/Bundle/TransformBundle/Normalizer/MongoDB/ProductValueNormalizerSpec.php
@@ -3,6 +3,7 @@
 namespace spec\Pim\Bundle\TransformBundle\Normalizer\MongoDB;
 
 use Akeneo\Bundle\StorageUtilsBundle\MongoDB\MongoObjectsFactory;
+use Doctrine\Common\Persistence\ManagerRegistry;
 use PhpSpec\ObjectBehavior;
 use Pim\Bundle\CatalogBundle\Model\AttributeInterface;
 use Pim\Bundle\CatalogBundle\Model\ProductValueInterface;
@@ -13,9 +14,9 @@ use Symfony\Component\Serializer\SerializerInterface;
  */
 class ProductValueNormalizerSpec extends ObjectBehavior
 {
-    function let(MongoObjectsFactory $mongoFactory, SerializerInterface $serializer)
+    function let(MongoObjectsFactory $mongoFactory, ManagerRegistry $managerRegistry, SerializerInterface $serializer)
     {
-        $this->beConstructedWith($mongoFactory);
+        $this->beConstructedWith($mongoFactory, $managerRegistry);
         $serializer->implement('Symfony\Component\Serializer\Normalizer\NormalizerInterface');
         $this->setSerializer($serializer);
     }
@@ -48,13 +49,14 @@ class ProductValueNormalizerSpec extends ObjectBehavior
         \MongoDBRef $mongoDBRef,
         \MongoId $mongoId
     ) {
-        $context = ['_id' => $mongoId, 'collection_name' => 'product'];
+        $context = ['_id' => $mongoId, 'collection_name' => 'product', 'database_name' => 'my_db'];
 
         $mongoFactory->createMongoId()->willReturn($mongoId);
-        $mongoFactory->createMongoDBRef('product', $mongoId)->willReturn($mongoDBRef);
+        $mongoFactory->createMongoDBRef('product', $mongoId, 'my_db')->willReturn($mongoDBRef);
 
         $attribute->getId()->willReturn(123);
         $attribute->getBackendType()->willReturn('text');
+        $attribute->getReferenceDataName()->willReturn(null);
 
         $value->getAttribute()->willReturn($attribute);
         $value->getData()->willReturn('my description');

--- a/spec/Pim/Bundle/VersioningBundle/Doctrine/MongoDBODM/BulkVersionBuilderSpec.php
+++ b/spec/Pim/Bundle/VersioningBundle/Doctrine/MongoDBODM/BulkVersionBuilderSpec.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace spec\Pim\Bundle\VersioningBundle\Doctrine\MongoDBODM;
+
+use Doctrine\MongoDB\Collection;
+use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\Query\Builder;
+use Doctrine\ODM\MongoDB\Query\Query;
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\VersioningBundle\Builder\VersionBuilder;
+use Pim\Bundle\VersioningBundle\Manager\VersionContext;
+use Pim\Bundle\VersioningBundle\Model\Version;
+use Pim\Bundle\VersioningBundle\Model\VersionableInterface;
+use Prophecy\Argument;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+class BulkVersionBuilderSpec extends ObjectBehavior
+{
+    const VERSION_CLASS = 'Pim\Bundle\VersioningBundle\Model\Version';
+
+    function let(
+        VersionBuilder $versionBuilder,
+        VersionContext $versionContext,
+        DocumentManager $documentManager,
+        EventDispatcherInterface $eventDispatcher
+    ) {
+        $this->beConstructedWith(
+            $versionBuilder,
+            $versionContext,
+            $documentManager,
+            $eventDispatcher,
+            self::VERSION_CLASS
+        );
+    }
+
+    function it_builds_versions_for_several_versionable_objects(
+        $versionBuilder,
+        $documentManager,
+        Collection $collection,
+        Builder $qb,
+        Query $query,
+        VersionableInterface $versionable_a,
+        VersionableInterface $versionable_b,
+        VersionableInterface $versionable_c,
+        Version $version_a,
+        Version $version_b,
+        Version $version_c
+    ) {
+        $documentManager->getDocumentCollection(self::VERSION_CLASS)->willReturn($collection);
+        $collection->getName()->willReturn('pim_versioning_version');
+
+        $documentManager->createQueryBuilder(Argument::any())->willReturn($qb);
+        $qb->field(Argument::any())->willReturn($qb);
+        $qb->equals(Argument::any())->willReturn($qb);
+        $qb->limit(Argument::any())->willReturn($qb);
+        $qb->sort(Argument::cetera())->willReturn($qb);
+        $qb->getQuery(Argument::any())->willReturn($query);
+        $query->getSingleResult()->willReturn(null);
+
+        $versionBuilder->buildVersion($versionable_a, Argument::cetera())->willReturn($version_a);
+        $versionBuilder->buildVersion($versionable_b, Argument::cetera())->willReturn($version_b);
+        $versionBuilder->buildVersion($versionable_c, Argument::cetera())->willReturn($version_c);
+        $version_a->getChangeset()->willReturn(['enabled' => ['old' => false, 'new' => true]]);
+        $version_b->getChangeset()->willReturn(['enabled' => ['old' => false, 'new' => true]]);
+        $version_c->getChangeset()->willReturn([]);
+
+        $this
+            ->buildVersions([$versionable_a, $versionable_b, $versionable_c])
+            ->shouldReturn([$version_a, $version_b]);
+    }
+
+}

--- a/spec/Pim/Bundle/VersioningBundle/Doctrine/MongoDBODM/BulkVersionSaverSpec.php
+++ b/spec/Pim/Bundle/VersioningBundle/Doctrine/MongoDBODM/BulkVersionSaverSpec.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace spec\Pim\Bundle\VersioningBundle\Doctrine\MongoDBODM;
+
+use Doctrine\MongoDB\Collection;
+use Doctrine\MongoDB\Query\Query;
+use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\Query\Builder;
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\CatalogBundle\Model\ProductInterface;
+use Pim\Bundle\VersioningBundle\Builder\VersionBuilder;
+use Pim\Bundle\VersioningBundle\Manager\VersionContext;
+use Pim\Bundle\VersioningBundle\Manager\VersionManager;
+use Pim\Bundle\VersioningBundle\Model\Version;
+use Prophecy\Argument;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+class BulkVersionSaverSpec extends ObjectBehavior
+{
+    function let(
+        DocumentManager $documentManager,
+        VersionBuilder $versionBuilder,
+        VersionManager $versionManager,
+        VersionContext $versionContext,
+        NormalizerInterface $normalizer,
+        EventDispatcherInterface $eventDispatcher,
+        Collection $collection,
+        Builder $qb,
+        Query $query
+    ) {
+        $this->beConstructedWith(
+            $documentManager,
+            $versionBuilder,
+            $versionManager,
+            $versionContext,
+            $normalizer,
+            $eventDispatcher,
+            'Pim\Bundle\VersioningBundle\Model\Version'
+        );
+
+        $documentManager->getDocumentCollection('Pim\Bundle\VersioningBundle\Model\Version')->willReturn($collection);
+        $collection->getName()->willReturn('pim_versioning_version');
+
+        $documentManager->createQueryBuilder(Argument::any())->willReturn($qb);
+        $qb->field(Argument::any())->willReturn($qb);
+        $qb->equals(Argument::any())->willReturn($qb);
+        $qb->limit(Argument::any())->willReturn($qb);
+        $qb->sort(Argument::cetera())->willReturn($qb);
+        $qb->getQuery(Argument::any())->willReturn($query);
+        $query->getSingleResult()->willReturn(null);
+    }
+
+    function it_builds_and_saves_several_versionable_objects(
+        $versionBuilder,
+        $normalizer,
+        $collection,
+        ProductInterface $product_a,
+        ProductInterface $product_b,
+        ProductInterface $product_c,
+        Version $version_a,
+        Version $version_b,
+        Version $version_c
+    ) {
+        $versionBuilder->buildVersion($product_a, Argument::cetera())->willReturn($version_a);
+        $versionBuilder->buildVersion($product_b, Argument::cetera())->willReturn($version_b);
+        $versionBuilder->buildVersion($product_c, Argument::cetera())->willReturn($version_c);
+        $version_a->getChangeset()->willReturn(['enabled' => ['old' => false, 'new' => true]]);
+        $version_b->getChangeset()->willReturn(['enabled' => ['old' => false, 'new' => true]]);
+        $version_c->getChangeset()->willReturn([]);
+
+        $product_a->getId()->willReturn('id_a');
+        $product_b->getId()->willReturn('id_b');
+
+        $normalizer->normalize($version_a, 'mongodb_document')->willReturn(['version_a_normalized']);
+        $normalizer->normalize($version_b, 'mongodb_document')->willReturn(['version_b_normalized']);
+
+        $collection->batchInsert(
+            [
+                ['version_a_normalized'],
+                ['version_b_normalized']
+            ]
+        )
+        ->shouldBeCalled();
+
+        $this
+            ->bulkSave([$product_a, $product_b])
+            ->shouldReturn(['id_a', 'id_b']);
+    }
+}

--- a/spec/Pim/Bundle/VersioningBundle/Doctrine/MongoDBODM/Saver/BulkVersionSaverSpec.php
+++ b/spec/Pim/Bundle/VersioningBundle/Doctrine/MongoDBODM/Saver/BulkVersionSaverSpec.php
@@ -3,75 +3,40 @@
 namespace spec\Pim\Bundle\VersioningBundle\Doctrine\MongoDBODM\Saver;
 
 use Doctrine\MongoDB\Collection;
-use Doctrine\MongoDB\Query\Query;
 use Doctrine\ODM\MongoDB\DocumentManager;
-use Doctrine\ODM\MongoDB\Query\Builder;
 use PhpSpec\ObjectBehavior;
-use Pim\Bundle\CatalogBundle\Model\ProductInterface;
-use Pim\Bundle\VersioningBundle\Builder\VersionBuilder;
-use Pim\Bundle\VersioningBundle\Manager\VersionContext;
-use Pim\Bundle\VersioningBundle\Manager\VersionManager;
 use Pim\Bundle\VersioningBundle\Model\Version;
 use Prophecy\Argument;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class BulkVersionSaverSpec extends ObjectBehavior
 {
     function let(
         DocumentManager $documentManager,
-        VersionBuilder $versionBuilder,
-        VersionManager $versionManager,
-        VersionContext $versionContext,
         NormalizerInterface $normalizer,
-        EventDispatcherInterface $eventDispatcher,
-        Collection $collection,
-        Builder $qb,
-        Query $query
+        Collection $collection
     ) {
         $this->beConstructedWith(
             $documentManager,
-            $versionBuilder,
-            $versionManager,
-            $versionContext,
             $normalizer,
-            $eventDispatcher,
             'Pim\Bundle\VersioningBundle\Model\Version'
         );
 
         $documentManager->getDocumentCollection('Pim\Bundle\VersioningBundle\Model\Version')->willReturn($collection);
         $collection->getName()->willReturn('pim_versioning_version');
-
-        $documentManager->createQueryBuilder(Argument::any())->willReturn($qb);
-        $qb->field(Argument::any())->willReturn($qb);
-        $qb->equals(Argument::any())->willReturn($qb);
-        $qb->limit(Argument::any())->willReturn($qb);
-        $qb->sort(Argument::cetera())->willReturn($qb);
-        $qb->getQuery(Argument::any())->willReturn($query);
-        $query->getSingleResult()->willReturn(null);
     }
 
-    function it_builds_and_saves_several_versionable_objects(
-        $versionBuilder,
+    function it_is_a_bulk_saver()
+    {
+        $this->shouldImplement('Akeneo\Component\StorageUtils\Saver\BulkSaverInterface');
+    }
+
+    function it_saves_several_versions(
         $normalizer,
         $collection,
-        ProductInterface $product_a,
-        ProductInterface $product_b,
-        ProductInterface $product_c,
         Version $version_a,
-        Version $version_b,
-        Version $version_c
+        Version $version_b
     ) {
-        $versionBuilder->buildVersion($product_a, Argument::cetera())->willReturn($version_a);
-        $versionBuilder->buildVersion($product_b, Argument::cetera())->willReturn($version_b);
-        $versionBuilder->buildVersion($product_c, Argument::cetera())->willReturn($version_c);
-        $version_a->getChangeset()->willReturn(['enabled' => ['old' => false, 'new' => true]]);
-        $version_b->getChangeset()->willReturn(['enabled' => ['old' => false, 'new' => true]]);
-        $version_c->getChangeset()->willReturn([]);
-
-        $product_a->getId()->willReturn('id_a');
-        $product_b->getId()->willReturn('id_b');
-
         $normalizer->normalize($version_a, 'mongodb_document')->willReturn(['version_a_normalized']);
         $normalizer->normalize($version_b, 'mongodb_document')->willReturn(['version_b_normalized']);
 
@@ -80,11 +45,8 @@ class BulkVersionSaverSpec extends ObjectBehavior
                 ['version_a_normalized'],
                 ['version_b_normalized']
             ]
-        )
-        ->shouldBeCalled();
+        )->shouldBeCalled();
 
-        $this
-            ->bulkSave([$product_a, $product_b])
-            ->shouldReturn(['id_a', 'id_b']);
+        $this->saveAll([$version_a, $version_b]);
     }
 }

--- a/spec/Pim/Bundle/VersioningBundle/Doctrine/MongoDBODM/Saver/BulkVersionSaverSpec.php
+++ b/spec/Pim/Bundle/VersioningBundle/Doctrine/MongoDBODM/Saver/BulkVersionSaverSpec.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace spec\Pim\Bundle\VersioningBundle\Doctrine\MongoDBODM;
+namespace spec\Pim\Bundle\VersioningBundle\Doctrine\MongoDBODM\Saver;
 
 use Doctrine\MongoDB\Collection;
 use Doctrine\MongoDB\Query\Query;

--- a/src/Akeneo/Bundle/StorageUtilsBundle/Doctrine/Common/Saver/BaseSaver.php
+++ b/src/Akeneo/Bundle/StorageUtilsBundle/Doctrine/Common/Saver/BaseSaver.php
@@ -65,9 +65,9 @@ class BaseSaver implements SaverInterface, BulkSaverInterface
             );
         }
 
+        $options = $this->optionsResolver->resolveSaveOptions($options);
         $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE, new GenericEvent($object, $options));
 
-        $options = $this->optionsResolver->resolveSaveOptions($options);
         $this->objectManager->persist($object);
 
         if (true === $options['flush']) {
@@ -86,9 +86,9 @@ class BaseSaver implements SaverInterface, BulkSaverInterface
             return;
         }
 
-        $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE_ALL, new GenericEvent($objects, $options));
-
         $allOptions = $this->optionsResolver->resolveSaveAllOptions($options);
+        $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE_ALL, new GenericEvent($objects, $allOptions));
+
         $itemOptions = $allOptions;
         $itemOptions['flush'] = false;
 
@@ -100,6 +100,6 @@ class BaseSaver implements SaverInterface, BulkSaverInterface
             $this->objectManager->flush();
         }
 
-        $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE_ALL, new GenericEvent($objects, $options));
+        $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE_ALL, new GenericEvent($objects, $allOptions));
     }
 }

--- a/src/Akeneo/Component/Versioning/BulkVersionBuilderInterface.php
+++ b/src/Akeneo/Component/Versioning/BulkVersionBuilderInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Akeneo\Component\Versioning;
+
+use Pim\Bundle\VersioningBundle\Model\Version;
+use Pim\Bundle\VersioningBundle\Model\VersionableInterface;
+
+/**
+ * Builds versions for a bulk of versionable objects.
+ *
+ * @author    Yohan Blain <yohan.blain@akeneo.com>
+ * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+interface BulkVersionBuilderInterface
+{
+    /**
+     * Build versions from the specified versionables
+     *
+     * @param VersionableInterface[] $versionables
+     *
+     * @return Version[]
+     */
+    public function buildVersions(array $versionables);
+}

--- a/src/Pim/Bundle/BaseConnectorBundle/Resources/config/storage_driver/doctrine/mongodb-odm.yml
+++ b/src/Pim/Bundle/BaseConnectorBundle/Resources/config/storage_driver/doctrine/mongodb-odm.yml
@@ -3,6 +3,7 @@ parameters:
     pim_base_connector.writer.direct_to_db.mongodb.product.class: Pim\Bundle\BaseConnectorBundle\Writer\DirectToDB\MongoDB\ProductWriter
 
 services:
+    # deprecated: will be removed in 1.6
     pim_base_connector.writer.direct_to_db.mongodb.product:
         class: %pim_base_connector.writer.direct_to_db.mongodb.product.class%
         arguments:

--- a/src/Pim/Bundle/BaseConnectorBundle/Writer/DirectToDB/MongoDB/ProductWriter.php
+++ b/src/Pim/Bundle/BaseConnectorBundle/Writer/DirectToDB/MongoDB/ProductWriter.php
@@ -27,6 +27,8 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
  * @author    Benoit Jacquemont <benoit@akeneo.com>
  * @copyright 2014 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *
+ * @deprecated Will be removed in 1.6
  */
 class ProductWriter extends AbstractConfigurableStepElement implements
     ItemWriterInterface,

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/GroupSaver.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/GroupSaver.php
@@ -84,7 +84,6 @@ class GroupSaver implements SaverInterface, BulkSaverInterface
      */
     public function save($group, array $options = [])
     {
-        /* @var GroupInterface */
         if (!$group instanceof GroupInterface) {
             throw new \InvalidArgumentException(
                 sprintf(
@@ -115,16 +114,16 @@ class GroupSaver implements SaverInterface, BulkSaverInterface
             $this->objectManager->flush();
         }
 
-        if (count($options['add_products']) > 0) {
-            $this->addProducts($options['add_products']);
-        }
-
-        if (count($options['remove_products']) > 0) {
-            $this->removeProducts($options['remove_products']);
-        }
-
         if ($group->getType()->isVariant() && true === $options['copy_values_to_products']) {
             $this->copyVariantGroupValues($group);
+        } else {
+            if (0 < count($options['add_products'])) {
+                $this->addProducts($options['add_products']);
+            }
+
+            if (0 < count($options['remove_products'])) {
+                $this->removeProducts($options['remove_products']);
+            }
         }
 
         $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE, new GenericEvent($group));

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/ProductSaver.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/ProductSaver.php
@@ -66,9 +66,9 @@ class ProductSaver implements SaverInterface, BulkSaverInterface
             );
         }
 
-        $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE, new GenericEvent($product));
-
         $options = $this->optionsResolver->resolveSaveOptions($options);
+        $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE, new GenericEvent($product, $options));
+
 
         $this->objectManager->persist($product);
 
@@ -84,7 +84,7 @@ class ProductSaver implements SaverInterface, BulkSaverInterface
             $this->completenessManager->generateMissingForProduct($product);
         }
 
-        $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE, new GenericEvent($product));
+        $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE, new GenericEvent($product, $options));
     }
 
     /**
@@ -96,9 +96,9 @@ class ProductSaver implements SaverInterface, BulkSaverInterface
             return;
         }
 
-        $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE_ALL, new GenericEvent($products));
-
         $allOptions = $this->optionsResolver->resolveSaveAllOptions($options);
+        $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE_ALL, new GenericEvent($products, $allOptions));
+
         $itemOptions = $allOptions;
         $itemOptions['flush'] = false;
 
@@ -110,6 +110,6 @@ class ProductSaver implements SaverInterface, BulkSaverInterface
             $this->objectManager->flush();
         }
 
-        $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE_ALL, new GenericEvent($products));
+        $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE_ALL, new GenericEvent($products, $allOptions));
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/ProductSaver.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/ProductSaver.php
@@ -96,20 +96,20 @@ class ProductSaver implements SaverInterface, BulkSaverInterface
             return;
         }
 
-        $allOptions = $this->optionsResolver->resolveSaveAllOptions($options);
-        $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE_ALL, new GenericEvent($products, $allOptions));
+        $options = $this->optionsResolver->resolveSaveAllOptions($options);
+        $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE_ALL, new GenericEvent($products, $options));
 
-        $itemOptions = $allOptions;
+        $itemOptions = $options;
         $itemOptions['flush'] = false;
 
         foreach ($products as $product) {
             $this->save($product, $itemOptions);
         }
 
-        if (true === $allOptions['flush']) {
+        if (true === $options['flush']) {
             $this->objectManager->flush();
         }
 
-        $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE_ALL, new GenericEvent($products, $allOptions));
+        $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE_ALL, new GenericEvent($products, $options));
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Saver/ProductSaver.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Saver/ProductSaver.php
@@ -12,7 +12,7 @@ use Pim\Bundle\CatalogBundle\Doctrine\Common\Saver\ProductSaver as BaseProductSa
 use Pim\Bundle\CatalogBundle\Manager\CompletenessManager;
 use Pim\Bundle\CatalogBundle\Model\ProductInterface;
 use Pim\Bundle\TransformBundle\Normalizer\MongoDB\ProductNormalizer;
-use Pim\Bundle\VersioningBundle\Doctrine\MongoDBODM\BulkVersionSaver;
+use Pim\Bundle\VersioningBundle\Doctrine\MongoDBODM\Saver\BulkVersionSaver;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Saver/ProductSaver.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Saver/ProductSaver.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Saver;
+
+use Akeneo\Bundle\StorageUtilsBundle\MongoDB\MongoObjectsFactory;
+use Akeneo\Component\StorageUtils\Saver\SavingOptionsResolverInterface;
+use Akeneo\Component\StorageUtils\StorageEvents;
+use Doctrine\Common\Util\ClassUtils;
+use Doctrine\MongoDB\Collection;
+use Doctrine\ODM\MongoDB\DocumentManager;
+use Pim\Bundle\CatalogBundle\Doctrine\Common\Saver\ProductSaver as BaseProductSaver;
+use Pim\Bundle\CatalogBundle\Manager\CompletenessManager;
+use Pim\Bundle\CatalogBundle\Model\ProductInterface;
+use Pim\Bundle\TransformBundle\Normalizer\MongoDB\ProductNormalizer;
+use Pim\Bundle\VersioningBundle\Doctrine\MongoDBODM\BulkVersionSaver;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * Direct To Db Mongo bulk product saver
+ *
+ * @author    Benoit Jacquemont <benoit@akeneo.com>
+ * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ProductSaver extends BaseProductSaver
+{
+    /**@var BulkVersionSaver */
+    protected $versionPersister;
+
+    /** @var NormalizerInterface */
+    protected $normalizer;
+
+    /** @var MongoObjectsFactory */
+    protected $mongoFactory;
+
+    /** @var string */
+    protected $productClass;
+
+    /** @var string */
+    protected $databaseName;
+
+    /** @var Collection */
+    protected $collection;
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param BulkVersionSaver    $versionPersister
+     * @param NormalizerInterface $normalizer
+     * @param MongoObjectsFactory $mongoFactory
+     * @param string              $productClass
+     * @param string              $databaseName
+     */
+    public function __construct(
+        DocumentManager $documentManager,
+        CompletenessManager $completenessManager,
+        SavingOptionsResolverInterface $optionsResolver,
+        EventDispatcherInterface $eventDispatcher,
+        BulkVersionSaver $versionPersister,
+        NormalizerInterface $normalizer,
+        MongoObjectsFactory $mongoFactory,
+        $productClass,
+        $databaseName
+    ) {
+        parent::__construct($documentManager, $completenessManager, $optionsResolver, $eventDispatcher);
+
+        $this->versionPersister = $versionPersister;
+        $this->normalizer       = $normalizer;
+        $this->mongoFactory     = $mongoFactory;
+        $this->productClass     = $productClass;
+        $this->databaseName     = $databaseName;
+
+        $this->collection = $this->objectManager->getDocumentCollection($this->productClass);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * Override to do a massive save for the products
+     */
+    public function saveAll(array $products, array $options = [])
+    {
+        if (empty($products)) {
+            return;
+        }
+
+        $allOptions = $this->optionsResolver->resolveSaveAllOptions($options);
+        $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE_ALL, new GenericEvent($products, $allOptions));
+
+        // TODO check the "schedule" options to remove the completeness or not
+        // TODO manage the "recalculate" options
+
+        $productsToInsert = [];
+        $productsToUpdate = [];
+
+        foreach ($products as $product) {
+            if (null === $product->getId()) {
+                $productsToInsert[] = $product;
+                $product->setId($this->mongoFactory->createMongoId());
+            } else {
+                $productsToUpdate[] = $product;
+            }
+        }
+
+        $insertDocs = $this->getDocsFromProducts($productsToInsert);
+        $updateDocs = $this->getDocsFromProducts($productsToUpdate);
+
+        if (count($insertDocs) > 0) {
+            $this->insertDocuments($insertDocs);
+        }
+
+        if (count($updateDocs) > 0) {
+            $this->updateDocuments($updateDocs);
+        }
+
+        $this->versionPersister->bulkPersist($products);
+
+        $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE_ALL, new GenericEvent($products, $allOptions));
+    }
+
+    /**
+     * Normalize products into their MongoDB document representation
+     *
+     * @param ProductInterface[] $products
+     *
+     * @return array
+     */
+    protected function getDocsFromProducts(array $products)
+    {
+        $context = [
+            ProductNormalizer::MONGO_COLLECTION_NAME => $this->collection->getName(),
+            ProductNormalizer::MONGO_DATABASE_NAME   => $this->databaseName
+        ];
+
+        $docs = [];
+        foreach ($products as $product) {
+            $docs[] = $this->normalizer->normalize($product, ProductNormalizer::FORMAT, $context);
+        }
+
+        return $docs;
+    }
+
+    /**
+     * Insert the provided products documents into MongoDB
+     * with the batch insert method
+     *
+     * @param array $docs
+     */
+    protected function insertDocuments($docs)
+    {
+        $this->collection->batchInsert($docs);
+    }
+
+    /**
+     * Apply update from the provided products documents into MongoDB
+     *
+     * @param array $docs
+     */
+    protected function updateDocuments($docs)
+    {
+        foreach ($docs as $doc) {
+            $id = $doc['_id'];
+            $this->collection->update(['_id' => $id], $doc);
+        }
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Saver/ProductSaver.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Saver/ProductSaver.php
@@ -27,7 +27,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 class ProductSaver extends BaseProductSaver
 {
     /**@var BulkVersionSaver */
-    protected $versionPersister;
+    protected $versionSaver;
 
     /** @var NormalizerInterface */
     protected $normalizer;
@@ -47,7 +47,7 @@ class ProductSaver extends BaseProductSaver
     /**
      * {@inheritdoc}
      *
-     * @param BulkVersionSaver    $versionPersister
+     * @param BulkVersionSaver    $versionSaver
      * @param NormalizerInterface $normalizer
      * @param MongoObjectsFactory $mongoFactory
      * @param string              $productClass
@@ -58,7 +58,7 @@ class ProductSaver extends BaseProductSaver
         CompletenessManager $completenessManager,
         SavingOptionsResolverInterface $optionsResolver,
         EventDispatcherInterface $eventDispatcher,
-        BulkVersionSaver $versionPersister,
+        BulkVersionSaver $versionSaver,
         NormalizerInterface $normalizer,
         MongoObjectsFactory $mongoFactory,
         $productClass,
@@ -66,11 +66,11 @@ class ProductSaver extends BaseProductSaver
     ) {
         parent::__construct($documentManager, $completenessManager, $optionsResolver, $eventDispatcher);
 
-        $this->versionPersister = $versionPersister;
-        $this->normalizer       = $normalizer;
-        $this->mongoFactory     = $mongoFactory;
-        $this->productClass     = $productClass;
-        $this->databaseName     = $databaseName;
+        $this->versionSaver = $versionSaver;
+        $this->normalizer   = $normalizer;
+        $this->mongoFactory = $mongoFactory;
+        $this->productClass = $productClass;
+        $this->databaseName = $databaseName;
 
         $this->collection = $this->objectManager->getDocumentCollection($this->productClass);
     }
@@ -115,7 +115,7 @@ class ProductSaver extends BaseProductSaver
             $this->updateDocuments($updateDocs);
         }
 
-        $this->versionPersister->bulkPersist($products);
+        $this->versionSaver->bulkSave($products);
 
         $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE_ALL, new GenericEvent($products, $allOptions));
     }

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Saver/ProductSaver.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Saver/ProductSaver.php
@@ -95,9 +95,6 @@ class ProductSaver extends BaseProductSaver
         $allOptions = $this->optionsResolver->resolveSaveAllOptions($options);
         $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE_ALL, new GenericEvent($products, $allOptions));
 
-        // TODO check the "schedule" options to remove the completeness or not
-        // TODO manage the "recalculate" options
-
         $productsToInsert = [];
         $productsToUpdate = [];
 
@@ -107,6 +104,14 @@ class ProductSaver extends BaseProductSaver
                 $product->setId($this->mongoFactory->createMongoId());
             } else {
                 $productsToUpdate[] = $product;
+            }
+
+            if (true === $allOptions['schedule'] || true === $allOptions['recalculate']) {
+                $this->completenessManager->schedule($product);
+            }
+
+            if (true === $allOptions['recalculate']) {
+                $this->completenessManager->generateMissingForProduct($product);
             }
         }
 

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/storage_driver/doctrine/mongodb-odm.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/storage_driver/doctrine/mongodb-odm.yml
@@ -245,6 +245,7 @@ services:
             - '@pim_catalog.manager.completeness'
             - '@pim_catalog.saver.product_options_resolver'
             - '@event_dispatcher'
+            - '@pim_versioning.doctrine.mongodb.bulk_builder.version'
             - '@pim_versioning.doctrine.mongodb.bulk_saver.version'
             - '@pim_serializer'
             - '@pim_catalog.mongodb.mongo_objects_factory'

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/storage_driver/doctrine/mongodb-odm.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/storage_driver/doctrine/mongodb-odm.yml
@@ -62,6 +62,8 @@ parameters:
     pim_catalog.doctrine.query.sorter.in_group.class:      Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Sorter\InGroupSorter
     pim_catalog.doctrine.query.sorter.is_associated.class: Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Sorter\BaseSorter
 
+    pim_catalog.saver.product.class: Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Saver\ProductSaver
+
 services:
     pim_catalog.object_manager.product:
         alias: doctrine.odm.mongodb.document_manager
@@ -217,6 +219,14 @@ services:
             - '@doctrine.orm.entity_manager'
             - %pim_catalog.entity.category.class%
 
+    pim_catalog.repository.completeness:
+        class: %pim_catalog.repository.completeness.class%
+        arguments:
+            - '@doctrine.odm.mongodb.document_manager'
+            - '@pim_catalog.manager.channel'
+            - '@pim_catalog.repository.category'
+            - %pim_catalog.entity.product.class%
+
     pim_catalog.repository.association:
         alias: pim_catalog.repository.product
 
@@ -228,6 +238,20 @@ services:
     pim_catalog.doctrine.smart_manager_registry:
         alias: akeneo_storage_utils.doctrine.smart_manager_registry
 
+    pim_catalog.saver.product:
+        class: %pim_catalog.saver.product.class%
+        arguments:
+            - '@pim_catalog.object_manager.product'
+            - '@pim_catalog.manager.completeness'
+            - '@pim_catalog.saver.product_options_resolver'
+            - '@event_dispatcher'
+            - '@pim_versioning.doctrine.mongodb.bulk_saver.version'
+            - '@pim_serializer'
+            - '@pim_catalog.mongodb.mongo_objects_factory'
+            - %pim_catalog.entity.product.class%
+            - %mongodb_database%
+
+    # Doctrine events subscribers
     pim_catalog.event_subscriber.mongodb.set_normalized_product_data:
         class: %pim_catalog.event_subscriber.mongodb.set_normalized_product_data.class%
         arguments:
@@ -259,14 +283,6 @@ services:
         tags:
             - { name: doctrine.event_subscriber, priority: 100 }
 
-    pim_catalog.repository.completeness:
-        class: %pim_catalog.repository.completeness.class%
-        arguments:
-            - '@doctrine.odm.mongodb.document_manager'
-            - '@pim_catalog.manager.channel'
-            - '@pim_catalog.repository.category'
-            - %pim_catalog.entity.product.class%
-
     pim_catalog.event_subscriber.mongodb.set_products:
         class: %pim_catalog.event_subscriber.mongodb.set_products.class%
         arguments:
@@ -278,8 +294,7 @@ services:
         tags:
             - { name: doctrine.event_subscriber }
 
-
-
+    # ODM query generators
     pim_catalog.mongodb_odm_query_generator.abstract_normalized_data:
         abstract: true
         class: %pim_catalog.mongodb_odm_query_generator.abstract_normalized_data.class%

--- a/src/Pim/Bundle/ReferenceDataBundle/MongoDB/Normalizer/ReferenceDataNormalizer.php
+++ b/src/Pim/Bundle/ReferenceDataBundle/MongoDB/Normalizer/ReferenceDataNormalizer.php
@@ -7,7 +7,9 @@ use Pim\Component\ReferenceData\Model\ReferenceDataInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
- * Normalize a reference data very simply to store it as mongodb_json
+ * Normalize a reference data very simply to store it as mongodb_json.
+ * Especially used to build normalized data (for filtering and sorting purpose) in MongoDB documents.
+ * The namespace follows the CatalogBundle one : Pim\Bundle\CatalogBundle\MongoDB\Normalizer
  *
  * @author    Julien Janvier <julien.janvier@akeneo.com>
  * @copyright 2015 Akeneo SAS (http://www.akeneo.com)

--- a/src/Pim/Bundle/ReferenceDataBundle/Normalizer/MongoDB/ReferenceDataNormalizer.php
+++ b/src/Pim/Bundle/ReferenceDataBundle/Normalizer/MongoDB/ReferenceDataNormalizer.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Pim\Bundle\ReferenceDataBundle\Normalizer\MongoDB;
+
+use Pim\Bundle\TransformBundle\Normalizer\MongoDB\ProductNormalizer;
+use Pim\Component\ReferenceData\Model\ReferenceDataInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * Normalizer especially used in documents normalization for MongoDB.
+ * The namespace follows the TransformBundle one : Pim\Bundle\TransformBundle\Normalizer\MongoDB
+ *
+ * @author    Yohan Blain <yohan.blain@akeneo.com>
+ * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ReferenceDataNormalizer implements NormalizerInterface
+{
+    /** @var array */
+    protected $supportedFormats = [ProductNormalizer::FORMAT];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function normalize($data, $format = null, array $context = [])
+    {
+        return $data->getId();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsNormalization($data, $format = null)
+    {
+        return $data instanceof ReferenceDataInterface && in_array($format, $this->supportedFormats);
+    }
+}

--- a/src/Pim/Bundle/ReferenceDataBundle/Resources/config/storage_driver/doctrine/mongodb-odm.yml
+++ b/src/Pim/Bundle/ReferenceDataBundle/Resources/config/storage_driver/doctrine/mongodb-odm.yml
@@ -2,6 +2,7 @@ parameters:
     pim_reference_data.doctrine.query.filter.reference_data.class: Pim\Bundle\ReferenceDataBundle\Doctrine\MongoDB\Filter\ReferenceDataFilter
     pim_reference_data.doctrine.query.sorter.reference_data.class: Pim\Bundle\ReferenceDataBundle\Doctrine\MongoDB\Sorter\ReferenceDataSorter
     pim_reference_data.mongodb.normalizer.reference_data.class:    Pim\Bundle\ReferenceDataBundle\MongoDB\Normalizer\ReferenceDataNormalizer
+    pim_reference_data.normalizer.mongodb.reference_data.class:    Pim\Bundle\ReferenceDataBundle\Normalizer\MongoDB\ReferenceDataNormalizer
 
 services:
     pim_reference_data.mongodb.normalizer.reference_data:
@@ -9,5 +10,11 @@ services:
         public: false
         arguments:
             - '@pim_reference_data.label_renderer'
+        tags:
+            - { name: pim_serializer.normalizer }
+
+    pim_reference_data.normalizer.mongodb.reference_data:
+        class: %pim_reference_data.normalizer.mongodb.reference_data.class%
+        public: false
         tags:
             - { name: pim_serializer.normalizer }

--- a/src/Pim/Bundle/TransformBundle/Normalizer/MongoDB/MetricNormalizer.php
+++ b/src/Pim/Bundle/TransformBundle/Normalizer/MongoDB/MetricNormalizer.php
@@ -54,20 +54,23 @@ class MetricNormalizer implements NormalizerInterface
      */
     public function normalize($metric, $format = null, array $context = [])
     {
-        if (null === $metric->getData() || "" === $metric->getData() ||
-            null === $metric->getUnit() || "" === $metric->getUnit()) {
-            return null;
+        $data = [
+            '_id'    => $this->mongoFactory->createMongoId(),
+            'family' => $metric->getFamily()
+        ];
+
+        if (null === $metric->getData() || '' === $metric->getData() ||
+            null === $metric->getUnit() || '' === $metric->getUnit()
+        ) {
+            return $data;
         }
 
         $this->createMetricBaseValues($metric);
 
-        $data = [];
-        $data['_id']      = $this->mongoFactory->createMongoId();
         $data['unit']     = $metric->getUnit();
         $data['data']     = $metric->getData();
         $data['baseUnit'] = $metric->getBaseUnit();
         $data['baseData'] = $metric->getBaseData();
-        $data['family']   = $metric->getFamily();
 
         return $data;
     }

--- a/src/Pim/Bundle/TransformBundle/Normalizer/MongoDB/ProductNormalizer.php
+++ b/src/Pim/Bundle/TransformBundle/Normalizer/MongoDB/ProductNormalizer.php
@@ -18,7 +18,7 @@ use Symfony\Component\Serializer\SerializerInterface;
 class ProductNormalizer implements NormalizerInterface, SerializerAwareInterface
 {
     /** @staticvar string */
-    const FORMAT = "mongodb_document";
+    const FORMAT = 'mongodb_document';
 
     /** @staticvar string */
     const MONGO_ID = '_id';

--- a/src/Pim/Bundle/TransformBundle/Normalizer/MongoDB/ProductValueNormalizer.php
+++ b/src/Pim/Bundle/TransformBundle/Normalizer/MongoDB/ProductValueNormalizer.php
@@ -66,8 +66,8 @@ class ProductValueNormalizer implements NormalizerInterface, SerializerAwareInte
         }
 
         $productCollection = $context[ProductNormalizer::MONGO_COLLECTION_NAME];
-        $productId = $context[ProductNormalizer::MONGO_ID];
-        $databaseName = $context[ProductNormalizer::MONGO_DATABASE_NAME];
+        $productId         = $context[ProductNormalizer::MONGO_ID];
+        $databaseName      = $context[ProductNormalizer::MONGO_DATABASE_NAME];
 
         $data = [];
         $data['_id'] = $this->mongoFactory->createMongoId();

--- a/src/Pim/Bundle/TransformBundle/Normalizer/MongoDB/ProductValueNormalizer.php
+++ b/src/Pim/Bundle/TransformBundle/Normalizer/MongoDB/ProductValueNormalizer.php
@@ -4,6 +4,9 @@ namespace Pim\Bundle\TransformBundle\Normalizer\MongoDB;
 
 use Akeneo\Bundle\StorageUtilsBundle\MongoDB\MongoObjectsFactory;
 use Doctrine\Common\Collections\Collection;
+use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Common\Util\ClassUtils;
+use Pim\Bundle\CatalogBundle\Model\AttributeInterface;
 use Pim\Bundle\CatalogBundle\Model\ProductValueInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\SerializerAwareInterface;
@@ -24,12 +27,17 @@ class ProductValueNormalizer implements NormalizerInterface, SerializerAwareInte
     /** @var MongoObjectsFactory */
     protected $mongoFactory;
 
+    /** @var ManagerRegistry */
+    protected $managerRegistry;
+
     /**
      * @param MongoObjectsFactory $mongoFactory
+     * @param ManagerRegistry     $managerRegistry
      */
-    public function __construct(MongoObjectsFactory $mongoFactory)
+    public function __construct(MongoObjectsFactory $mongoFactory, ManagerRegistry $managerRegistry)
     {
-        $this->mongoFactory = $mongoFactory;
+        $this->mongoFactory    = $mongoFactory;
+        $this->managerRegistry = $managerRegistry;
     }
 
     /**
@@ -57,17 +65,14 @@ class ProductValueNormalizer implements NormalizerInterface, SerializerAwareInte
             throw new \LogicException('Serializer must be a normalizer');
         }
 
-        if (null === $value->getData()) {
-            return null;
-        }
-
-        $productId = $context[ProductNormalizer::MONGO_ID];
         $productCollection = $context[ProductNormalizer::MONGO_COLLECTION_NAME];
+        $productId = $context[ProductNormalizer::MONGO_ID];
+        $databaseName = $context[ProductNormalizer::MONGO_DATABASE_NAME];
 
         $data = [];
         $data['_id'] = $this->mongoFactory->createMongoId();
         $data['attribute'] = $value->getAttribute()->getId();
-        $data['entity'] = $this->mongoFactory->createMongoDBRef($productCollection, $productId);
+        $data['entity'] = $this->mongoFactory->createMongoDBRef($productCollection, $productId, $databaseName);
 
         if (null !== $value->getLocale()) {
             $data['locale'] = $value->getLocale();
@@ -76,13 +81,10 @@ class ProductValueNormalizer implements NormalizerInterface, SerializerAwareInte
             $data['scope'] = $value->getScope();
         }
 
-        $backendType = $value->getAttribute()->getBackendType();
-
-        if ('options' !== $backendType) {
-            $data[$backendType] = $this->normalizeValueData($value->getData(), $backendType, $context);
-        } else {
-            $data['optionIds'] = $this->normalizeValueData($value->getData(), $backendType, $context);
-        }
+        $attribute   = $value->getAttribute();
+        $backendType = $attribute->getBackendType();
+        $key         = $this->getKeyForValue($value, $attribute, $backendType);
+        $data[$key]  = $this->normalizeValueData($value->getData(), $backendType, $context);
 
         return $data;
     }
@@ -101,7 +103,7 @@ class ProductValueNormalizer implements NormalizerInterface, SerializerAwareInte
         $targetData = null;
 
         if (is_array($data) || $data instanceof Collection) {
-            $targetData = array();
+            $targetData = [];
             foreach ($data as $dataItem) {
                 if (is_object($dataItem)) {
                     $targetData[] = $this->normalizer->normalize($dataItem, ProductNormalizer::FORMAT, $context);
@@ -116,5 +118,56 @@ class ProductValueNormalizer implements NormalizerInterface, SerializerAwareInte
         }
 
         return $targetData;
+    }
+
+    /**
+     * Decide what is the key used for data inside the normalized product value
+     *
+     * @param ProductValueInterface $value
+     * @param AttributeInterface    $attribute
+     * @param string                $backendType
+     *
+     * @return string
+     */
+    protected function getKeyForValue(ProductValueInterface $value, AttributeInterface $attribute, $backendType)
+    {
+        if ('options' === $backendType) {
+            return 'optionIds';
+        }
+
+        $refDataName = $attribute->getReferenceDataName();
+        if (null !== $refDataName) {
+            if ('reference_data_options' === $backendType) {
+                return $this->getReferenceDataFieldName($value, $refDataName);
+            }
+
+            return $refDataName;
+        }
+
+        return $backendType;
+    }
+
+    /**
+     * Search in Doctrine mapping what is the field name defined for the specified reference data
+     *
+     * @param ProductValueInterface $value
+     * @param string                $refDataName
+     *
+     * @throws \LogicException
+     *
+     * @return string
+     */
+    protected function getReferenceDataFieldName(ProductValueInterface $value, $refDataName)
+    {
+        $valueClass = ClassUtils::getClass($value);
+        $manager    = $this->managerRegistry->getManagerForClass($valueClass);
+        $metadata   = $manager->getClassMetadata($valueClass);
+        $fieldName  = $metadata->getFieldMapping($refDataName);
+
+        if (!isset($fieldName['idsField'])) {
+            throw new \LogicException(sprintf('No field name defined for reference data "%s"', $refDataName));
+        }
+
+        return $fieldName['idsField'];
     }
 }

--- a/src/Pim/Bundle/TransformBundle/Normalizer/MongoDB/ProductValueNormalizer.php
+++ b/src/Pim/Bundle/TransformBundle/Normalizer/MongoDB/ProductValueNormalizer.php
@@ -136,15 +136,15 @@ class ProductValueNormalizer implements NormalizerInterface, SerializerAwareInte
         }
 
         $refDataName = $attribute->getReferenceDataName();
-        if (null !== $refDataName) {
-            if ('reference_data_options' === $backendType) {
-                return $this->getReferenceDataFieldName($value, $refDataName);
-            }
-
-            return $refDataName;
+        if (null === $refDataName) {
+            return $backendType;
         }
 
-        return $backendType;
+        if ('reference_data_options' === $backendType) {
+            return $this->getReferenceDataFieldName($value, $refDataName);
+        }
+
+        return $refDataName;
     }
 
     /**

--- a/src/Pim/Bundle/TransformBundle/Normalizer/MongoDB/VersionNormalizer.php
+++ b/src/Pim/Bundle/TransformBundle/Normalizer/MongoDB/VersionNormalizer.php
@@ -18,7 +18,7 @@ use Symfony\Component\Serializer\SerializerInterface;
 class VersionNormalizer implements NormalizerInterface, SerializerAwareInterface
 {
     /** @staticvar string */
-    const FORMAT = "mongodb_document";
+    const FORMAT = 'mongodb_document';
 
     /** @staticvar string */
     const MONGO_ID = '_id';

--- a/src/Pim/Bundle/TransformBundle/Resources/config/storage_driver/doctrine/mongodb-odm.yml
+++ b/src/Pim/Bundle/TransformBundle/Resources/config/storage_driver/doctrine/mongodb-odm.yml
@@ -22,6 +22,7 @@ services:
         class: %pim_serializer.normalizer.mongodb.product_value.class%
         arguments:
             - '@pim_catalog.mongodb.mongo_objects_factory'
+            - '@pim_catalog.doctrine.smart_manager_registry'
         tags:
             - { name: pim_serializer.normalizer, priority: 100 }
 

--- a/src/Pim/Bundle/VersioningBundle/Doctrine/MongoDBODM/BulkVersionBuilder.php
+++ b/src/Pim/Bundle/VersioningBundle/Doctrine/MongoDBODM/BulkVersionBuilder.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Pim\Bundle\VersioningBundle\Doctrine\MongoDBODM;
+
+use Akeneo\Component\Versioning\BulkVersionBuilderInterface;
+use Doctrine\Common\Util\ClassUtils;
+use Doctrine\ODM\MongoDB\DocumentManager;
+use Pim\Bundle\VersioningBundle\Builder\VersionBuilder;
+use Pim\Bundle\VersioningBundle\Event\BuildVersionEvent;
+use Pim\Bundle\VersioningBundle\Event\BuildVersionEvents;
+use Pim\Bundle\VersioningBundle\Manager\VersionContext;
+use Pim\Bundle\VersioningBundle\Manager\VersionManager;
+use Pim\Bundle\VersioningBundle\Model\Version;
+use Pim\Bundle\VersioningBundle\Model\VersionableInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * Builds versions for a bulk of versionable objects.
+ *
+ * @author    Yohan Blain <yohan.blain@akeneo.com>
+ * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class BulkVersionBuilder implements BulkVersionBuilderInterface
+{
+    /** @var VersionBuilder */
+    protected $versionBuilder;
+
+    /** @var VersionContext */
+    protected $versionContext;
+
+    /** @var DocumentManager */
+    protected $documentManager;
+
+    /** @var EventDispatcherInterface */
+    protected $eventDispatcher;
+
+    /** @var string */
+    protected $versionClass;
+
+    /**
+     * @param VersionBuilder           $versionBuilder
+     * @param VersionContext           $versionContext
+     * @param DocumentManager          $documentManager
+     * @param EventDispatcherInterface $eventDispatcher
+     * @param string                   $versionClass
+     */
+    public function __construct(
+        VersionBuilder $versionBuilder,
+        VersionContext $versionContext,
+        DocumentManager $documentManager,
+        EventDispatcherInterface $eventDispatcher,
+        $versionClass
+    ) {
+        $this->versionBuilder  = $versionBuilder;
+        $this->versionContext  = $versionContext;
+        $this->documentManager = $documentManager;
+        $this->eventDispatcher = $eventDispatcher;
+        $this->versionClass    = $versionClass;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * If a versionable contains no change (i.e. has nothing in its changeset) no version will be built for it.
+     */
+    public function buildVersions(array $versionables)
+    {
+        $author = VersionManager::DEFAULT_SYSTEM_USER;
+        $event  = $this->eventDispatcher->dispatch(BuildVersionEvents::PRE_BUILD, new BuildVersionEvent());
+        if (null !== $event && null !== $event->getUsername()) {
+            $author = $event->getUsername();
+        }
+
+        $versions = [];
+        foreach ($versionables as $versionable) {
+            $context         = $this->versionContext->getContextInfo(ClassUtils::getClass($versionable));
+            $previousVersion = $this->getPreviousVersion($versionable);
+            $newVersion      = $this->versionBuilder->buildVersion($versionable, $author, $previousVersion, $context);
+
+            if (0 < count($newVersion->getChangeSet())) {
+                $versions[] = $newVersion;
+            }
+
+            if (null !== $previousVersion) {
+                $this->documentManager->detach($previousVersion);
+            }
+        }
+
+        return $versions;
+    }
+
+    /**
+     * Get the last available version for the provided document
+     *
+     * @param VersionableInterface $versionable
+     *
+     * @return Version|null
+     */
+    protected function getPreviousVersion(VersionableInterface $versionable)
+    {
+        $resourceName = ClassUtils::getClass($versionable);
+        $resourceId   = $versionable->getId();
+
+        $version = $this->documentManager
+            ->createQueryBuilder($this->versionClass)
+            ->field('resourceName')->equals($resourceName)
+            ->field('resourceId')->equals($resourceId)
+            ->limit(1)
+            ->sort('loggedAt', 'desc')
+            ->getQuery()
+            ->getSingleResult();
+
+        return $version;
+    }
+}

--- a/src/Pim/Bundle/VersioningBundle/Doctrine/MongoDBODM/BulkVersionSaver.php
+++ b/src/Pim/Bundle/VersioningBundle/Doctrine/MongoDBODM/BulkVersionSaver.php
@@ -81,7 +81,7 @@ class BulkVersionSaver
      *
      * @return array
      */
-    public function bulkPersist(array $versionables)
+    public function bulkSave(array $versionables)
     {
         $versions = [];
         $changedDocIds = [];
@@ -98,8 +98,8 @@ class BulkVersionSaver
             $newVersion      = $this->versionBuilder->buildVersion($versionable, $author, $previousVersion, $context);
 
             if (0 < count($newVersion->getChangeSet())) {
-                $versions[]    = $newVersion;
-                $changedDocIds = $versionable->getId();
+                $versions[]      = $newVersion;
+                $changedDocIds[] = $versionable->getId();
             }
 
             if (null !== $previousVersion) {

--- a/src/Pim/Bundle/VersioningBundle/Doctrine/MongoDBODM/BulkVersionSaver.php
+++ b/src/Pim/Bundle/VersioningBundle/Doctrine/MongoDBODM/BulkVersionSaver.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Pim\Bundle\VersioningBundle\Doctrine\MongoDBODM;
+
+use Doctrine\Common\Util\ClassUtils;
+use Doctrine\ODM\MongoDB\DocumentManager;
+use Pim\Bundle\TransformBundle\Normalizer\MongoDB\VersionNormalizer;
+use Pim\Bundle\VersioningBundle\Builder\VersionBuilder;
+use Pim\Bundle\VersioningBundle\Event\BuildVersionEvent;
+use Pim\Bundle\VersioningBundle\Event\BuildVersionEvents;
+use Pim\Bundle\VersioningBundle\Manager\VersionContext;
+use Pim\Bundle\VersioningBundle\Manager\VersionManager;
+use Pim\Bundle\VersioningBundle\Model\Version;
+use Pim\Bundle\VersioningBundle\Model\VersionableInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * Service to massively insert versions.
+ * Useful for bulk saving of versionable objects.
+ *
+ * @author    Benoit Jacquemont <benoit@akeneo.com>
+ * @copyright 2014 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class BulkVersionSaver
+{
+    /** @var DocumentManager */
+    protected $documentManager;
+
+    /** @var VersionBuilder */
+    protected $versionBuilder;
+
+    /** @var VersionManager */
+    protected $versionManager;
+
+    /** @var VersionContext */
+    protected $versionContext;
+
+    /** @var NormalizerInterface */
+    protected $normalizer;
+
+    /** @var EventDispatcherInterface */
+    protected $eventDispatcher;
+
+    /** @var string */
+    protected $versionClass;
+
+    /**
+     * @param DocumentManager          $documentManager
+     * @param VersionBuilder           $versionBuilder
+     * @param VersionManager           $versionManager
+     * @param VersionContext           $versionContext
+     * @param NormalizerInterface      $normalizer
+     * @param EventDispatcherInterface $eventDispatcher
+     * @param string                   $versionClass
+     */
+    public function __construct(
+        DocumentManager $documentManager,
+        VersionBuilder $versionBuilder,
+        VersionManager $versionManager,
+        VersionContext $versionContext,
+        NormalizerInterface $normalizer,
+        EventDispatcherInterface $eventDispatcher,
+        $versionClass
+    ) {
+        $this->documentManager = $documentManager;
+        $this->versionBuilder  = $versionBuilder;
+        $this->versionManager  = $versionManager;
+        $this->versionContext  = $versionContext;
+        $this->normalizer      = $normalizer;
+        $this->eventDispatcher = $eventDispatcher;
+        $this->versionClass    = $versionClass;
+    }
+
+    /**
+     * Bulk generates and inserts full version records for the provided versionable entities in MongoDB.
+     * Return an array of ids of documents that have really changed since the last version.
+     *
+     * @param array $versionables
+     *
+     * @return array
+     */
+    public function bulkPersist(array $versionables)
+    {
+        $versions = [];
+        $changedDocIds = [];
+
+        $author = VersionManager::DEFAULT_SYSTEM_USER;
+        $event  = $this->eventDispatcher->dispatch(BuildVersionEvents::PRE_BUILD, new BuildVersionEvent());
+        if (null !== $event && null !== $event->getUsername()) {
+            $author = $event->getUsername();
+        }
+
+        foreach ($versionables as $versionable) {
+            $context         = $this->versionContext->getContextInfo(ClassUtils::getClass($versionable));
+            $previousVersion = $this->getPreviousVersion($versionable);
+            $newVersion      = $this->versionBuilder->buildVersion($versionable, $author, $previousVersion, $context);
+
+            if (0 < count($newVersion->getChangeSet())) {
+                $versions[]    = $newVersion;
+                $changedDocIds = $versionable->getId();
+            }
+
+            if (null !== $previousVersion) {
+                $this->documentManager->detach($previousVersion);
+            }
+        }
+
+        $mongodbVersions = [];
+
+        foreach ($versions as $version) {
+            $mongodbVersions[] = $this->normalizer->normalize($version, VersionNormalizer::FORMAT);
+        }
+
+        if (0 < count($mongodbVersions)) {
+            $collection = $this->documentManager->getDocumentCollection($this->versionClass);
+            $collection->batchInsert($mongodbVersions);
+        }
+
+        return $changedDocIds;
+    }
+
+    /**
+     * Get the last available version for the provided document
+     *
+     * @param VersionableInterface $versionable
+     *
+     * @return Version
+     */
+    protected function getPreviousVersion(VersionableInterface $versionable)
+    {
+        $resourceName = ClassUtils::getClass($versionable);
+        $resourceId   = $versionable->getId();
+
+        $version = $this->documentManager
+            ->createQueryBuilder($this->versionClass)
+            ->field('resourceName')->equals($resourceName)
+            ->field('resourceId')->equals($resourceId)
+            ->limit(1)
+            ->sort('loggedAt', 'desc')
+            ->getQuery()
+            ->getSingleResult();
+
+        return $version;
+    }
+}

--- a/src/Pim/Bundle/VersioningBundle/Doctrine/MongoDBODM/PendingMassPersister.php
+++ b/src/Pim/Bundle/VersioningBundle/Doctrine/MongoDBODM/PendingMassPersister.php
@@ -17,6 +17,8 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
  * @author    Benoit Jacquemont <benoit@akeneo.com>
  * @copyright 2014 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *
+ * @deprecated Will be removed in 1.6
  */
 class PendingMassPersister extends AbstractPendingMassPersister
 {

--- a/src/Pim/Bundle/VersioningBundle/Doctrine/MongoDBODM/Saver/BulkVersionSaver.php
+++ b/src/Pim/Bundle/VersioningBundle/Doctrine/MongoDBODM/Saver/BulkVersionSaver.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Pim\Bundle\VersioningBundle\Doctrine\MongoDBODM;
+namespace Pim\Bundle\VersioningBundle\Doctrine\MongoDBODM\Saver;
 
 use Doctrine\Common\Util\ClassUtils;
 use Doctrine\ODM\MongoDB\DocumentManager;

--- a/src/Pim/Bundle/VersioningBundle/Doctrine/ORM/PendingMassPersister.php
+++ b/src/Pim/Bundle/VersioningBundle/Doctrine/ORM/PendingMassPersister.php
@@ -19,6 +19,8 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
  * @author    Benoit Jacquemont <benoit@akeneo.com>
  * @copyright 2014 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *
+ * @deprecated Will be removed in 1.6
  */
 class PendingMassPersister extends AbstractPendingMassPersister
 {

--- a/src/Pim/Bundle/VersioningBundle/Resources/config/storage_driver/doctrine/mongodb-odm.yml
+++ b/src/Pim/Bundle/VersioningBundle/Resources/config/storage_driver/doctrine/mongodb-odm.yml
@@ -31,6 +31,7 @@ services:
         tags:
             - { name: doctrine_mongodb.odm.event_subscriber }
 
+    # deprecated Will be removed in 1.6
     pim_versioning.doctrine.mongodb.pending_mass_persister:
         class: %pim_versioning.doctrine.mongodb.pending_mass_persister.class%
         arguments:

--- a/src/Pim/Bundle/VersioningBundle/Resources/config/storage_driver/doctrine/mongodb-odm.yml
+++ b/src/Pim/Bundle/VersioningBundle/Resources/config/storage_driver/doctrine/mongodb-odm.yml
@@ -2,6 +2,7 @@ parameters:
     pim_versioning.repository.version.class:                          Pim\Bundle\VersioningBundle\Doctrine\MongoDBODM\VersionRepository
     pim_versioning.update_guesser.contains_products.class:            Pim\Bundle\VersioningBundle\UpdateGuesser\MongoDBODM\ContainsProductsUpdateGuesser
     pim_versioning.event_subscriber.mongodb.product_addversion.class: Pim\Bundle\VersioningBundle\EventSubscriber\MongoDBODM\AddProductVersionSubscriber
+    pim_versioning.doctrine.mongodb.bulk_saver.version.class:         Pim\Bundle\VersioningBundle\Doctrine\MongoDBODM\BulkVersionSaver
     pim_versioning.doctrine.mongodb.pending_mass_persister.class:     Pim\Bundle\VersioningBundle\Doctrine\MongoDBODM\PendingMassPersister
 
 services:
@@ -39,6 +40,17 @@ services:
             - '@pim_serializer'
             - %pim_versioning.entity.version.class%
             - '@doctrine.odm.mongodb.document_manager'
+
+    pim_versioning.doctrine.mongodb.bulk_saver.version:
+        class: %pim_versioning.doctrine.mongodb.bulk_saver.version.class%
+        arguments:
+            - '@pim_versioning.object_manager.version'
+            - '@pim_versioning.builder.version'
+            - '@pim_versioning.manager.version'
+            - '@pim_versioning.context.version'
+            - '@pim_serializer'
+            - '@event_dispatcher'
+            - %pim_versioning.entity.version.class%
 
     pim_versioning.object_manager.version:
         alias: doctrine.odm.mongodb.document_manager

--- a/src/Pim/Bundle/VersioningBundle/Resources/config/storage_driver/doctrine/mongodb-odm.yml
+++ b/src/Pim/Bundle/VersioningBundle/Resources/config/storage_driver/doctrine/mongodb-odm.yml
@@ -3,6 +3,7 @@ parameters:
     pim_versioning.update_guesser.contains_products.class:            Pim\Bundle\VersioningBundle\UpdateGuesser\MongoDBODM\ContainsProductsUpdateGuesser
     pim_versioning.event_subscriber.mongodb.product_addversion.class: Pim\Bundle\VersioningBundle\EventSubscriber\MongoDBODM\AddProductVersionSubscriber
     pim_versioning.doctrine.mongodb.bulk_saver.version.class:         Pim\Bundle\VersioningBundle\Doctrine\MongoDBODM\Saver\BulkVersionSaver
+    pim_versioning.doctrine.mongodb.bulk_builder.version.class:       Pim\Bundle\VersioningBundle\Doctrine\MongoDBODM\BulkVersionBuilder
     pim_versioning.doctrine.mongodb.pending_mass_persister.class:     Pim\Bundle\VersioningBundle\Doctrine\MongoDBODM\PendingMassPersister
 
 services:
@@ -46,10 +47,15 @@ services:
         class: %pim_versioning.doctrine.mongodb.bulk_saver.version.class%
         arguments:
             - '@pim_versioning.object_manager.version'
-            - '@pim_versioning.builder.version'
-            - '@pim_versioning.manager.version'
-            - '@pim_versioning.context.version'
             - '@pim_serializer'
+            - %pim_versioning.entity.version.class%
+
+    pim_versioning.doctrine.mongodb.bulk_builder.version:
+        class: %pim_versioning.doctrine.mongodb.bulk_builder.version.class%
+        arguments:
+            - '@pim_versioning.builder.version'
+            - '@pim_versioning.context.version'
+            - '@pim_versioning.object_manager.version'
             - '@event_dispatcher'
             - %pim_versioning.entity.version.class%
 

--- a/src/Pim/Bundle/VersioningBundle/Resources/config/storage_driver/doctrine/mongodb-odm.yml
+++ b/src/Pim/Bundle/VersioningBundle/Resources/config/storage_driver/doctrine/mongodb-odm.yml
@@ -2,7 +2,7 @@ parameters:
     pim_versioning.repository.version.class:                          Pim\Bundle\VersioningBundle\Doctrine\MongoDBODM\VersionRepository
     pim_versioning.update_guesser.contains_products.class:            Pim\Bundle\VersioningBundle\UpdateGuesser\MongoDBODM\ContainsProductsUpdateGuesser
     pim_versioning.event_subscriber.mongodb.product_addversion.class: Pim\Bundle\VersioningBundle\EventSubscriber\MongoDBODM\AddProductVersionSubscriber
-    pim_versioning.doctrine.mongodb.bulk_saver.version.class:         Pim\Bundle\VersioningBundle\Doctrine\MongoDBODM\BulkVersionSaver
+    pim_versioning.doctrine.mongodb.bulk_saver.version.class:         Pim\Bundle\VersioningBundle\Doctrine\MongoDBODM\Saver\BulkVersionSaver
     pim_versioning.doctrine.mongodb.pending_mass_persister.class:     Pim\Bundle\VersioningBundle\Doctrine\MongoDBODM\PendingMassPersister
 
 services:

--- a/src/Pim/Bundle/VersioningBundle/Resources/config/storage_driver/doctrine/orm.yml
+++ b/src/Pim/Bundle/VersioningBundle/Resources/config/storage_driver/doctrine/orm.yml
@@ -11,6 +11,7 @@ services:
         tags:
             - { name: 'pim_repository' }
 
+    # deprecated: will be removed in 1.6
     pim_versioning.doctrine.orm.pending_mass_persister:
         class: %pim_versioning.doctrine.orm.pending_mass_persister.class%
         arguments:


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Specs             | yes
| Behats            | n/a
| Blue CI           | yes
| Changelog updated | yes
| Review and 2 GTM  | 

The goal of this PR is to incorporate https://github.com/akeneo-labs/DirectToMongoDBBundle in the PIM with some reordering / renaming, and depreciate the old MongoDB fast writer.