### PR TITLE
PIM-5577: remove schedule and reculate completeness option

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -161,3 +161,4 @@
 - Remove class `Pim\Component\Connector\Factory\JobConfigurationFactory`
 - Remove class `Pim\Component\Connector\Model\JobConfiguration`
 - Remove class `Pim\Component\Connector\Model\JobConfigurationInterface`
+- Removed the `recalculate` and `schedule` option from the `Pim\Bundle\CatalogBundle\Doctrine\Common\Saver\ProductSaver` and `Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Saver`

--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -17,6 +17,7 @@
 - PIM-5594: Panel state is now stored in the session storage
 - PIM-5645: Bath jobs configuration files can now also be loaded when contained in a folder named 'batch_jobs'. Introduces the new Akeneo XLSX Connector
 - TIP-342: be able to launch mass edit processes without having to previously store a JobConfiguration and only rely on dynamic configuration
+- PIM-5577: The completeness is now calculated every time a product is saved, ie during mass edit, product import and on edit/save of variant groups.
 
 ## BC breaks
 

--- a/features/Context/FixturesContext.php
+++ b/features/Context/FixturesContext.php
@@ -92,7 +92,7 @@ class FixturesContext extends BaseFixturesContext
 
         // use the processor part of the import system
         $product = $this->loadFixture('products', $data);
-        $this->getProductSaver()->save($product, ['recalculate' => false]);
+        $this->getProductSaver()->save($product);
 
         // reset the unique value set to allow to update product values
         $uniqueValueSet = $this->getContainer()->get('pim_catalog.validator.unique_value_set');
