### PR TITLE
Fix requirement of families at import

### DIFF
--- a/spec/Pim/Component/Catalog/Updater/FamilyUpdaterSpec.php
+++ b/spec/Pim/Component/Catalog/Updater/FamilyUpdaterSpec.php
@@ -132,6 +132,9 @@ class FamilyUpdaterSpec extends ObjectBehavior
             ->shouldBeCalled();
 
         $family->setCode('mycode')->shouldBeCalled();
+        $nameMobileRqrmt->setRequired(true)->shouldBeCalled();
+        $namePrintRqrmt->setRequired(true)->shouldBeCalled();
+        $descPrintRqrmt->setRequired(true)->shouldBeCalled();
 
         $family->addAttribute($skuAttribute)->shouldBeCalled();
         $family->addAttribute($nameAttribute)->shouldBeCalled();
@@ -248,6 +251,8 @@ class FamilyUpdaterSpec extends ObjectBehavior
             [$skuMobileRqrmt, $skuPrintRqrmt, $namePrintRqrmt, $descPrintRqrmt]
         )
         ->shouldBeCalled();
+        $namePrintRqrmt->setRequired(true)->shouldBeCalled();
+        $descPrintRqrmt->setRequired(true)->shouldBeCalled();
 
         $this->update($family, $values, []);
     }

--- a/src/Pim/Component/Catalog/Updater/FamilyUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/FamilyUpdater.php
@@ -266,14 +266,15 @@ class FamilyUpdater implements ObjectUpdaterInterface
             $requirement = $this->requirementRepo->findOneBy(
                 [
                     'attribute' => $attribute->getId(),
-                    'channel' => $channel->getId(),
-                    'family' => $family->getId()
+                    'channel'   => $channel->getId(),
+                    'family'    => $family->getId()
                 ]
             );
         }
         if (null === $requirement) {
             $requirement = $this->attrRequiFactory->createAttributeRequirement($attribute, $channel, true);
         }
+        $requirement->setRequired(true);
 
         return $requirement;
     }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This is end of my previous PR fixing FamilyUpdater. I added this very line as as soon as you get inside this method, requirement should be true. Otherwise, if the requirement existed and equaled false then it would remain... false. 

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | No
| Added Behats                      | N/A
| Changelog updated                 | No
| Review and 2 GTM                  | Pending
| Micro Demo to the PO (Story only) | N/A
| Migration script                  | N/A
| Tech Doc                          | N/A
