### PR TITLE
PIM-5125: Allow specific messages if datagrid is empty

### DIFF
--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/grid.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/grid.js
@@ -1,10 +1,10 @@
 /*jslint nomen: true, vars: true*/
 /*global define*/
-define(['jquery', 'underscore', 'backgrid', 'oro/translator', 'oro/mediator', 'oro/loading-mask',
+define(['jquery', 'underscore', 'backgrid', 'translator', 'oro/translator', 'oro/mediator', 'oro/loading-mask',
     'oro/datagrid/header', 'oro/datagrid/body', 'oro/datagrid/toolbar', 'oro/datagrid/action-column',
     'oro/datagrid/select-row-cell', 'oro/datagrid/select-all-header-cell',
     'oro/datagrid/refresh-collection-action', 'oro/datagrid/reset-collection-action'],
-    function ($, _, Backgrid, __, mediator, LoadingMask, GridHeader, GridBody, Toolbar, ActionColumn, SelectRowCell, SelectAllHeaderCell, RefreshCollectionAction, ResetCollectionAction) {
+    function ($, _, Backgrid, Translator, __, mediator, LoadingMask, GridHeader, GridBody, Toolbar, ActionColumn, SelectRowCell, SelectAllHeaderCell, RefreshCollectionAction, ResetCollectionAction) {
         'use strict';
 
         /**
@@ -473,12 +473,17 @@ define(['jquery', 'underscore', 'backgrid', 'oro/translator', 'oro/mediator', 'o
              * Render no data block.
              */
             renderNoDataBlock: function () {
-                var placeholders = {entityHint: (this.entityHint || __('oro.datagrid.entityHint')).toLowerCase()},
-                    template = _.isEmpty(this.collection.state.filters) ? 'oro.datagrid.noentities' :
-                        'oro.datagrid.noresults';
+                var entityHint = (this.entityHint || __('oro.datagrid.entityHint')).toLowerCase();
+                var template = 'oro.datagrid.' + (_.isEmpty(this.collection.state.filters) ? 'noentities' : 'noresults');
+
+                if (Translator.has('jsmessages:' + template + '.' + entityHint)) {
+                    template += '.' + entityHint;
+                }
+
                 this.$(this.selectors.noDataBlock).html($(this.noDataTemplate({
-                    hint: __(template, placeholders).replace('\n', '<br />')
+                    hint: __(template, {entityHint: entityHint}).replace('\n', '<br />')
                 }))).hide();
+
                 this._updateNoDataBlock();
             },
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Specs             | N/A
| Behats            | N/A
| Changelog updated | N/A
| Review and 2 GTM  | todo
| Micro Demo (PO)   | todo
| Migration script  | N/A
| Tech Doc          | N/A

# Goal

For some datagrids we have to specify specific messages when there is no results. Is actually possible to  use a specific key for datagrids rendered by the backend using the following keys:
```yaml
"oro_datagrid.no_data_hint %entityHint%": "No %entityHint% exists."
"oro_datagrid.not_found_hint %entityHint%":  "No %entityHint% was found to match your search. Try modifying your search criteria ..."
```

but it is not possible when the datagrid is rendered by the javascript.

# Solution

Here I basicly added the possibility to use translation keys like `oro.datagrid.noresults.product" or `oro.datagrid.noentities.product`.