### PR TITLE
TIP-266: Extract multiple files flush logic into a dedicated class

### DIFF
--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/writers.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/writers.yml
@@ -16,7 +16,7 @@ parameters:
     pim_connector.writer.file.xlsx_product.class:                  Pim\Component\Connector\Writer\File\XlsxProductWriter
     pim_connector.writer.file.xlsx_simple.class:                   Pim\Component\Connector\Writer\File\XlsxSimpleWriter
     pim_connector.writer.file.xlsx_variant_group.class:            Pim\Component\Connector\Writer\File\XlsxVariantGroupWriter
-    pim_connector.writer.file.product.flat_item_buffer.class:      Pim\Component\Connector\Writer\File\FlatItemBuffer
+    pim_connector.writer.file.flat_item_buffer.class:              Pim\Component\Connector\Writer\File\FlatItemBuffer
     pim_connector.writer.file.product.bulk_file_exporter.class:    Pim\Component\Connector\Writer\File\BulkFileExporter
     pim_connector.writer.file.default.column_sorter.class:         Pim\Component\Connector\Writer\File\DefaultColumnSorter
     pim_connector.writer.file.product.column_sorter.class:         Pim\Component\Connector\Writer\File\ProductColumnSorter
@@ -151,8 +151,8 @@ services:
     pim_connector.writer.file.media_exporter_path_generator:
         class: %pim_connector.writer.file.media_exporter_path_generator.class%
 
-    pim_connector.writer.file.product.flat_item_buffer:
-        class: %pim_connector.writer.file.product.flat_item_buffer.class%
+    pim_connector.writer.file.flat_item_buffer:
+        class: %pim_connector.writer.file.flat_item_buffer.class%
         arguments:
             - '@akeneo_buffer.factory.json_file_buffer'
 
@@ -182,14 +182,14 @@ services:
         class: %pim_connector.writer.file.csv.class%
         arguments:
             - '@pim_connector.writer.file.file_path_resolver'
-            - '@pim_connector.writer.file.product.flat_item_buffer'
+            - '@pim_connector.writer.file.flat_item_buffer'
             - '@pim_connector.writer.file.default.column_sorter'
 
     pim_connector.writer.file.csv_product:
         class: %pim_connector.writer.file.csv_product.class%
         arguments:
             - '@pim_connector.writer.file.file_path_resolver'
-            - '@pim_connector.writer.file.product.flat_item_buffer'
+            - '@pim_connector.writer.file.flat_item_buffer'
             - '@pim_connector.writer.file.product.bulk_file_exporter'
             - '@pim_connector.writer.file.product.column_sorter'
 
@@ -197,7 +197,7 @@ services:
         class: %pim_connector.writer.file.csv_variant_group.class%
         arguments:
             - '@pim_connector.writer.file.file_path_resolver'
-            - '@pim_connector.writer.file.product.flat_item_buffer'
+            - '@pim_connector.writer.file.flat_item_buffer'
             - '@pim_connector.writer.file.product.bulk_file_exporter'
             - '@pim_connector.writer.file.default.column_sorter'
 
@@ -224,14 +224,14 @@ services:
         class: %pim_connector.writer.file.xlsx_simple.class%
         arguments:
              - '@pim_connector.writer.file.file_path_resolver'
-             - '@pim_connector.writer.file.product.flat_item_buffer'
+             - '@pim_connector.writer.file.flat_item_buffer'
              - '@pim_connector.writer.file.flat_item_buffer_flusher'
 
     pim_connector.writer.file.xlsx_product:
         class: %pim_connector.writer.file.xlsx_product.class%
         arguments:
              - '@pim_connector.writer.file.file_path_resolver'
-             - '@pim_connector.writer.file.product.flat_item_buffer'
+             - '@pim_connector.writer.file.flat_item_buffer'
              - '@pim_connector.writer.file.product.bulk_file_exporter'
              - '@pim_connector.writer.file.flat_item_buffer_flusher'
 
