### PR TITLE
PIM-5697: Fix import form when a file extension is not allowed

### DIFF
--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 
+- PIM-5697: Fix import form when a file extension is not allowed
 - PIM-5695: Do not format price with currency if data is null
 - PIM-5643: Fix default system locale
 

--- a/features/import/check_mime_type_before_import.feature
+++ b/features/import/check_mime_type_before_import.feature
@@ -22,4 +22,4 @@ Feature:
     And I press the "Save" button
     When I am on the "footwear_product_import" import job page
     And I upload and import an invalid file "akeneo2.jpg"
-    Then I should see a flash message "The file extension is not allowed (allowed extensions: csv, zip)."
+    Then I should see the flash message "The file extension is not allowed (allowed extensions: csv, zip)."


### PR DESCRIPTION
There are constraints on our readers to check file extension before launch import. 
One of these (FileValidator) needs a Akeneo\Component\FileStorage\Model\FileInfoInterface, but the import form has not been changed when validator has added this check on FileInfoInterface

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | N
| Added Behats                      | fixed
| Changelog updated                 | Y
| Micro Demo to the PO (Story only) | Y
| Migration script                  | N
| Tech Doc                          | N

