### PR TITLE
PIM-5383: fix add attribute css

### DIFF
--- a/features/Context/FeatureContext.php
+++ b/features/Context/FeatureContext.php
@@ -10,6 +10,7 @@ use Behat\MinkExtension\Context\MinkContext;
 use Behat\Symfony2Extension\Context\KernelAwareInterface;
 use Context\Spin\SpinCapableTrait;
 use Pim\Behat\Context\Domain\Collect\ImportProfilesContext;
+use Pim\Behat\Context\Domain\Enrich\AttributeTabContext;
 use Pim\Behat\Context\Domain\Enrich\VariantGroupContext;
 use Pim\Behat\Context\Domain\Spread\ExportProfilesContext;
 use Pim\Behat\Context\Domain\TreeContext;
@@ -61,7 +62,7 @@ class FeatureContext extends MinkContext implements KernelAwareInterface
         $this->useContext('hook', new HookContext($parameters['window_width'], $parameters['window_height']));
         $this->useContext('domain-import-profiles', new ImportProfilesContext());
         $this->useContext('domain-export-profiles', new ExportProfilesContext());
-        $this->useContext('domain-variant-group', new VariantGroupContext());
+        $this->useContext('domain-attribute-tab', new AttributeTabContext());
 
         $this->setTimeout($parameters);
     }

--- a/features/Context/Page/Base/Base.php
+++ b/features/Context/Page/Base/Base.php
@@ -381,27 +381,6 @@ class Base extends Page
     }
 
     /**
-     * @param string $locale
-     *
-     * @throws \Exception
-     *
-     * @return bool
-     */
-    public function hasSelectedLocale($locale)
-    {
-        $selectedLocale = $this->spin(function () {
-            return $this->getElement('Locales dropdown')->find('css', 'li.active a');
-        }, 'Could not find locales in switcher.');
-
-        $title = $selectedLocale->getAttribute('title');
-        if ($locale !== $title) {
-            throw new \Exception(sprintf('Locale is expected to be "%s", actually is "%s".', $locale, $title));
-        }
-
-        return true;
-    }
-
-    /**
      * @return int timeout in millisecond
      */
     protected function getTimeout()

--- a/features/Context/Page/Base/Grid.php
+++ b/features/Context/Page/Base/Grid.php
@@ -33,17 +33,23 @@ class Grid extends Index
 
         $this->elements = array_merge(
             [
-                'Grid container'    => ['css' => '.grid-container'],
-                'Grid'              => ['css' => 'table.grid'],
-                'Grid content'      => ['css' => 'table.grid tbody'],
-                'Filters'           => ['css' => 'div.filter-box'],
-                'Grid toolbar'      => ['css' => 'div.grid-toolbar'],
-                'Manage filters'    => ['css' => 'div.filter-list'],
-                'Configure columns' => ['css' => 'a:contains("Columns")'],
-                'View selector'     => ['css' => '#view-selector'],
-                'Views list'        => ['css' => '.ui-multiselect-menu.highlight-hover'],
-                'Select2 results'   => ['css' => '#select2-drop .select2-results'],
-                'Mass Edit'         => ['css' => '.mass-actions-panel .action i.icon-edit'],
+                'Grid container'        => ['css' => '.grid-container'],
+                'Grid'                  => ['css' => 'table.grid'],
+                'Grid content'          => ['css' => 'table.grid tbody'],
+                'Filters'               => ['css' => 'div.filter-box'],
+                'Grid toolbar'          => ['css' => 'div.grid-toolbar'],
+                'Manage filters'        => ['css' => 'div.filter-list'],
+                'Configure columns'     => ['css' => 'a:contains("Columns")'],
+                'View selector'         => ['css' => '#view-selector'],
+                'Views list'            => ['css' => '.ui-multiselect-menu.highlight-hover'],
+                'Select2 results'       => ['css' => '#select2-drop .select2-results'],
+                'Mass Edit'             => ['css' => '.mass-actions-panel .action i.icon-edit'],
+                'Main context selector' => [
+                    'css'        => '#container',
+                    'decorators' => [
+                        'Pim\Behat\Decorator\ContextSwitcherDecorator'
+                    ]
+                ]
             ],
             $this->elements
         );
