### PR TITLE
add missing translations for default dialogs

### DIFF
--- a/src/Pim/Bundle/UIBundle/Resources/public/js/delete-confirmation.js
+++ b/src/Pim/Bundle/UIBundle/Resources/public/js/delete-confirmation.js
@@ -16,7 +16,8 @@ function (_, __, Modal) {
         initialize: function (options) {
             options = _.extend({
                 title: __('Delete Confirmation'),
-                okText: __('Yes, Delete')
+                okText: __('Yes, Delete'),
+                cancelText: __('Cancel')
             }, options);
 
             arguments[0] = options;

--- a/src/Pim/Bundle/UIBundle/Resources/public/js/pim-dialog.js
+++ b/src/Pim/Bundle/UIBundle/Resources/public/js/pim-dialog.js
@@ -1,6 +1,6 @@
 define(
-    ['jquery', 'underscore', 'backbone', 'oro/navigation', 'backbone/bootstrap-modal'],
-    function ($, _, Backbone, Navigation) {
+    ['jquery', 'underscore', 'backbone', 'oro/translator', 'oro/navigation', 'backbone/bootstrap-modal'],
+    function ($, _, Backbone, __, Navigation) {
         'use strict';
 
         /**
@@ -26,7 +26,8 @@ define(
                     var alert = new Backbone.BootstrapModal({
                         allowCancel: false,
                         title: title,
-                        content: content
+                        content: content,
+                        okText: __('OK')
                     });
                     alert.open();
                 } else {
@@ -47,7 +48,8 @@ define(
                         allowCancel: true,
                         title: title,
                         content: content,
-                        okText: okText
+                        okText: okText,
+                        cancelText: __('Cancel')
                     });
 
                     redirectModal.on('ok', function () {
@@ -84,7 +86,9 @@ define(
                 if (!_.isUndefined(Backbone.BootstrapModal)) {
                     var confirm = new Backbone.BootstrapModal({
                         title: title,
-                        content: content
+                        content: content,
+                        okText: __('OK'),
+                        cancelText: __('Cancel')
                     });
                     confirm.on('ok', success);
                     confirm.on('cancel', cancel);


### PR DESCRIPTION
Translate 'OK' and 'Cancel' messages in default dialogs.
These were missing, resulting in literally OK and Cancel ignoring the used language.

| Q                 | A
| ----------------- | ---
| Added Specs       | NA <- not applicable in this case as it's javascript only :)
| Added Behats      | N
| Travis CI is ok   | ? <- still running
| Changelog updated | N