### PR TITLE
Fix localized quick export

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.fr.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.fr.yml
@@ -89,6 +89,7 @@ Delete the product: Supprimer le produit
 Change status: Changer le statut
 Toggle status: Changer le statut
 pim.grid.mass_action.quick_export.csv_all: CSV (tous les attributs)
+pim.grid.mass_action.quick_export.xlsx_all: XLSX (tous les attributs)
 pim.grid.mass_action.delete: Supprimer
 pim.grid.mass_action.mass_edit: Edition de masse
 pim.grid.mass_action.sequential_edit: Modification séquentielle


### PR DESCRIPTION
Adds the french translation of the quick export button necessary in the features/localization/mass-action/quick_export.feature scenario.

Bug introduced in #4125.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Changelog updated                 | -
| Blue CI                 | Yes
| Review and 2 GTM                  | Yes
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

