### PR TITLE
PIM-5354: Keep select/boolean filter value after navigation

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 - PIM-5476: Fix issue with native csv product import, new products are created with extra optional values for media, metric, price
 - PIM-5470: Fix Doctrine memory leak
+- PIM-5354: Fix select/boolean filter value display after navigation
 
 # 1.4.18 (2016-01-28)
 

--- a/features/product/filtering/filter_product_per_boolean.feature
+++ b/features/product/filtering/filter_product_per_boolean.feature
@@ -68,3 +68,15 @@ Feature: Filter products by boolean field
     And I show the filter "Handmade"
     Then the grid should contain 2 elements
     And I should see entities pants and socks
+
+  @jira https://akeneo.atlassian.net/browse/PIM-5354
+  Scenario: Keep boolean filter value after navigation
+    Given the following products:
+      | sku              | family  | handmade |
+      | lumberjack-shirt | tshirts | 1        |
+    And I am on the products page
+    And I show the filter "Handmade"
+    And I filter by "Handmade" with value "yes"
+    When I am on the dashboard page
+    And I am on the products page
+    Then I should see the text "Handmade: yes"

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/select-filter.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/select-filter.js
@@ -161,6 +161,7 @@ function(_, __, AbstractFilter, MultiselectDecorator) {
                 })
             );
 
+            this._updateDOMValue();
             this._initializeSelectWidget();
 
             return this;


### PR DESCRIPTION
https://akeneo.atlassian.net/browse/PIM-5354

| Q                 | A
| ----------------- | ---
| Specs             | n/a
| Behats            | yes
| Blue CI           | running
| Changelog updated | yes
| Review and 2 GTM  |

Grid filter rendering in front works as follows :

1. filter is rendered
2. value coming from memorized grid state is set
3. optional treatment are applied (e.g. jQuery plugin initialization)

Except that for non-default filters (the ones you add via "Manage filters") the rendering is done at the end, so the value set in the DOM in previous steps is lost (at least for select filters).
The fix consist in refreshing the DOM from the value stored in the filter (because yes, filters are stateful :fire:) just after the rendering and just before jQuery multiselect initialization.