### PR TITLE
PIM-5532 : display picture thumbnail in datagrid

### DIFF
--- a/CHANGELOG-1.3.md
+++ b/CHANGELOG-1.3.md
@@ -1,3 +1,9 @@
+# 1.3.x
+
+## Bug fixes
+
+- PIM-5532: Fix localized media thumbnail not displayable in grid
+
 # 1.3.37 (2016-01-29)
 
 ## Bug fixes

--- a/features/Context/AssertionContext.php
+++ b/features/Context/AssertionContext.php
@@ -165,7 +165,6 @@ class AssertionContext extends RawMinkContext
      */
     public function iShouldSeeFlashMessage($text)
     {
-        // TODO Flash messages tests temporarily disabled because unstable on CI
         return true;
 //        if (!$this->getCurrentPage()->findFlashMessage($text)) {
 //            throw $this->createExpectationException(sprintf('No flash messages containing "%s" were found.', $text));

--- a/src/Pim/Bundle/DataGridBundle/Datasource/ResultRecord/MongoDbOdm/Product/ValuesTransformer.php
+++ b/src/Pim/Bundle/DataGridBundle/Datasource/ResultRecord/MongoDbOdm/Product/ValuesTransformer.php
@@ -26,17 +26,16 @@ class ValuesTransformer
         if (isset($result['values'])) {
             foreach ($result['values'] as $value) {
                 $filterValueLocale = isset($value['locale']) && ($value['locale'] !== $locale);
-                $filterValueScope = isset($value['scope']) && ($value['scope'] !== $scope);
-                $attributeId = $value['attribute'];
+                $filterValueScope  = isset($value['scope']) && ($value['scope'] !== $scope);
+                $attributeId       = $value['attribute'];
 
                 if (!$filterValueLocale && !$filterValueScope && isset($attributes[$attributeId])) {
-                    $attribute = $attributes[$attributeId];
-                    $attributeCode = $attribute['code'];
-                    $value['attribute'] = $attribute;
+                    $attribute              = $attributes[$attributeId];
+                    $attributeCode          = $attribute['code'];
+                    $value['attribute']     = $attribute;
                     $result[$attributeCode] = $value;
                     $result[$attributeCode] = $optionsTransformer->transform($result, $attribute, $locale, $scope);
                     $result[$attributeCode] = $this->prepareDateData($result, $attribute);
-                    $result[$attributeCode] = $this->prepareMediaData($result, $attribute);
                 }
             }
 
@@ -55,32 +54,13 @@ class ValuesTransformer
     protected function prepareDateData(array $result, array $attribute)
     {
         $dateTransformer = new DateTimeTransformer();
-        $attributeCode = $attribute['code'];
-        $backendType = $attribute['backendType'];
-        $value = $result[$attributeCode];
+        $attributeCode   = $attribute['code'];
+        $backendType     = $attribute['backendType'];
+        $value           = $result[$attributeCode];
 
         if ($attribute['attributeType'] === 'pim_catalog_date' && isset($value[$backendType])) {
-            $mongoDate = $value[$backendType];
+            $mongoDate           = $value[$backendType];
             $value[$backendType] = $dateTransformer->transform($mongoDate);
-        }
-
-        return $value;
-    }
-
-    /**
-     * @param array $result
-     * @param array $attribute
-     *
-     * @return array
-     */
-    protected function prepareMediaData(array $result, array $attribute)
-    {
-        $attributeCode = $attribute['code'];
-        $backendType = $attribute['backendType'];
-        $value = $result[$attributeCode];
-        if ($attribute['attributeType'] === 'pim_catalog_image' && isset($value[$backendType])) {
-            $normalizedData = $result['normalizedData'];
-            $value[$backendType] = $normalizedData[$attributeCode];
         }
 
         return $value;


### PR DESCRIPTION
When a media attribute is localized or/and scopable, we cannot use it in the grid because of an undefined index on `attributeCode` in normalizedData.

| Q                 | A
| ----------------- | ---
| Specs             |n
| Behats            |n
| Blue CI           |just check below ;)
| Changelog updated |yes
| Review and 2 GTM  |
