### PR TITLE
PIM-5428: Export product builder - export products according to their status

### DIFF
--- a/features/export/product-export-builder/export_products_status.feature
+++ b/features/export/product-export-builder/export_products_status.feature
@@ -1,0 +1,56 @@
+@javascript
+Feature: Export products according to their status
+  In order to use the enriched product data
+  As a product manager
+  I need to be able to export the product according their status
+
+  Background:
+    Given an "footwear" catalog configuration
+    And the following family:
+      | code    | requirements-mobile |
+      | rangers | sku, name           |
+    And the following products:
+      | sku      | enabled | family  | categories        | name-en_US    |
+      | SNKRS-1B | 1       | rangers | summer_collection | Black rangers |
+      | SNKRS-1R | 0       | rangers | summer_collection | Black rangers |
+    And I am logged in as "Julia"
+
+  Scenario: Export only enabled products
+    Given the following job "csv_footwear_product_export" configuration:
+      | filePath | %tmp%/product_export/product_export.csv |
+      | enabled  | enabled                                 |
+    When I am on the "csv_footwear_product_export" export job page
+    And I launch the export job
+    And I wait for the "csv_footwear_product_export" job to finish
+    Then exported file of "csv_footwear_product_export" should contain:
+    """
+    sku;categories;enabled;family;groups;name-en_US
+    SNKRS-1B;summer_collection;1;rangers;;Black rangers
+    """
+
+  Scenario: Export only disabled products
+    Given the following job "csv_footwear_product_export" configuration:
+      | filePath | %tmp%/product_export/product_export.csv |
+      | enabled  | disabled                                |
+    When I am on the "csv_footwear_product_export" export job page
+    And I launch the export job
+    And I wait for the "csv_footwear_product_export" job to finish
+    Then exported file of "csv_footwear_product_export" should contain:
+    """
+    sku;categories;enabled;family;groups;name-en_US
+    SNKRS-1R;summer_collection;0;rangers;;Black rangers
+    """
+
+  Scenario: Export products no matter their status
+    Given the following job "csv_footwear_product_export" configuration:
+      | filePath | %tmp%/product_export/product_export.csv |
+      | enabled  | all                                     |
+    When I am on the "csv_footwear_product_export" export job page
+    And I launch the export job
+    And I wait for the "csv_footwear_product_export" job to finish
+    Then exported file of "csv_footwear_product_export" should contain:
+    """
+    sku;categories;enabled;family;groups;name-en_US
+    SNKRS-1B;summer_collection;1;rangers;;Black rangers
+    SNKRS-1R;summer_collection;0;rangers;;Black rangers
+    """

--- a/features/export/product-export-builder/export_products_status.feature
+++ b/features/export/product-export-builder/export_products_status.feature
@@ -1,8 +1,8 @@
 @javascript
-Feature: Export products according to their status
+Feature: Export products according to their statuses
   In order to use the enriched product data
   As a product manager
-  I need to be able to export the product according their status
+  I need to be able to export the products according to their statuses
 
   Background:
     Given an "footwear" catalog configuration
