### PR TITLE
[TR] Fix edit_variant_group_attribute_value:115

### DIFF
--- a/features/Context/DataGridContext.php
+++ b/features/Context/DataGridContext.php
@@ -755,7 +755,14 @@ class DataGridContext extends RawMinkContext implements PageObjectAwareInterface
                 throw $this->createExpectationException(sprintf('Unable to find a checkbox for row %s', $row));
             }
 
-            $checkbox->check();
+            $this->spin(function () use ($checkbox) {
+                if ($checkbox->isChecked()) {
+                    return true;
+                }
+                $checkbox->check();
+
+                return false;
+            }, 'Unable to check the row.');
         }
     }
 
@@ -778,7 +785,14 @@ class DataGridContext extends RawMinkContext implements PageObjectAwareInterface
                 throw $this->createExpectationException(sprintf('Unable to find a checkbox for row %s', $row));
             }
 
-            $checkbox->uncheck();
+            $this->spin(function () use ($checkbox) {
+                if (!$checkbox->isChecked()) {
+                    return true;
+                }
+                $checkbox->uncheck();
+
+                return false;
+            }, 'Unable to uncheck the row.');
         }
     }
 
@@ -828,7 +842,7 @@ class DataGridContext extends RawMinkContext implements PageObjectAwareInterface
             }
 
             if ($checkbox->isChecked()) {
-                throw $this->createExpectationException(sprintf('Expecting row %s to be checked', $row));
+                throw $this->createExpectationException(sprintf('Expecting row %s to be unchecked', $row));
             }
         }
     }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Specs             | /
| Behats            | 
| Blue CI           | running
| Changelog updated | no
| Review and 2 GTM  |

Trying to fix `pim-community-dev/features/enrich/variant-group/edit_variant_group_attribute_value.feature:115`  -> `Scenario: Change a pim_catalog_image attribute of a variant group and ensure saving`.

The scenario try to add a media in a VG, save and then uncheck a product which is link to the VG and save. Then the page is reloaded and the row should be uncheck. When the scenario fails the row is checked :
![fail behat](https://cloud.githubusercontent.com/assets/7206368/12549105/3c9a0280-c35b-11e5-86c7-5e49cc859a90.png)

Maybe the row is not well unchecked at the previous step so I added a spin which verifies if the row is well checked/unchecked. If the scenario continues to fail, it will give us some tips to know where it fails.
