### PR TITLE
PIM-5450: add mongodb bundle to dev requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,19 @@ cache:
   directories:
     - $HOME/.composer/cache
 
-before_script:
+before_install:
+    - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then
+        phpenv config-rm xdebug.ini;
+      fi
     - echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
     - composer self-update --no-interaction
-    - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ] && [ "$TRAVIS_PHP_VERSION" != "7.0" ]; then echo "extension = mongo.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;'
-    - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ] && [ "$TRAVIS_PHP_VERSION" != "7.0" ]; then composer require --no-update doctrine/mongodb-odm v1.0.0-beta12@dev; fi;'
-    - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ] && [ "$TRAVIS_PHP_VERSION" != "7.0" ]; then composer require --no-update doctrine/mongodb-odm-bundle v3.0.0-BETA6@dev; fi;'
+
+install:
+    - if [ "$TRAVIS_PHP_VERSION" = "hhvm" ] || [ "$TRAVIS_PHP_VERSION" = "7.0" ]; then
+        composer remove --dev --no-update doctrine/mongodb-odm-bundle;
+      else
+        echo "extension = mongo.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini;
+      fi;
     - composer update --prefer-dist --no-interaction
     - ./app/console oro:requirejs:generate-config
     - ./app/console assets:install

--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -11,6 +11,7 @@
 - PIM-4646: TinyMCE wysiwyg editor is replaced by Summernote in the mass-edit and variant group
 - PIM-4999: jQuery UI datepicker is replaced by bootstrap datepicker in the mass-edit and variant group
 - A new twig extension (StyleExtension) in UIBundle now provides a "highlight" string filter
+- PIM-5450: MongoDb ODM bundle in dev requirements 
 
 ## Bug fixes
 

--- a/composer.json
+++ b/composer.json
@@ -74,6 +74,7 @@
         "behat/mink-selenium2-driver": "1.2.0",
         "behat/symfony2-extension": "1.1.2",
         "behat/transliterator":"1.0.1",
+        "doctrine/mongodb-odm-bundle": "3.0.1",
         "sensiolabs/behat-page-object-extension": "1.0.1",
         "phpspec/phpspec": "2.4.*",
         "akeneo/phpspec-skip-example-extension": "1.2.*",


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Specs             |not needed
| Behats            |not needed
| Blue CI           |yes
| Changelog updated |yes
| Review and 2 GTM  |

The purpose of this PR is to add Mongo requirements in the dev section of composer. This way, the developer will always have the good version of Doctrine MongoDb bundle.
As a side effect, the mongo php extension become mandatory to work on pim devs.

Also, i modified the Travis build by removing xdebug for extra speed.