### PR TITLE
[TR] [SLA] PIM-5202: Remove version is now created on PRE_REMOVE instead of POST

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -6,6 +6,8 @@
 
 ## BC Breaks
 - Changed constructor `Pim\Bundle\EnrichBundle\Form\Type\ProductCreateType` to add `Pim\Bundle\CatalogBundle\Doctrine\ORM\Repository\FamilyRepository` dependency
+- Updated event on which `Pim\Bundle\VersioningBundle\EventSubscriber\AddRemoveSubscriber` subscribing, PRE_REMOVE instead of POST_REMOVE.
+- Updated public method preRemove from `Pim\Bundle\VersioningBundle\EventSubscriber\AddRemoveSubscriber` to addRemoveVersion.
 
 ## Bug fixes
 - PIM-5295: Fix association product grid category filter

--- a/features/product/edit_and_remove_a_product.feature
+++ b/features/product/edit_and_remove_a_product.feature
@@ -1,0 +1,37 @@
+@javascript
+Feature: Edit and remove a product
+  In order to delete an unnecessary product from my PIM
+  As a product manager
+  I need to be able to work with a product and then remove it
+
+  Background:
+    Given the "footwear" catalog configuration
+    And the following family:
+      | code  | attributes                                                               |
+      | shoes | sku, name, description, price, rating, size, color, manufacturer, length |
+    And I am logged in as "Julia"
+    And I am on the products page
+    And I create a new product
+    And I fill in the following information in the popin:
+      | SKU             | boots |
+      | Choose a family | shoes |
+    And I press the "Save" button in the popin
+    Then I am on the "boots" product page
+    And I fill in the following information:
+      | Length | 5.0000 CENTIMETER |
+    And I press the "Save" button
+
+  Scenario: Successfully edit and then delete a product from the grid
+    Given I am on the products page
+    Then I should see product boots
+    When I click on the "Delete the product" action of the row which contains "boots"
+    Then I should see "Delete confirmation"
+    When I confirm the removal
+    Then I should be on the products page
+    And I should not see product boots
+
+  Scenario: Successfully delete a product from the edit form
+    Given I press the "Delete" button
+    Then I should see "Confirm deletion"
+    When I confirm the removal
+    Then I should not see product boots

--- a/spec/Pim/Bundle/VersioningBundle/EventSubscriber/AddRemoveVersionSubscriberSpec.php
+++ b/spec/Pim/Bundle/VersioningBundle/EventSubscriber/AddRemoveVersionSubscriberSpec.php
@@ -37,7 +37,7 @@ class AddRemoveVersionSubscriberSpec extends ObjectBehavior
     function it_subscribes_to_post_remove_events()
     {
         $this->getSubscribedEvents()->shouldReturn([
-            StorageEvents::POST_REMOVE => 'postRemove',
+            StorageEvents::PRE_REMOVE => 'addRemoveVersion',
         ]);
     }
 
@@ -76,6 +76,6 @@ class AddRemoveVersionSubscriberSpec extends ObjectBehavior
         $event->getSubjectId()->willReturn(12);
         $event->getArguments()->willReturn($saveOptions);
 
-        $this->postRemove($event);
+        $this->addRemoveVersion($event);
     }
 }

--- a/src/Pim/Bundle/VersioningBundle/EventSubscriber/AddRemoveVersionSubscriber.php
+++ b/src/Pim/Bundle/VersioningBundle/EventSubscriber/AddRemoveVersionSubscriber.php
@@ -63,14 +63,14 @@ class AddRemoveVersionSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return [
-            StorageEvents::POST_REMOVE => 'postRemove',
+            StorageEvents::PRE_REMOVE => 'addRemoveVersion',
         ];
     }
 
     /**
      * @param RemoveEvent $event
      */
-    public function postRemove(RemoveEvent $event)
+    public function addRemoveVersion(RemoveEvent $event)
     {
         $author  = '';
         $subject = $event->getSubject();

--- a/src/Pim/Bundle/VersioningBundle/Resources/config/event_subscribers.yml
+++ b/src/Pim/Bundle/VersioningBundle/Resources/config/event_subscribers.yml
@@ -37,4 +37,4 @@ services:
             - '@security.authorization_checker'
             - '@pim_versioning.saver.version'
         tags:
-            - { name: kernel.event_subscriber}
+            - { name: kernel.event_subscriber, priority: 0 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Specs             | ok
| Behats            | ok
| Blue CI           | running
| Changelog updated | yes
| Review and 2 GTM  |

From 1.4.0 to 1.5, remove a product add a flash message "Product cannot be deleted" but remove well the product and add the remove version. 
Bug come from the versionning. When we remove the product we try to create a version several time when the product is already deleted (and the version already added too) only if the product has a Metric product value. When we try to create the version a second time we have the product but not product values and normalizer throw an exception because it can't find the identifier product value.

We spent a lot of time with benoit to debug it and decided to fix the problem moving the AddRemoveVersionSubscriber to PRE_REMOVE. In this case, version are OK, product is removed, and with event subscriber priorities published products are safe.

I added a "Save" during behats because when we add products with behat (or when we create a product in local) product values are not in DB. We need to manually save the product to add product values in DB. We need a Metric attribute to break the scenario in the case of the bug.

The problem will be cleaned fix when we'll rework versionning.