### PR TITLE
PIM-5687: Allow to remove a product from a variant group at first attempt

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 - PIM-5820: Fix product value filtering by channel and locale in structured product normalizer
+- PIM-5687: Fix an issue that prevented the removal of a product from a variant group in MongoDB
 
 # 1.4.24 (2016-05-10)
 

--- a/features/Context/FixturesContext.php
+++ b/features/Context/FixturesContext.php
@@ -1600,12 +1600,9 @@ class FixturesContext extends BaseFixturesContext
      */
     protected function createProductGroup($code, $label, $type, array $attributes, array $products = [])
     {
-        $group = new Group();
+        $group = $this->getGroupFactory()->createGroup($type);
         $group->setCode($code);
         $group->setLocale('en_US')->setLabel($label); // TODO translation refactoring
-
-        $type = $this->getGroupType($type);
-        $group->setType($type);
 
         foreach ($attributes as $attributeCode) {
             $attribute = $this->getAttribute($attributeCode);
@@ -1624,6 +1621,14 @@ class FixturesContext extends BaseFixturesContext
                 $this->getProductSaver()->save($product);
             }
         }
+    }
+
+    /**
+     * @return \Pim\Bundle\CatalogBundle\Factory\GroupFactory
+     */
+    protected function getGroupFactory()
+    {
+        return $this->getContainer()->get('pim_catalog.factory.group');
     }
 
     /**

--- a/features/enrich/variant-group/remove_products.feature
+++ b/features/enrich/variant-group/remove_products.feature
@@ -1,0 +1,26 @@
+@javascript
+Feature: Remove products from a variant group
+  In order to manage existing variant groups for the catalog
+  As a product manager
+  I need to be able to remove products to a variant group
+
+  Background:
+    Given the "footwear" catalog configuration
+    And the following product groups:
+      | code   | label  | axis        | type    |
+      | SANDAL | Sandal | size, color | VARIANT |
+    And the following products:
+      | sku             | groups | family  | categories        | size | color |
+      | sandal-white-37 | SANDAL | sandals | winter_collection | 37   | white |
+      | sandal-white-38 | SANDAL | sandals | winter_collection | 38   | white |
+      | sandal-white-39 | SANDAL | sandals | winter_collection | 39   | white |
+    And I am logged in as "Julia"
+
+  @jira https://akeneo.atlassian.net/browse/PIM-3736
+  Scenario: Successfully remove a product from the variant group
+    Given I am on the "SANDAL" variant group page
+    And the grid should contain 3 elements
+    When I uncheck the row "sandal-white-37"
+    And I press the "Save" button
+    Then I should see "Products: 2"
+    And the row "sandal-white-37" should not be checked

--- a/src/Pim/Bundle/CatalogBundle/Factory/GroupFactory.php
+++ b/src/Pim/Bundle/CatalogBundle/Factory/GroupFactory.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Bundle\CatalogBundle\Factory;
 
+use Pim\Bundle\CatalogBundle\Entity\ProductTemplate;
 use Pim\Bundle\CatalogBundle\Model\GroupInterface;
 use Pim\Bundle\CatalogBundle\Repository\GroupTypeRepositoryInterface;
 
@@ -47,6 +48,10 @@ class GroupFactory
                 throw new \InvalidArgumentException(sprintf('Group type with code "%s" was not found', $groupTypeCode));
             }
             $group->setType($groupType);
+
+            if ($group->getType()->isVariant()) {
+                $group->setProductTemplate(new ProductTemplate());
+            }
         }
 
         return $group;

--- a/src/Pim/Component/Connector/Processor/Denormalization/GroupProcessor.php
+++ b/src/Pim/Component/Connector/Processor/Denormalization/GroupProcessor.php
@@ -36,6 +36,7 @@ class GroupProcessor extends AbstractProcessor
     /**
      * @param StandardArrayConverterInterface       $groupConverter
      * @param IdentifiableObjectRepositoryInterface $repository
+     * @param GroupFactory                          $groupFactory
      * @param ObjectUpdaterInterface                $groupUpdater
      * @param ValidatorInterface                    $validator
      */


### PR DESCRIPTION
**Description**

It was not possible to remove a product from a variant group at the first attempt when the PIM is installed in MongoDB. One needs to do it twice, and the second time the product is indeed removed.

Issue was caused by the fact that at creation, the variant group doesn’t have an associated product template. The template not created during variant group import, only when saved from the UI.

This PR adds an empty ProductTemplate during group creation, directly in the GroupFactory (and only for variant groups).

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | No
| Added Behats                      | Yes
| Changelog updated                 | Yes
| Review and 2 GTM                  | Pendong
| Micro Demo to the PO (Story only) | N/A
| Migration script                  | No
| Tech Doc                          | No