### PR TITLE
Return at least a minor hint, if file upload fail.

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/MediaController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/MediaController.php
@@ -47,6 +47,7 @@ class MediaController
      */
     public function postAction(Request $request)
     {
+        /** @var \Symfony\Component\HttpFoundation\File\UploadedFile $file */
         $file       = $request->files->get('file');
         $violations = $this->validator->validate($file);
 
@@ -70,8 +71,8 @@ class MediaController
                 $pathData['file_name']
             );
         } catch (FileException $e) {
-            //TODO: a message goes here
-            return new JsonResponse(null, 400);
+            //TODO: more specific message if debug mode is on?
+            return new JsonResponse("Unable to create target-directory, or moving file.", 400);
         }
 
         return new JsonResponse(


### PR DESCRIPTION
In my case, there was already a directory /tmp/pim/file_storage, but not the target directory "/tmp/pim/file_storage/b/f/8/0".
Thus, somehow the recursive mkdir-call in Symfony\Component\HttpFoundation\File\File->getTargetFile(...) failed and throw an exception.
After deleting the whole /tmp/pim directory, everything worked.

The best thing would be to have the real exception-message in the HTTP-400 result, which might be a security problem....