### PR TITLE
TIP-245: Extract a DateTimeFilter from DateFilter

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -29,6 +29,10 @@
 
 ## BC breaks
 
+- `Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/DateFilter` does not implement `Pim\Component\Catalog\Query\Filter\FieldFilterInterface`
+- `Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/DateFilter` does not implement `Pim\Component\Catalog\Query\Filter\FieldFilterInterface`
+- Change constructor of `Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/DateFilter`. Remove the third parameter `supportedFields`
+- Change constructor of `Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/DateFilter`. Remove the third parameter `supportedFields`
 - Remove `Pim\Bundle\CatalogBundle\Manager\ProductCategoryManager`
 - Remove methods `getTreesQB` and `getAllChildrenQueryBuilder` in `Akeneo\Component\Classification\Repository\CategoryRepositoryInterface`
 - Remove method `getItemIdsInCategory` in `Akeneo\Component\Classification\Repository\ItemCategoryRepositoryInterface`

--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -25,6 +25,7 @@
 - PIM-5653: When using the Product Query Builder, it is now possible to filter on completeness without specifying a locale. Products with a matching completeness for at least one of the locales of the scope will be selected.
 - PIM-5653: Introduce a new storage-agnostic Product Reader using the PQB
 - Integrates the AkeneoMeasureBundle in our main repository
+- TIP-245: Add datetime filters in the Product Query Builder, allowing to select products on "created at" and "updated at" fields.
 
 ## BC breaks
 

--- a/features/filter/date.feature
+++ b/features/filter/date.feature
@@ -7,10 +7,10 @@ Feature: Filter on date
     Given a "footwear" catalog configuration
     And the following products:
       | sku     | destocking_date |
+      | BOOTBL  | 2013-01-25      |
+      | BOOTBS  | 2015-01-20      |
       | BOOTBXS | 2015-01-25      |
       | BOOTWXS | 2015-03-25      |
-      | BOOTBS  | 2015-01-20      |
-      | BOOTBL  | 2013-01-25      |
       | BOOTRXS |                 |
     Then I should get the following results for the given filters:
       | filter                                                                                                                                   | result                                     |
@@ -18,7 +18,7 @@ Feature: Filter on date
       | [{"field":"destocking_date", "operator":">", "value": "2015-01-19"}]                                                                     | ["BOOTBXS", "BOOTBS", "BOOTWXS"]           |
       | [{"field":"destocking_date", "operator":"<", "value": "2015-01-21"}]                                                                     | ["BOOTBS", "BOOTBL"]                       |
       | [{"field":"destocking_date", "operator":"BETWEEN", "value": ["2015-01-20", "2015-03-25"]}]                                               | ["BOOTBXS", "BOOTWXS", "BOOTBS"]           |
-      | [{"field":"destocking_date", "operator":"NOT BETWEEN", "value": ["2015-01-20", "2015-03-25"]}]                                           | ["BOOTBL", "BOOTBS"]                       |
+      | [{"field":"destocking_date", "operator":"NOT BETWEEN", "value": ["2015-01-20", "2015-03-25"]}]                                           | ["BOOTBL"]                       |
       | [{"field":"destocking_date", "operator":"NOT EMPTY", "value": null}]                                                                     | ["BOOTBXS", "BOOTWXS", "BOOTBS", "BOOTBL"] |
       | [{"field":"destocking_date", "operator":"!=", "value": "2015-01-20"}]                                                                    | ["BOOTBXS", "BOOTWXS", "BOOTBL"]           |
       | [{"field":"destocking_date", "operator":">", "value":"2015-01-19"}, {"field":"destocking_date", "operator":"!=", "value":"2015-03-25"}]  | ["BOOTBXS", "BOOTBS"]                      |

--- a/features/filter/date.feature
+++ b/features/filter/date.feature
@@ -18,7 +18,7 @@ Feature: Filter on date
       | [{"field":"destocking_date", "operator":">", "value": "2015-01-19"}]                                                                     | ["BOOTBXS", "BOOTBS", "BOOTWXS"]           |
       | [{"field":"destocking_date", "operator":"<", "value": "2015-01-21"}]                                                                     | ["BOOTBS", "BOOTBL"]                       |
       | [{"field":"destocking_date", "operator":"BETWEEN", "value": ["2015-01-20", "2015-03-25"]}]                                               | ["BOOTBXS", "BOOTWXS", "BOOTBS"]           |
-      | [{"field":"destocking_date", "operator":"NOT BETWEEN", "value": ["2015-01-20", "2015-03-25"]}]                                           | ["BOOTBL"]                       |
+      | [{"field":"destocking_date", "operator":"NOT BETWEEN", "value": ["2015-01-20", "2015-03-25"]}]                                           | ["BOOTBL"]                                 |
       | [{"field":"destocking_date", "operator":"NOT EMPTY", "value": null}]                                                                     | ["BOOTBXS", "BOOTWXS", "BOOTBS", "BOOTBL"] |
       | [{"field":"destocking_date", "operator":"!=", "value": "2015-01-20"}]                                                                    | ["BOOTBXS", "BOOTWXS", "BOOTBL"]           |
       | [{"field":"destocking_date", "operator":">", "value":"2015-01-19"}, {"field":"destocking_date", "operator":"!=", "value":"2015-03-25"}]  | ["BOOTBXS", "BOOTBS"]                      |

--- a/features/product/filtering/filter_products_per_date_fields.feature
+++ b/features/product/filtering/filter_products_per_date_fields.feature
@@ -37,10 +37,11 @@ Feature: Filter products by date field
     Then the grid should contain 5 elements
     And I should see products postit, book, mug, tshirt and pen
     And I should be able to use the following filters:
-      | filter  | value                             | result               |
-      | release | more than 05/02/2014              | mug, tshirt and pen  |
-      | release | less than 05/03/2014              | postit and book      |
-      | release | between 05/02/2014 and 05/03/2014 | book, mug and tshirt |
+      | filter  | value                                 | result               |
+      | release | more than 05/02/2014                  | mug, tshirt and pen  |
+      | release | less than 05/03/2014                  | postit and book      |
+      | release | between 05/02/2014 and 05/03/2014     | book, mug and tshirt |
+      | release | not between 05/02/2014 and 05/03/2014 | postit and pen       |
 
   Scenario: Filter products by date attributes and keep the appropriate default filter values
     Given the following products:

--- a/spec/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/DateTimeFilterSpec.php
+++ b/spec/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/DateTimeFilterSpec.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace spec\Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter;
+
+use Doctrine\ODM\MongoDB\Query\Builder;
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Exception\InvalidArgumentException;
+use Prophecy\Argument;
+
+/**
+ * @require Doctrine\ODM\MongoDB\Query\Builder
+ */
+class DateTimeFilterSpec extends ObjectBehavior
+{
+    function let(Builder $queryBuilder)
+    {
+        $this->beConstructedWith(
+            ['created', 'updated'],
+            ['=', '<', '>', 'BETWEEN', 'NOT BETWEEN', 'EMPTY', 'NOT EMPTY', '!=']
+        );
+        $this->setQueryBuilder($queryBuilder);
+
+        $queryBuilder->field(Argument::any())->willReturn($queryBuilder);
+    }
+
+    function it_is_a_field_filter()
+    {
+        $this->shouldImplement('Pim\Component\Catalog\Query\Filter\FieldFilterInterface');
+    }
+
+    function it_supports_operators()
+    {
+        $this->getOperators()->shouldReturn(['=', '<', '>', 'BETWEEN', 'NOT BETWEEN', 'EMPTY', 'NOT EMPTY', '!=']);
+
+        $this->supportsOperator('=')->shouldReturn(true);
+        $this->supportsOperator('FAKE')->shouldReturn(false);
+    }
+
+    function it_adds_an_equal_filter_on_a_field_in_the_query($queryBuilder)
+    {
+        $queryBuilder->equals(strtotime('2014-03-15 12:03:00'))->shouldBeCalledTimes(2);
+
+        $this->addFieldFilter('updated', '=', '2014-03-15 12:03:00');
+        $this->addFieldFilter('updated', '=', new \DateTime('2014-03-15 12:03:00'));
+    }
+
+    function it_adds_a_less_than_filter_on_a_field_in_the_query($queryBuilder)
+    {
+        $queryBuilder->lt(strtotime('2014-03-15 12:03:00'))->shouldBeCalledTimes(2);
+
+        $this->addFieldFilter('updated', '<', '2014-03-15 12:03:00');
+        $this->addFieldFilter('updated', '<', new \DateTime('2014-03-15 12:03:00'));
+    }
+
+    function it_adds_a_greater_than_filter_on_a_field_in_the_query($queryBuilder)
+    {
+        $queryBuilder->gt(strtotime('2014-03-15 12:03:00'))->shouldBeCalledTimes(2);
+
+        $this->addFieldFilter('updated', '>', '2014-03-15 12:03:00');
+        $this->addFieldFilter('updated', '>', new \DateTime('2014-03-15 12:03:00'));
+    }
+
+    function it_adds_an_empty_filter_on_a_field_in_the_query($queryBuilder)
+    {
+        $queryBuilder->exists(false)->shouldBeCalled();
+
+        $this->addFieldFilter('updated', 'EMPTY', null);
+    }
+
+    function it_adds_a_not_empty_filter_on_a_field_in_the_query($queryBuilder)
+    {
+        $queryBuilder->exists(true)->shouldBeCalled();
+
+        $this->addFieldFilter('updated', 'NOT EMPTY', null);
+    }
+
+    function it_adds_a_between_filter_on_a_field_in_the_query($queryBuilder)
+    {
+        $queryBuilder->gte(strtotime('2014-03-15 12:03:00'))->shouldBeCalledTimes(2);
+        $queryBuilder->lte(strtotime('2014-03-20 12:03:00'))->shouldBeCalledTimes(2);
+
+        $this->addFieldFilter('updated', 'BETWEEN', ['2014-03-15 12:03:00', '2014-03-20 12:03:00']);
+        $this->addFieldFilter('updated', 'BETWEEN', [new \DateTime('2014-03-15 12:03:00'), new \DateTime('2014-03-20 12:03:00')]);
+    }
+
+    function it_adds_a_not_between_filter_on_a_field_in_the_query($queryBuilder)
+    {
+        $queryBuilder->expr()->willReturn($queryBuilder);
+        $queryBuilder->addAnd($queryBuilder)->willReturn($queryBuilder);
+        $queryBuilder->addOr($queryBuilder)->willReturn($queryBuilder);
+        $queryBuilder->lt(strtotime('2014-03-15 12:03:00'))->willReturn($queryBuilder)->shouldBeCalledTimes(2);
+        $queryBuilder->gt(strtotime('2014-03-20 12:03:00'))->willReturn($queryBuilder)->shouldBeCalledTimes(2);
+
+        $this->addFieldFilter('updated', 'NOT BETWEEN', ['2014-03-15 12:03:00', '2014-03-20 12:03:00']);
+        $this->addFieldFilter('updated', 'NOT BETWEEN', [new \DateTime('2014-03-15 12:03:00'), new \DateTime('2014-03-20 12:03:00')]);
+    }
+
+    function it_throws_an_exception_if_value_is_not_a_string_an_array_or_datetime()
+    {
+        $this->shouldThrow(
+            InvalidArgumentException::expected(
+                'updated',
+                'array with 2 elements, string or \DateTime',
+                'filter',
+                'date',
+                print_r(123, true)
+            )
+        )->during('addFieldFilter', ['updated', '>', 123]);
+    }
+
+    function it_throws_an_error_if_data_is_not_a_valid_date_format()
+    {
+        $this->shouldThrow(
+            InvalidArgumentException::expected(
+                'updated',
+                'a string with the format Y-m-d H:i:s',
+                'filter',
+                'date',
+                'not a valid date format'
+            )
+        )->during('addFieldFilter', ['updated', '>', ['not a valid date format', 'WRONG']]);
+    }
+
+    function it_throws_an_exception_if_value_is_an_array_but_does_not_contain_strings_or_dates()
+    {
+        $this->shouldThrow(
+            InvalidArgumentException::expected(
+                'updated',
+                'array with 2 elements, string or \DateTime',
+                'filter',
+                'date',
+                123
+            )
+        )->during('addFieldFilter', ['updated', '>', [123, 123]]);
+    }
+
+    function it_throws_an_exception_if_value_is_an_array_but_does_not_contain_two_values()
+    {
+        $this->shouldThrow(
+            InvalidArgumentException::expected(
+                'updated',
+                'array with 2 elements, string or \DateTime',
+                'filter',
+                'date',
+                print_r([123, 123, 'three'], true)
+            )
+        )->during('addFieldFilter', ['updated', '>', [123, 123, 'three']]);
+    }
+}

