### PR TITLE
PIM-5509: Fix grid date filters initialization

### DIFF
--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -1,5 +1,9 @@
 # 1.5.x
 
+## Bug fixes
+
+- PIM-5509: Fix grid date filters initialization
+
 # 1.5.0-RC1 (2016-03-02)
 
 ## BC breaks

--- a/features/attribute/delete_attribute.feature
+++ b/features/attribute/delete_attribute.feature
@@ -26,7 +26,6 @@ Feature: Delete an attribute
     When I am on the products page
     Then the grid should contain 1 elements
     And I should see products caterpillar_1
-    And I show the filter "name"
     Then I should be able to use the following filters:
       | filter      | value          | result        |
       | name        | My caterpillar | caterpillar_1 |

--- a/features/product/filtering/filter_products_per_date_fields.feature
+++ b/features/product/filtering/filter_products_per_date_fields.feature
@@ -6,13 +6,13 @@ Feature: Filter products by date field
 
   Background:
     Given the "default" catalog configuration
+    And the following attributes:
+      | label   | code    | type | localizable | scopable | useable_as_grid_filter |
+      | release | release | date | no          | no       | yes                    |
     And I am logged in as "Mary"
 
   Scenario: Successfully filter products by empty value for date attribute
-    Given the following attributes:
-      | label   | type | localizable | scopable | useable_as_grid_filter |
-      | release | date | no          | no       | yes                    |
-    And the following products:
+    Given the following products:
       | sku    | release    |
       | postit | 2014-05-01 |
       | book   |            |
@@ -25,24 +25,37 @@ Feature: Filter products by date field
       | filter  | value | result       |
       | release | empty | book and mug |
 
-  @skip @info Broken because timezone is not well managed yet (except for UTC)
   Scenario: Successfully filter products by date attributes
-    Given the following attributes:
-      | label   | code    | type | localizable | scopable | useable_as_grid_filter |
-      | release | release | date | no          | no       | yes                    |
-    And the following products:
+    Given the following products:
       | sku    | release    |
       | postit | 2014-05-01 |
       | book   | 2014-05-02 |
       | mug    | 2014-05-03 |
       | tshirt | 2014-05-03 |
       | pen    | 2014-05-06 |
-    And I am on the products page
+    When I am on the products page
     Then the grid should contain 5 elements
     And I should see products postit, book, mug, tshirt and pen
     And I should be able to use the following filters:
-      | filter  | value                                 | result                  |
-      | release | more than 2014-05-02                  | mug and tshirt and pen  |
-      | release | less than 2014-05-03                  | postit and book         |
-      | release | between 2014-05-02 and 2014-05-03     | book and mug and tshirt |
-      | release | not between 2014-05-02 and 2014-05-03 | postit and pen          |
+      | filter  | value                             | result               |
+      | release | more than 05/02/2014              | mug, tshirt and pen  |
+      | release | less than 05/03/2014              | postit and book      |
+      | release | between 05/02/2014 and 05/03/2014 | book, mug and tshirt |
+
+  Scenario: Filter products by date attributes and keep the appropriate default filter values
+    Given the following products:
+      | sku    | release    |
+      | book   | 2014-05-02 |
+      | pen    | 2014-05-06 |
+    And I am on the products page
+    And I show the filter "release"
+    When I filter by "release" with value "between 05/01/2014 and 05/03/2014"
+    Then the filter "release" should be set to "between 05/01/2014 and 05/03/2014"
+    And the filter "Created at" should be set to "All"
+    When I click on the "book" row
+    And I click back to grid
+    Then the filter "release" should be set to "between 05/01/2014 and 05/03/2014"
+    And the filter "Created at" should be set to "All"
+    When I refresh current page
+    Then the filter "release" should be set to "between 05/01/2014 and 05/03/2014"
+    And the filter "Created at" should be set to "All"

--- a/features/product/filtering/filter_products_per_text_fields.feature
+++ b/features/product/filtering/filter_products_per_text_fields.feature
@@ -50,7 +50,6 @@ Feature: Filter products by text field
     And I am on the products page
     Then the grid should contain 3 elements
     And I should see products postit, book and mug
-    When I show the filter "name"
     And I should be able to use the following filters:
       | filter      | value | result          |
       | name        | empty | book and mug    |
@@ -68,7 +67,6 @@ Feature: Filter products by text field
     And I am on the products page
     Then the grid should contain 3 elements
     And I should see products postit, book and mug
