### PR TITLE
TIP-428: move Doctrine readers and writers

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -40,6 +40,7 @@
 
 ## BC breaks
 
+- Move `Pim\Component\Connector\Writer\Doctrine` to `Pim\Component\Connector\Writer\Database`
 - Move `Pim\Component\Connector\Reader\ProductReader` to `Pim\Component\Connector\Reader\Database\ProductReader`
 - Move `Pim\Component\Connector\Reader\Doctrine\BaseReader` to `Pim\Component\Connector\Reader\Database\BaseReader`
 - Change constructor of `Pim\Bundle\BaseConnectorBundle\Processor\ProductToFlatArrayProcessor`. Add `Akeneo\Component\StorageUtils\Detacher\ObjectDetacherInterface` as the fourth argument.

--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -40,6 +40,8 @@
 
 ## BC breaks
 
+- Move `Pim\Component\Connector\Reader\ProductReader` to `Pim\Component\Connector\Reader\Database\ProductReader`
+- Move `Pim\Component\Connector\Reader\Doctrine\BaseReader` to `Pim\Component\Connector\Reader\Database\BaseReader`
 - Change constructor of `Pim\Bundle\BaseConnectorBundle\Processor\ProductToFlatArrayProcessor`. Add `Akeneo\Component\StorageUtils\Detacher\ObjectDetacherInterface` as the fourth argument.
 - Change constructor of `Pim\Component\Catalog\Factory\GroupFactory`. Add `Pim\Component\Catalog\Factory\ProductTemplateFactory` as the second argument.
 - Remove `Pim\Component\Connector\Writer\File\SimpleFileWriter` as it was not used

--- a/UPGRADE-1.6.md
+++ b/UPGRADE-1.6.md
@@ -176,4 +176,6 @@ Based on a PIM standard installation, execute the following command in your proj
     find ./src/ -type f -print0 | xargs -0 sed -i 's/Pim\\Component\\Connector\\Reader\\ProductReader/Pim\\Component\\Connector\\Reader\\Database\\ProductReader/g'
     find ./src/ -type f -print0 | xargs -0 sed -i 's/pim_connector\.reader\.product/pim_connector\.reader\.database\.product/g'
     find ./src/ -type f -print0 | xargs -0 sed -i 's/pim_connector\.reader\.doctrine/pim_connector\.reader\.database/g'
+    find ./src/ -type f -print0 | xargs -0 sed -i 's/Pim\\Component\\Connector\\Writer\\Doctrine/Pim\\Component\\Connector\\Writer\\Database/g'
+    find ./src/ -type f -print0 | xargs -0 sed -i 's/pim_connector\.writer\.doctrine/pim_connector\.writer\.database/g'
 ```

--- a/UPGRADE-1.6.md
+++ b/UPGRADE-1.6.md
@@ -172,4 +172,8 @@ Based on a PIM standard installation, execute the following command in your proj
     find ./src/ -type f -print0 | xargs -0 sed -i 's/implements StandardArrayConverterInterface/implements ArrayConverterInterface/g'
     find ./src/ -type f -print0 | xargs -0 sed -i 's/Pim\\Component\\Connector\\ArrayConverter\\Flat/Pim\\Component\\Connector\\ArrayConverter\\FlatToStandard/g'
     find ./src/ -type f -print0 | xargs -0 sed -i 's/pim_connector\.array_converter\.flat\./pim_connector\.array_converter\.flat_to_standard\./g'
+    find ./src/ -type f -print0 | xargs -0 sed -i 's/Pim\\Component\\Connector\\Reader\\Doctrine/Pim\\Component\\Connector\\Reader\\Database/g'
+    find ./src/ -type f -print0 | xargs -0 sed -i 's/Pim\\Component\\Connector\\Reader\\ProductReader/Pim\\Component\\Connector\\Reader\\Database\\ProductReader/g'
+    find ./src/ -type f -print0 | xargs -0 sed -i 's/pim_connector\.reader\.product/pim_connector\.reader\.database\.product/g'
+    find ./src/ -type f -print0 | xargs -0 sed -i 's/pim_connector\.reader\.doctrine/pim_connector\.reader\.database/g'
 ```

--- a/features/Context/fixtures/connector_deprecated_batch_jobs.yml
+++ b/features/Context/fixtures/connector_deprecated_batch_jobs.yml
@@ -15,13 +15,13 @@ connector:
 #                    services:
 #                        reader:    pim_base_connector.reader.file.csv_product
 #                        processor: pim_connector.processor.denormalization.product.flat
-#                        writer:    pim_connector.writer.doctrine.product
+#                        writer:    pim_connector.writer.database.product
 #                import_associations:
 #                    title:     pim_base_connector.jobs.csv_product_import.import_associations.title
 #                    services:
 #                        reader:    pim_base_connector.reader.file.csv_association
 #                        processor: pim_connector.processor.denormalization.product_association.flat
-#                        writer:    pim_connector.writer.doctrine.product_association
+#                        writer:    pim_connector.writer.database.product_association
 #        csv_attribute_import:
 #            title: pim_base_connector.jobs.csv_attribute_import.title
 #            type:  import
