### PR TITLE
PIM-5579: Enable FileWriterArchiver even for exports with several files

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -1,5 +1,8 @@
 # 1.4.x
 
+## Improvements
+- PIM-5579: Enable `Pim\Bundle\BaseConnectorBundle\Archiver\FileWriterArchiver` even for exports with several files
+
 ## Scalability improvements
 - PIM-5575: Remove families JS fetchers warmup
 

--- a/features/export/export_products_and_download_exported_file.feature
+++ b/features/export/export_products_and_download_exported_file.feature
@@ -4,14 +4,14 @@ Feature: Export products
   As a product manager
   I need to be able to export the products
 
-  Scenario: Successfully export products and be able to download exported file
+  Scenario: Successfully export products and be able to download exported files
     Given an "apparel" catalog configuration
     And the following job "ecommerce_product_export" configuration:
       | filePath | %tmp%/ecommerce_product_export/ecommerce_product_export.csv |
     And the following products:
-      | sku          | family  | categories                   | price                 | size   | color | manufacturer     | material | country_of_manufacture |
-      | tshirt-white | tshirts | men_2013, men_2014, men_2015 | 10 EUR, 15 USD, 9 GBP | size_M | white | american_apparel | cotton   | usa                    |
-      | tshirt-black | tshirts | men_2013, men_2014, men_2015 | 10 EUR, 15 USD, 9 GBP | size_L | black | american_apparel | cotton   | usa                    |
+      | sku          | family  | categories                   | price                 | size   | color | manufacturer     | material | country_of_manufacture | thumbnail                 |
+      | tshirt-white | tshirts | men_2013, men_2014, men_2015 | 10 EUR, 15 USD, 9 GBP | size_M | white | american_apparel | cotton   | usa                    | %fixtures%/SNKRS-1C-s.png |
+      | tshirt-black | tshirts | men_2013, men_2014, men_2015 | 10 EUR, 15 USD, 9 GBP | size_L | black | american_apparel | cotton   | usa                    | %fixtures%/SNKRS-1C-t.png |
     And the following product values:
       | product      | attribute   | value                                | locale | scope     |
       | tshirt-white | name        | White t-shirt                        | en_US  |           |
@@ -42,7 +42,8 @@ Feature: Export products
     Then exported file of "ecommerce_product_export" should contain:
     """
     sku;additional_colors;categories;color;cost-EUR;cost-GBP;cost-USD;country_of_manufacture;customer_rating-ecommerce;customs_tax-de_DE-EUR;customs_tax-de_DE-GBP;customs_tax-de_DE-USD;datasheet;description-de_DE-ecommerce;description-en_GB-ecommerce;description-en_US-ecommerce;description-fr_FR-ecommerce;enabled;family;groups;handmade;image;legend-de_DE;legend-en_GB;legend-en_US;legend-fr_FR;manufacturer;material;name-de_DE;name-en_GB;name-en_US;name-fr_FR;number_in_stock-ecommerce;price-EUR;price-GBP;price-USD;release_date-ecommerce;size;thumbnail;washing_temperature;weight
-    tshirt-white;;men_2013,men_2014,men_2015;white;;;;usa;;;;;;"Ein elegantes weißes T-Shirt";"An elegant white t-shirt";"A stylish white t-shirt";"Un T-shirt blanc élégant";1;tshirts;;;;;;;;american_apparel;cotton;"Weißes T-Shirt";"White t-shirt";"White t-shirt";"T-shirt blanc";;10.00;9.00;15.00;;size_M;;;
-    tshirt-black;;men_2013,men_2014,men_2015;black;;;;usa;;;;;;"Ein elegantes schwarzes T-Shirt";"An elegant black t-shirt";"A stylish black t-shirt";"Un T-shirt noir élégant";1;tshirts;;;;;;;;american_apparel;cotton;"Schwarzes T-Shirt";"Black t-shirt";"Black t-shirt";"T-shirt noir";;10.00;9.00;15.00;;size_L;;;
+    tshirt-white;;men_2013,men_2014,men_2015;white;;;;usa;;;;;;"Ein elegantes weißes T-Shirt";"An elegant white t-shirt";"A stylish white t-shirt";"Un T-shirt blanc élégant";1;tshirts;;;;;;;;american_apparel;cotton;"Weißes T-Shirt";"White t-shirt";"White t-shirt";"T-shirt blanc";;10.00;9.00;15.00;;size_M;files/tshirt-white/thumbnail/SNKRS-1C-s.png;;
+    tshirt-black;;men_2013,men_2014,men_2015;black;;;;usa;;;;;;"Ein elegantes schwarzes T-Shirt";"An elegant black t-shirt";"A stylish black t-shirt";"Un T-shirt noir élégant";1;tshirts;;;;;;;;american_apparel;cotton;"Schwarzes T-Shirt";"Black t-shirt";"Black t-shirt";"T-shirt noir";;10.00;9.00;15.00;;size_L;files/tshirt-black/thumbnail/SNKRS-1C-t.png;;
     """
     Then I should see "Download generated file"
