### PR TITLE
[TR] PIM-5412 Behat - Real natural login process

### DIFF
--- a/features/Context/DbSessionPurger.php
+++ b/features/Context/DbSessionPurger.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Context;
+
+use Doctrine\Common\DataFixtures\Purger\PurgerInterface;
+use Doctrine\DBAL\Connection;
+
+/**
+ * Session purger from DB
+ *
+ * @author    Benoit Jacquemont <benoit@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class DbSessionPurger implements PurgerInterface
+{
+    /** @var Connection */
+    protected $connection;
+
+    /** @var string */
+    protected $sessionTable;
+
+    /**
+     * Construct new session purger instance.
+     *
+     * @param Connection $connection
+     * @param string     $sesionTable
+     */
+    public function __construct(Connection $connection, $sessionTable)
+    {
+        $this->connection   = $connection;
+        $this->sessionTable = $sessionTable;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function purge()
+    {
+        $truncateSql = sprintf("TRUNCATE %s", $this->sessionTable);
+        $this->connection->exec($truncateSql);
+    }
+}

--- a/features/Context/FeatureContext.php
+++ b/features/Context/FeatureContext.php
@@ -326,6 +326,18 @@ class FeatureContext extends MinkContext implements KernelAwareInterface
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function assertPageContainsText($text)
+    {
+        $this->spin(function () use ($text) {
+            parent::assertPageContainsText($text);
+
+            return true;
+        }, "Spining for asserting page contains text $text");
+    }
+
+    /**
      * Set the waiting timeout
      *
      * @param $parameters

--- a/features/Context/Page/Base/Base.php
+++ b/features/Context/Page/Base/Base.php
@@ -60,14 +60,6 @@ class Base extends Page
     }
 
     /**
-     * Verify that page is loaded after login
-     */
-    public function verifyAfterLogin()
-    {
-        return true;
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function fillField($locator, $value)
@@ -164,12 +156,11 @@ class Base extends Page
         $name      = $elt->find('css', '.product-name');
 
         if (!$subtitle || !$separator || !$name) {
-            $title = $this->getElement('Product title')->find('css', '.product-label')->getText();
-            if (!$title) {
-                throw new \Exception('Could not find the page title');
-            }
+            $titleElt = $this->spin(function () {
+                return $this->getElement('Product title')->find('css', '.product-label');
+            }, "Could not find the page title");
 
-            return $title;
+            return $titleElt->getText();
         }
 
         return sprintf(

--- a/features/Context/Page/Base/Form.php
+++ b/features/Context/Page/Base/Form.php
@@ -75,13 +75,20 @@ class Form extends Base
      */
     public function visitTab($tab)
     {
-        $tabs = $this->find('css', $this->elements['Tabs']['css']);
-        if (!$tabs) {
-            $tabs = $this->find('css', $this->elements['Oro tabs']['css']);
-        }
-        if (!$tabs) {
-            $tabs = $this->find('css', $this->elements['Form tabs']['css']);
-        }
+        $tabs = $this->spin(function () {
+
+            $tabs = $this->find('css', $this->elements['Tabs']['css']);
+            if (!$tabs) {
+                $tabs = $this->find('css', $this->elements['Oro tabs']['css']);
+            }
+            if (!$tabs) {
+                $tabs = $this->find('css', $this->elements['Form tabs']['css']);
+            }
+
+            return $tabs;
+
+        }, "Findind $tab tab");
+
         $tabs->clickLink($tab);
     }
 
@@ -98,7 +105,10 @@ class Form extends Base
 
         $panel = strtolower($panel);
         if (null === $elt->find('css', sprintf('button[data-panel$="%s"].active', $panel))) {
-            $elt->find('css', sprintf('button[data-panel$="%s"]', $panel))->click();
+            $button = $this->spin(function () use ($elt, $panel) {
+                return $elt->find('css', sprintf('button[data-panel$="%s"]', $panel));
+            }, 'Cannot find the data-panel button in the panel');
+            $button->click();
         }
     }
 
@@ -178,8 +188,9 @@ class Form extends Base
         if (!$groups) {
             $groups = $this->getElement('Form Groups');
 
-            $groupsContainer = $groups
-                ->find('css', sprintf('.group-label:contains("%s")', $group));
+            $groupsContainer = $this->spin(function () use ($groups, $group) {
+                return $groups->find('css', sprintf('.group-label:contains("%s")', $group));
+            }, "Finding the group $group");
 
             $button = null;
 

--- a/features/Context/Page/Product/Edit.php
+++ b/features/Context/Page/Product/Edit.php
@@ -82,23 +82,20 @@ class Edit extends ProductEditForm
      */
     public function save()
     {
-        $this->getElement('Save')->click();
+        $element = $this->getElement('Save');
+
+        $this->spin(function () use ($element) {
+            return $element->isVisible();
+        }, "Waiting for save button to be visible");
+
+        $element->click();
+
         $this->spin(function () {
             return null === $this->find(
                 'css',
                 '*:not(.hash-loading-mask):not(.grid-container):not(.loading-mask) > .loading-mask'
             );
         });
-    }
-
-    public function verifyAfterLogin()
-    {
-        $formContainer = $this->find('css', 'div.product-edit-form');
-        if (!$formContainer) {
-            return false;
-        }
-
-        return true;
     }
 
     /**
@@ -192,18 +189,30 @@ class Edit extends ProductEditForm
      */
     public function getAttributePosition($attribute)
     {
-        $rows = $this->find('css', '.tab-pane.active.product-values')->findAll('css', '.field-container');
+        $productValues = $this->spin(function () {
+            return $this->find('css', '.tab-pane.active.product-values');
+        }, "Spining on find for product-values tab to get attribute position");
 
-        foreach ($rows as $index => $row) {
-            if ($row->find('css', sprintf(':contains("%s")', $attribute))) {
-                return $index + 1;
+        $rows = $this->spin(function () use ($productValues) {
+            return $productValues->findAll('css', '.field-container');
+        }, "Spining on findAll for rows on product-values to get attribute position");
+
+        $position = $this->spin(function () use ($rows, $attribute) {
+            foreach ($rows as $index => $row) {
+                if ($row->find('css', sprintf(':contains("%s")', $attribute))) {
+                    return $index + 1;
+                }
             }
+        }, "Spining on scanning rows to get attribute position");
+
+        if (!$position) {
+            throw new ElementNotFoundException(
+                $this->getSession(),
+                sprintf('Attribute "%s" not found', $attribute)
+            );
         }
 
-        throw new ElementNotFoundException(
-            $this->getSession(),
-            sprintf('Attribute "%s" not found', $attribute)
-        );
+        return $position;
     }
 
     /**
@@ -277,23 +286,27 @@ class Edit extends ProductEditForm
      */
     public function getRemoveLinkFor($field)
     {
-        $link = $this->find(
-            'css',
-            sprintf(
-                '.control-group:contains("%s") .remove-attribute',
-                $field
-            )
-        );
-
-        if (!$link) {
+        $link = $this->spin(function () use ($field) {
             $link = $this->find(
                 'css',
                 sprintf(
-                    '.field-container:contains("%s") .remove-attribute',
+                    '.control-group:contains("%s") .remove-attribute',
                     $field
                 )
             );
-        }
+
+            if (!$link) {
+                $link = $this->find(
+                    'css',
+                    sprintf(
+                        '.field-container:contains("%s") .remove-attribute',
+                        $field
+                    )
+                );
+            }
+
+            return $link;
+        }, "Spining to get remove link on product edit form for field $field");
 
         return $link;
     }
@@ -338,7 +351,12 @@ class Edit extends ProductEditForm
     public function disableProduct()
     {
         $el = $this->getElement('Status switcher');
-        $el->find('css', 'a.dropdown-toggle')->click();
+
+        $statusToggle = $this->spin(function () use ($el) {
+            return $el->find('css', 'a.dropdown-toggle');
+        }, "Spining to get the status dropdown toggle to disable product on PEF");
+
+        $statusToggle->click();
         $button = $el->find('css', 'ul a[data-status="disable"]');
         if ($button) {
             $button->click();
@@ -355,7 +373,12 @@ class Edit extends ProductEditForm
     public function enableProduct()
     {
         $el = $this->getElement('Status switcher');
-        $el->find('css', 'a.dropdown-toggle')->click();
+
+        $statusToggle = $this->spin(function () use ($el) {
+            return $el->find('css', 'a.dropdown-toggle');
+        }, "Spining to get the status dropdown toggle to enable product on PEF");
+
+        $statusToggle->click();
         $button = $el->find('css', 'ul a[data-status="enable"]');
         if ($button) {
             $button->click();

--- a/features/Context/WebUser.php
+++ b/features/Context/WebUser.php
@@ -13,6 +13,7 @@ use Behat\Mink\Exception\ExpectationException;
 use Behat\Mink\Exception\UnsupportedDriverActionException;
 use Behat\MinkExtension\Context\RawMinkContext;
 use Context\Spin\SpinCapableTrait;
+use Context\Spin\TimeoutException;
 use Pim\Bundle\EnrichBundle\Mailer\MailRecorder;
 use Pim\Bundle\EnrichBundle\MassEditAction\Operation\BatchableOperationInterface;
 use Pim\Component\Catalog\Model\Product;
@@ -984,7 +985,12 @@ class WebUser extends RawMinkContext
      */
     public function iShouldSeeARemoveLinkNextToTheField($not, $field)
     {
-        $removeLink = $this->getPage('Product edit')->getRemoveLinkFor($field);
+        try {
+            $removeLink = $this->getPage('Product edit')->getRemoveLinkFor($field);
+        } catch (TimeoutException $te) {
+            $removeLink = null;
+        }
+
         if ($not) {
             if ($removeLink) {
                 throw $this->createExpectationException(

--- a/features/Pim/Behat/Context/HookContext.php
+++ b/features/Pim/Behat/Context/HookContext.php
@@ -12,6 +12,7 @@ use Behat\Behat\Hook\Annotation\BeforeScenario;
 use Behat\Behat\Hook\Annotation\BeforeStep;
 use Behat\Mink\Driver\Selenium2Driver;
 use Behat\Mink\Exception\UnsupportedDriverActionException;
+use Context\DbSessionPurger;
 use Context\FeatureContext;
 use Context\SelectiveORMPurger;
 use Doctrine\Common\DataFixtures\Purger\MongoDBPurger;
@@ -73,6 +74,8 @@ class HookContext extends PimContext
         }
 
         $purgers[] = new SelectiveORMPurger($this->getService('doctrine')->getManager(), $excludedTables);
+
+        $purgers[] = new DbSessionPurger($this->getService("database_connection"), 'pim_session');
 
         foreach ($purgers as $purger) {
             $purger->purge();

--- a/features/attribute/delete_attribute.feature
+++ b/features/attribute/delete_attribute.feature
@@ -18,7 +18,7 @@ Feature: Delete an attribute
     And I fill in the following information in the popin:
       | SKU  | caterpillar_1 |
     And I press the "Save" button in the popin
-    When I am on the "caterpillar_1" product page
+    Then I wait to be on the "caterpillar_1" product page
     Then I add available attributes name
     And I fill in the following information:
       | name | My caterpillar |

--- a/features/localization/product/edit_product.feature
+++ b/features/localization/product/edit_product.feature
@@ -22,10 +22,10 @@ Feature: Edit a product with localized attributes
       | sku | family | number  | weight        | price-EUR | date       |
       | foo | baz    | -12.5   | 150.8675 GRAM | 1000.50   | 2015-05-28 |
     And I am logged in as "Julien"
-    And I am on the "foo" product page
 
   Scenario: Successfully view and edit localized number
-    Given the field Nombre should contain "-12,50"
+    Given I am on the "foo" product page
+    Then the field Nombre should contain "-12,50"
     When I change the "Nombre" to "-25,75"
     And I save the product
     Then the field Nombre should contain "-25,75"
@@ -33,7 +33,8 @@ Feature: Edit a product with localized attributes
       | number | -25.75 |
 
   Scenario: Successfully view and edit localized metric
-    Given the field Poids should contain "150,8675"
+    Given I am on the "foo" product page
+    Then the field Poids should contain "150,8675"
     When I change the "Poids" to "151"
     And I save the product
     Then the field Poids should contain "151"
@@ -41,7 +42,8 @@ Feature: Edit a product with localized attributes
       | weight | 151.0000 GRAM |
 
   Scenario: Successfully view and edit localized price
-    Given the field Prix should contain "1000,50"
+    Given I am on the "foo" product page
+    Then the field Prix should contain "1000,50"
     When I change the "Prix" to "1200,50 EUR"
     And I save the product
     Then the field Prix should contain "1200,50"
@@ -49,7 +51,8 @@ Feature: Edit a product with localized attributes
       | price-EUR | 1200.50 |
 
   Scenario: Successfully view and edit localized date
-    Given the field Date should contain "28/05/2015"
+    Given I am on the "foo" product page
+    Then the field Date should contain "28/05/2015"
     When I change the "Date" to "01/12/2015"
     And I save the product
     Then the field Date should contain "01/12/2015"
@@ -68,6 +71,7 @@ Feature: Edit a product with localized attributes
     Then the field Date should contain "28/05/2015"
 
   Scenario: Successfully show datetimepicker in my UI locale
+    Given I am on the "foo" product page
     When I click on the field Date
     Then I should see the text "Mai"
     And I should see the text "Lu"

--- a/features/navigation/navigation_title.feature
+++ b/features/navigation/navigation_title.feature
@@ -27,8 +27,6 @@ Feature: Well display navigation titles
       | "info" attribute group                    | Attribute groups Product information \| Edit    |
       | locales                                   | Locales                                         |
       | products                                  | Products                                        |
-      | "sandals" product                         | Products sandals \| Edit                        |
-      | variant groups                            | Variant groups                                  |
       | "caterpillar_boots" variant group         | Variant groups Caterpillar boots \| Edit        |
       | product groups                            | Groups                                          |
       | "similar_boots" product group             | Groups Similar boots \| Edit                    |
@@ -42,3 +40,5 @@ Feature: Well display navigation titles
       | "footwear_product_import" import job edit | Import profiles Footwear product import \| Edit |
       | import executions                         | Import executions history                       |
       | export executions                         | Export executions history                       |
+      | variant groups                            | Variant groups                                  |
+      | "sandals" product                         | Products sandals \| Edit                        |

--- a/features/product/edit_and_remove_a_product.feature
+++ b/features/product/edit_and_remove_a_product.feature
@@ -16,7 +16,7 @@ Feature: Edit and remove a product
       | SKU             | boots |
       | Choose a family | shoes |
     And I press the "Save" button in the popin
-    Then I am on the "boots" product page
+    And I wait to be on the "boots" product page
     And I fill in the following information:
       | Length | 5.0000 Centimeter |
     And I press the "Save" button

--- a/features/product/edit_product.feature
+++ b/features/product/edit_product.feature
@@ -22,7 +22,7 @@ Feature: Edit a product
       | product | attribute   | value                                | locale | scope     |
       | sandal  | description | My awesome description for ecommerce | en_US  | ecommerce |
       | sandal  | description | My awesome description for mobile    | en_US  | mobile    |
-      | sandal  | other_name  | My awesome sandals                   | en_US  | ecommerce |
+      | sandal  | other_name  | My awesome sandals for ecommerce     | en_US  | ecommerce |
       | sandal  | other_name  | My awesome sandals for mobile        | en_US  | mobile    |
       | sandal  | name        | My sandals name                      |        |           |
       | sandal  | length      | 29 CENTIMETER                        |        |           |
@@ -56,14 +56,14 @@ Feature: Edit a product
     And I reset the "Administrator" rights
 
   @jira https://akeneo.atlassian.net/browse/PIM-3615
-  Scenario: Successfully edit a product description, and have attributes set to the default scope (For Sandra => mobile and Julia => ecommerce).
+  Scenario: Successfully have attributes set to the default scope (For Sandra => mobile and Julia => ecommerce).
     Given I am logged in as "Sandra"
     And I am on the "sandal" product page
-    And the english mobile other_name of "sandal" should be "My awesome sandals for mobile"
+    Then the product Description should be "My awesome description for mobile"
     Then I logout
     And I am logged in as "Julia"
     When I am on the "sandal" product page
-    Then the english ecommerce other_name of "sandal" should be "My awesome sandals"
+    Then the product Description should be "My awesome description for ecommerce"
 
   # Working well in application but scenario fails
   @skip-pef

--- a/features/product/history/display_history.feature
+++ b/features/product/history/display_history.feature
@@ -12,7 +12,7 @@ Feature: Display the product history
     And I fill in the following information in the popin:
       | SKU | sandals-001 |
     And I press the "Save" button in the popin
-    And I edit the "sandals-001" product
+    And I wait to be on the "sandals-001" product page
     And the history of the product "sandals-001" has been built
     When I open the history
     Then there should be 1 update
@@ -29,7 +29,7 @@ Feature: Display the product history
     And I fill in the following information in the popin:
       | SKU | boots |
     And I press the "Save" button in the popin
-    And I edit the "boots" product
+    And I wait to be on the "boots" product page
     And I add available attributes Price
     When I visit the "Marketing" group
     And I change the "Price" to "10 EUR"

--- a/features/product/history/display_removed_value_history.feature
+++ b/features/product/history/display_removed_value_history.feature
@@ -13,7 +13,7 @@ Feature: Display the product history
     And I fill in the following information in the popin:
       | SKU | boots |
     And I press the "Save" button in the popin
-    And I am on the "boots" product page
+    And I wait to be on the "boots" product page
     And I add available attributes Weather conditions
     And I change the "Weather conditions" to "Cold, Snowy"
     And I save the product
@@ -44,7 +44,7 @@ Feature: Display the product history
     And I fill in the following information in the popin:
       | SKU | boots |
     And I press the "Save" button in the popin
-    And I edit the "boots" product
+    And I wait to be on the "boots" product page
     And I visit the "Categories" tab
     And I select the "2014 collection" tree
     And I expand the "2014 collection" category
@@ -76,7 +76,7 @@ Feature: Display the product history
     And I fill in the following information in the popin:
       | SKU | boots |
     And I press the "Save" button in the popin
-    And I edit the "boots" product
+    And I wait to be on the "boots" product page
     And I visit the "Categories" tab
     And I select the "2014 collection" tree
     And I expand the "2014 collection" category
@@ -113,7 +113,7 @@ Feature: Display the product history
     And I fill in the following information in the popin:
       | SKU | boots |
     And I press the "Save" button in the popin
-    And I am on the "boots" product page
+    And I wait to be on the "boots" product page
     And I add available attributes Manufacturer
     And I change the "Manufacturer" to "Converse"
     And I save the product
@@ -144,7 +144,7 @@ Feature: Display the product history
     And I fill in the following information in the popin:
       | SKU | boots |
     And I press the "Save" button in the popin
-    And I am on the "boots" product page
+    And I wait to be on the "boots" product page
     And I add available attributes Weather conditions, Comment
     And I change the "Weather conditions" to "Cold, Snowy"
     And I visit the "Other" group

--- a/features/product/history_update.feature
+++ b/features/product/history_update.feature
@@ -13,7 +13,7 @@ Feature: Update the product history
     And I fill in the following information in the popin:
       | SKU | boots |
     And I press the "Save" button in the popin
-    And I am on the "boots" product page
+    And I wait to be on the "boots" product page
     And I add available attributes Price
     And I change the Price to "20 USD"
     And I change the Price to "10 EUR"
@@ -57,7 +57,7 @@ Feature: Update the product history
     And I fill in the following information in the popin:
       | SKU | boots |
     And I press the "Save" button in the popin
-    And I am on the "boots" product page
+    And I wait to be on the "boots" product page
     And I add available attributes Length
     And I change the "Length" to "30"
     And I save the product


### PR DESCRIPTION
This PR replace the current Behat login behavior with a more natural one.
The current behavior is about trying to get to the target page, then apply the set login/pass when the redirection is done to the login screen.
This behavior has several drawbacks:
 - it does not represent how the way use will log in the application most of the time
 - it loads the target page twice (first after the redirection and then when the behat step ask for it)
 - it makes Behat debugging more difficult as the application flow is not the one described in the scenario ("the i am logged in as" step is a lie)

The new behavior simply follow the scenario and logged in when requested, thus avoiding redirect and difficult to debug flow.

| Q                 | A
| ----------------- | ---
| Added Specs       | N.A.
| Added Behats      | N.A.
| Travis CI is ok   |
| Changelog updated | N.A.