### PR TITLE
[WIP] PIM-4998: Translate error messages on import

### DIFF
--- a/src/Akeneo/Component/Batch/Item/InvalidItemException.php
+++ b/src/Akeneo/Component/Batch/Item/InvalidItemException.php
@@ -19,6 +19,9 @@ class InvalidItemException extends \Exception
     /** @var array */
     protected $messageParameters;
 
+    /** @var  array */
+    protected $details;
+
     /**
      * Constructor
      *
@@ -33,12 +36,14 @@ class InvalidItemException extends \Exception
         array $item,
         array $messageParameters = array(),
         $code = 0,
-        \Exception $previous = null
+        \Exception $previous = null,
+        array $details = array()
     ) {
         parent::__construct($message, $code, $previous);
 
         $this->item              = $item;
         $this->messageParameters = $messageParameters;
+        $this->details           = $details;
     }
 
     /**
@@ -49,6 +54,16 @@ class InvalidItemException extends \Exception
     public function getMessageParameters()
     {
         return $this->messageParameters;
+    }
+
+    /**
+     * Get message details
+     *
+     * @return array
+     */
+    public function getDetails()
+    {
+        return $this->details;
     }
 
     /**

--- a/src/Akeneo/Component/Batch/Step/ItemStep.php
+++ b/src/Akeneo/Component/Batch/Step/ItemStep.php
@@ -278,12 +278,14 @@ class ItemStep extends AbstractStep
             $warningName = get_class($element);
         }
 
-        $stepExecution->addWarning($warningName, $e->getMessage(), $e->getMessageParameters(), $e->getItem());
-        $this->dispatchInvalidItemEvent(
-            get_class($element),
-            $e->getMessage(),
-            $e->getMessageParameters(),
-            $e->getItem()
-        );
+        foreach($e->getMessageParameters() as $error){
+            $stepExecution->addWarning($warningName, $error["message"], $error, $e->getItem());
+            $this->dispatchInvalidItemEvent(
+                get_class($element),
+                $e->getMessage(),
+                $e->getMessageParameters(),
+                $e->getItem()
+            );
+        }
     }
 }

--- a/src/Pim/Bundle/BaseConnectorBundle/Processor/Denormalization/AbstractProcessor.php
+++ b/src/Pim/Bundle/BaseConnectorBundle/Processor/Denormalization/AbstractProcessor.php
@@ -192,14 +192,15 @@ abstract class AbstractProcessor extends AbstractConfigurableStepElement impleme
             } elseif (is_object($invalidValue)) {
                 $invalidValue = get_class($invalidValue);
             }
-            $errors[] = sprintf(
-                "%s: %s: %s\n",
-                $violation->getPropertyPath(),
-                $violation->getMessage(),
-                $invalidValue
-            );
+
+            $error = [];
+            $error['message'] = $violation->getMessageTemplate();
+            $error['parameters'] = $violation->getMessageParameters();
+            $error['parameters']['attribute'] = $violation->getPropertyPath();
+            $error['parameters']['invalid_value'] = $invalidValue;
+            $errors[] = $error;
         }
 
-        throw new InvalidItemException(implode("\n", $errors), $item, [], 0, $previousException);
+        throw new InvalidItemException('One or more errors occurred.', $item, [], 0, $previousException, $errors);
     }
 }

--- a/src/Pim/Bundle/ImportExportBundle/Normalizer/StepExecutionNormalizer.php
+++ b/src/Pim/Bundle/ImportExportBundle/Normalizer/StepExecutionNormalizer.php
@@ -80,7 +80,7 @@ class StepExecutionNormalizer implements NormalizerInterface
      */
     protected function normalizeWarnings(Collection $warnings, array $context = [])
     {
-        $result = [];
+        $results = [];
         $selectedWarnings = [];
 
         if (isset($context['limit_warnings']) && $context['limit_warnings'] > 0) {
@@ -89,16 +89,32 @@ class StepExecutionNormalizer implements NormalizerInterface
             $selectedWarnings = $warnings;
         }
 
+
+        $items = [];
         foreach ($selectedWarnings as $warning) {
-            $result[] =  [
-                'label'  => $this->translator->trans($warning->getName()),
-                'reason' => $this->translator->trans($warning->getReason(), $warning->getReasonParameters()),
-                'item'   => $warning->getItem(),
-            ];
+            $parameters = $warning->getReasonParameters();
+            $reason = sprintf('%s: %s: %s',
+                $parameters['attribute'],
+                $this->translator->trans($warning->getReason(), $parameters, 'validators'),
+                $parameters['invalid_value']
+            );
+            $itemIndex = array_search($warning->getItem(), $items);
+
+            if(False !== $itemIndex){
+                $results[$itemIndex]['reasons'][] = $reason;
+            } else {
+                $items[] = $warning->getItem();
+                $results[] = [
+                    'label'  => $this->translator->trans($warning->getName()),
+                    'reasons' => [$reason],
+                    'item'   => $warning->getItem(),
+                ];
+            }
         }
 
-        return $result;
+        return $results;
     }
