### PR TITLE
PIM-5712: Keep file reference in db after media removal

### DIFF
--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -8,6 +8,7 @@
 - PIM-5801: Fix save in product edit form when attribute code is only numeric
 - PIM-5802: Keep data previously filled in select2 filter
 - PIM-5824: Fix memory leak on products export
+- PIM-5712: Keep reference in "akeneo_file_storage_file_info" table after removing a media attribute from a product
 
 # 1.5.3 (2016-05-13)
 

--- a/features/Context/AssertionContext.php
+++ b/features/Context/AssertionContext.php
@@ -585,7 +585,7 @@ class AssertionContext extends RawMinkContext
     public function theScopableFieldShouldHaveTheFollowingColors($field, TableNode $table)
     {
         $element = $this->getCurrentPage()->find('css', sprintf('label:contains("%s")', $field))->getParent();
-        $colors  = $this->getMainContext()->getContainer()->getParameter('pim_enrich.colors');
+        $colors  = $this->getParameter('pim_enrich.colors');
         foreach ($table->getHash() as $item) {
             $style = $element->find('css', sprintf('label[title="%s"]', $item['scope']))->getAttribute('style');
             assertGreaterThanOrEqual(
@@ -837,6 +837,46 @@ class AssertionContext extends RawMinkContext
     public function iShouldNotSeeDefaultAvatar()
     {
         $this->assertSession()->elementAttributeNotContains('css', '.customer-info img', 'src', 'user-info.png');
+    }
+
+    /**
+     * Checks that a file (or media) exists in database
+     *
+     * @param string $originalFilename
+     *
+     * @Then /^The file with original filename "([^"]*)" should exists in database$/
+     */
+    public function theFileShouldExistInDatabase($originalFilename)
+    {
+        $fileInfoRepoClass  = $this->getParameter('akeneo_file_storage.model.file_info.class');
+        $fileInfoRepository = $this->getRepository($fileInfoRepoClass);
+
+        $fileInfo = $fileInfoRepository->findOneBy(['originalFilename' => $originalFilename]);
+
+        assertNotNull($fileInfo, sprintf(
+            'Unable to find file with original filename "%s" in database',
+            $originalFilename
+        ));
+    }
+
+    /**
+     * @param string $parameter
+     *
+     * @return string
+     */
+    protected function getParameter($parameter)
+    {
+        return $this->getMainContext()->getContainer()->getParameter($parameter);
+    }
+
+    /**
+     * @param string $entityClass
+     *
+     * @return \Doctrine\Common\Persistence\ObjectRepository
+     */
+    protected function getRepository($entityClass)
+    {
+        return $this->getMainContext()->getEntityManager()->getRepository($entityClass);
     }
 
     /**

--- a/features/product/join_an_image_to_a_product.feature
+++ b/features/product/join_an_image_to_a_product.feature
@@ -53,3 +53,24 @@ Feature: Join an image to a product
     And I save the product
     Then I should not see the text "akeneo.jpg"
     But I should see the text "bic-core-148.gif"
+
+  Scenario: Successfully remove an image then its field and keep a reference to the file in database
+    When I attach file "akeneo.jpg" to "Visual"
+    And I save the product
+    And I remove the "Visual" file
+    And I save the product
+    Then I should not see the text "akeneo.jpg"
+    When I remove the "Visual" attribute
+    And I confirm the deletion
+    And I save the product
+    Then I should see available attribute Visual in group "Other"
+    And The file with original filename "akeneo.jpg" should exists in database
+
+  Scenario: Successfully remove an image field containing an image and keep a reference to the file in database
+    When I attach file "akeneo.jpg" to "Visual"
+    And I save the product
+    And I remove the "Visual" attribute
+    And I confirm the deletion
+    And I save the product
+    Then I should see available attribute Visual in group "Other"
+    And The file with original filename "akeneo.jpg" should exists in database

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/model/doctrine/ProductValue.orm.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/model/doctrine/ProductValue.orm.yml
@@ -88,7 +88,6 @@ Pim\Component\Catalog\Model\ProductValue:
         media:
             targetEntity: Akeneo\Component\FileStorage\Model\FileInfoInterface
             cascade:
-                - remove
                 - persist
                 - refresh
                 - detach

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/ProductController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/ProductController.php
@@ -233,7 +233,7 @@ class ProductController
     }
 
     /**
-     * Remove an optional attribute form a product
+     * Remove an optional attribute from a product
      *
      * @param int $productId   The product id
      * @param int $attributeId The attribute id


### PR DESCRIPTION
**Description**

When adding a new media to a product, an entry is created in the table “akeneo_file_storage_file_info”. When removing the media, the entry in “akeneo_file_storage_file_info” must be kept so history is preserved, and revert is correctly done in EE.

If the user adds an attribute, upload a media, save the product, then directly remove the attribute field still containing the media, and save the product, in this case the entry in the database is deleted. This is due to the cascade remove perform by Doctrine on the product value.

This does not happen if one first removes the media (but keeps the attribute) and save the product as the product value is still here (as the field), just cleaned through JavaScript. Then, when the user removes the field, it is not linked to the media anymore, so the media is kept in a database.

This PR fixes the problem by removing the cascade remove on media in the product value.

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | No
| Added Behats                      | Yes
| Changelog updated                 | Yes
| Review and 2 GTM                  | Waiting
| Micro Demo to the PO (Story only) | No
| Migration script                  | No
| Tech Doc                          | No