### PR TITLE
[SLA][TR] PIM-5405: Add content type for stream upload

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -1,3 +1,8 @@
+# 1.4.x
+
+## Bug fixes
+- PIM-5405: Fix content type for stream upload
+
 # 1.4.15 (2015-12-30)
 
 ## Improvements

--- a/spec/Akeneo/Component/FileStorage/File/FileStorerSpec.php
+++ b/spec/Akeneo/Component/FileStorage/File/FileStorerSpec.php
@@ -39,7 +39,7 @@ class FileStorerSpec extends ObjectBehavior
         $mountManager->getFilesystem('destination')->willReturn($fs);
         $factory->createFromRawFile($rawFile, 'destination')->willReturn($fileInfo);
 
-        $fs->writeStream(Argument::any(), Argument::any())->shouldBeCalled();
+        $fs->writeStream(Argument::cetera())->shouldBeCalled();
 
         $saver->save($fileInfo)->shouldBeCalled();
         $this->store($rawFile, 'destination');
@@ -67,7 +67,7 @@ class FileStorerSpec extends ObjectBehavior
         $mountManager->getFilesystem('destination')->willReturn($fs);
         $factory->createFromRawFile($rawFile, 'destination')->willReturn($fileInfo);
 
-        $fs->writeStream(Argument::any(), Argument::any())->shouldBeCalled();
+        $fs->writeStream(Argument::cetera())->shouldBeCalled();
 
         $saver->save($fileInfo)->shouldBeCalled();
         $this->store($rawFile, 'destination', true);
@@ -88,7 +88,7 @@ class FileStorerSpec extends ObjectBehavior
         $rawFile->getPathname()->willReturn(__FILE__);
         $mountManager->getFilesystem('destination')->willReturn($fs);
         $factory->createFromRawFile($rawFile, 'destination')->willReturn($fileInfo);
-        $fs->writeStream(Argument::any(), Argument::any())->willReturn(false);
+        $fs->writeStream(Argument::cetera())->willReturn(false);
 
         $saver->save(Argument::any())->shouldNotBeCalled();
 
@@ -108,10 +108,11 @@ class FileStorerSpec extends ObjectBehavior
     ) {
         $rawFile->getPathname()->willReturn(__FILE__);
         $fs->has(Argument::any())->willReturn(true);
-        $fs->writeStream(Argument::any(), Argument::any())->willThrow(new FileExistsException('The file exists.'));
+        $fs->writeStream(Argument::cetera())->willThrow(new FileExistsException('The file exists.'));
         $mountManager->getFilesystem('destination')->willReturn($fs);
         $factory->createFromRawFile($rawFile, 'destination')->willReturn($fileInfo);
         $fileInfo->getKey()->willReturn('key-file');
+        $fileInfo->getMimeType()->willReturn('mime-type');
 
         $this->shouldThrow(
             new FileTransferException(

--- a/src/Akeneo/Component/FileStorage/File/FileStorer.php
+++ b/src/Akeneo/Component/FileStorage/File/FileStorer.php
@@ -65,7 +65,12 @@ class FileStorer implements FileStorerInterface
         }
 
         try {
-            $isFileWritten = $filesystem->writeStream($file->getKey(), $resource);
+            $options = [];
+            $mimeType = $file->getMimeType();
+            if (null !== $mimeType) {
+                $options['ContentType'] = $mimeType;
+            }
+            $isFileWritten = $filesystem->writeStream($file->getKey(), $resource, $options);
         } catch (FileExistsException $e) {
             throw new FileTransferException($error, $e->getCode(), $e);
         }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Specs             | n
| Behats            | n
| Blue CI           | y
| Changelog updated | TODO
| Review and 2 GTM  | n

The issue is about the upload of files through Amazon S3.
The file is sent with a stream method, without any information about the mime type. Because file is sent by stream and no information is given about mime type, it can not be guessed.
We added the mime type of the file to the options of the writer.