### PR TITLE
PIM-5653: Create a storage agnostic Product Reader using the PQB

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -22,6 +22,7 @@
 - PIM-5577: The completeness is now calculated every time a product is saved, ie during mass edit, product import and on edit/save of variant groups.
 - Call validation in the controller when adding/removing attributes to the family.
 - Simplify installation process and the loading of catalogs in Behat by using the import system and `akeneo:batch:job` commands.
+- PIM-5653: When using the Product Query Builder, it is now possible to filter on completeness without specifying a locale. Products with a matching completeness for at least one of the locales of the scope will be selected.
 
 ## BC breaks
 
@@ -189,3 +190,4 @@
 - Remove `Pim\Bundle\InstallerBundle\Command\LoadDataFixturesDoctrineCommand`, `Pim\Bundle\InstallerBundle\Command\LoadFixturesCommand`
 - Remove `Pim\Bundle\InstallerBundle\DataFixtures\*`
 - Remove `Pim\Bundle\InstallerBundle\FixtureLoader\*`
+- Change constructor of `Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\CompletenessFilter`, add `Pim\Component\Catalog\Repository\ChannelRepositoryInterface`

--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -23,6 +23,7 @@
 - Call validation in the controller when adding/removing attributes to the family.
 - Simplify installation process and the loading of catalogs in Behat by using the import system and `akeneo:batch:job` commands.
 - PIM-5653: When using the Product Query Builder, it is now possible to filter on completeness without specifying a locale. Products with a matching completeness for at least one of the locales of the scope will be selected.
+- PIM-5653: Introduce a new storage-agnostic Product Reader using the PQB
 
 ## BC breaks
 

--- a/features/filter/completeness.feature
+++ b/features/filter/completeness.feature
@@ -21,3 +21,16 @@ Feature: Filter on completeness
       | [{"field":"completeness", "operator":">=", "value": 50, "locale": "en_US", "scope": "mobile"}]  | ["BOOTBS", "BOOTWXS", "BOOTBXS"]           |
       | [{"field":"completeness", "operator":">",  "value": 80, "locale": "en_US", "scope": "mobile"}]  | ["BOOTBXS"]                                |
       | [{"field":"completeness", "operator":"!=", "value": 100, "locale": "en_US", "scope": "mobile"}] | ["BOOTWXS", "BOOTBS", "BOOTBL", "BOOTRXS"] |
+
+  Scenario: Successfully filter on completeness without specifying any locale
+    Given an "apparel" catalog configuration
+    And the following products:
+      | sku     | family  | name-en_US      | name-en_GB      | price         | size   | color | manufacturer     |
+      | TSHIRTS | tshirts | T-shirt S Black | T-shirt S Black | 10 USD, 9 GBP | size_S | black | american_apparel |
+      | TSHIRTM | tshirts | T-shirt M Black |                 | 10 USD, 9 GBP | size_M | black | american_apparel |
+      | TSHIRTL | tshirts | T-shirt L Black |                 | 10 USD, 9 GBP | size_L |       |                  |
+    And I launched the completeness calculator
+    Then I should get the following results for the given filters:
+      | filter                                                                       | result                 |
+      | [{"field":"completeness", "operator":"=",  "value": 100, "scope": "tablet"}] | ["TSHIRTS", "TSHIRTM"] |
+      | [{"field":"completeness", "operator":"<",  "value": 100, "scope": "tablet"}] | ["TSHIRTM", "TSHIRTL"] |

--- a/features/filter/completeness.feature
+++ b/features/filter/completeness.feature
@@ -21,16 +21,3 @@ Feature: Filter on completeness
       | [{"field":"completeness", "operator":">=", "value": 50, "locale": "en_US", "scope": "mobile"}]  | ["BOOTBS", "BOOTWXS", "BOOTBXS"]           |
       | [{"field":"completeness", "operator":">",  "value": 80, "locale": "en_US", "scope": "mobile"}]  | ["BOOTBXS"]                                |
       | [{"field":"completeness", "operator":"!=", "value": 100, "locale": "en_US", "scope": "mobile"}] | ["BOOTWXS", "BOOTBS", "BOOTBL", "BOOTRXS"] |
-
-  Scenario: Successfully filter on completeness without specifying any locale
-    Given an "apparel" catalog configuration
-    And the following products:
-      | sku     | family  | name-en_US      | name-en_GB      | price         | size   | color | manufacturer     |
-      | TSHIRTS | tshirts | T-shirt S Black | T-shirt S Black | 10 USD, 9 GBP | size_S | black | american_apparel |
-      | TSHIRTM | tshirts | T-shirt M Black |                 | 10 USD, 9 GBP | size_M | black | american_apparel |
-      | TSHIRTL | tshirts | T-shirt L Black |                 | 10 USD, 9 GBP | size_L |       |                  |
-    And I launched the completeness calculator
-    Then I should get the following results for the given filters:
-      | filter                                                                       | result                 |
-      | [{"field":"completeness", "operator":"=",  "value": 100, "scope": "tablet"}] | ["TSHIRTS", "TSHIRTM"] |
-      | [{"field":"completeness", "operator":"<",  "value": 100, "scope": "tablet"}] | ["TSHIRTM", "TSHIRTL"] |

--- a/features/filter/completeness_without_locale.feature
+++ b/features/filter/completeness_without_locale.feature
@@ -1,0 +1,17 @@
+Feature: Filter on completeness
+  In order to filter on products
+  As an internal process or any user
+  I need to be able to filter on product by completeness without specifying any locale
+
+  Scenario: Successfully filter on completeness without specifying any locale
+    Given an "apparel" catalog configuration
+    And the following products:
+      | sku     | family  | name-en_US      | name-en_GB      | price         | size   | color | manufacturer     |
+      | TSHIRTS | tshirts | T-shirt S Black | T-shirt S Black | 10 USD, 9 GBP | size_S | black | american_apparel |
+      | TSHIRTM | tshirts | T-shirt M Black |                 | 10 USD, 9 GBP | size_M | black | american_apparel |
+      | TSHIRTL | tshirts | T-shirt L Black |                 | 10 USD, 9 GBP | size_L |       |                  |
+    Then I should get the following results for the given filters:
+      | filter                                                                       | result                 |
+      | [{"field":"completeness", "operator":"=",  "value": 100, "scope": "tablet"}] | ["TSHIRTS", "TSHIRTM"] |
+      | [{"field":"completeness", "operator":"<",  "value": 100, "scope": "tablet"}] | ["TSHIRTM", "TSHIRTL"] |
+      | [{"field":"completeness", "operator":"!=", "value": 100, "scope": "tablet"}] | ["TSHIRTM", "TSHIRTL"] |

