### PR TITLE
PIM-5334: fix boolean filter on product grid

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -9,6 +9,7 @@
 
 ## Bug fixes
 - PIM-5295: Fix association product grid category filter
+- PIM-5334: Fix boolean filter on product grid
 
 # 1.4.13 (2015-12-10)
 

--- a/features/product/filtering/filter_product_per_boolean.feature
+++ b/features/product/filtering/filter_product_per_boolean.feature
@@ -46,3 +46,25 @@ Feature: Filter products by boolean field
       | filter | value    | result               |
       | Status | Enabled  | pants, shirt and hat |
       | Status | Disabled | shoes and socks      |
+
+  @jira https://akeneo.atlassian.net/browse/PIM-5334
+  Scenario: Successfully filter products by boolean value for boolean attributes and refresh the grid
+    Given the following products:
+      | sku   | family  | handmade |
+      | pants | tshirts | 1        |
+      | shirt | tshirts | 0        |
+      | shoes | tshirts | 0        |
+      | hat   | tshirts | 0        |
+      | socks | tshirts | 1        |
+    And I am on the products page
+    Then the grid should contain 5 elements
+    And I should see products pants, shirt, shoes, hat and socks
+    When I show the filter "Handmade"
+    And I filter by "Handmade" with value "yes"
+    Then the grid should contain 2 elements
+    And I should see entities pants and socks
+    When I reload the page
+    And I am on the products page
+    And I show the filter "Handmade"
+    Then the grid should contain 2 elements
+    And I should see entities pants and socks

--- a/features/product/sorting/sort_products_per_attribute.feature
+++ b/features/product/sorting/sort_products_per_attribute.feature
@@ -20,7 +20,7 @@ Feature: Sort products per attributes
     And the grid should contain 5 elements
     And I should be able to sort the rows by SKU
 
-  Scenario: Successfully filter products by boolean value for boolean attributes
+  Scenario: Successfully sort products by boolean value for boolean attributes
     And I am on the "blue_shirt" product page
     And I visit the "Additional" group
     When I check the "Handmade" switch

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/select-filter.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/select-filter.js
@@ -310,7 +310,10 @@ function(_, __, AbstractFilter, MultiselectDecorator) {
          */
         _onValueUpdated: function(newValue, oldValue) {
             AbstractFilter.prototype._onValueUpdated.apply(this, arguments);
-            this.selectWidget.multiselect('refresh');
+
+            if (this.selectWidget) {
+                this.selectWidget.multiselect('refresh');
+            }
         },
 
         /**


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Specs             | N
| Behats            | Y
| Blue CI           | Y
| Changelog updated | N
| Review and 2 GTM  | N

Boolean filters were not working well after a page reload. This was because the refresh call was called before the filter initialisation.