### PR TITLE
[WIP] PIM-5040 : disable currency

### DIFF
--- a/features/export/export_products_with_prices.feature
+++ b/features/export/export_products_with_prices.feature
@@ -1,0 +1,49 @@
+Feature: Deactivate a currency
+  In order to use the enriched product data
+  As a product manager
+  I need to be able to deactivate a currency
+
+  Background:
+    Given a "footwear" catalog configuration
+    And the following job "footwear_product_export" configuration:
+      | filePath | %tmp%/product_export/product_export.csv |
+    And the following products:
+      | sku      | family   | categories        | price          | size | color | name-en_US |
+      | SNKRS-1B | sneakers | summer_collection | 50 EUR, 70 USD | 45   | black | Sneakers   |
+    And I am logged in as "Julia"
+    When I am on the "tablet" channel page
+    And I change the Currencies to "EUR"
+    Then I save the channel
+    When I am on the currencies page
+    And I filter by "Activated" with value "yes"
+    Then I deactivate the USD currency
+
+  @javascript
+  Scenario: Do not export prices with disable currency
+    Given I am on the "footwear_product_export" export job page
+    And I launch the export job
+    And I wait for the "footwear_product_export" job to finish
+    Then exported file of "footwear_product_export" should contain:
+    """
+    sku;categories;color;description-en_US-mobile;enabled;family;groups;lace_color;manufacturer;name-en_US;price-EUR;rating;side_view;size;top_view;weather_conditions
+    SNKRS-1B;summer_collection;black;;1;sneakers;;;;Sneakers;50.00;;;45;;
+    """
+
+  @javascript
+  Scenario: Do not export prices with disable currency in quick export
+    Given I am on the products page
+    And I select rows SNKRS-1B
+    Then I press "CSV (All attributes)" on the "Quick Export" dropdown button
+    And I wait for the quick export to finish
+    Then exported file of "csv_product_quick_export" should contain:
+    """
+    sku;categories;color;description-en_US-tablet;enabled;family;groups;lace_color;manufacturer;name-en_US;price-EUR;rating;side_view;size;top_view;weather_conditions
+    SNKRS-1B;summer_collection;black;;1;sneakers;;;;Sneakers;50.00;;;45;;
+    """
+
+  @javascript
+  Scenario: Do not show disable currency in the PEF
+    Given I am on the "SNKRS-1B" product page
+    And I visit the "Marketing" group
+    Then I should see the Price in EUR fields
+    But I should not see the Price in USD fields

--- a/features/product/disable_currency.feature
+++ b/features/product/disable_currency.feature
@@ -1,0 +1,25 @@
+Feature: Deactivate a currency and edit a product
+  In order to use the enriched product data
+  As a product manager
+  I need to be able to deactivate a currency
+
+  Background:
+    Given a "footwear" catalog configuration
+    And the following products:
+      | sku      | family   | categories        | price          | size | color | name-en_US |
+      | Sneakers | sneakers | summer_collection | 50 EUR, 70 USD | 45   | black | Sneakers   |
+    And I am logged in as "Julia"
+    When I am on the "tablet" channel page
+    And I change the Currencies to "EUR"
+    Then I save the channel
+    When I am on the currencies page
+    And I filter by "Activated" with value "yes"
+    Then I deactivate the USD currency
+
+  @javascript
+  Scenario: Can edit product with disable currency
+    Given I am on the "Sneakers" product page
+    And I visit the "Marketing" group
+    Then I should not see the text "USD"
+    When I save the product
+    Then I should see the text "Product successfully updated"

--- a/spec/Pim/Bundle/CatalogBundle/Filter/ProductValueCurrencyFilterSpec.php
+++ b/spec/Pim/Bundle/CatalogBundle/Filter/ProductValueCurrencyFilterSpec.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace spec\Pim\Bundle\CatalogBundle\Filter;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\CatalogBundle\Model\ProductPrice;
+use Pim\Bundle\CatalogBundle\Model\ProductValueInterface;
+
+class ProductValueCurrencyFilterSpec extends ObjectBehavior
+{
+    public function it_filters_a_product_value_if_it_is_not_in_currency_option(
+        ProductValueInterface $price
+    ) {
+
+        $priceAttributeEur = new ProductPrice(111, 'EUR');
+        $priceAttributeUsd = new ProductPrice(666, 'USD');
+
+        $price->getPrices()->willReturn(new ArrayCollection([
+            $priceAttributeEur,
+            $priceAttributeUsd
+        ]));
+
+        $price->removePrice($priceAttributeEur)->shouldNotBeCalled();
+        $price->removePrice($priceAttributeUsd)->shouldBeCalled();
+
+        $options = [
+            'currencies' => ['EUR']
+        ];
+        $this->filterObject($price, 'pim.internal_api.product_value.view', $options)->shouldReturn(false);
+    }
+
+    public function it_filters_a_product_value_if_empty_currency_option(
+        ProductValueInterface $price
+    ) {
+
+        $priceAttributeEur = new ProductPrice(111, 'EUR');
+        $priceAttributeUsd = new ProductPrice(666, 'USD');
+
+        $price->getPrices()->willReturn(new ArrayCollection([
+            $priceAttributeEur,
+            $priceAttributeUsd
+        ]));
+
+        $price->removePrice($priceAttributeEur)->shouldBeCalled();
+        $price->removePrice($priceAttributeUsd)->shouldBeCalled();
+
+        $options = [];
+        $this->filterObject($price, 'pim.internal_api.product_value.view', $options)->shouldReturn(false);
+    }
+
+    public function it_fails_if_it_is_not_a_product_value(\StdClass $anOtherObject)
+    {
+        $this->shouldThrow('\LogicException')
+            ->during(
+                'filterObject',
+                [
+                    $anOtherObject,
+                    'pim.internal_api.product_value.view',
+                    []
+                ]
+            );
+    }
+}

