### PR TITLE
PIM-5145: Add locale filter on the product export profiles

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -8,6 +8,7 @@
 - PIM-5099: The catalog structure can now be exported in XLSX format (families, attributes, attribute options, association types and categories)
 - PIM-5097: The catalog structure can now be imported in XLSX format (families, attributes, attribute options, association types and categories)
 - PIM-5657: It is now possible to add custom tabs within the job profile and edit pages
+- PIM-5145: It is now possible to filter product exports by locale
 
 ## Scalability improvements
 

--- a/features/Context/catalog/apparel/jobs.yml
+++ b/features/Context/catalog/apparel/jobs.yml
@@ -35,6 +35,11 @@ jobs:
         type:      export
         configuration:
             channel:    ecommerce
+            locales:
+                - en_US
+                - en_GB
+                - fr_FR
+                - de_DE
             delimiter:  ;
             enclosure:  '"'
             withHeader: true
@@ -46,6 +51,9 @@ jobs:
         type:      export
         configuration:
             channel:    tablet
+            locales:
+                - en_US
+                - en_GB
             delimiter:  ;
             enclosure:  '"'
             withHeader: true
@@ -56,6 +64,9 @@ jobs:
         label:     XLSX product export for tablet
         type:      export
         configuration:
+            locales:
+                - en_US
+                - en_GB
             filePath: /tmp/products.xlsx
             channel:    tablet
             linesPerFile: 10000
@@ -67,6 +78,9 @@ jobs:
         type:      export
         configuration:
             channel:    print
+            locales:
+                - en_US
+                - de_DE
             delimiter:  ;
             enclosure:  '"'
             withHeader: true

--- a/features/Context/catalog/footwear/jobs.yml
+++ b/features/Context/catalog/footwear/jobs.yml
@@ -23,6 +23,8 @@ jobs:
         type:      export
         configuration:
             channel:    mobile
+            locales:
+                - en_US
             delimiter:  ;
             enclosure:  '"'
             withHeader: true

--- a/features/Pim/Behat/Context/JobContext.php
+++ b/features/Pim/Behat/Context/JobContext.php
@@ -29,6 +29,10 @@ class JobContext extends PimContext
                 $value = 'yes' === $value;
             }
 
+            if ($this->isJobParameterArray($property)) {
+                $value = $this->getMainContext()->listToArray($value);
+            }
+
             $configuration[$property] = $value;
         }
 
@@ -184,5 +188,15 @@ class JobContext extends PimContext
         $archives = $archiver->getArchives($jobExecution);
 
         return $archives;
+    }
+
+    /**
+     * @param string $property
+     *
+     * @return bool
+     */
+    protected function isJobParameterArray($property)
+    {
+        return in_array($property, ['locales']);
     }
 }

