### PR TITLE
Fix randoms on empty grid testing

### DIFF
--- a/features/Context/Page/Base/Grid.php
+++ b/features/Context/Page/Base/Grid.php
@@ -267,11 +267,12 @@ class Grid extends Index
      */
     public function isGridEmpty()
     {
-        $noDataDiv = $this->getElement('Grid')
-            ->getParent()
-            ->find('css', '.no-data');
+        $container = $this->getElement('Grid container');
+        $noDataDiv = $this->spin(function () use ($container) {
+            return $container->find('css', '.no-data');
+        }, 20, '"No data" div not found');
 
-        return $noDataDiv && $noDataDiv->isVisible();
+        return $noDataDiv->isVisible();
     }
 
     /**


### PR DESCRIPTION
Attempt to fix this random fatal :
```
PHP Fatal error:  Call to a member function find() on a non-object in /var/lib/jenkins/distributed-ci/builds/pim-community-dev_1265/features/Context/Page/Base/Grid.php on line 272
```
