### PR TITLE
PIM-5335: fix 'media save on variant group

### DIFF
--- a/CHANGELOG-1.3.md
+++ b/CHANGELOG-1.3.md
@@ -1,3 +1,9 @@
+# 1.3.x
+
+## Bug fixes
+
+- PIM-5335: Fix media save on variant group
+
 # 1.3.33 (2015-11-25)
 
 ## Bug fixes

--- a/features/Context/DataGridContext.php
+++ b/features/Context/DataGridContext.php
@@ -578,6 +578,32 @@ class DataGridContext extends RawMinkContext implements PageObjectAwareInterface
      *
      * @throws ExpectationException
      *
+     * @When /^I uncheck the rows? "([^"]*)"$/
+     */
+    public function iUncheckTheRows($rows)
+    {
+        //To rework on 1.4
+        $this->wait();
+        $rows = $this->getMainContext()->listToArray($rows);
+
+        foreach ($rows as $row) {
+            $gridRow = $this->datagrid->getRow($row);
+            $checkbox = $gridRow->find('css', 'td.boolean-cell input[type="checkbox"]:not(:disabled)');
+
+            if (!$checkbox) {
+                throw $this->createExpectationException(sprintf('Unable to find a checkbox for row %s', $row));
+            }
+
+            $checkbox->uncheck();
+        }
+        $this->wait();
+    }
+
+    /**
+     * @param string $rows
+     *
+     * @throws ExpectationException
+     *
      * @Then /^the rows? "([^"]*)" should be checked$/
      */
     public function theRowShouldBeChecked($rows)
@@ -593,6 +619,32 @@ class DataGridContext extends RawMinkContext implements PageObjectAwareInterface
             }
 
             if (!$checkbox->isChecked()) {
+                throw $this->createExpectationException(sprintf('Expecting row %s to be checked', $row));
+            }
+        }
+    }
+
+    /**
+     * @param string $rows
+     *
+     * @throws ExpectationException
+     *
+     * @Then /^the rows? "([^"]*)" should not be checked$/
+     */
+    public function theRowShouldBeUnchecked($rows)
+    {
+        //To rework on 1.4
+        $rows = $this->getMainContext()->listToArray($rows);
+
+        foreach ($rows as $row) {
+            $gridRow = $this->datagrid->getRow($row);
+            $checkbox = $gridRow->find('css', 'td.boolean-cell input[type="checkbox"]:not(:disabled)');
+
+            if (!$checkbox) {
+                throw $this->createExpectationException(sprintf('Unable to find a checkbox for row %s', $row));
+            }
+
+            if ($checkbox->isChecked()) {
                 throw $this->createExpectationException(sprintf('Expecting row %s to be checked', $row));
             }
         }

--- a/features/variant-group/edit_variant_group_attribute_value.feature
+++ b/features/variant-group/edit_variant_group_attribute_value.feature
@@ -110,6 +110,17 @@ Feature: Editing attribute values of a variant group also updates products
     Then the product "boot" should have the following values:
       | side_view | SNKRS-1R.png |
 
+  Scenario: Change a pim_catalog_image attribute of a variant group
+    When I add available attributes Side view
+    And I visit the "Media" group
+    And I attach file "SNKRS-1R.png" to "Side view"
+    And I save the variant group
+    And I visit the "Products" tab
+    And I uncheck the row "boot"
+    And I save the variant group
+    And I reload the page
+    Then the row "boot" should not be checked
+
   Scenario: Change a pim_catalog_file attribute of a variant group
     When I add available attributes Technical description
     And I visit the "Media" group

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/GroupSaver.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/GroupSaver.php
@@ -91,6 +91,14 @@ class GroupSaver implements SaverInterface
             sprintf('Comes from variant group %s', $group->getCode()),
             $this->productClassName
         );
+
+        if ($group->getType()->isVariant()) {
+            $template = $group->getProductTemplate();
+            if (null !== $template) {
+                $this->templateMediaManager->handleProductTemplateMedia($template);
+            }
+        }
+
         $this->objectManager->persist($group);
         if (true === $options['flush']) {
             $this->objectManager->flush();
@@ -102,13 +110,6 @@ class GroupSaver implements SaverInterface
 
         if (count($options['remove_products']) > 0) {
             $this->removeProducts($options['remove_products']);
-        }
-
-        if ($group->getType()->isVariant()) {
-            $template = $group->getProductTemplate();
-            if (null !== $template) {
-                $this->templateMediaManager->handleProductTemplateMedia($template);
-            }
         }
 
         if ($group->getType()->isVariant() && true === $options['copy_values_to_products']) {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Specs             | NA
| Behats            | Y
| Blue CI           | Y
| Changelog updated | N
| Review and 2 GTM  | N

Before this fix variant group media were handled by the VariantGroupMedia manager after the variant group save. So the new media location was never properly saved.

Before this fix media attributes does not work on variant groups