### PR TITLE
PIM-5600 : Quick export with grid configuration

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -12,6 +12,7 @@
 - PIM-5427: It is now possible to filter by families for product export
 - PIM-5145: It is now possible to filter product exports by locale
 - PIM-5426: It is now possible to filter product exports by completeness
+- PIM-5600: Introduce the product quick export with grid context in CSV and XLSX (exports selected products with a channel, a local and the shown columns)
 - PIM-5761: The channel no more contains any color information as it was not used anymore in the UI.
 - PIM-5431: export the products updated since a defined date
 
@@ -38,6 +39,7 @@
 
 ## BC breaks
 
+- Change constructor of `Pim\Bundle\EnrichBundle\Connector\Processor\QuickExport\ProductToFlatArrayProcessor` . Add `Pim\Component\Connector\ArrayConverter\Flat\Product\FieldSplitter`
 - Change constructor of `Pim\Component\Connector\Reader\ProductReader`. Add `Akeneo\Component\Batch\Job\JobRepositoryInterface`.
 - Add method `getLastJobExecution` to interface `Akeneo\Component\Batch\Job\JobRepositoryInterface`
 - Remove properties editTemplate, showTemplate from `src\Akeneo\Component\Batch\Job\Job`.

--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -39,6 +39,7 @@
 
 ## BC breaks
 
+- Move `Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\ProductQueryUtility` to `Pim\Bundle\CatalogBundle\ProductQueryUtility`
 - Change constructor of `Pim\Bundle\EnrichBundle\Connector\Processor\QuickExport\ProductToFlatArrayProcessor` . Add `Pim\Component\Connector\ArrayConverter\Flat\Product\FieldSplitter`
 - Change constructor of `Pim\Component\Connector\Reader\ProductReader`. Add `Akeneo\Component\Batch\Job\JobRepositoryInterface`.
 - Add method `getLastJobExecution` to interface `Akeneo\Component\Batch\Job\JobRepositoryInterface`

--- a/features/Context/catalog/default/jobs.yml
+++ b/features/Context/catalog/default/jobs.yml
@@ -34,6 +34,16 @@ jobs:
             enclosure:  '"'
             withHeader: true
             filePath:   /tmp/products-quick-export.csv
+    csv_product_grid_context_quick_export:
+        connector: Akeneo Mass Edit Connector
+        alias: csv_product_grid_context_quick_export
+        label: CSV product quick export grid context
+        type: quick_export
+        configuration:
+            delimiter:  ;
+            enclosure:  '"'
+            withHeader: true
+            filePath:   /tmp/products_export_grid_context_%locale%_%scope%.csv
     xlsx_product_quick_export:
         connector: Akeneo Mass Edit Connector
         alias: xlsx_product_quick_export
@@ -41,4 +51,14 @@ jobs:
         type: quick_export
         configuration:
             withHeader: true
+            linesPerFile: 10000
             filePath:   /tmp/products_export_%locale%_%scope%.xlsx
+    xlsx_product_grid_context_quick_export:
+        connector: Akeneo Mass Edit Connector
+        alias: xlsx_product_grid_context_quick_export
+        label: XLSX product quick export grid context
+        type: quick_export
+        configuration:
+            withHeader: true
+            linesPerFile: 10000
+            filePath:   /tmp/products_export_grid_context_%locale%_%scope%.xlsx

--- a/features/Context/catalog/footwear/jobs.yml
+++ b/features/Context/catalog/footwear/jobs.yml
@@ -293,6 +293,7 @@ jobs:
         type: quick_export
         configuration:
             withHeader: true
+            linesPerFile: 10000
             filePath:   /tmp/products_export_%locale%_%scope%.xlsx
     xlsx_footwear_family_export:
         connector: Akeneo XLSX Connector
@@ -339,3 +340,22 @@ jobs:
             withHeader: true
             linesPerFile: 10000
             filePath: /tmp/association_type.xlsx
+    csv_product_grid_context_quick_export:
+        connector: Akeneo Mass Edit Connector
+        alias: csv_product_grid_context_quick_export
+        label: CSV product quick export grid context
+        type: quick_export
+        configuration:
+            delimiter:  ;
+            enclosure:  '"'
+            withHeader: true
+            filePath:   /tmp/products_export_grid_context_%locale%_%scope%.csv
+    xlsx_product_grid_context_quick_export:
+        connector: Akeneo Mass Edit Connector
+        alias: xlsx_product_grid_context_quick_export
+        label: XLSX product quick export grid context
+        type: quick_export
+        configuration:
+            withHeader: true
+            linesPerFile: 10000
+            filePath:   /tmp/products_export_grid_context_%locale%_%scope%.xlsx

--- a/features/mass-action/quick_export_grid_context.feature
+++ b/features/mass-action/quick_export_grid_context.feature
@@ -1,0 +1,60 @@
+@javascript
+Feature: Quick export products according to the product grid context
+  In order to quick export a set of products
+  As a product manager
+  I need to be able to display products on the product grid and export them
+
+  Background:
+    Given a "footwear" catalog configuration
+    And the following attributes:
+      | label  | type   | useable_as_grid_filter | metric_family | default_metric_unit | decimals_allowed |
+      | Weight | metric | yes                    | Weight        | GRAM                | yes              |
+    And the following products:
+      | sku      | family   | categories        | name-en_US    | price          | size | color | 123 | description-en_US-tablet | weight | weight-unit |
+      | boots    | boots    | winter_collection | Amazing boots | 20 EUR, 25 USD | 40   | black | aaa | Mob                      | 20     | GRAM        |
+      | sneakers | sneakers | summer_collection | Sneakers      | 50 EUR, 60 USD | 42   | white | bbb | ylette                   | 4      | GRAM        |
+      | sandals  | sandals  | summer_collection | Sandals       | 5 EUR, 5 USD   | 40   | red   | ccc |                          |        |             |
+      | pump     |          | summer_collection | Pump          | 15 EUR, 20 USD | 41   | blue  | ddd |                          |        |             |
+    And I am logged in as "Julia"
+
+  Scenario: Successfully quick export products from grid context as a CSV file
+    Given I am on the products page
+    And I display the columns sku, name, label, family, categories, color, completeness, groups, price, size, created and updated, description, weight
+    And I select rows boots, sneakers, pump
+    When I press "CSV (Grid context)" on the "Quick Export" dropdown button
+    And I wait for the "csv_product_grid_context_quick_export" quick export to finish
+    And I am on the dashboard page
+    Then I should have 1 new notification
+    And I should see notification:
+      | type    | message                                                     |
+      | success | Quick export CSV product quick export grid context finished |
+    When I go on the last executed job resume of "csv_product_grid_context_quick_export"
+    Then I should see "COMPLETED"
+    And the name of the exported file of "csv_product_grid_context_quick_export" should be "products_export_grid_context_en_US_tablet.csv"
+    And exported file of "csv_product_grid_context_quick_export" should contain:
+    """
+    sku;categories;color;family;groups;name-en_US;price-EUR;price-USD;size;description-en_US-tablet;weight;weight-unit
+    boots;winter_collection;black;boots;;Amazing boots;20;25;40;Mob;20;GRAM
+    sneakers;summer_collection;white;sneakers;;Sneakers;50;60;42;ylette;4;GRAM
+    pump;summer_collection;blue;Pump;;;15;20;41;;;
+    """
+
+  Scenario: Successfully quick export products from grid context as a XSLX file
+    Given I am on the products page
+    And I display the columns sku, name, label,family, categories, color, completeness, groups, price, size, created and updated, description, weight
+    And I select rows boots, sneakers, pump
+    When I press "XLSX (Grid context)" on the "Quick Export" dropdown button
+    And I wait for the "xlsx_product_grid_context_quick_export" quick export to finish
+    And I am on the dashboard page
+    Then I should have 1 new notification
+    And I should see notification:
+      | type    | message                                                      |
+      | success | Quick export XLSX product quick export grid context finished |
+    When I go on the last executed job resume of "xlsx_product_grid_context_quick_export"
+    Then I should see "COMPLETED"
+    And the name of the exported file of "xlsx_product_grid_context_quick_export" should be "products_export_grid_context_en_US_tablet.xlsx"
+    And exported xlsx file of "xlsx_product_grid_context_quick_export" should contain:
+      | sku      | categories        | color | family   | groups | name-en_US    | price-EUR | price-USD | size | description-en_US-tablet | weight | weight-unit |
+      | boots    | winter_collection | black | boots    |        | Amazing boots | 20        | 25        | 40   | Mob                      | 20     | GRAM        |
+      | sneakers | summer_collection | white | sneakers |        | Sneakers      | 50        | 60        | 42   | ylette                   | 4      | GRAM        |
+      | pump     | summer_collection | blue  |          |        | Pump          | 15        | 20        | 41   |                          |        |             |

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/BooleanFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/BooleanFilter.php
@@ -2,11 +2,10 @@
 
 namespace Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter;
 
