### PR TITLE
PIM-5625: Currency uses tracking DEFERRED_EXPLICIT + cascade detach channel -> locales

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Resources/config/doctrine/Channel.orm.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/doctrine/Channel.orm.yml
@@ -36,8 +36,6 @@ Pim\Bundle\CatalogBundle\Entity\Channel:
             targetEntity: Pim\Component\Catalog\Model\CurrencyInterface
             mappedBy: null
             inversedBy: null
-            cascade:
-                - persist
             joinTable:
                 name: pim_catalog_channel_currency
                 schema: null
@@ -54,6 +52,7 @@ Pim\Bundle\CatalogBundle\Entity\Channel:
             inversedBy: channels
             cascade:
                 - persist
+                - detach
             joinTable:
                 name: pim_catalog_channel_locale
                 schema: null

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/doctrine/Currency.orm.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/doctrine/Currency.orm.yml
@@ -1,6 +1,7 @@
 Pim\Bundle\CatalogBundle\Entity\Currency:
     type: entity
     table: pim_catalog_currency
+    changeTrackingPolicy: DEFERRED_EXPLICIT
     repositoryClass: Pim\Bundle\CatalogBundle\Doctrine\ORM\Repository\CurrencyRepository
     fields:
         id:

--- a/src/Pim/Component/Catalog/Repository/ChannelRepositoryInterface.php
+++ b/src/Pim/Component/Catalog/Repository/ChannelRepositoryInterface.php
@@ -35,6 +35,8 @@ interface ChannelRepositoryInterface extends IdentifiableObjectRepositoryInterfa
      *
      * @param ChannelInterface $channel
      *
+     * @deprecated will be removed in 1.7, has been used by the removed method CompletenessManager::scheduleForChannel
+     *
      * @return array the list of deleted locales
      */
     public function getDeletedLocaleIdsForChannel(ChannelInterface $channel);


### PR DESCRIPTION
Fix legacy doctrine mapping weirdness causing issue in EE ProductAsset related to channel fetched from a locale but not managed because the channel has been detached previously in the process

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | N
| Added Behats                      | N
| Changelog updated                 | - 
| Review and 2 GTM                  | - 
| Micro Demo to the PO (Story only) | - 
| Migration script                  | - 
| Tech Doc                          | - 

…ocales from channel