### PR TITLE
[TR] Remove incoherent scenario

### DIFF
--- a/features/export/view_an_export_detail_page.feature
+++ b/features/export/view_an_export_detail_page.feature
@@ -13,11 +13,3 @@ Feature: View an export detail page
     When I click on the "footwear_product_export" row
     Then I should be on the "footwear_product_export" export job page
     And I should see "Export profile - Footwear product export"
-
-  @ce
-  Scenario: Successfully display the validation errors
-    Given the following job:
-      | connector            | alias              | code                | label                       | type   |
-      | Akeneo CSV Connector | csv_product_export | acme_product_export | Product export for Acme.com | export |
-    When I am on the "acme_product_export" export job page
-    Then I should see "This value should not be blank." next to the channel


### PR DESCRIPTION
This scenario is useless since an export job always has a channel. It's incoherent because the job is created directly in database without using the UI.
Plus it's broken on master because the validation error is not displayed anymore on the show page.