### PR TITLE
[RFC] Add align equals to php_cs

### DIFF
--- a/.php_cs-fixers.php
+++ b/.php_cs-fixers.php
@@ -12,6 +12,7 @@ return [
     '-unalign_equals',
     '-unalign_double_arrow',
     'align_double_arrow',
+    'align_equals',
     'newline_after_open_tag',
     'ordered_use',
     'phpdoc_order'


### PR DESCRIPTION
We vote on this PR 👍  or 👎 

Today we align the arrays:
```
$array = [
    'such' => 'align',
    'much' => 'nice'
]
```

but we don't align assignations:

```
$advice = 'you should vote for this pr';
$because = 'it will save penguins';
$and = 'penguins are really nice and funny'
```