### PR TITLE
Change installer to be able to use other catalogs fixtures

### DIFF
--- a/app/config/pim_parameters.yml
+++ b/app/config/pim_parameters.yml
@@ -21,6 +21,10 @@ parameters:
 
     installed:            ~
 
+    # You can use installer_data_dir to install an outside catalog (like one from akeneo/catalogs)
+    # installer_data_dir:   %kernel.root_dir%/../vendor/akeneo/catalogs/scalability/small/fixtures
+
+    # or you can use one of the provided catalogs
     # use PimInstallerBundle:minimal for minimal data set
     installer_data:       PimInstallerBundle:icecat_demo_dev
 

--- a/app/config/pim_parameters.yml
+++ b/app/config/pim_parameters.yml
@@ -22,8 +22,7 @@ parameters:
     installed:            ~
 
     # You can use installer_data to install an outside catalog (like one from akeneo/catalogs)
-    #installer_data: %kernel.root_dir%/../vendor/akeneo/catalogs/master/community/small/fixtures
-
+    # installer_data: %kernel.root_dir%/../vendor/akeneo/catalogs/master/community/small/fixtures
     # or you can use one of the provided catalogs
     # use PimInstallerBundle:minimal for minimal data set
     installer_data:       PimInstallerBundle:icecat_demo_dev

--- a/app/config/pim_parameters.yml
+++ b/app/config/pim_parameters.yml
@@ -22,7 +22,7 @@ parameters:
     installed:            ~
 
     # You can use installer_data to install an outside catalog (like one from akeneo/catalogs)
-    #installer_data: %kernel.root_dir%/../vendor/akeneo/catalogs/scalability/small/fixtures
+    #installer_data: %kernel.root_dir%/../vendor/akeneo/catalogs/master/community/small/fixtures
 
     # or you can use one of the provided catalogs
     # use PimInstallerBundle:minimal for minimal data set

--- a/app/config/pim_parameters.yml
+++ b/app/config/pim_parameters.yml
@@ -21,8 +21,8 @@ parameters:
 
     installed:            ~
 
-    # You can use installer_data_dir to install an outside catalog (like one from akeneo/catalogs)
-    # installer_data_dir:   %kernel.root_dir%/../vendor/akeneo/catalogs/scalability/small/fixtures
+    # You can use installer_data to install an outside catalog (like one from akeneo/catalogs)
+    #installer_data: %kernel.root_dir%/../vendor/akeneo/catalogs/scalability/small/fixtures
 
     # or you can use one of the provided catalogs
     # use PimInstallerBundle:minimal for minimal data set

