### PR TITLE
PIM-5714: Enforce coupling rules on PIM Catalog component - Part I - Reference Data

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -258,3 +258,10 @@
 - Remove methods `getConfiguration()`, `setConfiguration()` from `Akeneo\Component\Batch\Step\ItemStep`
 - Injects `Symfony\Component\DependencyInjection\ContainerInterface` in constructor of `Akeneo\Component\Batch\Updater\JobInstanceUpdater`, `Pim\Bundle\BaseConnectorBundle\Archiver\ArchivableFileWriterArchiver`, `Pim\Bundle\BaseConnectorBundle\Archiver\FileReaderArchiver`, `Pim\Bundle\BaseConnectorBundle\Archiver\FileWriterArchiver`, `Pim\Component\Connector\Processor\Denormalization\JobInstanceProcessor` (avoid a cricular reference due to ConnectorRegistry, should be fixed with TIP-418 by re-working the way we build Jobs)
 - Remove argument array $configuration from `Pim\Component\Connector\Step\TaskletInterface::execute()`, we can access to the JobParameters from the StepExecution $stepExecution
+- Change constructor of `Pim\Component\Catalog\Updater\AttributeUpdater`, remove `Pim\Component\ReferenceData\ConfigurationRegistryInterface` and the list of reference data types
+- Move class `Pim\Component\Catalog\Normalizer\Structured\ReferenceDataNormalizer` to `Pim\Component\ReferenceData\Normalizer\Structured\ReferenceDataNormalizer`
+- Move class `Pim\Component\Connector\Normalizer\Flat\ReferenceDataNormalizer` to `Pim\Component\ReferenceData\Normalizer\Flat\ReferenceDataNormalizer`
+- Move class `Pim\Component\Catalog\Denormalizer\Structured\ProductValue\ReferenceDataDenormalizer` to `Pim\Component\ReferenceData\Denormalizer\Structured\ProductValue\ReferenceDataDenormalizer`
+- Move class `Pim\Component\Catalog\Denormalizer\Structured\ProductValue\ReferenceDataCollectionDenormalizer` to `Pim\Component\ReferenceData\Denormalizer\Structured\ProductValue\ReferenceDataCollectionDenormalizer`
+- Move class `Pim\Component\Connector\Denormalizer\Flat\ProductValue\ReferenceDataDenormalizer` to `Pim\Component\ReferenceData\Denormalizer\Flat\ProductValue\ReferenceDataDenormalizer`
+- Move class `Pim\Component\Connector\Denormalizer\Flat\ProductValue\ReferenceDataCollectionDenormalizer` to `Pim\Component\ReferenceData\Denormalizer\Flat\ProductValue\ReferenceDataCollectionDenormalizer`

--- a/UPGRADE-1.6.md
+++ b/UPGRADE-1.6.md
@@ -145,4 +145,10 @@ Based on a PIM standard installation, execute the following command in your proj
     find ./src/ -type f -print0 | xargs -0 sed -i 's/Pim\\Bundle\\BaseConnectorBundle\\Processor\\Normalization\\VariantGroupProcessor/Pim\\Component\\Connector\\Processor\\Normalization\\VariantGroupProcessor/g'
     find ./src/ -type f -print0 | xargs -0 sed -i 's/Akeneo\\Bundle\\BatchBundle\\Job\\JobFactory/Akeneo\\Component\\Batch\\Job\\JobFactory/g'
     find ./src/ -type f -print0 | xargs -0 sed -i 's/Akeneo\\Bundle\\BatchBundle\\Step\\StepFactory/Akeneo\\Component\\Batch\\Step\\StepFactory/g'
