### PR TITLE
PIM-5426: Add completeness filter to the product export profiles

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -11,6 +11,7 @@
 - PIM-5427: Add possibility to filter by families for product export
 - PIM-5427: It is now possible to filter by families for product export
 - PIM-5145: It is now possible to filter product exports by locale
+- PIM-5426: It is now possible to filter product exports by completeness
 
 ## Scalability improvements
 

--- a/features/export/product-export-builder/export_products_by_completeness.feature
+++ b/features/export/product-export-builder/export_products_by_completeness.feature
@@ -1,0 +1,85 @@
+@javascript
+Feature: Export products according to a completeness policy
+  In order to use the enriched product data
+  As a product manager
+  I need to be able to export the products according to the completeness
+
+  Background:
+    Given a "default" catalog configuration
+    And the following attributes:
+      | code | type     | localizable | label |
+      | name | textarea | yes         | Name  |
+    And the following family:
+      | code      | requirements-ecommerce |
+      | localized | sku, name              |
+    And the following products:
+      | sku        | categories | family    | name-fr_FR | name-en_US |
+      | french     | default    | localized | French     |            |
+      | english    | default    | localized |            | English    |
+      | complete   | default    | localized | Complete   | Complete   |
+      | empty      | default    | localized |            |            |
+    And the following jobs:
+      | connector            | type   | alias              | code               | label              |
+      | Akeneo CSV Connector | export | csv_product_export | csv_product_export | CSV product export |
+    Given the following job "csv_product_export" configuration:
+      | channel  | ecommerce                               |
+      | filePath | %tmp%/product_export/product_export.csv |
+      | locales  | fr_FR, en_US                            |
+    And I am logged in as "Julia"
+
+  @ce
+  Scenario: Export the products complete from at least one selected locale (default)
+    Given the following job "csv_product_export" configuration:
+      | completeness | at_least_one_complete |
+    When I am on the "csv_product_export" export job page
+    And I launch the export job
+    And I wait for the "csv_product_export" job to finish
+    Then exported file of "csv_product_export" should contain:
+      """
+      sku;categories;enabled;family;groups;name-en_US;name-fr_FR
+      french;default;1;localized;;;French
+      english;default;1;localized;;English;
+      complete;default;1;localized;;Complete;Complete
+      """
+
+  @ce
+  Scenario: Export the complete products of all selected locales
+    Given the following job "csv_product_export" configuration:
+      | completeness | all_complete |
+    When I am on the "csv_product_export" export job page
+    And I launch the export job
+    And I wait for the "csv_product_export" job to finish
+    Then exported file of "csv_product_export" should contain:
+      """
+      sku;categories;enabled;family;groups;name-en_US;name-fr_FR
+      complete;default;1;localized;;Complete;Complete
+      """
+
+  @ce
+  Scenario: Export the incomplete products of all selected locales
+    Given the following job "csv_product_export" configuration:
+      | completeness | all_incomplete |
+    When I am on the "csv_product_export" export job page
+    And I launch the export job
+    And I wait for the "csv_product_export" job to finish
+    Then exported file of "csv_product_export" should contain:
+      """
+      sku;categories;enabled;family;groups;name-en_US;name-fr_FR
+      empty;default;1;localized;;;
+      """
+
+  @ce
+  Scenario: Export all products
+    Given the following job "csv_product_export" configuration:
+      | completeness | all |
+    When I am on the "csv_product_export" export job page
+    And I launch the export job
+    And I wait for the "csv_product_export" job to finish
+    Then exported file of "csv_product_export" should contain:
+      """
+      sku;categories;enabled;family;groups;name-en_US;name-fr_FR
+      french;default;1;localized;;;French
+      english;default;1;localized;;English;
+      complete;default;1;localized;;Complete;Complete
+      empty;default;1;localized;;;
+      """

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Join/CompletenessJoin.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Join/CompletenessJoin.php
@@ -64,9 +64,9 @@ class CompletenessJoin
                     'PimCatalogBundle:Locale',
                     $localeAlias,
                     'WITH',
