### PR TITLE
[SLA] PIM-5387: Fix memory leak on quick export

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -9,6 +9,7 @@
 ## Bug fixes
 - PIM-5348: fix group count on behats
 - PIM-5347: fix mongo database in case of attribute removal
+- PIM-5387: fix memory leak on quick export
 
 # 1.4.14 (2015-12-17)
 

--- a/src/Pim/Bundle/EnrichBundle/Connector/Processor/QuickExport/ProductToFlatArrayProcessor.php
+++ b/src/Pim/Bundle/EnrichBundle/Connector/Processor/QuickExport/ProductToFlatArrayProcessor.php
@@ -3,6 +3,7 @@
 namespace Pim\Bundle\EnrichBundle\Connector\Processor\QuickExport;
 
 use Akeneo\Bundle\BatchBundle\Item\InvalidItemException;
+use Akeneo\Component\StorageUtils\Detacher\ObjectDetacherInterface;
 use Pim\Bundle\CatalogBundle\AttributeType\AttributeTypes;
 use Pim\Bundle\CatalogBundle\Builder\ProductBuilderInterface;
 use Pim\Bundle\CatalogBundle\Exception\InvalidArgumentException;
@@ -43,19 +44,24 @@ class ProductToFlatArrayProcessor extends AbstractProcessor
     /** @var ProductBuilderInterface */
     protected $productBuilder;
 
+    /** @var  ObjectDetacherInterface */
+    protected $objectDetacher;
+
     /**
      * @param JobConfigurationRepositoryInterface $jobConfigurationRepo
      * @param SerializerInterface                 $serializer
      * @param ChannelManager                      $channelManager
      * @param string                              $uploadDirectory
      * @param ProductBuilderInterface             $productBuilder
+     * @param ObjectDetacherInterface             $objectDetacher
      */
     public function __construct(
         JobConfigurationRepositoryInterface $jobConfigurationRepo,
         SerializerInterface $serializer,
         ChannelManager $channelManager,
         $uploadDirectory,
-        ProductBuilderInterface $productBuilder = null
+        ProductBuilderInterface $productBuilder = null,
+        ObjectDetacherInterface $objectDetacher = null
     ) {
         parent::__construct($jobConfigurationRepo);
 
@@ -63,6 +69,7 @@ class ProductToFlatArrayProcessor extends AbstractProcessor
         $this->channelManager  = $channelManager;
         $this->uploadDirectory = $uploadDirectory;
         $this->productBuilder  = $productBuilder;
+        $this->objectDetacher  = $objectDetacher;
     }
 
     /**
@@ -104,6 +111,10 @@ class ProductToFlatArrayProcessor extends AbstractProcessor
         }
 
         $data['product'] = $this->serializer->normalize($product, 'flat', $this->getNormalizerContext());
+
+        if (null !== $this->objectDetacher) {
+            $this->objectDetacher->detach($product);
+        }
 
         return $data;
     }

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/connector/processors.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/connector/processors.yml
@@ -55,3 +55,4 @@ services:
             - '@pim_catalog.manager.channel'
             - %upload_dir%
             - '@pim_catalog.builder.product'
+            - '@akeneo_storage_utils.doctrine.object_detacher'


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Specs             | No
| Behats            | No
| Blue CI           | Not launched
| Changelog updated | Yes
| Review and 2 GTM  | Pending

# Memory leak
Let 270k products, with 8k attributes
Perform a quick export of ~nk products

x : number of products
y : memory usage (byte)
![memory_leak_quick_export](https://cloud.githubusercontent.com/assets/3594268/11978905/5977a7e4-a98f-11e5-93d7-2e18e53f068c.png)