### PR TITLE
PIM-5363: Reset the UniqueValueSet after a saveAll 

### DIFF
--- a/spec/Pim/Bundle/CatalogBundle/EventSubscriber/ResetUniqueValidationSubscriberSpec.php
+++ b/spec/Pim/Bundle/CatalogBundle/EventSubscriber/ResetUniqueValidationSubscriberSpec.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace spec\Pim\Bundle\CatalogBundle\EventSubscriber;
+
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Validator\UniqueValuesSet;
+use Prophecy\Argument;
+
+class ResetUniqueValidationSubscriberSpec extends ObjectBehavior
+{
+    function let(UniqueValuesSet $uniqueValueSet)
+    {
+        $this->beConstructedWith($uniqueValueSet);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Pim\Bundle\CatalogBundle\EventSubscriber\ResetUniqueValidationSubscriber');
+    }
+
+    function it_should_reset_unique_value_set($uniqueValueSet)
+    {
+        $uniqueValueSet->reset()->shouldBeCalled();
+        $this->onAkeneoStoragePostsaveall();
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/EventSubscriber/ResetUniqueValidationSubscriber.php
+++ b/src/Pim/Bundle/CatalogBundle/EventSubscriber/ResetUniqueValidationSubscriber.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\EventSubscriber;
+
+use Pim\Component\Catalog\Validator\UniqueValuesSet;
+
+/**
+ * The UniqueValueSet class is stateful, and used when you import several product, to check if in the product batch
+ * there is no unique identifier issues.
+ * This listener listen the StorageEvents::POST_SAVE_ALL to reset the UniqueValueSet information, to be able to
+ * work in another product batch without uniqueness issues.
+ *
+ * @author    Pierre Allard <pierre.allard@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ResetUniqueValidationSubscriber
+{
+    /** @var UniqueValuesSet */
+    protected $uniqueValueSet;
+
+    /**
+     * @param UniqueValuesSet $uniqueValueSet
+     */
+    public function __construct(UniqueValuesSet $uniqueValueSet)
+    {
+        $this->uniqueValueSet = $uniqueValueSet;
+    }
+
+    /**
+     * Reset the Unique Value Set.
+     * Called on StorageEvents::POST_SAVE_ALL
+     */
+    public function onAkeneoStoragePostsaveall()
+    {
+        $this->uniqueValueSet->reset();
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/event_subscribers.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/event_subscribers.yml
@@ -8,18 +8,19 @@ parameters:
     pim_catalog.event_subscriber.outdate_indexed_values.class:       Pim\Bundle\CatalogBundle\EventSubscriber\OutdateIndexedValuesSubscriber
     pim_catalog.event_subscriber.category.check_channels.class:      Pim\Bundle\CatalogBundle\EventSubscriber\Category\CheckChannelsOnDeletionSubscriber
     pim_catalog.event_subscriber.currency_disabling.class:           Pim\Bundle\CatalogBundle\EventSubscriber\CurrencyDisablingSubscriber
+    pim_catalog.event_subscriber.reset_unique_validation.class:      Pim\Bundle\CatalogBundle\EventSubscriber\ResetUniqueValidationSubscriber
 
 services:
     # Subscribers
     pim_catalog.event_subscriber.create_attribute_requirement:
-        class: %pim_catalog.event_subscriber.create_attribute_requirement.class%
+        class: '%pim_catalog.event_subscriber.create_attribute_requirement.class%'
         arguments:
             - '@pim_catalog.factory.attribute_requirement'
         tags:
             - { name: doctrine.event_subscriber }
 
     pim_catalog.event_subscriber.metric_base_values:
-        class: %pim_catalog.event_subscriber.metric_base_values.class%
+        class: '%pim_catalog.event_subscriber.metric_base_values.class%'
         arguments:
             - '@akeneo_measure.measure_converter'
             - '@akeneo_measure.manager'
@@ -28,7 +29,7 @@ services:
             - { name: doctrine_mongodb.odm.event_subscriber, priority: 1 }
 
     pim_catalog.event_subscriber.localizable:
-        class: %pim_catalog.event_subscriber.localizable.class%
+        class: '%pim_catalog.event_subscriber.localizable.class%'
         arguments:
             - '@pim_catalog.context.catalog'
         tags:
@@ -36,7 +37,7 @@ services:
             - { name: doctrine_mongodb.odm.event_subscriber }
 
     pim_catalog.event_subscriber.scopable:
-        class: %pim_catalog.event_subscriber.scopable.class%
+        class: '%pim_catalog.event_subscriber.scopable.class%'
         arguments:
             - '@pim_catalog.context.catalog'
         tags:
@@ -44,43 +45,50 @@ services:
             - { name: doctrine_mongodb.odm.event_subscriber }
 
     pim_catalog.event_subscriber.timestampable:
-        class: %pim_catalog.event_subscriber.timestampable.class%
+        class: '%pim_catalog.event_subscriber.timestampable.class%'
         tags:
             - { name: doctrine.event_subscriber }
             - { name: doctrine_mongodb.odm.event_subscriber }
 
     pim_catalog.event_subscriber.outdate_indexed_values:
-        class: %pim_catalog.event_subscriber.outdate_indexed_values.class%
+        class: '%pim_catalog.event_subscriber.outdate_indexed_values.class%'
         tags:
             - { name: doctrine.event_subscriber }
             - { name: doctrine_mongodb.odm.event_subscriber }
 
     pim_catalog.event_subscriber.category.check_channels:
-        class: %pim_catalog.event_subscriber.category.check_channels.class%
+        class: '%pim_catalog.event_subscriber.category.check_channels.class%'
         arguments:
             - '@translator'
         tags:
             - { name: kernel.event_subscriber }
 
     pim_catalog.event_subscriber.currency_disabling:
-        class: %pim_catalog.event_subscriber.currency_disabling.class%
+        class: '%pim_catalog.event_subscriber.currency_disabling.class%'
         arguments:
             - '@pim_catalog.repository.channel'
         tags:
             - { name: kernel.event_subscriber }
 
     pim_catalog.event_subscriber.product_category:
-        class: %pim_catalog.event_subscriber.product_category.class%
+        class: '%pim_catalog.event_subscriber.product_category.class%'
         arguments:
-            - @pim_catalog.saver.product
+            - '@pim_catalog.saver.product'
         tags:
             - { name: kernel.event_subscriber }
 
     pim_catalog.event_subscriber.product_template_attribute:
-        class: %pim_catalog.event_subscriber.product_template_attribute.class%
+        class: '%pim_catalog.event_subscriber.product_template_attribute.class%'
         arguments:
-            - @doctrine.orm.entity_manager
-            - @pim_catalog.builder.product_template
-            - @pim_catalog.repository.product_template
+            - '@doctrine.orm.entity_manager'
+            - '@pim_catalog.builder.product_template'
+            - '@pim_catalog.repository.product_template'
         tags:
             - { name: kernel.event_subscriber }
+
+    pim_catalog.event_subscriber.reset_unique_validation:
+        class: '%pim_catalog.event_subscriber.reset_unique_validation.class%'
+        arguments:
+            - '@pim_catalog.validator.unique_value_set'
+        tags:
+           - { name: kernel.event_listener, event: akeneo.storage.post_save_all }

--- a/src/Pim/Component/Connector/Processor/Denormalization/ProductProcessor.php
+++ b/src/Pim/Component/Connector/Processor/Denormalization/ProductProcessor.php
@@ -401,12 +401,12 @@ class ProductProcessor extends AbstractProcessor
      */
     protected function getIdentifier(array $convertedItem)
     {
-        $identifierProperty = $this->repository->getIdentifierProperties();
-        if (!isset($convertedItem[$identifierProperty[0]])) {
-            throw new \RuntimeException(sprintf('Identifier property "%s" is expected', $identifierProperty[0]));
+        $identifierProperty = $this->repository->getIdentifierProperties()[0];
+        if (!isset($convertedItem[$identifierProperty])) {
+            throw new \RuntimeException(sprintf('Identifier property "%s" is expected', $identifierProperty));
         }
 
-        return $convertedItem[$identifierProperty[0]][0]['data'];
+        return $convertedItem[$identifierProperty][0]['data'];
     }
 
     /**


### PR DESCRIPTION
There is an issue on imports when you have 2 steps managing the same set of products.
The UniqueValueSet class (stateful) keeps in memory the set of product identifiers, to prevent to not have uniqueness validation errors in a batch of products. This class is not reseted after each step, and throws errors when you try to update the same product in 2 differents steps.

This PR reset the UniqueValueSet after a "save_all" event, to remove the identifiers list after a mass products save.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | yes
| Added Behats                      | no
| Changelog updated                 | no
| Review and 2 GTM                  | no
