### PR TITLE
[TR] PIM-5592: keeps page number when back to the grid

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -1,5 +1,9 @@
 # 1.6.x
 
+## Functional improvements
+
+- PIM-5592: the product grid keeps the page number when you go back to it
+
 ## Technical improvements
 
 - PIM-5589: introduce a channels, attribute groups, group types and currencies import using the new import system introduced in v1.4

--- a/features/Context/FeatureContext.php
+++ b/features/Context/FeatureContext.php
@@ -11,6 +11,7 @@ use Behat\Symfony2Extension\Context\KernelAwareInterface;
 use Context\Spin\SpinCapableTrait;
 use Pim\Behat\Context\Domain\Collect\ImportProfilesContext;
 use Pim\Behat\Context\Domain\Enrich\AttributeTabContext;
+use Pim\Behat\Context\Domain\Enrich\GridPaginationContext;
 use Pim\Behat\Context\Domain\Enrich\PanelContext;
 use Pim\Behat\Context\Domain\Enrich\VariantGroupContext;
 use Pim\Behat\Context\Domain\Spread\ExportProfilesContext;
@@ -65,6 +66,7 @@ class FeatureContext extends MinkContext implements KernelAwareInterface
         $this->useContext('domain-export-profiles', new ExportProfilesContext());
         $this->useContext('domain-attribute-tab', new AttributeTabContext());
         $this->useContext('domain-panel', new PanelContext());
+        $this->useContext('domain-pagination-grid', new GridPaginationContext());
 
         $this->setTimeout($parameters);
     }