@@ -649,28 +655,6 @@ class Grid extends Index
     }
 
     /**
-     * Change the grid locale using the locale switcher
-     *
-     * @param string $locale
-     *
-     * @throws \Exception
-     */
-    public function switchLocale($locale)
-    {
-        $toggle = $this->getElement('Locales dropdown')->find('css', '.dropdown-toggle');
-        if (!$toggle) {
-            throw new \Exception('Could not find locale switcher.');
-        }
-        $toggle->click();
-
-        $link = $this->getElement('Locales dropdown')->find('css', sprintf('a[title="%s"]', $locale));
-        if (!$link) {
-            throw new \Exception(sprintf('Could not find locale "%s" in switcher.', $locale));
-        }
-        $link->click();
-    }
-
-    /**
      * Activate a filter
      *
      * @param string $filterName
@@ -795,13 +779,11 @@ class Grid extends Index
      */
     public function openFilter(NodeElement $filter)
     {
-        if (null !== $element = $filter->find('css', 'button')) {
-            $element->click();
-        } else {
-            throw new \InvalidArgumentException(
-                'Impossible to open filter or maybe its type is not yet implemented'
-            );
-        }
+        $element = $this->spin(function () use ($filter) {
+            return $filter->find('css', 'button');
+        }, 'Impossible to open filter or maybe its type is not yet implemented');
+
+        $element->click();
     }
 
     /**

--- a/features/Context/Page/Base/ProductEditForm.php
+++ b/features/Context/Page/Base/ProductEditForm.php
@@ -548,54 +548,6 @@ class ProductEditForm extends Form
     }
 
     /**
-     * @param string $localeCode
-     * @param bool   $copy
-     *
-     * @throws \Exception
-     */
-    public function switchLocale($localeCode, $copy = false)
-    {
-        $dropdown = $this->getElement(
-            $copy ? 'Copy locales dropdown' : 'Locales dropdown',
-            'Could not find locale switcher'
-        );
-
-        $toggle = $this->spin(function () use ($dropdown) {
-            return $dropdown->find('css', '.dropdown-toggle');
-        });
-        $toggle->click();
-
-        $option = $this->spin(function () use ($dropdown, $localeCode) {
-            return $dropdown->find('css', sprintf('a[data-locale="%s"]', $localeCode));
-        }, sprintf('Could not find locale "%s" in switcher', $localeCode));
-        $option->click();
-    }
-
-    /**
-     * @param string $scopeCode
-     * @param bool   $copy
-     *
-     * @throws \Exception
-     */
-    public function switchScope($scopeCode, $copy = false)
-    {
-        $dropdown = $this->getElement(
-            $copy ? 'Copy channel dropdown' : 'Channel dropdown',
-            'Could not find scope switcher'
-        );
-
-        $toggle = $this->spin(function () use ($dropdown) {
-            return $dropdown->find('css', '.dropdown-toggle');
-        });
-        $toggle->click();
-
-        $option = $this->spin(function () use ($dropdown, $scopeCode) {
-            return $dropdown->find('css', sprintf('a[data-scope="%s"]', $scopeCode));
-        }, sprintf('Could not find scope "%s" in switcher', $scopeCode));
-        $option->click();
-    }
-
-    /**
      * Find a validation tooltip containing a text
      *
      * @param string $text
@@ -617,6 +569,8 @@ class ProductEditForm extends Form
 
     /**
      * Checks if the specified field is set to the expected value, raises an exception if not
+     *
+     * Should be moved to a decorator
      *
      * @param string $label
      * @param string $expected

--- a/features/Context/Page/Batch/Classify.php
+++ b/features/Context/Page/Batch/Classify.php
@@ -26,7 +26,9 @@ class Classify extends Wizard
                 'Trees list'    => ['css' => '#trees-list'],
                 'Category tree' => [
                     'css'        => '#trees',
-                    'decorators' => ['Pim\Behat\Decorator\TreeDecorator\JsTreeDecorator']
+                    'decorators' => [
+                        'Pim\Behat\Decorator\TreeDecorator\JsTreeDecorator'
+                    ]
                 ],
             ]
         );

--- a/features/Context/Page/Category/CategoryView.php
+++ b/features/Context/Page/Category/CategoryView.php
@@ -28,7 +28,9 @@ abstract class CategoryView extends Form
             [
                 'Category tree'    => [
                     'css'        => '#tree',
-                    'decorators' => ['Pim\Behat\Decorator\TreeDecorator\JsTreeDecorator']
+                    'decorators' => [
+                        'Pim\Behat\Decorator\TreeDecorator\JsTreeDecorator'
+                    ]
                 ],
                 'Tree select'      => ['css' => '#tree_select'],
                 'Right click menu' => ['css' => '#vakata-contextmenu'],

--- a/features/Context/Page/Product/Index.php
+++ b/features/Context/Page/Product/Index.php
@@ -31,7 +31,13 @@ class Index extends Grid
         $this->elements = array_merge(
             $this->elements,
             [
-                'Categories tree'  => ['css' => '#tree'],
+                'Categories tree'       => ['css' => '#tree'],
+                'Main context selector' => [
+                    'css'        => '#container',
+                    'decorators' => [
+                        'Pim\Behat\Decorator\ContextSwitcherDecorator'
+                    ]
+                ],
                 'Tree select'      => ['css' => '#tree_select'],
                 'Locales dropdown' => ['css' => '#locale-switcher'],
             ]

--- a/features/Context/Page/VariantGroup/Edit.php
+++ b/features/Context/Page/VariantGroup/Edit.php
@@ -25,10 +25,16 @@ class Edit extends Form
     public function __construct($session, $pageFactory, $parameters = [])
     {
         parent::__construct($session, $pageFactory, $parameters);
+
         $this->elements = array_merge(
             $this->elements,
             [
-                'Locales dropdown' => ['css' => '#locale-switcher'],
+                'Main context selector' => [
+                    'css'        => '#attribute-buttons',
+                    'decorators' => [
+                        'Pim\Behat\Decorator\ContextSwitcherDecorator'
+                    ]
+                ]
             ]
         );
     }
@@ -94,25 +100,6 @@ class Edit extends Form
     public function getRemoveLinkFor($field)
     {
         return $this->find('css', sprintf('.control-group:contains("%s") .remove-attribute', $field));
-    }
-
-    /**
-     * @param string $locale
-     *
-     * @throws \Exception
-     */
-    public function switchLocale($locale)
-    {
-        $elt = $this->getElement('Locales dropdown')->find('css', '.dropdown-toggle');
-        if (!$elt) {
-            throw new \Exception('Could not find locale switcher.');
-        }
-        $elt->click();
-        $elt = $this->getElement('Locales dropdown')->find('css', sprintf('a[title="%s"]', $locale));
-        if (!$elt) {
-            throw new \Exception(sprintf('Could not find locale "%s" in switcher.', $locale));
-        }
-        $elt->click();
     }
 
     /**

--- a/features/Context/Spin/SpinCapableTrait.php
+++ b/features/Context/Spin/SpinCapableTrait.php
@@ -19,7 +19,7 @@ trait SpinCapableTrait
      *
      * @return mixed
      */
-    public function spin($callable, $message = 'no message')
+    public function spin($callable, $message = null)
     {
         $start   = microtime(true);
         $timeout = FeatureContext::getTimeout() / 1000.0;
@@ -45,6 +45,10 @@ trait SpinCapableTrait
             !$result &&
             !$previousException instanceof TimeoutException
         );