--- a/spec/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/DateTimeFilterSpec.php
+++ b/spec/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/DateTimeFilterSpec.php
@@ -1,0 +1,206 @@
+<?php
+
+namespace spec\Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter;
+
+use Doctrine\ORM\Query\Expr;
+use Doctrine\ORM\QueryBuilder;
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Exception\InvalidArgumentException;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Validator\AttributeValidatorHelper;
+use Prophecy\Argument;
+
+class DateTimeFilterSpec extends ObjectBehavior
+{
+    function let(QueryBuilder $qb)
+    {
+        $this->beConstructedWith(
+            ['created', 'updated'],
+            ['=', '<', '>', 'BETWEEN', 'NOT BETWEEN', 'EMPTY', 'NOT EMPTY', '!=']
+        );
+        $this->setQueryBuilder($qb);
+
+        $qb->getRootAliases()->willReturn(['p']);
+    }
+
+    function it_is_a_datetime_filter()
+    {
+        $this->shouldBeAnInstanceOf('Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\DateTimeFilter');
+    }
+
+    function it_is_a_field_filter()
+    {
+        $this->shouldBeAnInstanceOf('Pim\Component\Catalog\Query\Filter\FieldFilterInterface');
+    }
+
+    function it_supports_operators()
+    {
+        $this->getOperators()->shouldReturn(['=', '<', '>', 'BETWEEN', 'NOT BETWEEN', 'EMPTY', 'NOT EMPTY', '!=']);
+
+        $this->supportsOperator('=')->shouldReturn(true);
+        $this->supportsOperator('FAKE')->shouldReturn(false);
+    }
+
+    function it_supports_date_fields()
+    {
+        $this->supportsField('created')->shouldReturn(true);
+        $this->supportsField('updated')->shouldReturn(true);
+        $this->supportsField('other')->shouldReturn(false);
+    }
+
+    function it_adds_an_equal_filter_on_an_field_in_the_query(
+        $qb,
+        Expr $expr,
+        Expr\Comparison $comp
+    ) {
+        $qb->getRootAliases()->willReturn(['p']);
+        $qb->expr()->willReturn($expr);
+        $expr->literal('2014-03-15 12:03:00')->willReturn('2014-03-15 12:03:00');
+        $expr->eq('p.updated_at', '2014-03-15 12:03:00')->willReturn($comp);
+        $comp->__toString()->willReturn('p.updated_at = \'2014-03-15 12:03:00\'');
+
+        $qb->andWhere('p.updated_at = \'2014-03-15 12:03:00\'')->shouldBeCalled();
+
+        $this->addFieldFilter('updated_at', '=', '2014-03-15 12:03:00');
+    }
+
+    function it_adds_a_not_equal_filter_on_an_field_in_the_query(
+        $qb,
+        Expr $expr,
+        Expr\Comparison $comp
+    ) {
+        $qb->getRootAliases()->willReturn(['p']);
+        $qb->expr()->willReturn($expr);
+        $expr->literal('2014-03-15 12:03:00')->willReturn('2014-03-15 12:03:00');
+        $expr->neq('p.updated_at', '2014-03-15 12:03:00')->willReturn($comp);
+        $comp->__toString()->willReturn('p.updated_at != \'2014-03-15 12:03:00\'');
+
+        $qb->andWhere('p.updated_at != \'2014-03-15 12:03:00\'')->shouldBeCalled();
+
+        $this->addFieldFilter('updated_at', '!=', '2014-03-15 12:03:00');
+    }
+
+    function it_adds_a_less_than_filter_on_an_field_in_the_query(
+        $qb,
+        Expr $expr,
+        Expr\Comparison $comp
+    ) {
+        $qb->getRootAliases()->willReturn(['p']);
+        $qb->expr()->willReturn($expr);
+        $expr->literal('2014-03-15 12:03:00')->willReturn('2014-03-15 12:03:00');
+        $expr->lt('p.updated_at', '2014-03-15 12:03:00')->willReturn($comp);
+        $comp->__toString()->willReturn('p.updated_at < \'2014-03-15 12:03:00\'');
+
+        $qb->andWhere('p.updated_at < \'2014-03-15 12:03:00\'')->shouldBeCalled();
+
+        $this->addFieldFilter('updated_at', '<', '2014-03-15 12:03:00');
+    }
+
+    function it_adds_a_greater_than_filter_on_an_field_in_the_query(
+        $qb,
+        Expr $expr,
+        Expr\Comparison $comp
+    ) {
+        $qb->getRootAliases()->willReturn(['p']);
+        $qb->expr()->willReturn($expr);
+        $expr->literal('2014-03-15 12:03:00')->willReturn('2014-03-15 12:03:00');
+        $expr->gt('p.updated_at', '2014-03-15 12:03:00')->willReturn($comp);
+        $comp->__toString()->willReturn('p.updated_at > \'2014-03-15 12:03:00\'');
+
+        $qb->andWhere('p.updated_at > \'2014-03-15 12:03:00\'')->shouldBeCalled();
+
+        $this->addFieldFilter('updated_at', '>', '2014-03-15 12:03:00');
+    }
+
+    function it_adds_an_empty_filter_on_an_field_in_the_query($qb, Expr $expr)
+    {
+        $qb->expr()->willReturn($expr);
+        $expr->isNull('p.updated_at')->willReturn('p.updated_at IS NULL');
+
+        $qb->andWhere('p.updated_at IS NULL')->shouldBeCalled();
+
+        $this->addFieldFilter('updated_at', 'EMPTY', null);
+    }
+
+    function it_adds_a_not_empty_filter_on_an_field_in_the_query($qb, Expr $expr)
+    {
+        $qb->expr()->willReturn($expr);
+        $expr->isNotNull('p.updated_at')->shouldBeCalled()->willReturn('p.updated_at IS NOT NULL');
+
+        $qb->andWhere('p.updated_at IS NOT NULL')->shouldBeCalled();
+
+        $this->addFieldFilter('updated_at', 'NOT EMPTY', null);
+    }
+
+    function it_adds_a_between_filter_on_an_field_in_the_query($qb, Expr $expr) {
+        $qb->getRootAliases()->willReturn(['p']);
+        $qb->expr()->willReturn($expr);
+        $expr->literal('2014-03-15 12:03:00')->willReturn('2014-03-15 12:03:00');
+        $expr->literal('2014-03-16 12:03:00')->willReturn('2014-03-16 12:03:00');
+
+        $qb->andWhere('p.updated_at BETWEEN 2014-03-15 12:03:00 AND 2014-03-16 12:03:00')->shouldBeCalled();
+
+        $this->addFieldFilter('updated_at', 'BETWEEN', ['2014-03-15 12:03:00', '2014-03-16 12:03:00']);
+    }
+
+    function it_adds_a_not_between_filter_on_an_field_in_the_query(
+        $qb,
+        Expr $expr,
+        Expr $expr,
+        Expr\Comparison $ltComp,
+        Expr\Comparison $gtComp,
+        Expr\Orx $or
+    ) {
+        $qb->getRootAliases()->willReturn(['p']);
+        $qb->expr()->willReturn($expr);
+        $expr->literal('2014-03-15 12:03:00')->willReturn('2014-03-15 12:03:00');
+        $expr->literal('2014-03-16 12:03:00')->willReturn('2014-03-16 12:03:00');
+        $expr->lt('p.updated_at', '2014-03-15 12:03:00')->willReturn($ltComp);
+        $expr->gt('p.updated_at', '2014-03-16 12:03:00')->willReturn($gtComp);
+        $expr->orX($ltComp, $gtComp)->willReturn($or);
+
+        $qb->andWhere($or)->shouldBeCalled();
+
+        $this->addFieldFilter('updated_at', 'NOT BETWEEN', ['2014-03-15 12:03:00', '2014-03-16 12:03:00']);
+    }
+
+    function it_throws_an_exception_if_value_is_not_a_string_an_array_or_a_datetime()
+    {
+        $this->shouldThrow(
+            InvalidArgumentException::expected('updated_at', 'array with 2 elements, string or \DateTime', 'filter', 'date', print_r(123, true))
+        )->during('addFieldFilter', ['updated_at', '>', 123]);
+    }
+
+    function it_throws_an_error_if_data_is_not_a_valid_date_format()
+    {
+        $this->shouldThrow(
+            InvalidArgumentException::expected('updated_at', 'a string with the format Y-m-d H:i:s', 'filter', 'date', 'not a valid date format')
+        )->during('addFieldFilter', ['updated_at', '>', ['not a valid date format', 'WRONG']]);
+    }
+
+    function it_throws_an_exception_if_value_is_an_array_but_does_not_contain_strings_or_dates()
+    {
+        $this->shouldThrow(
+            InvalidArgumentException::expected(
+                'updated_at',
+                'array with 2 elements, string or \DateTime',
+                'filter',
+                'date',
+                123
+            )
+        )->during('addFieldFilter', ['updated_at', '>', [123, 123]]);
+    }
+
+    function it_throws_an_exception_if_value_is_an_array_but_does_not_contain_two_values()
+    {
+        $this->shouldThrow(
+            InvalidArgumentException::expected(
+                'updated_at',
+                'array with 2 elements, string or \DateTime',
+                'filter',
+                'date',
+                print_r([123, 123, 'three'], true)
+            )
+        )->during('addFieldFilter', ['updated_at', '>', [123, 123, 'three']]);
+    }
+}

--- a/spec/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/DateTimeFilterSpec.php
+++ b/spec/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/DateTimeFilterSpec.php
@@ -6,8 +6,6 @@ use Doctrine\ORM\Query\Expr;
 use Doctrine\ORM\QueryBuilder;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Exception\InvalidArgumentException;
-use Pim\Component\Catalog\Model\AttributeInterface;
-use Pim\Component\Catalog\Validator\AttributeValidatorHelper;
 use Prophecy\Argument;
 
 class DateTimeFilterSpec extends ObjectBehavior
@@ -132,7 +130,8 @@ class DateTimeFilterSpec extends ObjectBehavior
         $this->addFieldFilter('updated_at', 'NOT EMPTY', null);
     }
 