--- a/features/export/product-export-builder/export_products_by_locales.feature
+++ b/features/export/product-export-builder/export_products_by_locales.feature
@@ -1,0 +1,80 @@
+@javascript
+Feature: Export products according to a locale policy
+  In order to use the enriched product data
+  As a product manager
+  I need to be able to export the products according to a given locale
+
+  Background:
+    Given a "default" catalog configuration
+    And the following attributes:
+      | code     | type     | localizable | label    | available_locales |
+      | name     | textarea | yes         | Name     | all               |
+      | baguette | text     | yes         | Baguette | fr_FR             |
+    And the following family:
+      | code      | requirements-ecommerce |
+      | localized | sku, name              |
+    And the following products:
+      | sku        | categories | family    | name-fr_FR | name-en_US | baguette-fr_FR |
+      | french     | default    | localized | French     |            | Yes            |
+      | english    | default    | localized |            | English    | Yes            |
+      | complete   | default    | localized | Complete   | Complete   | Yes            |
+      | empty      | default    | localized |            |            | Yes            |
+    And the following jobs:
+      | connector            | type   | alias              | code               | label              |
+      | Akeneo CSV Connector | export | csv_product_export | csv_product_export | CSV product export |
+    And the following job "csv_product_export" configuration:
+      | channel  | ecommerce                               |
+      | filePath | %tmp%/product_export/product_export.csv |
+    And I am logged in as "Julia"
+
+  Scenario: Export only the product values from the selected locale
+    Given the following job "csv_product_export" configuration:
+      | locales  | fr_FR  |
+    When I am on the "csv_product_export" export job page
+    And I launch the export job
+    And I wait for the "csv_product_export" job to finish
+    Then exported file of "csv_product_export" should contain:
+      """
+      sku;baguette-fr_FR;categories;enabled;family;groups;name-fr_FR
+      french;Yes;default;1;localized;;French
+      english;Yes;default;1;localized;;
+      complete;Yes;default;1;localized;;Complete
+      """
+
+  Scenario: Export only the product values from locale specific attributes
+    Given the following job "csv_product_export" configuration:
+      | locales | en_US |
+    When I am on the "csv_product_export" export job page
+    And I launch the export job
+    And I wait for the "csv_product_export" job to finish
+    Then exported file of "csv_product_export" should contain:
+      """
+      sku;categories;enabled;family;groups;name-en_US
+      french;default;1;localized;;
+      english;default;1;localized;;English
+      complete;default;1;localized;;Complete
+      """
+
+  Scenario: Remove the locales from the channel after we set the export configuration
+    Given the following job "csv_product_export" configuration:
+      | locales | fr_FR, en_US |
+    When I set the "English (United States)" locale to the "ecommerce" channel
+    And I am on the "csv_product_export" export job page
+    And I launch the export job
+    And I wait for the "csv_product_export" job to finish
+    Then exported file of "csv_product_export" should contain:
+      """
+      sku;categories;enabled;family;groups;name-en_US
+      english;default;1;localized;;English
+      complete;default;1;localized;;Complete
+      """
+
+  Scenario: Selecting a channel from the export profile updates the locale choices
+    Given the following job "csv_product_export" configuration:
+      | locales | fr_FR |
+    And I am on the "csv_product_export" export job edit page
+    When I visit the "Content" tab
+    Then I should see the text "Locales fr_FR"
+    When I fill in the following information:
+      | Channel | Mobile |
+    Then I should see the text "Locales fr_FR en_US"

--- a/src/Pim/Bundle/BaseConnectorBundle/Processor/ProductToFlatArrayProcessor.php
+++ b/src/Pim/Bundle/BaseConnectorBundle/Processor/ProductToFlatArrayProcessor.php
@@ -106,7 +106,7 @@ class ProductToFlatArrayProcessor extends AbstractConfigurableStepElement implem
 
         $normalizerContext = [
             'scopeCode'         => $channel->getCode(),
-            'localeCodes'       => $channel->getLocaleCodes(),
+            'localeCodes'       => array_intersect($channel->getLocaleCodes(), $parameters->get('locales')),
             'decimal_separator' => $decimalSeparator,
             'date_format'       => $dateFormat,
         ];

--- a/src/Pim/Bundle/BaseConnectorBundle/spec/Processor/ProductToFlatArrayProcessorSpec.php
+++ b/src/Pim/Bundle/BaseConnectorBundle/spec/Processor/ProductToFlatArrayProcessorSpec.php
@@ -67,12 +67,11 @@ class ProductToFlatArrayProcessorSpec extends ObjectBehavior
         $jobParameters->get('channel')->willReturn('foobar');
         $jobParameters->get('decimalSeparator')->willReturn('.');
         $jobParameters->get('dateFormat')->willReturn('yyyy-MM-dd');
-
-        $localeCodes = ['en_US'];
+        $jobParameters->get('locales')->willReturn(['fr_FR', 'en_US']);
 
         $channel->getCode()->willReturn('foobar');
         $channel->getLocales()->willReturn(new ArrayCollection([$locale]));
-        $channel->getLocaleCodes()->willReturn($localeCodes);
+        $channel->getLocaleCodes()->willReturn(['en_US', 'de_DE']);
         $productBuilder->addMissingProductValues($product, [$channel], [$locale])->shouldBeCalled();
 
         $media1->getKey()->willReturn('key/to/media1.jpg');
@@ -105,7 +104,7 @@ class ProductToFlatArrayProcessorSpec extends ObjectBehavior
                 'flat',
                 [
                     'scopeCode'         => 'foobar',
-                    'localeCodes'       => $localeCodes,
+                    'localeCodes'       => ['en_US'],
                     'decimal_separator' => '.',
                     'date_format'       => 'yyyy-MM-dd',
                 ]
@@ -136,14 +135,12 @@ class ProductToFlatArrayProcessorSpec extends ObjectBehavior
         $jobParameters->get('channel')->willReturn('foobar');
         $jobParameters->get('decimalSeparator')->willReturn(',');
         $jobParameters->get('dateFormat')->willReturn('yyyy-MM-dd');
