### PR TITLE
[TR] PIM-5021: Forbid the use of code 'category' for an attribute

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -4,6 +4,7 @@
 - PIM-5213: Paginate loading of attributes on Product Edit Form and Mass Edit Common Attributes action
 
 ## Bug fixes
+- PIM-5021: Forbid the use of code `category` for an attribute
 - PIM-5233: Use an asynchronous dropdown list to mass edit family
 
 ## BC Breaks

--- a/features/attribute/create_text_attribute.feature
+++ b/features/attribute/create_text_attribute.feature
@@ -27,8 +27,9 @@ Feature: Create an attribute
       | code             |
       | id               |
       | associationTypes |
-      | categories       |
+      | category         |
       | categoryId       |
+      | categories       |
       | completeness     |
       | enabled          |
       | family           |

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/validation/attribute.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/validation/attribute.yml
@@ -32,7 +32,7 @@ Pim\Bundle\CatalogBundle\Entity\Attribute:
             - Length:
                 max: 255
             - Regex:
-                pattern: /^(?!(id|associationTypes|categories|categoryId|completeness|enabled|family|groups|associations|products|scope|treeId|values|(.)*_(products|groups))$)/
+                pattern: /^(?!(id|associationTypes|categories|categoryId|completeness|enabled|family|groups|associations|products|scope|treeId|values|category|(.)*_(products|groups))$)/
                 message: This code is not available
         localizable:
             - Type: bool


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Specs             | y
| Behats            | y
| Blue CI           | TODO
| Changelog updated | n
| Review and 2 GTM  | n

* The CHANGELOG needs to be updated or not ? *