### PR TITLE
Revert "PIM-5295: Fix association product grid category filter"

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -12,8 +12,9 @@
 - Updated public method preRemove from `Pim\Bundle\VersioningBundle\EventSubscriber\AddRemoveSubscriber` to addRemoveVersion.
 
 ## Bug fixes
-- PIM-5295: Fix association product grid category filter
 - PIM-5334: Fix boolean filter on product grid
+- PIM-5342: Fix 1.3 to 1.4 migration issue on media thumbnails
+- PIM-5202: Fix error message when deleting a product
 
 # 1.4.13 (2015-12-10)
 

--- a/features/Context/FeatureContext.php
+++ b/features/Context/FeatureContext.php
@@ -412,28 +412,4 @@ class FeatureContext extends MinkContext implements KernelAwareInterface
     {
         return $this->getContainer()->get('pim_enrich.mailer.mail_recorder');
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function clickLink($link)
-    {
-        $this->spin(function () use ($link) {
-            parent::clickLink($link);
-
-            return true;
-        });
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function assertNumElements($num, $element)
-    {
-        $this->spin(function () use ($num, $element) {
-            parent::assertNumElements($num, $element);
-
-            return true;
-        });
-    }
 }

--- a/features/product/associate_product.feature
+++ b/features/product/associate_product.feature
@@ -7,14 +7,14 @@ Feature: Associate a product
   Background:
     Given a "footwear" catalog configuration
     And the following products:
-      | sku            | categories        |
-      | charcoal-boots | Summer_collection |
-      | black-boots    |                   |
-      | gray-boots     |                   |
-      | brown-boots    |                   |
-      | green-boots    |                   |
-      | shoelaces      |                   |
-      | glossy-boots   |                   |
+      | sku            |
+      | charcoal-boots |
+      | black-boots    |
+      | gray-boots     |
+      | brown-boots    |
+      | green-boots    |
+      | shoelaces      |
+      | glossy-boots   |
     And I am logged in as "Julia"
 
   Scenario: Associate a product to another product
@@ -167,15 +167,3 @@ Feature: Associate a product
     And I edit the "red-boots" product
     When I visit the "Associations" tab
     Then I should be able to sort the rows by Is associated
-
-  @jira https://akeneo.atlassian.net/browse/PIM-5295
-  Scenario: Association product grid is not filtered by the category selected in the product grid
-    Given I am on the products page
-    When I filter by "category" with value "Summer_collection"
-    Then I should see product charcoal-boots
-    And I should not see product black-boots
-    When I click on the "charcoal-boots" row
-    And I follow "Associations"
-    Then I should see 6 "#grid-association-product-grid tbody tr" elements
-    When I follow "Upsell"
-    Then I should see 6 "#grid-association-product-grid tbody tr" elements

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/association_product.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/association_product.yml
@@ -122,3 +122,13 @@ datagrid:
                     options:
                         field_options:
                             choices: '@pim_catalog.manager.channel->getChannelChoices'
+                category:
+                    type:      product_category
+                    label:     Category
+                    data_name: category
+            default:
+                category:
+                    value:
+                        treeId: %pim_filter.product_category_filter.class%::UNKNOWN_TREE
+                        categoryId: %pim_filter.product_category_filter.class%::ALL_CATEGORY
+                    type: %pim_filter.product_category_filter.class%::DEFAULT_TYPE


### PR DESCRIPTION
This reverts commit ea58d4e0c245e61a25cfa681193edb8934460925.

Conflicts:
	CHANGELOG-1.4.md