### PR TITLE
PIM-5762: Removed unused filters on product datagrids

### DIFF
--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -13,6 +13,7 @@
 
 ## Technical improvements
 
+- PIM-5762: Removed unused category filters on product datagrids
 - Upgrade "akeneo/measure-bundle" from "0.4.1" to "0.5.0", details in the release note https://github.com/akeneo/MeasureBundle/releases/tag/0.5.0
 
 # 1.5.2 (2016-04-25)

--- a/src/Akeneo/Component/Classification/Repository/CategoryFilterableRepositoryInterface.php
+++ b/src/Akeneo/Component/Classification/Repository/CategoryFilterableRepositoryInterface.php
@@ -9,6 +9,8 @@ namespace Akeneo\Component\Classification\Repository;
  */
 interface CategoryFilterableRepositoryInterface
 {
+    const JOIN_ALIAS = 'CategoryFilterableRepositoryInterface';
+
     /**
      * Apply a filter by unclassified (not placed in any categories)
      *

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/association_product.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/association_product.yml
@@ -128,9 +128,3 @@ datagrid:
                     type:      product_category
                     label:     Category
                     data_name: category
-            default:
-                category:
-                    value:
-                        treeId: %pim_filter.product_category_filter.class%::UNKNOWN_TREE
-                        categoryId: %pim_filter.product_category_filter.class%::ALL_CATEGORY
-                    type: %pim_filter.product_category_filter.class%::DEFAULT_TYPE

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product.yml
@@ -209,9 +209,3 @@ datagrid:
                     ftype:     date
                     data_name: updated
                     label:     Updated At
-            default:
-                category:
-                    value:
-                        treeId: %pim_filter.product_category_filter.class%::UNKNOWN_TREE
-                        categoryId: %pim_filter.product_category_filter.class%::ALL_CATEGORY
-                    type: %pim_filter.product_category_filter.class%::DEFAULT_TYPE

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product_group.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product_group.yml
@@ -127,13 +127,3 @@ datagrid:
                     options:
                         field_options:
                             choices: '@pim_catalog.manager.channel->getChannelChoices'
-                category:
-                    type:      product_category
-                    label:     Category
-                    data_name: category
-            default:
-                category:
-                    value:
-                        treeId: %pim_filter.product_category_filter.class%::UNKNOWN_TREE
-                        categoryId: %pim_filter.product_category_filter.class%::ALL_CATEGORY
-                    type: %pim_filter.product_category_filter.class%::DEFAULT_TYPE

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product_variant_group.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product_variant_group.yml
@@ -128,13 +128,3 @@ datagrid:
                     options:
                         field_options:
                             choices: '@pim_catalog.manager.channel->getChannelChoices'
-                category:
-                    type:      product_category
-                    label:     Category
-                    data_name: category
-            default:
-                category:
-                    value:
-                        treeId: %pim_filter.product_category_filter.class%::UNKNOWN_TREE
-                        categoryId: %pim_filter.product_category_filter.class%::ALL_CATEGORY
-                    type: %pim_filter.product_category_filter.class%::DEFAULT_TYPE

--- a/src/Pim/Bundle/FilterBundle/Resources/config/filters.yml
+++ b/src/Pim/Bundle/FilterBundle/Resources/config/filters.yml
@@ -8,7 +8,7 @@ parameters:
     pim_filter.product_groups_filter.class:        Pim\Bundle\FilterBundle\Filter\Product\GroupsFilter
     pim_filter.product_family_filter.class:        Pim\Bundle\FilterBundle\Filter\Product\FamilyFilter
     pim_filter.product_completeness_filter.class:  Pim\Bundle\FilterBundle\Filter\Product\CompletenessFilter
-    pim_filter.product_category_filter.class:      Pim\Bundle\FilterBundle\Filter\CategoryFilter
+    pim_filter.category_filter.class:              Pim\Bundle\FilterBundle\Filter\CategoryFilter
     pim_filter.product_date_filter.class:          Pim\Bundle\FilterBundle\Filter\ProductValue\DateRangeFilter
     pim_filter.product_enabled_filter.class:       Pim\Bundle\FilterBundle\Filter\Product\EnabledFilter
     pim_filter.product_in_group_filter.class:      Pim\Bundle\FilterBundle\Filter\Product\InGroupFilter
@@ -21,6 +21,9 @@ parameters:
     pim_filter.product_value_boolean.class:    Pim\Bundle\FilterBundle\Filter\ProductValue\BooleanFilter
     pim_filter.product_value_metric.class:     Pim\Bundle\FilterBundle\Filter\ProductValue\MetricFilter
     pim_filter.product_value_price.class:      Pim\Bundle\FilterBundle\Filter\ProductValue\PriceFilter
+
+    # deprecated: will be removed in 1.6, use pim_filter.category_filter.class instead
+    pim_filter.product_category_filter.class: Pim\Bundle\FilterBundle\Filter\CategoryFilter
 
 services:
     pim_filter.ajax_choice_filter:
@@ -42,7 +45,7 @@ services:
             - { name: oro_filter.extension.orm_filter.filter, type: product_scope }
 
     pim_filter.product_category_filter:
-        class: %pim_filter.product_category_filter.class%
+        class: %pim_filter.category_filter.class%
         arguments:
             - '@form.factory'
             - '@pim_filter.product_utility'


### PR DESCRIPTION
# Description
I removed all category filters that were wrongly injected in some datagrids only to ensure permissions related filtering in the enterprise edition.

I also added an interface for the FilterUtility because we rely on it on the enterprise edition and could make sense in the community too.

# Definition of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | y
| Added Behats                      | N/A
| Changelog updated                 | y
| Review and 2 GTM                  | todo
| Micro Demo to the PO (Story only) | N/A
| Migration script                  | N/A
| Tech Doc                          | /NA

