### PR TITLE
Detach entity removal

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -186,3 +186,11 @@
 - Change route `pim_enrich_channel_edit` to use `code` identifier instead of `id`
 - Change method `indexAction` of `Pim\Bundle\EnrichBundle\Controller\Rest\LocaleController` to return all locales by default and only activated if `activated` parameter `true`
 - Change constructor of `Pim\Bundle\EnrichBundle\Normalizer\ChannelNormalizer` to add `Pim\Bundle\VersioningBundle\Manager\VersionManager` and `Symfony\Component\Serializer\Normalizer\NormalizerInterface`
+- Change the constructor of `Pim\Bundle\CatalogBundle\EventSubscriber\MongoDBODM\ProductRelatedEntityRemovalSubscriber`
+    to replace `Doctrine\Common\Persistence\ManagerRegistry` argument by `Akeneo\Component\Console\CommandLauncher`,
+    and replace the product class parameter by `ProductRelatedEntityRemovalCommand` logfile path.
+- Change the constructor of `Pim\Bundle\CatalogBundle\EventSubscriber\MongoDBODM\RemoveOutdatedProductsFromAssociationsSubscriber`
+    to replace `Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\ProductRepositoryInterface` argument by `Akeneo\Component\Console\CommandLauncher`
+    and `Pim\Component\Catalog\Repository\AssociationTypeRepositoryInterface` argument by `RemoveOutdatedProductsFromAssociationsCommand` logfile path.
+- Change the constructor of `Pim\Bundle\CatalogBundle\EventSubscriber\MongoDBODM\UpdateNormalizedProductDataSubscriber`
+    to replace `Doctrine\Common\Persistence\ManagerRegistry` argument by `Akeneo\Component\Console\CommandLauncher` and add `UpdateNormalizedProductDataCommand` logfile path as third argument.

