### PR TITLE
[TR][SLA]PIM-5295: Fix association product grid category filter

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -8,6 +8,7 @@
 - Changed constructor `Pim\Bundle\EnrichBundle\Form\Type\ProductCreateType` to add `Pim\Bundle\CatalogBundle\Doctrine\ORM\Repository\FamilyRepository` dependency
 
 ## Bug fixes
+- PIM-5295: Fix association product grid category filter
 
 # 1.4.13 (2015-12-10)
 

--- a/features/Context/FeatureContext.php
+++ b/features/Context/FeatureContext.php
@@ -412,4 +412,28 @@ class FeatureContext extends MinkContext implements KernelAwareInterface
     {
         return $this->getContainer()->get('pim_enrich.mailer.mail_recorder');
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function clickLink($link)
+    {
+        $this->spin(function () use ($link) {
+            parent::clickLink($link);
+
+            return true;
+        });
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function assertNumElements($num, $element)
+    {
+        $this->spin(function () use ($num, $element) {
+            parent::assertNumElements($num, $element);
+
+            return true;
+        });
+    }
 }

--- a/features/product/associate_product.feature
+++ b/features/product/associate_product.feature
@@ -7,14 +7,14 @@ Feature: Associate a product
   Background:
     Given a "footwear" catalog configuration
     And the following products:
-      | sku            |
-      | charcoal-boots |
-      | black-boots    |
-      | gray-boots     |
-      | brown-boots    |
-      | green-boots    |
-      | shoelaces      |
-      | glossy-boots   |
+      | sku            | categories        |
+      | charcoal-boots | Summer_collection |
+      | black-boots    |                   |
+      | gray-boots     |                   |
+      | brown-boots    |                   |
+      | green-boots    |                   |
+      | shoelaces      |                   |
+      | glossy-boots   |                   |
     And I am logged in as "Julia"
 
   Scenario: Associate a product to another product
@@ -167,3 +167,15 @@ Feature: Associate a product
     And I edit the "red-boots" product
     When I visit the "Associations" tab
     Then I should be able to sort the rows by Is associated
+
+  @jira https://akeneo.atlassian.net/browse/PIM-5295
+  Scenario: Association product grid is not filtered by the category selected in the product grid
+    Given I am on the products page
+    When I filter by "category" with value "Summer_collection"
+    Then I should see product charcoal-boots
+    And I should not see product black-boots
+    When I click on the "charcoal-boots" row
+    And I follow "Associations"
+    Then I should see 6 "#grid-association-product-grid tbody tr" elements
+    When I follow "Upsell"
+    Then I should see 6 "#grid-association-product-grid tbody tr" elements

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/association_product.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/association_product.yml
@@ -122,13 +122,3 @@ datagrid:
                     options:
                         field_options:
                             choices: '@pim_catalog.manager.channel->getChannelChoices'
-                category:
-                    type:      product_category
-                    label:     Category
-                    data_name: category
-            default:
-                category:
-                    value:
-                        treeId: %pim_filter.product_category_filter.class%::UNKNOWN_TREE
-                        categoryId: %pim_filter.product_category_filter.class%::ALL_CATEGORY
-                    type: %pim_filter.product_category_filter.class%::DEFAULT_TYPE


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Specs             | N/A
| Behats            | Y
| Blue CI           | Running
| Changelog updated | Y
| Review and 2 GTM  | TODO

Actually when you go to a product page, throuth the grid filtered by a category, their is a bug in the association panel, the products displayed in the datagrid are filtered by the category used in the product grid but, as the filter is hidden (you dont see the category tree in this page) you are not able to see that the grid is filtered. The quick fix it to completely remove the filter on the product association datagrid so the filter from the product grid dont apply here.

Dev Note concerning Behat: I'm trying here to use only Behat methods so I overrode some native function in order to be able to use them in a SPA context, wrapping them in a spin. This way we could be able to use them in the future as it / without a page context.