-
-        $localeCodes = ['en_US'];
+        $jobParameters->get('locales')->willReturn(['en_US']);
 
         $channel->getCode()->willReturn('foobar');
         $channel->getLocales()->willReturn(new ArrayCollection([$locale]));
-        $channel->getLocaleCodes()->willReturn($localeCodes);
+        $channel->getLocaleCodes()->willReturn(['en_US']);
         $productBuilder->addMissingProductValues($product, [$channel], [$locale])->shouldBeCalled();
-
         $product->getValues()->willReturn([]);
 
         $serializer
@@ -152,7 +149,7 @@ class ProductToFlatArrayProcessorSpec extends ObjectBehavior
                 'flat',
                 [
                     'scopeCode' => 'foobar',
-                    'localeCodes' => $localeCodes,
+                    'localeCodes' => ['en_US'],
                     'decimal_separator' => ',',
                     'date_format'       => 'yyyy-MM-dd',
                 ]

--- a/src/Pim/Bundle/ConnectorBundle/Resources/translations/messages.en.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/translations/messages.en.yml
@@ -51,6 +51,11 @@ pim_connector:
         channel:
             label: Channel
             help: The channel you want to export
+        locales:
+            label: Locales
+            help: The locales you want to export
+            validation:
+                not_blank: One locale must be selected, please choose a locale to export.
         status:
             label: Status
             help: The status of the products you want to export

