### PR TITLE
Added new behat function to be able to assert a datagrid cell contains some text

### DIFF
--- a/features/Context/DataGridContext.php
+++ b/features/Context/DataGridContext.php
@@ -187,12 +187,44 @@ class DataGridContext extends RawMinkContext implements PageObjectAwareInterface
      * @param string    $code
      * @param TableNode $table
      *
+     * @Then /^the row "([^"]*)" should contain the texts:$/
+     */
+    public function theRowShouldContainText($code, TableNode $table)
+    {
+        foreach ($table->getHash() as $data) {
+            $this->assertColumnContainsText($code, $data['column'], $data['value']);
+        }
+    }
+
+    /**
+     * @param string    $code
+     * @param TableNode $table
+     *
      * @Then /^the row "([^"]*)" should contain the images:$/
      */
     public function theRowShouldContainImages($code, TableNode $table)
     {
         foreach ($table->getHash() as $data) {
             $this->assertColumnContainsImage($code, $data['column'], $data['title']);
+        }
+    }
+
+    /**
+     * @param string $row
+     * @param string $column
+     * @param string $expectation
+     *
+     * @throws ExpectationException
+     */
+    public function assertColumnContainsText($row, $column, $expectation)
+    {
+        $column = strtoupper($column);
+        $actual = $this->datagrid->getColumnValue($column, $row);
+
+        if (!preg_match('/'.preg_quote($expectation, '/').'/ui', $actual)) {
+            throw $this->createExpectationException(
+                sprintf('Expecting column "%s" to contain the text "%s", got "%s"', $column, $expectation, $actual)
+            );
         }
     }
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Specs             | N/A
| Behats            | N/A
| Blue CI           | Y
| Changelog updated | N/A

Problem
-----------
The actual step `@Then /^the row "([^"]*)" should contain:$/` split the text of the cell using a comma separator to be able to do things like `Then the row "foo" should contain "foo, bar"` so you can't ensure that the expected text is really present in the datagrid cell.

More than that, splitting on a comma don't work at all if you have commas in the datagrid as it do an `array_diff` to know if the behat should fail or not, here is an example:

```
    Then the row "copy_description" should contain:
      | column    | value                                  |
      | Condition | If name equals My nice tshirt [ en ]   |
      | Condition | If weather_conditions.code in dry, wet |
      | Condition | If comment starts with promo           |
```
and this is what I get:
```
Expecting column "CONDITION" to contain "If name equals My nice tshirt [ en ]", got "If name equals My nice tshirt [ en ] If weather_conditions.code in dry, wet If comment starts with promo"
```

Fix
----
To do that kind of assertion I created a similar method that do not split the cell content on a comma but, in the other hand, use `preg_match` to assert that the text is found in the cell.