@@ -239,7 +239,7 @@ services:
         class: %pim_connector.writer.file.xlsx_variant_group.class%
         arguments:
              - '@pim_connector.writer.file.file_path_resolver'
-             - '@pim_connector.writer.file.product.flat_item_buffer'
+             - '@pim_connector.writer.file.flat_item_buffer'
              - '@pim_connector.writer.file.product.bulk_file_exporter'
              - '@pim_connector.writer.file.flat_item_buffer_flusher'
 

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/writers.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/writers.yml
@@ -20,6 +20,7 @@ parameters:
     pim_connector.writer.file.product.bulk_file_exporter.class:    Pim\Component\Connector\Writer\File\BulkFileExporter
     pim_connector.writer.file.default.column_sorter.class:         Pim\Component\Connector\Writer\File\DefaultColumnSorter
     pim_connector.writer.file.product.column_sorter.class:         Pim\Component\Connector\Writer\File\ProductColumnSorter
+    pim_connector.writer.file.flat_item_buffer_flusher.class:      Pim\Component\Connector\Writer\File\FlatItemBufferFlusher
 
 services:
     # Dummy writer
@@ -170,6 +171,12 @@ services:
         arguments:
             - '@pim_connector.writer.file.file_path_resolver'
 
+    pim_connector.writer.file.flat_item_buffer_flusher:
+        class: %pim_connector.writer.file.flat_item_buffer_flusher.class%
+        arguments:
+             - '@pim_connector.writer.file.file_path_resolver'
+             - '@pim_connector.writer.file.default.column_sorter'
+
     # CSV
     pim_connector.writer.file.csv:
         class: %pim_connector.writer.file.csv.class%
@@ -218,7 +225,7 @@ services:
         arguments:
              - '@pim_connector.writer.file.file_path_resolver'
              - '@pim_connector.writer.file.product.flat_item_buffer'
-             - '@pim_connector.writer.file.default.column_sorter'
+             - '@pim_connector.writer.file.flat_item_buffer_flusher'
 
     pim_connector.writer.file.xlsx_product:
         class: %pim_connector.writer.file.xlsx_product.class%
@@ -226,7 +233,7 @@ services:
              - '@pim_connector.writer.file.file_path_resolver'
              - '@pim_connector.writer.file.product.flat_item_buffer'
              - '@pim_connector.writer.file.product.bulk_file_exporter'
-             - '@pim_connector.writer.file.product.column_sorter'
+             - '@pim_connector.writer.file.flat_item_buffer_flusher'
 
     pim_connector.writer.file.xlsx_variant_group:
         class: %pim_connector.writer.file.xlsx_variant_group.class%
@@ -234,7 +241,7 @@ services:
              - '@pim_connector.writer.file.file_path_resolver'
              - '@pim_connector.writer.file.product.flat_item_buffer'
              - '@pim_connector.writer.file.product.bulk_file_exporter'
-             - '@pim_connector.writer.file.default.column_sorter'
+             - '@pim_connector.writer.file.flat_item_buffer_flusher'
 
     pim_connector.writer.file.xlsx_group:
         alias: pim_connector.writer.file.xlsx

--- a/src/Pim/Component/Connector/Writer/File/FlatItemBuffer.php
+++ b/src/Pim/Component/Connector/Writer/File/FlatItemBuffer.php
@@ -6,7 +6,7 @@ use Akeneo\Component\Buffer\BufferFactory;
 use Akeneo\Component\Buffer\BufferInterface;
 
 /**
- * Write items into a buffer and calculate headers during a flat file export
+ * Puts items into a buffer and calculate headers during a flat file export
  *
  * @author    Arnaud Langlade <arnaud.langlade@akeneo.com>
  * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
@@ -36,12 +36,12 @@ class FlatItemBuffer implements \Countable
      * Write an item into the buffer
      *
      * @param array $items
-     * @param $addHeader
+     * @param bool  $addToHeaders
      */
