### PR TITLE
TIP-36: Ensure datagrid is correclty reseted before checking more filter

### DIFF
--- a/features/Context/DataGridContext.php
+++ b/features/Context/DataGridContext.php
@@ -85,22 +85,11 @@ class DataGridContext extends RawMinkContext implements PageObjectAwareInterface
             return;
         }
 
+        $this->theGridToolbarCountShouldBe($count);
+
         if ($count > 10) {
             $this->getCurrentPage()->getCurrentGrid()->setPageSize(100);
         }
-
-        $this->spin(function () use ($count) {
-            assertEquals(
-                $count,
-                $actualCount = $this->datagrid->getToolbarCount()
-            );
-
-            return true;
-        }, sprintf(
-            'Expecting to see %d record(s) in the datagrid toolbar, actually saw %d',
-            $count,
-            $this->datagrid->countRows()
-        ));
 
         $this->spin(function () use ($count) {
             assertEquals(
@@ -113,6 +102,25 @@ class DataGridContext extends RawMinkContext implements PageObjectAwareInterface
             'Expecting to see %d row(s) in the datagrid, actually saw %d.',
             $count,
             $this->datagrid->countRows()
+        ));
+    }
+
+    /**
+     * @param int $count
+     *
+     * @throws TimeoutException
+     *
+     * @Then /^the grid toolbar count should be (\d+) elements?$/
+     */
+    public function theGridToolbarCountShouldBe($count)
+    {
+        $count = (int) $count;
+        $this->spin(function () use ($count) {
+            return $this->datagrid->getToolbarCount() === $count;
+        }, sprintf(
+            'Expecting to see %d record(s) in the datagrid toolbar, actually saw %d',
+            $count,
+            $this->datagrid->getToolbarCount()
         ));
     }
 
@@ -525,7 +533,7 @@ class DataGridContext extends RawMinkContext implements PageObjectAwareInterface
             if (!$isCategoryFilter) {
                 $steps[] = new Step\Then(sprintf('I hide the filter "%s"', $filter));
                 if (null !== $countBeforeFilter) {
-                    $steps[] = new Step\Then(sprintf('the grid should contain %d elements', $countBeforeFilter));
+                    $steps[] = new Step\Then(sprintf('the grid toolbar count should be %s elements', $countBeforeFilter));
                 }
             }
         }

--- a/features/Context/DataGridContext.php
+++ b/features/Context/DataGridContext.php
@@ -533,7 +533,21 @@ class DataGridContext extends RawMinkContext implements PageObjectAwareInterface
             if (!$isCategoryFilter) {
                 $steps[] = new Step\Then(sprintf('I hide the filter "%s"', $filter));
                 if (null !== $countBeforeFilter) {
-                    $steps[] = new Step\Then(sprintf('the grid toolbar count should be %s elements', $countBeforeFilter));
+                    /**
+                     * At the end of the loop, we ensure we get back to the initial state of the loop.
+                     * To do this, we add a validation step checking if the number of initial elements in the datagrid
+                     * is the same than the number of elements in the datagrid after removing the filter.
+                     *
+                     * This has a second effect: it ensure the fact that the datagrid is well loaded. It fixes some
+                     * random features, where Metric and Price filters were closed during behat execution, when the
+                     * datagrid finished to be load.
+                     *
+                     * // TODO Refactor this using a comparison with content of the datagrid.
+                     */
+                    $steps[] = new Step\Then(sprintf(
+                        'the grid toolbar count should be %s elements',
+                        $countBeforeFilter
+                    ));
                 }
             }
         }

--- a/features/Context/DataGridContext.php
+++ b/features/Context/DataGridContext.php
@@ -508,8 +508,10 @@ class DataGridContext extends RawMinkContext implements PageObjectAwareInterface
             $count  = count($this->getMainContext()->listToArray($item['result']));
             $filter = $item['filter'];
             $isCategoryFilter = false !== strpos(strtolower($filter), 'category');