@@ -264,6 +266,9 @@ class FeatureContext extends MinkContext implements KernelAwareInterface
 
     /**
      * Fills in form field with specified id|name|label|value.
+     *
+     * @param string $field
+     * @param string $value
      *
      * @When /^(?:|I )fill in "(?P<field>(?:[^"]|\\")*)" with "(?P<value>(?:[^"]|\\")*)" on the current page$/
      * @When /^(?:|I )fill in "(?P<value>(?:[^"]|\\")*)" for "(?P<field>(?:[^"]|\\")*)" on the current page$/

--- a/features/Context/Page/Base/Grid.php
+++ b/features/Context/Page/Base/Grid.php
@@ -62,9 +62,10 @@ class Grid extends Index
      */
     public function getGrid()
     {
+        $body = $this->getElement('Body');
         return $this->spin(
-            function () {
-                $modal = $this->getElement('Body')->find('css', $this->elements['Dialog']['css']);
+            function () use ($body) {
+                $modal = $body->find('css', $this->elements['Dialog']['css']);
                 if (null !== $modal && $modal->isVisible()) {
                     return $modal->find('css', $this->elements['Grid']['css']);
                 }
@@ -306,39 +307,6 @@ class Grid extends Index
         } else {
             throw new \InvalidArgumentException('Impossible to get count of datagrid records');
         }
-    }
-
-    /**
-     * @param int $num
-     */
-    public function changePageSize($num)
-    {
-        assertContains($num, [10, 25, 50, 100], 'Only 10, 25, 50 and 100 records per page are available');
-
-        $element = $this->spin(function () {
-            return $this->getGrid()
-                ->getParent()
-                ->getParent()
-                ->getParent()
-                ->find('css', $this->elements['Grid toolbar']['css']);
-        }, 'Cannot find the grid toolbar');
-
-        $dropdownButton = $this->spin(function () use ($element) {
-            return $element->find('css', '.page-size button.dropdown-toggle');
-        }, 'Cannot find the change page size button');
-        $dropdownButton->click();
-
-        $element->find('css', sprintf('ul.dropdown-menu li a:contains("%d")', $num))->click();
-    }
-
-    /**
-     * @param int $num
-     */
-    public function pageSizeIs($num)
-    {
-        assertContains($num, [10, 25, 50, 100], 'Only 10, 25, 50 and 100 records per page are available');
-        $element = $this->getElement('Grid toolbar')->find('css', '.page-size');
-        assertNotNull($element->find('css', sprintf('button:contains("%d")', $num)));
     }
 
     /**

--- a/features/Context/Page/Batch/EditCommonAttributes.php
+++ b/features/Context/Page/Batch/EditCommonAttributes.php
@@ -32,8 +32,14 @@ class EditCommonAttributes extends ProductEditForm
                 'Next'                      => ['css' => '.configuration .btn-primary'],
                 'Confirm'                   => ['css' => '.confirmation .btn-primary'],
                 'Available attributes form' => [
-                    'css' => '#pim_enrich_mass_edit_choose_action_operation_displayedAttributes'
-                ]
+                    'css' => '#pim_enrich_mass_edit_choose_action_operation_displayedAttributes',
+                ],
+                'Grid toolbar'              => [
+                    'css'        => '.grid-toolbar',
+                    'decorators' => [
+                        'Pim\Behat\Decorator\GridDecorator\PaginationDecorator',
+                    ],
+                ],
             ]
         );
     }

--- a/features/Pim/Behat/Context/Domain/Enrich/GridPaginationContext.php
+++ b/features/Pim/Behat/Context/Domain/Enrich/GridPaginationContext.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Pim\Behat\Context\Domain\Enrich;
+
+use Pim\Behat\Context\PimContext;
+
+/**
+ * A context for managing the grid pagination and size
+ *
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class GridPaginationContext extends PimContext
+{
+
+    /**
+     * @param int $num
+     *
+     * @throws ExpectationException
+     *
+     * @Then /^the page number should be (\d+)$/
+     */
+    public function thePageNumberShouldBe($num)
+    {
+        $pageNumber = $this->getCurrentPage()->getCurrentGrid()->getPageNumber();
+
+        if ($pageNumber !== (int) $num) {
+            throw  $this->getMainContext()->createExpectationException(
+                sprintf('Expecting page "%s" got "%s" instead', $num, $pageNumber)
+            );
+        }
+    }
+
+    /**
+     * @param int $num
+     *
+     * @Then /^I change the page number to (\d+)$/
+     */
+    public function iChangeThePageNumber($num)
+    {
+        $this->getCurrentPage()->getCurrentGrid()->setPageNumber($num);
+    }
+
+    /**
+     * @param int $size
+     *
+     * @throws ExpectationException
+     *
+     * @When /^the page size should be (\d+)$/
+     */
+    public function thePageSizeShouldBe($size)
+    {
+        $pageSize = $this->getCurrentPage()->getCurrentGrid()->getPageSize();
+
+        if ($pageSize != $size) {
+            throw  $this->getMainContext()->createExpectationException(
+                sprintf('Expecting page "%s" got "%s" instead', $size, $pageSize)
+            );
+        }
+    }
+
+    /**
+     * @param int $size
+     *
+     * @When /^I change the page size to (\d+)$/
+     */
+    public function iChangeThePageSize($size)
+    {
+        assertContains($size, [10, 25, 50, 100], 'Only 10, 25, 50 and 100 records per page are available');
+        $this->getCurrentPage()->getCurrentGrid()->setPageSize($size);
+        $this->wait();
+    }
+}

--- a/features/Pim/Behat/Context/NavigationContext.php
+++ b/features/Pim/Behat/Context/NavigationContext.php
@@ -61,6 +61,11 @@ class NavigationContext extends PimContext implements PageObjectAwareInterface
         'my account'               => 'User profile',
     ];
 
+    /** @var array */
+    protected $pageDecorators = [
+        'Pim\Behat\Decorator\PageDecorator\GridCapableDecorator',
+    ];
+
     /**
      * @param string $baseUrl
      */
@@ -86,7 +91,7 @@ class NavigationContext extends PimContext implements PageObjectAwareInterface
     }
 
     /**
-     * @param string  $username
+     * @param string $username
      *
      * @Given /^I am logged in as "([^"]*)"$/
      */
