### PR TITLE
[SLA] PIM-5727: Fix permission issue on add-attribute extension on edit common attributes step

### DIFF
--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -1,5 +1,8 @@
 # 1.5.x
 
+## Technical improvements
+
+- PIM-5762: Removed unused category filters on product datagrids
 - Upgrade "akeneo/measure-bundle" from "0.4.1" to "0.5.0", details in the release note https://github.com/akeneo/MeasureBundle/releases/tag/0.5.0
 
 # 1.5.2 (2016-04-25)

--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -12,6 +12,7 @@
 - PIM-5697: Fix import form when a file extension is not allowed
 - PIM-5695: Do not format price with currency if data is null
 - PIM-5643: Fix default system locale
+- PIM-5666: Fix product value saving with value '0'
 
 # 1.5.1 (2016-03-09)
 

--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -1,5 +1,10 @@
 # 1.5.x
 
+## Bug fixes
+
+- PIM-5666: Fix product value saving with value '0'
+- PIM-5738: fix malformed query failing with sql_mode=only_full_group_by
+
 ## Technical improvements
 
 - PIM-5762: Removed unused category filters on product datagrids
@@ -12,7 +17,6 @@
 - PIM-5697: Fix import form when a file extension is not allowed
 - PIM-5695: Do not format price with currency if data is null
 - PIM-5643: Fix default system locale
-- PIM-5666: Fix product value saving with value '0'
 
 # 1.5.1 (2016-03-09)
 

--- a/features/mass-action/validate/edit_common_attributes_permissions.feature
+++ b/features/mass-action/validate/edit_common_attributes_permissions.feature
@@ -1,0 +1,24 @@
+@javascript
+Feature: Edit common attributes with permissions
+  In order to update attributes with edit common attributes
+  As a product manager
+  I need to be able to add attributes with edit common attributes when I have no 'add attribute' permission
+
+  Background:
+    Given a "footwear" catalog configuration
+    And the following products:
+      | sku   | family |
+      | boots | boots  |
+
+  @jira https://akeneo.atlassian.net/browse/PIM-5727
+  Scenario: Successfully select attribute when user have no "add attributes" permission
+    Given I am logged in as "Mary"
+    And I am on the products page
+    And I mass-edit products boots
+    When I choose the "Edit common attributes" operation
+    Then I should see the text "Select attributes"
+    And I display the Name attribute
+    And I change the "Name" to "boots"
+    And I move on to the next step
+    And I wait for the "edit-common-attributes" mass-edit job to finish
+    And the english name of "boots" should be "boots"

--- a/features/product/create_product_and_save_added_attributes.feature
+++ b/features/product/create_product_and_save_added_attributes.feature
@@ -1,0 +1,32 @@
+@javascript
+Feature: Create product and save a new product value
+  In order to enrich a new product
+  As a product manager
+  I need to be able to create a product, add attributes and save
+
+  @jira https://akeneo.atlassian.net/browse/PIM-5666
+  Scenario: Successfully create a product, fill in product values with 0 and save
+    Given a "footwear" catalog configuration
+    And the following attributes:
+      | code      | label     | type   | group     |
+      | tmp_price | Tmp Price | prices | marketing |
+    And I am logged in as "Julia"
+    And I am on the products page
+    And I create a new product
+    And I fill in the following information in the popin:
+      | SKU             | gladiator |
+      | Choose a family | Sandals   |
+    And I press the "Save" button in the popin
+    And I am on the "gladiator" product page
+    And I add available attributes Rate of sale, Weight and Tmp Price
+    And I visit the "Product information" group
+    And I fill in "Weight" with "0"
+    And I visit the "Marketing" group
+    And I fill in "Rate of sale" with "0"
+    And I fill in the following information:
+      | Tmp Price | 0 EUR |
+    And I save the product
+    Then the product "gladiator" should have the following values:
+      | rate_sale | 0           |
+      | tmp_price | 0.00 EUR    |
+      | weight    | 0.0000 GRAM |

--- a/spec/Pim/Component/Catalog/Comparator/Attribute/NumberComparatorSpec.php
+++ b/spec/Pim/Component/Catalog/Comparator/Attribute/NumberComparatorSpec.php
@@ -61,4 +61,12 @@ class NumberComparatorSpec extends ObjectBehavior
 
         $this->compare($changes, $originals)->shouldReturn(null);
     }
+
+    function it_returns_changes_if_it_compares_0_to_null()
+    {
+        $changes   = ['data' => 0, 'locale' => 'en_US', 'scope' => 'ecommerce'];
+        $originals = ['data' => null, 'locale' => null, 'scope' => null];
+
+        $this->compare($changes, $originals)->shouldReturn($changes);
+    }
 }

--- a/src/Pim/Bundle/DataGridBundle/Extension/Pager/Orm/Pager.php
+++ b/src/Pim/Bundle/DataGridBundle/Extension/Pager/Orm/Pager.php
@@ -99,7 +99,9 @@ class Pager extends AbstractPager implements PagerInterface
 
         $rootAlias  = $qb->getRootAlias();
         $rootField  = $rootAlias.'.id';