-    When I show the filter "name"
     And I should be able to use the following filters:
       | filter | value | result       |
       | name   | empty | book and mug |
@@ -85,7 +83,6 @@ Feature: Filter products by text field
     And I am on the products page
     Then the grid should contain 3 elements
     And I should see products postit, book and mug
-    When I show the filter "name"
     And I should be able to use the following filters:
       | filter | value | result       |
       | name   | empty | book and mug |
@@ -103,7 +100,6 @@ Feature: Filter products by text field
     And I am on the products page
     Then the grid should contain 3 elements
     And I should see products postit, book and mug
-    When I show the filter "name"
     And I should be able to use the following filters:
       | filter | value | result       |
       | name   | empty | book and mug |

--- a/features/product/filtering/filter_products_per_with_multiple_metrics.feature
+++ b/features/product/filtering/filter_products_per_with_multiple_metrics.feature
@@ -27,12 +27,11 @@ Feature: Filter products with multiples metrics filters
       | POST-3 | furniture | 20 GRAM   |          |
     And I am logged in as "Mary"
     And I am on the products page
-    And I show the filter "Packaging"
-    And I show the filter "Weight"
 
   Scenario: Successfully filter products with the sames attributes
+    Given I show the filter "Packaging"
     And I filter by "Packaging" with value "> 30 Gram"
-    And I should be able to use the following filters:
+    Then I should be able to use the following filters:
       | filter | value        | result                 |
       | Weight | = 200 Gram   | MUG-2, MUG-3 and MUG-4 |
       | Weight | >= 200 Gram  | MUG-2, MUG-3 and MUG-4 |
@@ -41,12 +40,11 @@ Feature: Filter products with multiples metrics filters
       | Weight | <= 200 Gram  | MUG-2, MUG-3 and MUG-4 |
       | Weight | < 201 Gram   | MUG-2, MUG-3 and MUG-4 |
       | Weight | empty        | POST-1 and POST-2      |
-    And I hide the filter "Packaging"
-    And I hide the filter "Weight"
 
   Scenario: Successfully filter product without commons attributes
-    Given I filter by "Weight" with value "> 100 Gram"
-    And I should be able to use the following filters:
+    Given I show the filter "Weight"
+    And I filter by "Weight" with value "> 100 Gram"
+    Then I should be able to use the following filters:
       | filter    | value      | result                        |
       | Packaging | = 10 Gram  | MUG-1                         |
       | Packaging | >= 10 Gram | MUG-1, MUG-2, MUG-3 and MUG-4 |
@@ -55,10 +53,6 @@ Feature: Filter products with multiples metrics filters
       | Packaging | <= 10 Gram | MUG-1                         |
       | Packaging | < 11 Gram  | MUG-1                         |
       | Packaging | empty      | MUG-5                         |
-    And I hide the filter "Packaging"
-    And I hide the filter "Weight"
-    And I hide the filter "Packaging"
-    And I hide the filter "Weight"
 
   @unstable
   Scenario: Successfully filter only one product

--- a/features/product/filtering/filter_products_per_with_multiple_multiselect.feature
+++ b/features/product/filtering/filter_products_per_with_multiple_multiselect.feature
@@ -29,34 +29,28 @@ Feature: Filter products with multiples multiselect filters
       | POST-3 | furniture | black   |       |
     And I am logged in as "Mary"
     And I am on the products page
-    And I show the filter "Company"
-    And I show the filter "Color"
 
   Scenario: Successfully filter products with the sames attributes
-    Given I filter by "Company" with value "Red"
-    And I should be able to use the following filters:
+    Given I show the filter "Company"
+    And I filter by "Company" with value "Red"
+    Then I should be able to use the following filters:
       | filter | value    | result                 |
       | Color  | green    | MUG-2, MUG-3 and MUG-4 |
       | Color  | is empty | POST-1 and POST-2      |
-    And I hide the filter "Company"
-    And I hide the filter "Color"
 
   Scenario: Successfully filter product without commons attributes
-    Given I filter by "Color" with value "Green"
-    And I should be able to use the following filters:
+    Given I show the filter "Color"
+    And I filter by "Color" with value "Green"
+    Then I should be able to use the following filters:
       | filter  | value    | result |
       | Company | White    | MUG-1  |
       | Company | is empty | MUG-5  |
