### PR TITLE
PIM-5589: Change mapping configuration from category repositories

### DIFF
--- a/src/Akeneo/Bundle/ClassificationBundle/Doctrine/ORM/Repository/AbstractItemCategoryRepository.php
+++ b/src/Akeneo/Bundle/ClassificationBundle/Doctrine/ORM/Repository/AbstractItemCategoryRepository.php
@@ -210,4 +210,16 @@ abstract class AbstractItemCategoryRepository implements
             'relation'           => key($categoryAssoc['relationToSourceKeyColumns']),
         ];
     }
+
+    /**
+     * Get category mapping information to build SQL query.
+     *
+     * @return array
+     */
+    protected function getCategoryMappingConfig()
+    {
+        $fakeItem = new $this->entityName();
+
+        return $this->getMappingConfig($fakeItem);
+    }
 }


### PR DESCRIPTION
Add a method for the mapping configuration.
This is used for functions calling it without any item ; the information can be retrieved directly from repository.