-use Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\ProductQueryUtility;
+use Pim\Bundle\CatalogBundle\ProductQueryUtility;
 use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Query\Filter\AttributeFilterInterface;
-use Pim\Component\Catalog\Query\Filter\FieldFilterHelper;
 use Pim\Component\Catalog\Query\Filter\FieldFilterInterface;
 use Pim\Component\Catalog\Query\Filter\Operators;
 use Pim\Component\Catalog\Validator\AttributeValidatorHelper;

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/CompletenessFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/CompletenessFilter.php
@@ -3,7 +3,7 @@
 namespace Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter;
 
 use Doctrine\ODM\MongoDB\Query\Expr;
-use Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\ProductQueryUtility;
+use Pim\Bundle\CatalogBundle\ProductQueryUtility;
 use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Exception\ObjectNotFoundException;
 use Pim\Component\Catalog\Model\ChannelInterface;

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/DateFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/DateFilter.php
@@ -2,7 +2,7 @@
 
 namespace Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter;
 
-use Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\ProductQueryUtility;
+use Pim\Bundle\CatalogBundle\ProductQueryUtility;
 use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Query\Filter\AttributeFilterInterface;

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/DateTimeFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/DateTimeFilter.php
@@ -2,7 +2,7 @@
 
 namespace Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter;
 
-use Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\ProductQueryUtility;
+use Pim\Bundle\CatalogBundle\ProductQueryUtility;
 use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Query\Filter\FieldFilterInterface;
 use Pim\Component\Catalog\Query\Filter\Operators;

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/FamilyFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/FamilyFilter.php
@@ -3,7 +3,6 @@
 namespace Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter;
 
 use Pim\Bundle\CatalogBundle\Doctrine\Common\Filter\ObjectIdResolverInterface;
-use Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\ProductQueryUtility;
 use Pim\Component\Catalog\Query\Filter\FieldFilterHelper;
 use Pim\Component\Catalog\Query\Filter\FieldFilterInterface;
 use Pim\Component\Catalog\Query\Filter\Operators;

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/GroupsFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/GroupsFilter.php
@@ -3,7 +3,6 @@
 namespace Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter;
 
 use Pim\Bundle\CatalogBundle\Doctrine\Common\Filter\ObjectIdResolverInterface;
-use Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\ProductQueryUtility;
 use Pim\Component\Catalog\Query\Filter\FieldFilterHelper;
 use Pim\Component\Catalog\Query\Filter\FieldFilterInterface;
 use Pim\Component\Catalog\Query\Filter\Operators;

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/MediaFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/MediaFilter.php
@@ -2,7 +2,7 @@
 
 namespace Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter;
 
-use Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\ProductQueryUtility;
+use Pim\Bundle\CatalogBundle\ProductQueryUtility;
 use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Query\Filter\AttributeFilterInterface;

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/MetricFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/MetricFilter.php
@@ -4,7 +4,7 @@ namespace Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter;
 
 use Akeneo\Bundle\MeasureBundle\Convert\MeasureConverter;
 use Akeneo\Bundle\MeasureBundle\Manager\MeasureManager;
-use Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\ProductQueryUtility;
+use Pim\Bundle\CatalogBundle\ProductQueryUtility;
 use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Query\Filter\AttributeFilterInterface;

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/NumberFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/NumberFilter.php
@@ -2,7 +2,7 @@
 
 namespace Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter;
 
-use Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\ProductQueryUtility;
+use Pim\Bundle\CatalogBundle\ProductQueryUtility;
 use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Query\Filter\AttributeFilterInterface;

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/OptionFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/OptionFilter.php
@@ -3,7 +3,7 @@
 namespace Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter;
 
 use Pim\Bundle\CatalogBundle\Doctrine\Common\Filter\ObjectIdResolverInterface;
-use Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\ProductQueryUtility;
+use Pim\Bundle\CatalogBundle\ProductQueryUtility;
 use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Query\Filter\AttributeFilterInterface;

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/OptionsFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/OptionsFilter.php
@@ -3,7 +3,7 @@
 namespace Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter;
 
 use Pim\Bundle\CatalogBundle\Doctrine\Common\Filter\ObjectIdResolverInterface;
-use Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\ProductQueryUtility;
+use Pim\Bundle\CatalogBundle\ProductQueryUtility;
 use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Query\Filter\AttributeFilterInterface;

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/PriceFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/PriceFilter.php
@@ -2,7 +2,7 @@
 
 namespace Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter;
 
-use Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\ProductQueryUtility;
+use Pim\Bundle\CatalogBundle\ProductQueryUtility;
 use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Query\Filter\AttributeFilterInterface;

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/StringFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/StringFilter.php
@@ -2,7 +2,7 @@
 
 namespace Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter;
 
-use Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\ProductQueryUtility;
+use Pim\Bundle\CatalogBundle\ProductQueryUtility;
 use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Query\Filter\AttributeFilterInterface;

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/IndexCreator.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/IndexCreator.php
@@ -4,6 +4,7 @@ namespace Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\MongoDB\Collection;
+use Pim\Bundle\CatalogBundle\ProductQueryUtility;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\ChannelInterface;
 use Pim\Component\Catalog\Model\CurrencyInterface;

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/IndexPurger.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/IndexPurger.php
@@ -4,6 +4,7 @@ namespace Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\MongoDB\Collection;
+use Pim\Bundle\CatalogBundle\ProductQueryUtility;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\ChannelInterface;
 use Pim\Component\Catalog\Model\CurrencyInterface;

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/NamingUtility.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/NamingUtility.php
@@ -3,6 +3,7 @@
 namespace Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
+use Pim\Bundle\CatalogBundle\ProductQueryUtility;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\ChannelInterface;
 use Pim\Component\Catalog\Model\CurrencyInterface;

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/QueryGenerator/AttributeDeletedQueryGenerator.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/QueryGenerator/AttributeDeletedQueryGenerator.php
@@ -2,7 +2,7 @@
 
 namespace Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\QueryGenerator;
 
