### PR TITLE
[WIP] JML - Resolve multiple bundle children

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -1,7 +1,7 @@
 <?php
 
+use Akeneo\Component\HttpKernel\AkeneoKernel;
 use Symfony\Component\Config\Loader\LoaderInterface;
-use Symfony\Component\HttpKernel\Kernel;
 
 /**
  * PIM AppKernel
@@ -10,7 +10,7 @@ use Symfony\Component\HttpKernel\Kernel;
  * @copyright 2013 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class AppKernel extends Kernel
+class AppKernel extends AkeneoKernel
 {
     /**
      * Registers your custom bundles

--- a/src/Akeneo/Component/HttpKernel/AkeneoKernel.php
+++ b/src/Akeneo/Component/HttpKernel/AkeneoKernel.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Akeneo\Component\HttpKernel;
+
+use Symfony\Component\HttpKernel\Kernel;
+
+abstract class AkeneoKernel extends Kernel
+{
+    /**
+     * @inheritdoc
+     */
+    protected function initializeBundles()
+    {
+        // init bundles
+        $this->bundles = [];
+        $topMostBundles = [];
+        $directChildren = [];
+
+        foreach ($this->registerBundles() as $bundle) {
+            $name = $bundle->getName();
+            if (isset($this->bundles[$name])) {
+                throw new \LogicException(sprintf('Trying to register two bundles with the same name "%s"', $name));
+            }
+            $this->bundles[$name] = $bundle;
+
+            if ($parentName = $bundle->getParent()) {
+                $directChildren = $this->resolveChildren($name, $parentName, $directChildren);
+            } else {
+                $topMostBundles[$name] = $bundle;
+            }
+        }
+
+        // look for orphans
+        if (!empty($directChildren) && count($diff = array_diff_key($directChildren, $this->bundles))) {
+            $diff = array_keys($diff);
+
+            throw new \LogicException(sprintf('Bundle "%s" extends bundle "%s", which is not registered.',
+                $directChildren[$diff[0]], $diff[0]));
+        }
+
+        // inheritance
+        $this->bundleMap = [];
+        foreach ($topMostBundles as $name => $bundle) {
+            $bundleMap = [$bundle];
+            $hierarchy = [$name];
+
+            while (isset($directChildren[$name])) {
+                $name = $directChildren[$name];
+                array_unshift($bundleMap, $this->bundles[$name]);
+                $hierarchy[] = $name;
+            }
+
+            foreach ($hierarchy as $bundle) {
+                $this->bundleMap[$bundle] = $bundleMap;
+                array_pop($bundleMap);
+            }
+        }
+    }
+
+    /**
+     * @param string $name
+     * @param string $parentName
+     * @param array  $directChildren
+     *
+     * @return array
+     */
+    public function resolveChildren($name, $parentName, $directChildren)
+    {
+        if ($parentName == $name) {
+            throw new \LogicException(sprintf('Bundle "%s" can not extend itself.', $name));
+        }
+        if (isset($directChildren[$parentName])) {
+            $newParent = $directChildren[$parentName];
+            $directChildren = $this->resolveChildren($name, $newParent, $directChildren);
+        } else {
+            $directChildren[$parentName] = $name;
+        }
+
+        return $directChildren;
+    }
+}


### PR DESCRIPTION
A WIP experimentation to solve the problem of an external extension overriding an already overriden bundle.

The principle is simple: it replace the parent by its direct child recursively to rebuild the bundles hierarchy.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       |n
| Added Behats                      |n
| Changelog updated                 |todo
| Review and 2 GTM                  |
| Tech Doc                          |todo

## How it works ?

Let's say we have a base `PimImportExportBundle` and we want to overiide a template in `FooBundle`. We would have to declare the parent in FoofBundle:

```php
<?php

namespace Jml;

use Symfony\Component\HttpKernel\Bundle\Bundle;

class FooBundle extends Bundle
{
    public function getParent()
    {
        return 'PimImportExportBundle';
    }
}
```

At boot time, SF will initialize a bundle hierarchy with this code: https://github.com/symfony/symfony/blob/master/src/Symfony/Component/HttpKernel/Kernel.php#L389 and the resulting array would be something like this

```php
//dump of the $directChildren array
'PimImportExportBundle' => 
    array (size=2)
      0 => 
        object(Jml\FooBundle)[17]
          protected 'name' => string 'FooBundle' (length=9)
          protected 'extension' => null
          protected 'path' => null
          protected 'container' => null
      1 => 
        object(Pim\Bundle\ImportExportBundle\PimImportExportBundle)[69]
          protected 'name' => string 'PimImportExportBundle' (length=21)
          protected 'extension' => null
          protected 'path' => null
          protected 'container' => null
  'FooBundle' => 
    array (size=1)
      0 => 
        object(Jml\FooBundle)[17]
          protected 'name' => string 'FooBundle' (length=9)
          protected 'extension' => null
          protected 'path' => null
          protected 'container' => null
  'PimVersioningBundle' => 
    array (size=1)
      0 => 
        object(Pim\Bundle\VersioningBundle\PimVersioningBundle)[70]
          protected 'name' => string 'PimVersioningBundle' (length=19)
          protected 'extension' => null
          protected 'path' => null
          protected 'container' => null
```

Thus `PimImportExportBundle` can be overriden by `FooBundle`.

### The problem

But if i have a third `BarBundle` as a second child of `PimImportExportBundle`, SF will throw an exception because it forbids more than one direct child. The solution could be to declare `BarBundle` as child of `FooBundle`. It works, and the resulting hierarchy is like this:

```php
'PimImportExportBundle' => 
    array (size=3)
      0 => 
        object(Jml\BarBundle)[18]
          protected 'name' => string 'BarBundle' (length=9)
          protected 'extension' => null
          protected 'path' => null
          protected 'container' => null
      1 => 
        object(Jml\FooBundle)[17]
          protected 'name' => string 'FooBundle' (length=9)
          protected 'extension' => null
          protected 'path' => null
          protected 'container' => null
      2 => 
        object(Pim\Bundle\ImportExportBundle\PimImportExportBundle)[69]
          protected 'name' => string 'PimImportExportBundle' (length=21)
          protected 'extension' => null
          protected 'path' => null
          protected 'container' => null
  'FooBundle' => 
    array (size=2)
      0 => 
        object(Jml\BarBundle)[18]
          protected 'name' => string 'BarBundle' (length=9)
          protected 'extension' => null
          protected 'path' => null
          protected 'container' => null
      1 => 
        object(Jml\FooBundle)[17]
          protected 'name' => string 'FooBundle' (length=9)
          protected 'extension' => null
          protected 'path' => null
          protected 'container' => null
  'BarBundle' => 
    array (size=1)
      0 => 
        object(Jml\BarBundle)[18]
          protected 'name' => string 'BarBundle' (length=9)
          protected 'extension' => null
          protected 'path' => null
          protected 'container' => null
  'PimVersioningBundle' => 
    array (size=1)
      0 => 
        object(Pim\Bundle\VersioningBundle\PimVersioningBundle)[70]
          protected 'name' => string 'PimVersioningBundle' (length=19)
          protected 'extension' => null
          protected 'path' => null
          protected 'container' => null
```

The problem appears if Foo and Bar are PIM extensions.
**They don't know each other and we won't modify BarBundle code to make it compatible.**

### Solution

The idea of this PR is to allow for multiple children of a base bundle by automatically building the previous hierarchy.

In previous example, if i declare Foo and Bar bundles as children of PimImportExportBundle, the PR will make FooBundle a direct child of PimImportExport and BarBundle a direct child of FooBundle.