### PR TITLE
PIM-5696: Fix XLSX products import with numeric values in text attributes

### DIFF
--- a/features/Pim/Behat/Context/Domain/Collect/ImportProfilesContext.php
+++ b/features/Pim/Behat/Context/Domain/Collect/ImportProfilesContext.php
@@ -37,7 +37,14 @@ class ImportProfilesContext extends PimContext
             $writer = WriterFactory::create($extension);
             $writer->openToFile($filename);
             foreach (explode(PHP_EOL, $string) as $row) {
-                $writer->addRow(explode(";", $row));
+                $rowCells = explode(";", $row);
+                foreach ($rowCells as &$cell) {
+                    if (is_numeric($cell)) {
+                        $cell = false === strpos($cell, '.') ? (int) $cell : (float) $cell;
+                    }
+                }
+
+                $writer->addRow($rowCells);
             }
             $writer->close();
         } else {

--- a/features/import/product/import_products_with_associations.feature
+++ b/features/import/product/import_products_with_associations.feature
@@ -2,7 +2,7 @@
 Feature: Execute a job
   In order to use existing product information
   As a product manager
-  I need to be able to import products
+  I need to be able to import products with associations
 
   Background:
     Given the "footwear" catalog configuration

--- a/features/import/product/xlsx/import_products.feature
+++ b/features/import/product/xlsx/import_products.feature
@@ -57,3 +57,20 @@ Feature: Import XLSX products
     And I launch the import job
     And I wait for the "xlsx_footwear_product_import" job to finish
     Then there should be 2 products
+
+  @jira https://akeneo.atlassian.net/browse/PIM-5696
+  Scenario: Successfully import products with numeric values in text attributes
+    Given the following XLSX file to import:
+      """
+      sku;family;groups;name-en_US;description-en_US-tablet
+      123;boots;CROSS;456;7890
+      """
+    And the following job "xlsx_footwear_product_import" configuration:
+      | filePath | %file to import% |
+    When I am on the "xlsx_footwear_product_import" import job page
+    And I launch the import job
+    And I wait for the "xlsx_footwear_product_import" job to finish
+    Then there should be 1 product
+    And the english tablet name of "123" should be "456"
+    And the english tablet description of "123" should be "7890"
+

--- a/features/import/product/xlsx/import_products_with_associations.feature
+++ b/features/import/product/xlsx/import_products_with_associations.feature
@@ -2,7 +2,7 @@
 Feature: Execute a job
   In order to use existing product information
   As a product manager
-  I need to be able to import products
+  I need to be able to import products with associations
 
   Background:
     Given the "footwear" catalog configuration
@@ -130,3 +130,20 @@ Feature: Execute a job
     And I visit the "Associations" tab
     And I visit the "Cross sell" group
     Then I should see "0 products and 0 groups"
+
+  @jira https://akeneo.atlassian.net/browse/PIM-5696
+  Scenario: Successfully import products with associations and numeric value as SKU
+    Given the following XLSX file to import:
+    """
+      sku;family;groups;X_SELL-groups
+      123;boots;CROSS;CROSS
+      """
+    And the following job "xlsx_footwear_product_import" configuration:
+      | filePath | %file to import% |
+    And I am on the "xlsx_footwear_product_import" import job page
+    When I launch the import job
+    And I wait for the "xlsx_footwear_product_import" job to finish
+    And I edit the "123" product
+    And I visit the "Associations" tab
+    And I visit the "Cross sell" group
+    Then I should see "0 products and 1 groups"

--- a/spec/Pim/Component/Catalog/Comparator/Filter/ProductAssociationFilterSpec.php
+++ b/spec/Pim/Component/Catalog/Comparator/Filter/ProductAssociationFilterSpec.php
@@ -121,24 +121,4 @@ class ProductAssociationFilterSpec extends ObjectBehavior
 
         $this->filter($product, $newValues)->shouldReturn([]);
     }
-
-    function it_throws_an_exception_if_new_values_contain_other_than_associations(
-        $normalizer,
-        ProductInterface $product
-    ) {
-        $originalValues = $newValues = [
-            'family' => [],
-            'associations' => ['groups' => [1]],
-        ];
-
-        $normalizer->normalize($product, 'json', ['only_associations' => true])
-            ->willReturn($originalValues);
-
-        $this
-            ->shouldThrow('LogicException')
-            ->during(
-                'filter',
-                [$product, $newValues]
-            );
-    }
 }

--- a/spec/Pim/Component/Connector/ArrayConverter/Flat/Product/ValueConverter/TextConverterSpec.php
+++ b/spec/Pim/Component/Connector/ArrayConverter/Flat/Product/ValueConverter/TextConverterSpec.php
@@ -6,16 +6,16 @@ use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Connector\ArrayConverter\Flat\Product\FieldSplitter;
 
