### PR TITLE
PIM-5347: fix mongo database in case of attribute removal

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -5,6 +5,7 @@
 
 ## Bug fixes
 - PIM-5348: fix group count on behats
+- PIM-5347: fix mongo database in case of attribute removal
 
 # 1.4.14 (2015-12-17)
 
@@ -36,7 +37,7 @@
 - In case you wrote your own associations import, please add the parameter `batch_size: 1` to the `import_associations` step element of your `batch_jobs.yml`.
 - Changed constructor of `Pim\Bundle\EnrichBundle\Connector\Processor\MassEdit\Product\EditCommonAttributesProcessor` to add a `Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface`.
   Required, because we now use the standard ProductUpdater to be consistent.
-- Changed constructor of `Pim\Bundle\EnrichBundle\MassEditAction\Operation\EditCommonAttributes` to add 
+- Changed constructor of `Pim\Bundle\EnrichBundle\MassEditAction\Operation\EditCommonAttributes` to add
     `Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface`,
     `Symfony\Component\Validator\Validator\ValidatorInterface`,
     `Symfony\Component\Serializer\Normalizer\NormalizerInterface`.

--- a/features/Context/FixturesContext.php
+++ b/features/Context/FixturesContext.php
@@ -1529,8 +1529,12 @@ class FixturesContext extends RawMinkContext
         $this->refresh($user);
         $actualCount = null;
         if ($associationType == 'group') {
-            //We remove 1 for the "All" group which is not displayed to the user
-            $actualCount = count($user->getGroupNames()) - 1;
+            //We remove the "All" group which is not displayed to the user
+            $groupNames = $user->getGroupNames();
+            if (($key = array_search('All', $groupNames)) !== false) {
+                unset($groupNames[$key]);
+            }
+            $actualCount = count($groupNames);
         } elseif ($associationType == 'role') {
             $actualCount = count($user->getRoles());
         }

--- a/features/attribute/delete_attribute.feature
+++ b/features/attribute/delete_attribute.feature
@@ -1,0 +1,44 @@
+@javascript
+Feature: Delete an attribute
+  In order to remove an attribute
+  As a product manager
+  I need to delete a text attribute
+
+  Background:
+    Given the "default" catalog configuration
+    And the following attribute:
+      | label | type | useable_as_grid_filter | localizable |
+      | name  | text | yes                    | yes         |
+    And I am logged in as "Julia"
+
+  @jira https://akeneo.atlassian.net/browse/PIM-5347
+  Scenario: Sucessfully delete and recreate a text attribute used in a product and filter on it
+    Given I am on the products page
+    When I create a new product
+    And I fill in the following information in the popin:
+      | SKU  | caterpillar_1 |
+    And I press the "Save" button in the popin
+    When I am on the "caterpillar_1" product page
+    Then I add available attributes name
+    And I fill in the following information:
+      | name | My caterpillar |
+    Then I save the product
+    When I am on the products page
+    Then the grid should contain 1 elements
+    And I should see products caterpillar_1
+    And I show the filter "name"
+    Then I should be able to use the following filters:
+      | filter      | value          | result        |
+      | name        | My caterpillar | caterpillar_1 |
+    When I am on the attributes page
+    Then I click on the "delete" action of the row which contains "name"
+    And I confirm the deletion
+    And the following attribute:
+      | label | type | useable_as_grid_filter | localizable |
+      | name  | text | yes                    | yes         |
+    When I am on the products page
+    Then the grid should contain 1 elements
+    And I should see products caterpillar_1
+    Then I should be able to use the following filters:
+      | filter | value          | result |
+      | name   | My caterpillar |        |

--- a/features/user/edit_user_group_and_role_assignations.feature
+++ b/features/user/edit_user_group_and_role_assignations.feature
@@ -47,8 +47,9 @@ Feature: Edit a user groups and roles
     And I click on the "Peter" row
     And I save the group
     Then I should see "Group saved"
-    And the user "Peter" should be in 1 group
+    And the user "Peter" should be in 2 group
     And the user "Peter" should be in the "Redactor" group
+    And the user "Peter" should be in the "IT support" group
 
   Scenario: Assign a role to a user from the role page
     Given I edit the "Catalog manager" user role