-    public function write(array $items, $addHeader)
+    public function write(array $items, $addToHeaders)
     {
         foreach ($items as $item) {
-            if ($addHeader) {
+            if ($addToHeaders) {
                 $this->addToHeaders(array_keys($item));
             }
 

--- a/src/Pim/Component/Connector/Writer/File/FlatItemBufferFlusher.php
+++ b/src/Pim/Component/Connector/Writer/File/FlatItemBufferFlusher.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace Pim\Component\Connector\Writer\File;
+
+use Akeneo\Component\Batch\Model\StepExecution;
+use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
+use Box\Spout\Common\Type;
+use Box\Spout\Writer\WriterFactory;
+use Box\Spout\Writer\WriterInterface;
+
+/**
+ * Flushes the flat item buffer into one or multiple output files.
+ * @see Pim\Component\Connector\Writer\File\FlatItemBuffer
+ *
+ * Several output files are created if the buffer contains more items that maximum lines authorized per output file.
+ *
+ * @author    Julien Janvier <jjanvier@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class FlatItemBufferFlusher implements StepExecutionAwareInterface
+{
+    /** @var FilePathResolverInterface */
+    protected $filePathResolver;
+
+    /** @var StepExecution */
+    protected $stepExecution;
+
+    /** @var ColumnSorterInterface */
+    protected $columnSorter;
+
+    /**
+     * @param FilePathResolverInterface $filePathResolver
+     * @param ColumnSorterInterface     $columnSorter
+     */
+    public function __construct(FilePathResolverInterface $filePathResolver, ColumnSorterInterface $columnSorter = null)
+    {
+        $this->filePathResolver = $filePathResolver;
+        $this->columnSorter = $columnSorter;
+    }
+
+    /**
+     * Flushes the flat item buffer into one or multiple output files.
+     * Several output files are created if the buffer contains more items that maximum lines authorized per output file.
+     *
+     * @param FlatItemBuffer $buffer
+     * @param int            $maxLinesPerFile
+     * @param string         $baseFilePath
+     * @param array          $filePathResolverOptions
+     *
+     * @return array the list of file paths that have been written
+     */
+    public function flush(FlatItemBuffer $buffer, $maxLinesPerFile, $baseFilePath, array $filePathResolverOptions = [])
+    {
+        $writtenFiles = [];
+
+        $pathPattern = $baseFilePath;
+        if ($this->areSeveralFilesNeeded($buffer, $maxLinesPerFile)) {
+            $pathPattern = $this->getNumberedFilePath($baseFilePath);
+        }
+
+        $headers    = $this->sortHeaders($buffer->getHeaders());
+        $hollowItem = array_fill_keys($headers, '');
+
+        $fileCount         = 1;
+        $writtenLinesCount = 0;
+        foreach ($buffer->getBuffer() as $count => $incompleteItem) {
+            if (0 === $writtenLinesCount % $maxLinesPerFile) {
+                $filePath = $this->resolveFilePath(
+                    $buffer,
+                    $maxLinesPerFile,
+                    $pathPattern,
+                    $fileCount,
+                    $filePathResolverOptions
+                );
+
+                $writtenLinesCount = 0;
+                $writer            = $this->getWriter($filePath);
+                $writer->addRow($headers);
+            }
+
+            $item = array_replace($hollowItem, $incompleteItem);
+            $writer->addRow($item);
+            $writtenLinesCount++;
+
+            if (null !== $this->stepExecution) {
+                $this->stepExecution->incrementSummaryInfo('write');
+            }
+
+            if (0 === $writtenLinesCount % $maxLinesPerFile || $buffer->count() === $count + 1) {
+                $writer->close();
+                $writtenFiles[] = $filePath;
+                $fileCount++;
+            }
+        }
+
+        return $writtenFiles;
+    }
+
+    /**
+     * @param StepExecution $stepExecution
+     */
+    public function setStepExecution(StepExecution $stepExecution)
+    {
+        $this->stepExecution = $stepExecution;
+    }
+
+    /**
+     * @param ColumnSorterInterface $columnSorter
+     */
+    public function setColumnSorter(ColumnSorterInterface $columnSorter)
+    {
+        $this->columnSorter = $columnSorter;
+    }
+
+    /**
+     * @param array $headers
+     *
+     * @return array
+     */
+    protected function sortHeaders(array $headers)
+    {
+        if (null !== $this->columnSorter) {
+            $headers = $this->columnSorter->sort($headers);
+        }
+
+        return $headers;
+    }
+
+    /**
+     * @param FlatItemBuffer $buffer
+     * @param int            $linesPerFile
+     *
+     * @return bool
+     */
+    protected function areSeveralFilesNeeded(FlatItemBuffer $buffer, $linesPerFile)
+    {
+        return $buffer->count() > $linesPerFile;
+    }
+
+    /**
+     * Return the given file path in terms of the current file count if needed
+     *
+     * @param FlatItemBuffer $buffer
+     * @param int            $linesPerFile
+     * @param string         $pathPattern
+     * @param int            $currentFileCount
+     * @param array          $filePathResolverOptions
+     *
+     * @return string
+     */
+    protected function resolveFilePath(
+        FlatItemBuffer $buffer,
+        $linesPerFile,
+        $pathPattern,
+        $currentFileCount,
+        $filePathResolverOptions
+    ) {
+        $resolvedFilePath = $pathPattern;
+        if ($this->areSeveralFilesNeeded($buffer, $linesPerFile)) {
+            $resolvedFilePath = $this->filePathResolver->resolve(
+                $pathPattern,
+                array_merge_recursive(
+                    $filePathResolverOptions,
+                    ['parameters' => ['%fileNb%' => '_' . $currentFileCount]]
+                )
+            );
+        }
+
+        return $resolvedFilePath;
+    }
+
+    /**
+     * Return the given file path with %fileNb% placeholder just before the extension of the file
+     * ie: in -> '/path/myFile.txt' ; out -> '/path/myFile%fileNb%.txt'
+     *
+     * @param string $originalFilePath
+     *
+     * @return string
+     */
+    protected function getNumberedFilePath($originalFilePath)
+    {
+        $extension = '.' . pathinfo($originalFilePath, PATHINFO_EXTENSION);
+        $filePath  = strstr($originalFilePath, $extension, true);
+
+        return $filePath . '%fileNb%' . $extension;
+    }
+
+    /**
+     * @param string $filePath File path to open with the writer
+     *
+     * @return WriterInterface
+     */
+    protected function getWriter($filePath)
+    {
+        $writer = WriterFactory::create(Type::XLSX);
+        $writer->openToFile($filePath);
+
+        return $writer;
+    }
+}

--- a/src/Pim/Component/Connector/Writer/File/XlsxProductWriter.php
+++ b/src/Pim/Component/Connector/Writer/File/XlsxProductWriter.php
@@ -22,8 +22,8 @@ class XlsxProductWriter extends AbstractFileWriter implements ItemWriterInterfac
     /** @var array */
     protected $writtenFiles;
 
-    /** @var ColumnSorterInterface */
-    protected $columnSorter;
+    /** @var FlatItemBufferFlusher */
+    protected $flusher;
 
     /** @var BulkFileExporter */
     protected $fileExporter;
@@ -32,19 +32,19 @@ class XlsxProductWriter extends AbstractFileWriter implements ItemWriterInterfac
      * @param FilePathResolverInterface $filePathResolver
      * @param FlatItemBuffer            $flatRowBuffer
      * @param BulkFileExporter          $fileExporter
-     * @param ColumnSorterInterface     $columnSorter
+     * @param FlatItemBufferFlusher     $flusher
      */
     public function __construct(
         FilePathResolverInterface $filePathResolver,
         FlatItemBuffer $flatRowBuffer,
         BulkFileExporter $fileExporter,
-        ColumnSorterInterface $columnSorter
+        FlatItemBufferFlusher $flusher
     ) {
         parent::__construct($filePathResolver);
 
         $this->flatRowBuffer = $flatRowBuffer;
         $this->fileExporter  = $fileExporter;
-        $this->columnSorter  = $columnSorter;
+        $this->flusher       = $flusher;
         $this->writtenFiles  = [];
     }
 
@@ -88,41 +88,17 @@ class XlsxProductWriter extends AbstractFileWriter implements ItemWriterInterfac
      */
     public function flush()
     {
-        $pathPattern = $this->getPath();
-        if ($this->areSeveralFilesNeeded()) {
-            $pathPattern = $this->getNumberedFilePath($this->getPath());
-        }
+        $this->flusher->setStepExecution($this->stepExecution);
 
-        $parameters = $this->stepExecution->getJobParameters();
-        $linesPerFile = $parameters->get('linesPerFile');
+        $writtenFiles = $this->flusher->flush(
+            $this->flatRowBuffer,
+            $this->stepExecution->getJobParameters()->get('linesPerFile'),
+            $this->getPath(),
+            $this->filePathResolverOptions
+        );
 
-        $headers = $this->columnSorter->sort($this->flatRowBuffer->getHeaders());
-        $hollowItem = array_fill_keys($headers, '');
-
-        $fileCount = 1;
-        $writtenLinesCount = 0;
-        foreach ($this->flatRowBuffer->getBuffer() as $count => $incompleteItem) {
-            if (0 === $writtenLinesCount % $linesPerFile) {
-                $filePath = $this->resolveFilePath($pathPattern, $fileCount);
-
-                $writtenLinesCount = 0;
-                $writer = $this->getWriter($filePath);
-                $writer->addRow($headers);
-            }
-
-            $item = array_replace($hollowItem, $incompleteItem);
-            $writer->addRow($item);
-            $writtenLinesCount++;
-
-            if (null !== $this->stepExecution) {
-                $this->stepExecution->incrementSummaryInfo('write');
-            }
-
-            if (0 === $writtenLinesCount % $linesPerFile || $this->flatRowBuffer->count() === $count + 1) {
-                $writer->close();
-                $this->writtenFiles[$filePath] = basename($filePath);
-                $fileCount++;
-            }
+        foreach ($writtenFiles as $writtenFile) {
+            $this->writtenFiles[$writtenFile] = basename($writtenFile);
         }
     }
 
@@ -132,68 +108,5 @@ class XlsxProductWriter extends AbstractFileWriter implements ItemWriterInterfac
     public function getWrittenFiles()
     {
         return $this->writtenFiles;
-    }
-
-    /**
-     * @return bool
-     */
-    protected function areSeveralFilesNeeded()
-    {
-        $parameters = $this->stepExecution->getJobParameters();
-
-        return $this->flatRowBuffer->count() > $parameters->get('linesPerFile');
-    }
-
-    /**
-     * Return the file path including file count if needed
-     *
-     * @param string $pathPattern
-     * @param int    $currentFileCount
-     *
-     * @return string
-     */
-    protected function resolveFilePath($pathPattern, $currentFileCount)
-    {
-        $resolvedFilePath = $pathPattern;
-        if ($this->areSeveralFilesNeeded()) {
-            $resolvedFilePath = $this->filePathResolver->resolve(
-                $pathPattern,
-                array_merge_recursive(
-                    $this->filePathResolverOptions,
-                    ['parameters' => ['%fileNb%' => '_' . $currentFileCount]]
-                )
-            );
-        }
-
-        return $resolvedFilePath;
-    }
-
-    /**
-     * Return the given file path with %fileNb% placeholder just before the extension of the file
-     * ie: in -> '/path/myFile.txt' ; out -> '/path/myFile%fileNb%.txt'
-     *
-     * @param string $originalFilePath
-     *
-     * @return string
-     */
-    protected function getNumberedFilePath($originalFilePath)
-    {
-        $extension = '.' . pathinfo($originalFilePath, PATHINFO_EXTENSION);
-        $filePath  = strstr($originalFilePath, $extension, true);
-
-        return $filePath . '%fileNb%' . $extension;
-    }
-
-    /**
-     * @param string $filePath File path to open with the writer
-     *
-     * @return WriterInterface
-     */
-    protected function getWriter($filePath)
-    {
-        $writer = WriterFactory::create(Type::XLSX);
-        $writer->openToFile($filePath);
-
-        return $writer;
     }
 }

--- a/src/Pim/Component/Connector/Writer/File/XlsxSimpleWriter.php
+++ b/src/Pim/Component/Connector/Writer/File/XlsxSimpleWriter.php
@@ -2,10 +2,6 @@
 
 namespace Pim\Component\Connector\Writer\File;
 
-use Box\Spout\Common\Type;
-use Box\Spout\Writer\WriterFactory;
-use Box\Spout\Writer\WriterInterface;
-
 /**
  * Write simple data into a XLSX file on the local filesystem
  *
@@ -18,26 +14,27 @@ class XlsxSimpleWriter extends AbstractFileWriter implements ArchivableWriterInt
     /** @var FlatItemBuffer */
     protected $flatRowBuffer;
 
-    /** @var ColumnSorterInterface */
-    protected $columnSorter;
+    /** @var FlatItemBufferFlusher */
+    protected $flusher;
 
     /** @var array */
-    protected $writtenFiles = [];
+    protected $writtenFiles;
 
     /**
      * @param FilePathResolverInterface $filePathResolver
      * @param FlatItemBuffer            $flatRowBuffer
-     * @param ColumnSorterInterface     $columnSorter
+     * @param FlatItemBufferFlusher     $flusher
      */
     public function __construct(
         FilePathResolverInterface $filePathResolver,
         FlatItemBuffer $flatRowBuffer,
-        ColumnSorterInterface $columnSorter
+        FlatItemBufferFlusher $flusher
     ) {
         parent::__construct($filePathResolver);
 
         $this->flatRowBuffer = $flatRowBuffer;
-        $this->columnSorter  = $columnSorter;
+        $this->flusher       = $flusher;
+        $this->writtenFiles  = [];
     }
 
     /**
@@ -60,44 +57,19 @@ class XlsxSimpleWriter extends AbstractFileWriter implements ArchivableWriterInt
      */
     public function flush()
     {
-        $pathPattern = $this->getPath();
-        if ($this->areSeveralFilesNeeded()) {
-            $pathPattern = $this->getNumberedFilePath($this->getPath());
-        }
+        $this->flusher->setStepExecution($this->stepExecution);
 
-        $headers = $this->columnSorter->sort($this->flatRowBuffer->getHeaders());
-        $hollowItem = array_fill_keys($headers, '');
+        $writtenFiles = $this->flusher->flush(
+            $this->flatRowBuffer,
+            $this->stepExecution->getJobParameters()->get('linesPerFile'),
+            $this->getPath(),
+            $this->filePathResolverOptions
+        );
 
-        $parameters = $this->stepExecution->getJobParameters();
-        $linesPerFile = $parameters->get('linesPerFile');
-
-        $fileCount = 1;
-        $writtenLinesCount = 0;
-        foreach ($this->flatRowBuffer->getBuffer() as $count => $incompleteItem) {
-            if (0 === $writtenLinesCount % $linesPerFile) {
-                $filePath = $this->resolveFilePath($pathPattern, $fileCount);
-
-                $writtenLinesCount = 0;
-                $writer = $this->getWriter($filePath);
-                $writer->addRow($headers);
-            }
-
-            $item = array_replace($hollowItem, $incompleteItem);
-            $writer->addRow($item);
-            $writtenLinesCount++;
-
-            if (null !== $this->stepExecution) {
-                $this->stepExecution->incrementSummaryInfo('write');
-            }
-
-            if (0 === $writtenLinesCount % $linesPerFile || $this->flatRowBuffer->count() === $count + 1) {
-                $writer->close();
-                $this->writtenFiles[$filePath] = basename($filePath);
-                $fileCount++;
-            }
+        foreach ($writtenFiles as $writtenFile) {
+            $this->writtenFiles[$writtenFile] = basename($writtenFile);
         }
     }
-
 
     /**
      * {@inheritdoc}
@@ -105,68 +77,5 @@ class XlsxSimpleWriter extends AbstractFileWriter implements ArchivableWriterInt
     public function getWrittenFiles()
     {
         return $this->writtenFiles;
-    }
-
-    /**
-     * @return bool
-     */
-    protected function areSeveralFilesNeeded()
-    {
-        $parameters = $this->stepExecution->getJobParameters();
-
-        return $this->flatRowBuffer->count() > $parameters->get('linesPerFile');
-    }
-
-    /**
-     * Return the given file path in terms of the current file count if needed
-     *
-     * @param string $pathPattern
-     * @param int    $currentFileCount
-     *
-     * @return string
-     */
-    protected function resolveFilePath($pathPattern, $currentFileCount)
-    {
-        $resolvedFilePath = $pathPattern;
-        if ($this->areSeveralFilesNeeded()) {
-            $resolvedFilePath = $this->filePathResolver->resolve(
-                $pathPattern,
-                array_merge_recursive(
-                    $this->filePathResolverOptions,
-                    ['parameters' => ['%fileNb%' => '_' . $currentFileCount]]
-                )
-            );
-        }
-
-        return $resolvedFilePath;
-    }
-
-    /**
-     * Return the given file path with %fileNb% placeholder just before the extension of the file
-     * ie: in -> '/path/myFile.txt' ; out -> '/path/myFile%fileNb%.txt'
-     *
-     * @param string $originalFilePath
-     *
-     * @return string
-     */
-    protected function getNumberedFilePath($originalFilePath)
-    {
-        $extension = '.' . pathinfo($originalFilePath, PATHINFO_EXTENSION);
-        $filePath  = strstr($originalFilePath, $extension, true);
-
-        return $filePath . '%fileNb%' . $extension;
-    }
-
-    /**
-     * @param string $filePath File path to open with the writer
-     *
-     * @return WriterInterface
-     */
-    protected function getWriter($filePath)
-    {
-        $writer = WriterFactory::create(Type::XLSX);
-        $writer->openToFile($filePath);
-
-        return $writer;
     }
 }

--- a/src/Pim/Component/Connector/spec/Writer/File/XlsxProductWriterSpec.php
+++ b/src/Pim/Component/Connector/spec/Writer/File/XlsxProductWriterSpec.php
@@ -4,16 +4,12 @@ namespace spec\Pim\Component\Connector\Writer\File;
 
 use Akeneo\Component\Batch\Job\JobParameters;
 use Akeneo\Component\Batch\Model\StepExecution;
-use Akeneo\Component\Buffer\BufferInterface;
-use PhpSpec\Exception\Example\FailureException;
 use PhpSpec\ObjectBehavior;
-use Pim\Component\Connector\Writer\File\ColumnSorterInterface;
 use Pim\Component\Connector\Writer\File\FilePathResolverInterface;
+use Pim\Component\Connector\Writer\File\FlatItemBufferFlusher;
 use Pim\Component\Connector\Writer\File\FlatItemBuffer;
 use Pim\Component\Connector\Writer\File\BulkFileExporter;
 use Prophecy\Argument;
-use Symfony\Component\Validator\Constraints\GreaterThan;
-use Symfony\Component\Validator\Constraints\NotBlank;
 
 class XlsxProductWriterSpec extends ObjectBehavior
 {
@@ -21,9 +17,9 @@ class XlsxProductWriterSpec extends ObjectBehavior
         FilePathResolverInterface $filePathResolver,
         FlatItemBuffer $flatRowBuffer,
         BulkFileExporter $mediaCopier,
-        ColumnSorterInterface $columnSorter
+        FlatItemBufferFlusher $flusher
     ) {
-        $this->beConstructedWith($filePathResolver, $flatRowBuffer, $mediaCopier, $columnSorter, 10000);
+        $this->beConstructedWith($filePathResolver, $flatRowBuffer, $mediaCopier, $flusher);
 
         $filePathResolver->resolve(Argument::any(), Argument::type('array'))
             ->willReturn('/tmp/export/export.xlsx');
@@ -115,24 +111,26 @@ class XlsxProductWriterSpec extends ObjectBehavior
     }
 
     function it_writes_the_xlsx_file(
+        $flusher,
         $flatRowBuffer,
-	    $columnSorter,
-        BufferInterface $buffer,
         StepExecution $stepExecution,
         JobParameters $jobParameters
     ) {
         $this->setStepExecution($stepExecution);
+
+        $flusher->setStepExecution($stepExecution)->shouldBeCalled();
+
         $stepExecution->getJobParameters()->willReturn($jobParameters);
-        $jobParameters->get('withHeader')->willReturn(true);
-        $jobParameters->get('filePath')->willReturn('my/file/path');
+        $jobParameters->get('linesPerFile')->willReturn(2);
+        $jobParameters->get('filePath')->willReturn('my/file/path/foo');
         $jobParameters->has('mainContext')->willReturn(false);
-        $jobParameters->get('linesPerFile')->willReturn(10000);
 
-        $flatRowBuffer->count()->willReturn(10);
-        $flatRowBuffer->getHeaders()->willReturn(['id', 'family']);
-        $flatRowBuffer->getBuffer()->willReturn($buffer);
-
-        $columnSorter->sort(['id','family'])->willReturn(['id','family']);
+        $flusher->flush(
+            $flatRowBuffer,
+            2,
+            Argument::type('string'),
+            Argument::type('array')
+        )->willReturn(['my/file/path/foo1', 'my/file/path/foo2']);
 
         $this->flush();
     }


### PR DESCRIPTION
This PR aims to:
* avoid to duplicate the "I write into multiple files" logic among all the XLSX writers (currently, the code of the methods `flush`, `areSeveralFilesNeeded`, `resolveFilePath`, `getNumberedFilePath`, and `getWriter` is copied/pasted in `XlsxProductWriter`, `XlsxSimpleWriter` and `XlsxVariantGroupWriter` )
* avoid to tie the "I write into multiple files" logic with the XLSX format. It has nothing to do with. The object `` could worker exactly the same with any flat format (xlsx, csv) that uses our `FlatItemBuffer`)

Notes:

1.  we could remove even more duplicated code if `XlsxVariantGroupWriter` and `XlsxProductWriter` extended `XlsxSimpleWriter` (as the `flush` methods are still the same). Not sure it's a good thing or not, but it works like that for the CSV.. :+1: or :-1: ?
2. we could remove even more code if  the `FlatBufferToOutputFilesFlusher` was used in the CSV writers... (and btw we don't use spout there atm) :+1: or :-1: ?
3. this PR moves some code. I didn't recode anything here.
4. I didn't put an interface to `FlatBufferToOutputFilesFlusher`. At the moment, it seems to be purely internal stuff. Maybe later?

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | N
| Added Behats                      | -
| Changelog updated                 | -
| Review and 2 GTM                  | 
| Micro Demo to the PO (Story only) |
| Migration script                  | -
| Tech Doc                          | -
