### PR TITLE
[TR] PIM-5571: sort completeness in product edit form

### DIFF
--- a/features/Context/FeatureContext.php
+++ b/features/Context/FeatureContext.php
@@ -11,6 +11,7 @@ use Behat\Symfony2Extension\Context\KernelAwareInterface;
 use Context\Spin\SpinCapableTrait;
 use Pim\Behat\Context\Domain\Collect\ImportProfilesContext;
 use Pim\Behat\Context\Domain\Enrich\AttributeTabContext;
+use Pim\Behat\Context\Domain\Enrich\CompletenessContext;
 use Pim\Behat\Context\Domain\Enrich\VariantGroupContext;
 use Pim\Behat\Context\Domain\Spread\ExportProfilesContext;
 use Pim\Behat\Context\Domain\TreeContext;
@@ -63,6 +64,7 @@ class FeatureContext extends MinkContext implements KernelAwareInterface
         $this->useContext('domain-import-profiles', new ImportProfilesContext());
         $this->useContext('domain-export-profiles', new ExportProfilesContext());
         $this->useContext('domain-attribute-tab', new AttributeTabContext());
+        $this->useContext('domain-completeness', new CompletenessContext());
 
         $this->setTimeout($parameters);
     }

--- a/features/Context/Page/Product/Edit.php
+++ b/features/Context/Page/Product/Edit.php
@@ -40,7 +40,12 @@ class Edit extends ProductEditForm
                 'Copy source dropdown'    => ['css' => '.attribute-copy-actions .source-switcher'],
                 'Status switcher'         => ['css' => '.status-switcher'],
                 'Image preview'           => ['css' => '#lbImage'],
