### PR TITLE
[TR] Report page to ease support qualification

### DIFF
--- a/spec/Akeneo/Component/Analytics/ChainedDataCollectorSpec.php
+++ b/spec/Akeneo/Component/Analytics/ChainedDataCollectorSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Akeneo\Component\Analytics;
 
+use Akeneo\Component\Analytics\ChainedDataCollector;
 use Akeneo\Component\Analytics\DataCollectorInterface;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
@@ -11,24 +12,26 @@ class ChainedDataCollectorSpec extends ObjectBehavior
     function it_is_initializable()
     {
         $this->shouldHaveType('Akeneo\Component\Analytics\ChainedDataCollector');
-        $this->shouldHaveType('Akeneo\Component\Analytics\ChainedDataCollectorInterface');
-        $this->shouldHaveType('Akeneo\Component\Analytics\DataCollectorInterface');
-    }
-
-    function it_collects()
-    {
-        $this->collect()->shouldReturn([]);
     }
 
     function it_aggregates_data_from_registered_collectors(
         DataCollectorInterface $collectorOne,
-        DataCollectorInterface $collectorTwo
+        DataCollectorInterface $collectorTwo,
+        DataCollectorInterface $collectorThree,
+        DataCollectorInterface $defaultTypeCollector
     ) {
         $collectorOne->collect()->willReturn(['data_one' => 'one']);
         $collectorTwo->collect()->willReturn(['data_two' => 'two', 'data_three' => 'three']);
+        $collectorThree->collect()->willReturn(['data_four' => 'four']);
+        $defaultTypeCollector->collect()->willReturn(['data_five' => 'five']);
 
-        $this->addCollector($collectorOne);
-        $this->addCollector($collectorTwo);
-        $this->collect()->shouldReturn(['data_one' => 'one', 'data_two' => 'two', 'data_three' => 'three']);
+        $this->addCollector($collectorOne, 'type1');
+        $this->addCollector($collectorTwo, 'type2');
+        $this->addCollector($collectorThree, 'type2');
+        $this->addCollector($defaultTypeCollector);
+
+        $this->collect('type1')->shouldReturn(['data_one' => 'one']);
+        $this->collect('type2')->shouldReturn(['data_two' => 'two', 'data_three' => 'three', 'data_four' => 'four']);
+        $this->collect(ChainedDataCollector::DEFAULT_COLLECTOR_TYPE)->shouldReturn(['data_five' => 'five']);
     }
 }

--- a/spec/Pim/Bundle/AnalyticsBundle/Controller/DataControllerSpec.php
+++ b/spec/Pim/Bundle/AnalyticsBundle/Controller/DataControllerSpec.php
@@ -2,13 +2,13 @@
 
 namespace spec\Pim\Bundle\AnalyticsBundle\Controller;
 