@@ -349,7 +354,13 @@ class NavigationContext extends PimContext implements PageObjectAwareInterface
      */
     public function getCurrentPage()
     {
-        return $this->getPage($this->currentPage);
+        $page = $this->getPage($this->currentPage);
+
+        foreach ($this->pageDecorators as $decorator) {
+            $page = new $decorator($page);
+        }
+
+        return $page;
     }
 
     /**

--- a/features/Pim/Behat/Decorator/ElementDecorator.php
+++ b/features/Pim/Behat/Decorator/ElementDecorator.php
@@ -2,6 +2,8 @@
 
 namespace Pim\Behat\Decorator;
 
+use Behat\Mink\Element\Element;
+
 /**
  * Simple abstract class to ease the decorator pattern on Mink elements
  */
@@ -27,5 +29,22 @@ abstract class ElementDecorator
     public function __call($name, array $arguments)
     {
         return call_user_func_array([$this->element, $name], $arguments);
+    }
+
+    /**
+     * Decorates an element
+     *
+     * @param Element $element
+     * @param array   $decorators
+     *
+     * @return ElementDecorator
+     */
+    protected function decorate(Element $element, array $decorators)
+    {
+        foreach ($decorators as $decorator) {
+            $element = new $decorator($element);
+        }
+
+        return $element;
     }
 }

--- a/features/Pim/Behat/Decorator/GridDecorator/PaginationDecorator.php
+++ b/features/Pim/Behat/Decorator/GridDecorator/PaginationDecorator.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Pim\Behat\Decorator\GridDecorator;
+
+use Context\Spin\SpinCapableTrait;
+use Pim\Behat\Decorator\ElementDecorator;
+
+/**
+ * Decorator to add pagination features to an element
+ *
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class PaginationDecorator extends ElementDecorator
+{
+    use SpinCapableTrait;
+
+    /** @var array selectors for pagination components*/
+    protected $selectors = [
+        'pagination input' => '.icons-holder input[type="text"]',
+        'page size button' => '.page-size .dropdown-toggle',
+        'page size list'   => '.page-size .dropdown-menu',
+    ];
+
+    /**
+     * Get the page number
+     *
+     * @return int
+     */
+    public function getPageNumber()
+    {
+        return (int) $this->getPaginationField()->getValue();
+    }
+
+    /**
+     * Set the grid page number
+     *
+     * @param mixed $num
+     */
+    public function setPageNumber($num)
+    {
+        $pagination = $this->getPaginationField();
+        $pagination->setValue($num);
+        $pagination->blur();
+    }
+
+    /**
+     * Get the page size
+     *
+     * @return int
+     */
+    public function getPageSize()
+    {
+        preg_match('/^\d+/', $this->getPageSizeButton()->getHtml(), $size);
+        return (int) $size[0];
+    }
+
+    /**
+     * Set the page size
+     *
+     * @param mixed $num
+     */
+    public function setPageSize($num)
+    {
+        $this->getPageSizeButton()->click();
+
+        $list = $this->spin(function () {
+            return $this->find('css', $this->selectors['page size list']);
+        }, 'Cannot find the change page size list');
+
+        $list->find('css', sprintf('li a:contains("%d")', (int) $num))->click();
+    }
+
+    /**
+     * Get the pagination element
+     *
+     * @return mixed
+     */
+    protected function getPaginationField()
+    {
+        return $this->spin(function () {
+            return $this->find('css', $this->selectors['pagination input']);
+        }, 'Cannot find the pagination filter');
+    }
+
+    /**
+     * Get the button element managing the size
+     *
+     * @return mixed
+     */
+    protected function getPageSizeButton()
+    {
+        return $this->spin(function () {
+            return $this->find('css', $this->selectors['page size button']);
+        }, 'Cannot find the change page size button');
+    }
+}

