### PR TITLE
[TR] PIM-5473 + PIM-5474: Improve completeness rescheduling on family

### DIFF
--- a/spec/Pim/Bundle/CatalogBundle/Manager/CompletenessManagerSpec.php
+++ b/spec/Pim/Bundle/CatalogBundle/Manager/CompletenessManagerSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Pim\Bundle\CatalogBundle\Manager;
 
+use Akeneo\Component\Console\CommandLauncher;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\AbstractQuery;
 use Doctrine\ORM\QueryBuilder;
@@ -19,7 +20,6 @@ use Pim\Component\Catalog\Repository\ChannelRepositoryInterface;
 use Pim\Bundle\CatalogBundle\Repository\FamilyRepositoryInterface;
 use Pim\Component\Catalog\Repository\LocaleRepositoryInterface;
 use Pim\Component\Catalog\Completeness\Checker\ProductValueCompleteCheckerInterface;
-use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class CompletenessManagerSpec extends ObjectBehavior
 {
@@ -28,7 +28,8 @@ class CompletenessManagerSpec extends ObjectBehavior
         ChannelRepositoryInterface $channelRepository,
         LocaleRepositoryInterface $localeRepository,
         CompletenessGeneratorInterface $generator,
-        ProductValueCompleteCheckerInterface $productValueCompleteChecker
+        ProductValueCompleteCheckerInterface $productValueCompleteChecker,
+        CommandLauncher $commandLauncher
     ) {
         $this->beConstructedWith(
             $familyRepository,
@@ -36,6 +37,7 @@ class CompletenessManagerSpec extends ObjectBehavior
             $localeRepository,
             $generator,
             $productValueCompleteChecker,
+            $commandLauncher,
             'Pim\Bundle\CatalogBundle\Entity\Channel'
         );
     }

--- a/src/Akeneo/Component/Console/CommandLauncher.php
+++ b/src/Akeneo/Component/Console/CommandLauncher.php
@@ -96,4 +96,16 @@ class CommandLauncher
 
         return $result;
     }
+
+    /**
+     * Builds logfile path from root directory
+     *
+     * @param string $logfile
+     *
+     * @return string
+     */
+    public function buildLogfilePath($logfile)
+    {
+        return $this->rootDir .'/logs/'. $logfile;
+    }
 }

--- a/src/Pim/Bundle/CatalogBundle/Command/CompletenessFamilySchedulerCommand.php
+++ b/src/Pim/Bundle/CatalogBundle/Command/CompletenessFamilySchedulerCommand.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\Command;
+
+use Pim\Bundle\CatalogBundle\Doctrine\CompletenessGeneratorInterface;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Reschedule completeness for family command
+ *
+ * @author Romain Monceau <romain@akeneo.com>
+ */
+class CompletenessFamilySchedulerCommand extends ContainerAwareCommand
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('pim:completeness:schedule-family')
+            ->setDescription('Schedule completeness calculation for the specified family')
+            ->addArgument('family', InputArgument::REQUIRED, 'The family code');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $familyCode = $input->getArgument('family');
+
+        $family = $this->findFamily($familyCode);
+        if (null === $family) {
+            $output->writeln(
+                sprintf('<error>Family "%s" not found</error>', $familyCode)
+            );
+
+            return 1;
+        }
+
+        $this->getCompletenessGenerator()->scheduleForFamily($family);
+
+        return 0;
+    }
+
+    /**
+     * @return \Pim\Bundle\CatalogBundle\Doctrine\ORM\Repository\FamilyRepository
+     */
+    protected function getFamilyRepository()
+    {
+        return $this->getContainer()->get('pim_catalog.repository.family');
+    }
+
+    /**
+     * @param string $familyCode
+     *
+     * @return null|object
+     */
+    protected function findFamily($familyCode)
+    {
+        return $this->getFamilyRepository()->findOneByIdentifier($familyCode);
+    }
+
+    /**
+     * @return CompletenessGeneratorInterface
+     */
+    protected function getCompletenessGenerator()
+    {
+        return $this->getContainer()->get('pim_catalog.doctrine.completeness_generator');
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/managers.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/managers.yml
@@ -93,6 +93,7 @@ services:
             - '@pim_catalog.repository.locale'
             - '@pim_catalog.doctrine.completeness_generator'
             - '@pim_catalog.completeness.checker.chained'
+            - '@pim_catalog.command_launcher'
             - %pim_catalog.entity.completeness.class%
 
     pim_catalog.manager.product_template_media:


### PR DESCRIPTION
2 tickets in this PR (1 commit per ticket) about scalability improvements:
- PIM-5473: When launching the completeness scheduling per family, it happens there is a timeout on MongoDB cursor. The request is well done but it returns an error due to the timeout (default conf = 30 seconds). I reproduce with almost 50k products in my family.

The improvement consists in doing many little queries instead of a huge one which take too much time. As we can't use skip + limit on a MongoDB query using the "multiple" option (and we need it to impact many documents), I implemented an internal pagination to iterate on ids and then call the update.
- PIM-5474: When saving the family, the call to the completeness scheduling takes a long time and it blocks the UI.
  The solution consists in launching a dedicated command as a backend task.

| Q | A |
| --- | --- |
| Added Specs | N |
| Added Behats | N |
| Travis CI is ok | ? |
| Changelog updated | N |