-                'Completeness'            => ['css' => '.completeness-block'],
+                'Completeness'            => [
+                    'css'        => '.completeness-block',
+                    'decorators' => [
+                        'Pim\Behat\Decorator\Completeness\PanelDecorator'
+                    ]
+                ],
                 'Category pane'           => ['css' => '#product-categories'],
                 'Category tree'           => [
                     'css'        => '#trees',

--- a/features/Context/WebUser.php
+++ b/features/Context/WebUser.php
@@ -1950,7 +1950,10 @@ class WebUser extends RawMinkContext
      */
     public function iShouldSeeTheCompleteness(TableNode $table)
     {
-        $this->wait();
+        $this->spin(function () {
+            return $this->getCurrentPage()->find('css', '.completeness-block');
+        }, sprintf('Can\'t find completeness block in panel'));
+
         $collapseSwitchers = $this->getCurrentPage()->findAll('css', '.completeness-block header .btn');
 
         foreach ($collapseSwitchers as $switcher) {

--- a/features/Pim/Behat/Context/Domain/Enrich/CompletenessContext.php
+++ b/features/Pim/Behat/Context/Domain/Enrich/CompletenessContext.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Pim\Behat\Context\Domain\Enrich;
+
+use Behat\Mink\Exception\ExpectationException;
+use Pim\Behat\Context\PimContext;
+
+/**
+ * This context is about to test the behavior of the completeness
+ *
+ * @author    Willy Mesnage <willy.mesnage@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class CompletenessContext extends PimContext
+{
+    /**
+     * @param string $locale   en_US, fr_FR, etc.
+     * @param int    $position
+     *
+     * @Given /^I should see the "([^"]*)" completeness in position ([0-9]+)$/
+     */
+    public function iShouldSeeTheCompletenessInPositionNth($locale, $position)
+    {
+        $completeness = $this->getCurrentPage()->getElement('Completeness')->findNthCompleteness($position);
+        if ($completeness->getLocale() !== $locale) {
+            throw new ExpectationException(
+                sprintf(
+                    '"%s" completeness found in position %s in tab. "%s" expected.',
+                    $completeness->getLocale(),
+                    $position,
+                    $locale
+                ),
+                $this->getSession()
+            );
+        }
+    }
+
+    /**
+     * @param string $locale
+     *
+     * @Given /^The completeness "([^"]*)" should be (closed|opened)$/
+     */
+    public function theCompletenessShouldBeOpenedOrClosed($locales, $state)
+    {
+        $completenessPanel = $this->getCurrentPage()->getElement('Completeness');
+
+        $locales = explode(',', $locales);
+        foreach ($locales as $locale) {
+            $locale = trim($locale);
+
+            $completeness = $completenessPanel->findCompletenessForLocale($locale);
+            $condition    = 'closed' === $state ? 'true' : 'false';
+            if ($completeness->getState() !== $condition) {
+                throw new ExpectationException(
+                    sprintf('Expected to see "%s" completeness %s.', $locale, $state),
+                    $this->getSession()
+                );
+            }
+        }
+    }
+}

--- a/features/Pim/Behat/Decorator/Completeness/BlockDecorator.php
+++ b/features/Pim/Behat/Decorator/Completeness/BlockDecorator.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Pim\Behat\Decorator\Completeness;
+
+use Behat\Mink\Element\NodeElement;
+use Context\Spin\SpinCapableTrait;
+use Pim\Behat\Decorator\ElementDecorator;
+
+/**
+ * This class contains methods to find some properties on completeness blocks from the panel in the product edit form.
+ *
+ * @author    Willy Mesnage <willy.mesnage@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class BlockDecorator extends ElementDecorator
+{
+    use SpinCapableTrait;
+
+    /** @var array Selectors to ease find */
+    protected $selectors = [
+        'locale' => [
+            'css'       => 'header .locale',
+            'attribute' => 'data-locale'
+        ],
+        'state' => [
+            'attribute' => 'data-closed'
+        ]
+    ];
+
+    /**
+     * @param NodeElement $completeness
+     *
+     * @return string
+     */
+    public function getLocale()
+    {
+        $locale = $this->spin(function () {
+            return $this->find('css', $this->selectors['locale']['css']);
+        }, 'Can\'t find locale in completeness block');
+
+        return $locale->getAttribute($this->selectors['locale']['attribute']);
+    }
+
+    /**
+     * @param NodeElement $completeness
+     *
+     * @return string
+     */
+    public function getState()
+    {
+        return $this->spin(function () {
+            return $this->getAttribute($this->selectors['state']['attribute']);
+        }, 'Can\'t find state open or close in completeness block');
+    }
+}

--- a/features/Pim/Behat/Decorator/Completeness/PanelDecorator.php
+++ b/features/Pim/Behat/Decorator/Completeness/PanelDecorator.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Pim\Behat\Decorator\Completeness;
+
+use Behat\Mink\Element\NodeElement;
+use Context\Spin\SpinCapableTrait;
+use Pim\Behat\Decorator\ElementDecorator;
+
+/**
+ * This class contains methods to find specific completeness blocks from the panel in the product edit form.
+ *
+ * @author    Willy Mesnage <willy.mesnage@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class PanelDecorator extends ElementDecorator
+{
+    use SpinCapableTrait;
+
+    /** @var array Selectors to ease find */
+    protected $selectors = [
+        'Completeness blocks' => [
+            'css'        => '.completeness-block',
+            'decorators' => [
+                'Pim\Behat\Decorator\Completeness\BlockDecorator'
+            ]
+        ]
+    ];
+
+    /**
+     * @param string $locale en_US, fr_FR, etc.
+     *
+     * @return NodeElement
+     */
+    public function findCompletenessForLocale($locale)
+    {
+        $block = $this->findBlock(
+            sprintf($this->selectors['Completeness blocks']['css'] . ' header .locale[data-locale="%s"]', $locale)
+        );
+        $completeness = $block->getParent()->getParent();
+
+        return $this->decorate($completeness, $this->selectors['Completeness blocks']['decorators']);
+    }
+
+    /**
+     * @param int $position Begin to 1
+     *
+     * @throws \LogicException If the nth completeness is not found
+     *
+     * @return null|NodeElement
+     */
+    public function findNthCompleteness($position)
+    {
+        $blocks = $this->findAllBlocks($this->selectors['Completeness blocks']['css']);
+        if (!is_array($blocks) || count($blocks) < $position) {
+            throw new \LogicException(sprintf(
+                'The completeness in position %s has not been found. It seems there is less then %s completenesses',
+                $position,
+                $position
+            ));
+        }
+
+        return $this->decorate($blocks[$position - 1], $this->selectors['Completeness blocks']['decorators']);
+    }
+
+    /**
+     * Spin to know if the panel is available
+     *
+     * @param string $selector
+     *
+     * @return NodeElement
+     */
+    protected function findBlock($selector)
+    {
+        return $this->spin(function () use ($selector) {
+            return $this->find('css', $selector);
+        }, 'Can\'t find completeness block in panel');
+    }
+
+    /**
+     * @param string $selector
+     *
+     * @return []NodeElement
+     */
+    protected function findAllBlocks($selector)
+    {
+        return $this->spin(function () use ($selector) {
+            return $this->findAll('css', $selector);
+        }, 'Can\'t find completeness block in panel');
+    }
+}

--- a/features/Pim/Behat/Decorator/ElementDecorator.php
+++ b/features/Pim/Behat/Decorator/ElementDecorator.php
@@ -2,6 +2,8 @@
 
 namespace Pim\Behat\Decorator;
 