+
+        if (null === $message) {
+            $message = (null !== $previousException) ? $previousException->getMessage() : 'no message';
+        }
 
         if (!$result) {
             $infos = sprintf('Spin : timeout of %d excedeed, with message : %s', $timeout, $message);

--- a/features/Context/WebUser.php
+++ b/features/Context/WebUser.php
@@ -335,7 +335,7 @@ class WebUser extends RawMinkContext
      */
     public function theLocaleShouldBeSelected($locale)
     {
-        $this->getCurrentPage()->hasSelectedLocale($locale);
+        $this->getCurrentPage()->getElement('Main context selector')->hasSelectedLocale($locale);
     }
 
     /**
@@ -345,8 +345,7 @@ class WebUser extends RawMinkContext
      */
     public function iSwitchTheLocaleTo($locale)
     {
-        $this->wait();
-        $this->getCurrentPage()->switchLocale($locale);
+        $this->getCurrentPage()->getElement('Main context selector')->switchLocale($locale);
         $this->wait();
     }
 
@@ -357,7 +356,7 @@ class WebUser extends RawMinkContext
      */
     public function iSwitchTheScopeTo($scope)
     {
-        $this->getCurrentPage()->switchScope($scope);
+        $this->getCurrentPage()->getElement('Main context selector')->switchScope($scope);
         $this->wait();
     }
 
@@ -785,20 +784,6 @@ class WebUser extends RawMinkContext
                 )
             );
         }
-    }
-
-    /**
-     * @param string $fieldName
-     * @param string $locale
-     * @param string $scope
-     * @param string $expected
-     *
-     * @Then /^the ([^"]*) copy value for scope "([^"]*)" and locale "([^"]*)" should be "([^"]*)"$/
-     */
-    public function theCopyValueShouldBe($fieldName, $scope, $locale, $expected)
-    {
-        $this->getCurrentPage()->compareWith($locale, $scope);
-        $this->getCurrentPage()->compareFieldValue($fieldName, $expected, true);
     }
 
     /**
@@ -2129,52 +2114,6 @@ class WebUser extends RawMinkContext
     public function iClickOnTheAkeneoLogo()
     {
         $this->getCurrentPage()->clickOnAkeneoLogo();
-    }
-
-    /**
-     * @When /^I start the copy$/
-     */
-    public function iStartTheCopy()
-    {
-        $this->getCurrentPage()->startCopy();
-    }
-
-    /**
-     * @param string $locale
-     *
-     * @When /^I compare values with the "([^"]*)" translation$/
-     */
-    public function iCompareValuesWithTheTranslation($locale)
-    {
-        $this->getCurrentPage()->compareWith($locale);
-    }
-
-    /**
-     * @param string $field
-     *
-     * @Given /^I select translations for "([^"]*)"$/
-     */
-    public function iSelectTranslationsFor($field)
-    {
-        $this->getCurrentPage()->manualSelectTranslation($field);
-    }
-
-    /**
-     * @param string $mode
-     *
-     * @Given /^I select (.*) translations$/
-     */
-    public function iSelectTranslations($mode)
-    {
-        $this->getCurrentPage()->autoSelectTranslations(ucfirst($mode));
-    }
-
-    /**
-     * @Given /^I copy selected translations$/
-     */
-    public function iCopySelectedTranslations()
-    {
-        $this->getCurrentPage()->copySelectedTranslations();
     }
 
     /**

--- a/features/Pim/Behat/Context/Domain/Enrich/AttributeTabContext.php
+++ b/features/Pim/Behat/Context/Domain/Enrich/AttributeTabContext.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Pim\Behat\Context\Domain\Enrich;
+
+use Context\Spin\TimeoutException;
+use Pim\Behat\Context\PimContext;
+
+class AttributeTabContext extends PimContext
+{
+    /**
+     * @When /^I open the comparison panel$/
+     */
+    public function iStartTheCopy()
+    {
+        $this->getCurrentPage()
+            ->getElement('Attribute tab')
+            ->startComparison();
+    }
+
+    /**
+     * @param string $field
+     *
+     * @Given /^I select translations for "([^"]*)"$/
+     */
+    public function iSelectTranslationsFor($field)
+    {
+        $this->getCurrentPage()
+            ->getElement('Attribute tab')
+            ->manualSelectComparedElement($field);
+    }
+
+    /**
+     * @param string $mode
+     *
+     * @Given /^I select (.*) translations$/
+     */
+    public function iSelectTranslations($mode)
+    {
+        $this->getCurrentPage()
+            ->getElement('Comparison panel')
+            ->selectElements($mode);
+    }
+
+    /**
+     * @Given /^I copy selected translations$/
+     */
+    public function iCopySelectedTranslations()
+    {
+        $this->getCurrentPage()
+            ->getElement('Comparison panel')
+            ->copySelectedElements();
+    }
+
+    /**
+     * @param string $locale
+     *
+     * @When /^I switch the comparison (locale|scope|source) to "([^"]*)"$/
+     */
+    public function iSwitchTheComparisonContextTo($type, $selection)
+    {
+        $method = 'switch' . ucfirst($type);
+
+        $this->getCurrentPage()
+            ->getElement('Comparison panel')
+            ->$method($selection);
+    }
+
+    /**
+     * @param string $fieldName
+     * @param string $expected
+     *
+     * @Then /^the ([^"]*) comparison value should be "([^"]*)"$/
+     */
+    public function theComparisonValueShouldBe($fieldName, $expected)
+    {
+        $this->getCurrentPage()->compareFieldValue($fieldName, $expected, true);
+    }
+
+    /**
+     * @Then /^I should see the comparison field "([^"]*)"$/
+     */
+    public function iShouldSeeTheComparisonField($fieldLabel)
+    {
+        $field = $this->getCurrentPage()
+            ->getElement('Attribute tab')
+            ->getComparisonFieldContainer($fieldLabel);
+
+        assertNotNull($field);
+    }
+
+    /**
+     * @Then /^I should not see the comparison field "([^"]*)"$/
+     */
+    public function iShouldNotSeeTheComparisonField($fieldLabel)
+    {
+        try {
+            $this->getCurrentPage()
+                ->getElement('Attribute tab')
+                ->getComparisonFieldContainer($fieldLabel);
+        } catch (TimeoutException $e) {
+            return true;
+        }
+
+        throw $this->getMainContext()->createExpectationException(
+            sprintf(
+                'Expected to not see the field "%s".',
+                $field
+            )
+        );
+    }
+}

