### PR TITLE
PIM-5700: Fix scope filter shiftting

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/associations.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/associations.js
@@ -290,7 +290,7 @@ define(
                 }
 
                 $.get(Routing.generate('pim_datagrid_load', urlParams)).then(function (resp) {
-                    this.$('.grid-' + gridName).data({ 'metadata': resp.metadata, 'data': JSON.parse(resp.data) });
+                    this.$('#grid-' + gridName).data({ 'metadata': resp.metadata, 'data': JSON.parse(resp.data) });
 
                     var gridModules = resp.metadata.requireJSModules;
                     gridModules.push('pim/datagrid/state-listener');

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/tab/associations.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/tab/associations.html
@@ -30,11 +30,11 @@
             </div>
 
             <div class="association-product-grid<% if ('products' !== currentAssociationTarget) { %> hide<% } %>">
-                <div class="grid-association-product-grid" data-type="datagrid"></div>
+                <div id="grid-association-product-grid" data-type="datagrid"></div>
             </div>
 
             <div class="association-group-grid<% if ('groups' !== currentAssociationTarget) { %> hide<% } %>">
-                <div class="grid-association-group-grid" data-type="datagrid"></div>
+                <div id="grid-association-group-grid" data-type="datagrid"></div>
             </div>
 
             <div class="selection-inputs">


### PR DESCRIPTION
**The problem**
In the association grid, the scope selector (which is a filter) is displayed in the filter toolbar. It is a regression as it should be shown near the reset grid button.

This problem has been introduced while changing the html element id and class of the association grid.
While all grids are instanciated with the *id* in the PIM. the association grid has a className instead of an id.

**The solution**
Discussing it with @juliensnz. It seems complicated to adapt the grid declaration of all datagrids of the pim to use the class instead of the ids.

So, in this PR I put back the id of the grid instead of the class name.

(The association grid html element declaration has been changed from Id to class in this PR:
https://github.com/akeneo/pim-community-dev/pull/4210/files)


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Changelog updated                 | should I ?
| Review and 2 GTM                  | yes
| Micro Demo to the PO (Story only) | yes
| Migration script                  | -
| Tech Doc                          | -
