### PR TITLE
PIM-5710: Display image even if FileInfo doesnt exist

### DIFF
--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -1,3 +1,9 @@
+# 1.5.x
+
+## Bug fixes
+
+- PIM-5710: Fix thumbnail display after file upload in the product edit form
+
 # 1.5.3 (2016-05-13)
 
 ## Bug fixes


### PR DESCRIPTION
<3 Thanks for taking the time to contribute! You're awesome! <3

When you upload an image and the transfer finishes, there is no image displayed.

Refers to https://github.com/akeneo/pim-community-dev/issues/3553

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | n
| Added Behats                      | no
| Changelog updated                 | y
| Review and 2 GTM                  | TODO
| Micro Demo to the PO (Story only) | n
| Migration script                  | n
| Tech Doc                          | n

These scenarii fail on EE, OK in local
features/file_transformer/apply_transformations_on_images.feature:6
features/product_draft/validation/validate_textarea_attributes.feature:43
features/revert_version/attribute_types/metric.feature:11
features/product_draft/validation/validate_textarea_attributes.feature:37
features/product_asset/completeness.feature:34
features/reference_data/workflow/submit_product_draft.feature:26
features/reference_data/workflow/submit_product_draft.feature:35
vendor/akeneo/pim-community-dev/features/datagrid/datagrid_views.feature:82
vendor/akeneo/pim-community-dev/features/product/filtering/filter_products_per_metric.feature:24
vendor/akeneo/pim-community-dev/features/product/filtering/filter_products_per_with_multiple_metrics.feature:44
vendor/akeneo/pim-community-dev/features/reference-data/product/filtering/filtering_by_reference_data_with_locale_and_scope.feature:24
vendor/akeneo/pim-community-dev/features/product/filtering/filter_products_per_with_multiple_prices.feature:53
vendor/akeneo/pim-community-dev/features/product/filtering/filter_products_per_with_multiple_metrics.feature:31