--- a/features/Pim/Behat/Context/NavigationContext.php
+++ b/features/Pim/Behat/Context/NavigationContext.php
@@ -327,12 +327,14 @@ class NavigationContext extends PimContext implements PageObjectAwareInterface
      */
     public function assertAddress($expected)
     {
-        $actualFullUrl = $this->getSession()->getCurrentUrl();
-        $actualUrl     = $this->sanitizeUrl($actualFullUrl);
+        $this->spin(function () use ($expected) {
+            $actualFullUrl = $this->getSession()->getCurrentUrl();
+            $actualUrl     = $this->sanitizeUrl($actualFullUrl);
+            $result        = parse_url($expected, PHP_URL_PATH) === $actualUrl;
+            assertTrue($result, sprintf('Expecting to be on page "%s", not "%s"', $expected, $actualUrl));
 
-        $result = parse_url($expected, PHP_URL_PATH) === $actualUrl;
-
-        assertTrue($result, sprintf('Expecting to be on page "%s", not "%s"', $expected, $actualUrl));
+            return true;
+        });
     }
 
     /**

--- a/features/Pim/Behat/Decorator/ContextSwitcherDecorator.php
+++ b/features/Pim/Behat/Decorator/ContextSwitcherDecorator.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Pim\Behat\Decorator;
+
+use Context\Spin\SpinCapableTrait;
+use Pim\Behat\Decorator\ElementDecorator;
+
+/**
+ * Decorator to add switch context feature to an element
+ */
+class ContextSwitcherDecorator extends ElementDecorator
+{
+    use SpinCapableTrait;
+
+    protected $selectors = [
+        'Locales dropdown' => '.locale-switcher',
+        'Channel dropdown' => '.scope-switcher',
+    ];
+
+    /**
+     * @param string $localeCode
+     */
+    public function switchLocale($localeCode)
+    {
+        $dropdown = $this->spin(function () {
+            return $this->find('css', $this->selectors['Locales dropdown']);
+        }, 'Could not find locale switcher');
+
+        $toggle = $this->spin(function () use ($dropdown) {
+            return $dropdown->find('css', '.dropdown-toggle');
+        });
+        $toggle->click();
+
+        $option = $this->spin(function () use ($dropdown, $localeCode) {
+            return $dropdown->find('css', sprintf('a[data-locale="%s"], a[href*="%s"]', $localeCode, $localeCode));
+        }, sprintf('Could not find locale "%s" in switcher', $localeCode));
+        $option->click();
+    }
+
+    /**
+     * @param string $locale
+     *
+     * @return bool
+     */
+    public function hasSelectedLocale($localeCode)
+    {
+        $dropdown = $this->spin(function () {
+            return $this->find('css', $this->selectors['Locales dropdown']);
+        }, 'Could not find locale switcher');
+
+        $selectedLocale = $this->spin(function () use ($dropdown, $localeCode) {
+            return $dropdown->find('css', sprintf('li.active a[href*="%s"]', $localeCode));
+        }, sprintf(
+            'Locale is expected to be "%s", actually is "%s".',
+            $localeCode,
+            $dropdown->find('css', sprintf('li.active a'))->getAttribute('title')
+        ));
+
+        return true;
+    }
+
+    /**
+     * @param string $scopeCode
+     *
+     * @throws \Exception
+     */
+    public function switchScope($scopeCode)
+    {
+        $dropdown = $this->spin(function () {
+            return $this->find('css', $this->selectors['Channel dropdown']);
+        }, 'Could not find scope switcher');
+
+        $toggle = $this->spin(function () use ($dropdown) {
+            return $dropdown->find('css', '.dropdown-toggle');
+        });
+        $toggle->click();
+
+        $option = $this->spin(function () use ($dropdown, $scopeCode) {
+            return $dropdown->find('css', sprintf('a[data-scope="%s"]', $scopeCode));
+        }, sprintf('Could not find scope "%s" in switcher', $scopeCode));
+        $option->click();
+    }
+}

--- a/features/Pim/Behat/Decorator/ElementDecorator.php
+++ b/features/Pim/Behat/Decorator/ElementDecorator.php
@@ -2,8 +2,6 @@
 
 namespace Pim\Behat\Decorator;
 
-use Behat\Mink\Element\NodeElement;
-
 /**
  * Simple abstract class to ease the decorator pattern on Mink elements
  */
@@ -13,9 +11,9 @@ abstract class ElementDecorator
     protected $element;
 
     /**
-     * @param NodeElement $element
+     * @param $element
      */
-    public function __construct(NodeElement $element)
+    public function __construct($element)
     {
         $this->element = $element;
     }

