### PR TITLE
Add doctrine schema update to create default indexes as well

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Command/MongoDBIndexCreatorCommand.php
+++ b/src/Pim/Bundle/CatalogBundle/Command/MongoDBIndexCreatorCommand.php
@@ -43,6 +43,9 @@ class MongoDBIndexCreatorCommand extends ContainerAwareCommand
             return -1;
         }
 
+        $command = $this->getApplication()->find('doctrine:mongodb:schema:update');
+        $command->run($input, $output);
+
         $indexCreator = $this->getIndexCreator();
         $indexCreator->ensureUniqueAttributesIndexes();
         $indexCreator->ensureCompletenessesIndexes();


### PR DESCRIPTION
When creating indexes in MongoDB, add a call to doctrine:mongodb:schema:update to make sure default collection indexes are created as well

| Q                 | A
| ----------------- | ---
| Specs             |no
| Behats            |no
| Changelog updated |not needed
| Review and 2 GTM  |