### PR TITLE
PIM-5575 : remove JS fetchers warmup

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -1,3 +1,8 @@
+# 1.4.x
+
+## Scalability improvements
+- PIM-5575: Remove families JS fetchers warmup
+
 # 1.4.19 (2016-02-11)
 
 ## Bug fixes

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
@@ -45,6 +45,7 @@ config:
                 family:
                     module: pim/base-fetcher
                     options:
+                        warmup: false
                         urls:
                             list: pim_enrich_family_rest_index
                             get: pim_enrich_family_rest_get

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/fetcher/fetcher-registry.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/fetcher/fetcher-registry.js
@@ -41,7 +41,9 @@ define(['module', 'jquery', 'underscore'], function (module, $, _) {
         warmUp: function () {
             if (!this.warm) {
                 _.each(this.fetchers, function (fetcher, code) {
-                    this.getFetcher(code).fetchAll();
+                    if (undefined === fetcher.options.warmup || fetcher.options.warmup) {
+                        this.getFetcher(code).fetchAll();
+                    }
                 }.bind(this));
 
                 this.warm = true;


### PR DESCRIPTION
We should not fetch all families on page refresh.
As we should only do fetchall on small collections, warmup is maybe not usefull anymore. Will be treated by PIM-5542

| Q                 | A
| ----------------- | ---
| Specs             |no
| Behats            |no
| Changelog updated |yes
| Review and 2 GTM  |