### PR TITLE
PIM-5622: Fix NOT IN operator behavior for ORM groups filter

### DIFF
--- a/features/filter/group.feature
+++ b/features/filter/group.feature
@@ -1,0 +1,19 @@
+Feature: Filter on groups
+  In order to filter on groups
+  As an internal process or any user
+  I need to be able to filter on product by group
+
+  Scenario: Successfully filter on groups
+    Given a "apparel" catalog configuration
+    And the following products:
+      | sku    | groups             |
+      | TSHIRT | upsell, related    |
+      | JACKET | substitute         |
+      | SWEAT  | upsell, substitute |
+      | PANT   | related            |
+      | BOOT   |                    |
+    Then I should get the following results for the given filters:
+      | filter                                                                            | result                        |
+      | [{"field":"groups.code", "operator":"IN",     "value": ["substitute", "upsell"]}] | ["TSHIRT", "JACKET", "SWEAT"] |
+      | [{"field":"groups.code", "operator":"NOT IN", "value": ["substitute", "upsell"]}] | ["PANT", "BOOT"]              |
+      | [{"field":"groups.code", "operator":"EMPTY",  "value": null}]                     | ["BOOT"]                      |

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/GroupsFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/GroupsFilter.php
@@ -61,12 +61,10 @@ class GroupsFilter extends AbstractFilter implements FieldFilterInterface
                 $this->qb->expr()->in($entityAlias . '.id', $value)
             );
         } elseif ($operator === Operators::NOT_IN_LIST) {
-            $this->qb->andWhere(
-                $this->qb->expr()->orX(
-                    $this->qb->expr()->notIn($entityAlias . '.id', $value),
-                    $this->qb->expr()->isNull($entityAlias . '.id')
-                )
-            );
+            $this->qb->andWhere($this->qb->expr()->notIn(
+                $rootAlias . '.id',
+                $this->getNotInSubquery(FieldFilterHelper::getCode($field), $value)
+            ));
         } elseif ($operator === Operators::IS_EMPTY) {
             $this->qb->andWhere(
                 $this->qb->expr()->isNull($entityAlias.'.id')
@@ -82,6 +80,32 @@ class GroupsFilter extends AbstractFilter implements FieldFilterInterface
     public function supportsField($field)
     {
         return in_array($field, $this->supportedFields);
+    }
+
+    /**
+     * Subquery matching all products that actually have one of $value groups
+     *
+     * @param string $field
+     * @param array  $value
+     *
+     * @return string
+     */
+    protected function getNotInSubquery($field, $value)
+    {
+        $notInQb      = $this->qb->getEntityManager()->createQueryBuilder();
+        $rootEntity   = current($this->qb->getRootEntities());
+        $notInAlias   = $this->getUniqueAlias('productsNotIn');
+        $joinAlias    = $this->getUniqueAlias('filter' . $field);
+
+        $notInQb->select($notInAlias . '.id')
+            ->from($rootEntity, $notInAlias, $notInAlias . '.id')
+            ->innerJoin(
+                sprintf('%s.%s', $notInQb->getRootAlias(), $field),
+                $joinAlias
+            )
+            ->where($notInQb->expr()->in($joinAlias . '.id', $value));
+
+        return $notInQb->getDQL();
     }
 
     /**


### PR DESCRIPTION
Cherry pick @phaseinducer 's commit to fix "NOT IN" operator in 1.5

Recall:
Currently, "NOT IN [a,b]" is equivalent to "NOT IN a || NOT IN b". When you filter "NOT IN [a, b]", if group belongs to a but not b, it's not filtered.
This PR fixes it: "NOT IN [a,b]" begins "NOT IN a && NOT IN b".