### PR TITLE
PIM-5756: Fix empty min and max numbers on attributes import

### DIFF
--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -1,5 +1,8 @@
 # 1.5.x
 
+## Technical improvements
+
+- PIM-5762: Removed unused category filters on product datagrids
 - Upgrade "akeneo/measure-bundle" from "0.4.1" to "0.5.0", details in the release note https://github.com/akeneo/MeasureBundle/releases/tag/0.5.0
 
 # 1.5.2 (2016-04-25)

--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -4,6 +4,11 @@
 
 - PIM-5666: Fix product value saving with value '0'
 - PIM-5738: fix malformed query failing with sql_mode=only_full_group_by
+- PIM-5728: Fix bug in price and metric datagrid filters
+- PIM-5727: Fix permission issue on add-attribute extension on edit common attributes step
+- PIM-5754: Add labels to simple and multi select fields
+- PIM-5763: Add Boolean presenter for fields
+- PIM-5622: Fix NOT IN operator behavior for ORM groups filter
 
 ## Technical improvements
 

--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -12,6 +12,7 @@
 - PIM-5697: Fix import form when a file extension is not allowed
 - PIM-5695: Do not format price with currency if data is null
 - PIM-5643: Fix default system locale
+- PIM-5666: Fix product value saving with value '0'
 
 # 1.5.1 (2016-03-09)
 

--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -1,5 +1,10 @@
 # 1.5.x
 
+## Bug fixes
+
+- PIM-5666: Fix product value saving with value '0'
+- PIM-5738: fix malformed query failing with sql_mode=only_full_group_by
+
 ## Technical improvements
 
 - PIM-5762: Removed unused category filters on product datagrids
@@ -12,7 +17,6 @@
 - PIM-5697: Fix import form when a file extension is not allowed
 - PIM-5695: Do not format price with currency if data is null
 - PIM-5643: Fix default system locale
-- PIM-5666: Fix product value saving with value '0'
 
 # 1.5.1 (2016-03-09)
 

--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -9,6 +9,7 @@
 - PIM-5754: Add labels to simple and multi select fields
 - PIM-5763: Add Boolean presenter for fields
 - PIM-5622: Fix NOT IN operator behavior for ORM groups filter
+- PIM-5756: Fix empty min and max numbers on attributes import
 
 ## Technical improvements
 

--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -22,6 +22,7 @@
 - PIM-5697: Fix import form when a file extension is not allowed
 - PIM-5695: Do not format price with currency if data is null
 - PIM-5643: Fix default system locale
+- PIM-5728: Fix bug in price and metric datagrid filters
 
 # 1.5.1 (2016-03-09)
 

--- a/features/Context/FixturesContext.php
+++ b/features/Context/FixturesContext.php
@@ -362,6 +362,8 @@ class FixturesContext extends BaseFixturesContext
     /**
      * @param TableNode $table
      *
+     * @throws \Exception
+     *
      * @Then /^there should be the following attributes:$/
      */
     public function thereShouldBeTheFollowingAttributes(TableNode $table)
@@ -370,24 +372,70 @@ class FixturesContext extends BaseFixturesContext
             $attribute = $this->getAttribute($data['code']);
             $this->refresh($attribute);
 
