### PR TITLE
PIM-5642: fix catalog scope filter from the product grid

### DIFF
--- a/features/Context/Page/Base/Grid.php
+++ b/features/Context/Page/Base/Grid.php
@@ -185,7 +185,7 @@ class Grid extends Index
                 foreach ($values as $value) {
                     $driver->executeScript(
                         sprintf(
-                            "$('.ui-multiselect-menu:visible input[title=\"%s\"]').click().trigger('click');",
+                            "$('.ui-multiselect-menu:visible input[title=\"%s\"]').attr('checked', true).trigger('click');",
                             $value
                         )
                     );

--- a/features/Context/catalog/footwear/families.csv
+++ b/features/Context/catalog/footwear/families.csv
@@ -3,3 +3,4 @@ boots;Boots;sku,name,manufacturer,description,weather_conditions,price,rating,si
 heels;Heels;sku,name,manufacturer,description,price,side_view,top_view,size,color,heel_color,sole_color,sole_fabric;name;sku,name,description,price,side_view,size,color,heel_color,sole_color;sku,name,price,size,color,heel_color,sole_color
 sneakers;Sneakers;sku,name,manufacturer,description,weather_conditions,price,rating,side_view,top_view,size,color,lace_color;name;sku,name,description,weather_conditions,price,rating,side_view,size,color;sku,name,price,size,color
 sandals;Sandals;sku,name,manufacturer,description,price,rating,side_view,size,color;name;sku,name,description,price,rating,side_view,size,color;sku,name,price,size,color
+led_tvs;LED TVs;sku,name,manufacturer,description,price,rating,side_view,size,color;name;sku,name,description,price,rating,side_view,size,color;sku,name,price,size,color

--- a/features/Pim/Behat/Context/NavigationContext.php
+++ b/features/Pim/Behat/Context/NavigationContext.php
@@ -366,6 +366,10 @@ class NavigationContext extends PimContext implements PageObjectAwareInterface
             $filteredUrl = $urlWithoutGrid;
         }
 
+        if ((strlen($filteredUrl) - 1) === strpos($filteredUrl, '#')) {
+            $filteredUrl = strstr($filteredUrl, '#', true);
+        }
+
         return $filteredUrl;
     }
 

--- a/features/datagrid/products_backtothegrid.feature
+++ b/features/datagrid/products_backtothegrid.feature
@@ -29,3 +29,15 @@ Feature: Products back to the grid
     And I should see "SKU: contains \"sneakers_1\""
     And I should see product sneakers_1
     And I should not see product boots_1
+
+  Scenario: Successfully restore the scope dropdown
+    Given I filter by "SKU" with value "sneakers_1"
+    And the grid should contain 1 element
+    And I should see the text "E-Commerce"
+    And I should not see the text "Mobile"
+    And I click on the "sneakers_1" row
+    And I switch the scope to "mobile"
+    And I click back to grid
+    Then the grid should contain 1 element
+    And I should see the text "Mobile"
+    And I should not see the text "E-Commerce"

--- a/features/family/browse_families.feature
+++ b/features/family/browse_families.feature
@@ -8,7 +8,7 @@ Feature: Browse families
     Given a "footwear" catalog configuration
     And I am logged in as "Peter"
     When I am on the families page
-    Then the grid should contain 4 elements
+    Then the grid should contain 5 elements
     And I should see the columns Code, Label and Attribute as label
     And I should see families boots, sandals and sneakers
     And the rows should be sorted ascending by Code
@@ -17,7 +17,7 @@ Feature: Browse families
       | filter             | value | result                             |
       | Code               | a     | sandals and sneakers               |
       | Label              | Boo   | boots                              |
-      | Attribute as label | Name  | boots, heels, sandals and sneakers |
+      | Attribute as label | Name  | boots, heels, sandals, led_tvs and sneakers |
 
   Scenario: Successfully keep descending sorting order after refreshing the page
     Given a "footwear" catalog configuration

--- a/features/family/delete_family.feature
+++ b/features/family/delete_family.feature
@@ -19,7 +19,7 @@ Feature: Delete a family
     Given I edit the "sneakers" family
     When I press the "Delete" button
     And I confirm the deletion
-    Then the grid should contain 3 elements
+    Then the grid should contain 4 elements
     And I should not see family sneakers
 
   Scenario: Successfully delete a family used by a product

--- a/features/product/edit_product_family.feature
+++ b/features/product/edit_product_family.feature
@@ -27,3 +27,11 @@ Feature: Edit the family of a product
     Then I should see the text "Family: Boots"
     When I save the product
     Then I should see the text "Family: Boots"