--- a/src/Pim/Bundle/ImportExportBundle/Form/Type/ProductExport/LocaleChoiceType.php
+++ b/src/Pim/Bundle/ImportExportBundle/Form/Type/ProductExport/LocaleChoiceType.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Pim\Bundle\ImportExportBundle\Form\Type\ProductExport;
+
+use Pim\Component\Catalog\Repository\LocaleRepositoryInterface;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Locale selector in the product export builder form
+ *
+ * @author    Clement Gautier <clement.gautier@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class LocaleChoiceType extends AbstractType
+{
+    /** @var LocaleRepositoryInterface */
+    protected $localeRepository;
+
+    /**
+     * @param LocaleRepositoryInterface $localeRepository
+     */
+    public function __construct(LocaleRepositoryInterface $localeRepository)
+    {
+        $this->localeRepository = $localeRepository;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $locales = $this->localeRepository->getActivatedLocaleCodes();
+
+        $resolver->setDefaults([
+            'choices'  => array_combine($locales, $locales),
+            'required' => true,
+            'select2'  => true,
+            'multiple' => true,
+            'label'    => 'pim_connector.export.locales.label',
+            'help'     => 'pim_connector.export.locales.help',
+            'attr'     => ['data-tab' => 'content']
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'pim_import_export_product_export_locale_choice';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getParent()
+    {
+        return 'choice';
+    }
+}

--- a/src/Pim/Bundle/ImportExportBundle/JobParameters/FormConfigurationProvider/ProductCsvExport.php
+++ b/src/Pim/Bundle/ImportExportBundle/JobParameters/FormConfigurationProvider/ProductCsvExport.php
@@ -105,6 +105,7 @@ class ProductCsvExport implements FormConfigurationProviderInterface
                     'attr'     => ['data-tab' => 'content']
                 ]
             ],
+            'locales' => ['type' => 'pim_import_export_product_export_locale_choice'],
             'enabled' => [
                 'type'    => 'choice',
                 'options' => [

--- a/src/Pim/Bundle/ImportExportBundle/JobParameters/FormConfigurationProvider/ProductXlsxExport.php
+++ b/src/Pim/Bundle/ImportExportBundle/JobParameters/FormConfigurationProvider/ProductXlsxExport.php
@@ -105,6 +105,7 @@ class ProductXlsxExport implements FormConfigurationProviderInterface
                     'attr'     => ['data-tab' => 'content']
                 ]
             ],
+            'locales' => ['type' => 'pim_import_export_product_export_locale_choice'],
             'enabled' => [
                 'type'    => 'choice',
                 'options' => [

--- a/src/Pim/Bundle/ImportExportBundle/Resources/config/form_types.yml
+++ b/src/Pim/Bundle/ImportExportBundle/Resources/config/form_types.yml
@@ -1,6 +1,7 @@
 parameters:
     pim_import_export.form.type.job_instance.class:   Pim\Bundle\ImportExportBundle\Form\Type\JobInstanceType
     pim_import_export.form.type.job_parameters.class: Pim\Bundle\ImportExportBundle\Form\Type\JobParametersType
+    pim_import_export.form.type.product_export.locale_choice.class: Pim\Bundle\ImportExportBundle\Form\Type\ProductExport\LocaleChoiceType
 
 services:
     pim_import_export.form.type.job_instance:
@@ -22,3 +23,10 @@ services:
             - '%akeneo_batch.job.job_parameters.class%'
         tags:
             - { name: form.type, alias: pim_import_export_job_parameters }
+
+    pim_import_export.form.type.product_export.locale_choice:
+        class: '%pim_import_export.form.type.product_export.locale_choice.class%'
+        arguments:
+            - '@pim_catalog.repository.locale'
+        tags:
+            - { name: form.type, alias: pim_import_export_product_export_locale_choice }

--- a/src/Pim/Bundle/ImportExportBundle/Resources/config/requirejs.yml
+++ b/src/Pim/Bundle/ImportExportBundle/Resources/config/requirejs.yml
@@ -1,3 +1,4 @@
 config:
     paths:
         pim/job-execution-view: pimimportexport/js/job-execution-view
+        pim/product-export/locales-selector: pimimportexport/js/product-export/locales-selector

--- a/src/Pim/Bundle/ImportExportBundle/Resources/public/js/product-export/locales-selector.js
+++ b/src/Pim/Bundle/ImportExportBundle/Resources/public/js/product-export/locales-selector.js
@@ -1,0 +1,55 @@
+'use strict';
+/**
+ * Dynamic locales selector in the product export builder form
+ *
+ * @author    Clement Gautier <clement.gautier@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+define(
+    ['jquery', 'underscore', 'pim/fetcher-registry'],
+    function ($, _, FetcherRegistry) {
+
+        /** @type {Object} JQuery object of the locales selector */
+        var $target;
+
+        return {
+            /**
+             * Load the locales choices depending on the channel selected
+             */
+            reload: function (event) {
+                FetcherRegistry.getFetcher('channel')
+                    .fetch(event.val)
+                    .then(function (channel) {
+
+                        $target.select2('destroy');
+                        $target.empty();
+
+                        _.each(channel.locales, function (locale) {
+                            $target.append('<option value="' + locale + '">' + locale + '</option>');
+                        });
+
+                        $target.select2();
+                        $target.select2('data', _.map(channel.locales, function (locale) {
+                            return {id: locale, text: locale};
+                        }));
+
+                    }.bind(this));
+            },
+
+            /**
+             * Initialize the behavior by listening to the event on the channel select
+             *
+             * @param {String} sourceSelector
+             * @param {String} targetSelector
+             */
+            init: function (sourceSelector, targetSelector) {
+                $target = $(targetSelector);
+
+                FetcherRegistry.initialize().then(function () {
+                    $(sourceSelector).on('select2-selecting', this.reload);
+                }.bind(this));
+            }
+        };
+    }
+);

--- a/src/Pim/Bundle/ImportExportBundle/Resources/translations/jsmessages.en.yml
+++ b/src/Pim/Bundle/ImportExportBundle/Resources/translations/jsmessages.en.yml
@@ -2,3 +2,9 @@ job_execution:
     summary:
         display_item: Display item
         hide_item: Hide item
+
+pim_connector:
+    export:
+        locales:
+            validation:
+                not_blank: One locale must be selected, please choose a locale to export.

--- a/src/Pim/Bundle/ImportExportBundle/Resources/views/JobProfile/Tab/job_content.html.twig
+++ b/src/Pim/Bundle/ImportExportBundle/Resources/views/JobProfile/Tab/job_content.html.twig
@@ -6,5 +6,22 @@
             {% endif %}
         {% endfor %}
     {% endset %}
+
+    <script type="text/javascript">
+        require(
+                ['jquery', 'pim/product-export/locales-selector'],
+                function($, LocaleSelector){
+                    'use strict';
+
+                    $(function () {
+                        LocaleSelector.init(
+                            '#pim_import_export_jobInstance_configuration_channel',
+                            '#pim_import_export_jobInstance_configuration_locales'
+                        );
+                    });
+                }
+        );
+    </script>
+
     {{ elements.accordion({ 'pane.accordion.filters': filtersSettings }, 3) }}
 </div>

--- a/src/Pim/Bundle/ImportExportBundle/spec/Form/Type/ProductExport/LocaleChoiceTypeSpec.php
+++ b/src/Pim/Bundle/ImportExportBundle/spec/Form/Type/ProductExport/LocaleChoiceTypeSpec.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace spec\Pim\Bundle\ImportExportBundle\Form\Type\ProductExport;
+
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Repository\LocaleRepositoryInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class LocaleChoiceTypeSpec extends ObjectBehavior
+{
+    function let(LocaleRepositoryInterface $repository)
+    {
+        $this->beConstructedWith($repository);
+    }
+
+    function it_is_a_form_type()
+    {
+        $this->shouldImplement('Symfony\Component\Form\FormTypeInterface');
+    }
+
+    function it_is_a_child_of_choice()
+    {
+        $this->getParent()->shouldReturn('choice');
+    }
+
+    function it_has_a_name()
+    {
+        $this->getName()->shouldReturn('pim_import_export_product_export_locale_choice');
+    }
+
+    function it_configure_options($repository, OptionsResolver $resolver)
+    {
+        $repository->getActivatedLocaleCodes()->willReturn(['fr_FR', 'en_US']);
+        $resolver->setDefaults([
+            'choices' => ['fr_FR' => 'fr_FR', 'en_US' => 'en_US'],
+            'required' => true,
+            'select2'  => true,
+            'multiple' => true,
+            'label'    => 'pim_connector.export.locales.label',
+            'help'     => 'pim_connector.export.locales.help',
+            'attr'     => ['data-tab' => 'content']
+        ])->shouldBeCalled();
+
+        $this->configureOptions($resolver);
+    }
+}

--- a/src/Pim/Bundle/ImportExportBundle/spec/JobParameters/FormConfigurationProvider/ProductCsvExportSpec.php
+++ b/src/Pim/Bundle/ImportExportBundle/spec/JobParameters/FormConfigurationProvider/ProductCsvExportSpec.php
@@ -106,6 +106,7 @@ class ProductCsvExportSpec extends ObjectBehavior
             'mobile'    => 'Mobile',
             'ecommerce' => 'E-commerce'
         ];