--- a/spec/Pim/Bundle/EnrichBundle/Connector/Processor/MassEdit/Product/EditCommonAttributesProcessorSpec.php
+++ b/spec/Pim/Bundle/EnrichBundle/Connector/Processor/MassEdit/Product/EditCommonAttributesProcessorSpec.php
@@ -7,9 +7,11 @@ use Akeneo\Bundle\BatchBundle\Entity\StepExecution;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Akeneo\Component\StorageUtils\Updater\PropertySetterInterface;
 use PhpSpec\ObjectBehavior;
+use Pim\Bundle\CatalogBundle\Filter\CollectionFilterInterface;
 use Pim\Bundle\CatalogBundle\Model\AttributeInterface;
 use Pim\Bundle\CatalogBundle\Model\ProductInterface;
 use Pim\Bundle\CatalogBundle\Repository\AttributeRepositoryInterface;
+use Pim\Bundle\CatalogBundle\Repository\CurrencyRepositoryInterface;
 use Pim\Bundle\CatalogBundle\Repository\ProductMassActionRepositoryInterface;
 use Pim\Component\Connector\Model\JobConfigurationInterface;
 use Pim\Component\Connector\Repository\JobConfigurationRepositoryInterface;
@@ -27,7 +29,9 @@ class EditCommonAttributesProcessorSpec extends ObjectBehavior
         ProductMassActionRepositoryInterface $massActionRepository,
         AttributeRepositoryInterface $attributeRepository,
         JobConfigurationRepositoryInterface $jobConfigurationRepo,
-        ObjectUpdaterInterface $productUpdater
+        ObjectUpdaterInterface $productUpdater,
+        CollectionFilterInterface $objectFilter,
+        CurrencyRepositoryInterface $currencyRepository
     ) {
         $this->beConstructedWith(
             $propertySetter,
@@ -35,7 +39,9 @@ class EditCommonAttributesProcessorSpec extends ObjectBehavior
             $massActionRepository,
             $attributeRepository,
             $jobConfigurationRepo,
-            $productUpdater
+            $productUpdater,
+            $objectFilter,
+            $currencyRepository
         );
     }
 
@@ -99,6 +105,9 @@ class EditCommonAttributesProcessorSpec extends ObjectBehavior
 
         $attributeRepository->findOneByIdentifier('categories')->willReturn($attribute);
         $product->isAttributeEditable($attribute)->willReturn(false);
+
+        $product->getValues()->willReturn([]);
+
         $productUpdater->update($product, Argument::any())->shouldNotBeCalled();
 
         $this->process($product)->shouldReturn(null);
@@ -148,6 +157,9 @@ class EditCommonAttributesProcessorSpec extends ObjectBehavior
 
         $attributeRepository->findOneByIdentifier('categories')->willReturn($attribute);
         $product->isAttributeEditable($attribute)->willReturn(true);
+
+        $product->getValues()->willReturn([]);
+
         $productUpdater->update($product, $values)->shouldBeCalled();
 
         $this->process($product);
@@ -199,6 +211,7 @@ class EditCommonAttributesProcessorSpec extends ObjectBehavior
 
         $attributeRepository->findOneByIdentifier('categories')->willReturn($attribute);
         $product->isAttributeEditable($attribute)->willReturn(true);
+        $product->getValues()->willReturn([]);
 
         $productUpdater->update($product, $values)->shouldBeCalled();
         $this->setStepExecution($stepExecution);

--- a/src/Pim/Bundle/CatalogBundle/Filter/ProductValueCurrencyFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Filter/ProductValueCurrencyFilter.php
@@ -11,7 +11,7 @@ use Pim\Bundle\CatalogBundle\Model\ProductValueInterface;
  * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class ProductValueCurrencyFilter extends AbstractFilter implements CollectionFilterInterface, ObjectFilterInterface
