### PR TITLE
PIM-5577: Fix random behats on Tree checkboxes

### DIFF
--- a/features/Pim/Behat/Context/Domain/TreeContext.php
+++ b/features/Pim/Behat/Context/Domain/TreeContext.php
@@ -4,6 +4,7 @@ namespace Pim\Behat\Context\Domain;
 
 use Behat\Mink\Exception\ExpectationException;
 use Context\Spin\SpinCapableTrait;
+use Context\Spin\TimeoutException;
 use Pim\Behat\Context\PimContext;
 
 class TreeContext extends PimContext
@@ -107,9 +108,11 @@ class TreeContext extends PimContext
         } else {
             try {
                 $checkbox = $this->spin(function () use ($node) {
-                    return $node->find('css', '.jstree-checkbox');
+                    $result = $node->find('css', '.jstree-checkbox');
+
+                    return (null !== $result && $result->isVisible()) ? $result : null;
                 });
-            } catch (\Exception $e) {
+            } catch (TimeoutException $e) {
                 $checkbox = null;
             }
 


### PR DESCRIPTION
This fix "may" fix random failures on DCI with tree element selections.

EE ODM 2 random http://core-ci.akeneo.com/job/dci_behat/3873/
Validate metric attributes of a product.Validate the number max constraint of metric attribute
Revert a product to a previous version.Successfully revert the category of a product

EE ORM 1 fails, random http://core-ci.akeneo.com/job/dci_behat/3890/

CE ORM

CE ODM