### PR TITLE
Update Travis and Grunt to manage imports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ before_script:
     - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then composer require --no-update doctrine/mongodb-odm-bundle v3.0.0-BETA6@dev; fi;'
     - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then composer update --prefer-dist --no-interaction; else composer update --prefer-dist --no-interaction --no-scripts; fi;'
     - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then ./app/console oro:requirejs:generate-config; fi;'
+    - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then ./app/console assets:install; fi;'
     - npm install -g grunt-cli
     - npm install
     - curl http://get.sensiolabs.org/php-cs-fixer.phar -o php-cs-fixer

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -34,14 +34,14 @@ module.exports = function (grunt) {
         },
         recess: {
             all: [
-                'src/**/*.css',
-                'src/**/*.less',
-                '!src/**/lib/**/*.css',
-                '!src/**/lib/**/*.less',
-                '!src/Pim/Bundle/UIBundle/Resources/public/css/less/oro.less',
-                '!src/Pim/Bundle/UIBundle/Resources/public/css/pim.less',
-                '!src/Pim/Bundle/UIBundle/Resources/public/css/form.less',
-                '!src/Pim/Bundle/UIBundle/Resources/public/css/flags.less'
+                'web/bundles/pim*/**/*.css',
+                'web/bundles/pim*/**/*.less',
+                '!web/bundles/**/lib/**/*.css',
+                '!web/bundles/**/lib/**/*.less',
+                '!web/bundles/pimui/css/flags.less',
+                '!web/bundles/pimui/css/form.less',
+                '!web/bundles/pimui/css/less/oro.less',
+                '!web/bundles/pimui/css/pim.less'
             ],
             options: {
                 strictPropertyOrder: false,


### PR DESCRIPTION
The issue is that the .less have @import xxx lines, and the path is a relative path for the less compilation, when the files are on /web folder (and not in /src/bundles).

This commit adds a app/console assets:install to copy the .less and .css into /web folder, to be closer than real compilation.

Commit needed for #5210 and #5024 .