### PR TITLE
[SLA] PIM-5492: Fix complete group loading on useless cases

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 - PIM-5478: Fix attribute permissions issue in attribute searchable repository
+- PIM-5492: Fix complete group loading on useless cases
 
 # 1.4.17 (2016-01-19)
 

--- a/features/datagrid/products_backtothegrid.feature
+++ b/features/datagrid/products_backtothegrid.feature
@@ -13,6 +13,7 @@ Feature: Products back to the grid
 
   Scenario: Successfully restore filters without hashnav
     Given I filter by "SKU" with value "boots_1"
+    And the grid should contain 1 element
     And I am on the products page
     Then the grid should contain 1 element
     And I should see "SKU: contains \"boots_1\""
@@ -21,6 +22,7 @@ Feature: Products back to the grid
 
   Scenario: Successfully restore filters with hashnav
     Given I filter by "SKU" with value "sneakers_1"
+    And the grid should contain 1 element
     And I click on the "sneakers_1" row
     And I click back to grid
     Then the grid should contain 1 element

--- a/spec/Pim/Bundle/EnrichBundle/Normalizer/AttributeNormalizerSpec.php
+++ b/spec/Pim/Bundle/EnrichBundle/Normalizer/AttributeNormalizerSpec.php
@@ -50,7 +50,6 @@ class AttributeNormalizerSpec extends ObjectBehavior
         $fieldProvider->getField($price)->willReturn('akeneo-text-field');
         $emptyValueProvider->getEmptyValue($price)->willReturn([]);
 
-
         $this->normalize($price, 'internal_api', [])->shouldReturn(
             [
                 'code'                  => 'price',
@@ -73,6 +72,7 @@ class AttributeNormalizerSpec extends ObjectBehavior
                 'default_metric_unit'   => '',
                 'max_file_size'         => '',
                 'sort_order'            => 2,
+                'group_code'            => null,
                 'group'                 => null,
             ]
         );
@@ -132,6 +132,7 @@ class AttributeNormalizerSpec extends ObjectBehavior
                 'default_metric_unit'   => '',
                 'max_file_size'         => '',
                 'sort_order'            => 2,
+                'group_code'            => null,
                 'group'                 => null,
             ]
         );
@@ -163,6 +164,7 @@ class AttributeNormalizerSpec extends ObjectBehavior
                 'default_metric_unit'   => '',
                 'max_file_size'         => '',
                 'sort_order'            => 2,
+                'group_code'            => null,
                 'group'                 => null,
             ]
         );
@@ -194,6 +196,7 @@ class AttributeNormalizerSpec extends ObjectBehavior
                 'default_metric_unit'   => '',
                 'max_file_size'         => '',
                 'sort_order'            => 2,
+                'group_code'            => null,
                 'group'                 => null,
             ]
         );
@@ -225,6 +228,7 @@ class AttributeNormalizerSpec extends ObjectBehavior
                 'default_metric_unit'   => '',
                 'max_file_size'         => '',
                 'sort_order'            => 2,
+                'group_code'            => null,
                 'group'                 => null,
             ]
         );
@@ -257,18 +261,24 @@ class AttributeNormalizerSpec extends ObjectBehavior
                 'default_metric_unit'   => 'kg',
                 'max_file_size'         => '',
                 'sort_order'            => 2,
+                'group_code'            => null,
                 'group'                 => null,
             ]
         );
 
-        $normalizer->normalize($attribute, 'json', [])->willReturn(['code' => 'default']);
+        $normalizer
+            ->normalize($attribute, 'json', ['include_group' => true])
+            ->willReturn(['code' => 'default']);
         $attribute->getId()->willReturn(12);
         $attribute->isWysiwygEnabled()->willReturn(false);
         $attribute->getAttributeType()->willReturn('unknown');
         $attribute->getGroup()->willReturn($group);
-        $normalizer->normalize($group, 'json', [])->willReturn(['code' => 'the_group_is_normalized']);
+        $normalizer
+            ->normalize($group, 'json', ['include_group' => true])
+            ->willReturn(['code' => 'the_group_is_normalized']);
+        $group->getCode()->willReturn('the_group_code');
 
-        $this->normalize($attribute, 'internal_api', [])->shouldReturn(
+        $this->normalize($attribute, 'internal_api', ['include_group' => true])->shouldReturn(
             [
                 'code'                  => 'default',
                 'id'                    => 12,
@@ -290,6 +300,7 @@ class AttributeNormalizerSpec extends ObjectBehavior
                 'default_metric_unit'   => 'kg',
                 'max_file_size'         => '',
                 'sort_order'            => 2,
+                'group_code'            => 'the_group_code',
                 'group'                 => ['code' => 'the_group_is_normalized'],
             ]
         );

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/AttributeController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/AttributeController.php
@@ -69,8 +69,11 @@ class AttributeController
     public function indexAction(Request $request)
     {
         $options = [];
+        $context = ['include_group' => true];
+
         if ($request->request->has('identifiers')) {
             $options['identifiers'] = explode(',', $request->request->get('identifiers'));
+            $context['include_group'] = false;
         }
 
         if ($request->request->has('types')) {
@@ -98,7 +101,7 @@ class AttributeController
             $attributes = $this->attributeRepository->findBy($options);
         }
 
-        $normalizedAttributes = $this->normalizer->normalize($attributes, 'internal_api');
+        $normalizedAttributes = $this->normalizer->normalize($attributes, 'internal_api', $context);
 
         return new JsonResponse($normalizedAttributes);
     }

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/AttributeNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/AttributeNormalizer.php
@@ -50,6 +50,7 @@ class AttributeNormalizer implements NormalizerInterface
     {
         $dateMin = (null === $attribute->getDateMin()) ? '' : $attribute->getDateMin()->format(\DateTime::ISO8601);
         $dateMax = (null === $attribute->getDateMax()) ? '' : $attribute->getDateMax()->format(\DateTime::ISO8601);
+        $groupCode = (null === $attribute->getGroup()) ? null : $attribute->getGroup()->getCode();
 
         $normalizedAttribute = $this->normalizer->normalize($attribute, 'json', $context) + [
             'id'                    => $attribute->getId(),
@@ -71,9 +72,12 @@ class AttributeNormalizer implements NormalizerInterface
             'default_metric_unit'   => $attribute->getDefaultMetricUnit(),
             'max_file_size'         => $attribute->getMaxFileSize(),
             'sort_order'            => $attribute->getSortOrder(),
+            'group_code'            => $groupCode,
         ];
 
-        if (null !== $attribute->getGroup()) {
+        // This normalizer is used in the PEF attributes loading and in the add_attributes widget. The attributes
+        // loading does not need complete group normalization. This has to be cleaned.
+        if (isset($context['include_group']) && $context['include_group'] && null !== $attribute->getGroup()) {
             $normalizedAttribute['group'] = $this->normalizer->normalize($attribute->getGroup(), 'json', $context);
         } else {
             $normalizedAttribute['group'] = null;

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/attributes.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/attributes.js
@@ -190,7 +190,7 @@ define(
                     });
 
                     this.getExtension('attribute-group-selector').setCurrent(
-                        _.first(attributes).group.code
+                        _.first(attributes).group_code
                     );
 
                     this.setData(product);


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Specs             | n
| Behats            | y
| Blue CI           | processing
| Changelog updated | y
| Review and 2 GTM  | y

There is an issue in the PEF because when it loads, the rest attribute loads every product attribute, at each attribute the complete group is loaded, and the group contains the set of attributes. So we transfer n*n attributes (3Mb for a big project) and load in more than 2 secs.
This PR fix this with a specific context on this query to only load code.