-            assertEquals($data['label-en_US'], $attribute->getTranslation('en_US')->getLabel());
-            assertEquals($this->getAttributeType($data['type']), $attribute->getAttributeType());
-            assertEquals(($data['localizable'] == 1), $attribute->isLocalizable());
-            assertEquals(($data['scopable'] == 1), $attribute->isScopable());
-            assertEquals($data['group'], $attribute->getGroup()->getCode());
-            assertEquals(($data['useable_as_grid_filter'] == 1), $attribute->isUseableAsGridFilter());
-            assertEquals(($data['unique'] == 1), $attribute->isUnique());
-            if ($data['allowed_extensions'] != '') {
-                assertEquals(explode(',', $data['allowed_extensions']), $attribute->getAllowedExtensions());
-            }
-            assertEquals($data['metric_family'], $attribute->getMetricFamily());
-            assertEquals($data['default_metric_unit'], $attribute->getDefaultMetricUnit());
-
-            if (isset($data['reference_data_name'])) {
-                if ('' === $data['reference_data_name']) {
-                    assertNull($attribute->getReferenceDataName());
-                } else {
-                    assertEquals($data['reference_data_name'], $attribute->getReferenceDataName());
+            foreach ($data as $method => $value) {
+                switch ($method) {
+                    case 'code':
+                        // Untestable method
+                        break;
+                    case 'label-en_US':
+                        assertEquals($value, $attribute->getTranslation('en_US')->getLabel());
+                        break;
+                    case 'type':
+                        assertEquals($this->getAttributeType($value), $attribute->getAttributeType());
+                        break;
+                    case 'localizable':
+                        assertEquals('1' === $value, $attribute->isLocalizable());
+                        break;
+                    case 'scopable':
+                        assertEquals('1' === $value, $attribute->isLocalizable());
+                        break;
+                    case 'group':
+                        assertEquals($value, $attribute->getGroup()->getCode());
+                        break;
+                    case 'useable_as_grid_filter':
+                        assertEquals('1' === $value, $attribute->isUseableAsGridFilter());
+                        break;
+                    case 'unique':
+                        assertEquals('1' === $value, $attribute->isUnique());
+                        break;
+                    case 'allowed_extensions':
+                        if ('' !== $value) {
+                            assertEquals(explode(',', $value), $attribute->getAllowedExtensions());
+                        }
+                        break;
+                    case 'metric_family':
+                        assertEquals($value, $attribute->getMetricFamily());
+                        break;
+                    case 'default_metric_unit':
+                        assertEquals($value, $attribute->getDefaultMetricUnit());
+                        break;
+                    case 'reference_data_name':
+                        if ('' === $value) {
+                            assertNull($attribute->getReferenceDataName());
+                        } else {
+                            assertEquals($value, $attribute->getReferenceDataName());
+                        }
+                        break;
+                    case 'number_min':
+                        if ('' === $value) {
+                            assertNull($attribute->getNumberMin());
+                        } else {
+                            assertEquals($value, $attribute->getNumberMin());
+                        }
+                        break;
+                    case 'number_max':
+                        if ('' === $value) {
+                            assertNull($attribute->getNumberMax());
+                        } else {
+                            assertEquals($value, $attribute->getNumberMax());
+                        }
+                        break;
+                    default:
+                        throw new \Exception(sprintf(
+                            "The attribute method '%s' is not testable, please add it in %s",
+                            $method,
+                            get_class($this)
+                        ));
                 }
             }
         }

--- a/features/Context/catalog/apparel/attributes.yml
+++ b/features/Context/catalog/apparel/attributes.yml
@@ -81,6 +81,7 @@ attributes:
         numberMax:           1000
         sortOrder:           1
         decimalsAllowed:     true
+        sortOrder:           1
     customer_rating:
         labels:
             en_US: Customer rating
@@ -804,6 +805,7 @@ attributes:
             - de_DE
             - fr_FR
         useableAsGridFilter: true
+        sortOrder:           4
     datasheet:
         labels:
             en_US: Datasheet

--- a/features/Context/catalog/footwear/attributes.yml
+++ b/features/Context/catalog/footwear/attributes.yml
@@ -85,6 +85,7 @@ attributes:
         type:  pim_catalog_text
         useableAsGridFilter: true
         maxCharacters:       255
+        sortOrder:           0
     price:
         labels:
             en_US: Price
@@ -278,6 +279,7 @@ attributes:
         group: other
         decimalsAllowed:     false
         negativeAllowed:     false
+        sortOrder:           1
     destocking_date:
         labels:
             en_US: Destocking date
@@ -365,7 +367,8 @@ attributes:
     123:
         labels:
             en_US: Attribute 123
-        type:  pim_catalog_text
+        type:                pim_catalog_text
         useableAsGridFilter: true
-        group: other
-        maxCharacters: 255
+        group:               other
+        maxCharacters:       255
+        sortOrder:           2

--- a/features/filter/group.feature
+++ b/features/filter/group.feature
@@ -1,0 +1,19 @@
+Feature: Filter on groups
+  In order to filter on groups
+  As an internal process or any user
+  I need to be able to filter on product by group
+
+  Scenario: Successfully filter on groups
+    Given a "apparel" catalog configuration
+    And the following products:
+      | sku    | groups             |
+      | TSHIRT | upsell, related    |
+      | JACKET | substitute         |
+      | SWEAT  | upsell, substitute |
+      | PANT   | related            |
+      | BOOT   |                    |
+    Then I should get the following results for the given filters:
+      | filter                                                                            | result                        |
+      | [{"field":"groups.code", "operator":"IN",     "value": ["substitute", "upsell"]}] | ["TSHIRT", "JACKET", "SWEAT"] |
+      | [{"field":"groups.code", "operator":"NOT IN", "value": ["substitute", "upsell"]}] | ["PANT", "BOOT"]              |
+      | [{"field":"groups.code", "operator":"EMPTY",  "value": null}]                     | ["BOOT"]                      |

--- a/features/import/attribute/import_attributes.feature
+++ b/features/import/attribute/import_attributes.feature
@@ -22,7 +22,6 @@ Feature: Import attributes
       pim_catalog_image;image_upload;"Image upload";media;0;0;0;0;gif,png;;
       pim_catalog_date;release;"Release date";info;0;1;0;0;;;
       pim_catalog_metric;lace_length;"Lace length";info;0;0;0;0;;Length;CENTIMETER
-
       """
     And the following job "footwear_attribute_import" configuration:
       | filePath | %file to import% |
@@ -73,7 +72,6 @@ Feature: Import attributes
       type;code;label-en_US;group;unique;useable_as_grid_filter;localizable;scopable;allowed_extensions;metric_family;default_metric_unit
       pim_catalog_simpleselect;lace_color;"New lace color";colors;0;1;0;0;;;
       pim_catalog_metric;new_length;"New length";info;0;0;0;0;;Length;INVALID_LENGTH
-
       """
     And the following job "footwear_attribute_import" configuration:
       | filePath | %file to import% |
@@ -95,7 +93,6 @@ Feature: Import attributes
       type;code;label-en_US;group;unique;useable_as_grid_filter;localizable;scopable;allowed_extensions;metric_family;default_metric_unit
       pim_catalog_simpleselect;lace_color;"New lace color";colors;0;1;0;0;;;
       pim_catalog_metric;length;"New length";info;0;0;0;0;;Length;INVALID_LENGTH
-
       """
     And the following job "footwear_attribute_import" configuration:
       | filePath | %file to import% |
@@ -149,7 +146,6 @@ Feature: Import attributes
       """
       type;code;label-de_DE;label-en_US;label-fr_FR;group;unique;useable_as_grid_filter;allowed_extensions;metric_family;default_metric_unit;reference_data_name;localizable;scopable;available_locales;sort_order;max_characters;validation_rule;validation_regexp;wysiwyg_enabled;number_min;number_max;decimals_allowed;negative_allowed;date_min;date_max;metric_family;default_metric_unit;max_file_size;allowed_extensions
       pim_catalog_simpleselect;manufacturer;Meine große Code;My awesome code;Mon super code;marketing;0;1;;;;;0;0;en_US,fr_FR;3;300;validation_rule;;1;3;5;true;true;2000-12-12;2015-08-08;;EUR;452;jpg
-
       """
     And the following job "footwear_attribute_import" configuration:
       | filePath | %file to import% |
@@ -169,7 +165,6 @@ Feature: Import attributes
       """
       type;code;label-de_DE;label-en_US;label-fr_FR;group;unique;useable_as_grid_filter;allowed_extensions;metric_family;default_metric_unit;reference_data_name;localizable;scopable;available_locales;sort_order;max_characters;validation_rule;validation_regexp;wysiwyg_enabled;number_min;number_max;decimals_allowed;negative_allowed;date_min;date_max;metric_family;default_metric_unit;max_file_size;allowed_extensions
       pim_catalog_simpleselect;manufacturer;Meine große Code;My awesome code;Mon super code;marketing;0;1;;family;;;0;0;en_US,fr_FR;3;300;validation_rule;;1;3;5;true;true;2000/12/12;2015/08/08;;EUR;452;jpg
-
       """
     And the following job "footwear_attribute_import" configuration:
       | filePath | %file to import% |
@@ -187,7 +182,6 @@ Feature: Import attributes
       """
       type;code;label-de_DE;label-en_US;label-fr_FR;group;unique;useable_as_grid_filter;allowed_extensions;metric_family;default_metric_unit;reference_data_name;localizable;scopable;available_locales;sort_order;max_characters;validation_rule;validation_regexp;wysiwyg_enabled;number_min;number_max;decimals_allowed;negative_allowed;date_min;date_max;metric_family;default_metric_unit;max_file_size;allowed_extensions
       pim_catalog_simpleselect;manufacturer;Meine große Code;My awesome code;Mon super code;marketing;0;1;;family;;;0;0;en_US,fr_FR;3;300;validation_rule;;1;3;5;true;true;2000-99-12;2015/08/08;;EUR;452;jpg
-
       """
     And the following job "footwear_attribute_import" configuration:
       | filePath | %file to import% |
@@ -206,7 +200,6 @@ Feature: Import attributes
       type;code;label-de_DE;label-en_US;label-fr_FR;group;unique;useable_as_grid_filter;allowed_extensions;metric_family;default_metric_unit;reference_data_name;localizable;scopable;available_locales;sort_order;max_characters;validation_rule;validation_regexp;wysiwyg_enabled;number_min;number_max;decimals_allowed;negative_allowed;date_min;date_max;metric_family;default_metric_unit;max_file_size;allowed_extensions
       pim_catalog_image;media_code;Meine große Code;My awesome code;Mon super code;marketing;0;1;;family;;;0;0;en_US,fr_FR;3;300;validation_rule;;1;3;5;true;true;2000-08-08;2015-08-08;;EUR;not an int;jpg
       pim_catalog_image;media_code;Meine große Code;My awesome code;Mon super code;not a group;0;1;;family;;;0;0;en_US,fr_FR;3;300;validation_rule;;1;3;5;true;true;2000-08-08;2015-08-08;;EUR;not an int;jpg
-
       """
     And the following job "footwear_attribute_import" configuration:
       | filePath | %file to import% |
@@ -225,7 +218,6 @@ Feature: Import attributes
       """
       type;code;label-de_DE;label-en_US;label-fr_FR;group;unique;useable_as_grid_filter;allowed_extensions;metric_family;default_metric_unit;reference_data_name;localizable;scopable;available_locales;sort_order;max_characters;validation_rule;validation_regexp;wysiwyg_enabled;number_min;number_max;decimals_allowed;negative_allowed;date_min;date_max;metric_family;default_metric_unit;max_file_size;allowed_extensions
       pim_catalog_simpleselect;myawesomecode;Meine große Code;My awesome code;Mon super code;marketing;0;1;;;;;0;0;en_US,fr_FR;3;300;validation_rule;;1;3;5;true;true;2000-12-12;2015-08-08;;EUR;452;jpg
-
       """
     And the following job "footwear_attribute_import" configuration:
       | filePath | %file to import% |
@@ -245,7 +237,6 @@ Feature: Import attributes
       """
       type;code;label-en_US;group;unique;useable_as_grid_filter;localizable;scopable;allowed_extensions;metric_family;default_metric_unit
       pim_catalog_text;sku;SKU;info;0;1;1;0;;;
-
       """
     And the following job "footwear_attribute_import" configuration:
       | filePath | %file to import% |
@@ -257,3 +248,28 @@ Feature: Import attributes
     Then I should see "attributeType: This property cannot be changed.: SKU"
     Then I should see "localizable: This property cannot be changed.: SKU"
     Then I should see "unique: This property cannot be changed.: SKU"
+
+  Scenario: Only set min_number and max_number when field is filled
+    Given the "footwear" catalog configuration
+    And I am logged in as "Julia"
+    And the following CSV file to import:
+      """
+      type;code;label-en_US;group;unique;useable_as_grid_filter;localizable;scopable;negative_allowed;number_min;number_max
+      pim_catalog_number;number;number1;info;0;1;0;0;1;;
+      pim_catalog_number;number_with_min;number2;info;0;1;0;0;1;-10;
+      pim_catalog_number;number_with_max;number3;info;0;1;0;0;1;;10
+      pim_catalog_number;number_with_min_max;number4;info;0;1;0;0;1;-10;10
+      """
+    And the following job "footwear_attribute_import" configuration:
+      | filePath | %file to import% |
+    When I am on the "footwear_attribute_import" import job page
+    And I launch the import job
+    And I wait for the "footwear_attribute_import" job to finish
+    Then I should see "read lines 4"
+    Then I should see "created 4"
+    And there should be the following attributes:
+      | type   | code                | label-en_US | group | unique | useable_as_grid_filter | localizable | scopable | number_min | number_max |
+      | number | number              | number1     | info  | 0      | 1                      | 0           | 0        |            |            |
+      | number | number_with_min     | number2     | info  | 0      | 1                      | 0           | 0        | -10        |            |
+      | number | number_with_max     | number3     | info  | 0      | 1                      | 0           | 0        |            | 10         |
+      | number | number_with_min_max | number4     | info  | 0      | 1                      | 0           | 0        | -10        | 10         |

--- a/features/mass-action/validate/edit_common_attributes_permissions.feature
+++ b/features/mass-action/validate/edit_common_attributes_permissions.feature
@@ -1,0 +1,24 @@
+@javascript
+Feature: Edit common attributes with permissions
+  In order to update attributes with edit common attributes
+  As a product manager
+  I need to be able to add attributes with edit common attributes when I have no 'add attribute' permission
+
+  Background:
+    Given a "footwear" catalog configuration
+    And the following products:
+      | sku   | family |
+      | boots | boots  |
+
+  @jira https://akeneo.atlassian.net/browse/PIM-5727
+  Scenario: Successfully select attribute when user have no "add attributes" permission
+    Given I am logged in as "Mary"
+    And I am on the products page
+    And I mass-edit products boots
+    When I choose the "Edit common attributes" operation
+    Then I should see the text "Select attributes"
+    And I display the Name attribute
+    And I change the "Name" to "boots"
+    And I move on to the next step
+    And I wait for the "edit-common-attributes" mass-edit job to finish
+    And the english name of "boots" should be "boots"

--- a/features/product/create_product_and_save_added_attributes.feature
+++ b/features/product/create_product_and_save_added_attributes.feature
@@ -1,0 +1,32 @@
+@javascript
+Feature: Create product and save a new product value
+  In order to enrich a new product
+  As a product manager
+  I need to be able to create a product, add attributes and save
+
+  @jira https://akeneo.atlassian.net/browse/PIM-5666
+  Scenario: Successfully create a product, fill in product values with 0 and save
+    Given a "footwear" catalog configuration
+    And the following attributes:
+      | code      | label     | type   | group     |
+      | tmp_price | Tmp Price | prices | marketing |
+    And I am logged in as "Julia"
+    And I am on the products page
+    And I create a new product
+    And I fill in the following information in the popin:
+      | SKU             | gladiator |
+      | Choose a family | Sandals   |
+    And I press the "Save" button in the popin
+    And I am on the "gladiator" product page
+    And I add available attributes Rate of sale, Weight and Tmp Price
+    And I visit the "Product information" group
+    And I fill in "Weight" with "0"
+    And I visit the "Marketing" group
+    And I fill in "Rate of sale" with "0"
+    And I fill in the following information:
+      | Tmp Price | 0 EUR |
+    And I save the product
+    Then the product "gladiator" should have the following values:
+      | rate_sale | 0           |
+      | tmp_price | 0.00 EUR    |
+      | weight    | 0.0000 GRAM |

--- a/spec/Akeneo/Component/Localization/Presenter/BooleanPresenterSpec.php
+++ b/spec/Akeneo/Component/Localization/Presenter/BooleanPresenterSpec.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace spec\Akeneo\Component\Localization\Presenter;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class BooleanPresenterSpec extends ObjectBehavior
+{
+    function let()
+    {
+        $this->beConstructedWith(['enabled']);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Akeneo\Component\Localization\Presenter\BooleanPresenter');
+    }
+
+    function it_supports_enabled()
+    {
+        $this->supports('enabled')->shouldReturn(true);
+        $this->supports('yolo')->shouldReturn(false);
+    }
+
+    function it_presents_values()
+    {
+        $this->present(true)->shouldReturn('true');
+        $this->present('true')->shouldReturn('true');
+        $this->present('1')->shouldReturn('true');
+        $this->present(1)->shouldReturn('true');
+        $this->present(false)->shouldReturn('false');
+        $this->present('false')->shouldReturn('false');
+        $this->present('0')->shouldReturn('false');
+        $this->present(0)->shouldReturn('false');
+        $this->present('yolo')->shouldReturn('');
+    }
+}

--- a/spec/Pim/Component/Catalog/Comparator/Attribute/NumberComparatorSpec.php
+++ b/spec/Pim/Component/Catalog/Comparator/Attribute/NumberComparatorSpec.php
@@ -61,4 +61,12 @@ class NumberComparatorSpec extends ObjectBehavior
 
         $this->compare($changes, $originals)->shouldReturn(null);
     }