-                    $localeAlias.'.code = :cLocaleCode'
+                    sprintf('%s.code = :%scLocaleCode', $localeAlias, $localeAlias)
                 )
-                ->setParameter('cLocaleCode', $locale);
+                ->setParameter($localeAlias.'cLocaleCode', $locale);
 
             $joinCondition .= sprintf(' AND %s.locale = %s.id', $completenessAlias, $localeAlias);
         }

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/CompletenessFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/CompletenessFilterSpec.php
@@ -70,7 +70,7 @@ class CompletenessFilterSpec extends ObjectBehavior
             Argument::any()
         )->shouldBeCalled()->willReturn($qb);
 
-        $qb->setParameter('cLocaleCode', Argument::any())->shouldBeCalled();
+        $qb->setParameter(Argument::any(), Argument::any())->shouldBeCalled();
         $qb->setParameter('cScopeCode', Argument::any())->shouldBeCalled();
 
         $qb->andWhere('filterCompleteness.ratio = 100')->shouldBeCalled();
@@ -118,7 +118,7 @@ class CompletenessFilterSpec extends ObjectBehavior
             Argument::any()
         )->shouldBeCalled()->willReturn($qb);
 
-        $qb->setParameter('cLocaleCode', Argument::any())->shouldBeCalled();
+        $qb->setParameter(Argument::any(), Argument::any())->shouldBeCalled();
         $qb->setParameter('cScopeCode', Argument::any())->shouldBeCalled();
 
         $qb->andWhere('filterCompleteness.ratio < 100')->shouldBeCalled();

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Sorter/CompletenessSorterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Sorter/CompletenessSorterSpec.php
@@ -48,7 +48,7 @@ class CompletenessSorterSpec extends ObjectBehavior
                 'PimCatalogBundle:Locale',
                 'sorterCompletenessLocale',
                 'WITH',
-                'sorterCompletenessLocale.code = :cLocaleCode'
+                Argument::any()
             )
             ->shouldBeCalled()
             ->willReturn($qb);
@@ -72,8 +72,8 @@ class CompletenessSorterSpec extends ObjectBehavior
             )
             ->shouldBeCalled()
             ->willReturn($qb);
-        $qb->setParameter('cLocaleCode', Argument::any())->shouldBeCalled()->willReturn($qb);
-        $qb->setParameter('cScopeCode', Argument::any())->shouldBeCalled()->willReturn($qb);
+
+        $qb->setParameter(Argument::any(), Argument::any())->shouldBeCalled()->willReturn($qb);
 
         $qb->addOrderBy('sorterCompleteness.ratio', 'DESC')->shouldBeCalled();
         $qb->addOrderBy('r.id')->shouldBeCalled();

--- a/src/Pim/Bundle/ConnectorBundle/Resources/translations/messages.en.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/translations/messages.en.yml
@@ -63,6 +63,14 @@ pim_connector:
                 enabled: Enabled
                 disabled: Disabled
                 all: All
+        completeness:
+            label: Completeness
+            help: The completeness of the products you want to export
+            choice:
+                at_least_one_complete: Complete on at least one selected locale
+                all_complete: Complete on all selected locales
+                all_incomplete: Not complete on all selected locales
+                all: No condition on completeness
         updated:
             label: Updated time condition
             help: The time condition of the products you want to export