+
+  Scenario: Successfully change the product family searching by label
+    Given I am on the "sneakers" product page
+    Then I should see the text "Family: Sneakers"
+    When I change the family of the product to "LED TVs"
+    Then I should see the text "Family: LED TVs"
+    When I save the product
+    Then I should see the text "Family: LED TVs"

--- a/src/Oro/Bundle/FilterBundle/Twig/RenderLayoutExtension.php
+++ b/src/Oro/Bundle/FilterBundle/Twig/RenderLayoutExtension.php
@@ -94,6 +94,7 @@ class RenderLayoutExtension extends AbstractExtension
                 ];
             }
         }
+
         return $result;
     }
 }

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/product_scope-filter.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/product_scope-filter.js
@@ -21,10 +21,13 @@ define(
              * @see Oro.Filter.SelectFilter
              */
             contextSearch: false,
+            catalogScope: null,
 
             initialize: function() {
                 SelectFilter.prototype.initialize.apply(this, arguments);
+                this.catalogScope = UserContext.get('catalogScope');
 
+                mediator.once('datagrid_filters:rendered', this.resetValue.bind(this));
                 mediator.once('datagrid_filters:rendered', this.moveFilter.bind(this));
 
                 mediator.bind('grid_load:complete', function(collection) {
@@ -32,6 +35,11 @@ define(
                 });
             },
 
+            /**
+             * Move the filter to its proper position
+             *
+             * @param {Array} collection
+             */
             moveFilter: function (collection) {
                 var $grid = $('#grid-' + collection.inputName);
                 this.$el.addClass('pull-right').insertBefore($grid.find('.actions-panel'));
@@ -40,6 +48,15 @@ define(
                 $filterChoices.find('option[value="scope"]').remove();
                 $filterChoices.multiselect('refresh');
 
+                this.selectWidget.multiselect('refresh');
+            },
+
+            /**
+             * Update the current filter value using the UserContext.
+             */
+            resetValue: function () {
+                this.setValue({value: this.catalogScope});
+                UserContext.set('catalogScope', this.catalogScope);
                 this.selectWidget.multiselect('refresh');
             },
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/meta/change-family.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/meta/change-family.js
@@ -84,8 +84,9 @@ define(
                                 search: term,
                                 options: {
                                     limit: 20,
-                                    page: page
-                                }
+                                    page: page,
+                                    locale: UserContext.get('catalogLocale')
+                                },
                             };
                         },
                         results: function (families) {

--- a/src/Pim/Bundle/FilterBundle/Filter/Product/ScopeFilter.php
+++ b/src/Pim/Bundle/FilterBundle/Filter/Product/ScopeFilter.php
@@ -82,15 +82,8 @@ class ScopeFilter extends ChoiceFilter
         $metadata = parent::getMetadata();
 
         $defaultScope = $this->userContext->getUserChannel();
-
-        $metadata['populateDefault'] = true;
-        $metadata['placeholder']     = $defaultScope->getLabel();
-        $metadata['choices']         = array_filter(
-            $metadata['choices'],
-            function ($choice) use ($defaultScope) {
-                return $choice['value'] !== $defaultScope->getCode();
-            }
-        );
+        $metadata['populateDefault'] = false;
+        unset($metadata['placeholder']);
 
         return $metadata;
     }

--- a/src/Pim/Bundle/UIBundle/Resources/public/js/pim-initselect2.js
+++ b/src/Pim/Bundle/UIBundle/Resources/public/js/pim-initselect2.js
@@ -1,7 +1,7 @@
 /* jshint unused:vars */
 define(
-    ['jquery', 'underscore', 'pim/formatter/choices/base', 'jquery.select2'],
-    function ($, _, ChoicesFormatter) {
+    ['jquery', 'underscore', 'pim/formatter/choices/base', 'pim/user-context', 'jquery.select2'],
+    function ($, _, ChoicesFormatter, UserContext) {
         'use strict';
         return {
             resultsPerPage: 20,
@@ -91,7 +91,8 @@ define(
                                 search: options.term,
                                 options: {
                                     limit: self.resultsPerPage,
-                                    page: page
+                                    page: page,
+                                    locale: UserContext.get('catalogLocale')
                                 }
                             },
                             dataType: 'json',


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Problem is that currently the product grid has it's own state. So it means that each time the grid is rendered, the previous state is set back. When you go on a product edit form, you can switch the catalog locale and catalog scope which updates the usercontext.

The problem is that the user context is not used to configure the grid and we lose it's value each time we render a grid. 

This fix is kind of dirty but as the scope selector is a filter (and should not) it's the only way to fix it.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | NA
| Added Behats                      | Y
| Changelog updated                 | N
| Review and 2 GTM                  | N
| Micro Demo to the PO (Story only) | NA
| Migration script                  | N
| Tech Doc                          | N
 
