### PR TITLE
PIM-5277: Translate datetimepicker

### DIFF
--- a/features/Context/WebUser.php
+++ b/features/Context/WebUser.php
@@ -869,6 +869,18 @@ class WebUser extends RawMinkContext
     }
 
     /**
+     * @param $field
+     *
+     * @When /^I click on the field (?P<field>\w+)$/
+     * @When /^I click on the field "(?P<field>[^"]+)"$/
+     */
+    public function iClickOnTheField($field)
+    {
+        $field = $this->getCurrentPage()->findField($field);
+        $field->click();
+    }
+
+    /**
      * @param string $not
      * @param string $attributes
      * @param string $group

--- a/features/localization/product/edit_product.feature
+++ b/features/localization/product/edit_product.feature
@@ -66,3 +66,8 @@ Feature: Edit a product with localized attributes
     And I follow "Products"
     And I click on the "foo" row
     Then the field Date should contain "28/05/2015"
+
+  Scenario: Successfully show datetimepicker in my UI locale
+    When I click on the field Date
+    Then I should see the text "Mai"
+    And I should see the text "Lu"

--- a/src/Pim/Bundle/DataGridBundle/Resources/config/requirejs.yml
+++ b/src/Pim/Bundle/DataGridBundle/Resources/config/requirejs.yml
@@ -99,3 +99,4 @@ config:
         pim/template/datagrid/actions-group:                    pimdatagrid/templates/datagrid/actions-group.html
         pim/template/datagrid/configure-columns-action:         pimdatagrid/templates/configure-columns-action.html
         pim/template/datagrid/filter/select2-choice-filter:     pimdatagrid/templates/filter/select2-choice-filter.html
+        pim/template/datagrid/filter/date-filter:               pimdatagrid/templates/filter/date-filter.html

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/date-filter.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/date-filter.js
@@ -27,9 +27,9 @@ function($, _, __, ChoiceFilter, Datepicker) {
                     '</select>' +
                 '</div>' +
                 '<div>' +
-                    '<span class="start"><input type="text" value="" class="<%= inputClass %> add-on" name="start" placeholder="'+__('from')+'"></span>' +
+                    '<span class="start"><input type="text" value="" class="<%= inputClass %> add-on" name="start" placeholder="' + __('from') + '"></span>' +
                     '<span class="filter-separator">-</span>' +
-                    '<span class="end"><input type="text" value="" class="<%= inputClass %> add-on" name="end" placeholder="'+__('to')+'"></span>' +
+                    '<span class="end"><input type="text" value="" class="<%= inputClass %> add-on" name="end" placeholder="' + __('to') + '"></span>' +
                 '</div>' +
                 '<div class="oro-action">' +
                     '<div class="btn-group">' +

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/date-filter.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/date-filter.js
@@ -1,7 +1,21 @@
 /* global define */
 define(
-    ['jquery', 'underscore', 'oro/translator', 'oro/datafilter/choice-filter', 'datepicker'],
-function($, _, __, ChoiceFilter, Datepicker) {
+    [
+        'jquery',
+        'underscore',
+        'oro/translator',
+        'oro/datafilter/choice-filter',
+        'datepicker',
+        'text!pim/template/datagrid/filter/date-filter'
+    ],
+function(
+    $,
+    _,
+    __,
+    ChoiceFilter,
+    Datepicker,
+    template
+) {
     'use strict';
 
     /**
@@ -17,27 +31,7 @@ function($, _, __, ChoiceFilter, Datepicker) {
          *
          * @property {function(Object, ?Object=): String}
          */
-        popupCriteriaTemplate: _.template(
-            '<div>' +
-                '<div class="horizontal clearfix type">' +
-                    '<select name="<%= name %>" class="filter-select-oro">' +
-                        '<% _.each(choices, function (option) { %>' +
-                        '<option value="<%= option.value %>"<% if (option.value == selectedChoice) { %> selected="selected"<% } %>><%= option.label %></option>' +
-                        '<% }); %>' +
-                    '</select>' +
-                '</div>' +
-                '<div>' +
-                    '<span class="start"><input type="text" value="" class="<%= inputClass %> add-on" name="start" placeholder="' + __('from') + '"></span>' +
-                    '<span class="filter-separator">-</span>' +
-                    '<span class="end"><input type="text" value="" class="<%= inputClass %> add-on" name="end" placeholder="' + __('to') + '"></span>' +
-                '</div>' +
-                '<div class="oro-action">' +
-                    '<div class="btn-group">' +
-                        '<button class="btn btn-primary filter-update" type="button"><%- _.__("Update") %></button>' +
-                    '</div>' +
-                '</div>' +
-            '</div>'
-        ),
+        popupCriteriaTemplate: _.template(template),
 
         /**
          * Selectors for filter data

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/date-filter.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/date-filter.js
@@ -27,9 +27,9 @@ function($, _, __, ChoiceFilter, Datepicker) {
                     '</select>' +
                 '</div>' +
                 '<div>' +
-                    '<span class="start"><input type="text" value="" class="<%= inputClass %> add-on" name="start" placeholder="from"></span>' +
+                    '<span class="start"><input type="text" value="" class="<%= inputClass %> add-on" name="start" placeholder="'+__('from')+'"></span>' +
                     '<span class="filter-separator">-</span>' +
-                    '<span class="end"><input type="text" value="" class="<%= inputClass %> add-on" name="end" placeholder="to"></span>' +
+                    '<span class="end"><input type="text" value="" class="<%= inputClass %> add-on" name="end" placeholder="'+__('to')+'"></span>' +
                 '</div>' +
                 '<div class="oro-action">' +
                     '<div class="btn-group">' +

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/datetime-filter.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/datetime-filter.js
@@ -25,7 +25,7 @@ define(['jquery', 'underscore', 'oro/datafilter/date-filter', 'pim/date-context'
         datetimepickerOptions: {
             format: DateContext.get('time').format,
             defaultFormat: DateContext.get('time').defaultFormat,
-            locale: DateContext.get('language'),
+            language: DateContext.get('language'),
             pickTime: true,
             pickSeconds: false
         }

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/templates/filter/date-filter.html
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/templates/filter/date-filter.html
@@ -1,0 +1,19 @@
+<div>
+    <div class="horizontal clearfix type">
+        <select name="<%= name %>" class="filter-select-oro">
+            <% _.each(choices, function (option) { %>
+            <option value="<%= option.value %>"<% if (option.value == selectedChoice) { %> selected="selected"<% } %>><%= option.label %></option>
+            <% }); %>
+        </select>
+    </div>
+    <div>
+        <span class="start"><input type="text" value="" class="<%= inputClass %> add-on" name="start" placeholder="<%- _.__('from') %>"></span>
+        <span class="filter-separator">-</span>
+        <span class="end"><input type="text" value="" class="<%= inputClass %> add-on" name="end" placeholder="<%- _.__('to') %>"></span>
+    </div>
+    <div class="oro-action">
+        <div class="btn-group">
+            <button class="btn btn-primary filter-update" type="button"><%- _.__('Update') %></button>
+        </div>
+    </div>
+</div>

--- a/src/Pim/Bundle/DataGridBundle/Resources/translations/jsmessages.en.yml
+++ b/src/Pim/Bundle/DataGridBundle/Resources/translations/jsmessages.en.yml
@@ -77,3 +77,7 @@ Please select view: Please select view
 Loading...: Loading...
 
 View : View
+
+# Datetimepicker
+from: from
+to: to

--- a/src/Pim/Bundle/DataGridBundle/Resources/translations/jsmessages.fr.yml
+++ b/src/Pim/Bundle/DataGridBundle/Resources/translations/jsmessages.fr.yml
@@ -69,3 +69,5 @@ pim.grid.action.show.title: Afficher
 Please select view: Veuillez sélectionner une vue
 Loading...: Chargement en cours...
 View: Voir
+from: à partir de
+to: jusqu'à

--- a/src/Pim/Bundle/UIBundle/Resources/public/js/pim-datepicker.js
+++ b/src/Pim/Bundle/UIBundle/Resources/public/js/pim-datepicker.js
@@ -1,6 +1,6 @@
 define(
-    ['jquery', 'underscore', 'pim/date-context', 'bootstrap.datetimepicker'],
-    function ($, _, DateContext) {
+    ['jquery', 'underscore', 'oro/translator', 'pim/date-context', 'bootstrap.datetimepicker'],
+    function ($, _, __, DateContext) {
         'use strict';
 
         return {
@@ -20,7 +20,7 @@ define(
                     _.each(_.keys(defaultOptions), function (key) {
                         languageOptions[key] = [];
                         _.each(defaultOptions[key], function (value) {
-                            languageOptions[key].push(_.__('datetimepicker.' + key + '.' + value));
+                            languageOptions[key].push(__('datetimepicker.' + key + '.' + value));
                         });
                     });
 

--- a/src/Pim/Bundle/UIBundle/Resources/public/js/pim-datepicker.js
+++ b/src/Pim/Bundle/UIBundle/Resources/public/js/pim-datepicker.js
@@ -1,17 +1,31 @@
 define(
-    ['jquery', 'pim/date-context', 'bootstrap.datetimepicker'],
-    function ($, DateContext) {
+    ['jquery', 'underscore', 'pim/date-context', 'bootstrap.datetimepicker'],
+    function ($, _, DateContext) {
         'use strict';
 
         return {
             options: {
                 format: DateContext.get('date').format,
                 defaultFormat: DateContext.get('date').defaultFormat,
-                locale: DateContext.get('language'),
+                language: DateContext.get('language'),
                 pickTime: false
             },
             init: function ($target, options) {
                 options = $.extend(true, this.options, options);
+
+                if (('en' !== options.language) && (undefined === $.fn.datetimepicker.dates[options.language])) {
+                    var languageOptions = {};
+                    var defaultOptions = $.fn.datetimepicker.dates.en;
+
+                    _.each(_.keys(defaultOptions), function (key) {
+                        languageOptions[key] = [];
+                        _.each(defaultOptions[key], function (value) {
+                            languageOptions[key].push(_.__('datetimepicker.' + key + '.' + value));
+                        });
+                    });
+
+                    $.fn.datetimepicker.dates[options.language] = languageOptions;
+                }
 
                 $target.datetimepicker(options);
 

--- a/src/Pim/Bundle/UIBundle/Resources/translations/jsmessages.en.yml
+++ b/src/Pim/Bundle/UIBundle/Resources/translations/jsmessages.en.yml
@@ -51,3 +51,56 @@ jstree:
     no_tree:      No tree available
     include_sub:  Include sub-categories
     loading:      Loading ...
+
+# Datetimepicker
+datetimepicker:
+    days:
+        Sunday: Sunday
+        Monday: Monday
+        Tuesday: Tuesday
+        Wednesday: Wednesday
+        Thursday: Thursday
+        Friday: Friday
+        Saturday: Saturday
+    daysShort:
+        Sun: Sun
+        Mon: Mon
+        Tue: Tue
+        Wed: Wed
+        Thu: Thu
+        Fri: Fri
+        Sat: Sat
+    daysMin:
+        Su: Su
+        Mo: Mo
+        Tu: Tu
+        We: We
+        Th: Th
+        Fr: Fr
+        Sa: Sa
+    months:
+       January: January
+       February: February
+       March: March
+       April: April
+       May: May
+       June: June
+       July: July
+       August: August
+       September: September
+       October: October
+       November: November
+       December: December
+    monthsShort:
+       Jan: Jan
+       Feb: Feb
+       Mar: Mar
+       Apr: Apr
+       May: May
+       Jun: Jun
+       Jul: Jul
+       Aug: Aug
+       Sep: Sep
+       Oct: Oct
+       Nov: Nov
+       Dec: Dec

--- a/src/Pim/Bundle/UIBundle/Resources/translations/jsmessages.fr.yml
+++ b/src/Pim/Bundle/UIBundle/Resources/translations/jsmessages.fr.yml
@@ -72,7 +72,7 @@ datetimepicker:
     Sa: Sa
   months:
     January: Janvier
-    February: Févier
+    February: Février
     March: Mars
     April: Avril
     May: Mai

--- a/src/Pim/Bundle/UIBundle/Resources/translations/jsmessages.fr.yml
+++ b/src/Pim/Bundle/UIBundle/Resources/translations/jsmessages.fr.yml
@@ -45,3 +45,54 @@ jstree:
   no_tree: "Pas d'arborescence disponible"
   include_sub: Inc. les sous-catégories
   loading: Chargement ...
+datetimepicker:
+  days:
+    Sunday: Dimanche
+    Monday: Lundi
+    Tuesday: Mardi
+    Wednesday: Mercredi
+    Thursday: Jeudi
+    Friday: Vendredi
+    Saturday: Samedi
+  daysShort:
+    Sun: Dim
+    Mon: Lun
+    Tue: Mar
+    Wed: Mer
+    Thu: Jeu
+    Fri: Ven
+    Sat: Sam
+  daysMin:
+    Su: Di
+    Mo: Lu
+    Tu: Ma
+    We: Me
+    Th: Je
+    Fr: Ve
+    Sa: Sa
+  months:
+    January: Janvier
+    February: Févier
+    March: Mars
+    April: Avril
+    May: Mai
+    June: Juin
+    July: Juillet
+    August: Août
+    September: Septembre
+    October: Octobre
+    November: Novembre
+    December: Décembre
+  monthsShort:
+    Jan: Janv.
+    Feb: Févr.
+    Mar: Mars
+    Apr: Avr.
+    May: Mai
+    Jun: Juin
+    Jul: Juil.
+    Aug: Août
+    Sep: Sept.
+    Oct: Oct.
+    Nov: Nov.
+    Dec: Déc.


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Specs             | n
| Behats            | y
| Blue CI           | TODO
| Changelog updated | ?
| Review and 2 GTM  | TODO
| Micro Demo (PO)   | y
| Migration script  | n
| Tech Doc          | n

This PR translates the datepicker. The translations will be done in Crowdin.
The JS part just set a configuration option to add the current locale translations, like described here.
http://www.malot.fr/bootstrap-datetimepicker/

The french translations are for demo-PO and behats.