--- a/src/Pim/Bundle/ImportExportBundle/JobParameters/FormConfigurationProvider/ProductCsvExport.php
+++ b/src/Pim/Bundle/ImportExportBundle/JobParameters/FormConfigurationProvider/ProductCsvExport.php
@@ -117,13 +117,13 @@ class ProductCsvExport implements FormConfigurationProviderInterface
                 'type'    => 'select_family_type',
                 'options' => [
                     'repository' => $this->familyRepository,
-                    'route' => 'pim_enrich_family_rest_index',
-                    'required' => false,
-                    'multiple' => true,
-                    'label' => 'pim_base_connector.export.families.label',
-                    'help' => 'pim_base_connector.export.families.help',
-                    'attr' => [
-                        'data-tab' => 'content',
+                    'route'      => 'pim_enrich_family_rest_index',
+                    'required'   => false,
+                    'multiple'   => true,
+                    'label'      => 'pim_base_connector.export.families.label',
+                    'help'       => 'pim_base_connector.export.families.help',
+                    'attr'       => [
+                        'data-tab'         => 'content',
                         'data-placeholder' => 'pim_base_connector.export.families.placeholder'
                     ]
                 ]
@@ -140,6 +140,22 @@ class ProductCsvExport implements FormConfigurationProviderInterface
                     'select2'  => true,
                     'label'    => 'pim_connector.export.status.label',
                     'help'     => 'pim_connector.export.status.help',
+                    'attr'     => ['data-tab' => 'content']
+                ]
+            ],
+            'completeness' => [
+                'type'    => 'choice',
+                'options' => [
+                    'choices'  => [
+                        'at_least_one_complete' => 'pim_connector.export.completeness.choice.at_least_one_complete',
+                        'all_complete'          => 'pim_connector.export.completeness.choice.all_complete',
+                        'all_incomplete'        => 'pim_connector.export.completeness.choice.all_incomplete',
+                        'all'                   => 'pim_connector.export.completeness.choice.all'
+                    ],
+                    'required' => true,
+                    'select2'  => true,
+                    'label'    => 'pim_connector.export.completeness.label',
+                    'help'     => 'pim_connector.export.completeness.help',
                     'attr'     => ['data-tab' => 'content']
                 ]
             ],

--- a/src/Pim/Bundle/ImportExportBundle/JobParameters/FormConfigurationProvider/ProductXlsxExport.php
+++ b/src/Pim/Bundle/ImportExportBundle/JobParameters/FormConfigurationProvider/ProductXlsxExport.php
@@ -112,18 +112,18 @@ class ProductXlsxExport implements FormConfigurationProviderInterface
                     'attr'     => ['data-tab' => 'content']
                 ]
             ],
-            'locales' => ['type' => 'pim_import_export_product_export_locale_choice'],
+            'locales'  => ['type' => 'pim_import_export_product_export_locale_choice'],
             'families' => [
                 'type'    => 'select_family_type',
                 'options' => [
                     'repository' => $this->familyRepository,
-                    'route' => 'pim_enrich_family_rest_index',
-                    'required' => false,
-                    'multiple' => true,
-                    'label' => 'pim_base_connector.export.families.label',
-                    'help' => 'pim_base_connector.export.families.help',
-                    'attr' => [
-                        'data-tab' => 'content',
+                    'route'      => 'pim_enrich_family_rest_index',
+                    'required'   => false,
+                    'multiple'   => true,
+                    'label'      => 'pim_base_connector.export.families.label',
+                    'help'       => 'pim_base_connector.export.families.help',
+                    'attr'       => [
+                        'data-tab'         => 'content',
                         'data-placeholder' => 'pim_base_connector.export.families.placeholder'
                     ]
                 ]
@@ -140,6 +140,22 @@ class ProductXlsxExport implements FormConfigurationProviderInterface
                     'select2'  => true,
                     'label'    => 'pim_connector.export.status.label',
                     'help'     => 'pim_connector.export.status.help',
+                    'attr'     => ['data-tab' => 'content']
+                ]
+            ],
+            'completeness' => [
+                'type'    => 'choice',
+                'options' => [
+                    'choices'  => [
+                        'at_least_one_complete' => 'pim_connector.export.completeness.choice.at_least_one_complete',
+                        'all_complete'          => 'pim_connector.export.completeness.choice.all_complete',
+                        'all_incomplete'        => 'pim_connector.export.completeness.choice.all_incomplete',
+                        'all'                   => 'pim_connector.export.completeness.choice.all'
+                    ],
+                    'required' => true,
+                    'select2'  => true,
+                    'label'    => 'pim_connector.export.completeness.label',
+                    'help'     => 'pim_connector.export.completeness.help',
                     'attr'     => ['data-tab' => 'content']
                 ]
             ],