+use Behat\Mink\Element\Element;
+
 /**
  * Simple abstract class to ease the decorator pattern on Mink elements
  */
@@ -27,5 +29,22 @@ abstract class ElementDecorator
     public function __call($name, array $arguments)
     {
         return call_user_func_array([$this->element, $name], $arguments);
+    }
+
+    /**
+     * Decorates an element
+     *
+     * @param Element $element
+     * @param array   $decorators
+     *
+     * @return ElementDecorator
+     */
+    protected function decorate(Element $element, array $decorators)
+    {
+        foreach ($decorators as $decorator) {
+            $element = new $decorator($element);
+        }
+
+        return $element;
     }
 }

--- a/features/product/completeness/display_completeness.feature
+++ b/features/product/completeness/display_completeness.feature
@@ -26,15 +26,26 @@ Feature: Display the completeness of a product
     Given I am on the "sneakers" product page
     When I open the "Completeness" panel
     Then I should see the completeness summary
+    And I should see the "en_US" completeness in position 1
+    And The completeness "fr_FR" should be closed
+    And The completeness "en_US" should be opened
     And I should see the completeness:
       | channel | locale | state   | missing_values        | ratio |
       | mobile  | en_US  | success |                       | 100%  |
       | mobile  | fr_FR  | success |                       | 100%  |
       | tablet  | en_US  | warning | side_view             | 89%   |
       | tablet  | fr_FR  | warning | description side_view | 78%   |
-    When I am on the "sandals" product page
+    When I am on the products page
+    Then I am on the "sandals" product page
     And I open the "Completeness" panel
     Then I should see the completeness summary
+    And I should see the "en_US" completeness in position 1
+    And The completeness "fr_FR" should be closed
+    And The completeness "en_US" should be opened
+    When I switch the locale to "fr_FR"
+    Then I should see the "fr_FR" completeness in position 1
+    And The completeness "en_US" should be closed
+    And The completeness "fr_FR" should be opened
     And I should see the completeness:
       | channel | locale | state   | missing_values                               | ratio |
       | mobile  | en_US  | warning | name price size                              | 40%   |
@@ -48,6 +59,9 @@ Feature: Display the completeness of a product
     And I save the product
     When I open the "Completeness" panel
     Then I should see the completeness summary
+    And I should see the "en_US" completeness in position 1
+    And The completeness "fr_FR" should be closed
+    And The completeness "en_US" should be opened
     And I should see the completeness:
       | channel | locale | state   | missing_values        | ratio |
       | mobile  | en_US  | success |                       | 100%  |
@@ -58,6 +72,9 @@ Feature: Display the completeness of a product
     And I save the product
     And I open the "Completeness" panel
     Then I should see the completeness summary
+    And I should see the "en_US" completeness in position 1
+    And The completeness "fr_FR" should be closed
+    And The completeness "en_US" should be opened
     And I should see the completeness:
       | channel | locale | state   | missing_values                               | ratio |
       | mobile  | en_US  | warning | name price size                              | 40%   |

