### PR TITLE
Download always the same php-cs-fixer version

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -158,7 +158,17 @@
     <target name="php-cs-fixer" description="Find coding standard violations using PHP_CodeSniffer and print human readable output. Intended for usage on the command line before committing.">
         <exec executable="bash">
             <arg value="-c"/>
-            <arg value="curl http://get.sensiolabs.org/php-cs-fixer.phar -o ${basedir}/bin/php-cs-fixer"/>
+            <arg value="wget https://github.com/FriendsOfPHP/PHP-CS-Fixer/archive/v1.11.3.tar.gz -O ${basedir}/bin/php-cs-fixer.tar.gz"/>
+        </exec>
+
+        <exec executable="bash">
+            <arg value="-c"/>
+            <arg value="tar -xzvf ${basedir}/bin/php-cs-fixer.tar.gz -C ${basedir}/bin --strip=1 PHP-CS-Fixer-1.11.3/php-cs-fixer"/>
+        </exec>
+
+        <exec executable="bash">
+            <arg value="-c"/>
+            <arg value="rm -Rf ${basedir}/bin/php-cs-fixer.tar.gz"/>
         </exec>
 
         <exec executable="bash">


### PR DESCRIPTION
The url `http://get.sensiolabs.org/php-cs-fixer.phar` can lead to a bumped version of php-cs-fixer (eg. an alpha 2.0 version).

By getting the explicit GitHub version, we ensure the stability of this tool.