--- a/spec/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/CompletenessFilterSpec.php
+++ b/spec/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/CompletenessFilterSpec.php
@@ -3,8 +3,11 @@
 namespace spec\Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter;
 
 use Doctrine\ODM\MongoDB\Query\Builder;
+use Doctrine\ODM\MongoDB\Query\Expr;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Exception\InvalidArgumentException;
+use Pim\Component\Catalog\Model\ChannelInterface;
+use Pim\Component\Catalog\Repository\ChannelRepositoryInterface;
 use Prophecy\Argument;
 
 /**
@@ -12,10 +15,10 @@ use Prophecy\Argument;
  */
 class CompletenessFilterSpec extends ObjectBehavior
 {
-    function let(Builder $queryBuilder)
+    function let(ChannelRepositoryInterface $channelRepository, Builder $qb)
     {
-        $this->beConstructedWith(['completeness'], ['=', '<', '>', '>=', '<=', '!=']);
-        $this->setQueryBuilder($queryBuilder);
+        $this->beConstructedWith($channelRepository, ['completeness'], ['=', '<', '>', '>=', '<=', '!=']);
+        $this->setQueryBuilder($qb);
     }
 
     function it_is_a_field_filter()
@@ -30,63 +33,131 @@ class CompletenessFilterSpec extends ObjectBehavior
         $this->supportsOperator('FAKE')->shouldReturn(false);
     }
 
-    function it_adds_an_equals_filter_on_completeness_in_the_query($queryBuilder)
+    function it_adds_an_equals_filter_on_completeness_in_the_query($qb, Expr $expr)
     {
-        $queryBuilder->field('normalizedData.completenesses.mobile-en_US')->shouldBeCalled()->willReturn($queryBuilder);
-        $queryBuilder->equals(100)->shouldBeCalled();
+        $qb->expr()->willReturn($expr);
+        $expr->field('normalizedData.completenesses.mobile-en_US')
+            ->shouldBeCalled()
+            ->willReturn($expr);
+        $expr->equals(100)
+            ->shouldBeCalled()
+            ->willReturn($expr);
+        $qb->addOr($expr)->shouldBeCalled();
 
         $this->addFieldFilter('completeness', '=', 100, 'en_US', 'mobile');
     }
 
-    function it_adds_a_not_equals_filter_on_completeness_in_the_query($queryBuilder)
+    function it_adds_a_not_equals_filter_on_completeness_in_the_query($qb, Expr $expr)
     {
-        $queryBuilder->field('normalizedData.completenesses.mobile-en_US')->shouldBeCalled()->willReturn($queryBuilder);
-        $queryBuilder->exists(true)->shouldBeCalled();
-        $queryBuilder->notEqual(100)->shouldBeCalled();
+        $qb->expr()->willReturn($expr);
+        $expr->field('normalizedData.completenesses.mobile-en_US')
+            ->shouldBeCalled()
+            ->willReturn($expr);
+        $expr->exists(true)
+            ->shouldBeCalled()
+            ->willReturn($expr);
+        $expr->notEqual(100)
+            ->shouldBeCalled()
+            ->willReturn($expr);
+        $expr->addAnd($expr)
+            ->shouldBeCalled()
+            ->willReturn($expr);
+        $qb->addOr($expr)->shouldBeCalled();
 
         $this->addFieldFilter('completeness', '!=', 100, 'en_US', 'mobile');
     }
 
-    function it_adds_a_lower_than_filter_on_completeness_in_the_query($queryBuilder)
+    function it_adds_a_lower_than_filter_on_completeness_in_the_query($qb, Expr $expr)
     {
-        $queryBuilder->field('normalizedData.completenesses.mobile-en_US')->shouldBeCalled()->willReturn($queryBuilder);
-        $queryBuilder->lt(100)->shouldBeCalled();
+        $qb->expr()->willReturn($expr);
+        $expr->field('normalizedData.completenesses.mobile-en_US')
+            ->shouldBeCalled()
+            ->willReturn($expr);
+        $expr->lt(100)
+            ->shouldBeCalled()
+            ->willReturn($expr);
+        $qb->addOr($expr)->shouldBeCalled();
 
         $this->addFieldFilter('completeness', '<', 100, 'en_US', 'mobile');
     }
 
-    function it_adds_a_greater_than_filter_on_completeness_in_the_query($queryBuilder)
+    function it_adds_a_greater_than_filter_on_completeness_in_the_query($qb, Expr $expr)
     {
-        $queryBuilder->field('normalizedData.completenesses.mobile-en_US')->shouldBeCalled()->willReturn($queryBuilder);
-        $queryBuilder->gt(55)->shouldBeCalled();
+        $qb->expr()->willReturn($expr);
+        $expr->field('normalizedData.completenesses.mobile-en_US')
+            ->shouldBeCalled()
+            ->willReturn($expr);
+        $expr->gt(55)
+            ->shouldBeCalled()
+            ->willReturn($expr);
+        $qb->addOr($expr)->shouldBeCalled();
 
         $this->addFieldFilter('completeness', '>', 55, 'en_US', 'mobile');
     }
 
-    function it_adds_a_greater_or_equal_than_filter_on_completeness_in_the_query($queryBuilder)
+    function it_adds_a_greater_or_equal_than_filter_on_completeness_in_the_query($qb, Expr $expr)
     {
-        $queryBuilder->field('normalizedData.completenesses.mobile-en_US')->shouldBeCalled()->willReturn($queryBuilder);
-        $queryBuilder->gte(55)->shouldBeCalled();
+        $qb->expr()->willReturn($expr);
+        $expr->field('normalizedData.completenesses.mobile-en_US')
+            ->shouldBeCalled()
+            ->willReturn($expr);
+        $expr->gte(55)
+            ->shouldBeCalled()
+            ->willReturn($expr);
+        $qb->addOr($expr)->shouldBeCalled();
 
         $this->addFieldFilter('completeness', '>=', 55, 'en_US', 'mobile');
     }
 
-    function it_adds_a_lower_or_equal_than_filter_on_completeness_in_the_query($queryBuilder)
+    function it_adds_a_lower_or_equal_than_filter_on_completeness_in_the_query($qb, Expr $expr)
     {
-        $queryBuilder->field('normalizedData.completenesses.mobile-en_US')->shouldBeCalled()->willReturn($queryBuilder);
-        $queryBuilder->lte(60)->shouldBeCalled();
+        $qb->expr()->willReturn($expr);
+        $expr->field('normalizedData.completenesses.mobile-en_US')
+            ->shouldBeCalled()
+            ->willReturn($expr);
+        $expr->lte(60)
+            ->shouldBeCalled()
+            ->willReturn($expr);
+        $qb->addOr($expr)->shouldBeCalled();
 
         $this->addFieldFilter('completeness', '<=', 60, 'en_US', 'mobile');
     }
 
