### PR TITLE
only cache downloaded packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
 
 cache:
   directories:
-    - $HOME/.composer/cache
+    - $HOME/.composer/cache/files
 
 before_script:
     - echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config


### PR DESCRIPTION
Caching only `$HOME/.composer/cache/files` means that the Cache doesn't
invalidate because of stale Packagist metadata (which happens more often
making the cache nearly useless).