### PR TITLE
PIM-5233 : change mass edit family to use an ajax dropdown

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -5,7 +5,11 @@
 
 ## Bug fixes
 - PIM-5405: Fix content type for stream upload
+- PIM-5233: Use an asynchronous dropdown list to mass edit family
 - PIM-5331: Fix product save issue when categories have code as integer
+
+## BC Breaks
+- Changed constructor `Pim\Bundle\EnrichBundle\Form\Type\ProductCreateType` to add `Pim\Bundle\CatalogBundle\Doctrine\ORM\Repository\FamilyRepository` dependency
 
 # 1.4.15 (2015-12-30)
 

--- a/features/Context/Page/Batch/ChangeFamily.php
+++ b/features/Context/Page/Batch/ChangeFamily.php
@@ -9,6 +9,7 @@ use Context\Page\Base\Wizard;
  * Batch ChangeFamily page
  *
  * @author    Filips Alpe <filips@akeneo.com>
+ * @author    JM Leroux <jean-marie.leroux@akeneo.com>
  * @copyright 2013 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
@@ -17,12 +18,26 @@ class ChangeFamily extends Wizard
     /**
      * {@inheritdoc}
      */
-    public function fillField($labelContent, $value, Element $element = null)
+    public function fillField($locator, $value, Element $modal = null)
     {
-        if ('Family' === $labelContent && 'None' === $value) {
-            $value = '';
+        // Simply do not select a family
+        if ('Family' === $locator && 'None' === $value) {
+            return;
         }
 
-        return parent::fillField($labelContent, $value, $element);
+        $select2Locator = sprintf(
+            'label:contains("%s") + .select2-container',
+            $locator
+        );
+
+        $selectContainer = $this->spin(function () use ($select2Locator) {
+            return $this->find('css', $select2Locator);
+        });
+
+        if ($selectContainer) {
+            $this->fillSelect2Field($selectContainer, $value);
+        } else {
+            parent::fillField($locator, $value, $modal);
+        }
     }
 }

--- a/spec/Pim/Bundle/EnrichBundle/Form/Type/MassEditAction/ChangeFamilyTypeSpec.php
+++ b/spec/Pim/Bundle/EnrichBundle/Form/Type/MassEditAction/ChangeFamilyTypeSpec.php
@@ -3,14 +3,16 @@
 namespace spec\Pim\Bundle\EnrichBundle\Form\Type\MassEditAction;
 
 use PhpSpec\ObjectBehavior;