-    function it_throws_an_exception_when_the_locale_and_scope_are_not_provided()
+    function it_filters_on_completeness_on_any_locale(
+        $channelRepository,
+        $qb,
+        ChannelInterface $channel,
+        Expr $expr
+    ) {
+        $channelRepository->findOneByIdentifier('mobile')->willReturn($channel);
+        $channel->getLocaleCodes()->willReturn(['en_US', 'fr_FR']);
+
+        $qb->expr()->willReturn($expr);
+
+        $expr->field('normalizedData.completenesses.mobile-en_US')
+            ->shouldBeCalled()
+            ->willReturn($expr);
+        $expr->lte(60)
+            ->shouldBeCalled()
+            ->willReturn($expr);
+        $qb->addOr($expr)->shouldBeCalled();
+
+        $expr->field('normalizedData.completenesses.mobile-fr_FR')
+            ->shouldBeCalled()
+            ->willReturn($expr);
+        $expr->lte(60)
+            ->shouldBeCalled()
+            ->willReturn($expr);
+        $qb->addOr($expr)->shouldBeCalled();
+
+        $this->addFieldFilter('completeness', '<=', 60, null, 'mobile');
+    }
+
+    function it_throws_an_exception_when_scope_is_not_provided()
     {
         $this
             ->shouldThrow('Pim\Component\Catalog\Exception\InvalidArgumentException')
             ->duringAddFieldFilter('completeness', '=', 100);
-        $this
-            ->shouldThrow('Pim\Component\Catalog\Exception\InvalidArgumentException')
-            ->duringAddFieldFilter('completeness', '=', 100, null, 'ecommerce');
         $this
             ->shouldThrow('Pim\Component\Catalog\Exception\InvalidArgumentException')
             ->duringAddFieldFilter('completeness', '=', 100, 'fr_FR', null);

--- a/spec/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/CompletenessFilterSpec.php
+++ b/spec/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/CompletenessFilterSpec.php
@@ -12,10 +12,10 @@ use Prophecy\Argument;
 
 class CompletenessFilterSpec extends ObjectBehavior
 {
-    function let(QueryBuilder $queryBuilder)
+    function let(QueryBuilder $qb)
     {
         $this->beConstructedWith(['completeness'], ['<', '<=', '=', '>=', '>', '!=']);
-        $this->setQueryBuilder($queryBuilder);
+        $this->setQueryBuilder($qb);
     }
 
     function it_is_a_filter()
@@ -31,44 +31,47 @@ class CompletenessFilterSpec extends ObjectBehavior
     }
 
     function it_adds_an_equal_filter_on_a_field_in_the_query(
-        QueryBuilder $qb,
+        $qb,
         Expr $expr,
         EntityManager $em,
         ClassMetadata $cm,
         Expr\Comparison $comparison
     ) {
         $qb->expr()->willReturn($expr);
-        $qb->getRootAlias()->willReturn('p');
-        $qb->getRootEntities()->willReturn([]);
+        $qb->getRootAliases()->willReturn(['c']);
+        $qb->getRootEntities()->willReturn(['Completeness']);
         $qb->getEntityManager()->willReturn($em);
-        $em->getClassMetadata(false)->willReturn($cm);
+        $em->getClassMetadata('Completeness')->willReturn($cm);
         $comparison->__toString()->willReturn('filterCompleteness.ratio = 100');
         $cm->getAssociationMapping('completenesses')->willReturn(['targetEntity' => 'test']);
         $expr->literal('100')
             ->willReturn('100');
         $expr->eq(Argument::any(), '100')
             ->willReturn($comparison);
-        $this->setQueryBuilder($qb);
+
         $qb->leftJoin(
             'PimCatalogBundle:Locale',
             Argument::any(),
             'WITH',
             Argument::any()
-        )->willReturn($qb);
+        )->shouldBeCalled()->willReturn($qb);
+
         $qb->leftJoin(
             'PimCatalogBundle:Channel',
             Argument::any(),
             'WITH',
             Argument::any()
-        )->willReturn($qb);
+        )->shouldBeCalled()->willReturn($qb);
+
         $qb->leftJoin(
             'test',
             Argument::any(),
             'WITH',
             Argument::any()
-        )->willReturn($qb);
-        $qb->setParameter('cLocaleCode', Argument::any())->willReturn($qb);
-        $qb->setParameter('cScopeCode', Argument::any())->willReturn($qb);
+        )->shouldBeCalled()->willReturn($qb);
+
+        $qb->setParameter('cLocaleCode', Argument::any())->shouldBeCalled();
+        $qb->setParameter('cScopeCode', Argument::any())->shouldBeCalled();
 
         $qb->andWhere('filterCompleteness.ratio = 100')->shouldBeCalled();
 
@@ -76,48 +79,99 @@ class CompletenessFilterSpec extends ObjectBehavior
     }
 
     function it_adds_a_filter_on_a_field_in_the_query(
-        QueryBuilder $qb,
+        $qb,
         Expr $expr,
         EntityManager $em,
         ClassMetadata $cm,
         Expr\Comparison $comparison
     ) {
         $qb->expr()->willReturn($expr);
-        $qb->getRootAlias()->willReturn('p');
-        $qb->getRootEntities()->willReturn([]);
+        $qb->getRootAliases()->willReturn(['c']);
+        $qb->getRootEntities()->willReturn(['Completeness']);
         $qb->getEntityManager()->willReturn($em);
-        $em->getClassMetadata(false)->willReturn($cm);
+        $em->getClassMetadata('Completeness')->willReturn($cm);
         $comparison->__toString()->willReturn('filterCompleteness.ratio < 100');
         $cm->getAssociationMapping('completenesses')->willReturn(['targetEntity' => 'test']);
         $expr->literal('100')
             ->willReturn('100');
         $expr->lt(Argument::any(), '100')
             ->willReturn($comparison);
-        $this->setQueryBuilder($qb);
+
         $qb->leftJoin(
             'PimCatalogBundle:Locale',
             Argument::any(),
             'WITH',
             Argument::any()
-        )->willReturn($qb);
+        )->shouldBeCalled()->willReturn($qb);
+
         $qb->leftJoin(
             'PimCatalogBundle:Channel',
             Argument::any(),
             'WITH',
             Argument::any()
-        )->willReturn($qb);
+        )->shouldBeCalled()->willReturn($qb);
+
         $qb->leftJoin(
             'test',
             Argument::any(),
             'WITH',
             Argument::any()
-        )->willReturn($qb);
-        $qb->setParameter('cLocaleCode', Argument::any())->willReturn($qb);
-        $qb->setParameter('cScopeCode', Argument::any())->willReturn($qb);
+        )->shouldBeCalled()->willReturn($qb);
+
+        $qb->setParameter('cLocaleCode', Argument::any())->shouldBeCalled();
+        $qb->setParameter('cScopeCode', Argument::any())->shouldBeCalled();
 
         $qb->andWhere('filterCompleteness.ratio < 100')->shouldBeCalled();
 
         $this->addFieldFilter('completeness', '<', 100, 'en_US', 'mobile');
