### PR TITLE
PIM-5643 : Fix default system locale was not fixed by the last PIM-5643 ticket, tagged in 1.5.2

### DIFF
--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -24,6 +24,10 @@
 - PIM-5762: Removed unused category filters on product datagrids
 - Upgrade "akeneo/measure-bundle" from "0.4.1" to "0.5.0", details in the release note https://github.com/akeneo/MeasureBundle/releases/tag/0.5.0
 
+## Bug fixes
+
+- PIM-5643: Fix default system locale was not fixed by the last PIM-5643 ticket, tagged in 1.5.2
+
 # 1.5.2 (2016-04-25)
 
 ## Bug fixes

--- a/features/Context/Page/Base/Base.php
+++ b/features/Context/Page/Base/Base.php
@@ -219,12 +219,16 @@ class Base extends Page
     {
         // Search with exact name at first
         $button = $this->find('xpath', sprintf("//button[text() = '%s']", $locator));
-
-        if (!$button) {
+        
+        if (null === $button) {
             $button = $this->find('xpath', sprintf("//a[text() = '%s']", $locator));
         }
 
-        if (!$button) {
+        if (null === $button) {
+            $button = $this->find('css', sprintf('a[title="%s"]', $locator));
+        }
+
+        if (null === $button) {
             // Use Mink search, which use "contains" xpath condition
             $button = $this->findButton($locator);
         }

--- a/features/Context/WebUser.php
+++ b/features/Context/WebUser.php
@@ -1438,7 +1438,9 @@ class WebUser extends RawMinkContext
      */
     public function iShouldSeeTheButton($button)
     {
-        $this->getCurrentPage()->getButton($button);
+        $this->getMainContext()->spin(function () use ($button) {
+            return $this->getCurrentPage()->getButton($button);
+        }, sprintf("Can not find any '%s' button", $button));
     }
 
     /**

--- a/features/locale/change_system_locale.feature
+++ b/features/locale/change_system_locale.feature
@@ -27,7 +27,8 @@ Feature: Change system locale
     Then I should see the text "Successfully updated"
     Then I logout
     Then I should see the "Anmelden" button
-    Given I edit the system configuration
+    When I am logged in as "Julia"
+    And I edit the system configuration
     And I select fr_FR locale
     And I save the configuration
     Then I should see the text "Successfully updated"

--- a/src/Pim/Bundle/LocalizationBundle/DependencyInjection/Configuration.php
+++ b/src/Pim/Bundle/LocalizationBundle/DependencyInjection/Configuration.php
@@ -21,19 +21,31 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
-
-        $treeBuilder
+        $rootNode = $treeBuilder
             ->root('pim_localization')
-            ->children()
-                ->arrayNode('settings')
                 ->children()
                     ->arrayNode('language')
                     ->children()
-                        ->scalarNode('value')->defaultNull()->end()
+                        ->scalarNode('value')->defaultValue('en')->end()
                         ->scalarNode('scope')->defaultValue('app')->end()
                     ->end()
                 ->end()
             ->end();
+
+        $builder = new TreeBuilder();
+        $node    = $builder
+            ->root('settings')
+            ->addDefaultsIfNotSet()
+            ->children()
+                ->arrayNode('language')
+                ->addDefaultsIfNotSet()
+                ->children()
+                    ->scalarNode('value')->defaultValue('en')->end()
+                    ->scalarNode('scope')->defaultValue('app')->end()
+                ->end()
+            ->end();
+
+        $rootNode->children()->append($node->end());
 
         return $treeBuilder;
     }


### PR DESCRIPTION
Backport of this fix https://github.com/akeneo/pim-community-dev/commit/5d326e2ea654e5bba955e7e776c0853c267863f4