--- a/features/Pim/Behat/Decorator/TabDecorator/ComparableTabDecorator.php
+++ b/features/Pim/Behat/Decorator/TabDecorator/ComparableTabDecorator.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Pim\Behat\Decorator\TabDecorator;
+
+use Behat\Mink\Exception\ElementNotFoundException;
+use Context\Spin\SpinCapableTrait;
+use Pim\Behat\Decorator\ElementDecorator;
+
+/**
+ * Decorator to add comparison feature to an element
+ */
+class ComparableTabDecorator extends ElementDecorator
+{
+    use SpinCapableTrait;
+
+    protected $selectors = [
+        'Start copy button' => '.attribute-copy-actions .start-copying',
+        'Stop copy button'  => '.attribute-copy-actions .stop-copying'
+    ];
+
+    /**
+     * Enter in copy mode
+     */
+    public function startComparison()
+    {
+        $startCopyBtn = $this->spin(function () {
+            return $this->find('css', $this->selectors['Start copy button']);
+        }, 'Cannot find the start copy button');
+        $startCopyBtn->click();
+    }
+
+    /**
+     * Manually select translation given the specified field label
+     *
+     * @param string $fieldLabel
+     */
+    public function manualSelectComparedElement($fieldLabel)
+    {
+        $fieldContainer = $this->getComparisonFieldContainer($fieldLabel);
+
+        $this->spin(function () use ($fieldContainer) {
+            return $fieldContainer->find('css', '.copy-field-selector');
+        }, 'Cannot find the check selector')->check();
+    }
+
+    /**
+     * Get a comparison field container
+     *
+     * @param string $fieldLabel
+     */
+    public function getComparisonFieldContainer($fieldLabel)
+    {
+        $label = $this->spin(function () use ($fieldLabel) {
+            return $this->find('css', sprintf('.copy-container header label:contains("%s")', $fieldLabel));
+        }, sprintf('Cannot find the comparison field with the label "%s"', $fieldLabel));
+
+        return $label->getParent()->getParent()->getParent();
+    }
+}

--- a/features/Pim/Behat/Decorator/TabElementDecorator/ComparisonPanelDecorator.php
+++ b/features/Pim/Behat/Decorator/TabElementDecorator/ComparisonPanelDecorator.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Pim\Behat\Decorator\TabElementDecorator;
+
+use Context\Spin\SpinCapableTrait;
+use Pim\Behat\Decorator\ElementDecorator;
+
+/**
+ * Decorator to add comparison feature to an element
+ */
+class ComparisonPanelDecorator extends ElementDecorator
+{
+    use SpinCapableTrait;
+
+    protected $selectors = [
+        'Change selection dropdown' => '.attribute-copy-actions .selection-dropdown .dropdown-toggle',
+        'Copy selected button'      => '.attribute-copy-actions .copy',
+        'Copy source dropdown'      => '.attribute-copy-actions .source-switcher',
+    ];
+
+    /**
+     * Change the current comparison selection given the specified mode ("all visible" or "all")
+     *
+     * @param string $mode
+     */
+    public function selectElements($mode)
+    {
+        $dropdown = $this->spin(function () {
+            return $this->find('css', $this->selectors['Change selection dropdown']);
+        }, 'Cannot find the select element dropdown');
+
+        $dropdown->click();
+
+        $selector = $dropdown->getParent()->find('css', sprintf('a:contains("%s")', ucfirst($mode)));
+        $selector->click();
+    }
+
+    /**
+     * Click the link to copy selected translations
+     */
+    public function copySelectedElements()
+    {
+        $this->spin(function () {
+            return $this->find('css', $this->selectors['Copy selected button']);
+        }, 'Cannot find the "copy" button')->click();
+    }
+
+    /**
+     * @param string $source
+     */
+    public function switchSource($source)
+    {
+        $dropdown = $this->spin(function () {
+            return $this->find('css', $this->selectors['Copy source dropdown']);
+        }, 'Cannot find the comparison source dropdown');
+
+        $toggle = $this->spin(function () use ($dropdown) {
+            return $dropdown->find('css', '.dropdown-toggle');
+        }, 'Could not find copy source switcher.');
+        $toggle->click();
+
+        $option = $this->spin(function () use ($dropdown, $source) {
+            return $dropdown->find('css', sprintf('a[data-source="%s"]', $source));
+        }, sprintf('Could not find source "%s" in switcher', $source));
+        $option->click();
+    }
+}

--- a/features/Pim/Behat/Decorator/TreeDecorator/JsTreeDecorator.php
+++ b/features/Pim/Behat/Decorator/TreeDecorator/JsTreeDecorator.php
@@ -2,7 +2,6 @@
 
 namespace Pim\Behat\Decorator\TreeDecorator;
 
-use Behat\Mink\Element\NodeElement;
 use Context\Spin\SpinCapableTrait;
 use Pim\Behat\Decorator\ElementDecorator;
 
