### PR TITLE
TIP-36: fix association

### DIFF
--- a/features/Pim/Behat/Context/Domain/Enrich/Product/AssociationTabContext.php
+++ b/features/Pim/Behat/Context/Domain/Enrich/Product/AssociationTabContext.php
@@ -31,12 +31,17 @@ class AssociationTabContext extends PimContext
      */
     public function iShouldBeOnTheAssociation($association)
     {
-        $list       = $this->getCurrentPage()->getAssociationsList();
-        $currentTab = $this->spin(function () use ($list) {
-            return $list->find('css', '.active');
+        $list     = $this->getCurrentPage()->getAssociationsList();
+        $tabLabel = $this->spin(function () use ($list) {
+            $activeTab = $list->find('css', '.active');
+            if (null !== $activeTab) {
+                return $activeTab->getText();
+            }
+
+            return false;
         }, 'Cannot find ".active" element');
 
-        $tabLabel = trim($currentTab->getText());
+        $tabLabel = trim($tabLabel);
         if ($tabLabel !== $association) {
             throw $this->createExpectationException(
                 sprintf(


### PR DESCRIPTION
It happened when `$activeTab->getText()` that `$activeTab` was not in the DOM. We spin on it now to avoid that.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       |
| Added Behats                      |
| Changelog updated                 |
| Review and 2 GTM                  |
| Micro Demo to the PO (Story only) |
| Migration script                  |
| Tech Doc                          |