--- a/features/Pim/Behat/Decorator/PageDecorator/GridCapableDecorator.php
+++ b/features/Pim/Behat/Decorator/PageDecorator/GridCapableDecorator.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Pim\Behat\Decorator\PageDecorator;
+
+use Context\Spin\SpinCapableTrait;
+use Pim\Behat\Decorator\ElementDecorator;
+
+/**
+ * Decorator to handle the grid of a page
+ *
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class GridCapableDecorator extends ElementDecorator
+{
+    use SpinCapableTrait;
+
+    /** @var array Selectors to ease find */
+    protected $selectors = [
+        'Dialog grid' => '.modal',
+        'Grid'        => 'table.grid',
+    ];
+
+    /** @var array */
+    protected $decorators = [
+        'Pim\Behat\Decorator\GridDecorator\PaginationDecorator',
+    ];
+
+    /**
+     * Returns the currently visible grid, if there is one
+     *
+     * @return NodeElement
+     */
+    public function getCurrentGrid()
+    {
+        $grid = $this->spin(
+            function () {
+                $modal = $this->find('css', $this->selectors['Dialog grid']);
+                if (null !== $modal && $modal->isVisible()) {
+                    return $modal->find('css', $this->selectors['Grid']);
+                }
+
+                return $this->find('css', $this->selectors['Grid']);
+            },
+            'No visible grid found'
+        );
+
+        return $this->decorate($grid->getParent()->getParent()->getParent(), $this->decorators);
+    }
+}

--- a/features/datagrid/datagrid_views.feature
+++ b/features/datagrid/datagrid_views.feature
@@ -75,9 +75,9 @@ Feature: Datagrid views
     Given I am on the attributes page
     And I change the page size to 50
     When I am on the products page
-    Then page size should be 25
+    Then the page size should be 25
     When I am on the attributes page
-    Then page size should be 50
+    Then the page size should be 50
 
   Scenario: Successfully choose my default view
     Given I filter by "Family" with value "Sneakers"

--- a/features/datagrid/products_backtothegrid.feature
+++ b/features/datagrid/products_backtothegrid.feature
@@ -29,3 +29,21 @@ Feature: Products back to the grid
     And I should see "SKU: contains \"sneakers_1\""
     And I should see product sneakers_1
     And I should not see product boots_1
+
+  Scenario: Successfully restore page number with hashnav
+    Given the following products:
+      | sku        |
+      | sneakers_0 |
+      | sneakers_2 |
+      | sneakers_3 |
+      | sneakers_4 |
+      | sneakers_5 |
+      | sneakers_6 |
+      | sneakers_7 |
+      | sneakers_8 |
+      | sneakers_9 |
+    And I should be able to sort the rows by SKU
+    When I change the page number to 2
+    And I click on the "boots_1" row
+    And I click back to grid
+    Then the page number should be 2

--- a/src/Pim/Bundle/DataGridBundle/Resources/views/macros.html.twig
+++ b/src/Pim/Bundle/DataGridBundle/Resources/views/macros.html.twig
@@ -59,8 +59,12 @@
                                     'ASC';
                         }
 
-                        if (undefined != filters.pageSize) {
+                        if (undefined !== filters.pageSize) {
                             urlParams['{{ name }}[_pager][_per_page]'] = filters.pageSize;
+                        }
+
+                        if (undefined !== filters.currentPage) {
+                            urlParams['{{ name }}[_pager][_page]'] = filters.currentPage;
                         }
                     };
 


### PR DESCRIPTION
#Ensures the product grid is correctly initialised with the its parameters stored in the session storage including the number of the page for the product grid.

- In a separate commit, the grid page size filter (number of item per page) was also incorporated in this decorator.
- fixes some phpdoc in behats.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | Yes
| Changelog updated                 | Yes
| Review and 2 GTM                  | Yes
| Micro Demo to the PO (Story only) | Yes
| Migration script                  | -
| Tech Doc                          | -

