### PR TITLE
PIM-5711: Don't create empty attribute translations if attributes are imported with empty labels

### DIFF
--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -9,6 +9,7 @@
 - PIM-5802: Keep data previously filled in select2 filter
 - PIM-5824: Fix memory leak on products export
 - PIM-5712: Keep reference in "akeneo_file_storage_file_info" table after removing a media attribute from a product
+- PIM-5711: Don't create empty attribute translations if attributes are imported with empty labels
 
 # 1.5.3 (2016-05-13)
 

--- a/features/import/attribute/import_attributes.feature
+++ b/features/import/attribute/import_attributes.feature
@@ -273,3 +273,47 @@ Feature: Import attributes
       | number | number_with_min     | number2     | info  | 0      | 1                      | 0           | 0        | -10        |            |
       | number | number_with_max     | number3     | info  | 0      | 1                      | 0           | 0        |            | 10         |
       | number | number_with_min_max | number4     | info  | 0      | 1                      | 0           | 0        | -10        | 10         |
+
+  @jira https://akeneo.atlassian.net/browse/PIM-5711
+  Scenario: Import attributes with no label and successfully display its code in family attribute drop down:
+    Given the "footwear" catalog configuration
+    And I am logged in as "Julia"
+    And the following CSV file to import:
+      """
+      type;code;group;unique;useable_as_grid_filter;localizable;scopable
+      pim_catalog_text;new_name;other;0;1;0;0
+      pim_catalog_textarea;new_description;other;0;1;1;1
+      """
+    And the following job "footwear_attribute_import" configuration:
+      | filePath | %file to import% |
+    When I am on the "footwear_attribute_import" import job page
+    And I launch the import job
+    And I wait for the "footwear_attribute_import" job to finish
+    Then I should see "read lines 2"
+    And I should see "created 2"
+    When I am on the "Boots" family page
+    And I visit the "Attributes" tab
+    Then I should see available attribute [new_name] in group "Other"
+    And I should see available attribute [new_description] in group "Other"
+
+  @jira https://akeneo.atlassian.net/browse/PIM-5711
+  Scenario: Import attributes with blank label and successfully display its code in family attribute drop down:
+    Given the "footwear" catalog configuration
+    And I am logged in as "Julia"
+    And the following CSV file to import:
+      """
+      type;code;label-de_DE;label-en_US;label-fr_FR;group;unique;useable_as_grid_filter;localizable;scopable
+      pim_catalog_text;new_name;;;;other;0;1;0;0
+      pim_catalog_textarea;new_description;;;;other;0;1;1;1
+      """
+    And the following job "footwear_attribute_import" configuration:
+      | filePath | %file to import% |
+    When I am on the "footwear_attribute_import" import job page
+    And I launch the import job
+    And I wait for the "footwear_attribute_import" job to finish
+    Then I should see "read lines 2"
+    And I should see "created 2"
+    When I am on the "Boots" family page
+    And I visit the "Attributes" tab
+    Then I should see available attribute [new_name] in group "Other"
+    And I should see available attribute [new_description] in group "Other"

--- a/features/product/join_an_image_to_a_product.feature
+++ b/features/product/join_an_image_to_a_product.feature
@@ -54,6 +54,7 @@ Feature: Join an image to a product
     Then I should not see the text "akeneo.jpg"
     But I should see the text "bic-core-148.gif"
 
+  @jira https://akeneo.atlassian.net/browse/PIM-5712
   Scenario: Successfully remove an image then its field and keep a reference to the file in database
     When I attach file "akeneo.jpg" to "Visual"
     And I save the product
@@ -66,6 +67,7 @@ Feature: Join an image to a product
     Then I should see available attribute Visual in group "Other"
     And The file with original filename "akeneo.jpg" should exists in database
 
+  @jira https://akeneo.atlassian.net/browse/PIM-5712
   Scenario: Successfully remove an image field containing an image and keep a reference to the file in database
     When I attach file "akeneo.jpg" to "Visual"
     And I save the product

--- a/src/Pim/Component/Catalog/Updater/AttributeUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/AttributeUpdater.php
@@ -150,9 +150,11 @@ class AttributeUpdater implements ObjectUpdaterInterface
     protected function setLabels(AttributeInterface $attribute, array $data)
     {
         foreach ($data as $localeCode => $label) {
-            $attribute->setLocale($localeCode);
-            $translation = $attribute->getTranslation();
-            $translation->setLabel($label);
+            if (null !== $label && '' !== $label) {
+                $attribute->setLocale($localeCode);
+                $translation = $attribute->getTranslation();
+                $translation->setLabel($label);
+            }
         }
     }
 


### PR DESCRIPTION
**Description**

When importing attributes without labels, no default attributes label are displayed (should be “[attribute_code]”. Things are fine if no label column is present in the imported file (default label is displayed in the family “Add attribute” drop-down, for example). However, if imported file contains empty label columns, the attribute is not displayed (see screenshot below).

![image](https://cloud.githubusercontent.com/assets/5039018/15704405/e3aa8038-27ea-11e6-9ba7-55a53ec4ff91.png)

This PR fixes this behavior by preventing the creation of attribute translations if label is empty.

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | No
| Added Behats                      | Yes
| Changelog updated                 | Yes
| Review and 2 GTM                  | Pending
| Micro Demo to the PO (Story only) | N/A
| Migration script                  | No
| Tech Doc                          | No

