### PR TITLE
[SLA][TR] PIM-5331: Fix product save issue when categories having code as integer

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 - PIM-5405: Fix content type for stream upload
+- PIM-5331: Fix product save issue when categories have code as integer
 
 # 1.4.15 (2015-12-30)
 

--- a/features/Context/WebUser.php
+++ b/features/Context/WebUser.php
@@ -1693,6 +1693,30 @@ class WebUser extends RawMinkContext
     }
 
     /**
+     * @param string $sku
+     * @param string $categoryCode
+     *
+     * @Then /^the category of (?:the )?product "([^"]*)" should be "([^"]*)"$/
+     */
+    public function theCategoryOfProductShouldBe($sku, $categoryCode)
+    {
+        $this->clearUOW();
+        $product = $this->getFixturesContext()->getProduct($sku);
+
+        $categoryCodes = $product->getCategoryCodes();
+        assertEquals(
+            [$categoryCode],
+            $categoryCodes,
+            sprintf(
+                'Expecting the category of "%s" to be "%s", not "%s".',
+                $sku,
+                $categoryCode,
+                implode(', ', $categoryCodes)
+            )
+        );
+    }
+
+    /**
      * @param int $count
      *
      * @Then /^there should be (\d+) updates?$/

--- a/features/import/product/import_products.feature
+++ b/features/import/product/import_products.feature
@@ -229,3 +229,23 @@ Feature: Execute a job
     And I launch the import job
     And I wait for the "footwear_product_import" job to finish
     Then there should be 2 products
+
+  Scenario: Successfully import products when category code is integer
+    Given the following products:
+      | sku    |
+      | jacket |
+    And I am on the category "2014_collection" node creation page
+    And I fill in the following information:
+      | Code | 123 |
+    And I save the category
+    And the following CSV file to import:
+      """
+      sku;categories
+      jacket;123
+      """
+    And the following job "footwear_product_import" configuration:
+      | filePath | %file to import% |
+    When I am on the "footwear_product_import" import job page
+    And I launch the import job
+    And I wait for the "footwear_product_import" job to finish
+    Then the category of the product "jacket" should be "123"

--- a/features/product/classify_product.feature
+++ b/features/product/classify_product.feature
@@ -37,3 +37,15 @@ Feature: Classify a product
     And I press the "Save" button
     And I visit the "Categories" tab
     Then I should see 2 category count
+
+  Scenario: Successfully save product when category code is integer
+    Given I am on the category "2014_collection" node creation page
+    And I fill in the following information:
+      | Code | 123 |
+    And I save the category
+    And I edit the "tea" product
+    And I visit the "Categories" tab
+    And I expand the "2014 collection" category
+    And I click on the "123" category
+    When I save the product
+    Then I should see "Product successfully updated"

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/categories.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/categories.js
@@ -164,7 +164,7 @@ define(
                     var $categoryElement = this.$('#node_' + id);
                     var $rootElement     = $categoryElement.closest('.root-unselectable');
                     this.cache[id] = {
-                        code: $categoryElement.data('code'),
+                        code: String($categoryElement.data('code')),
                         rootId: $rootElement.data('tree-id')
                     };
                 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Specs             | n
| Behats            | y
| Blue CI           | y
| Changelog updated | y
| Review and 2 GTM  | n

The issue is the params sent to product update. When category code is an integer, it's sent as an integer, like this:
`[ "categories" => [ 0 => 123 ] ]`
This fix cast category codes to string, like this:
`[ "categories" => [ 0 => "123" ] ]`