### PR TITLE
PIM-5112: remove timezone from date filters

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/DateFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/DateFilter.php
@@ -164,7 +164,6 @@ class DateFilter extends AbstractAttributeFilter implements AttributeFilterInter
         }
 
         if ($value instanceof \DateTime) {
-            $value->setTimezone(new \DateTimeZone('UTC'));
             return $value->getTimestamp();
         }
 

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/DateFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/DateFilter.php
@@ -145,7 +145,6 @@ class DateFilter extends AbstractAttributeFilter implements AttributeFilterInter
         }
 
         if ($value instanceof \DateTime) {
-            $value->setTimezone(new \DateTimeZone('UTC'));
             return $value->format(static::DATETIME_FORMAT);
         }
 


### PR DESCRIPTION
Fix regression made with https://github.com/akeneo/pim-community-dev/pull/4471
It breaks `pim_catalog_date` attribute on ODM 

Currently on ORM, `pim_catalog_date` is stored as a date : `2016-05-24`. but on ODM it's stored as an IsoDate: `ISODate('2016-05-24T08:13:53.0Z')`

When DateFilter is called, when we force timezone, it works on ORM because we don't care about the time, not in ODM. Hours are postponed and date is wrong.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       |
| Added Behats                      |
| Changelog updated                 |
| Review and 2 GTM                  |
| Micro Demo to the PO (Story only) |
| Migration script                  |
| Tech Doc                          |

