### PR TITLE
PIM-5542: Optimized Family normalization

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -6,6 +6,10 @@
 - PIM-5096: Introduce the XLSX quick export
 - PIM-5593: The context is now kept in the associations tab of the product edit form
 
+## Scalability improvements
+
+- PIM-5542: Optimize the Family normalization
+
 ## Technical improvements
 
 - PIM-5589: Introduce a channels, attribute groups, group types, locales and currencies import using the new import system introduced in v1.4
@@ -124,3 +128,4 @@
 - Remove namespace `Pim\Bundle\BaseConnectorBundle\Exception`
 - Remove `TransformBundle`
 - Change constructor of `Pim\Component\Catalog\Updater\GroupUpdater` and `Pim\Component\Catalog\Updater\VariantGroupUpdater`, add `Pim\Component\Catalog\Repository\AttributeRepositoryInterface`
+- Change constructor of `Akeneo\Bundle\BatchBundle\Job\Pim\Bundle\TransformBundle\Normalizer\Structured\FamilyNormalizer` to inject two more dependendies `Pim\Component\Catalog\Repository\AttributeRepositoryInterface` and `Pim\Component\Catalog\Repository\AttributeRequirementRepositoryInterface`

--- a/features/export/export_families.feature
+++ b/features/export/export_families.feature
@@ -17,10 +17,10 @@ Feature: Export families
     And exported file of "footwear_family_export" should contain:
       """
       code;label-en_US;attributes;attribute_as_label;requirements-mobile;requirements-tablet
-      boots;Boots;sku,name,manufacturer,weather_conditions,description,price,rating,side_view,top_view,size,color,lace_color;name;sku,name,price,size,color;sku,name,description,weather_conditions,price,rating,side_view,size,color
-      heels;Heels;sku,name,manufacturer,description,price,side_view,top_view,size,color,heel_color,sole_color,sole_fabric;name;sku,name,price,size,color,heel_color,sole_color;sku,name,description,price,side_view,size,color,heel_color,sole_color
-      sneakers;Sneakers;sku,name,manufacturer,weather_conditions,description,price,rating,side_view,top_view,size,color,lace_color;name;sku,name,price,size,color;sku,name,description,weather_conditions,price,rating,side_view,size,color
-      sandals;Sandals;sku,name,manufacturer,description,price,rating,side_view,size,color;name;sku,name,price,size,color;sku,name,description,price,rating,side_view,size,color
+      boots;Boots;color,description,lace_color,manufacturer,name,price,rating,side_view,size,sku,top_view,weather_conditions;name;color,name,price,size,sku;color,description,name,price,rating,side_view,size,sku,weather_conditions
+      heels;Heels;color,description,heel_color,manufacturer,name,price,side_view,size,sku,sole_color,sole_fabric,top_view;name;color,heel_color,name,price,size,sku,sole_color;color,description,heel_color,name,price,side_view,size,sku,sole_color
+      sneakers;Sneakers;color,description,lace_color,manufacturer,name,price,rating,side_view,size,sku,top_view,weather_conditions;name;color,name,price,size,sku;color,description,name,price,rating,side_view,size,sku,weather_conditions
+      sandals;Sandals;color,description,manufacturer,name,price,rating,side_view,size,sku;name;color,name,price,size,sku;color,description,name,price,rating,side_view,size,sku
       """
 
   @javascript
