### PR TITLE
TIP-405: fix browse groups behat scenario

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/AttributeGroupRepository.php
+++ b/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/AttributeGroupRepository.php
@@ -32,8 +32,7 @@ class AttributeGroupRepository extends EntityRepository implements TranslatedLab
         $queryBuilder = $this->createQueryBuilder('g')
             ->select('g.code')
             ->addSelect('COALESCE(t.label, CONCAT(\'[\', g.code, \']\')) as label')
-            ->leftJoin('g.translations', 't')
-            ->andWhere('t.locale = :locale')
+            ->leftJoin('g.translations', 't', 'WITH', 't.locale = :locale')
             ->setParameter('locale', $this->userContext->getCurrentLocaleCode())
             ->orderBy('t.label')
             ->getQuery();

--- a/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/CategoryRepository.php
+++ b/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/CategoryRepository.php
@@ -32,8 +32,7 @@ class CategoryRepository extends NestedTreeRepository implements TranslatedLabel
         $query = $this->childrenQueryBuilder(null, true, 'created', 'DESC')
             ->select('node.id')
             ->addSelect('COALESCE(t.label, CONCAT(\'[\', node.code, \']\')) as label')
-            ->leftJoin('node.translations', 't')
-            ->where('t.locale = :locale')
+            ->leftJoin('node.translations', 't', 'WITH', 't.locale = :locale')
             ->setParameter('locale', $this->userContext->getCurrentLocaleCode())
             ->orderBy('t.label')
             ->getQuery();

--- a/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/GroupRepository.php
+++ b/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/GroupRepository.php
@@ -37,8 +37,7 @@ class GroupRepository extends EntityRepository implements TranslatedLabelsProvid
         $queryBuilder = $this->createQueryBuilder('g')
             ->select('g.id')
             ->addSelect('COALESCE(t.label, CONCAT(\'[\', g.code, \']\')) as label')
-            ->leftJoin('g.translations', 't')
-            ->andWhere('t.locale = :locale')
+            ->leftJoin('g.translations', 't', 'WITH', 't.locale = :locale')
             ->setParameter('locale', $this->userContext->getCurrentLocaleCode())
             ->orderBy('t.label')
             ->getQuery();

--- a/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/GroupTypeRepository.php
+++ b/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/GroupTypeRepository.php
@@ -37,8 +37,7 @@ class GroupTypeRepository extends EntityRepository implements TranslatedLabelsPr
         $queryBuilder = $this->createQueryBuilder('g')
             ->select('g.id')
             ->addSelect('COALESCE(t.label, CONCAT(\'[\', g.code, \']\')) as label')
-            ->leftJoin('g.translations', 't')
-            ->andWhere('t.locale = :locale')
+            ->leftJoin('g.translations', 't', 'WITH', 't.locale = :locale')
             ->setParameter('locale', $this->userContext->getCurrentLocaleCode())
             ->orderBy('t.label');
 

--- a/src/Pim/Bundle/EnrichBundle/spec/Doctrine/ORM/Repository/AttributeGroupRepositorySpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Doctrine/ORM/Repository/AttributeGroupRepositorySpec.php
@@ -44,8 +44,7 @@ class AttributeGroupRepositorySpec extends ObjectBehavior
         $queryBuilder->select('g.code')->willReturn($queryBuilder);
         $queryBuilder->addSelect('COALESCE(t.label, CONCAT(\'[\', g.code, \']\')) as label')->willReturn($queryBuilder);
         $queryBuilder->from('attribute_group', 'g')->willReturn($queryBuilder);
-        $queryBuilder->leftJoin('g.translations', 't')->willReturn($queryBuilder);
-        $queryBuilder->andWhere('t.locale = :locale')->willReturn($queryBuilder);
+        $queryBuilder->leftJoin('g.translations', 't', 'WITH', 't.locale = :locale')->willReturn($queryBuilder);
         $queryBuilder->setParameter('locale', 'en_US')->willReturn($queryBuilder);
         $queryBuilder->orderBy('t.label')->willReturn($queryBuilder);
         $queryBuilder->getQuery()->willReturn($query);

--- a/src/Pim/Bundle/EnrichBundle/spec/Doctrine/ORM/Repository/GroupRepositorySpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Doctrine/ORM/Repository/GroupRepositorySpec.php
@@ -44,8 +44,7 @@ class GroupRepositorySpec extends ObjectBehavior
         $queryBuilder->select('g.id')->willReturn($queryBuilder);
         $queryBuilder->addSelect('COALESCE(t.label, CONCAT(\'[\', g.code, \']\')) as label')->willReturn($queryBuilder);
         $queryBuilder->from('group', 'g')->willReturn($queryBuilder);
-        $queryBuilder->leftJoin('g.translations', 't')->willReturn($queryBuilder);
-        $queryBuilder->andWhere('t.locale = :locale')->willReturn($queryBuilder);
+        $queryBuilder->leftJoin('g.translations', 't', 'WITH', 't.locale = :locale')->willReturn($queryBuilder);
         $queryBuilder->setParameter('locale', 'en_US')->willReturn($queryBuilder);
         $queryBuilder->orderBy('t.label')->willReturn($queryBuilder);
         $queryBuilder->getQuery()->willReturn($query);

--- a/src/Pim/Bundle/EnrichBundle/spec/Doctrine/ORM/Repository/GroupTypeRepositorySpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Doctrine/ORM/Repository/GroupTypeRepositorySpec.php
@@ -44,9 +44,8 @@ class GroupTypeRepositorySpec extends ObjectBehavior
         $queryBuilder->select('g.id')->willReturn($queryBuilder);
         $queryBuilder->addSelect('COALESCE(t.label, CONCAT(\'[\', g.code, \']\')) as label')->willReturn($queryBuilder);
         $queryBuilder->from('group_type', 'g')->willReturn($queryBuilder);
-        $queryBuilder->leftJoin('g.translations', 't')->willReturn($queryBuilder);
+        $queryBuilder->leftJoin('g.translations', 't', 'WITH', 't.locale = :locale')->willReturn($queryBuilder);
         $queryBuilder->andWhere('g.variant = :is_variant')->willReturn($queryBuilder);
-        $queryBuilder->andWhere('t.locale = :locale')->willReturn($queryBuilder);
         $queryBuilder->orderBy('t.label')->willReturn($queryBuilder);
         $queryBuilder->setParameter('locale', 'en_US')->willReturn($queryBuilder);
         $queryBuilder->getQuery()->willReturn($query);


### PR DESCRIPTION
This fix the scenario features/product-group/browse_product_groups.feature

Behind the hound, it fixes several legacy issues in `findTranslatedLabels(` implementation which returns translated label or the code like "[code]" when the label is not translated.

The query is not ok because it does not return a row when the label is not translated (i fixed to use the same query than in other working implementations).

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | N
| Added Behats                      | N
| Changelog updated                 | N
| Review and 2 GTM                  | ?
| Micro Demo to the PO (Story only) | N
| Migration script                  | N
| Tech Doc                          | N

