### PR TITLE
PIM-5507 : Memory leak during mass edit attributes, mass publish

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -1,5 +1,15 @@
 # 1.4.x
 
+## Scalability improvements
+- PIM-5507 : Memory leak during mass edit attributes, mass publish
+
+## BC Breaks
+- Changed constructor `Pim\Bundle\EnrichBundle\Connector\Processor\MassEdit\Product\EditCommonAttributesProcessor`
+- Added method `hasAttribute` to `Pim\Bundle\CatalogBundle\Repository\FamilyRepositoryInterface`
+- Added method `hasAttribute` to `Pim\Bundle\CatalogBundle\Repository\GroupRepositoryInterface`
+- Added method `hasAttributeInFamily` to `Pim\Bundle\CatalogBundle\Repository\ProductRepositoryInterface`
+- Added method `hasAttributeInVariantGroup` to `Pim\Bundle\CatalogBundle\Repository\ProductRepositoryInterface`
+
 ## Bug fixes
 
 - PIM-5699: Fix 'is equal to' operator in export / import history grid filter

--- a/spec/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Repository/ProductRepositorySpec.php
+++ b/spec/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Repository/ProductRepositorySpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Repository;
 
+use Akeneo\Component\Classification\Repository\CategoryRepositoryInterface;
 use Doctrine\MongoDB\Collection;
 use Doctrine\MongoDB\Cursor;
 use Doctrine\MongoDB\CursorInterface;
@@ -11,6 +12,13 @@ use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\UnitOfWork;
 use PhpSpec\ObjectBehavior;