@@ -40,9 +40,9 @@ Feature: Export families
     And exported file of "footwear_family_export" should contain:
       """
       code;label-en_US;attributes;attribute_as_label;requirements-mobile;requirements-tablet
-      boots;Boots;sku,name,manufacturer,weather_conditions,description,price,rating,side_view,top_view,size,color,lace_color;name;sku,name,price,size,color;sku,name,description,weather_conditions,price,rating,side_view,size,color
-      heels;Heels;sku,name,manufacturer,description,price,side_view,top_view,size,color,heel_color,sole_color,sole_fabric;name;sku,name,price,size,color,heel_color,sole_color;sku,name,description,price,side_view,size,color,heel_color,sole_color
-      sneakers;Sneakers;sku,name,manufacturer,weather_conditions,description,price,rating,side_view,top_view,size,color,lace_color;name;sku,name,price,size,color;sku,name,description,weather_conditions,price,rating,side_view,size,color
-      sandals;Sandals;sku,name,manufacturer,description,price,rating,side_view,size,color;name;sku,name,price,size,color;sku,name,description,price,rating,side_view,size,color
+      boots;Boots;color,description,lace_color,manufacturer,name,price,rating,side_view,size,sku,top_view,weather_conditions;name;color,name,price,size,sku;color,description,name,price,rating,side_view,size,sku,weather_conditions
+      heels;Heels;color,description,heel_color,manufacturer,name,price,side_view,size,sku,sole_color,sole_fabric,top_view;name;color,heel_color,name,price,size,sku,sole_color;color,description,heel_color,name,price,side_view,size,sku,sole_color
+      sneakers;Sneakers;color,description,lace_color,manufacturer,name,price,rating,side_view,size,sku,top_view,weather_conditions;name;color,name,price,size,sku;color,description,name,price,rating,side_view,size,sku,weather_conditions
+      sandals;Sandals;color,description,manufacturer,name,price,rating,side_view,size,sku;name;color,name,price,size,sku;color,description,name,price,rating,side_view,size,sku
       tractors;;sku;sku;sku;sku
       """

--- a/spec/Pim/Component/Catalog/Normalizer/Structured/FamilyNormalizerSpec.php
+++ b/spec/Pim/Component/Catalog/Normalizer/Structured/FamilyNormalizerSpec.php
@@ -3,20 +3,23 @@
 namespace spec\Pim\Component\Catalog\Normalizer\Structured;
 
 use PhpSpec\ObjectBehavior;
-use Pim\Bundle\CatalogBundle\Entity\AttributeRequirement;
+use Pim\Bundle\CatalogBundle\Filter\CollectionFilterInterface;
 use Pim\Component\Catalog\Model\AttributeInterface;
-use Pim\Component\Catalog\Model\ChannelInterface;
 use Pim\Component\Catalog\Model\FamilyInterface;
 use Pim\Component\Connector\Normalizer\Flat\TranslationNormalizer;
+use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
+use Pim\Component\Catalog\Repository\AttributeRequirementRepositoryInterface;
 use Prophecy\Argument;
 
 class FamilyNormalizerSpec extends ObjectBehavior
 {
     function let(
-        TranslationNormalizer $transnormalizer,
-        FamilyInterface $family
+        TranslationNormalizer $normalizer,
+        CollectionFilterInterface $filter,
+        AttributeRepositoryInterface $attributeRepository,
+        AttributeRequirementRepositoryInterface $requirementsRepository
     ) {
-        $this->beConstructedWith($transnormalizer);
+        $this->beConstructedWith($normalizer, $filter, $attributeRepository, $requirementsRepository);
     }
 
     function it_is_initializable()
@@ -29,7 +32,7 @@ class FamilyNormalizerSpec extends ObjectBehavior
         $this->shouldImplement('Symfony\Component\Serializer\Normalizer\NormalizerInterface');
     }
 
-    function it_supports_family_normalization_into_json_and_xml($family)
+    function it_supports_family_normalization_into_json_and_xml(FamilyInterface $family)
     {
         $this->supportsNormalization($family, 'csv')->shouldBe(false);
         $this->supportsNormalization($family, 'json')->shouldBe(true);
@@ -37,37 +40,38 @@ class FamilyNormalizerSpec extends ObjectBehavior
     }
 
     function it_normalizes_family(
-        $transnormalizer,
-        $family,
+        $normalizer,
+        $attributeRepository,
+        $requirementsRepository,
+        $filter,
+        FamilyInterface $family,
         AttributeInterface $name,
-        AttributeInterface $price,
-        AttributeRequirement $ecommercereq,
-        AttributeRequirement $mobilereq,
-        ChannelInterface $ecommerce,
-        ChannelInterface $mobile
+        AttributeInterface $description,
+        AttributeInterface $price
     ) {
-        $transnormalizer->normalize(Argument::cetera())->willReturn([]);
+        $attributeRepository->findAttributesByFamily($family)->willReturn([$name, $description, $price]);
+        $requirementsRepository->findRequiredAttributesCodesByFamily($family)->willReturn([
+            ['attribute' => 'name', 'channel' => 'mobile'],
+            ['attribute' => 'price', 'channel' => 'ecommerce'],
+            ['attribute' => 'name', 'channel' => 'ecommerce'],
+        ]);
+
+        $filter->filterCollection([$name, $description, $price], 'pim.internal_api.attribute.view')
+            ->willReturn([$price, $name]);
+
+        $normalizer->normalize(Argument::cetera())->willReturn([]);
         $family->getCode()->willReturn('mugs');
-        $family->getAttributes()->willReturn([$name, $price]);
+        $family->getAttributeAsLabel()->willReturn($name);
         $name->getCode()->willReturn('name');
         $price->getCode()->willReturn('price');
-        $family->getAttributeAsLabel()->willReturn($name);
-        $family->getAttributeRequirements()->willReturn([$ecommercereq, $mobilereq]);
-        $ecommercereq->getChannel()->willReturn($ecommerce);
-        $mobilereq->getChannel()->willReturn($mobile);
-        $ecommercereq->isRequired()->willReturn(true);
-        $mobilereq->isRequired()->willReturn(false);
-        $ecommerce->getCode()->willReturn('ecommerce');
-        $mobile->getCode()->willReturn('mobile');
-        $ecommercereq->getAttribute()->willReturn($name);
 
         $this->normalize($family)->shouldReturn(
             [
                 'code'                   => 'mugs',
                 'attributes'             => ['name', 'price'],
                 'attribute_as_label'     => 'name',
-                'requirements-ecommerce' => ['name'],
-                'requirements-mobile'    => [],
+                'requirements-ecommerce' => ['name', 'price'],
+                'requirements-mobile'    => ['name'],
             ]
         );
     }

