### PR TITLE
[TR] PIM-5170: Fixes MongoDB memory leak at association import time

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -3,6 +3,7 @@
 ## BC Breaks
 - Changed constructor of `Pim\Bundle\TransformBundle\Normalizer\MongoDB\ProductValueNormalizer`to add a `Doctrine\Common\Persistence\ManagerRegistry` (instead of a DocumentManager to avoid circular references)
   It is required because normalization of reference data in product values is based on Doctrine metadata.
+- In case you wrote your own associations import, please add the parameter `batch_size: 1` to the `import_associations` step element of your `batch_jobs.yml`.
 
 ## Bug fixes
 - PIM-5238: fix scroll on multiselect for mass edit

--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -10,6 +10,7 @@
 
 ## Performance improvements
 - PIM-5218: Use DirectToMongoDB bulk product saver natively. This considerably speeds up all bulk actions on a MongoDB storage install (imports, mass edit, rules application, etc.).
+- PIM-5170: Fixes memory leak on MongoDB at association import time
 
 # 1.4.12 (2015-12-03)
 

--- a/spec/Pim/Component/Connector/Processor/Denormalization/ProductAssociationProcessorSpec.php
+++ b/spec/Pim/Component/Connector/Processor/Denormalization/ProductAssociationProcessorSpec.php
@@ -5,6 +5,7 @@ namespace spec\Pim\Component\Connector\Processor\Denormalization;
 use Akeneo\Bundle\BatchBundle\Entity\JobExecution;
 use Akeneo\Bundle\BatchBundle\Entity\JobInstance;
 use Akeneo\Bundle\BatchBundle\Entity\StepExecution;
+use Akeneo\Component\StorageUtils\Detacher\ObjectDetacherInterface;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use PhpSpec\ObjectBehavior;
@@ -26,14 +27,16 @@ class ProductAssociationProcessorSpec extends ObjectBehavior
         ObjectUpdaterInterface $productUpdater,
         ValidatorInterface $productValidator,
         StepExecution $stepExecution,
-        ProductFilterInterface $productAssocFilter
+        ProductFilterInterface $productAssocFilter,
+        ObjectDetacherInterface $productDetacher
     ) {
         $this->beConstructedWith(
             $arrayConverter,
             $productRepository,
             $productUpdater,
             $productValidator,
-            $productAssocFilter
+            $productAssocFilter,
+            $productDetacher
         );
 
         $this->setStepExecution($stepExecution);
@@ -116,13 +119,14 @@ class ProductAssociationProcessorSpec extends ObjectBehavior
             ->process($originalData)
             ->shouldReturn($product);
     }
