### PR TITLE
[WIP] Install command events (any demand for this?)

### DIFF
--- a/src/Pim/Bundle/InstallerBundle/Command/AssetsCommand.php
+++ b/src/Pim/Bundle/InstallerBundle/Command/AssetsCommand.php
@@ -1,5 +1,5 @@
 <?php
-namespace Erp\Bundle\InstallerBundle\Command;
+namespace Pim\Bundle\InstallerBundle\Command;
 
 use Pim\Bundle\InstallerBundle\Event\CommandBatchEvent;
 use Pim\Bundle\InstallerBundle\Event\CommandEvent;

--- a/src/Pim/Bundle/InstallerBundle/Command/AssetsCommand.php
+++ b/src/Pim/Bundle/InstallerBundle/Command/AssetsCommand.php
@@ -1,11 +1,17 @@
 <?php
+namespace Erp\Bundle\InstallerBundle\Command;
 
-namespace Pim\Bundle\InstallerBundle\Command;
-
-use Pim\Bundle\InstallerBundle\CommandExecutor;
-use Symfony\Component\Console\Command\Command;
+use Pim\Bundle\InstallerBundle\Event\CommandBatchEvent;
+use Pim\Bundle\InstallerBundle\Event\CommandEvent;
+use Pim\Bundle\InstallerBundle\Event\InstallEvent;
+use Pim\Bundle\InstallerBundle\Event\InstallEvents;
+use Pim\Bundle\InstallerBundle\SimpleCommand\SimpleCommand;
+use Pim\Bundle\InstallerBundle\SimpleCommand\SimpleCommandBatch;
+use Pim\Bundle\InstallerBundle\SimpleCommand\SimpleCommandExecutor;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Assets dump command
@@ -14,8 +20,14 @@ use Symfony\Component\Console\Output\OutputInterface;
  * @copyright 2013 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class AssetsCommand extends Command
