### PR TITLE
[TR] PIM-5666: Fix number comparator

### DIFF
--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -1,5 +1,8 @@
 # 1.5.x
 
+## Technical improvements
+
+- PIM-5762: Removed unused category filters on product datagrids
 - Upgrade "akeneo/measure-bundle" from "0.4.1" to "0.5.0", details in the release note https://github.com/akeneo/MeasureBundle/releases/tag/0.5.0
 
 # 1.5.2 (2016-04-25)

--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -12,6 +12,7 @@
 - PIM-5697: Fix import form when a file extension is not allowed
 - PIM-5695: Do not format price with currency if data is null
 - PIM-5643: Fix default system locale
+- PIM-5666: Fix product value saving with value '0'
 
 # 1.5.1 (2016-03-09)
 

--- a/features/product/create_product_and_save_added_attributes.feature
+++ b/features/product/create_product_and_save_added_attributes.feature
@@ -1,0 +1,32 @@
+@javascript
+Feature: Create product and save a new product value
+  In order to enrich a new product
+  As a product manager
+  I need to be able to create a product, add attributes and save
+
+  @jira https://akeneo.atlassian.net/browse/PIM-5666
+  Scenario: Successfully create a product, fill in product values with 0 and save
+    Given a "footwear" catalog configuration
+    And the following attributes:
+      | code      | label     | type   | group     |
+      | tmp_price | Tmp Price | prices | marketing |
+    And I am logged in as "Julia"
+    And I am on the products page
+    And I create a new product
+    And I fill in the following information in the popin:
+      | SKU             | gladiator |
+      | Choose a family | Sandals   |
+    And I press the "Save" button in the popin
+    And I am on the "gladiator" product page
+    And I add available attributes Rate of sale, Weight and Tmp Price
+    And I visit the "Product information" group
+    And I fill in "Weight" with "0"
+    And I visit the "Marketing" group
+    And I fill in "Rate of sale" with "0"
+    And I fill in the following information:
+      | Tmp Price | 0 EUR |
+    And I save the product
+    Then the product "gladiator" should have the following values:
+      | rate_sale | 0           |
+      | tmp_price | 0.00 EUR    |
+      | weight    | 0.0000 GRAM |

--- a/spec/Pim/Component/Catalog/Comparator/Attribute/NumberComparatorSpec.php
+++ b/spec/Pim/Component/Catalog/Comparator/Attribute/NumberComparatorSpec.php
@@ -61,4 +61,12 @@ class NumberComparatorSpec extends ObjectBehavior
 
         $this->compare($changes, $originals)->shouldReturn(null);
     }
+
+    function it_returns_changes_if_it_compares_0_to_null()
+    {
+        $changes   = ['data' => 0, 'locale' => 'en_US', 'scope' => 'ecommerce'];
+        $originals = ['data' => null, 'locale' => null, 'scope' => null];
+
+        $this->compare($changes, $originals)->shouldReturn($changes);
+    }
 }

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product_group.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product_group.yml
@@ -127,13 +127,3 @@ datagrid:
                     options:
                         field_options:
                             choices: '@pim_catalog.manager.channel->getChannelChoices'
-                category:
-                    type:      product_category
-                    label:     Category
-                    data_name: category
-            default:
-                category:
-                    value:
-                        treeId: %pim_filter.product_category_filter.class%::UNKNOWN_TREE
-                        categoryId: %pim_filter.product_category_filter.class%::ALL_CATEGORY
-                    type: %pim_filter.product_category_filter.class%::DEFAULT_TYPE

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product_variant_group.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product_variant_group.yml
@@ -128,13 +128,3 @@ datagrid:
                     options:
                         field_options:
                             choices: '@pim_catalog.manager.channel->getChannelChoices'
