### PR TITLE
FamilySearchRepository: extract applyQueryOptions protected method

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/FamilySearchableRepository.php
+++ b/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/FamilySearchableRepository.php
@@ -4,6 +4,7 @@ namespace Pim\Bundle\EnrichBundle\Doctrine\ORM\Repository;
 
 use Akeneo\Component\StorageUtils\Repository\SearchableRepositoryInterface;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\QueryBuilder;
 use Pim\Component\Catalog\Model\FamilyInterface;
 
 /**
@@ -50,18 +51,27 @@ class FamilySearchableRepository implements SearchableRepositoryInterface
             }
         }
 
+        $this->applyQueryOptions($qb, $options);
+
+        return $qb->getQuery()->getResult();
+    }
+
+    /**
+     * @param QueryBuilder $qb
+     * @param array        $options
+     */
+    protected function applyQueryOptions(QueryBuilder $qb, array $options)
+    {
         if (isset($options['identifiers']) && is_array($options['identifiers']) && !empty($options['identifiers'])) {
             $qb->andWhere('f.code in (:codes)');
             $qb->setParameter('codes', $options['identifiers']);
         }
 
         if (isset($options['limit'])) {
-            $qb->setMaxResults((int) $options['limit']);
+            $qb->setMaxResults((int)$options['limit']);
             if (isset($options['page'])) {
-                $qb->setFirstResult((int) $options['limit'] * ((int) $options['page'] - 1));
+                $qb->setFirstResult((int)$options['limit'] * ((int)$options['page'] - 1));
             }
         }
-
-        return $qb->getQuery()->getResult();
     }
 }

--- a/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/FamilySearchableRepository.php
+++ b/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/FamilySearchableRepository.php
@@ -29,7 +29,7 @@ class FamilySearchableRepository implements SearchableRepositoryInterface
     public function __construct(EntityManagerInterface $entityManager, $entityName)
     {
         $this->entityManager = $entityManager;
-        $this->entityName = $entityName;
+        $this->entityName    = $entityName;
     }
 
     /**

--- a/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/FamilySearchableRepository.php
+++ b/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/FamilySearchableRepository.php
@@ -29,7 +29,7 @@ class FamilySearchableRepository implements SearchableRepositoryInterface
     public function __construct(EntityManagerInterface $entityManager, $entityName)
     {
         $this->entityManager = $entityManager;
-        $this->entityName    = $entityName;
+        $this->entityName = $entityName;
     }
 
     /**
@@ -51,7 +51,7 @@ class FamilySearchableRepository implements SearchableRepositoryInterface
             }
         }
 
-        $this->applyQueryOptions($qb, $options);
+        $qb = $this->applyQueryOptions($qb, $options);
 
         return $qb->getQuery()->getResult();
     }
@@ -59,6 +59,8 @@ class FamilySearchableRepository implements SearchableRepositoryInterface
     /**
      * @param QueryBuilder $qb
      * @param array        $options
+     *
+     * @return QueryBuilder
      */
     protected function applyQueryOptions(QueryBuilder $qb, array $options)
     {
@@ -68,10 +70,12 @@ class FamilySearchableRepository implements SearchableRepositoryInterface
         }
 
         if (isset($options['limit'])) {
-            $qb->setMaxResults((int)$options['limit']);
+            $qb->setMaxResults((int) $options['limit']);
             if (isset($options['page'])) {
-                $qb->setFirstResult((int)$options['limit'] * ((int)$options['page'] - 1));
+                $qb->setFirstResult((int) $options['limit'] * ((int) $options['page'] - 1));
             }
         }
+
+        return $qb;
     }
 }


### PR DESCRIPTION
This PR extract the options filters in a protected method to allow overriding the class.

Before this PR, i could not even properly override the service:

```php
class MyFamilySearchableRepository extends FamilySearchableRepository
{
     public function function findBySearch($search = null, array $options = [])
    {
        // the parent $qb is not available :(
    }
}
```

After the PR, i can do it easily:

```php
class MyFamilySearchableRepository extends FamilySearchableRepository
{
     protected function applyQueryOptions(QueryBuilder $qb, array $options)
    {
        parent::applyQueryOptions($qb, $options);
        // i can add filters to the query builder
    }
}
```


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       |no
| Added Behats                      |no
| Changelog updated                 |no
| Review and 2 GTM                  |
| Migration script                  |no
| Tech Doc                          |no