+class ProductValueCurrencyFilter extends AbstractFilter implements ObjectFilterInterface
 {
     /**
      * {@inheritdoc}

--- a/src/Pim/Bundle/CatalogBundle/Filter/ProductValueCurrencyFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Filter/ProductValueCurrencyFilter.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\Filter;
+
+use Pim\Bundle\CatalogBundle\Model\ProductValueInterface;
+
+/**
+ * Filter the product values according to currency codes provided in options.
+ *
+ * @author    Marie Bochu <marie.bochu@akeneo.com>
+ * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ProductValueCurrencyFilter extends AbstractFilter implements CollectionFilterInterface, ObjectFilterInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function filterObject($productValue, $type, array $options = [])
+    {
+        if (!$productValue instanceof ProductValueInterface) {
+            throw new \LogicException('This filter only handles objects of type "ProductValueInterface"');
+        }
+
+        $currencies = isset($options['currencies']) ? $options['currencies'] : [];
+        $prices     = $productValue->getPrices();
+
+        if (0 === $prices->count()) {
+            return false;
+        }
+
+        foreach ($prices as $price) {
+            if (!in_array($price->getCurrency(), $currencies)) {
+                $productValue->removePrice($price);
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/filters.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/filters.yml
@@ -2,6 +2,7 @@ parameters:
     pim_catalog.filter.chained.class:                        Pim\Bundle\CatalogBundle\Filter\ChainedFilter
     pim_enrich.filter.product_value.locale.class:            Pim\Bundle\CatalogBundle\Filter\ProductValueLocaleFilter
     pim_enrich.filter.product_value.channel.class:           Pim\Bundle\CatalogBundle\Filter\ProductValueChannelFilter
+    pim_enrich.filter.product_value.currency.class:          Pim\Bundle\CatalogBundle\Filter\ProductValueCurrencyFilter
     pim_catalog.comparator.filter.product.class:             Pim\Component\Catalog\Comparator\Filter\ProductFilter
     pim_catalog.comparator.filter.product_association.class: Pim\Component\Catalog\Comparator\Filter\ProductAssociationFilter
 
@@ -22,6 +23,11 @@ services:
             - { name: pim_catalog.filter.collection, type: pim.transform.product_value.flat }
             - { name: pim_catalog.filter.collection, type: pim.transform.product_value.structured }
             - { name: pim_catalog.filter.collection, type: pim.external_api.product.view }
+
+    pim_enrich.filter.product_value.currency:
+        class: %pim_enrich.filter.product_value.currency.class%
+        tags:
+            - { name: pim_catalog.filter.collection, type: pim.internal_api.product_value.view }
 
     pim_catalog.comparator.filter.product:
         class: %pim_catalog.comparator.filter.product.class%

--- a/src/Pim/Bundle/EnrichBundle/Connector/Processor/MassEdit/Product/EditCommonAttributesProcessor.php
+++ b/src/Pim/Bundle/EnrichBundle/Connector/Processor/MassEdit/Product/EditCommonAttributesProcessor.php
@@ -51,7 +51,7 @@ class EditCommonAttributesProcessor extends AbstractProcessor
      * @param AttributeRepositoryInterface         $attributeRepository
      * @param JobConfigurationRepositoryInterface  $jobConfigurationRepo
      * @param ObjectUpdaterInterface               $productUpdater
-     * @param CollectionFilterInterface                $objectFilter
+     * @param CollectionFilterInterface            $objectFilter
      * @param CurrencyRepositoryInterface          $currencyRepository
      */
     public function __construct(

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/ProductController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/ProductController.php
@@ -55,7 +55,7 @@ class ProductController
     /** @var UserContext */
     protected $userContext;
 
-    /** @var ObjectFilterInterface */
+    /** @var ObjectFilterInterface | CollectionFilterInterface */
     protected $objectFilter;
 
     /** @var CollectionFilterInterface */
@@ -96,7 +96,7 @@ class ProductController
         CollectionFilterInterface $productEditDataFilter,
         RemoverInterface $productRemover,
         ProductBuilderInterface $productBuilder,
-        CurrencyRepositoryInterface $currencyRepository = null
+        CurrencyRepositoryInterface $currencyRepository
     ) {
         $this->productRepository     = $productRepository;
         $this->attributeRepository   = $attributeRepository;

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/ProductController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/ProductController.php
@@ -13,6 +13,7 @@ use Pim\Bundle\CatalogBundle\Filter\ObjectFilterInterface;
 use Pim\Bundle\CatalogBundle\Model\AttributeInterface;
 use Pim\Bundle\CatalogBundle\Model\ProductInterface;
 use Pim\Bundle\CatalogBundle\Repository\AttributeRepositoryInterface;
+use Pim\Bundle\CatalogBundle\Repository\CurrencyRepositoryInterface;
 use Pim\Bundle\CatalogBundle\Repository\ProductRepositoryInterface;
 use Pim\Bundle\UserBundle\Context\UserContext;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
@@ -66,6 +67,9 @@ class ProductController
     /** @var ProductBuilderInterface */
     protected $productBuilder;
 
+    /** @var CurrencyRepositoryInterface */
+    protected $currencyRepository;
+
     /**
      * @param ProductRepositoryInterface   $productRepository
      * @param AttributeRepositoryInterface $attributeRepository
@@ -78,6 +82,7 @@ class ProductController
      * @param CollectionFilterInterface    $productEditDataFilter
      * @param RemoverInterface             $productRemover
      * @param ProductBuilderInterface      $productBuilder
+     * @param CurrencyRepositoryInterface  $currencyRepository
      */
     public function __construct(
         ProductRepositoryInterface $productRepository,
@@ -90,7 +95,8 @@ class ProductController
         ObjectFilterInterface $objectFilter,
         CollectionFilterInterface $productEditDataFilter,
         RemoverInterface $productRemover,
-        ProductBuilderInterface $productBuilder
+        ProductBuilderInterface $productBuilder,
+        CurrencyRepositoryInterface $currencyRepository = null
     ) {
         $this->productRepository     = $productRepository;
         $this->attributeRepository   = $attributeRepository;
@@ -103,6 +109,7 @@ class ProductController
         $this->productEditDataFilter = $productEditDataFilter;
         $this->productRemover        = $productRemover;
         $this->productBuilder        = $productBuilder;
+        $this->currencyRepository    = $currencyRepository;
     }
 
     /**
@@ -135,6 +142,7 @@ class ProductController
         $this->productBuilder->addMissingAssociations($product);
         $channels = array_keys($this->userContext->getChannelChoicesWithUserChannel());
         $locales  = $this->userContext->getUserLocaleCodes();
+        $currencies = $this->currencyRepository->getActivatedCurrencyCodes();
 
         return new JsonResponse(
             $this->normalizer->normalize(
@@ -143,6 +151,7 @@ class ProductController
                 [
                     'locales'     => $locales,
                     'channels'    => $channels,
+                    'currencies'  => $currencies,
                     'filter_type' => 'pim.internal_api.product_value.view'
                 ]
             )
@@ -184,7 +193,10 @@ class ProductController
         if (0 === $violations->count()) {
             $this->productSaver->save($product);
 
-            return new JsonResponse($this->normalizer->normalize($product, 'internal_api'));
+            $currencies = $this->currencyRepository->getActivatedCurrencyCodes();
+            return new JsonResponse($this->normalizer->normalize($product, 'internal_api', [
+                'currencies' => $currencies
+            ]));
         } else {
             $errors = [
                 'values' => $this->normalizer->normalize($violations, 'internal_api')
@@ -257,6 +269,11 @@ class ProductController
     {
         $product = $this->productRepository->findOneByWithValues($id);
         $product = $this->objectFilter->filterObject($product, 'pim.internal_api.product.view') ? null : $product;
+
+        $currencies = $this->currencyRepository->getActivatedCurrencyCodes();
+        $this->objectFilter->filterCollection($product->getValues(), 'pim.internal_api.product_value.view', [
+            'currencies' => $currencies
+        ]);
 
         if (!$product) {
             throw new NotFoundHttpException(

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/connector/processors.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/connector/processors.yml
@@ -30,6 +30,8 @@ services:
             - '@pim_catalog.repository.attribute'
             - '@pim_connector.repository.job_configuration'
             - '@pim_catalog.updater.product'
+            - '@pim_catalog.filter.chained'
+            - '@pim_catalog.repository.currency'
 
     pim_enrich.connector.processor.mass_edit.family.set_requirements:
         class: %pim_enrich.connector.processor.mass_edit.family.set_requirements.class%

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/controllers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/controllers.yml
@@ -381,6 +381,7 @@ services:
             - '@pim_enrich.filter.product_edit_data'
             - '@pim_catalog.remover.product'
             - '@pim_catalog.builder.product'
+            - '@pim_catalog.repository.currency'
 
     pim_enrich.controller.rest.product_category:
         class: %pim_enrich.controller.rest.product_category.class%


### PR DESCRIPTION
**What is fixed ?**
When I disable a currency after having set prices to a product, the currency is still visible in the PEF and I cannot save the product anymore. The error message is "Please specify a valid currency".

**How is it fixed ?**
Disabled currencies must be filtered from the product value as they are not deleted from the database.
This is done via a new tagged service filter : ProductValueCurrencyFilter