### PR TITLE
Fix product value filtering in structured ProductNormalizer

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -23,6 +23,7 @@
 - PIM-5725: Fix reference data name of the attribute in case this attribute is not a reference data
 - PIM-5699: Fix 'is equal to' operator in export / import history grid filter
 - PIM-5650: Fix events binding on PEF grid refresh.
+- Fix product value filtering by channel and locales in structured product normalizer
 
 # 1.4.22 (2016-03-23)
 

--- a/src/Pim/Bundle/TransformBundle/Normalizer/Structured/ProductNormalizer.php
+++ b/src/Pim/Bundle/TransformBundle/Normalizer/Structured/ProductNormalizer.php
@@ -4,6 +4,7 @@ namespace Pim\Bundle\TransformBundle\Normalizer\Structured;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Pim\Bundle\CatalogBundle\Filter\CollectionFilterInterface;
+use Pim\Bundle\CatalogBundle\Model\Association;
 use Pim\Bundle\CatalogBundle\Model\ProductInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\SerializerAwareNormalizer;
@@ -103,7 +104,7 @@ class ProductNormalizer extends SerializerAwareNormalizer implements NormalizerI
     }
 
     /**
-     * Normalize the values of the product
+     * Normalizes the values of the product
      *
      * @param ArrayCollection $values
      * @param string          $format
@@ -113,11 +114,7 @@ class ProductNormalizer extends SerializerAwareNormalizer implements NormalizerI
      */
     protected function normalizeValues(ArrayCollection $values, $format, array $context = [])
     {
-        $values = $this->filter->filterCollection(
-            $values,
-            isset($context['filter_type']) ? $context['filter_type'] : 'pim.transform.product_value.structured',
-            $context
-        );
+        $values = $this->getFilteredValues($values, $context);
 
         $data = [];
         foreach ($values as $value) {
@@ -128,7 +125,33 @@ class ProductNormalizer extends SerializerAwareNormalizer implements NormalizerI
     }
 
     /**
-     * Normalize the associations of the product
+     * Gets filtered values
+     *
+     * @param ArrayCollection $values
+     * @param array           $context
+     *
+     * @return ArrayCollection
+     */
+    protected function getFilteredValues(ArrayCollection $values, array $context = [])
+    {
+        if (isset($context['scopeCode'])) {
+            $context['channels'] = [$context['scopeCode']];
+        }
+        if (isset($context['localeCodes'])) {
+            $context['locales'] = $context['localeCodes'];
+        }
+
+        $values = $this->filter->filterCollection(
+            $values,
+            isset($context['filter_type']) ? $context['filter_type'] : 'pim.transform.product_value.structured',
+            $context
+        );
+
+        return $values;
+    }
+
+    /**
+     * Normalizes the associations of the product
      *
      * @param Association[] $associations
      *


### PR DESCRIPTION
**Description**

I’m currently working on a [JSON connector](https://github.com/damien-carcel/JsonConnectorBundle). For the product export, I use the structured ProductNormalizer, and I encountered a bug: when filtering the product values before normalizing them, the filtering on scope does not work (I got values for all channels instead of just the one I asked).

This is caused by the context passed to the filter, which does not contain the correct information. This PR intends to fix this.

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Yes
| Added Behats                      | No
| Changelog updated                 | Yes
| Review and 2 GTM                  | Yes
| Micro Demo to the PO (Story only) |  No
| Migration script                  | No
| Tech Doc                          | No