+
+    function it_returns_changes_if_it_compares_0_to_null()
+    {
+        $changes   = ['data' => 0, 'locale' => 'en_US', 'scope' => 'ecommerce'];
+        $originals = ['data' => null, 'locale' => null, 'scope' => null];
+
+        $this->compare($changes, $originals)->shouldReturn($changes);
+    }
 }

--- a/spec/Pim/Component/Connector/ArrayConverter/Flat/AttributeStandardConverterSpec.php
+++ b/spec/Pim/Component/Connector/ArrayConverter/Flat/AttributeStandardConverterSpec.php
@@ -93,4 +93,34 @@ class AttributeStandardConverterSpec extends ObjectBehavior
 
         $this->convert($item)->shouldReturn($result);
     }
+
+    function it_fills_options_only_when_not_blank()
+    {
+        $itemBlank = [
+            'attributeType' => 'pim_catalog_integer',
+            'code'          => 'num',
+            'number_min'    => '',
+            'number_max'    => '',
+        ];
+        $itemFilled = [
+            'attributeType' => 'pim_catalog_integer',
+            'code'          => 'num',
+            'number_min'    => '12',
+            'number_max'    => '15',
+        ];
+        $this->convert($itemBlank)->shouldReturn([
+            'labels'        => [],
+            'attributeType' => 'pim_catalog_integer',
+            'code'          => 'num',
+            'number_min'    => null,
+            'number_max'    => null,
+        ]);
+        $this->convert($itemFilled)->shouldReturn([
+            'labels'        => [],
+            'attributeType' => 'pim_catalog_integer',
+            'code'          => 'num',
+            'number_min'    => 12.0,
+            'number_max'    => 15.0,
+        ]);
+    }
 }

