### PR TITLE
PIM-5130: Improve behat message

### DIFF
--- a/features/Context/NavigationContext.php
+++ b/features/Context/NavigationContext.php
@@ -39,30 +39,29 @@ class NavigationContext extends BaseNavigationContext
         $this->wait();
     }
 
+    /**
+     * @Given /^I edit my profile$/
+     */
+    public function iAmOnMyProfileEditPage()
+    {
+        $this->openPage('User profile edit');
+    }
 
-        /**
-         * @Given /^I edit my profile$/
-         */
-        public function iAmOnMyProfileEditPage()
-        {
-                $this->openPage('User profile edit');
-        }
+    /**
+     * @Given /^I am on my profile page$/
+     */
+    public function iAmOnMyProfilePage()
+    {
+        $this->openPage('User profile show');
+    }
 
-        /**
-         * @Given /^I am on my profile page$/
-         */
-        public function iAmOnMyProfilePage()
-        {
-                $this->openPage('User profile show');
-        }
-
-        /**
-         * @Given /^I edit the system configuration$/
-         */
-        public function iAmOnTheSystemEditPage()
-        {
-                $this->openPage('System index');
-        }
+    /**
+     * @Given /^I edit the system configuration$/
+     */
+    public function iAmOnTheSystemEditPage()
+    {
+        $this->openPage('System index');
+    }
 
     /**
      * @param string $identifier


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Specs             | n
| Behats            | y
| Blue CI           | y
| Changelog updated | n
| Review and 2 GTM  | n
| Micro Demo (PO)   | n
| Migration script  | n
| Tech Doc          | n

# Goal of this PR
This PR is just here to improve message from behat exceptions.
Before, we had message like "I can't find the notification".
Now, you have the list of available notification, very useful when you have to debug and see the text of all the displayed notifications.