@@ -1373,7 +1373,7 @@ class FixturesContext extends BaseFixturesContext
     {
         $product->setUpdated(new \DateTime($expected));
 
-        $this->getProductSaver()->save($product, ['recalculate' => false]);
+        $this->getProductSaver()->save($product);
     }
 
     /**
@@ -1419,7 +1419,7 @@ class FixturesContext extends BaseFixturesContext
             $association->addProduct($this->getProduct($row['product']));
         }
 
-        $this->getProductSaver()->save($owner, ['recalculate' => false]);
+        $this->getProductSaver()->save($owner);
     }
 
     /**

--- a/features/Context/FixturesContext.php
+++ b/features/Context/FixturesContext.php
@@ -98,6 +98,8 @@ class FixturesContext extends BaseFixturesContext
         $uniqueValueSet = $this->getContainer()->get('pim_catalog.validator.unique_value_set');
         $uniqueValueSet->reset();
 
+        $this->refresh($product);
+
         return $product;
     }
 

--- a/features/Pim/Behat/Context/Domain/TreeContext.php
+++ b/features/Pim/Behat/Context/Domain/TreeContext.php
@@ -4,6 +4,7 @@ namespace Pim\Behat\Context\Domain;
 
 use Behat\Mink\Exception\ExpectationException;
 use Context\Spin\SpinCapableTrait;
+use Context\Spin\TimeoutException;
 use Pim\Behat\Context\PimContext;
 
 class TreeContext extends PimContext
@@ -107,9 +108,11 @@ class TreeContext extends PimContext
         } else {
             try {
                 $checkbox = $this->spin(function () use ($node) {
-                    return $node->find('css', '.jstree-checkbox');
+                    $result = $node->find('css', '.jstree-checkbox');
+
+                    return $result->isVisible() ? $result : null;
                 });
-            } catch (\Exception $e) {
+            } catch (TimeoutException $e) {
                 $checkbox = null;
             }
 

--- a/features/Pim/Behat/Context/Domain/TreeContext.php
+++ b/features/Pim/Behat/Context/Domain/TreeContext.php
@@ -4,7 +4,6 @@ namespace Pim\Behat\Context\Domain;
 
 use Behat\Mink\Exception\ExpectationException;
 use Context\Spin\SpinCapableTrait;
-use Context\Spin\TimeoutException;
 use Pim\Behat\Context\PimContext;
 
 class TreeContext extends PimContext
@@ -108,11 +107,9 @@ class TreeContext extends PimContext
         } else {
             try {
                 $checkbox = $this->spin(function () use ($node) {
-                    $result = $node->find('css', '.jstree-checkbox');
-
-                    return $result->isVisible() ? $result : null;
+                    return $node->find('css', '.jstree-checkbox');
                 });
-            } catch (TimeoutException $e) {
+            } catch (\Exception $e) {
                 $checkbox = null;
             }
 

--- a/features/enrich/variant-group/display_variant_history.feature
+++ b/features/enrich/variant-group/display_variant_history.feature
@@ -33,6 +33,7 @@ Feature: Display the variant group history
     And I change the "Name" to "Ultra boots"
     And I change the "Length" to "5"
     And I save the variant group
+    When I am on the "caterpillar_boots" variant group page
     And I visit the "History" tab
     And I should see history:
       | version | property   | value       |

--- a/features/enrich/variant-group/edit_variant_group.feature
+++ b/features/enrich/variant-group/edit_variant_group.feature
@@ -31,3 +31,24 @@ Feature: Edit a variant group
     Given I fill in the following information:
       | English (United States) | My boots |
     Then I should see "There are unsaved changes."
+
+  @javascript
+  Scenario: Successfully edit a variant group and the completeness should be computed
+    Given I add the "french" locale to the "tablet" channel
+    And I add the "french" locale to the "mobile" channel
+    And the following products:
+      | sku      | family   | manufacturer | weather_conditions | color | name-en_US | name-fr_FR  | price          | rating | size | lace_color  |
+      | sneakers | sneakers | Converse     | hot                | blue  | Sneakers   | Espadrilles | 69 EUR, 99 USD | 4      | 43   | laces_white |
+    And the following product values:
+      | product  | attribute   | value                 | locale | scope  |
+      | sneakers | description | Great sneakers        | en_US  | mobile |
+      | sneakers | description | Really great sneakers | en_US  | tablet |
+      | sneakers | description | Grandes espadrilles   | fr_FR  | mobile |
+    And I visit the "Attributes" tab
+    When I add available attributes Description
+    And I visit the "Products" tab
+    And I press the "Save" button
+    And I should see the text "89%"
+    And I check the row "sneakers"
+    And I press the "Save" button
+    Then I should see the text "78%"

--- a/features/import/product/import_products.feature
+++ b/features/import/product/import_products.feature
@@ -301,3 +301,28 @@ Feature: Execute a job
     And I launch the import job
     And I wait for the "csv_footwear_product_import" job to finish
     Then the category of the product "jacket" should be "123"
+
+  Scenario: Successfully import a csv file of products and the completeness should be computed
+    Given the following CSV file to import:
+      """
+      sku;family;groups;categories;name-en_US;description-en_US-tablet;price;size;color
+      SKU-001;boots;similar_boots;winter_boots;Donec;dictum magna. Ut tincidunt orci quis lectus. Nullam suscipit, est;"100 EUR, 90 USD";40;
+      SKU-002;sneakers;;winter_boots;Donex;Pellentesque habitant morbi tristique senectus et netus et malesuada fames;"100 EUR, 90 USD";37;red
+      """
+    And the following job "csv_footwear_product_import" configuration:
+      | filePath | %file to import% |
+    When I am on the "csv_footwear_product_import" import job page
+    And I launch the import job
+    And I wait for the "csv_footwear_product_import" job to finish
+    And I am on the "SKU-001" product page
+    When I open the "Completeness" panel
+    And I should see the completeness:
+      | channel | locale | state   | missing_values                                        | ratio |
+      | mobile  | en_US  | warning | color                                                 | 80%   |
+      | tablet  | en_US  | warning | weather_conditions rating side_view color             | 56%   |
+    And I am on the "SKU-002" product page
+    When I open the "Completeness" panel
+    And I should see the completeness:
+      | channel | locale | state   | missing_values                                  | ratio |
+      | mobile  | en_US  | success |                                                 | 100%  |
+      | tablet  | en_US  | warning | weather_conditions rating side_view             | 67%   |

--- a/features/mass-action/edit_common_attributes-01.feature
+++ b/features/mass-action/edit_common_attributes-01.feature
@@ -142,3 +142,41 @@ Feature: Edit common attributes of many products at once
     And I wait for the "edit-common-attributes" mass-edit job to finish
     Then the metric "heel_height" of products highheels, blue_highheels should be "12"
     And the metric "heel_height" of products sandals should be "3"
+
+  Scenario: Successfully mass edit products and the completeness should be computed
+    Given I am on the "sneakers" product page
+    When I open the "Completeness" panel
+    Then I should see the completeness:
+      | channel | locale | state   | missing_values                                                        | ratio |
+      | mobile  | en_US  | warning | name price size color                                                 | 20%   |
+      | tablet  | en_US  | warning | name description weather_conditions price rating side_view size color | 11%   |
+    And I am on the "sandals" product page
+    When I open the "Completeness" panel
+    Then I should see the completeness:
+      | channel | locale | state   | missing_values                                     | ratio |
+      | mobile  | en_US  | warning | name price size color                              | 20%   |
+      | tablet  | en_US  | warning | name description price rating side_view size color | 13%   |
+    Then I am on the products page
+    And I mass-edit products sandals, sneakers
+    And I choose the "Edit common attributes" operation
+    And I display the Name, Price and Size attribute
+    And I change the "Name" to "boots"
+    Then I visit the "Marketing" group
+    And I change the "Price" to "100 USD"
+    And I change the "Price" to "150 EUR"
+    Then I visit the "Sizes" group
+    And I change the "Size" to "37"
+    And I move on to the next step
+    And I wait for the "edit-common-attributes" mass-edit job to finish
+    Then I am on the "sneakers" product page
+    When I open the "Completeness" panel
+    And I should see the completeness:
+      | channel | locale | state   | missing_values                     | ratio |
+      | mobile  | en_US  | warning | color                              | 80%   |
+      | tablet  | en_US  | warning | description rating side_view color | 44%   |
+    And I am on the "sandals" product page
+    When I open the "Completeness" panel
+    And I should see the completeness:
+      | channel | locale | state   | missing_values                     | ratio |
+      | mobile  | en_US  | warning | color                              | 80%   |
+      | tablet  | en_US  | warning | description rating side_view color | 50%   |

--- a/features/product/completeness/update_completeness.feature
+++ b/features/product/completeness/update_completeness.feature
@@ -51,6 +51,7 @@ Feature: Display the completeness of a product
     And I visit the "Attributes" tab
     And I switch the attribute "Rating" requirement in channel "Mobile"
     And I save the family
+    And I should see "Family successfully updated"
     And I am on the "sneakers" product page
     When I open the "Completeness" panel
     Then I should see the completeness summary

--- a/spec/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/AttributeSaverSpec.php
+++ b/spec/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/AttributeSaverSpec.php
@@ -39,7 +39,7 @@ class AttributeSaverSpec extends ObjectBehavior
         $attribute->getCode()->willReturn('my_code');
         $optionsResolver->resolveSaveOptions([])
             ->shouldBeCalled()
-            ->willReturn(['flush' => true, 'schedule' => true]);
+            ->willReturn(['flush' => true]);
         $eventDispatcher
             ->dispatch(
                 Argument::exact(StorageEvents::PRE_SAVE),

--- a/spec/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/GroupSaverSpec.php
+++ b/spec/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/GroupSaverSpec.php
@@ -98,9 +98,7 @@ class GroupSaverSpec extends ObjectBehavior
         $objectManager->persist($group)->shouldBeCalled();
         $objectManager->flush()->shouldBeCalled();
 
-        $productSaver
-            ->saveAll([$addedProduct], ['recalculate' => false, 'schedule' => false])
-            ->shouldBeCalled();
+        $productSaver->saveAll([$addedProduct])->shouldBeCalled();
 
         $eventDispatcher->dispatch(StorageEvents::PRE_SAVE, Argument::cetera())->shouldBeCalled();
         $eventDispatcher->dispatch(StorageEvents::POST_SAVE, Argument::cetera())->shouldBeCalled();
@@ -132,7 +130,7 @@ class GroupSaverSpec extends ObjectBehavior
         $objectManager->flush()->shouldBeCalled();
 
         $productSaver
-            ->saveAll([$removedProduct], ['recalculate' => false, 'schedule' => false])
+            ->saveAll([$removedProduct])
             ->shouldBeCalled();
 
         $eventDispatcher->dispatch(StorageEvents::PRE_SAVE, Argument::cetera())->shouldBeCalled();

--- a/spec/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/ProductSaverSpec.php
+++ b/spec/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/ProductSaverSpec.php
@@ -32,16 +32,16 @@ class ProductSaverSpec extends ObjectBehavior
         $this->shouldHaveType('Akeneo\Component\StorageUtils\Saver\BulkSaverInterface');
     }
 
-    function it_persists_flushes_schedule_and_recalculate_completeness_of_products_in_database(
+    function it_persists_flushes_and_schedule_completeness_of_products_in_database(
         $objectManager,
         $completenessManager,
         $optionsResolver,
         $eventDispatcher,
         ProductInterface $product
     ) {
-        $optionsResolver->resolveSaveOptions(['recalculate' => true, 'flush' => true, 'schedule' => true])
+        $optionsResolver->resolveSaveOptions(['flush' => true])
             ->shouldBeCalled()
-            ->willReturn(['recalculate' => true, 'flush' => true, 'schedule' => true]);
+            ->willReturn(['flush' => true]);
         $objectManager->persist($product)->shouldBeCalled();
         $objectManager->flush()->shouldBeCalled();
         $completenessManager->schedule($product)->shouldBeCalled();
@@ -50,49 +50,7 @@ class ProductSaverSpec extends ObjectBehavior
         $eventDispatcher->dispatch(StorageEvents::PRE_SAVE, Argument::cetera())->shouldBeCalled();
         $eventDispatcher->dispatch(StorageEvents::POST_SAVE, Argument::cetera())->shouldBeCalled();
 
-        $this->save($product, ['recalculate' => true, 'flush' => true, 'schedule' => true]);
-    }
-
-    function it_does_not_schedule_neither_recalculate_completeness_when_persisting(
-        $objectManager,
-        $completenessManager,
-        $optionsResolver,
-        $eventDispatcher,
-        ProductInterface $product
-    ) {
-        $optionsResolver->resolveSaveOptions(['recalculate' => false, 'flush' => true, 'schedule' => false])
-            ->shouldBeCalled()
-            ->willReturn(['recalculate' => false, 'flush' => true, 'schedule' => false]);
-        $objectManager->persist($product)->shouldBeCalled();
-        $objectManager->flush()->shouldBeCalled();
-        $completenessManager->schedule($product)->shouldNotBeCalled();
-        $completenessManager->generateMissingForProduct($product)->shouldNotBeCalled();
-
-        $eventDispatcher->dispatch(StorageEvents::PRE_SAVE, Argument::cetera())->shouldBeCalled();
-        $eventDispatcher->dispatch(StorageEvents::POST_SAVE, Argument::cetera())->shouldBeCalled();
-
-        $this->save($product, ['recalculate' => false, 'flush' => true, 'schedule' => false]);
-    }
-
-    function it_does_not_flush_object_manager_when_persisting(
-        $objectManager,
-        $completenessManager,
-        $optionsResolver,
-        $eventDispatcher,
-        ProductInterface $product
-    ) {
-        $optionsResolver->resolveSaveOptions(['recalculate' => false, 'flush' => false, 'schedule' => true])
-            ->shouldBeCalled()
-            ->willReturn(['recalculate' => false, 'flush' => false, 'schedule' => true]);
-        $objectManager->persist($product)->shouldBeCalled();
-        $objectManager->flush()->shouldNotBeCalled();
-        $completenessManager->schedule($product)->shouldBeCalled();
-        $completenessManager->generateMissingForProduct($product)->shouldNotBeCalled();
-
-        $eventDispatcher->dispatch(StorageEvents::PRE_SAVE, Argument::cetera())->shouldBeCalled();
-        $eventDispatcher->dispatch(StorageEvents::POST_SAVE, Argument::cetera())->shouldBeCalled();
-
-        $this->save($product, ['recalculate' => false, 'flush' => false, 'schedule' => true]);
+        $this->save($product, ['flush' => true]);
     }
 
     function it_throws_an_exception_when_try_to_save_something_else_than_a_product(
@@ -103,6 +61,6 @@ class ProductSaverSpec extends ObjectBehavior
 
         $this
             ->shouldThrow(new \InvalidArgumentException('Expects a Pim\Component\Catalog\Model\ProductInterface, "stdClass" provided'))
-            ->duringSave($otherObject, ['recalculate' => false, 'flush' => false, 'schedule' => true]);
+            ->duringSave($otherObject, ['flush' => false]);
     }
 }

--- a/spec/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Saver/ProductSaverSpec.php
+++ b/spec/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Saver/ProductSaverSpec.php
@@ -51,15 +51,7 @@ class ProductSaverSpec extends ObjectBehavior
 
         $bulkVersionBuilder->buildVersions(Argument::any())->willReturn([]);
 
-        $optionsResolver
-            ->resolveSaveAllOptions(Argument::any())
-            ->willReturn(
-                [
-                    'flush'       => true,
-                    'recalculate' => false,
-                    'schedule'    => true
-                ]
-            );
+        $optionsResolver->resolveSaveAllOptions(Argument::any())->willReturn(['flush' => true]);
     }
 
     function it_is_a_saver()

--- a/spec/Pim/Bundle/CatalogBundle/EventSubscriber/ProductCategorySubscriberSpec.php
+++ b/spec/Pim/Bundle/CatalogBundle/EventSubscriber/ProductCategorySubscriberSpec.php
@@ -48,11 +48,7 @@ class ProductCategorySubscriberSpec extends ObjectBehavior
 
     function it_applies_on_related_products($saver, RemoveEvent $event, CategoryInterface $object, ProductInterface $product)
     {
-        $saver->saveAll([$product], [
-            'flush'       => 'expected_flush_value',
-            'recalculate' => false,
-            'schedule'    => false,
-        ])->shouldBeCalled();
+        $saver->saveAll([$product], ['flush' => 'expected_flush_value'])->shouldBeCalled();
 
         $event->getSubject()->willReturn($object);
         $event->getArgument('flush')->willReturn('expected_flush_value');

--- a/spec/Pim/Component/Connector/Writer/Doctrine/ProductWriterSpec.php
+++ b/spec/Pim/Component/Connector/Writer/Doctrine/ProductWriterSpec.php
@@ -73,7 +73,7 @@ class ProductWriterSpec extends ObjectBehavior
         $product2->getId()->willReturn(null);
 
         $this->setStepExecution($stepExecution);
-        $productSaver->saveAll($items, ['recalculate' => false])->shouldBeCalled();
+        $productSaver->saveAll($items)->shouldBeCalled();
         $this->write($items);
     }
 

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/FamilySaver.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/FamilySaver.php
@@ -70,9 +70,11 @@ class FamilySaver implements SaverInterface, BulkSaverInterface
 
         $options = $this->optionsResolver->resolveSaveOptions($options);
         $this->objectManager->persist($family);
+
         if (true === $options['flush']) {
             $this->objectManager->flush();
         }
+
         if (true === $options['schedule']) {
             $this->completenessManager->scheduleForFamily($family);
         }

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/GroupSaver.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/GroupSaver.php
@@ -160,7 +160,7 @@ class GroupSaver implements SaverInterface, BulkSaverInterface
      */
     protected function addProducts(array $products)
     {
-        $this->productSaver->saveAll($products, ['recalculate' => false, 'schedule' => false]);
+        $this->productSaver->saveAll($products);
     }
 
     /**
@@ -168,7 +168,7 @@ class GroupSaver implements SaverInterface, BulkSaverInterface
      */
     protected function removeProducts(array $products)
     {
-        $this->productSaver->saveAll($products, ['recalculate' => false, 'schedule' => false]);
+        $this->productSaver->saveAll($products);
     }
 
     /**

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/ProductSaver.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/ProductSaver.php
@@ -69,20 +69,11 @@ class ProductSaver implements SaverInterface, BulkSaverInterface
         $options = $this->optionsResolver->resolveSaveOptions($options);
         $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE, new GenericEvent($product, $options));
 
+        $this->completenessManager->schedule($product);
+        $this->completenessManager->generateMissingForProduct($product);
 
         $this->objectManager->persist($product);
-
-        if (true === $options['schedule'] || true === $options['recalculate']) {
-            $this->completenessManager->schedule($product);
-        }
-
-        if (true === $options['recalculate'] || true === $options['flush']) {
-            $this->objectManager->flush();
-        }
-
-        if (true === $options['recalculate']) {
-            $this->completenessManager->generateMissingForProduct($product);
-        }
+        $this->objectManager->flush();
 
         $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE, new GenericEvent($product, $options));
     }
@@ -99,11 +90,8 @@ class ProductSaver implements SaverInterface, BulkSaverInterface
         $options = $this->optionsResolver->resolveSaveAllOptions($options);
         $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE_ALL, new GenericEvent($products, $options));
 
-        $itemOptions = $options;
-        $itemOptions['flush'] = false;
-
         foreach ($products as $product) {
-            $this->save($product, $itemOptions);
+            $this->save($product);
         }
 
         if (true === $options['flush']) {

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/ProductSaver.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/ProductSaver.php
@@ -70,10 +70,13 @@ class ProductSaver implements SaverInterface, BulkSaverInterface
         $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE, new GenericEvent($product, $options));
 
         $this->completenessManager->schedule($product);
-        $this->completenessManager->generateMissingForProduct($product);
-
         $this->objectManager->persist($product);
-        $this->objectManager->flush();
+
+        if (true === $options['flush']) {
+            $this->objectManager->flush();
+        }
+
+        $this->completenessManager->generateMissingForProduct($product);
 
         $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE, new GenericEvent($product, $options));
     }
@@ -91,7 +94,7 @@ class ProductSaver implements SaverInterface, BulkSaverInterface
         $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE_ALL, new GenericEvent($products, $options));
 
         foreach ($products as $product) {
-            $this->save($product);
+            $this->save($product, $options);
         }
 
         if (true === $options['flush']) {

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/CompletenessGenerator.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/CompletenessGenerator.php
@@ -67,7 +67,9 @@ class CompletenessGenerator implements CompletenessGeneratorInterface
     {
         $this->generate($product);
 
-        $this->documentManager->refresh($product);
+        if ($this->documentManager->contains($product)) {
+            $this->documentManager->refresh($product);
+        }
     }
 
     /**

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Saver/ProductSaver.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Saver/ProductSaver.php
@@ -118,10 +118,8 @@ class ProductSaver extends BaseProductSaver
             $this->updateDocuments($updateDocs);
         }
         
-        if (true === $options['recalculate']) {
-            foreach ($products as $product) {
-                $this->completenessManager->generateMissingForProduct($product);
-            }
+        foreach ($products as $product) {
+            $this->completenessManager->generateMissingForProduct($product);
         }
 
         $versions = $this->bulkVersionBuilder->buildVersions($products);

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/ProductRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/ProductRepository.php
@@ -213,22 +213,6 @@ class ProductRepository extends EntityRepository implements
      */
     public function getFullProduct($id)
     {
-        $qb = $this->getFullProductQB();
-
-        return $qb
-            ->where('p.id=:id')
-            ->setParameter('id', $id)
-            ->getQuery()
-            ->getOneOrNullResult();
-    }
-
-    /**
-     * Get full product query builder
-     *
-     * @return \Doctrine\ORM\QueryBuilder
-     */
-    protected function getFullProductQB()
-    {
         return $this
             ->createQueryBuilder('p')
             ->select('p, f, v, pr, m, o, os')
@@ -237,7 +221,11 @@ class ProductRepository extends EntityRepository implements
             ->leftJoin('v.prices', 'pr')
             ->leftJoin('v.media', 'm')
             ->leftJoin('v.option', 'o')
-            ->leftJoin('v.options', 'os');
+            ->leftJoin('v.options', 'os')
+            ->where('p.id=:id')
+            ->setParameter('id', $id)
+            ->getQuery()
+            ->getOneOrNullResult();
     }
 
     /**

--- a/src/Pim/Bundle/CatalogBundle/EventSubscriber/ProductCategorySubscriber.php
+++ b/src/Pim/Bundle/CatalogBundle/EventSubscriber/ProductCategorySubscriber.php
@@ -55,11 +55,7 @@ class ProductCategorySubscriber implements EventSubscriberInterface
         }
 
         if (count($productsToUpdate) > 0) {
-            $this->saver->saveAll($productsToUpdate, [
-                'flush'       => $event->getArgument('flush'),
-                'recalculate' => false,
-                'schedule'    => false,
-            ]);
+            $this->saver->saveAll($productsToUpdate, ['flush'=> $event->getArgument('flush')]);
         }
     }
 }

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/CompletenessController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/CompletenessController.php
@@ -64,7 +64,7 @@ class CompletenessController
     /**
      * Get completeness for a product
      *
-     * @param int $id
+     * @param int|string $id
      *
      * @return JSONResponse
      */

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/ProductController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/ProductController.php
@@ -260,7 +260,7 @@ class ProductController
         }
 
         $this->productBuilder->removeAttributeFromProduct($product, $attribute);