-use Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\ProductQueryUtility;
+use Pim\Bundle\CatalogBundle\ProductQueryUtility;
 
 /**
  * Attribute deleted query generator

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/QueryGenerator/ChannelDeletedQueryGenerator.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/QueryGenerator/ChannelDeletedQueryGenerator.php
@@ -2,7 +2,7 @@
 
 namespace Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\QueryGenerator;
 
-use Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\ProductQueryUtility;
+use Pim\Bundle\CatalogBundle\ProductQueryUtility;
 
 /**
  * Channel deleted query generator

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Sorter/BaseSorter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Sorter/BaseSorter.php
@@ -3,7 +3,7 @@
 namespace Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Sorter;
 
 use Doctrine\ODM\MongoDB\Query\Builder as QueryBuilder;
-use Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\ProductQueryUtility;
+use Pim\Bundle\CatalogBundle\ProductQueryUtility;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Query\Sorter\AttributeSorterInterface;
 use Pim\Component\Catalog\Query\Sorter\FieldSorterInterface;

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Sorter/CompletenessSorter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Sorter/CompletenessSorter.php
@@ -3,7 +3,7 @@
 namespace Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Sorter;
 
 use Doctrine\ODM\MongoDB\Query\Builder as QueryBuilder;
-use Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\ProductQueryUtility;
+use Pim\Bundle\CatalogBundle\ProductQueryUtility;
 use Pim\Component\Catalog\Query\Sorter\FieldSorterInterface;
 
 /**

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Sorter/FamilySorter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Sorter/FamilySorter.php
@@ -3,7 +3,7 @@
 namespace Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Sorter;
 
 use Doctrine\ODM\MongoDB\Query\Builder as QueryBuilder;
-use Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\ProductQueryUtility;
+use Pim\Bundle\CatalogBundle\ProductQueryUtility;
 use Pim\Component\Catalog\Query\Sorter\FieldSorterInterface;
 
 /**

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Sorter/InGroupSorter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Sorter/InGroupSorter.php
@@ -3,7 +3,7 @@
 namespace Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Sorter;
 
 use Doctrine\ODM\MongoDB\Query\Builder as QueryBuilder;
-use Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\ProductQueryUtility;
+use Pim\Bundle\CatalogBundle\ProductQueryUtility;
 use Pim\Component\Catalog\Query\Sorter\FieldSorterInterface;
 
 /**

--- a/src/Pim/Bundle/CatalogBundle/ProductQueryUtility.php
+++ b/src/Pim/Bundle/CatalogBundle/ProductQueryUtility.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM;
+namespace Pim\Bundle\CatalogBundle;
 
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\ProductValueInterface;

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/writers.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/writers.yml
@@ -177,6 +177,12 @@ services:
              - '@pim_connector.writer.file.file_path_resolver'
              - '@pim_connector.writer.file.default.column_sorter'
 
+    pim_connector.writer.file.product.flat_item_buffer_flusher:
+        class: '%pim_connector.writer.file.flat_item_buffer_flusher.class%'
+        arguments:
+             - '@pim_connector.writer.file.file_path_resolver'
+             - '@pim_connector.writer.file.product.column_sorter'
+
     # CSV
     pim_connector.writer.file.csv:
         class: '%pim_connector.writer.file.csv.class%'
@@ -233,7 +239,7 @@ services:
              - '@pim_connector.writer.file.file_path_resolver'
              - '@pim_connector.writer.file.flat_item_buffer'
              - '@pim_connector.writer.file.product.bulk_file_exporter'
-             - '@pim_connector.writer.file.flat_item_buffer_flusher'
+             - '@pim_connector.writer.file.product.flat_item_buffer_flusher'
 
     pim_connector.writer.file.xlsx_variant_group:
         class: '%pim_connector.writer.file.xlsx_variant_group.class%'

--- a/src/Pim/Bundle/DataGridBundle/Controller/DatagridViewController.php
+++ b/src/Pim/Bundle/DataGridBundle/Controller/DatagridViewController.php
@@ -130,9 +130,10 @@ class DatagridViewController
         return $this->templating->renderResponse(
             'PimDataGridBundle:Datagrid:_views.html.twig',
             [
-                'alias' => $alias,
-                'views' => $views,
-                'form'  => $form->createView(),
+                'alias'              => $alias,
+                'views'              => $views,
+                'defaultViewColumns' => array_keys($this->datagridViewManager->getColumnChoices($alias, true)),
+                'form'               => $form->createView(),
             ]
         );
     }

--- a/src/Pim/Bundle/DataGridBundle/Datasource/ResultRecord/MongoDbOdm/Product/CompletenessTransformer.php
+++ b/src/Pim/Bundle/DataGridBundle/Datasource/ResultRecord/MongoDbOdm/Product/CompletenessTransformer.php
@@ -2,7 +2,7 @@
 
 namespace Pim\Bundle\DataGridBundle\Datasource\ResultRecord\MongoDbOdm\Product;
 
-use Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\ProductQueryUtility;
+use Pim\Bundle\CatalogBundle\ProductQueryUtility;
 
 /**
  * Transform sub-part or product

--- a/src/Pim/Bundle/DataGridBundle/Datasource/ResultRecord/MongoDbOdm/Product/FamilyTransformer.php
+++ b/src/Pim/Bundle/DataGridBundle/Datasource/ResultRecord/MongoDbOdm/Product/FamilyTransformer.php
@@ -2,7 +2,7 @@
 
 namespace Pim\Bundle\DataGridBundle\Datasource\ResultRecord\MongoDbOdm\Product;
 
-use Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\ProductQueryUtility;
+use Pim\Bundle\CatalogBundle\ProductQueryUtility;
 
 /**
  * Transform sub-part or product

--- a/src/Pim/Bundle/DataGridBundle/Datasource/ResultRecord/MongoDbOdm/Product/GroupsTransformer.php
+++ b/src/Pim/Bundle/DataGridBundle/Datasource/ResultRecord/MongoDbOdm/Product/GroupsTransformer.php
@@ -2,7 +2,7 @@
 
 namespace Pim\Bundle\DataGridBundle\Datasource\ResultRecord\MongoDbOdm\Product;
 
-use Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\ProductQueryUtility;
+use Pim\Bundle\CatalogBundle\ProductQueryUtility;
 
 /**
  * Transform sub-part or product

--- a/src/Pim/Bundle/DataGridBundle/Datasource/ResultRecord/MongoDbOdm/Product/OptionsTransformer.php
+++ b/src/Pim/Bundle/DataGridBundle/Datasource/ResultRecord/MongoDbOdm/Product/OptionsTransformer.php
@@ -2,7 +2,7 @@
 
 namespace Pim\Bundle\DataGridBundle\Datasource\ResultRecord\MongoDbOdm\Product;
 
-use Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\ProductQueryUtility;
+use Pim\Bundle\CatalogBundle\ProductQueryUtility;
 use Pim\Component\Catalog\AttributeTypes;
 
 /**

--- a/src/Pim/Bundle/DataGridBundle/Datasource/ResultRecord/MongoDbOdm/Product/ValuesTransformer.php
+++ b/src/Pim/Bundle/DataGridBundle/Datasource/ResultRecord/MongoDbOdm/Product/ValuesTransformer.php
@@ -2,7 +2,7 @@
 
 namespace Pim\Bundle\DataGridBundle\Datasource\ResultRecord\MongoDbOdm\Product;
 
-use Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\ProductQueryUtility;
+use Pim\Bundle\CatalogBundle\ProductQueryUtility;
 use Pim\Bundle\ReferenceDataBundle\DataGrid\Datasource\ResultRecord\MongoDbOdm\Product\ReferenceDataTransformer;
 use Pim\Component\Catalog\AttributeTypes;
 

--- a/src/Pim/Bundle/DataGridBundle/Resources/views/Datagrid/_views.html.twig
+++ b/src/Pim/Bundle/DataGridBundle/Resources/views/Datagrid/_views.html.twig
@@ -15,7 +15,7 @@
     {% endfor %}
 
     {% if not hasDefaultView %}
-        <option value="0" data-default="1">
+        <option value="0" data-default="1" data-columns="{{ defaultViewColumns|join(',') }}">
             {{- 'datagrid_view.default'|trans -}}
         </option>
     {% endif %}
@@ -231,6 +231,9 @@ require(
                 setTitle(activeViewLabel);
                 $updateLink.addClass('hide');
 
+                if ($activeView.data('default') && !$activeView.data('removable') && !currentState.columns) {
+                    DatagridState.set('{{ alias }}', {'columns': $activeView.data('columns')});
+                }
             } else {
                 setTitle(activeViewLabel, ' *');
                 if (!$activeView.data('default') && $activeView.data('removable')) {

--- a/src/Pim/Bundle/EnrichBundle/Connector/Job/JobParameters/ConstraintCollectionProvider/ProductQuickExport.php
+++ b/src/Pim/Bundle/EnrichBundle/Connector/Job/JobParameters/ConstraintCollectionProvider/ProductQuickExport.php
@@ -42,6 +42,7 @@ class ProductQuickExport implements ConstraintCollectionProviderInterface
         $constraintFields = $baseConstraint->fields;
         $constraintFields['filters'] = new NotBlank(['groups' => 'Execution']);
         $constraintFields['mainContext'] = new NotBlank(['groups' => 'Execution']);
+        $constraintFields['selected_properties'] = null;
 
         return new Collection(['fields' => $constraintFields]);
     }

--- a/src/Pim/Bundle/EnrichBundle/Connector/Job/JobParameters/DefaultValuesProvider/ProductQuickExport.php
+++ b/src/Pim/Bundle/EnrichBundle/Connector/Job/JobParameters/DefaultValuesProvider/ProductQuickExport.php
@@ -38,6 +38,7 @@ class ProductQuickExport implements DefaultValuesProviderInterface
         $parameters = $this->simpleProvider->getDefaultValues();
         $parameters['filters'] = null;
         $parameters['mainContext'] = null;
+        $parameters['selected_properties'] = null;
 
         return $parameters;
     }

--- a/src/Pim/Bundle/EnrichBundle/Connector/Processor/QuickExport/ProductToFlatArrayProcessor.php
+++ b/src/Pim/Bundle/EnrichBundle/Connector/Processor/QuickExport/ProductToFlatArrayProcessor.php
@@ -6,11 +6,13 @@ use Akeneo\Component\Batch\Item\InvalidItemException;
 use Akeneo\Component\Batch\Model\StepExecution;
 use Akeneo\Component\FileStorage\Model\FileInfoInterface;
 use Akeneo\Component\StorageUtils\Detacher\ObjectDetacherInterface;
+use Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\ProductQueryUtility;
 use Pim\Bundle\EnrichBundle\Connector\Processor\AbstractProcessor;
 use Pim\Component\Catalog\AttributeTypes;
 use Pim\Component\Catalog\Builder\ProductBuilderInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Repository\ChannelRepositoryInterface;
+use Pim\Component\Connector\ArrayConverter\FlatToStandard\Product\FieldSplitter;
 use Symfony\Component\HttpFoundation\File\Exception\FileNotFoundException;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
@@ -43,6 +45,9 @@ class ProductToFlatArrayProcessor extends AbstractProcessor
     /** @var  ObjectDetacherInterface */
     protected $objectDetacher;
 