-        $qb->groupBy($rootField);
+        $qb->resetDQLPart('select')
+            ->select($rootField)
+            ->distinct(true);
 
         $qb->setFirstResult(null)
             ->setMaxResults(null)

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product_group.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product_group.yml
@@ -127,13 +127,3 @@ datagrid:
                     options:
                         field_options:
                             choices: '@pim_catalog.manager.channel->getChannelChoices'
-                category:
-                    type:      product_category
-                    label:     Category
-                    data_name: category
-            default:
-                category:
-                    value:
-                        treeId: %pim_filter.product_category_filter.class%::UNKNOWN_TREE
-                        categoryId: %pim_filter.product_category_filter.class%::ALL_CATEGORY
-                    type: %pim_filter.product_category_filter.class%::DEFAULT_TYPE

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product_variant_group.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product_variant_group.yml
@@ -128,13 +128,3 @@ datagrid:
                     options:
                         field_options:
                             choices: '@pim_catalog.manager.channel->getChannelChoices'
-                category:
-                    type:      product_category
-                    label:     Category
-                    data_name: category
-            default:
-                category:
-                    value:
-                        treeId: %pim_filter.product_category_filter.class%::UNKNOWN_TREE
-                        categoryId: %pim_filter.product_category_filter.class%::ALL_CATEGORY
-                    type: %pim_filter.product_category_filter.class%::DEFAULT_TYPE

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/mass_product_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/mass_product_edit.yml
@@ -24,7 +24,6 @@ extensions:
         module: pim/mass-product-edit-form/add-attribute
         parent: pim-mass-product-edit-form-attributes
         targetZone: other-actions
-        aclResourceId: pim_enrich_product_add_attribute
         position: 90
 
     pim-mass-product-edit-form-validation:

--- a/src/Pim/Bundle/FilterBundle/Filter/DatasourceFilterUtilityInterface.php
+++ b/src/Pim/Bundle/FilterBundle/Filter/DatasourceFilterUtilityInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Pim\Bundle\FilterBundle\Filter;
+
+use Oro\Bundle\DataGridBundle\Datasource\DatasourceInterface;
+
+/**
+ * Used when you want to apply the filter from the outside, for example from a listener that access the datasource
+ *
+ * @author    Clement Gautier <clement.gautier@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface DatasourceFilterUtilityInterface
+{
+    /**
+     * Applies a filter on a datasource
+     *
+     * @param DatasourceInterface $ds
+     * @param string              $field
+     * @param string              $operator
+     * @param mixed               $value
+     */
+    public function filterDatasource(DatasourceInterface $ds, $field, $operator, $value);
+}

--- a/src/Pim/Bundle/FilterBundle/Filter/ProductFilterUtility.php
+++ b/src/Pim/Bundle/FilterBundle/Filter/ProductFilterUtility.php
@@ -2,8 +2,10 @@
 
 namespace Pim\Bundle\FilterBundle\Filter;
 
+use Oro\Bundle\DataGridBundle\Datasource\DatasourceInterface;
 use Oro\Bundle\FilterBundle\Datasource\FilterDatasourceAdapterInterface;
 use Oro\Bundle\FilterBundle\Filter\FilterUtility as BaseFilterUtility;
+use Pim\Bundle\DataGridBundle\Datasource\ProductDatasource;
 
 /**
  * Product filter utility
@@ -12,7 +14,7 @@ use Oro\Bundle\FilterBundle\Filter\FilterUtility as BaseFilterUtility;
  * @copyright 2013 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class ProductFilterUtility extends BaseFilterUtility
+class ProductFilterUtility extends BaseFilterUtility implements DatasourceFilterUtilityInterface
 {
     /**
      * Applies filter to query by attribute
@@ -24,6 +26,18 @@ class ProductFilterUtility extends BaseFilterUtility
      */
     public function applyFilter(FilterDatasourceAdapterInterface $ds, $field, $operator, $value)
     {
+        $ds->getProductQueryBuilder()->addFilter($field, $operator, $value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function filterDatasource(DatasourceInterface $ds, $field, $operator, $value)
+    {
+        if (!$ds instanceof ProductDatasource) {
+            throw new \RuntimeException(sprintf('Expected ProductDatasource, "%s" given ', get_class($ds)));
+        }
+
         $ds->getProductQueryBuilder()->addFilter($field, $operator, $value);
     }
 }

--- a/src/Pim/Component/Catalog/Comparator/Attribute/NumberComparator.php
+++ b/src/Pim/Component/Catalog/Comparator/Attribute/NumberComparator.php
@@ -48,6 +48,10 @@ class NumberComparator implements ComparatorInterface
             return $data;
         }
 
+        if (null !== $data['data'] && null === $originals['data']) {
+            return $data;
+        }
+
         return (float) $data['data'] !== (float) $originals['data'] ? $data : null;
     }
 }


### PR DESCRIPTION
<3 Thanks for taking the time to contribute! You're awesome! <3

Thank you, that's my job

**Description (for Contributor and Core Developer)**

When a user have no rights to "add attribute" on a product form, the "add-attribute" form extension is not loaded on the "Edit common attributes" step, event if he have permission.

The solution is to remove the permission check because this form extension should always be loaded (seen with PO's).

**Definition Of Done (for Core Developer only)**


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | n
| Added Behats                      | y
| Changelog updated                 | n
| Review and 2 GTM                  | n
| Micro Demo to the PO (Story only) | n
| Migration script                  | n
| Tech Doc                          | n
