### PR TITLE
PIM-5593: Keep context in the associations tab of the product edit form

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -2,13 +2,14 @@
 
 ## Functional improvements
 
-- PIM-5592: the product grid keeps the page number when you go back to it
-- PIM-5096: introduces the XLSX quick export
+- PIM-5592: The product grid keeps the page number when you go back to it
+- PIM-5096: Introduce the XLSX quick export
+- PIM-5593: The context is now kept in the associations tab of the product edit form
 
 ## Technical improvements
 
-- PIM-5589: introduce a channels, attribute groups, group types, locales and currencies import using the new import system introduced in v1.4
-- PIM-5589: introduce a SimpleFactoryInterface to create simple entities
+- PIM-5589: Introduce a channels, attribute groups, group types, locales and currencies import using the new import system introduced in v1.4
+- PIM-5589: Introduce a SimpleFactoryInterface to create simple entities
 - PIM-5594: Panel state is now stored in the session storage
 
 ## BC breaks

--- a/features/Context/FeatureContext.php
+++ b/features/Context/FeatureContext.php
@@ -14,6 +14,7 @@ use Pim\Behat\Context\Domain\Enrich\AttributeTabContext;
 use Pim\Behat\Context\Domain\Enrich\CompletenessContext;
 use Pim\Behat\Context\Domain\Enrich\GridPaginationContext;
 use Pim\Behat\Context\Domain\Enrich\PanelContext;
+use Pim\Behat\Context\Domain\Enrich\Product\AssociationTabContext;
 use Pim\Behat\Context\Domain\Enrich\VariantGroupContext;
 use Pim\Behat\Context\Domain\Spread\ExportProfilesContext;
 use Pim\Behat\Context\Domain\TreeContext;
@@ -60,16 +61,17 @@ class FeatureContext extends MinkContext implements KernelAwareInterface
         $this->useContext('assertions', new AssertionContext());
         $this->useContext('technical', new TechnicalContext());
 
-        $this->useContext('domain-variant-group', new VariantGroupContext());
-        $this->useContext('domain-tree', new TreeContext());
-        $this->useContext('job', new JobContext());
-        $this->useContext('hook', new HookContext($parameters['window_width'], $parameters['window_height']));
-        $this->useContext('domain-import-profiles', new ImportProfilesContext());
-        $this->useContext('domain-export-profiles', new ExportProfilesContext());
         $this->useContext('domain-attribute-tab', new AttributeTabContext());
-        $this->useContext('domain-panel', new PanelContext());
-        $this->useContext('domain-pagination-grid', new GridPaginationContext());
         $this->useContext('domain-completeness', new CompletenessContext());
+        $this->useContext('domain-export-profiles', new ExportProfilesContext());
+        $this->useContext('domain-import-profiles', new ImportProfilesContext());
+        $this->useContext('domain-pagination-grid', new GridPaginationContext());
+        $this->useContext('domain-panel', new PanelContext());
+        $this->useContext('domain-product-association-tab', new AssociationTabContext());
+        $this->useContext('domain-tree', new TreeContext());
+        $this->useContext('domain-variant-group', new VariantGroupContext());
+        $this->useContext('hook', new HookContext($parameters['window_width'], $parameters['window_height']));
+        $this->useContext('job', new JobContext());
         $this->useContext('storage-product', new ProductStorage());
 
         $this->setTimeout($parameters);

--- a/features/Context/Page/Base/Form.php
+++ b/features/Context/Page/Base/Form.php
@@ -30,7 +30,7 @@ class Form extends Base
                 'Oro tabs'                        => ['css' => '.navbar.scrollspy-nav'],
                 'Dialog'                          => ['css' => 'div.modal'],
                 'Form tabs'                       => ['css' => '.nav-tabs.form-tabs'],
-                'Associations list'               => ['css' => '#associations-list'],
+                'Associations list'               => ['css' => '.associations-list'],
                 'Active tab'                      => ['css' => '.form-horizontal .tab-pane.active'],
                 'Groups'                          => ['css' => '.tab-groups'],
                 'Form Groups'                     => ['css' => '.group-selector'],
