### PR TITLE
Remove measure bundle from composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
     },
     "require": {
         "php": ">=5.4.4",
-        "akeneo/measure-bundle": "0.5.0",
         "apy/jsfv-bundle": "2.0.1",
         "ass/xmlsecurity": "1.1.1",
         "doctrine/annotations": "1.2.6",


### PR DESCRIPTION
Measure bundle is now under akeneo namespace, no needs to add it through composer

| Q                                 | A
| --------------------------------- | ---
| Review and 2 GTM                  | No