--- a/spec/Pim/Bundle/CatalogBundle/Manager/CompletenessManagerSpec.php
+++ b/spec/Pim/Bundle/CatalogBundle/Manager/CompletenessManagerSpec.php
@@ -81,9 +81,9 @@ class CompletenessManagerSpec extends ObjectBehavior
         $productValueCompleteChecker->isComplete($nameValue, $mobile, $en);
 
         $this->getProductCompleteness($product, [$mobile], [$en], 'en_US')->shouldReturn([
-            'en_US' => [
+            [
                 'channels' => [
-                    'mobile' => [
+                    [
                         'completeness' => $completeness,
                         'missing' => [
                             $name
@@ -94,6 +94,7 @@ class CompletenessManagerSpec extends ObjectBehavior
                     'total' => 1,
                     'complete' => 0,
                 ],
+                'locale' => 'en_US'
             ],
         ]);
     }
@@ -139,9 +140,9 @@ class CompletenessManagerSpec extends ObjectBehavior
         $productValueCompleteChecker->isComplete($nameValue, $mobile, $en);
 
         $this->getProductCompleteness($product, [$mobile], [$en], 'en_US')->shouldReturn([
-            'en_US' => [
+            [
                 'channels' => [
-                    'mobile' => [
+                    [
                         'completeness' => $completeness,
                         'missing' => [],
                     ],
@@ -150,6 +151,7 @@ class CompletenessManagerSpec extends ObjectBehavior
                     'total' => 1,
                     'complete' => 0,
                 ],
+                'locale' => 'en_US'
             ],
         ]);
     }
@@ -157,17 +159,16 @@ class CompletenessManagerSpec extends ObjectBehavior
     function it_provide_product_completeness_if_family_is_not_defined(
         ProductInterface $product,
         ChannelInterface $mobile,
-        LocaleInterface $en,
-        FamilyInterface $shirt
+        LocaleInterface $en
     ) {
         $product->getFamily()->willReturn(null);
         $en->getCode()->willReturn('en_US');
         $mobile->getCode()->willReturn('mobile');
 
         $this->getProductCompleteness($product, [$mobile], [$en], 'en_US')->shouldReturn([
-            'en_US' => [
+            [
                 'channels' => [
-                    'mobile' => [
+                    [
                         'completeness' => null,
                         'missing' => [],
                     ],
@@ -176,6 +177,7 @@ class CompletenessManagerSpec extends ObjectBehavior
                     'total' => 0,
                     'complete' => 0,
                 ],
+                'locale' => ''
             ],
         ]);
     }

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/panel/completeness.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/panel/completeness.html
@@ -7,24 +7,24 @@
         <%- _.__('pim_enrich.form.product.panel.completeness.info.no_completeness') %>
     </p>
 <% } else { %>
-    <% _.each(completenesses, function(channels, locale) { %>
-        <% var ratio = (channels['stats']['complete'] / channels['stats']['total']) * 100; %>
-        <div class="completeness-block" data-closed="<%- 100 === ratio ? 'true' : 'false' %>">
+    <% _.each(completenesses, function(locale) { %>
+        <% var ratio = (locale['stats']['complete'] / locale['stats']['total']) * 100; %>
+        <div class="completeness-block" data-closed="<%- (100 === ratio || locale['locale'] !== catalogLocale) ? 'true' : 'false' %>">
             <header>
-                <span class="locale" data-locale="<%- locale %>"><%= i18n.getFlag(locale, false) %> <%- _.findWhere(locales, {code: locale}).language %></span>
+                <span class="locale" data-locale="<%- locale['locale'] %>"><%= i18n.getFlag(locale['locale'], false) %> <%- _.findWhere(locales, {code: locale['locale']}).language %></span>
                 <span class="stats">
-                    <span><%- channels['stats']['complete'] %>/<%- channels['stats']['total'] %></span>
+                    <span><%- locale['stats']['complete'] %>/<%- locale['stats']['total'] %></span>
                     <div class="progress <%- 100 === ratio ? 'progress-success' : 'progress-warning' %>">
                         <div class="bar" data-ratio="<%- ratio %>" style="width: <%- ratio %>%;"></div>
                     </div>
                 </span>
                 <span class="btn"><i class="icon-angle-down"></i></span>
-                </header>
+            </header>
             <div class="content">
-                <% _.each(channels['channels'], function(completeness, channel) { %>
+                <% _.each(locale['channels'], function(completeness) { %>
                     <% if (completeness.completeness) { %>
                         <div>
-                            <span class="channel" data-channel="<%- channel %>"><%- channel %></span>
+                            <span class="channel" data-channel="<%- completeness.completeness['channel'] %>"><%- completeness.completeness['channel'] %></span>
                             <span class="literal-progress"><%- completeness.completeness.ratio %>%</span>
                             <div class="progress <%- completeness.completeness.ratio === 100 ? 'progress-success' : 'progress-warning' %>">
                                 <div class="bar" data-ratio="<%- completeness.completeness.ratio %>" style="width: <%- completeness.completeness.ratio %>%;"></div>
@@ -34,7 +34,7 @@
                                  <%- _.__('pim_enrich.form.product.panel.completeness.missing_values') %>:
                                  <span class="missing-attributes">
                                     <% _.each(completeness.missing, function(missing) { %>
-                                        <span data-attribute="<%- missing %>" data-locale="<%- locale %>" data-channel="<%- channel %>"><%- missing %></span>
+                                        <span data-attribute="<%- missing %>" data-locale="<%- locale['locale'] %>" data-channel="<%- completeness.completeness['channel'] %>"><%- missing %></span>
                                     <% }) %>
                                 </span>
                                 <% } %>


### PR DESCRIPTION
**Description**

Purpose of this PR is to re-order the completeness panel in the product edit from.
The first completeness shown must be that of the locale switcher or the catalog locale choose in the product grid by the user. Others completeness must be closed.
Channels in completeness must be ordered as they are in the scope switcher.

**Definition Of Done (for Core Developer only)**

```
| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | yes
| Added Behats                      | yes
| Changelog updated                 | no
| Review and 2 GTM                  |
| Micro Demo to the PO (Story only) | ok
| Migration script                  | no
| Tech Doc                          | no
```

