### PR TITLE
[TR] PIM-5476: fix issue with native csv product import and product creation

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -1,3 +1,8 @@
+# 1.4.x
+
+## Bug fixes
+- PIM-5476: Fix issue with native csv product import, new products are created with extra optional values for media, metric, price
+
 # 1.4.18 (2016-01-28)
 
 ## Bug fixes

--- a/features/import/product/import_products_with_invalid_data.feature
+++ b/features/import/product/import_products_with_invalid_data.feature
@@ -18,7 +18,7 @@ Feature: Execute a job
       sku;price
       SKU-001;"100 EUR, 90 USD"
       SKU-002;50 EUR
-      SKU-003;invalid
+      SKU-003;12 invalid
       """
     And the following job "footwear_product_import" configuration:
       | filePath | %file to import% |
@@ -44,7 +44,7 @@ Feature: Execute a job
       sku;price
       SKU-001;"100 EUR, 90 USD"
       SKU-002;50 EUR
-      SKU-003;invalid
+      SKU-003;12 invalid
       """
     And the following job "footwear_product_import" configuration:
       | filePath | %file to import% |
@@ -66,7 +66,7 @@ Feature: Execute a job
       """
       sku;length
       SKU-001;4000 CENTIMETER
-      SKU-002;invalid
+      SKU-002;12 invalid
       """
     And the following job "footwear_product_import" configuration:
       | filePath | %file to import% |
@@ -88,7 +88,7 @@ Feature: Execute a job
       """
       sku;length
       SKU-001;4000 CENTIMETER
-      SKU-002;invalid
+      SKU-002;12 invalid
       """
     And the following job "footwear_product_import" configuration:
       | filePath | %file to import% |
@@ -103,7 +103,7 @@ Feature: Execute a job
       | length | 2.0000 KILOMETER |
 
   @jira https://akeneo.atlassian.net/browse/PIM-3266
-  Scenario: Skip new products with invalid number during an import
+  Scenario: Skip new products with invalid number during an import, as a not allowed negative number
     Given the following products:
       | sku     | number_in_stock |
       | SKU-001 | 4000            |
@@ -111,7 +111,7 @@ Feature: Execute a job
       """
       sku;number_in_stock
       SKU-001;2000
-      SKU-002;invalid_stock
+      SKU-002;-12
       """
     And the following job "footwear_product_import" configuration:
       | filePath | %file to import% |
@@ -323,14 +323,14 @@ Feature: Execute a job
 
   Scenario: Skip new products with invalid price during an import
     Given the following attributes:
-      | label        | type   |
-      | Public Price | prices |
+      | label        | type   | negative_allowed |
+      | Public Price | prices | no               |
     And the following CSV file to import:
       """
       sku;publicPrice
       renault-kangoo;20000 EUR
-      honda-civic;15EUR
-      seat-ibiza;111
+      honda-civic;15 notExisting
+      seat-ibiza;-111 USD
       """
     And the following job "footwear_product_import" configuration:
       | filePath | %file to import% |

--- a/spec/Pim/Component/Connector/Processor/Denormalization/ProductProcessorSpec.php
+++ b/spec/Pim/Component/Connector/Processor/Denormalization/ProductProcessorSpec.php
@@ -802,6 +802,7 @@ class ProductProcessorSpec extends ObjectBehavior
                 ],
             ],
             'family' => 'Tshirt',
+            'enabled' => true
         ];
         $converterOptions = [
             "mapping"           => ["family" => "family", "categories" => "categories", "groups" => "groups"],
@@ -814,9 +815,10 @@ class ProductProcessorSpec extends ObjectBehavior
 
         $filteredData = [
             'family' => 'Tshirt',
+            'enabled' => true
         ];
 
-        $productFilter->filter($product, $filteredData)->shouldNotBeCalled();
+        $productFilter->filter($product, $filteredData)->willReturn($filteredData);
 
         $productUpdater
             ->update($product, $filteredData)

--- a/src/Pim/Component/Connector/Processor/Denormalization/ProductProcessor.php
+++ b/src/Pim/Component/Connector/Processor/Denormalization/ProductProcessor.php
@@ -101,13 +101,11 @@ class ProductProcessor extends AbstractProcessor
 
         $familyCode    = $this->getFamilyCode($convertedItem);
         $filteredItem  = $this->filterItemData($convertedItem);
-
         $product = $this->findOrCreateProduct($identifier, $familyCode);
-
-        if ($this->enabledComparison && null !== $product->getId()) {
+        if ($this->enabledComparison) {
             $filteredItem = $this->filterIdenticalData($product, $filteredItem);
 
-            if (empty($filteredItem)) {
+            if (empty($filteredItem) && null != $product->getId()) {
                 $this->detachProduct($product);
                 $this->stepExecution->incrementSummaryInfo('product_skipped_no_diff');
 


### PR DESCRIPTION
We introduced a regression with fix #3412 in 1.4.

The case was to allow to import products from a csv file with only the sku and the familly columns.

This applied fix in 1.4.4 removed the appliance of data filtering in product processor for new products and create too much values.

I have firstly submitted a PR with a more complex approach which prepares the removal of any empty values in the DB, but we'll do this only in a upcoming minor version, not in a patch.

With small catalog, before the fix:
```
mysql> select count(*) from pim_catalog_product_value;
+----------+
|   342029 |
+----------+

Import small_cat has been successfully executed.
real    21m1.744s
user    17m53.809s
sys 0m30.667s
```

With small catalog, after the fix:
```
+----------+
| count(*) |
+----------+
|   159676 |
+----------+

Import small_cat has been successfully executed.
real	10m43.969s
user	9m23.369s
sys	0m16.664s
```

| Q                 | A
| ----------------- | ---
| Specs             | Y
| Behats            | Y
| Changelog updated | Y
| Review and 2 GTM  |