### PR TITLE
TIP-431: Ease the migration by using JobParametersFactory in ConfigurationToJobParametersTransformer

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -282,3 +282,4 @@
 - Change constructor of `Pim\Bundle\ImportExportBundle\Datagrid\JobDatagridProvider`, add `Pim\Bundle\ImportExportBundle\JobLabel\TranslatedLabelProvider`
 - Change constructor of `Pim\Bundle\ImportExportBundle\Normalizer\JobExecutionNormalizer`, add `Pim\Bundle\ImportExportBundle\JobLabel\TranslatedLabelProvider`
 - Change constructor of `Pim\Bundle\ImportExportBundle\Normalizer\StepExecutionNormalizer`, add `Pim\Bundle\ImportExportBundle\JobLabel\TranslatedLabelProvider`
+- Change constructor of `Pim\Bundle\ImportExportBundle\Form\Type\JobInstanceType`, add `Akeneo\Component\Batch\Job\JobParametersFactory` and `Pim\Bundle\ImportExportBundle\JobLabel\TranslatedLabelProvider` arguments

--- a/src/Akeneo/Component/Batch/spec/Job/JobParametersFactorySpec.php
+++ b/src/Akeneo/Component/Batch/spec/Job/JobParametersFactorySpec.php
@@ -22,8 +22,10 @@ class JobParametersFactorySpec extends ObjectBehavior
         DefaultValuesProviderInterface $provider,
         JobInterface $job
     ) {
+        $job->getName()->willReturn('foo');
         $registry->get($job)->willReturn($provider);
         $provider->getDefaultValues()->willReturn(['my_default_field' => 'my default value']);
+
         $jobParameters = $this->create($job, ['my_defined_field' => 'my defined value']);
 
         $jobParameters->shouldReturnAnInstanceOf('Akeneo\Component\Batch\Job\JobParameters');

--- a/src/Pim/Bundle/ImportExportBundle/Form/DataTransformer/ConfigurationToJobParametersTransformer.php
+++ b/src/Pim/Bundle/ImportExportBundle/Form/DataTransformer/ConfigurationToJobParametersTransformer.php
@@ -2,12 +2,13 @@
 
 namespace Pim\Bundle\ImportExportBundle\Form\DataTransformer;
 
+use Akeneo\Component\Batch\Job\JobInterface;
 use Akeneo\Component\Batch\Job\JobParameters;
+use Akeneo\Component\Batch\Job\JobParametersFactory;
 use Symfony\Component\Form\DataTransformerInterface;
-use Symfony\Component\Form\Exception\TransformationFailedException;
 
 /**
- * Transform a configuration array to a JobParameters and conversely
+ * Transforms a configuration array to a JobParameters and conversely.
  *
  * @author    Nicolas Dupont <nicolas@akeneo.com>
  * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
@@ -15,28 +16,40 @@ use Symfony\Component\Form\Exception\TransformationFailedException;
  */
 class ConfigurationToJobParametersTransformer implements DataTransformerInterface
 {
+    /** @var JobParametersFactory */
+    protected $jobParametersFactory;
+
+    /** @var JobInterface */
+    protected $job;
+
     /**
-     * Transforms an configuration (array) to a job parameters (object)
+     * @param JobParametersFactory $jobParametersFactory
+     * @param JobInterface         $job
+     */
+    public function __construct(JobParametersFactory $jobParametersFactory, JobInterface $job)
+    {
+        $this->jobParametersFactory = $jobParametersFactory;
+        $this->job                  = $job;
+    }
+
+    /**
+     * {@inheritdoc}
      *
-     * @param  array|null $configuration
-     *
-     * @return JobParameters
+     * Transforms a configuration (array) to a job parameters (object).
      */
     public function transform($configuration)
     {
         if (null === $configuration) {
-            return new JobParameters([]);
+            $configuration = [];
         }
 
-        return new JobParameters($configuration);
+        return $this->jobParametersFactory->create($this->job, $configuration);
     }
 
     /**
+     * {@inheritdoc}
+     *
      * Transforms a job parameters (object) to a configuration (array).
-     *
-     * @param  object|null
-     *
-     * @return array|null
      */
     public function reverseTransform($jobParameters)
     {

--- a/src/Pim/Bundle/ImportExportBundle/Resources/config/form_types.yml
+++ b/src/Pim/Bundle/ImportExportBundle/Resources/config/form_types.yml
@@ -1,19 +1,20 @@
 parameters:
-    pim_import_export.form.type.job_instance.class:                                         Pim\Bundle\ImportExportBundle\Form\Type\JobInstanceType
-    pim_import_export.form.type.job_parameters.class:                                       Pim\Bundle\ImportExportBundle\Form\Type\JobParametersType
+    pim_import_export.form.type.job_instance.class:   Pim\Bundle\ImportExportBundle\Form\Type\JobInstanceType
+    pim_import_export.form.type.job_parameters.class: Pim\Bundle\ImportExportBundle\Form\Type\JobParametersType
 
 services:
     pim_import_export.form.type.job_instance:
-        class: %pim_import_export.form.type.job_instance.class%
+        class: '%pim_import_export.form.type.job_instance.class%'
         arguments:
             - '@akeneo_batch.connectors'
             - '@translator'
             - '@pim_import_export.job_label.translated_label_provider'
+            - '@akeneo_batch.job_parameters_factory'
         tags:
             - { name: form.type, alias: pim_import_export_job_instance }
 
     pim_import_export.form.type.job_parameters:
-        class: %pim_import_export.form.type.job_parameters.class%
+        class: '%pim_import_export.form.type.job_parameters.class%'
         arguments:
             - '@pim_import_export.job_parameters.form_configuration_provider_registry'
             - '@akeneo_batch.job.job_parameters.constraint_collection_provider_registry'


### PR DESCRIPTION
**Description**

For now, JobParameters is directly instantiated in ConfigurationToJobParametersTransformer. This prevents to automatically fill an incomplete rawConfiguration when editing a profile of an existing job instance.

This can occur only with the job instance created before the merge of the JobParameters PR, if a job instance exists in the database with a rawConfiguration where a parameter is missing (but can be reproduced by changing the conf directly in the database, by removing the separator configuration for instance).

This PR solves this by avoiding to do a “new JobParameters()”, but use the JobParametersFactory instead. This will ensure that the default values are added if they do not exist.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Yes
| Added Behats                      | No
| Changelog updated                 | Yes
| Review and 2 GTM                  | Waiting
| Micro Demo to the PO (Story only) | N/A
| Migration script                  | No
| Tech Doc                          | No