### PR TITLE
[TR][SLA] PIM-5446: Replace rest attribute configuration action from GET to POST to prevent too long URI

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -8,6 +8,7 @@
 - PIM-5233: Use an asynchronous dropdown list to mass edit family
 - PIM-5418: Fix limit on localizable families search
 - PIM-5379, PIM-5429: Fix memory leak on MongoDB `ProductSaver` and wrong completeness generation
+- PIM-5446: Replace rest attribute configuration action from GET to POST to prevent too long URI
 
 ## BC Breaks
 - Changed constructor `Pim\Bundle\EnrichBundle\Form\Type\MassEditAction\ChangeFamilyType` to add `Pim\Bundle\CatalogBundle\Repository\FamilyRepositoryInterface` dependency

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/AttributeController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/AttributeController.php
@@ -57,7 +57,10 @@ class AttributeController
     }
 
     /**
-     * Get the attribute collection
+     * Get the attribute collection.
+     *
+     * TODO This action is only accessible via a POST query, because of too long query URI. To respect standards, a
+     * refactor must be done.
      *
      * @param Request $request
      *
@@ -66,15 +69,15 @@ class AttributeController
     public function indexAction(Request $request)
     {
         $options = [];
-        if ($request->query->has('identifiers')) {
-            $options['identifiers'] = explode(',', $request->query->get('identifiers'));
+        if ($request->request->has('identifiers')) {
+            $options['identifiers'] = explode(',', $request->request->get('identifiers'));
         }
 
-        if ($request->query->has('types')) {
-            $options['types'] = explode(',', $request->query->get('types'));
+        if ($request->request->has('types')) {
+            $options['types'] = explode(',', $request->request->get('types'));
         }
         if (empty($options)) {
-            $options = $request->query->get(
+            $options = $request->request->get(
                 'options',
                 ['limit' => SearchableRepositoryInterface::FETCH_LIMIT, 'locale' => null]
             );
@@ -85,7 +88,7 @@ class AttributeController
 
         if (null !== $this->attributeSearchRepository) {
             $attributes = $this->attributeSearchRepository->findBySearch(
-                $request->query->get('search'),
+                $request->request->get('search'),
                 $options
             );
         } else {

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/routing/attribute.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/routing/attribute.yml
@@ -35,7 +35,7 @@ pim_enrich_attribute_create_option:
 pim_enrich_attribute_rest_index:
     path: /rest
     defaults: { _controller: pim_enrich.controller.rest.attribute:indexAction, _format: json }
-    methods: [GET]
+    methods: [POST]
 
 pim_enrich_attribute_rest_get:
     path: /rest/{identifier}

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/fetcher/attribute-fetcher.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/fetcher/attribute-fetcher.js
@@ -42,6 +42,22 @@ define(['jquery', 'underscore', 'pim/base-fetcher', 'routing'], function ($, _, 
         },
 
         /**
+         * This method overrides the base method, to send a POST query instead of a GET query, because the request
+         * URI can be too long.
+         * TODO Should be deleted to set it back to GET.
+         *
+         * {@inheritdoc}
+         */
+        getListAsJSON: function (identifiers) {
+            return $.post(
+                Routing.generate(this.options.urls.list),
+                { identifiers: identifiers.join(',') },
+                null,
+                'json'
+            );
+        },
+
+        /**
          * {@inheritdoc}
          */
         clear: function () {

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/fetcher/attribute-fetcher.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/fetcher/attribute-fetcher.js
@@ -36,7 +36,7 @@ define(['jquery', 'underscore', 'pim/base-fetcher', 'routing'], function ($, _, 
          * @return {Promise}
          */
         fetchByTypes: function (attributeTypes) {
-            return $.getJSON(Routing.generate(this.options.urls.list, { types: attributeTypes.join(',') }))
+            return this.getJSON(this.options.urls.list, { types: attributeTypes.join(',') })
                 .then(_.identity)
                 .promise();
         },

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/fetcher/attribute-fetcher.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/fetcher/attribute-fetcher.js
@@ -48,13 +48,8 @@ define(['jquery', 'underscore', 'pim/base-fetcher', 'routing'], function ($, _, 
          *
          * {@inheritdoc}
          */
-        getListAsJSON: function (identifiers) {
-            return $.post(
-                Routing.generate(this.options.urls.list),
-                { identifiers: identifiers.join(',') },
-                null,
-                'json'
-            );
+        getJSON: function (url, parameters) {
+            return $.post(Routing.generate(url), parameters, null, 'json');
         },
 
         /**

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/fetcher/base-fetcher.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/fetcher/base-fetcher.js
@@ -50,9 +50,7 @@ define(['jquery', 'underscore', 'backbone', 'routing'], function ($, _, Backbone
                 return $.Deferred().reject().promise();
             }
 
-            return $.getJSON(
-                Routing.generate(this.options.urls.list, searchOptions)
-            ).then(_.identity).promise();
+            return this.getJSON(this.options.urls.list, searchOptions).then(_.identity).promise();
         },
 
         /**
@@ -114,7 +112,7 @@ define(['jquery', 'underscore', 'backbone', 'routing'], function ($, _, Backbone
             }
 
             return $.when(
-                    this.getListAsJSON(uncachedIdentifiers)
+                    this.getJSON(this.options.urls.list, { identifiers: uncachedIdentifiers.join(',') })
                         .then(_.identity),
                     this.getIdentifierField()
                 ).then(function (entities, identifierCode) {
@@ -129,12 +127,13 @@ define(['jquery', 'underscore', 'backbone', 'routing'], function ($, _, Backbone
         /**
          * Get the list of elements in JSON format.
          *
-         * @param {Array} identifiers
+         * @param {string} url
+         * @param {Object} parameters
          *
          * @returns {Promise}
          */
-        getListAsJSON: function (identifiers) {
-            return $.getJSON(Routing.generate(this.options.urls.list, { identifiers: identifiers.join(',') }));
+        getJSON: function (url, parameters) {
+            return $.getJSON(Routing.generate(url, parameters));
         },
 
         /**

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/fetcher/base-fetcher.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/fetcher/base-fetcher.js
@@ -114,7 +114,7 @@ define(['jquery', 'underscore', 'backbone', 'routing'], function ($, _, Backbone
             }
 
             return $.when(
-                    $.getJSON(Routing.generate(this.options.urls.list, { identifiers: uncachedIdentifiers.join(',') }))
+                    this.getListAsJSON(uncachedIdentifiers)
                         .then(_.identity),
                     this.getIdentifierField()
                 ).then(function (entities, identifierCode) {
@@ -124,6 +124,17 @@ define(['jquery', 'underscore', 'backbone', 'routing'], function ($, _, Backbone
 
                     return getObjects(_.pick(this.entityPromises, identifiers));
                 }.bind(this));
+        },
+
+        /**
+         * Get the list of elements in JSON format.
+         *
+         * @param {Array} identifiers
+         *
+         * @returns {Promise}
+         */
+        getListAsJSON: function (identifiers) {
+            return $.getJSON(Routing.generate(this.options.urls.list, { identifiers: identifiers.join(',') }));
         },
 
         /**


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Specs             | n
| Behats            | n
| Blue CI           | y
| Changelog updated | y
| Review and 2 GTM  | y

The issue raised is that when there is a lot of attributes with long codes, we have a "too long URI" error.
The first workaround is to increase the limit of URI, but this PR will fix it.

This PR changes GET method into POST, only for this action.