### PR TITLE
PIM-5640: Apply permissions on quick export

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -199,3 +199,4 @@
 - Remove `Pim\Bundle\InstallerBundle\DataFixtures\*`
 - Remove `Pim\Bundle\InstallerBundle\FixtureLoader\*`
 - Change constructor of `Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\CompletenessFilter`, add `Pim\Component\Catalog\Repository\ChannelRepositoryInterface`
+- Change constructor of `Pim\Bundle\EnrichBundle\Connector\Processor\QuickExport\ProductToFlatArrayProcessor`, add `Symfony\Component\Security\Core\User\UserProviderInterface` and `Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface`

--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -200,3 +200,5 @@
 - Remove `Pim\Bundle\InstallerBundle\FixtureLoader\*`
 - Change constructor of `Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\CompletenessFilter`, add `Pim\Component\Catalog\Repository\ChannelRepositoryInterface`
 - Change constructor of `Pim\Bundle\EnrichBundle\Connector\Processor\QuickExport\ProductToFlatArrayProcessor`, add `Symfony\Component\Security\Core\User\UserProviderInterface` and `Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface`
+- Context option `filter_type` of `Pim\Component\Connector\Normalizer\Flat\ProductNormalizer` changed to `filter_types` and now accepts an array of filter names instead of just one filter name
+- Context option `filter_type` of `Pim\Component\Catalog\Normalizer\Structured\ProductNormalizer` changed to `filter_types` and  now accepts an array of filter names instead of just one filter name

--- a/features/Context/WebUser.php
+++ b/features/Context/WebUser.php
@@ -2507,6 +2507,9 @@ class WebUser extends RawMinkContext
         // Force to retrieve its job executions
         $jobInstance->getJobExecutions()->setInitialized(false);
         $jobExecution = $jobInstance->getJobExecutions()->last();
+        if (false === $jobExecution) {
+            throw new \InvalidArgumentException(sprintf('No job execution found for job with code "%s"', $code));
+        }
 
         $this->openPage('massEditJob show', ['id' => $jobExecution->getId()]);
 