@@ -20,11 +19,9 @@ class JsTreeDecorator extends ElementDecorator
      */
     public function findNodeInTree($nodeName)
     {
-        $node = $this->spin(function () use ($nodeName) {
-            return $this->element->find('css', sprintf('li a:contains("%s")', $nodeName));
-        }, sprintf('Unable to find node "%s" in the tree', $nodeName));
-
-        return $node;
+        return $this->spin(function () use ($nodeName) {
+            return $this->find('css', sprintf('li a:contains("%s")', $nodeName));
+        }, sprintf('Cannot find the node "%s"', $nodeName));
     }
 
     /**
@@ -39,9 +36,6 @@ class JsTreeDecorator extends ElementDecorator
             });
 
             $nodeElement->click();
-
-            //Needed to be sure that the smooth js tree animation is finished to be expanded
-            sleep(1);
         }
     }
 }

--- a/features/enrich/variant-group/edit_attributes_of_a_variant_group.feature
+++ b/features/enrich/variant-group/edit_attributes_of_a_variant_group.feature
@@ -39,43 +39,43 @@ Feature: Edit attributes of a variant group
     Then the field Manufacturer should contain "Lacoste"
 
   Scenario: Successfully edit a localizable attribute of a variant group
-    Given I switch the locale to "French (France)"
+    Given I switch the locale to "fr_FR"
     And I fill in the following information:
       | Nom | French name |
     And I press the "Save" button
-    And I switch the locale to "anglais (États-Unis)"
+    And I switch the locale to "en_US"
     And I fill in the following information:
       | Name | English name |
     And I press the "Save" button
-    When I switch the locale to "French (France)"
+    When I switch the locale to "fr_FR"
     Then the field Nom should contain "French name"
-    When I switch the locale to "anglais (États-Unis)"
+    When I switch the locale to "en_US"
     Then the field Name should contain "English name"
 
   Scenario: Successfully edit a localizable and scopable attribute of a variant group
-    Given I switch the locale to "German (Germany)"
+    Given I switch the locale to "de_DE"
     And I expand the "Beschreibung" attribute
     And I fill in the following information:
       | ecommerce Beschreibung | German ecommerce description |
       | print Beschreibung     | German print description     |
     And I press the "Save" button
-    And I switch the locale to "Englisch (Vereinigtes Königreich)"
+    And I switch the locale to "en_US"
     And I expand the "Description" attribute
     And I fill in the following information:
       | ecommerce Description | British ecommerce description |
       | tablet Description    | British tablet description    |
     And I press the "Save" button
-    When I switch the locale to "German (Germany)"
+    When I switch the locale to "de_DE"
     Then the field ecommerce Beschreibung should contain "German ecommerce description"
     Then the field print Beschreibung should contain "German print description"
-    When I switch the locale to "Englisch (Vereinigtes Königreich)"
+    When I switch the locale to "en_US"
     Then the field ecommerce Description should contain "British ecommerce description"
     And the field tablet Description should contain "British tablet description"
 
   Scenario: Display a message when variant group has no attributes
     Given I am on the "jackets" variant group page
     And I visit the "Attributes" tab
-    And I switch the locale to "French (France)"
+    And I switch the locale to "fr_FR"
     Then I should see "This variant group has no attributes in this locale"
     When I am on the "sweaters" variant group page
     And I visit the "Attributes" tab

--- a/features/localization/product/datagrid/display_localized_dates.feature
+++ b/features/localization/product/datagrid/display_localized_dates.feature
@@ -31,7 +31,7 @@ Feature: Localize dates in the product grid
     And I add the "french" locale to the "mobile" channel
     And I am on the products page
     And I display the columns sku, destocking_date
-    When I switch the locale to "French (France)"
+    When I switch the locale to "fr_FR"
     Then the row "sandals" should contain:
       | column            | value      |
       | [Destocking_date] | 01/31/2015 |

--- a/features/localization/product/datagrid/display_localized_numbers.feature
+++ b/features/localization/product/datagrid/display_localized_numbers.feature
@@ -38,7 +38,7 @@ Feature: Localize numbers in the product grid
     And I add the "french" locale to the "mobile" channel
     And I am on the products page
     And I display the columns sku, big_price, rate_sale and weight
-    When I switch the locale to "French (France)"
+    When I switch the locale to "fr_FR"
     Then the row "sandals" should contain:
       | column        | value                |
       | big_price     | $1,000.12, €1,000.01 |

--- a/features/mass-action/edit_common_attributes_groups.feature
+++ b/features/mass-action/edit_common_attributes_groups.feature
@@ -20,7 +20,7 @@ Feature: Edit common attributes of many products at once
       | size      | french | Taille |
     And I am on the products page
     And I filter by "channel" with value "Mobile"
-    And I switch the locale to "French (France)"
+    And I switch the locale to "fr_FR"
     When I mass-edit products boots and sandals
     And I choose the "Edit common attributes" operation
     And I display the Nom and Taille attributes

--- a/features/mass-action/edit_common_attributes_locale_specific.feature
+++ b/features/mass-action/edit_common_attributes_locale_specific.feature
@@ -14,14 +14,14 @@ Feature: Edit common attributes of many products at once with locale specific ca
 
   @jira https://akeneo.atlassian.net/browse/PIM-3298
   Scenario: Allow editing only common attributes, including locale specific attribute
-    Given I switch the locale to "German (Germany)"
+    Given I switch the locale to "de_DE"
     And I mass-edit products tshirt
     And I choose the "Edit common attributes" operation
     Then I should see available attributes Kosten, Anzahl auf Lager, Datenblatt, Zollsteuer in group "Intern"
 
   @jira https://akeneo.atlassian.net/browse/PIM-3298
   Scenario: Allow editing only common attributes, excluding locale specific attribute
-    Given I switch the locale to "English (United States)"
+    Given I switch the locale to "en_US"
     And I mass-edit products tshirt
     And I choose the "Edit common attributes" operation
     Then I should see available attributes Cost, Number in stock, Datasheet in group "Internal"

--- a/features/mass-action/edit_common_attributes_scopable_localizable.feature
+++ b/features/mass-action/edit_common_attributes_scopable_localizable.feature
@@ -30,7 +30,7 @@ Feature: Edit common attributes of many products at once
 
   @info https://akeneo.atlassian.net/browse/PIM-5351
   Scenario: Successfully mass edit localized product values
-    Given I switch the locale to "German (Germany)"
+    Given I switch the locale to "de_DE"
     And I filter by "channel" with value "Ecommerce"
     And I mass-edit products black_jacket and white_jacket
     And I choose the "Edit common attributes" operation

--- a/features/product/browse_products_by_locale_and_scope.feature
+++ b/features/product/browse_products_by_locale_and_scope.feature
@@ -23,7 +23,7 @@ Feature: Browse products by locale and scope
 
   @skip
   Scenario: Successfully display english data on products page
-    Given I switch the locale to "English (United States)"
+    Given I switch the locale to "en_US"
     Then I should see product postit
     When I filter by "Channel" with value "E-Commerce"
     Then the row "postit" should contain:
@@ -44,7 +44,7 @@ Feature: Browse products by locale and scope
 
   @skip
   Scenario: Successfully display french data on products page
-    Given I switch the locale to "French (France)"
+    Given I switch the locale to "fr_FR"
     Then I should see product postit
     When I filter by "Channel" with value "E-Commerce"
     Then the row "postit" should contain:

--- a/features/product/compare_and_copy_localized_fields.feature
+++ b/features/product/compare_and_copy_localized_fields.feature
@@ -13,7 +13,7 @@ Feature: Compare and copy localized fields
 
   Scenario: Successfully display available comparison languages
     Given I am on the "tshirt" product page
-    And I start the copy
+    And I open the comparison panel
     Then the copy locale switcher should contain the following items:
       | language | flag    | locale |
       | German   | flag-de | de_DE  |
@@ -23,7 +23,8 @@ Feature: Compare and copy localized fields
 
   Scenario: Successfully copy all compared product localized values
     Given I am on the "tshirt" product page
-    When I compare values with the "fr_FR" translation
+    When I open the comparison panel
+    And I switch the comparison locale to "fr_FR"
     And I select all translations
     And I copy selected translations
     Then the product Name should be "Floup"
@@ -33,7 +34,8 @@ Feature: Compare and copy localized fields
 
   Scenario: Successfully copy current tab compared product localized values
     Given I am on the "tshirt" product page
-    When I compare values with the "fr_FR" translation
+    When I open the comparison panel
+    And I switch the comparison locale to "fr_FR"
     And I select all visible translations
     And I copy selected translations
     Then the product Name should be "Floup"
@@ -43,7 +45,8 @@ Feature: Compare and copy localized fields
 
   Scenario: Successfully copy manually selected compared product localized values
     Given I am on the "tshirt" product page
-    When I compare values with the "fr_FR" translation
+    When I open the comparison panel
+    And I switch the comparison locale to "fr_FR"
     And I select translations for "Name"
     And I copy selected translations
     Then the product Name should be "Floup"

--- a/features/product/completeness/display_completeness.feature
+++ b/features/product/completeness/display_completeness.feature
@@ -67,7 +67,7 @@ Feature: Display the completeness of a product
 
   Scenario: Successfully display the completeness of the products in the grid
     Given I am on the products page
-    And I switch the locale to "English (United States)"
+    And I switch the locale to "en_US"
     And I filter by "Channel" with value "Mobile"
     Then the row "sneakers" should contain:
      | column   | value |
@@ -82,7 +82,7 @@ Feature: Display the completeness of a product
     Then the row "sandals" should contain:
      | column   | value |
      | complete | 25%   |
-    And I switch the locale to "French (France)"
+    And I switch the locale to "fr_FR"
     And I filter by "Channel" with value "Mobile"
     Then the row "sneakers" should contain:
      | column   | value |
@@ -105,7 +105,7 @@ Feature: Display the completeness of a product
     And I attach file "SNKRS-1C-s.png" to "Side view"
     And I save the product
     And I am on the products page
-    And I switch the locale to "English (United States)"
+    And I switch the locale to "en_US"
     And I filter by "Channel" with value "Mobile"
     Then the row "sneakers" should contain:
      | column   | value |
@@ -114,7 +114,7 @@ Feature: Display the completeness of a product
     Then the row "sneakers" should contain:
      | column   | value |
      | complete | 100%  |
-    And I switch the locale to "French (France)"
+    And I switch the locale to "fr_FR"
     And I filter by "Channel" with value "Mobile"
     Then the row "sneakers" should contain:
      | column   | value |

--- a/features/product/completeness/remove_completeness.feature
+++ b/features/product/completeness/remove_completeness.feature
@@ -28,7 +28,7 @@ Feature: Display the completeness of a product
     And I switch the attribute "Rating" requirement in channel "Mobile"
     And I save the family
     And I am on the products page
-    And I switch the locale to "English (United States)"
+    And I switch the locale to "en_US"
     And I filter by "Channel" with value "Mobile"
     Then the row "sneakers" should contain:
      | column   | value |
@@ -43,7 +43,7 @@ Feature: Display the completeness of a product
     Then the row "sandals" should contain:
      | column   | value |
      | complete | 25%   |
-    And I switch the locale to "French (France)"
+    And I switch the locale to "fr_FR"
     And I filter by "Channel" with value "Mobile"
     Then the row "sneakers" should contain:
      | column   | value |
@@ -85,7 +85,7 @@ Feature: Display the completeness of a product
     And I change the "Locales" to "French (France)"
     And I press the "Save" button
     And I am on the products page
-    And I switch the locale to "English (United States)"
+    And I switch the locale to "en_US"
     And I filter by "Channel" with value "Mobile"
     Then the row "sneakers" should contain:
      | column   | value |
@@ -100,7 +100,7 @@ Feature: Display the completeness of a product
     Then the row "sandals" should contain:
      | column   | value |
      | complete | -     |
-    And I switch the locale to "French (France)"
+    And I switch the locale to "fr_FR"
     And I filter by "Channel" with value "Mobile"
     Then the row "sneakers" should contain:
      | column   | value |

--- a/features/reference-data/product/completeness.feature
+++ b/features/reference-data/product/completeness.feature
@@ -67,7 +67,7 @@ Feature: Display the completeness of a product
 
   Scenario: Successfully display the completeness of the products with reference data in the grid
     Given I am on the products page
-    And I switch the locale to "English (United States)"
+    And I switch the locale to "en_US"
     And I filter by "Channel" with value "Mobile"
     Then the row "red-heels" should contain:
       | column   | value |
@@ -94,7 +94,7 @@ Feature: Display the completeness of a product
     Then the row "high-heels" should contain:
       | column   | value |
       | complete | 25%   |
-    And I switch the locale to "French (France)"
+    And I switch the locale to "fr_FR"
     And I filter by "Channel" with value "Mobile"
     Then the row "red-heels" should contain:
       | column   | value |

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/attributes/add-attribute.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/attributes/add-attribute.js
@@ -80,6 +80,7 @@ define(
                 var $select = this.$('input[type="hidden"]');
 
                 var opts = {
+                    dropdownCssClass: 'bigdrop add-attribute',
                     /**
                      * Format result (attribute list) method of select2.
                      * This way we can display attributes and their attribute group beside them.

--- a/src/Pim/Bundle/EnrichBundle/Resources/views/Locale/_locale_switcher.html.twig
+++ b/src/Pim/Bundle/EnrichBundle/Resources/views/Locale/_locale_switcher.html.twig
@@ -1,5 +1,5 @@
 {% set localeParamName = localeParamName|default('dataLocale') %}
-<div id="locale-switcher" class="btn-group">
+<div id="locale-switcher" class="btn-group locale-switcher">
     <span class="btn dropdown-toggle" data-toggle="dropdown">
         {{ currentLocaleCode|flag }}
         <i class="icon-caret-down"></i>

--- a/src/Pim/Bundle/UIBundle/Resources/public/css/pim.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/css/pim.less
@@ -140,6 +140,7 @@ tr:hover>.action-cell a.action>i {
   color: @color-purple_light;
   &:hover, &:active {
     color: darken(@color-purple_light, 5%);
+    cursor: pointer;
   }
 }
 
@@ -695,7 +696,7 @@ h3.tab-header {
       .display-flex();
       .flex(1);
       .justify-content(flex-end);
-      min-width: 300px;
+      min-width: 100px;
     }
   }
 

--- a/src/Pim/Bundle/UIBundle/Resources/public/css/select2.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/css/select2.less
@@ -170,9 +170,13 @@ a.select2-choice {
 }
 
 .add-attribute {
+  &.bigdrop {
+    width: 300px !important;
+  }
+
   .select2-container {
     margin: 6px 5px;
-    width: 300px;
+    width: 200px;
 
     a.select2-choice {
       background: #ffffff;


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Specs             | NA
| Behats            | Y
| Blue CI           | Y
| Changelog updated | NA
| Review and 2 GTM  | Y
| Micro Demo (PO)   | Y
| Migration script  | NA
| Tech Doc          | NA

Behat refactor:

# About contexts
## Before

```php
    /**
     * @param string $locale
     *
     * @When /^I switch the locale to "([^"]*)"$/
     */
    public function iSwitchTheLocaleTo($locale)
    {
        $this->wait();
        $this->getCurrentPage()->switchLocale($locale);
        $this->wait();
    }
