### PR TITLE
PIM-5422: fix memory leak on import products

### DIFF
--- a/CHANGELOG-1.3.md
+++ b/CHANGELOG-1.3.md
@@ -1,3 +1,9 @@
+# 1.3.x
+
+## Bug fixes
+
+- PIM-5422: Fix memory leak on import product
+
 # 1.3.35 (2015-12-29)
 
 # 1.3.34 (2015-12-17)

--- a/src/Akeneo/Bundle/StorageUtilsBundle/Doctrine/Common/Detacher/ObjectDetacher.php
+++ b/src/Akeneo/Bundle/StorageUtilsBundle/Doctrine/Common/Detacher/ObjectDetacher.php
@@ -3,9 +3,12 @@
 namespace Akeneo\Bundle\StorageUtilsBundle\Doctrine\Common\Detacher;
 
 use Akeneo\Component\StorageUtils\Detacher\ObjectDetacherInterface;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\Common\Util\ClassUtils;
+use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\PersistentCollection;
 
 /**
  * Detacher, detaches an object from its ObjectManager
@@ -33,7 +36,13 @@ class ObjectDetacher implements ObjectDetacherInterface
     public function detach($object)
     {
         $objectManager = $this->getObjectManager($object);
-        $objectManager->detach($object);
+
+        if ($objectManager instanceof DocumentManager) {
+            $visited = [];
+            $this->doDetach($object, $visited);
+        } else {
+            $objectManager->detach($object);
+        }
     }
 
     /**
@@ -44,5 +53,58 @@ class ObjectDetacher implements ObjectDetacherInterface
     protected function getObjectManager($object)
     {
         return $this->managerRegistry->getManagerForClass(ClassUtils::getClass($object));
+    }
+
+    /**
+     * Do detach objects on DocumentManager
+     *
+     * @param document $document
+     * @param array    $visited   Prevent infinite recursion
+     */
+    protected function doDetach($document, array &$visited)
+    {
+        $oid = spl_object_hash($document);
+        if (isset($visited[$oid])) {
+            return;
+        }
+
+        $documentManager = $this->getObjectManager($document);
+
+        $visited[$oid] = $document;
+
+        $documentManager->detach($document);
+
+        $this->cascadeDetach($document, $visited);
+    }
+
+    /**
+     * Cascade detach objects to overcome MongoDB detach
+     * cascade bug on MongoDB ODM BETA12.
+     * See https://github.com/doctrine/mongodb-odm/pull/979.
+     *
+     * @param object $object
+     * @param array  $visited Prevent infinite recursion
+     */
+    protected function cascadeDetach($document, array &$visited)
+    {
+        $documentManager = $this->getObjectManager($document);
+
+        $class = $documentManager->getClassMetadata(ClassUtils::getClass($document));
+        foreach ($class->fieldMappings as $mapping) {
+            if (!$mapping['isCascadeDetach']) {
+                continue;
+            }
+            $relatedDocuments = $class->reflFields[$mapping['fieldName']]->getValue($document);
+            if (($relatedDocuments instanceof Collection || is_array($relatedDocuments))) {
+                if ($relatedDocuments instanceof PersistentCollection) {
+                    $relatedDocuments = $relatedDocuments->unwrap();
+                }
+                foreach ($relatedDocuments as $relatedDocument) {
+                    $this->doDetach($relatedDocument, $visited);
+                }
+            } elseif ($relatedDocuments !== null) {
+                $this->doDetach($relatedDocuments, $visited);
+            }
+        }
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/ProductRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/ProductRepository.php
@@ -320,22 +320,11 @@ class ProductRepository extends DocumentRepository implements
     /**
      * {@inheritdoc}
      */
-    public function findAllForVariantGroup(GroupInterface $variantGroup, array $criteria = array())
+    public function findAllForVariantGroup(GroupInterface $variantGroup, array $criteria = [])
     {
-        $qb = $this->createQueryBuilder()->eagerCursor(true);
-
-        $qb->field('groupIds')->in([$variantGroup->getId()]);
-
-        foreach ($criteria as $item) {
-            $andExpr = $qb
-                ->expr()
-                ->field('values')
-                ->elemMatch(['attribute' => (int) $item['attribute']->getId(), 'option' => $item['option']->getId()]);
-
-            $qb->addAnd($andExpr);
-        }
-
+        $qb     = $this->findAllForVariantGroupQB($variantGroup, $criteria);
         $cursor = $qb->getQuery()->execute();
+
         $products = [];
         foreach ($cursor as $product) {
             $products[] = $product;
@@ -397,7 +386,7 @@ class ProductRepository extends DocumentRepository implements
      */
     public function getIdentifierProperties()
     {
-        return array($this->attributeRepository->getIdentifierCode());
+        return [$this->attributeRepository->getIdentifierCode()];
     }
 
     /**
@@ -409,11 +398,9 @@ class ProductRepository extends DocumentRepository implements
         $qb = $productQueryBuilder->getQueryBuilder();
 
         $productQueryBuilder->addFilter($value->getAttribute()->getCode(), '=', $value->getData());
-        $result = $qb->hydrate(false)->getQuery()->execute();
+        $result = $qb->hydrate(false)->getQuery()->getSingleResult();
 
-        if (0 === $result->count() ||
-            (1 === $result->count() && $value->getEntity()->getId() === (string) $result->getNext()['_id'])
-        ) {
+        if (null === $result || (null !== $result && $value->getEntity()->getId() === (string) $result['_id'])) {
             return false;
         }
 
@@ -455,7 +442,7 @@ class ProductRepository extends DocumentRepository implements
      *
      * @return QueryBuilder
      */
-    public function createVariantGroupDatagridQueryBuilder(array $params = array())
+    public function createVariantGroupDatagridQueryBuilder(array $params = [])
     {
         $qb = $this->createQueryBuilder();
 
@@ -471,7 +458,7 @@ class ProductRepository extends DocumentRepository implements
      *
      * @return QueryBuilder
      */
-    public function createAssociationDatagridQueryBuilder(array $params = array())
+    public function createAssociationDatagridQueryBuilder(array $params = [])
     {
         $qb = $this->createQueryBuilder();
 
@@ -585,7 +572,7 @@ class ProductRepository extends DocumentRepository implements
     /**
      * {@inheritdoc}
      */
-    public function getFullProducts(array $productIds, array $attributeIds = array())
+    public function getFullProducts(array $productIds, array $attributeIds = [])
     {
         $qb = $this->createQueryBuilder('p');
         $qb->field('_id')->in($productIds);
@@ -745,5 +732,53 @@ class ProductRepository extends DocumentRepository implements
         $count = $qb->getQuery()->execute()->count();
 
         return $count;
+    }
+
+    /**
+     * @param GroupInterface $variantGroup
+     * @param array          $criteria
+     *
+     * @return array
+     */
+    public function findProductIdsForVariantGroup(GroupInterface $variantGroup, array $criteria = [])
+    {
+        $qb = $this->findAllForVariantGroupQB($variantGroup, $criteria);
+        $qb
+            ->select('_id')
+            ->hydrate(false);
+
+        $cursor = $qb->getQuery()->execute();
+
+        $products = [];
+        foreach ($cursor as $product) {
+            $product['id'] = (string) $product['_id'];
+            $products[] = $product;
+        }
+
+        return $products;
+    }
+
+    /**
+     * @param GroupInterface $variantGroup
+     * @param array          $criteria
+     *
+     * @return array
+     */
+    protected function findAllForVariantGroupQB(GroupInterface $variantGroup, array $criteria = [])
+    {
+        $qb = $this->createQueryBuilder('p')->eagerCursor(true);
+
+        $qb->field('groupIds')->in([$variantGroup->getId()]);
+
+        foreach ($criteria as $item) {
+            $andExpr = $qb
+                ->expr()
+                ->field('values')
+                ->elemMatch(['attribute' => (int) $item['attribute']->getId(), 'option' => $item['option']->getId()]);
+
+            $qb->addAnd($andExpr);
+        }
+
+        return $qb;
     }
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Added Specs       | N
| Added Behats      | N
| Travis CI is ok   | Y
| Changelog updated | Y

A cherry pick has been done from 1.4 to detach product value.
UniqueVariantAxisValidator has been reworked to avoid to hydrate products whereas we need only the id.

Result, import a rule with 3000 products inpacted:

before patch | after patch
------------ | -------------
20 minutes | 13 minutes
625Mb | 70.75Mb