+    /** @var FieldSplitter */
+    protected $fieldSplitter;
+
     /**
      * @param SerializerInterface        $serializer
      * @param ChannelRepositoryInterface $channelRepository
@@ -50,6 +55,7 @@ class ProductToFlatArrayProcessor extends AbstractProcessor
      * @param ObjectDetacherInterface    $objectDetacher
      * @param UserProviderInterface      $userProvider
      * @param TokenStorageInterface      $tokenStorage
+     * @param FieldSplitter              $fieldSplitter
      * @param string                     $uploadDirectory
      */
     public function __construct(
@@ -59,6 +65,7 @@ class ProductToFlatArrayProcessor extends AbstractProcessor
         ObjectDetacherInterface $objectDetacher,
         UserProviderInterface $userProvider,
         TokenStorageInterface $tokenStorage,
+        FieldSplitter $fieldSplitter,
         $uploadDirectory
     ) {
         $this->serializer        = $serializer;
@@ -67,6 +74,7 @@ class ProductToFlatArrayProcessor extends AbstractProcessor
         $this->objectDetacher    = $objectDetacher;
         $this->userProvider      = $userProvider;
         $this->tokenStorage      = $tokenStorage;
+        $this->fieldSplitter     = $fieldSplitter;
         $this->uploadDirectory   = $uploadDirectory;
     }
 
@@ -102,10 +110,87 @@ class ProductToFlatArrayProcessor extends AbstractProcessor
             }
         }
 
-        $data['product'] = $this->serializer->normalize($product, 'flat', $this->getNormalizerContext());
+        $normalizerContext = $this->getNormalizerContext();
+        $data['product'] = $this->serializer->normalize($product, 'flat', $normalizerContext);
+
+        if (isset($normalizerContext['selected_properties']) && !empty($normalizerContext['selected_properties'])) {
+            $data['product'] = $this->filterProperties(
+                $product,
+                $data['product'],
+                $normalizerContext['selected_properties'],
+                $normalizerContext['locale'],
+                $normalizerContext['scopeCode']
+            );
+        }
+
         $this->objectDetacher->detach($product);
 
         return $data;
