### PR TITLE
Search inside attribute options

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/AttributeOptionRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/AttributeOptionRepository.php
@@ -49,7 +49,7 @@ class AttributeOptionRepository extends EntityRepository implements
             ->setParameter('attribute', $collectionId);
         if ($search) {
             $qb->andWhere('v.value like :search OR o.code LIKE :search')
-                ->setParameter('search', "$search%");
+                ->setParameter('search', "%$search%");
         }
 
         if (isset($options['ids'])) {


### PR DESCRIPTION
Our users want to search attribute options *inside* attribute option labels.

This worked already in the filters for the product grid, but inside the PEF the user can just search at the beginning of the attribute option labels.