### PR TITLE
Fix behat when we update an export

### DIFF
--- a/features/export/edit_an_export.feature
+++ b/features/export/edit_an_export.feature
@@ -16,7 +16,7 @@ Feature: Edit an export
     And I press the "Save" button
     Then I should see "My export"
 
-  @javascript @unstable
+  @javascript
   Scenario: Successfully update export job configuration
     Given I am on the "footwear_product_export" export job edit page
     Then I should see the Channel, Delimiter, Enclosure, With header, File path and Decimal separator fields
@@ -29,13 +29,13 @@ Feature: Edit an export
       | Date format       | yyyy-MM-dd |
     And I uncheck the "With header" switch
     And I press the "Save" button
-    Then I should see "Channel tablet"
-    And I should see "File path file.csv"
-    And I should see "Delimiter |"
-    And I should see "Enclosure '"
-    And I should see "With header No"
-    And I should see "Decimal Separator ,"
-    And I should see "Date format yyyy-MM-dd"
+    Then I should see the text "Channel tablet"
+    And I should see the text "File path file.csv"
+    And I should see the text "Delimiter |"
+    And I should see the text "Enclosure '"
+    And I should see the text "With header No"
+    And I should see the text "Decimal Separator comma (,)"
+    And I should see the text "Date format yyyy-MM-dd"
 
   Scenario: Successfully display a dialog when we quit a page with unsaved changes
     Given I am on the "footwear_product_export" export job edit page


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Specs             | N
| Behats            | :white_check_mark: 
| Blue CI           | :white_check_mark: 
| Changelog updated | N
| Review and 2 GTM  | :white_check_mark: 

This scenario has been tagged unstable because sometimes, an error occured with "Enclosure" field and form was not validated.
Then, scenario became really wrong because, instead of just display the key of decimal separator value, we displayed the value.
So, this PR fix the behat and remove tag unstable (CI has been launched 4 times, and it never failed).