### PR TITLE
Added a twig extension to highlight some texts

### DIFF
--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -10,6 +10,7 @@
 - PIM-5217: Create a Buffer component and new file writer implementations that use it
 - PIM-4646: TinyMCE wysiwyg editor is replaced by Summernote in the mass-edit and variant group
 - PIM-4999: jQuery UI datepicker is replaced by bootstrap datepicker in the mass-edit and variant group
+- A new twig extension (StyleExtension) in UIBundle now provides a "highlight" string filter
 
 ## Bug fixes
 

--- a/spec/Pim/Bundle/UIBundle/Twig/StyleExtensionSpec.php
+++ b/spec/Pim/Bundle/UIBundle/Twig/StyleExtensionSpec.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace spec\Pim\Bundle\UIBundle\Twig;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class StyleExtensionSpec extends ObjectBehavior
+{
+    function it_is_a_twig_extension()
+    {
+        $this->shouldHaveType('\Twig_Extension');
+    }
+
+    function it_has_a_name()
+    {
+        $this->getName()->shouldReturn('pim_ui_style_extension');
+    }
+
+    function it_defines_filters()
+    {
+        $filters = $this->getFilters();
+
+        $filters->shouldHaveCount(1);
+        $filters[0]->shouldBeAnInstanceOf('\Twig_SimpleFilter');
+        $filters[0]->getName()->shouldReturn('highlight');
+    }
+
+    function it_highlights()
+    {
+        $this->highlight('toto')->shouldReturn('<span class="highlight">toto</span>');
+    }
+}

--- a/src/Pim/Bundle/UIBundle/DependencyInjection/PimUIExtension.php
+++ b/src/Pim/Bundle/UIBundle/DependencyInjection/PimUIExtension.php
@@ -24,5 +24,6 @@ class PimUIExtension extends Extension
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__ .'/../Resources/config'));
         $loader->load('controllers.yml');
         $loader->load('forms.yml');
+        $loader->load('twig.yml');
     }
 }

--- a/src/Pim/Bundle/UIBundle/Resources/config/twig.yml
+++ b/src/Pim/Bundle/UIBundle/Resources/config/twig.yml
@@ -1,0 +1,9 @@
+parameters:
+    pim_ui.twig.style_extension.class: Pim\Bundle\UIBundle\Twig\StyleExtension
+
+services:
+    pim_ui.twig.style_extension:
+        class: %pim_ui.twig.style_extension.class%
+        public: false
+        tags:
+            - { name: twig.extension }

--- a/src/Pim/Bundle/UIBundle/Resources/public/css/pim.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/css/pim.less
@@ -1749,3 +1749,8 @@ h3.tab-header {
 .scopable-input .note-editor {
   display: inline-block;
 }
+
+.highlight {
+  color: @akeneo-purple;
+  font-weight: bold;
+}

--- a/src/Pim/Bundle/UIBundle/Twig/StyleExtension.php
+++ b/src/Pim/Bundle/UIBundle/Twig/StyleExtension.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Pim\Bundle\UIBundle\Twig;
+
+/**
+ * Some presentation filters
+ *
+ * @author    Clement Gautier <clement.gautier@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class StyleExtension extends \Twig_Extension
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getFilters()
+    {
+        return [
+            new \Twig_SimpleFilter('highlight', [$this, 'highlight'])
+        ];
+    }
+
+    /**
+     * Return a string wrapper in a span with a specific class
+     *
+     * @param string $content
+     *
+     * @return string
+     */
+    public function highlight($content)
+    {
+        return sprintf('<span class="highlight">%s</span>', $content);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'pim_ui_style_extension';
+    }
+}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Specs             | Y
| Behats            | N/A
| Blue CI           | Y
| Changelog updated | Y
| Review and 2 GTM  | Y

In many screens we have to highlights some variables in texts and their is no easy way to do it actually.