+use Pim\Bundle\CatalogBundle\Repository\FamilyRepositoryInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ChangeFamilyTypeSpec extends ObjectBehavior
 {
-    function let()
+    function let(FamilyRepositoryInterface $repository)
     {
         $this->beConstructedWith(
-            'Pim\Bundle\EnrichBundle\MassEditAction\Operation\ChangeFamily'
+            'Pim\Bundle\EnrichBundle\MassEditAction\Operation\ChangeFamily',
+            $repository
         );
     }
 

--- a/src/Pim/Bundle/EnrichBundle/Form/Type/MassEditAction/ChangeFamilyType.php
+++ b/src/Pim/Bundle/EnrichBundle/Form/Type/MassEditAction/ChangeFamilyType.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Bundle\EnrichBundle\Form\Type\MassEditAction;
 
+use Pim\Bundle\CatalogBundle\Repository\FamilyRepositoryInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -18,12 +19,17 @@ class ChangeFamilyType extends AbstractType
     /** @var string */
     protected $dataClass;
 
+    /** @var FamilyRepositoryInterface */
+    protected $familyRepository;
+
     /**
-     * @param string $dataClass
+     * @param string                    $dataClass
+     * @param FamilyRepositoryInterface $familyRepository
      */
-    public function __construct($dataClass)
+    public function __construct($dataClass, FamilyRepositoryInterface $familyRepository)
     {
-        $this->dataClass = $dataClass;
+        $this->dataClass        = $dataClass;
+        $this->familyRepository = $familyRepository;
     }
 
     /**
@@ -33,12 +39,14 @@ class ChangeFamilyType extends AbstractType
     {
         $builder->add(
             'family',
-            'entity',
+            'pim_async_select',
             [
-                'class'       => 'PimCatalogBundle:Family',
-                'empty_value' => 'None',
-                'required'    => false,
-                'select2'     => true
+                'repository' => $this->familyRepository,
+                'route'      => 'pim_enrich_family_rest_index',
+                'required'   => false,
+                'attr'       => [
+                    'data-placeholder' => 'pim_enrich.mass_edit_action.change-family.no_family'
+                ],
             ]
         );
     }

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_types.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_types.yml
@@ -355,6 +355,7 @@ services:
         class: %pim_enrich.form.type.change_family.class%
         arguments:
             - %pim_enrich.mass_edit_action.change_family.class%
+            - '@pim_catalog.repository.family'
         tags:
             - { name: form.type, alias: pim_enrich_mass_change_family }
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/meta/change-family-modal.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/meta/change-family-modal.html
@@ -1,4 +1,12 @@
-<%- _.__('pim_enrich.form.product.change_family.modal.merge_attributes')%><br />
-<%- _.__('pim_enrich.form.product.change_family.modal.keep_attributes')%><br />
-<%- _.__('pim_enrich.form.product.change_family.modal.change_family_to')%>:
-<input type="hidden" class="input-large family-select2" value="<%- product.family !== null ? product.family.code : '' %>" <%- product.family ? ' selected' : '' %> data-placeholder="<%- _.__('pim_enrich.form.product.change_family.modal.empty_selection') %>" />
+<p>
+    <%- _.__('pim_enrich.form.product.change_family.modal.merge_attributes')%><br />
+    <%- _.__('pim_enrich.form.product.change_family.modal.keep_attributes')%>
+</p>
+<form class="form-horizontal">
+    <label class="control-label"><%- _.__('pim_enrich.form.product.change_family.modal.change_family_to')%>&nbsp;:</label>
+    <input type="hidden" class="input-large family-select2"
+           value="<%- product.family !== null ? product.family.code : '' %>"
+           <%- product.family ? ' selected' : '' %>
+           data-placeholder="<%- _.__('pim_enrich.form.product.change_family.modal.empty_selection') %>"
+    />
+</form>

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/messages.en.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/messages.en.yml
@@ -619,7 +619,7 @@ Cancel:               Cancel
 Choose a family:      Choose a family
 Choose a unit:        Choose a unit
 No matches found:     No matches found
-Create:                   Create
+Create:               Create
 
 Category tree: Category tree
 Completeness: Completeness
@@ -808,6 +808,7 @@ pim_enrich.mass_edit_action:
         label:         Change the family of products
         description:   The family of the selected products will be changed to the chosen family
         success_flash: The family of selected product(s) has been successfully changed
+        no_family:     No family
 
     add-to-groups:
         label:         Add to groups

--- a/src/Pim/Bundle/EnrichBundle/Resources/views/MassEditAction/configure/change-family.html.twig
+++ b/src/Pim/Bundle/EnrichBundle/Resources/views/MassEditAction/configure/change-family.html.twig
@@ -1,5 +1,9 @@
 {% extends 'PimEnrichBundle:MassEditAction:configure/layout.html.twig' %}
 
 {% block formContent %}
-    {{ form_row(form.operation.family) }}
+    <label class="control-label">{{ 'Family'|trans }}</label>
+    {{ form_row(
+        form.operation.family,
+        {'attr': {'data-placeholder': form.operation.family.vars.attr['data-placeholder']|trans } }
+    ) }}
 {% endblock %}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Specs             |fixed
| Behats            |fixed
| Blue CI           |Yes
| Changelog updated |OK
| Review and 2 GTM  |Yes
| Micro Demo (PO)   |OK
| Migration script  |not needed
| Tech Doc          |not needed

This PR is about using an asynchronous dropdown to choose the new family for the edited products.