-    function it_adds_a_between_filter_on_an_field_in_the_query($qb, Expr $expr) {
+    function it_adds_a_between_filter_on_an_field_in_the_query($qb, Expr $expr)
+    {
         $qb->getRootAliases()->willReturn(['p']);
         $qb->expr()->willReturn($expr);
         $expr->literal('2014-03-15 12:03:00')->willReturn('2014-03-15 12:03:00');
@@ -145,7 +144,6 @@ class DateTimeFilterSpec extends ObjectBehavior
 
     function it_adds_a_not_between_filter_on_an_field_in_the_query(
         $qb,
-        Expr $expr,
         Expr $expr,
         Expr\Comparison $ltComp,
         Expr\Comparison $gtComp,

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/DateFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/DateFilter.php
@@ -155,7 +155,7 @@ class DateFilter extends AbstractAttributeFilter implements AttributeFilterInter
      *
      * @throws InvalidArgumentException
      *
-     * @return integer
+     * @return int|null
      */
     protected function formatSingleValue($type, $value)
     {

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/DateTimeFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/DateTimeFilter.php
@@ -4,68 +4,52 @@ namespace Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter;
 
 use Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\ProductQueryUtility;
 use Pim\Component\Catalog\Exception\InvalidArgumentException;
-use Pim\Component\Catalog\Model\AttributeInterface;
-use Pim\Component\Catalog\Query\Filter\AttributeFilterInterface;
+use Pim\Component\Catalog\Query\Filter\FieldFilterInterface;
 use Pim\Component\Catalog\Query\Filter\Operators;
-use Pim\Component\Catalog\Validator\AttributeValidatorHelper;
 
 /**
- * Date filter
+ * Datetime filter
  *
- * @author    Nicolas Dupont <nicolas@akeneo.com>
- * @copyright 2014 Akeneo SAS (http://www.akeneo.com)
+ * @author    Yohan Blain <yohan.blain@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class DateFilter extends AbstractAttributeFilter implements AttributeFilterInterface
+class DateTimeFilter extends AbstractFilter implements FieldFilterInterface
 {
-    const DATETIME_FORMAT = 'Y-m-d';
+    const DATETIME_FORMAT = 'Y-m-d H:i:s';
 
     /** @var array */
-    protected $supportedAttributes;
+    protected $supportedFields;
 
     /**
-     * @param AttributeValidatorHelper $attrValidatorHelper
-     * @param array                    $supportedAttributes
-     * @param array                    $supportedOperators
+     * @param array $supportedFields
+     * @param array $supportedOperators
      */
     public function __construct(
-        AttributeValidatorHelper $attrValidatorHelper,
-        array $supportedAttributes = [],
+        array $supportedFields = [],
         array $supportedOperators = []
     ) {
-        $this->attrValidatorHelper = $attrValidatorHelper;
-        $this->supportedAttributes = $supportedAttributes;
-        $this->supportedOperators  = $supportedOperators;
+        $this->supportedFields    = $supportedFields;
+        $this->supportedOperators = $supportedOperators;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function supportsAttribute(AttributeInterface $attribute)
+    public function supportsField($field)
     {
-        return in_array($attribute->getAttributeType(), $this->supportedAttributes);
+        return in_array($field, $this->supportedFields);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function addAttributeFilter(
-        AttributeInterface $attribute,
-        $operator,
-        $value,
-        $locale = null,
-        $scope = null,
-        $options = []
-    ) {
-        $this->checkLocaleAndScope($attribute, $locale, $scope, 'date');
-
-        if (Operators::IS_EMPTY === $operator || Operators::IS_NOT_EMPTY === $operator) {
-            $value = null;
-        } else {
-            $value = $this->formatValues($attribute->getCode(), $value);
+    public function addFieldFilter($field, $operator, $value, $locale = null, $scope = null, $options = [])
+    {
+        if (Operators::IS_EMPTY !== $operator && Operators::IS_NOT_EMPTY !== $operator) {
+            $value = $this->formatValues($field, $value);
         }
 
-        $field = ProductQueryUtility::getNormalizedValueFieldFromAttribute($attribute, $locale, $scope);
         $field = sprintf('%s.%s', ProductQueryUtility::NORMALIZED_FIELD, $field);
 
         $this->applyFilter($field, $operator, $value);
@@ -179,8 +163,6 @@ class DateFilter extends AbstractAttributeFilter implements AttributeFilterInter
                     $value
                 );
             }
-
-            $dateTime->setTime(0, 0, 0);
 
             return $dateTime->getTimestamp();
         }

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/DateTimeFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/DateTimeFilter.php
@@ -106,6 +106,8 @@ class DateTimeFilter extends AbstractFilter implements FieldFilterInterface
      * @param string $type
      * @param mixed  $value
      *
+     * @throws InvalidArgumentException
+     *
      * @return mixed $value
      */
     protected function formatValues($type, $value)

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/DateFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/DateFilter.php
@@ -5,7 +5,6 @@ namespace Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter;
 use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Query\Filter\AttributeFilterInterface;
-use Pim\Component\Catalog\Query\Filter\FieldFilterInterface;
 use Pim\Component\Catalog\Query\Filter\Operators;
 use Pim\Component\Catalog\Validator\AttributeValidatorHelper;
 
@@ -16,40 +15,26 @@ use Pim\Component\Catalog\Validator\AttributeValidatorHelper;
  * @copyright 2014 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class DateFilter extends AbstractAttributeFilter implements FieldFilterInterface, AttributeFilterInterface
+class DateFilter extends AbstractAttributeFilter implements AttributeFilterInterface
 {
+    const DATETIME_FORMAT = 'Y-m-d';
+
     /** @var array */
     protected $supportedAttributes;
 
-    /** @var array */
-    protected $supportedFields;
-
     /**
-     * Instantiate the base filter
-     *
      * @param AttributeValidatorHelper $attrValidatorHelper
      * @param array                    $supportedAttributes
-     * @param array                    $supportedFields
      * @param array                    $supportedOperators
      */
     public function __construct(
         AttributeValidatorHelper $attrValidatorHelper,
         array $supportedAttributes = [],
-        array $supportedFields = [],
         array $supportedOperators = []
     ) {
         $this->attrValidatorHelper = $attrValidatorHelper;
         $this->supportedAttributes = $supportedAttributes;
-        $this->supportedFields     = $supportedFields;
         $this->supportedOperators  = $supportedOperators;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function supportsField($field)
-    {
-        return in_array($field, $this->supportedFields);
     }
 
     /**
@@ -77,142 +62,39 @@ class DateFilter extends AbstractAttributeFilter implements FieldFilterInterface
             $value = $this->formatValues($attribute->getCode(), $value);
         }
 
-        $joinAlias    = $this->getUniqueAlias('filter' . $attribute->getCode());
-        $backendField = sprintf('%s.%s', $joinAlias, $attribute->getBackendType());
+        $joinAlias     = $this->getUniqueAlias('filter' . $attribute->getCode());
+        $backendField  = sprintf('%s.%s', $joinAlias, $attribute->getBackendType());
+        $joinCondition = $this->prepareAttributeJoinCondition($attribute, $joinAlias, $locale, $scope);
 
         if ($operator === Operators::IS_EMPTY || $operator === Operators::IS_NOT_EMPTY) {
             $this->qb->leftJoin(
                 $this->qb->getRootAlias() . '.values',
                 $joinAlias,
                 'WITH',
-                $this->prepareAttributeJoinCondition($attribute, $joinAlias, $locale, $scope)
+                $joinCondition
             );
             $this->qb->andWhere($this->prepareCriteriaCondition($backendField, $operator, null));
-        } elseif ($operator === Operators::NOT_BETWEEN) {
-            $this->qb->leftJoin(
-                $this->qb->getRootAlias() . '.values',
-                $joinAlias,
-                'WITH',
-                $this->prepareAttributeJoinCondition($attribute, $joinAlias, $locale, $scope)
-            );
-            $this->qb->andWhere(
-                $this->qb->expr()->orX(
-                    $this->qb->expr()->lt($backendField, $this->getDateLiteralExpr($value[0], true)),
-                    $this->qb->expr()->gt($backendField, $this->getDateLiteralExpr($value[1], true))
-                )
-            );
         } else {
-            $condition = $this->prepareAttributeJoinCondition($attribute, $joinAlias, $locale, $scope);
-            $condition .= ' AND ' . $this->prepareCriteriaCondition($backendField, $operator, $value);
             $this->qb->innerJoin(
                 $this->qb->getRootAlias() . '.values',
                 $joinAlias,
                 'WITH',
-                $condition
+                $joinCondition
             );
+
+            if ($operator === Operators::NOT_BETWEEN) {
+                $this->qb->andWhere(
+                    $this->qb->expr()->orX(
+                        $this->qb->expr()->lt($backendField, $this->qb->expr()->literal($value[0])),
+                        $this->qb->expr()->gt($backendField, $this->qb->expr()->literal($value[1]))
+                    )
+                );
+            } else {
+                $this->qb->andWhere($this->prepareCriteriaCondition($backendField, $operator, $value));
+            }
         }
 
         return $this;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function addFieldFilter($field, $operator, $value, $locale = null, $scope = null, $options = [])
-    {
-        if (Operators::IS_EMPTY !== $operator && Operators::IS_NOT_EMPTY !== $operator) {
-            $value = $this->formatValues($field, $value);
-        }
-
-        $field = current($this->qb->getRootAliases()) . '.' . $field;
-
-        switch ($operator) {
-            case Operators::BETWEEN:
-                $this->qb->andWhere(
-                    $this->qb->expr()->andX(
-                        $this->qb->expr()->gt($field, $this->getDateLiteralExpr($value[0])),
-                        $this->qb->expr()->lt($field, $this->getDateLiteralExpr($value[1], true))
-                    )
-                );
-                break;
-
-            case Operators::NOT_BETWEEN:
-                $this->qb->andWhere(
-                    $this->qb->expr()->orX(
-                        $this->qb->expr()->lt($field, $this->getDateLiteralExpr($value[0])),
-                        $this->qb->expr()->gt($field, $this->getDateLiteralExpr($value[1], true))
-                    )
-                );
-                break;
-
-            case Operators::GREATER_THAN:
-                $this->qb->andWhere($this->qb->expr()->gt($field, $this->getDateLiteralExpr($value, true)));
-                break;
-
-            case Operators::LOWER_THAN:
-                $this->qb->andWhere($this->qb->expr()->lt($field, $this->getDateLiteralExpr($value)));
-                break;
-
-            case Operators::EQUALS:
-                $this->qb->andWhere(
-                    $this->qb->expr()->andX(
-                        $this->qb->expr()->gt($field, $this->getDateLiteralExpr($value)),
-                        $this->qb->expr()->lt($field, $this->getDateLiteralExpr($value, true))
-                    )
-                );
-                break;
-
-            case Operators::NOT_EQUAL:
-                $this->qb->andWhere(
-                    $this->qb->expr()->orX(
-                        $this->qb->expr()->lt($field, $this->getDateLiteralExpr($value)),
-                        $this->qb->expr()->gt($field, $this->getDateLiteralExpr($value, true))
-                    )
-                );
-                break;
-
-            case Operators::IS_EMPTY:
-                $this->qb->andWhere($this->qb->expr()->isNull($field));
-                break;
-
-            case Operators::IS_NOT_EMPTY:
-                $this->qb->andWhere($this->qb->expr()->isNotNull($field));
-                break;
-        }
-
-        return $this;
-    }
-
-    /**
-     * Get the literal expression of the date
-     *
-     * @param string $data
-     * @param bool   $endOfDay
-     *
-     * @return \Doctrine\ORM\Query\Expr\Literal
-     */
-    protected function getDateLiteralExpr($data, $endOfDay = false)
-    {
-        return $this->qb->expr()->literal($this->getDateValue($data, $endOfDay));
-    }
-
-    /**
-     * Get the date formatted from data
-     *
-     * @param \DateTime|string $data
-     * @param bool             $endOfDay
-     *
-     * @return string
-     */
-    protected function getDateValue($data, $endOfDay = false)
-    {
-        if ($data instanceof \DateTime && true === $endOfDay) {
-            $data->setTime(23, 59, 59);
-        } elseif (!$data instanceof \DateTime && true === $endOfDay) {
-            $data = sprintf('%s 23:59:59', $data);
-        }
-
-        return $data instanceof \DateTime ? $data->format('Y-m-d H:i:s') : $data;
     }
 
     /**
@@ -252,48 +134,42 @@ class DateFilter extends AbstractAttributeFilter implements FieldFilterInterface
      * @param string $type
      * @param mixed  $value
      *
+     * @throws InvalidArgumentException
+     *
      * @return string
      */
     protected function formatSingleValue($type, $value)
     {
+        if (null === $value) {
+            return $value;
+        }
+
         if ($value instanceof \DateTime) {
-            $value = $value->format('Y-m-d');
-        } elseif (is_string($value)) {
-            $this->validateDateFormat($type, $value);
-        } elseif (null !== $value) {
-            throw InvalidArgumentException::expected(
-                $type,
-                'array with 2 elements, string or \DateTime',
-                'filter',
-                'date',
-                print_r($value, true)
-            );
+            return $value->format(static::DATETIME_FORMAT);
         }
 
-        return $value;
-    }
+        if (is_string($value)) {
+            $dateTime = \DateTime::createFromFormat(static::DATETIME_FORMAT, $value);
 
-    /**
-     * Check if the date format is valid
-     *
-     * @param string $type
-     * @param string $value
-     */
-    protected function validateDateFormat($type, $value)
-    {
-        $dateValues = explode('-', $value);
+            if (!$dateTime || 0 < $dateTime->getLastErrors()['warning_count']) {
+                throw InvalidArgumentException::expected(
+                    $type,
+                    'a string with the format ' . static::DATETIME_FORMAT,
+                    'filter',
+                    'date',
+                    $value
+                );
+            }
 
-        if (count($dateValues) !== 3
-            || (!is_numeric($dateValues[0]) || !is_numeric($dateValues[1]) || !is_numeric($dateValues[2]))
-            || !checkdate($dateValues[1], $dateValues[2], $dateValues[0])
-        ) {
-            throw InvalidArgumentException::expected(
-                $type,
-                'a string with the format yyyy-mm-dd',
-                'filter',
-                'date',
-                $value
-            );
+            return $dateTime->format(static::DATETIME_FORMAT);
         }
+
+        throw InvalidArgumentException::expected(
+            $type,
+            'array with 2 elements, string or \DateTime',
+            'filter',
+            'date',
+            print_r($value, true)
+        );
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/DateTimeFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/DateTimeFilter.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter;
+
+use Pim\Component\Catalog\Exception\InvalidArgumentException;
+use Pim\Component\Catalog\Query\Filter\FieldFilterInterface;
+use Pim\Component\Catalog\Query\Filter\Operators;
+
+/**
+ * Datetime filter
+ *
+ * @author    Yohan Blain <yohan.blain@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class DateTimeFilter extends AbstractFilter implements FieldFilterInterface
+{
+    const DATETIME_FORMAT = 'Y-m-d H:i:s';
+
+    /** @var array */
+    protected $supportedFields;
+
+    /**
+     * @param array $supportedFields
+     * @param array $supportedOperators
+     */
+    public function __construct(array $supportedFields = [], array $supportedOperators = []) {
+        $this->supportedFields     = $supportedFields;
+        $this->supportedOperators  = $supportedOperators;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsField($field)
+    {
+        return in_array($field, $this->supportedFields);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addFieldFilter($field, $operator, $value, $locale = null, $scope = null, $options = [])
+    {
+        if (Operators::IS_EMPTY === $operator) {
+            $value = null;
+        } else {
+            $value = $this->formatValues($field, $value);
+        }
+
+        $field = current($this->qb->getRootAliases()) . '.' . $field;
+
+        if (Operators::NOT_BETWEEN === $operator) {
+            $this->qb->andWhere(
+                $this->qb->expr()->orX(
+                    $this->qb->expr()->lt($field, $this->qb->expr()->literal($value[0])),
+                    $this->qb->expr()->gt($field, $this->qb->expr()->literal($value[1]))
+                )
+            );
+        } else {
+            $this->qb->andWhere($this->prepareCriteriaCondition($field, $operator, $value));
+        }
+
+        return $this;
+    }
+
+    /**
+     * Format values to string or array of strings
+     *
+     * @param string $type
+     * @param mixed  $value
+     *
+     * @return mixed $value
+     */
+    protected function formatValues($type, $value)
+    {
+        if (is_array($value) && 2 !== count($value)) {
+            throw InvalidArgumentException::expected(
+                $type,
+                'array with 2 elements, string or \DateTime',
+                'filter',
+                'date',
+                print_r($value, true)
+            );
+        }
+
+        if (is_array($value)) {
+            $tmpValues = [];
+            foreach ($value as $tmp) {
+                $tmpValues[] = $this->formatSingleValue($type, $tmp);
+            }
+            $value = $tmpValues;
+        } else {
+            $value = $this->formatSingleValue($type, $value);
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param string $type
+     * @param mixed  $value
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return string
+     */
+    protected function formatSingleValue($type, $value)
+    {
+        if (null === $value) {
+            return $value;
+        }
+
+        if ($value instanceof \DateTime) {
+            return $value->format(static::DATETIME_FORMAT);
+        }
+
+        if (is_string($value)) {
+            $dateTime = \DateTime::createFromFormat(static::DATETIME_FORMAT, $value);
+
+            if (!$dateTime || 0 < $dateTime->getLastErrors()['warning_count']) {
+                throw InvalidArgumentException::expected(
+                    $type,
+                    'a string with the format ' . static::DATETIME_FORMAT,
+                    'filter',
+                    'date',
+                    $value
+                );
+            }
+
+            return $dateTime->format(static::DATETIME_FORMAT);
+        }
+
+        throw InvalidArgumentException::expected(
+            $type,
+            'array with 2 elements, string or \DateTime',
+            'filter',
+            'date',
+            print_r($value, true)
+        );
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/DateTimeFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/DateTimeFilter.php
@@ -24,7 +24,8 @@ class DateTimeFilter extends AbstractFilter implements FieldFilterInterface
      * @param array $supportedFields
      * @param array $supportedOperators
      */
-    public function __construct(array $supportedFields = [], array $supportedOperators = []) {
+    public function __construct(array $supportedFields = [], array $supportedOperators = [])
+    {
         $this->supportedFields     = $supportedFields;
         $this->supportedOperators  = $supportedOperators;
     }
@@ -42,12 +43,7 @@ class DateTimeFilter extends AbstractFilter implements FieldFilterInterface
      */
     public function addFieldFilter($field, $operator, $value, $locale = null, $scope = null, $options = [])
     {
-        if (Operators::IS_EMPTY === $operator) {
-            $value = null;
-        } else {
-            $value = $this->formatValues($field, $value);
-        }
-
+        $value = Operators::IS_EMPTY === $operator ? null : $this->formatValues($field, $value);
         $field = current($this->qb->getRootAliases()) . '.' . $field;
 
         if (Operators::NOT_BETWEEN === $operator) {
@@ -69,6 +65,8 @@ class DateTimeFilter extends AbstractFilter implements FieldFilterInterface
      *
      * @param string $type
      * @param mixed  $value
+     *
+     * @throws InvalidArgumentException
      *
      * @return mixed $value
      */

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
@@ -116,6 +116,13 @@ services:
         arguments:
             - @pim_catalog.validator.helper.attribute
             - ['pim_catalog_date']
+            - ['=', '<', '>', 'BETWEEN', 'NOT BETWEEN', 'EMPTY', 'NOT EMPTY', '!=']
+        tags:
+            - { name: 'pim_catalog.doctrine.query.filter', priority: 30 }
+
+    pim_catalog.doctrine.query.filter.datetime:
+        class: %pim_catalog.doctrine.query.filter.datetime.class%
+        arguments:
             - ['created', 'updated']
             - ['=', '<', '>', 'BETWEEN', 'NOT BETWEEN', 'EMPTY', 'NOT EMPTY', '!=']
         tags:

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/storage_driver/doctrine/mongodb-odm.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/storage_driver/doctrine/mongodb-odm.yml
@@ -54,6 +54,7 @@ parameters:
     pim_catalog.doctrine.query.filter.string.class:       Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\StringFilter
     pim_catalog.doctrine.query.filter.boolean.class:      Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\BooleanFilter
     pim_catalog.doctrine.query.filter.date.class:         Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\DateFilter
+    pim_catalog.doctrine.query.filter.datetime.class:     Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\DateTimeFilter
     pim_catalog.doctrine.query.filter.product_id.class:   Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\ProductIdFilter
     pim_catalog.doctrine.query.filter.family.class:       Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\FamilyFilter
     pim_catalog.doctrine.query.filter.groups.class:       Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\GroupsFilter

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/storage_driver/doctrine/orm.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/storage_driver/doctrine/orm.yml
@@ -16,6 +16,7 @@ parameters:
     pim_catalog.doctrine.query.filter.family.class:       Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\FamilyFilter
     pim_catalog.doctrine.query.filter.groups.class:       Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\GroupsFilter
     pim_catalog.doctrine.query.filter.date.class:         Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\DateFilter
+    pim_catalog.doctrine.query.filter.datetime.class:     Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\DateTimeFilter
     pim_catalog.doctrine.query.filter.completeness.class: Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\CompletenessFilter
     pim_catalog.doctrine.query.filter.price.class:        Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\PriceFilter
     pim_catalog.doctrine.query.filter.metric.class:       Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\MetricFilter

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/DateFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/DateFilterSpec.php
@@ -19,7 +19,6 @@ class DateFilterSpec extends ObjectBehavior
         $this->beConstructedWith(
             $attrValidatorHelper,
             ['pim_catalog_date'],
-            ['created', 'updated'],
             ['=', '<', '>', 'BETWEEN', 'NOT BETWEEN', 'EMPTY', 'NOT EMPTY', '!=']
         );
         $this->setQueryBuilder($queryBuilder);
@@ -32,17 +31,49 @@ class DateFilterSpec extends ObjectBehavior
         $this->shouldImplement('Pim\Component\Catalog\Query\Filter\AttributeFilterInterface');
     }
 
-    function it_is_a_field_filter()
-    {
-        $this->shouldImplement('Pim\Component\Catalog\Query\Filter\FieldFilterInterface');
-    }
-
     function it_supports_operators()
     {
         $this->getOperators()->shouldReturn(['=', '<', '>', 'BETWEEN', 'NOT BETWEEN', 'EMPTY', 'NOT EMPTY', '!=']);
 
         $this->supportsOperator('=')->shouldReturn(true);
         $this->supportsOperator('FAKE')->shouldReturn(false);
+    }
+
+    function it_adds_an_equal_filter_on_an_attribute_value_in_the_query(
+        $attrValidatorHelper,
+        $queryBuilder,
+        AttributeInterface $date
+    ) {
+        $attrValidatorHelper->validateLocale($date, Argument::any())->shouldBeCalled();
+        $attrValidatorHelper->validateScope($date, Argument::any())->shouldBeCalled();
+
+        $date->getCode()->willReturn('release_date');
+        $date->isLocalizable()->willReturn(false);
+        $date->isScopable()->willReturn(false);
+
+        $queryBuilder->equals(strtotime('2014-03-15'))->shouldBeCalledTimes(2);
+
+        $this->addAttributeFilter($date, '=', '2014-03-15');
+        $this->addAttributeFilter($date, '=', new \DateTime('2014-03-15'));
+    }
+
+    function it_adds_a_not_equal_filter_on_an_attribute_value_in_the_query(
+        $attrValidatorHelper,
+        $queryBuilder,
+        AttributeInterface $date
+    ) {
+        $attrValidatorHelper->validateLocale($date, Argument::any())->shouldBeCalled();
+        $attrValidatorHelper->validateScope($date, Argument::any())->shouldBeCalled();
+
+        $date->getCode()->willReturn('release_date');
+        $date->isLocalizable()->willReturn(false);
+        $date->isScopable()->willReturn(false);
+
+        $queryBuilder->exists(true)->shouldBeCalledTimes(2);
+        $queryBuilder->notEqual(strtotime('2014-03-15'))->shouldBeCalledTimes(2);
+
+        $this->addAttributeFilter($date, '!=', '2014-03-15');
+        $this->addAttributeFilter($date, '!=', new \DateTime('2014-03-15'));
     }
 
     function it_adds_a_less_than_filter_on_an_attribute_value_in_the_query(
@@ -56,10 +87,11 @@ class DateFilterSpec extends ObjectBehavior
         $date->getCode()->willReturn('release_date');
         $date->isLocalizable()->willReturn(false);
         $date->isScopable()->willReturn(false);
-        $queryBuilder->lt(strtotime('2014-03-15'))->willReturn($queryBuilder)->shouldBeCalledTimes(2);
+
+        $queryBuilder->lt(strtotime('2014-03-15'))->shouldBeCalledTimes(2);
 
         $this->addAttributeFilter($date, '<', '2014-03-15');
-        $this->addAttributeFilter($date, '<', new \Datetime('2014-03-15'));
+        $this->addAttributeFilter($date, '<', new \DateTime('2014-03-15'));
     }
 
     function it_adds_a_greater_than_filter_on_an_attribute_value_in_the_query(
@@ -73,10 +105,11 @@ class DateFilterSpec extends ObjectBehavior
         $date->getCode()->willReturn('release_date');
         $date->isLocalizable()->willReturn(false);
         $date->isScopable()->willReturn(false);
-        $queryBuilder->gt(strtotime('2014-03-15 23:59:59'))->willReturn($queryBuilder)->shouldBeCalledTimes(2);
+
+        $queryBuilder->gt(strtotime('2014-03-15'))->shouldBeCalledTimes(2);
 
         $this->addAttributeFilter($date, '>', '2014-03-15');
-        $this->addAttributeFilter($date, '>', new \Datetime('2014-03-15'));
+        $this->addAttributeFilter($date, '>', new \DateTime('2014-03-15'));
     }
 
     function it_adds_an_empty_filter_on_an_attribute_value_in_the_query(
@@ -91,7 +124,7 @@ class DateFilterSpec extends ObjectBehavior
         $date->isLocalizable()->willReturn(false);
         $date->isScopable()->willReturn(false);
 
-        $queryBuilder->exists(false)->shouldBeCalled()->willReturn($queryBuilder);
+        $queryBuilder->exists(false)->shouldBeCalled();
 
         $this->addAttributeFilter($date, 'EMPTY', null);
     }
@@ -108,7 +141,7 @@ class DateFilterSpec extends ObjectBehavior
         $date->isLocalizable()->willReturn(false);
         $date->isScopable()->willReturn(false);
 
-        $queryBuilder->exists(true)->shouldBeCalled()->willReturn($queryBuilder);
+        $queryBuilder->exists(true)->shouldBeCalled();
 
         $this->addAttributeFilter($date, 'NOT EMPTY', null);
     }
@@ -124,90 +157,93 @@ class DateFilterSpec extends ObjectBehavior
         $date->getCode()->willReturn('release_date');
         $date->isLocalizable()->willReturn(false);
         $date->isScopable()->willReturn(false);
-        $queryBuilder->gte(strtotime('2014-03-15'))->willReturn($queryBuilder)->shouldBeCalledTimes(2);
-        $queryBuilder->lte(strtotime('2014-03-20 23:59:59'))->willReturn($queryBuilder)->shouldBeCalledTimes(2);
+
+        $queryBuilder->gte(strtotime('2014-03-15'))->shouldBeCalledTimes(2);
+        $queryBuilder->lte(strtotime('2014-03-20'))->shouldBeCalledTimes(2);
 
         $this->addAttributeFilter($date, 'BETWEEN', ['2014-03-15', '2014-03-20']);
-        $this->addAttributeFilter($date, 'BETWEEN', [new \Datetime('2014-03-15'), new \Datetime('2014-03-20')]);
+        $this->addAttributeFilter($date, 'BETWEEN', [new \DateTime('2014-03-15'), new \DateTime('2014-03-20')]);
     }
 
-    function it_adds_a_not_between_filter_on_an_attribute_value_in_the_query($queryBuilder, $attrValidatorHelper, AttributeInterface $date)
-    {
+    function it_adds_a_not_between_filter_on_an_attribute_value_in_the_query(
+        $queryBuilder,
+        $attrValidatorHelper,
+        AttributeInterface $date
+    ) {
         $attrValidatorHelper->validateLocale($date, Argument::any())->shouldBeCalled();
         $attrValidatorHelper->validateScope($date, Argument::any())->shouldBeCalled();
 
         $date->getCode()->willReturn('release_date');
         $date->isLocalizable()->willReturn(false);
         $date->isScopable()->willReturn(false);
+
         $queryBuilder->expr()->willReturn($queryBuilder);
         $queryBuilder->addAnd($queryBuilder)->willReturn($queryBuilder);
         $queryBuilder->addOr($queryBuilder)->willReturn($queryBuilder);
-        $queryBuilder->addOr($queryBuilder)->willReturn($queryBuilder);
-        $queryBuilder->lte(strtotime('2014-03-15'))->willReturn($queryBuilder)->shouldBeCalledTimes(2);
-        $queryBuilder->gte(strtotime('2014-03-20 23:59:59'))->willReturn($queryBuilder)->shouldBeCalledTimes(2);
+        $queryBuilder->lt(strtotime('2014-03-15'))->willReturn($queryBuilder)->shouldBeCalledTimes(2);
+        $queryBuilder->gt(strtotime('2014-03-20'))->willReturn($queryBuilder)->shouldBeCalledTimes(2);
 
         $this->addAttributeFilter($date, 'NOT BETWEEN', ['2014-03-15', '2014-03-20']);
-        $this->addAttributeFilter($date, 'NOT BETWEEN', [new \Datetime('2014-03-15'), new \Datetime('2014-03-20')]);
+        $this->addAttributeFilter($date, 'NOT BETWEEN', [new \DateTime('2014-03-15'), new \DateTime('2014-03-20')]);
     }
 
-    function it_adds_a_between_filter_on_a_field_in_the_query($queryBuilder)
+    function it_throws_an_exception_if_value_is_not_a_string_an_array_or_datetime(AttributeInterface $date)
     {
-        $queryBuilder->gte(strtotime('2014-03-15'))->willReturn($queryBuilder)->shouldBeCalledTimes(2);
-        $queryBuilder->lte(strtotime('2014-03-20 23:59:59'))->willReturn($queryBuilder)->shouldBeCalledTimes(2);
+        $date->getCode()->willReturn('release_date');
 
-        $this->addFieldFilter('created', 'BETWEEN', ['2014-03-15', '2014-03-20']);
-        $this->addFieldFilter('created', 'BETWEEN', [new \Datetime('2014-03-15'), new \Datetime('2014-03-20')]);
-    }
-
-    function it_throws_an_exception_if_value_is_not_a_string_an_array_or_datetime()
-    {
         $this->shouldThrow(
             InvalidArgumentException::expected(
                 'release_date',
-                'array with 2 elements, string or \Datetime',
+                'array with 2 elements, string or \DateTime',
                 'filter',
                 'date',
                 print_r(123, true)
             )
-        )->during('addFieldFilter', ['release_date', '>', 123]);
+        )->during('addAttributeFilter', [$date, '>', 123]);
     }
 
-    function it_throws_an_error_if_data_is_not_a_valid_date_format()
+    function it_throws_an_error_if_data_is_not_a_valid_date_format(AttributeInterface $date)
     {
+        $date->getCode()->willReturn('release_date');
+
         $this->shouldThrow(
             InvalidArgumentException::expected(
                 'release_date',
-                'a string with the format yyyy-mm-dd',
+                'a string with the format Y-m-d',
                 'filter',
                 'date',
                 'not a valid date format'
             )
-        )->during('addFieldFilter', ['release_date', '>', ['not a valid date format', 'WRONG']]);
+        )->during('addAttributeFilter', [$date, '>', ['not a valid date format', 'WRONG']]);
     }
 
-    function it_throws_an_exception_if_value_is_an_array_but_does_not_contain_strings_or_dates()
+    function it_throws_an_exception_if_value_is_an_array_but_does_not_contain_strings_or_dates(AttributeInterface $date)
     {
+        $date->getCode()->willReturn('release_date');
+
         $this->shouldThrow(
             InvalidArgumentException::expected(
                 'release_date',
-                'array with 2 elements, string or \Datetime',
+                'array with 2 elements, string or \DateTime',
                 'filter',
                 'date',
                 123
             )
-        )->during('addFieldFilter', ['release_date', '>', [123, 123]]);
+        )->during('addAttributeFilter', [$date, '>', [123, 123]]);
     }
 
-    function it_throws_an_exception_if_value_is_an_array_but_does_not_contain_two_values()
+    function it_throws_an_exception_if_value_is_an_array_but_does_not_contain_two_values(AttributeInterface $date)
     {
+        $date->getCode()->willReturn('release_date');
+
         $this->shouldThrow(
             InvalidArgumentException::expected(
                 'release_date',
-                'array with 2 elements, string or \Datetime',
+                'array with 2 elements, string or \DateTime',
                 'filter',
                 'date',
                 print_r([123, 123, 'three'], true)
             )
-        )->during('addFieldFilter', ['release_date', '>', [123, 123, 'three']]);
+        )->during('addAttributeFilter', [$date, '>', [123, 123, 'three']]);
     }
 }

--- a/src/Pim/Bundle/FilterBundle/Filter/ProductValue/AbstractDateFilter.php
+++ b/src/Pim/Bundle/FilterBundle/Filter/ProductValue/AbstractDateFilter.php
@@ -27,11 +27,9 @@ abstract class AbstractDateFilter extends OroAbstractDateFilter
             return false;
         }
 
-        /** @var $dateStartValue \DateTime */
         $dateStartValue = $data['date_start'];
-        /** @var $dateEndValue \DateTime */
-        $dateEndValue = $data['date_end'];
-        $type         = $data['type'];
+        $dateEndValue   = $data['date_end'];
+        $type           = $data['type'];
 
         $this->applyFilterByAttributeDependingOnType(
             $type,

--- a/src/Pim/Bundle/FilterBundle/Filter/ProductValue/DateTimeRangeFilter.php
+++ b/src/Pim/Bundle/FilterBundle/Filter/ProductValue/DateTimeRangeFilter.php
@@ -2,7 +2,7 @@
 
 namespace Pim\Bundle\FilterBundle\Filter\ProductValue;
 
-use Oro\Bundle\FilterBundle\Form\Type\Filter\DateTimeRangeFilterType;
+use Oro\Bundle\FilterBundle\Form\Type\Filter\DateRangeFilterType;
 
 /**
  * Date time filter
@@ -13,18 +13,39 @@ use Oro\Bundle\FilterBundle\Form\Type\Filter\DateTimeRangeFilterType;
  */
 class DateTimeRangeFilter extends AbstractDateFilter
 {
-    /**
-     * DateTime object as string format
-     *
-     * @staticvar string
-     */
     const DATETIME_FORMAT = 'Y-m-d H:i:s';
+
+    /**
+     * {@inheritdoc}
+     *
+     * Override to set the time of the DateTime object on-the-fly according to the chosen operator.
+     */
+    public function parseData($data)
+    {
+        switch ($data['type']) {
+            case DateRangeFilterType::TYPE_MORE_THAN:
+                $data['value']['start']->setTime(23, 59, 59);
+                break;
+            case DateRangeFilterType::TYPE_LESS_THAN:
+                $data['value']['end']->setTime(0, 0, 0);
+                break;
+            default:
+                if (isset($data['value']['start']) && $data['value']['start'] instanceof \DateTime) {
+                    $data['value']['start']->setTime(0, 0, 0);
+                }
+                if (isset($data['value']['end']) && $data['value']['end'] instanceof \DateTime) {
+                    $data['value']['end']->setTime(23, 59, 59);
+                }
+        }
+
+        return parent::parseData($data);
+    }
 
     /**
      * {@inheritdoc}
      */
     protected function getFormType()
     {
-        return DateTimeRangeFilterType::NAME;
+        return DateRangeFilterType::NAME;
     }
 }

--- a/src/Pim/Bundle/FilterBundle/Resources/config/filters.yml
+++ b/src/Pim/Bundle/FilterBundle/Resources/config/filters.yml
@@ -9,18 +9,18 @@ parameters:
     pim_filter.product_family_filter.class:        Pim\Bundle\FilterBundle\Filter\Product\FamilyFilter
     pim_filter.product_completeness_filter.class:  Pim\Bundle\FilterBundle\Filter\Product\CompletenessFilter
     pim_filter.product_category_filter.class:      Pim\Bundle\FilterBundle\Filter\CategoryFilter
-    pim_filter.product_date_filter.class:          Pim\Bundle\FilterBundle\Filter\ProductValue\DateRangeFilter
+    pim_filter.product_date_filter.class:          Pim\Bundle\FilterBundle\Filter\ProductValue\DateTimeRangeFilter
     pim_filter.product_enabled_filter.class:       Pim\Bundle\FilterBundle\Filter\Product\EnabledFilter
     pim_filter.product_in_group_filter.class:      Pim\Bundle\FilterBundle\Filter\Product\InGroupFilter
     pim_filter.product_is_associated_filter.class: Pim\Bundle\FilterBundle\Filter\Product\IsAssociatedFilter
-    pim_filter.product_value_string.class:     Pim\Bundle\FilterBundle\Filter\ProductValue\StringFilter
-    pim_filter.product_value_choice.class:     Pim\Bundle\FilterBundle\Filter\ProductValue\ChoiceFilter
-    pim_filter.product_value_number.class:     Pim\Bundle\FilterBundle\Filter\ProductValue\NumberFilter
-    pim_filter.product_value_date.class:       Pim\Bundle\FilterBundle\Filter\ProductValue\DateRangeFilter
-    pim_filter.product_value_datetime.class:   Pim\Bundle\FilterBundle\Filter\ProductValue\DateTimeRangeFilter
-    pim_filter.product_value_boolean.class:    Pim\Bundle\FilterBundle\Filter\ProductValue\BooleanFilter
-    pim_filter.product_value_metric.class:     Pim\Bundle\FilterBundle\Filter\ProductValue\MetricFilter
-    pim_filter.product_value_price.class:      Pim\Bundle\FilterBundle\Filter\ProductValue\PriceFilter
+    pim_filter.product_value_string.class:         Pim\Bundle\FilterBundle\Filter\ProductValue\StringFilter
+    pim_filter.product_value_choice.class:         Pim\Bundle\FilterBundle\Filter\ProductValue\ChoiceFilter
+    pim_filter.product_value_number.class:         Pim\Bundle\FilterBundle\Filter\ProductValue\NumberFilter
+    pim_filter.product_value_date.class:           Pim\Bundle\FilterBundle\Filter\ProductValue\DateRangeFilter
+    pim_filter.product_value_datetime.class:       Pim\Bundle\FilterBundle\Filter\ProductValue\DateTimeRangeFilter
+    pim_filter.product_value_boolean.class:        Pim\Bundle\FilterBundle\Filter\ProductValue\BooleanFilter
+    pim_filter.product_value_metric.class:         Pim\Bundle\FilterBundle\Filter\ProductValue\MetricFilter
+    pim_filter.product_value_price.class:          Pim\Bundle\FilterBundle\Filter\ProductValue\PriceFilter
 
 services:
     pim_filter.ajax_choice_filter:


### PR DESCRIPTION
**Why?**

Natively, a product can have multiple dates :
- fields "updated_at" and "created_at"
- attributes of type "pim_catalog_date"

Until now in the PQB we had only a DateFilter that handled both cases. It was complicated, buggy (with the "not between" operator for example) and it didn't allow to filter precisely on "created at" and "updated at" since all inputs were dates without time.

**What this PR does?**

- It separates the two cases with one DateFilter that handles attributes only, and one DateTimeFilter that handles fields only.
- The DateTimeFilter can now filter to the second.
- In the case of filtering the product grid, it's not the responsibility of the PQB filters anymore to add times to input values. This logic has been moved to the grid filter (Pim\Bundle\FilterBundle\Filter\ProductValue\DateTimeRangeFilter).

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | yes
| Added Behats                      | yes
| Changelog updated                 | yes
| Review and 2 GTM                  | 
| Micro Demo to the PO (Story only) |
| Migration script                  | n/a
| Tech Doc                          | 