@@ -36,7 +36,7 @@ connector:
 #                    services:
 #                        reader:    pim_base_connector.reader.file.csv_attribute
 #                        processor: pim_connector.processor.denormalization.attribute.flat
-#                        writer:    pim_connector.writer.doctrine.attribute
+#                        writer:    pim_connector.writer.database.attribute
 #        csv_attribute_option_import:
 #            title: pim_base_connector.jobs.csv_attribute_option_import.title
 #            type:  import
@@ -51,7 +51,7 @@ connector:
 #                    services:
 #                        reader:    pim_base_connector.reader.file.csv_attribute_option
 #                        processor: pim_connector.processor.denormalization.attribute_option.flat
-#                        writer:    pim_connector.writer.doctrine.attribute_option
+#                        writer:    pim_connector.writer.database.attribute_option
 #        csv_variant_group_import:
 #            title: pim_base_connector.jobs.csv_variant_group_import.title
 #            type:  import
@@ -66,7 +66,7 @@ connector:
 #                    services:
 #                        reader:    pim_base_connector.reader.file.csv_variant_group
 #                        processor: pim_connector.processor.denormalization.variant_group.flat
-#                        writer:    pim_connector.writer.doctrine.variant_group
+#                        writer:    pim_connector.writer.database.variant_group
 #                    parameters:
 #                        batchSize: 1
 #        csv_category_import:
@@ -83,7 +83,7 @@ connector:
 #                    services:
 #                        reader:    pim_connector.reader.file.csv_category
 #                        processor: pim_connector.processor.denormalization.category.flat
-#                        writer:    pim_connector.writer.doctrine.category
+#                        writer:    pim_connector.writer.database.category
 #                    parameters:
 #                        batchSize: 1
 #        csv_group_import:
@@ -100,7 +100,7 @@ connector:
 #                    services:
 #                        reader:    pim_base_connector.reader.file.csv_group
 #                        processor: pim_connector.processor.denormalization.group.flat
-#                        writer:    pim_connector.writer.doctrine.group
+#                        writer:    pim_connector.writer.database.group
 #        csv_association_type_import:
 #            title: pim_base_connector.jobs.csv_association_type_import.title
 #            type: import
@@ -115,4 +115,4 @@ connector:
 #                    services:
 #                        reader:    pim_base_connector.reader.file.csv_association_type
 #                        processor: pim_connector.processor.denormalization.association_type.flat
-#                        writer:    pim_connector.writer.doctrine.association_type
+#                        writer:    pim_connector.writer.database.association_type

--- a/src/Pim/Bundle/BaseConnectorBundle/Reader/Doctrine/ODMProductReader.php
+++ b/src/Pim/Bundle/BaseConnectorBundle/Reader/Doctrine/ODMProductReader.php
@@ -19,7 +19,7 @@ use Pim\Component\Catalog\Repository\ProductRepositoryInterface;
  * @copyright 2014 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  *
