### PR TITLE
Fix typo in FamilyProcessor

### DIFF
--- a/src/Pim/Component/Connector/Processor/Denormalization/FamilyProcessor.php
+++ b/src/Pim/Component/Connector/Processor/Denormalization/FamilyProcessor.php
@@ -47,10 +47,10 @@ class FamilyProcessor extends AbstractProcessor
     ) {
         parent::__construct($repository);
 
-        $this->arrayConverter = $familyConverter;
-        $this->familyFactory  = $familyFactory;
-        $this->updater        = $updater;
-        $this->validator      = $validator;
+        $this->familyConverter = $familyConverter;
+        $this->familyFactory   = $familyFactory;
+        $this->updater         = $updater;
+        $this->validator       = $validator;
     }
 
     /**
@@ -82,7 +82,7 @@ class FamilyProcessor extends AbstractProcessor
      */
     protected function convertItemData(array $item)
     {
-        return $this->arrayConverter->convert($item);
+        return $this->familyConverter->convert($item);
     }
 
     /**


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This PR fixes a typo in a name of a variable which came to be dynamically created. The name of the property in the class is `familyConverter`.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | No
| Added Behats                      | N/A
| Changelog updated                 | No
| Review and 2 GTM                  | Yes
| Micro Demo to the PO (Story only) | N/A
| Migration script                  | N/A
| Tech Doc                          | N/A