--- a/src/Pim/Bundle/ImportExportBundle/spec/JobParameters/FormConfigurationProvider/ProductCsvExportSpec.php
+++ b/src/Pim/Bundle/ImportExportBundle/spec/JobParameters/FormConfigurationProvider/ProductCsvExportSpec.php
@@ -200,6 +200,22 @@ class ProductCsvExportSpec extends ObjectBehavior
                     'attr'     => ['data-tab' => 'content']
                 ]
             ],
+            'completeness' => [
+                'type'    => 'choice',
+                'options' => [
+                    'choices'  => [
+                        'at_least_one_complete' => 'pim_connector.export.completeness.choice.at_least_one_complete',
+                        'all_complete'          => 'pim_connector.export.completeness.choice.all_complete',
+                        'all_incomplete'        => 'pim_connector.export.completeness.choice.all_incomplete',
+                        'all'                   => 'pim_connector.export.completeness.choice.all'
+                    ],
+                    'required' => true,
+                    'select2'  => true,
+                    'label'    => 'pim_connector.export.completeness.label',
+                    'help'     => 'pim_connector.export.completeness.help',
+                    'attr'     => ['data-tab' => 'content']
+                ]
+            ],
             'updated' => [
                 'type'    => 'choice',
                 'options' => [

--- a/src/Pim/Bundle/ImportExportBundle/spec/JobParameters/FormConfigurationProvider/ProductXlsxExportSpec.php
+++ b/src/Pim/Bundle/ImportExportBundle/spec/JobParameters/FormConfigurationProvider/ProductXlsxExportSpec.php
@@ -194,6 +194,22 @@ class ProductXlsxExportSpec extends ObjectBehavior
                     'attr'     => ['data-tab' => 'content']
                 ]
             ],
+            'completeness' => [
+                'type'    => 'choice',
+                'options' => [
+                    'choices'  => [
+                        'at_least_one_complete' => 'pim_connector.export.completeness.choice.at_least_one_complete',
+                        'all_complete'          => 'pim_connector.export.completeness.choice.all_complete',
+                        'all_incomplete'        => 'pim_connector.export.completeness.choice.all_incomplete',
+                        'all'                   => 'pim_connector.export.completeness.choice.all'
+                    ],
+                    'required' => true,
+                    'select2'  => true,
+                    'label'    => 'pim_connector.export.completeness.label',
+                    'help'     => 'pim_connector.export.completeness.help',
+                    'attr'     => ['data-tab' => 'content']
+                ]
+            ],
             'updated' => [
                 'type'    => 'choice',
                 'options' => [

--- a/src/Pim/Component/Connector/Job/JobParameters/ConstraintCollectionProvider/ProductCsvExport.php
+++ b/src/Pim/Component/Connector/Job/JobParameters/ConstraintCollectionProvider/ProductCsvExport.php
@@ -5,6 +5,7 @@ namespace Pim\Component\Connector\Job\JobParameters\ConstraintCollectionProvider
 use Akeneo\Component\Batch\Job\JobInterface;
 use Akeneo\Component\Batch\Job\JobParameters\ConstraintCollectionProviderInterface;
 use Pim\Bundle\BaseConnectorBundle\Validator\Constraints\Channel;
+use Symfony\Component\Validator\Constraints\Choice;
 use Symfony\Component\Validator\Constraints\Collection;
 use Symfony\Component\Validator\Constraints\NotBlank;
 
@@ -53,6 +54,15 @@ class ProductCsvExport implements ConstraintCollectionProviderInterface
             'message' => 'pim_connector.export.locales.validation.not_blank'
         ]);
         $constraintFields['families'] = [];
+        $constraintFields['completeness'] = [
+            new NotBlank(['groups' => 'Execution']),
+            new Choice(['choices' => [
+                'at_least_one_complete',
+                'all_complete',
+                'all_incomplete',
+                'all',
+            ], 'groups' => 'Execution'])
+        ];
 
         return new Collection(['fields' => $constraintFields]);
     }

