### PR TITLE
Add Doctrine MongoDb to dev requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,8 @@ cache:
 before_script:
     - echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
     - composer self-update --no-interaction
+    - sh -c 'if [ "$TRAVIS_PHP_VERSION" == "hhvm" ]; then composer remove --no-update doctrine/mongodb-odm-bundle; fi;'
     - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then echo "extension = mongo.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;'
-    - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then composer require --no-update doctrine/mongodb-odm v1.0.0-beta12@dev; fi;'
-    - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then composer require --no-update doctrine/mongodb-odm-bundle v3.0.0-BETA6@dev; fi;'
     - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then composer update --prefer-dist --no-interaction; else composer update --prefer-dist --no-interaction --no-scripts; fi;'
     - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then ./app/console oro:requirejs:generate-config; fi;'
     - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then ./app/console assets:install; fi;'

--- a/composer.json
+++ b/composer.json
@@ -78,6 +78,7 @@
         "behat/mink-selenium2-driver": "1.2.0",
         "behat/symfony2-extension": "1.1.2",
         "behat/transliterator":"1.0.1",
+        "doctrine/mongodb-odm-bundle": "v3.0.1",
         "sensiolabs/behat-page-object-extension": "1.0.1",
         "phpspec/phpspec": "2.1.*",
         "akeneo/phpspec-skip-example-extension": "1.1.*"


### PR DESCRIPTION
With this PR, i want to add MongoDb bundle to our dev requirements.

It has multiple advantages : 
- No need to modify your `composer.json` when working on a Mongo evironment
- It will ALWAYS run ALL specs : you will not break specs anymore
- You will always have the good version of MongoDb bundle : i had an old 1.4 Mongo db env on wich i used to stash my composer before updating and then pop stash to quickly set my Mongo env. But by doing that, i didn't see that i was using an old version of the bundle.

| Q                 | A
| ----------------- | ---
| Added Specs       |no
| Added Behats      |no
| Travis CI is ok   |yes
| Changelog updated |no