### PR TITLE
[TR] PIM-5232: Ajaxify product grid family filter

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -1,3 +1,8 @@
+# 1.4.x
+
+## Bug fixes
+- PIM-5232: Load choices asynchronously in the product family filter to improve grid loading time 
+
 # 1.4.13 (2015-12-10)
 
 ## BC Breaks

--- a/features/product/filtering/filter_products_per_family.feature
+++ b/features/product/filtering/filter_products_per_family.feature
@@ -27,8 +27,8 @@ Feature: Filter products per family
     And the grid should contain 7 elements
     Then I should see the filter "Family"
     And I should be able to use the following filters:
-      | filter | value               | result                               |
-      | Family | [computers]         | PC and Laptop                        |
-      | Family | [hi_fi],[computers] | Amplifier, CD changer, PC and Laptop |
-      | Family | [washing_machines]  | Whirlpool and Electrolux             |
-      | Family | is empty            | Mug                                  |
+      | filter | value            | result                               |
+      | Family | computers        | PC and Laptop                        |
+      | Family | hi_fi,computers  | Amplifier, CD changer, PC and Laptop |
+      | Family | washing_machines | Whirlpool and Electrolux             |
+      | Family | is empty         | Mug                                  |

--- a/spec/Pim/Bundle/FilterBundle/Filter/Product/FamilyFilterSpec.php
+++ b/spec/Pim/Bundle/FilterBundle/Filter/Product/FamilyFilterSpec.php
@@ -23,7 +23,7 @@ class FamilyFilterSpec extends ObjectBehavior
         FilterDatasourceAdapterInterface $datasource,
         $utility
     ) {
-        $utility->applyFilter($datasource, 'family.id', 'IN', [2, 3])->shouldBeCalled();
+        $utility->applyFilter($datasource, 'family.code', 'IN', [2, 3])->shouldBeCalled();
 
         $this->apply($datasource, ['type' => null, 'value' => [2, 3]]);
     }

--- a/spec/Pim/Bundle/FilterBundle/Filter/ProductValue/ChoiceFilterSpec.php
+++ b/spec/Pim/Bundle/FilterBundle/Filter/ProductValue/ChoiceFilterSpec.php
@@ -7,7 +7,6 @@ use Oro\Bundle\FilterBundle\Datasource\FilterDatasourceAdapterInterface;
 use PhpSpec\ObjectBehavior;
 use Pim\Bundle\CatalogBundle\Doctrine\ORM\Repository\AttributeRepository;
 use Pim\Bundle\CatalogBundle\Model\AttributeInterface;
-use Pim\Bundle\CatalogBundle\Repository\AttributeRepositoryInterface;
 use Pim\Bundle\FilterBundle\Filter\ProductFilterUtility;
 use Pim\Bundle\FilterBundle\Form\Type\Filter\AjaxChoiceFilterType;
 use Pim\Bundle\UserBundle\Context\UserContext;
