### PR TITLE
Fixed behat issues

### DIFF
--- a/features/Context/Page/Base/Grid.php
+++ b/features/Context/Page/Base/Grid.php
@@ -196,17 +196,21 @@ class Grid extends Index
             $results = $this->getElement('Select2 results');
             $select2 = $filter->find('css', '.select2-input');
 
+            if (in_array($value, ['empty', 'is empty'])) {
+                $operator = 'empty';
+            }
+
+            if (null !== $results && null !== $select2) {
+                $driver->executeScript("jQuery('.select2-drop-mask').click();");
+            }
+
             if (false !== $operator) {
                 $filter->find('css', 'button.dropdown-toggle')->click();
                 $filter->find('css', sprintf('[data-value="%s"]', $operator))->click();
             }
 
             if (null !== $results && null !== $select2) {
-                if (in_array($value, ['empty', 'is empty'])) {
-                    // Allow passing 'empty' as value too (for backwards compability with existing scenarios)
-                    $filter->find('css', 'button.dropdown-toggle')->click();
-                    $filter->find('css', '[data-value="empty"]')->click();
-                } else {
+                if (!in_array($value, ['empty', 'is empty'])) {
                     $values = explode(',', $value);
                     foreach ($values as $value) {
                         $driver->getWebDriverSession()

--- a/features/Context/Page/Base/ProductEditForm.php
+++ b/features/Context/Page/Base/ProductEditForm.php
@@ -79,8 +79,8 @@ class ProductEditForm extends Form
             }
         }
 
-        // Close select2
-        $selector->click();
+        // Close select2 if open
+        $this->getDriver()->executeScript("jQuery('.select2-drop-mask').click();");
 
         return isset($results[$attribute]) ? $results[$attribute] : null;
     }


### PR DESCRIPTION
Select2 filters crash when we try to close them by clicking direcly on the element using Selenium Driver so we use the Javascript API to ensure that the select2 closes properly