### PR TITLE
PIM-5753: Array converters ordered by tag priority

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -1,3 +1,11 @@
+# 1.4.x
+
+## Improvements
+- PIM-5753: Add a `priority` tag parameter for `ValueConverterRegistry` to allow ordering of array converters.
+
+## BC Breaks
+- ValueConverterRegistryInterface: added parameter `$priority` in `register` method to allow priority queue
+
 # 1.4.23 (2016-04-14)
 
 ## Scalability improvements

--- a/spec/Pim/Component/Connector/ArrayConverter/Flat/Product/ValueConverter/ValueConverterRegistrySpec.php
+++ b/spec/Pim/Component/Connector/ArrayConverter/Flat/Product/ValueConverter/ValueConverterRegistrySpec.php
@@ -17,7 +17,7 @@ class ValueConverterRegistrySpec extends ObjectBehavior
     function it_gets_converters(ValueConverterInterface $converter)
     {
         $converter->supportsField('pim_catalog_identifier')->willReturn(true);
-        $this->register($converter);
+        $this->register($converter, 100);
 
         $this->getConverter('pim_catalog_identifier')->shouldReturn($converter);
     }
@@ -25,7 +25,7 @@ class ValueConverterRegistrySpec extends ObjectBehavior
     function it_does_not_find_supported_converters(ValueConverterInterface $converter)
     {
         $converter->supportsField('pim_catalog_identifier')->willReturn(false);
-        $this->register($converter);
+        $this->register($converter, 100);
 
         $this->getConverter('pim_catalog_identifier')->shouldReturn(null);
     }

--- a/src/Pim/Bundle/ConnectorBundle/DependencyInjection/Compiler/RegisterConverterPass.php
+++ b/src/Pim/Bundle/ConnectorBundle/DependencyInjection/Compiler/RegisterConverterPass.php
@@ -4,10 +4,11 @@ namespace Pim\Bundle\ConnectorBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
- * Register converters
+ * Register converters ordered by priority
  *
  * @author    Olivier Soulet <olivier.soulet@akeneo.com>
  * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
@@ -20,6 +21,9 @@ class RegisterConverterPass implements CompilerPassInterface
 
     /** @staticvar */
     const CONVERTER_TAG = 'pim_connector.array_converter.flat.product.value_converter';
+
+    /** @staticvar int The default priority in registry stack */
+    const DEFAULT_PRIORITY = 100;
 
     /**
      * {@inheritdoc}
@@ -34,11 +38,31 @@ class RegisterConverterPass implements CompilerPassInterface
      */
     protected function registerConverters(ContainerBuilder $container)
     {
-        $registry = $container->getDefinition(self::CONVERTER_REGISTRY);
-        $converters = $container->findTaggedServiceIds(self::CONVERTER_TAG);
+        if (!$container->hasDefinition(static::CONVERTER_REGISTRY)) {
+            return;
+        }
 
-        foreach (array_keys($converters) as $converterId) {
-            $registry->addMethodCall('register', [new Reference($converterId)]);
+        $registry = $container->getDefinition(static::CONVERTER_REGISTRY);
+        $converters = $container->findTaggedServiceIds(static::CONVERTER_TAG);
+
+        foreach ($converters as $serviceId => $tags) {
+            $this->registerConverter($registry, $serviceId, $tags);
+        }
+    }
+
+    /**
+     * @param Definition $registry
+     * @param string     $serviceId
+     * @param string[]   $tags
+     */
+    protected function registerConverter(Definition $registry, $serviceId, $tags)
+    {
+        foreach ($tags as $tag) {
+            $priority = isset($tag['priority']) ? (int)$tag['priority'] : static::DEFAULT_PRIORITY;
+            $registry->addMethodCall(
+                'register',
+                [new Reference($serviceId), $priority]
+            );
         }
     }
 }

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/array_converters.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/array_converters.yml
@@ -31,27 +31,27 @@ parameters:
 services:
     # array converters
     pim_connector.array_converter.flat.attribute_option:
-        class: %pim_connector.array_converter.flat.attribute_option.class%
+        class: '%pim_connector.array_converter.flat.attribute_option.class%'
         arguments:
             - '@pim_catalog.repository.locale'
 
     pim_connector.array_converter.flat.attribute:
-        class: %pim_connector.array_converter.flat.attribute.class%
+        class: '%pim_connector.array_converter.flat.attribute.class%'
 
     pim_connector.array_converter.flat.category:
-        class: %pim_connector.array_converter.flat.category.class%
+        class: '%pim_connector.array_converter.flat.category.class%'
 
     pim_connector.array_converter.flat.family:
-        class: %pim_connector.array_converter.flat.family.class%
+        class: '%pim_connector.array_converter.flat.family.class%'
 
     pim_connector.array_converter.flat.association_type:
-        class: %pim_connector.array_converter.flat.association_type.class%
+        class: '%pim_connector.array_converter.flat.association_type.class%'
 
     pim_connector.array_converter.structured.attribute_option:
-        class: %pim_connector.array_converter.structured.attribute_option.class%
+        class: '%pim_connector.array_converter.structured.attribute_option.class%'
 
     pim_connector.array_converter.flat.product:
-        class: %pim_connector.array_converter.flat.product.class%
+        class: '%pim_connector.array_converter.flat.product.class%'
         arguments:
             - '@pim_connector.array_converter.flat.product.attribute_column_info_extractor'
             - '@pim_connector.array_converter.flat.product.value_converter.registry'
@@ -62,27 +62,27 @@ services:
             - '@pim_connector.array_converter.flat.product.columns_mapper'
 
     pim_connector.array_converter.flat.product_association:
-        class: %pim_connector.array_converter.flat.product_association.class%
+        class: '%pim_connector.array_converter.flat.product_association.class%'
         arguments:
             - '@pim_connector.array_converter.flat.product'
             - '@pim_connector.array_converter.flat.product.attribute_columns_resolver'
 
     pim_connector.array_converter.flat.variant_group:
-        class: %pim_connector.array_converter.flat.variant_group.class%
+        class: '%pim_connector.array_converter.flat.variant_group.class%'
         arguments:
             - '@pim_catalog.repository.locale'
             - '@pim_catalog.repository.attribute'
             - '@pim_connector.array_converter.flat.product'
 
     pim_connector.array_converter.flat.group:
-        class: %pim_connector.array_converter.flat.group.class%
+        class: '%pim_connector.array_converter.flat.group.class%'
         arguments:
             - '@pim_catalog.repository.locale'
             - '@pim_catalog.repository.attribute'
 
     # extractors
     pim_connector.array_converter.flat.product.attribute_column_info_extractor:
-        class: %pim_connector.array_converter.flat.product.attribute_column_info_extractor.class%
+        class: '%pim_connector.array_converter.flat.product.attribute_column_info_extractor.class%'
         arguments:
             - '@pim_catalog.repository.attribute'
             - '@pim_catalog.repository.channel'
@@ -90,15 +90,15 @@ services:
 
     # product value converters
     pim_connector.array_converter.flat.product.value_converter.registry:
-        class: %pim_connector.array_converter.flat.product.value_converter.registry.class%
+        class: '%pim_connector.array_converter.flat.product.value_converter.registry.class%'
 
     pim_connector.array_converter.flat.product.value_converter.abstract:
-        class: %pim_connector.array_converter.flat.product.value_converter.abstract.class%
+        class: '%pim_connector.array_converter.flat.product.value_converter.abstract.class%'
         arguments:
             - '@pim_connector.array_converter.flat.product.field_splitter'
 
     pim_connector.array_converter.flat.product.value_converter.price:
-        class: %pim_connector.array_converter.flat.product.value_converter.price.class%
+        class: '%pim_connector.array_converter.flat.product.value_converter.price.class%'
         parent: pim_connector.array_converter.flat.product.value_converter.abstract
         arguments:
             - ['pim_catalog_price_collection']
@@ -106,7 +106,7 @@ services:
             - { name: 'pim_connector.array_converter.flat.product.value_converter' }
 
     pim_connector.array_converter.flat.product.value_converter.metric:
-        class: %pim_connector.array_converter.flat.product.value_converter.metric.class%
+        class: '%pim_connector.array_converter.flat.product.value_converter.metric.class%'
         parent: pim_connector.array_converter.flat.product.value_converter.abstract
         arguments:
             - ['pim_catalog_metric']
@@ -114,7 +114,7 @@ services:
             - { name: 'pim_connector.array_converter.flat.product.value_converter' }
 
     pim_connector.array_converter.flat.product.value_converter.multiselect:
-        class: %pim_connector.array_converter.flat.product.value_converter.multiselect.class%
+        class: '%pim_connector.array_converter.flat.product.value_converter.multiselect.class%'
         parent: pim_connector.array_converter.flat.product.value_converter.abstract
         arguments:
             - ['pim_catalog_multiselect', 'pim_reference_data_multiselect']
@@ -122,7 +122,7 @@ services:
             - { name: 'pim_connector.array_converter.flat.product.value_converter' }
 
     pim_connector.array_converter.flat.product.value_converter.simpleselect:
-        class: %pim_connector.array_converter.flat.product.value_converter.simpleselect.class%
+        class: '%pim_connector.array_converter.flat.product.value_converter.simpleselect.class%'
         parent: pim_connector.array_converter.flat.product.value_converter.abstract
         arguments:
             - ['pim_catalog_simpleselect', 'pim_reference_data_simpleselect']
@@ -130,15 +130,15 @@ services:
             - { name: 'pim_connector.array_converter.flat.product.value_converter' }
 
     pim_connector.array_converter.flat.product.value_converter.scalar:
-        class: %pim_connector.array_converter.flat.product.value_converter.scalar.class%
+        class: '%pim_connector.array_converter.flat.product.value_converter.scalar.class%'
         parent: pim_connector.array_converter.flat.product.value_converter.abstract
         arguments:
             - ['pim_catalog_identifier', 'pim_catalog_text', 'pim_catalog_textarea', 'pim_catalog_date', 'pim_catalog_boolean', 'pim_catalog_number']
         tags:
-            - { name: 'pim_connector.array_converter.flat.product.value_converter' }
+            - { name: 'pim_connector.array_converter.flat.product.value_converter', priority: 150 }
 
     pim_connector.array_converter.flat.product.value_converter.media:
-        class: %pim_connector.array_converter.flat.product.value_converter.media.class%
+        class: '%pim_connector.array_converter.flat.product.value_converter.media.class%'
         parent: pim_connector.array_converter.flat.product.value_converter.abstract
         arguments:
             - ['pim_catalog_image', 'pim_catalog_file']
@@ -147,7 +147,7 @@ services:
 
     # product field converter
     pim_connector.array_converter.flat.product.field_converter:
-        class: %pim_connector.array_converter.flat.product.field_converter.class%
+        class: '%pim_connector.array_converter.flat.product.field_converter.class%'
         arguments:
             - '@pim_connector.array_converter.flat.product.field_splitter'
             - '@pim_connector.array_converter.flat.product.association_columns_resolver'
@@ -155,27 +155,27 @@ services:
 
     # columns resolvers
     pim_connector.array_converter.flat.product.attribute_columns_resolver:
-        class: %pim_connector.array_converter.flat.product.attribute_columns_resolver.class%
+        class: '%pim_connector.array_converter.flat.product.attribute_columns_resolver.class%'
         arguments:
             - '@pim_catalog.repository.attribute'
             - '@pim_catalog.repository.currency'
             - '@pim_catalog.resolver.attribute_values'
 
     pim_connector.array_converter.flat.product.association_columns_resolver:
-        class: %pim_connector.array_converter.flat.product.association_columns_resolver.class%
+        class: '%pim_connector.array_converter.flat.product.association_columns_resolver.class%'
         arguments:
             - '@pim_catalog.repository.association_type'
 
     # splitters
     pim_connector.array_converter.flat.product.field_splitter:
-        class: %pim_connector.array_converter.flat.product.field_splitter.class%
+        class: '%pim_connector.array_converter.flat.product.field_splitter.class%'
 
     # columns mergers
     pim_connector.array_converter.flat.product.columns_merger:
-        class: %pim_connector.array_converter.flat.product.columns_merger.class%
+        class: '%pim_connector.array_converter.flat.product.columns_merger.class%'
         arguments:
             - '@pim_connector.array_converter.flat.product.attribute_column_info_extractor'
 
     # columns mappers
     pim_connector.array_converter.flat.product.columns_mapper:
-        class: %pim_connector.array_converter.flat.product.columns_mapper.class%
+        class: '%pim_connector.array_converter.flat.product.columns_mapper.class%'

--- a/src/Pim/Component/Connector/ArrayConverter/Flat/Product/ValueConverter/ValueConverterRegistry.php
+++ b/src/Pim/Component/Connector/ArrayConverter/Flat/Product/ValueConverter/ValueConverterRegistry.php
@@ -17,11 +17,16 @@ class ValueConverterRegistry implements ValueConverterRegistryInterface
     /**
      * {@inheritdoc}
      */
-    public function register(ValueConverterInterface $converter)
+    public function register(ValueConverterInterface $converter, $priority)
     {
-        if ($converter instanceof ValueConverterInterface) {
-            $this->converters[] = $converter;
+        $priority = (int)$priority;
+        if (!isset($this->converters[$priority])) {
+            $this->converters[$priority] = $converter;
+        } else {
+            $this->register($converter, ++$priority);
         }
+
+        ksort($this->converters);
 
         return $this;
     }

--- a/src/Pim/Component/Connector/ArrayConverter/Flat/Product/ValueConverter/ValueConverterRegistryInterface.php
+++ b/src/Pim/Component/Connector/ArrayConverter/Flat/Product/ValueConverter/ValueConverterRegistryInterface.php
@@ -15,10 +15,11 @@ interface ValueConverterRegistryInterface
      * Register a converter.
      *
      * @param ValueConverterInterface $converter
+     * @param int                     $priority FIFO order : converter with lower priority is inspected first.
      *
      * @return ValueConverterRegistry
      */
-    public function register(ValueConverterInterface $converter);
+    public function register(ValueConverterInterface $converter, $priority);
 
     /**
      * @param string $attributeType


### PR DESCRIPTION
**Description**

This PR add an ordering feature for arrays converters.
Related issue: PIM-5753 Accept numeric values for text attributes in import

Btw, we should add position tags to all of our registries to allow external extension to register their services in the right place.

**Definition Of Done (for Core Developer only)**
_As a traitor, i will fill the DoD anyway_

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       |only modified
| Added Behats                      |no
| Changelog updated                 |yes
| Review and 2 GTM                  |
| Micro Demo to the PO (Story only) |no
| Migration script                  |no
| Tech Doc                          |no

