### PR TITLE
Export products performance

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Builder/ProductBuilder.php
+++ b/src/Pim/Bundle/CatalogBundle/Builder/ProductBuilder.php
@@ -273,9 +273,8 @@ class ProductBuilder implements ProductBuilderInterface
      */
     public function addMissingPrices(ProductValueInterface $value)
     {
-        $activeCurrencyCodes = $this->currencyRepository->getActivatedCurrencyCodes();
-
         if (AttributeTypes::PRICE_COLLECTION === $value->getAttribute()->getAttributeType()) {
+            $activeCurrencyCodes = $this->currencyRepository->getActivatedCurrencyCodes();
             $prices = $value->getPrices();
 
             foreach ($activeCurrencyCodes as $currencyCode) {


### PR DESCRIPTION
Most of our products have about 250 attributes, but we only have few price attributes.
With this small change exporting products is 10% faster for us.