### PR TITLE
Revert "PIM-5715: Remove use of Form component from UniqueValueValida…

### DIFF
--- a/src/Pim/Component/Catalog/Validator/Constraints/UniqueValueValidator.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/UniqueValueValidator.php
@@ -2,9 +2,11 @@
 
 namespace Pim\Component\Catalog\Validator\Constraints;
 
+use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Model\ProductValueInterface;
 use Pim\Component\Catalog\Repository\ProductRepositoryInterface;
 use Pim\Component\Catalog\Validator\UniqueValuesSet;
+use Symfony\Component\Form\Form;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 
@@ -29,42 +31,52 @@ class UniqueValueValidator extends ConstraintValidator
      */
     public function __construct(ProductRepositoryInterface $repository, UniqueValuesSet $uniqueValueSet)
     {
-        $this->repository      = $repository;
+        $this->repository = $repository;
         $this->uniqueValuesSet = $uniqueValueSet;
     }
 
     /**
-     * {@inheritdoc}
-     *
      * Validates if the product value exists in database or if we already tried to validate such value for another
      * product to handle bulk updates
      *
      * It means that we make this validator stateful which is a bad news, the good one is we ensure this validation
      * for any processes (other option was to mess the import as we did with previous implementation)
      *
-     * Due to constraint guesser, the constraint is applied on ProductValueInterface when applied directly through
-     * validator
+     * Due to constraint guesser, the constraint is applied on :
+     * - ProductValueInterface data when applied through form
+     * - ProductValueInterface when applied directly through validator
      *
      * The constraint guesser should be re-worked in a future version to avoid such behavior
      *
+     * @param ProductValueInterface|mixed $data
+     * @param Constraint                  $constraint
+     *
      * @see Pim\Bundle\CatalogBundle\Validator\ConstraintGuesser\UniqueValueGuesser
      */
-    public function validate($productValue, Constraint $constraint)
+    public function validate($data, Constraint $constraint)
     {
+        if (empty($data)) {
+            return;
+        }
+
+        if (is_object($data) && $data instanceof ProductValueInterface) {
+            $productValue = $data;
+        } else {
+            $productValue = $this->getProductValueFromForm();
+        }
+
         if ($productValue instanceof ProductValueInterface && $productValue->getAttribute()->isUnique()) {
-            $valueAlreadyExists    = $this->alreadyExists($productValue);
+            $valueAlreadyExists = $this->alreadyExists($productValue);
             $valueAlreadyProcessed = $this->hasAlreadyValidatedTheSameValue($productValue);
 
             if ($valueAlreadyExists || $valueAlreadyProcessed) {
-                $valueData     = $this->formatData($productValue->getData());
+                $valueData = $this->formatData($productValue->getData());
                 $attributeCode = $productValue->getAttribute()->getCode();
-
                 if (null !== $valueData && '' !== $valueData) {
-                    $this->context
-                        ->buildViolation($constraint->message)
-                        ->setParameter('%value%', $valueData)
-                        ->setParameter('%attribute%', $attributeCode)
-                        ->addViolation();
+                    $this->context->buildViolation(
+                        $constraint->message,
+                        ['%value%' => $valueData, '%attribute%' => $attributeCode]
+                    )->addViolation();
                 }
             }
         }
@@ -99,14 +111,47 @@ class UniqueValueValidator extends ConstraintValidator
     }
 
     /**
-     * @param mixed $productValueData
+     * @param $mixed $data
      *
      * @return string
      */
-    protected function formatData($productValueData)
+    protected function formatData($data)
     {
-        return ($productValueData instanceof \DateTime) ?
-            $productValueData->format('Y-m-d') :
-            (string) $productValueData;
+        return ($data instanceof \DateTime) ? $data->format('Y-m-d') : (string) $data;
+    }
+
+    /**
+     * Get product value from form
+     *
+     * @return ProductValueInterface|null
+     */
+    protected function getProductValueFromForm()
+    {
+        $root = $this->context->getRoot();
+        if (!$root instanceof Form) {
+            return;
+        }
+
+        preg_match(
+            '/children\[values\].children\[(\w+)\].children\[\w+\].data/',
+            $this->context->getPropertyPath(),
+            $matches
+        );
+        if (!isset($matches[1])) {
+            return;
+        }
+
+        $product = $this->context->getRoot()->getData();
+        if (!$product instanceof ProductInterface) {
+            return;
+        }
+
+        $value = $product->getValue($matches[1]);
+
+        if (false === $value) {
+            return;
+        }
+
+        return $value;
     }
 }


### PR DESCRIPTION
This reverts commit bb352dbafac7bb6bcd4c1868f0a994564f03bd34.
Fix features/product/create_product.feature:36
Since last change the uniqueness of a sku is not ensured in product creation popin.
Run with success here http://core-ci-staging.akeneo.com/job/dci_behat/531/
I created the TIP-445 to re-work the product creation popin to use the business validation and get rid of the form.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | N
| Added Behats                      | N
| Changelog updated                 | N
| Review and 2 GTM                  | -
| Micro Demo to the PO (Story only) |
| Migration script                  |
| Tech Doc                          |
