### PR TITLE
Add a registerProjectBundles method in the AppKernel

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -17,7 +17,7 @@ class AppKernel extends Kernel
      */
     protected function registerProjectBundles()
     {
-        $bundles = [
+        return [
             // your app bundles should be registered here
             new Acme\Bundle\AppBundle\AcmeAppBundle(),
         ];

--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -14,6 +14,8 @@ class AppKernel extends Kernel
 {
     /**
      * Registers your custom bundles
+     * 
+     * @return array
      */
     protected function registerProjectBundles()
     {

--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -13,14 +13,22 @@ use Symfony\Component\HttpKernel\Kernel;
 class AppKernel extends Kernel
 {
     /**
-     * {@inheritdoc}
+     * Registers your custom bundles
      */
-    public function registerBundles()
+    protected function registerProjectBundles()
     {
         $bundles = [
             // your app bundles should be registered here
             new Acme\Bundle\AppBundle\AcmeAppBundle(),
         ];
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function registerBundles()
+    {
+        $bundles = $this->registerProjectBundles();
 
         if (in_array($this->getEnvironment(), array('dev', 'test', 'behat'))) {
             $bundles[] = new Symfony\Bundle\WebProfilerBundle\WebProfilerBundle();


### PR DESCRIPTION
Here is a way to ease the registration of the project bundles. A dedicated method has been extracted and put at the top of the AppKernel.