--- a/spec/Pim/Component/Connector/Normalizer/Flat/FamilyNormalizerSpec.php
+++ b/spec/Pim/Component/Connector/Normalizer/Flat/FamilyNormalizerSpec.php
@@ -3,18 +3,23 @@
 namespace spec\Pim\Component\Connector\Normalizer\Flat;
 
 use PhpSpec\ObjectBehavior;
-use Pim\Bundle\CatalogBundle\Entity\AttributeRequirement;
+use Pim\Bundle\CatalogBundle\Filter\CollectionFilterInterface;
 use Pim\Component\Catalog\Model\AttributeInterface;
-use Pim\Component\Catalog\Model\ChannelInterface;
 use Pim\Component\Catalog\Model\FamilyInterface;
 use Pim\Component\Connector\Normalizer\Flat\TranslationNormalizer;
+use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
+use Pim\Component\Catalog\Repository\AttributeRequirementRepositoryInterface;
 use Prophecy\Argument;
 
 class FamilyNormalizerSpec extends ObjectBehavior
 {
-    function let(\Pim\Component\Connector\Normalizer\Flat\TranslationNormalizer $transnormalizer)
-    {
-        $this->beConstructedWith($transnormalizer);
+    function let(
+        TranslationNormalizer $normalizer,
+        CollectionFilterInterface $filter,
+        AttributeRepositoryInterface $attributeRepository,
+        AttributeRequirementRepositoryInterface $requirementsRepository
+    ) {
+        $this->beConstructedWith($normalizer, $filter, $attributeRepository, $requirementsRepository);
     }
 
     function it_is_initializable()
@@ -35,37 +40,38 @@ class FamilyNormalizerSpec extends ObjectBehavior
     }
 
     function it_normalizes_family(
-        $transnormalizer,
+        $normalizer,
+        $attributeRepository,
+        $requirementsRepository,
+        $filter,
         FamilyInterface $family,
         AttributeInterface $name,
-        AttributeInterface $price,
-        AttributeRequirement $ecommercereq,
-        AttributeRequirement $mobilereq,
-        ChannelInterface $ecommerce,
-        ChannelInterface $mobile
+        AttributeInterface $description,
+        AttributeInterface $price
     ) {
-        $transnormalizer->normalize(Argument::cetera())->willReturn([]);
+        $attributeRepository->findAttributesByFamily($family)->willReturn([$name, $description, $price]);
+        $requirementsRepository->findRequiredAttributesCodesByFamily($family)->willReturn([
+            ['attribute' => 'name', 'channel' => 'mobile'],
+            ['attribute' => 'price', 'channel' => 'ecommerce'],
+            ['attribute' => 'name', 'channel' => 'ecommerce'],
+        ]);
+
+        $filter->filterCollection([$name, $description, $price], 'pim.internal_api.attribute.view')
+            ->willReturn([$price, $name]);
+
+        $normalizer->normalize(Argument::cetera())->willReturn([]);
         $family->getCode()->willReturn('mugs');
-        $family->getAttributes()->willReturn([$name, $price]);
+        $family->getAttributeAsLabel()->willReturn($name);
         $name->getCode()->willReturn('name');
         $price->getCode()->willReturn('price');
-        $family->getAttributeAsLabel()->willReturn($name);
-        $family->getAttributeRequirements()->willReturn([$ecommercereq, $mobilereq]);
-        $ecommercereq->getChannel()->willReturn($ecommerce);
-        $mobilereq->getChannel()->willReturn($mobile);
-        $ecommercereq->isRequired()->willReturn(true);
-        $mobilereq->isRequired()->willReturn(false);
-        $ecommerce->getCode()->willReturn('ecommerce');
-        $mobile->getCode()->willReturn('mobile');
-        $ecommercereq->getAttribute()->willReturn($name);
 
         $this->normalize($family)->shouldReturn(
             [
                 'code'                   => 'mugs',
                 'attributes'             => 'name,price',
                 'attribute_as_label'     => 'name',
-                'requirements-ecommerce' => 'name',
-                'requirements-mobile'    => '',
+                'requirements-ecommerce' => 'name,price',
+                'requirements-mobile'    => 'name',
             ]
         );
     }

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/AttributeRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/AttributeRepository.php
@@ -10,6 +10,7 @@ use Pim\Bundle\CatalogBundle\Entity\AttributeGroup;
 use Pim\Component\Catalog\AttributeTypes;
 use Pim\Component\Catalog\Model\AttributeGroupInterface;
 use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\FamilyInterface;
 use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
 
 /**
@@ -453,6 +454,21 @@ class AttributeRepository extends EntityRepository implements
         }
 
         return array_map('current', $qb->getQuery()->getScalarResult());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function findAttributesByFamily(FamilyInterface $family)
+    {
+        $qb = $this->createQueryBuilder('a');
+        $qb
+            ->select('a, g')
+            ->join('a.group', 'g')
+            ->innerJoin('a.families', 'f', 'WITH', 'f.id = :family')
+            ->setParameter(':family', $family->getId());
+
+        return $qb->getQuery()->getResult();
     }
 
     /**

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/AttributeRequirementRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/AttributeRequirementRepository.php
@@ -3,6 +3,7 @@
 namespace Pim\Bundle\CatalogBundle\Doctrine\ORM\Repository;
 
 use Doctrine\ORM\EntityRepository;
+use Pim\Component\Catalog\Model\FamilyInterface;
 use Pim\Component\Catalog\Repository\AttributeRequirementRepositoryInterface;
 
 /**
@@ -14,4 +15,21 @@ use Pim\Component\Catalog\Repository\AttributeRequirementRepositoryInterface;
  */
 class AttributeRequirementRepository extends EntityRepository implements AttributeRequirementRepositoryInterface
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function findRequiredAttributesCodesByFamily(FamilyInterface $family)
+    {
+        $qb = $this->createQueryBuilder('ar');
+        $qb
+            ->select('a.code AS attribute, c.code AS channel')
+            ->innerJoin('ar.attribute', 'a')
+            ->innerJoin('ar.channel', 'c')
+            ->where('ar.family = :family')
+            ->andWhere('ar.required = :required')
+            ->setParameter(':family', $family)
+            ->setParameter(':required', true);
+
+        return $qb->getQuery()->getArrayResult();
+    }
 }

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/serializers.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/serializers.yml
@@ -123,6 +123,8 @@ services:
         arguments:
             - '@pim_serializer.normalizer.label_translation'
             - '@pim_catalog.filter.chained'
