### PR TITLE
Fix Yaml translation to be parsed by crowdin

### DIFF
--- a/src/Pim/Bundle/ConnectorBundle/Resources/translations/messages.en.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/translations/messages.en.yml
@@ -84,7 +84,7 @@ pim_connector:
                 error: The date must not be empty
             last_execution:
                 none: This job has never been exported
-                last: Last export: %date%
+                last: "Last export: %date%"
         decimalSeparator:
             label: Decimal separator
             help: Determine the decimal separator


### PR DESCRIPTION
Crowdin is very strict with Yaml parsing (not like Sf parser)
This fix may avoid that:

https://crowdin.com/translate/akeneo/111/en-fr#12463