### PR TITLE
PIM-5728: Fix metric and price datagrid filter

### DIFF
--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -5,6 +5,7 @@
 - PIM-5697: Fix import form when a file extension is not allowed
 - PIM-5695: Do not format price with currency if data is null
 - PIM-5643: Fix default system locale
+- PIM-5728: Fix bug in price and metric datagrid filters
 
 # 1.5.1 (2016-03-09)
 

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/metric-filter.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/metric-filter.js
@@ -137,24 +137,12 @@ define(
             /**
              * Empty value object
              *
-             * @property {0bject}
+             * @property {Object}
              */
             emptyValue: {
                 unit:  '',
                 type:  '',
                 value: ''
-            },
-
-            /**
-             * Check if all properties of the value have been specified or all are empty (for reseting filter)
-             *
-             * @param value
-             * @return boolean
-             */
-            _isValueValid: function(value) {
-                return (value.unit && value.type && !_.isUndefined(value.value)) ||
-                       (!value.unit && !value.type && _.isUndefined(value.value)) ||
-                       value.type === 'empty';
             },
 
             /**
@@ -201,14 +189,13 @@ define(
              */
             setValue: function(value) {
                 value = this._formatRawValue(value);
-                if (this._isValueValid(value)) {
-                    if (this._isNewValueUpdated(value)) {
-                        var oldValue = this.value;
-                        this.value = app.deepClone(value);
-                        this._updateDOMValue();
-                        this._onValueUpdated(this.value, oldValue);
-                    }
+                if (this._isNewValueUpdated(value)) {
+                    var oldValue = this.value;
+                    this.value = app.deepClone(value);
+                    this._updateDOMValue();
+                    this._onValueUpdated(this.value, oldValue);
                 }
+
                 return this;
             },
 
@@ -223,6 +210,16 @@ define(
                 } else {
                     parentDiv.find('input[name="value"], .btn-group:eq(1)').show();
                 }
+            },
+
+            /**
+             * @inheritDoc
+             */
+            reset: function() {
+                this.setValue(this.emptyValue);
+                this.trigger('update');
+
+                return this;
             }
         });
     }

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/price-filter.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/price-filter.js
@@ -131,7 +131,7 @@ define(
             /**
              * Empty value object
              *
-             * @property {0bject}
+             * @property {Object}
              */
             emptyValue: {
                 currency: '',
@@ -195,14 +195,13 @@ define(
              */
             setValue: function(value) {
                 value = this._formatRawValue(value);
-                if (this._isValueValid(value)) {
-                    if (this._isNewValueUpdated(value)) {
-                        var oldValue = this.value;
-                        this.value = app.deepClone(value);
-                        this._updateDOMValue();
-                        this._onValueUpdated(this.value, oldValue);
-                    }
+                if (this._isNewValueUpdated(value)) {
+                    var oldValue = this.value;
+                    this.value = app.deepClone(value);
+                    this._updateDOMValue();
+                    this._onValueUpdated(this.value, oldValue);
                 }
+
                 return this;
             },
 
@@ -219,6 +218,16 @@ define(
                         parentDiv.find('input[name="value"]').show();
                     }
                 }
+            },
+
+            /**
+             * @inheritDoc
+             */
+            reset: function() {
+                this.setValue(this.emptyValue);
+                this.trigger('update');
+
+                return this;
             }
         });
     }


### PR DESCRIPTION
**Description**

When removing a price or a metric filter from the active filters, the product datagrid should be back to the state it was previously to the filtering.
It does not, and if adding the filter again, one can see the filtering choices are still there. This PR fixes this bug.

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | No
| Added Behats                      | No
| Changelog updated                 | Yes
| Review and 2 GTM                  | Yes
| Micro Demo to the PO (Story only) |  No
| Migration script                  | No
| Tech Doc                          | No