-class ScalarConverterSpec extends ObjectBehavior
+class TextConverterSpec extends ObjectBehavior
 {
     function let(FieldSplitter $fieldSplitter)
     {
         $this->beConstructedWith(
             $fieldSplitter,
             [
-                'pim_catalog_date',
-                'pim_catalog_boolean',
-                'pim_catalog_number'
+                'pim_catalog_identifier',
+                'pim_catalog_text',
+                'pim_catalog_textarea'
             ]
         );
     }
@@ -27,45 +27,29 @@ class ScalarConverterSpec extends ObjectBehavior
 
     function it_supports_converter_field()
     {
-        $this->supportsField('pim_catalog_date')->shouldReturn(true);
-        $this->supportsField('pim_catalog_boolean')->shouldReturn(true);
-        $this->supportsField('pim_catalog_number')->shouldReturn(true);
+        $this->supportsField('pim_catalog_identifier')->shouldReturn(true);
+        $this->supportsField('pim_catalog_text')->shouldReturn(true);
+        $this->supportsField('pim_catalog_textarea')->shouldReturn(true);
         $this->supportsField('pim_catalog_price')->shouldReturn(false);
     }
 
-    function it_converts_a_date(AttributeInterface $attribute)
+    function it_converts_a_string(AttributeInterface $attribute)
     {
         $attribute->getCode()->willReturn('attribute_code');
         $fieldNameInfo = ['attribute' => $attribute, 'locale_code' => 'en_US', 'scope_code' => 'mobile'];
 
-        $value = '30/03/2016';
+        $value = 'my awesome text';
 
         $expectedResult = ['attribute_code' => [[
             'locale' => 'en_US',
             'scope'  => 'mobile',
-            'data'   => '30/03/2016',
+            'data'   => 'my awesome text',
         ]]];
 
         $this->convert($fieldNameInfo, $value)->shouldReturn($expectedResult);
     }
 
-    function it_converts_a_boolean(AttributeInterface $attribute)
-    {
-        $attribute->getCode()->willReturn('attribute_code');
-        $fieldNameInfo = ['attribute' => $attribute, 'locale_code' => 'en_US', 'scope_code' => 'mobile'];
-
-        $value = false;
-
-        $expectedResult = ['attribute_code' => [[
-            'locale' => 'en_US',
-            'scope'  => 'mobile',
-            'data'   => false,
-        ]]];
-
-        $this->convert($fieldNameInfo, $value)->shouldReturn($expectedResult);
-    }
-
-    function it_converts_a_number(AttributeInterface $attribute)
+    function it_casts_a_number_to_string_during_conversion(AttributeInterface $attribute)
     {
         $attribute->getCode()->willReturn('attribute_code');
         $fieldNameInfo = ['attribute' => $attribute, 'locale_code' => 'en_US', 'scope_code' => 'mobile'];
@@ -75,7 +59,7 @@ class ScalarConverterSpec extends ObjectBehavior
         $expectedResult = ['attribute_code' => [[
             'locale' => 'en_US',
             'scope'  => 'mobile',
-            'data'   => 1234,
+            'data'   => '1234',
         ]]];
 
         $this->convert($fieldNameInfo, $value)->shouldReturn($expectedResult);

--- a/spec/Pim/Component/Connector/Processor/Denormalization/ProductAssociationProcessorSpec.php
+++ b/spec/Pim/Component/Connector/Processor/Denormalization/ProductAssociationProcessorSpec.php
@@ -73,7 +73,7 @@ class ProductAssociationProcessorSpec extends ObjectBehavior
             'XSELL-groups'  => ['akeneo_tshirt, oro_tshirt'],
             'XSELL-product' => ['AKN_TS, ORO_TSH']
         ];
-        $convertedData =                 [
+        $convertedData = [
             'sku' => [
                 [
                     'locale' => null,
@@ -89,10 +89,10 @@ class ProductAssociationProcessorSpec extends ObjectBehavior
             ]
         ];
         $arrayConverter
-            ->convert($originalData, ["with_associations" => true])
+            ->convert($originalData, ['with_associations' => true])
             ->willReturn($convertedData);
 
-        $preFilteredData = $filteredData = [
+        $filteredData = [
             'associations' => [
                 'XSELL' => [
                     'groups'  => ['akeneo_tshirt', 'oro_tshirt'],
@@ -102,7 +102,7 @@ class ProductAssociationProcessorSpec extends ObjectBehavior
         ];
 
         unset($filteredData['associations']['XSELL']['groups']);
-        $productAssocFilter->filter($product, $preFilteredData)
+        $productAssocFilter->filter($product, $convertedData)
             ->shouldBeCalled()
             ->willReturn($filteredData);
 
@@ -138,7 +138,7 @@ class ProductAssociationProcessorSpec extends ObjectBehavior
             'NOT_FOUND-groups'  => ['akeneo_tshirt, oro_tshirt'],
             'NOT_FOUND-product' => ['AKN_TS, ORO_TSH']
         ];
-        $convertedData =                 [
+        $convertedData = [
             'sku' => [
                 [
                     'locale' => null,
@@ -154,7 +154,7 @@ class ProductAssociationProcessorSpec extends ObjectBehavior
             ]
         ];
         $arrayConverter
-            ->convert($originalData, ["with_associations" => true])
+            ->convert($originalData, ['with_associations' => true])
             ->willReturn($convertedData);
 
         $filteredData = [
@@ -166,7 +166,9 @@ class ProductAssociationProcessorSpec extends ObjectBehavior
             ]
         ];
 
-        $productAssocFilter->filter($product, $filteredData)->willReturn($filteredData);
+        $productAssocFilter->filter($product, $convertedData)
+            ->shouldBeCalled()
+            ->willReturn($filteredData);
 
         $productUpdater
             ->update($product, $filteredData)
@@ -205,7 +207,7 @@ class ProductAssociationProcessorSpec extends ObjectBehavior
             'XSELL-groups'  => ['akeneo_tshirt, oro_tshirt'],
             'XSELL-product' => ['AKN_TS, ORO_TSH']
         ];
-        $convertedData =                 [
+        $convertedData = [
             'sku' => [
                 [
                     'locale' => null,
@@ -221,7 +223,7 @@ class ProductAssociationProcessorSpec extends ObjectBehavior
             ]
         ];
         $arrayConverter
-            ->convert($originalData, ["with_associations" => true])
+            ->convert($originalData, ['with_associations' => true])
             ->willReturn($convertedData);
 
         $filteredData = [
@@ -233,7 +235,9 @@ class ProductAssociationProcessorSpec extends ObjectBehavior
             ]
         ];
 
-        $productAssocFilter->filter($product, $filteredData)->willReturn($filteredData);
+        $productAssocFilter->filter($product, $convertedData)
+            ->shouldBeCalled()
+            ->willReturn($filteredData);
 
         $productUpdater
             ->update($product, $filteredData)
@@ -277,7 +281,7 @@ class ProductAssociationProcessorSpec extends ObjectBehavior
             'XSELL-groups'  => ['akeneo_tshirt, oro_tshirt'],
             'XSELL-product' => ['AKN_TS, ORO_TSH']
         ];
-        $convertedData =                 [
+        $convertedData = [
             'sku' => [
                 [
                     'locale' => null,
@@ -293,7 +297,7 @@ class ProductAssociationProcessorSpec extends ObjectBehavior
             ]
         ];
         $arrayConverter
-            ->convert($originalData, ["with_associations" => true])
+            ->convert($originalData, ['with_associations' => true])
             ->willReturn($convertedData);
 
         $filteredData = [
@@ -305,7 +309,9 @@ class ProductAssociationProcessorSpec extends ObjectBehavior
             ]
         ];
 
-        $productAssocFilter->filter($product, $filteredData)->willReturn([]);
+        $productAssocFilter->filter($product, $convertedData)
+            ->shouldBeCalled()
+            ->willReturn([]);
 
         $productUpdater
             ->update($product, $filteredData)

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/array_converters.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/array_converters.yml
@@ -26,6 +26,7 @@ parameters:
     pim_connector.array_converter.flat.product.value_converter.multiselect.class:     Pim\Component\Connector\ArrayConverter\Flat\Product\ValueConverter\MultiSelectConverter
     pim_connector.array_converter.flat.product.value_converter.simpleselect.class:    Pim\Component\Connector\ArrayConverter\Flat\Product\ValueConverter\SimpleSelectConverter
     pim_connector.array_converter.flat.product.value_converter.media.class:           Pim\Component\Connector\ArrayConverter\Flat\Product\ValueConverter\MediaConverter
+    pim_connector.array_converter.flat.product.value_converter.text.class:            Pim\Component\Connector\ArrayConverter\Flat\Product\ValueConverter\TextConverter
     pim_connector.array_converter.flat.product.value_converter.scalar.class:          Pim\Component\Connector\ArrayConverter\Flat\Product\ValueConverter\ScalarConverter
 
     pim_connector.array_converter.flat.product.field_converter.class:                 Pim\Component\Connector\ArrayConverter\Flat\Product\FieldConverter
@@ -198,11 +199,19 @@ services:
         tags:
             - { name: 'pim_connector.array_converter.flat.product.value_converter' }
 
+    pim_connector.array_converter.flat.product.value_converter.text:
+        class: %pim_connector.array_converter.flat.product.value_converter.text.class%
+        parent: pim_connector.array_converter.flat.product.value_converter.abstract
+        arguments:
+            - ['pim_catalog_identifier', 'pim_catalog_text', 'pim_catalog_textarea']
+        tags:
+            - { name: 'pim_connector.array_converter.flat.product.value_converter' }
+
     pim_connector.array_converter.flat.product.value_converter.scalar:
         class: %pim_connector.array_converter.flat.product.value_converter.scalar.class%
         parent: pim_connector.array_converter.flat.product.value_converter.abstract
         arguments:
-            - ['pim_catalog_identifier', 'pim_catalog_text', 'pim_catalog_textarea', 'pim_catalog_date', 'pim_catalog_boolean', 'pim_catalog_number']
+            - ['pim_catalog_date', 'pim_catalog_boolean', 'pim_catalog_number']
         tags:
             - { name: 'pim_connector.array_converter.flat.product.value_converter' }
 

--- a/src/Pim/Component/Catalog/Comparator/Filter/ProductAssociationFilter.php
+++ b/src/Pim/Component/Catalog/Comparator/Filter/ProductAssociationFilter.php
@@ -47,18 +47,12 @@ class ProductAssociationFilter implements ProductFilterInterface
         }
 
         $result = [];
-        foreach ($newValues as $code => $associations) {
-            if (self::ASSOCIATIONS_FIELD !== $code) {
-                throw new \LogicException(sprintf('Only "%s" field can be compared.', self::ASSOCIATIONS_FIELD));
-            }
+        foreach ($newValues[self::ASSOCIATIONS_FIELD] as $type => $field) {
+            foreach ($field as $key => $association) {
+                $data = $this->compareAssociation($originalAssociations, $association, $type, $key);
 
-            foreach ($associations as $type => $field) {
-                foreach ($field as $key => $association) {
-                    $data = $this->compareAssociation($originalAssociations, $association, $type, $key);
-
-                    if (null !== $data) {
-                        $result[self::ASSOCIATIONS_FIELD][$type][$key] = $data;
-                    }
+                if (null !== $data) {
+                    $result[self::ASSOCIATIONS_FIELD][$type][$key] = $data;
                 }
             }
         }

--- a/src/Pim/Component/Connector/ArrayConverter/Flat/Product/ValueConverter/TextConverter.php
+++ b/src/Pim/Component/Connector/ArrayConverter/Flat/Product/ValueConverter/TextConverter.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Pim\Component\Connector\ArrayConverter\Flat\Product\ValueConverter;
+
+use Pim\Component\Connector\ArrayConverter\Flat\Product\FieldSplitter;
+
+/**
+ * Converts text value into structured one.
+ *
+ * @author    Yohan Blain <yohan.blain@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class TextConverter extends AbstractValueConverter
+{
+    /**
+     * @param FieldSplitter $fieldSplitter
+     * @param array         $supportedFieldType
+     */
+    public function __construct(FieldSplitter $fieldSplitter, array $supportedFieldType)
+    {
+        parent::__construct($fieldSplitter);
+
+        $this->supportedFieldType = $supportedFieldType;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function convert(array $attributeFieldInfo, $value)
+    {
+        if ('' !== $value) {
+            $data = (string) $value;
+        } else {
+            $data = null;
+        }
+
+        return [$attributeFieldInfo['attribute']->getCode() => [[
+            'locale' => $attributeFieldInfo['locale_code'],
+            'scope'  => $attributeFieldInfo['scope_code'],
+            'data'   => $data,
+        ]]];
+    }
+}


### PR DESCRIPTION
**What was the issue?**

When you edit an Excel file and put a numeric value in a cell, it is stored as a number in the xlsx file.
It is a problem if it concerns a text attribute or the sku. During import you will have an error like "Attribute ... expects a string as data, interger given".

**What's the fix?**

The processor use converters located in Pim\Component\Connector\ArrayConverter\Flat\Product\ValueConverter to transform the data coming from the reader into the standard format. One of these converters is the ScalarConverter, which does nothing but build the standard format array (locale + scope + value) and handles several attribute types : texts, dates, numbers and booleans.
I created a separated TextConverter that allow to cast the value to string during conversion.

I also had to modify the ProductAssociationProcessor to convert the data properly and make it work with a full numeric sku.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | yes
| Added Behats                      | yes
| Changelog updated                 | n/a
| Review and 2 GTM                  | yes
| Micro Demo to the PO (Story only) | yes
| Migration script                  | n/a
| Tech Doc                          |