### PR TITLE
[WIP] PIM-5170: bump Doctrine Mongo libs

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project name="pim" default="build"
-    xmlns:if="ant:if"
-    xmlns:unless="ant:unless"
 >
     <property name="symfony.catalog.storage.dir" value="catalog" />
 
@@ -362,13 +360,13 @@
             <arg value="require" />
             <arg value="--no-update" />
             <arg value="doctrine/mongodb-odm-bundle" />
-            <arg value="v3.0.0-BETA6@dev" />
+            <arg value="v3.0.1" />
         </exec>
         <exec executable="${basedir}/composer.phar" failonerror="true">
             <arg value="require" />
             <arg value="--no-update" />
             <arg value="doctrine/mongodb-odm" />
-            <arg value="v1.0.0-beta12@dev" />
+            <arg value="v1.0.3" />
         </exec>
     </target>
 


### PR DESCRIPTION
TODO:
 - [x] merge https://github.com/akeneo/pim-community-dev/pull/3716 on 1.4 first
 - [ ] try to bump Doctrine libs to stable versions
 - [ ] change the doc for Doctrine bump
 - [ ] merge 1.4 on master on remove Benoits commits related to cascade detach
 - [ ] retest import of 5k products if ensure memory leak problem is fixed on associations