### PR TITLE
PIM-5650: unbind events before refresh grid

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -4,6 +4,7 @@
 
 - PIM-5725: Fix reference data name of the attribute in case this attribute is not a reference data
 - PIM-5699: Fix 'is equal to' operator in export / import history grid filter
+- PIM-5650: Fix events binding on PEF grid refresh.
 
 # 1.4.22 (2016-03-23)
 

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/grid.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/grid.js
@@ -292,6 +292,7 @@ define(['jquery', 'underscore', 'backgrid', 'oro/translator', 'oro/mediator', 'o
                         }
                     });
 
+                    mediator.off('datagrid:doRefresh:' + grid.name);
                     mediator.on('datagrid:doRefresh:' + grid.name, function () {
                         grid.refreshAction.execute();
                     });


### PR DESCRIPTION
Bug description : 
In product edit form, under "Associations" tab :

If you click on another association type to change the current one, the datagrid is refreshed by the two next calls :

http://demo.akeneo.com/datagrid/association-product-grid?association-product-grid...
http://demo.akeneo.com/datagrid/association-group-grid?association-group-grid...
=> OK

events: { 'click .nav-tabs li': 'changeAssociationType', 'click #association-buttons button': 'changeAssociationTargets' }

But if you switch to an other main tab "Attributes" and go back then to "Associations" tab : the datagrid is reloaded with duplicate calls of the two previously listed actions :

http://demo.akeneo.com/datagrid/association-product-grid?association-product-grid... x2
http://demo.akeneo.com/datagrid/association-group-grid?association-group-grid... x2
=> KO

Fix : 

Unbind events before refreshing the grid.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | no
| Added Behats                      | no
| Changelog updated                 | yes
| Review and 2 GTM                  |
| Micro Demo to the PO (Story only) |
| Migration script                  |
| Tech Doc                          |

EE ODM 2 r http://core-ci.akeneo.com/job/dci_behat/3885/