+use Pim\Bundle\CatalogBundle\Model\AttributeInterface;
+use Pim\Bundle\CatalogBundle\Model\ProductInterface;
+use Pim\Bundle\CatalogBundle\Model\ProductValueInterface;
+use Pim\Bundle\CatalogBundle\Repository\AttributeRepositoryInterface;
+use Pim\Bundle\CatalogBundle\Repository\FamilyRepositoryInterface;
+use Pim\Bundle\CatalogBundle\Repository\GroupRepositoryInterface;
+use Prophecy\Argument;
 
 /**
  * @require Doctrine\MongoDB\Collection
@@ -59,5 +67,127 @@ class ProductRepositorySpec extends ObjectBehavior
         $cursor->count()->shouldBeCalled();
 
         $this->countAll();
+    }
+
+    function it_has_attribute_repository(AttributeRepositoryInterface $attributeRepository)
+    {
+        $this->setAttributeRepository($attributeRepository)->shouldReturn($this);
+    }
+
+    function it_has_category_repository(CategoryRepositoryInterface $categoryRepository)
+    {
+        $this->setCategoryRepository($categoryRepository)->shouldReturn($this);
+    }
+
+    function it_has_family_repository(FamilyRepositoryInterface $familyRepository)
+    {
+        $this->setFamilyRepository($familyRepository)->shouldReturn($this);
+    }
+
+    function it_has_group_repository(GroupRepositoryInterface $groupRepository)
+    {
+        $this->setGroupRepository($groupRepository)->shouldReturn($this);
+    }
+
+    function it_checks_if_the_product_has_an_attribute_in_its_variant_group(
+        GroupRepositoryInterface $groupRepository,
+        ProductInterface $product,
+        DocumentManager $dm,
+        Builder $builder,
+        Query $query
+    ) {
+        $this->setGroupRepository($groupRepository);
+
+        $product->getId()->willReturn(10);
+
+        $dm->createQueryBuilder('foobar')->willReturn($builder);
+        $builder->field('_id')->willReturn($builder);
+        $builder->equals(10)->willReturn($builder);
+        $builder->hydrate(false)->willReturn($builder);
+        $builder->getQuery()->willReturn($query);
+
+        $query->getSingleResult()->willReturn([
+            'groupIds' => [10, 11]
+        ]);
+
+        $groupRepository->hasAttribute([10, 11], 'attribute_code')->willReturn(true);
+
+        $this->hasAttributeInVariantGroup($product, 'attribute_code')->shouldReturn(true);
+    }
+
+    function it_checks_if_the_product_has_an_attribute_in_its_variant_group_but_it_doesnt_have_one(
+        GroupRepositoryInterface $groupRepository,
+        ProductInterface $product,
+        DocumentManager $dm,
+        Builder $builder,
+        Query $query
+    ) {
+        $this->setGroupRepository($groupRepository);
+
+        $product->getId()->willReturn(10);
+
+        $dm->createQueryBuilder('foobar')->willReturn($builder);
+        $builder->field('_id')->willReturn($builder);
+        $builder->equals(10)->willReturn($builder);
+        $builder->hydrate(false)->willReturn($builder);
+        $builder->getQuery()->willReturn($query);
+
+        $query->getSingleResult()->willReturn([
+            'groupIds' => null
+        ]);
+
+        $groupRepository->hasAttribute([10, 11], 'attribute_code')->willReturn(false);
+
+        $this->hasAttributeInVariantGroup($product, 'attribute_code')->shouldReturn(false);
+    }
+
+    function it_checks_if_the_product_has_an_attribute_in_its_family(
+        FamilyRepositoryInterface $familyRepository,
+        ProductInterface $product,
+        DocumentManager $dm,
+        Builder $builder,
+        Query $query
+    ) {
+        $this->setFamilyRepository($familyRepository);
+
+        $product->getId()->willReturn(10);
+
+        $dm->createQueryBuilder('foobar')->willReturn($builder);
+        $builder->field('_id')->willReturn($builder);
+        $builder->equals(10)->willReturn($builder);
+        $builder->hydrate(false)->willReturn($builder);
+        $builder->getQuery()->willReturn($query);
+
+        $query->getSingleResult()->willReturn([
+            'family' => 10
+        ]);
+
+        $familyRepository->hasAttribute(10, 'attribute_code')->willReturn(true);
+
+        $this->hasAttributeInFamily($product, 'attribute_code')->shouldReturn(true);
+    }
+
+    function it_checks_if_the_product_has_an_attribute_in_its_family_but_it_does_not_have_one(
+        FamilyRepositoryInterface $familyRepository,
+        ProductInterface $product,
+        DocumentManager $dm,
+        Builder $builder,
+        Query $query
+    ) {
+        $this->setFamilyRepository($familyRepository);
+
+        $product->getId()->willReturn(10);
+
+        $dm->createQueryBuilder('foobar')->willReturn($builder);
+        $builder->field('_id')->willReturn($builder);
+        $builder->equals(10)->willReturn($builder);
+        $builder->hydrate(false)->willReturn($builder);
+        $builder->getQuery()->willReturn($query);
+
+        $query->getSingleResult()->willReturn([]);
+
+        $familyRepository->hasAttribute(Argument::cetera())->shouldNotBeCalled();
+
+        $this->hasAttributeInFamily($product, 'attribute_code')->shouldReturn(false);
     }
 }

--- a/spec/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Repository/ProductRepositorySpec.php
+++ b/spec/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Repository/ProductRepositorySpec.php
@@ -91,14 +91,11 @@ class ProductRepositorySpec extends ObjectBehavior
 
     function it_checks_if_the_product_has_an_attribute_in_its_variant_group(
         GroupRepositoryInterface $groupRepository,
-        ProductInterface $product,
         DocumentManager $dm,
         Builder $builder,
         Query $query
     ) {
         $this->setGroupRepository($groupRepository);
-
-        $product->getId()->willReturn(10);
 
         $dm->createQueryBuilder('foobar')->willReturn($builder);
         $builder->field('_id')->willReturn($builder);
@@ -112,19 +109,16 @@ class ProductRepositorySpec extends ObjectBehavior
 
         $groupRepository->hasAttribute([10, 11], 'attribute_code')->willReturn(true);
 
-        $this->hasAttributeInVariantGroup($product, 'attribute_code')->shouldReturn(true);
+        $this->hasAttributeInVariantGroup(10, 'attribute_code')->shouldReturn(true);
     }
 
     function it_checks_if_the_product_has_an_attribute_in_its_variant_group_but_it_doesnt_have_one(
         GroupRepositoryInterface $groupRepository,
-        ProductInterface $product,
         DocumentManager $dm,
         Builder $builder,
         Query $query
     ) {
         $this->setGroupRepository($groupRepository);
-
-        $product->getId()->willReturn(10);
 
         $dm->createQueryBuilder('foobar')->willReturn($builder);
         $builder->field('_id')->willReturn($builder);
@@ -138,19 +132,16 @@ class ProductRepositorySpec extends ObjectBehavior
 
         $groupRepository->hasAttribute([10, 11], 'attribute_code')->willReturn(false);
 
-        $this->hasAttributeInVariantGroup($product, 'attribute_code')->shouldReturn(false);
+        $this->hasAttributeInVariantGroup(10, 'attribute_code')->shouldReturn(false);
     }
 
     function it_checks_if_the_product_has_an_attribute_in_its_family(
         FamilyRepositoryInterface $familyRepository,
-        ProductInterface $product,
         DocumentManager $dm,
         Builder $builder,
         Query $query
     ) {
         $this->setFamilyRepository($familyRepository);
-
-        $product->getId()->willReturn(10);
 
         $dm->createQueryBuilder('foobar')->willReturn($builder);
         $builder->field('_id')->willReturn($builder);
@@ -164,19 +155,16 @@ class ProductRepositorySpec extends ObjectBehavior
 
         $familyRepository->hasAttribute(10, 'attribute_code')->willReturn(true);
 
-        $this->hasAttributeInFamily($product, 'attribute_code')->shouldReturn(true);
+        $this->hasAttributeInFamily(10, 'attribute_code')->shouldReturn(true);
     }
 
     function it_checks_if_the_product_has_an_attribute_in_its_family_but_it_does_not_have_one(
         FamilyRepositoryInterface $familyRepository,
-        ProductInterface $product,
         DocumentManager $dm,
         Builder $builder,
         Query $query
     ) {
         $this->setFamilyRepository($familyRepository);
-
-        $product->getId()->willReturn(10);
 
         $dm->createQueryBuilder('foobar')->willReturn($builder);
         $builder->field('_id')->willReturn($builder);
@@ -188,6 +176,6 @@ class ProductRepositorySpec extends ObjectBehavior
 
         $familyRepository->hasAttribute(Argument::cetera())->shouldNotBeCalled();
 
-        $this->hasAttributeInFamily($product, 'attribute_code')->shouldReturn(false);
+        $this->hasAttributeInFamily(10, 'attribute_code')->shouldReturn(false);
     }
 }

--- a/spec/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/FamilyRepositorySpec.php
+++ b/spec/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/FamilyRepositorySpec.php
@@ -44,5 +44,29 @@ class FamilyRepositorySpec extends ObjectBehavior
 
         $this->countAll();
     }
+
+    function it_checks_if_family_has_attribute($em, QueryBuilder $queryBuilder, AbstractQuery $query)
+    {
+        $em->createQueryBuilder()->willReturn($queryBuilder);
+        $queryBuilder->select('f')->willReturn($queryBuilder);
+        $queryBuilder->select('COUNT(f.id)')->willReturn($queryBuilder);
+        $queryBuilder->from('family', 'f')->willReturn($queryBuilder);
+        $queryBuilder->leftJoin('f.attributes', 'a')->willReturn($queryBuilder);
+        $queryBuilder->where('f.id = :id')->willReturn($queryBuilder);
+        $queryBuilder->andWhere('a.code = :code')->willReturn($queryBuilder);
+        $queryBuilder->setMaxResults(1)->willReturn($queryBuilder);
+        $queryBuilder->setParameters([
+            'id' => 10,
+            'code' => 'attribute_code',
+        ])->willReturn($queryBuilder);
+
+        $queryBuilder->getQuery()->willReturn($query);
+
+        $query->getSingleScalarResult()->willReturn(['id' => 12]);
+        $this->hasAttribute(10, 'attribute_code')->shouldReturn(true);
+
+        $query->getSingleScalarResult()->willReturn(null);
+        $this->hasAttribute(10, 'attribute_code')->shouldReturn(false);
+    }
 }
 

--- a/spec/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/FamilyRepositorySpec.php
+++ b/spec/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/FamilyRepositorySpec.php
@@ -32,7 +32,7 @@ class FamilyRepositorySpec extends ObjectBehavior
         $this->shouldImplement('Pim\Bundle\CatalogBundle\Repository\FamilyRepositoryInterface');
     }
 
-    function it_count_all_familys($em, QueryBuilder $queryBuilder, AbstractQuery $query)
+    function it_count_all_families($em, QueryBuilder $queryBuilder, AbstractQuery $query)
     {
         $em->createQueryBuilder()->willReturn($queryBuilder);
         $queryBuilder->select('f')->willReturn($queryBuilder);
@@ -54,6 +54,7 @@ class FamilyRepositorySpec extends ObjectBehavior
         $queryBuilder->leftJoin('f.attributes', 'a')->willReturn($queryBuilder);
         $queryBuilder->where('f.id = :id')->willReturn($queryBuilder);
         $queryBuilder->andWhere('a.code = :code')->willReturn($queryBuilder);
+        $queryBuilder->addGroupBy('a.id')->willReturn($queryBuilder);
         $queryBuilder->setMaxResults(1)->willReturn($queryBuilder);
         $queryBuilder->setParameters([
             'id' => 10,
@@ -62,11 +63,10 @@ class FamilyRepositorySpec extends ObjectBehavior
 
         $queryBuilder->getQuery()->willReturn($query);
 
-        $query->getSingleScalarResult()->willReturn(['id' => 12]);
+        $query->getArrayResult()->willReturn(['id' => 12]);
         $this->hasAttribute(10, 'attribute_code')->shouldReturn(true);
 
-        $query->getSingleScalarResult()->willReturn(null);
+        $query->getArrayResult()->willReturn([]);
         $this->hasAttribute(10, 'attribute_code')->shouldReturn(false);
     }
 }
-

--- a/spec/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/GroupRepositorySpec.php
+++ b/spec/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/GroupRepositorySpec.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace spec\Pim\Bundle\CatalogBundle\Doctrine\ORM\Repository;
+
+use Doctrine\ORM\Query\Expr;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\AbstractQuery;
+use Doctrine\ORM\QueryBuilder;
+use Prophecy\Promise\ReturnPromise;
+
+class GroupRepositorySpec extends ObjectBehavior
+{
+    function let(EntityManager $em, ClassMetadata $classMetadata)
+    {
+        $this->beConstructedWith($em, $classMetadata);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Pim\Bundle\CatalogBundle\Doctrine\ORM\Repository\GroupRepository');
+    }
+
+    function it_checks_if_group_has_attribute_in_family(
+        $em,
+        QueryBuilder $queryBuilder1,
+        QueryBuilder $queryBuilder2,
+        AbstractQuery $query1,
+        Expr $expr1
+    ) {
+
+        $em->createQueryBuilder()->willReturn($expr1);
+        $em->createQueryBuilder()->willReturn($queryBuilder1);
+
+        $queryBuilder1->expr()->willReturn($expr1);
+        $expr1->in('g.id', [10, 12])->willReturn($expr1);
+        $queryBuilder1->select('g')->willReturn($queryBuilder1);
+        $queryBuilder1->select('COUNT(g.id)')->willReturn($queryBuilder1);
+        $queryBuilder1->from(Argument::any(), 'g')->willReturn($queryBuilder1);
+        $queryBuilder1->leftJoin('g.attributes', 'a')->willReturn($queryBuilder1);
+        $queryBuilder1->leftJoin('g.type', 't')->willReturn($queryBuilder1);
+        $queryBuilder1->where($expr1)->willReturn($queryBuilder1);
+        $queryBuilder1->andWhere('t.variant = :variant')->willReturn($queryBuilder1);
+        $queryBuilder1->andWhere('a.code = :code')->willReturn($queryBuilder1);
+        $queryBuilder1->setMaxResults(1)->willReturn($queryBuilder1);
+        $queryBuilder1->setParameters([
+            'variant' => true,
+            'code' => 'attribute_code',
+        ])->willReturn($queryBuilder1);
+
+        $queryBuilder1->getQuery()->willReturn($query1);
+        $query1->getSingleResult()->willReturn(1);
+
+        $this->hasAttribute([10, 12], 'attribute_code')->shouldReturn(true);
+    }
+
+    function it_checks_if_group_has_attribute_in_product_template(
+        $em,
+        QueryBuilder $queryBuilder1,
+        QueryBuilder $queryBuilder2,
+        AbstractQuery $query1,
+        AbstractQuery $query2,
+        Expr $expr1,
+        Expr $expr2
+    ) {
+
+        $em->createQueryBuilder()->will(new ReturnPromise([$expr1, $expr2]));
+        $em->createQueryBuilder()->will(new ReturnPromise([$queryBuilder1, $queryBuilder2]));
+
+        $queryBuilder1->expr()->willReturn($expr1);
+        $expr1->in('g.id', [10, 12])->willReturn($expr1);
+        $queryBuilder1->select('g')->willReturn($queryBuilder1);
+        $queryBuilder1->select('COUNT(g.id)')->willReturn($queryBuilder1);
+        $queryBuilder1->from(Argument::any(), 'g')->willReturn($queryBuilder1);
+        $queryBuilder1->leftJoin('g.attributes', 'a')->willReturn($queryBuilder1);
+        $queryBuilder1->leftJoin('g.type', 't')->willReturn($queryBuilder1);
+        $queryBuilder1->where($expr1)->willReturn($queryBuilder1);
+        $queryBuilder1->andWhere('t.variant = :variant')->willReturn($queryBuilder1);
+        $queryBuilder1->andWhere('a.code = :code')->willReturn($queryBuilder1);
+        $queryBuilder1->setMaxResults(1)->willReturn($queryBuilder1);
+        $queryBuilder1->setParameters([
+            'variant' => true,
+            'code' => 'attribute_code',
+        ])->willReturn($queryBuilder1);
+
+        $queryBuilder1->getQuery()->willReturn($query1);
+        $query1->getSingleResult()->willReturn(0);
+
+        $queryBuilder2->expr()->willReturn($expr2);
+        $expr2->in('g.id', [10, 12])->willReturn($expr2);
+        $queryBuilder2->select('g')->willReturn($queryBuilder2);
+        $queryBuilder2->select('pt.valuesData')->willReturn($queryBuilder2);
+        $queryBuilder2->from(Argument::any(), 'g')->willReturn($queryBuilder2);
+        $queryBuilder2->leftJoin('g.type', 't')->willReturn($queryBuilder2);
+        $queryBuilder2->leftJoin('g.productTemplate', 'pt')->willReturn($queryBuilder2);
+        $queryBuilder2->where($expr2)->willReturn($queryBuilder2);
+        $queryBuilder2->andWhere('t.variant = :variant')->willReturn($queryBuilder2);
+        $queryBuilder2->setParameters([
+            'variant' => true,
+            'id' => 10,
+        ])->willReturn($queryBuilder2);
+
+        $queryBuilder2->getQuery()->willReturn($query2);
+        $query2->getArrayResult()->willReturn(['attribute_code' => '...']);
+
+        $this->hasAttribute([10, 12], 'attribute_code')->shouldReturn(true);
+    }
+}

--- a/spec/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/GroupRepositorySpec.php
+++ b/spec/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/GroupRepositorySpec.php
@@ -26,32 +26,27 @@ class GroupRepositorySpec extends ObjectBehavior
     function it_checks_if_group_has_attribute_in_family(
         $em,
         QueryBuilder $queryBuilder1,
-        QueryBuilder $queryBuilder2,
-        AbstractQuery $query1,
-        Expr $expr1
+        AbstractQuery $query1
     ) {
 
-        $em->createQueryBuilder()->willReturn($expr1);
         $em->createQueryBuilder()->willReturn($queryBuilder1);
 
-        $queryBuilder1->expr()->willReturn($expr1);
-        $expr1->in('g.id', [10, 12])->willReturn($expr1);
         $queryBuilder1->select('g')->willReturn($queryBuilder1);
-        $queryBuilder1->select('COUNT(g.id)')->willReturn($queryBuilder1);
         $queryBuilder1->from(Argument::any(), 'g')->willReturn($queryBuilder1);
         $queryBuilder1->leftJoin('g.attributes', 'a')->willReturn($queryBuilder1);
         $queryBuilder1->leftJoin('g.type', 't')->willReturn($queryBuilder1);
-        $queryBuilder1->where($expr1)->willReturn($queryBuilder1);
+        $queryBuilder1->where('g.id IN (:ids)')->willReturn($queryBuilder1);
         $queryBuilder1->andWhere('t.variant = :variant')->willReturn($queryBuilder1);
         $queryBuilder1->andWhere('a.code = :code')->willReturn($queryBuilder1);
         $queryBuilder1->setMaxResults(1)->willReturn($queryBuilder1);
         $queryBuilder1->setParameters([
             'variant' => true,
             'code' => 'attribute_code',
+            'ids' => [10, 12],
         ])->willReturn($queryBuilder1);
 
         $queryBuilder1->getQuery()->willReturn($query1);
-        $query1->getSingleResult()->willReturn(1);
+        $query1->getArrayResult()->willReturn([10]);
 
         $this->hasAttribute([10, 12], 'attribute_code')->shouldReturn(true);
     }
@@ -61,50 +56,45 @@ class GroupRepositorySpec extends ObjectBehavior
         QueryBuilder $queryBuilder1,
         QueryBuilder $queryBuilder2,
         AbstractQuery $query1,
-        AbstractQuery $query2,
-        Expr $expr1,
-        Expr $expr2
+        AbstractQuery $query2
     ) {
 
-        $em->createQueryBuilder()->will(new ReturnPromise([$expr1, $expr2]));
         $em->createQueryBuilder()->will(new ReturnPromise([$queryBuilder1, $queryBuilder2]));
 
-        $queryBuilder1->expr()->willReturn($expr1);
-        $expr1->in('g.id', [10, 12])->willReturn($expr1);
         $queryBuilder1->select('g')->willReturn($queryBuilder1);
-        $queryBuilder1->select('COUNT(g.id)')->willReturn($queryBuilder1);
         $queryBuilder1->from(Argument::any(), 'g')->willReturn($queryBuilder1);
         $queryBuilder1->leftJoin('g.attributes', 'a')->willReturn($queryBuilder1);
         $queryBuilder1->leftJoin('g.type', 't')->willReturn($queryBuilder1);
-        $queryBuilder1->where($expr1)->willReturn($queryBuilder1);
+        $queryBuilder1->where('g.id IN (:ids)')->willReturn($queryBuilder1);
         $queryBuilder1->andWhere('t.variant = :variant')->willReturn($queryBuilder1);
         $queryBuilder1->andWhere('a.code = :code')->willReturn($queryBuilder1);
         $queryBuilder1->setMaxResults(1)->willReturn($queryBuilder1);
         $queryBuilder1->setParameters([
             'variant' => true,
             'code' => 'attribute_code',
+            'ids' => [10, 12],
         ])->willReturn($queryBuilder1);
 
         $queryBuilder1->getQuery()->willReturn($query1);
-        $query1->getSingleResult()->willReturn(0);
+        $query1->getArrayResult()->willReturn([]);
 
-        $queryBuilder2->expr()->willReturn($expr2);
-        $expr2->in('g.id', [10, 12])->willReturn($expr2);
         $queryBuilder2->select('g')->willReturn($queryBuilder2);
         $queryBuilder2->select('pt.valuesData')->willReturn($queryBuilder2);
         $queryBuilder2->from(Argument::any(), 'g')->willReturn($queryBuilder2);
         $queryBuilder2->leftJoin('g.type', 't')->willReturn($queryBuilder2);
         $queryBuilder2->leftJoin('g.productTemplate', 'pt')->willReturn($queryBuilder2);
-        $queryBuilder2->where($expr2)->willReturn($queryBuilder2);
+        $queryBuilder2->where('g.id IN (:ids)')->willReturn($queryBuilder2);
         $queryBuilder2->andWhere('t.variant = :variant')->willReturn($queryBuilder2);
         $queryBuilder2->setParameters([
             'variant' => true,
-            'id' => 10,
+            'ids' => [10, 12],
         ])->willReturn($queryBuilder2);
 
         $queryBuilder2->getQuery()->willReturn($query2);
-        $query2->getArrayResult()->willReturn(['attribute_code' => '...']);
-
+        $query2->getArrayResult()->willReturn([
+            ['valuesData' => ['foo' => 'val1', 'attribute_code' => 'val2']],
+            ['valuesData' => ['foo' => 'val3', 'bar' => 'val4']]
+        ]);
         $this->hasAttribute([10, 12], 'attribute_code')->shouldReturn(true);
     }
 }

--- a/spec/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/ProductRepositorySpec.php
+++ b/spec/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/ProductRepositorySpec.php
@@ -150,13 +150,10 @@ class ProductRepositorySpec extends ObjectBehavior
     function it_checks_if_the_product_has_an_attribute_in_its_variant_group(
         $em,
         GroupRepositoryInterface $groupRepository,
-        ProductInterface $product,
         QueryBuilder $queryBuilder,
         AbstractQuery $query
     ) {
         $this->setGroupRepository($groupRepository);
-
-        $product->getId()->willReturn(10);
 
         $em->createQueryBuilder()->willReturn($queryBuilder);
         $queryBuilder->select('p')->willReturn($queryBuilder);
@@ -176,19 +173,16 @@ class ProductRepositorySpec extends ObjectBehavior
 
         $groupRepository->hasAttribute([1, 2], 'attribute_code')->willReturn(true);
 
-        $this->hasAttributeInVariantGroup($product, 'attribute_code')->shouldReturn(true);
+        $this->hasAttributeInVariantGroup(10, 'attribute_code')->shouldReturn(true);
     }
 
     function it_checks_if_the_product_has_an_attribute_in_its_variant_group_but_it_has_not_group(
         $em,
         GroupRepositoryInterface $groupRepository,
-        ProductInterface $product,
         QueryBuilder $queryBuilder,
         AbstractQuery $query
     ) {
         $this->setGroupRepository($groupRepository);
-
-        $product->getId()->willReturn(10);
 
         $em->createQueryBuilder()->willReturn($queryBuilder);
         $queryBuilder->select('p')->willReturn($queryBuilder);
@@ -208,17 +202,14 @@ class ProductRepositorySpec extends ObjectBehavior
 
         $groupRepository->hasAttribute(Argument::cetera())->shouldNotBeCalled();
 
-        $this->hasAttributeInVariantGroup($product, 'attribute_code')->shouldReturn(false);
+        $this->hasAttributeInVariantGroup(10, 'attribute_code')->shouldReturn(false);
     }
 
     function it_checks_if_the_product_has_an_attribute_in_its_family(
         $em,
-        ProductInterface $product,
         QueryBuilder $queryBuilder,
         AbstractQuery $query
     ) {
-        $product->getId()->willReturn(10);
-
         $em->createQueryBuilder()->willReturn($queryBuilder);
         $queryBuilder->select('p')->willReturn($queryBuilder);
         $queryBuilder->from(Argument::type('string'), "p")->willReturn($queryBuilder);
@@ -235,10 +226,10 @@ class ProductRepositorySpec extends ObjectBehavior
         $queryBuilder->getQuery()->willReturn($query);
 
         $query->getArrayResult()->willReturn(['id' => 10]);
-        $this->hasAttributeInFamily($product, 'attribute_code')->shouldReturn(true);
+        $this->hasAttributeInFamily(10, 'attribute_code')->shouldReturn(true);
 
         $query->getArrayResult()->willReturn([]);
-        $this->hasAttributeInFamily($product, 'attribute_code')->shouldReturn(false);
+        $this->hasAttributeInFamily(10, 'attribute_code')->shouldReturn(false);
     }
 
     function it_count_all_products($em, QueryBuilder $queryBuilder, AbstractQuery $query)

--- a/spec/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/ProductRepositorySpec.php
+++ b/spec/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/ProductRepositorySpec.php
@@ -234,10 +234,10 @@ class ProductRepositorySpec extends ObjectBehavior
 
         $queryBuilder->getQuery()->willReturn($query);
 
-        $query->getScalarResult()->willReturn(['id' => 10]);
+        $query->getArrayResult()->willReturn(['id' => 10]);
         $this->hasAttributeInFamily($product, 'attribute_code')->shouldReturn(true);
 
-        $query->getSingleScalarResult()->willReturn(null);
+        $query->getArrayResult()->willReturn([]);
         $this->hasAttributeInFamily($product, 'attribute_code')->shouldReturn(false);
     }
 

--- a/spec/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/ProductRepositorySpec.php
+++ b/spec/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/ProductRepositorySpec.php
@@ -8,7 +8,11 @@ use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Query\Expr;
 use PhpSpec\ObjectBehavior;
+use Pim\Bundle\CatalogBundle\AttributeType\AttributeTypes;
+use Pim\Bundle\CatalogBundle\Model\ProductInterface;
+use Pim\Bundle\CatalogBundle\Model\ProductValueInterface;
 use Pim\Bundle\CatalogBundle\Query\ProductQueryBuilderFactory;
+use Pim\Bundle\CatalogBundle\Repository\GroupRepositoryInterface;
 use Pim\Component\ReferenceData\ConfigurationRegistryInterface;
 use Prophecy\Argument;
 use Doctrine\ORM\AbstractQuery;
@@ -23,6 +27,11 @@ class ProductRepositorySpec extends ObjectBehavior
         $this->beConstructedWith($em, $class);
         $this->setReferenceDataRegistry($registry);
         $this->setProductQueryBuilderFactory($pqbFactory);
+    }
+
+    function it_has_group_repository(GroupRepositoryInterface $groupRepository)
+    {
+        $this->setGroupRepository($groupRepository)->shouldReturn($this);
     }
 
     function it_is_a_product_repository()
@@ -136,6 +145,100 @@ class ProductRepositorySpec extends ObjectBehavior
         $queryBuilder->getQuery()->willReturn($query);
 
         $this->getFullProducts([42]);
+    }
+
+    function it_checks_if_the_product_has_an_attribute_in_its_variant_group(
+        $em,
+        GroupRepositoryInterface $groupRepository,
+        ProductInterface $product,
+        QueryBuilder $queryBuilder,
+        AbstractQuery $query
+    ) {
+        $this->setGroupRepository($groupRepository);
+
+        $product->getId()->willReturn(10);
+
+        $em->createQueryBuilder()->willReturn($queryBuilder);
+        $queryBuilder->select('p')->willReturn($queryBuilder);
+        $queryBuilder->select('g.id')->willReturn($queryBuilder);
+        $queryBuilder->from(Argument::type('string'), "p")->willReturn($queryBuilder);
+        $queryBuilder->leftJoin('p.groups', 'g')->willReturn($queryBuilder);
+        $queryBuilder->where('p.id = :id')->willReturn($queryBuilder);
+        $queryBuilder->setParameters([
+            'id' => 10,
+        ])->willReturn($queryBuilder);
+
+        $queryBuilder->getQuery()->willReturn($query);
+        $query->getScalarResult()->willReturn([
+            ['id' => 1],
+            ['id' => 2]
+        ]);
+
+        $groupRepository->hasAttribute([1, 2], 'attribute_code')->willReturn(true);
+
+        $this->hasAttributeInVariantGroup($product, 'attribute_code')->shouldReturn(true);
+    }
+
+    function it_checks_if_the_product_has_an_attribute_in_its_variant_group_but_it_has_not_group(
+        $em,
+        GroupRepositoryInterface $groupRepository,
+        ProductInterface $product,
+        QueryBuilder $queryBuilder,
+        AbstractQuery $query
+    ) {
+        $this->setGroupRepository($groupRepository);
+
+        $product->getId()->willReturn(10);
+
+        $em->createQueryBuilder()->willReturn($queryBuilder);
+        $queryBuilder->select('p')->willReturn($queryBuilder);
+        $queryBuilder->select('g.id')->willReturn($queryBuilder);
+        $queryBuilder->from(Argument::type('string'), "p")->willReturn($queryBuilder);
+        $queryBuilder->leftJoin('p.groups', 'g')->willReturn($queryBuilder);
+        $queryBuilder->where('p.id = :id')->willReturn($queryBuilder);
+        $queryBuilder->setParameters([
+            'id' => 10,
+        ])->willReturn($queryBuilder);
+
+        $queryBuilder->getQuery()->willReturn($query);
+
+        $query->getScalarResult()->willReturn([
+            ['id' => null],
+        ]);
+
+        $groupRepository->hasAttribute(Argument::cetera())->shouldNotBeCalled();
+
+        $this->hasAttributeInVariantGroup($product, 'attribute_code')->shouldReturn(false);
+    }
+
+    function it_checks_if_the_product_has_an_attribute_in_its_family(
+        $em,
+        ProductInterface $product,
+        QueryBuilder $queryBuilder,
+        AbstractQuery $query
+    ) {
+        $product->getId()->willReturn(10);
+
+        $em->createQueryBuilder()->willReturn($queryBuilder);
+        $queryBuilder->select('p')->willReturn($queryBuilder);
+        $queryBuilder->from(Argument::type('string'), "p")->willReturn($queryBuilder);
+        $queryBuilder->leftJoin('p.family', 'f')->willReturn($queryBuilder);
+        $queryBuilder->leftJoin('f.attributes', 'a')->willReturn($queryBuilder);
+        $queryBuilder->where('p.id = :id')->willReturn($queryBuilder);
+        $queryBuilder->andWhere('a.code = :code')->willReturn($queryBuilder);
+        $queryBuilder->setMaxResults(1)->willReturn($queryBuilder);
+        $queryBuilder->setParameters([
+            'id' => 10,
+            'code' => 'attribute_code',
+        ])->willReturn($queryBuilder);
+
+        $queryBuilder->getQuery()->willReturn($query);
+
+        $query->getScalarResult()->willReturn(['id' => 10]);
+        $this->hasAttributeInFamily($product, 'attribute_code')->shouldReturn(true);
+
+        $query->getSingleScalarResult()->willReturn(null);
+        $this->hasAttributeInFamily($product, 'attribute_code')->shouldReturn(false);
     }
 
     function it_count_all_products($em, QueryBuilder $queryBuilder, AbstractQuery $query)

--- a/spec/Pim/Bundle/EnrichBundle/Connector/Processor/MassEdit/Product/EditCommonAttributesProcessorSpec.php
+++ b/spec/Pim/Bundle/EnrichBundle/Connector/Processor/MassEdit/Product/EditCommonAttributesProcessorSpec.php
@@ -105,8 +105,8 @@ class EditCommonAttributesProcessorSpec extends ObjectBehavior
         $violations = new ConstraintViolationList([]);
         $validator->validate($product)->willReturn($violations);
 
-        $productRepository->hasAttributeInFamily($product, 'categories')->shouldBeCalled()->willReturn(false);
-        $productRepository->hasAttributeInVariantGroup($product, 'categories')->shouldBeCalled()->willReturn(false);
+        $productRepository->hasAttributeInFamily($product, 'categories')->shouldBeCalled()->willReturn(true);
+        $productRepository->hasAttributeInVariantGroup($product, 'categories')->shouldBeCalled()->willReturn(true);
         $productUpdater->update($product, Argument::any())->shouldNotBeCalled();
 
         $this->process($product)->shouldReturn(null);
@@ -153,8 +153,8 @@ class EditCommonAttributesProcessorSpec extends ObjectBehavior
         $violations = new ConstraintViolationList([]);
         $validator->validate($product)->willReturn($violations);
 
-        $productRepository->hasAttributeInFamily($product, 'categories')->shouldBeCalled()->willReturn(false);
-        $productRepository->hasAttributeInVariantGroup($product, 'categories')->shouldBeCalled()->willReturn(true);
+        $productRepository->hasAttributeInFamily($product, 'categories')->shouldBeCalled()->willReturn(true);
+        $productRepository->hasAttributeInVariantGroup($product, 'categories')->shouldBeCalled()->willReturn(false);
 
         $productUpdater->update($product, $values)->shouldBeCalled();
 
@@ -205,7 +205,7 @@ class EditCommonAttributesProcessorSpec extends ObjectBehavior
         $validator->validate($product)->willReturn($violations);
 
         $productRepository->hasAttributeInFamily($product, 'categories')->shouldBeCalled()->willReturn(true);
-        $productRepository->hasAttributeInVariantGroup($product, 'categories')->shouldNotBeCalled();
+        $productRepository->hasAttributeInVariantGroup($product, 'categories')->shouldBeCalled()->willReturn(false);
 
         $productUpdater->update($product, $values)->shouldBeCalled();
         $this->setStepExecution($stepExecution);

--- a/spec/Pim/Bundle/EnrichBundle/Connector/Processor/MassEdit/Product/EditCommonAttributesProcessorSpec.php
+++ b/spec/Pim/Bundle/EnrichBundle/Connector/Processor/MassEdit/Product/EditCommonAttributesProcessorSpec.php
@@ -64,7 +64,7 @@ class EditCommonAttributesProcessorSpec extends ObjectBehavior
         $this->setStepExecution($stepExecution);
 
         $product->getIdentifier()->shouldBeCalled()->willReturn($productValue);
-        $product->getId()->shouldBeCalled();
+        $product->getId()->willReturn(10);
         $productValue->getData()->shouldBeCalled();
 
         $stepExecution->getJobExecution()->willReturn($jobExecution);
@@ -105,8 +105,8 @@ class EditCommonAttributesProcessorSpec extends ObjectBehavior
         $violations = new ConstraintViolationList([]);
         $validator->validate($product)->willReturn($violations);
 
-        $productRepository->hasAttributeInFamily($product, 'categories')->shouldBeCalled()->willReturn(true);
-        $productRepository->hasAttributeInVariantGroup($product, 'categories')->shouldBeCalled()->willReturn(true);
+        $productRepository->hasAttributeInFamily(10, 'categories')->shouldBeCalled()->willReturn(true);
+        $productRepository->hasAttributeInVariantGroup(10, 'categories')->shouldBeCalled()->willReturn(true);
         $productUpdater->update($product, Argument::any())->shouldNotBeCalled();
 
         $this->process($product)->shouldReturn(null);
@@ -152,9 +152,10 @@ class EditCommonAttributesProcessorSpec extends ObjectBehavior
 
         $violations = new ConstraintViolationList([]);
         $validator->validate($product)->willReturn($violations);
+        $product->getId()->willReturn(10);
 
-        $productRepository->hasAttributeInFamily($product, 'categories')->shouldBeCalled()->willReturn(true);
-        $productRepository->hasAttributeInVariantGroup($product, 'categories')->shouldBeCalled()->willReturn(false);
+        $productRepository->hasAttributeInFamily(10, 'categories')->shouldBeCalled()->willReturn(true);
+        $productRepository->hasAttributeInVariantGroup(10, 'categories')->shouldBeCalled()->willReturn(false);
 
         $productUpdater->update($product, $values)->shouldBeCalled();
 
@@ -204,8 +205,9 @@ class EditCommonAttributesProcessorSpec extends ObjectBehavior
         $violations = new ConstraintViolationList([$violation, $violation]);
         $validator->validate($product)->willReturn($violations);
 
-        $productRepository->hasAttributeInFamily($product, 'categories')->shouldBeCalled()->willReturn(true);
-        $productRepository->hasAttributeInVariantGroup($product, 'categories')->shouldBeCalled()->willReturn(false);
+        $product->getId()->willReturn(10);
+        $productRepository->hasAttributeInFamily(10, 'categories')->shouldBeCalled()->willReturn(true);
+        $productRepository->hasAttributeInVariantGroup(10, 'categories')->shouldBeCalled()->willReturn(false);
 
         $productUpdater->update($product, $values)->shouldBeCalled();
         $this->setStepExecution($stepExecution);

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Repository/ProductRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Repository/ProductRepository.php
@@ -771,9 +771,9 @@ class ProductRepository extends DocumentRepository implements
     /**
      * {@inheritdoc}
      */