--- a/src/Pim/Component/Connector/Job/JobParameters/ConstraintCollectionProvider/ProductXlsxExport.php
+++ b/src/Pim/Component/Connector/Job/JobParameters/ConstraintCollectionProvider/ProductXlsxExport.php
@@ -55,6 +55,7 @@ class ProductXlsxExport implements ConstraintCollectionProviderInterface
 
         $constraintFields['enabled'] = new NotBlank(['groups' => 'Execution']);
         $constraintFields['updated'] = new NotBlank(['groups' => 'Execution']);
+        $constraintFields['completeness'] = new NotBlank(['groups' => 'Execution']);
         $constraintFields['linesPerFile'] = [
             new NotBlank(),
             new GreaterThan(1)

--- a/src/Pim/Component/Connector/Job/JobParameters/DefaultValuesProvider/ProductCsvExport.php
+++ b/src/Pim/Component/Connector/Job/JobParameters/DefaultValuesProvider/ProductCsvExport.php
@@ -44,6 +44,7 @@ class ProductCsvExport implements DefaultValuesProviderInterface
         $parameters['enabled'] = 'enabled';
         $parameters['updated'] = 'all';
         $parameters['families'] = null;
+        $parameters['completeness'] = 'at_least_one_complete';
 
         return $parameters;
     }

--- a/src/Pim/Component/Connector/Job/JobParameters/DefaultValuesProvider/ProductXlsxExport.php
+++ b/src/Pim/Component/Connector/Job/JobParameters/DefaultValuesProvider/ProductXlsxExport.php
@@ -43,6 +43,7 @@ class ProductXlsxExport implements DefaultValuesProviderInterface
         $parameters['locales'] = [];
         $parameters['enabled'] = 'enabled';
         $parameters['updated'] = 'all';
+        $parameters['completeness'] = 'at_least_one_complete';
         $parameters['linesPerFile'] = 10000;
         $parameters['families'] = null;
 

--- a/src/Pim/Component/Connector/spec/Job/JobParameters/ConstraintCollectionProvider/ProductCsvExportSpec.php
+++ b/src/Pim/Component/Connector/spec/Job/JobParameters/ConstraintCollectionProvider/ProductCsvExportSpec.php
@@ -28,7 +28,7 @@ class ProductCsvExportSpec extends ObjectBehavior
         $collection =  $this->getConstraintCollection();
         $collection->shouldReturnAnInstanceOf('Symfony\Component\Validator\Constraints\Collection');
         $fields = $collection->fields;
-        $fields->shouldHaveCount(7);
+        $fields->shouldHaveCount(8);
         $fields->shouldHaveKey('decimalSeparator');
         $fields->shouldHaveKey('dateFormat');
         $fields->shouldHaveKey('channel');
@@ -36,6 +36,7 @@ class ProductCsvExportSpec extends ObjectBehavior
         $fields->shouldHaveKey('updated');
         $fields->shouldHaveKey('locales');
         $fields->shouldHaveKey('families');
+        $fields->shouldHaveKey('completeness');
     }
 
     function it_supports_a_job(JobInterface $job)

--- a/src/Pim/Component/Connector/spec/Job/JobParameters/ConstraintCollectionProvider/ProductXlsxExportSpec.php
+++ b/src/Pim/Component/Connector/spec/Job/JobParameters/ConstraintCollectionProvider/ProductXlsxExportSpec.php
@@ -28,13 +28,14 @@ class ProductXlsxExportSpec extends ObjectBehavior
         $collection =  $this->getConstraintCollection();
         $collection->shouldReturnAnInstanceOf('Symfony\Component\Validator\Constraints\Collection');
         $fields = $collection->fields;
-        $fields->shouldHaveCount(8);
+        $fields->shouldHaveCount(9);
         $fields->shouldHaveKey('decimalSeparator');
         $fields->shouldHaveKey('dateFormat');
         $fields->shouldHaveKey('enabled');
         $fields->shouldHaveKey('channel');
         $fields->shouldHaveKey('locales');
         $fields->shouldHaveKey('updated');
+        $fields->shouldHaveKey('completeness');
         $fields->shouldHaveKey('linesPerFile');
         $fields->shouldHaveKey('families');
     }