-use Akeneo\Component\Analytics\DataCollectorInterface;
+use Akeneo\Component\Analytics\ChainedDataCollector;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
 class DataControllerSpec extends ObjectBehavior
 {
-    function let(DataCollectorInterface $dataCollector)
+    function let(ChainedDataCollector $dataCollector)
     {
         $this->beConstructedWith($dataCollector);
     }
@@ -20,7 +20,7 @@ class DataControllerSpec extends ObjectBehavior
 
     function it_collects_data($dataCollector)
     {
-        $dataCollector->collect()->shouldBeCalled();
+        $dataCollector->collect('update_checker')->shouldBeCalled();
 
         $this->collectAction()->shouldReturnAnInstanceOf('Symfony\Component\HttpFoundation\Response');
     }

--- a/spec/Pim/Bundle/AnalyticsBundle/DataCollector/BundlesDataCollectorSpec.php
+++ b/spec/Pim/Bundle/AnalyticsBundle/DataCollector/BundlesDataCollectorSpec.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace spec\Pim\Bundle\AnalyticsBundle\DataCollector;
+
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\CatalogBundle\VersionProviderInterface;
+use Prophecy\Argument;
+
+class BundlesDataCollectorSpec extends ObjectBehavior
+{
+    function let()
+    {
+        $this->beConstructedWith(
+            [
+                'Pim\Bundle\A',
+                'Pim\Bundle\C',
+                'Pim\Bundle\B'
+            ]
+        );
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Pim\Bundle\AnalyticsBundle\DataCollector\BundlesDataCollector');
+        $this->shouldHaveType('Akeneo\Component\Analytics\DataCollectorInterface');
+    }
+
+    function it_collects_registered_bundles()
+    {
+        $this->collect()->shouldReturn(
+            [
+                'registered_bundles' => [
+                    'Pim\Bundle\A',
+                    'Pim\Bundle\B',
+                    'Pim\Bundle\C'
+                ]
+            ]
+        );
+    }
+}

--- a/src/Akeneo/Component/Analytics/ChainedDataCollector.php
+++ b/src/Akeneo/Component/Analytics/ChainedDataCollector.php
@@ -2,9 +2,6 @@
 
 namespace Akeneo\Component\Analytics;
 
-use Akeneo\Component\Analytics\ChainedDataCollectorInterface;
-use Akeneo\Component\Analytics\DataCollectorInterface;
-
 /**
  * Aggregate data collected by registered collectors
  *
@@ -12,28 +9,34 @@ use Akeneo\Component\Analytics\DataCollectorInterface;
  * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class ChainedDataCollector implements ChainedDataCollectorInterface
+class ChainedDataCollector
 {
-    /** @var DataCollectorInterface[] */
+    const DEFAULT_COLLECTOR_TYPE = 'default';
+
+    /** @var DataCollectorInterface[][] */
     protected $collectors = [];
 
     /**
-     * {@inheritdoc}
+     * @param DataCollectorInterface $collector
+     * @param string                 $type
      */
-    public function addCollector(DataCollectorInterface $collector)
+    public function addCollector(DataCollectorInterface $collector, $type = self::DEFAULT_COLLECTOR_TYPE)
     {
-        $this->collectors[] = $collector;
+        $this->collectors[$type][] = $collector;
     }
 
     /**
-     * {@inheritdoc}
+     * Collect aggregated data from collectors of the specified type.
+     *
+     * @param string $type
+     *
+     * @return array
      */
-    public function collect()
+    public function collect($type)
     {
         $aggregatedData = [];
-        foreach ($this->collectors as $collector) {
-            $collectedData  = $collector->collect();
-            $aggregatedData = $aggregatedData + $collectedData;
+        foreach ($this->collectors[$type] as $collector) {
+            $aggregatedData += $collector->collect();
         }
 
         return $aggregatedData;

--- a/src/Akeneo/Component/Analytics/ChainedDataCollectorInterface.php
+++ b/src/Akeneo/Component/Analytics/ChainedDataCollectorInterface.php
@@ -8,6 +8,8 @@ namespace Akeneo\Component\Analytics;
  * @author    Nicolas Dupont <nicolas@akeneo.com>
  * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *
+ * @deprecated Will be removed in 1.5, please use directly Akeneo\Component\Analytics\ChainedDataCollector
  */
 interface ChainedDataCollectorInterface extends DataCollectorInterface
 {

--- a/src/Pim/Bundle/AnalyticsBundle/Controller/DataController.php
+++ b/src/Pim/Bundle/AnalyticsBundle/Controller/DataController.php
@@ -2,7 +2,7 @@
 
 namespace Pim\Bundle\AnalyticsBundle\Controller;
 
-use Akeneo\Component\Analytics\DataCollectorInterface;
+use Akeneo\Component\Analytics\ChainedDataCollector;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
 /**
@@ -14,13 +14,13 @@ use Symfony\Component\HttpFoundation\JsonResponse;
  */
 class DataController
 {
-    /** @var DataCollectorInterface */
+    /** @var ChainedDataCollector */
     protected $dataCollector;
 
     /**
-     * @param DataCollectorInterface $dataCollector
+     * @param ChainedDataCollector $dataCollector
      */
-    public function __construct(DataCollectorInterface $dataCollector)
+    public function __construct(ChainedDataCollector $dataCollector)
     {
         $this->dataCollector = $dataCollector;
     }
@@ -32,7 +32,7 @@ class DataController
      */
     public function collectAction()
     {
-        $data = $this->dataCollector->collect();
+        $data = $this->dataCollector->collect('update_checker');
 
         return new JsonResponse($data);
     }

--- a/src/Pim/Bundle/AnalyticsBundle/Controller/SystemInfoController.php
+++ b/src/Pim/Bundle/AnalyticsBundle/Controller/SystemInfoController.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Pim\Bundle\AnalyticsBundle\Controller;
+
+use Akeneo\Component\Analytics\ChainedDataCollector;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+
+/**
+ * System info controller
+ *
+ * @author    Yohan Blain <yohan.blain@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class SystemInfoController
+{
+    /**
+     * @param EngineInterface      $templating
+     * @param ChainedDataCollector $dataCollector
+     */
+    public function __construct(EngineInterface $templating, ChainedDataCollector $dataCollector)
+    {
+        $this->templating    = $templating;
+        $this->dataCollector = $dataCollector;
+    }
+
+    /**
+     * @param string $_format
+     *
+     * @return Response
+     */
+    public function indexAction($_format)
+    {
+        $data    = $this->dataCollector->collect('system_info_report');
+        $content = $this->templating->render(
+            sprintf('PimAnalyticsBundle:SystemInfo:index.%s.twig', $_format),
+            ['data' => $data]
+        );
+
+        $response = new Response($content);
+        if ('txt' === $_format) {
+            $response->headers->set('Content-Type', 'text/plain');
+            $response->headers->set('Content-Disposition', sprintf(
+                '%s; filename="akeneo-pim-system-info_%s.txt"',
+                ResponseHeaderBag::DISPOSITION_ATTACHMENT,
+                date('Y-m-d_H:i')
+            ));
+        }
+
+        return $response;
+    }
+}

--- a/src/Pim/Bundle/AnalyticsBundle/DataCollector/BundlesDataCollector.php
+++ b/src/Pim/Bundle/AnalyticsBundle/DataCollector/BundlesDataCollector.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Pim\Bundle\AnalyticsBundle\DataCollector;
+
+use Akeneo\Component\Analytics\DataCollectorInterface;
+
+/**
+ * Class BundlesDataCollector
+ *
+ * @author    Yohan Blain <yohan.blain@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class BundlesDataCollector implements DataCollectorInterface
+{
+    /** @var array */
+    protected $bundles;
+
+    /**
+     * @param array $bundles
+     */
+    public function __construct(array $bundles)
+    {
+        $this->bundles = $bundles;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * Collect the list of registered bundles
+     */
+    public function collect()
+    {
+        $bundles = $this->bundles;
+        natsort($bundles);
+
+        return ['registered_bundles' => array_values($bundles)];
+    }
+}

--- a/src/Pim/Bundle/AnalyticsBundle/DependencyInjection/Compiler/RegisterDataCollectorPass.php
+++ b/src/Pim/Bundle/AnalyticsBundle/DependencyInjection/Compiler/RegisterDataCollectorPass.php
@@ -15,10 +15,7 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class RegisterDataCollectorPass implements CompilerPassInterface
 {
-    /** @staticvar string The registry service id */
-    const REGISTRY_ID = 'pim_analytics.data_collector.chained';
-
-    /** @staticvar string */
+    const REGISTRY_ID   = 'pim_analytics.data_collector.chained';
     const COLLECTOR_TAG = 'pim_analytics.data_collector';
 
     /**
@@ -32,13 +29,16 @@ class RegisterDataCollectorPass implements CompilerPassInterface
 
         $registryDefinition = $container->getDefinition(static::REGISTRY_ID);
         $services = $container->findTaggedServiceIds(static::COLLECTOR_TAG);
-        foreach (array_keys($services) as $serviceId) {
-            $registryDefinition->addMethodCall(
-                'addCollector',
-                [
-                    new Reference($serviceId)
-                ]
-            );
+        foreach ($services as $serviceId => $tags) {
+            foreach ($tags as $tag) {
+                $registryDefinition->addMethodCall(
+                    'addCollector',
+                    [
+                        new Reference($serviceId),
+                        $tag['type']
+                    ]
+                );
+            }
         }
     }
 }

--- a/src/Pim/Bundle/AnalyticsBundle/Resources/config/acl.yml
+++ b/src/Pim/Bundle/AnalyticsBundle/Resources/config/acl.yml
@@ -1,0 +1,4 @@
+pim_analytics_system_info_index:
+    type: action
+    label: pim_analytics.acl.system_info.index
+    group_name: pim_analytics.acl_group.system_info

--- a/src/Pim/Bundle/AnalyticsBundle/Resources/config/controllers.yml
+++ b/src/Pim/Bundle/AnalyticsBundle/Resources/config/controllers.yml
@@ -1,8 +1,15 @@
 parameters:
     pim_analytics.controller.data.class: Pim\Bundle\AnalyticsBundle\Controller\DataController
+    pim_analytics.controller.system_info.class: Pim\Bundle\AnalyticsBundle\Controller\SystemInfoController
 
 services:
     pim_analytics.controller.data:
         class: %pim_analytics.controller.data.class%
         arguments:
+            - '@pim_analytics.data_collector.chained'
+
+    pim_analytics.controller.system_info:
+        class: %pim_analytics.controller.system_info.class%
+        arguments:
+            - '@templating'
             - '@pim_analytics.data_collector.chained'

--- a/src/Pim/Bundle/AnalyticsBundle/Resources/config/data_collectors.yml
+++ b/src/Pim/Bundle/AnalyticsBundle/Resources/config/data_collectors.yml
@@ -5,6 +5,7 @@ parameters:
     pim_analytics.data_collector.operating_system.class: Pim\Bundle\AnalyticsBundle\DataCollector\OSDataCollector
     pim_analytics.data_collector.version.class:          Pim\Bundle\AnalyticsBundle\DataCollector\VersionDataCollector
     pim_analytics.data_collector.database.class:         Pim\Bundle\AnalyticsBundle\DataCollector\DBDataCollector
+    pim_analytics.data_collector.bundles.class:          Pim\Bundle\AnalyticsBundle\DataCollector\BundlesDataCollector
 
 services:
     pim_analytics.data_collector.chained:
@@ -51,3 +52,10 @@ services:
             - '@pim_user.repository.user'
         tags:
             - { name: pim_analytics.data_collector, type: update_checker }
+
+    pim_analytics.data_collector.bundles:
+        class: %pim_analytics.data_collector.bundles.class%
+        arguments:
+            - '%kernel.bundles%'
+        tags:
+            - { name: pim_analytics.data_collector, type: system_info_report }

--- a/src/Pim/Bundle/AnalyticsBundle/Resources/config/data_collectors.yml
+++ b/src/Pim/Bundle/AnalyticsBundle/Resources/config/data_collectors.yml
@@ -15,19 +15,19 @@ services:
         arguments:
             - '@request_stack'
         tags:
-            - { name: pim_analytics.data_collector }
+            - { name: pim_analytics.data_collector, type: update_checker }
 
     pim_analytics.data_collector.token_storage:
         class: %pim_analytics.data_collector.token_storage.class%
         arguments:
             - '@security.token_storage'
         tags:
-            - { name: pim_analytics.data_collector }
+            - { name: pim_analytics.data_collector, type: update_checker }
 
     pim_analytics.data_collector.operating_system:
         class: %pim_analytics.data_collector.operating_system.class%
         tags:
-            - { name: pim_analytics.data_collector }
+            - { name: pim_analytics.data_collector, type: update_checker }
 
     pim_analytics.data_collector.version:
         class: %pim_analytics.data_collector.version.class%
@@ -37,7 +37,8 @@ services:
             - '%kernel.environment%'
             - '%installed%'
         tags:
-            - { name: pim_analytics.data_collector }
+            - { name: pim_analytics.data_collector, type: update_checker }
+            - { name: pim_analytics.data_collector, type: system_info_report }
 
     pim_analytics.data_collector.database:
         class: %pim_analytics.data_collector.database.class%
@@ -49,4 +50,4 @@ services:
             - '@pim_catalog.repository.family'
             - '@pim_user.repository.user'
         tags:
-            - { name: pim_analytics.data_collector }
+            - { name: pim_analytics.data_collector, type: update_checker }

--- a/src/Pim/Bundle/AnalyticsBundle/Resources/config/navigation.yml
+++ b/src/Pim/Bundle/AnalyticsBundle/Resources/config/navigation.yml
@@ -1,0 +1,18 @@
+oro_menu_config:
+    items:
+        pim_analytics_system_info:
+            label: pim_menu.item.system_info
+            route: pim_analytics_system_info_index
+            aclResourceId: pim_analytics_system_info_index
+            extras:
+                routes: ['pim_analytics_system_info_index']
+
+    tree:
+        application_menu:
+            children:
+                system_tab:
+                    children:
+                        pim_analytics_system_info: ~
+
+oro_titles:
+    pim_analytics_system_info_index: pim_analytics.system_info.title

--- a/src/Pim/Bundle/AnalyticsBundle/Resources/config/routing.yml
+++ b/src/Pim/Bundle/AnalyticsBundle/Resources/config/routing.yml
@@ -1,3 +1,11 @@
 pim_analytics_data_collect:
     path: /analytics/collect_data
     defaults: { _controller: pim_analytics.controller.data:collectAction, _format: json }
+
+pim_analytics_system_info_index:
+    path: /system_info
+    defaults: { _controller: pim_analytics.controller.system_info:indexAction, _format: html }
+
+pim_analytics_system_info_download:
+    path: /system_info/download
+    defaults: { _controller: pim_analytics.controller.system_info:indexAction, _format: txt }

--- a/src/Pim/Bundle/AnalyticsBundle/Resources/translations/messages.en.yml
+++ b/src/Pim/Bundle/AnalyticsBundle/Resources/translations/messages.en.yml
@@ -7,3 +7,23 @@ pim_analytics:
         form:
             version_update.label: New versions notifications
             version_update.tooltip: Send request to a distant server to retrieve information about the release of new patchs
+
+    system_info:
+        title: System information
+        download: TXT
+
+    info_type:
+        pim_edition: Edition
+        pim_version: Version
+        pim_storage_driver: Storage
+        pim_environment: Environment
+        pim_install_time: Install time
+        registered_bundles: Registered bundles
+
+    acl:
+        system_info:
+            index: System information
+
+pim_menu:
+    item:
+        system_info: System information

--- a/src/Pim/Bundle/AnalyticsBundle/Resources/views/SystemInfo/index.html.twig
+++ b/src/Pim/Bundle/AnalyticsBundle/Resources/views/SystemInfo/index.html.twig
@@ -1,0 +1,29 @@
+{% extends 'PimEnrichBundle::layout.html.twig' %}
+
+{% block content %}
+    {% set buttons %}
+        <a href="{{ path('pim_analytics_system_info_download') }}" class="btn no-hash btn-download">
+            <i class="icon-download-alt"></i>
+            {{ 'pim_analytics.system_info.download'|trans }}
+        </a>
+    {% endset %}
+
+    {{ elements.page_header('pim_analytics.system_info.title'|trans, buttons) }}
+
+    <div class="row-fluid tab-content">
+        <table class="table">
+            {% for infoType,info in data %}
+                <tr>
+                    <th>{{ ('pim_analytics.info_type.' ~ infoType)|trans }}</th>
+                    <td>
+                        {% if info is iterable %}
+                            {{ infoRow|join('<br>') }}
+                        {% else %}
+                            {{ info }}
+                        {% endif %}
+                    </td>
+                </tr>
+            {% endfor %}
+        </table>
+    </div>
+{% endblock %}

--- a/src/Pim/Bundle/AnalyticsBundle/Resources/views/SystemInfo/index.txt.twig
+++ b/src/Pim/Bundle/AnalyticsBundle/Resources/views/SystemInfo/index.txt.twig
@@ -1,0 +1,11 @@
+{% for infoType,info in data %}
+[{{ ('pim_analytics.info_type.' ~ infoType)|trans }}]
+{% if info is iterable %}
+{% for infoRow in info %}
+{{ infoRow }}
+{% endfor %}
+{% else %}
+{{ info }}
+{% endif %}
+
+{% endfor %}


### PR DESCRIPTION
A new page mainly designed to ease the qualification by the Super Squirrels Support Squad. It displays basic information about the current PIM instance :

![system information](https://cloud.githubusercontent.com/assets/659491/12975371/4a7bc81c-d0bb-11e5-8f0f-8e7b1c6ab6cb.png)

User can also download a plain text version to join it to a SDS ticket for example :
```
[Edition]
EE

[Version]
1.4.18

[Storage]
doctrine/mongodb-odm

[Environment]
dev

[Install time]
2016-02-10T14:19:23+01:00

[Registered bundles]
APY\JsFormValidationBundle\APYJsFormValidationBundle
AcmeEnterprise\Bundle\AppBundle\AcmeEnterpriseAppBundle
Akeneo\Bundle\BatchBundle\AkeneoBatchBundle
...
```

Content is extensible since it uses the data collectors system @nidup made for stats about PIM usage.