### PR TITLE
Fix Typo in CategoryRepositoryInterface::getCategoriesByCodes

### DIFF
--- a/src/Akeneo/Component/Classification/Repository/CategoryRepositoryInterface.php
+++ b/src/Akeneo/Component/Classification/Repository/CategoryRepositoryInterface.php
@@ -42,20 +42,20 @@ interface CategoryRepositoryInterface extends
     /**
      * Get a collection of categories based on the array of id provided
      *
-     * @param array $categoriesIds
+     * @param array $categoryIds
      *
      * @return Collection of categories
      */
-    public function getCategoriesByIds(array $categoriesIds = []);
+    public function getCategoriesByIds(array $categoryIds = []);
 
     /**
      * Get a collection of categories based on the array of code provided
      *
-     * @param array $categoriesCodes
+     * @param array $categoryCodes
      *
      * @return Collection of categories
      */
-    public function getCategoriesByCodes(array $categoriesCodes = []);
+    public function getCategoriesByCodes(array $categoryCodes = []);
 
     /**
      * Get a tree filled with children and their parents

--- a/src/Akeneo/Component/Classification/Repository/CategoryRepositoryInterface.php
+++ b/src/Akeneo/Component/Classification/Repository/CategoryRepositoryInterface.php
@@ -51,11 +51,11 @@ interface CategoryRepositoryInterface extends
     /**
      * Get a collection of categories based on the array of code provided
      *
-     * @param array $categoriesIds
+     * @param array $categoriesCodes
      *
      * @return Collection of categories
      */
-    public function getCategoriesByCodes(array $categoriesIds = []);
+    public function getCategoriesByCodes(array $categoriesCodes = []);
 
     /**
      * Get a tree filled with children and their parents


### PR DESCRIPTION
No description needed for this simple fix.