+
 
     /**
      * Normalizes the summary

--- a/src/Pim/Bundle/ImportExportBundle/Normalizer/StepExecutionNormalizer.php
+++ b/src/Pim/Bundle/ImportExportBundle/Normalizer/StepExecutionNormalizer.php
@@ -89,32 +89,33 @@ class StepExecutionNormalizer implements NormalizerInterface
             $selectedWarnings = $warnings;
         }
 
-
         $items = [];
         foreach ($selectedWarnings as $warning) {
             $parameters = $warning->getReasonParameters();
-            $reason = sprintf('%s: %s: %s',
-                $parameters['attribute'],
-                $this->translator->trans($warning->getReason(), $parameters, 'validators'),
-                $parameters['invalid_value']
-            );
+            $reason = $this->translator->trans($warning->getReason(), $parameters, 'validators');
+            if(array_key_exists('attribute', $parameters)) {
+                $reason = sprintf('%s: %s: %s',
+                    $parameters['attribute'],
+                    $this->translator->trans($warning->getReason(), $parameters, 'validators'),
+                    $parameters['invalid_value']
+                );
+            }
             $itemIndex = array_search($warning->getItem(), $items);
 
-            if(False !== $itemIndex){
-                $results[$itemIndex]['reasons'][] = $reason;
-            } else {
+            if(false === $itemIndex){
                 $items[] = $warning->getItem();
                 $results[] = [
-                    'label'  => $this->translator->trans($warning->getName()),
+                    'label' => $this->translator->trans($warning->getName()),
                     'reasons' => [$reason],
-                    'item'   => $warning->getItem(),
+                    'item' => $warning->getItem(),
                 ];
+            } else {
+                $results[$itemIndex]['reasons'][] = $reason;
             }
         }
 
         return $results;
     }
-
 
     /**
      * Normalizes the summary

--- a/src/Pim/Bundle/ImportExportBundle/Resources/views/JobExecution/show.html.twig
+++ b/src/Pim/Bundle/ImportExportBundle/Resources/views/JobExecution/show.html.twig
@@ -71,7 +71,7 @@
                     <td colspan="5">
                         <span class="title"><%= warning.label.toUpperCase() %></span>&nbsp;
                         <ul>
-                            <% _.each(warning.reason.split("\n"), function(warningItem) { %>
+                            <% _.each(warning.reasons, function(warningItem) { %>
                                 <% if (warningItem) { %>
                                     <li><%= warningItem %></li>
                                 <% } %>

--- a/src/Pim/Component/Connector/Processor/Denormalization/AbstractProcessor.php
+++ b/src/Pim/Component/Connector/Processor/Denormalization/AbstractProcessor.php
@@ -118,7 +118,8 @@ abstract class AbstractProcessor extends AbstractConfigurableStepElement impleme
             $this->stepExecution->incrementSummaryInfo('skip');
         }
 
-        $errorsParameters = [];
+        $errors = [];
+
         /** @var ConstraintViolationInterface $violation */
         foreach ($violations as $violation) {
             // TODO re-format the message, property path doesn't exist for class constraint
@@ -134,23 +135,14 @@ abstract class AbstractProcessor extends AbstractConfigurableStepElement impleme
                 $invalidValue = implode(', ', $invalidValue);
             }
 
-
-            $violationParameters = $violation->getMessageParameters();
-            $violationParameters["message"] = $violation->getMessageTemplate();
-            $violationParameters["attribute"] = $violation->getPropertyPath();
-            $violationParameters["invalid_value"] = $invalidValue;
-
-            $errorsParameters[] = $violationParameters;
+            $error = [];
+            $error['message'] = $violation->getMessageTemplate();
+            $error['parameters'] = $violation->getMessageParameters();
+            $error['parameters']['attribute'] = $violation->getPropertyPath();
+            $error['parameters']['invalid_value'] = $invalidValue;
+            $errors[] = $error;
         }
 
-        $errorSummary = implode('\n', array_map(function($error){
-            return $error["message"];
-        }, $errorsParameters));
-
-        dump("######");
-        dump($errorSummary);
-        dump("######");
-
-        throw new InvalidItemException($errorSummary, $item, $errorsParameters, 0, $previousException);
+        throw new InvalidItemException('One or more errors occurred.', $item, [], 0, $previousException, $errors);
     }
 }


### PR DESCRIPTION
These changes adapts the way warnings are saved during an import (of products for instance) into the database and the way they are shown to the user.
### Objectives:
- Each error messages is stored in the akeneo_batch_warning table (potentially multiple lines for one product)
- Error messages are shown translated and grouped by product in the view

Problem:
Example: On import, an `ItemStep` instance runs a `productProcessor` to process a product.

Multiple errors are detected for this product, so we send a `InvalidItemException` with a "\n" separated message representing the errors.

Today, those messages are not translated in the UI because they are stored in the database already parsed with parameters (values for the message).

Solution:
a new array attribute was added to the `InvalidItemException` class called `details` in which optionally more information can be provided to the exception.
We used this array to provide the message as well as parameters for placeholders of the message.

```
| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | N
| Added Behats                      | N
| Changelog updated                 | N
| Review and 2 GTM                  | N
| Micro Demo to the PO (Story only) | N
| Migration script                  | N
| Tech Doc                          | N
```