--- a/spec/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/QueryGenerator/AttributeDeletedQueryGeneratorSpec.php
+++ b/spec/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/QueryGenerator/AttributeDeletedQueryGeneratorSpec.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace spec\Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\QueryGenerator;
+
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\NamingUtility;
+use Pim\Bundle\CatalogBundle\Model\AttributeInterface;
+use Pim\Bundle\CatalogBundle\Model\ChannelInterface;
+
+class AttributeDeletedQueryGeneratorSpec extends ObjectBehavior
+{
+    function let(NamingUtility $namingUtility)
+    {
+        $this->beConstructedWith($namingUtility, 'Pim\Bundle\CatalogBundle\Model\Attribute', '');
+    }
+
+    function it_generates_a_query_to_update_product_with_the_deleted_attribute(
+        $namingUtility,
+        AttributeInterface $label
+    ) {
+        $namingUtility->getAttributeNormFields($label)->willReturn(['normalizedData.label-en_US', 'normalizedData.label-fr_FR']);
+
+        $this->generateQuery($label, '', '', '')->shouldReturn([
+            [
+                ['normalizedData.label-en_US' => [ '$exists' => true ]],
+                ['$unset' => ['normalizedData.label-en_US' => '']],
+                ['multiple' => true]
+            ],
+            [
+                ['normalizedData.label-fr_FR' => [ '$exists' => true ]],
+                ['$unset' => ['normalizedData.label-fr_FR' => '']],
+                ['multiple' => true]
+            ]
+        ]);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/QueryGenerator/AttributeDeletedQueryGenerator.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/QueryGenerator/AttributeDeletedQueryGenerator.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\QueryGenerator;
+
+use Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\ProductQueryUtility;
+
+/**
+ * Attribute deleted query generator
+ *
+ * @author    Julien Sanchez <julien@akeneo.com>
+ * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class AttributeDeletedQueryGenerator extends AbstractQueryGenerator
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function generateQuery($attribute, $field, $oldValue, $newValue)
+    {
+        $queries = [];
+        $attributeNormFields = $this->namingUtility->getAttributeNormFields($attribute);
+
+        foreach ($attributeNormFields as $attributeNormField) {
+            $queries[] = [
+                [$attributeNormField => [ '$exists' => true ]],
+                ['$unset'   => [$attributeNormField => '']],
+                ['multiple' => true]
+            ];
+        }
+
+        return $queries;
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/QueryGenerator/NormalizedDataQueryGeneratorInterface.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/QueryGenerator/NormalizedDataQueryGeneratorInterface.php
@@ -5,6 +5,10 @@ namespace Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\QueryGenerator;
 /**
  * NormalizedData query generator interface
  *
+ * The interface is meant to generate queries to execute in case of modification on other entities.
+ * For example if we remove a channel, we need to remove every product values for this channel in normalized data.
+ * This was formerly done by plain php code and was time and memory consuming.
+ *
  * @author    Julien Sanchez <julien@akeneo.com>
  * @copyright 2014 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/storage_driver/doctrine/mongodb-odm.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/storage_driver/doctrine/mongodb-odm.yml
@@ -31,6 +31,7 @@ parameters:
     pim_catalog.mongodb_odm_query_generator.abstract_normalized_data.class:      Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\QueryGenerator\AbstractQueryGenerator
     pim_catalog.mongodb_odm_query_generator.attribute_as_label_updated.class:    Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\QueryGenerator\AttributeAsLabelUpdatedQueryGenerator
     pim_catalog.mongodb_odm_query_generator.channel_deleted.class:               Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\QueryGenerator\ChannelDeletedQueryGenerator
+    pim_catalog.mongodb_odm_query_generator.attribute_deleted.class:             Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\QueryGenerator\AttributeDeletedQueryGenerator
     pim_catalog.mongodb_odm_query_generator.family_label_updated.class:          Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\QueryGenerator\FamilyLabelUpdatedQueryGenerator
     pim_catalog.mongodb_odm_query_generator.option_code_updated.class:           Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\QueryGenerator\OptionCodeUpdatedQueryGenerator
     pim_catalog.mongodb_odm_query_generator.option_deleted.class:                Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\QueryGenerator\OptionDeletedQueryGenerator
@@ -308,6 +309,14 @@ services:
         arguments:
             - %pim_catalog.entity.family.class%
             - 'attributeAsLabel'
+        tags:
+            - { name: pim_catalog.mongodb_odm_query_generator }
+
+    pim_catalog.mongodb_odm_query_generator.attribute_deleted:
+        class: %pim_catalog.mongodb_odm_query_generator.attribute_deleted.class%
+        parent: pim_catalog.mongodb_odm_query_generator.abstract_normalized_data
+        arguments:
+            - %pim_catalog.entity.attribute.class%
         tags:
             - { name: pim_catalog.mongodb_odm_query_generator }
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Specs             | Y
| Behats            | Y
| Blue CI           | Y
| Changelog updated | Y
| Review and 2 GTM  | Y

Before this bug fix we didn't remove the old normalised data when we removed an old attribute. The problem was: If you remove an attribute, recreate it with the same option: you could filter on it and even if the product values where not here anymore.

I added a query generator to remove the corresponding product values in normalized data and added a behat to cover this case. 