### PR TITLE
PIM-5627: Set white background for wysiwyg editor on mass edit

### DIFF
--- a/src/Pim/Bundle/UIBundle/Resources/public/css/pim.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/css/pim.less
@@ -1298,6 +1298,10 @@ h3.tab-header {
   color: @color-form-info;
 }
 
+.field-input .note-editable {
+  background: #fff;
+}
+
 .media-uploader {
   background: #eee;
   width: 100%;


### PR DESCRIPTION
Previously, background was gray. Now, it's white.

![capture du 2016-05-19 13 12 53](https://cloud.githubusercontent.com/assets/1590933/15391777/81b8ffde-1dc3-11e6-883b-9dd1a5ad78ba.png)
