### PR TITLE
[SLA] PIM-5268: Fixed PDF display to be able to display long attribute name

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -6,6 +6,7 @@
 - PIM-5235: Fix empty reference data name on attributes import
 - PIM-5208: Fix the datagrid performance issue related to large number of attributes, only attribute usable in grid will be available
 - PIM-5215: Create empty product values for new family attributes after product import with family change
+- PIM-5268: Fix PDF display to be able to display long attribute name
 
 # 1.4.11 (2015-11-27)
 

--- a/src/Pim/Bundle/PdfGeneratorBundle/Resources/views/Product/renderPdf.html.twig
+++ b/src/Pim/Bundle/PdfGeneratorBundle/Resources/views/Product/renderPdf.html.twig
@@ -67,11 +67,13 @@
                 position: absolute;
                 left: 0;
                 padding: 5px;
+                width: 35%;
             }
 
             .right-column {
                 margin-left: 35%;
                 padding: 5px;
+                width: 65%;
             }
         </style>
     </head>
@@ -97,17 +99,24 @@
                         <h2>{{ group }}</h2>
                         {% for attribute in attributes %}
                             {% block attribute %}
-                                <div class="attributes">
+
+                                {% if 'pim_catalog_image' == attribute.attributeType and product.getValue(attribute.code, locale, scope).media is not null %}
+                                    {% set content = product.getValue(attribute.code, locale, scope).media.originalFilename %}
+                                    {% set manualHeight = false %}
+                                {% else %}
+                                    {% set content = product.getValue(attribute.code, locale, scope) %}
+                                    {% set manualHeight = attribute.label|length > (content.__toString()|length / 3) %}
+                                {% endif %}
+
+                                <div class="attributes"{% if manualHeight %} style="height: {{ (attribute.label|length / 30)|round(0, 'ceil') * 18 + 10 }}px"{% endif %}>
                                     <div class="left-column">
                                         {{ attribute.label }}
                                     </div>
                                     <div class="right-column">
-                                        {% if attribute.attributeType == 'pim_catalog_image' and product.getValue(attribute.code, locale, scope).media is not null %}
-                                            {{ product.getValue(attribute.code, locale, scope).media.originalFilename }}
-                                        {% elseif attribute.attributeType == 'pim_catalog_textarea' and attribute.isWysiwygEnabled %}
-                                            {{ product.getValue(attribute.code, locale, scope)|raw }}
+                                        {% if 'pim_catalog_textarea' == attribute.attributeType and attribute.isWysiwygEnabled %}
+                                            {{ content|raw }}
                                         {% else %}
-                                            {{ product.getValue(attribute.code, locale, scope) }}
+                                            {{ content }}
                                         {% endif %}
                                         &nbsp;
                                     </div>


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Specs             | N/A
| Behats            | N/A
| Blue CI           | Running
| Changelog updated | Y
| Review and 2 GTM  | todo

Dev Notes:

* We can't use a simple table here: it breaks with big cells (it does a page break before the cell and let a huge blank space). This was the original implementation of this feature and was reviewed by @damien-carcel to fix this case.
* Floats are not well implemented in DOMPDF (its an experimental feature that you can enable with a flag), and breaks everything if a floating element have to be displayed on multiple pages (which happens in our case).

With that said I came to the conclusion that only absolute boxing model is possible and, to be able to compute the height of the boxes, I have to set the height manually depending on the number of characters.

BTW min-height does not work with DOMPDF (cf https://github.com/dompdf/dompdf/issues/825) So I have to ensure first that my label length is greater that the value to set the height only when needed.