--- a/src/Akeneo/Component/Localization/Presenter/BooleanPresenter.php
+++ b/src/Akeneo/Component/Localization/Presenter/BooleanPresenter.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Akeneo\Component\Localization\Presenter;
+
+/**
+ * Boolean presenter, able to render booleans readable for a human.
+ *
+ * @author    Pierre Allard <pierre.allard@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class BooleanPresenter implements PresenterInterface
+{
+    /** @var string[] */
+    protected $allowedFields;
+
+    /**
+     * @param string[] $allowedFields
+     */
+    public function __construct(array $allowedFields)
+    {
+        $this->allowedFields = $allowedFields;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function present($value, array $options = [])
+    {
+        if (in_array($value, [true, 'true', '1', 1], true)) {
+            return 'true';
+        }
+        if (in_array($value, [false, 'false', '0', 0], true)) {
+            return 'false';
+        }
+
+        return '';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports($fieldCode)
+    {
+        return in_array($fieldCode, $this->allowedFields);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/GroupsFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/GroupsFilter.php
@@ -61,12 +61,10 @@ class GroupsFilter extends AbstractFilter implements FieldFilterInterface
                 $this->qb->expr()->in($entityAlias . '.id', $value)
             );
         } elseif ($operator === Operators::NOT_IN_LIST) {
-            $this->qb->andWhere(
-                $this->qb->expr()->orX(
-                    $this->qb->expr()->notIn($entityAlias . '.id', $value),
-                    $this->qb->expr()->isNull($entityAlias . '.id')
-                )
-            );
+            $this->qb->andWhere($this->qb->expr()->notIn(
+                $rootAlias . '.id',
+                $this->getNotInSubquery(FieldFilterHelper::getCode($field), $value)
+            ));
         } elseif ($operator === Operators::IS_EMPTY) {
             $this->qb->andWhere(
                 $this->qb->expr()->isNull($entityAlias.'.id')
@@ -82,6 +80,32 @@ class GroupsFilter extends AbstractFilter implements FieldFilterInterface
     public function supportsField($field)
     {
         return in_array($field, $this->supportedFields);
+    }
+
+    /**
+     * Subquery matching all products that actually have one of $value groups
+     *
+     * @param string $field
+     * @param array  $value
+     *
+     * @return string
+     */
+    protected function getNotInSubquery($field, $value)
+    {
+        $notInQb      = $this->qb->getEntityManager()->createQueryBuilder();
+        $rootEntity   = current($this->qb->getRootEntities());
+        $notInAlias   = $this->getUniqueAlias('productsNotIn');
+        $joinAlias    = $this->getUniqueAlias('filter' . $field);
+
+        $notInQb->select($notInAlias . '.id')
+            ->from($rootEntity, $notInAlias, $notInAlias . '.id')
+            ->innerJoin(
+                sprintf('%s.%s', $notInQb->getRootAlias(), $field),
+                $joinAlias
+            )
+            ->where($notInQb->expr()->in($joinAlias . '.id', $value));
+
+        return $notInQb->getDQL();
     }
 
     /**

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/localization/presenters.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/localization/presenters.yml
@@ -5,6 +5,7 @@ parameters:
     pim_catalog.localization.presenter.metric.class:   Pim\Component\Catalog\Localization\Presenter\MetricPresenter
     pim_catalog.localization.presenter.number.class:   Akeneo\Component\Localization\Presenter\NumberPresenter
     pim_catalog.localization.presenter.date.class:     Akeneo\Component\Localization\Presenter\DatePresenter
+    pim_catalog.localization.presenter.boolean.class:  Akeneo\Component\Localization\Presenter\BooleanPresenter
 
 services:
     pim_catalog.localization.presenter.registry:
@@ -12,6 +13,7 @@ services:
         arguments:
             - '@pim_catalog.repository.attribute'
 
+    # Product values
     pim_catalog.localization.presenter.prices:
         class: %pim_catalog.localization.presenter.prices.class%
         arguments:
@@ -45,12 +47,23 @@ services:
         tags:
             - { name: pim_catalog.localization.presenter, type: 'product_value' }
 
+    # Product fields
     pim_catalog.localization.presenter.datetime:
         class: %pim_catalog.localization.presenter.date.class%
         arguments:
             - '@pim_catalog.localization.factory.datetime'
-            - []
+            - ['created_at', 'updated_at']
+        tags:
+            - { name: pim_catalog.localization.presenter, type: 'product_field' }
 
+    pim_catalog.localization.presenter.boolean:
+        class: %pim_catalog.localization.presenter.boolean.class%
+        arguments:
+            - ['enabled']
+        tags:
+            - { name: pim_catalog.localization.presenter, type: 'product_field' }
+
+    # Attribute options
     pim_catalog.localization.presenter.number.attribute_option:
         class: %pim_catalog.localization.presenter.number.class%
         arguments:

--- a/src/Pim/Bundle/DataGridBundle/Extension/Pager/Orm/Pager.php
+++ b/src/Pim/Bundle/DataGridBundle/Extension/Pager/Orm/Pager.php
@@ -99,7 +99,9 @@ class Pager extends AbstractPager implements PagerInterface
 
         $rootAlias  = $qb->getRootAlias();
         $rootField  = $rootAlias.'.id';
-        $qb->groupBy($rootField);
+        $qb->resetDQLPart('select')
+            ->select($rootField)
+            ->distinct(true);
 
         $qb->setFirstResult(null)
             ->setMaxResults(null)

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/metric-filter.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/metric-filter.js
@@ -137,24 +137,12 @@ define(
             /**
              * Empty value object
              *
-             * @property {0bject}
+             * @property {Object}
              */
             emptyValue: {
                 unit:  '',
                 type:  '',
                 value: ''
-            },
-
-            /**
-             * Check if all properties of the value have been specified or all are empty (for reseting filter)
-             *
-             * @param value
-             * @return boolean
-             */
-            _isValueValid: function(value) {
-                return (value.unit && value.type && !_.isUndefined(value.value)) ||
-                       (!value.unit && !value.type && _.isUndefined(value.value)) ||
-                       value.type === 'empty';
             },
 
             /**
@@ -201,14 +189,13 @@ define(
              */
             setValue: function(value) {
                 value = this._formatRawValue(value);
-                if (this._isValueValid(value)) {
-                    if (this._isNewValueUpdated(value)) {
-                        var oldValue = this.value;
-                        this.value = app.deepClone(value);
-                        this._updateDOMValue();
-                        this._onValueUpdated(this.value, oldValue);
-                    }
+                if (this._isNewValueUpdated(value)) {
+                    var oldValue = this.value;
+                    this.value = app.deepClone(value);
+                    this._updateDOMValue();
+                    this._onValueUpdated(this.value, oldValue);
                 }
+
                 return this;
             },
 
@@ -223,6 +210,16 @@ define(
                 } else {
                     parentDiv.find('input[name="value"], .btn-group:eq(1)').show();
                 }
+            },
+
+            /**
+             * @inheritDoc
+             */
+            reset: function() {
+                this.setValue(this.emptyValue);
+                this.trigger('update');
+
+                return this;
             }
         });
     }

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/price-filter.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/price-filter.js
@@ -131,7 +131,7 @@ define(
             /**
              * Empty value object
              *
-             * @property {0bject}
+             * @property {Object}
              */
             emptyValue: {
                 currency: '',
@@ -195,14 +195,13 @@ define(
              */
             setValue: function(value) {
                 value = this._formatRawValue(value);
-                if (this._isValueValid(value)) {
-                    if (this._isNewValueUpdated(value)) {
-                        var oldValue = this.value;
-                        this.value = app.deepClone(value);
-                        this._updateDOMValue();
-                        this._onValueUpdated(this.value, oldValue);
-                    }
+                if (this._isNewValueUpdated(value)) {
+                    var oldValue = this.value;
+                    this.value = app.deepClone(value);
+                    this._updateDOMValue();
+                    this._onValueUpdated(this.value, oldValue);
                 }
+
                 return this;
             },
 
@@ -219,6 +218,16 @@ define(
                         parentDiv.find('input[name="value"]').show();
                     }
                 }
+            },
+
+            /**
+             * @inheritDoc
+             */
+            reset: function() {
+                this.setValue(this.emptyValue);
+                this.trigger('update');
+
+                return this;
             }
         });
     }

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/select2-choice-filter.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/select2-choice-filter.js
@@ -6,9 +6,10 @@ define(
         'routing',
         'text!pim/template/datagrid/filter/select2-choice-filter',
         'pim/initselect2',
+        'pim/user-context',
         'jquery.select2'
     ],