+
         $channelRepository->getLabelsIndexedByCode()->willReturn($channelCodes);
 
         $result = $this->getConfiguration($channelCodes, 'Last export: 15/12/2015 16:00:50') + $baseExport;
@@ -140,6 +141,7 @@ class ProductCsvExportSpec extends ObjectBehavior
             'mobile'    => 'Mobile',
             'ecommerce' => 'E-commerce'
         ];
+
         $channelRepository->getLabelsIndexedByCode()->willReturn($channelCodes);
 
         $result = $this->getConfiguration($channelCodes, 'This job has never been exported') + $baseExport;
@@ -160,6 +162,7 @@ class ProductCsvExportSpec extends ObjectBehavior
                     'attr'     => ['data-tab' => 'content']
                 ]
             ],
+            'locales' => ['type' => 'pim_import_export_product_export_locale_choice'],
             'enabled' => [
                 'type'    => 'choice',
                 'options' => [

--- a/src/Pim/Bundle/ImportExportBundle/spec/JobParameters/FormConfigurationProvider/ProductXlsxExportSpec.php
+++ b/src/Pim/Bundle/ImportExportBundle/spec/JobParameters/FormConfigurationProvider/ProductXlsxExportSpec.php
@@ -101,6 +101,7 @@ class ProductXlsxExportSpec extends ObjectBehavior
             'mobile'    => 'Mobile',
             'ecommerce' => 'E-commerce'
         ];
+
         $channelRepository->getLabelsIndexedByCode()->willReturn($channelCodes);
 
         $result = $this->getConfiguration($channelCodes, 'Last export: 15/12/2015 16:00:50') + $baseExport;
@@ -134,6 +135,7 @@ class ProductXlsxExportSpec extends ObjectBehavior
             'mobile'    => 'Mobile',
             'ecommerce' => 'E-commerce'
         ];
+
         $channelRepository->getLabelsIndexedByCode()->willReturn($channelCodes);
 
         $result = $this->getConfiguration($channelCodes, 'This job has never been exported') + $baseExport;