-                category:
-                    type:      product_category
-                    label:     Category
-                    data_name: category
-            default:
-                category:
-                    value:
-                        treeId: %pim_filter.product_category_filter.class%::UNKNOWN_TREE
-                        categoryId: %pim_filter.product_category_filter.class%::ALL_CATEGORY
-                    type: %pim_filter.product_category_filter.class%::DEFAULT_TYPE

--- a/src/Pim/Bundle/FilterBundle/Filter/DatasourceFilterUtilityInterface.php
+++ b/src/Pim/Bundle/FilterBundle/Filter/DatasourceFilterUtilityInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Pim\Bundle\FilterBundle\Filter;
+
+use Oro\Bundle\DataGridBundle\Datasource\DatasourceInterface;
+
+/**
+ * Used when you want to apply the filter from the outside, for example from a listener that access the datasource
+ *
+ * @author    Clement Gautier <clement.gautier@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface DatasourceFilterUtilityInterface
+{
+    /**
+     * Applies a filter on a datasource
+     *
+     * @param DatasourceInterface $ds
+     * @param string              $field
+     * @param string              $operator
+     * @param mixed               $value
+     */
+    public function filterDatasource(DatasourceInterface $ds, $field, $operator, $value);
+}

--- a/src/Pim/Bundle/FilterBundle/Filter/ProductFilterUtility.php
+++ b/src/Pim/Bundle/FilterBundle/Filter/ProductFilterUtility.php
@@ -2,8 +2,10 @@
 
 namespace Pim\Bundle\FilterBundle\Filter;
 
+use Oro\Bundle\DataGridBundle\Datasource\DatasourceInterface;
 use Oro\Bundle\FilterBundle\Datasource\FilterDatasourceAdapterInterface;
 use Oro\Bundle\FilterBundle\Filter\FilterUtility as BaseFilterUtility;
+use Pim\Bundle\DataGridBundle\Datasource\ProductDatasource;
 
 /**
  * Product filter utility
@@ -12,7 +14,7 @@ use Oro\Bundle\FilterBundle\Filter\FilterUtility as BaseFilterUtility;
  * @copyright 2013 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class ProductFilterUtility extends BaseFilterUtility
+class ProductFilterUtility extends BaseFilterUtility implements DatasourceFilterUtilityInterface
 {
     /**
      * Applies filter to query by attribute
@@ -24,6 +26,18 @@ class ProductFilterUtility extends BaseFilterUtility
      */
     public function applyFilter(FilterDatasourceAdapterInterface $ds, $field, $operator, $value)
     {
+        $ds->getProductQueryBuilder()->addFilter($field, $operator, $value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function filterDatasource(DatasourceInterface $ds, $field, $operator, $value)
+    {
+        if (!$ds instanceof ProductDatasource) {
+            throw new \RuntimeException(sprintf('Expected ProductDatasource, "%s" given ', get_class($ds)));
+        }
+
         $ds->getProductQueryBuilder()->addFilter($field, $operator, $value);
     }
 }

--- a/src/Pim/Component/Catalog/Comparator/Attribute/NumberComparator.php
+++ b/src/Pim/Component/Catalog/Comparator/Attribute/NumberComparator.php
@@ -48,6 +48,10 @@ class NumberComparator implements ComparatorInterface
             return $data;
         }
 
+        if (null !== $data['data'] && null === $originals['data']) {
+            return $data;
+        }
+
         return (float) $data['data'] !== (float) $originals['data'] ? $data : null;
     }
 }


### PR DESCRIPTION
Save a new metric product value filled with '0' on a product, save the new attribute but not the value "0".

In the NumberComparator we were comparing `(float) 0` the new value with `(float) null` the value from db. But `(float) null` is equal to `0`, PHP is magic \o/

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | yes
| Added Behats                      | yes
| Changelog updated                 | yes
| Review and 2 GTM                  |
| Micro Demo to the PO (Story only) |
| Migration script                  |
| Tech Doc                          |

EE ODM = http://core-ci.akeneo.com/job/dci_behat/3882/ 1 random