-    public function hasAttributeInFamily(ProductInterface $product, $attributeCode)
+    public function hasAttributeInFamily($productId, $attributeCode)
     {
-        $product = $this->getProductAsArray($product);
+        $product = $this->getProductAsArray($productId);
 
         if (!isset($product['family'])) {
             return false;
@@ -785,9 +785,9 @@ class ProductRepository extends DocumentRepository implements
     /**
      * {@inheritdoc}
      */
-    public function hasAttributeInVariantGroup(ProductInterface $product, $attributeCode)
+    public function hasAttributeInVariantGroup($productId, $attributeCode)
     {
-        $product = $this->getProductAsArray($product);
+        $product = $this->getProductAsArray($productId);
 
         if (!isset($product['groupIds'])) {
             return false;
@@ -797,14 +797,14 @@ class ProductRepository extends DocumentRepository implements
     }
 
     /**
-     * @param ProductInterface $product
+     * @param mixed $productId
      *
      * @return array
      */
-    protected function getProductAsArray(ProductInterface $product)
+    protected function getProductAsArray($productId)
     {
         $query = $this->createQueryBuilder()
-            ->field('_id')->equals($product->getId())
+            ->field('_id')->equals($productId)
             ->hydrate(false)
             ->getQuery();
 

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Repository/ProductRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Repository/ProductRepository.php
@@ -22,6 +22,7 @@ use Pim\Bundle\CatalogBundle\Query\ProductQueryBuilderFactoryInterface;
 use Pim\Bundle\CatalogBundle\Repository\AssociationRepositoryInterface;
 use Pim\Bundle\CatalogBundle\Repository\AttributeRepositoryInterface;
 use Pim\Bundle\CatalogBundle\Repository\FamilyRepositoryInterface;
+use Pim\Bundle\CatalogBundle\Repository\GroupRepositoryInterface;
 use Pim\Bundle\CatalogBundle\Repository\ProductRepositoryInterface;
 
 /**
@@ -48,6 +49,12 @@ class ProductRepository extends DocumentRepository implements
 
     /** @var CategoryRepositoryInterface */
     protected $categoryRepository;
+
+    /** @var FamilyRepositoryInterface */
+    protected $familyRepository;
+
+    /** @var FamilyRepositoryInterface */
+    protected $groupRepository;
 
     /**
      * Set the EntityManager
@@ -85,6 +92,34 @@ class ProductRepository extends DocumentRepository implements
     public function setCategoryRepository(CategoryRepositoryInterface $categoryRepository)
     {
         $this->categoryRepository = $categoryRepository;
+
+        return $this;
+    }
+
+    /**
+     * Set family repository
+     *
+     * @param FamilyRepositoryInterface $familyRepository
+     *
+     * @return ProductRepositoryInterface
+     */
+    public function setFamilyRepository(FamilyRepositoryInterface $familyRepository)
+    {
+        $this->familyRepository = $familyRepository;
+
+        return $this;
+    }
+
+    /**
+     * Sets group repository
+     *
+     * @param GroupRepositoryInterface $groupRepository
+     *
+     * @return ProductRepositoryInterface
+     */
+    public function setGroupRepository(GroupRepositoryInterface $groupRepository)
+    {
+        $this->groupRepository = $groupRepository;
 
         return $this;
     }
@@ -581,20 +616,6 @@ class ProductRepository extends DocumentRepository implements
     }
 
     /**
-     * Set family repository
-     *
-     * @param FamilyRepositoryInterface $familyRepository
-     *
-     * @return ProductRepositoryInterface
-     */
-    public function setFamilyRepository(FamilyRepositoryInterface $familyRepository)
-    {
-        $this->familyRepository = $familyRepository;
-
-        return $this;
-    }
-
-    /**
      * {@inheritdoc}
      *
      * TODO: find a way to do it efficiently
@@ -745,6 +766,49 @@ class ProductRepository extends DocumentRepository implements
         }
 
         return $products;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasAttributeInFamily(ProductInterface $product, $attributeCode)
+    {
+        $product = $this->getProductAsArray($product);
+
+        if (!isset($product['family'])) {
+            return false;
+        }
+
+        return $this->familyRepository->hasAttribute($product['family'], $attributeCode);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasAttributeInVariantGroup(ProductInterface $product, $attributeCode)
+    {
+        $product = $this->getProductAsArray($product);
+
+        if (!isset($product['groupIds'])) {
+            return false;
+        }
+
+        return $this->groupRepository->hasAttribute($product['groupIds'], $attributeCode);
+    }
+
+    /**
+     * @param ProductInterface $product
+     *
+     * @return array
+     */
+    protected function getProductAsArray(ProductInterface $product)
+    {
+        $query = $this->createQueryBuilder()
+            ->field('_id')->equals($product->getId())
+            ->hydrate(false)
+            ->getQuery();
+
+        return $query->getSingleResult();
     }
 
     /**

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/FamilyRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/FamilyRepository.php
@@ -244,7 +244,7 @@ class FamilyRepository extends EntityRepository implements FamilyRepositoryInter
      */
     public function hasAttribute($id, $attributeCode)
     {
-        $query = $this->createQueryBuilder('f')
+        $queryBuilder = $this->createQueryBuilder('f')
             ->leftJoin('f.attributes', 'a')
             ->where('f.id = :id')
             ->andWhere('a.code = :code')
@@ -253,12 +253,10 @@ class FamilyRepository extends EntityRepository implements FamilyRepositoryInter
                 'id'   => $id,
                 'code' => $attributeCode,
             ])
-            ->getQuery();
+            ->addGroupBy('a.id');
 
-        try {
-            return $query->getSingleResult();
-        } catch (NoResultException $e) {
-            return false;
-        }
+        $result = $queryBuilder->getQuery()->getArrayResult();
+
+        return count($result) > 0;
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/FamilyRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/FamilyRepository.php
@@ -3,6 +3,7 @@
 namespace Pim\Bundle\CatalogBundle\Doctrine\ORM\Repository;
 
 use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\NoResultException;
 use Pim\Bundle\CatalogBundle\Model\ChannelInterface;
 use Pim\Bundle\CatalogBundle\Model\FamilyInterface;
 use Pim\Bundle\CatalogBundle\Repository\FamilyRepositoryInterface;
@@ -236,5 +237,28 @@ class FamilyRepository extends EntityRepository implements FamilyRepositoryInter
             ->getSingleScalarResult();
 
         return $count;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasAttribute($id, $attributeCode)
+    {
+        $query = $this->createQueryBuilder('f')
+            ->leftJoin('f.attributes', 'a')
+            ->where('f.id = :id')
+            ->andWhere('a.code = :code')
+            ->setMaxResults(1)
+            ->setParameters([
+                'id'   => $id,
+                'code' => $attributeCode,
+            ])
+            ->getQuery();
+
+        try {
+            return $query->getSingleResult();
+        } catch (NoResultException $e) {
+            return false;
+        }
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/ProductRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/ProductRepository.php
@@ -616,7 +616,7 @@ class ProductRepository extends EntityRepository implements
     /**
      * {@inheritdoc}
      */
-    public function hasAttributeInFamily(ProductInterface $product, $attributeCode)
+    public function hasAttributeInFamily($productId, $attributeCode)
     {
         $queryBuilder = $this->createQueryBuilder('p')
             ->leftJoin('p.family', 'f')
@@ -624,7 +624,7 @@ class ProductRepository extends EntityRepository implements
             ->where('p.id = :id')
             ->andWhere('a.code = :code')
             ->setParameters([
-                'id'   => $product->getId(),
+                'id'   => $productId,
                 'code' => $attributeCode,
             ])
             ->setMaxResults(1);
@@ -635,14 +635,14 @@ class ProductRepository extends EntityRepository implements
     /**
      * {@inheritdoc}
      */
-    public function hasAttributeInVariantGroup(ProductInterface $product, $attributeCode)
+    public function hasAttributeInVariantGroup($productId, $attributeCode)
     {
         $queryBuilder = $this->createQueryBuilder('p')
             ->select('g.id')
             ->leftJoin('p.groups', 'g')
             ->where('p.id = :id')
             ->setParameters([
-                'id' => $product->getId(),
+                'id' => $productId,
             ]);
 
         $groupIds = $queryBuilder->getQuery()->getScalarResult();

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/ProductRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/ProductRepository.php
@@ -12,10 +12,12 @@ use Pim\Bundle\CatalogBundle\Model\AttributeInterface;
 use Pim\Bundle\CatalogBundle\Model\AttributeOptionInterface;
 use Pim\Bundle\CatalogBundle\Model\ChannelInterface;
 use Pim\Bundle\CatalogBundle\Model\GroupInterface;
+use Pim\Bundle\CatalogBundle\Model\ProductInterface;
 use Pim\Bundle\CatalogBundle\Model\ProductValueInterface;
 use Pim\Bundle\CatalogBundle\Query\Filter\Operators;
 use Pim\Bundle\CatalogBundle\Query\ProductQueryBuilderFactoryInterface;
 use Pim\Bundle\CatalogBundle\Repository\AttributeRepositoryInterface;
+use Pim\Bundle\CatalogBundle\Repository\GroupRepositoryInterface;
 use Pim\Bundle\CatalogBundle\Repository\ProductRepositoryInterface;
 use Pim\Component\ReferenceData\ConfigurationRegistryInterface;
 use Pim\Component\ReferenceData\Model\ConfigurationInterface;
@@ -41,6 +43,9 @@ class ProductRepository extends EntityRepository implements
     /** @var ConfigurationRegistryInterface */
     protected $referenceDataRegistry;
 
+    /** @var GroupRepositoryInterface */
+    protected $groupRepository;
+
     /**
      * {@inheritdoc}
      */
@@ -59,6 +64,20 @@ class ProductRepository extends EntityRepository implements
     public function setAttributeRepository(AttributeRepositoryInterface $attributeRepository)
     {
         $this->attributeRepository = $attributeRepository;
+
+        return $this;
+    }
+
+    /**
+     * Set group repository
+     *
+     * @param GroupRepositoryInterface $groupRepository
+     *
+     * @return ProductRepository
+     */
+    public function setGroupRepository(GroupRepositoryInterface $groupRepository)
+    {
+        $this->groupRepository = $groupRepository;
 
         return $this;
     }
@@ -592,6 +611,57 @@ class ProductRepository extends EntityRepository implements
             ->getSingleScalarResult();
 
         return $count;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasAttributeInFamily(ProductInterface $product, $attributeCode)
+    {
+        $query = $this->createQueryBuilder('p')
+            ->leftJoin('p.family', 'f')
+            ->leftJoin('f.attributes', 'a')
+            ->where('p.id = :id')
+            ->andWhere('a.code = :code')
+            ->setParameters([
+                'id'   => $product->getId(),
+                'code' => $attributeCode,
+            ])
+            ->setMaxResults(1)
+            ->getQuery();
+
+        return 0 < count($query->getScalarResult());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasAttributeInVariantGroup(ProductInterface $product, $attributeCode)
+    {
+        $query = $this->createQueryBuilder('p')
+            ->select('g.id')
+            ->leftJoin('p.groups', 'g')
+            ->where('p.id = :id')
+            ->setParameters([
+                'id' => $product->getId(),
+            ])
+            ->getQuery();
+
+        $groupIds = $query->getScalarResult();
+
+        $groupIds = array_reduce($groupIds,function($carry, $item) {
+            if (isset($item['id'])) {
+                $carry[] = $item['id'];
+            }
+
+            return $carry;
+        }, []);
+
+        if (0 === count($groupIds)) {
+            return false;
+        }
+
+        return $this->groupRepository->hasAttribute($groupIds, $attributeCode);
     }
 
     /**

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/ProductRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/ProductRepository.php
@@ -618,7 +618,7 @@ class ProductRepository extends EntityRepository implements
      */
     public function hasAttributeInFamily(ProductInterface $product, $attributeCode)
     {
-        $query = $this->createQueryBuilder('p')
+        $queryBuilder = $this->createQueryBuilder('p')
             ->leftJoin('p.family', 'f')
             ->leftJoin('f.attributes', 'a')
             ->where('p.id = :id')
@@ -627,10 +627,9 @@ class ProductRepository extends EntityRepository implements
                 'id'   => $product->getId(),
                 'code' => $attributeCode,
             ])
-            ->setMaxResults(1)
-            ->getQuery();
+            ->setMaxResults(1);
 
-        return 0 < count($query->getScalarResult());
+        return count($queryBuilder->getQuery()->getArrayResult()) > 0;
     }
 
     /**
@@ -638,18 +637,17 @@ class ProductRepository extends EntityRepository implements
      */
     public function hasAttributeInVariantGroup(ProductInterface $product, $attributeCode)
     {
-        $query = $this->createQueryBuilder('p')
+        $queryBuilder = $this->createQueryBuilder('p')
             ->select('g.id')
             ->leftJoin('p.groups', 'g')
             ->where('p.id = :id')
             ->setParameters([
                 'id' => $product->getId(),
-            ])
-            ->getQuery();
+            ]);
 
-        $groupIds = $query->getScalarResult();
+        $groupIds = $queryBuilder->getQuery()->getScalarResult();
 
-        $groupIds = array_reduce($groupIds,function($carry, $item) {
+        $groupIds = array_reduce($groupIds, function ($carry, $item) {
             if (isset($item['id'])) {
                 $carry[] = $item['id'];
             }

--- a/src/Pim/Bundle/CatalogBundle/Repository/FamilyRepositoryInterface.php
+++ b/src/Pim/Bundle/CatalogBundle/Repository/FamilyRepositoryInterface.php
@@ -79,4 +79,14 @@ interface FamilyRepositoryInterface extends
      * @return int
      */
     public function countAll();
+
+    /**
+     * Checks if a family has the attribute with specified code.
+     *
+     * @param int    $id
+     * @param string $attributeCode
+     *
+     * @return bool
+     */
+    public function hasAttribute($id, $attributeCode);
 }

--- a/src/Pim/Bundle/CatalogBundle/Repository/GroupRepositoryInterface.php
+++ b/src/Pim/Bundle/CatalogBundle/Repository/GroupRepositoryInterface.php
@@ -113,4 +113,13 @@ interface GroupRepositoryInterface extends IdentifiableObjectRepositoryInterface
      * @return GroupInterface|null
      */
     public function getVariantGroupByProductTemplate(ProductTemplateInterface $productTemplate);
+
+    /**
+     * Check if a group has the attribute with specified code
+     *
+     * @param array|int $id
+     * @param string $attributeCode
+     * @return bool
+     */
+    public function hasAttribute(array $id, $attributeCode);
 }

--- a/src/Pim/Bundle/CatalogBundle/Repository/GroupRepositoryInterface.php
+++ b/src/Pim/Bundle/CatalogBundle/Repository/GroupRepositoryInterface.php
@@ -117,8 +117,9 @@ interface GroupRepositoryInterface extends IdentifiableObjectRepositoryInterface
     /**
      * Check if a group has the attribute with specified code
      *
-     * @param array|int $id
+     * @param int[]  $id
      * @param string $attributeCode
+     *
      * @return bool
      */
     public function hasAttribute(array $id, $attributeCode);

--- a/src/Pim/Bundle/CatalogBundle/Repository/ProductRepositoryInterface.php
+++ b/src/Pim/Bundle/CatalogBundle/Repository/ProductRepositoryInterface.php
@@ -170,20 +170,20 @@ interface ProductRepositoryInterface
     /**
      * Checks if the family has the specified attribute
      *
-     * @param ProductInterface $product
-     * @param string           $attributeCode
+     * @param mixed  $productId
+     * @param string $attributeCode
      *
      * @return bool
      */
-    public function hasAttributeInFamily(ProductInterface $product, $attributeCode);
+    public function hasAttributeInFamily($productId, $attributeCode);
 
     /**
      * Checks if the group has the specified attribute
      *
-     * @param ProductInterface $product
-     * @param string           $attributeCode
+     * @param mixed  $productId
+     * @param string $attributeCode
      *
      * @return bool
      */
-    public function hasAttributeInVariantGroup(ProductInterface $product, $attributeCode);
+    public function hasAttributeInVariantGroup($productId, $attributeCode);
 }

--- a/src/Pim/Bundle/CatalogBundle/Repository/ProductRepositoryInterface.php
+++ b/src/Pim/Bundle/CatalogBundle/Repository/ProductRepositoryInterface.php
@@ -166,4 +166,24 @@ interface ProductRepositoryInterface
      * @return int
      */
     public function countAll();
+
+    /**
+     * Checks if the family has the specified attribute
+     *
+     * @param ProductInterface $product
+     * @param string           $attributeCode
+     *
+     * @return bool
+     */
+    public function hasAttributeInFamily(ProductInterface $product, $attributeCode);
+
+    /**
+     * Checks if the group has the specified attribute
+     *
+     * @param ProductInterface $product
+     * @param string           $attributeCode
+     *
+     * @return bool
+     */
+    public function hasAttributeInVariantGroup(ProductInterface $product, $attributeCode);
 }

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/storage_driver/doctrine/mongodb-odm.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/storage_driver/doctrine/mongodb-odm.yml
@@ -202,6 +202,7 @@ services:
             - [setAttributeRepository, ['@pim_catalog.repository.attribute']]
             - [setFamilyRepository, ['@pim_catalog.repository.family']]
             - [setCategoryRepository, ['@pim_catalog.repository.category']]
+            - [setGroupRepository, ['@pim_catalog.repository.group']]
         tags:
             - { name: 'pim_repository' }
 

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/storage_driver/doctrine/orm.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/storage_driver/doctrine/orm.yml
@@ -64,6 +64,7 @@ services:
         calls:
             - [setProductQueryBuilderFactory, ['@pim_catalog.query.product_query_builder_factory']]
             - [setAttributeRepository, ['@pim_catalog.repository.attribute']]
+            - [setGroupRepository, ['@pim_catalog.repository.group']]
             - [setReferenceDataRegistry, ['@?pim_reference_data.registry']]
         tags:
             - { name: 'pim_repository' }

--- a/src/Pim/Bundle/ConnectorBundle/JobLauncher/SimpleJobLauncher.php
+++ b/src/Pim/Bundle/ConnectorBundle/JobLauncher/SimpleJobLauncher.php
@@ -79,7 +79,7 @@ class SimpleJobLauncher extends BaseSimpleJobLauncher
             !empty($rawConfiguration) ? sprintf('--config="%s"', $rawConfiguration) : '',
             $this->rootDir
         );
-
+        
         $this->launchInBackground($cmd);
 
         return $jobExecution;

--- a/src/Pim/Bundle/EnrichBundle/Connector/Processor/MassEdit/Product/EditCommonAttributesProcessor.php
+++ b/src/Pim/Bundle/EnrichBundle/Connector/Processor/MassEdit/Product/EditCommonAttributesProcessor.php
@@ -78,7 +78,7 @@ class EditCommonAttributesProcessor extends AbstractProcessor
 
         if (!$this->isProductEditable($product)) {
             $this->stepExecution->incrementSummaryInfo('skipped_products');
-            $this->detachProduct($product);
+            $this->productDetacher->detach($product);
 
             return null;
         }
@@ -88,7 +88,7 @@ class EditCommonAttributesProcessor extends AbstractProcessor
         if (null !== $product) {
             if (!$this->isProductValid($product)) {
                 $this->stepExecution->incrementSummaryInfo('skipped_products');
-                $this->detachProduct($product);
+                $this->productDetacher->detach($product);
 
                 return null;
             }
@@ -157,7 +157,7 @@ class EditCommonAttributesProcessor extends AbstractProcessor
         if (empty($filteredValues)) {
             $this->stepExecution->incrementSummaryInfo('skipped_products');
             $this->addWarning($product);
-            $this->detachProduct($product);
+            $this->productDetacher->detach($product);
 
             return null;
         }
@@ -175,15 +175,15 @@ class EditCommonAttributesProcessor extends AbstractProcessor
      */
     protected function isAttributeEditable(ProductInterface $product, $attributeCode)
     {
-        if ($this->productRepository->hasAttributeInFamily($product, $attributeCode)) {
-            return true;
+        if (!$this->productRepository->hasAttributeInFamily($product, $attributeCode)) {
+            return false;
         }
 
         if ($this->productRepository->hasAttributeInVariantGroup($product, $attributeCode)) {
-            return true;
+            return false;
         }
 
-        return false;
+        return true;
     }
 
     /**
@@ -209,14 +209,6 @@ class EditCommonAttributesProcessor extends AbstractProcessor
     protected function isProductEditable(ProductInterface $product)
     {
         return true;
-    }
-
-    /**
-     * @param ProductInterface $product
-     */
-    protected function detachProduct(ProductInterface $product)
-    {
-        $this->productDetacher->detach($product);
     }
 
     /**

--- a/src/Pim/Bundle/EnrichBundle/Connector/Processor/MassEdit/Product/EditCommonAttributesProcessor.php
+++ b/src/Pim/Bundle/EnrichBundle/Connector/Processor/MassEdit/Product/EditCommonAttributesProcessor.php
@@ -175,11 +175,11 @@ class EditCommonAttributesProcessor extends AbstractProcessor
      */
     protected function isAttributeEditable(ProductInterface $product, $attributeCode)
     {
-        if (!$this->productRepository->hasAttributeInFamily($product, $attributeCode)) {
+        if (!$this->productRepository->hasAttributeInFamily($product->getId(), $attributeCode)) {
             return false;
         }
 
-        if ($this->productRepository->hasAttributeInVariantGroup($product, $attributeCode)) {
+        if ($this->productRepository->hasAttributeInVariantGroup($product->getId(), $attributeCode)) {
             return false;
         }
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/connector/processors.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/connector/processors.yml
@@ -26,10 +26,10 @@ services:
         arguments:
             - '@pim_catalog.updater.product_property_setter'
             - '@pim_catalog.validator.product'
-            - '@pim_catalog.repository.product_mass_action'
-            - '@pim_catalog.repository.attribute'
+            - '@pim_catalog.repository.product'
             - '@pim_connector.repository.job_configuration'
             - '@pim_catalog.updater.product'
+            - '@akeneo_storage_utils.doctrine.object_detacher'
 
     pim_enrich.connector.processor.mass_edit.family.set_requirements:
         class: %pim_enrich.connector.processor.mass_edit.family.set_requirements.class%


### PR DESCRIPTION
| Q                    | A
| ----------------- | ---
| Specs             | Yes
| Behats            | No
| Blue CI            | TODO
| Changelog updated | No
| Review and 2 GTM  | No

The EditCommonAttributesProcessor has been rewored. Now the skipped products are detached from the UnitOfWork. Some methods are not directly on the product model because it hydrates lot of models and it causes memory leak...