--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,6 @@
         "twig/extensions": "1.2.0"
     },
     "require-dev": {
-        "akeneo/catalogs": "dev-master",
         "phpunit/phpunit": "3.7.*",
         "squizlabs/php_codesniffer": "2.*",
         "pdepend/pdepend": "2.1.*",
@@ -82,7 +81,8 @@
         "akeneo/php-coupling-detector": "dev-master"
     },
     "suggest": {
-        "doctrine/mongodb-odm-bundle": "In order to activate the MongoDB support within Akeneo"
+        "doctrine/mongodb-odm-bundle": "In order to activate the MongoDB support within Akeneo",
+        "akeneo/catalogs": "In order one of the Akeneo catalogs for installation"
     },
     "scripts": {
         "post-install-cmd": [

--- a/composer.json
+++ b/composer.json
@@ -82,7 +82,7 @@
     },
     "suggest": {
         "doctrine/mongodb-odm-bundle": "In order to activate the MongoDB support within Akeneo",
-        "akeneo/catalogs": "In order one of the Akeneo catalogs for installation"
+        "akeneo/catalogs": "In order to install one of the Akeneo catalogs"
     },
     "scripts": {
         "post-install-cmd": [

--- a/composer.json
+++ b/composer.json
@@ -60,6 +60,7 @@
         "twig/extensions": "1.2.0"
     },
     "require-dev": {
+        "akeneo/catalogs": "dev-master",
         "phpunit/phpunit": "3.7.*",
         "squizlabs/php_codesniffer": "2.*",
         "pdepend/pdepend": "2.1.*",

--- a/src/Pim/Bundle/InstallerBundle/Command/DatabaseCommand.php
+++ b/src/Pim/Bundle/InstallerBundle/Command/DatabaseCommand.php
@@ -148,19 +148,17 @@ class DatabaseCommand extends ContainerAwareCommand
             $input->setOption('fixtures', self::LOAD_BASE);
         }
 
+        $fixturesCatalog = $this->getContainer()->hasParameter('installer_data_dir') ?
+            $this->getContainer()->getParameter('installer_data_dir') :
+            $this->getContainer()->getParameter('installer_data');
+
         $output->writeln(
-            sprintf(
-                '<info>Load jobs for fixtures. (data set: %s)</info>',
-                $this->getContainer()->getParameter('installer_data')
-            )
+            sprintf('<info>Load jobs for fixtures. (data set: %s)</info>', $fixturesCatalog)
         );
         $this->getFixtureJobLoader()->load();
 
         $output->writeln(
-            sprintf(
-                '<info>Load fixtures. (data set: %s)</info>',
-                $this->getContainer()->getParameter('installer_data')
-            )
+            sprintf('<info>Load fixtures. (data set: %s)</info>', $fixturesCatalog)
         );
 
         $params = [

--- a/src/Pim/Bundle/InstallerBundle/Command/DatabaseCommand.php
+++ b/src/Pim/Bundle/InstallerBundle/Command/DatabaseCommand.php
@@ -148,17 +148,13 @@ class DatabaseCommand extends ContainerAwareCommand
             $input->setOption('fixtures', self::LOAD_BASE);
         }
 
-        $fixturesCatalog = $this->getContainer()->hasParameter('installer_data_dir') ?
-            $this->getContainer()->getParameter('installer_data_dir') :
-            $this->getContainer()->getParameter('installer_data');
-
         $output->writeln(
-            sprintf('<info>Load jobs for fixtures. (data set: %s)</info>', $fixturesCatalog)
+            sprintf('<info>Load jobs for fixtures. (data set: %s)</info>', $this->getContainer()->getParameter('installer_data'))
         );
         $this->getFixtureJobLoader()->load();
 
         $output->writeln(
-            sprintf('<info>Load fixtures. (data set: %s)</info>', $fixturesCatalog)
+            sprintf('<info>Load fixtures. (data set: %s)</info>', $this->getContainer()->getParameter('installer_data'))
         );
 
         $params = [

--- a/src/Pim/Bundle/InstallerBundle/DataFixtures/ORM/AbstractInstallerFixture.php
+++ b/src/Pim/Bundle/InstallerBundle/DataFixtures/ORM/AbstractInstallerFixture.php
@@ -7,6 +7,7 @@ use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\OrderedFixtureInterface as OrderedFixtureInt;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface as ContainerAwareInt;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Finder\Finder;
 
 /**
  * Abstract installer fixture
@@ -18,28 +19,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 abstract class AbstractInstallerFixture extends AbstractFixture implements OrderedFixtureInt, ContainerAwareInt
 {
-    /** @var string[] */
-    protected $entities = [
-        'channels',
-        'locales',
-        'currencies',
-        'families',
-        'attribute_groups',
-        'attributes',
-        'categories',
-        'group_types',
-        'groups',
-        'associations',
-        'jobs',
-        'products',
-        'user_groups',
-        'user_roles',
-        'users'
-    ];
-
-    /**
-     * @var ContainerInterface
-     */
+    /** @var ContainerInterface */
     protected $container;
 
     /** @var string[] */
@@ -80,14 +60,13 @@ abstract class AbstractInstallerFixture extends AbstractFixture implements Order
 
         $installerFiles = [];
 
-        foreach ($this->entities as $entity) {
-            $file = $installerDataDir . $entity;
-            foreach (['.yml', '.csv'] as $extension) {
-                if (is_file($file . $extension)) {
-                    $installerFiles[$entity] = $file . $extension;
-                    break;
-                }
-            }
+        $finder = new Finder();
+        $finder->in($installerDataDir)->name('/\.(yml|csv)$/');
+
+        foreach ($finder as $file) {
+            $info = pathinfo($file->getFileName());
+            $entity = basename($file->getFileName(), '.'.$info['extension']);
+            $installerFiles[$entity] = $file->getPathName();
         }
 
         return $installerFiles;

--- a/src/Pim/Bundle/InstallerBundle/DataFixtures/ORM/AbstractInstallerFixture.php
+++ b/src/Pim/Bundle/InstallerBundle/DataFixtures/ORM/AbstractInstallerFixture.php
@@ -12,11 +12,13 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * Abstract installer fixture
  *
  * @author    Nicolas Dupont <nicolas@akeneo.com>
+ * @author    JM Leroux <jean-marie.leroux@akeneo.com>
  * @copyright 2013 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 abstract class AbstractInstallerFixture extends AbstractFixture implements OrderedFixtureInt, ContainerAwareInt
 {
+    /** @var string[] */
     protected $entities = [
         'channels',
         'locales',
@@ -36,13 +38,11 @@ abstract class AbstractInstallerFixture extends AbstractFixture implements Order
     ];
 
     /**
-     * @var \Symfony\Component\DependencyInjection\ContainerInterface
+     * @var ContainerInterface
      */
     protected $container;
 
-    /**
-     * array
-     */
+    /** @var string[] */
     protected $files;
 
     /**
@@ -54,6 +54,13 @@ abstract class AbstractInstallerFixture extends AbstractFixture implements Order
         $this->files     = $this->addInstallerDataFiles($container);
     }
 
+    /**
+     * Retrieve fixtures files
+     *
+     * @param ContainerInterface $container
+     *
+     * @return string[]
+     */
     protected function addInstallerDataFiles(ContainerInterface $container)
     {
         $installerDataDir = null;

--- a/src/Pim/Bundle/InstallerBundle/DataFixtures/ORM/AbstractInstallerFixture.php
+++ b/src/Pim/Bundle/InstallerBundle/DataFixtures/ORM/AbstractInstallerFixture.php
@@ -51,17 +51,17 @@ abstract class AbstractInstallerFixture extends AbstractFixture implements Order
     public function setContainer(ContainerInterface $container = null)
     {
         $this->container = $container;
-        $this->files = $this->addInstallerDataFiles($container);
+        $this->files     = $this->addInstallerDataFiles($container);
     }
 
     protected function addInstallerDataFiles(ContainerInterface $container)
     {
         $installerDataDir = null;
-        $installerData = $container->getParameter('installer_data');
+        $installerData    = $container->getParameter('installer_data');
 
         if (preg_match('/^(?P<bundle>\w+):(?P<directory>\w+)$/', $installerData, $matches)) {
-            $bundles = $container->getParameter('kernel.bundles');
-            $reflection = new \ReflectionClass($bundles[$matches['bundle']]);
+            $bundles          = $container->getParameter('kernel.bundles');
+            $reflection       = new \ReflectionClass($bundles[$matches['bundle']]);
             $installerDataDir = dirname($reflection->getFilename()) . '/Resources/fixtures/' . $matches['directory'];
         } else {
             $installerDataDir = $container->getParameter('installer_data');
@@ -75,7 +75,6 @@ abstract class AbstractInstallerFixture extends AbstractFixture implements Order
 
         foreach ($this->entities as $entity) {
             $file = $installerDataDir . $entity;
-            var_dump($file);
             foreach (['.yml', '.csv'] as $extension) {
                 if (is_file($file . $extension)) {
                     $installerFiles[$entity] = $file . $extension;
@@ -83,8 +82,6 @@ abstract class AbstractInstallerFixture extends AbstractFixture implements Order
                 }
             }
         }
-
-        $container->setParameter('pim_installer.files', $installerFiles);
 
         return $installerFiles;
     }
@@ -107,7 +104,7 @@ abstract class AbstractInstallerFixture extends AbstractFixture implements Order
      */
     public function validate($entity, $item)
     {
-        $validator = $this->container->get('validator');
+        $validator  = $this->container->get('validator');
         $violations = $validator->validate($entity);
         if ($violations->count() > 0) {
             $messages = [];

--- a/src/Pim/Bundle/InstallerBundle/DependencyInjection/PimInstallerExtension.php
+++ b/src/Pim/Bundle/InstallerBundle/DependencyInjection/PimInstallerExtension.php
@@ -14,59 +14,13 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
  */
 class PimInstallerExtension extends Extension
 {
-    protected $entities = [
-        'channels',
-        'locales',
-        'currencies',
-        'families',
-        'attribute_groups',
-        'attributes',
-        'categories',
-        'group_types',
-        'groups',
-        'associations',
-        'jobs',
-        'products',
-        'user_groups',
-        'user_roles',
-        'users'
-    ];
-
     /**
      * {@inheritdoc}
      */
     public function load(array $configs, ContainerBuilder $container)
     {
-        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('fixture_loader.yml');
         $loader->load('services.yml');
-        $this->addInstallerDataFiles($container);
-    }
-
-    /**
-     * Prepare data files that installer takes in account
-     *
-     * @param ContainerBuilder $container
-     */
-    protected function addInstallerDataFiles(ContainerBuilder $container)
-    {
-        $dataParam = $container->getParameter('installer_data');
-        preg_match('/^(?P<bundle>\w+):(?P<directory>\w+)$/', $dataParam, $matches);
-        $bundles    = $container->getParameter('kernel.bundles');
-        $reflection = new \ReflectionClass($bundles[$matches['bundle']]);
-        $dataPath   = dirname($reflection->getFilename()) . '/Resources/fixtures/' . $matches['directory'] . '/';
-
-        $installerFiles = [];
-
-        foreach ($this->entities as $entity) {
-            $file = $dataPath.$entity;
-            foreach (['.yml', '.csv'] as $extension) {
-                if (is_file($file . $extension)) {
-                    $installerFiles[$entity] = $file . $extension;
-                    break;
-                }
-            }
-        }
-        $container->setParameter('pim_installer.files', $installerFiles);
     }
 }

--- a/src/Pim/Bundle/InstallerBundle/FixtureLoader/FixtureJobLoader.php
+++ b/src/Pim/Bundle/InstallerBundle/FixtureLoader/FixtureJobLoader.php
@@ -34,7 +34,7 @@ class FixtureJobLoader
     /** @var EntityManagerInterface */
     protected $em;
 
-    /** @var ContainerInterface  */
+    /** @var ContainerInterface */
     protected $container;
 
     /**
@@ -64,7 +64,7 @@ class FixtureJobLoader
         $fileLocator = $this->container->get('file_locator');
 
         foreach ($this->jobsFilePaths as $jobsFilePath) {
-            $realPath = $fileLocator->locate('@'.$jobsFilePath);
+            $realPath = $fileLocator->locate('@' . $jobsFilePath);
             $this->reader->setFilePath($realPath);
 
             // read the jobs list
@@ -105,7 +105,7 @@ class FixtureJobLoader
     public function deleteJobs()
     {
         $jobs = $this->em->getRepository($this->container->getParameter('akeneo_batch.entity.job_instance.class'))
-                ->findBy(['type' => static::JOB_TYPE]);
+            ->findBy(['type' => static::JOB_TYPE]);
 
         foreach ($jobs as $job) {
             $this->em->remove($job);
@@ -121,11 +121,21 @@ class FixtureJobLoader
      */
     protected function getInstallerDataPath()
     {
-        $installerData = $this->container->getParameter('installer_data');
-        preg_match('/^(?P<bundle>\w+):(?P<directory>\w+)$/', $installerData, $matches);
-        $bundles    = $this->container->getParameter('kernel.bundles');
-        $reflection = new \ReflectionClass($bundles[$matches['bundle']]);
+        $installerDataDir = null;
+        if ($this->container->hasParameter('installer_data_dir')) {
+            $installerDataDir = $this->container->getParameter('installer_data_dir');
+        } elseif ($this->container->hasParameter('installer_data')) {
+            $installerData = $this->container->getParameter('installer_data');
+            preg_match('/^(?P<bundle>\w+):(?P<directory>\w+)$/', $installerData, $matches);
+            $bundles = $this->container->getParameter('kernel.bundles');
+            $reflection = new \ReflectionClass($bundles[$matches['bundle']]);
+            $installerDataDir = dirname($reflection->getFilename()) . '/Resources/fixtures/' . $matches['directory'];
+        }
 
-        return dirname($reflection->getFilename()) . '/Resources/fixtures/' . $matches['directory'];
+        if (null === $installerDataDir || !is_dir($installerDataDir)) {
+            throw new \RuntimeException('Installer data directory cannot be found.');
+        }
+
+        return $installerDataDir;
     }
 }

--- a/src/Pim/Bundle/InstallerBundle/FixtureLoader/FixtureJobLoader.php
+++ b/src/Pim/Bundle/InstallerBundle/FixtureLoader/FixtureJobLoader.php
@@ -40,6 +40,7 @@ class FixtureJobLoader
     /**
      * @param ContainerInterface $container
      * @param array              $jobsFilePaths
+     * @throws \Exception
      */
     public function __construct(ContainerInterface $container, array $jobsFilePaths)
     {
@@ -122,18 +123,22 @@ class FixtureJobLoader
     protected function getInstallerDataPath()
     {
         $installerDataDir = null;
-        if ($this->container->hasParameter('installer_data_dir')) {
-            $installerDataDir = $this->container->getParameter('installer_data_dir');
-        } elseif ($this->container->hasParameter('installer_data')) {
-            $installerData = $this->container->getParameter('installer_data');
-            preg_match('/^(?P<bundle>\w+):(?P<directory>\w+)$/', $installerData, $matches);
+        $installerData = $this->container->getParameter('installer_data');
+
+        if (preg_match('/^(?P<bundle>\w+):(?P<directory>\w+)$/', $installerData, $matches)) {
             $bundles = $this->container->getParameter('kernel.bundles');
             $reflection = new \ReflectionClass($bundles[$matches['bundle']]);
             $installerDataDir = dirname($reflection->getFilename()) . '/Resources/fixtures/' . $matches['directory'];
+        } else {
+            $installerDataDir = $this->container->getParameter('installer_data');
         }
 
         if (null === $installerDataDir || !is_dir($installerDataDir)) {
             throw new \RuntimeException('Installer data directory cannot be found.');
+        }
+
+        if ('/' !== substr($installerDataDir, -1, 1)) {
+            $installerDataDir .= '/';
         }
 
         return $installerDataDir;


### PR DESCRIPTION
Just a proposal for an easier installation.
With this PR, we can install a catalog from [akeneo/catalogs](https://github.com/akeneo/catalogs) or even a completely new catalog outside of the project.

Now, you can use for example:
installer_data: %kernel.root_dir%/../vendor/akeneo/catalogs/master/enterprise/small/fixtures
... to directly install a catalog from path.