### PR TITLE
[TR] Fix archive to download when exporting items with media

### DIFF
--- a/spec/Pim/Component/Connector/Writer/File/CsvProductWriterSpec.php
+++ b/spec/Pim/Component/Connector/Writer/File/CsvProductWriterSpec.php
@@ -58,6 +58,16 @@ class CsvProductWriterSpec extends ObjectBehavior
         ], '/tmp/export')->shouldBeCalled();
 
         $mediaCopier->getErrors()->willReturn([]);
+        $mediaCopier->getCopiedMedia()->willReturn([
+            [
+                'copyPath'       => '/tmp/export',
+                'originalMedium' => [
+                    'filePath'     => 'img/product1.jpg',
+                    'exportPath'   => 'export',
+                    'storageAlias' => 'storageAlias',
+                ]
+            ]
+        ]);
 
         $this->write([
             [
@@ -82,6 +92,10 @@ class CsvProductWriterSpec extends ObjectBehavior
                     'storageAlias' => 'storageAlias',
                 ],
             ]
+        ]);
+
+        $this->getWrittenFiles()->shouldBeEqualTo([
+            '/tmp/export' => 'export'
         ]);
     }
 }

--- a/spec/Pim/Component/Connector/Writer/File/XlsxProductWriterSpec.php
+++ b/spec/Pim/Component/Connector/Writer/File/XlsxProductWriterSpec.php
@@ -74,7 +74,7 @@ class XlsxProductWriterSpec extends ObjectBehavior
 
         $mediaCopier->exportAll([
             [
-                'filePath' => null,
+                'filePath' => 'wrong/path',
                 'exportPath' => 'export',
                 'storageAlias' => 'storageAlias',
             ],
@@ -87,14 +87,34 @@ class XlsxProductWriterSpec extends ObjectBehavior
 
         $mediaCopier->getErrors()->willReturn([
             [
-                'medium' => ['...'],
+                'medium' => [
+                    [
+                        'filePath' => 'wrong/path',
+                        'exportPath' => 'export',
+                        'storageAlias' => 'storageAlias',
+                    ]
+                ],
                 'message' => 'Error message',
+            ]
+        ]);
+        $mediaCopier->getCopiedMedia()->willReturn([
+            [
+                'copyPath'       => '/tmp/export',
+                'originalMedium' => [
+                    'filePath'     => 'img/product1.jpg',
+                    'exportPath'   => 'export',
+                    'storageAlias' => 'storageAlias',
+                ]
             ]
         ]);
 
         $stepExecution->addWarning(Argument::cetera())->shouldBeCalled();
 
         $this->write($items);
+
+        $this->getWrittenFiles()->shouldBeEqualTo([
+            '/tmp/export' => 'export'
+        ]);
     }
 
     function it_writes_the_xlsx_file($flatRowBuffer, BufferInterface $buffer)
@@ -114,7 +134,7 @@ class XlsxProductWriterSpec extends ObjectBehavior
                     'family' => 12,
                 ],
                 'media' => [
-                    'filePath' => null,
+                    'filePath' => 'wrong/path',
                     'exportPath' => 'export',
                     'storageAlias' => 'storageAlias',
                 ],

--- a/src/Pim/Component/Connector/Writer/File/CsvProductWriter.php
+++ b/src/Pim/Component/Connector/Writer/File/CsvProductWriter.php
@@ -2,11 +2,6 @@
 
 namespace Pim\Component\Connector\Writer\File;
 
-use Akeneo\Component\Buffer\BufferFactory;
-use Akeneo\Component\FileStorage\Exception\FileTransferException;
-use Pim\Component\Connector\Writer\File\BulkFileExporter;
-use Pim\Component\Connector\Writer\File\FlatItemBuffer;
-
 /**
  * Write product data into a csv file on the local filesystem
  *
@@ -19,6 +14,11 @@ class CsvProductWriter extends CsvWriter
     /** @var BulkFileExporter */
     protected $mediaCopier;
 
+    /**
+     * @param FilePathResolverInterface $filePathResolver
+     * @param FlatItemBuffer            $flatRowBuffer
+     * @param BulkFileExporter          $mediaCopier
+     */
     public function __construct(
         FilePathResolverInterface $filePathResolver,
         FlatItemBuffer $flatRowBuffer,
@@ -48,6 +48,10 @@ class CsvProductWriter extends CsvWriter
         parent::write($products);
 
         $this->mediaCopier->exportAll($media, $exportDirectory);
+
+        foreach ($this->mediaCopier->getCopiedMedia() as $copy) {
+            $this->writtenFiles[$copy['copyPath']] = $copy['originalMedium']['exportPath'];
+        }
 
         foreach ($this->mediaCopier->getErrors() as $error) {
             $this->stepExecution->addWarning(

--- a/src/Pim/Component/Connector/Writer/File/CsvWriter.php
+++ b/src/Pim/Component/Connector/Writer/File/CsvWriter.php
@@ -3,8 +3,6 @@
 namespace Pim\Component\Connector\Writer\File;
 
 use Akeneo\Component\Batch\Job\RuntimeErrorException;
-use Akeneo\Component\Buffer\BufferFactory;
-use Akeneo\Component\Buffer\BufferInterface;
 use Symfony\Component\Validator\Constraints as Assert;
 
 /**
@@ -34,6 +32,10 @@ class CsvWriter extends AbstractFileWriter implements ArchivableWriterInterface
     /** @var array */
     protected $writtenFiles = [];
 
+    /**
+     * @param FilePathResolverInterface $filePathResolver
+     * @param FlatItemBuffer            $flatRowBuffer
+     */
     public function __construct(FilePathResolverInterface $filePathResolver, FlatItemBuffer $flatRowBuffer)
     {
         parent::__construct($filePathResolver);


### PR DESCRIPTION
This PR fixes a bug with CSV Product Export, XLSX Product Export, but CSV variant group Export is ok. When we export items with media, there is no archive to download with media.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | ok
| Added Behats                      | They are in 1.4, need to be remontay Waiting for CI
| Changelog updated                 | Bug has been merge in master, no need to update
| Review and 2 GTM                  | 
| Micro Demo to the PO (Story only) |
| Migration script                  |
| Tech Doc                          |