+    find ./src/ -type f -print0 | xargs -0 sed -i 's/Pim\\Component\\Catalog\\Normalizer\\Structured\\ReferenceDataNormalizer/Pim\\Component\\ReferenceData\\Normalizer\\Structured\\ReferenceDataNormalizer/g'
+    find ./src/ -type f -print0 | xargs -0 sed -i 's/Pim\\Component\\Connector\\Normalizer\\Flat\\ReferenceDataNormalizer/Pim\\Component\\ReferenceData\\Normalizer\\Flat\\ReferenceDataNormalizer/g'
+    find ./src/ -type f -print0 | xargs -0 sed -i 's/Pim\\Component\\Catalog\\Denormalizer\\Structured\\ProductValue\\ReferenceDataDenormalizer/Pim\\Component\\ReferenceData\\Denormalizer\\Structured\\ProductValue\\ReferenceDataDenormalizer/g'
+    find ./src/ -type f -print0 | xargs -0 sed -i 's/Pim\\Component\\Catalog\\Denormalizer\\Structured\\ProductValue\\ReferenceDataCollectionDenormalizer/Pim\\Component\\ReferenceData\\Denormalizer\\Structured\\ProductValue\\ReferenceDataCollectionDenormalizer/g'
+    find ./src/ -type f -print0 | xargs -0 sed -i 's/Pim\\Component\\Connector\\Denormalizer\\Flat\\ProductValue\\ReferenceDataDenormalizer/Pim\\Component\\ReferenceData\\Denormalizer\\Flat\\ProductValue\\ReferenceDataDenormalizer/g'
+    find ./src/ -type f -print0 | xargs -0 sed -i 's/Pim\\Component\\Connector\\Denormalizer\\Flat\\ProductValue\\ReferenceDataCollectionDenormalizer/Pim\\Component\\ReferenceData\\Denormalizer\\Flat\\ProductValue\\ReferenceDataCollectionDenormalizer/g'
 ```

--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -14,7 +14,7 @@ class AppKernel extends Kernel
 {
     /**
      * Registers your custom bundles
-     * 
+     *
      * @return array
      */
     protected function registerProjectBundles()
@@ -24,7 +24,7 @@ class AppKernel extends Kernel
             new Acme\Bundle\AppBundle\AcmeAppBundle(),
         ];
     }
-    
+
     /**
      * {@inheritdoc}
      */

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/serializers.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/serializers.yml
@@ -23,7 +23,6 @@ parameters:
     pim_serializer.normalizer.product_price.class:          Pim\Component\Catalog\Normalizer\Structured\ProductPriceNormalizer
     pim_serializer.normalizer.product_values.class:         Pim\Component\Catalog\Normalizer\Structured\ProductValuesNormalizer
     pim_serializer.normalizer.product_value.class:          Pim\Component\Catalog\Normalizer\Structured\ProductValueNormalizer
-    pim_serializer.normalizer.reference_data.class:         Pim\Component\Catalog\Normalizer\Structured\ReferenceDataNormalizer
     pim_serializer.normalizer.file.class:                   Pim\Component\Catalog\Normalizer\Structured\FileNormalizer
 
     # Denormalizers
@@ -38,8 +37,6 @@ parameters:
     pim_serializer.denormalizer.datetime.class:                  Pim\Component\Catalog\Denormalizer\Structured\ProductValue\DateTimeDenormalizer
     pim_serializer.denormalizer.file.class:                      Pim\Component\Catalog\Denormalizer\Structured\ProductValue\FileDenormalizer
     pim_serializer.denormalizer.boolean.class:                   Pim\Component\Catalog\Denormalizer\Structured\ProductValue\BooleanDenormalizer
-    pim_serializer.denormalizer.reference_data.class:            Pim\Component\Catalog\Denormalizer\Structured\ProductValue\ReferenceDataDenormalizer
-    pim_serializer.denormalizer.reference_data_collection.class: Pim\Component\Catalog\Denormalizer\Structured\ProductValue\ReferenceDataCollectionDenormalizer
 
 services:
     # Serializer, TODO : should be moved somewhere else
@@ -76,11 +73,6 @@ services:
         class: %pim_serializer.normalizer.product_value.class%
         arguments:
             - '@pim_catalog.localization.localizer.registry'
-        tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
-
-    pim_serializer.normalizer.reference_data:
-        class: %pim_serializer.normalizer.reference_data.class%
         tags:
             - { name: pim_serializer.normalizer, priority: 90 }
 
@@ -256,21 +248,5 @@ services:
         class: %pim_serializer.denormalizer.boolean.class%
         arguments:
             - ['pim_catalog_boolean']
-        tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
-
-    pim_serialize.denormalizer.reference_data:
-        class: %pim_serializer.denormalizer.reference_data.class%
-        arguments:
-            - ['pim_reference_data_simpleselect']
-            - '@?pim_reference_data.repository_resolver'
-        tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
-
-    pim_serialize.denormalizer.reference_data_collection:
-        class: %pim_serializer.denormalizer.reference_data_collection.class%
-        arguments:
-            - ['pim_reference_data_multiselect']
-            - '@pim_serialize.denormalizer.reference_data'
         tags:
             - { name: pim_serializer.normalizer, priority: 90 }

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/updaters.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/updaters.yml
@@ -110,9 +110,7 @@ services:
         class: %pim_catalog.updater.attribute.class%
         arguments:
             - '@pim_catalog.repository.attribute_group'
-            - ['pim_reference_data_multiselect', 'pim_reference_data_simpleselect']
             - '@pim_catalog.repository.locale'
-            - '@?pim_reference_data.registry'
 
     pim_catalog.updater.category:
         class: %akeneo_classification.updater.category.class%

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/validation/attribute.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/validation/attribute.yml
@@ -2,6 +2,7 @@ Pim\Bundle\CatalogBundle\Entity\Attribute:
     constraints:
         - Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity: code
         - Pim\Component\Catalog\Validator\Constraints\SingleIdentifierAttribute: ~
+        - Pim\Component\Catalog\Validator\Constraints\IsReferenceDataConfigured: ~
         - Pim\Component\Catalog\Validator\Constraints\Immutable:
             properties:
                 - code

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/validators.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/validators.yml
@@ -16,6 +16,7 @@ parameters:
     pim_catalog.validator.constraint.scopable_value.class:                 Pim\Component\Catalog\Validator\Constraints\ScopableValueValidator
     pim_catalog.validator.constraint.localizable_value.class:              Pim\Component\Catalog\Validator\Constraints\LocalizableValueValidator
     pim_catalog.validator.constraint.attribute_type_for_option.class:      Pim\Component\Catalog\Validator\Constraints\AttributeTypeForOptionValidator
+    pim_catalog.validator.constraint.is_reference_data_configured.class:   Pim\Component\Catalog\Validator\Constraints\IsReferenceDataConfiguredValidator
     pim_catalog.validator.constraint_guesser.chained.class:                Pim\Component\Catalog\Validator\ChainedAttributeConstraintGuesser
     pim_catalog.validator.constraint_guesser.email.class:                  Pim\Component\Catalog\Validator\ConstraintGuesser\EmailGuesser
     pim_catalog.validator.constraint_guesser.file.class:                   Pim\Component\Catalog\Validator\ConstraintGuesser\FileGuesser
@@ -144,6 +145,14 @@ services:
         class: %pim_catalog.validator.constraint.attribute_type_for_option.class%
         tags:
             - { name: validator.constraint_validator, alias: pim_attribute_type_for_option_validator }
+
+    pim_catalog.validator.constraint.is_reference_data_configured:
+        class: %pim_catalog.validator.constraint.is_reference_data_configured.class%
+        arguments:
+            - ['pim_reference_data_multiselect', 'pim_reference_data_simpleselect']
+            - '@?pim_reference_data.registry'
+        tags:
+            - { name: validator.constraint_validator, alias: pim_is_reference_data_configured_validator }
 
     # Attribute constraint guesser
     pim_catalog.validator.constraint_guesser.chained_attribute:

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/serializer.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/serializer.yml
@@ -21,7 +21,6 @@ parameters:
     pim_serializer.normalizer.flat.metric.class:            Pim\Component\Connector\Normalizer\Flat\MetricNormalizer
     pim_serializer.normalizer.flat.option.class:            Pim\Component\Connector\Normalizer\Flat\AttributeOptionNormalizer
     pim_serializer.normalizer.flat.price.class:             Pim\Component\Connector\Normalizer\Flat\PriceNormalizer
-    pim_serializer.normalizer.flat.reference_data.class:    Pim\Component\Connector\Normalizer\Flat\ReferenceDataNormalizer
     pim_serializer.normalizer.flat.file.class:              Pim\Component\Connector\Normalizer\Flat\FileNormalizer
 
      # Denormalizers
@@ -39,8 +38,6 @@ parameters:
     pim_serializer.denormalizer.flat.metric.class:                    Pim\Component\Connector\Denormalizer\Flat\ProductValue\MetricDenormalizer
     pim_serializer.denormalizer.flat.datetime.class:                  Pim\Component\Connector\Denormalizer\Flat\ProductValue\DateTimeDenormalizer
     pim_serializer.denormalizer.flat.file.class:                      Pim\Component\Connector\Denormalizer\Flat\ProductValue\FileDenormalizer
-    pim_serializer.denormalizer.flat.reference_data.class:            Pim\Component\Connector\Denormalizer\Flat\ProductValue\ReferenceDataDenormalizer
-    pim_serializer.denormalizer.flat.reference_data_collection.class: Pim\Component\Connector\Denormalizer\Flat\ProductValue\ReferenceDataCollectionDenormalizer
 
 services:
     # Encoder
@@ -152,11 +149,6 @@ services:
 
     pim_serializer.normalizer.flat.price:
         class: %pim_serializer.normalizer.flat.price.class%
-        tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
-
-    pim_serializer.normalizer.flat.reference_data:
-        class: %pim_serializer.normalizer.flat.reference_data.class%
         tags:
             - { name: pim_serializer.normalizer, priority: 90 }
 
@@ -281,22 +273,6 @@ services:
             - ['pim_catalog_image', 'pim_catalog_file']
             - '@akeneo_file_storage.repository.file_info'
             - '@akeneo_file_storage.file_storage.file.file_storer'
-        tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
-
-    pim_serializer.denormalizer.flat.reference_data:
-        class: %pim_serializer.denormalizer.flat.reference_data.class%
-        arguments:
-            - ['pim_reference_data_simpleselect']
-            - '@?pim_reference_data.repository_resolver'
-        tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
-
-    pim_serializer.denormalizer.flat.reference_data_collection:
-        class: %pim_serializer.denormalizer.flat.reference_data_collection.class%
-        arguments:
-            - ['pim_reference_data_multiselect']
-            - '@?pim_reference_data.repository_resolver'
         tags:
             - { name: pim_serializer.normalizer, priority: 90 }
 

--- a/src/Pim/Bundle/ReferenceDataBundle/DependencyInjection/PimReferenceDataExtension.php
+++ b/src/Pim/Bundle/ReferenceDataBundle/DependencyInjection/PimReferenceDataExtension.php
@@ -35,8 +35,8 @@ class PimReferenceDataExtension extends Extension
         $loader->load('datagrid/selectors.yml');
         $loader->load('datagrid/sorters.yml');
         $loader->load('models.yml');
-        $loader->load('normalizers.yml');
         $loader->load('providers.yml');
+        $loader->load('serializers.yml');
         $loader->load('services.yml');
         $loader->load('updaters.yml');
 

--- a/src/Pim/Bundle/ReferenceDataBundle/MongoDB/Normalizer/Document/ReferenceDataNormalizer.php
+++ b/src/Pim/Bundle/ReferenceDataBundle/MongoDB/Normalizer/Document/ReferenceDataNormalizer.php
@@ -17,7 +17,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 class ReferenceDataNormalizer implements NormalizerInterface
 {
     /** @var array */
-    protected $supportedFormats = [\Pim\Bundle\CatalogBundle\MongoDB\Normalizer\Document\ProductNormalizer::FORMAT];
+    protected $supportedFormats = [ProductNormalizer::FORMAT];
 
     /**
      * {@inheritdoc}

--- a/src/Pim/Bundle/ReferenceDataBundle/Resources/config/normalizers.yml
+++ b/src/Pim/Bundle/ReferenceDataBundle/Resources/config/normalizers.yml
@@ -1,8 +1,0 @@
-parameters:
-    pim_reference_data.normalizer.configuration.class: Pim\Bundle\ReferenceDataBundle\Normalizer\ConfigurationNormalizer
-
-services:
-    pim_reference_data.normalizer.configuration:
-        class: %pim_reference_data.normalizer.configuration.class%
-        tags:
-            - { name: pim_internal_api_serializer.normalizer }

--- a/src/Pim/Bundle/ReferenceDataBundle/Resources/config/serializers.yml
+++ b/src/Pim/Bundle/ReferenceDataBundle/Resources/config/serializers.yml
@@ -21,11 +21,13 @@ services:
         class: '%pim_reference_data.normalizer.reference_data.class%'
         tags:
             - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_webservice.serializer.normalizer, priority: 90 }
 
     pim_reference_data.normalizer.flat.reference_data:
         class: '%pim_reference_data.normalizer.flat.reference_data.class%'
         tags:
             - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_versioning.serializer.normalizer, priority: 90 }
 
     # Denormalizers
     pim_reference_data.denormalizer.reference_data:

--- a/src/Pim/Bundle/ReferenceDataBundle/Resources/config/serializers.yml
+++ b/src/Pim/Bundle/ReferenceDataBundle/Resources/config/serializers.yml
@@ -1,0 +1,61 @@
+parameters:
+    # Normalizers
+    pim_reference_data.normalizer.configuration.class:       Pim\Bundle\ReferenceDataBundle\Normalizer\ConfigurationNormalizer
+    pim_reference_data.normalizer.reference_data.class:      Pim\Component\ReferenceData\Normalizer\Structured\ReferenceDataNormalizer
+    pim_reference_data.normalizer.flat.reference_data.class: Pim\Component\ReferenceData\Normalizer\Flat\ReferenceDataNormalizer
+
+    # Denormalizers
+    pim_reference_data.denormalizer.reference_data.class:                 Pim\Component\ReferenceData\Denormalizer\Structured\ProductValue\ReferenceDataDenormalizer
+    pim_reference_data.denormalizer.reference_data_collection.class:      Pim\Component\ReferenceData\Denormalizer\Structured\ProductValue\ReferenceDataCollectionDenormalizer
+    pim_reference_data.denormalizer.flat.reference_data.class:            Pim\Component\ReferenceData\Denormalizer\Flat\ProductValue\ReferenceDataDenormalizer
+    pim_reference_data.denormalizer.flat.reference_data_collection.class: Pim\Component\ReferenceData\Denormalizer\Flat\ProductValue\ReferenceDataCollectionDenormalizer
+
+services:
+    # Normalizers
+    pim_reference_data.normalizer.configuration:
+        class: '%pim_reference_data.normalizer.configuration.class%'
+        tags:
+            - { name: pim_internal_api_serializer.normalizer }
+
+    pim_reference_data.normalizer.reference_data:
+        class: '%pim_reference_data.normalizer.reference_data.class%'
+        tags:
+            - { name: pim_serializer.normalizer, priority: 90 }
+
+    pim_reference_data.normalizer.flat.reference_data:
+        class: '%pim_reference_data.normalizer.flat.reference_data.class%'
+        tags:
+            - { name: pim_serializer.normalizer, priority: 90 }
+
+    # Denormalizers
+    pim_reference_data.denormalizer.reference_data:
+        class: '%pim_reference_data.denormalizer.reference_data.class%'
+        arguments:
+            - ['pim_reference_data_simpleselect']
+            - '@?pim_reference_data.repository_resolver'
+        tags:
+            - { name: pim_serializer.normalizer, priority: 90 }
+
+    pim_reference_data.denormalizer.reference_data_collection:
+        class: '%pim_reference_data.denormalizer.reference_data_collection.class%'
+        arguments:
+            - ['pim_reference_data_multiselect']
+            - '@pim_reference_data.denormalizer.reference_data'
+        tags:
+            - { name: pim_serializer.normalizer, priority: 90 }
+
+    pim_reference_data.denormalizer.flat.reference_data:
+        class: '%pim_reference_data.denormalizer.flat.reference_data.class%'
+        arguments:
+            - ['pim_reference_data_simpleselect']
+            - '@?pim_reference_data.repository_resolver'
+        tags:
+            - { name: pim_serializer.normalizer, priority: 90 }
+
+    pim_reference_data.denormalizer.flat.reference_data_collection:
+        class: '%pim_reference_data.denormalizer.flat.reference_data_collection.class%'
+        arguments:
+            - ['pim_reference_data_multiselect']
+            - '@?pim_reference_data.repository_resolver'
+        tags:
+            - { name: pim_serializer.normalizer, priority: 90 }

--- a/src/Pim/Bundle/VersioningBundle/Resources/config/serializer/flat.yml
+++ b/src/Pim/Bundle/VersioningBundle/Resources/config/serializer/flat.yml
@@ -101,11 +101,6 @@ services:
         tags:
             - { name: pim_versioning.serializer.normalizer, priority: 90 }
 
-    pim_versioning.serializer.normalizer.flat.reference_data:
-        class: %pim_reference_data.normalizer.flat.reference_data.class%
-        tags:
-            - { name: pim_versioning.serializer.normalizer, priority: 90 }
-
     pim_versioning.serializer.normalizer.flat.file:
         class: %pim_serializer.normalizer.flat.file.class%
         arguments:

--- a/src/Pim/Bundle/VersioningBundle/Resources/config/serializer/flat.yml
+++ b/src/Pim/Bundle/VersioningBundle/Resources/config/serializer/flat.yml
@@ -102,7 +102,7 @@ services:
             - { name: pim_versioning.serializer.normalizer, priority: 90 }
 
     pim_versioning.serializer.normalizer.flat.reference_data:
-        class: %pim_serializer.normalizer.flat.reference_data.class%
+        class: %pim_reference_data.normalizer.flat.reference_data.class%
         tags:
             - { name: pim_versioning.serializer.normalizer, priority: 90 }
 

--- a/src/Pim/Bundle/WebServiceBundle/Resources/config/serializer/structured.yml
+++ b/src/Pim/Bundle/WebServiceBundle/Resources/config/serializer/structured.yml
@@ -38,8 +38,3 @@ services:
         class: %pim_serializer.normalizer.attribute_option.class%
         tags:
             - { name: pim_webservice.serializer.normalizer, priority: 90 }
-
-    pim_webservice.serializer.normalizer.reference_data:
-        class: %pim_reference_data.normalizer.reference_data.class%
-        tags:
-            - { name: pim_webservice.serializer.normalizer, priority: 90 }

--- a/src/Pim/Bundle/WebServiceBundle/Resources/config/serializer/structured.yml
+++ b/src/Pim/Bundle/WebServiceBundle/Resources/config/serializer/structured.yml
@@ -40,6 +40,6 @@ services:
             - { name: pim_webservice.serializer.normalizer, priority: 90 }
 
     pim_webservice.serializer.normalizer.reference_data:
-        class: %pim_serializer.normalizer.reference_data.class%
+        class: %pim_reference_data.normalizer.reference_data.class%
         tags:
             - { name: pim_webservice.serializer.normalizer, priority: 90 }

--- a/src/Pim/Component/Catalog/Updater/AttributeUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/AttributeUpdater.php
@@ -8,7 +8,6 @@ use Pim\Component\Catalog\Model\AttributeGroupInterface;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Repository\AttributeGroupRepositoryInterface;
 use Pim\Component\Catalog\Repository\LocaleRepositoryInterface;
-use Pim\Component\ReferenceData\ConfigurationRegistryInterface;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 
@@ -27,32 +26,20 @@ class AttributeUpdater implements ObjectUpdaterInterface
     /** @var PropertyAccessor */
     protected $accessor;
 
-    /** @var ConfigurationRegistryInterface */
-    protected $registry;
-
-    /** @var array */
-    protected $referenceDataType;
-
     /** @var LocaleRepositoryInterface */
     protected $localeRepository;
 
     /**
      * @param AttributeGroupRepositoryInterface $attrGroupRepo
-     * @param array                             $referenceDataType
      * @param LocaleRepositoryInterface         $localeRepository
-     * @param ConfigurationRegistryInterface    $registry
      */
     public function __construct(
         AttributeGroupRepositoryInterface $attrGroupRepo,
-        array $referenceDataType,
-        LocaleRepositoryInterface $localeRepository,
-        ConfigurationRegistryInterface $registry = null
+        LocaleRepositoryInterface $localeRepository
     ) {
         $this->attrGroupRepo     = $attrGroupRepo;
-        $this->accessor          = PropertyAccess::createPropertyAccessor();
-        $this->registry          = $registry;
-        $this->referenceDataType = $referenceDataType;
         $this->localeRepository  = $localeRepository;
+        $this->accessor          = PropertyAccess::createPropertyAccessor();
     }
 
     /**
@@ -68,8 +55,6 @@ class AttributeUpdater implements ObjectUpdaterInterface
                 )
             );
         }
-
-        $this->checkIfReferenceDataExists($data);
 
         foreach ($data as $field => $value) {
             $this->setData($attribute, $field, $value);
@@ -122,27 +107,6 @@ class AttributeUpdater implements ObjectUpdaterInterface
         $attributeGroup = $this->attrGroupRepo->findOneByIdentifier($code);
 
         return $attributeGroup;
-    }
-
-    /**
-     * @param string $value
-     *
-     * @throws \InvalidArgumentException
-     */
-    protected function checkIfReferenceDataExists($value)
-    {
-        if (isset($value['attributeType']) && in_array($value['attributeType'], $this->referenceDataType)) {
-            if (!$this->registry->has($value['reference_data_name'])) {
-                $references = array_keys($this->registry->all());
-                throw new \InvalidArgumentException(
-                    sprintf(
-                        'Reference data "%s" does not exist. Allowed values are: %s',
-                        $value['reference_data_name'],
-                        implode(', ', $references)
-                    )
-                );
-            }
-        }
     }
 
     /**

--- a/src/Pim/Component/Catalog/Validator/Constraints/IsReferenceDataConfigured.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/IsReferenceDataConfigured.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Pim\Component\Catalog\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Checks if data is a reference data and if this reference data is configured.
+ *
+ * @author    Damien Carcel <damien.carcel@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class IsReferenceDataConfigured extends Constraint
+{
+    /** @var string */
+    public $message = 'Reference data "%reference_data_name%" does not exist. Allowed values are: %references%';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validatedBy()
+    {
+        return 'pim_is_reference_data_configured_validator';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTargets()
+    {
+        return self::CLASS_CONSTRAINT;
+    }
+}

--- a/src/Pim/Component/Catalog/Validator/Constraints/IsReferenceDataConfiguredValidator.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/IsReferenceDataConfiguredValidator.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Pim\Component\Catalog\Validator\Constraints;
+
+use Pim\Component\ReferenceData\ConfigurationRegistryInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ * Checks if data is a reference data and if this reference data is configured.
+ *
+ * @author    Damien Carcel <damien.carcel@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class IsReferenceDataConfiguredValidator extends ConstraintValidator
+{
+    /** @var ConfigurationRegistryInterface */
+    protected $registry;
+
+    /** @var array */
+    protected $referenceDataType;
+
+    /**
+     * @param array                               $referenceDataType
+     * @param ConfigurationRegistryInterface|null $registry
+     */
+    public function __construct(array $referenceDataType, ConfigurationRegistryInterface $registry = null)
+    {
+        $this->referenceDataType = $referenceDataType;
+        $this->registry          = $registry;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validate($attribute, Constraint $constraint)
+    {
+        $referenceDataName = $attribute->getProperty('reference_data_name');
+
+        if (null !== $this->registry &&
+            in_array($attribute->getAttributeType(), $this->referenceDataType) &&
+            !$this->registry->has($referenceDataName)
+        ) {
+            $references = array_keys($this->registry->all());
+
+            $this->context
+                ->buildViolation($constraint->message)
+                ->setParameter('%reference_data_name%', $referenceDataName)
+                ->setParameter('%references%', implode(', ', $references))
+                ->addViolation();
+        }
+    }
+}

--- a/src/Pim/Component/Catalog/spec/Updater/AttributeUpdaterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/AttributeUpdaterSpec.php
@@ -16,16 +16,9 @@ class AttributeUpdaterSpec extends ObjectBehavior
 {
     function let(
         AttributeGroupRepositoryInterface $attrGroupRepo,
-        ConfigurationRegistryInterface $registry,
         LocaleRepositoryInterface $localeRepository
-    )
-    {
-        $this->beConstructedWith(
-            $attrGroupRepo,
-            ['pim_reference_data_multiselect', 'pim_reference_data_simpleselect'],
-            $localeRepository,
-            $registry
-        );
+    ) {
+        $this->beConstructedWith($attrGroupRepo, $localeRepository);
     }
 
     function it_is_initializable()

--- a/src/Pim/Component/Catalog/spec/Validator/Constraints/IsReferenceDataConfiguredSpec.php
+++ b/src/Pim/Component/Catalog/spec/Validator/Constraints/IsReferenceDataConfiguredSpec.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace spec\Pim\Component\Catalog\Validator\Constraints;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class IsReferenceDataConfiguredSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Pim\Component\Catalog\Validator\Constraints\IsReferenceDataConfigured');
+    }
+
+    function it_has_message()
+    {
+        $this->message
+            ->shouldBe('Reference data "%reference_data_name%" does not exist. Allowed values are: %references%');
+    }
+
+    function it_is_a_validator_constraint()
+    {
+        $this->shouldBeAnInstanceOf('Symfony\Component\Validator\Constraint');
+    }
+}

--- a/src/Pim/Component/Catalog/spec/Validator/Constraints/IsReferenceDataConfiguredValidatorSpec.php
+++ b/src/Pim/Component/Catalog/spec/Validator/Constraints/IsReferenceDataConfiguredValidatorSpec.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace spec\Pim\Component\Catalog\Validator\Constraints;
+
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\CatalogBundle\Entity\Attribute;
+use Pim\Component\Catalog\Validator\Constraints\IsReferenceDataConfigured;
+use Pim\Component\ReferenceData\ConfigurationRegistryInterface;
+use Prophecy\Argument;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
+
+class IsReferenceDataConfiguredValidatorSpec extends ObjectBehavior
+{
+    function let(ExecutionContextInterface $context, ConfigurationRegistryInterface $registry)
+    {
+        $this->beConstructedWith(
+            ['pim_reference_data_multiselect', 'pim_reference_data_simpleselect'],
+            $registry
+        );
+        $this->initialize($context);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Pim\Component\Catalog\Validator\Constraints\IsReferenceDataConfiguredValidator');
+    }
+
+    function it_builds_violation_for_non_configured_simpleselect_reference_data(
+        $registry,
+        $context,
+        Attribute $attribute,
+        IsReferenceDataConfigured $constraint,
+        ConstraintViolationBuilderInterface $violation
+    ) {
+        $attribute->getAttributeType()->willReturn('pim_reference_data_simpleselect');
+        $attribute->getProperty('reference_data_name')->willReturn('foo');
+        $registry->has('foo')->willReturn(false);
+        $registry->all()->willReturn(['bar' => 'bar']);
+
+        $context->buildViolation($constraint->message)
+            ->shouldBeCalled()
+            ->willReturn($violation);
+        $violation->setParameter('%reference_data_name%', 'foo')->shouldBeCalled()->willReturn($violation);
+        $violation->setParameter('%references%', 'bar')->shouldBeCalled()->willReturn($violation);
+        $violation->addViolation()->shouldBeCalled();
+
+        $this->validate($attribute, $constraint);
+    }
+
+    function it_does_not_build_violation_for_configured_simpleselect_reference_data(
+        $registry,
+        $context,
+        Attribute $attribute,
+        IsReferenceDataConfigured $constraint
+    ) {
+        $attribute->getAttributeType()->willReturn('pim_reference_data_simpleselect');
+        $attribute->getProperty('reference_data_name')->willReturn('foo');
+        $registry->has('foo')->willReturn(true);
+
+        $registry->all()->shouldNotBeCalled();
+        $context
+            ->buildViolation(Argument::any())
+            ->shouldNotBeCalled();
+
+        $this->validate($attribute, $constraint);
+    }
+
+    function it_builds_violation_for_non_configured_multiselect_reference_data(
+        $registry,
+        $context,
+        Attribute $attribute,
+        IsReferenceDataConfigured $constraint,
+        ConstraintViolationBuilderInterface $violation
+    ) {
+        $attribute->getAttributeType()->willReturn('pim_reference_data_multiselect');
+        $attribute->getProperty('reference_data_name')->willReturn('foo');
+        $registry->has('foo')->willReturn(false);
+        $registry->all()->willReturn(['bar' => 'bar']);
+
+        $context->buildViolation($constraint->message)
+            ->shouldBeCalled()
+            ->willReturn($violation);
+        $violation->setParameter('%reference_data_name%', 'foo')->shouldBeCalled()->willReturn($violation);
+        $violation->setParameter('%references%', 'bar')->shouldBeCalled()->willReturn($violation);
+        $violation->addViolation()->shouldBeCalled();
+
+        $this->validate($attribute, $constraint);
+    }
+
+    function it_does_not_build_violation_for_configured_multiselect_reference_data(
+        $registry,
+        $context,
+        Attribute $attribute,
+        IsReferenceDataConfigured $constraint
+    ) {
+        $attribute->getAttributeType()->willReturn('pim_reference_data_multiselect');
+        $attribute->getProperty('reference_data_name')->willReturn('foo');
+        $registry->has('foo')->willReturn(true);
+
+        $registry->all()->shouldNotBeCalled();
+        $context
+            ->buildViolation(Argument::any())
+            ->shouldNotBeCalled();
+
+        $this->validate($attribute, $constraint);
+    }
+}

--- a/src/Pim/Component/ReferenceData/Denormalizer/Flat/ProductValue/ReferenceDataDenormalizer.php
+++ b/src/Pim/Component/ReferenceData/Denormalizer/Flat/ProductValue/ReferenceDataDenormalizer.php
@@ -1,20 +1,19 @@
 <?php
 
-namespace Pim\Component\Connector\Denormalizer\Flat\ProductValue;
+namespace Pim\Component\ReferenceData\Denormalizer\Flat\ProductValue;
 
-use Doctrine\Common\Collections\ArrayCollection;
 use Pim\Component\Catalog\Model\ProductValueInterface;
+use Pim\Component\Connector\Denormalizer\Flat\ProductValue\AbstractValueDenormalizer;
 use Pim\Component\ReferenceData\Repository\ReferenceDataRepositoryResolverInterface;
-use Symfony\Component\Routing\Exception\InvalidParameterException;
 
 /**
  * @author    Marie Bochu <marie.bochu@akeneo.com>
  * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class ReferenceDataCollectionDenormalizer extends AbstractValueDenormalizer
+class ReferenceDataDenormalizer extends AbstractValueDenormalizer
 {
-    /** @var ReferenceDataRepositoryResolverInterface  */
+    /** @var ReferenceDataRepositoryResolverInterface */
     protected $repositoryResolver;
 
     /**
@@ -35,35 +34,25 @@ class ReferenceDataCollectionDenormalizer extends AbstractValueDenormalizer
      */
     public function denormalize($data, $referenceDataClass, $format = null, array $context = [])
     {
-        $collection = new ArrayCollection();
         if (null === $this->repositoryResolver || empty($data)) {
-            return $collection;
+            return null;
         }
 
         if (!$context['value'] instanceof ProductValueInterface) {
-            throw new InvalidParameterException(
+            throw new \InvalidArgumentException(
                 'Value is not an instance of Pim\Component\Catalog\Model\ProductValueInterface.'
             );
         }
 
         $attribute = $context['value']->getAttribute();
         if (null === $attribute) {
-            throw new InvalidParameterException(
+            throw new \InvalidArgumentException(
                 'Denormalizer\'s context expected to have an attribute, none found.'
             );
         }
 
         $repository = $this->repositoryResolver->resolve($attribute->getReferenceDataName());
 
-        $codes = explode(',', $data);
-        foreach ($codes as $code) {
-            $referenceData = $repository->findOneBy(['code' => trim($code)]);
-
-            if (null !== $referenceData) {
-                $collection->add($referenceData);
-            }
-        }
-
-        return $collection;
+        return $repository->findOneBy(['code' => $data]);
     }
 }

--- a/src/Pim/Component/ReferenceData/Denormalizer/Structured/ProductValue/ReferenceDataCollectionDenormalizer.php
+++ b/src/Pim/Component/ReferenceData/Denormalizer/Structured/ProductValue/ReferenceDataCollectionDenormalizer.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Pim\Component\Catalog\Denormalizer\Structured\ProductValue;
+namespace Pim\Component\ReferenceData\Denormalizer\Structured\ProductValue;
 
 use Doctrine\Common\Collections\ArrayCollection;
-use Symfony\Component\Routing\Exception\InvalidParameterException;
+use Pim\Component\Catalog\Denormalizer\Structured\ProductValue\AbstractValueDenormalizer;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 
 /**
@@ -39,7 +39,7 @@ class ReferenceDataCollectionDenormalizer extends AbstractValueDenormalizer
         }
 
         if (false === is_array($data)) {
-            throw new InvalidParameterException(sprintf('Data expected to be an array.'));
+            throw new \InvalidArgumentException(sprintf('Data expected to be an array.'));
         }
 
         $referenceDataColl = new ArrayCollection();

--- a/src/Pim/Component/ReferenceData/Denormalizer/Structured/ProductValue/ReferenceDataDenormalizer.php
+++ b/src/Pim/Component/ReferenceData/Denormalizer/Structured/ProductValue/ReferenceDataDenormalizer.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Pim\Component\Catalog\Denormalizer\Structured\ProductValue;
+namespace Pim\Component\ReferenceData\Denormalizer\Structured\ProductValue;
 
+use Pim\Component\Catalog\Denormalizer\Structured\ProductValue\AbstractValueDenormalizer;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\ReferenceData\Repository\ReferenceDataRepositoryResolverInterface;
-use Symfony\Component\Routing\Exception\InvalidParameterException;
 
 /**
  * @author    Adrien Pétremann <adrien.petremann@akeneo.com>
@@ -39,7 +39,7 @@ class ReferenceDataDenormalizer extends AbstractValueDenormalizer
         }
 
         if (false === isset($context['attribute'])) {
-            throw new InvalidParameterException(
+            throw new \InvalidArgumentException(
                 sprintf('Denormalizer\'s context expected to have an attribute, none found.')
             );
         }
@@ -47,7 +47,7 @@ class ReferenceDataDenormalizer extends AbstractValueDenormalizer
         $attribute = $context['attribute'];
 
         if (!$attribute instanceof AttributeInterface) {
-            throw new InvalidParameterException(
+            throw new \InvalidArgumentException(
                 sprintf('Attribute is not an instance of Pim\Component\Catalog\Model\AttributeInterface.')
             );
         }

--- a/src/Pim/Component/ReferenceData/Normalizer/Flat/ReferenceDataNormalizer.php
+++ b/src/Pim/Component/ReferenceData/Normalizer/Flat/ReferenceDataNormalizer.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace Pim\Component\Connector\Normalizer\Flat;
+namespace Pim\Component\ReferenceData\Normalizer\Flat;
 
+use Pim\Component\Connector\Normalizer\Flat\AbstractProductValueDataNormalizer;
 use Pim\Component\ReferenceData\Model\ReferenceDataInterface;
 
 /**

--- a/src/Pim/Component/ReferenceData/Normalizer/Structured/ReferenceDataNormalizer.php
+++ b/src/Pim/Component/ReferenceData/Normalizer/Structured/ReferenceDataNormalizer.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Pim\Component\Catalog\Normalizer\Structured;
+namespace Pim\Component\ReferenceData\Normalizer\Structured;
 
 use Pim\Component\ReferenceData\Model\ReferenceDataInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;

--- a/src/Pim/Component/ReferenceData/spec/Denormalizer/Flat/ReferenceDataCollectionDenormalizerSpec.php
+++ b/src/Pim/Component/ReferenceData/spec/Denormalizer/Flat/ReferenceDataCollectionDenormalizerSpec.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace spec\Pim\Component\Connector\Denormalizer\Flat\ProductValue;
+namespace spec\Pim\Component\ReferenceData\Denormalizer\Flat\ProductValue;
 
 use Doctrine\Common\Persistence\ObjectRepository;
 use PhpSpec\ObjectBehavior;
@@ -46,7 +46,7 @@ class ReferenceDataCollectionDenormalizerSpec extends ObjectBehavior
 
     function it_throws_an_exception_if_context_value_is_not_a_product_value_inteface()
     {
-        $this->shouldThrow('Symfony\Component\Routing\Exception\InvalidParameterException')
+        $this->shouldThrow('\InvalidArgumentException')
             ->during(
                 'denormalize',
                 [
@@ -60,7 +60,7 @@ class ReferenceDataCollectionDenormalizerSpec extends ObjectBehavior
 
     function it_throws_an_exception_if_there_is_no_attribute_in_context(ProductValueInterface $productValue)
     {
-        $this->shouldThrow('Symfony\Component\Routing\Exception\InvalidParameterException')
+        $this->shouldThrow('\InvalidArgumentException')
             ->during(
                 'denormalize',
                 [

--- a/src/Pim/Component/ReferenceData/spec/Denormalizer/Structured/ProductValue/ReferenceDataCollectionDenormalizerSpec.php
+++ b/src/Pim/Component/ReferenceData/spec/Denormalizer/Structured/ProductValue/ReferenceDataCollectionDenormalizerSpec.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace spec\Pim\Component\Catalog\Denormalizer\Structured\ProductValue;
+namespace spec\Pim\Component\ReferenceData\Denormalizer\Structured\ProductValue;
 
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Model\AttributeInterface;
@@ -43,7 +43,7 @@ class ReferenceDataCollectionDenormalizerSpec extends ObjectBehavior
 
     function it_throws_an_exception_if_data_is_not_an_array(AttributeInterface $attribute)
     {
-        $this->shouldThrow('Symfony\Component\Routing\Exception\InvalidParameterException')
+        $this->shouldThrow('\InvalidArgumentException')
             ->during(
                 'denormalize',
                 [
@@ -54,7 +54,7 @@ class ReferenceDataCollectionDenormalizerSpec extends ObjectBehavior
                 ]
             );
 
-        $this->shouldThrow('Symfony\Component\Routing\Exception\InvalidParameterException')
+        $this->shouldThrow('\InvalidArgumentException')
             ->during(
                 'denormalize',
                 [

--- a/src/Pim/Component/ReferenceData/spec/Normalizer/Flat/ReferenceDataNormalizerSpec.php
+++ b/src/Pim/Component/ReferenceData/spec/Normalizer/Flat/ReferenceDataNormalizerSpec.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace spec\Pim\Component\Connector\Normalizer\Flat;
+namespace spec\Pim\Component\ReferenceData\Normalizer\Flat;
 
 use PhpSpec\ObjectBehavior;
 use Pim\Component\ReferenceData\Model\ReferenceDataInterface;

--- a/src/Pim/Component/ReferenceData/spec/Normalizer/Structured/ReferenceDataNormalizerSpec.php
+++ b/src/Pim/Component/ReferenceData/spec/Normalizer/Structured/ReferenceDataNormalizerSpec.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace spec\Pim\Component\Catalog\Normalizer\Structured;
+namespace spec\Pim\Component\ReferenceData\Normalizer\Structured;
 
 use PhpSpec\ObjectBehavior;
 use Pim\Component\ReferenceData\Model\ReferenceDataInterface;


### PR DESCRIPTION
**Description**

Reference Data is considered as extended feature of the PIM. In this current form, we should be able to toggle or not this feature (this should work already actually). It also means that the code related to reference data should remain in the reference data folders. We have a few classes that does not respect this rule.

To check if the rules are enforced, use the following command:
```bash
bin/php-coupling-detector detect src/Pim/Component/Catalog --config-file=.php_cd_transitional.php
```

This PR intends to fix reference data violations (**24** violations before, **21** in this PR)

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Yes
| Added Behats                      | No
| Changelog updated                 | Yes
| Review and 2 GTM                  | Yes
| Micro Demo to the PO (Story only) | N/A
| Migration script                  | Yes
| Tech Doc                          | No