--- a/src/Pim/Bundle/CatalogBundle/Command/ProductRelatedEntityRemovalCommand.php
+++ b/src/Pim/Bundle/CatalogBundle/Command/ProductRelatedEntityRemovalCommand.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\Command;
+
+use Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\ProductRepositoryInterface;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Removes the values of a specific entity from all products.
+ *
+ * @author    Damien Carcel <damien.carcel@akeneo.com>
+ * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ProductRelatedEntityRemovalCommand extends ContainerAwareCommand
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('pim:product:remove-related-entity')
+            ->setDescription('Removes the values of a specific entity from all products')
+            ->addArgument('entityName', InputArgument::REQUIRED, 'The entity name')
+            ->addArgument(
+                'ids',
+                InputArgument::REQUIRED,
+                'The list of entity IDs to remove from the products, comma separated'
+            )
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+
+        $productRepository = $this->getContainer()->get('pim_catalog.repository.product');
+        $entityName        = $input->getArgument('entityName');
+        $ids               = explode(',', $input->getArgument('ids'));
+
+        foreach ($ids as $id) {
+            $this->remove($productRepository, $entityName, (int) $id);
+        }
+    }
+
+    /**
+     * Removes an entity value linked to products and returns the IDs the
+     * updated products.
+     *
+     * @param ProductRepositoryInterface $productRepository
+     * @param string                     $entityName
+     * @param int                        $id
+     */
+    protected function remove(ProductRepositoryInterface $productRepository, $entityName, $id)
+    {
+        switch ($entityName) {
+            case 'AssociationType':
+                $productRepository->cascadeAssociationTypeRemoval($id);
+                break;
+            case 'Attribute':
+                $productRepository->cascadeAttributeRemoval($id);
+                break;
+            case 'AttributeOption':
+                $productRepository->cascadeAttributeOptionRemoval($id);
+                break;
+            case 'Category':
+                $productRepository->cascadeCategoryRemoval($id);
+                break;
+            case 'Family':
+                $productRepository->cascadeFamilyRemoval($id);
+                break;
+            case 'Group':
+                $productRepository->cascadeGroupRemoval($id);
+                break;
+            case 'Channel':
+                $productRepository->cascadeChannelRemoval($id);
+                break;
+            default:
+                throw new \InvalidArgumentException(sprintf(
+                    'The entity "%s" is not a product related entity',
+                    $entityName
+                ));
+        }
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Command/ProductRelatedEntityRemovalCommand.php
+++ b/src/Pim/Bundle/CatalogBundle/Command/ProductRelatedEntityRemovalCommand.php
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  * Removes the values of a specific entity from all products.
  *
  * @author    Damien Carcel <damien.carcel@akeneo.com>
- * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 class ProductRelatedEntityRemovalCommand extends ContainerAwareCommand
@@ -39,7 +39,6 @@ class ProductRelatedEntityRemovalCommand extends ContainerAwareCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-
         $productRepository = $this->getContainer()->get('pim_catalog.repository.product');
         $entityName        = $input->getArgument('entityName');
         $ids               = explode(',', $input->getArgument('ids'));

--- a/src/Pim/Bundle/CatalogBundle/Command/RemoveOutdatedProductsFromAssociationsCommand.php
+++ b/src/Pim/Bundle/CatalogBundle/Command/RemoveOutdatedProductsFromAssociationsCommand.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  * Removes product associations.
  *
  * @author    Damien Carcel <damien.carcel@akeneo.com>
- * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 class RemoveOutdatedProductsFromAssociationsCommand extends ContainerAwareCommand

--- a/src/Pim/Bundle/CatalogBundle/Command/RemoveOutdatedProductsFromAssociationsCommand.php
+++ b/src/Pim/Bundle/CatalogBundle/Command/RemoveOutdatedProductsFromAssociationsCommand.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\Command;
+
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Removes product associations.
+ *
+ * @author    Damien Carcel <damien.carcel@akeneo.com>
+ * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class RemoveOutdatedProductsFromAssociationsCommand extends ContainerAwareCommand
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('pim:product:remove-from-associations')
+            ->setDescription('Removes a bulk of product associations (this does not remove the products themselves)')
+            ->addArgument(
+                'productIds',
+                InputArgument::REQUIRED,
+                'The list of product IDs to disassociate (comma separated)'
+            );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $assocTypeRepository = $this->getContainer()->get('pim_catalog.repository.association_type');
+        $productRepository   = $this->getContainer()->get('pim_catalog.repository.product');
+
+        $productIds     = explode(',', $input->getArgument('productIds'));
+        $assocTypeCount = $assocTypeRepository->countAll();
+
+        foreach ($productIds as $productId) {
+            $productRepository->removeAssociatedProduct($productId, $assocTypeCount);
+        }
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Command/UpdateNormalizedProductDataCommand.php
+++ b/src/Pim/Bundle/CatalogBundle/Command/UpdateNormalizedProductDataCommand.php
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  * product document when related entities are modified.
  *
  * @author    Damien Carcel <damien.carcel@akeneo.com>
- * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 class UpdateNormalizedProductDataCommand extends ContainerAwareCommand

--- a/src/Pim/Bundle/CatalogBundle/Command/UpdateNormalizedProductDataCommand.php
+++ b/src/Pim/Bundle/CatalogBundle/Command/UpdateNormalizedProductDataCommand.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\Command;
+
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Executes a list of queries to updates the normalized data of a
+ * product document when related entities are modified.
+ *
+ * @author    Damien Carcel <damien.carcel@akeneo.com>
+ * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class UpdateNormalizedProductDataCommand extends ContainerAwareCommand
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('pim:product:update-normalized-data')
+            ->setDescription('Updates the normalized data of a product when related entities are modified')
+            ->addArgument(
+                'queries',
+                InputArgument::REQUIRED,
+                'The list of queries to execute (JSON formatted)'
+            );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $documentManager = $this->getContainer()->get('doctrine_mongodb.odm.document_manager');
+        $productClass    = $this->getContainer()->getParameter('pim_catalog.entity.product.class');
+        $queries         = json_decode($input->getArgument('queries'), true);
+
+        if (null === $queries) {
+            throw new \InvalidArgumentException('There is no valid queries to execute or the JSON syntax is wrong');
+        }
+
+        $collection = $documentManager->getDocumentCollection($productClass);
+
+        foreach ($queries as $query) {
+            list($query, $compObject, $options) = $query;
+
+            // It is possible to define an option here to avoid a MongoDB timeout when having a lot of data.
+            // $options['socketTimeoutMS'] = -1;
+            $collection->update($query, $compObject, $options);
+        }
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Command/UpdateNormalizedProductDataCommand.php
+++ b/src/Pim/Bundle/CatalogBundle/Command/UpdateNormalizedProductDataCommand.php
@@ -38,8 +38,11 @@ class UpdateNormalizedProductDataCommand extends ContainerAwareCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $documentManager = $this->getContainer()->get('doctrine_mongodb.odm.document_manager');
+
         $productClass    = $this->getContainer()->getParameter('pim_catalog.entity.product.class');
-        $queries         = json_decode($input->getArgument('queries'), true);
+        $socketTimeoutMS = $this->getContainer()->getParameter('pim_catalog.mongodb.cursor.socket_timeout_ms');
+
+        $queries = json_decode($input->getArgument('queries'), true);
 
         if (null === $queries) {
             throw new \InvalidArgumentException('There is no valid queries to execute or the JSON syntax is wrong');
@@ -50,8 +53,7 @@ class UpdateNormalizedProductDataCommand extends ContainerAwareCommand
         foreach ($queries as $query) {
             list($query, $compObject, $options) = $query;
 
-            // It is possible to define an option here to avoid a MongoDB timeout when having a lot of data.
-            // $options['socketTimeoutMS'] = -1;
+            $options['socketTimeoutMS'] = (int) $socketTimeoutMS;
             $collection->update($query, $compObject, $options);
         }
     }

--- a/src/Pim/Bundle/CatalogBundle/EventSubscriber/MongoDBODM/ProductRelatedEntityRemovalSubscriber.php
+++ b/src/Pim/Bundle/CatalogBundle/EventSubscriber/MongoDBODM/ProductRelatedEntityRemovalSubscriber.php
@@ -58,7 +58,7 @@ class ProductRelatedEntityRemovalSubscriber implements EventSubscriber
         $entities       = $unitOfWork->getScheduledEntityDeletions();
         $pendingUpdates = $this->getPendingUpdates($entities);
 
-        if (null !== $pendingUpdates && $pendingUpdates['entityName'] && !empty($pendingUpdates['ids'])) {
+        if (null !== $pendingUpdates && isset($pendingUpdates['entityName']) && !empty($pendingUpdates['ids'])) {
             $command = sprintf(
                 'pim:product:remove-related-entity %s %s',
                 $pendingUpdates['entityName'],

--- a/src/Pim/Bundle/CatalogBundle/EventSubscriber/MongoDBODM/ProductRelatedEntityRemovalSubscriber.php
+++ b/src/Pim/Bundle/CatalogBundle/EventSubscriber/MongoDBODM/ProductRelatedEntityRemovalSubscriber.php
@@ -127,34 +127,36 @@ class ProductRelatedEntityRemovalSubscriber implements EventSubscriber
      */
     protected function getEntityName($entity)
     {
+        $entityName = null;
+
         if ($entity instanceof AssociationTypeInterface) {
-            return 'AssociationType';
+            $entityName = 'AssociationType';
         }
 
         if ($entity instanceof AttributeInterface) {
-            return 'Attribute';
+            $entityName = 'Attribute';
         }
 
         if ($entity instanceof AttributeOptionInterface) {
-            return 'AttributeOption';
+            $entityName = 'AttributeOption';
         }
 
         if ($entity instanceof CategoryInterface) {
-            return 'Category';
+            $entityName = 'Category';
         }
 
         if ($entity instanceof FamilyInterface) {
-            return 'Family';
+            $entityName = 'Family';
         }
 
         if ($entity instanceof GroupInterface) {
-            return 'Group';
+            $entityName = 'Group';
         }
 
         if ($entity instanceof ChannelInterface) {
-            return 'Channel';
+            $entityName = 'Channel';
         }
 
-        return null;
+        return $entityName;
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/EventSubscriber/MongoDBODM/UpdateNormalizedProductDataSubscriber.php
+++ b/src/Pim/Bundle/CatalogBundle/EventSubscriber/MongoDBODM/UpdateNormalizedProductDataSubscriber.php
@@ -24,9 +24,6 @@ class UpdateNormalizedProductDataSubscriber implements EventSubscriber
     /** @var string */
     protected $logFile;
 
-    /** @var string */
-    protected $productClass;
-
     /** @var array */
     protected $queryGenerators = [];
 
@@ -39,16 +36,11 @@ class UpdateNormalizedProductDataSubscriber implements EventSubscriber
 
     /**
      * @param CommandLauncher $commandLauncher
-     * @param string          $productClass
      * @param string          $logFile
      */
-    public function __construct(
-        CommandLauncher $commandLauncher,
-        $productClass,
-        $logFile
-    ) {
+    public function __construct(CommandLauncher $commandLauncher, $logFile)
+    {
         $this->commandLauncher = $commandLauncher;
-        $this->productClass    = $productClass;
         $this->logFile         = $logFile;
     }
 

--- a/src/Pim/Bundle/CatalogBundle/EventSubscriber/MongoDBODM/UpdateNormalizedProductDataSubscriber.php
+++ b/src/Pim/Bundle/CatalogBundle/EventSubscriber/MongoDBODM/UpdateNormalizedProductDataSubscriber.php
@@ -41,7 +41,7 @@ class UpdateNormalizedProductDataSubscriber implements EventSubscriber
     public function __construct(CommandLauncher $commandLauncher, $logFile)
     {
         $this->commandLauncher = $commandLauncher;
-        $this->logFile         = $logFile;
+        $this->logFile = $logFile;
     }
 
     /**

--- a/src/Pim/Bundle/CatalogBundle/EventSubscriber/MongoDBODM/UpdateNormalizedProductDataSubscriber.php
+++ b/src/Pim/Bundle/CatalogBundle/EventSubscriber/MongoDBODM/UpdateNormalizedProductDataSubscriber.php
@@ -2,10 +2,11 @@
 
 namespace Pim\Bundle\CatalogBundle\EventSubscriber\MongoDBODM;
 
+use Akeneo\Component\Console\CommandLauncher;
 use Doctrine\Common\EventSubscriber;
-use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ORM\Event\OnFlushEventArgs;
 use Doctrine\ORM\Event\PostFlushEventArgs;
+use Doctrine\ORM\Events;
 use Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\QueryGenerator\NormalizedDataQueryGeneratorInterface;
 
 /**
@@ -17,6 +18,15 @@ use Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\QueryGenerator\NormalizedDataQu
  */
 class UpdateNormalizedProductDataSubscriber implements EventSubscriber
 {
+    /** @var CommandLauncher */
+    protected $commandLauncher;
+
+    /** @var string */
+    protected $logFile;
+
+    /** @var string */
+    protected $productClass;
+
     /** @var array */
     protected $queryGenerators = [];
 
@@ -27,27 +37,27 @@ class UpdateNormalizedProductDataSubscriber implements EventSubscriber
      */
     protected $scheduledQueries = [];
 
-    /** @var ManagerRegistry */
-    protected $registry;
-
-    /** @var string */
-    protected $productClass;
-
     /**
-     * @param ManagerRegistry $registry
+     * @param CommandLauncher $commandLauncher
      * @param string          $productClass
+     * @param string          $logFile
      */
-    public function __construct(ManagerRegistry $registry, $productClass)
-    {
-        $this->registry = $registry;
-        $this->productClass = $productClass;
+    public function __construct(
+        CommandLauncher $commandLauncher,
+        $productClass,
+        $logFile
+    ) {
+        $this->commandLauncher = $commandLauncher;
+        $this->productClass    = $productClass;
+        $this->logFile         = $logFile;
     }
+
     /**
      * {@inheritdoc}
      */
     public function getSubscribedEvents()
     {
-        return ['onFlush', 'postFlush'];
+        return [Events::onFlush, Events::postFlush];
     }
 
     /**
@@ -157,14 +167,17 @@ class UpdateNormalizedProductDataSubscriber implements EventSubscriber
      */
     protected function executeQueries()
     {
-        $collection = $this->registry
-            ->getManagerForClass($this->productClass)
-            ->getDocumentCollection($this->productClass);
-
-        foreach ($this->scheduledQueries as $query) {
-            list($query, $compObject, $options) = $query;
-
-            $collection->update($query, $compObject, $options);
+        if (empty($this->scheduledQueries)) {
+            return;
         }
+
+        $scheduledQueries = json_encode($this->scheduledQueries);
+
+        $command = sprintf(
+            'pim:product:update-normalized-data \'%s\'',
+            $scheduledQueries
+        );
+
+        $this->commandLauncher->executeBackground($command, $this->logFile);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/storage_driver/doctrine/mongodb-odm.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/storage_driver/doctrine/mongodb-odm.yml
@@ -326,8 +326,8 @@ services:
     pim_catalog.event_subscriber.mongodb.product_related_entity_removal:
         class: '%pim_catalog.event_subscriber.mongodb.product_related_entity_removal.class%'
         arguments:
-            - '@akeneo_storage_utils.doctrine.smart_manager_registry'
-            - '%pim_catalog.entity.product.class%'
+            - '@pim_catalog.command_launcher'
+            - '%kernel.root_dir%/logs/product-related-entity-removal.log'
         tags:
             - { name: doctrine.event_subscriber, priority: 100 }
 

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/storage_driver/doctrine/mongodb-odm.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/storage_driver/doctrine/mongodb-odm.yml
@@ -317,8 +317,9 @@ services:
     pim_catalog.event_subscriber.mongodb.update_normalized_product_data:
         class: '%pim_catalog.event_subscriber.mongodb.update_normalized_product_data.class%'
         arguments:
-            - '@akeneo_storage_utils.doctrine.smart_manager_registry'
+            - '@pim_catalog.command_launcher'
             - '%pim_catalog.entity.product.class%'
+            - '%kernel.root_dir%/logs/product-update-normalized-data.log'
         tags:
             - { name: doctrine.event_subscriber, priority: 50 }
 

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/storage_driver/doctrine/mongodb-odm.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/storage_driver/doctrine/mongodb-odm.yml
@@ -454,8 +454,8 @@ services:
     pim_catalog.event_subscriber.remove_outdated_products_from_associations:
         class: '%pim_catalog.event_subscriber.remove_outdated_products_from_associations.class%'
         arguments:
-            - '@pim_catalog.repository.product'
-            - '@pim_catalog.repository.association_type'
+            - '@pim_catalog.command_launcher'
+            - '%kernel.root_dir%/logs/product-from-association-removal.log'
         tags:
             - { name: kernel.event_subscriber }
 

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/storage_driver/doctrine/mongodb-odm.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/storage_driver/doctrine/mongodb-odm.yml
@@ -320,7 +320,6 @@ services:
         class: '%pim_catalog.event_subscriber.mongodb.update_normalized_product_data.class%'
         arguments:
             - '@pim_catalog.command_launcher'
-            - '%pim_catalog.entity.product.class%'
             - '%kernel.root_dir%/logs/product-update-normalized-data.log'
         tags:
             - { name: doctrine.event_subscriber, priority: 50 }

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/storage_driver/doctrine/mongodb-odm.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/storage_driver/doctrine/mongodb-odm.yml
@@ -78,6 +78,8 @@ parameters:
 
     pim_catalog.saver.product.class: Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Saver\ProductSaver
 
+    pim_catalog.mongodb.cursor.socket_timeout_ms: 30000
+
 services:
     pim_catalog.object_manager.product:
         alias: doctrine.odm.mongodb.document_manager

--- a/src/Pim/Bundle/CatalogBundle/spec/EventSubscriber/MongoDBODM/ProductRelatedEntityRemovalSubscriberSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/EventSubscriber/MongoDBODM/ProductRelatedEntityRemovalSubscriberSpec.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace spec\Pim\Bundle\CatalogBundle\EventSubscriber\MongoDBODM;
+
+use Akeneo\Component\Console\CommandLauncher;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Event\OnFlushEventArgs;
+use Doctrine\ORM\Events;
+use Doctrine\ORM\UnitOfWork;
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\FamilyInterface;
+use Prophecy\Argument;
+
+class ProductRelatedEntityRemovalSubscriberSpec extends ObjectBehavior
+{
+    function let(CommandLauncher $launcher, $logFile)
+    {
+        $this->beConstructedWith($launcher, $logFile);
+    }
+
+    function it_is_an_event_subscriber()
+    {
+        $this->shouldImplement('Doctrine\Common\EventSubscriber');
+    }
+
+    function it_subscribes_to_some_product_events()
+    {
+        $this->getSubscribedEvents()->shouldReturn([Events::onFlush]);
+    }
+
+    function it_removes_related_entities_in_background_if_there_is_pending_updates(
+        $launcher,
+        $logFile,
+        FamilyInterface $family1,
+        FamilyInterface $family2,
+        FamilyInterface $family3,
+        OnFlushEventArgs $args,
+        EntityManagerInterface $em,
+        UnitOfWork $unitOfWork
+    ) {
+        $family1->getId()->willReturn(1);
+        $family2->getId()->willReturn(2);
+        $family3->getId()->willReturn(3);
+
+        $args->getEntityManager()->willReturn($em);
+        $em->getUnitOfWork()->willReturn($unitOfWork);
+        $unitOfWork->getScheduledEntityDeletions()->willReturn([$family1, $family2, $family3]);
+
+        $launcher->executeBackground('pim:product:remove-related-entity Family 1,2,3', $logFile)->shouldBeCalled();
+
+        $this->onFlush($args);
+    }
+
+    function it_does_not_remove_related_entities_in_background_if_there_is_no_pending_updates(
+        $launcher,
+        $logFile,
+        OnFlushEventArgs $args,
+        EntityManagerInterface $em,
+        UnitOfWork $unitOfWork
+    ) {
+        $args->getEntityManager()->willReturn($em);
+        $em->getUnitOfWork()->willReturn($unitOfWork);
+        $unitOfWork->getScheduledEntityDeletions()->willReturn([]);
+
+        $launcher->executeBackground('pim:product:remove-related-entity', $logFile)->shouldNotBeCalled();
+
+        $this->onFlush($args);
+    }
+
+    function it_throws_an_exeption_if_there_is_pending_updates_for_several_type_of_entity(
+        FamilyInterface $family,
+        AttributeInterface $attribute,
+        OnFlushEventArgs $args,
+        EntityManagerInterface $em,
+        UnitOfWork $unitOfWork
+    ) {
+        $args->getEntityManager()->willReturn($em);
+        $em->getUnitOfWork()->willReturn($unitOfWork);
+        $unitOfWork->getScheduledEntityDeletions()->willReturn([$family, $attribute]);
+
+        $this->shouldThrow('\InvalidArgumentException')->duringOnFlush($args);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/spec/EventSubscriber/MongoDBODM/RemoveOutdatedProductsFromAssociationsSubscriberSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/EventSubscriber/MongoDBODM/RemoveOutdatedProductsFromAssociationsSubscriberSpec.php
@@ -29,12 +29,12 @@ class RemoveOutdatedProductsFromAssociationsSubscriberSpec extends ObjectBehavio
         $this->getSubscribedEvents()->shouldReturn(
             [
                 StorageEvents::POST_REMOVE      => 'removeAssociatedProduct',
-                ProductEvents::POST_MASS_REMOVE => 'removeAssociatedProducts'
+                ProductEvents::POST_MASS_REMOVE => 'removeAssociatedProducts',
             ]
         );
     }
 
-    function it_removed_associated_product(
+    function it_removes_associated_product_in_background(
         $launcher,
         $logFile,
         RemoveEvent $event,
@@ -48,7 +48,7 @@ class RemoveOutdatedProductsFromAssociationsSubscriberSpec extends ObjectBehavio
         $this->removeAssociatedProduct($event);
     }
 
-    function it_removed_associated_products_on_many_products(
+    function it_removes_associated_products_on_many_products_in_background(
         $launcher,
         $logFile,
         RemoveEvent $event

--- a/src/Pim/Bundle/CatalogBundle/spec/EventSubscriber/MongoDBODM/UpdateNormalizedProductDataSubscriberSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/EventSubscriber/MongoDBODM/UpdateNormalizedProductDataSubscriberSpec.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace spec\Pim\Bundle\CatalogBundle\EventSubscriber\MongoDBODM;
+
+use Akeneo\Component\Console\CommandLauncher;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Event\OnFlushEventArgs;
+use Doctrine\ORM\Events;
+use Doctrine\ORM\UnitOfWork;
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\QueryGenerator\NormalizedDataQueryGeneratorInterface;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\AttributeOptionInterface;
+use Pim\Component\Catalog\Model\FamilyInterface;
+use Prophecy\Argument;
+
+class UpdateNormalizedProductDataSubscriberSpec extends ObjectBehavior
+{
+    function let(
+        NormalizedDataQueryGeneratorInterface $queryGenerator,
+        CommandLauncher $launcher,
+        $logFile
+    ) {
+        $this->beConstructedWith($launcher, $logFile);
+        $this->addQueryGenerator($queryGenerator);
+    }
+
+    function it_is_an_event_subscriber()
+    {
+        $this->shouldImplement('Doctrine\Common\EventSubscriber');
+    }
+
+    function it_subscribes_to_some_product_events()
+    {
+        $this->getSubscribedEvents()->shouldReturn([Events::onFlush, Events::postFlush]);
+    }
+
+    function it_does_not_generate_query_if_no_update_or_delete_are_schedule(
+        $queryGenerator,
+        OnFlushEventArgs $args,
+        EntityManagerInterface $em,
+        UnitOfWork $uow
+    ) {
+        $args->getEntityManager()->willReturn($em);
+        $em->getUnitOfWork()->willReturn($uow);
+
+        $uow->getScheduledEntityUpdates()->willReturn([]);
+        $uow->getScheduledEntityDeletions()->willReturn([]);
+        $uow->getScheduledCollectionDeletions()->willReturn([]);
+        $uow->getScheduledCollectionUpdates()->willReturn([]);
+
+        $uow->getEntityChangeSet(null)->willReturn([]);
+
+        $queryGenerator->supports()->shouldNotBeCalled();
+        $queryGenerator->generateQuery()->shouldNotBeCalled();
+
+        $this->onFlush($args);
+    }
+
+    function it_generates_query_if_entity_update_is_schedule(
+        $queryGenerator,
+        FamilyInterface $family,
+        AttributeInterface $attribute1,
+        AttributeInterface $attribute2,
+        OnFlushEventArgs $args,
+        EntityManagerInterface $em,
+        UnitOfWork $uow
+    ) {
+        $family->getAttributeAsLabel()->willReturn($attribute1);
+
+        $family->setAttributeAsLabel($attribute2);
+
+        $args->getEntityManager()->willReturn($em);
+        $em->getUnitOfWork()->willReturn($uow);
+
+        $uow->getScheduledEntityUpdates()->willReturn([$family]);
+        $uow->getScheduledEntityDeletions()->willReturn([]);
+        $uow->getScheduledCollectionDeletions()->willReturn([]);
+        $uow->getScheduledCollectionUpdates()->willReturn([]);
+
+        $uow->getEntityChangeSet($family)->willReturn(['attributeAsLabel' => [$attribute1, $attribute2]]);
+
+        $queryGenerator->supports($family, 'attributeAsLabel')->willReturn(true);
+        $queryGenerator->generateQuery($family, 'attributeAsLabel', $attribute1, $attribute2)->shouldBeCalled();
+
+        $this->onFlush($args);
+    }
+
+    function it_generates_query_if_entity_delete_is_schedule(
+        $queryGenerator,
+        AttributeInterface $attribute,
+        OnFlushEventArgs $args,
+        EntityManagerInterface $em,
+        UnitOfWork $uow
+    ) {
+        $args->getEntityManager()->willReturn($em);
+        $em->getUnitOfWork()->willReturn($uow);
+
+        $uow->getScheduledEntityUpdates()->willReturn([]);
+        $uow->getScheduledEntityDeletions()->willReturn([$attribute]);
+        $uow->getScheduledCollectionDeletions()->willReturn([]);
+        $uow->getScheduledCollectionUpdates()->willReturn([]);
+
+        $queryGenerator->supports($attribute, '')->willReturn(true);
+        $queryGenerator->generateQuery($attribute, '', '', '')->shouldBeCalled();
+
+        $this->onFlush($args);
+    }
+
+    function it_generates_query_if_collection_delete_is_schedule(
+        $queryGenerator,
+        AttributeOptionInterface $option,
+        OnFlushEventArgs $args,
+        EntityManagerInterface $em,
+        UnitOfWork $uow
+    ) {
+        $optionCollection = new ArrayCollection([$option]);
+
+        $args->getEntityManager()->willReturn($em);
+        $em->getUnitOfWork()->willReturn($uow);
+
+        $uow->getScheduledEntityUpdates()->willReturn([]);
+        $uow->getScheduledEntityDeletions()->willReturn([]);
+        $uow->getScheduledCollectionDeletions()->willReturn($optionCollection);
+        $uow->getScheduledCollectionUpdates()->willReturn([]);
+
+        $queryGenerator->supports($option, '')->willReturn(true);
+        $queryGenerator->generateQuery($option, '', '', '')->shouldBeCalled();
+
+        $this->onFlush($args);
+    }
+}


### PR DESCRIPTION
**Description**

When having a lot of products in a MongoDB installation, one cannot remove a product related entity (attribute, family, association, group…) without freezing the UI, as it takes some time to check all products to remove all corresponding data (for instance the product values if one delete an attribute) from all the products. In some case, it will even cause a timeout, causing the operation too fail and resulting in an error 500 for products that have not been cleaned.
The same problem happen when removing a product, as every other products will be checked to remove a possible association.

The operation responsible of these UI freeze are done in 3 event subscribers:
- ProductRelatedEntityRemovalSubscriber,
- RemoveOutdatedProductsFromAssociationsSubscriber,
- UpdateNormalizedProductDataSubscriber.
  The goal of this PR is to prevent that by detaching the logic into symfony commands. The subscribers only launch the commands, and so do not freeze the UI anymore.

This behavior can also happen with small number of products but great number of channels. I already encountered a CE project with less than 5M product values, but with 8 channels, with 8 activated locale each at least! In this case, the Mongo queries are very slow because all the indexes are taken by the completeness, and deleting an attribute takes several minutes!
In this case, the "UpdateNormalizedProductDataCommand" is responsible, as the MongoDB request it performs are very slow due to the lack of indexes. A possibility (placed in the PR as commented code) is to control the Mongo time out with the "socketTimeoutMS" option.

**Definition Of Done**

| Q | A |
| --- | --- |
| Added Specs | Yes |
| Added Behats | No |
| Changelog updated | Yes |
| Review and 2 GTM | Waiting |
| Micro Demo to the PO (Story only) | No |
| Migration script | No |
|  Tech Doc | No |