-    function($, _, TextFilter, Routing, template, initSelect2) {
+    function($, _, TextFilter, Routing, template, initSelect2, UserContext) {
         'use strict';
 
         return TextFilter.extend({
@@ -91,7 +92,8 @@ define(
                                 search: term,
                                 options: {
                                     limit: this.resultsPerPage,
-                                    page: page
+                                    page: page,
+                                    locale: UserContext.get('catalogLocale')
                                 }
                             };
                         }, this),

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product_group.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product_group.yml
@@ -127,13 +127,3 @@ datagrid:
                     options:
                         field_options:
                             choices: '@pim_catalog.manager.channel->getChannelChoices'
-                category:
-                    type:      product_category
-                    label:     Category
-                    data_name: category
-            default:
-                category:
-                    value:
-                        treeId: %pim_filter.product_category_filter.class%::UNKNOWN_TREE
-                        categoryId: %pim_filter.product_category_filter.class%::ALL_CATEGORY
-                    type: %pim_filter.product_category_filter.class%::DEFAULT_TYPE

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product_variant_group.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product_variant_group.yml
@@ -128,13 +128,3 @@ datagrid:
                     options:
                         field_options:
                             choices: '@pim_catalog.manager.channel->getChannelChoices'
-                category:
-                    type:      product_category
-                    label:     Category
-                    data_name: category
-            default:
-                category:
-                    value:
-                        treeId: %pim_filter.product_category_filter.class%::UNKNOWN_TREE
-                        categoryId: %pim_filter.product_category_filter.class%::ALL_CATEGORY
-                    type: %pim_filter.product_category_filter.class%::DEFAULT_TYPE

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/mass_product_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/mass_product_edit.yml
@@ -24,7 +24,6 @@ extensions:
         module: pim/mass-product-edit-form/add-attribute
         parent: pim-mass-product-edit-form-attributes
         targetZone: other-actions
-        aclResourceId: pim_enrich_product_add_attribute
         position: 90
 
     pim-mass-product-edit-form-validation:

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/multi-select-field.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/multi-select-field.js
@@ -16,9 +16,10 @@ define(
         'routing',
         'pim/attribute-option/create',
         'pim/security-context',
-        'pim/initselect2'
+        'pim/initselect2',
+        'pim/user-context'
     ],
-    function ($, Field, _, fieldTemplate, Routing, createOption, SecurityContext, initSelect2) {
+    function ($, Field, _, fieldTemplate, Routing, createOption, SecurityContext, initSelect2, UserContext) {
         return Field.extend({
             fieldTemplate: _.template(fieldTemplate),
             choicePromise: null,
@@ -75,7 +76,12 @@ define(
                             url: choiceUrl,
                             cache: true,
                             data: function (term) {
-                                return {search: term};
+                                return {
+                                    search: term,
+                                    options: {
+                                        locale: UserContext.get('catalogLocale')
+                                    }
+                                };
                             },
                             results: function (data) {
                                 return data;

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/simple-select-field.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/simple-select-field.js
@@ -16,9 +16,10 @@ define(
         'routing',
         'pim/attribute-option/create',
         'pim/security-context',
-        'pim/initselect2'
+        'pim/initselect2',
+        'pim/user-context'
     ],
-    function ($, Field, _, fieldTemplate, Routing, createOption, SecurityContext, initSelect2) {
+    function ($, Field, _, fieldTemplate, Routing, createOption, SecurityContext, initSelect2, UserContext) {
         return Field.extend({
             fieldTemplate: _.template(fieldTemplate),
             choicePromise: null,
@@ -74,7 +75,12 @@ define(
                             url: choiceUrl,
                             cache: true,
                             data: function (term) {
-                                return {search: term};
+                                return {
+                                    search: term,
+                                    options: {
+                                        locale: UserContext.get('catalogLocale')
+                                    }
+                                };
                             },
                             results: function (data) {
                                 return data;

--- a/src/Pim/Bundle/FilterBundle/Filter/DatasourceFilterUtilityInterface.php
+++ b/src/Pim/Bundle/FilterBundle/Filter/DatasourceFilterUtilityInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Pim\Bundle\FilterBundle\Filter;
+
+use Oro\Bundle\DataGridBundle\Datasource\DatasourceInterface;
+
+/**
+ * Used when you want to apply the filter from the outside, for example from a listener that access the datasource
+ *
+ * @author    Clement Gautier <clement.gautier@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface DatasourceFilterUtilityInterface
+{
+    /**
+     * Applies a filter on a datasource
+     *
+     * @param DatasourceInterface $ds
+     * @param string              $field
+     * @param string              $operator
+     * @param mixed               $value
+     */
+    public function filterDatasource(DatasourceInterface $ds, $field, $operator, $value);
+}

--- a/src/Pim/Bundle/FilterBundle/Filter/ProductFilterUtility.php
+++ b/src/Pim/Bundle/FilterBundle/Filter/ProductFilterUtility.php
@@ -2,8 +2,10 @@
 
 namespace Pim\Bundle\FilterBundle\Filter;
 
+use Oro\Bundle\DataGridBundle\Datasource\DatasourceInterface;
 use Oro\Bundle\FilterBundle\Datasource\FilterDatasourceAdapterInterface;
 use Oro\Bundle\FilterBundle\Filter\FilterUtility as BaseFilterUtility;
+use Pim\Bundle\DataGridBundle\Datasource\ProductDatasource;
 
 /**
  * Product filter utility
@@ -12,7 +14,7 @@ use Oro\Bundle\FilterBundle\Filter\FilterUtility as BaseFilterUtility;
  * @copyright 2013 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class ProductFilterUtility extends BaseFilterUtility
+class ProductFilterUtility extends BaseFilterUtility implements DatasourceFilterUtilityInterface
 {
     /**
      * Applies filter to query by attribute
@@ -24,6 +26,18 @@ class ProductFilterUtility extends BaseFilterUtility
      */
     public function applyFilter(FilterDatasourceAdapterInterface $ds, $field, $operator, $value)
     {
+        $ds->getProductQueryBuilder()->addFilter($field, $operator, $value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function filterDatasource(DatasourceInterface $ds, $field, $operator, $value)
+    {
+        if (!$ds instanceof ProductDatasource) {
+            throw new \RuntimeException(sprintf('Expected ProductDatasource, "%s" given ', get_class($ds)));
+        }
+
         $ds->getProductQueryBuilder()->addFilter($field, $operator, $value);
     }
 }

--- a/src/Pim/Component/Catalog/Comparator/Attribute/NumberComparator.php
+++ b/src/Pim/Component/Catalog/Comparator/Attribute/NumberComparator.php
@@ -48,6 +48,10 @@ class NumberComparator implements ComparatorInterface
             return $data;
         }
 
+        if (null !== $data['data'] && null === $originals['data']) {
+            return $data;
+        }
+
         return (float) $data['data'] !== (float) $originals['data'] ? $data : null;
     }
 }

--- a/src/Pim/Component/Catalog/Localization/Presenter/PresenterRegistry.php
+++ b/src/Pim/Component/Catalog/Localization/Presenter/PresenterRegistry.php
@@ -3,6 +3,7 @@
 namespace Pim\Component\Catalog\Localization\Presenter;
 
 use Akeneo\Component\Localization\Presenter\PresenterInterface;
+use Pim\Bundle\CatalogBundle\AttributeType\AttributeTypes;
 use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
 
 /**
@@ -16,6 +17,8 @@ use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
 class PresenterRegistry implements PresenterRegistryInterface
 {
     const TYPE_PRODUCT_VALUE = 'product_value';
+
+    const TYPE_PRODUCT_FIELD = 'product_field';
 
     const TYPE_ATTRIBUTE_OPTION = 'attribute_option';
 
@@ -67,6 +70,14 @@ class PresenterRegistry implements PresenterRegistryInterface
     public function getAttributeOptionPresenter($optionName)
     {
         return $this->getPresenter($optionName, self::TYPE_ATTRIBUTE_OPTION);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPresenterByFieldCode($code)
+    {
+        return $this->getPresenter($code, self::TYPE_PRODUCT_FIELD);
     }
 
     /**

--- a/src/Pim/Component/Catalog/Localization/Presenter/PresenterRegistryInterface.php
+++ b/src/Pim/Component/Catalog/Localization/Presenter/PresenterRegistryInterface.php
@@ -33,6 +33,15 @@ interface PresenterRegistryInterface
     public function getPresenterByAttributeCode($code);
 
     /**
+     * Get the first presenter supporting a field code
+     *
+     * @param string $code
+     *
+     * @return PresenterInterface|null
+     */
+    public function getPresenterByFieldCode($code);
+
+    /**
      * Get the first presenter supporting an attribute option
      *
      * @param string $optionName

--- a/src/Pim/Component/Connector/ArrayConverter/Flat/AttributeStandardConverter.php
+++ b/src/Pim/Component/Connector/ArrayConverter/Flat/AttributeStandardConverter.php
@@ -103,11 +103,11 @@ class AttributeStandardConverter implements StandardArrayConverterInterface
             case 'number_min':
             case 'number_max':
             case 'max_file_size':
-                $convertedItem[$field] = (float) $data;
+                $convertedItem[$field] = ('' === $data) ? null : (float) $data;
                 break;
             case 'sort_order':
             case 'max_characters':
-                $convertedItem[$field] = (int) $data;
+                $convertedItem[$field] = ('' === $data) ? null : (int) $data;
                 break;
             case 'options':
             case 'available_locales':


### PR DESCRIPTION
<3 Thanks for taking the time to contribute! You're awesome! <3

De nada

**Description (for Contributor and Core Developer)**

When you import attributes and set min_number and max_number as "empty" column, these properties are set to 0.
This PR fix it by checking before assign variable if column is empty or not (and fix it too for some other fields)

**Definition Of Done (for Core Developer only)**


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | n
| Added Behats                      | y
| Changelog updated                 | TODO
| Review and 2 GTM                  | TODO
| Micro Demo to the PO (Story only) | TODO
| Migration script                  | n
| Tech Doc                          | n