--- a/features/Pim/Behat/Context/JobContext.php
+++ b/features/Pim/Behat/Context/JobContext.php
@@ -125,6 +125,10 @@ class JobContext extends PimContext
     {
         $jobInstance = $this->getFixturesContext()->getJobInstance($code);
         $jobExecution = $jobInstance->getJobExecutions()->first();
+        if (false === $jobExecution) {
+            throw new \InvalidArgumentException(sprintf('No job execution found for job with code "%s"', $code));
+        }
+
         $archiver = $this->getMainContext()->getContainer()->get('pim_base_connector.archiver.file_writer_archiver');
         $archives = $archiver->getArchives($jobExecution);
 

--- a/features/import/product/import_products_with_invalid_data.feature
+++ b/features/import/product/import_products_with_invalid_data.feature
@@ -197,7 +197,6 @@ Feature: Execute a job
     And import directory of "csv_footwear_product_import" contains the following media:
       | fanatic-freewave-76.gif |
       | fanatic-freewave-76.txt |
-    And I am logged in as "Julia"
     When I am on the "csv_footwear_product_import" import job page
     And I launch the import job
     And I wait for the "csv_footwear_product_import" job to finish
@@ -229,7 +228,6 @@ Feature: Execute a job
     And import directory of "csv_footwear_product_import" contains the following media:
       | fanatic-freewave-76.gif |
       | fanatic-freewave-76.txt |
-    And I am logged in as "Julia"
     When I am on the "csv_footwear_product_import" import job page
     And I launch the import job
     And I wait for the "csv_footwear_product_import" job to finish

--- a/features/product/comments.feature
+++ b/features/product/comments.feature
@@ -6,7 +6,6 @@ Feature: Leave a comment on a product
 
   Background:
     Given the "footwear" catalog configuration
-    And I am logged in as "Julia"
     And the following product:
       | sku        |
       | rangers    |
@@ -20,7 +19,8 @@ Feature: Leave a comment on a product
       | high-heels | 5 | Mary   | Should be associated with red heel.                            |        | 28-Aug-14  |
 
   Scenario: Successfully add a new comment on a product
-    Given I am on the "rangers" product page
+    Given I am logged in as "Julia"
+    And I am on the "rangers" product page
     And I open the "Comments" panel
     Then I should see "No comment for now"
     When I add a new comment "My comment"
@@ -30,7 +30,8 @@ Feature: Leave a comment on a product
       | rangers | 1 | Julia  | My comment |        |
 
   Scenario: View the list of comments on a product
-    Given I am on the "high-heels" product page
+    Given I am logged in as "Julia"
+    And I am on the "high-heels" product page
     And I open the "Comments" panel
     Then I should see the following product comments:
       | product    | # | author | message                                                        | parent |
@@ -41,7 +42,8 @@ Feature: Leave a comment on a product
       | high-heels | 5 | Mary   | Should be associated with red heel.                            |        |
 
   Scenario: Successfully reply to an existing comment
-    Given I am on the "high-heels" product page
+    Given I am logged in as "Julia"
+    And I am on the "high-heels" product page
     And I open the "Comments" panel
     When I reply to the comment "Should be associated with red heel." of "Mary" with "No, with black heels."
     Then I should see the following product comments:
@@ -54,7 +56,8 @@ Feature: Leave a comment on a product
       | high-heels | 6 | Julia  | No, with black heels.                                          | 5      |
 
   Scenario: Successfully remove my own comments
-    Given I am on the "rangers" product page
+    Given I am logged in as "Julia"
+    And I am on the "rangers" product page
     And I open the "Comments" panel
     And I add a new comment "My comment"
     When I delete the "My comment" comment
@@ -63,7 +66,8 @@ Feature: Leave a comment on a product
     Then I should not see "My comment"
 
   Scenario: Not being able to remove a comment that is not mine
-    Given I am on the "high-heels" product page
+    Given I am logged in as "Julia"
+    And I am on the "high-heels" product page
     And I open the "Comments" panel
     Then I should not see the link to delete the "Should be associated with red heel." comment of "Mary"
 

--- a/features/product/sequential_edit/sequential_edit.feature
+++ b/features/product/sequential_edit/sequential_edit.feature
@@ -6,7 +6,6 @@ Feature: Edit sequentially some products
 
   Background:
     Given a "footwear" catalog configuration
-    And I am logged in as "Mary"
     And the following products:
       | sku          | family   |
       | blue_sandal  | sandals  |

--- a/src/Pim/Bundle/CatalogBundle/Filter/ChainedFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Filter/ChainedFilter.php
@@ -48,7 +48,9 @@ class ChainedFilter implements CollectionFilterInterface, ObjectFilterInterface
     {
         if (isset($this->objectFilters[$type])) {
             foreach ($this->objectFilters[$type] as $filter) {
-                if ($filter->supportsObject($object, $type, $options) && $filter->filterObject($object, $options)) {
+                if ($filter->supportsObject($object, $type, $options) &&
+                    $filter->filterObject($object, $type, $options)
+                ) {
                     return true;
                 }
             }

--- a/src/Pim/Bundle/EnrichBundle/Connector/Processor/QuickExport/ProductToFlatArrayProcessor.php
+++ b/src/Pim/Bundle/EnrichBundle/Connector/Processor/QuickExport/ProductToFlatArrayProcessor.php
@@ -182,11 +182,17 @@ class ProductToFlatArrayProcessor extends AbstractProcessor
      */
     protected function getNormalizerContext()
     {
-        $this->normalizerContext = [
-            'scopeCode'   => $this->channelCode,
-            'localeCodes' => $this->getLocaleCodes($this->channelCode),
-            'locale'      => $this->locale,
-        ];
+        if (null === $this->normalizerContext) {
+            $this->normalizerContext = [
+                'scopeCode'    => $this->channelCode,
+                'localeCodes'  => $this->getLocaleCodes($this->channelCode),
+                'locale'       => $this->locale,
+                'filter_types' => [
+                    'pim.transform.product_value.flat',
+                    'pim.transform.product_value.flat.quick_export'
+                ]
+            ];
+        }
 
         return $this->normalizerContext;
     }

--- a/src/Pim/Bundle/EnrichBundle/Connector/Processor/QuickExport/ProductToFlatArrayProcessor.php
+++ b/src/Pim/Bundle/EnrichBundle/Connector/Processor/QuickExport/ProductToFlatArrayProcessor.php
@@ -3,6 +3,7 @@
 namespace Pim\Bundle\EnrichBundle\Connector\Processor\QuickExport;
 
 use Akeneo\Component\Batch\Item\InvalidItemException;
+use Akeneo\Component\Batch\Model\StepExecution;
 use Akeneo\Component\FileStorage\Model\FileInfoInterface;
 use Akeneo\Component\StorageUtils\Detacher\ObjectDetacherInterface;
 use Pim\Bundle\EnrichBundle\Connector\Processor\AbstractProcessor;
@@ -12,6 +13,9 @@ use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Repository\ChannelRepositoryInterface;
 use Symfony\Component\HttpFoundation\File\Exception\FileNotFoundException;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 
 /**
@@ -31,6 +35,12 @@ class ProductToFlatArrayProcessor extends AbstractProcessor
     /** @var ChannelRepositoryInterface */
     protected $channelRepository;
 
+    /** @var ProductBuilderInterface */
+    protected $productBuilder;
+
+    /** @var  ObjectDetacherInterface */
+    protected $objectDetacher;
+
     /** @var string */
     protected $uploadDirectory;
 
@@ -40,37 +50,37 @@ class ProductToFlatArrayProcessor extends AbstractProcessor
     /** @var string */
     protected $locale;
 
-    /** @var array Normalizer context */
+    /** @var array */
     protected $normalizerContext;
-
-    /** @var ProductBuilderInterface */
-    protected $productBuilder;
-
-    /** @var  ObjectDetacherInterface */
-    protected $objectDetacher;
 
     /** @var array */
     protected $mainContext;
 
     /**
-     * @param SerializerInterface                 $serializer
-     * @param ChannelRepositoryInterface          $channelRepository
-     * @param ProductBuilderInterface             $productBuilder
-     * @param ObjectDetacherInterface             $objectDetacher
-     * @param string                              $uploadDirectory
+     * @param SerializerInterface        $serializer
+     * @param ChannelRepositoryInterface $channelRepository
+     * @param ProductBuilderInterface    $productBuilder
+     * @param ObjectDetacherInterface    $objectDetacher
+     * @param UserProviderInterface      $userProvider
+     * @param TokenStorageInterface      $tokenStorage
+     * @param string                     $uploadDirectory
      */
     public function __construct(
         SerializerInterface $serializer,
         ChannelRepositoryInterface $channelRepository,
         ProductBuilderInterface $productBuilder,
         ObjectDetacherInterface $objectDetacher,
+        UserProviderInterface $userProvider,
+        TokenStorageInterface $tokenStorage,
         $uploadDirectory
     ) {
         $this->serializer        = $serializer;
         $this->channelRepository = $channelRepository;
-        $this->uploadDirectory   = $uploadDirectory;
         $this->productBuilder    = $productBuilder;
         $this->objectDetacher    = $objectDetacher;
+        $this->userProvider      = $userProvider;
+        $this->tokenStorage      = $tokenStorage;
+        $this->uploadDirectory   = $uploadDirectory;
     }
 
     /**
@@ -86,6 +96,8 @@ class ProductToFlatArrayProcessor extends AbstractProcessor
      */
     public function process($product)
     {
+        $this->initSecurityContext($this->stepExecution);
+
         if (null !== $this->productBuilder) {
             $this->productBuilder->addMissingProductValues($product);
         }
@@ -231,5 +243,19 @@ class ProductToFlatArrayProcessor extends AbstractProcessor
 
         $this->setChannelCode($configuration['mainContext']['scope']);
         $this->setLocale($configuration['mainContext']['ui_locale']);
+    }
+
+    /**
+     * Initialize the SecurityContext from the given $stepExecution
+     *
+     * @param StepExecution $stepExecution
+     */
+    protected function initSecurityContext(StepExecution $stepExecution)
+    {
+        $username = $stepExecution->getJobExecution()->getUser();
+        $user = $this->userProvider->loadUserByUsername($username);
+
+        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
+        $this->tokenStorage->setToken($token);
     }
 }

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/ProductController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/ProductController.php
@@ -149,7 +149,7 @@ class ProductController
         $this->productBuilder->addMissingAssociations($product);
 
         $normalizationContext = $this->userContext->toArray() + [
-            'filter_type'                => 'pim.internal_api.product_value.view',
+            'filter_types'               => ['pim.internal_api.product_value.view'],
             'disable_grouping_separator' => true
         ];
 
@@ -197,7 +197,7 @@ class ProductController
             $this->productSaver->save($product);
 
             $normalizationContext = $this->userContext->toArray() + [
-                'filter_type'                => 'pim.internal_api.product_value.view',
+                'filter_types'               => ['pim.internal_api.product_value.view'],
                 'disable_grouping_separator' => true
             ];
 

--- a/src/Pim/Bundle/EnrichBundle/Filter/ProductValuesEditDataFilter.php
+++ b/src/Pim/Bundle/EnrichBundle/Filter/ProductValuesEditDataFilter.php
@@ -6,6 +6,7 @@ use Pim\Bundle\CatalogBundle\Filter\CollectionFilterInterface;
 use Pim\Bundle\CatalogBundle\Filter\ObjectFilterInterface;
 use Pim\Component\Catalog\Exception\ObjectNotFoundException;
 use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\ChannelInterface;
 use Pim\Component\Catalog\Model\LocaleInterface;
 use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
 use Pim\Component\Catalog\Repository\ChannelRepositoryInterface;
@@ -161,8 +162,6 @@ class ProductValuesEditDataFilter implements CollectionFilterInterface
     /**
      * @param string $code
      *
-     * @throws ObjectNotFoundException
-     *
      * @return AttributeInterface
      */
     protected function getAttribute($code)
@@ -176,9 +175,6 @@ class ProductValuesEditDataFilter implements CollectionFilterInterface
 
     /**
      * @param string $code
-     * @param bool   $activeOnly
-     *
-     * @throws ObjectNotFoundException
      *
      * @return LocaleInterface
      */
@@ -193,8 +189,6 @@ class ProductValuesEditDataFilter implements CollectionFilterInterface
 
     /**
      * @param string $code
-     *
-     * @throws ObjectNotFoundException
      *
      * @return ChannelInterface
      */

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/connector/processors.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/connector/processors.yml
@@ -47,4 +47,6 @@ services:
             - '@pim_catalog.repository.channel'
             - '@pim_catalog.builder.product'
             - '@akeneo_storage_utils.doctrine.object_detacher'
+            - '@pim_user.provider.user'
+            - '@security.token_storage'
             - %upload_dir%

--- a/src/Pim/Bundle/EnrichBundle/spec/Connector/Processor/QuickExport/ProductToFlatArrayProcessorSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Connector/Processor/QuickExport/ProductToFlatArrayProcessorSpec.php
@@ -137,11 +137,17 @@ class ProductToFlatArrayProcessorSpec extends ObjectBehavior
             ->willReturn(['normalized_media1', 'normalized_media2']);
 
         $serializer
-            ->normalize($product, 'flat',
+            ->normalize(
+                $product,
+                'flat',
                 [
-                    'scopeCode'   => 'mobile',
-                    'localeCodes' => '',
-                    'locale'      => 'en_US',
+                    'scopeCode'    => 'mobile',
+                    'localeCodes'  => '',
+                    'locale'       => 'en_US',
+                    'filter_types' => [
+                        'pim.transform.product_value.flat',
+                        'pim.transform.product_value.flat.quick_export'
+                    ]
                 ]
             )
             ->willReturn(['normalized_product']);
@@ -181,11 +187,17 @@ class ProductToFlatArrayProcessorSpec extends ObjectBehavior
         $product->getValues()->willReturn([]);
 
         $serializer
-            ->normalize($product, 'flat',
+            ->normalize(
+                $product,
+                'flat',
                 [
                     'scopeCode'   => 'mobile',
                     'localeCodes' => '',
                     'locale'      => 'en_US',
+                    'filter_types' => [
+                        'pim.transform.product_value.flat',
+                        'pim.transform.product_value.flat.quick_export'
+                    ]
                 ]
             )
             ->willReturn(['normalized_product']);
@@ -282,11 +294,17 @@ class ProductToFlatArrayProcessorSpec extends ObjectBehavior
         $product->getValues()->willReturn([$number, $metricValue, $priceValue, $dateValue]);
 
         $serializer
-            ->normalize($product, 'flat',
+            ->normalize(
+                $product,
+                'flat',
                 [
                     'scopeCode'   => 'mobile',
                     'localeCodes' => '',
                     'locale'      => 'en_US',
+                    'filter_types' => [
+                        'pim.transform.product_value.flat',
+                        'pim.transform.product_value.flat.quick_export'
+                    ]
                 ]
             )
             ->willReturn(['10.50', '10.00 GRAM', '10.00 EUR', '10/25/15']);
@@ -344,11 +362,17 @@ class ProductToFlatArrayProcessorSpec extends ObjectBehavior
         $product->getValues()->willReturn([$number, $metricValue, $priceValue]);
 
         $serializer
-            ->normalize($product, 'flat',
+            ->normalize(
+                $product,
+                'flat',
                 [
                     'scopeCode'   => 'mobile',
                     'localeCodes' => '',
-                    'locale'      => 'fr_FR'
+                    'locale'      => 'fr_FR',
+                    'filter_types' => [
+                        'pim.transform.product_value.flat',
+                        'pim.transform.product_value.flat.quick_export'
+                    ]
                 ]
             )
             ->willReturn(['10,50', '10,00 GRAM', '10,00 EUR', '25/10/2015']);

--- a/src/Pim/Bundle/EnrichBundle/spec/Connector/Processor/QuickExport/ProductToFlatArrayProcessorSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Connector/Processor/QuickExport/ProductToFlatArrayProcessorSpec.php
@@ -8,6 +8,7 @@ use Akeneo\Component\Batch\Item\InvalidItemException;
 use Akeneo\Component\FileStorage\Model\FileInfoInterface;
 use Akeneo\Component\StorageUtils\Detacher\ObjectDetacherInterface;
 use PhpSpec\ObjectBehavior;
+use Pim\Bundle\UserBundle\Entity\UserInterface;
 use Pim\Component\Catalog\Builder\ProductBuilderInterface;
 use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Bundle\CatalogBundle\Manager\ChannelManager;
@@ -20,6 +21,8 @@ use Pim\Component\Catalog\Model\ProductValueInterface;
 use Pim\Component\Catalog\Repository\ChannelRepositoryInterface;
 use Prophecy\Argument;
 use Symfony\Component\HttpFoundation\File\Exception\FileNotFoundException;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Component\Serializer\Serializer;
 
 class ProductToFlatArrayProcessorSpec extends ObjectBehavior
@@ -29,13 +32,17 @@ class ProductToFlatArrayProcessorSpec extends ObjectBehavior
         ChannelRepositoryInterface $channelRepository,
         StepExecution $stepExecution,
         ProductBuilderInterface $productBuilder,
-        ObjectDetacherInterface $objectDetacher
+        ObjectDetacherInterface $objectDetacher,
+        UserProviderInterface $userProvider,
+        TokenStorageInterface $tokenStorage
     ) {
         $this->beConstructedWith(
             $serializer,
             $channelRepository,
             $productBuilder,
             $objectDetacher,
+            $userProvider,
+            $tokenStorage,
             'upload/path/'
         );
         $this->setStepExecution($stepExecution);
@@ -97,6 +104,10 @@ class ProductToFlatArrayProcessorSpec extends ObjectBehavior
         $serializer,
         $productBuilder,
         $objectDetacher,
+        $userProvider,
+        $stepExecution,
+        JobExecution $jobExecution,
+        UserInterface $user,
         ChannelInterface $channel,
         ProductInterface $product,
         FileInfoInterface $media1,
@@ -105,6 +116,11 @@ class ProductToFlatArrayProcessorSpec extends ObjectBehavior
         ProductValueInterface $value2,
         AttributeInterface $attribute
     ) {
+        $stepExecution->getJobExecution()->willReturn($jobExecution);
+        $jobExecution->getUser()->willReturn('michel');
+        $userProvider->loadUserByUsername('michel')->willReturn($user);
+        $user->getRoles()->willReturn(['ROLE_MICHEL']);
+
         $this->setLocale('en_US');
 
         $productBuilder->addMissingProductValues($product)->shouldBeCalled();
@@ -145,11 +161,20 @@ class ProductToFlatArrayProcessorSpec extends ObjectBehavior
     function it_returns_flat_data_without_media(
         $productBuilder,
         $objectDetacher,
+        $userProvider,
+        $stepExecution,
+        JobExecution $jobExecution,
+        UserInterface $user,
         ChannelInterface $channel,
         ChannelRepositoryInterface $channelRepository,
         ProductInterface $product,
         Serializer $serializer
     ) {
+        $stepExecution->getJobExecution()->willReturn($jobExecution);
+        $jobExecution->getUser()->willReturn('michel');
+        $userProvider->loadUserByUsername('michel')->willReturn($user);
+        $user->getRoles()->willReturn(['ROLE_MICHEL']);
+
         $productBuilder->addMissingProductValues($product)->shouldBeCalled();
 
         $this->setLocale('en_US');
@@ -174,12 +199,21 @@ class ProductToFlatArrayProcessorSpec extends ObjectBehavior
 
     function it_throws_an_exception_if_something_goes_wrong_with_media_normalization(
         $serializer,
+        $userProvider,
+        $stepExecution,
+        JobExecution $jobExecution,
+        UserInterface $user,
         ProductInterface $product,
         FileInfoInterface $media,
         ProductValueInterface $value,
         ProductValueInterface $value2,
         AttributeInterface $attribute
     ) {
+        $stepExecution->getJobExecution()->willReturn($jobExecution);
+        $jobExecution->getUser()->willReturn('michel');
+        $userProvider->loadUserByUsername('michel')->willReturn($user);
+        $user->getRoles()->willReturn(['ROLE_MICHEL']);
+
         $product->getValues()->willReturn([$value]);
         $product->getIdentifier()->willReturn($value2);
 
@@ -204,6 +238,10 @@ class ProductToFlatArrayProcessorSpec extends ObjectBehavior
     function it_returns_flat_data_with_english_attributes(
         $channelRepository,
         $serializer,
+        $userProvider,
+        $stepExecution,
+        JobExecution $jobExecution,
+        UserInterface $user,
         ChannelInterface $channel,
         ProductInterface $product,
         ProductValueInterface $number,
@@ -215,6 +253,11 @@ class ProductToFlatArrayProcessorSpec extends ObjectBehavior
         AttributeInterface $date,
         ProductValueInterface $dateValue
     ) {
+        $stepExecution->getJobExecution()->willReturn($jobExecution);
+        $jobExecution->getUser()->willReturn('michel');
+        $userProvider->loadUserByUsername('michel')->willReturn($user);
+        $user->getRoles()->willReturn(['ROLE_MICHEL']);
+
         $this->setLocale('en_US');
 
         $attribute->getAttributeType()->willReturn('pim_catalog_number');
@@ -262,6 +305,10 @@ class ProductToFlatArrayProcessorSpec extends ObjectBehavior
     function it_returns_flat_data_with_french_attribute(
         $channelRepository,
         $serializer,
+        $userProvider,
+        $stepExecution,
+        JobExecution $jobExecution,
+        UserInterface $user,
         ChannelInterface $channel,
         ProductInterface $product,
         ProductValueInterface $number,
@@ -271,6 +318,11 @@ class ProductToFlatArrayProcessorSpec extends ObjectBehavior
         ProductPriceInterface $price,
         ProductValueInterface $priceValue
     ) {
+        $stepExecution->getJobExecution()->willReturn($jobExecution);
+        $jobExecution->getUser()->willReturn('michel');
+        $userProvider->loadUserByUsername('michel')->willReturn($user);
+        $user->getRoles()->willReturn(['ROLE_MICHEL']);
+
         $this->setLocale('fr_FR');
 
         $attribute->getAttributeType()->willReturn('pim_catalog_number');

--- a/src/Pim/Component/Catalog/Builder/ProductBuilderInterface.php
+++ b/src/Pim/Component/Catalog/Builder/ProductBuilderInterface.php
@@ -3,6 +3,8 @@
 namespace Pim\Component\Catalog\Builder;
 
 use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\ChannelInterface;
+use Pim\Component\Catalog\Model\LocaleInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Model\ProductPriceInterface;
 use Pim\Component\Catalog\Model\ProductValueInterface;
@@ -34,11 +36,13 @@ interface ProductBuilderInterface
      * It makes sure that if an attribute is localizable/scopable, then all values in the required locales/channels
      * exist. If the attribute is not scopable or localizable, makes sure that a single value exists.
      *
-     * @param ProductInterface $product
+     * @param ProductInterface   $product
+     * @param ChannelInterface[] $channels
+     * @param LocaleInterface[]  $locales
      *
      * @return ProductBuilderInterface
      */
-    public function addMissingProductValues(ProductInterface $product);
+    public function addMissingProductValues(ProductInterface $product, array $channels = null, array $locales = null);
 
     /**
      * Add empty associations for each association types when they don't exist yet

--- a/src/Pim/Component/Catalog/Normalizer/Structured/ProductNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Structured/ProductNormalizer.php
@@ -68,6 +68,7 @@ class ProductNormalizer extends SerializerAwareNormalizer implements NormalizerI
         $defaultContext = [
             'only_associations'    => false,
             'exclude_associations' => false,
+            'filter_types'         => ['pim.transform.product_value.structured']
         ];
 
         $context = array_merge($defaultContext, $context);
@@ -117,15 +118,12 @@ class ProductNormalizer extends SerializerAwareNormalizer implements NormalizerI
      */
     protected function normalizeValues(ArrayCollection $values, $format, array $context = [])
     {
-        $values = $this->filter->filterCollection(
-            $values,
-            isset($context['filter_type']) ? $context['filter_type'] : 'pim.transform.product_value.structured',
-            $context
-        );
+        foreach ($context['filter_types'] as $filterType) {
+            $values = $this->filter->filterCollection($values, $filterType, $context);
+        }
 
         $data = [];
         foreach ($values as $value) {
-            /* @var ProductValueInterface $value */
             $data[$value->getAttribute()->getCode()][] = $this->serializer->normalize($value, $format, $context);
         }
 

--- a/src/Pim/Component/Connector/Normalizer/Flat/ProductValueNormalizer.php
+++ b/src/Pim/Component/Connector/Normalizer/Flat/ProductValueNormalizer.php
@@ -59,7 +59,7 @@ class ProductValueNormalizer implements NormalizerInterface, SerializerAwareInte
     public function normalize($entity, $format = null, array $context = [])
     {
         $data = $entity->getData();
-        $fieldName = $this->getFieldValue($entity);
+        $fieldName = $this->getFieldName($entity);
         if ($this->filterLocaleSpecific($entity)) {
             return [];
         }
@@ -140,7 +140,7 @@ class ProductValueNormalizer implements NormalizerInterface, SerializerAwareInte
      *
      * @return string
      */
-    protected function getFieldValue($value)
+    protected function getFieldName(ProductValueInterface $value)
     {
         // TODO : should be extracted
         $suffix = '';


### PR DESCRIPTION
**What does this PR do?**
- Quick export processor is now user aware (like the mass edit processor for example)
- Product normalizers (structured & flat) now accept several filters in context

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | yes
| Added Behats                      | n/a
| Changelog updated                 | yes
| Review and 2 GTM                  |
| Micro Demo to the PO (Story only) | in progress
| Migration script                  | n/a
| Tech Doc                          | 
