### PR TITLE
PIM-5318: Translate missing labels in all screens

### DIFF
--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -1,6 +1,8 @@
 # 1.5.x
 
 ## BC breaks
+- Change constructor of `Pim\Bundle\CommentBundle\Normalizer\Structured\CommentNormalizer` to add `Pim\Component\Localization\Presenter\PresenterInterface` and `Pim\Component\Localization\LocaleResolver`
+- Change constructor of `Pim\Bundle\EnrichBundle\Normalizer\VersionNormalizer` to add `Pim\Component\Localization\Presenter\PresenterInterface`
 - Change constructor of `Pim\Bundle\DashboardBundle\Widget\LastOperationsWidget` to add `Pim\Component\Localization\Presenter\PresenterInterface` and `Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface`
 - Removed `Pim\Bundle\EnrichBundle\AbstractController\AbstractDoctrineController` and `Pim\Bundle\EnrichBundle\AbstractController\AbstractController`.
 - Change constructor of `Pim\Bundle\EnrichBundle\Filter\ProductEditDataFilter` to add `Pim\Bundle\CatalogBundle\Filter\CollectionFilterInterface` and to remove `Oro\Bundle\SecurityBundle\SecurityFacade`, `Pim\Bundle\CatalogBundle\Filter\ObjectFilterInterface`, `Pim\Component\Catalog\Repository\AttributeRepositoryInterface`, `Pim\Component\Catalog\Repository\LocaleRepositoryInterface` and `Pim\Component\Catalog\Repository\ChannelRepositoryInterface`

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -6,7 +6,7 @@ imports:
 
 framework:
     #esi:             ~
-    translator:      { fallback: en_US }
+    translator:      { fallback: en }
     secret:          %secret%
     router:
         resource: "%kernel.root_dir%/config/routing.yml"

--- a/spec/Pim/Bundle/EnrichBundle/Normalizer/VersionNormalizerSpec.php
+++ b/spec/Pim/Bundle/EnrichBundle/Normalizer/VersionNormalizerSpec.php
@@ -4,6 +4,7 @@ namespace spec\Pim\Bundle\EnrichBundle\Normalizer;
 
 use Pim\Bundle\UserBundle\Entity\User;
 use Oro\Bundle\UserBundle\Entity\UserManager;
+use Pim\Component\Localization\Presenter\PresenterInterface;
 use PhpSpec\ObjectBehavior;
 use Akeneo\Component\Versioning\Model\Version;
 use Prophecy\Argument;
@@ -11,9 +12,12 @@ use Symfony\Component\Translation\TranslatorInterface;
 
 class VersionNormalizerSpec extends ObjectBehavior
 {
-    function let(UserManager $userManager, TranslatorInterface $translator)
-    {
-        $this->beConstructedWith($userManager, $translator);
+    function let(
+        UserManager $userManager,
+        TranslatorInterface $translator,
+        PresenterInterface $datetimePresenter
+    ) {
+        $this->beConstructedWith($userManager, $translator, $datetimePresenter);
     }
 
     function it_supports_versions(Version $version)
@@ -21,8 +25,15 @@ class VersionNormalizerSpec extends ObjectBehavior
         $this->supportsNormalization($version, 'internal_api')->shouldReturn(true);
     }
 
-    function it_normalize_versions($userManager, Version $version, \DateTime $versionTime, User $steve)
-    {
+    function it_normalize_versions(
+        $userManager,
+        $translator,
+        $datetimePresenter,
+        Version $version,
+        User $steve
+    ) {
+        $versionTime = new \DateTime();
+
         $version->getId()->willReturn(12);
         $version->getResourceId()->willReturn(112);
         $version->getSnapshot()->willReturn('a nice snapshot');
@@ -30,7 +41,8 @@ class VersionNormalizerSpec extends ObjectBehavior
         $version->getContext()->willReturn(['locale' => 'en_US', 'channel' => 'mobile']);
         $version->getVersion()->willReturn(12);
         $version->getLoggedAt()->willReturn($versionTime);
-        $versionTime->format('Y-m-d H:i:s')->willReturn('1985-10-1 09:41:00');
+        $translator->getLocale()->willReturn('en_US');
+        $datetimePresenter->present($versionTime, Argument::any())->willReturn('01/01/1985 09:41 AM');
         $version->isPending()->willReturn(false);
 
         $version->getAuthor()->willReturn('steve');
@@ -47,13 +59,19 @@ class VersionNormalizerSpec extends ObjectBehavior
             'changeset'   => 'the changeset',
             'context'     => ['locale' => 'en_US', 'channel' => 'mobile'],
             'version'     => 12,
-            'logged_at'   => '1985-10-1 09:41:00',
+            'logged_at'   => '01/01/1985 09:41 AM',
             'pending'     => false
         ]);
     }
 
-    function it_normalize_versions_with_deleted_user($userManager, $translator, Version $version, \DateTime $versionTime)
-    {
+    function it_normalize_versions_with_deleted_user(
+        $userManager,
+        $translator,
+        $datetimePresenter,
+        Version $version
+    ) {
+        $versionTime = new \DateTime();
+
         $version->getId()->willReturn(12);
         $version->getResourceId()->willReturn(112);
         $version->getSnapshot()->willReturn('a nice snapshot');
@@ -61,7 +79,8 @@ class VersionNormalizerSpec extends ObjectBehavior
         $version->getContext()->willReturn(['locale' => 'en_US', 'channel' => 'mobile']);
         $version->getVersion()->willReturn(12);
         $version->getLoggedAt()->willReturn($versionTime);
-        $versionTime->format('Y-m-d H:i:s')->willReturn('1985-10-1 09:41:00');
+        $translator->getLocale()->willReturn('en_US');
+        $datetimePresenter->present($versionTime, Argument::any())->willReturn('01/01/1985 09:41 AM');
         $version->isPending()->willReturn(false);
 
         $version->getAuthor()->willReturn('steve');
@@ -77,7 +96,7 @@ class VersionNormalizerSpec extends ObjectBehavior
             'changeset'   => 'the changeset',
             'context'     => ['locale' => 'en_US', 'channel' => 'mobile'],
             'version'     => 12,
-            'logged_at'   => '1985-10-1 09:41:00',
+            'logged_at'   => '01/01/1985 09:41 AM',
             'pending'     => false
         ]);
     }

