### PR TITLE
[TR][SLA] PIM-5418: Fix limit on localizable families search

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -5,6 +5,7 @@
 
 ## Bug fixes
 - PIM-5233: Use an asynchronous dropdown list to mass edit family
+- PIM-5418: Fix limit on localizable families search
 
 ## BC Breaks
 - Changed constructor `Pim\Bundle\EnrichBundle\Form\Type\MassEditAction\ChangeFamilyType` to add `Pim\Bundle\CatalogBundle\Repository\FamilyRepositoryInterface` dependency

--- a/features/Context/DataGridContext.php
+++ b/features/Context/DataGridContext.php
@@ -794,7 +794,10 @@ class DataGridContext extends RawMinkContext implements PageObjectAwareInterface
     public function iClickBackToGrid()
     {
         $this->wait();
-        $this->getSession()->getPage()->clickLink('Back to grid');
+        $link = $this->spin(function () {
+           return $this->getSession()->getPage()->findLink('Back to grid');
+        });
+        $link->click();
         $this->wait();
     }
 

--- a/features/Context/WebUser.php
+++ b/features/Context/WebUser.php
@@ -2684,4 +2684,27 @@ class WebUser extends RawMinkContext
             }
         }
     }
+
+    /**
+     * Check the number of items in a select2 autocomplete. This function spins when autocomplete is searching; it
+     * returns 0 only if special dom item is found.
+     *
+     * @param string $expectedCount
+     *
+     * @Then /^I should see (\d+) items? in the autocomplete$/
+     */
+    public function iShouldSeeAutocompleteItems($expectedCount)
+    {
+        $items = $this->spin(function () {
+            return $this
+                ->getCurrentPage()
+                ->findAll('css', '.select2-results .select2-result-selectable, .select2-results .select2-no-results');
+        }, 20, 'Cannot find any select2 items');
+
+        if ($items[0]->hasClass('select2-no-results')) {
+            assertEquals((int) $expectedCount, 0);
+        } else {
+            assertEquals((int) $expectedCount, count($items));
+        }
+    }
 }

--- a/features/product/filtering/filter_products_per_family.feature
+++ b/features/product/filtering/filter_products_per_family.feature
@@ -32,3 +32,32 @@ Feature: Filter products per family
       | Family | hi_fi,computers  | Amplifier, CD changer, PC and Laptop |
       | Family | washing_machines | Whirlpool and Electrolux             |
       | Family | is empty         | Mug                                  |
+
+  Scenario: Successfully filter 20 first families on search input
+    Given the following families:
+      | code   | label-fr_FR | label-en_US | label-de_DE |
+      | code1  | code1fr     | code1en     | code1de     |
+      | code2  | code2fr     | code2en     | code2de     |
+      | code3  | code3fr     | code3en     | code3de     |
+      | code4  | code4fr     | code4en     | code4de     |
+      | code5  | code5fr     | code5en     | code5de     |
+      | code6  | code6fr     | code6en     | code6de     |
+      | code7  | code7fr     | code7en     | code7de     |
+      | code8  | code8fr     | code8en     | code8de     |
+      | code9  | code9fr     | code9en     | code9de     |
+      | code10 | code10fr    | code10e     | code10de    |
+      | code11 | code11fr    | code11en    | code11de    |
+      | code12 | code12fr    | code12en    | code12de    |
+      | code13 | code13fr    | code13en    | code13de    |
+      | code14 | code14fr    | code14en    | code14de    |
+      | code15 | code15fr    | code15en    | code15de    |
+      | code16 | code16fr    | code16en    | code16de    |
+      | code17 | code17fr    | code17en    | code17de    |
+      | code18 | code18fr    | code18en    | code18de    |
+      | code19 | code19fr    | code19en    | code19de    |
+      | code20 | code20fr    | code20en    | code20de    |
+      | code21 | code21fr    | code21en    | code21de    |
+    And I am on the products page
+    And I should see the filter "Family"
+    When I press the "Family:" button
+    Then I should see 20 items in the autocomplete

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/select2-rest-choice-filter.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/select2-rest-choice-filter.js
@@ -7,10 +7,11 @@ define(
         'routing',
         'oro/datafilter/text-filter',
         'pim/formatter/choices/base',
+        'pim/user-context',
         'text!pim/template/datagrid/filter/select2-choice-filter',
         'jquery.select2'
     ],
-    function($, _, Routing, TextFilter, ChoicesFormatter, template) {
+    function($, _, Routing, TextFilter, ChoicesFormatter, UserContext, template) {
         return TextFilter.extend({
             operatorChoices: [],
             choiceUrl: null,
@@ -81,7 +82,8 @@ define(
                                     search: term,
                                     options: {
                                         limit: this.resultsPerPage,
-                                        page: page
+                                        page: page,
+                                        locale: UserContext.get('catalogLocale')
                                     }
                                 };
                             }.bind(this),

--- a/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/FamilySearchableRepository.php
+++ b/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/FamilySearchableRepository.php
@@ -39,11 +39,15 @@ class FamilySearchableRepository implements SearchableRepositoryInterface
     public function findBySearch($search = null, array $options = [])
     {
         $qb = $this->entityManager->createQueryBuilder()->select('f')->from($this->entityName, 'f');
-        $qb->leftJoin('f.translations', 'ft');
 
         if (null !== $search && '' !== $search) {
-            $qb->where('f.code like :search')->setParameter('search', "%$search%");
-            $qb->orWhere('ft.label like :search')->setParameter('search', "%$search%");
+            $qb->where('f.code like :search')->setParameter('search', '%' . $search . '%');
+            if (isset($options['locale'])) {
+                $qb->leftJoin('f.translations', 'ft');
+                $qb->orWhere('ft.label like :search AND ft.locale = :locale');
+                $qb->setParameter('search', '%' . $search . '%');
+                $qb->setParameter('locale', $options['locale']);
+            }
         }
 
         if (isset($options['identifiers']) && is_array($options['identifiers']) && !empty($options['identifiers'])) {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Specs             | n
| Behats            | y
| Blue CI           | yellow
| Changelog updated | y
| Review and 2 GTM  | TODO

The issue is that when user searches a family and they are localizable families, it returns a line per translation, and the limit is < to 20.
Now, it's 20.