### PR TITLE
Remove 'I should not see there is unsaved changed' to replace it

### DIFF
--- a/features/Context/WebUser.php
+++ b/features/Context/WebUser.php
@@ -10,6 +10,7 @@ use Behat\Gherkin\Node\TableNode;
 use Behat\Mink\Driver\Selenium2Driver;
 use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Exception\ExpectationException;
+use Behat\Mink\Exception\ResponseTextException;
 use Behat\Mink\Exception\UnsupportedDriverActionException;
 use Behat\MinkExtension\Context\RawMinkContext;
 use Box\Spout\Common\Type;
@@ -406,6 +407,28 @@ class WebUser extends RawMinkContext
     public function iSave()
     {
         $this->getCurrentPage()->save();
+    }
+
+    /**
+     * @Given /^I successfully save the (.*)$/
+     */
+    public function iSuccessfullySave()
+    {
+        $message = 'There are unsaved changes';
+
+        $this->assertSession()->pageTextContains($message);
+
+        $this->getCurrentPage()->save();
+
+        $this->spin(function () use ($message) {
+            try {
+                $this->assertSession()->pageTextNotContains($message);
+
+                return true;
+            } catch (ResponseTextException $exception) {
+                return false;
+            }
+        }, sprintf('The message "%s" remains after saving.', $message));
     }
 
     /**

--- a/features/datagrid/datagrid_views.feature
+++ b/features/datagrid/datagrid_views.feature
@@ -92,8 +92,7 @@ Feature: Datagrid views
     Then I should see the text "Default product grid view"
     And I fill in the following information:
       | Default product grid view | Sneakers only |
-    And I press the "Save" button
-    Then I should not see the text "There are unsaved changes."
+    And I successfully save the profile
     When I logout
     And I am logged in as "Julia"
     And I am on the products page

--- a/features/enrich/variant-group/add_products/add_products_updated_with_values.feature
+++ b/features/enrich/variant-group/add_products/add_products_updated_with_values.feature
@@ -27,8 +27,7 @@ Feature: Add products to a variant group
     And I should see products sandal-white-37, sandal-white-38, sandal-white-39
     And I check the row "sandal-white-37"
     And I check the row "sandal-white-38"
-    And I press the "Save" button
-    Then I should not see the text "There are unsaved changes."
+    And I successfully save the variant group
     And the rows "sandal-white-37 and sandal-white-38" should be checked
     And the product "sandal-white-37" should have the following value:
       | name-en_US   | EN name     |

--- a/features/enrich/variant-group/edit_attributes_of_a_variant_group.feature
+++ b/features/enrich/variant-group/edit_attributes_of_a_variant_group.feature
@@ -42,8 +42,7 @@ Feature: Edit attributes of a variant group
     Given I switch the locale to "fr_FR"
     And I fill in the following information:
       | Nom | French name |
-    And I press the "Save" button
-    Then I should not see the text "There are unsaved changes."
+    And I successfully save the variant group
     When I switch the locale to "en_US"
     And I fill in the following information:
       | Name | English name |
@@ -60,8 +59,7 @@ Feature: Edit attributes of a variant group
     And I fill in the following information:
       | ecommerce Beschreibung | German ecommerce description |
       | print Beschreibung     | German print description     |
-    And I press the "Save" button
-    Then I should not see the text "There are unsaved changes."
+    And I successfully save the variant group
     When I switch the locale to "en_US"
     And I expand the "Description" attribute
     And I fill in the following information:

--- a/features/enrich/variant-group/edit_variant_group_attribute_value.feature
+++ b/features/enrich/variant-group/edit_variant_group_attribute_value.feature
@@ -47,9 +47,7 @@ Feature: Editing attribute values of a variant group also updates products
     When I add available attributes Handmade
     And I visit the "Other" group
     And I check the "Handmade" switch
-    And I save the variant group
-    And I should see the flash message "Variant group successfully updated"
-    And I should not see the text "There are unsaved changes."
+    And I successfully save the variant group
     When I am on the "boot" product page
     And I visit the "Other" group
     Then the field Handmade should contain "on"
@@ -67,8 +65,7 @@ Feature: Editing attribute values of a variant group also updates products
   Scenario: Change a pim_catalog_metric attribute of a variant group
     When I change the "Length" to "5"
     And I save the variant group
-    And I should see the flash message "Variant group successfully updated"
-    And I should not see the text "There are unsaved changes."
+    And I successfully save the variant group
     When I am on the "boot" product page
     Then the field Length should contain "5"
 
@@ -83,9 +80,7 @@ Feature: Editing attribute values of a variant group also updates products
   Scenario: Change a pim_catalog_number attribute of a variant group
     When I visit the "Other" group
     And I change the "Number in stock" to "8000"
-    And I save the variant group
-    And I should see the flash message "Variant group successfully updated"
-    And I should not see the text "There are unsaved changes."
+    And I successfully save the variant group
     When I am on the "boot" product page
     And I visit the "Other" group
     Then the field Number in stock should contain "8000"
@@ -103,9 +98,7 @@ Feature: Editing attribute values of a variant group also updates products
   Scenario: Change a pim_catalog_simpleselect attribute of a variant group
     When I visit the "Marketing" group
     And I change the "Rating" to "5"
-    And I save the variant group
-    And I should see the flash message "Variant group successfully updated"
-    And I should not see the text "There are unsaved changes."
+    And I successfully save the variant group
     When I am on the "boot" product page
     And I visit the "Marketing" group
     Then the field Rating should contain "5 stars"
@@ -120,9 +113,7 @@ Feature: Editing attribute values of a variant group also updates products
 
   Scenario: Change a pim_catalog_textarea attribute of a variant group
     When I change the "tablet Description" to "The best boots!"
-    And I save the variant group
-    And I should see the flash message "Variant group successfully updated"
-    And I should not see the text "There are unsaved changes."
+    And I successfully save the variant group
     When I am on the "boot" product page
     Then the field Description should contain "The best boots!"
 
@@ -142,9 +133,7 @@ Feature: Editing attribute values of a variant group also updates products
     When I add available attributes Side view
     And I visit the "Media" group
     And I attach file "SNKRS-1R.png" to "Side view"
-    And I save the variant group
-    And I should see the flash message "Variant group successfully updated"
-    And I should not see the text "There are unsaved changes."
+    And I successfully save the variant group
     And I visit the "Products" tab
     And I uncheck the row "boot"
     And I save the variant group
@@ -157,9 +146,7 @@ Feature: Editing attribute values of a variant group also updates products
     When I add available attributes Technical description
     And I visit the "Media" group
     And I attach file "SNKRS-1R.png" to "Technical description"
-    And I save the variant group
-    And I should see the flash message "Variant group successfully updated"
-    And I should not see the text "There are unsaved changes."
+    And I successfully save the variant group
     When I am on the "boot" product page
     And I visit the "Media" group
     Then I should see the text "SNKRS-1R.png"

--- a/features/family/define_the_attribute_requirement.feature
+++ b/features/family/define_the_attribute_requirement.feature
@@ -19,9 +19,7 @@ Feature: Define the attribute requirement
   Scenario: Successfully make an attribute required for a channel
     Given I visit the "Attributes" tab
     And I switch the attribute "Rating" requirement in channel "Mobile"
-    And I save the family
-    And I should see the flash message "Family successfully updated"
-    And I should not see the text "There are unsaved changes."
+    And I successfully save the family
     And I visit the "Attributes" tab
     Then attribute "rating" should be required in channels mobile and tablet
 
@@ -50,9 +48,7 @@ Feature: Define the attribute requirement
     And I am on the "Boots" family page
     And I visit the "Attributes" tab
     And I switch the attribute "Rating" requirement in channel "Mobile"
-    And I save the family
-    And I should see the flash message "Family successfully updated"
-    And I should not see the text "There are unsaved changes."
+    And I successfully save the family
     When I remove the "Rating" attribute
     And I confirm the deletion
     Then I should not see the "Rating" attribute

--- a/features/family/display_family_history.feature
+++ b/features/family/display_family_history.feature
@@ -20,8 +20,6 @@ Feature: Display the family history
     And I fill in the following information in the popin:
       | Code | Flyer |
     And I save the family
-    And I should see the flash message "Family successfully created"
-    And I should not see the text "There are unsaved changes."
     And I edit the "Flyer" family
     When I visit the "History" tab
     Then there should be 1 update
@@ -31,9 +29,7 @@ Feature: Display the family history
     When I visit the "Properties" tab
     And I fill in the following information:
       | English (United States) | Fly |
-    And I save the family
-    And I should see the flash message "Family successfully updated"
-    And I should not see the text "There are unsaved changes."
+    And I successfully save the family
     When I visit the "History" tab
     Then there should be 2 updates
     And I should see history:

--- a/features/product/associate_product.feature
+++ b/features/product/associate_product.feature
@@ -51,8 +51,7 @@ Feature: Associate a product
     And I check the row "similar_boots"
     And I press the "Show products" button
     And I check the rows "shoelaces, gray-boots, brown-boots and green-boots"
-    When I save the product
-    Then I should not see the text "There are unsaved changes."
+    When I successfully save the product
     And I should see the text "4 products and 1 groups"
     And I select the "Upsell" association
     Then I should see the text "1 products and 1 groups"
@@ -116,8 +115,7 @@ Feature: Associate a product
     Then I should see the text "There are unsaved changes."
     And I visit the "Attributes" tab
     Then I should see the text "There are unsaved changes."
-    When I save the product
-    Then I should not see the text "There are unsaved changes."
+    When I successfully save the product
     When I visit the "Associations" tab
     And I uncheck the rows "black-boots"
     Then I should see the text "There are unsaved changes."

--- a/features/product/classify_product.feature
+++ b/features/product/classify_product.feature
@@ -19,8 +19,7 @@ Feature: Classify a product
     And I expand the "2014_collection" category
     And I click on the "summer_collection" category
     And I click on the "winter_collection" category
-    And I press the "Save" button
-    Then I should not see the text "There are unsaved changes."
+    And I save the product
     And the categories of "tea" should be "summer_collection and winter_collection"
 
   Scenario: Count product categories

--- a/features/product/comments.feature
+++ b/features/product/comments.feature
@@ -76,7 +76,6 @@ Feature: Leave a comment on a product
     And I am on the "Administrator" role page
     And I visit the "Permissions" tab
     And I remove rights to Comment products
-    And I save the role
-    Then I should not see the text "There are unsaved changes."
+    And I successfully save the role
     When I am on the "rangers" product page
     Then I should not see the text "Comments"

--- a/features/product/edit_and_remove_a_product.feature
+++ b/features/product/edit_and_remove_a_product.feature
@@ -19,8 +19,7 @@ Feature: Edit and remove a product
     And I wait to be on the "boots" product page
     And I fill in the following information:
       | Length | 5.0000 Centimeter |
-    And I press the "Save" button
-    Then I should not see the text "There are unsaved changes."
+    And I successfully save the product
 
   Scenario: Successfully edit and then delete a product from the grid
     Given I am on the products page

--- a/features/product/edit_boolean_value.feature
+++ b/features/product/edit_boolean_value.feature
@@ -14,26 +14,21 @@ Feature: Edit a boolean value
     And I am logged in as "Mary"
     And I am on the "tshirt" product page
     And I add available attributes Boolean and Scopable boolean
-    And I save the product
-    Then I should not see the text "There are unsaved changes."
+    And I successfully save the product
 
   Scenario: Successfully update a boolean value
     When I check the "Boolean" switch
-    And I press the "Save" button
-    Then I should not see the text "There are unsaved changes."
+    And I successfully save the product
     And attribute boolean of "tshirt" should be "true"
     When I uncheck the "Boolean" switch
-    And I press the "Save" button
-    Then I should not see the text "There are unsaved changes."
-    And attribute boolean of "tshirt" should be "false"
+    And I successfully save the product
+    Then attribute boolean of "tshirt" should be "false"
 
   Scenario: Successfully update a scopable boolean value
     Given I switch the scope to "ecommerce"
     When I check the "Scopable boolean" switch
-    And I press the "Save" button
-    Then I should not see the text "There are unsaved changes."
+    And I successfully save the product
     And the english ecommerce scopable_boolean of "tshirt" should be "true"
     When I uncheck the "Scopable boolean" switch
-    And I press the "Save" button
-    Then I should not see the text "There are unsaved changes."
-    And the english ecommerce scopable_boolean of "tshirt" should be "false"
+    And I successfully save the product
+    Then the english ecommerce scopable_boolean of "tshirt" should be "false"

--- a/features/product/edit_product.feature
+++ b/features/product/edit_product.feature
@@ -32,8 +32,7 @@ Feature: Edit a product
     And I am on the "sandal" product page
     And I fill in the following information:
       | Name | My Sandal |
-    When I press the "Save" button
-    Then I should not see the text "There are unsaved changes."
+    When I successfully save the product
     And the product Name should be "My Sandal"
 
   Scenario: Successfully updates the updated date of the product
@@ -51,8 +50,7 @@ Feature: Edit a product
     Given I am logged in as "Peter"
     And I am on the "Administrator" role page
     And I remove rights to Edit attributes of a product
-    And I save the role
-    Then I should not see the text "There are unsaved changes."
+    And I successfully save the role
     When I am on the "sandal" product page
     Then I should not see "Attributes"
 

--- a/features/product/sorting/sort_products_per_attribute.feature
+++ b/features/product/sorting/sort_products_per_attribute.feature
@@ -24,13 +24,11 @@ Feature: Sort products per attributes
     And I am on the "blue_shirt" product page
     And I visit the "Additional" group
     When I check the "Handmade" switch
-    And I press the "Save" button
-    Then I should not see the text "There are unsaved changes."
+    And I successfully save the product
     When I am on the "orange_shirt" product page
     And I visit the "Additional" group
     When I check the "Handmade" switch
-    And I press the "Save" button
-    Then I should not see the text "There are unsaved changes."
+    And I successfully save the product
     When I am on the products page
     Then the grid should contain 5 elements
     When I display the columns sku, label, family, status, complete, created, updated, groups and handmade

--- a/features/reference-data/attribute/display_attribute_history.feature
+++ b/features/reference-data/attribute/display_attribute_history.feature
@@ -18,9 +18,7 @@ Feature: Display the attribute history
       | Code                | mycolor |
       | Reference data name | color   |
       | Attribute group     | Other   |
-    And I save the attribute
-    Then I should see the flash message "Attribute successfully created"
-    And I should not see the text "There are unsaved changes."
+    And I successfully save the attribute
     When I change the "Attribute group" to "Technical"
     And I save the attribute
     Then I should see the flash message "Attribute successfully updated"

--- a/features/reference-data/variant-group/add_products.feature
+++ b/features/reference-data/variant-group/add_products.feature
@@ -45,8 +45,7 @@ Feature: Add products with reference data to a variant group
     And I am on the "SANDAL" variant group page
     Then the grid should contain 6 elements
     And I check the row "heel-yellow-37"
-    And I press the "Save" button
-    And I should not see the text "There are unsaved changes"
+    And I successfully save the variant group
     # TODO: see with @nidup => temporary fix (broken since the deferred explicit persist of Doctrine)
     And I press the "Save" button
     And I should not see the text "There are unsaved changes"

--- a/features/user/update_user_preferences.feature
+++ b/features/user/update_user_preferences.feature
@@ -40,9 +40,7 @@ Feature: Update user preferences
     Given I edit the "Julia" user
     And I visit the "Additional" tab
     And I change the "Catalog locale" to "fr_FR"
-    And I save the user
-    Then I should see the flash message "User saved"
-    And I should not see the text "There are unsaved changes."
+    And I successfully save the user
     When I visit the "Additional Information" tab
     Then I should see the text "Catalog locale"
     And I should see the text "fr_FR"

--- a/features/versioning/ensure_versioning_on_family.feature
+++ b/features/versioning/ensure_versioning_on_family.feature
@@ -15,7 +15,6 @@ Feature: Ensure versioning on family
     Then I visit the "Properties" tab
     When I fill in the following information:
       | English (United States) | My heels |
-    And I press the "Save" button
-    Then I should not see the text "There are unsaved changes."
+    And I successfully save the family
     When I visit the "History" tab
     Then there should be 2 updates


### PR DESCRIPTION
# Issue

There is a lot of "Save + check if text 'there was unsaved changes'" in the scenarii.
The issue is that iShouldNotSeeTheText is spinning the maximum delay on the CI (50s), to be sure the text is not in the page.

# What we do ?

Here, we added a "I successfully save the xxx", it:
- checks there is a modifications on the current form
- save the form
- waits the message of modifications disappear.

Expected a little gain on the DCI, and a less verbose check.