@@ -180,13 +180,14 @@ class Form extends Base
         return true;
     }
 
-    public function selectAssociation($assocation)
+    /**
+     * @return NodeElement
+     */
+    public function getAssociationsList()
     {
-        $associations = $this->spin(function () {
+        return $this->spin(function () {
             return $this->find('css', $this->elements['Associations list']['css']);
         });
-
-        $associations->clickLink($assocation);
     }
 
     /**

--- a/features/Context/Page/Base/Grid.php
+++ b/features/Context/Page/Base/Grid.php
@@ -63,6 +63,7 @@ class Grid extends Index
     public function getGrid()
     {
         $body = $this->getElement('Body');
+
         return $this->spin(
             function () use ($body) {
                 $modal = $body->find('css', $this->elements['Dialog']['css']);
@@ -97,7 +98,7 @@ class Grid extends Index
      */
     public function getRow($value)
     {
-        $value   = str_replace('"', '', $value);
+        $value = str_replace('"', '', $value);
 
         try {
             $gridRow = $this->getGridContent()->find('css', sprintf('tr td:contains("%s")', $value));

--- a/features/Context/WebUser.php
+++ b/features/Context/WebUser.php
@@ -14,7 +14,6 @@ use Behat\Mink\Exception\UnsupportedDriverActionException;
 use Behat\MinkExtension\Context\RawMinkContext;
 use Context\Spin\SpinCapableTrait;
 use Context\Spin\TimeoutException;
-use Pim\Bundle\EnrichBundle\Mailer\MailRecorder;
 use Pim\Bundle\EnrichBundle\MassEditAction\Operation\BatchableOperationInterface;
 use Pim\Component\Catalog\Model\Product;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Page;
@@ -239,17 +238,6 @@ class WebUser extends RawMinkContext
     public function iClickOnTheACLRole($group)
     {
         $this->getCurrentPage()->selectRole($group);
-    }
-
-    /**
-     * @param string $association
-     *
-     * @Given /^I select the "([^"]*)" association$/
-     */
-    public function iSelectTheAssociation($association)
-    {
-        $this->getCurrentPage()->selectAssociation($association);
-        $this->wait();
     }
 
     /**

--- a/features/Pim/Behat/Context/Domain/Enrich/AttributeTabContext.php
+++ b/features/Pim/Behat/Context/Domain/Enrich/AttributeTabContext.php
@@ -104,7 +104,7 @@ class AttributeTabContext extends PimContext
         throw $this->getMainContext()->createExpectationException(
             sprintf(
                 'Expected to not see the field "%s".',
-                $field
+                $fieldLabel
             )
         );
     }

--- a/features/Pim/Behat/Context/Domain/Enrich/Product/AssociationTabContext.php
+++ b/features/Pim/Behat/Context/Domain/Enrich/Product/AssociationTabContext.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Pim\Behat\Context\Domain\Enrich\Product;
+
+use Behat\Mink\Exception\ExpectationException;
+use Context\Spin\SpinCapableTrait;
+use Pim\Behat\Context\PimContext;
+
+class AssociationTabContext extends PimContext
+{
+    use SpinCapableTrait;
+
+    /**
+     * @param string $association
+     *
+     * @Given /^I select the "([^"]*)" association$/
+     */
+    public function iSelectTheAssociation($association)
+    {
+        $this->getCurrentPage()
+            ->getAssociationsList()
+            ->clickLink($association);
+    }
+
+    /**
+     * @param string $association
+     *
+     * @throws ExpectationException
+     *
+     * @Given /^I should be on the "([^"]*)" association$/
+     */
+    public function iShouldBeOnTheAssociation($association)
+    {
+        $list       = $this->getCurrentPage()->getAssociationsList();
+        $currentTab = $this->spin(function () use ($list) {
+            return $list->find('css', '.active');
+        });
+
+        $tabLabel = trim($currentTab->getText());
+        if ($tabLabel !== $association) {
+            throw $this->createExpectationException(
+                sprintf(
+                    'Expecting "%s" to be the current association type, got "%s"',
+                    $association,
+                    $tabLabel
+                )
+            );
+        }
+    }
+}

--- a/features/product/associate_product.feature
+++ b/features/product/associate_product.feature
@@ -20,7 +20,6 @@ Feature: Associate a product
   Scenario: Associate a product to another product
     Given I edit the "charcoal-boots" product
     When I visit the "Associations" tab
-    And I select the "Cross sell" association
     And I check the row "shoelaces"
     And I save the product
     Then I should see the text "1 products and 0 groups"
@@ -34,7 +33,6 @@ Feature: Associate a product
     And I press the "Show groups" button
     And I check the row "caterpillar_boots"
     And I save the product
-    And I select the "Upsell" association
     And I press the "Show groups" button
     Then I should see the text "0 products and 1 groups"
     Then the row "caterpillar_boots" should be checked
@@ -42,7 +40,7 @@ Feature: Associate a product
   @skip @jira https://akeneo.atlassian.net/browse/PIM-4788
   Scenario: Associate a product to multiple products and groups
     Given I edit the "black-boots" product
-    When I visit the "Associations" tab
+    And I visit the "Associations" tab
     And I select the "Substitution" association
     And I check the row "charcoal-boots"
     And I select the "Upsell" association
@@ -53,8 +51,7 @@ Feature: Associate a product
     And I check the row "similar_boots"
     And I press the "Show products" button
     And I check the rows "shoelaces, gray-boots, brown-boots and green-boots"
-    And I save the product
-    And I select the "Cross sell" association
+    When I save the product
     Then I should see the text "4 products and 1 groups"
     And I select the "Upsell" association
     Then I should see the text "1 products and 1 groups"
@@ -65,11 +62,10 @@ Feature: Associate a product
 
   Scenario: Sort associated products
     Given I edit the "charcoal-boots" product
-    When I visit the "Associations" tab
-    And I select the "Cross sell" association
+    And I visit the "Associations" tab
     And I check the row "shoelaces"
     And I check the row "black-boots"
-    And I save the product
+    When I save the product
     Then the row "shoelaces" should be checked
     And the row "black-boots" should be checked
     And I should be able to sort the rows by Is associated
@@ -79,7 +75,6 @@ Feature: Associate a product
   Scenario: Keep association selection between tabs
     Given I edit the "charcoal-boots" product
     When I visit the "Associations" tab
-    And I select the "Cross sell" association
     And I check the row "gray-boots"
     And I check the row "black-boots"
     And I select the "Pack" association
@@ -114,7 +109,6 @@ Feature: Associate a product
   Scenario: Detect unsaved changes when modifying associations
     Given I edit the "charcoal-boots" product
     When I visit the "Associations" tab
-    And I select the "Cross sell" association
     And I check the row "gray-boots"
     And I check the row "black-boots"
     Then I should see the text "There are unsaved changes."
@@ -123,7 +117,6 @@ Feature: Associate a product
     When I save the product
     Then I should not see the text "There are unsaved changes."
     When I visit the "Associations" tab
-    And I select the "Cross sell" association
     And I uncheck the rows "black-boots"
     Then I should see the text "There are unsaved changes."
     And I check the rows "black-boots"
@@ -179,3 +172,18 @@ Feature: Associate a product
     Then the grid should contain 6 elements
     When I follow "Upsell"
     Then the grid should contain 6 elements
+
+  @jira https://akeneo.atlassian.net/browse/PIM-5593
+  Scenario: Keep product associations grids context
+    Given I edit the "shoelaces" product
+    And I visit the "Associations" tab
+    And I select the "Substitution" association
+    And I filter by "SKU" with value "contains gr"
+    And I press the "Show groups" button
+    And I filter by "Type" with value "[RELATED]"
+    When I edit the "gray-boots" product
+    Then I should be on the "Substitution" association
+    And I should see the text "Show products"
+    And I should see the text "Type: [RELATED]"
+    When I press the "Show products" button
+    Then I should see the text "SKU: Contains \"gr\""

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/tab/association-panes.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/tab/association-panes.html
@@ -1,5 +1,5 @@
 <% _.each(associationTypes, function (associationType) { %>
-     <div data-association-type="<%- associationType.code %>" class="tab-pane association-type<% if (associationType.code === state.currentAssociationType) { %> active<% } %>">
+     <div data-association-type="<%- associationType.code %>" class="tab-pane association-type<% if (associationType.code === currentAssociationType) { %> active<% } %>">
         <h3 class="tab-header unspaced">
             <%- associationType.label[locale] || '[' + associationType.code + ']'  %>
             <span class="muted small">

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/tab/associations.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/tab/associations.html
@@ -7,10 +7,10 @@
 <% } else { %>
     <div class="tabbable tabs-left">
         <div class="sidebar">
-            <ul class="nav nav-tabs tab-groups" id="associations-list">
+            <ul class="associations-list nav nav-tabs tab-groups">
                 <% _.each(associationTypes, function (associationType) { %>
-                    <li data-association-type="<%- associationType.code %>"<% if (associationType.code === state.currentAssociationType) { %> class="active"<% } %>>
-                        <a href="javascript:void(0);">
+                    <li data-association-type="<%- associationType.code %>"<% if (associationType.code === currentAssociationType) { %> class="active"<% } %>>
+                        <a href="#">
                             <%- associationType.label[locale] || '[' + associationType.code + ']'  %>
                         </a>
                     </li>
@@ -18,23 +18,23 @@
             </ul>
         </div>
         <div class="tab-content">
-            <div id="association-buttons" class="navbar-extra pull-right">
-                <button type="button" class="btn pull-right hide" data-association-target="products">
+            <div class="association-buttons navbar-extra pull-right">
+                <button type="button" class="target-button btn pull-right<% if ('products' === currentAssociationTarget) { %> hide<% } %>" data-association-target="products">
                     <i class="icon-random"></i>
                     <%- _.__('pim_enrich.form.product.tab.associations.info.show_products') %>
                 </button>
-                <button type="button" class="btn pull-right" data-association-target="groups">
+                <button type="button" class="target-button btn pull-right<% if ('groups' === currentAssociationTarget) { %> hide<% } %>" data-association-target="groups">
                     <i class="icon-random"></i>
                     <%- _.__('pim_enrich.form.product.tab.associations.info.show_groups') %>
                 </button>
             </div>
 
-            <div id="association-product-grid">
-                <div id="grid-association-product-grid" data-type="datagrid"></div>
+            <div class="association-product-grid<% if ('products' !== currentAssociationTarget) { %> hide<% } %>">
+                <div class="grid-association-product-grid" data-type="datagrid"></div>
             </div>
 
-            <div id="association-group-grid" class="hide">
-                <div id="grid-association-group-grid" data-type="datagrid"></div>
+            <div class="association-group-grid<% if ('groups' !== currentAssociationTarget) { %> hide<% } %>">
+                <div class="grid-association-group-grid" data-type="datagrid"></div>
             </div>
 
             <div class="selection-inputs">

--- a/src/Pim/Bundle/UIBundle/Resources/public/css/form.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/css/form.less
@@ -270,8 +270,10 @@ div.btn-group > .has-switch {
   }
 }
 
-#association-buttons {
-  padding-top: 7px;
+#product-associations {
+  .association-buttons {
+    padding-top: 7px;
+  }
 }
 
 .comparison {


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

The state of the following elements is now memorized in session storage (idem products grid) :

![associations](https://cloud.githubusercontent.com/assets/659491/14022111/aaba5646-f1de-11e5-8aa1-6e74f812ecb0.png)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | n/a
| Added Behats                      | yes
| Changelog updated                 | yes
| Review and 2 GTM                  | 
| Micro Demo to the PO (Story only) | 
| Migration script                  | n/a
| Tech Doc                          | n/a