```

Multiple wait, the logic is done by the page

## After

```php
    /**
     * @param string $locale
     *
     * @When /^I switch the locale to "([^"]*)"$/
     */
    public function iSwitchTheLocaleTo($locale)
    {
        $this->getCurrentPage()
            ->getElement('Main context selector')
            ->switchLocale($locale);
    }
```

No more waits, the logic is maid by the element itself

# About pages
## Before

```php
    /**
     * Change the grid locale using the locale switcher
     *
     * @param string $locale
     *
     * @throws \Exception
     */
    public function switchLocale($locale)
    {
        $toggle = $this->getElement('Locales dropdown')->find('css', '.dropdown-toggle');
        if (!$toggle) {
            throw new \Exception('Could not find locale switcher.');
        }
        $toggle->click();
  
        $link = $this->getElement('Locales dropdown')->find('css', sprintf('a[title="%s"]', $locale));
        if (!$link) {
            throw new \Exception(sprintf('Could not find locale "%s" in switcher.', $locale));
        }
        $link->click();
    }
```

4 different implementations to do the same job, not always spinning, lot of copy/paste

## After

```php
$this->elements = [
    'Main context selector' => [
        'css'        => '.asset-variations-pane h3',
        'decorators' => [
            'Pim\Behat\Decorator\SpinableDecorator',
            'Pim\Behat\Decorator\ContextSwitcherDecorator\BaseDecorator'
        ]
    ]
];
 ```

```php
<?php

