### PR TITLE
[TR] PIM-5211: display the variant group edit form in less than 2 sec

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -3,6 +3,7 @@
 ## Scalability improvements
 - PIM-5231: Use new AsyncSelectType for family selector in product creation form
 - PIM-5232: Load choices asynchronously in the product family filter to improve grid loading time
+- PIM-5211: Do not load all axes on the variant group form during edition
 
 ## BC Breaks
 - Changed constructor `Pim\Bundle\EnrichBundle\Form\Type\ProductCreateType` to add `Pim\Bundle\CatalogBundle\Doctrine\ORM\Repository\FamilyRepository` dependency

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/AttributeRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/AttributeRepository.php
@@ -207,7 +207,7 @@ class AttributeRepository extends EntityRepository implements
             ->andWhere(
                 $qb->expr()->in(
                     'a.attributeType',
-                    [AttributeTypes::OPTION_SIMPLE_SELECT, 'pim_reference_data_simpleselect']
+                    [AttributeTypes::OPTION_SIMPLE_SELECT, AttributeTypes::REFERENCE_DATA_SIMPLE_SELECT]
                 )
             )
             ->andWhere($qb->expr()->neq('a.scopable', 1))

--- a/src/Pim/Bundle/EnrichBundle/Form/Subscriber/AddVariantGroupAxesSubscriber.php
+++ b/src/Pim/Bundle/EnrichBundle/Form/Subscriber/AddVariantGroupAxesSubscriber.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Pim\Bundle\EnrichBundle\Form\Subscriber;
+
+use Pim\Bundle\CatalogBundle\Model\AttributeInterface;
+use Pim\Bundle\CatalogBundle\Model\GroupInterface;
+use Pim\Bundle\CatalogBundle\Repository\AttributeRepositoryInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+
+/**
+ * Adds axes to the variant group form
+ *
+ * @author    Julien Janvier <jjanvier@akeneo.com>
+ * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class AddVariantGroupAxesSubscriber implements EventSubscriberInterface
+{
+    /** @var string */
+    protected $attributeClass;
+
+    /**
+     * @param string $attributeClass
+     */
+    public function __construct($attributeClass)
+    {
+        $this->attributeClass = $attributeClass;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            FormEvents::PRE_SET_DATA => 'preSetData',
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function preSetData(FormEvent $event)
+    {
+        $group = $event->getData();
+        $options = [
+            'label'    => 'Axis',
+            'required' => true,
+            'multiple' => true,
+            'class'    => $this->attributeClass,
+            'help'     => 'pim_enrich.group.axis.help',
+            'select2'  => true,
+        ];
+
+        if (null !== $group &&
+            null !== $group->getId() &&
+            null !== $group->getType() &&
+            $group->getType()->isVariant()
+        ) {
+            $extraOptions = $this->getFormOptionsForEdition($group);
+        } else {
+            $extraOptions = $this->getFormOptionsForCreation();
+        }
+
+        $form = $event->getForm();
+        $form->add(
+            'attributes',
+            'entity',
+            array_merge($options, $extraOptions)
+        );
+    }
+
+    /**
+     * @param GroupInterface $group
+     *
+     * @return array
+     */
+    protected function getFormOptionsForEdition(GroupInterface $group)
+    {
+        $axesIds = array_map(
+            function (AttributeInterface $attribute) {
+                return $attribute->getId();
+            },
+            $group->getAxisAttributes()->toArray()
+        );
+
+        $options = [
+            'data'      => $group->getAxisAttributes(),
+            'disabled'  => true,
+            'read_only' => true,
+            // only define a qb with the axes we want to avoid useless lazy loading on attribute translations
+            'query_builder' => function (AttributeRepositoryInterface $repository) use ($axesIds) {
+                $qb = $repository->findAllAxisQB();
+                $qb->andWhere('a.id IN (:ids)');
+                $qb->setParameter('ids', $axesIds);
+
+                return $qb;
+            },
+        ];
+
+        return $options;
+    }
+
+    /**
+     * @return array
+     */
+    protected function getFormOptionsForCreation()
+    {
+        $options = [
+            'query_builder' => function (AttributeRepositoryInterface $repository) {
+                return $repository->findAllAxisQB();
+            },
+        ];
+
+        return $options;
+    }
+}

