### PR TITLE
FieldFilterInterface: $operator should not be array

### DIFF
--- a/src/Pim/Component/Catalog/Query/Filter/FieldFilterInterface.php
+++ b/src/Pim/Component/Catalog/Query/Filter/FieldFilterInterface.php
@@ -15,7 +15,7 @@ interface FieldFilterInterface extends FilterInterface
      * Add an attribute to filter
      *
      * @param string       $field    the field
-     * @param string|array $operator the used operator
+     * @param string       $operator the used operator
      * @param string|array $value    the value(s) to filter
      * @param string       $locale   the locale
      * @param string       $scope    the scope


### PR DESCRIPTION
Fix PHPDoc for FieldFilterInterface

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       |n
| Added Behats                      |n
| Changelog updated                 |n
| Review and 2 GTM                  |
| Micro Demo to the PO (Story only) |n
| Migration script                  |n
| Tech Doc                          |n

