### PR TITLE
[TR] PIM-5034: Display currency in product history

### DIFF
--- a/features/Context/AssertionContext.php
+++ b/features/Context/AssertionContext.php
@@ -431,11 +431,13 @@ class AssertionContext extends RawMinkContext
 
             $matchingRow = null;
             $parsedText = '';
+            $parsedTexts = [];
             foreach ($changesetRows as $row) {
                 $innerHtml = $row->find('css', 'td:first-of-type')->getHtml();
 
                 $parsedText = trim(preg_replace('/(<[^>]+>)+/', ' ', $innerHtml));
                 $parsedText = preg_replace('/\s+/', ' ', $parsedText);
+                $parsedTexts[] = $parsedText;
 
                 if ($parsedText === $data['property']) {
                     $matchingRow = $row;
@@ -445,7 +447,7 @@ class AssertionContext extends RawMinkContext
 
             if (!$matchingRow) {
                 throw $this->createExpectationException(
-                    sprintf('No row found for property %s, found %s', $data['property'], $parsedText)
+                    sprintf('No row found for property %s, found %s', $data['property'], implode(', ', $parsedTexts))
                 );
             }
 

--- a/features/Context/AssertionContext.php
+++ b/features/Context/AssertionContext.php
@@ -461,7 +461,7 @@ class AssertionContext extends RawMinkContext
             }
 
             if (!preg_match(
-                sprintf('/^%s$/', str_replace('/', '\/', $newValue)),
+                sprintf('/^%s$/', str_replace(['/', '$', '^'], ['\/', '\$', '\^'], $newValue)),
                 $actual = $matchingRow->find('css', 'td:last-of-type')->getText()
             )) {
                 throw $this->createExpectationException(

--- a/features/localization/product/display_localized_history.feature
+++ b/features/localization/product/display_localized_history.feature
@@ -22,13 +22,13 @@ Feature: Display the localized product history
     When I open the history
     Then there should be 1 update
     And I should see history:
-      | version | property      | value   |
-      | 1       | SKU           | boots   |
-      | 1       | Metrique      | 12,1234 |
-      | 1       | Metrique unit | GRAM    |
-      | 1       | Nombre        | 98,7654 |
-      | 1       | Prix EUR      | 20,80   |
-      | 1       | Prix USD      | 25,35   |
+      | version | property      | value     |
+      | 1       | SKU           | boots     |
+      | 1       | Metrique      | 12,1234   |
+      | 1       | Metrique unit | GRAM      |
+      | 1       | Nombre        | 98,7654   |
+      | 1       | Prix EUR      | 20,80 €   |
+      | 1       | Prix USD      | 25,35 $US |
 
   Scenario: Display english-format product history numbers
     Given I am logged in as "Julia"
@@ -41,5 +41,5 @@ Feature: Display the localized product history
       | 1       | Metric      | 12.1234 |
       | 1       | Metric unit | Gram    |
       | 1       | Number      | 98.7654 |
-      | 1       | Price EUR   | 20.80   |
-      | 1       | Price USD   | 25.35   |
+      | 1       | Price EUR   | €20.80  |
+      | 1       | Price USD   | $25.35  |

--- a/features/localization/product/display_localized_history_of_complex_prices.feature
+++ b/features/localization/product/display_localized_history_of_complex_prices.feature
@@ -1,0 +1,61 @@
+@javascript
+Feature: Display the localized product history for complex prices
+  In order to have complete localized UI
+  As a product manager
+  I need to have show localized localizable and scopable prices
+
+  Background:
+    Given a "apparel" catalog configuration
+    And the following attributes:
+      | code            | label           | label-fr_FR     | type   | decimals_allowed | negative_allowed | group | locales      | localizable | scopable |
+      | localized_price | localized_price | localized_price | prices | yes              | no               | other | fr_FR, en_US | yes         | no       |
+      | scoped_price    | scoped_price    | scoped_price    | prices | yes              | no               | other |              | no          | yes      |
+      | complex_price   | complex_price   | complex_price   | prices | yes              | no               | other | fr_FR, en_US | yes         | yes      |
+    And the following products:
+      | sku      |
+      | sandal   |
+    And I am logged in as "admin"
+    And I edit the "sandal" product
+    And I add available attributes localized_price, scoped_price and complex_price
+    And I change the "localized_price" to "0.12 EUR"
+    And I change the "localized_price" to "3.45 USD"
+    And I change the "scoped_price" to "2.34 EUR"
+    And I change the "scoped_price" to "5.67 USD"
+    And I change the "complex_price" to "4.56 EUR"
+    And I change the "complex_price" to "7.89 USD"
+    And I switch the locale to "fr_FR"
+    And I change the "localized_price" to "1.23 EUR"
+    And I change the "localized_price" to "4.56 USD"
+    And I change the "complex_price" to "5.67 EUR"
+    And I change the "complex_price" to "8.90 USD"
+    And I switch the scope to "print"
+    And I change the "scoped_price" to "3.45 EUR"
+    And I change the "scoped_price" to "6.78 USD"
+    And I switch the locale to "en_US"
+    And I change the "complex_price" to "5.67 EUR"
+    And I change the "complex_price" to "8.90 USD"
+    And I save the product
+    And I logout
+    And the history of the product "sandal" has been built
+
+  Scenario: Display french-format product history prices
+    Given I am logged in as "Julien"
+    And I edit the "sandal" product
+    When I open the history
+    Then there should be 2 update
+    And I should see history:
+      | version | property                       | value    |
+      | 2       | localized_price EUR en         | 0,12 €   |
+      | 2       | localized_price USD en         | 3,45 $US |
+      | 2       | localized_price EUR fr         | 1,23 €   |
+      | 2       | localized_price USD fr         | 4,56 $US |
+      | 2       | scoped_price EUR ecommerce     | 2,34 €   |
+      | 2       | scoped_price USD ecommerce     | 5,67 $US |
+      | 2       | scoped_price EUR print         | 3,45 €   |
+      | 2       | scoped_price USD print         | 6,78 $US |
+      | 2       | complex_price EUR ecommerce en | 4,56 €   |
+      | 2       | complex_price USD ecommerce en | 7,89 $US |
+      | 2       | complex_price EUR print en     | 5,67 €   |
+      | 2       | complex_price USD print en     | 8,90 $US |
+      | 2       | complex_price EUR ecommerce fr | 5,67 €   |
+      | 2       | complex_price USD ecommerce fr | 8,90 $US |

--- a/features/product/history/display_history.feature
+++ b/features/product/history/display_history.feature
@@ -32,9 +32,9 @@ Feature: Display the product history
     When I open the history
     Then there should be 1 update
     And I should see history:
-      | version | property  | value |
-      | 1       | Price EUR | 10    |
-      | 1       | Price USD | 20    |
+      | version | property  | value  |
+      | 1       | Price EUR | €10.00 |
+      | 1       | Price USD | $20.00 |
     When I visit the "Attributes" tab
     And I visit the "Marketing" group
     And I change the "Price" to "19 USD"
@@ -43,8 +43,8 @@ Feature: Display the product history
     When I open the history
     Then there should be 2 updates
     And I should see history:
-      | version | property  | value |
-      | 2       | Price USD | 19    |
+      | version | property  | value  |
+      | 2       | Price USD | $19.00 |
     When I close the "history" panel
     When I visit the "Attributes" tab
     And I visit the "Marketing" group

--- a/features/product/history_update.feature
+++ b/features/product/history_update.feature
@@ -151,9 +151,9 @@ Feature: Update the product history
     When I open the history
     Then there should be 1 update
     And I should see history:
-      | version | property  | value |
-      | 1       | Price EUR | 10    |
-      | 1       | Price USD | 20    |
+      | version | property  | value  |
+      | 1       | Price EUR | €10.00 |
+      | 1       | Price USD | $20.00 |
     When I visit the "Attributes" tab
     And I visit the "Marketing" group
     And I change the "Price" to "19 USD"
@@ -162,8 +162,8 @@ Feature: Update the product history
     When I open the history
     Then there should be 2 updates
     And I should see history:
-      | version | property  | value |
-      | 2       | Price USD | 19    |
+      | version | property  | value  |
+      | 2       | Price USD | $19.00 |
     When I close the "history" panel
     When I visit the "Attributes" tab
     And I visit the "Marketing" group


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Specs             | n
| Behats            |  y
| Blue CI           | running
| Changelog updated | n
| Review and 2 GTM  | n
| Micro Demo (PO)   | n
| Migration script  | n
| Tech Doc          | n

# Goal
This PR changes the display in the product history.
Before: "price-EUR | 12,34"
After: "price-EUR | 12,34 €"