### PR TITLE
PIM-5801: Fix save in PEF when attribute code is only numeric

### DIFF
--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -5,6 +5,7 @@
 - PIM-5710: Fix thumbnail display after file upload in the product edit form
 - PIM-5811: Fix family export with multiple locales activated
 - PIM-5726: Fix number of product displayed on Product Grid when category panel is withdrawn
+- PIM-5801: Fix save in product edit form when attribute code is only numeric
 
 # 1.5.3 (2016-05-13)
 

--- a/features/product/add_attributes_to_a_product.feature
+++ b/features/product/add_attributes_to_a_product.feature
@@ -39,3 +39,12 @@ Feature: Add attributes to a product
   Scenario: Successfully display unclassified attributes in group "Other"
     Given I am on the "sandals" product page
     Then I should see available attribute Comment in group "Other"
+
+  @jira https://akeneo.atlassian.net/browse/PIM-5801
+  Scenario: Successfully add an attribute with fully numeric identifier
+    Given I am on the "boots" product page
+    And I add available attribute 123
+    And I change the "Attribute 123" to "foobar"
+    When I save the product
+    Then I should not see the text "There are unsaved changes."
+    And the field Attribute 123 should contain "foobar"

--- a/features/product/filtering/filter_products_per_category.feature
+++ b/features/product/filtering/filter_products_per_category.feature
@@ -30,6 +30,7 @@ Feature: Filter products by category
       | filter   | value    | result     |
       | category | men_2015 | blue-jeans |
 
+  @jira https://akeneo.atlassian.net/browse/PIM-5726
   Scenario: Successfully filter products by category when hiding the category sidebar
     Given I am on the products page
     When I select the "2015 collection" tree

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/ProductController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/ProductController.php
@@ -325,7 +325,7 @@ class ProductController
         $values = $this->emptyValuesFilter->filter($product, $values);
 
         unset($data['values']);
-        $data = array_merge($data, $values);
+        $data = array_replace($data, $values);
 
         $this->productUpdater->update($product, $data);
     }


### PR DESCRIPTION
**Description**

When one add to a product an attribute with a code containing only numbers values, it is not possible to save the product when this attribute has been filled.

See screenshot below:

![image](https://cloud.githubusercontent.com/assets/5039018/15536404/4b6a5038-2271-11e6-8e64-56c155981316.png)

As data is passed to the product updater as an array, with the attribute code as an array key, ```array_merge``` replace the numerical codes (first it encounters by 0, second by 1, etc…) so the updater doesn't understand to which attribute the value is related. Using the union operator instead of ```array_merge``` solve this.

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | No
| Added Behats                      | Yes
| Changelog updated                 | Yes
| Review and 2 GTM                  | Waiting
| Micro Demo to the PO (Story only) | N/A
| Migration script                  | No
| Tech Doc                          | No