@@ -106,21 +105,18 @@ class ChoiceFilterSpec extends ObjectBehavior
      */
     function it_provides_a_choice_filter_form(
         Form $form,
-        AttributeRepositoryInterface $attributeRepository,
         AttributeInterface $attribute,
-        $utility,
         $factory,
         $repository
     ) {
         $repository->findOneByCode('data_name_key')->willReturn($attribute);
 
         $factory->create(AjaxChoiceFilterType::NAME, [], [
-            'csrf_protection' => false,
-            'field_options' => [],
-            'choice_url' => 'pim_ui_ajaxentity_list',
+            'csrf_protection'   => false,
+            'choice_url'        => 'pim_ui_ajaxentity_list',
             'choice_url_params' => [
-                'class' => 'attributeOptionClass',
-                'dataLocale' => null,
+                'class'        => 'attributeOptionClass',
+                'dataLocale'   => null,
                 'collectionId' => null
             ]
         ])->willReturn($form);

--- a/src/Pim/Bundle/DataGridBundle/Resources/config/requirejs.yml
+++ b/src/Pim/Bundle/DataGridBundle/Resources/config/requirejs.yml
@@ -97,4 +97,5 @@ config:
         oro/datafilter/collection-filters-manager:  pimdatagrid/js/datafilter/collection-filters-manager
         oro/datafilter-builder:                     pimdatagrid/js/datafilter-builder
 
-        pim/template/datagrid/configure-columns-action: pimdatagrid/templates/configure-columns-action.html
+        pim/template/datagrid/configure-columns-action:         pimdatagrid/templates/configure-columns-action.html
+        pim/template/datagrid/filter/select2-choice-filter:     pimdatagrid/templates/filter/select2-choice-filter.html

--- a/src/Pim/Bundle/DataGridBundle/Resources/config/requirejs.yml
+++ b/src/Pim/Bundle/DataGridBundle/Resources/config/requirejs.yml
@@ -80,6 +80,7 @@ config:
         oro/datafilter/product_completeness-filter: pimdatagrid/js/datafilter/filter/product_completeness-filter
         oro/datafilter/ajax-choice-filter:          pimdatagrid/js/datafilter/filter/ajax-choice-filter
         oro/datafilter/select2-choice-filter:       pimdatagrid/js/datafilter/filter/select2-choice-filter
+        oro/datafilter/select2-rest-choice-filter:  pimdatagrid/js/datafilter/filter/select2-rest-choice-filter
 
         oro/datafilter/abstract-filter:             pimdatagrid/js/datafilter/filter/abstract-filter
         oro/datafilter/none-filter:                 pimdatagrid/js/datafilter/filter/none-filter

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/select2-choice-filter.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/select2-choice-filter.js
@@ -1,6 +1,13 @@
 define(
-    ['jquery', 'underscore', 'oro/datafilter/text-filter', 'routing', 'jquery.select2'],
-    function($, _, TextFilter, Routing) {
+    [
+        'jquery',
+        'underscore',
+        'oro/datafilter/text-filter',
+        'routing',
+        'text!pim/template/datagrid/filter/select2-choice-filter',
+        'jquery.select2'
+    ],
+    function($, _, TextFilter, Routing, template) {
         'use strict';
 
         return TextFilter.extend({
@@ -11,31 +18,7 @@ define(
             resultCache: {},
             resultsPerPage: 20,
             choices: [],
-            popupCriteriaTemplate: _.template(
-                '<div class="choicefilter">' +
-                    '<div class="input-prepend">' +
-                        '<div class="btn-group">' +
-                            '<% if (emptyChoice) { %>' +
-                                '<button class="btn dropdown-toggle" data-toggle="dropdown">' +
-                                    '<%= selectedOperatorLabel %>' +
-                                    '<span class="caret"></span>' +
-                                '</button>' +
-                                '<ul class="dropdown-menu">' +
-                                    '<% _.each(operatorChoices, function (label, operator) { %>' +
-                                        '<li<% if (selectedOperator == operator) { %> class="active"<% } %>>' +
-                                            '<a class="operator_choice" href="#" data-value="<%= operator %>"><%= label %></a>' +
-                                        '</li>' +
-                                    '<% }); %>' +
-                                '</ul>' +
-                            '<% } %>' +
-                            '<input type="text" name="value" value=""/>' +
-                        '</div>' +
-                    '</div>' +
-                    '<div class="btn-group">' +
-                        '<button type="button" class="btn btn-primary filter-update"><%- _.__("Update") %></button>' +
-                    '</div>' +
-                '</div>'
-            ),
+            popupCriteriaTemplate: _.template(template),
 
             events: {
                 'click .operator_choice': '_onSelectOperator'

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/select2-rest-choice-filter.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/select2-rest-choice-filter.js
@@ -1,0 +1,234 @@
+'use strict';
+
+define(
+    [
+        'jquery',
+        'underscore',
+        'routing',
+        'oro/datafilter/text-filter',
+        'pim/formatter/choices/base',
+        'text!pim/template/datagrid/filter/select2-choice-filter',
+        'jquery.select2'
+    ],
+    function($, _, Routing, TextFilter, ChoicesFormatter, template) {
+        return TextFilter.extend({
+            operatorChoices: [],
+            choiceUrl: null,
+            choiceUrlParams: {},
+            emptyChoice: false,
+            resultsPerPage: 20,
+            popupCriteriaTemplate: _.template(template),
+
+            events: {
+                'click .operator_choice': '_onSelectOperator'
+            },
+
+            initialize: function(options) {
+                _.extend(this.events, TextFilter.prototype.events);
+
+                if (!_.isUndefined(options)) {
+                    _.extend(this, _.pick(options, 'choiceUrl', 'choiceUrlParams', 'emptyChoice'));
+                }
+
+                if (_.isUndefined(this.emptyValue)) {
+                    this.emptyValue = {
+                        type: 'in',
+                        value: ''
+                    };
+                }
+
+                TextFilter.prototype.initialize.apply(this, arguments);
+            },
+
+            _onSelectOperator: function(e) {
+                $(e.currentTarget).parent().parent().find('li').removeClass('active');
+                $(e.currentTarget).parent().addClass('active');
+                var parentDiv = $(e.currentTarget).parent().parent().parent();
+
+                if ($(e.currentTarget).attr('data-value') === 'empty') {
+                    this._disableInput();
+                } else {
+                    this._enableInput();
+                }
+                parentDiv.find('button').html($(e.currentTarget).html() + '<span class="caret"></span>');
+                e.preventDefault();
+            },
+
+            _enableInput: function() {
+                this.$(this.criteriaValueSelectors.value).select2(this._getSelect2Config());
+                this.$(this.criteriaValueSelectors.value).show();
+            },
+
+            _disableInput: function() {
+                this.$(this.criteriaValueSelectors.value).val('').select2('destroy');
+                this.$(this.criteriaValueSelectors.value).hide();
+            },
+
+            _getSelect2Config: function() {
+                var config = {
+                    multiple: true,
+                    allowClear: false,
+                    width: '290px',
+                    minimumInputLength: 0
+                };
+
+                if (null !== this.choiceUrl) {
+                    config.ajax = {
+                        url: Routing.generate(this.choiceUrl, this.choiceUrlParams),
+                        cache: true,
+                        data: function(term, page) {
+                                return {
+                                    search: term,
+                                    options: {
+                                        limit: this.resultsPerPage,
+                                        page: page
+                                    }
+                                };
+                            }.bind(this),
+                        results: function(data) {
+                                data.results = ChoicesFormatter.format(data);
+                                data.more    = this.resultsPerPage === data.results.length;
+
+                                return data;
+                            }.bind(this)
+                    };
+                }
+
+                return config;
+            },
+
+            _writeDOMValue: function(value) {
+                this.$('li .operator_choice[data-value="' + value.type + '"]').trigger('click');
+                var operator = this.$('li.active .operator_choice').data('value');
+                if ('empty' === operator) {
+                    this._setInputValue(this.criteriaValueSelectors.value, []);
+                } else {
+                    this._setInputValue(this.criteriaValueSelectors.value, value.value);
+                }
+
+                return this;
+            },
+
+            _readDOMValue: function() {
+                var operator = this.emptyChoice ? this.$('li.active .operator_choice').data('value') : 'in';
+
+                return {
+                    value: operator === 'empty' ? {} : this._getInputValue(this.criteriaValueSelectors.value),
+                    type: operator
+                };
+            },
+
+            _renderCriteria: function(el) {
+                this.operatorChoices = {
+                    'in':    _.__('pim.grid.choice_filter.label_in_list'),
+                    'empty': _.__('pim.grid.choice_filter.label_empty')
+                };
+
+                $(el).append(
+                    this.popupCriteriaTemplate({
+                        emptyChoice:           this.emptyChoice,
+                        selectedOperatorLabel: this.operatorChoices[this.emptyValue.type],
+                        operatorChoices:       this.operatorChoices,
+                        selectedOperator:      this.emptyValue.type
+                    })
+                );
+
+                this.$(this.criteriaValueSelectors.value).select2(this._getSelect2Config());
+            },
+
+            _onClickCriteriaSelector: function(e) {
+                e.stopPropagation();
+                $('body').trigger('click');
+                if (!this.popupCriteriaShowed) {
+                    this._showCriteria();
+                    this.$(this.criteriaValueSelectors.value).select2('open');
+                } else {
+                    this._hideCriteria();
+                }
+            },
+
+            _onClickCloseCriteria: function() {
+                TextFilter.prototype._onClickCloseCriteria.apply(this, arguments);
+
+                this.$(this.criteriaValueSelectors.value).select2('close');
+            },
+
+            _onClickOutsideCriteria: function(e) {
+                var elem = this.$(this.criteriaSelector);
+
+                if (e.target != $('body').get(0) && e.target !== elem.get(0) && !elem.has(e.target).length) {
+                    this._hideCriteria();
+                    this.setValue(this._formatRawValue(this._readDOMValue()));
+                    e.stopPropagation();
+                }
+            },
+
+            _onReadCriteriaInputKey: function(e) {
+                if (e.which == 13) {
+                    this.$(this.criteriaValueSelectors.value).select2('close');
+                    this._hideCriteria();
+                    this.setValue(this._formatRawValue(this._readDOMValue()));
+                }
+            },
+
+            _getResults: function(identifiers) {
+                var results = [];
+                var params  = {options: {identifiers: identifiers}};
+
+                $.ajax({
+                    url: Routing.generate(this.choiceUrl, this.choiceUrlParams) + '?' + $.param(params),
+                    success: function(data) {
+                        results = ChoicesFormatter.format(data);
+                    },
+                    async: false
+                });
+
+                return results;
+            },
+
+            _getInputValue: function(input) {
+                return this.$(input).select2('val');
+            },
+
+            _setInputValue: function(input, value) {
+                this.$(input).select2('data', this._getResults(value));
+
+                return this;
+            },
+
+            _updateDOMValue: function() {
+                var currentValue = this.getValue();
+                var data         = this.$(this.criteriaValueSelectors.value).select2('data');
+                if (0 === _.difference(currentValue.value, _.pluck(data, 'id')).length) {
+                    return;
+                }
+
+                return this._writeDOMValue(currentValue);
+            },
+
+            _formatDisplayValue: function(value) {
+                if (_.isEmpty(value.value)) {
+                    return value;
+                }
+
+                return {
+                    value: _.pluck(
+                        this.$(this.criteriaValueSelectors.value).select2('data'),
+                        'text'
+                    ).join(', ')
+                };
+            },
+
+            _getCriteriaHint: function() {
+                var operator = this.$('li.active .operator_choice').data('value');
+                if ('empty' === operator) {
+                    return this.operatorChoices[operator];
+                }
+
+                var value = (arguments.length > 0) ? this._getDisplayValue(arguments[0]) : this._getDisplayValue();
+
+                return !_.isEmpty(value.value) ? '"' + value.value + '"': this.placeholder;
+            }
+        });
+    }
+);

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/templates/filter/select2-choice-filter.html
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/templates/filter/select2-choice-filter.html
@@ -1,0 +1,23 @@
+<div class="choicefilter">
+    <div class="input-prepend">
+        <div class="btn-group">
+            <% if (emptyChoice) { %>
+                <button class="btn dropdown-toggle" data-toggle="dropdown">
+                    <%= selectedOperatorLabel %>
+                    <span class="caret"></span>
+                </button>
+                <ul class="dropdown-menu">
+                    <% _.each(operatorChoices, function (label, operator) { %>
+                        <li<% if (selectedOperator == operator) { %> class="active"<% } %>>
+                            <a class="operator_choice" href="#" data-value="<%= operator %>"><%= label %></a>
+                        </li>
+                    <% }); %>
+                </ul>
+            <% } %>
+            <input type="text" name="value">
+        </div>
+    </div>
+    <div class="btn-group">
+        <button type="button" class="btn btn-primary filter-update"><%- _.__('Update') %></button>
+    </div>
+</div>

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/templates/filter/select2-choice-filter.html
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/templates/filter/select2-choice-filter.html
@@ -2,7 +2,7 @@
     <div class="input-prepend">
         <div class="btn-group">
             <% if (emptyChoice) { %>
-                <button class="btn dropdown-toggle" data-toggle="dropdown">
+                <button type="button" class="btn dropdown-toggle" data-toggle="dropdown">
                     <%= selectedOperatorLabel %>
                     <span class="caret"></span>
                 </button>

--- a/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/FamilySearchableRepository.php
+++ b/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/FamilySearchableRepository.php
@@ -46,6 +46,11 @@ class FamilySearchableRepository implements SearchableRepositoryInterface
             $qb->orWhere('ft.label like :search')->setParameter('search', "%$search%");
         }
 
+        if (isset($options['identifiers']) && is_array($options['identifiers']) && !empty($options['identifiers'])) {
+            $qb->andWhere('f.code in (:codes)');
+            $qb->setParameter('codes', $options['identifiers']);
+        }
+
         if (isset($options['limit'])) {
             $qb->setMaxResults((int) $options['limit']);
             if (isset($options['page'])) {

--- a/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/FamilySearchableRepository.php
+++ b/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/FamilySearchableRepository.php
@@ -39,9 +39,9 @@ class FamilySearchableRepository implements SearchableRepositoryInterface
     public function findBySearch($search = null, array $options = [])
     {
         $qb = $this->entityManager->createQueryBuilder()->select('f')->from($this->entityName, 'f');
-        $qb->join('f.translations', 'ft');
+        $qb->leftJoin('f.translations', 'ft');
 
-        if (null !== $search) {
+        if (null !== $search && '' !== $search) {
             $qb->where('f.code like :search')->setParameter('search', "%$search%");
             $qb->orWhere('ft.label like :search')->setParameter('search', "%$search%");
         }

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product.yml
@@ -158,10 +158,9 @@ datagrid:
                     data_name: family
                     options:
                         field_options:
+                            multiple: true
                             attr:
                                 empty_choice: true
-                            multiple: true
-                            choices:  '@pim_catalog.manager.family->getChoices'
                 groups:
                     type:      product_groups
                     label:     Groups

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
@@ -202,6 +202,9 @@ config:
         pim/textarea-field:                 pimenrich/js/product/field/textarea-field
         pim/wysiwyg-field:                  pimenrich/js/product/field/wysiwyg-field
 
+        # Fromatters
+        pim/formatter/choices/base: pimenrich/js/formatter/choices/base
+
         # Templates
         pim/template/product/form:                                   pimenrich/templates/product/form.html
         pim/template/product/tab/categories:                         pimenrich/templates/product/tab/categories.html

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
@@ -202,7 +202,7 @@ config:
         pim/textarea-field:                 pimenrich/js/product/field/textarea-field
         pim/wysiwyg-field:                  pimenrich/js/product/field/wysiwyg-field
 
-        # Fromatters
+        # Formatters
         pim/formatter/choices/base: pimenrich/js/formatter/choices/base
 
         # Templates

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/formatter/choices/base.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/formatter/choices/base.js
@@ -1,0 +1,50 @@
+'use strict';
+
+define(['underscore', 'pim/user-context', 'pim/i18n'], function (_, UserContext, i18n) {
+    return {
+        /**
+         * Format a collection of entities into a list of choices as follows.
+         * From :
+         * [
+         *     {
+         *         code: 'webcams',
+         *         label: {
+         *             en_US:'Webcams',
+         *             fr_FR:'Webcams',
+         *             de_DE:'Webcams'
+         *         }
+         *     },
+         *     {
+         *         code: 'mugs',
+         *         label: {
+         *             en_US: 'Mugs',
+         *             fr_FR: 'Chopes\/Mugs',
+         *             de_DE: 'Tassen'
+         *         }
+         *     }
+         * ]
+         *
+         * to (for locale "de_DE") :
+         *
+         * [
+         *     { id: 'webcams', text: 'Webcams' },
+         *     { id: 'mugs', text: 'Tassen' }
+         * ]
+         *
+         * @param {Array} entities
+         *
+         * @return {Array}
+         */
+        format: function (entities) {
+            var choices = [];
+            _.each(entities, function (entity) {
+                choices.push({
+                    id: entity.code,
+                    text: i18n.getLabel(entity.label, UserContext.get('catalogLocale'), entity.code)
+                });
+            });
+
+            return choices;
+        }
+    };
+});

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/spec/formatter/choices/BaseChoicesFormatterSpec.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/spec/formatter/choices/BaseChoicesFormatterSpec.js
@@ -1,0 +1,54 @@
+/* global describe, it, expect, beforeEach, spyOn */
+'use strict';
+
+define(
+    ['pim/formatter/choices/base', 'pim/user-context', 'pim/i18n'],
+    function (Formatter, UserContext, i18n) {
+        describe('Base choices formatter', function () {
+            beforeEach(function () {
+                this.entities = [
+                    {
+                        code: 'webcams',
+                        label: {
+                            en_US:'Webcams',
+                            fr_FR:'Webcams',
+                            de_DE:'Webcams'
+                        }
+                    },
+                    {
+                        code: 'mugs',
+                        label: {
+                            en_US: 'Mugs',
+                            fr_FR: 'Chopes\/Mugs',
+                            de_DE: 'Tassen'
+                        }
+                    }
+                ];
+            });
+
+            it('provides a method to format a list of choices', function () {
+                expect(Formatter.format).toBeDefined();
+            });
+
+            it('it formats a list of choices', function () {
+                spyOn(UserContext, 'get').and.returnValue('de_DE');
+                spyOn(i18n, 'getLabel').and.callThrough();
+
+                expect(Formatter.format(this.entities)).toEqual([
+                    { id: 'webcams', text: 'Webcams' },
+                    { id: 'mugs', text: 'Tassen' }
+                ]);
+            });
+
+            it('it formats a list of choices with fallbacks for labels', function () {
+                spyOn(UserContext, 'get').and.returnValue('unsupported_locale');
+                spyOn(i18n, 'getLabel').and.callThrough();
+
+                expect(Formatter.format(this.entities)).toEqual([
+                    { id: 'webcams', text: '[webcams]' },
+                    { id: 'mugs', text: '[mugs]' }
+                ]);
+            });
+        });
+    }
+);

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/spec/formatter/choices/BaseChoicesFormatterSpec.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/spec/formatter/choices/BaseChoicesFormatterSpec.js
@@ -10,9 +10,9 @@ define(
                     {
                         code: 'webcams',
                         label: {
-                            en_US:'Webcams',
-                            fr_FR:'Webcams',
-                            de_DE:'Webcams'
+                            en_US: 'Webcams',
+                            fr_FR: 'Webcams',
+                            de_DE: 'Webcams'
                         }
                     },
                     {

--- a/src/Pim/Bundle/FilterBundle/Filter/AjaxChoiceFilter.php
+++ b/src/Pim/Bundle/FilterBundle/Filter/AjaxChoiceFilter.php
@@ -30,7 +30,7 @@ class AjaxChoiceFilter extends ChoiceFilter
      */
     public function getForm()
     {
-        if (!$this->form) {
+        if (null === $this->form) {
             $this->form = $this->formFactory->create($this->getFormType(), [], $this->getFormOptions());
         }
 

--- a/src/Pim/Bundle/FilterBundle/Filter/AjaxChoiceFilter.php
+++ b/src/Pim/Bundle/FilterBundle/Filter/AjaxChoiceFilter.php
@@ -28,6 +28,18 @@ class AjaxChoiceFilter extends ChoiceFilter
     /**
      * {@inheritdoc}
      */
+    public function getForm()
+    {
+        if (!$this->form) {
+            $this->form = $this->formFactory->create($this->getFormType(), [], $this->getFormOptions());
+        }
+
+        return $this->form;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getMetadata()
     {
         $formView = $this->getForm()->createView();
@@ -79,5 +91,18 @@ class AjaxChoiceFilter extends ChoiceFilter
         }
 
         return parent::parseData($data);
+    }
+
+    /**
+     * Return options passed to the form factory
+     *
+     * @return array
+     */
+    protected function getFormOptions()
+    {
+        return array_merge(
+            $this->getOr(FilterUtility::FORM_OPTIONS_KEY, []),
+            ['csrf_protection' => false]
+        );
     }
 }

--- a/src/Pim/Bundle/FilterBundle/Filter/Product/FamilyFilter.php
+++ b/src/Pim/Bundle/FilterBundle/Filter/Product/FamilyFilter.php
@@ -27,9 +27,9 @@ class FamilyFilter extends AjaxChoiceFilter
         }
 
         if (Operators::IS_EMPTY === strtoupper($data['type'])) {
-            $this->util->applyFilter($dataSource, 'family.id', Operators::IS_EMPTY, null);
+            $this->util->applyFilter($dataSource, 'family.code', Operators::IS_EMPTY, null);
         } else {
-            $this->util->applyFilter($dataSource, 'family.id', Operators::IN_LIST, $data['value']);
+            $this->util->applyFilter($dataSource, 'family.code', Operators::IN_LIST, $data['value']);
         }
 
         return true;
@@ -43,7 +43,7 @@ class FamilyFilter extends AjaxChoiceFilter
         $metadata = parent::getMetadata();
 
         $metadata['emptyChoice'] = true;
-        $metadata[FilterUtility::TYPE_KEY] = 'select2-choice';
+        $metadata[FilterUtility::TYPE_KEY] = 'select2-rest-choice';
 
         return $metadata;
     }
@@ -51,13 +51,11 @@ class FamilyFilter extends AjaxChoiceFilter
     /**
      * {@inheritdoc}
      */
-    protected function parseData($data)
+    protected function getFormOptions()
     {
-        $data = parent::parseData($data);
-        if (is_array($data['value'])) {
-            $data['value'] = array_map('intval', $data['value']);
-        }
-
-        return $data;
+        return array_merge(
+            parent::getFormOptions(),
+            ['choice_url' => 'pim_enrich_family_rest_index']
+        );
     }
 }

--- a/src/Pim/Bundle/FilterBundle/Filter/Product/GroupsFilter.php
+++ b/src/Pim/Bundle/FilterBundle/Filter/Product/GroupsFilter.php
@@ -62,34 +62,18 @@ class GroupsFilter extends AjaxChoiceFilter
     /**
      * {@inheritdoc}
      */
-    public function getForm()
+    protected function getFormOptions()
     {
-        $options = array_merge(
-            $this->getOr('options', []),
-            ['csrf_protection' => false]
+        return array_merge(
+            parent::getFormOptions(),
+            [
+                'choice_url'        => 'pim_ui_ajaxentity_list',
+                'choice_url_params' => [
+                    'class'        => $this->groupClass,
+                    'dataLocale'   => $this->userContext->getCurrentLocaleCode(),
+                    'collectionId' => null
+                ]
+            ]
         );
-
-        $options['field_options']     = isset($options['field_options']) ? $options['field_options'] : [];
-        $options['choice_url']        = 'pim_ui_ajaxentity_list';
-        $options['choice_url_params'] = $this->getChoiceUrlParams();
-        $options['preload_choices']   = false;
-
-        if (!$this->form) {
-            $this->form = $this->formFactory->create($this->getFormType(), [], $options);
-        }
-
-        return $this->form;
-    }
-
-    /**
-     * @return array
-     */
-    protected function getChoiceUrlParams()
-    {
-        return [
-            'class'        => $this->groupClass,
-            'dataLocale'   => $this->userContext->getCurrentLocaleCode(),
-            'collectionId' => null
-        ];
     }
 }

--- a/src/Pim/Bundle/FilterBundle/Filter/ProductValue/ChoiceFilter.php
+++ b/src/Pim/Bundle/FilterBundle/Filter/ProductValue/ChoiceFilter.php
@@ -74,33 +74,12 @@ class ChoiceFilter extends AjaxChoiceFilter
     }
 
     /**
-     * {@inheritdoc}
-     */
-    public function getForm()
-    {
-        $attribute = $this->getAttribute();
-
-        $options = array_merge(
-            $this->getOr('options', []),
-            ['csrf_protection' => false]
-        );
-
-        $options['field_options']     = isset($options['field_options']) ? $options['field_options'] : [];
-        $options['choice_url']        = 'pim_ui_ajaxentity_list';
-        $options['choice_url_params'] = $this->getChoiceUrlParams($attribute);
-
-        if (!$this->form) {
-            $this->form = $this->formFactory->create($this->getFormType(), [], $options);
-        }
-
-        return $this->form;
-    }
-
-    /**
      * Load the attribute for this filter
      * Required to prepare choice url params and filter configuration
      *
      * @throws \LogicException
+     *
+     * @return AttributeInterface
      */
     protected function getAttribute()
     {
@@ -115,16 +94,22 @@ class ChoiceFilter extends AjaxChoiceFilter
     }
 
     /**
-     * @param AttributeInterface $attribute
-     *
-     * @return array
+     * {@inheritdoc}
      */
-    protected function getChoiceUrlParams(AttributeInterface $attribute)
+    protected function getFormOptions()
     {
-        return [
-            'class'        => $this->optionRepoClass,
-            'dataLocale'   => $this->userContext->getCurrentLocaleCode(),
-            'collectionId' => $attribute->getId()
-        ];
+        $attribute = $this->getAttribute();
+
+        return array_merge(
+            parent::getFormOptions(),
+            [
+                'choice_url'        => 'pim_ui_ajaxentity_list',
+                'choice_url_params' => [
+                    'class'        => $this->optionRepoClass,
+                    'dataLocale'   => $this->userContext->getCurrentLocaleCode(),
+                    'collectionId' => $attribute->getId()
+                ]
+            ]
+        );
     }
 }

--- a/src/Pim/Bundle/FilterBundle/Form/Type/Filter/AjaxChoiceFilterType.php
+++ b/src/Pim/Bundle/FilterBundle/Form/Type/Filter/AjaxChoiceFilterType.php
@@ -60,7 +60,8 @@ class AjaxChoiceFilterType extends ChoiceFilterType
                 'choices'           => [],
                 'preload_choices'   => false,
                 'choice_url'        => null,
-                'choice_url_params' => null
+                'choice_url_params' => null,
+                'field_options'     => []
             ]
         );
     }

--- a/src/Pim/Bundle/ReferenceDataBundle/DataGrid/Filter/ReferenceDataFilter.php
+++ b/src/Pim/Bundle/ReferenceDataBundle/DataGrid/Filter/ReferenceDataFilter.php
@@ -2,7 +2,6 @@
 
 namespace Pim\Bundle\ReferenceDataBundle\DataGrid\Filter;
 
-use Pim\Bundle\CatalogBundle\Model\AttributeInterface;
 use Pim\Bundle\CatalogBundle\Repository\AttributeRepositoryInterface;
 use Pim\Bundle\FilterBundle\Filter\ProductFilterUtility;
 use Pim\Bundle\FilterBundle\Filter\ProductValue\ChoiceFilter;
@@ -44,22 +43,27 @@ class ReferenceDataFilter extends ChoiceFilter
     }
 
     /**
-     * @param AttributeInterface $attribute
-     *
-     * @return array
+     * {@inheritdoc}
      */
-    protected function getChoiceUrlParams(AttributeInterface $attribute)
+    protected function getFormOptions()
     {
+        $attribute         = $this->getAttribute();
         $referenceDataName = $attribute->getReferenceDataName();
-        $referenceData = $this->registry->get($referenceDataName);
+        $referenceData     = $this->registry->get($referenceDataName);
+
         if (null === $referenceData) {
             throw new \InvalidArgumentException(sprintf('Reference data "%s" does not exist', $referenceDataName));
         }
 
-        return [
-            'class'        => $referenceData->getClass(),
-            'dataLocale'   => $this->userContext->getCurrentLocaleCode(),
-            'collectionId' => $attribute->getId()
-        ];
+        return array_merge(
+            parent::getFormOptions(),
+            [
+                'choice_url_params' => [
+                    'class'        => $referenceData->getClass(),
+                    'dataLocale'   => $this->userContext->getCurrentLocaleCode(),
+                    'collectionId' => $attribute->getId()
+                ]
+            ]
+        );
     }
 }

--- a/src/Pim/Bundle/UIBundle/Entity/Repository/OptionRepositoryInterface.php
+++ b/src/Pim/Bundle/UIBundle/Entity/Repository/OptionRepositoryInterface.php
@@ -10,6 +10,8 @@ namespace Pim\Bundle\UIBundle\Entity\Repository;
  * @author    Antoine Guigan <antoine@akeneo.com>
  * @copyright 2013 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *
+ * @deprecated Will be removed in 1.6, please use Akeneo\Component\StorageUtils\Repository\SearchableRepositoryInterface
  */
 interface OptionRepositoryInterface
 {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Specs             | yes
| Behats            | n/a
| Blue CI           | yes
| Changelog updated | yes
| Review and 2 GTM  | 

Done in this PR :
- Refactor AjaxChoiceFilter children to avoid overriding the `getForm()` just to change the conf
- Modify the family filter type to be able to filter by codes instead of ids
- Add a new choices filter in front able to fetch choices from any rest route that return a normalized response (PEF style), not select2 formatted one
- Add a formatter that transform the normalized response into the select2 format