- * @deprecated Will be removed in 1.7, please use Pim\Component\Connector\Reader\ProductReader instead.
+ * @deprecated Will be removed in 1.7, please use Pim\Component\Connector\Reader\Database\ProductReader instead.
  */
 class ODMProductReader extends AbstractConfigurableStepElement implements ProductReaderInterface
 {

--- a/src/Pim/Bundle/BaseConnectorBundle/Resources/config/readers.yml
+++ b/src/Pim/Bundle/BaseConnectorBundle/Resources/config/readers.yml
@@ -10,7 +10,7 @@ parameters:
     pim_base_connector.reader.cached.class:            Pim\Bundle\BaseConnectorBundle\Reader\CachedReader
 
 services:
-    # Deprecated: Will be removed in 1.7, please use @pim_connector.reader.product instead.
+    # Deprecated: Will be removed in 1.7, please use @pim_connector.reader.database.product instead.
     pim_base_connector.reader.doctrine.product:
         class: '%pim_base_connector.reader.doctrine.product.class%'
         arguments:

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/batch_jobs/csv_connector.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/batch_jobs/csv_connector.yml
@@ -113,7 +113,7 @@ connector:
             steps:
                 export:
                     services:
-                        reader:    pim_connector.reader.product
+                        reader:    pim_connector.reader.database.product
                         processor: pim_base_connector.processor.product_to_flat_array
                         writer:    pim_connector.writer.file.csv_product
                     parameters:

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/batch_jobs/csv_connector.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/batch_jobs/csv_connector.yml
@@ -12,12 +12,12 @@ connector:
                     services:
                         reader:    pim_connector.reader.file.csv_product
                         processor: pim_connector.processor.denormalization.product.flat
-                        writer:    pim_connector.writer.doctrine.product
+                        writer:    pim_connector.writer.database.product
                 import_associations:
                     services:
                         reader:    pim_connector.reader.file.csv_association
                         processor: pim_connector.processor.denormalization.product_association.flat
-                        writer:    pim_connector.writer.doctrine.product_association
+                        writer:    pim_connector.writer.database.product_association
                     parameters:
                         batch_size: 1
         csv_attribute_import:
@@ -31,7 +31,7 @@ connector:
                     services:
                         reader:    pim_connector.reader.file.csv_attribute
                         processor: pim_connector.processor.denormalization.attribute.flat
-                        writer:    pim_connector.writer.doctrine.attribute
+                        writer:    pim_connector.writer.database.attribute
         csv_attribute_option_import:
             type:  import
             steps:
@@ -43,7 +43,7 @@ connector:
                     services:
                         reader:    pim_connector.reader.file.csv_attribute_option
                         processor: pim_connector.processor.denormalization.attribute_option.flat
-                        writer:    pim_connector.writer.doctrine.attribute_option
+                        writer:    pim_connector.writer.database.attribute_option
         csv_variant_group_import:
             type:  import
             steps:
@@ -55,7 +55,7 @@ connector:
                     services:
                         reader:    pim_connector.reader.file.csv_variant_group
                         processor: pim_connector.processor.denormalization.variant_group.flat
-                        writer:    pim_connector.writer.doctrine.variant_group
+                        writer:    pim_connector.writer.database.variant_group
                     parameters:
                         batchSize: 1
         csv_category_import:
@@ -69,7 +69,7 @@ connector:
                     services:
                         reader:    pim_connector.reader.file.csv_category
                         processor: pim_connector.processor.denormalization.category.flat
-                        writer:    pim_connector.writer.doctrine.category
+                        writer:    pim_connector.writer.database.category
                     parameters:
                         batchSize: 1
         csv_group_import:
@@ -83,7 +83,7 @@ connector:
                     services:
                         reader:    pim_connector.reader.file.csv_group
                         processor: pim_connector.processor.denormalization.group.flat
-                        writer:    pim_connector.writer.doctrine.group
+                        writer:    pim_connector.writer.database.group
         csv_association_type_import:
             type: import
             steps:
@@ -95,7 +95,7 @@ connector:
                     services:
                         reader:    pim_connector.reader.file.csv_association_type
                         processor: pim_connector.processor.denormalization.association_type.flat
-                        writer:    pim_connector.writer.doctrine.association_type
+                        writer:    pim_connector.writer.database.association_type
         csv_family_import:
             type: import
             steps:
@@ -107,7 +107,7 @@ connector:
                     services:
                         reader:    pim_connector.reader.file.csv_family
                         processor: pim_connector.processor.denormalization.family.flat
-                        writer:    pim_connector.writer.doctrine.family
+                        writer:    pim_connector.writer.database.family
         csv_product_export:
             type:  export
             steps:

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/batch_jobs/xlsx_connector.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/batch_jobs/xlsx_connector.yml
@@ -87,7 +87,7 @@ connector:
              steps:
                  export:
                      services:
-                         reader:    pim_connector.reader.product
+                         reader:    pim_connector.reader.database.product
                          processor: pim_base_connector.processor.product_to_flat_array
                          writer:    pim_connector.writer.file.xlsx_product
                      parameters:

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/batch_jobs/xlsx_connector.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/batch_jobs/xlsx_connector.yml
@@ -12,12 +12,12 @@ connector:
                     services:
                         reader:    pim_connector.reader.file.xlsx_product
                         processor: pim_connector.processor.denormalization.product.flat
-                        writer:    pim_connector.writer.doctrine.product
+                        writer:    pim_connector.writer.database.product
                 import_associations:
                     services:
                         reader:    pim_connector.reader.file.xlsx_association_type
                         processor: pim_connector.processor.denormalization.product_association.flat
-                        writer:    pim_connector.writer.doctrine.product_association
+                        writer:    pim_connector.writer.database.product_association
                     parameters:
                         batch_size: 1
         xlsx_category_import:
@@ -31,7 +31,7 @@ connector:
                     services:
                         reader:    pim_connector.reader.file.xlsx_category
                         processor: pim_connector.processor.denormalization.category.flat
-                        writer:    pim_connector.writer.doctrine.category
+                        writer:    pim_connector.writer.database.category
                     parameters:
                         batchSize: 1
         xlsx_attribute_import:
@@ -45,7 +45,7 @@ connector:
                     services:
                         reader:    pim_connector.reader.file.xlsx_attribute
                         processor: pim_connector.processor.denormalization.attribute.flat
-                        writer:    pim_connector.writer.doctrine.attribute
+                        writer:    pim_connector.writer.database.attribute
         xlsx_attribute_option_import:
             type:  import
             steps:
@@ -57,7 +57,7 @@ connector:
                     services:
                         reader:    pim_connector.reader.file.xlsx_attribute_option
                         processor: pim_connector.processor.denormalization.attribute_option.flat
-                        writer:    pim_connector.writer.doctrine.attribute_option
+                        writer:    pim_connector.writer.database.attribute_option
         xlsx_association_type_import:
             type: import
             steps:
@@ -69,7 +69,7 @@ connector:
                     services:
                         reader:    pim_connector.reader.file.xlsx_association_type
                         processor: pim_connector.processor.denormalization.association_type.flat
-                        writer:    pim_connector.writer.doctrine.association_type
+                        writer:    pim_connector.writer.database.association_type
         xlsx_family_import:
             type: import
             steps:
@@ -81,7 +81,7 @@ connector:
                     services:
                         reader:    pim_connector.reader.file.xlsx_family
                         processor: pim_connector.processor.denormalization.family.flat
-                        writer:    pim_connector.writer.doctrine.family
+                        writer:    pim_connector.writer.database.family
         xlsx_product_export:
              type:  export
              steps:
@@ -123,7 +123,7 @@ connector:
                     services:
                         reader:    pim_connector.reader.file.xlsx_group
                         processor: pim_connector.processor.denormalization.group.flat
-                        writer:    pim_connector.writer.doctrine.group
+                        writer:    pim_connector.writer.database.group
         xlsx_variant_group_import:
             type:  import
             steps:
@@ -135,7 +135,7 @@ connector:
                     services:
                         reader:    pim_connector.reader.file.xlsx_variant_group
                         processor: pim_connector.processor.denormalization.variant_group.flat
-                        writer:    pim_connector.writer.doctrine.variant_group
+                        writer:    pim_connector.writer.database.variant_group
                     parameters:
                         batchSize: 1
         xlsx_family_export:

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/readers.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/readers.yml
@@ -1,7 +1,8 @@
 parameters:
-    pim_connector.reader.product.class:       Pim\Component\Connector\Reader\ProductReader
-    pim_connector.reader.dummy_item.class:    Pim\Component\Connector\Reader\DummyItemReader
-    pim_connector.reader.doctrine.base.class: Pim\Component\Connector\Reader\Doctrine\BaseReader
+    pim_connector.reader.dummy_item.class: Pim\Component\Connector\Reader\DummyItemReader
+
+    pim_connector.reader.database.product.class: Pim\Component\Connector\Reader\Database\ProductReader
+    pim_connector.reader.database.base.class:    Pim\Component\Connector\Reader\Database\BaseReader
 
     pim_connector.reader.file.csv.class:         Pim\Component\Connector\Reader\File\CsvReader
     pim_connector.reader.file.csv_product.class: Pim\Component\Connector\Reader\File\Product\CsvProductReader
@@ -14,8 +15,8 @@ parameters:
     pim_connector.reader.file.media_path_transformer.class: Pim\Component\Connector\Reader\File\Product\MediaPathTransformer
 
 services:
-    pim_connector.reader.product:
-        class: '%pim_connector.reader.product.class%'
+    pim_connector.reader.database.product:
+        class: '%pim_connector.reader.database.product.class%'
         arguments:
             - '@pim_catalog.query.product_query_builder_factory'
             - '@pim_catalog.repository.channel'

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/writers.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/writers.yml
@@ -1,9 +1,9 @@
 parameters:
     pim_connector.writer.dummy_item.class:                         Pim\Component\Connector\Writer\DummyItemWriter
-    pim_connector.writer.doctrine.base.class:                      Pim\Component\Connector\Writer\Doctrine\BaseWriter
-    pim_connector.writer.doctrine.product.class:                   Pim\Component\Connector\Writer\Doctrine\ProductWriter
-    pim_connector.writer.doctrine.product_association.class:       Pim\Component\Connector\Writer\Doctrine\ProductAssociationWriter
-    pim_connector.writer.doctrine.variant_group.class:             Pim\Component\Connector\Writer\Doctrine\VariantGroupWriter
+    pim_connector.writer.database.base.class:                      Pim\Component\Connector\Writer\Database\BaseWriter
+    pim_connector.writer.database.product.class:                   Pim\Component\Connector\Writer\Database\ProductWriter
+    pim_connector.writer.database.product_association.class:       Pim\Component\Connector\Writer\Database\ProductAssociationWriter
+    pim_connector.writer.database.variant_group.class:             Pim\Component\Connector\Writer\Database\VariantGroupWriter
     pim_connector.writer.file.abstract.class:                      Pim\Component\Connector\Writer\File\AbstractFileWriter
     pim_connector.writer.file.csv.class:                           Pim\Component\Connector\Writer\File\CsvWriter
     pim_connector.writer.file.csv_product.class:                   Pim\Component\Connector\Writer\File\CsvProductWriter
@@ -27,112 +27,112 @@ services:
         class: '%pim_connector.writer.dummy_item.class%'
 
     # Database writers
-    pim_connector.writer.doctrine.attribute_option:
-        class: '%pim_connector.writer.doctrine.base.class%'
+    pim_connector.writer.database.attribute_option:
+        class: '%pim_connector.writer.database.base.class%'
         arguments:
             - '@pim_catalog.saver.attribute_option'
             - '@akeneo_storage_utils.doctrine.object_detacher'
 
-    pim_connector.writer.doctrine.category:
-        class: '%pim_connector.writer.doctrine.base.class%'
+    pim_connector.writer.database.category:
+        class: '%pim_connector.writer.database.base.class%'
         arguments:
             - '@pim_catalog.saver.category'
             - '@akeneo_storage_utils.doctrine.object_detacher'
 
-    pim_connector.writer.doctrine.family:
-        class: '%pim_connector.writer.doctrine.base.class%'
+    pim_connector.writer.database.family:
+        class: '%pim_connector.writer.database.base.class%'
         arguments:
             - '@pim_catalog.saver.family'
             - '@akeneo_storage_utils.doctrine.object_detacher'
 
-    pim_connector.writer.doctrine.product:
-        class: '%pim_connector.writer.doctrine.product.class%'
+    pim_connector.writer.database.product:
+        class: '%pim_connector.writer.database.product.class%'
         arguments:
             - '@pim_versioning.manager.version'
             - '@pim_catalog.saver.product'
             - '@akeneo_storage_utils.doctrine.object_detacher'
 
-    pim_connector.writer.doctrine.product_association:
-        class: '%pim_connector.writer.doctrine.product_association.class%'
+    pim_connector.writer.database.product_association:
+        class: '%pim_connector.writer.database.product_association.class%'
         arguments:
             - '@pim_catalog.saver.product'
             - '@akeneo_storage_utils.doctrine.object_detacher'
 
-    pim_connector.writer.doctrine.attribute:
-        class: '%pim_connector.writer.doctrine.base.class%'
+    pim_connector.writer.database.attribute:
+        class: '%pim_connector.writer.database.base.class%'
         arguments:
             - '@pim_catalog.saver.attribute'
             - '@akeneo_storage_utils.doctrine.object_detacher'
 
-    pim_connector.writer.doctrine.group:
-        class: '%pim_connector.writer.doctrine.base.class%'
+    pim_connector.writer.database.group:
+        class: '%pim_connector.writer.database.base.class%'
         arguments:
             - '@pim_catalog.saver.group'
             - '@akeneo_storage_utils.doctrine.object_detacher'
 
-    pim_connector.writer.doctrine.user:
-        class: '%pim_connector.writer.doctrine.base.class%'
+    pim_connector.writer.database.user:
+        class: '%pim_connector.writer.database.base.class%'
         arguments:
             - '@pim_user.saver.user'
             - '@akeneo_storage_utils.doctrine.object_detacher'
 
-    pim_connector.writer.doctrine.user_role:
-        class: '%pim_connector.writer.doctrine.base.class%'
+    pim_connector.writer.database.user_role:
+        class: '%pim_connector.writer.database.base.class%'
         arguments:
             - '@pim_user.saver.role'
             - '@akeneo_storage_utils.doctrine.object_detacher'
 
-    pim_connector.writer.doctrine.user_group:
-        class: '%pim_connector.writer.doctrine.base.class%'
+    pim_connector.writer.database.user_group:
+        class: '%pim_connector.writer.database.base.class%'
         arguments:
             - '@pim_user.saver.group'
             - '@akeneo_storage_utils.doctrine.object_detacher'
 
-    pim_connector.writer.doctrine.association_type:
-        class: '%pim_connector.writer.doctrine.base.class%'
+    pim_connector.writer.database.association_type:
+        class: '%pim_connector.writer.database.base.class%'
         arguments:
             - '@pim_catalog.saver.association_type'
             - '@akeneo_storage_utils.doctrine.object_detacher'
 
-    pim_connector.writer.doctrine.variant_group:
-        class: '%pim_connector.writer.doctrine.variant_group.class%'
+    pim_connector.writer.database.variant_group:
+        class: '%pim_connector.writer.database.variant_group.class%'
         arguments:
             - '@pim_catalog.saver.group'
             - '@akeneo_storage_utils.doctrine.object_detacher'
             - '@pim_catalog.applier.product_template'
 
-    pim_connector.writer.doctrine.channel:
-        class: '%pim_connector.writer.doctrine.base.class%'
+    pim_connector.writer.database.channel:
+        class: '%pim_connector.writer.database.base.class%'
         arguments:
             - '@pim_catalog.saver.channel'
             - '@akeneo_storage_utils.doctrine.object_detacher'
 
-    pim_connector.writer.doctrine.locale:
-        class: '%pim_connector.writer.doctrine.base.class%'
+    pim_connector.writer.database.locale:
+        class: '%pim_connector.writer.database.base.class%'
         arguments:
             - '@pim_catalog.saver.locale'
             - '@akeneo_storage_utils.doctrine.object_detacher'
 
-    pim_connector.writer.doctrine.attribute_group:
-        class: '%pim_connector.writer.doctrine.base.class%'
+    pim_connector.writer.database.attribute_group:
+        class: '%pim_connector.writer.database.base.class%'
         arguments:
             - '@pim_catalog.saver.attribute_group'
             - '@akeneo_storage_utils.doctrine.object_detacher'
 
-    pim_connector.writer.doctrine.group_type:
-        class: '%pim_connector.writer.doctrine.base.class%'
+    pim_connector.writer.database.group_type:
+        class: '%pim_connector.writer.database.base.class%'
         arguments:
             - '@pim_catalog.saver.group_type'
             - '@akeneo_storage_utils.doctrine.object_detacher'
 
-    pim_connector.writer.doctrine.currency:
-        class: '%pim_connector.writer.doctrine.base.class%'
+    pim_connector.writer.database.currency:
+        class: '%pim_connector.writer.database.base.class%'
         arguments:
             - '@pim_catalog.saver.currency'
             - '@akeneo_storage_utils.doctrine.object_detacher'
 
-    pim_connector.writer.doctrine.job_instance:
-        class: '%pim_connector.writer.doctrine.base.class%'
+    pim_connector.writer.database.job_instance:
+        class: '%pim_connector.writer.database.base.class%'
         arguments:
             - '@akeneo_batch.saver.job_instance'
             - '@akeneo_storage_utils.doctrine.object_detacher'

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/batch_jobs.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/batch_jobs.yml
@@ -8,7 +8,7 @@ connector:
                     services:
                         reader:    pim_enrich.connector.reader.mass_edit.product
                         processor: pim_enrich.connector.processor.mass_edit.product.update_value
-                        writer:    pim_connector.writer.doctrine.product
+                        writer:    pim_connector.writer.database.product
         add_product_value:
             type:  mass_edit
             steps:
@@ -16,7 +16,7 @@ connector:
                     services:
                         reader:    pim_enrich.connector.reader.mass_edit.product
                         processor: pim_enrich.connector.processor.mass_edit.product.add_value
-                        writer:    pim_connector.writer.doctrine.product
+                        writer:    pim_connector.writer.database.product
         edit_common_attributes:
             type:  mass_edit
             steps:
@@ -24,7 +24,7 @@ connector:
                     services:
                         reader:    pim_enrich.connector.reader.mass_edit.product
                         processor: pim_enrich.connector.processor.mass_edit.product.edit_common_attributes
-                        writer:    pim_connector.writer.doctrine.product
+                        writer:    pim_connector.writer.database.product
                 clean:
                     class: "%pim_enrich.step.mass_edit.step.class%"
                     services:
@@ -36,7 +36,7 @@ connector:
                     services:
                         reader:    pim_enrich.connector.reader.mass_edit.family
                         processor: pim_enrich.connector.processor.mass_edit.family.set_requirements
-                        writer:    pim_connector.writer.doctrine.family
+                        writer:    pim_connector.writer.database.family
         csv_product_quick_export:
             type: quick_export
             steps:
@@ -84,4 +84,4 @@ connector:
                     services:
                         reader:    pim_enrich.connector.reader.mass_edit.variant_group_product
                         processor: pim_enrich.connector.processor.mass_edit.product.add_to_variant_group
-                        writer:    pim_connector.writer.doctrine.product
+                        writer:    pim_connector.writer.database.product

--- a/src/Pim/Bundle/InstallerBundle/Resources/config/batch_jobs.yml
+++ b/src/Pim/Bundle/InstallerBundle/Resources/config/batch_jobs.yml
@@ -12,7 +12,7 @@ connector:
                     services:
                         reader:    pim_connector.reader.file.csv_category
                         processor: pim_connector.processor.denormalization.category.flat
-                        writer:    pim_connector.writer.doctrine.category
+                        writer:    pim_connector.writer.database.category
                     parameters:
                         batchSize: 1
 
@@ -27,7 +27,7 @@ connector:
                     services:
                         reader:    pim_connector.reader.file.csv_attribute_group
                         processor: pim_connector.processor.denormalization.attribute_group.flat
-                        writer:    pim_connector.writer.doctrine.attribute_group
+                        writer:    pim_connector.writer.database.attribute_group
 
         fixtures_channel_csv:
             type:  fixtures
@@ -40,7 +40,7 @@ connector:
                     services:
                         reader:    pim_connector.reader.file.csv_channel
                         processor: pim_connector.processor.denormalization.channel.flat
-                        writer:    pim_connector.writer.doctrine.channel
+                        writer:    pim_connector.writer.database.channel
 
         fixtures_locale_csv:
             type:  fixtures
@@ -53,7 +53,7 @@ connector:
                     services:
                         reader:    pim_connector.reader.file.csv_locale
                         processor: pim_connector.processor.denormalization.locale.flat
-                        writer:    pim_connector.writer.doctrine.locale
+                        writer:    pim_connector.writer.database.locale
 
         fixtures_currency_csv:
             type:  fixtures
@@ -66,7 +66,7 @@ connector:
                     services:
                         reader:    pim_connector.reader.file.csv_currency
                         processor: pim_connector.processor.denormalization.currency.flat
-                        writer:    pim_connector.writer.doctrine.currency
+                        writer:    pim_connector.writer.database.currency
 
         fixtures_group_type_csv:
             type:  fixtures
@@ -79,7 +79,7 @@ connector:
                     services:
                         reader:    pim_connector.reader.file.csv_group_type
                         processor: pim_connector.processor.denormalization.group_type.flat
-                        writer:    pim_connector.writer.doctrine.group_type
+                        writer:    pim_connector.writer.database.group_type
 
         fixtures_association_type_csv:
             type:  fixtures
@@ -92,7 +92,7 @@ connector:
                     services:
                         reader:    pim_connector.reader.file.csv
                         processor: pim_connector.processor.denormalization.association_type.flat
-                        writer:    pim_connector.writer.doctrine.association_type
+                        writer:    pim_connector.writer.database.association_type
 
         fixtures_attribute_csv:
             type:  fixtures
@@ -105,7 +105,7 @@ connector:
                     services:
                         reader:    pim_connector.reader.file.csv_attribute
                         processor: pim_connector.processor.denormalization.attribute.flat
-                        writer:    pim_connector.writer.doctrine.attribute
+                        writer:    pim_connector.writer.database.attribute
 
         fixtures_attribute_options_csv:
             type:  fixtures
@@ -118,7 +118,7 @@ connector:
                     services:
                         reader:    pim_connector.reader.file.csv_attribute_option
                         processor: pim_connector.processor.denormalization.attribute_option.flat
-                        writer:    pim_connector.writer.doctrine.attribute_option
+                        writer:    pim_connector.writer.database.attribute_option
 
         fixtures_family_csv:
             type:  fixtures
@@ -131,7 +131,7 @@ connector:
                     services:
                         reader:    pim_connector.reader.file.csv
                         processor: pim_connector.processor.denormalization.family.flat
-                        writer:    pim_connector.writer.doctrine.family
+                        writer:    pim_connector.writer.database.family
 
         fixtures_variant_group_csv:
             type:  fixtures
@@ -144,7 +144,7 @@ connector:
                     services:
                         reader:    pim_connector.reader.file.csv_variant_group
                         processor: pim_connector.processor.denormalization.variant_group.flat
-                        writer:    pim_connector.writer.doctrine.variant_group
+                        writer:    pim_connector.writer.database.variant_group
 
         fixtures_product_csv:
             type:  fixtures
@@ -157,12 +157,12 @@ connector:
                     services:
                         reader:    pim_connector.reader.file.csv_product
                         processor: pim_connector.processor.denormalization.product.flat
-                        writer:    pim_connector.writer.doctrine.product
+                        writer:    pim_connector.writer.database.product
                 import_associations:
                     services:
                         reader:    pim_connector.reader.file.csv_association
                         processor: pim_connector.processor.denormalization.product_association.flat
-                        writer:    pim_connector.writer.doctrine.product_association
+                        writer:    pim_connector.writer.database.product_association
                     parameters:
                         batch_size: 1
 
@@ -177,7 +177,7 @@ connector:
                     services:
                         reader:    pim_base_connector.reader.file.yaml
                         processor: pim_connector.processor.denormalization.job_instance.flat
-                        writer:    pim_connector.writer.doctrine.job_instance
+                        writer:    pim_connector.writer.database.job_instance
 
         fixtures_user_csv:
             type:  fixtures
@@ -190,7 +190,7 @@ connector:
                     services:
                         reader:    pim_connector.reader.file.csv
                         processor: pim_connector.processor.denormalization.user.flat
-                        writer:    pim_connector.writer.doctrine.user
+                        writer:    pim_connector.writer.database.user
 
         fixtures_user_role_csv:
             type:  fixtures
@@ -203,7 +203,7 @@ connector:
                     services:
                         reader:    pim_connector.reader.file.csv
                         processor: pim_connector.processor.denormalization.user_role.flat
-                        writer:    pim_connector.writer.doctrine.user_role
+                        writer:    pim_connector.writer.database.user_role
 
         fixtures_user_group_csv:
             type:  fixtures
@@ -216,7 +216,7 @@ connector:
                     services:
                         reader:    pim_connector.reader.file.csv
                         processor: pim_connector.processor.denormalization.user_group.flat
-                        writer:    pim_connector.writer.doctrine.user_group
+                        writer:    pim_connector.writer.database.user_group
 
         fixtures_group_csv:
             type:  fixtures
@@ -229,4 +229,4 @@ connector:
                     services:
                         reader:    pim_connector.reader.file.csv_group
                         processor: pim_connector.processor.denormalization.group.flat
-                        writer:    pim_connector.writer.doctrine.group
+                        writer:    pim_connector.writer.database.group

--- a/src/Pim/Component/Connector/Reader/Database/BaseReader.php
+++ b/src/Pim/Component/Connector/Reader/Database/BaseReader.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Pim\Component\Connector\Reader\Doctrine;
+namespace Pim\Component\Connector\Reader\Database;
 
 use Akeneo\Component\Batch\Item\AbstractConfigurableStepElement;
 use Akeneo\Component\Batch\Item\ItemReaderInterface;

--- a/src/Pim/Component/Connector/Reader/Database/ProductReader.php
+++ b/src/Pim/Component/Connector/Reader/Database/ProductReader.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Pim\Component\Connector\Reader;
+namespace Pim\Component\Connector\Reader\Database;
 
 use Akeneo\Component\Batch\Item\AbstractConfigurableStepElement;
 use Akeneo\Component\Batch\Item\ItemReaderInterface;

--- a/src/Pim/Component/Connector/Writer/Database/BaseWriter.php
+++ b/src/Pim/Component/Connector/Writer/Database/BaseWriter.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Pim\Component\Connector\Writer\Doctrine;
+namespace Pim\Component\Connector\Writer\Database;
 
 use Akeneo\Component\Batch\Item\AbstractConfigurableStepElement;
 use Akeneo\Component\Batch\Item\ItemWriterInterface;

--- a/src/Pim/Component/Connector/Writer/Database/ProductAssociationWriter.php
+++ b/src/Pim/Component/Connector/Writer/Database/ProductAssociationWriter.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Pim\Component\Connector\Writer\Doctrine;
+namespace Pim\Component\Connector\Writer\Database;
 
 /**
  * Custom writer for product associations to indicate the number of created/updated association targets

--- a/src/Pim/Component/Connector/Writer/Database/ProductWriter.php
+++ b/src/Pim/Component/Connector/Writer/Database/ProductWriter.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Pim\Component\Connector\Writer\Doctrine;
+namespace Pim\Component\Connector\Writer\Database;
 
 use Akeneo\Component\Batch\Item\AbstractConfigurableStepElement;
 use Akeneo\Component\Batch\Item\ItemWriterInterface;

--- a/src/Pim/Component/Connector/Writer/Database/VariantGroupWriter.php
+++ b/src/Pim/Component/Connector/Writer/Database/VariantGroupWriter.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Pim\Component\Connector\Writer\Doctrine;
+namespace Pim\Component\Connector\Writer\Database;
 
 use Akeneo\Component\StorageUtils\Detacher\BulkObjectDetacherInterface;
 use Akeneo\Component\StorageUtils\Saver\BulkSaverInterface;

--- a/src/Pim/Component/Connector/spec/Reader/Database/BaseReaderSpec.php
+++ b/src/Pim/Component/Connector/spec/Reader/Database/BaseReaderSpec.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace spec\Pim\Component\Connector\Reader\Doctrine;
+namespace spec\Pim\Component\Connector\Reader\Database;
 
 use Akeneo\Component\Batch\Model\StepExecution;
 use Doctrine\Common\Persistence\ObjectRepository;

--- a/src/Pim/Component/Connector/spec/Reader/Database/ProductReaderSpec.php
+++ b/src/Pim/Component/Connector/spec/Reader/Database/ProductReaderSpec.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace spec\Pim\Component\Connector\Reader;
+namespace spec\Pim\Component\Connector\Reader\Database;
 
 use Akeneo\Component\Batch\Job\BatchStatus;
 use Akeneo\Component\Batch\Job\JobParameters;

--- a/src/Pim/Component/Connector/spec/Writer/Database/BaseWriterSpec.php
+++ b/src/Pim/Component/Connector/spec/Writer/Database/BaseWriterSpec.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace spec\Pim\Component\Connector\Writer\Doctrine;
+namespace spec\Pim\Component\Connector\Writer\Database;
 
 use Akeneo\Component\Batch\Model\StepExecution;
 use Akeneo\Component\StorageUtils\Detacher\BulkObjectDetacherInterface;

--- a/src/Pim/Component/Connector/spec/Writer/Database/ProductAssociationWriterSpec.php
+++ b/src/Pim/Component/Connector/spec/Writer/Database/ProductAssociationWriterSpec.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace spec\Pim\Component\Connector\Writer\Doctrine;
+namespace spec\Pim\Component\Connector\Writer\Database;
 
 use Akeneo\Component\Batch\Model\StepExecution;
 use Akeneo\Component\StorageUtils\Detacher\BulkObjectDetacherInterface;

--- a/src/Pim/Component/Connector/spec/Writer/Database/ProductWriterSpec.php
+++ b/src/Pim/Component/Connector/spec/Writer/Database/ProductWriterSpec.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace spec\Pim\Component\Connector\Writer\Doctrine;
+namespace spec\Pim\Component\Connector\Writer\Database;
 
 use Akeneo\Component\Batch\Job\JobParameters;
 use Akeneo\Component\Batch\Model\StepExecution;
@@ -24,7 +24,7 @@ class ProductWriterSpec extends ObjectBehavior
 
     function it_is_initializable()
     {
-        $this->shouldHaveType('\Pim\Component\Connector\Writer\Doctrine\ProductWriter');
+        $this->shouldHaveType('\Pim\Component\Connector\Writer\Database\ProductWriter');
     }
 
     function it_is_an_item_writer()

--- a/src/Pim/Component/Connector/spec/Writer/Database/VariantGroupWriterSpec.php
+++ b/src/Pim/Component/Connector/spec/Writer/Database/VariantGroupWriterSpec.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace spec\Pim\Component\Connector\Writer\Doctrine;
+namespace spec\Pim\Component\Connector\Writer\Database;
 
 use Akeneo\Component\Batch\Job\JobParameters;
 use Akeneo\Component\Batch\Model\StepExecution;


### PR DESCRIPTION
Move Doctrine readers ans writers to a more generic `Database` namespace. (As we don't really use Doctrine inside). The is the twin of the *File* readers/writers.


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Changelog updated                 | Y
| Review and 2 GTM                  |
| Micro Demo to the PO (Story only) | -
| Migration script                  | - 
| Tech Doc                          | -