-    And I hide the filter "Company"
-    And I hide the filter "Color"
 
   Scenario: Successfully filter only one product
     Given I am on the products page
-    And I show the filter "Company"
+    When I show the filter "Company"
     And I filter by "Company" with value "White"
     And I show the filter "Color"
     And I filter by "Color" with value "Green"
     Then the grid should contain 1 elements
     And I should see entities "MUG-1"
-    And I hide the filter "Company"
-    And I hide the filter "Color"

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/date-filter.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/date-filter.js
@@ -39,32 +39,10 @@ function(
          * @property
          */
         criteriaValueSelectors: {
-            type: '.type',
+            type: '.type select:first',
             value: {
                 start: '.start',
                 end: '.end'
-            }
-        },
-
-        /**
-         * Values for filter data
-         *
-         * "format" is used to stock localized date
-         * "defaultFormat" is used to stock the default pattern
-         *
-         * @property
-         */
-        values: {
-            type: null,
-            value: {
-                start: {
-                    format: null,
-                    defaultFormat: null
-                },
-                end: {
-                    format: null,
-                    defaultFormat: null
-                }
             }
         },
 
@@ -109,7 +87,7 @@ function(
          *
          * @property
          */
-        dateWidgetSelector: 'div.datepicker',
+        dateWidgetSelector: '.datepicker',
 
         /**
          * @inheritDoc
@@ -129,6 +107,9 @@ function(
             ChoiceFilter.prototype.initialize.apply(this, arguments);
         },
 
+        /**
+         * @param {Event} e
+         */
         changeFilterType: function (e) {
             var select = this.$el.find(e.currentTarget);
             var selectedValue = select.val();
@@ -170,8 +151,8 @@ function(
 
             $(el).find('select:first').bind('change', _.bind(this.changeFilterType, this));
 
-            _.each(this.criteriaValueSelectors.value, function(actualSelector, name) {
-                this.dateWidgets[name] = this._initializeDateWidget(actualSelector);
+            _.each(this.criteriaValueSelectors.value, function(selector, name) {
+                this.dateWidgets[name] = Datepicker.init(this.$(selector), this.datetimepickerOptions);
             }, this);
 
             return this;
@@ -180,45 +161,18 @@ function(
         /**
          * @inheritDoc
          */
-        _initializeDateWidget: function(widgetSelector) {
-            var $widget = Datepicker.init(this.$(widgetSelector), this.datetimepickerOptions);
-
-            var picker = $widget.data('datetimepicker');
-            $widget.on('changeDate', function(e) {
-                picker.format = Datepicker.options.defaultFormat;
-                this.values.value[e.target.className].defaultFormat = picker.formatDate(e.date);
-
-                picker.format = Datepicker.options.format;
-                this.values.value[e.target.className].format = picker.formatDate(e.date);
-            }.bind(this));
-
-            return $widget;
-        },
-
-        /**
-         * @inheritDoc
-         */
-        _getInputValue: function(node) {
-            var $select = this.$(node).find('select');
-
-            return $select.val();
-        },
-
-        /**
-         * @inheritDoc
-         */
         _getCriteriaHint: function() {
             var hint = '',
                 option, start, end, type,
-                value = (arguments.length > 0) ? this._getDisplayValue(arguments[0]) : this.values;
+                value = (arguments.length > 0) ? this._getDisplayValue(arguments[0]) : this._getDisplayValue();
 
             if (value.type === 'empty') {
                 return this._getChoiceOption(value.type).label;
             }
 
             if (value.value) {
-                start = value.value.start.format;
-                end   = value.value.end.format;
+                start = value.value.start;
+                end   = value.value.end;
                 type  = value.type ? value.type.toString() : '';
 
                 switch (type) {
@@ -261,9 +215,66 @@ function(
         /**
          * @inheritDoc
          */
+        _formatDisplayValue: function(value) {
+            var fakeDatepicker = Datepicker.init($('<input>'), this.datetimepickerOptions).data('datetimepicker');
+            _.each(value.value, function(dateValue, name) {
+                if (dateValue) {
+                    value.value[name] = this._formatDate(
+                        dateValue,
+                        Datepicker.options.defaultFormat,
+                        Datepicker.options.format
+                    );
+                }
+            }, this);
+
+            return value;
+        },
+
+        /**
+         * @inheritDoc
+         */
+        _formatRawValue: function(value) {
+            _.each(value.value, function(dateValue, name) {
+                if (dateValue) {
+                    value.value[name] = this._formatDate(
+                        dateValue,
+                        Datepicker.options.format,
+                        Datepicker.options.defaultFormat
+                    );
+                }
+            }, this);
+
+            return value;
+        },
+
+        /**
+         * Format a date according to specified format.
+         * It instantiates a datepicker on-the-fly to perform the conversion. Not possible to use the "real" ones since
+         * we need to format a date even when the UI is not initialized yet.
+         *
+         * @param {String} date
+         * @param {String} fromFormat
+         * @param {String} toFormat
+         *
+         * @return {String}
+         */
+        _formatDate: function (date, fromFormat, toFormat) {
+            var options = $.extend({}, this.datetimepickerOptions, {format: fromFormat});
+            var fakeDatepicker = Datepicker.init($('<input>'), options).data('datetimepicker');
+
+            fakeDatepicker.setValue(date);
+            fakeDatepicker.format = toFormat;
+            fakeDatepicker._compileFormat();
+
+            return fakeDatepicker.formatDate(fakeDatepicker.getDate());
+        },
+
+        /**
+         * @inheritDoc
+         */
         _writeDOMValue: function(value) {
-            this._setInputValue(this.criteriaValueSelectors.value.start, value.value.start);
-            this._setInputValue(this.criteriaValueSelectors.value.end, value.value.end);
+            this._setInputValue(this.criteriaValueSelectors.value.start + ' input', value.value.start);
+            this._setInputValue(this.criteriaValueSelectors.value.end + ' input', value.value.end);
             this._setInputValue(this.criteriaValueSelectors.type, value.type);
 
             return this;
@@ -276,8 +287,8 @@ function(
             return {
                 type: this._getInputValue(this.criteriaValueSelectors.type),
                 value: {
-                    start: this.values.value.start.defaultFormat,
-                    end:   this.values.value.end.defaultFormat
+                    start: this._getInputValue(this.criteriaValueSelectors.value.start + ' input'),
+                    end:   this._getInputValue(this.criteriaValueSelectors.value.end + ' input')
                 }
             };
         },
@@ -302,20 +313,11 @@ function(
         /**
          * @inheritDoc
          */
-        setValue: function(value) {
-            if (this._isValueValid(value)) {
-                return ChoiceFilter.prototype.setValue.apply(this, arguments);
-            }
-            return this;
-        },
-
-        /**
-         * @inheritDoc
-         */
         _isValueValid: function(value) {
             if (_.isEqual(value, this.emptyValue) && !_.isEqual(this.value, value)) {
                 return true;
             }
+
             return value.type === 'empty' || value.value.start || value.value.end;
         },
 

--- a/src/Pim/Bundle/UIBundle/Resources/public/js/pim-datepicker.js
+++ b/src/Pim/Bundle/UIBundle/Resources/public/js/pim-datepicker.js
@@ -11,7 +11,7 @@ define(
                 pickTime: false
             },
             init: function ($target, options) {
-                options = $.extend(true, this.options, options);
+                options = $.extend(true, {}, this.options, options);
 
                 if (('en' !== options.language) && (undefined === $.fn.datetimepicker.dates[options.language])) {
                     var languageOptions = {};


### PR DESCRIPTION
```
| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | n/a
| Added Behats                      | yes
| Changelog updated                 | yes
| Review and 2 GTM                  | 
| Micro Demo to the PO (Story only) | n/a
| Migration script                  | n/a
| Tech Doc                          | n/a
```

**What does it fix ?**
https://akeneo.atlassian.net/browse/PIM-5509
A regression has been introduced with datepickers rework : when you filtered on a date, all date filters shared the same displayed value (but the filter was ok on backend). Also when the date filter value was memorized in session storage, it was never read again after page reload.

**How does it fix ?**
The main problem was that the front filter has been transformed to become stateful : it used to stock selected values on datepicker events in order to return it directly and bypass the ""normal"" flow of grid filters. This has been decided to handle multiple date format. We need localized format (05/01/2014) for UI and db format to filter in backend (2014-05-01).

This fix makes the filter stateless again by formatting dates on-the-fly on `getValue` and `setValue`.
It internally uses a fake datepicker instance, not relatted to the UI, that performs the formatting. It's kind of ugly but guarantees behavior consistency.

The right way to do it would have been maybe to extract a formatting component and use it both in datepicker and in filter, but huge work needed.