### PR TITLE
PIM-5379: Remove completeness calculation from MongoDB saver

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -7,6 +7,7 @@
 - PIM-5021: Forbid the use of code `category` for an attribute
 - PIM-5233: Use an asynchronous dropdown list to mass edit family
 - PIM-5418: Fix limit on localizable families search
+- PIM-5379, PIM-5429: Fix memory leak on MongoDB `ProductSaver` and wrong completeness generation
 
 ## BC Breaks
 - Changed constructor `Pim\Bundle\EnrichBundle\Form\Type\MassEditAction\ChangeFamilyType` to add `Pim\Bundle\CatalogBundle\Repository\FamilyRepositoryInterface` dependency

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Saver/ProductSaver.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Saver/ProductSaver.php
@@ -105,14 +105,6 @@ class ProductSaver extends BaseProductSaver
             } else {
                 $productsToUpdate[] = $product;
             }
-
-            if (true === $options['schedule'] || true === $options['recalculate']) {
-                $this->completenessManager->schedule($product);
-            }
-
-            if (true === $options['recalculate']) {
-                $this->completenessManager->generateMissingForProduct($product);
-            }
         }
 
         $insertDocs = $this->getDocsFromProducts($productsToInsert);
@@ -124,6 +116,12 @@ class ProductSaver extends BaseProductSaver
 
         if (count($updateDocs) > 0) {
             $this->updateDocuments($updateDocs);
+        }
+        
+        if (true === $options['recalculate']) {
+            foreach ($products as $product) {
+                $this->completenessManager->generateMissingForProduct($product);
+            }
         }
 
         $versions = $this->bulkVersionBuilder->buildVersions($products);


### PR DESCRIPTION
Just some words to explain this PR.

3 issues are fixed here:

1. Useless completeness scheduling.
Completeness is overridden each time we save the product with this direct to db saver. No need to reschedule it, it will be done.

2. Wrong completeness generation.
The real saving part is done at the end of the `saveAll` method calling `insertDocuments` and `updateDocuments`. As long these methods are not called, the MongoDB collection current state is before the product update. In this case, the completeness is done on the "old" datas.

3. Memory leak on the product saver.
The rescheduling of the completeness is done with: `CompletenessGenerator::schedule(ProductInterface)`. It calls a clear to the collection. Accordingly, this will schedule the completeness to be removed in the UOW.
But now, we don't work anymore with the UOW here and there is no flush or clear of it. So products are detached from the UOW but completenesses are not and they are linked to products. Then products will be kept in memory.


This PR consists in removing the completeness scheduling and move the completeness calculation to call it after the product has been updated.