--- a/spec/Pim/Bundle/LocalizationBundle/Provider/UiLocaleProviderSpec.php
+++ b/spec/Pim/Bundle/LocalizationBundle/Provider/UiLocaleProviderSpec.php
@@ -4,27 +4,40 @@ namespace spec\Pim\Bundle\LocalizationBundle\Provider;
 
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
+use Symfony\Component\Translation\MessageCatalogueInterface;
 use Symfony\Component\Translation\Translator;
 
 class UiLocaleProviderSpec extends ObjectBehavior
 {
-    function let(Translator $translator)
-    {
+    function let(
+        Translator $translator,
+        MessageCatalogueInterface $messageCatalogueAll,
+        MessageCatalogueInterface $messageCatalogueFR,
+        MessageCatalogueInterface $messageCatalogueEN,
+        MessageCatalogueInterface $messageCatalogueDE
+    ) {
         $this->beConstructedWith($translator, 0.7);
         $translator->getFallbackLocales()->willReturn(['en_US']);
-        $translator->getMessages(Argument::any())->willReturn([]);
-        $translator->getMessages('en')->willReturn([
-            'scope1' => ['k1' => 't1', 'k2' => 't2'],
+        $translator->getCatalogue(Argument::any())->willReturn($messageCatalogueAll);
+        $messageCatalogueAll->all()->willReturn([]);
+
+        $messageCatalogueEN->all()->willReturn([
+            'scope1' => ['k1' => 't1', 'k2' => 't2', 'k3' => 't3'],
             'scope2' => ['k3' => 't3']
         ]);
-        $translator->getMessages('fr')->willReturn([
+        $translator->getCatalogue('en')->willReturn($messageCatalogueEN);
+
+        $messageCatalogueFR->all()->willReturn([
             'scope1' => ['k1' => 't1', 'k2' => 't2'],
             'scope2' => ['k3' => 't3' ]
         ]);
-        $translator->getMessages('de')->willReturn([
+        $translator->getCatalogue('fr')->willReturn($messageCatalogueFR);
+
+        $messageCatalogueDE->all()->willReturn([
             'scope1' => ['k1' => 't1'],
             'scope2' => ['k3' => 'k3']
         ]);
+        $translator->getCatalogue('de')->willReturn($messageCatalogueDE);
     }
 
     function it_is_initializable()

--- a/src/Oro/Bundle/ConfigBundle/Resources/public/js/form/system/group/localization.js
+++ b/src/Oro/Bundle/ConfigBundle/Resources/public/js/form/system/group/localization.js
@@ -4,13 +4,15 @@ define([
         'pim/form',
         'pim/fetcher-registry',
         'oro/loading-mask',
-        'text!oro/template/system/group/localization'
+        'text!oro/template/system/group/localization',
+        'pim/initselect2'
     ],
     function(
         BaseForm,
         FetcherRegistry,
         LoadingMask,
-        template
+        template,
+        initSelect2
     ) {
         return BaseForm.extend({
             className: 'tab-pane',
@@ -34,7 +36,7 @@ define([
                         selected: this.getFormData()['oro_locale___language'].value
                     }));
 
-                    this.$('select').select2();
+                    initSelect2.init(this.$('select'));
                     loadingMask.hide().$el.remove();
                 }.bind(this));
 

--- a/src/Oro/Bundle/ConfigBundle/Resources/public/js/templates/system/group/localization.html
+++ b/src/Oro/Bundle/ConfigBundle/Resources/public/js/templates/system/group/localization.html
@@ -1,7 +1,7 @@
 <div class="system-locale-field">
     <label for="system-locale"><%- _.__('oro_config.form.config.group.localization.system_locale') %></label>
 
-    <select class="select2" name="system-locale">
+    <select class="select2 select-field" name="system-locale">
     <% _.each(locales, function(label, code) { %>
         <option value="<%- code %>" <%- code === selected ? 'selected' : '' %>><%- label %></option>
     <% }); %>

--- a/src/Pim/Bundle/CommentBundle/Resources/config/normalizers.yml
+++ b/src/Pim/Bundle/CommentBundle/Resources/config/normalizers.yml
@@ -4,5 +4,8 @@ parameters:
 services:
     pim_serializer.normalizer.comment:
         class: %pim_serializer.normalizer.comment.class%
+        arguments:
+            - '@pim_localization.presenter.datetime'
+            - '@pim_localization.resolver.locale'
         tags:
             - { name: pim_serializer.normalizer, priority: 90 }

--- a/src/Pim/Bundle/ConnectorBundle/Resources/translations/messages.en.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/translations/messages.en.yml
@@ -106,6 +106,8 @@ pim_connector:
         channel:
             label: Channel
             help: The channel you want to export
+        header:
+            label: Header
     import:
         enabled:
             label: Enable the product

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/choice-filter.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/choice-filter.js
@@ -1,6 +1,6 @@
 /* global define */
-define(['jquery', 'underscore', 'oro/translator', 'oro/app', 'oro/datafilter/text-filter', 'jquery.select2'],
-function($, _, __, app, TextFilter) {
+define(['jquery', 'underscore', 'oro/translator', 'oro/app', 'oro/datafilter/text-filter', 'pim/initselect2', 'jquery.select2'],
+function($, _, __, app, TextFilter, initSelect2) {
     'use strict';
 
     /**
@@ -29,7 +29,7 @@ function($, _, __, app, TextFilter) {
                                 '<li<% if (selectedChoice == option.value) { %> class="active"<% } %>><a class="choice_value" href="#" data-value="<%= option.value %>"><%= option.label %></a></li>' +
                             '<% }); %>' +
                         '</ul>' +
-                        '<input type="text" name="value" value="">' +
+                        '<input type="text" class="select-field" name="value" value="">' +
                         '<input class="name_input" type="hidden" name="<%= name %>" id="<%= name %>" value="<%= selectedChoice %>"/>' +
                         '</div>' +
                     '</div>' +
@@ -225,7 +225,7 @@ function($, _, __, app, TextFilter) {
         },
 
         _enableListSelection: function() {
-            this.$(this.criteriaValueSelectors.value).select2({
+            initSelect2.init(this.$(this.criteriaValueSelectors.value), {
                 multiple: true,
                 tokenSeparators: [',', ' ', ';'],
                 tags: [],

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/date-filter.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/date-filter.js
@@ -1,7 +1,7 @@
 /* global define */
 define(
-    ['jquery', 'underscore', 'oro/translator', 'oro/datafilter/choice-filter', 'pim/date-context', 'bootstrap.datetimepicker'],
-function($, _, __, ChoiceFilter, DateContext) {
+    ['jquery', 'underscore', 'oro/translator', 'oro/datafilter/choice-filter', 'datepicker'],
+function($, _, __, ChoiceFilter, Datepicker) {
     'use strict';
 
     /**
@@ -86,20 +86,7 @@ function($, _, __, ChoiceFilter, DateContext) {
          *
          * @property
          */
-        datetimepickerOptions: {
-            format: DateContext.get('date').format,
-            defaultFormat: DateContext.get('date').defaultFormat,
-            locale: DateContext.get('language'),
-            pickTime: false
-        },
-
-        /**
-         * Additional date widget options that might be passed to filter
-         * http://api.jqueryui.com/datepicker/
-         *
-         * @property
-         */
-        externalWidgetOptions: {},
+        datetimepickerOptions: {},
 
         /**
          * References to date widgets
@@ -134,7 +121,6 @@ function($, _, __, ChoiceFilter, DateContext) {
          * @inheritDoc
          */
         initialize: function () {
-            _.extend(this.datetimepickerOptions, this.externalWidgetOptions);
             // init empty value object if it was not initialized so far
             if (_.isUndefined(this.emptyValue)) {
                 this.emptyValue = {
@@ -201,20 +187,18 @@ function($, _, __, ChoiceFilter, DateContext) {
          * @inheritDoc
          */
         _initializeDateWidget: function(widgetSelector) {
-            var widget = this.$(widgetSelector);
-            widget.datetimepicker(this.datetimepickerOptions);
-            widget.addClass(this.datetimepickerOptions.className);
+            var $widget = Datepicker.init(this.$(widgetSelector), this.datetimepickerOptions);
 
-            var picker = widget.data('datetimepicker');
-            widget.on('changeDate', function(e) {
-                picker.format = this.datetimepickerOptions.defaultFormat;
+            var picker = $widget.data('datetimepicker');
+            $widget.on('changeDate', function(e) {
+                picker.format = Datepicker.options.defaultFormat;
                 this.values.value[e.target.className].defaultFormat = picker.formatDate(e.date);
 
-                picker.format = this.datetimepickerOptions.format;
+                picker.format = Datepicker.options.format;
                 this.values.value[e.target.className].format = picker.formatDate(e.date);
             }.bind(this));
 
-            return widget;
+            return $widget;
         },
 
         /**

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/datetime-filter.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/datetime-filter.js
@@ -26,6 +26,7 @@ define(['jquery', 'underscore', 'oro/datafilter/date-filter', 'pim/date-context'
             format: DateContext.get('time').format,
             defaultFormat: DateContext.get('time').defaultFormat,
             locale: DateContext.get('language'),
+            pickTime: true,
             pickSeconds: false
         }
     });

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/select2-choice-filter.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/select2-choice-filter.js
@@ -5,9 +5,10 @@ define(
         'oro/datafilter/text-filter',
         'routing',
         'text!pim/template/datagrid/filter/select2-choice-filter',
+        'pim/initselect2',
         'jquery.select2'
     ],
-    function($, _, TextFilter, Routing, template) {
+    function($, _, TextFilter, Routing, template, initSelect2) {
         'use strict';
 
         return TextFilter.extend({
@@ -65,7 +66,7 @@ define(
             },
 
             _enableInput: function() {
-                this.$(this.criteriaValueSelectors.value).select2(this._getSelect2Config());
+                initSelect2.init(this.$(this.criteriaValueSelectors.value), this._getSelect2Config());
                 this.$(this.criteriaValueSelectors.value).show();
             },
 
@@ -77,7 +78,6 @@ define(
             _getSelect2Config: function() {
                 var config = {
                     multiple: true,
-                    allowClear: false,
                     width: '290px',
                     minimumInputLength: 0
                 };
@@ -150,7 +150,7 @@ define(
                     })
                 );
 
-                this.$(this.criteriaValueSelectors.value).select2(this._getSelect2Config());
+                initSelect2.init(this.$(this.criteriaValueSelectors.value), this._getSelect2Config());
             },
 
             _onClickCriteriaSelector: function(e) {
@@ -158,7 +158,7 @@ define(
                 $('body').trigger('click');
                 if (!this.popupCriteriaShowed) {
                     this._showCriteria();
-                    this.$(this.criteriaValueSelectors.value).select2('open');
+                    initSelect2.init(this.$(this.criteriaValueSelectors.value), this._getSelect2Config()).select2('open');
                 } else {
                     this._hideCriteria();
                 }

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/select2-rest-choice-filter.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/select2-rest-choice-filter.js
@@ -9,9 +9,10 @@ define(
         'pim/formatter/choices/base',
         'pim/user-context',
         'text!pim/template/datagrid/filter/select2-choice-filter',
+        'pim/initselect2',
         'jquery.select2'
     ],
-    function($, _, Routing, TextFilter, ChoicesFormatter, UserContext, template) {
+    function($, _, Routing, TextFilter, ChoicesFormatter, UserContext, template, initSelect2) {
         return TextFilter.extend({
             operatorChoices: [],
             choiceUrl: null,
@@ -68,7 +69,6 @@ define(
             _getSelect2Config: function() {
                 var config = {
                     multiple: true,
-                    allowClear: false,
                     width: '290px',
                     minimumInputLength: 0
                 };
@@ -135,7 +135,7 @@ define(
                     })
                 );
 
-                this.$(this.criteriaValueSelectors.value).select2(this._getSelect2Config());
+                initSelect2.init(this.$(this.criteriaValueSelectors.value), this._getSelect2Config());
             },
 
             _onClickCriteriaSelector: function(e) {

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/templates/filter/select2-choice-filter.html
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/templates/filter/select2-choice-filter.html
@@ -14,7 +14,7 @@
                     <% }); %>
                 </ul>
             <% } %>
-            <input type="text" name="value">
+            <input type="text" name="value" class="select-field">
         </div>
     </div>
     <div class="btn-group">

--- a/src/Pim/Bundle/EnrichBundle/Controller/JobTrackerController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/JobTrackerController.php
@@ -129,7 +129,10 @@ class JobTrackerController extends Controller
             }
 
             // limit the number of step execution returned to avoid memory overflow
-            $context = ['limit_warnings' => 100];
+            $context = [
+                'limit_warnings' => 100,
+                'locale'         => $request->getLocale()
+            ];
 
             return new JsonResponse(
                 [

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/VersionNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/VersionNormalizer.php
@@ -4,6 +4,7 @@ namespace Pim\Bundle\EnrichBundle\Normalizer;
 
 use Akeneo\Component\Versioning\Model\Version;
 use Oro\Bundle\UserBundle\Entity\UserManager;
+use Pim\Component\Localization\Presenter\PresenterInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 
@@ -28,14 +29,22 @@ class VersionNormalizer implements NormalizerInterface
     /** @var array */
     protected $authorCache = [];
 
+    /** @var PresenterInterface */
+    protected $datetimePresenter;
+
     /**
      * @param UserManager         $userManager
      * @param TranslatorInterface $translator
+     * @param PresenterInterface  $datetimePresenter
      */
-    public function __construct(UserManager $userManager, TranslatorInterface $translator)
-    {
-        $this->userManager = $userManager;
-        $this->translator  = $translator;
+    public function __construct(
+        UserManager $userManager,
+        TranslatorInterface $translator,
+        PresenterInterface $datetimePresenter
+    ) {
+        $this->userManager       = $userManager;
+        $this->translator        = $translator;
+        $this->datetimePresenter = $datetimePresenter;
     }
 
     /**
@@ -43,6 +52,8 @@ class VersionNormalizer implements NormalizerInterface
      */
     public function normalize($version, $format = null, array $context = [])
     {
+        $context = ['locale' => $this->translator->getLocale()];
+
         return [
             'id'           => $version->getId(),
             'author'       => $this->normalizeAuthor($version->getAuthor()),
@@ -51,7 +62,7 @@ class VersionNormalizer implements NormalizerInterface
             'changeset'    => $version->getChangeset(),
             'context'      => $version->getContext(),
             'version'      => $version->getVersion(),
-            'logged_at'    => $version->getLoggedAt()->format('Y-m-d H:i:s'),
+            'logged_at'    => $this->datetimePresenter->present($version->getLoggedAt(), $context),
             'pending'      => $version->isPending()
         ];
     }

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/bundles/oro_translation.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/bundles/oro_translation.yml
@@ -1,4 +1,4 @@
 oro_translation:
     js_translation:
         # order of domains reflects messages fallback
-        domains: [jsmessages, validators, measures]
+        domains: [measures, jsmessages, validators]

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/history.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/history.yml
@@ -15,7 +15,7 @@ datagrid:
                 frontend_type: string
             loggedAt:
                 label: Logged at
-                type: product_value_date
+                type: product_value_datetime
                 frontend_type: datetime
             old:
                 label: Old values

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/job_tracker.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/job_tracker.yml
@@ -19,7 +19,7 @@ datagrid:
             started_at:
                 label: job_tracker.filter.started_at
                 data_name: startTime
-                type: product_value_date
+                type: product_value_datetime
                 frontend_type: datetime
         actions:
             view:

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/normalizers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/normalizers.yml
@@ -61,6 +61,7 @@ services:
         arguments:
             - '@oro_user.manager'
             - '@translator'
+            - '@pim_localization.presenter.datetime'
         tags:
             - { name: pim_internal_api_serializer.normalizer }
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/date-field.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/date-field.js
@@ -12,22 +12,16 @@ define(
         'pim/field',
         'underscore',
         'text!pim/template/product/field/date',
-        'pim/date-context',
-        'bootstrap.datetimepicker'
+        'datepicker'
     ],
     function (
         Field,
         _,
         fieldTemplate,
-        DateContext
+        Datepicker
     ) {
         return Field.extend({
             fieldTemplate: _.template(fieldTemplate),
-            datetimepickerOptions: {
-                format: DateContext.get('date').format,
-                language: DateContext.get('language'),
-                pickTime: false
-            },
             events: {
                 'change .field-input:first input[type="text"]': 'updateModel',
                 'click .field-input:first input[type="text"]': 'click'
@@ -36,7 +30,7 @@ define(
                 return this.fieldTemplate(context);
             },
             click: function () {
-                this.$('.datetimepicker').datetimepicker(this.datetimepickerOptions).datetimepicker('show');
+                Datepicker.init(this.$('.datetimepicker')).datetimepicker('show');
 
                 this.$('.datetimepicker').on('changeDate', function (e) {
                     this.setCurrentValue(this.$(e.target).find('input[type="text"]').val());

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/metric-field.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/metric-field.js
@@ -13,8 +13,8 @@ define([
         'underscore',
         'pim/fetcher-registry',
         'text!pim/template/product/field/metric',
-        'jquery.select2'
-        ], function ($, Field, _, FetcherRegistry, fieldTemplate) {
+        'pim/initselect2'
+        ], function ($, Field, _, FetcherRegistry, fieldTemplate, initSelect2) {
     return Field.extend({
         fieldTemplate: _.template(fieldTemplate),
         events: {
@@ -22,7 +22,7 @@ define([
         },
         renderInput: function (context) {
             var $element = $(this.fieldTemplate(context));
-            $element.find('.unit').select2('destroy').select2();
+            initSelect2.init($element.find('.unit'));
 
             return $element;
         },

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/multi-select-field.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/multi-select-field.js
@@ -16,8 +16,7 @@ define(
         'routing',
         'pim/attribute-option/create',
         'pim/security-context',
-        'pim/initselect2',
-        'jquery.select2'
+        'pim/initselect2'
     ],
     function ($, Field, _, fieldTemplate, Routing, createOption, SecurityContext, initSelect2) {
         return Field.extend({
@@ -98,9 +97,7 @@ define(
                         multiple: true
                     };
 
-                    options = initSelect2.options(options);
-
-                    this.$('input.select-field').select2('destroy').select2(options);
+                    initSelect2.init(this.$('input.select-field'), options);
                 }.bind(this));
             },
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/multi-select-field.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/multi-select-field.js
@@ -16,9 +16,10 @@ define(
         'routing',
         'pim/attribute-option/create',
         'pim/security-context',
+        'pim/initselect2',
         'jquery.select2'
     ],
-    function ($, Field, _, fieldTemplate, Routing, createOption, SecurityContext) {
+    function ($, Field, _, fieldTemplate, Routing, createOption, SecurityContext, initSelect2) {
         return Field.extend({
             fieldTemplate: _.template(fieldTemplate),
             choicePromise: null,
@@ -70,7 +71,7 @@ define(
             postRender: function () {
                 this.$('[data-toggle="tooltip"]').tooltip();
                 this.getChoiceUrl().then(function (choiceUrl) {
-                    this.$('input.select-field').select2('destroy').select2({
+                    var options = {
                         ajax: {
                             url: choiceUrl,
                             cache: true,
@@ -95,7 +96,11 @@ define(
                             });
                         }.bind(this),
                         multiple: true
-                    });
+                    };
+
+                    options = initSelect2.options(options);
+
+                    this.$('input.select-field').select2('destroy').select2(options);
                 }.bind(this));
             },
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/simple-select-field.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/simple-select-field.js
@@ -16,9 +16,10 @@ define(
         'routing',
         'pim/attribute-option/create',
         'pim/security-context',
+        'pim/initselect2',
         'jquery.select2'
     ],
-    function ($, Field, _, fieldTemplate, Routing, createOption, SecurityContext) {
+    function ($, Field, _, fieldTemplate, Routing, createOption, SecurityContext, initSelect2) {
         return Field.extend({
             fieldTemplate: _.template(fieldTemplate),
             choicePromise: null,
@@ -69,7 +70,7 @@ define(
             postRender: function () {
                 this.$('[data-toggle="tooltip"]').tooltip();
                 this.getChoiceUrl().then(function (choiceUrl) {
-                    this.$('input.select-field').select2('destroy').select2({
+                    var options = {
                         ajax: {
                             url: choiceUrl,
                             cache: true,
@@ -95,7 +96,11 @@ define(
                         }.bind(this),
                         placeholder: ' ',
                         allowClear: true
-                    });
+                    };
+
+                    options = initSelect2.options(options);
+
+                    this.$('input.select-field').select2('destroy').select2(options);
                 }.bind(this));
             },
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/simple-select-field.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/simple-select-field.js
@@ -16,8 +16,7 @@ define(
         'routing',
         'pim/attribute-option/create',
         'pim/security-context',
-        'pim/initselect2',
-        'jquery.select2'
+        'pim/initselect2'
     ],
     function ($, Field, _, fieldTemplate, Routing, createOption, SecurityContext, initSelect2) {
         return Field.extend({
@@ -98,9 +97,7 @@ define(
                         allowClear: true
                     };
 
-                    options = initSelect2.options(options);
-
-                    this.$('input.select-field').select2('destroy').select2(options);
+                    initSelect2.init(this.$('input.select-field'), options);
                 }.bind(this));
             },
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/attributes/add-attribute.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/attributes/add-attribute.js
@@ -18,7 +18,8 @@ define(
         'pim/attribute/add-attribute-footer',
         'pim/user-context',
         'pim/fetcher-registry',
-        'pim/formatter/choices/base'
+        'pim/formatter/choices/base',
+        'pim/initselect2',
     ],
     function (
         $,
@@ -30,7 +31,8 @@ define(
         AttributeFooter,
         UserContext,
         FetcherRegistry,
-        ChoicesFormatter
+        ChoicesFormatter,
+        initSelect2
     ) {
         return BaseForm.extend({
             tagName: 'div',
@@ -147,7 +149,7 @@ define(
                     }.bind(this)
                 };
 
-                opts = $.extend(true, this.defaultOptions, opts);
+                opts = initSelect2.options($.extend(true, this.defaultOptions, opts));
 
                 var select2 = $select.select2(opts);
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/attributes/add-attribute.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/attributes/add-attribute.js
@@ -19,7 +19,7 @@ define(
         'pim/user-context',
         'pim/fetcher-registry',
         'pim/formatter/choices/base',
-        'pim/initselect2',
+        'pim/initselect2'
     ],
     function (
         $,
@@ -149,12 +149,11 @@ define(
                     }.bind(this)
                 };
 
-                opts = initSelect2.options($.extend(true, this.defaultOptions, opts));
-
-                var select2 = $select.select2(opts);
+                opts = $.extend(true, this.defaultOptions, opts);
+                $select = initSelect2.init($select, opts);
 
                 // On select2 "selecting" event, we bypass the selection to handle it ourself.
-                select2.on('select2-selecting', function (event) {
+                $select.on('select2-selecting', function (event) {
                     var attributeCode = event.val;
                     var alreadySelected = _.contains(this.selection, attributeCode);
 
@@ -171,7 +170,7 @@ define(
                     event.preventDefault();
                 }.bind(this));
 
-                select2.on('select2-open', function () {
+                $select.on('select2-open', function () {
                     this.selection = [];
                     this.attributeViews = [];
                     this.updateSelectedCounter();

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/meta/change-family.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/meta/change-family.js
@@ -18,10 +18,22 @@ define(
         'pim/user-context',
         'pim/i18n',
         'routing',
+        'pim/initselect2',
         'backbone/bootstrap-modal',
         'jquery.select2'
     ],
-    function (_, Backbone, BaseForm, FetcherRegistry, ProductManager, modalTemplate, UserContext, i18n, Routing) {
+    function (
+        _,
+        Backbone,
+        BaseForm,
+        FetcherRegistry,
+        ProductManager,
+        modalTemplate,
+        UserContext,
+        i18n,
+        Routing,
+        initSelect2
+    ) {
         return BaseForm.extend({
             tagName: 'i',
             className: 'icon-pencil change-family',
@@ -37,6 +49,7 @@ define(
             showModal: function () {
                 var familyModal = new Backbone.BootstrapModal({
                     allowCancel: true,
+                    cancelText: _.__('pim_enrich.entity.product.meta.groups.modal.close'),
                     title: _.__('pim_enrich.form.product.change_family.modal.title'),
                     content: this.modalTemplate({
                         product: this.getFormData()
@@ -58,7 +71,9 @@ define(
                 }.bind(this));
 
                 familyModal.open();
-                familyModal.$('.family-select2').select2({
+                var self = this;
+
+                var options = {
                     allowClear: true,
                     ajax: {
                         url: Routing.generate('pim_enrich_family_rest_index'),
@@ -89,10 +104,10 @@ define(
                         }
                     },
                     initSelection: function (element, callback) {
-                        var productFamily = this.getFormData().family;
+                        var productFamily = self.getFormData().family;
                         if (null !== productFamily) {
                             FetcherRegistry.getFetcher('family')
-                                .fetch(this.getFormData().family)
+                                .fetch(self.getFormData().family)
                                 .then(function (family) {
                                     callback({
                                         id: family.code,
@@ -100,8 +115,11 @@ define(
                                     });
                                 });
                         }
-                    }.bind(this)
-                }).select2('val', []);
+
+                    }
+                };
+
+                initSelect2.init(familyModal.$('.family-select2'), options).select2('val', []);
                 familyModal.$('.modal-body').css({'line-height': '25px', 'height': 130});
             }
         });

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/meta/change-family-modal.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/meta/change-family-modal.html
@@ -4,7 +4,7 @@
 </p>
 <form class="form-horizontal">
     <label class="control-label"><%- _.__('pim_enrich.form.product.change_family.modal.change_family_to')%>&nbsp;:</label>
-    <input type="hidden" class="input-large family-select2"
+    <input type="hidden" class="input-large family-select2 select-field"
            value="<%- product.family !== null ? product.family.code : '' %>"
            <%- product.family ? ' selected' : '' %>
            data-placeholder="<%- _.__('pim_enrich.form.product.change_family.modal.empty_selection') %>"

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/tab/attributes/add-attribute.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/tab/attributes/add-attribute.html
@@ -1,1 +1,1 @@
-<input type="hidden" multiple="true"/>
+<input type="hidden" multiple="true" class="select-field"/>

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
@@ -227,9 +227,11 @@ pim_enrich:
                         add: Add
                         add_attributes: Add attributes
                     info:
-                        search_attributes: Search
+                        search_attributes: Search...
                         no_available_attributes: There are no more attributes to add
                         attributes_selected: "{{ attributeCount }} attribute(s) selected"
+                        no_match: No matches found
+                        load_more: Loading more results...
                 categories:
                     title: Categories
             panel:

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/messages.en.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/messages.en.yml
@@ -613,6 +613,9 @@ Drop a file or click here:           Drop a file or click here
 Drop an image or click here:         Drop an image or click here
 Automatic option sorting:            Automatic option sorting
 save_attribute_before_manage_option: To manage options, please save the attribute first
+Please select:                       Please select
+Active:                              Active
+Inactive:                            Inactive
 
 Create:               Create
 Cancel:               Cancel

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/messages.en.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/messages.en.yml
@@ -48,6 +48,10 @@ pim_enrich:
         tab:
             property.title: Properties
             history.title:  History
+    # Category
+    locale:
+        tab:
+            property.title: Properties
     # Product group
     group:
         axis.help: 'Axis define the attributes over which the products of the group should vary. Axis are attributes with options, not localizable and not scoped. They cannot be changed after the creation of the variant group.'
@@ -616,6 +620,7 @@ save_attribute_before_manage_option: To manage options, please save the attribut
 Please select:                       Please select
 Active:                              Active
 Inactive:                            Inactive
+Do not convert:                      Do not convert
 
 Create:               Create
 Cancel:               Cancel

--- a/src/Pim/Bundle/EnrichBundle/Resources/views/Attribute/_js-handler.html.twig
+++ b/src/Pim/Bundle/EnrichBundle/Resources/views/Attribute/_js-handler.html.twig
@@ -60,7 +60,7 @@ require(
                 });
 
                 _.each($(formName + ' input.datepicker:not(.hasPicker)'), function (field) {
-                    datepicker.init(field.getAttribute('id'));
+                    datepicker.init($(field).closest('div'));
                 });
 
                 $(formName+'_metricFamily').select2({

--- a/src/Pim/Bundle/EnrichBundle/Resources/views/Attribute/form.html.twig
+++ b/src/Pim/Bundle/EnrichBundle/Resources/views/Attribute/form.html.twig
@@ -33,8 +33,8 @@
         {% set left %}
             {% if form.vars.value.id %}
             <ul class="inline">
-                <li>{{ 'Last update'|trans }}: {{ updated ? updated.loggedAt|date("Y-m-d H:i:s") : 'N/A'|trans }} {{ 'by'|trans }} {{ updated ? updated.author : 'N/A'|trans }}</li>
-                <li>{{ 'Created'|trans }}: {{ created ? created.loggedAt|date("Y-m-d H:i:s") : 'N/A'|trans }} {{ 'by'|trans }} {{ created ? created.author : 'N/A'|trans }}</li>
+                <li>{{ 'Last update'|trans }}: {{ updated ? updated.loggedAt|datetime_presenter : 'N/A'|trans }} {{ 'by'|trans }} {{ updated ? updated.author : 'N/A'|trans }}</li>
+                <li>{{ 'Created'|trans }}: {{ created ? created.loggedAt|datetime_presenter : 'N/A'|trans }} {{ 'by'|trans }} {{ created ? created.author : 'N/A'|trans }}</li>
             </ul>
             {% endif %}
         {% endset %}

--- a/src/Pim/Bundle/EnrichBundle/Resources/views/VariantGroup/_js-handler.html.twig
+++ b/src/Pim/Bundle/EnrichBundle/Resources/views/VariantGroup/_js-handler.html.twig
@@ -1,6 +1,6 @@
 <script type="text/javascript">
     require(
-        ['jquery', 'underscore', 'pim/optionform', 'pim/scopable', 'pim/currencyfield', 'datepicker', 'pim/dialog', 'pim/dialogform', 'oro/mediator', 'backbone/bootstrap-modal', 'jquery.select2'],
+        ['jquery', 'underscore', 'pim/optionform', 'pim/scopable', 'pim/currencyfield', 'datepicker', 'pim/dialog', 'pim/dialogform', 'oro/mediator', 'backbone/bootstrap-modal'],
         function ($, _, optionform, Scopable, CurrencyField, datepicker, Dialog, DialogForm, mediator) {
             'use strict';
 
@@ -17,8 +17,8 @@
                     new CurrencyField({ el: $(field) });
                 });
 
-                _.each($('form input.datepicker:not(.hasPicker)'), function (field) {
-                    datepicker.init(field.getAttribute('id'));
+                _.each($('form input.datepicker'), function (field) {
+                    datepicker.init($(field).closest('div'));
                 });
 
                 mediator.trigger('pim:reinit');

--- a/src/Pim/Bundle/ImportExportBundle/Controller/JobExecutionController.php
+++ b/src/Pim/Bundle/ImportExportBundle/Controller/JobExecutionController.php
@@ -138,7 +138,10 @@ class JobExecutionController
             }
 
             // limit the number of step execution returned to avoid memory overflow
-            $context = ['limit_warnings' => 100];
+            $context = [
+                'limit_warnings' => 100,
+                'locale'         => $request->getLocale()
+            ];
 
             return new JsonResponse(
                 [

--- a/src/Pim/Bundle/ImportExportBundle/Controller/JobProfileController.php
+++ b/src/Pim/Bundle/ImportExportBundle/Controller/JobProfileController.php
@@ -442,7 +442,7 @@ class JobProfileController
         $this->eventDispatcher->dispatch(JobProfileEvents::POST_EXECUTE, new GenericEvent($jobInstance));
 
         $this->request->getSession()->getFlashBag()
-            ->add('success', new Message(sprintf('The %s is running.', $this->getJobType())));
+            ->add('success', new Message(sprintf('flash.%s.running', $this->getJobType())));
 
         return $jobExecution;
     }

--- a/src/Pim/Bundle/ImportExportBundle/Normalizer/StepExecutionNormalizer.php
+++ b/src/Pim/Bundle/ImportExportBundle/Normalizer/StepExecutionNormalizer.php
@@ -4,6 +4,7 @@ namespace Pim\Bundle\ImportExportBundle\Normalizer;
 
 use Akeneo\Component\Batch\Model\StepExecution;
 use Doctrine\Common\Collections\Collection;
+use Pim\Component\Localization\Presenter\PresenterInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 
@@ -19,14 +20,19 @@ class StepExecutionNormalizer implements NormalizerInterface
     /** @var TranslatorInterface */
     protected $translator;
 
+    /** @var PresenterInterface */
+    protected $presenter;
+
     /**
      * Constructor
      *
      * @param TranslatorInterface $translator
+     * @param PresenterInterface  $presenter
      */
-    public function __construct(TranslatorInterface $translator)
+    public function __construct(TranslatorInterface $translator, PresenterInterface $presenter)
     {
         $this->translator = $translator;
+        $this->presenter  = $presenter;
     }
 
     /**
@@ -44,8 +50,8 @@ class StepExecutionNormalizer implements NormalizerInterface
             'label'     => $this->translator->trans($object->getStepName()),
             'status'    => $this->normalizeStatus($object->getStatus()->getValue()),
             'summary'   => $this->normalizeSummary($object->getSummary()),
-            'startedAt' => $this->normalizeDateTime($object->getStartTime()),
-            'endedAt'   => $this->normalizeDateTime($object->getEndTime()),
+            'startedAt' => $this->presenter->present($object->getStartTime(), $context),
+            'endedAt'   => $this->presenter->present($object->getEndTime(), $context),
             'warnings'  => $normalizedWarnings,
             'failures'  => array_map(
                 function ($failure) {
@@ -62,26 +68,6 @@ class StepExecutionNormalizer implements NormalizerInterface
     public function supportsNormalization($data, $format = null)
     {
         return $data instanceof StepExecution;
-    }
-
-    /**
-     * Normalizes DateTime object
-     *
-     * @param null|\Datetime $utcDatetime
-     *
-     * @return null|string
-     */
-    protected function normalizeDateTime($utcDatetime)
-    {
-        if (!$utcDatetime instanceof \DateTime) {
-            return;
-        }
-
-        $datetime = new \DateTime();
-
-        $datetime->setTimestamp($utcDatetime->getTimestamp());
-
-        return $datetime->format('Y-m-d g:i:s A');
     }
 
     /**

--- a/src/Pim/Bundle/ImportExportBundle/Resources/config/normalizers.yml
+++ b/src/Pim/Bundle/ImportExportBundle/Resources/config/normalizers.yml
@@ -15,6 +15,7 @@ services:
         class: %pim_import_export.normalizer.step_execution.class%
         arguments:
             - '@translator'
+            - '@pim_localization.presenter.datetime'
         tags:
             - { name: pim_serializer.normalizer, priority: 90 }
             - { name: pim_versioning.serializer.normalizer, priority: 90 }

--- a/src/Pim/Bundle/ImportExportBundle/Resources/translations/messages.en.yml
+++ b/src/Pim/Bundle/ImportExportBundle/Resources/translations/messages.en.yml
@@ -119,10 +119,12 @@ flash:
         created: The export has been successfully created
         removed: The export has been removed
         updated: The export has been successfully updated
+        running: The export is running
     import:
         created: The import has been successfully created
         removed: The import has been removed
         updated: The import has been successfully updated
+        running: The import is running
 
 # Menu entries
 pim_menu:

--- a/src/Pim/Bundle/LocalizationBundle/Controller/FormatController.php
+++ b/src/Pim/Bundle/LocalizationBundle/Controller/FormatController.php
@@ -20,7 +20,7 @@ class FormatController
     protected $dateFactory;
 
     /** @var DateFactory */
-    protected $datetimeFactoty;
+    protected $datetimeFactory;
 
     /** @var LocaleResolver */
     protected $localeResolver;

--- a/src/Pim/Bundle/LocalizationBundle/Provider/UiLocaleProvider.php
+++ b/src/Pim/Bundle/LocalizationBundle/Provider/UiLocaleProvider.php
@@ -44,11 +44,11 @@ class UiLocaleProvider implements LocaleProviderInterface
         $locales = [];
 
         $fallbackLocales = $this->translator->getFallbackLocales();
-        $localeNames = Intl::getLocaleBundle()->getLocaleNames($this::MAIN_LOCALE);
-        $mainProgress = $this->getProgress($this::MAIN_LOCALE);
+        $localeNames = Intl::getLocaleBundle()->getLocaleNames(self::MAIN_LOCALE);
+        $mainProgress = $this->getProgress(self::MAIN_LOCALE);
 
         foreach ($localeNames as $code => $locale) {
-            if ($this->isAvailableLocale($fallbackLocales, $code, $mainProgress)) {
+            if ($this->isAvailableLocale($fallbackLocales, $locales, $code, $mainProgress)) {
                 $locales[$code] = $locale;
             }
         }
@@ -65,9 +65,9 @@ class UiLocaleProvider implements LocaleProviderInterface
      */
     protected function getProgress($locale)
     {
-        $messages = $this->translator->getMessages($locale);
+        $catalogue = $this->translator->getCatalogue($locale);
 
-        return count($messages, COUNT_RECURSIVE) - count($messages);
+        return count($catalogue->all(), COUNT_RECURSIVE);
     }
 
     /**
@@ -75,14 +75,19 @@ class UiLocaleProvider implements LocaleProviderInterface
      * translated to more than the percentage of the main locale.
      *
      * @param array  $fallbackLocales
+     * @param array  $locales
      * @param string $code
      * @param int    $mainProgress
      *
      * @return bool
      */
-    protected function isAvailableLocale(array $fallbackLocales, $code, $mainProgress)
+    protected function isAvailableLocale(array $fallbackLocales, array $locales, $code, $mainProgress)
     {
         if (in_array($code, $fallbackLocales)) {
+            return true;
+        }
+
+        if (strlen($code) > 2 && isset($locales[substr($code, 0, 2)])) {
             return true;
         }
         $progress = $this->getProgress($code);

--- a/src/Pim/Bundle/LocalizationBundle/Resources/config/factories.yml
+++ b/src/Pim/Bundle/LocalizationBundle/Resources/config/factories.yml
@@ -1,6 +1,7 @@
 parameters:
-    pim_localization.factory.date.class: Pim\Component\Localization\Factory\DateFactory
-    pim_localization.factory.number.class: Pim\Component\Localization\Factory\NumberFactory
+    pim_localization.factory.date.class:     Pim\Component\Localization\Factory\DateFactory
+    pim_localization.factory.datetime.class: Pim\Component\Localization\Factory\DateTimeFactory
+    pim_localization.factory.number.class:   Pim\Component\Localization\Factory\NumberFactory
 
     pim_localization.factory.date.formats:
         en_US: 'MM/dd/yyyy'
@@ -29,6 +30,6 @@ services:
             - %pim_localization.factory.date.formats%
 
     pim_localization.factory.datetime:
-        class: %pim_localization.factory.date.class%
+        class: %pim_localization.factory.datetime.class%
         arguments:
             - %pim_localization.factory.datetime.formats%

--- a/src/Pim/Bundle/LocalizationBundle/Resources/config/factories.yml
+++ b/src/Pim/Bundle/LocalizationBundle/Resources/config/factories.yml
@@ -3,14 +3,10 @@ parameters:
     pim_localization.factory.number.class: Pim\Component\Localization\Factory\NumberFactory
 
     pim_localization.factory.date.formats:
-        en: 'MM/dd/yyyy'
         en_US: 'MM/dd/yyyy'
-        fr: 'dd/MM/yyyy'
         fr_FR: 'dd/MM/yyyy'
     pim_localization.factory.datetime.formats:
-        en: 'MM/dd/yyyy HH:mm'
-        en_US: 'MM/dd/yyyy HH:mm'
-        fr: 'dd/MM/yyyy HH:mm'
+        en_US: 'MM/dd/yyyy hh:mm a'
         fr_FR: 'dd/MM/yyyy HH:mm'
     pim_localization.factory.currency.formats:
         en_US: '¤#,##0.00'

--- a/src/Pim/Bundle/LocalizationBundle/Resources/config/twig.yml
+++ b/src/Pim/Bundle/LocalizationBundle/Resources/config/twig.yml
@@ -21,6 +21,7 @@ services:
         class: %pim_localization.twig.attribute_extension.class%
         arguments:
             - '@pim_localization.presenter.date'
+            - '@pim_localization.presenter.datetime'
             - '@pim_localization.resolver.locale'
         tags:
             - { name: twig.extension }

--- a/src/Pim/Bundle/LocalizationBundle/Twig/AttributeExtension.php
+++ b/src/Pim/Bundle/LocalizationBundle/Twig/AttributeExtension.php
@@ -17,17 +17,25 @@ class AttributeExtension extends \Twig_Extension
     /** @var PresenterInterface */
     protected $datePresenter;
 
+    /** @var PresenterInterface */
+    protected $datetimePresenter;
+
     /** @var LocaleResolver */
     protected $localeResolver;
 
     /**
      * @param PresenterInterface $datePresenter
+     * @param PresenterInterface $datetimePresenter
      * @param LocaleResolver     $localeResolver
      */
-    public function __construct(PresenterInterface $datePresenter, LocaleResolver $localeResolver)
-    {
-        $this->datePresenter  = $datePresenter;
-        $this->localeResolver = $localeResolver;
+    public function __construct(
+        PresenterInterface $datePresenter,
+        PresenterInterface $datetimePresenter,
+        LocaleResolver $localeResolver
+    ) {
+        $this->datePresenter     = $datePresenter;
+        $this->datetimePresenter = $datetimePresenter;
+        $this->localeResolver    = $localeResolver;
     }
 
     /**
@@ -58,7 +66,7 @@ class AttributeExtension extends \Twig_Extension
      */
     public function datetimePresenter($date)
     {
-        return $this->datePresenter->present($date, ['locale' => $this->localeResolver->getCurrentLocale()]);
+        return $this->datetimePresenter->present($date, ['locale' => $this->localeResolver->getCurrentLocale()]);
     }
 
     /**

--- a/src/Pim/Bundle/NotificationBundle/Resources/public/templates/notification/notification-list.html
+++ b/src/Pim/Bundle/NotificationBundle/Resources/public/templates/notification/notification-list.html
@@ -10,6 +10,6 @@
     <% if (comment) { %> <div class="comment"><%= comment %></div> <% } %>
     <i class="icon-<%= viewed ? 'trash' : 'eye-close' %> action"></i>
     <% if (showReportButton) { %>
-    <button class="btn icons-holder-text"><i class="icon-file-text-alt"></i>Report</button>
+    <button class="btn icons-holder-text"><i class="icon-file-text-alt"></i><%- _.__('pim_notification.report') %></button>
     <% } %>
 </a>

--- a/src/Pim/Bundle/NotificationBundle/Resources/translations/jsmessages.en.yml
+++ b/src/Pim/Bundle/NotificationBundle/Resources/translations/jsmessages.en.yml
@@ -1,0 +1,2 @@
+pim_notification:
+  report: Report

--- a/src/Pim/Bundle/UIBundle/Resources/public/js/pim-datepicker.js
+++ b/src/Pim/Bundle/UIBundle/Resources/public/js/pim-datepicker.js
@@ -3,20 +3,20 @@ define(
     function ($, DateContext) {
         'use strict';
 
-        var datetimepickerOptions = {
-            format: DateContext.get('date').format,
-            language: DateContext.get('language'),
-            pickTime: false
-        };
-
-        var init = function (id) {
-            var $field = $('#' + id).closest('div');
-
-            $field.datetimepicker(datetimepickerOptions);
-        };
-
         return {
-            init: init
+            options: {
+                format: DateContext.get('date').format,
+                defaultFormat: DateContext.get('date').defaultFormat,
+                locale: DateContext.get('language'),
+                pickTime: false
+            },
+            init: function ($target, options) {
+                options = $.extend(true, this.options, options);
+
+                $target.datetimepicker(options);
+
+                return $target;
+            }
         };
     }
 );

--- a/src/Pim/Bundle/UIBundle/Resources/public/js/pim-initselect2.js
+++ b/src/Pim/Bundle/UIBundle/Resources/public/js/pim-initselect2.js
@@ -5,19 +5,37 @@ define(
         'use strict';
         return {
             resultsPerPage: 20,
-            init: function ($target) {
+            defaultOptions: {
+                allowClear: false,
+                formatSearching: function () {
+                    return _.__('pim_enrich.form.product.tab.attributes.info.search_attributes');
+                },
+                formatNoMatches: function () {
+                    return _.__('pim_enrich.form.product.tab.attributes.info.no_match');
+                },
+                formatLoadMore: function (pageNumber) {
+                    return _.__('pim_enrich.form.product.tab.attributes.info.load_more');
+                }
+            },
+            init: function ($target, options) {
                 var self = this;
 
                 $target.find('input.select2:not(.select2-offscreen)').each(function () {
+                    var options = self.initOptions(options);
+
                     var $el = $(this);
                     var value = _.map(_.compact($el.val().split(',')), $.trim);
                     var tags  = _.map(_.compact($el.attr('data-tags').split(',')), $.trim);
 
-                    tags = _.union(tags, value).sort();
-                    $el.select2({tags: tags, tokenSeparators: [',', ' ']});
+                    $el.select2($.extend(true, options, {
+                        tags: _.union(tags, value).sort(),
+                        tokenSeparators: [',', ' ']
+                    }));
                 });
 
                 $target.find('select.select2:not(.select2-offscreen)').each(function () {
+                    var options = self.initOptions(options);
+
                     var $el = $(this);
                     var $empty = $el.children('[value=""]');
 
@@ -25,15 +43,25 @@ define(
                         $el.attr('data-placeholder', $empty.html());
                         $empty.html('');
                     }
-                    $el.select2({allowClear: true});
+
+                    $el.select2($.extend(true, options, {
+                        allowClear: true
+                    }));
                 });
 
                 $target.find('input.pim-ajax-entity:not(.select2-offscreen)').each(function () {
                     self.initSelect.call(self, $(this));
                 });
+
+                if ($target.hasClass('select-field')) {
+                    options = self.initOptions(options);
+                    $target.select2('destroy').select2(options);
+                }
+
+                return $target;
             },
-            initSelect: function ($select) {
-                var options = this.options();
+            initSelect: function ($select, options) {
+                options = this.initOptions(options);
                 var self = this;
                 var queryTimer;
 
@@ -107,22 +135,10 @@ define(
 
                 return _.extend({}, data, {results: matchingResults});
             },
-            options: function (options) {
-                var baseOptions = {
-                    multiple: false,
-                    allowClear: false,
-                    formatSearching: function () {
-                        return _.__('pim_enrich.form.product.tab.attributes.info.search_attributes');
-                    },
-                    formatNoMatches: function () {
-                        return _.__('pim_enrich.form.product.tab.attributes.info.no_match');
-                    },
-                    formatLoadMore: function (pageNumber) {
-                      return _.__('pim_enrich.form.product.tab.attributes.info.load_more');
-                    }
-                };
+            initOptions: function (options) {
+                var defaultOptions = $.extend(true, {}, this.defaultOptions);
 
-                return $.extend(true, baseOptions, options);
+                return $.extend(true, defaultOptions, options);
             }
         };
     }

--- a/src/Pim/Bundle/UIBundle/Resources/public/js/pim-initselect2.js
+++ b/src/Pim/Bundle/UIBundle/Resources/public/js/pim-initselect2.js
@@ -33,10 +33,7 @@ define(
                 });
             },
             initSelect: function ($select) {
-                var options = {
-                    multiple: false,
-                    allowClear: false
-                };
+                var options = this.options();
                 var self = this;
                 var queryTimer;
 
@@ -91,6 +88,7 @@ define(
 
                     callback(choices);
                 };
+
                 $select.select2(options);
             },
             getSelectOptions: function (data, options) {
@@ -108,6 +106,23 @@ define(
                 });
 
                 return _.extend({}, data, {results: matchingResults});
+            },
+            options: function (options) {
+                var baseOptions = {
+                    multiple: false,
+                    allowClear: false,
+                    formatSearching: function () {
+                        return _.__('pim_enrich.form.product.tab.attributes.info.search_attributes');
+                    },
+                    formatNoMatches: function () {
+                        return _.__('pim_enrich.form.product.tab.attributes.info.no_match');
+                    },
+                    formatLoadMore: function (pageNumber) {
+                      return _.__('pim_enrich.form.product.tab.attributes.info.load_more');
+                    }
+                };
+
+                return $.extend(true, baseOptions, options);
             }
         };
     }

--- a/src/Pim/Bundle/UserBundle/EventListener/LocaleListener.php
+++ b/src/Pim/Bundle/UserBundle/EventListener/LocaleListener.php
@@ -20,6 +20,6 @@ class LocaleListener
     {
         $user = $event->getAuthenticationToken()->getUser();
 
-        $event->getRequest()->getSession()->set('_locale', $user->getUiLocale()->getLanguage());
+        $event->getRequest()->getSession()->set('_locale', $user->getUiLocale()->getCode());
     }
 }

--- a/src/Pim/Bundle/UserBundle/EventSubscriber/LocaleSubscriber.php
+++ b/src/Pim/Bundle/UserBundle/EventSubscriber/LocaleSubscriber.php
@@ -45,7 +45,7 @@ class LocaleSubscriber implements EventSubscriberInterface
         if ($user === $event->getArgument('current_user')) {
             $request = $this->requestStack->getMasterRequest();
             $request->getSession()->set('_locale', $user->getUiLocale()->getCode());
-            $this->translator->setLocale($user->getUiLocale()->getLanguage());
+            $this->translator->setLocale($user->getUiLocale()->getCode());
         }
     }
 

--- a/src/Pim/Bundle/UserBundle/Form/Type/UserType.php
+++ b/src/Pim/Bundle/UserBundle/Form/Type/UserType.php
@@ -132,6 +132,7 @@ class UserType extends AbstractType
                 'oro_change_password'
             )
             ->add('productGridFilters', 'pim_datagrid_product_filter_choice', [
+                'label'    => 'user.product_grid_filters',
                 'multiple' => true,
             ]);
     }

--- a/src/Pim/Bundle/UserBundle/Resources/views/User/update.html.twig
+++ b/src/Pim/Bundle/UserBundle/Resources/views/User/update.html.twig
@@ -22,7 +22,7 @@
                 initSelect2.init($('#{{ form.vars.id }}'));
 
                 _.each($('#{{ form.vars.id }} input.datepicker:not(.hasPicker)'), function (field) {
-                    datepicker.init(field.getAttribute('id'));
+                    datepicker.init($(field).closest('div'));
                 });
 
                 {% if form.rolesCollection is defined %}

--- a/src/Pim/Component/Connector/Writer/File/YamlWriter.php
+++ b/src/Pim/Component/Connector/Writer/File/YamlWriter.php
@@ -50,7 +50,14 @@ class YamlWriter extends AbstractFileWriter
     public function getConfigurationFields()
     {
         $configuration = parent::getConfigurationFields();
-        $configuration = $configuration + ['header' => ['header' => null]];
+        $configuration = $configuration + [
+            'header' => [
+                'header'  => null,
+                'options' => [
+                    'label' => 'pim_connector.export.header.label'
+                ]
+            ]
+        ];
 
         return $configuration;
     }

--- a/src/Pim/Component/Localization/Factory/DateFactory.php
+++ b/src/Pim/Component/Localization/Factory/DateFactory.php
@@ -11,6 +11,9 @@ namespace Pim\Component\Localization\Factory;
  */
 class DateFactory
 {
+    const TYPE_DATE = \IntlDateFormatter::SHORT;
+    const TYPE_TIME = \IntlDateFormatter::NONE;
+
     /** @var array */
     protected $dateFormats;
 
@@ -55,8 +58,8 @@ class DateFactory
 
         $options = array_merge([
             'locale'      => 'en',
-            'datetype'    => \IntlDateFormatter::SHORT,
-            'timetype'    => \IntlDateFormatter::NONE,
+            'datetype'    => static::TYPE_DATE,
+            'timetype'    => static::TYPE_TIME,
             'timezone'    => null,
             'calendar'    => null,
             'date_format' => null,

--- a/src/Pim/Component/Localization/Factory/DateTimeFactory.php
+++ b/src/Pim/Component/Localization/Factory/DateTimeFactory.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Pim\Component\Localization\Factory;
+
+/**
+ * Create a new instance of IntlDateFormatter
+ *
+ * @author    Marie Bochu <marie.bochu@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class DateTimeFactory extends DateFactory
+{
+    const TYPE_TIME = \IntlDateFormatter::SHORT;
+}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Specs             | Y
| Behats            | Y
| Blue CI           | ?
| Changelog updated | Y
| Review and 2 GTM  | 
| Micro Demo (PO)   | Y
| Migration script  | N
| Tech Doc          | N

- missing keys added
- fix locale fallback in config
- factorize initialization of select2 & datetimepicker
- show datetime instead of date in grids