### PR TITLE
Make the PIM installable with PHP7

### DIFF
--- a/src/Pim/Bundle/BaseConnectorBundle/Reader/File/YamlReader.php
+++ b/src/Pim/Bundle/BaseConnectorBundle/Reader/File/YamlReader.php
@@ -42,7 +42,7 @@ class YamlReader extends FileReader implements
      * @var bool
      *
      * @Assert\Type(type="bool")
-     * @Assert\True(groups={"UploadExecution"})
+     * @Assert\IsTrue(groups={"UploadExecution"})
      */
     protected $uploadAllowed = false;
 

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/validation/attribute.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/validation/attribute.yml
@@ -36,12 +36,12 @@ Pim\Bundle\CatalogBundle\Entity\Attribute:
                 message: This code is not available
         localizable:
             - Type: bool
-            - 'False':
+            - 'IsFalse':
                 message: An unique attribute can not be localizable
                 groups: [unique]
         scopable:
             - NotNull: ~
-            - 'False':
+            - 'IsFalse':
                 message: An unique attribute can not be scopable
                 groups: [unique]
         useableAsGridFilter:
@@ -69,11 +69,11 @@ Pim\Bundle\CatalogBundle\Entity\Attribute:
                 value: 0
         required:
             - Type: bool
-            - 'True':
+            - 'IsTrue':
                 message: This attribute type must be required
                 groups:
                     - pim_catalog_identifier
-            - 'False':
+            - 'IsFalse':
                 message: This attribute type can't be required
                 groups:
                     - pim_catalog_text
@@ -82,6 +82,7 @@ Pim\Bundle\CatalogBundle\Entity\Attribute:
                     - pim_catalog_price_collection
                     - pim_catalog_multiselect
                     - pim_catalog_simpleselect
+
                     - pim_catalog_file
                     - pim_catalog_image
                     - pim_catalog_boolean
@@ -89,7 +90,7 @@ Pim\Bundle\CatalogBundle\Entity\Attribute:
                     - pim_catalog_metric
         unique:
             - Type: bool
-            - 'False':
+            - 'IsFalse':
                 message: This attribute type can't have unique value
                 groups:
                     - pim_catalog_textarea

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/validation/csvReader.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/validation/csvReader.yml
@@ -20,5 +20,5 @@ Pim\Component\Connector\Reader\File\CsvReader:
             - NotBlank: ~
         uploadAllowed:
             - Type: bool
-            - 'True':
+            - 'IsTrue':
                 groups: [UploadExecution]


### PR DESCRIPTION
Installation of a small catalog, 5000 products:
```
time php app/console pim:installer:db -e prod  32.76s user 1.44s system 60% cpu 56.115 total
time php7.0 app/console pim:installer:db -e prod  15.95s user 1.30s system 46% cpu 37.050 total
time php app/console akeneo:batch:job csv_product_import -e prod  1153.08s user 28.00s system 85% cpu 22:58.98 total
time php7.0 app/console akeneo:batch:job csv_product_import -e prod  379.59s user 25.28s system 69% cpu 9:46.33 total
```

| Q                 | A
| ----------------- | ---
| Specs             | -
| Behats            | - 
| Blue CI           | Running
| Changelog updated |  -
| Review and 2 GTM  |
| Micro Demo (PO)   | -
| Migration script  | -
| Tech Doc          | -