+    }
+
+    /**
+     * filter the properties that has to be exported based on a product and a list of properties
+     *
+     * @param ProductInterface $product
+     * @param array            $normalizedProduct
+     * @param array            $properties
+     * @param string           $localeCode
+     * @param string           $channelCode
+     *
+     * @return array
+     */
+    protected function filterProperties(
+        ProductInterface $product,
+        array $normalizedProduct,
+        array $properties,
+        $localeCode = null,
+        $channelCode = null
+    ) {
+        $filteredColumnList = [];
+
+        foreach ($properties as $column) {
+            if ('label' === $column && null !== $product->getFamily()) {
+                $column = $product->getFamily()->getAttributeAsLabel()->getCode();
+            }
+
+            $attribute = $product->getAttributeByCode($column);
+            if (null !== $attribute) {
+                if (AttributeTypes::PRICE_COLLECTION === $attribute->getAttributeType()) {
+                    foreach ($normalizedProduct as $key => $value) {
+                        if ($column === $this->fieldSplitter->splitFieldName($key)[0]) {
+                            $filteredColumnList[] = $key;
+                        }
+                    };
+                } else {
+                    $filteredColumnList[] = ProductQueryUtility::getNormalizedValueFieldFromAttribute(
+                        $attribute,
+                        $localeCode,
+                        $channelCode
+                    );
+                }
+            } else {
+                $filteredColumnList[] = $column;
+            }
+        }
+
+        return array_intersect_key($normalizedProduct, array_flip($filteredColumnList));
+    }
+
+    /**
+     * @param ProductInterface $product
+     * @param string           $attributeCode
+     *
+     * @return AttributeInterface|null
+     */
+    protected function getProductAttributeByCode(ProductInterface $product, $attributeCode)
+    {
+        foreach ($product->getValues() as $value) {
+            if ($attributeCode === $value->getAttribute()->getCode()) {
+                return $value->getAttribute();
+            }
+        }
+
+        return null;
     }
 
     /**
@@ -117,6 +202,7 @@ class ProductToFlatArrayProcessor extends AbstractProcessor
     {
         $jobParameters = $this->stepExecution->getJobParameters();
         $mainContext = $jobParameters->get('mainContext');
+        $columns = $jobParameters->get('selected_properties');
 
         if (!isset($mainContext['scope'])) {
             throw new \InvalidArgumentException('No channel found');
@@ -126,14 +212,19 @@ class ProductToFlatArrayProcessor extends AbstractProcessor
             throw new \InvalidArgumentException('No UI locale found');
         }
 
+        if (isset($columns) && 0 !== count($columns)) {
+            $columns[] = 'sku';
+        }
+
         $normalizerContext = [
-            'scopeCode'    => $mainContext['scope'],
-            'localeCodes'  => $this->getLocaleCodes($mainContext['scope']),
-            'locale'       => $mainContext['ui_locale'],
-            'filter_types' => [
+            'scopeCode'           => $mainContext['scope'],
+            'localeCodes'         => $this->getLocaleCodes($mainContext['scope']),
+            'locale'              => $mainContext['ui_locale'],
+            'filter_types'        => [
                 'pim.transform.product_value.flat',
                 'pim.transform.product_value.flat.quick_export'
-            ]
+            ],
+            'selected_properties' => $columns
         ];
 
         return $normalizerContext;

--- a/src/Pim/Bundle/EnrichBundle/Connector/Processor/QuickExport/ProductToFlatArrayProcessor.php
+++ b/src/Pim/Bundle/EnrichBundle/Connector/Processor/QuickExport/ProductToFlatArrayProcessor.php
@@ -6,10 +6,11 @@ use Akeneo\Component\Batch\Item\InvalidItemException;
 use Akeneo\Component\Batch\Model\StepExecution;
 use Akeneo\Component\FileStorage\Model\FileInfoInterface;
 use Akeneo\Component\StorageUtils\Detacher\ObjectDetacherInterface;
-use Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\ProductQueryUtility;
+use Pim\Bundle\CatalogBundle\ProductQueryUtility;
 use Pim\Bundle\EnrichBundle\Connector\Processor\AbstractProcessor;
 use Pim\Component\Catalog\AttributeTypes;
 use Pim\Component\Catalog\Builder\ProductBuilderInterface;
+use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Repository\ChannelRepositoryInterface;
 use Pim\Component\Connector\ArrayConverter\FlatToStandard\Product\FieldSplitter;
@@ -153,9 +154,12 @@ class ProductToFlatArrayProcessor extends AbstractProcessor
                 $column = $product->getFamily()->getAttributeAsLabel()->getCode();
             }
 
-            $attribute = $product->getAttributeByCode($column);
+            $attribute = $this->getProductAttributeByCode($product, $column);
             if (null !== $attribute) {
-                if (AttributeTypes::PRICE_COLLECTION === $attribute->getAttributeType()) {
+                if (in_array(
+                    $attribute->getAttributeType(),
+                    [AttributeTypes::PRICE_COLLECTION, AttributeTypes::METRIC]
+                )) {
                     foreach ($normalizedProduct as $key => $value) {
                         if ($column === $this->fieldSplitter->splitFieldName($key)[0]) {
                             $filteredColumnList[] = $key;

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/batch_jobs.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/batch_jobs.yml
@@ -40,11 +40,23 @@ connector:
         csv_product_quick_export:
             type: quick_export
             steps:
-                perform:
+                export:
                     services:
                         reader:    pim_enrich.connector.reader.mass_edit.product
                         processor: pim_enrich.connector.processor.quick_export.product_to_flat_array
                         writer:    pim_connector.writer.file.csv_product
+                    parameters:
+                        batch_size: 1000
+        csv_product_grid_context_quick_export:
+            type: quick_export
+            steps:
+                export:
+                    services:
+                        reader:    pim_enrich.connector.reader.mass_edit.product
+                        processor: pim_enrich.connector.processor.quick_export.product_to_flat_array
+                        writer:    pim_connector.writer.file.csv_product
+                    parameters:
+                        batch_size: 1000
         xlsx_product_quick_export:
              type:  quick_export
              steps:
@@ -53,6 +65,18 @@ connector:
                          reader:    pim_enrich.connector.reader.mass_edit.product
                          processor: pim_enrich.connector.processor.quick_export.product_to_flat_array
                          writer:    pim_connector.writer.file.xlsx_product
+                     parameters:
+                         batch_size: 1000
+        xlsx_product_grid_context_quick_export:
+             type:  quick_export
+             steps:
+                 export:
+                     services:
+                         reader:    pim_enrich.connector.reader.mass_edit.product
+                         processor: pim_enrich.connector.processor.quick_export.product_to_flat_array
+                         writer:    pim_connector.writer.file.xlsx_product
+                     parameters:
+                          batch_size: 1000
         add_to_variant_group:
             type:  mass_edit
             steps:

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/connector/processors.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/connector/processors.yml
@@ -50,4 +50,5 @@ services:
             - '@akeneo_storage_utils.doctrine.object_detacher'
             - '@pim_user.provider.user'
             - '@security.token_storage'
+            - '@pim_connector.array_converter.flat_to_standard.product.field_splitter'
             - '%upload_dir%'

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product.yml
@@ -110,16 +110,17 @@ datagrid:
                     empty_selection: pim_datagrid.mass_action.delete.empty_selection
                 launcherOptions:
                     icon: trash
-            quick_export_csv:
+            quick_export_grid_context_xlsx:
                 type: export
-                label: pim.grid.mass_action.quick_export.csv_all
+                label: pim.grid.mass_action.quick_export.xlsx_grid_context
                 icon: download
                 handler: product_quick_export
                 route: pim_datagrid_export_product_index
                 route_parameters:
-                    _format: csv
-                    _contentType: text/csv
-                    _jobCode: csv_product_quick_export
+                    _format: xlsx
+                    _contentType: application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+                    _jobCode: xlsx_product_grid_context_quick_export
+                    _displayedColumnsOnly: 1
                 context:
                     withHeader: true
                 messages:
@@ -136,6 +137,41 @@ datagrid:
                     _format: xlsx
                     _contentType: application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
                     _jobCode: xlsx_product_quick_export
+                    _displayedColumnsOnly: 0
+                context:
+                    withHeader: true
+                messages:
+                    empty_selection: pim_datagrid.mass_action.delete.empty_selection
+                launcherOptions:
+                    group: quick_export
+            quick_export_grid_context_csv:
+                type: export
+                label: pim.grid.mass_action.quick_export.csv_grid_context
+                icon: download
+                handler: product_quick_export
+                route: pim_datagrid_export_product_index
+                route_parameters:
+                    _format: csv
+                    _contentType: text/csv
+                    _jobCode: csv_product_grid_context_quick_export
+                    _displayedColumnsOnly: 1
+                context:
+                    withHeader: true
+                messages:
+                    empty_selection: pim_datagrid.mass_action.delete.empty_selection
+                launcherOptions:
+                    group: quick_export
+            quick_export_csv:
+                type: export
+                label: pim.grid.mass_action.quick_export.csv_all
+                icon: download
+                handler: product_quick_export
+                route: pim_datagrid_export_product_index
+                route_parameters:
+                    _format: csv
+                    _contentType: text/csv
+                    _jobCode: csv_product_quick_export
+                    _displayedColumnsOnly: 0
                 context:
                     withHeader: true
                 messages:

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/job_constraints.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/job_constraints.yml
@@ -21,6 +21,7 @@ services:
             - '@pim_connector.job.job_parameters.constraint_collection_provider.simple_csv_export'
             -
                 - 'csv_product_quick_export'
+                - 'csv_product_grid_context_quick_export'
         tags:
             - { name: akeneo_batch.job.job_parameters.constraint_collection_provider }
 
@@ -30,5 +31,6 @@ services:
             - '@pim_connector.job.job_parameters.constraint_collection_provider.simple_xlsx_export'
             -
                 - 'xlsx_product_quick_export'
+                - 'xlsx_product_grid_context_quick_export'
         tags:
             - { name: akeneo_batch.job.job_parameters.constraint_collection_provider }

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/job_defaults.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/job_defaults.yml
@@ -21,6 +21,7 @@ services:
             - '@pim_connector.job.job_parameters.default_values_provider.simple_csv_export'
             -
                 - 'csv_product_quick_export'
+                - 'csv_product_grid_context_quick_export'
         tags:
             - { name: akeneo_batch.job.job_parameters.default_values_provider }
 
@@ -30,5 +31,6 @@ services:
             - '@pim_connector.job.job_parameters.default_values_provider.simple_xlsx_export'
             -
                 - 'xlsx_product_quick_export'
+                - 'xlsx_product_grid_context_quick_export'
         tags:
             - { name: akeneo_batch.job.job_parameters.default_values_provider }

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
@@ -98,7 +98,9 @@ Toggle status:                  Toggle status
 
 # Quick export labels
 pim.grid.mass_action.quick_export.csv_all: CSV (All attributes)
+pim.grid.mass_action.quick_export.csv_grid_context: CSV (Grid context)
 pim.grid.mass_action.quick_export.xlsx_all: XLSX (All attributes)
+pim.grid.mass_action.quick_export.xlsx_grid_context: XLSX (Grid context)
 pim.grid.mass_action.delete:               Delete
 pim.grid.mass_action.mass_edit:            Mass Edit
 pim.grid.mass_action.sequential_edit:      Sequential Edit

--- a/src/Pim/Bundle/EnrichBundle/spec/Connector/Processor/QuickExport/ProductToFlatArrayProcessorSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Connector/Processor/QuickExport/ProductToFlatArrayProcessorSpec.php
@@ -11,7 +11,6 @@ use Akeneo\Component\StorageUtils\Detacher\ObjectDetacherInterface;
 use PhpSpec\ObjectBehavior;
 use Pim\Bundle\UserBundle\Entity\UserInterface;
 use Pim\Component\Catalog\Builder\ProductBuilderInterface;
-use Pim\Bundle\CatalogBundle\Manager\ChannelManager;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\ChannelInterface;
 use Pim\Component\Catalog\Model\MetricInterface;
@@ -19,6 +18,7 @@ use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Model\ProductPriceInterface;
 use Pim\Component\Catalog\Model\ProductValueInterface;
 use Pim\Component\Catalog\Repository\ChannelRepositoryInterface;
+use Pim\Component\Connector\ArrayConverter\FlatToStandard\Product\FieldSplitter;
 use Prophecy\Argument;
 use Symfony\Component\HttpFoundation\File\Exception\FileNotFoundException;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
@@ -34,7 +34,8 @@ class ProductToFlatArrayProcessorSpec extends ObjectBehavior
         ProductBuilderInterface $productBuilder,
         ObjectDetacherInterface $objectDetacher,
         UserProviderInterface $userProvider,
-        TokenStorageInterface $tokenStorage
+        TokenStorageInterface $tokenStorage,
+        FieldSplitter $fieldSplitter
     ) {
         $this->beConstructedWith(
             $serializer,
@@ -43,6 +44,7 @@ class ProductToFlatArrayProcessorSpec extends ObjectBehavior
             $objectDetacher,
             $userProvider,
             $tokenStorage,
+            $fieldSplitter,
             'upload/path/'
         );
         $this->setStepExecution($stepExecution);
@@ -63,10 +65,18 @@ class ProductToFlatArrayProcessorSpec extends ObjectBehavior
         $stepExecution,
         JobParameters $jobParameters
     ) {
-        $configuration = ['filters' => [], 'mainContext' => ['scope' => 'ecommerce', 'ui_locale' => 'en_US']];
+        $configuration = [
+            'filters'             => [],
+            'mainContext'         => [
+                'scope'     => 'ecommerce',
+                'ui_locale' => 'en_US',
+            ],
+            'selected_properties' => [],
+        ];
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $jobParameters->get('filters')->willReturn($configuration['filters']);
         $jobParameters->get('mainContext')->willReturn($configuration['mainContext']);
+        $jobParameters->get('selected_properties')->willReturn($configuration['selected_properties']);
 
         $stepExecution->getJobExecution()->willReturn($jobExecution);
 
@@ -91,10 +101,18 @@ class ProductToFlatArrayProcessorSpec extends ObjectBehavior
         AttributeInterface $attribute,
         JobParameters $jobParameters
     ) {
-        $configuration = ['filters' => [], 'mainContext' => ['scope' => 'mobile', 'ui_locale' => 'en_US']];
+        $configuration = [
+            'filters'             => [],
+            'mainContext'         => [
+                'scope'     => 'mobile',
+                'ui_locale' => 'en_US',
+            ],
+            'selected_properties' => null,
+        ];
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $jobParameters->get('filters')->willReturn($configuration['filters']);
         $jobParameters->get('mainContext')->willReturn($configuration['mainContext']);
+        $jobParameters->get('selected_properties')->willReturn($configuration['selected_properties']);
 
         $stepExecution->getJobExecution()->willReturn($jobExecution);
         $jobExecution->getUser()->willReturn('michel');
@@ -125,7 +143,8 @@ class ProductToFlatArrayProcessorSpec extends ObjectBehavior
                     'filter_types' => [
                         'pim.transform.product_value.flat',
                         'pim.transform.product_value.flat.quick_export'
-                    ]
+                    ],
+                    'selected_properties' => null,
                 ]
             )
             ->willReturn(['normalized_product']);
@@ -154,10 +173,18 @@ class ProductToFlatArrayProcessorSpec extends ObjectBehavior
         Serializer $serializer,
         JobParameters $jobParameters
     ) {
-        $configuration = ['filters' => [], 'mainContext' => ['scope' => 'mobile', 'ui_locale' => 'en_US']];
+        $configuration = [
+            'filters'     => [],
+            'mainContext' => [
+                'scope'     => 'mobile',
+                'ui_locale' => 'en_US',
+            ],
+            'selected_properties'     => null,
+        ];
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $jobParameters->get('filters')->willReturn($configuration['filters']);
         $jobParameters->get('mainContext')->willReturn($configuration['mainContext']);
+        $jobParameters->get('selected_properties')->willReturn($configuration['selected_properties']);
 
         $stepExecution->getJobExecution()->willReturn($jobExecution);
         $jobExecution->getUser()->willReturn('michel');
@@ -179,7 +206,8 @@ class ProductToFlatArrayProcessorSpec extends ObjectBehavior
                     'filter_types' => [
                         'pim.transform.product_value.flat',
                         'pim.transform.product_value.flat.quick_export'
-                    ]
+                    ],
+                    'selected_properties' => null,
                 ]
             )
             ->willReturn(['normalized_product']);
@@ -203,10 +231,18 @@ class ProductToFlatArrayProcessorSpec extends ObjectBehavior
         AttributeInterface $attribute,
         JobParameters $jobParameters
     ) {
-        $configuration = ['filters' => [], 'mainContext' => ['scope' => 'mobile', 'ui_locale' => 'en_US']];
+        $configuration = [
+            'filters'     => [],
+            'mainContext' => [
+                'scope'     => 'mobile',
+                'ui_locale' => 'en_US',
+            ],
+            'selected_properties'     => null,
+        ];
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $jobParameters->get('filters')->willReturn($configuration['filters']);
         $jobParameters->get('mainContext')->willReturn($configuration['mainContext']);
+        $jobParameters->get('selected_properties')->willReturn($configuration['selected_properties']);
 
         $stepExecution->getJobExecution()->willReturn($jobExecution);
         $jobExecution->getUser()->willReturn('michel');
@@ -253,10 +289,19 @@ class ProductToFlatArrayProcessorSpec extends ObjectBehavior
         ProductValueInterface $dateValue,
         JobParameters $jobParameters
     ) {
-        $configuration = ['filters' => [], 'mainContext' => ['scope' => 'mobile', 'ui_locale' => 'en_US']];
+        $configuration = [
+            'filters'     => [],
+            'mainContext' => [
+                'scope'     => 'mobile',
+                'ui_locale' => 'en_US',
+            ],
+            'selected_properties'     => null,
+        ];
+
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $jobParameters->get('filters')->willReturn($configuration['filters']);
         $jobParameters->get('mainContext')->willReturn($configuration['mainContext']);
+        $jobParameters->get('selected_properties')->willReturn($configuration['selected_properties']);
 
         $stepExecution->getJobExecution()->willReturn($jobExecution);
         $jobExecution->getUser()->willReturn('michel');
@@ -295,7 +340,8 @@ class ProductToFlatArrayProcessorSpec extends ObjectBehavior
                     'filter_types' => [
                         'pim.transform.product_value.flat',
                         'pim.transform.product_value.flat.quick_export'
-                    ]
+                    ],
+                    'selected_properties' => null,
                 ]
             )
             ->willReturn(['10.50', '10.00 GRAM', '10.00 EUR', '10/25/15']);
@@ -327,10 +373,19 @@ class ProductToFlatArrayProcessorSpec extends ObjectBehavior
         ProductValueInterface $priceValue,
         JobParameters $jobParameters
     ) {
-        $configuration = ['filters' => [], 'mainContext' => ['scope' => 'mobile', 'ui_locale' => 'fr_FR']];
+        $configuration = [
+            'filters'     => [],
+            'mainContext' => [
+                'scope'     => 'mobile',
+                'ui_locale' => 'fr_FR',
+            ],
+            'selected_properties'     => null,
+        ];
+
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $jobParameters->get('filters')->willReturn($configuration['filters']);
         $jobParameters->get('mainContext')->willReturn($configuration['mainContext']);
+        $jobParameters->get('selected_properties')->willReturn($configuration['selected_properties']);
 
         $stepExecution->getJobExecution()->willReturn($jobExecution);
         $jobExecution->getUser()->willReturn('michel');
@@ -366,7 +421,8 @@ class ProductToFlatArrayProcessorSpec extends ObjectBehavior
                     'filter_types' => [
                         'pim.transform.product_value.flat',
                         'pim.transform.product_value.flat.quick_export'
-                    ]
+                    ],
+                    'selected_properties' => null,
                 ]
             )
             ->willReturn(['10,50', '10,00 GRAM', '10,00 EUR', '25/10/2015']);

--- a/src/Pim/Bundle/InstallerBundle/Resources/fixtures/icecat_demo_dev/jobs.yml
+++ b/src/Pim/Bundle/InstallerBundle/Resources/fixtures/icecat_demo_dev/jobs.yml
@@ -206,6 +206,16 @@ jobs:
             enclosure:  '"'
             withHeader: true
             filePath:   /tmp/products_export_%locale%_%scope%_%datetime%.csv
+    csv_product_grid_context_quick_export:
+        connector: Akeneo Mass Edit Connector
+        alias: csv_product_grid_context_quick_export
+        label: CSV product quick export grid context
+        type: quick_export
+        configuration:
+            delimiter:  ;
+            enclosure:  '"'
+            withHeader: true
+            filePath:   /tmp/products_export_grid_context_%locale%_%scope%_%datetime%.csv
     csv_family_export:
         connector: Akeneo CSV Connector
         alias:     csv_family_export
@@ -258,6 +268,15 @@ jobs:
             withHeader: true
             linesPerFile: 10000
             filePath:   /tmp/products_export_%locale%_%scope%_%datetime%.xlsx
+    xlsx_product_grid_context_quick_export:
+        connector: Akeneo Mass Edit Connector
+        alias: xlsx_product_grid_context_quick_export
+        label: XLSX product quick export grid context
+        type: quick_export
+        configuration:
+            withHeader:   true
+            filePath:     /tmp/products_export_grid_context_%locale%_%scope%_%datetime%.xlsx
+            linesPerFile: 10000
     xlsx_product_import:
         connector: Akeneo XLSX Connector
         alias:     xlsx_product_import

--- a/src/Pim/Bundle/InstallerBundle/Resources/fixtures/minimal/jobs.yml
+++ b/src/Pim/Bundle/InstallerBundle/Resources/fixtures/minimal/jobs.yml
@@ -34,6 +34,16 @@ jobs:
             enclosure:  '"'
             withHeader: true
             filePath:   /tmp/products_export_%locale%_%scope%_%datetime%.csv
+    csv_product_grid_context_quick_export:
+        connector: Akeneo Mass Edit Connector
+        alias: csv_product_grid_context_quick_export
+        label: CSV product quick export grid context
+        type: quick_export
+        configuration:
+            delimiter:  ;
+            enclosure:  '"'
+            withHeader: true
+            filePath:   /tmp/products_export_grid_context_%locale%_%scope%_%datetime%.csv
     xlsx_product_quick_export:
         connector: Akeneo Mass Edit Connector
         alias: xlsx_product_quick_export
@@ -43,3 +53,12 @@ jobs:
             withHeader: true
             linesPerFile: 10000
             filePath:   /tmp/products_export_%locale%_%scope%_%datetime%.xlsx
+    xlsx_product_grid_context_quick_export:
+        connector: Akeneo Mass Edit Connector
+        alias: xlsx_product_grid_context_quick_export
+        label: XLSX product quick export grid context
+        type: quick_export
+        configuration:
+            withHeader:   true
+            filePath:     /tmp/products_export_grid_context_%locale%_%scope%_%datetime%.xlsx
+            linesPerFile: 10000

--- a/src/Pim/Bundle/ReferenceDataBundle/DataGrid/Datasource/ResultRecord/MongoDbOdm/Product/ReferenceDataTransformer.php
+++ b/src/Pim/Bundle/ReferenceDataBundle/DataGrid/Datasource/ResultRecord/MongoDbOdm/Product/ReferenceDataTransformer.php
@@ -2,7 +2,7 @@
 
 namespace Pim\Bundle\ReferenceDataBundle\DataGrid\Datasource\ResultRecord\MongoDbOdm\Product;
 
-use Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\ProductQueryUtility;
+use Pim\Bundle\CatalogBundle\ProductQueryUtility;
 use Pim\Component\Catalog\AttributeTypes;
 
 /**

--- a/src/Pim/Bundle/ReferenceDataBundle/Doctrine/MongoDB/Filter/ReferenceDataFilter.php
+++ b/src/Pim/Bundle/ReferenceDataBundle/Doctrine/MongoDB/Filter/ReferenceDataFilter.php
@@ -3,7 +3,7 @@
 namespace Pim\Bundle\ReferenceDataBundle\Doctrine\MongoDB\Filter;
 
 use Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\AbstractAttributeFilter;
-use Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\ProductQueryUtility;
+use Pim\Bundle\CatalogBundle\ProductQueryUtility;
 use Pim\Bundle\ReferenceDataBundle\Doctrine\ReferenceDataIdResolver;
 use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;

--- a/src/Pim/Bundle/ReferenceDataBundle/Doctrine/MongoDB/Sorter/ReferenceDataSorter.php
+++ b/src/Pim/Bundle/ReferenceDataBundle/Doctrine/MongoDB/Sorter/ReferenceDataSorter.php
@@ -3,7 +3,7 @@
 namespace Pim\Bundle\ReferenceDataBundle\Doctrine\MongoDB\Sorter;
 
 use Doctrine\ODM\MongoDB\Query\Builder as QueryBuilder;
-use Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\ProductQueryUtility;
+use Pim\Bundle\CatalogBundle\ProductQueryUtility;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Query\Sorter\AttributeSorterInterface;
 use Pim\Component\ReferenceData\ConfigurationRegistryInterface;

--- a/src/Pim/Component/Catalog/Model/AbstractProduct.php
+++ b/src/Pim/Component/Catalog/Model/AbstractProduct.php
@@ -420,22 +420,6 @@ abstract class AbstractProduct implements ProductInterface
     /**
      * {@inheritdoc}
      */