--- a/src/Pim/Bundle/EnrichBundle/Form/Type/GroupType.php
+++ b/src/Pim/Bundle/EnrichBundle/Form/Type/GroupType.php
@@ -3,7 +3,6 @@
 namespace Pim\Bundle\EnrichBundle\Form\Type;
 
 use Doctrine\ORM\EntityRepository;
-use Pim\Bundle\CatalogBundle\Repository\AttributeRepositoryInterface;
 use Pim\Bundle\CatalogBundle\Repository\ProductRepositoryInterface;
 use Pim\Bundle\EnrichBundle\Form\Subscriber\BindGroupProductsSubscriber;
 use Pim\Bundle\EnrichBundle\Form\Subscriber\DisableFieldSubscriber;
@@ -59,8 +58,6 @@ class GroupType extends AbstractType
         $this->addTypeField($builder);
 
         $this->addLabelField($builder);
-
-        $this->addAttributesField($builder);
 
         $this->addProductsField($builder);
 
@@ -140,32 +137,6 @@ class GroupType extends AbstractType
                 'property_path'     => 'translations'
             ]
         );
-    }
-
-    /**
-     * Add attributes field
-     *
-     * @param FormBuilderInterface $builder
-     */
-    protected function addAttributesField(FormBuilderInterface $builder)
-    {
-        $builder
-            ->add(
-                'attributes',
-                'entity',
-                [
-                    'label'         => 'Axis',
-                    'required'      => true,
-                    'multiple'      => true,
-                    'class'         => $this->attributeClass,
-                    'query_builder' => function (AttributeRepositoryInterface $repository) {
-                        return $repository->findAllAxisQB();
-                    },
-                    'help'     => 'pim_enrich.group.axis.help',
-                    'select2'  => true
-                ]
-            )
-            ->addEventSubscriber(new DisableFieldSubscriber('attributes'));
     }
 
     /**

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_subscribers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_subscribers.yml
@@ -7,6 +7,7 @@ parameters:
     pim_enrich.form.subscriber.set_attribute_group_sort_order.class: Pim\Bundle\EnrichBundle\Form\Subscriber\SetAttributeGroupSortOrderSubscriber
     pim_enrich.form.subscriber.transform_product_template_values.class: Pim\Bundle\EnrichBundle\Form\Subscriber\TransformProductTemplateValuesSubscriber
     pim_enrich.form.subscriber.add_variant_group_template.class: Pim\Bundle\EnrichBundle\Form\Subscriber\AddVariantGroupTemplateSubscriber
+    pim_enrich.form.subscriber.add_variant_group_axes.class: Pim\Bundle\EnrichBundle\Form\Subscriber\AddVariantGroupAxesSubscriber
 
 services:
     # Subscribers
@@ -54,3 +55,8 @@ services:
         class: %pim_enrich.form.subscriber.add_variant_group_template.class%
         arguments:
             - '@pim_user.context.user'
+
+    pim_enrich.form.subscriber.add_variant_group_axes:
+        class: %pim_enrich.form.subscriber.add_variant_group_axes.class%
+        arguments:
+            - %pim_catalog.entity.attribute.class%

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_types.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_types.yml
@@ -234,6 +234,7 @@ services:
             - %pim_catalog.entity.group.class%
         calls:
             - [addEventSubscriber, ['@pim_enrich.form.subscriber.add_variant_group_template']]
+            - [addEventSubscriber, ['@pim_enrich.form.subscriber.add_variant_group_axes']]
         tags:
             - { name: form.type, alias: pim_enrich_variant_group }
 


### PR DESCRIPTION
Tested on a catalog with 10k attributes. xdebug disabled.
NB: curl calls are slighty faster than real UI calls.

 Mean time of 25 curls call to `/enrich/variant-group/4/edit':
  * before patch: 10.068s (more than 10k requests to DB)
  * after patch: 1.602s (165 requests to DB)

Mean time of 25 curls call to `/enrich/group/5/edit':
  * before patch: 10.983s (more than 10k requests to DB)
  * after patch: 1.237s (160 request to DB)

| Q                 | A
| ----------------- | ---
| Specs             | Y
| Behats            | Y
| Blue CI           | running
| Changelog updated | Y
| Review and 2 GTM  |