### PR TITLE
(Proposition) PIM-5364: Take the full step name for warning base title

### DIFF
--- a/spec/Akeneo/Component/Batch/Model/StepExecutionSpec.php
+++ b/spec/Akeneo/Component/Batch/Model/StepExecutionSpec.php
@@ -11,7 +11,7 @@ class StepExecutionSpec extends ObjectBehavior
 {
     function let(JobExecution $jobExecution)
     {
-        $this->beConstructedWith('myStepName', $jobExecution);
+        $this->beConstructedWith('my.step.title', $jobExecution);
     }
 
     function it_is_properly_instanciated()
@@ -66,6 +66,18 @@ class StepExecutionSpec extends ObjectBehavior
         $this->getWarnings()->shouldHaveCount(1);
     }
 
+    function it_adds_warning_and_respects_the_name()
+    {
+        $this->addWarning(
+            'excluded',
+            'my reason',
+            [],
+            ['myitem']
+        );
+        $warnings = $this->getWarnings();
+        $warnings[0]->getName()->shouldReturn('my.step.steps.excluded.title');
+    }
+
     function it_increments_summary_info()
     {
         $this->incrementSummaryInfo('counter');
@@ -76,6 +88,6 @@ class StepExecutionSpec extends ObjectBehavior
 
     function it_is_displayable()
     {
-        $this->__toString()->shouldReturn('id=0, name=[myStepName], status=[2], exitCode=[EXECUTING], exitDescription=[]');
+        $this->__toString()->shouldReturn('id=0, name=[my.step.title], status=[2], exitCode=[EXECUTING], exitDescription=[]');
     }
 }