namespace Pim\Behat\Decorator\ContextSwitcherDecorator;

use Context\Spin\SpinCapableTrait;
use Pim\Behat\Decorator\ElementDecorator;

/**
 * Decorator to add switch context feature to an element
 */
class BaseDecorator extends ElementDecorator
{
    protected $selectors = [
        'Locales dropdown' => '.locale-switcher',
        'Channel dropdown' => '.scope-switcher',
    ];

    /**
     * @param string $localeCode
     * @param bool   $copy
     *
     * @throws \Exception
     */
    public function switchLocale($localeCode)
    {
        $dropdown = $this->find(
            'css',
            $this->selectors['Locales dropdown'],
            'Could not find locale switcher'
        );

        $toggle = $this->spin(function () use ($dropdown) {
            return $dropdown->find('css', '.dropdown-toggle');
        });
        $toggle->click();

        $option = $this->spin(function () use ($dropdown, $localeCode) {
            return $dropdown->find('css', sprintf('a[data-locale="%s"], a[href*="%s"]', $localeCode, $localeCode));
        }, sprintf('Could not find locale "%s" in switcher', $localeCode));
        $option->click();
    }
}
```

Only configuration in pages, no more logic, no more copy/paste

# Assertions
## Before

```
Then the decimal_price copy value for scope "ecommerce" and locale "fr_FR" should be "10.12"
And the decimal_number copy value for scope "ecommerce" and locale "fr_FR" should be "12.1234"
And the decimal_metric copy value for scope "ecommerce" and locale "fr_FR" should be "10.3456 Centimeter"
```

## After
```
And I open the comparison panel
And I switch the comparison locale to "fr_FR"
And I switch the comparison scope to "ecommerce"
Then the decimal_price comparison value should be "10.12"
And the decimal_number comparison value should be "12.1234"
And the decimal_metric comparison value should be "10.3456 Centimeter"
```

# Other changes
## Before

`Given I switch the locale to "French (France)"` On some grids in english
`Given I switch the locale to "fr_FR"` On forms
`Given I switch the locale to "français (France)"` On some forms and grids in french

## After
`Given I switch the locale to "fr_FR"`

As the `French (France)` was not even displayed (it what a title attribute on html element) I think that the locale code is way more simple and robust to select a locale.