### PR TITLE
PIM-5726: fix number of product displayed on Product Grid when category panel is withdrawn

### DIFF
--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -4,6 +4,7 @@
 
 - PIM-5710: Fix thumbnail display after file upload in the product edit form
 - PIM-5811: Fix family export with multiple locales activated
+- PIM-5726: Fix number of product displayed on Product Grid when category panel is withdrawn
 
 # 1.5.3 (2016-05-13)
 

--- a/features/Context/Page/Product/Index.php
+++ b/features/Context/Page/Product/Index.php
@@ -31,15 +31,15 @@ class Index extends Grid
         $this->elements = array_merge(
             $this->elements,
             [
-                'Categories tree'       => ['css' => '#tree'],
-                'Main context selector' => [
+                'Categories tree'         => ['css' => '#tree'],
+                'Main context selector'   => [
                     'css'        => '#container',
-                    'decorators' => [
-                        'Pim\Behat\Decorator\ContextSwitcherDecorator'
-                    ]
+                    'decorators' => ['Pim\Behat\Decorator\ContextSwitcherDecorator'],
                 ],
-                'Tree select'      => ['css' => '#tree_select'],
-                'Locales dropdown' => ['css' => '#locale-switcher'],
+                'Tree select'             => ['css' => '#tree_select'],
+                'Locales dropdown'        => ['css' => '#locale-switcher'],
+                'Sidebar collapse button' => ['css' => '.sidebar .sidebar-controls i.icon-double-angle-left'],
+                'Sidebar expand button'   => ['css' => '.separator.collapsed i.icon-double-angle-right'],
             ]
         );
     }

--- a/features/Context/WebUser.php
+++ b/features/Context/WebUser.php
@@ -2630,4 +2630,20 @@ class WebUser extends RawMinkContext
             assertEquals((int) $expectedCount, count($items));
         }
     }
+
+    /**
+     * @When /^I collapse the category sidebar$/
+     */
+    public function iCollapseTheCategorySidebar()
+    {
+        $this->getCurrentPage()->getElement('Sidebar collapse button')->click();
+    }
+
+    /**
+     * @When /^I expand the category sidebar$/
+     */
+    public function iExpandTheCategorySidebar()
+    {
+        $this->getCurrentPage()->getElement('Sidebar expand button')->click();
+    }
 }

--- a/features/product/filtering/filter_products_per_category.feature
+++ b/features/product/filtering/filter_products_per_category.feature
@@ -29,3 +29,18 @@ Feature: Filter products by category
     Then I should be able to use the following filters:
       | filter   | value    | result     |
       | category | men_2015 | blue-jeans |
+
+  Scenario: Successfully filter products by category when hiding the category sidebar
+    Given I am on the products page
+    When I select the "2015 collection" tree
+    Then I should see products purple-tshirt, green-tshirt and blue-jeans
+    Then I should be able to use the following filters:
+      | filter   | value      | result                         |
+      | category | women_2015 | purple-tshirt and green-tshirt |
+    And the grid should contain 2 elements
+    When I collapse the category sidebar
+    And I change the page size to 50
+    Then the grid should contain 2 elements
+    When I expand the category sidebar
+    And I change the page size to 25
+    Then the grid should contain 2 elements

--- a/src/Pim/Bundle/UIBundle/Resources/public/js/jquery.sidebarize.js
+++ b/src/Pim/Bundle/UIBundle/Resources/public/js/jquery.sidebarize.js
@@ -33,11 +33,14 @@
     }
 
     function collapse($element, opts) {
-        $('>.sidebar', $element).hide();
+        var $switchInputLabel = $('label[for="nested_switch_input"]');
+
+        $('>.sidebar', $element).width(0);
         $('>.separator', $element).toggleClass('expanded collapsed').css({
             'width': opts.collapsedSeparatorWidth - 2 + 'px',
             'cursor': 'default'
         });
+        $switchInputLabel.hide();
         adjustWidth($element, opts);
         $element.find('.separator i').addClass(opts.expandIcon);
         $element.find('.separator b').removeClass(opts.dragIcon);
@@ -45,11 +48,14 @@
     }
 
     function expand($element, opts) {
-        $('>.sidebar', $element).show();
+        var $switchInputLabel = $('label[for="nested_switch_input"]');
+
+        $('>.sidebar', $element).width(parseInt(getState(opts.widthStorageKey), 10) || opts.sidebarWidth);
         $('>.separator', $element).toggleClass('expanded collapsed').css({
             'width': opts.separatorWidth - 2 + 'px',
             'cursor': opts.resizeCursor
         });
+        $switchInputLabel.show();
         adjustWidth($element, opts);
         $element.find('.separator i').removeClass(opts.expandIcon);
         $element.find('.separator b').addClass(opts.dragIcon);


### PR DESCRIPTION
**Description**

On product data grid, when the category panel is retracted on the left side, the number of products displayed is not accurate anymore.

For instance:
- Select a category (with more than 100 products) 
- Change the default pagination (put it to 50 products per page) 
- Then remove the category left panel = reduce it. 
- Rechange the default pagination 
- The page now displays ALL products, not only products from the selected category.

This PR fix it by setting the sidebar width to 0 (and restoring it to its previous value) rather than just hiding (and showing) it.

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | No
| Added Behats                      | No
| Changelog updated                 | Yes
| Review and 2 GTM                  | Waiting
| Micro Demo to the PO (Story only) | No
| Migration script                  | No
| Tech Doc                          | No
