### PR TITLE
PIM-4897: count on product values is now bypassed with high volume of data

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Collector/DatabaseCollector.php
+++ b/src/Pim/Bundle/CatalogBundle/Collector/DatabaseCollector.php
@@ -57,8 +57,8 @@ class DatabaseCollector extends DataCollector
     {
         $this->data = [
             'mongodb_enabled'     => $this->isMongoDbEnabled(),
-            'product_value_count' => $this->productValueRepository->count(),
             'require_mongodb'     => !($this->isMongoDbEnabled() || !$this->isMongoDbRequired()),
+            'product_value_count' => $this->isMongoDbEnabled() ? null : $this->getProductValueCount(),
             'version'             => [
                 'patch' => $this->versionProvider->getPatch(),
                 'minor' => $this->versionProvider->getMinor()
@@ -125,7 +125,7 @@ class DatabaseCollector extends DataCollector
      */
     public function getProductValueCount()
     {
-        return $this->data['product_value_count'];
+        return $this->productValueRepository->count();
     }
 
     /**

--- a/src/Pim/Bundle/CatalogBundle/Resources/views/Collector/database.html.twig
+++ b/src/Pim/Bundle/CatalogBundle/Resources/views/Collector/database.html.twig
@@ -40,13 +40,13 @@
 
     <h3>MongoDB support</h3>
         {% if collector.hasMongoDb %}
-            <p>Your current installation has {{ collector.getProductValueCount }} product values and support is enabled on your installation.</p>
+            <p>MongoDB is enabled on your installation.</p>
         {% else %}
             {% if collector.requireMongoDb %}
-                <p>Your current installation has {{ collector.getProductValueCount }} product values but MongoDB isn't installed yet. <br />
+                <p>Your current installation has more than 5M product values but MongoDB isn't installed yet. <br />
                 You should consider enabling MongoDB.</p>
             {% elseif not collector.requireMongoDb %}
-                <p>Your current installation has {{ collector.getProductValueCount }} product values and MongoDB isn't installed yet.<br />
+                <p>Your current installation has less than 5M product values and MongoDB isn't installed yet.<br />
                 Please note that if you  were to have more than 5M of product values, you will have to consider enabling MongoDB.</p>
             {% endif %}
             <p>Please read <a href="http://docs.akeneo.com/{{ collector.version.minor }}/reference/performances_guide/index.html#more-than-5-millions-of-product-values">this documentation</a> for more details.<br />


### PR DESCRIPTION
The  `count()` inside `ProductValueCounterRepository` wasn't working witth a high volume of data and lead to an error:
`exception: distinct too big, 16mb cap`

| Q                 | A
| ----------------- | ---
| Specs             | Yes
| Behats            | No
| Blue CI           | N/A
| Changelog updated | No
| Review and 2 GTM  | OK