+    }
+
+    function it_filters_on_completeness_on_any_locale(
+        $qb,
+        Expr $expr,
+        EntityManager $em,
+        ClassMetadata $cm,
+        Expr\Comparison $comparison
+    ) {
+        $qb->expr()->willReturn($expr);
+        $qb->getRootAliases()->willReturn(['c']);
+        $qb->getRootEntities()->willReturn(['Completeness']);
+        $qb->getEntityManager()->willReturn($em);
+        $em->getClassMetadata('Completeness')->willReturn($cm);
+        $comparison->__toString()->willReturn('filterCompleteness.ratio < 100');
+        $cm->getAssociationMapping('completenesses')->willReturn(['targetEntity' => 'test']);
+        $expr->literal('100')
+            ->willReturn('100');
+        $expr->lt(Argument::any(), '100')
+            ->willReturn($comparison);
+
+        $qb->leftJoin(
+            'PimCatalogBundle:Locale',
+            Argument::any(),
+            'WITH',
+            Argument::any()
+        )->shouldNotBeCalled();
+
+        $qb->leftJoin(
+            'PimCatalogBundle:Channel',
+            Argument::any(),
+            'WITH',
+            Argument::any()
+        )->shouldBeCalled()->willReturn($qb);
+
+        $qb->leftJoin(
+            'test',
+            Argument::any(),
+            'WITH',
+            Argument::any()
+        )->shouldBeCalled()->willReturn($qb);
+
+        $qb->setParameter('cLocaleCode', Argument::any())->shouldNotBeCalled();
+        $qb->setParameter('cScopeCode', Argument::any())->shouldBeCalled();
+
+        $qb->andWhere('filterCompleteness.ratio < 100')->shouldBeCalled();
+
+        $this->addFieldFilter('completeness', '<', 100, null, 'mobile');
     }
 
     function it_checks_if_field_is_supported()

--- a/spec/Pim/Bundle/CatalogBundle/Doctrine/ORM/Sorter/CompletenessSorterSpec.php
+++ b/spec/Pim/Bundle/CatalogBundle/Doctrine/ORM/Sorter/CompletenessSorterSpec.php
@@ -39,6 +39,7 @@ class CompletenessSorterSpec extends ObjectBehavior
             ->willReturn(['targetEntity' => 'CompletenessClass'])
         ;
         $qb->getRootAlias()->willReturn('r');
+        $qb->getRootAliases()->willReturn(['r']);
 
         $qb->getRootEntities()->willReturn(['rootEntity']);
         $qb->getEntityManager()->willReturn($em);
@@ -65,9 +66,9 @@ class CompletenessSorterSpec extends ObjectBehavior
                 'CompletenessClass',
                 'sorterCompleteness',
                 'WITH',
-                'sorterCompleteness.locale = sorterCompletenessLocale.id AND '.
+                'sorterCompleteness.product = r.id AND '.
                 'sorterCompleteness.channel = sorterCompletenessChannel.id AND '.
-                'sorterCompleteness.product = r.id'
+                'sorterCompleteness.locale = sorterCompletenessLocale.id'
             )
             ->shouldBeCalled()
             ->willReturn($qb);
@@ -77,6 +78,6 @@ class CompletenessSorterSpec extends ObjectBehavior
         $qb->addOrderBy('sorterCompleteness.ratio', 'DESC')->shouldBeCalled();
         $qb->addOrderBy('r.id')->shouldBeCalled();
 
-        $this->addFieldSorter('completeness', 'DESC');
+        $this->addFieldSorter('completeness', 'DESC', 'en_US', 'mobile');
     }
 }

--- a/spec/Pim/Component/Catalog/Query/ProductQueryBuilderSpec.php
+++ b/spec/Pim/Component/Catalog/Query/ProductQueryBuilderSpec.php
@@ -43,11 +43,18 @@ class ProductQueryBuilderSpec extends ObjectBehavior
 
     function it_adds_a_field_filter($repository, $filterRegistry, FieldFilterInterface $filter)
     {
-        $repository->findOneBy(['code' => 'id'])->willReturn(null);
+        $repository->findOneByIdentifier('id')->willReturn(null);
         $filterRegistry->getFieldFilter('id')->willReturn($filter);
         $filter->supportsOperator('=')->willReturn(true);
         $filter->setQueryBuilder(Argument::any())->shouldBeCalled();
-        $filter->addFieldFilter('id', '=', '42', 'en_US', 'print')->shouldBeCalled();
+        $filter->addFieldFilter(
+            'id',
+            '=',
+            '42',
+            'en_US',
+            'print',
+            ['locale' => 'en_US', 'scope' => 'print']
+        )->shouldBeCalled();
 
         $this->addFilter('id', '=', '42', []);
     }
