### PR TITLE
Add validation in family controller

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -20,9 +20,11 @@
 - PIM-5645: Bath jobs configuration files can now also be loaded when contained in a folder named 'batch_jobs'. Introduces the new Akeneo XLSX Connector
 - TIP-342: be able to launch mass edit processes without having to previously store a JobConfiguration and only rely on dynamic configuration
 - PIM-5577: The completeness is now calculated every time a product is saved, ie during mass edit, product import and on edit/save of variant groups.
+- Call validation in the controller when adding/removing attributes to the family.
 
 ## BC breaks
 
+- Change constructor of `Pim\Bundle\EnrichBundle\Controller\FamilyController`. Add Symfony validator.
 - Change constructor of `Pim\Component\Connector\Reader\File\CsvReader`. Add `Pim\Component\Connector\Reader\File\FileIteratorFactory`.
 - Move `Pim\Component\Connector\Reader\File\CsvProductReader` to `Pim\Component\Connector\Reader\File\Product\CsvProductReader`
 - Change constructor of `Pim\Component\Connector\Reader\File\Product\CsvProductReader`. Remove `Pim\Component\Catalog\Repository\AttributeRepositoryInterface`. Add `Pim\Component\Connector\Reader\File\FileIteratorFactory` and `Pim\Component\Connector\Reader\File\Product\MediaPathTransformer` 

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/controllers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/controllers.yml
@@ -110,6 +110,7 @@ services:
             - '@pim_catalog.remover.family'
             - '@pim_catalog.repository.attribute'
             - '@pim_catalog.repository.family'
+            - '@validator'
             - %pim_catalog.entity.attribute.class%
             - %pim_catalog.entity.family.class%
 


### PR DESCRIPTION
Validate family when adding or removing attributes.

It is just a first step. The second one needs to move the hardcoded validation from the controller to dedicated constraint.

| Q                 | A
| ----------------- | ---
| Added Specs       | N/A
| Added Behats      | N
| Travis CI is ok   |
| Changelog updated | Y