@@ -41,7 +41,7 @@ Feature: Export products according to their status
     SNKRS-1R;summer_collection;0;rangers;;Black rangers
     """
 
-  Scenario: Export products no matter their status
+  Scenario: Export products no matter their statuses
     Given the following job "csv_footwear_product_export" configuration:
       | filePath | %tmp%/product_export/product_export.csv |
       | enabled  | all                                     |

--- a/src/Pim/Bundle/ConnectorBundle/Resources/translations/messages.en.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/translations/messages.en.yml
@@ -167,6 +167,13 @@ pim_connector:
         channel:
             label: Channel
             help: The channel you want to export
+        status:
+            label: Status
+            help: The status of the products you want to export
+            choice:
+                enabled: Enabled
+                disabled: Disabled
+                all: All
         decimalSeparator:
             label: Decimal separator
             help: Determine the decimal separator

--- a/src/Pim/Bundle/ImportExportBundle/Resources/translations/messages.en.yml
+++ b/src/Pim/Bundle/ImportExportBundle/Resources/translations/messages.en.yml
@@ -146,6 +146,7 @@ History: History
 pane.accordion:
     properties: Properties
     global_settings: Global settings
+    filters: Filters
 
 # Popin titles
 popin.create:

--- a/src/Pim/Bundle/ImportExportBundle/Resources/views/JobProfile/Tab/job_content.html.twig
+++ b/src/Pim/Bundle/ImportExportBundle/Resources/views/JobProfile/Tab/job_content.html.twig
@@ -1,2 +1,14 @@
 <div id="{{ viewElement.alias|replace({' ': '-', '.': '-'})|lower }}" class="tab-pane buffer-top">
+    {% set filtersSettings %}
+        {% for step in form.job.steps %}
+            {% for stepElement in step.children %}
+                {% for field in stepElement.children %}
+                    {% if field.vars.attr['data-tab'] is defined and 'content' == field.vars.attr['data-tab'] %}
+                        {{ form_row(field) }}
+                    {% endif %}
+                {% endfor %}
+            {% endfor %}
+        {% endfor %}
+    {% endset %}
+    {{ elements.accordion({ 'pane.accordion.filters': filtersSettings }, 3) }}
 </div>

--- a/src/Pim/Bundle/ImportExportBundle/Resources/views/JobProfile/Tab/property_edit.html.twig
+++ b/src/Pim/Bundle/ImportExportBundle/Resources/views/JobProfile/Tab/property_edit.html.twig
@@ -7,8 +7,12 @@
 
     {% set globalSettings %}
         {% for step in form.job.steps %}
-            {% for child in step.children %}
-                {{ form_widget(child) }}
+            {% for stepElement in step.children %}
+                {% for field in stepElement.children %}
+                    {% if field.vars.attr['data-tab'] is not defined %}
+                        {{ form_row(field) }}
+                    {% endif %}
+                {% endfor %}
             {% endfor %}
         {% endfor %}
     {% endset %}

--- a/src/Pim/Component/Connector/Reader/ProductReader.php
+++ b/src/Pim/Component/Connector/Reader/ProductReader.php
@@ -130,6 +130,7 @@ class ProductReader extends AbstractConfigurableStepElement implements ItemReade
                     'select2'  => true,
                     'label'    => 'pim_connector.export.channel.label',
                     'help'     => 'pim_connector.export.channel.help',
+                    'attr'     => ['data-tab' => 'content']
                 ],
             ],
             'enabled' => [
@@ -144,6 +145,7 @@ class ProductReader extends AbstractConfigurableStepElement implements ItemReade
                     'select2'  => true,
                     'label'    => 'pim_connector.export.status.label',
                     'help'     => 'pim_connector.export.status.help',
+                    'attr'     => ['data-tab' => 'content']
                 ]
             ],
         ];

--- a/src/Pim/Component/Connector/Reader/ProductReader.php
+++ b/src/Pim/Component/Connector/Reader/ProductReader.php
@@ -14,7 +14,6 @@ use Pim\Component\Catalog\Manager\CompletenessManager;
 use Pim\Component\Catalog\Model\ChannelInterface;
 use Pim\Component\Catalog\Query\Filter\Operators;
 use Pim\Component\Catalog\Query\ProductQueryBuilderFactoryInterface;
-use Pim\Component\Catalog\Query\ProductQueryBuilderInterface;
 use Pim\Component\Catalog\Repository\ChannelRepositoryInterface;
 
 /**
@@ -56,6 +55,9 @@ class ProductReader extends AbstractConfigurableStepElement implements ItemReade
     /** @var ChannelInterface */
     protected $channel;
 
+    /** @var string */
+    protected $enabled;
+
     /**
      * @param ProductQueryBuilderFactoryInterface $pqbFactory
      * @param ChannelRepositoryInterface          $channelRepository
@@ -78,10 +80,11 @@ class ProductReader extends AbstractConfigurableStepElement implements ItemReade
         $this->metricConverter      = $metricConverter;
         $this->objectDetacher       = $objectDetacher;
         $this->generateCompleteness = (bool) $generateCompleteness;
+        $this->enabled              = 'enabled'; // enabled by default to be compatible with former/custom exports
     }
 
     /**
-     * {@inheritdoc}
+     * @param string $channelCode
      */
     public function setChannel($channelCode)
     {
@@ -90,11 +93,27 @@ class ProductReader extends AbstractConfigurableStepElement implements ItemReade
     }
 
     /**
-     * {@inheritdoc}
+     * @return string
      */
     public function getChannel()
     {
         return $this->channelCode;
+    }
+
+    /**
+     * @return string
+     */
+    public function getEnabled()
+    {
+        return $this->enabled;
+    }
+
+    /**
+     * @param string $enabled
+     */
+    public function setEnabled($enabled)
+    {
+        $this->enabled = $enabled;
     }
 
     /**
@@ -112,7 +131,21 @@ class ProductReader extends AbstractConfigurableStepElement implements ItemReade
                     'label'    => 'pim_connector.export.channel.label',
                     'help'     => 'pim_connector.export.channel.help',
                 ],
-            ]
+            ],
+            'enabled' => [
+                'type'    => 'choice',
+                'options' => [
+                    'choices'  => [
+                        'enabled'  => 'pim_connector.export.status.choice.enabled',
+                        'disabled' => 'pim_connector.export.status.choice.disabled',
+                        'all'      => 'pim_connector.export.status.choice.all'
+                    ],
+                    'required' => true,
+                    'select2'  => true,
+                    'label'    => 'pim_connector.export.status.label',
+                    'help'     => 'pim_connector.export.status.help',
+                ]
+            ],
         ];
     }
 
@@ -122,7 +155,18 @@ class ProductReader extends AbstractConfigurableStepElement implements ItemReade
     public function initialize()
     {
         $this->channel = $this->getChannelByCode($this->channelCode);
-        $pqb           = $this->getProductQueryBuilder($this->channel);
+
+        $pqb     = $this->pqbFactory->create(['default_scope' => $this->channel->getCode()]);
+        $filters = $this->getFilters($this->channel, $this->rawToStandardProductStatus($this->enabled));
+
+        foreach ($filters as $filter) {
+            $pqb->addFilter(
+                $filter['field'],
+                $filter['operator'],
+                $filter['value'],
+                $filter['context']
+            );
+        }
 
         if ($this->generateCompleteness) {
             $this->completenessManager->generateMissingForChannel($this->channel);
@@ -161,33 +205,9 @@ class ProductReader extends AbstractConfigurableStepElement implements ItemReade
     }
 
     /**
-     * Return the product query builder instance with filters configured.
-     *
-     * @param ChannelInterface $channel
-     *
-     * @return ProductQueryBuilderInterface
-     */
-    protected function getProductQueryBuilder(ChannelInterface $channel)
-    {
-        $pqb = $this->pqbFactory->create(['default_scope' => $channel->getCode()]);
-
-        foreach ($this->getFilters($channel) as $filter) {
-            $pqb->addFilter(
-                $filter['field'],
-                $filter['operator'],
-                $filter['value'],
-                $filter['context']
-            );
-        }
-
-        return $pqb;
-    }
-
-    /**
      * @param string $code
      *
      * @throws ObjectNotFoundException
-     *
      * @return ChannelInterface
      */
     protected function getChannelByCode($code)
@@ -204,18 +224,13 @@ class ProductReader extends AbstractConfigurableStepElement implements ItemReade
      * Return the filters to be applied on the PQB instance.
      *
      * @param ChannelInterface $channel
+     * @param bool             $status
      *
      * @return array
      */
-    protected function getFilters(ChannelInterface $channel)
+    protected function getFilters(ChannelInterface $channel, $status)
     {
-        return [
-            [
-                'field'    => 'enabled',
-                'operator' => Operators::EQUALS,
-                'value'    => true,
-                'context'  => []
-            ],
+        $filters = [
             [
                 'field'    => 'completeness',
                 'operator' => Operators::EQUALS,
@@ -229,5 +244,39 @@ class ProductReader extends AbstractConfigurableStepElement implements ItemReade
                 'context'  => []
             ]
         ];
+
+        if (null !== $status) {
+            $filters[] = [
+                'field'    => 'enabled',
+                'operator' => Operators::EQUALS,
+                'value'    => $status,
+                'context'  => []
+            ];
+        }
+
+        return $filters;
+    }
+
+    /**
+     * Convert the UI product status to the standard product status
+     *
+     * @param string $rawStatus
+     *
+     * @return bool|null
+     */
+    protected function rawToStandardProductStatus($rawStatus)
+    {
+        switch ($rawStatus) {
+            case 'enabled':
+                $status = true;
+                break;
+            case 'disabled':
+                $status = false;
+                break;
+            default:
+                $status = null;
+        }
+
+        return $status;
     }
 }

--- a/src/Pim/Component/Connector/spec/Reader/ProductReaderSpec.php
+++ b/src/Pim/Component/Connector/spec/Reader/ProductReaderSpec.php
@@ -46,7 +46,7 @@ class ProductReaderSpec extends ObjectBehavior
         $this->getChannel()->shouldReturn('mobile');
     }
 
-    function it_reads_products(
+    function it_reads_enabled_products(
         $pqbFactory,
         $channelRepository,
         $metricConverter,
@@ -97,6 +97,112 @@ class ProductReaderSpec extends ObjectBehavior
         $this->read()->shouldReturn(null);
     }
 
+    function it_reads_disabled_products(
+        $pqbFactory,
+        $channelRepository,
+        $metricConverter,
+        $objectDetacher,
+        $stepExecution,
+        ChannelInterface $channel,
+        CategoryInterface $channelRoot,
+        ProductQueryBuilderInterface $pqb,
+        CursorInterface $cursor,
+        ProductInterface $product1,
+        ProductInterface $product2,
+        ProductInterface $product3
+    ) {
+        $this->setEnabled('disabled');
+
+        $channelRepository->findOneByIdentifier('mobile')->willReturn($channel);
+        $channel->getCategory()->willReturn($channelRoot);
+        $channelRoot->getId()->willReturn(42);
+        $channel->getCode()->willReturn('mobile');
+
+        $pqbFactory->create(['default_scope' => 'mobile'])
+            ->shouldBeCalled()
+            ->willReturn($pqb);
+        $pqb->addFilter('enabled', '=', false, [])->shouldBeCalled();
+        $pqb->addFilter('completeness', '=', 100, [])->shouldBeCalled();
+        $pqb->addFilter('categories.id', 'IN CHILDREN', [42], [])->shouldBeCalled();
+        $pqb->execute()
+            ->shouldBeCalled()
+            ->willReturn($cursor);
+
+        $products = [$product1, $product2, $product3];
+        $productsCount = count($products);
+        $cursor->valid()->will(
+            function () use (&$productsCount) {
+                return $productsCount-- > 0;
+            }
+        );
+        $cursor->next()->shouldBeCalled();
+        $cursor->current()->will(new ReturnPromise($products));
+
+        $stepExecution->incrementSummaryInfo('read')->shouldBeCalledTimes(3);
+        $objectDetacher->detach(Argument::any())->shouldBeCalledTimes(3);
+        $metricConverter->convert(Argument::any(), $channel)->shouldBeCalledTimes(3);
+
+        $this->setChannel('mobile');
+        $this->initialize();
+        $this->read()->shouldReturn($product1);
+        $this->read()->shouldReturn($product2);
+        $this->read()->shouldReturn($product3);
+        $this->read()->shouldReturn(null);
+    }
+
+    function it_reads_all_products(
+        $pqbFactory,
+        $channelRepository,
+        $metricConverter,
+        $objectDetacher,
+        $stepExecution,
+        ChannelInterface $channel,
+        CategoryInterface $channelRoot,
+        ProductQueryBuilderInterface $pqb,
+        CursorInterface $cursor,
+        ProductInterface $product1,
+        ProductInterface $product2,
+        ProductInterface $product3
+    ) {
+        $this->setEnabled('all');
+
+        $channelRepository->findOneByIdentifier('mobile')->willReturn($channel);
+        $channel->getCategory()->willReturn($channelRoot);
+        $channelRoot->getId()->willReturn(42);
+        $channel->getCode()->willReturn('mobile');
+
+        $pqbFactory->create(['default_scope' => 'mobile'])
+            ->shouldBeCalled()
+            ->willReturn($pqb);
+        $pqb->addFilter('enabled', Argument::cetera())->shouldNotBeCalled();
+        $pqb->addFilter('completeness', '=', 100, [])->shouldBeCalled();
+        $pqb->addFilter('categories.id', 'IN CHILDREN', [42], [])->shouldBeCalled();
+        $pqb->execute()
+            ->shouldBeCalled()
+            ->willReturn($cursor);
+
+        $products = [$product1, $product2, $product3];
+        $productsCount = count($products);
+        $cursor->valid()->will(
+            function () use (&$productsCount) {
+                return $productsCount-- > 0;
+            }
+        );
+        $cursor->next()->shouldBeCalled();
+        $cursor->current()->will(new ReturnPromise($products));
+
+        $stepExecution->incrementSummaryInfo('read')->shouldBeCalledTimes(3);
+        $objectDetacher->detach(Argument::any())->shouldBeCalledTimes(3);
+        $metricConverter->convert(Argument::any(), $channel)->shouldBeCalledTimes(3);
+
+        $this->setChannel('mobile');
+        $this->initialize();
+        $this->read()->shouldReturn($product1);
+        $this->read()->shouldReturn($product2);
+        $this->read()->shouldReturn($product3);
+        $this->read()->shouldReturn(null);
+    }
+
     function it_generates_the_completeness_on_initialization(
         $pqbFactory,
         $channelRepository,
@@ -116,7 +222,7 @@ class ProductReaderSpec extends ObjectBehavior
         $this->initialize();
     }
 
-    function it_exposes_the_channel_field($channelRepository)
+    function it_exposes_the_channel_and_status_fields($channelRepository)
     {
         $channelRepository->getLabelsIndexedByCode()->willReturn(
             [
@@ -139,7 +245,21 @@ class ProductReaderSpec extends ObjectBehavior
                         'label'    => 'pim_connector.export.channel.label',
                         'help'     => 'pim_connector.export.channel.help'
                     ]
-                ]
+                ],
+                'enabled' => [
+                    'type'    => 'choice',
+                    'options' => [
+                        'choices'  => [
+                            'enabled' => 'pim_connector.export.status.choice.enabled',
+                            'disabled' => 'pim_connector.export.status.choice.disabled',
+                            'all' => 'pim_connector.export.status.choice.all'
+                        ],
+                        'required' => true,
+                        'select2'  => true,
+                        'label'    => 'pim_connector.export.status.label',
+                        'help'     => 'pim_connector.export.status.help',
+                    ]
+                ],
             ]
         );
     }


### PR DESCRIPTION

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Y
| Added Behats                      | Y
| Changelog updated                 | -
| Review and 2 GTM                  |
| Micro Demo to the PO (Story only) |
| Migration script                  | -
| Tech Doc                          | -

This PR replaces https://github.com/akeneo/pim-community-dev/pull/4429. It's a simple and dumb implementation of the product export builder without changing the product reader behavior. As a matter of fact, this is not that easy to build something solid at the moment as:
* @nidup is currently rewriting the batch foundations https://github.com/akeneo/pim-community-dev/pull/4326
* the previous PR has some design drawbacks https://github.com/akeneo/pim-community-dev/pull/4429
* last but not least, it's kind of silly to write a brand new system that transforms UI options to PQB filters without knowing where we go. We need to do something usable both by the datagrid and the export builder. 

That's why we decided to keep it really really simple at the moment even knowing it not perfect. But it's better to stick with protected methods we already have (without changing the product reader behavior, it's purely internal), rather than introducing a whole bunch of public stuff without knowing the impacts and what we want and can achieve in the time we have.

A new folder for Behats dedicated to the export product builder. I created a dedicated simple family in the background of the Behat to make them much easy to read, and not dependant of other product filters or future changes.