-        $this->productSaver->save($product, ['recalculate' => false, 'schedule' => false]);
+        $this->productSaver->save($product);
 
         return new JsonResponse();
     }

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/CompletenessCollectionNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/CompletenessCollectionNormalizer.php
@@ -94,6 +94,8 @@ class CompletenessCollectionNormalizer implements NormalizerInterface
      */
     protected function normalizeChannelCompleteness($format, array $context, array $channels, array $locales)
     {
+        $normalizedCompChannels = [];
+
         //TODO: workaround in order to handle behat empty completeness
         foreach ($channels as $channelCompleteness) {
             $channelCode = null;

--- a/src/Pim/Component/Connector/Writer/Doctrine/ProductWriter.php
+++ b/src/Pim/Component/Connector/Writer/Doctrine/ProductWriter.php
@@ -100,7 +100,7 @@ class ProductWriter extends AbstractConfigurableStepElement implements
             $this->incrementCount($item);
         }
 
-        $this->productSaver->saveAll($items, ['recalculate' => false]);
+        $this->productSaver->saveAll($items);
         $this->detacher->detachAll($items);
     }
 


### PR DESCRIPTION
As Julia, when I save several products, I would like to have the completeness calculated in order to always have a completeness calculated and up-to-date.

Must be covered:

- [x] When Julia mass edits products, the completeness of the products updated is calculated.
- [x] When Julia imports some products, the completeness for the products imported is calculated.
- [x] When Julia edit then saves a variant group, the completeness for the products belonging to the variant group is calculated.
- [x] Run all tests, add behat scenario to check that completeness is computed on these processes 
- [x] Measure perf impacts

Here the bulk save for products is now saving products one by one. As there are no significant overhead we keep it as it for the moment.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | No
| Added Behats                      | Yes
| Changelog updated                 | Yes
| Review and 2 GTM                  | Yes
| Micro Demo to the PO (Story only) | Yes

## Measures:
CE:
Create on 1121 products:

    master-ODM:     1min12
    PIM-5577-ODM: 2min48

    master-ORM: 2min15
    PIM-5577:      3min15

Update on 1121 products

    master-ODM:     1min23
    PIM-5577-ODM: 2min43

    master-ORM:     1min50
    PIM-5577-ORM: 6min44