-    
+
     function it_skips_a_product_when_update_fails(
         $arrayConverter,
         $productRepository,
         $productUpdater,
         $productAssocFilter,
         $stepExecution,
+        $productDetacher,
         ProductInterface $product
     ) {
         $productRepository->getIdentifierProperties()->willReturn(['sku']);
@@ -171,6 +175,8 @@ class ProductAssociationProcessorSpec extends ObjectBehavior
         $stepExecution->incrementSummaryInfo('skip')->shouldBeCalled();
         $this->setStepExecution($stepExecution);
 
+        $productDetacher->detach($product)->shouldBeCalled();
+
         $this
             ->shouldThrow('Akeneo\Bundle\BatchBundle\Item\InvalidItemException')
             ->during(
@@ -186,6 +192,7 @@ class ProductAssociationProcessorSpec extends ObjectBehavior
         $productValidator,
         $productAssocFilter,
         $stepExecution,
+        $productDetacher,
         AssociationInterface $association,
         ProductInterface $product
     ) {
@@ -242,6 +249,8 @@ class ProductAssociationProcessorSpec extends ObjectBehavior
         $stepExecution->incrementSummaryInfo('skip')->shouldBeCalled();
         $this->setStepExecution($stepExecution);
 
+        $productDetacher->detach($product)->shouldBeCalled();
+
         $this
             ->shouldThrow('Akeneo\Bundle\BatchBundle\Item\InvalidItemException')
             ->during(
@@ -256,6 +265,7 @@ class ProductAssociationProcessorSpec extends ObjectBehavior
         $productUpdater,
         $productAssocFilter,
         $stepExecution,
+        $productDetacher,
         ProductInterface $product
     ) {
         $productRepository->getIdentifierProperties()->willReturn(['sku']);
@@ -303,6 +313,8 @@ class ProductAssociationProcessorSpec extends ObjectBehavior
 
         $stepExecution->incrementSummaryInfo('product_skipped_no_diff')->shouldBeCalled();
         $this->setStepExecution($stepExecution);
+
+        $productDetacher->detach($product)->shouldBeCalled();
 
         $this->process($originalData)
             ->shouldReturn(null);

--- a/spec/Pim/Component/Connector/Processor/Denormalization/ProductProcessorSpec.php
+++ b/spec/Pim/Component/Connector/Processor/Denormalization/ProductProcessorSpec.php
@@ -672,7 +672,7 @@ class ProductProcessorSpec extends ObjectBehavior
             ->validate($product)
             ->willReturn($violations);
 
-        $productDetacher->detach($product);
+        $productDetacher->detach($product)->shouldBeCalled();
 
         $this
             ->shouldThrow('Akeneo\Bundle\BatchBundle\Item\InvalidItemException')
@@ -686,6 +686,7 @@ class ProductProcessorSpec extends ObjectBehavior
         $arrayConverter,
         $productRepository,
         $productUpdater,
+        $productDetacher,
         $productFilter,
         ProductInterface $product
     ) {
@@ -765,6 +766,8 @@ class ProductProcessorSpec extends ObjectBehavior
 
         $productUpdater
             ->update($product, $filteredData)->shouldNotBeCalled();
+
+        $productDetacher->detach($product)->shouldBeCalled();
 
         $this
             ->process($originalData)

--- a/src/Akeneo/Bundle/StorageUtilsBundle/Doctrine/Common/Detacher/ObjectDetacher.php
+++ b/src/Akeneo/Bundle/StorageUtilsBundle/Doctrine/Common/Detacher/ObjectDetacher.php
@@ -4,9 +4,12 @@ namespace Akeneo\Bundle\StorageUtilsBundle\Doctrine\Common\Detacher;
 
 use Akeneo\Component\StorageUtils\Detacher\BulkObjectDetacherInterface;
 use Akeneo\Component\StorageUtils\Detacher\ObjectDetacherInterface;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\Common\Util\ClassUtils;
+use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\PersistentCollection;
 
 /**
  * Detacher, detaches an object from its ObjectManager
@@ -34,7 +37,13 @@ class ObjectDetacher implements ObjectDetacherInterface, BulkObjectDetacherInter
     public function detach($object)
     {
         $objectManager = $this->getObjectManager($object);
-        $objectManager->detach($object);
+
+        if ($objectManager instanceof DocumentManager) {
+            $visited = [];
+            $this->doDetach($object, $visited);
+        } else {
+            $objectManager->detach($object);
+        }
     }
 
     /**
@@ -59,5 +68,58 @@ class ObjectDetacher implements ObjectDetacherInterface, BulkObjectDetacherInter
     protected function getObjectManager($object)
     {
         return $this->managerRegistry->getManagerForClass(ClassUtils::getClass($object));
+    }
+
+    /**
+     * Do detach objects on DocumentManager
+     *
+     * @param document $document
+     * @param array    $visited   Prevent infinite recursion
+     */
+    protected function doDetach($document, array &$visited)
+    {
+        $oid = spl_object_hash($document);
+        if (isset($visited[$oid])) {
+            return;
+        }
+
+        $documentManager = $this->getObjectManager($document);
+
+        $visited[$oid] = $document;
+
+        $documentManager->detach($document);
+
+        $this->cascadeDetach($document, $visited);
+    }
+
+    /**
+     * Cascade detach objects to overcome MongoDB detach
+     * cascade bug on MongoDB ODM BETA12.
+     * See https://github.com/doctrine/mongodb-odm/pull/979.
+     *
+     * @param object $object
+     * @param array  $visited Prevent infinite recursion
+     */
+    protected function cascadeDetach($document, array &$visited)
+    {
+        $documentManager = $this->getObjectManager($document);
+
+        $class = $documentManager->getClassMetadata(ClassUtils::getClass($document));
+        foreach ($class->fieldMappings as $mapping) {
+            if (!$mapping['isCascadeDetach']) {
+                continue;
+            }
+            $relatedDocuments = $class->reflFields[$mapping['fieldName']]->getValue($document);
+            if (($relatedDocuments instanceof Collection || is_array($relatedDocuments))) {
+                if ($relatedDocuments instanceof PersistentCollection) {
+                    $relatedDocuments = $relatedDocuments->unwrap();
+                }
+                foreach ($relatedDocuments as $relatedDocument) {
+                    $this->doDetach($relatedDocument, $visited);
+                }
+            } elseif ($relatedDocuments !== null) {
+                $this->doDetach($relatedDocuments, $visited);
+            }
+        }
     }
 }

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/batch_jobs.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/batch_jobs.yml
@@ -22,6 +22,8 @@ connector:
                         reader:    pim_connector.reader.file.csv_association
                         processor: pim_connector.processor.denormalization.product_association.flat
                         writer:    pim_connector.writer.doctrine.product_association
+                    parameters:
+                        batch_size: 1
         csv_attribute_import:
             title: pim_connector.jobs.csv_attribute_import.title
             type:  import

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/processors.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/processors.yml
@@ -71,6 +71,7 @@ services:
             - '@pim_catalog.updater.product'
             - '@pim_catalog.validator.product'
             - '@pim_catalog.comparator.filter.product_association'
+            - '@akeneo_storage_utils.doctrine.object_detacher'
 
     pim_connector.processor.denormalization.variant_group.flat:
         class: %pim_connector.processor.denormalization.variant_group.class%

--- a/src/Pim/Bundle/InstallerBundle/Resources/config/batch_jobs.yml
+++ b/src/Pim/Bundle/InstallerBundle/Resources/config/batch_jobs.yml
@@ -169,7 +169,8 @@ connector:
                         reader:    pim_connector.reader.file.csv_association
                         processor: pim_connector.processor.denormalization.product_association.flat
                         writer:    pim_connector.writer.doctrine.product_association
-
+                    parameters:
+                        batch_size: 1
         fixtures_job_yml:
             title: pim_installer.jobs.fixtures_job_yml.title
             type:  fixtures

--- a/src/Pim/Component/Connector/Processor/Denormalization/ProductAssociationProcessor.php
+++ b/src/Pim/Component/Connector/Processor/Denormalization/ProductAssociationProcessor.php
@@ -72,7 +72,7 @@ class ProductAssociationProcessor extends AbstractProcessor
      */
     public function process($item)
     {
-        $identifier    = $this->getIdentifier($item);
+        $identifier = $this->getIdentifier($item);
 
         if (null === $identifier) {
             $this->skipItemWithMessage($item, 'The identifier must be filled');

--- a/src/Pim/Component/Connector/Processor/Denormalization/ProductAssociationProcessor.php
+++ b/src/Pim/Component/Connector/Processor/Denormalization/ProductAssociationProcessor.php
@@ -3,6 +3,7 @@
 namespace Pim\Component\Connector\Processor\Denormalization;
 
 use Akeneo\Bundle\BatchBundle\Item\InvalidItemException;
+use Akeneo\Component\StorageUtils\Detacher\ObjectDetacherInterface;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Pim\Bundle\CatalogBundle\Model\ProductInterface;
@@ -31,6 +32,9 @@ class ProductAssociationProcessor extends AbstractProcessor
     /** @var ValidatorInterface */
     protected $validator;
 
+    /** @var ObjectDetacherInterface */
+    protected $detacher;
+
     /** @var ProductFilterInterface */
     protected $productAssocFilter;
 
@@ -43,13 +47,15 @@ class ProductAssociationProcessor extends AbstractProcessor
      * @param ObjectUpdaterInterface                $updater            product updater
      * @param ValidatorInterface                    $validator          validator of the object
      * @param ProductFilterInterface                $productAssocFilter product association filter
+     * @param ObjectDetacherInterface               $detacher       detacher to remove it from UOW when skip
      */
     public function __construct(
         StandardArrayConverterInterface $arrayConverter,
         IdentifiableObjectRepositoryInterface $repository,
         ObjectUpdaterInterface $updater,
         ValidatorInterface $validator,
-        ProductFilterInterface $productAssocFilter
+        ProductFilterInterface $productAssocFilter,
+        ObjectDetacherInterface $detacher = null
     ) {
         parent::__construct($repository);
 
@@ -58,6 +64,7 @@ class ProductAssociationProcessor extends AbstractProcessor
         $this->updater            = $updater;
         $this->validator          = $validator;
         $this->productAssocFilter = $productAssocFilter;
+        $this->detacher           = $detacher;
     }
 
     /**
@@ -65,28 +72,40 @@ class ProductAssociationProcessor extends AbstractProcessor
      */
     public function process($item)
     {
-        $identifier = $this->getIdentifier($item);
+        $identifier    = $this->getIdentifier($item);
+
+        if (null === $identifier) {
+            $this->skipItemWithMessage($item, 'The identifier must be filled');
+        }
+
         $product = $this->findProduct($identifier);
+
         if (!$product) {
             $this->skipItemWithMessage($item, sprintf('No product with identifier "%s" has been found', $identifier));
         }
 
         $convertedItem = $this->convertItemData($item);
-        $convertedItem = $this->filterIdenticalData($product, $convertedItem);
-        if (empty($convertedItem)) {
-            $this->stepExecution->incrementSummaryInfo('product_skipped_no_diff');
+        if ($this->enabledComparison) {
+            $convertedItem = $this->filterIdenticalData($product, $convertedItem);
 
-            return null;
+            if (empty($convertedItem)) {
+                $this->detachProduct($product);
+                $this->stepExecution->incrementSummaryInfo('product_skipped_no_diff');
+
+                return null;
+            }
         }
 
         try {
             $this->updateProduct($product, $convertedItem);
         } catch (\InvalidArgumentException $exception) {
+            $this->detachProduct($product);
             $this->skipItemWithMessage($item, $exception->getMessage(), $exception);
         }
 
         $violations = $this->validateProductAssociations($product);
         if ($violations && $violations->count() > 0) {
+            $this->detachProduct($product);
             $this->skipItemWithConstraintViolations($item, $violations);
         }
 
@@ -204,5 +223,19 @@ class ProductAssociationProcessor extends AbstractProcessor
         }
 
         return null;
+    }
+
+    /**
+     * Detaches the product from the unit of work is the responsibility of the writer but in this case we
+     * want ensure that an updated and invalid product will not be used in the association processor.
+     * Also we don't want to keep skipped products in memory
+     *
+     * @param ProductInterface $product
+     */
+    protected function detachProduct(ProductInterface $product)
+    {
+        if (null !== $this->detacher) {
+            $this->detacher->detach($product);
+        }
     }
 }

--- a/src/Pim/Component/Connector/Processor/Denormalization/ProductProcessor.php
+++ b/src/Pim/Component/Connector/Processor/Denormalization/ProductProcessor.php
@@ -108,6 +108,7 @@ class ProductProcessor extends AbstractProcessor
             $filteredItem = $this->filterIdenticalData($product, $filteredItem);
 
             if (empty($filteredItem)) {
+                $this->detachProduct($product);
                 $this->stepExecution->incrementSummaryInfo('product_skipped_no_diff');
 
                 return null;


### PR DESCRIPTION
**Related to https://github.com/akeneo/pim-community-dev/pull/3599, please read it first ;)**

| Q                 | A
| ----------------- | ---
| Specs             | Y
| Behats            | -
| Blue CI           | Y in CE (running in EE)
| Changelog updated | Y
| Review and 2 GTM  |

Import of 5k products, on my local machine, no xdebug:
* ORM:  11 minutes, small memory leak during `import_products` step (176mB at 300 products, 190mB at 2k products and 210mB at 5k products), no leak at all on the `import_associations` step (stable at 210mB)
* ODM: 4 minutes, small memory leak during `import_products` step (105mB at 300 products, 116mB at 2k products and 117mB at 5k products), no leak at all on the `import_associations` step (stable at 156mB)

Without this fix (branch 1.4)
* ODM : 3minutes 35sec, small memory leak during `import_products` step (105mB at 300 products, 116mB at 2k products and 117mB at 5k products), huge leak at all on the `import_associations` step (up to 1gB)