### PR TITLE
[DX] attempts around git subtree split to extract batch and batch bundle

### DIFF
--- a/src/Akeneo/Bundle/BatchBundle/README.md
+++ b/src/Akeneo/Bundle/BatchBundle/README.md
@@ -12,6 +12,14 @@ Akeneo PIM
 
 Originally written to be used in [Akeneo PIM](https://www.akeneo.com/).
 
+This extraction aims to make it usable outside of the Akeneo PIM project.
+
+Please consider that this process is still in a very experimental stage.
+
+We don't have all the tests and automation which could ensure that this component will work smoothly outside of the Akeneo PIM full stack.
+
+TODO: this Bundle now depends on Akeneo/StorageUtils component and related bundle and can't be extracted without those two.
+
 Documentation
 -------------
 

--- a/src/Akeneo/Bundle/BatchBundle/README.md
+++ b/src/Akeneo/Bundle/BatchBundle/README.md
@@ -1,6 +1,39 @@
-BatchBundle
-===========
+Batch Bundle
+============
 
 Batch architecture bundle inspired by Spring Batch.
 
-See http://docs.spring.io/spring-batch/reference/html/domain.html for an explanation of the Domain Language objects you will find in this BatchBundle.
+See http://docs.spring.io/spring-batch/reference/html/domain.html for an explanation of the Domain Language objects you will find.
+
+Based on the [Batch component](https://github.com/akeneo/batch).
+
+Akeneo PIM
+----------
+
+Originally written to be used in [Akeneo PIM](https://www.akeneo.com/).
+
+Documentation
+-------------
+
+Documentation is available on [docs.akeneo.com](http://docs.akeneo.com)
+
+Contributing
+------------
+
+This bundle is developed in our [main repository](https://github.com/akeneo/pim-community-dev).
+
+If you want to contribute (and we will be pleased if you do!), you'l find more information on [this page](http://docs.akeneo.com/latest/contributing/index.html).
+
+About versioning, the version 0.6.x is developed in akeneo/pim-community-dev 1.6.x.
+
+For older versions,
+ - akeneo/pim-community-dev 1.1.x uses akeneo/batch-bundle 0.1.x
+ - akeneo/pim-community-dev 1.2.x uses akeneo/batch-bundle 0.2.x
+ - akeneo/pim-community-dev 1.3.x uses akeneo/batch-bundle 0.3.x
+ - akeneo/pim-community-dev 1.4.x uses akeneo/batch-bundle 0.4.x
+ - akeneo/pim-community-dev 1.5.x re-integrates this bundle in our main repository
+
+OSL Licence
+-----------
+
+Licence can be found [Here](https://github.com/akeneo/pim-community-dev/blob/master/LICENCE.txt).

--- a/src/Akeneo/Bundle/BatchBundle/composer.json
+++ b/src/Akeneo/Bundle/BatchBundle/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "akeneo/batch-bundle",
     "type": "symfony-bundle",
-    "description": "Akeneo Batch Bundle",
+    "description": "Akeneo Symfony Batch Bundle",
     "keywords": ["Akeneo", "Batch", "Job", "Reader", "Writer", "Processor"],
     "license": "OSL-3.0",
     "authors": [
@@ -12,25 +12,29 @@
     ],
     "require": {
         "php": ">=5.4.4",
-        "symfony/symfony": "^2.1",
-        "symfony/swiftmailer-bundle": "^2.3.5",
+        "akeneo/batch": "0.6.x-dev",
+        "symfony/config": "^2.3",
+        "symfony/console": "^2.3",
+        "symfony/dependency-injection": "^2.3",
+        "symfony/event-dispatcher": "^2.3",
+        "symfony/http-foundation": "^2.3",
+        "symfony/http-kernel": "^2.3",
+        "symfony/translation": "^2.3",
+        "symfony/process": "^2.3",
+        "symfony/security": "^2.3",
+        "symfony/validator": "^2.3",
+        "symfony/yaml": "^2.3",
+        "symfony/framework-bundle": "^2.3",
         "doctrine/orm": "^2.1.3",
         "monolog/monolog": "^1.1.0"
-    },
-    "require-dev": {
-      "phpspec/phpspec": "2.1.*"
     },
     "autoload": {
         "psr-4": { "Akeneo\\Bundle\\BatchBundle": "" }
     },
-    "target-dir": "Akeneo/Bundle/BatchBundle",
-    "config": {
-      "bin-dir": "bin"
-    },
     "minimum-stability": "stable",
     "extra": {
         "branch-alias": {
-            "dev-master": "0.5.x-dev"
+            "dev-master": "0.6.x-dev"
         }
     }
 }

--- a/src/Akeneo/Bundle/BatchBundle/composer.json
+++ b/src/Akeneo/Bundle/BatchBundle/composer.json
@@ -3,7 +3,13 @@
     "type": "symfony-bundle",
     "description": "Akeneo Batch Bundle",
     "keywords": ["Akeneo", "Batch", "Job", "Reader", "Writer", "Processor"],
-    "license": "MIT",
+    "license": "OSL-3.0",
+    "authors": [
+        {
+            "name": "Akeneo",
+            "homepage": "http://www.akeneo.com"
+        }
+    ],
     "require": {
         "php": ">=5.4.4",
         "symfony/symfony": "^2.1",
@@ -15,7 +21,7 @@
       "phpspec/phpspec": "2.1.*"
     },
     "autoload": {
-        "psr-0": { "Akeneo\\Bundle\\BatchBundle": "" }
+        "psr-4": { "Akeneo\\Bundle\\BatchBundle": "" }
     },
     "target-dir": "Akeneo/Bundle/BatchBundle",
     "config": {

--- a/src/Akeneo/Component/Batch/README.md
+++ b/src/Akeneo/Component/Batch/README.md
@@ -1,0 +1,32 @@
+Batch Component
+===============
+
+Batch architecture component inspired by Spring Batch.
+
+See http://docs.spring.io/spring-batch/reference/html/domain.html for an explanation of the Domain Language objects you will find.
+
+A [Symfony Bundle](https://github.com/akeneo/BatchBundle) also exists to integrate this component in your Symfony project.
+
+Akeneo PIM
+----------
+
+Originally written to be used in [Akeneo PIM](https://www.akeneo.com/).
+
+Documentation
+-------------
+
+Documentation is available on [docs.akeneo.com](http://docs.akeneo.com)
+
+Contributing
+------------
+
+This component is developed in our [main repository](https://github.com/akeneo/pim-community-dev).
+
+If you want to contribute (and we will be pleased if you do!), you'l find more information on [this page](http://docs.akeneo.com/latest/contributing/index.html).
+
+About versioning, the version 0.6.x is developed in akeneo/pim-community-dev 1.6.x.
+
+OSL Licence
+-----------
+
+Licence can be found [Here](https://github.com/akeneo/pim-community-dev/blob/master/LICENCE.txt).

--- a/src/Akeneo/Component/Batch/README.md
+++ b/src/Akeneo/Component/Batch/README.md
@@ -12,6 +12,12 @@ Akeneo PIM
 
 Originally written to be used in [Akeneo PIM](https://www.akeneo.com/).
 
+This extraction aims to make it usable outside of the Akeneo PIM project.
+
+Please consider that this process is still in a very experimental stage.
+
+We don't have all the tests and automation which could ensure that this component will work smoothly outside of the Akeneo PIM full stack.
+
 Documentation
 -------------
 

--- a/src/Akeneo/Component/Batch/composer.json
+++ b/src/Akeneo/Component/Batch/composer.json
@@ -19,7 +19,6 @@
     "autoload": {
         "psr-4": { "Akeneo\\Component\\Batch\\": "" }
     },
-    "target-dir": "Akeneo/Component/Batch",
     "minimum-stability": "stable",
     "extra": {
         "branch-alias": {

--- a/src/Akeneo/Component/Batch/composer.json
+++ b/src/Akeneo/Component/Batch/composer.json
@@ -1,0 +1,29 @@
+{
+    "name": "akeneo/batch",
+    "type": "library",
+    "description": "Akeneo Batch",
+    "keywords": ["Akeneo", "Batch", "Job", "Reader", "Writer", "Processor"],
+    "license": "OSL-3.0",
+    "authors": [
+        {
+            "name": "Akeneo",
+            "homepage": "http://www.akeneo.com"
+        }
+    ],
+    "require": {
+        "php": ">=5.4.4",
+        "symfony/event-dispatcher": "^2.3",
+        "symfony/property-access": "^2.3",
+        "doctrine/common": "^2.1"
+    },
+    "autoload": {
+        "psr-4": { "Akeneo\\Component\\Batch\\": "" }
+    },
+    "target-dir": "Akeneo/Component/Batch",
+    "minimum-stability": "stable",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "0.6.x-dev"
+        }
+    }
+}


### PR DESCRIPTION
As follow up of issues https://github.com/akeneo/BatchBundle/issues/88 and https://github.com/akeneo/BatchBundle/issues/87

**TL;DR**

This PR is a first attempt to extract akeneo/batch and akeneo/batch-bundle to make them usable outside of the Akeneo PIM full stack in read only repositories https://github.com/akeneo/batch and https://github.com/akeneo/BatchBundle.

Batch component is now usable outside of the PIM.

There is still some work to do on BatchBundle because in dev-master, it now uses storage utils interface (to prepare the decoupling from doctrine storage), so to be extracted, it requires to extract StorageUtils and related StorageUtilsBundle in dedicated read only repositories too.

Lot of new questions about versioning, branching strategy, main repo organization to easily ship phpspec in the readonly repo etc, so please consider this extraction as an experimental process in a very early stage.

**Long story about BatchBundle status**

The Akeneo/BatchBundle has been introduced in the very first version of the PIM.

It has been located in a dedicated Github repository and, due to that, it has not been enhanced as much as the other bundles, it's a shame because this bundle provides the main interfaces and classes to structure the connectors for import/export.

To ease the improvements of this key part of the PIM, we moved the bundle in the pim-community-dev repository during the 1.5 release.

With the same strategy than for other "old" bundles, business interfaces and classes have been extracted in a Akeneo/Batch component. It helps to clearly separate its business logic and the Symfony and Doctrine "glue" cf http://docs.akeneo.com/latest/reference/components/index.html

There are still lot of known design issues with the Batch component and bundle, we're working on improving it for the upcoming 1.6 which will hopefully ease the extraction.