@@ -154,6 +156,7 @@ class ProductXlsxExportSpec extends ObjectBehavior
                     'attr'     => ['data-tab' => 'content']
                 ]
             ],
+            'locales' => ['type' => 'pim_import_export_product_export_locale_choice'],
             'enabled' => [
                 'type'    => 'choice',
                 'options' => [

--- a/src/Pim/Bundle/InstallerBundle/Resources/fixtures/icecat_demo_dev/jobs.yml
+++ b/src/Pim/Bundle/InstallerBundle/Resources/fixtures/icecat_demo_dev/jobs.yml
@@ -24,6 +24,10 @@ jobs:
         type:      export
         configuration:
             channel:    mobile
+            locales:
+                - fr_FR
+                - en_US
+                - de_DE
             delimiter:  ;
             enclosure:  '"'
             withHeader: true
@@ -222,6 +226,10 @@ jobs:
             linesPerFile: 10000
             filePath:   /tmp/product.xlsx
             channel:    mobile
+            locales:
+                - fr_FR
+                - en_US
+                - de_DE
     xlsx_group_export:
         connector: Akeneo XLSX Connector
         alias:     xlsx_group_export

--- a/src/Pim/Component/Connector/Job/JobParameters/ConstraintCollectionProvider/ProductCsvExport.php
+++ b/src/Pim/Component/Connector/Job/JobParameters/ConstraintCollectionProvider/ProductCsvExport.php
@@ -48,6 +48,10 @@ class ProductCsvExport implements ConstraintCollectionProviderInterface
         ];
         $constraintFields['enabled'] = new NotBlank(['groups' => 'Execution']);
         $constraintFields['updated'] = new NotBlank(['groups' => 'Execution']);
+        $constraintFields['locales'] = new NotBlank([
+            'groups'  => 'Execution',
+            'message' => 'pim_connector.export.locales.validation.not_blank'
+        ]);
 
         return new Collection(['fields' => $constraintFields]);
     }

--- a/src/Pim/Component/Connector/Job/JobParameters/ConstraintCollectionProvider/ProductXlsxExport.php
+++ b/src/Pim/Component/Connector/Job/JobParameters/ConstraintCollectionProvider/ProductXlsxExport.php
@@ -47,6 +47,12 @@ class ProductXlsxExport implements ConstraintCollectionProviderInterface
             new NotBlank(['groups' => 'Execution']),
             new Channel()
         ];
+
+        $constraintFields['locales'] = new NotBlank([
+            'groups'  => 'Execution',
+            'message' => 'pim_connector.export.locales.validation.not_blank'
+        ]);
+
         $constraintFields['enabled'] = new NotBlank(['groups' => 'Execution']);
         $constraintFields['updated'] = new NotBlank(['groups' => 'Execution']);
         $constraintFields['linesPerFile'] = [

--- a/src/Pim/Component/Connector/Job/JobParameters/DefaultValuesProvider/ProductCsvExport.php
+++ b/src/Pim/Component/Connector/Job/JobParameters/DefaultValuesProvider/ProductCsvExport.php
@@ -40,6 +40,7 @@ class ProductCsvExport implements DefaultValuesProviderInterface
         $parameters['decimalSeparator'] = LocalizerInterface::DEFAULT_DECIMAL_SEPARATOR;
         $parameters['dateFormat'] = LocalizerInterface::DEFAULT_DATE_FORMAT;
         $parameters['channel'] = null;
+        $parameters['locales'] = [];
         $parameters['enabled'] = 'enabled';
         $parameters['updated'] = 'all';
 

--- a/src/Pim/Component/Connector/Job/JobParameters/DefaultValuesProvider/ProductXlsxExport.php
+++ b/src/Pim/Component/Connector/Job/JobParameters/DefaultValuesProvider/ProductXlsxExport.php
@@ -40,6 +40,7 @@ class ProductXlsxExport implements DefaultValuesProviderInterface
         $parameters['decimalSeparator'] = LocalizerInterface::DEFAULT_DECIMAL_SEPARATOR;
         $parameters['dateFormat'] = LocalizerInterface::DEFAULT_DATE_FORMAT;
         $parameters['channel'] = null;
+        $parameters['locales'] = [];
         $parameters['enabled'] = 'enabled';
         $parameters['updated'] = 'all';
         $parameters['linesPerFile'] = 10000;

--- a/src/Pim/Component/Connector/spec/Job/JobParameters/ConstraintCollectionProvider/ProductCsvExportSpec.php
+++ b/src/Pim/Component/Connector/spec/Job/JobParameters/ConstraintCollectionProvider/ProductCsvExportSpec.php
@@ -28,12 +28,13 @@ class ProductCsvExportSpec extends ObjectBehavior
         $collection =  $this->getConstraintCollection();
         $collection->shouldReturnAnInstanceOf('Symfony\Component\Validator\Constraints\Collection');
         $fields = $collection->fields;
-        $fields->shouldHaveCount(5);
+        $fields->shouldHaveCount(6);
         $fields->shouldHaveKey('decimalSeparator');
         $fields->shouldHaveKey('dateFormat');
         $fields->shouldHaveKey('channel');
         $fields->shouldHaveKey('enabled');
         $fields->shouldHaveKey('updated');
+        $fields->shouldHaveKey('locales');
     }
 
     function it_supports_a_job(JobInterface $job)