+            $countBeforeFilter = null;
 
             if (!$isCategoryFilter) {
+                $countBeforeFilter = $this->datagrid->getToolbarCount();
                 $steps[] = new Step\Then(sprintf('I show the filter "%s"', $filter));
             }
             $steps[] = new Step\Then(sprintf(
@@ -522,6 +524,9 @@ class DataGridContext extends RawMinkContext implements PageObjectAwareInterface
             $steps[] = new Step\Then(sprintf('I should see entities %s', $item['result']));
             if (!$isCategoryFilter) {
                 $steps[] = new Step\Then(sprintf('I hide the filter "%s"', $filter));
+                if (null !== $countBeforeFilter) {
+                    $steps[] = new Step\Then(sprintf('the grid should contain %d elements', $countBeforeFilter));
+                }
             }
         }
 

--- a/features/Context/Page/Base/Grid.php
+++ b/features/Context/Page/Base/Grid.php
@@ -291,12 +291,14 @@ class Grid extends Index
             ->find('css', 'div label.dib:contains("record")');
 
         // If pagination not found or is empty, count rows
+        // TODO Remove this! We have to find another toolbar count. If there is no toolbar count, this method
+        // should even not be called or should raise a not found exception.
         if (!$pagination || !$pagination->getText()) {
             return $this->countRows();
         }
 
         if (preg_match('/([0-9][0-9 ]*) records?$/', $pagination->getText(), $matches)) {
-            return $matches[1];
+            return (int) $matches[1];
         } else {
             throw new \InvalidArgumentException('Impossible to get count of datagrid records');
         }
@@ -494,7 +496,7 @@ class Grid extends Index
      */
     public function showFilter($filterName)
     {
-        $this->spin(function() {
+        $this->spin(function () {
             return $this->getElement('Body')->find('css', '.filter-box');
         }, 'The filter box is not loaded');
 

--- a/features/Context/Page/Base/Grid.php
+++ b/features/Context/Page/Base/Grid.php
@@ -290,15 +290,19 @@ class Grid extends Index
             ->getElement('Grid toolbar')
             ->find('css', 'div label.dib:contains("record")');
 
-        // If pagination not found or is empty, count rows
-        // TODO Remove this! We have to find another toolbar count. If there is no toolbar count, this method
-        // should even not be called or should raise a not found exception.
+        /**
+         * If pagination not found or is empty, it actually count rows
+         *
+         * TODO Remove this. We have to find another toolbar count.
+         * If there is no toolbar count, this method
+         * should even not be called or should raise a not found exception.
+         */
         if (!$pagination || !$pagination->getText()) {
             return $this->countRows();
         }
 
-        if (preg_match('/([0-9][0-9 ]*) records?$/', $pagination->getText(), $matches)) {
-            return (int) $matches[1];
+        if (preg_match('/(?P<count>[0-9][0-9 ]*) records?$/', $pagination->getText(), $matches)) {
+            return (int) preg_replace('/[^0-9]/', '', $matches['count']);
         } else {
             throw new \InvalidArgumentException('Impossible to get count of datagrid records');
         }


### PR DESCRIPTION
Fixes
vendor/akeneo/pim-community-dev/features/product/filtering/filter_products_per_metric.feature:24
vendor/akeneo/pim-community-dev/features/product/filtering/filter_products_per_with_multiple_metrics.feature:44
vendor/akeneo/pim-community-dev/features/product/filtering/filter_products_per_with_multiple_metrics.feature:31
vendor/akeneo/pim-community-dev/features/product/filtering/filter_products_per_price.feature:24
vendor/akeneo/pim-community-dev/features/product/filtering/filter_products_per_with_multiple_prices.feature:33

# HOW IT WORKS AND WHY IT RANDOMIZED

Before, the mink method do these steps n times:
- add a filter
- checks the filtered elements are the good ones
- remove the filter
- add a filter ... and again and again.

Sometimes, it happens that the filter box reload or close itself, without any reason. This imples a "I can not found my button" because filter open and closed.
So we added a step in this method : we now check that after the filter is removed, we're in the same step than before adding the filter.
This imples more strengh on the tests, and plays role of "spin" to be sure we're on a stable state to continue tests.

# To refactor

Card registered into TIP-462