+class AssetsCommand extends ContainerAwareCommand
 {
+    /** @var SimpleCommandExecutor */
+    protected $commandExecutor;
+
+    /** @var EventDispatcherInterface */
+    protected $eventDispatcher;
+
     /**
      * {@inheritdoc}
      */
@@ -31,7 +43,8 @@ class AssetsCommand extends Command
      */
     protected function initialize(InputInterface $input, OutputInterface $output)
     {
-        $this->commandExecutor = new CommandExecutor(
+        $this->eventDispatcher = $this->getContainer()->get("event_dispatcher");
+        $this->commandExecutor = new SimpleCommandExecutor(
             $input,
             $output,
             $this->getApplication()
@@ -43,17 +56,66 @@ class AssetsCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $this->eventDispatcher->dispatch(InstallEvents::ASSETS_PRE_INSTALL, new InstallEvent());
+
         $output->writeln('<info>Akeneo PIM assets</info>');
 
-        $this->commandExecutor
-            ->runCommand('oro:navigation:init')
-            ->runCommand('fos:js-routing:dump', ['--target' => 'web/js/routes.js'])
-            ->runCommand('assets:install')
-            ->runCommand('assetic:dump')
-            ->runCommand('oro:assetic:dump');
-        $defaultLocales = ['en', 'fr', 'nl', 'de', 'ru', 'ja', 'pt', 'it'];
-        $this->commandExecutor->runCommand('oro:translation:dump', ['locale' => $defaultLocales]);
+        $this
+            ->dumpAssets($input, $output)
+            ->dumpTranslations($input, $output);
+
+        $this->eventDispatcher->dispatch(InstallEvents::ASSETS_POST_INSTALL, new InstallEvent());
+        return $this;
+    }
+
+    /**
+     * Executes all asset dumping commands
+     *
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     *
+     * @return $this
+     */
+    protected function dumpAssets(InputInterface $input, OutputInterface $output)
+    {
+        $commands = [
+            "oro:navigation:init" => [],
+            "fos:js-routing:dump" => ["--target" => "web/js/routes.js"],
+            "assets:install" => [],
+            "assetic:dump" => [],
+            "oro:assetic:dump" => [],
+        ];
+        $commandBatch = SimpleCommandBatch::create($commands);
+
+        $event = new CommandBatchEvent($commandBatch);
+        $this->getContainer()->get("event_dispatcher")->dispatch(InstallEvents::ASSETS_DUMP, $event);
+        $commandBatch = $event->getCommandBatch();
+
+        $this->commandExecutor->runBatch($commandBatch);
 
         return $this;
     }
+
+    /**
+     * Executes translation asset dump command
+     *
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     *
+     * @return $this
+     */
+    protected function dumpTranslations(InputInterface $input, OutputInterface $output)
+    {
+        $defaultLocales = ['en', 'fr', 'nl', 'de', 'ru', 'ja', 'pt', 'it'];
+        $command = SimpleCommand::create("oro:translation:dump", ["locale" => $defaultLocales]);
+
+        $event = new CommandEvent($command);
+        $this->getContainer()->get("event_dispatcher")->dispatch(InstallEvents::ASSETS_DUMP_TRANSLATIONS, $event);
+        $command = $event->getCommand();
+        $this->commandExecutor->run($command);
+
+        return $this;
+    }
+
+
 }

--- a/src/Pim/Bundle/InstallerBundle/Event/CommandBatchEvent.php
+++ b/src/Pim/Bundle/InstallerBundle/Event/CommandBatchEvent.php
@@ -1,0 +1,46 @@
+<?php
+namespace Pim\Bundle\InstallerBundle\Event;
+
+use Pim\Bundle\InstallerBundle\SimpleCommand\SimpleCommandBatch;
+
+class CommandBatchEvent extends InstallEvent
+{
+    /** @var SimpleCommandBatch */
+    protected $commandBatch;
+
+    /**
+     * SimpleCommandBatchEvent constructor.
+     * @param SimpleCommandBatch $commandBatch
+     * @param array $arguments
+     */
+    public function __construct(SimpleCommandBatch $commandBatch, array $arguments = [])
+    {
+        $this->commandBatch = $commandBatch;
+        parent::__construct($commandBatch, $arguments);
+    }
+
+    /**
+     * Gets the command batch
+     *
+     * @return SimpleCommandBatch
+     */
+    public function getCommandBatch()
+    {
+        return $this->commandBatch;
+    }
+
+    /**
+     * Sets the command batch
+     *
+     * @param SimpleCommandBatch $commandBatch
+     *
+     * @return $this
+     */
+    public function setCommandBatch($commandBatch)
+    {
+        $this->commandBatch = $commandBatch;
+        return $this;
+    }
+
+
+}

--- a/src/Pim/Bundle/InstallerBundle/Event/CommandEvent.php
+++ b/src/Pim/Bundle/InstallerBundle/Event/CommandEvent.php
@@ -1,0 +1,39 @@
+<?php
+namespace Pim\Bundle\InstallerBundle\Event;
+
+use Pim\Bundle\InstallerBundle\SimpleCommand\SimpleCommandInterface;
+
+class CommandEvent extends InstallEvent
+{
+    /** @var SimpleCommandInterface */
+    protected $command;
+
+    public function __construct(SimpleCommandInterface $command, array $arguments = [])
+    {
+        $this->command = $command;
+        parent::__construct($command, $arguments);
+    }
+
+    /**
+     * Gets the command
+     *
+     * @return SimpleCommandInterface
+     */
+    public function getCommand()
+    {
+        return $this->command;
+    }
+
+    /**
+     * Sets the command
+     *
+     * @param SimpleCommandInterface $command
+     *
+     * @return $this
+     */
+    public function setCommand($command)
+    {
+        $this->command = $command;
+        return $this;
+    }
+}

--- a/src/Pim/Bundle/InstallerBundle/Event/FixtureLoaderEvent.php
+++ b/src/Pim/Bundle/InstallerBundle/Event/FixtureLoaderEvent.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Pim\Bundle\InstallerBundle\Event;
 
 use Symfony\Component\EventDispatcher\Event;

--- a/src/Pim/Bundle/InstallerBundle/Event/InstallEvent.php
+++ b/src/Pim/Bundle/InstallerBundle/Event/InstallEvent.php
@@ -1,0 +1,8 @@
+<?php
+namespace Pim\Bundle\InstallerBundle\Event;
+
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+class InstallEvent extends GenericEvent
+{
+}

--- a/src/Pim/Bundle/InstallerBundle/Event/InstallEvents.php
+++ b/src/Pim/Bundle/InstallerBundle/Event/InstallEvents.php
@@ -1,0 +1,20 @@
+<?php
+namespace Pim\Bundle\InstallerBundle\Event;
+
+class InstallEvents
+{
+    /**
+     * InstallCommand events
+     */
+    const PRE_INSTALL   = "pim_install.pre_install";
+    const POST_INSTALL  = "pim_install.post_install";
+
+
+    /**
+     * AssetCommand events
+     */
+    const ASSETS_PRE_INSTALL        = "pim_install.assets.pre_install";
+    const ASSETS_POST_INSTALL       = "pim_install.assets.post_install";
+    const ASSETS_DUMP               = "pim_install.assets.dump";
+    const ASSETS_DUMP_TRANSLATIONS  = "pim_install.assets.dump_translations";
+}

--- a/src/Pim/Bundle/InstallerBundle/SimpleCommand/SimpleCommand.php
+++ b/src/Pim/Bundle/InstallerBundle/SimpleCommand/SimpleCommand.php
@@ -1,0 +1,91 @@
+<?php
+namespace Pim\Bundle\InstallerBundle\SimpleCommand;
+
+class SimpleCommand implements SimpleCommandInterface
+{
+    /** @var string */
+    protected $command;
+    /** @var array */
+    protected $params;
+
+    /**
+     * SimpleCommand constructor.
+     * @param string $command
+     * @param array $params
+     */
+    public function __construct($command, array $params = [])
+    {
+        $this->command = $command;
+        $this->params = $params;
+    }
+
+    /**
+     * Creates a new command
+     *
+     * @param string $command
+     * @param array $params
+     *
+     * @return SimpleCommand
+     */
+    public static function create($command, array $params = [])
+    {
+        return new self($command, $params);
+    }
+
+    /**
+     * Creates multiple commands
+     *
+     * Expected input is an array of arrays representing commands,
+     * with the key being the command and the value being the parameters
+     *
+     * Example input: ["fos:js-routing:dump" => ["--target" => "web/js/routes.js"]]
+     *
+     * @param array $commandDefinitions
+     *
+     * @return array - Array of SimpleCommandInterface
+     */
+    public static function createAll(array $commandDefinitions)
+    {
+        $commands = [];
+        foreach($commandDefinitions as $command => $params)
+        {
+            $commands[] = new self($command, $params);
+        }
+
+        return $commands;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getCommand()
+    {
+        return $this->command;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function setCommand($command)
+    {
+        $this->command = $command;
+        return $this;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getParams()
+    {
+        return $this->params;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function setParams(array $params)
+    {
+        $this->params = $params;
+        return $this;
+    }
+}

--- a/src/Pim/Bundle/InstallerBundle/SimpleCommand/SimpleCommandBatch.php
+++ b/src/Pim/Bundle/InstallerBundle/SimpleCommand/SimpleCommandBatch.php
@@ -1,0 +1,49 @@
+<?php
+namespace Pim\Bundle\InstallerBundle\SimpleCommand;
+
+use Doctrine\Common\Collections\ArrayCollection;
+
+class SimpleCommandBatch implements SimpleCommandBatchInterface
+{
+    /** @var ArrayCollection */
+    protected $commands;
+    public function __construct(array $commands)
+    {
+        $this->commands = new ArrayCollection($commands);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function create(array $commandDefinitions)
+    {
+        $commands = SimpleCommand::createAll($commandDefinitions);
+        return new self($commands);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getCommands()
+    {
+        return $this->commands;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function addCommand(SimpleCommandInterface $command)
+    {
+        $this->commands->add($command);
+        return $this;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function removeCommand(SimpleCommandInterface $command)
+    {
+        $this->commands->removeElement($command);
+    }
+
+}

--- a/src/Pim/Bundle/InstallerBundle/SimpleCommand/SimpleCommandBatchInterface.php
+++ b/src/Pim/Bundle/InstallerBundle/SimpleCommand/SimpleCommandBatchInterface.php
@@ -1,0 +1,51 @@
+<?php
+namespace Pim\Bundle\InstallerBundle\SimpleCommand;
+
+use Doctrine\Common\Collections\ArrayCollection;
+
+interface SimpleCommandBatchInterface
+{
+    public function __construct(array $commands);
+
+    /**
+     * TODO: Improve this, so that commands without params do not have to include [] as a value
+     *
+     * Creates a new SimpleCommandBatch
+     *
+     * Expected input is an array of arrays representing commands,
+     * with the key being the command and the value being the parameters
+     *
+     * Example input: ["fos:js-routing:dump" => ["--target" => "web/js/routes.js"]]
+     *
+     * @param array $commandDefinitions
+     *
+     * @return ArrayCollection - Array of SimpleCommandInterface
+     */
+    public static function create(array $commandDefinitions);
+
+    /**
+     * Gets the commands
+     *
+     * @return ArrayCollection
+     */
+    public function getCommands();
+
+    /**
+     * Adds a new command to the batch
+     *
+     * @param SimpleCommandInterface $command
+     *
+     * @return $this
+     */
+    public function addCommand(SimpleCommandInterface $command);
+
+    /**
+     * Removes a command from the batch
+     *
+     * @param SimpleCommandInterface $command
+     *
+     * @return $this
+     */
+    public function removeCommand(SimpleCommandInterface $command);
+
+}

--- a/src/Pim/Bundle/InstallerBundle/SimpleCommand/SimpleCommandExecutor.php
+++ b/src/Pim/Bundle/InstallerBundle/SimpleCommand/SimpleCommandExecutor.php
@@ -1,0 +1,47 @@
+<?php
+namespace Pim\Bundle\InstallerBundle\SimpleCommand;
+
+use Pim\Bundle\InstallerBundle\CommandExecutor;
+
+class SimpleCommandExecutor extends CommandExecutor
+{
+    /**
+     * Run single command
+     *
+     * @param SimpleCommandInterface $command
+     *
+     * @return $this
+     */
+    public function run(SimpleCommandInterface $command)
+    {
+        return parent::runCommand($command->getCommand(), $command->getParams());
+    }
+
+    /**
+     * Runs multiple commands
+     *
+     * @param array $commands
+     *
+     * @return $this
+     */
+    public function runAll(array $commands)
+    {
+        foreach($commands as $command)
+        {
+            $this->run($command);
+        }
+        return $this;
+    }
+
+    /**
+     * Runs a command batch
+     *
+     * @param SimpleCommandBatchInterface $commandBatch
+     *
+     * @return $this
+     */
+    public function runBatch(SimpleCommandBatchInterface $commandBatch)
+    {
+        return $this->runAll($commandBatch->getCommands()->toArray());
+    }
+}

--- a/src/Pim/Bundle/InstallerBundle/SimpleCommand/SimpleCommandInterface.php
+++ b/src/Pim/Bundle/InstallerBundle/SimpleCommand/SimpleCommandInterface.php
@@ -1,0 +1,37 @@
+<?php
+namespace Pim\Bundle\InstallerBundle\SimpleCommand;
+
+interface SimpleCommandInterface
+{
+    /**
+     * Gets the command
+     *
+     * @return string
+     */
+    public function getCommand();
+
+    /**
+     * Sets the command
+     *
+     * @param string$command
+     *
+     * @return $this
+     */
+    public function setCommand($command);
+
+    /**
+     * Gets the params
+     *
+     * @return array
+     */
+    public function getParams();
+
+    /**
+     * Sets the params
+     *
+     * @param array $params
+     *
+     * @return $this
+     */
+    public function setParams(array $params);
+}


### PR DESCRIPTION
This is something I've cooked up to fulfill one of my own needs. Extending the install command is impossible without extending the existing classes, copy/pasting a lot of code.  
For the problem I ran into a post-install event was enough, but I figured I'd build a bit upon this idea and add some more events, which you can view in the AssetsCommand.  

I realise that there probably won't be much demand for this feature, since a lot of you will be deploying PIM only once and be done with it. If there is though, I'd gladly continue working on it and submit a pull request.