--- a/src/Akeneo/Component/Batch/Model/StepExecution.php
+++ b/src/Akeneo/Component/Batch/Model/StepExecution.php
@@ -440,8 +440,8 @@ class StepExecution
     public function addWarning($name, $reason, array $reasonParameters, $item)
     {
         $element = $this->stepName;
-        if (strpos($element, '.')) {
-            $element = substr($element, 0, strpos($element, '.'));
+        if (substr($element, -6) === '.title') {
+            $element = substr($element, 0, -6);
         }
         if (is_object($item)) {
             $item = [

--- a/src/Pim/Bundle/EnrichBundle/Connector/Item/MassEdit/VariantGroupCleaner.php
+++ b/src/Pim/Bundle/EnrichBundle/Connector/Item/MassEdit/VariantGroupCleaner.php
@@ -258,7 +258,9 @@ class VariantGroupCleaner
                     $stepExecution
                         ->addWarning(
                             'duplicated',
-                            $this->translator->trans('add_to_variant_group.steps.cleaner.warning.description'),
+                            $this->translator->trans(
+                                'pim_enrich.jobs.add_to_variant_group.steps.cleaner.warning.description'
+                            ),
                             [],
                             $product
                         );

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/batch_jobs.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/batch_jobs.yml
@@ -2,11 +2,11 @@ connector:
     name: Akeneo Mass Edit Connector
     jobs:
         update_product_value:
-            title: update_product_value
+            title: pim_enrich.jobs.update_product_value.title
             type:  mass_edit
             steps:
                 perform:
-                    title: update_product_value
+                    title: pim_enrich.jobs.update_product_value.steps.perform.title
                     services:
                         reader:    pim_enrich.connector.reader.mass_edit.product
                         processor: pim_enrich.connector.processor.mass_edit.product.update_value
@@ -14,11 +14,11 @@ connector:
                     parameters:
                         batch_size: 1000
         add_product_value:
-            title: add_product_value
+            title: pim_enrich.jobs.add_product_value.title
             type:  mass_edit
             steps:
                 perform:
-                    title: add_product_value
+                    title: pim_enrich.jobs.add_product_value.steps.perform.title
                     services:
                         reader:    pim_enrich.connector.reader.mass_edit.product
                         processor: pim_enrich.connector.processor.mass_edit.product.add_value
@@ -26,11 +26,11 @@ connector:
                     parameters:
                         batch_size: 1000
         edit_common_attributes:
-            title: edit_common_attributes
+            title: pim_enrich.jobs.edit_common_attributes.title
             type:  mass_edit
             steps:
                 perform:
-                    title: edit_common_attributes
+                    title: pim_enrich.jobs.edit_common_attributes.steps.perform.title
                     services:
                         reader:    pim_enrich.connector.reader.mass_edit.product
                         processor: pim_enrich.connector.processor.mass_edit.product.edit_common_attributes
@@ -38,16 +38,16 @@ connector:
                     parameters:
                         batch_size: 1000
                 clean:
-                    title: edit_common_attributes_clean
+                    title: pim_enrich.jobs.edit_common_attributes.steps.clean.title
                     class: "%pim_enrich.step.mass_edit.step.class%"
                     services:
                         cleaner: pim_enrich.connector.item.mass_edit.temporary_file_cleaner
         set_attribute_requirements:
-            title: set_attribute_requirements
+            title: pim_enrich.jobs.set_attribute_requirements.title
             type:  mass_edit
             steps:
                 perform:
-                    title: set_attribute_requirements
+                    title: pim_enrich.jobs.set_attribute_requirements.steps.perform.title
                     services:
                         reader:    pim_enrich.connector.reader.mass_edit.family
                         processor: pim_enrich.connector.processor.mass_edit.family.set_requirements
@@ -79,11 +79,11 @@ connector:
                      parameters:
                          batch_size: 1000
         add_to_variant_group:
-            title: add_to_variant_group
+            title: pim_enrich.jobs.add_to_variant_group.title
             type:  mass_edit
             steps:
                 perform:
-                    title: add_to_variant_group
+                    title: pim_enrich.jobs.add_to_variant_group.steps.perform.title
                     services:
                         reader:    pim_enrich.connector.reader.mass_edit.variant_group_product
                         processor: pim_enrich.connector.processor.mass_edit.product.add_to_variant_group

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/messages.en.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/messages.en.yml
@@ -293,6 +293,33 @@ pim_enrich:
             reference_data_type:
                 label: Choose the reference data type
 
+    # Background jobs
+    jobs:
+        update_product_value:
+            title: Update product value
+            steps.perform.title: Update product value
+        add_product_value:
+            title: Add product value
+            steps.perform.title: Add product value
+        edit_common_attributes:
+            title: Edit common attributes
+            steps:
+                perform.title: Edit common attributes
+                clean.title: Clean files for common attributes
+        set_attribute_requirements:
+            title: Set attribute requirements
+            steps.perform.title: Set attribute requirements
+        add_to_variant_group:
+            title: Add products to variant group
+            steps:
+                perform:
+                    title: Add products to variant group
+                    steps:
+                        excluded.title: Excluded product
+                        duplicated.title: Duplicated Axis
+                cleaner:
+                    warning.description: "Product can't be set in the selected variant group: duplicate variation axis values with another product in selection"
+
 # Entity and page header titles
 attribute:
     title:    attribute
@@ -969,16 +996,6 @@ job_execution.summary:
     skipped_attributes: Skipped attributes
 
 pim_mass_edit_execution_show:  Mass edit executions | Details
-
-edit_common_attributes.steps.edit_common_attributes_processor.title: Edit common attributes
-update_product_value.steps.update_product_value_processor.title: Update product value
-add_to_variant_group_clean.steps.excluded.title: Excluded product
-add_to_variant_group_clean.steps.duplicated.title: Duplicated Axis
-add_to_variant_group.steps.excluded.title: Excluded product
-add_to_variant_group.steps.duplicated.title: Duplicated Axis
-add_to_variant_group.steps.cleaner.warning.description: "Product can't be set in the selected variant group: duplicate variation axis values with another product in selection"
-edit_common_attributes: Edit common attributes
-edit_common_attributes_clean: Clean files for common attributes
 
 mass_edit report:
     overview: Mass edit reports

--- a/src/Pim/Bundle/ImportExportBundle/Resources/translations/messages.en.yml
+++ b/src/Pim/Bundle/ImportExportBundle/Resources/translations/messages.en.yml
@@ -175,7 +175,6 @@ Start:   Start
 End:     End
 
 # Process tracker
-set_attribute_requirements: Set attribute requirements
 COMPLETED: COMPLETED
 STARTING: STARTING
 STARTED: STARTED


### PR DESCRIPTION
## Explanation
Giving a job:

```yml
update_products:
    title: pim.jobs.update_products.title
    steps:
        perform:
            title: pim.jobs.update_products.steps.perform.title
            (...)
```
Currently, if there is a warning during a step, the warning translation key is based on the first word of the step translation key. So if a warning is raised for the step **perform**, it will be `PIM.STEPS.EXCLUDED.TITLE`. 

![process tracker show job](https://cloud.githubusercontent.com/assets/301169/14817992/df3d9202-0bba-11e6-82c6-6ab745e21e75.png)

This PR aims to keep the step name to build a consistent warning title. Taking the same example, the warning title will be `PIM.JOBS.UPDATE_PRODUCTS.STEPS.PERFORM.STEPS.EXCLUDED.TITLE`.

## DOD
| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Y
| Added Behats                      |
| Changelog updated                 |
| Review and 2 GTM                  |
| Micro Demo to the PO (Story only) | N
| Migration script                  | N
| Tech Doc                          | N

