### PR TITLE
Dummy items should extend AbstractConfigurableStepElement

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -110,3 +110,6 @@
 - Change constructor of `Pim/Component/Catalog/Repository/ChannelRepositoryInterface` replace argument `Pim\Bundle\CatalogBundle\Manager\ChannelManager` by `Pim\Component\Catalog\Repository\ChannelRepositoryInterface`.
 - Rename `Pim\Component\Catalog\Repository\ChannelRepositoryInterface::getChannelChoices` to `Pim\Component\Catalog\Repository\ChannelRepositoryInterface::getLabelsIndexedByCode`
 - Change constructor of `Akeneo\Bundle\BatchBundle\Job\DoctrineJobRepository` to inject two more arguments `%akeneo_batch.entity.job_instance.class%` and `%pim_import_export.repository.job_instance.class%`
+- `DummyItemReader` now extends `AbstractConfigurableStepElement`
+- `DummyItemProcessor` now extends `AbstractConfigurableStepElement`
+- `DummyItemWriter` now extends `AbstractConfigurableStepElement`

--- a/src/Pim/Component/Connector/Processor/DummyItemProcessor.php
+++ b/src/Pim/Component/Connector/Processor/DummyItemProcessor.php
@@ -12,7 +12,7 @@ use Akeneo\Component\Batch\Item\ItemProcessorInterface;
  * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class DummyItemProcessor implements ItemProcessorInterface
+class DummyItemProcessor extends AbstractConfigurableStepElement implements ItemProcessorInterface
 {
     /**
      * {@inheritdoc}
@@ -20,5 +20,13 @@ class DummyItemProcessor implements ItemProcessorInterface
     public function process($item)
     {
         return null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getConfigurationFields()
+    {
+        return [];
     }
 }

--- a/src/Pim/Component/Connector/Reader/DummyItemReader.php
+++ b/src/Pim/Component/Connector/Reader/DummyItemReader.php
@@ -12,7 +12,7 @@ use Akeneo\Component\Batch\Item\ItemReaderInterface;
  * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class DummyItemReader implements ItemReaderInterface
+class DummyItemReader extends AbstractConfigurableStepElement implements ItemReaderInterface
 {
     /**
      * {@inheritdoc}
@@ -20,5 +20,13 @@ class DummyItemReader implements ItemReaderInterface
     public function read()
     {
         return null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getConfigurationFields()
+    {
+        return [];
     }
 }

--- a/src/Pim/Component/Connector/Writer/DummyItemWriter.php
+++ b/src/Pim/Component/Connector/Writer/DummyItemWriter.php
@@ -12,7 +12,7 @@ use Akeneo\Component\Batch\Item\ItemWriterInterface;
  * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class DummyItemWriter implements ItemWriterInterface
+class DummyItemWriter extends AbstractConfigurableStepElement implements ItemWriterInterface
 {
     /**
      * {@inheritdoc}
@@ -20,5 +20,13 @@ class DummyItemWriter implements ItemWriterInterface
     public function write(array $items)
     {
         return null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getConfigurationFields()
+    {
+        return [];
     }
 }


### PR DESCRIPTION
**Description**

Dummy items (reader, processor and writer) should extends AbstractConfigurableStepElement, otherwise, it is not possible to use them in import/export:  the lack of the "getName" method (defined in the abstract class) prevent the form to be rendered.

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | No
| Added Behats                      | No
| Changelog updated                 | Yes
| Review and 2 GTM                  | Waiting
| Micro Demo to the PO (Story only) | No
| Migration script                  | No
| Tech Doc                          | No