@@ -58,7 +65,7 @@ class ProductQueryBuilderSpec extends ObjectBehavior
         AttributeFilterInterface $filter,
         AttributeInterface $attribute
     ) {
-        $repository->findOneBy(['code' => 'sku'])->willReturn($attribute);
+        $repository->findOneByIdentifier('sku')->willReturn($attribute);
         $filterRegistry->getAttributeFilter($attribute)->willReturn($filter);
         $attribute->isScopable()->willReturn(true);
         $attribute->isLocalizable()->willReturn(true);

--- a/spec/Pim/Component/Connector/Reader/ProductReaderSpec.php
+++ b/spec/Pim/Component/Connector/Reader/ProductReaderSpec.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace spec\Pim\Component\Connector\Reader;
+
+use Akeneo\Component\Batch\Model\StepExecution;
+use Akeneo\Component\StorageUtils\Cursor\CursorInterface;
+use Akeneo\Component\StorageUtils\Detacher\ObjectDetacherInterface;
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Converter\MetricConverter;
+use Pim\Component\Catalog\Manager\CompletenessManager;
+use Pim\Component\Catalog\Model\CategoryInterface;
+use Pim\Component\Catalog\Model\ChannelInterface;
+use Pim\Component\Catalog\Model\ProductInterface;
+use Pim\Component\Catalog\Query\ProductQueryBuilderFactoryInterface;
+use Pim\Component\Catalog\Query\ProductQueryBuilderInterface;
+use Pim\Component\Catalog\Repository\ChannelRepositoryInterface;
+use Prophecy\Argument;
+use Prophecy\Promise\ReturnPromise;
+
+class ProductReaderSpec extends ObjectBehavior
+{
+    function let(
+        ProductQueryBuilderFactoryInterface $pqbFactory,
+        ChannelRepositoryInterface $channelRepository,
+        CompletenessManager $completenessManager,
+        MetricConverter $metricConverter,
+        ObjectDetacherInterface $objectDetacher,
+        StepExecution $stepExecution
+    ) {
+        $this->beConstructedWith(
+            $pqbFactory,
+            $channelRepository,
+            $completenessManager,
+            $metricConverter,
+            $objectDetacher,
+            true
+        );
+
+        $this->setStepExecution($stepExecution);
+    }
+
+    function it_is_configurable()
+    {
+        $this->getChannel()->shouldReturn(null);
+        $this->setChannel('mobile');
+        $this->getChannel()->shouldReturn('mobile');
+    }
+
+    function it_reads_products(
+        $pqbFactory,
+        $channelRepository,
+        $metricConverter,
+        $objectDetacher,
+        $stepExecution,
+        ChannelInterface $channel,
+        CategoryInterface $channelRoot,
+        ProductQueryBuilderInterface $pqb,
+        CursorInterface $cursor,
+        ProductInterface $product1,
+        ProductInterface $product2,
+        ProductInterface $product3
+    ) {
+        $channelRepository->findOneByIdentifier('mobile')->willReturn($channel);
+        $channel->getCategory()->willReturn($channelRoot);
+        $channelRoot->getId()->willReturn(42);
+        $channel->getCode()->willReturn('mobile');
+
+        $pqbFactory->create(['default_scope' => 'mobile'])
+            ->shouldBeCalled()
+            ->willReturn($pqb);
+        $pqb->addFilter('enabled', '=', true, [])->shouldBeCalled();
+        $pqb->addFilter('completeness', '=', 100, [])->shouldBeCalled();
+        $pqb->addFilter('categories.id', 'IN CHILDREN', [42], [])->shouldBeCalled();
+        $pqb->execute()
+            ->shouldBeCalled()
+            ->willReturn($cursor);
+
+        $products = [$product1, $product2, $product3];
+        $productsCount = count($products);
+        $cursor->valid()->will(
+            function () use (&$productsCount) {
+                return $productsCount-- > 0;
+            }
+        );
+        $cursor->next()->shouldBeCalled();
+        $cursor->current()->will(new ReturnPromise($products));
+
+        $stepExecution->incrementSummaryInfo('read')->shouldBeCalledTimes(3);
+        $objectDetacher->detach(Argument::any())->shouldBeCalledTimes(3);
+        $metricConverter->convert(Argument::any(), $channel)->shouldBeCalledTimes(3);
+
+        $this->setChannel('mobile');
+        $this->initialize();
+        $this->read()->shouldReturn($product1);
+        $this->read()->shouldReturn($product2);
+        $this->read()->shouldReturn($product3);
+        $this->read()->shouldReturn(null);
+    }
+
+    function it_generates_the_completeness_on_initialization(
+        $pqbFactory,
+        $channelRepository,
+        $completenessManager,
+        ChannelInterface $channel,
+        CategoryInterface $channelRoot,
+        ProductQueryBuilderInterface $pqb
+    ) {
+        $channelRepository->findOneByIdentifier('mobile')->willReturn($channel);
+        $channel->getCategory()->willReturn($channelRoot);
+        $channel->getCode()->willReturn('mobile');
+        $pqbFactory->create(['default_scope' => 'mobile'])->willReturn($pqb);
+
+        $completenessManager->generateMissingForChannel($channel)->shouldBeCalledTimes(1);
+
+        $this->setChannel('mobile');
+        $this->initialize();
+    }
+
+    function it_exposes_the_channel_field($channelRepository)
+    {
+        $channelRepository->getLabelsIndexedByCode()->willReturn(
+            [
+                'foo' => 'Foo',
+                'bar' => 'Bar',
+            ]
+        );
+
+        $this->getConfigurationFields()->shouldReturn(
+            [
+                'channel' => [
+                    'type'    => 'choice',
+                    'options' => [
+                        'choices'  => [
+                            'foo' => 'Foo',
+                            'bar' => 'Bar',
+                        ],
+                        'required' => true,
+                        'select2'  => true,
+                        'label'    => 'pim_connector.export.channel.label',
+                        'help'     => 'pim_connector.export.channel.help'
+                    ]
+                ]
+            ]
+        );
+    }
+}

--- a/src/Pim/Bundle/BaseConnectorBundle/Reader/Doctrine/ODMProductReader.php
+++ b/src/Pim/Bundle/BaseConnectorBundle/Reader/Doctrine/ODMProductReader.php
@@ -18,6 +18,8 @@ use Pim\Component\Catalog\Repository\ProductRepositoryInterface;
  * @author    Olivier Soulet <olivier.soulet@akeneo.com>
  * @copyright 2014 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *
+ * @deprecated Will be removed in 1.7, please use Pim\Component\Connector\Reader\ProductReader instead.
  */
 class ODMProductReader extends AbstractConfigurableStepElement implements ProductReaderInterface
 {

--- a/src/Pim/Bundle/BaseConnectorBundle/Reader/Doctrine/ORMProductReader.php
+++ b/src/Pim/Bundle/BaseConnectorBundle/Reader/Doctrine/ORMProductReader.php
@@ -18,6 +18,8 @@ use Pim\Component\Catalog\Repository\ProductRepositoryInterface;
  * @author    Olivier Soulet <olivier.soulet@akeneo.com>
  * @copyright 2014 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *
+ * @deprecated Will be removed in 1.7, please use Pim\Component\Connector\Reader\ProductReader instead.
  */
 class ORMProductReader extends AbstractConfigurableStepElement implements ProductReaderInterface
 {

--- a/src/Pim/Bundle/BaseConnectorBundle/Resources/config/readers.yml
+++ b/src/Pim/Bundle/BaseConnectorBundle/Resources/config/readers.yml
@@ -10,6 +10,7 @@ parameters:
     pim_base_connector.reader.cached.class:            Pim\Bundle\BaseConnectorBundle\Reader\CachedReader
 
 services:
+    # Deprecated: Will be removed in 1.7, please use @pim_connector.reader.product instead.
     pim_base_connector.reader.doctrine.product:
         class: %pim_base_connector.reader.doctrine.product.class%
         arguments:

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/CompletenessFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/CompletenessFilter.php
@@ -19,8 +19,6 @@ class CompletenessFilter extends AbstractFilter implements FieldFilterInterface
     protected $supportedFields;
 
     /**
-     * Instanciate the base filter
-     *
      * @param array $supportedFields
      * @param array $supportedOperators
      */
@@ -34,6 +32,9 @@ class CompletenessFilter extends AbstractFilter implements FieldFilterInterface
 
     /**
      * {@inheritdoc}
+     *
+     * If locale is omitted, all products having a matching completeness for
+     * the specified scope (no matter on which locale) will be selected.
      */
     public function addFieldFilter($field, $operator, $value, $locale = null, $scope = null, $options = [])
     {
@@ -63,8 +64,8 @@ class CompletenessFilter extends AbstractFilter implements FieldFilterInterface
             throw InvalidArgumentException::numericExpected($field, 'filter', 'completeness', gettype($value));
         }
 
-        if (null === $locale || null === $scope) {
-            throw InvalidArgumentException::localeAndScopeExpected($field, 'filter', 'completeness');
+        if (null === $scope) {
+            throw InvalidArgumentException::scopeExpected($field, 'filter', 'completeness');
         }
     }
 

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
@@ -73,14 +73,6 @@ services:
         tags:
             - { name: 'pim_catalog.doctrine.query.filter', priority: 30 }
 
-    pim_catalog.doctrine.query.filter.completeness:
-        class: %pim_catalog.doctrine.query.filter.completeness.class%
-        arguments:
-            - ['completeness']
-            - ['<', '<=', '=', '>=', '>', '!=']
-        tags:
-            - { name: 'pim_catalog.doctrine.query.filter', priority: 30 }
-
     pim_catalog.doctrine.query.filter.family:
         class: %pim_catalog.doctrine.query.filter.family.class%
         arguments:

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/storage_driver/doctrine/mongodb-odm.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/storage_driver/doctrine/mongodb-odm.yml
@@ -459,3 +459,12 @@ services:
         class: %pim_catalog.doctrine.query.sorter.is_associated.class%
         tags:
             - { name: 'pim_catalog.doctrine.query.sorter', priority: 30 }
+
+    pim_catalog.doctrine.query.filter.completeness:
+        class: %pim_catalog.doctrine.query.filter.completeness.class%
+        arguments:
+            - '@pim_catalog.repository.channel'
+            - ['completeness']
+            - ['<', '<=', '=', '>=', '>', '!=']
+        tags:
+            - { name: 'pim_catalog.doctrine.query.filter', priority: 30 }

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/storage_driver/doctrine/orm.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/storage_driver/doctrine/orm.yml
@@ -119,3 +119,11 @@ services:
             - %pim_catalog.doctrine.query.cursor.class%
             - @pim_catalog.object_manager.product
             - %pim_catalog.factory.product_cursor.page_size%
+
+    pim_catalog.doctrine.query.filter.completeness:
+        class: %pim_catalog.doctrine.query.filter.completeness.class%
+        arguments:
+            - ['completeness']
+            - ['<', '<=', '=', '>=', '>', '!=']
+        tags:
+            - { name: 'pim_catalog.doctrine.query.filter', priority: 30 }

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/batch_jobs/csv_connector.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/batch_jobs/csv_connector.yml
@@ -140,7 +140,7 @@ connector:
                 export:
                     title:     pim_connector.jobs.csv_product_export.export.title
                     services:
-                        reader:    pim_base_connector.reader.doctrine.product
+                        reader:    pim_connector.reader.product
                         processor: pim_base_connector.processor.product_to_flat_array
                         writer:    pim_connector.writer.file.csv_product
                     parameters:

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/batch_jobs/xlsx_connector.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/batch_jobs/xlsx_connector.yml
@@ -108,7 +108,7 @@ connector:
                  export:
                      title: pim_connector.jobs.xlsx_product_export.export.title
                      services:
-                         reader:    pim_base_connector.reader.doctrine.product
+                         reader:    pim_connector.reader.product
                          processor: pim_base_connector.processor.product_to_flat_array
                          writer:    pim_connector.writer.file.xlsx_product
                      parameters:

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/readers.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/readers.yml
@@ -1,4 +1,5 @@
 parameters:
+    pim_connector.reader.product.class:       Pim\Component\Connector\Reader\ProductReader
     pim_connector.reader.dummy_item.class:    Pim\Component\Connector\Reader\DummyItemReader
     pim_connector.reader.doctrine.base.class: Pim\Component\Connector\Reader\Doctrine\BaseReader
 
@@ -13,6 +14,16 @@ parameters:
     pim_connector.reader.file.media_path_transformer.class: Pim\Component\Connector\Reader\File\Product\MediaPathTransformer
 
 services:
+    pim_connector.reader.product:
+        class: %pim_connector.reader.product.class%
+        arguments:
+            - '@pim_catalog.query.product_query_builder_factory'
+            - '@pim_catalog.repository.channel'
+            - '@pim_catalog.manager.completeness'
+            - '@pim_catalog.converter.metric'
+            - '@akeneo_storage_utils.doctrine.object_detacher'
+            - true
+
     pim_connector.reader.file.csv_iterator_factory:
         class: %pim_connector.reader.file.file_iterator_factory.class%
         arguments:

--- a/src/Pim/Component/Catalog/Exception/InvalidArgumentException.php
+++ b/src/Pim/Component/Catalog/Exception/InvalidArgumentException.php
@@ -56,19 +56,19 @@ class InvalidArgumentException extends \InvalidArgumentException
     }
 
     /**
-     * @param string $attribute
+     * @param string $name
      * @param string $action
      * @param string $type
      * @param string $data
      *
      * @return InvalidArgumentException
      */
-    public static function floatExpected($attribute, $action, $type, $data)
+    public static function floatExpected($name, $action, $type, $data)
     {
         return new self(
             sprintf(
                 'Attribute or field "%s" expects a float as data, "%s" given (for %s %s).',
-                $attribute,
+                $name,
                 $data,
                 $action,
                 $type
@@ -77,19 +77,19 @@ class InvalidArgumentException extends \InvalidArgumentException
     }
 
     /**
-     * @param string $attribute
+     * @param string $name
      * @param string $action
      * @param string $type
      * @param string $data
      *
      * @return InvalidArgumentException
      */
-    public static function integerExpected($attribute, $action, $type, $data)
+    public static function integerExpected($name, $action, $type, $data)
     {
         return new self(
             sprintf(
                 'Attribute or field "%s" expects an integer as data, "%s" given (for %s %s).',
-                $attribute,
+                $name,
                 $data,
                 $action,
                 $type
@@ -108,7 +108,13 @@ class InvalidArgumentException extends \InvalidArgumentException
     public static function numericExpected($name, $action, $type, $data)
     {
         return new self(
-            sprintf('Attribute or field "%s" expects a numeric as data (for %s %s).', $name, $data, $action, $type)
+            sprintf(
+                'Attribute or field "%s" expects a numeric as data, "%s" given (for %s %s).',
+                $name,
+                $data,
+                $action,
+                $type
+            )
         );
     }
 
@@ -155,19 +161,19 @@ class InvalidArgumentException extends \InvalidArgumentException
     }
 
     /**
-     * @param string $attribute
+     * @param string $name
      * @param string $action
      * @param string $type
      * @param string $data
      *
      * @return InvalidArgumentException
      */
-    public static function arrayOfArraysExpected($attribute, $action, $type, $data)
+    public static function arrayOfArraysExpected($name, $action, $type, $data)
     {
         return new self(
             sprintf(
                 'Attribute or field "%s" expects an array of arrays as data, "%s" given (for %s %s).',
-                $attribute,
+                $name,
                 $data,
                 $action,
                 $type
@@ -233,7 +239,7 @@ class InvalidArgumentException extends \InvalidArgumentException
     }
 
     /**
-     * @param string $attribute
+     * @param string $name
      * @param string $key
      * @param string $action
      * @param string $type
@@ -241,12 +247,12 @@ class InvalidArgumentException extends \InvalidArgumentException
      *
      * @return InvalidArgumentException
      */
-    public static function arrayNumericKeyExpected($attribute, $key, $action, $type, $data)
+    public static function arrayNumericKeyExpected($name, $key, $action, $type, $data)
     {
         return new self(
             sprintf(
                 'Attribute or field "%s" expects an array with numeric data for the key "%s", "%s" given (for %s %s).',
-                $attribute,
+                $name,
                 $key,
                 $data,
                 $action,
@@ -314,6 +320,25 @@ class InvalidArgumentException extends \InvalidArgumentException
         return new self(
             sprintf(
                 'Attribute or field "%s" expects a valid scope and locale (for %s %s).',
+                $name,
+                $action,
+                $type
+            )
+        );
+    }
+
+    /**
+     * @param string $name
+     * @param string $action
+     * @param string $type
+     *
+     * @return InvalidArgumentException
+     */
+    public static function scopeExpected($name, $action, $type)
+    {
+        return new self(
+            sprintf(
+                'Attribute or field "%s" expects a valid scope (for %s %s).',
                 $name,
                 $action,
                 $type

--- a/src/Pim/Component/Catalog/Exception/ObjectNotFoundException.php
+++ b/src/Pim/Component/Catalog/Exception/ObjectNotFoundException.php
@@ -12,9 +12,9 @@ namespace Pim\Component\Catalog\Exception;
 class ObjectNotFoundException extends \Exception
 {
     /**
-     * @param string    $message
-     * @param int       $code
-     * @param Exception $previous
+     * @param string     $message
+     * @param int        $code
+     * @param \Exception $previous
      */
     public function __construct($message = 'Object was not found.', $code = 0, $previous = null)
     {

--- a/src/Pim/Component/Catalog/Query/ProductQueryBuilder.php
+++ b/src/Pim/Component/Catalog/Query/ProductQueryBuilder.php
@@ -105,28 +105,28 @@ class ProductQueryBuilder implements ProductQueryBuilderInterface
      */
     public function addFilter($field, $operator, $value, array $context = [])
     {
-        $attribute = $this->attributeRepository->findOneBy(['code' => FieldFilterHelper::getCode($field)]);
+        $attribute = $this->attributeRepository->findOneByIdentifier(FieldFilterHelper::getCode($field));
 
-        if ($attribute !== null) {
+        if (null !== $attribute) {
             $filter = $this->filterRegistry->getAttributeFilter($attribute);
         } else {
             $filter = $this->filterRegistry->getFieldFilter($field);
         }
 
-        if ($filter === null) {
+        if (null === $filter) {
             throw new \LogicException(
                 sprintf('Filter on field "%s" is not supported', $field)
             );
         }
 
-        if ($filter->supportsOperator($operator) === false) {
+        if (!$filter->supportsOperator($operator)) {
             throw new \LogicException(
                 sprintf('Filter on field "%s" doesn\'t provide operator "%s"', $field, $operator)
             );
         }
 
         $context = $this->getFinalContext($context);
-        if ($attribute !== null) {
+        if (null !== $attribute) {
             $context['field'] = $field;
 
             $this->addAttributeFilter($filter, $attribute, $operator, $value, $context);
@@ -151,20 +151,20 @@ class ProductQueryBuilder implements ProductQueryBuilderInterface
     {
         $attribute = $this->attributeRepository->findOneBy(['code' => $field]);
 
-        if ($attribute !== null) {
+        if (null !== $attribute) {
             $sorter = $this->sorterRegistry->getAttributeSorter($attribute);
         } else {
             $sorter = $this->sorterRegistry->getFieldSorter($field);
         }
 
-        if ($sorter === null) {
+        if (null === $sorter) {
             throw new \LogicException(
                 sprintf('Sorter on field "%s" is not supported', $field)
             );
         }
 
         $context = $this->getFinalContext($context);
-        if ($attribute !== null) {
+        if (null !== $attribute) {
             $this->addAttributeSorter($sorter, $attribute, $direction, $context);
         } else {
             $this->addFieldSorter($sorter, $field, $direction, $context);

--- a/src/Pim/Component/Catalog/Query/ProductQueryBuilder.php
+++ b/src/Pim/Component/Catalog/Query/ProductQueryBuilder.php
@@ -195,7 +195,7 @@ class ProductQueryBuilder implements ProductQueryBuilderInterface
     protected function addFieldFilter(FieldFilterInterface $filter, $field, $operator, $value, array $context)
     {
         $filter->setQueryBuilder($this->getQueryBuilder());
-        $filter->addFieldFilter($field, $operator, $value, $context['locale'], $context['scope']);
+        $filter->addFieldFilter($field, $operator, $value, $context['locale'], $context['scope'], $context);
 
         return $this;
     }

--- a/src/Pim/Component/Connector/Reader/ProductReader.php
+++ b/src/Pim/Component/Connector/Reader/ProductReader.php
@@ -1,0 +1,233 @@
+<?php
+
+namespace Pim\Component\Connector\Reader;
+
+use Akeneo\Component\Batch\Item\AbstractConfigurableStepElement;
+use Akeneo\Component\Batch\Item\ItemReaderInterface;
+use Akeneo\Component\Batch\Model\StepExecution;
+use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
+use Akeneo\Component\StorageUtils\Cursor\CursorInterface;
+use Akeneo\Component\StorageUtils\Detacher\ObjectDetacherInterface;
+use Pim\Component\Catalog\Converter\MetricConverter;
+use Pim\Component\Catalog\Exception\ObjectNotFoundException;
+use Pim\Component\Catalog\Manager\CompletenessManager;
+use Pim\Component\Catalog\Model\ChannelInterface;
+use Pim\Component\Catalog\Query\Filter\Operators;
+use Pim\Component\Catalog\Query\ProductQueryBuilderFactoryInterface;
+use Pim\Component\Catalog\Query\ProductQueryBuilderInterface;
+use Pim\Component\Catalog\Repository\ChannelRepositoryInterface;
+
+/**
+ * Storage-agnostic product reader using the Product Query Builder
+ *
+ * @author    Yohan Blain <yohan.blain@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ProductReader extends AbstractConfigurableStepElement implements ItemReaderInterface, StepExecutionAwareInterface
+{
+    /** @var ProductQueryBuilderFactoryInterface */
+    protected $pqbFactory;
+
+    /** @var ChannelRepositoryInterface */
+    protected $channelRepository;
+
+    /** @var CompletenessManager */
+    protected $completenessManager;
+
+    /** @var MetricConverter */
+    protected $metricConverter;
+
+    /** @var ObjectDetacherInterface */
+    protected $objectDetacher;
+
+    /** @var bool */
+    protected $generateCompleteness;
+
+    /** @var StepExecution */
+    protected $stepExecution;
+
+    /** @var CursorInterface */
+    protected $products;
+
+    /** @var string */
+    protected $channelCode;
+
+    /** @var ChannelInterface */
+    protected $channel;
+
+    /**
+     * @param ProductQueryBuilderFactoryInterface $pqbFactory
+     * @param ChannelRepositoryInterface          $channelRepository
+     * @param CompletenessManager                 $completenessManager
+     * @param MetricConverter                     $metricConverter
+     * @param ObjectDetacherInterface             $objectDetacher
+     * @param bool                                $generateCompleteness
+     */
+    public function __construct(
+        ProductQueryBuilderFactoryInterface $pqbFactory,
+        ChannelRepositoryInterface $channelRepository,
+        CompletenessManager $completenessManager,
+        MetricConverter $metricConverter,
+        ObjectDetacherInterface $objectDetacher,
+        $generateCompleteness
+    ) {
+        $this->pqbFactory           = $pqbFactory;
+        $this->channelRepository    = $channelRepository;
+        $this->completenessManager  = $completenessManager;
+        $this->metricConverter      = $metricConverter;
+        $this->objectDetacher       = $objectDetacher;
+        $this->generateCompleteness = (bool) $generateCompleteness;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setChannel($channelCode)
+    {
+        $this->channelCode = $channelCode;
+        $this->channel     = null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getChannel()
+    {
+        return $this->channelCode;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getConfigurationFields()
+    {
+        return [
+            'channel' => [
+                'type'    => 'choice',
+                'options' => [
+                    'choices'  => $this->channelRepository->getLabelsIndexedByCode(),
+                    'required' => true,
+                    'select2'  => true,
+                    'label'    => 'pim_connector.export.channel.label',
+                    'help'     => 'pim_connector.export.channel.help',
+                ],
+            ]
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function initialize()
+    {
+        $this->channel = $this->getChannelByCode($this->channelCode);
+        $pqb           = $this->getProductQueryBuilder($this->channel);
+
+        if ($this->generateCompleteness) {
+            $this->completenessManager->generateMissingForChannel($this->channel);
+        }
+
+        $this->products = $pqb->execute();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function read()
+    {
+        $product = null;
+
+        if ($this->products->valid()) {
+            $product = $this->products->current();
+            $this->stepExecution->incrementSummaryInfo('read');
+            $this->products->next();
+        }
+
+        if (null !== $product) {
+            $this->objectDetacher->detach($product);
+            $this->metricConverter->convert($product, $this->channel);
+        }
+
+        return $product;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setStepExecution(StepExecution $stepExecution)
+    {
+        $this->stepExecution = $stepExecution;
+    }
+
+    /**
+     * Return the product query builder instance with filters configured.
+     *
+     * @param ChannelInterface $channel
+     *
+     * @return ProductQueryBuilderInterface
+     */
+    protected function getProductQueryBuilder(ChannelInterface $channel)
+    {
+        $pqb = $this->pqbFactory->create(['default_scope' => $channel->getCode()]);
+
+        foreach ($this->getFilters($channel) as $filter) {
+            $pqb->addFilter(
+                $filter['field'],
+                $filter['operator'],
+                $filter['value'],
+                $filter['context']
+            );
+        }
+
+        return $pqb;
+    }
+
+    /**
+     * @param string $code
+     *
+     * @throws ObjectNotFoundException
+     *
+     * @return ChannelInterface
+     */
+    protected function getChannelByCode($code)
+    {
+        $channel = $this->channelRepository->findOneByIdentifier($code);
+        if (null === $channel) {
+            throw new ObjectNotFoundException(sprintf('Channel with "%s" code does not exist', $code));
+        }
+
+        return $channel;
+    }
+
+    /**
+     * Return the filters to be applied on the PQB instance.
+     *
+     * @param ChannelInterface $channel
+     *
+     * @return array
+     */
+    protected function getFilters(ChannelInterface $channel)
+    {
+        return [
+            [
+                'field'    => 'enabled',
+                'operator' => Operators::EQUALS,
+                'value'    => true,
+                'context'  => []
+            ],
+            [
+                'field'    => 'completeness',
+                'operator' => Operators::EQUALS,
+                'value'    => 100,
+                'context'  => []
+            ],
+            [
+                'field'    => 'categories.id',
+                'operator' => Operators::IN_CHILDREN_LIST,
+                'value'    => [$channel->getCategory()->getId()],
+                'context'  => []
+            ]
+        ];
+    }
+}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This PR introduces a new product reader. It's storage-agnostic thanks to the PQB.
It will replace the old ORM/Mongo readers, which are now deprecated.
Inspired by what has been done on [mass edit](https://github.com/akeneo/pim-community-dev/blob/master/src/Pim/Bundle/EnrichBundle/Connector/Reader/MassEdit/FilteredProductReader.php) and [EnhancedConnectorBundle](https://github.com/akeneo-labs/EnhancedConnectorBundle).

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | yes
| Added Behats                      | n/a
| Changelog updated                 | yes
| Review and 2 GTM                  | 
| Micro Demo to the PO (Story only) | n/a
| Migration script                  | n/a
| Tech Doc                          | 