+            - '@pim_catalog.repository.attribute'
+            - '@pim_catalog.repository.attribute_requirement'
         tags:
             - { name: pim_serializer.normalizer, priority: 90 }
 

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/serializer.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/serializer.yml
@@ -85,6 +85,9 @@ services:
         class: %pim_serializer.normalizer.flat.family.class%
         arguments:
             - '@pim_serializer.normalizer.flat.label_translation'
+            - '@pim_catalog.filter.chained'
+            - '@pim_catalog.repository.attribute'
+            - '@pim_catalog.repository.attribute_requirement'
         tags:
             - { name: pim_serializer.normalizer, priority: 90 }
 

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/FamilyController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/FamilyController.php
@@ -15,8 +15,6 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
  * @author    Julien Sanchez <julien@akeneo.com>
  * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
- *
- * TODO: PIM-5194: to rework on master
  */
 class FamilyController
 {
@@ -37,7 +35,7 @@ class FamilyController
     public function __construct(
         FamilyRepositoryInterface $familyRepository,
         NormalizerInterface $normalizer,
-        FamilySearchableRepository $familySearchableRepo = null
+        FamilySearchableRepository $familySearchableRepo
     ) {
         $this->familyRepository     = $familyRepository;
         $this->normalizer           = $normalizer;
@@ -53,15 +51,10 @@ class FamilyController
      */
     public function indexAction(Request $request)
     {
-        #TODO: PIM-5194: to rework on master, drop the if condition
-        if (null !== $this->familySearchableRepo) {
-            $query  = $request->query;
-            $search = $query->get('search');
-
-            $families = $this->familySearchableRepo->findBySearch($search, $query->get('options', []));
-        } else {
-            $families = $this->familyRepository->findAll();
-        }
+        $families = $this->familySearchableRepo->findBySearch(
+            $request->query->get('search'),
+            $request->query->get('options', ['limit' => 20])
+        );
 
         $normalizedFamilies = [];
         foreach ($families as $family) {

--- a/src/Pim/Bundle/VersioningBundle/Resources/config/serializer/flat.yml
+++ b/src/Pim/Bundle/VersioningBundle/Resources/config/serializer/flat.yml
@@ -31,6 +31,9 @@ services:
         class: %pim_serializer.normalizer.flat.family.class%
         arguments:
             - '@pim_serializer.normalizer.flat.label_translation'
+            - '@pim_catalog.filter.chained'
+            - '@pim_catalog.repository.attribute'
+            - '@pim_catalog.repository.attribute_requirement'
         tags:
             - { name: pim_versioning.serializer.normalizer, priority: 90 }
 

--- a/src/Pim/Component/Catalog/Repository/AttributeRepositoryInterface.php
+++ b/src/Pim/Component/Catalog/Repository/AttributeRepositoryInterface.php
@@ -7,6 +7,7 @@ use Doctrine\Common\Persistence\ObjectRepository;
 use Pim\Bundle\EnrichBundle\Form\DataTransformer\ChoicesProviderInterface;
 use Pim\Component\Catalog\Model\AttributeGroupInterface;
 use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\FamilyInterface;
 
 /**
  * Repository interface for attribute
@@ -160,6 +161,15 @@ interface AttributeRepositoryInterface extends
      * @return string[]
      */
     public function getAttributeCodesByGroup(AttributeGroupInterface $group);
+
+    /**
+     * Get attributes by family
+     *
+     * @param FamilyInterface $family
+     *
+     * @return AttributeInterface[]
+     */
+    public function findAttributesByFamily(FamilyInterface $family);
 
     /**
      * Return the number of existing attributes

--- a/src/Pim/Component/Catalog/Repository/AttributeRequirementRepositoryInterface.php
+++ b/src/Pim/Component/Catalog/Repository/AttributeRequirementRepositoryInterface.php
@@ -3,6 +3,7 @@
 namespace Pim\Component\Catalog\Repository;
 
 use Doctrine\Common\Persistence\ObjectRepository;
+use Pim\Component\Catalog\Model\FamilyInterface;
 
 /**
  * Repository interface for attribute requirements
@@ -13,4 +14,12 @@ use Doctrine\Common\Persistence\ObjectRepository;
  */
 interface AttributeRequirementRepositoryInterface extends ObjectRepository
 {
+    /**
+     * Returns attributes requirements codes and channel code for the given family
+     *
+     * @param FamilyInterface $family
+     *
+     * @return array
+     */
+    public function findRequiredAttributesCodesByFamily(FamilyInterface $family);
 }


### PR DESCRIPTION
# Description

We had a scalability issue on route `/configuration/family/rest` (even using a limit). As we have to hydrate every attributes of each families in order to apply rights in the enterprise edition or some other filters we needed to optimize this part of the code as much as possible.

# Definition of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Y
| Added Behats                      | N/A
| Changelog updated                 | Y
| Review and 2 GTM                  | todo
| Micro Demo to the PO (Story only) | N/A
| Migration script                  | N/A
| Tech Doc                          | N/A

