### PR TITLE
PIM-5824: detach product at the end of process() method

### DIFF
--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -7,6 +7,7 @@
 - PIM-5726: Fix number of product displayed on Product Grid when category panel is withdrawn
 - PIM-5801: Fix save in product edit form when attribute code is only numeric
 - PIM-5802: Keep data previously filled in select2 filter
+- PIM-5824: Fix memory leak on products export
 
 # 1.5.3 (2016-05-13)
 

--- a/spec/Pim/Bundle/BaseConnectorBundle/Processor/ProductToFlatArrayProcessorSpec.php
+++ b/spec/Pim/Bundle/BaseConnectorBundle/Processor/ProductToFlatArrayProcessorSpec.php
@@ -3,6 +3,7 @@
 namespace spec\Pim\Bundle\BaseConnectorBundle\Processor;
 
 use Akeneo\Component\FileStorage\Model\FileInfoInterface;
+use Akeneo\Component\StorageUtils\Detacher\ObjectDetacherInterface;
 use Doctrine\Common\Collections\ArrayCollection;
 use League\Flysystem\Filesystem;
 use PhpSpec\ObjectBehavior;
@@ -18,8 +19,12 @@ use Symfony\Component\Serializer\Serializer;
 
 class ProductToFlatArrayProcessorSpec extends ObjectBehavior
 {
-    function let(Serializer $serializer, ChannelManager $channelManager, ProductBuilderInterface $productBuilder)
-    {
+    function let(
+        Serializer $serializer,
+        ChannelManager $channelManager,
+        ProductBuilderInterface $productBuilder,
+        ObjectDetacherInterface $detacher
+    ) {
         $this->beConstructedWith(
             $serializer,
             $channelManager,
@@ -29,7 +34,8 @@ class ProductToFlatArrayProcessorSpec extends ObjectBehavior
             [
                 ['value' => 'yyyy-MM-dd', 'label' => 'yyyy-mm-dd'],
                 ['value' => 'dd.MM.yyyy', 'label' => 'dd.mm.yyyy'],
-            ]
+            ],
+            $detacher
         );
     }
 
@@ -97,6 +103,9 @@ class ProductToFlatArrayProcessorSpec extends ObjectBehavior
 
     function it_returns_flat_data_with_media(
         $channelManager,
+        $serializer,
+        $productBuilder,
+        $detacher,
         Filesystem $filesystem,
         ChannelInterface $channel,
         LocaleInterface $locale,
@@ -107,9 +116,7 @@ class ProductToFlatArrayProcessorSpec extends ObjectBehavior
         ProductValueInterface $value2,
         AttributeInterface $attribute,
         ProductValueInterface $identifierValue,
-        AttributeInterface $identifierAttribute,
-        $serializer,
-        $productBuilder
+        AttributeInterface $identifierAttribute
     ) {
         $localeCodes = ['en_US'];
 
@@ -155,6 +162,8 @@ class ProductToFlatArrayProcessorSpec extends ObjectBehavior
             ->willReturn(['normalized_product']);
 
         $channelManager->getChannelByCode('foobar')->willReturn($channel);
+
+        $detacher->detach($product)->shouldBeCalled();
 
         $this->setChannel('foobar');
         $this->process($product)->shouldReturn(

--- a/src/Pim/Bundle/BaseConnectorBundle/Processor/ProductToFlatArrayProcessor.php
+++ b/src/Pim/Bundle/BaseConnectorBundle/Processor/ProductToFlatArrayProcessor.php
@@ -5,6 +5,7 @@ namespace Pim\Bundle\BaseConnectorBundle\Processor;
 use Akeneo\Component\Batch\Item\AbstractConfigurableStepElement;
 use Akeneo\Component\Batch\Item\ItemProcessorInterface;
 use Akeneo\Component\Localization\Localizer\LocalizerInterface;
+use Akeneo\Component\StorageUtils\Detacher\ObjectDetacherInterface;
 use Pim\Bundle\BaseConnectorBundle\Validator\Constraints\Channel;
 use Pim\Bundle\CatalogBundle\Builder\ProductBuilder;
 use Pim\Bundle\CatalogBundle\Manager\ChannelManager;
@@ -58,13 +59,17 @@ class ProductToFlatArrayProcessor extends AbstractConfigurableStepElement implem
     /** @var ProductBuilder */
     protected $productBuilder;
 
+    /** @var ObjectDetacherInterface */
+    protected $detacher;
+
     /**
      * @param Serializer              $serializer
      * @param ChannelManager          $channelManager
+     * @param ProductBuilderInterface $productBuilder
      * @param string[]                $mediaAttributeTypes
      * @param array                   $decimalSeparators
      * @param array                   $dateFormats
-     * @param ProductBuilderInterface $productBuilder
+     * @param ObjectDetacherInterface $detacher
      */
     public function __construct(
         Serializer $serializer,
@@ -72,7 +77,8 @@ class ProductToFlatArrayProcessor extends AbstractConfigurableStepElement implem
         ProductBuilderInterface $productBuilder,
         array $mediaAttributeTypes,
         array $decimalSeparators,
-        array $dateFormats
+        array $dateFormats,
+        ObjectDetacherInterface $detacher = null
     ) {
         $this->serializer          = $serializer;
         $this->channelManager      = $channelManager;
@@ -80,6 +86,7 @@ class ProductToFlatArrayProcessor extends AbstractConfigurableStepElement implem
         $this->decimalSeparators   = $decimalSeparators;
         $this->dateFormats         = $dateFormats;
         $this->productBuilder      = $productBuilder;
+        $this->detacher            = $detacher;
     }
 
     /**
@@ -103,6 +110,9 @@ class ProductToFlatArrayProcessor extends AbstractConfigurableStepElement implem
         }
 
         $data['product'] = $this->serializer->normalize($product, 'flat', $this->getNormalizerContext());
+        if (null !== $this->detacher) {
+            $this->detacher->detach($product);
+        }
 
         return $data;
     }

--- a/src/Pim/Bundle/BaseConnectorBundle/Resources/config/processors.yml
+++ b/src/Pim/Bundle/BaseConnectorBundle/Resources/config/processors.yml
@@ -45,6 +45,7 @@ services:
             - ['pim_catalog_file', 'pim_catalog_image']
             - %pim_catalog.localization.decimal_separators%
             - %pim_catalog.localization.date_formats%
+            - '@akeneo_storage_utils.doctrine.object_detacher'
 
     pim_base_connector.processor.dummy:
         class: %pim_base_connector.processor.dummy.class%


### PR DESCRIPTION
PR to fix a memory leak on products export.

Problem occurs when PIM is used with EnhancedConnectorBundle. This bundle has it own reader and detach the product in it (https://github.com/akeneo-labs/EnhancedConnectorBundle/blob/v1.2.0/Reader/ProductReader.php#L388). But, if an entity linked to a product (product value, metric, etc) is handled during processor, Doctrine add a reference to the product in unit of work (so in memory) and the product will never detach from it => memory leak :)

There is no problem with the original reader of the PIM because there is a `$this->entityManager->clear()` before read products

@nidup we already call `detach()` for quick export (https://github.com/akeneo/pim-community-dev/blob/master/src/Pim/Bundle/EnrichBundle/Connector/Processor/QuickExport/ProductToFlatArrayProcessor.php#L106)

Before this fix, export was impossible.
With this fix: 20K products exported in 24 minutes


| Q                 | A
| ----------------- | ---
| Specs             | Y
| Behats            | N
| Blue CI           | ?
| Changelog updated | Y