--- a/src/Pim/Component/Connector/spec/Job/JobParameters/DefaultValuesProvider/ProductCsvExportSpec.php
+++ b/src/Pim/Component/Connector/spec/Job/JobParameters/DefaultValuesProvider/ProductCsvExportSpec.php
@@ -25,13 +25,14 @@ class ProductCsvExportSpec extends ObjectBehavior
         $this->getDefaultValues()->shouldReturn(
             [
                 'decoratedParam'   => true,
-                'decimalSeparator' => ".",
-                'dateFormat'       => "yyyy-MM-dd",
+                'decimalSeparator' => '.',
+                'dateFormat'       => 'yyyy-MM-dd',
                 'channel'          => null,
                 'locales'          => [],
-                'enabled'          => "enabled",
-                'updated'          => "all",
+                'enabled'          => 'enabled',
+                'updated'          => 'all',
                 'families'         => null,
+                'completeness'     => 'at_least_one_complete',
             ]
         );
     }

--- a/src/Pim/Component/Connector/spec/Job/JobParameters/DefaultValuesProvider/ProductXlsxExportSpec.php
+++ b/src/Pim/Component/Connector/spec/Job/JobParameters/DefaultValuesProvider/ProductXlsxExportSpec.php
@@ -31,9 +31,9 @@ class ProductXlsxExportSpec extends ObjectBehavior
                 'locales'          => [],
                 'enabled'          => "enabled",
                 'updated'          => "all",
+                'completeness'     => 'at_least_one_complete',
                 'linesPerFile'     => 10000,
                 'families'         => null,
-
             ]
         );
     }

--- a/src/Pim/Component/Connector/spec/Reader/ProductReaderSpec.php
+++ b/src/Pim/Component/Connector/spec/Reader/ProductReaderSpec.php
@@ -66,6 +66,7 @@ class ProductReaderSpec extends ObjectBehavior
         $jobParameters->get('enabled')->willReturn('enabled');
         $jobParameters->get('updated')->willReturn('all');
         $jobParameters->get('families')->willReturn('');
+        $jobParameters->get('completeness')->willReturn('all');
 
         $channelRepository->findOneByIdentifier('mobile')->willReturn($channel);
         $channel->getCategory()->willReturn($channelRoot);
@@ -76,7 +77,7 @@ class ProductReaderSpec extends ObjectBehavior
             ->shouldBeCalled()
             ->willReturn($pqb);
         $pqb->addFilter('enabled', '=', true, [])->shouldBeCalled();
-        $pqb->addFilter('completeness', '=', 100, [])->shouldBeCalled();
+        $pqb->addFilter('completeness', Argument::cetera())->shouldNotBeCalled();
         $pqb->addFilter('categories.id', 'IN CHILDREN', [42], [])->shouldBeCalled();
         $pqb->execute()
             ->shouldBeCalled()
@@ -108,6 +109,8 @@ class ProductReaderSpec extends ObjectBehavior
         $channelRepository,
         $metricConverter,
         $objectDetacher,
+        $pqbFactory,
+        $channelRepository,
         $stepExecution,
         ChannelInterface $channel,
         CategoryInterface $channelRoot,
@@ -117,12 +120,14 @@ class ProductReaderSpec extends ObjectBehavior
         ProductInterface $product2,
         ProductInterface $product3,
         JobParameters $jobParameters
