### PR TITLE
[WIP] MongoDB automatic requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,12 +27,15 @@
         "doctrine/doctrine-fixtures-bundle": "2.2.0",
         "doctrine/doctrine-migrations-bundle": "1.0.0",
         "doctrine/migrations": "1.0.0-alpha3@alpha",
+        "doctrine/mongodb-odm": "v1.0.0-beta12@dev",
+        "doctrine/mongodb-odm-bundle": "v3.0.0-BETA6@dev",
         "doctrine/orm": "2.4.7",
         "dompdf/dompdf" : "0.6.1",
         "escapestudios/wsse-authentication-bundle": "2.0.2",
         "friendsofsymfony/jsrouting-bundle": "1.5.4",
         "friendsofsymfony/rest-bundle": "0.12.0",
         "gedmo/doctrine-extensions":"v2.4.3",
+        "imagine/imagine": "0.6.2",
         "incenteev/composer-parameter-handler": "2.1.1",
         "jms/serializer": "1.0.0",
         "jms/serializer-bundle": "1.0.0",
@@ -46,7 +49,6 @@
         "league/flysystem-sftp": "1.0.5",
         "league/flysystem-ziparchive": "1.0.2",
         "liip/imagine-bundle": "1.3.0",
-        "imagine/imagine": "0.6.2",
         "monolog/monolog": "1.10.0",
         "nelmio/api-doc-bundle": "2.9.0",
         "oneup/flysystem-bundle": "1.1.0",
@@ -61,12 +63,9 @@
         "twig/extensions": "1.2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "3.7.*",
-        "squizlabs/php_codesniffer": "2.*",
-        "pdepend/pdepend": "2.1.*",
-        "phpmd/phpmd": "1.*",
+        "akeneo/php-coupling-detector": "dev-master",
+        "akeneo/phpspec-skip-example-extension": "1.1.*",
         "behat/behat": "2.5.5",
-        "kriswallsmith/buzz": ">=0.5",
         "behat/common-contexts": "1.2.0",
         "behat/gherkin":"2.3.5",
         "behat/mink":"1.6.0",
@@ -75,15 +74,24 @@
         "behat/mink-selenium2-driver": "1.2.0",
         "behat/symfony2-extension": "1.1.2",
         "behat/transliterator":"1.0.1",
-        "sensiolabs/behat-page-object-extension": "1.0.1",
+        "kriswallsmith/buzz": ">=0.5",
+        "pdepend/pdepend": "2.1.*",
+        "phpmd/phpmd": "1.*",
         "phpspec/phpspec": "2.1.*",
-        "akeneo/phpspec-skip-example-extension": "1.1.*",
-        "akeneo/php-coupling-detector": "dev-master"
+        "phpunit/phpunit": "3.7.*",
+        "sensiolabs/behat-page-object-extension": "1.0.1",
+        "squizlabs/php_codesniffer": "2.*"
     },
     "suggest": {
         "doctrine/mongodb-odm-bundle": "In order to activate the MongoDB support within Akeneo"
     },
     "scripts": {
+        "pre-install-cmd": [
+            "bash pre-install.sh"
+        ],
+        "pre-update-cmd": [
+            "bash pre-install.sh"
+        ],
         "post-install-cmd": [
             "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::buildBootstrap",

--- a/pre-install.sh
+++ b/pre-install.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+echo "Checking MongoDB extension"
+php -r "extension_loaded('mongo') ? exit(0):exit(1);"
+if [[ $? > 0 ]]; then
+    php ./composer.phar --no-update remove doctrine/mongodb-odm
+    php ./composer.phar --no-update remove doctrine/mongodb-odm-bundle
+    echo "removed doctrine MongoDB bundles"
+fi;


### PR DESCRIPTION
Provides doctrine MongoDB bundles by default and remove them if the extension is not loaded.
This will remove the need to edit composer.json when using MongoDB.