### PR TITLE
Exclude LongVariable rule from pmd conf

### DIFF
--- a/app/Resources/jenkins/phpmd.xml
+++ b/app/Resources/jenkins/phpmd.xml
@@ -17,6 +17,7 @@
 
     <rule ref="rulesets/naming.xml">
         <exclude name="ShortVariable" />
+        <exclude name="LongVariable" />
     </rule>
 
     <rule name="ShortVariableWithExclusion"


### PR DESCRIPTION
This rule doesn't always improve readability, sometimes it's even the opposite.
It remove ~50 warnings, so we can concentrate on more important problems like refactoring and simplification of algorithms.