--- a/src/Pim/Component/Connector/spec/Job/JobParameters/ConstraintCollectionProvider/ProductXlsxExportSpec.php
+++ b/src/Pim/Component/Connector/spec/Job/JobParameters/ConstraintCollectionProvider/ProductXlsxExportSpec.php
@@ -28,11 +28,12 @@ class ProductXlsxExportSpec extends ObjectBehavior
         $collection =  $this->getConstraintCollection();
         $collection->shouldReturnAnInstanceOf('Symfony\Component\Validator\Constraints\Collection');
         $fields = $collection->fields;
-        $fields->shouldHaveCount(6);
+        $fields->shouldHaveCount(7);
         $fields->shouldHaveKey('decimalSeparator');
         $fields->shouldHaveKey('dateFormat');
         $fields->shouldHaveKey('enabled');
         $fields->shouldHaveKey('channel');
+        $fields->shouldHaveKey('locales');
         $fields->shouldHaveKey('updated');
         $fields->shouldHaveKey('linesPerFile');
     }

--- a/src/Pim/Component/Connector/spec/Job/JobParameters/DefaultValuesProvider/ProductCsvExportSpec.php
+++ b/src/Pim/Component/Connector/spec/Job/JobParameters/DefaultValuesProvider/ProductCsvExportSpec.php
@@ -28,6 +28,7 @@ class ProductCsvExportSpec extends ObjectBehavior
                 'decimalSeparator' => ".",
                 'dateFormat'       => "yyyy-MM-dd",
                 'channel'          => null,
+                'locales'          => [],
                 'enabled'          => "enabled",
                 'updated'          => "all",
             ]

--- a/src/Pim/Component/Connector/spec/Job/JobParameters/DefaultValuesProvider/ProductXlsxExportSpec.php
+++ b/src/Pim/Component/Connector/spec/Job/JobParameters/DefaultValuesProvider/ProductXlsxExportSpec.php
@@ -28,6 +28,7 @@ class ProductXlsxExportSpec extends ObjectBehavior
                 'decimalSeparator' => ".",
                 'dateFormat'       => "yyyy-MM-dd",
                 'channel'          => null,
+                'locales'          => [],
                 'enabled'          => "enabled",
                 'updated'          => "all",
                 'linesPerFile'     => 10000


### PR DESCRIPTION
# Description
As Peter, I would like to choose for which locales the products are exported in order to have only the needed locale by an user or an output channel.
Example: Peter exports for the spanish translator the locales French and Spanish in order the translator enriches the spanish translation
There is a new parameter "Locale" on all products exports and published products (CSV and Excel) in a new tab "Contents".
This parameter is a list of locales with multiselection. By default all the locales of the channel are selected. If the channel is changed, the locales are updated by the locales of the channel. The user can add a locale or delete a locale.
At least one locale must be selected, the filter is manadatory. If no locale is selected, the following message is displayed "One locale must be selected, please choose a locale to export."
In the exported file:
- For localized attributes, only the values for the selected locales are exported.
- For the attributes specific to a locale, they are exported only if the locale is selected.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | :white_check_mark: 
| Added Behats                      | :white_check_mark: 
| Changelog updated                 | :white_check_mark: 
| Review and 2 GTM                  | :white_check_mark: 
| Micro Demo to the PO (Story only) | :white_check_mark: 
| Migration script                  | N/A
| Tech Doc                          | N/A
