### PR TITLE
PIM-5456: behat do not use a mock session storage

### DIFF
--- a/app/config/config_behat.yml
+++ b/app/config/config_behat.yml
@@ -4,8 +4,6 @@ imports:
 
 framework:
     test: ~
-    session:
-        storage_id: session.storage.mock_file
     csrf_protection: true
 
 doctrine:


### PR DESCRIPTION
Behat should use the same session storage than the live application.
Also, it improves the CI stability.

| Q                 | A
| ----------------- | ---
| Added Specs       |no
| Added Behats      |no
| Travis CI is ok   |yes, orm and odm
| Changelog updated |no