-    ) {
+    )
+    {
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $jobParameters->get('channel')->willReturn('mobile');
         $jobParameters->get('enabled')->willReturn('enabled');
         $jobParameters->get('updated')->willReturn('all');
         $jobParameters->get('families')->willReturn('mugs,webcams');
+        $jobParameters->get('completeness')->willReturn('all');
 
         $channelRepository->findOneByIdentifier('mobile')->willReturn($channel);
         $channel->getCategory()->willReturn($channelRoot);
@@ -132,15 +137,15 @@ class ProductReaderSpec extends ObjectBehavior
         $pqbFactory->create(['default_scope' => 'mobile'])
             ->shouldBeCalled()
             ->willReturn($pqb);
+
         $pqb->addFilter('family.code', 'IN', ['mugs', 'webcams'], [])->shouldBeCalled();
         $pqb->addFilter('enabled', '=', true, [])->shouldBeCalled();
-        $pqb->addFilter('completeness', '=', 100, [])->shouldBeCalled();
         $pqb->addFilter('categories.id', 'IN CHILDREN', [42], [])->shouldBeCalled();
         $pqb->execute()
             ->shouldBeCalled()
             ->willReturn($cursor);
 
-        $products = [$product1, $product2, $product3];
+        $products      = [$product1, $product2, $product3];
         $productsCount = count($products);
         $cursor->valid()->will(
             function () use (&$productsCount) {
@@ -159,6 +164,106 @@ class ProductReaderSpec extends ObjectBehavior
         $this->read()->shouldReturn($product2);
         $this->read()->shouldReturn($product3);
         $this->read()->shouldReturn(null);
+    }
+
+    function it_reads_complete_products(
+        $pqbFactory,
+        $channelRepository,
+        $stepExecution,
+        ChannelInterface $channel,
+        CategoryInterface $channelRoot,
+        ProductQueryBuilderInterface $pqb,
+        JobParameters $jobParameters
+    ) {
+        $stepExecution->getJobParameters()->willReturn($jobParameters);
+        $jobParameters->get('channel')->willReturn('mobile');
+        $jobParameters->get('enabled')->willReturn('all');
+        $jobParameters->get('updated')->willReturn('all');
+        $jobParameters->get('locales')->willReturn(['fr_FR', 'en_US']);
+        $jobParameters->get('families')->willReturn('');
+        $jobParameters->get('completeness')->willReturn('all_complete');
+
+        $channelRepository->findOneByIdentifier('mobile')->willReturn($channel);
+        $channel->getCategory()->willReturn($channelRoot);
+        $channelRoot->getId()->willReturn(42);
+        $channel->getCode()->willReturn('mobile');
+
+        $pqbFactory->create(['default_scope' => 'mobile'])
+            ->shouldBeCalled()
+            ->willReturn($pqb);
+
+        $pqb->addFilter('completeness', '=', 100, ['locale' => 'fr_FR'])->shouldBeCalled();
+        $pqb->addFilter('completeness', '=', 100, ['locale' => 'en_US'])->shouldBeCalled();
+        $pqb->addFilter('categories.id', 'IN CHILDREN', [42], [])->shouldBeCalled();
+        $pqb->execute()->shouldBeCalled();
+
+        $this->initialize();
+    }
+
+    function it_reads_incomplete_products(
+        $pqbFactory,
+        $channelRepository,
+        $stepExecution,
+        ChannelInterface $channel,
+        CategoryInterface $channelRoot,
+        ProductQueryBuilderInterface $pqb,
+        JobParameters $jobParameters
+    ) {
+        $stepExecution->getJobParameters()->willReturn($jobParameters);
+        $jobParameters->get('channel')->willReturn('mobile');
+        $jobParameters->get('enabled')->willReturn('all');
+        $jobParameters->get('updated')->willReturn('all');
+        $jobParameters->get('locales')->willReturn(['fr_FR', 'en_US']);
+        $jobParameters->get('families')->willReturn('');
+        $jobParameters->get('completeness')->willReturn('all_incomplete');
+
+        $channelRepository->findOneByIdentifier('mobile')->willReturn($channel);
+        $channel->getCategory()->willReturn($channelRoot);
+        $channelRoot->getId()->willReturn(42);
+        $channel->getCode()->willReturn('mobile');
+
+        $pqbFactory->create(['default_scope' => 'mobile'])
+            ->shouldBeCalled()
+            ->willReturn($pqb);
+
+        $pqb->addFilter('completeness', '<', 100, ['locale' => 'fr_FR'])->shouldBeCalled();
+        $pqb->addFilter('completeness', '<', 100, ['locale' => 'en_US'])->shouldBeCalled();
+        $pqb->addFilter('categories.id', 'IN CHILDREN', [42], [])->shouldBeCalled();
+        $pqb->execute()->shouldBeCalled();
+
+        $this->initialize();
+    }
+
+    function it_reads_at_least_one_complete_products(
+        $pqbFactory,
+        $channelRepository,
+        $stepExecution,
+        ChannelInterface $channel,
+        CategoryInterface $channelRoot,
+        ProductQueryBuilderInterface $pqb,
+        JobParameters $jobParameters
+    ) {
+        $stepExecution->getJobParameters()->willReturn($jobParameters);
+        $jobParameters->get('channel')->willReturn('mobile');
+        $jobParameters->get('enabled')->willReturn('all');
+        $jobParameters->get('updated')->willReturn('all');
+        $jobParameters->get('families')->willReturn('');
+        $jobParameters->get('completeness')->willReturn('at_least_one_complete');
+
+        $channelRepository->findOneByIdentifier('mobile')->willReturn($channel);
+        $channel->getCategory()->willReturn($channelRoot);
+        $channelRoot->getId()->willReturn(42);
+        $channel->getCode()->willReturn('mobile');
+
+        $pqbFactory->create(['default_scope' => 'mobile'])
+            ->shouldBeCalled()
+            ->willReturn($pqb);
+
+        $pqb->addFilter('completeness', '=', 100, [])->shouldBeCalled();
+        $pqb->addFilter('categories.id', 'IN CHILDREN', [42], [])->shouldBeCalled();
+        $pqb->execute()->shouldBeCalled();
+
+        $this->initialize();
     }
 
     function it_reads_disabled_products(
@@ -181,6 +286,7 @@ class ProductReaderSpec extends ObjectBehavior
         $jobParameters->get('enabled')->willReturn('disabled');
         $jobParameters->get('updated')->willReturn('all');
         $jobParameters->get('families')->willReturn('');
+        $jobParameters->get('completeness')->willReturn('at_least_one_complete');
 
         $channelRepository->findOneByIdentifier('mobile')->willReturn($channel);
         $channel->getCategory()->willReturn($channelRoot);
@@ -238,6 +344,7 @@ class ProductReaderSpec extends ObjectBehavior
         $jobParameters->get('enabled')->willReturn('all');
         $jobParameters->get('updated')->willReturn('all');
         $jobParameters->get('families')->willReturn('');
+        $jobParameters->get('completeness')->willReturn('at_least_one_complete');
 
         $channelRepository->findOneByIdentifier('mobile')->willReturn($channel);
         $channel->getCategory()->willReturn($channelRoot);
@@ -290,6 +397,7 @@ class ProductReaderSpec extends ObjectBehavior
         $jobParameters->get('enabled')->willReturn('enabled');
         $jobParameters->get('updated')->willReturn('all');
         $jobParameters->get('families')->willReturn('');
+        $jobParameters->get('completeness')->willReturn('at_least_one_complete');
 
         $channelRepository->findOneByIdentifier('mobile')->willReturn($channel);
         $channel->getCategory()->willReturn($channelRoot);
@@ -325,6 +433,7 @@ class ProductReaderSpec extends ObjectBehavior
         $jobParameters->get('enabled')->willReturn('all');
         $jobParameters->get('updated')->willReturn('last_export');
         $jobParameters->get('families')->willReturn('');
+        $jobParameters->get('completeness')->willReturn('at_least_one_complete');
 
         $channelRepository->findOneByIdentifier('mobile')->willReturn($channel);
         $channel->getCategory()->willReturn($channelRoot);


### PR DESCRIPTION
# Description
As Peter, I would like to filter on the completeness to export products in order to export only the data needed by an user or an output channel.

There is a new parameter "*Complete*" on all products exports and published products (CSV and Excel) in a new tab "Contents". This parameter is a list of 4 options to define a filter on the completeness on the selected locales:

- Complete on at least one selected locale : option by default, as today
- Complete on all selected locales
- Not complete on all selected locales
- No condition on completeness

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | :white_check_mark: 
| Added Behats                      | :white_check_mark: 
| Changelog updated                 | :white_check_mark: 
| Review and 2 GTM                  | :ballot_box_with_check: 
| Micro Demo to the PO (Story only) | :ballot_box_with_check: 
| Migration script                  | N/A
| Tech Doc                          | N/A

