### PR TITLE
PIM-5802: keep data previously filled in select2 filter

### DIFF
--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -6,6 +6,7 @@
 - PIM-5811: Fix family export with multiple locales activated
 - PIM-5726: Fix number of product displayed on Product Grid when category panel is withdrawn
 - PIM-5801: Fix save in product edit form when attribute code is only numeric
+- PIM-5802: Keep data previously filled in select2 filter
 
 # 1.5.3 (2016-05-13)
 

--- a/features/Context/DataGridContext.php
+++ b/features/Context/DataGridContext.php
@@ -737,6 +737,53 @@ class DataGridContext extends RawMinkContext implements PageObjectAwareInterface
     }
 
     /**
+     * @param string $filterName
+     *
+     * @When /^I open the "([^"]*)" filter$/
+     */
+    public function iOpenTheFilter($filterName)
+    {
+        $filter = $this->datagrid->getFilter($filterName);
+
+        $this->datagrid->openFilter($filter);
+    }
+
+    /**
+     * @param string $optionNames
+     * @param string $filterName
+     *
+     * @throws ExpectationException
+     *
+     * @Then /^I should see options? "([^"]*)" in filter "([^"]*)"$/
+     */
+    public function iShouldSeeOptionInFilter($optionNames, $filterName)
+    {
+        $expectedOptions = $this->getMainContext()->listToArray($optionNames);
+        $filter = $this->datagrid->getFilter($filterName);
+
+        $options = $filter->findAll('css', '.select2-choices .select2-search-choice');
+        if (null === $options) {
+            throw $this->createExpectationException(sprintf('Unable to find choices in filter "%s"', $filterName));
+        }
+
+        $data = [];
+        foreach ($options as $option) {
+            $data[] = $option->getText();
+        }
+
+        if ($data != $expectedOptions) {
+            throw $this->createExpectationException(
+                sprintf(
+                    'Expecting filter "%s" to contain the options "%s", got "%s"',
+                    $filterName,
+                    implode(', ', $expectedOptions),
+                    implode(', ', $data)
+                )
+            );
+        }
+    }
+
+    /**
      * @param string $row
      *
      * @When /^I click on the "([^"]*)" row$/
@@ -1117,7 +1164,6 @@ class DataGridContext extends RawMinkContext implements PageObjectAwareInterface
     /**
      * Wait
      *
-     * @param int    $time
      * @param string $condition
      */
     protected function wait($condition = null)

--- a/features/product/filtering/filter_products_per_option_fields.feature
+++ b/features/product/filtering/filter_products_per_option_fields.feature
@@ -10,7 +10,7 @@ Feature: Filter products per option
       | label | type         | localizable | scopable | useable_as_grid_filter |
       | color | multiselect  | no          | no       | yes                    |
       | size  | simpleselect | no          | no       | yes                    |
-    And the following "color" attribute options: Black and White
+    And the following "color" attribute options: Black, White and Red
     And the following "size" attribute options: S, M and L
     And the following products:
       | sku   | color | size |
@@ -35,3 +35,24 @@ Feature: Filter products per option
       | filter | value    | result          |
       | color  | Black    | Shoes           |
       | color  | is empty | Shirt and Sweat |
+
+  @jira https://akeneo.atlassian.net/browse/PIM-5802
+  Scenario: Successfully keep data previsouly filled on a simple option
+    Given I am on the products page
+    And the grid should contain 3 elements
+    When I show the filter "size"
+    And I filter by "size" with value "M"
+    And I should see entities Sweat
+    And I open the "size" filter
+    Then I should see option "[M]" in filter "size"
+
+  @jira https://akeneo.atlassian.net/browse/PIM-5802
+  Scenario: Successfully keep data previsouly filled on a multi option
+    Given I am on the products page
+    And the grid should contain 3 elements
+    When I show the filter "color"
+    And I filter by "color" with value "Black"
+    And I filter by "color" with value "White"
+    And I should see entities Shoes
+    And I open the "color" filter
+    Then I should see option "[Black], [White]" in filter "color"

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/select2-choice-filter.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/select2-choice-filter.js
@@ -160,7 +160,10 @@ define(
                 $('body').trigger('click');
                 if (!this.popupCriteriaShowed) {
                     this._showCriteria();
-                    initSelect2.init(this.$(this.criteriaValueSelectors.value), this._getSelect2Config()).select2('open');
+
+                    initSelect2.init(this.$(this.criteriaValueSelectors.value), this._getSelect2Config())
+                        .select2('data', this._getCachedResults(this.getValue().value))
+                        .select2('open');
                 } else {
                     this._hideCriteria();
                 }


### PR DESCRIPTION
When you filter on multi or simple select attributes, once you have put a value in the filter and saved it, you cannot remove this value because values are never filled into filter. You have to remove completely the filter

| Q                 | A
| ----------------- | ---
| Specs             | N
| Behats            | :white_check_mark: 
| Blue CI           | ?
| Changelog updated | :white_check_mark: 