### PR TITLE
PIM-5725: Fix reference data name of the attribute in case it's not

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 
+- PIM-5725: Fix reference data name of the attribute in case this attribute is not a reference data
 - PIM-5699: Fix 'is equal to' operator in export / import history grid filter
 
 # 1.4.22 (2016-03-23)

--- a/src/Pim/Bundle/CatalogBundle/Model/AbstractAttribute.php
+++ b/src/Pim/Bundle/CatalogBundle/Model/AbstractAttribute.php
@@ -1035,6 +1035,10 @@ abstract class AbstractAttribute implements AttributeInterface
      */
     public function getReferenceDataName()
     {
+        if (!$this->isBackendTypeReferenceData()) {
+            return null;
+        }
+
         return $this->getProperty('reference_data_name');
     }
 


### PR DESCRIPTION
PIM-5725: Fix reference data name of the attribute in case this attribute is not a reference data

Add a wrong configuration to your SKU attribute. In the column "properties" set:
`a:1:{s:19:"reference_data_name";s:0:"";}
`. AFAIK, it can only be done manually. So that's impossible to add a Behat on this.

During the product normalization, `""` is returned instead of `null` here https://github.com/akeneo/pim-community-dev/blob/1.4/src/Pim/Bundle/TransformBundle/Normalizer/MongoDB/ProductValueNormalizer.php#L138.
Then the product normalization is totally wrong and the product can not be saved.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | impossible
| Changelog updated                 | Y
| Review and 2 GTM                  | 
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