+    And I should see "Download generated archive"

--- a/spec/Pim/Bundle/BaseConnectorBundle/Archiver/FileWriterArchiverSpec.php
+++ b/spec/Pim/Bundle/BaseConnectorBundle/Archiver/FileWriterArchiverSpec.php
@@ -15,14 +15,7 @@ use Prophecy\Argument;
 
 class FileWriterArchiverSpec extends ObjectBehavior
 {
-    function let(
-        Filesystem $filesystem,
-        CsvWriter $writer,
-        JobExecution $jobExecution,
-        JobInstance $jobInstance,
-        Job $job,
-        ItemStep $step
-    ) {
+    function let(Filesystem $filesystem) {
         $this->beConstructedWith($filesystem);
     }
 
@@ -31,8 +24,14 @@ class FileWriterArchiverSpec extends ObjectBehavior
         $this->shouldHaveType('Pim\Bundle\BaseConnectorBundle\Archiver\FileWriterArchiver');
     }
 
-    function it_creates_a_file_when_writer_is_valid($filesystem, $writer, $jobExecution, $jobInstance, $job, $step)
-    {
+    function it_creates_a_file_when_writer_is_valid(
+        $filesystem,
+        CsvWriter $writer,
+        JobExecution $jobExecution,
+        JobInstance $jobInstance,
+        Job $job,
+        ItemStep $step
+    ) {
         $pathname = tempnam(sys_get_temp_dir(), 'spec');
         $filename = basename($pathname);
 
@@ -60,13 +59,13 @@ class FileWriterArchiverSpec extends ObjectBehavior
         unlink($pathname);
     }
 
-    function it_doesnt_create_a_file_when_written_files_is_greater_than_two(
+    function it_creates_a_file_even_when_written_files_is_greater_than_two(
         $filesystem,
-        $writer,
-        $jobExecution,
-        $jobInstance,
-        $job,
-        $step
+        CsvWriter $writer,
+        JobExecution $jobExecution,
+        JobInstance $jobInstance,
+        Job $job,
+        ItemStep $step
     ) {
         $jobExecution->getJobInstance()->willReturn($jobInstance);
         $jobExecution->getId()->willReturn(12);
@@ -75,21 +74,36 @@ class FileWriterArchiverSpec extends ObjectBehavior
         $jobInstance->getAlias()->willReturn('alias');
         $job->getSteps()->willReturn([$step]);
         $step->getWriter()->willReturn($writer);
-        $writer->getWrittenFiles()->willReturn(['path_one', 'path_two']);
-        $writer->getPath()->willReturn('/tmp/tmp');
 
-        $filesystem->put(Argument::any())->shouldNotBeCalled();
+        $pathname1 = tempnam(sys_get_temp_dir(), 'spec1');
+        $filename1 = basename($pathname1);
+        $pathname2 = tempnam(sys_get_temp_dir(), 'spec2');
+        $filename2 = basename($pathname2);
+        $pathname3 = tempnam(sys_get_temp_dir(), 'spec3');
+        $writer->getWrittenFiles()->willReturn(
+            [
+                $pathname1 => $filename1,
+                $pathname2 => $filename2
+            ]
+        );
+        $writer->getPath()->willReturn($pathname3);
+
+        $filesystem->put(Argument::cetera())->shouldBeCalled();
 
         $this->archive($jobExecution);
+
+        unlink($pathname1);
+        unlink($pathname2);
+        unlink($pathname3);
     }
 
     function it_doesnt_create_a_file_when_writer_is_invalid(
         $filesystem,
         ItemWriterInterface $writer,
-        $jobExecution,
-        $jobInstance,
-        $job,
-        $step
+        JobExecution $jobExecution,
+        JobInstance $jobInstance,
+        Job $job,
+        ItemStep $step
     ) {
         $jobExecution->getJobInstance()->willReturn($jobInstance);
         $jobExecution->getId()->willReturn(12);
@@ -98,10 +112,8 @@ class FileWriterArchiverSpec extends ObjectBehavior
         $jobInstance->getAlias()->willReturn('alias');
         $job->getSteps()->willReturn([$step]);
         $step->getWriter()->willReturn($writer);
-        $writer->getWrittenFiles()->willReturn(['path_one']);
-        $writer->getPath()->willReturn('/tmp/invalidwriter');
 
-        $filesystem->put(Argument::any())->shouldNotBeCalled();
+        $filesystem->put(Argument::cetera())->shouldNotBeCalled();
 
         $this->archive($jobExecution);
     }
@@ -113,9 +125,9 @@ class FileWriterArchiverSpec extends ObjectBehavior
 
     function it_doesnt_create_a_file_if_step_is_not_an_item_step(
         $filesystem,
-        $jobExecution,
-        $jobInstance,
-        $job,
+        JobExecution $jobExecution,
+        JobInstance $jobInstance,
+        Job $job,
         AbstractStep $step
     ) {
         $jobExecution->getJobInstance()->willReturn($jobInstance);
@@ -125,17 +137,17 @@ class FileWriterArchiverSpec extends ObjectBehavior
         $jobInstance->getAlias()->willReturn('alias');
         $job->getSteps()->willReturn([$step]);
 
-        $filesystem->put(Argument::any())->shouldNotBeCalled();
+        $filesystem->put(Argument::cetera())->shouldNotBeCalled();
 
         $this->archive($jobExecution);
     }
 
-    function it_returns_true_for_the_supported_job(
-        $writer,
-        $jobExecution,
-        $jobInstance,
-        $job,
-        $step
+    function it_supports_a_compatible_job(
+        CsvWriter $writer,
+        JobExecution $jobExecution,
+        JobInstance $jobInstance,
+        Job $job,
+        ItemStep $step
     ) {
         $pathname = tempnam(sys_get_temp_dir(), 'spec');
 
@@ -154,12 +166,12 @@ class FileWriterArchiverSpec extends ObjectBehavior
         unlink($pathname);
     }
 
-    function it_returns_false_for_the_unsupported_job(
+    function it_does_not_support_a_incompatible_job(
         ItemWriterInterface $writer,
-        $jobExecution,
-        $jobInstance,
-        $job,
-        $step
+        JobExecution $jobExecution,
+        JobInstance $jobInstance,
+        Job $job,
+        ItemStep $step
     ) {
         $jobExecution->getJobInstance()->willReturn($jobInstance);
         $jobExecution->getId()->willReturn(12);
@@ -168,8 +180,6 @@ class FileWriterArchiverSpec extends ObjectBehavior
         $jobInstance->getAlias()->willReturn('alias');
         $job->getSteps()->willReturn([$step]);
         $step->getWriter()->willReturn($writer);
-        $writer->getWrittenFiles()->willReturn(['path_one']);
-        $writer->getPath()->willReturn('/tmp/unsupported_job_file_writer_archiver');
 
         $this->supports($jobExecution)->shouldReturn(false);
     }

--- a/src/Pim/Bundle/BaseConnectorBundle/Archiver/FileWriterArchiver.php
+++ b/src/Pim/Bundle/BaseConnectorBundle/Archiver/FileWriterArchiver.php
@@ -60,13 +60,7 @@ class FileWriterArchiver extends AbstractFilesystemArchiver
      */
     protected function isUsableWriter(ItemWriterInterface $writer)
     {
-        if ($writer instanceof ArchivableWriterInterface && count($writer->getWrittenFiles()) > 1) {
-            return false;
-        } elseif ($writer instanceof FileWriter && is_file($writer->getPath())) {
-            return true;
-        }
-
-        return false;
+        return $writer instanceof FileWriter && is_file($writer->getPath());
     }
 
     /**

--- a/src/Pim/Bundle/EnrichBundle/Controller/JobTrackerController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/JobTrackerController.php
@@ -108,7 +108,7 @@ class JobTrackerController extends Controller
         if ('json' === $request->getRequestFormat()) {
             $archives = [];
             foreach ($this->archivist->getArchives($jobExecution) as $archiveName => $files) {
-                $label = $this->translator->transchoice(
+                $label = $this->translator->transChoice(
                     sprintf('pim_import_export.download_archive.%s', $archiveName),
                     count($files)
                 );

--- a/src/Pim/Bundle/ImportExportBundle/Resources/translations/messages.en.yml
+++ b/src/Pim/Bundle/ImportExportBundle/Resources/translations/messages.en.yml
@@ -18,7 +18,7 @@ pim_import_export:
         8: UNKNOWN
 
     download_archive:
-        archive: download generated file|download generated files
+        archive: download generated archive|download generated archives
         output:  download generated file|download generated files
         input:   download read file|download read files
         invalid: download invalid data


### PR DESCRIPTION
This PR replaces https://github.com/akeneo/pim-community-dev/pull/4006.

| Q                 | A
| ----------------- | ---
| Specs             | yes
| Behats            | yes
| Blue CI           | running
| Changelog updated | yes
| Review and 2 GTM  | yes

Currently there are two native archivers for exports. Their role is to copy exported files (csv, media, etc.) from the export location to the archive directory (usually under app/archive/export/...). These files are used especially to be downloaded from the job page (button "Download generated file").

**How it worked before**
- Only one file exported (usually just the csv and no media) : FileWriterArchiver is used, csv is archived
- Several files exported (csv + media) : ArchivableFileWriterArchiver is used, all files are archived in a zip

**How it works now**
- Only one file exported : same as before
- Several files exported : both archivers are used, the zip is created and the csv is archived too separately.

The consequence is that now you have two download buttons, one for each archiver :
![export_archives](https://cloud.githubusercontent.com/assets/659491/13220664/99d640a8-d977-11e5-8153-3da1ace35ec7.png)

**Why ?**
The goal is that you can easily disable ArchivableFileWriterArchiver if you experience problems with media archiving. Also :
- the media export is untouched (not the case with the previous PR), only the archiving is disabled
- the csv file can still be downloaded from the job page without any additional tweaking

(Benoît & Delphine approved)