### PR TITLE
Remove template annotation from import/export controllers

### DIFF
--- a/src/Pim/Bundle/ImportExportBundle/Controller/ExportProfileController.php
+++ b/src/Pim/Bundle/ImportExportBundle/Controller/ExportProfileController.php
@@ -4,8 +4,8 @@ namespace Pim\Bundle\ImportExportBundle\Controller;
 
 use Akeneo\Component\Batch\Model\JobInstance;
 use Oro\Bundle\SecurityBundle\Annotation\AclAncestor;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Export controller
@@ -19,17 +19,19 @@ class ExportProfileController extends JobProfileController
     /**
      * List the export profiles
      *
-     * @Template
      * @AclAncestor("pim_importexport_export_profile_index")
      *
-     * @return array
+     * @return Response
      */
     public function indexAction()
     {
-        return [
-            'jobType'    => $this->getJobType(),
-            'connectors' => $this->connectorRegistry->getJobs($this->getJobType())
-        ];
+        return $this->templating->renderResponse(
+            'PimImportExportBundle:ExportProfile:index.html.twig',
+            [
+                'jobType'    => $this->getJobType(),
+                'connectors' => $this->connectorRegistry->getJobs($this->getJobType())
+            ]
+        );
     }
 
     /**

--- a/src/Pim/Bundle/ImportExportBundle/Controller/ImportProfileController.php
+++ b/src/Pim/Bundle/ImportExportBundle/Controller/ImportProfileController.php
@@ -4,8 +4,8 @@ namespace Pim\Bundle\ImportExportBundle\Controller;
 
 use Akeneo\Component\Batch\Model\JobInstance;
 use Oro\Bundle\SecurityBundle\Annotation\AclAncestor;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Import controller
@@ -19,19 +19,19 @@ class ImportProfileController extends JobProfileController
     /**
      * List the import profiles
      *
-     * @param Request $request
-     *
-     * @Template
      * @AclAncestor("pim_importexport_import_profile_index")
      *
-     * @return array
+     * @return Response
      */
-    public function indexAction(Request $request)
+    public function indexAction()
     {
-        return [
-            'jobType'    => $this->getJobType(),
-            'connectors' => $this->connectorRegistry->getJobs($this->getJobType())
-        ];
+        return $this->templating->renderResponse(
+            'PimImportExportBundle:ImportProfile:index.html.twig',
+            [
+                'jobType'    => $this->getJobType(),
+                'connectors' => $this->connectorRegistry->getJobs($this->getJobType())
+            ]
+        );
     }
 
     /**

--- a/src/Pim/Bundle/ImportExportBundle/Controller/JobExecutionController.php
+++ b/src/Pim/Bundle/ImportExportBundle/Controller/JobExecutionController.php
@@ -6,7 +6,6 @@ use Akeneo\Bundle\BatchBundle\Manager\JobExecutionManager;
 use Akeneo\Bundle\BatchBundle\Monolog\Handler\BatchLogHandler;
 use Akeneo\Component\FileStorage\StreamedFileResponse;
 use Pim\Bundle\BaseConnectorBundle\EventListener\JobExecutionArchivist;
-use Pim\Bundle\EnrichBundle\AbstractController\AbstractDoctrineController;
 use Pim\Bundle\ImportExportBundle\Entity\Repository\JobExecutionRepository;
 use Pim\Bundle\ImportExportBundle\Event\JobExecutionEvents;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;


### PR DESCRIPTION
Without the `@Template` annotation, we're no longer constrained to override this bundle when creating a new profile in an external bundle.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       |n
| Added Behats                      |n
| Changelog updated                 |todo
| Review and 2 GTM                  |
| Tech Doc                          |todo