-    public function getAttributeByCode($attributeCode)
-    {
-        $attribute = null;
-
-        foreach ($this->values as $value) {
-            if ($attributeCode === $value->getAttribute()->getCode()) {
-                $attribute = $value->getAttribute();
-            }
-        }
-
-        return $attribute;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getValues()
     {
         $values = new ArrayCollection();

--- a/src/Pim/Component/Catalog/Model/AbstractProduct.php
+++ b/src/Pim/Component/Catalog/Model/AbstractProduct.php
@@ -420,6 +420,22 @@ abstract class AbstractProduct implements ProductInterface
     /**
      * {@inheritdoc}
      */
+    public function getAttributeByCode($attributeCode)
+    {
+        $attribute = null;
+
+        foreach ($this->values as $value) {
+            if ($attributeCode === $value->getAttribute()->getCode()) {
+                $attribute = $value->getAttribute();
+            }
+        }
+
+        return $attribute;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getValues()
     {
         $values = new ArrayCollection();

--- a/src/Pim/Component/Catalog/Model/ProductInterface.php
+++ b/src/Pim/Component/Catalog/Model/ProductInterface.php
@@ -227,15 +227,6 @@ interface ProductInterface extends
     public function getAttributes();
 
     /**
-     * Get the attributes of the product for an attribute code
-     *
-     * @param string $attributeCode
-     *
-     * @return AttributeInterface
-     */
-    public function getAttributeByCode($attributeCode);
-
-    /**
      * Get whether or not an attribute is part of a product
      *
      * @param AttributeInterface $attribute

--- a/src/Pim/Component/Catalog/Model/ProductInterface.php
+++ b/src/Pim/Component/Catalog/Model/ProductInterface.php
@@ -227,6 +227,15 @@ interface ProductInterface extends
     public function getAttributes();
 
     /**
+     * Get the attributes of the product for an attribute code
+     *
+     * @param string $attributeCode
+     *
+     * @return AttributeInterface
+     */
+    public function getAttributeByCode($attributeCode);
+
+    /**
      * Get whether or not an attribute is part of a product
      *
      * @param AttributeInterface $attribute

--- a/upgrades/schema/Version_1_6_201603100000_batch_jobs.php
+++ b/upgrades/schema/Version_1_6_201603100000_batch_jobs.php
@@ -23,8 +23,9 @@ class Version_1_6_201603100000_batch_jobs extends AbstractMigration
             INSERT INTO akeneo_batch_job_instance
                 (`code`, `label`, `alias`, `status`, `connector`, `rawConfiguration`, `type`)
             VALUES
-                ('xlsx_product_quick_export', 'XLSX product quick export', 'xlsx_product_quick_export', 0, 'Akeneo Mass Edit Connector', 'a:2:{s:10:"withHeader";b:1;s:8:"filePath";s:53:"/tmp/products_export_%locale%_%scope%_%datetime%.xlsx";}', 'quick_export'),
-                ('xlsx_published_product_quick_export', 'XLSX published product quick export', 'xlsx_published_product_quick_export', 0, 'Akeneo Mass Edit Connector', 'a:2:{s:10:"withHeader";b:1;s:8:"filePath";s:63:"/tmp/published-products_export_%locale%_%scope%_%datetime%.xlsx";}', 'quick_export')
+			    ('csv_product_grid_context_quick_export', 'CSV product quick export grid context', 'csv_product_grid_context_quick_export', 0,'Akeneo Mass Edit Connector', 'a:6:{s:8:"filePath";s:65:"/tmp/products_export_grid_context_%locale%_%scope%_%datetime%.csv";s:9:"delimiter";s:1:";";s:9:"enclosure";s:1:""";s:10:"withHeader";b:1;s:7:"filters";N;s:11:"mainContext";N;}', 'quick_export'),
+			    ('xlsx_product_quick_export', 'XLSX product quick export', 'xlsx_product_quick_export', 0,'Akeneo Mass Edit Connector', 'a:4:{s:8:"filePath";s:53:"/tmp/products_export_%locale%_%scope%_%datetime%.xlsx";s:10:"withHeader";b:1;s:7:"filters";N;s:11:"mainContext";N;}', 'quick_export'),
+			    ('xlsx_product_grid_context_quick_export', 'XLSX product quick export grid context', 'xlsx_product_grid_context_quick_export', 0,'Akeneo Mass Edit Connector', 'a:4:{s:8:"filePath";s:66:"/tmp/products_export_grid_context_%locale%_%scope%_%datetime%.xlsx";s:10:"withHeader";b:1;s:7:"filters";N;s:11:"mainContext";N;}', 'quick_export')
             ;
 SQL
         );


### PR DESCRIPTION
This PR Adds a product quick export job that exports products following the configuration of the datagrid. eg, **channel**, **scope**, and **displayed columns**.

We chose to make the selection of the product attributes to export into the processor.
The normalizer will process the said product data (values, properties, familly, groups etc) as usual.

Then a second step will "eventually" remove some of the properties generated by the normalizer if a list of properties to keep was provided to the processor.

**Notes:** 
- Introduce a new mass_edit action option `_displayedColumnsOnly` used for quick_export to indicate that we want to export only the shown columns of the datagrid.
(https://github.com/akeneo/pim-community-dev/blob/d2a515ab40329fe7561734a4a4752c2f2df53b37/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product.yml#L123)

- We use JobParameters to hold the list of columns to export.


https://akeneo.atlassian.net/browse/TIP-449


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | yes
| Added Behats                      | yes
| Changelog updated                 | yes
| Review and 2 GTM                  | yes
| Micro Demo to the PO (Story only) | no
| Migration script                  | yes
| Tech Doc                          | -
