### PR TITLE
PIM-5828: Fix "Product | Edit" entry in history menu

### DIFF
--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -2,6 +2,7 @@
 
 - PIM-5711: Don't create empty attribute translations if attributes are imported with empty labels
 - PIM-5829: Fix an issue with wrong parameters order in FamilyUpdater
+- PIM-5828: Correctly render product SKU in history pin bar
 
 # 1.5.4 (2016-06-01)
 

--- a/features/Pim/Behat/Context/NavigationContext.php
+++ b/features/Pim/Behat/Context/NavigationContext.php
@@ -60,6 +60,11 @@ class NavigationContext extends PimContext implements PageObjectAwareInterface
         'my account'               => 'User profile',
     ];
 
+    protected $elements = [
+        'Dot menu'    => ['css' => '.pin-bar .pin-menus i.icon-ellipsis-horizontal'],
+        'Pinned item' => ['css' => '.pin-bar a[title="%s"]'],
+    ];
+
     /**
      * @param string $baseUrl
      */
@@ -281,10 +286,22 @@ class NavigationContext extends PimContext implements PageObjectAwareInterface
     public function iClickOnThePinnedItem($label)
     {
         $pinnedItem = $this->spin(function () use ($label) {
-            return $this->getCurrentPage()->find('css', sprintf('.pin-bar a[title="%s"]', $label));
-        });
+            return $this->getCurrentPage()->find('css', sprintf($this->elements['Pinned item']['css'], $label));
+        }, sprintf('Unable to click on the pinned element "%s"', $label));
 
         $pinnedItem->click();
+    }
+
+    /**
+     * @When /^I click on the pin bar dot menu$/
+     */
+    public function iClickOnThePinBarDotMenu()
+    {
+        $pinDotMenu = $this->spin(function () {
+            return $this->getCurrentPage()->find('css', $this->elements['Dot menu']['css']);
+        }, 'Unable to click on the pin bar dot menu');
+
+        $pinDotMenu->click();
     }
 
     /**

--- a/features/navigation/browse_navigation_history.feature
+++ b/features/navigation/browse_navigation_history.feature
@@ -1,0 +1,20 @@
+@javascript
+Feature: Browse the history in the history tab of the pinbar
+  In order to easily know what pages were visited
+  As a regular user
+  I need to be able to see navigation history
+
+  Background:
+    Given a "default" catalog configuration
+    And the following products:
+      | sku       |
+      | pineapple |
+    And I am logged in as "Mary"
+
+  @jira https://akeneo.atlassian.net/browse/PIM-5828
+  Scenario: Add pages to the pinbar
+    Given I am on the "pineapple" product page
+    And I am on the home page
+    When I click on the pin bar dot menu
+    And I press the "History" button
+    Then I should see the text "Products pineapple | Edit"

--- a/src/Oro/Bundle/NavigationBundle/Event/ResponseHistoryListener.php
+++ b/src/Oro/Bundle/NavigationBundle/Event/ResponseHistoryListener.php
@@ -101,6 +101,7 @@ class ResponseHistoryListener
      *
      * @param  Response $response
      * @param  Request  $request
+     *
      * @return bool
      */
     private function matchRequest(Response $response, Request $request)
@@ -114,6 +115,7 @@ class ResponseHistoryListener
                 && !$request->headers->get(ResponseHashnavListener::HASH_NAVIGATION_HEADER))
             || $route[0] == '_'
             || $route == 'oro_default'
-            || is_null($this->user));
+            || is_null($this->user)
+            || 'pim_enrich_product_edit' === $route);
     }
 }

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/NavigationHistoryController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/NavigationHistoryController.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Pim\Bundle\EnrichBundle\Controller\Rest;
+
+use Akeneo\Component\StorageUtils\Saver\SaverInterface;
+use Oro\Bundle\NavigationBundle\Entity\Builder\ItemFactory;
+use Oro\Bundle\NavigationBundle\Entity\NavigationHistoryItem;
+use Oro\Bundle\NavigationBundle\Entity\NavigationItemInterface;
+use Oro\Bundle\NavigationBundle\Entity\Repository\NavigationRepositoryInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * @author    Damien Carcel <damien.carcel@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class NavigationHistoryController
+{
+    /** @var TokenStorageInterface */
+    protected $tokenStorage;
+
+    /** @var NavigationRepositoryInterface */
+    protected $repository;
+
+    /** @var ItemFactory */
+    protected $itemFactory;
+
+    /** @var SaverInterface */
+    protected $saver;
+
+    /**
+     * @param TokenStorageInterface         $tokenStorage
+     * @param NavigationRepositoryInterface $repository
+     * @param ItemFactory                   $itemFactory
+     * @param SaverInterface                $saver
+     */
+    public function __construct(
+        TokenStorageInterface $tokenStorage,
+        NavigationRepositoryInterface $repository,
+        ItemFactory $itemFactory,
+        SaverInterface $saver
+    ) {
+        $this->tokenStorage = $tokenStorage;
+        $this->repository   = $repository;
+        $this->itemFactory  = $itemFactory;
+        $this->saver        = $saver;
+    }
+
+    /**
+     * Saves a history item, by creating a new one if the page is visited for
+     * the first time, or by updating an existing one if the user has already
+     * visited the page.
+     *
+     * @param Request $request
+     *
+     * @return JsonResponse
+     */
+    public function postAction(Request $request)
+    {
+        $history = json_decode($request->getContent(), true);
+
+        $historyItem = $this->findOrCreate($this->getUser(), $history['url']);
+        $historyItem->setTitle(json_encode($history['title']));
+        $historyItem->doUpdate();
+
+        $this->saver->save($historyItem);
+
+        return new JsonResponse();
+    }
+
+    /**
+     * @return UserInterface|string
+     */
+    protected function getUser()
+    {
+        return $this->tokenStorage->getToken()->getUser();
+    }
+
+    /**
+     * Returns an existing history item, finding it by URL and user,
+     * or creates and returns a new one.
+     *
+     * @param UserInterface $user
+     * @param string        $url
+     *
+     * @return NavigationItemInterface
+     */
+    protected function findOrCreate(UserInterface $user, $url)
+    {
+        $historyItem = $this->repository->findOneBy([
+            'user' => $user,
+            'url'  => $url,
+        ]);
+
+        if (null === $historyItem) {
+            $historyItem = $this->itemFactory->createItem(
+                NavigationHistoryItem::NAVIGATION_HISTORY_ITEM_TYPE,
+                [
+                    'user' => $user,
+                    'url'  => $url,
+                ]
+            );
+        }
+
+        return $historyItem;
+    }
+}

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/controllers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/controllers.yml
@@ -28,6 +28,7 @@ parameters:
     pim_enrich.controller.rest.family.class:             Pim\Bundle\EnrichBundle\Controller\Rest\FamilyController
     pim_enrich.controller.rest.form_extension.class:     Pim\Bundle\EnrichBundle\Controller\Rest\FormExtensionController
     pim_enrich.controller.rest.group.class:              Pim\Bundle\EnrichBundle\Controller\Rest\GroupController
+    pim_enrich.controller.rest.navigation_history.class: Pim\Bundle\EnrichBundle\Controller\Rest\NavigationHistoryController
     pim_enrich.controller.rest.locale.class:             Pim\Bundle\EnrichBundle\Controller\Rest\LocaleController
     pim_enrich.controller.rest.measures.class:           Pim\Bundle\EnrichBundle\Controller\Rest\MeasuresController
     pim_enrich.controller.rest.media.class:              Pim\Bundle\EnrichBundle\Controller\Rest\MediaController
@@ -376,6 +377,14 @@ services:
             - '@pim_catalog.repository.group'
             - '@pim_catalog.repository.product'
             - '@pim_internal_api_serializer'
+
+    pim_enrich.controller.rest.navigation_history:
+        class: '%pim_enrich.controller.rest.navigation_history.class%'
+        arguments:
+            - '@security.token_storage'
+            - '@pim_navigation.repository.navigation_history'
+            - '@oro_navigation.item.factory'
+            - '@pim_navigation.saver.navigation_history_item'
 
     pim_enrich.controller.rest.locale:
         class: %pim_enrich.controller.rest.locale.class%

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
@@ -136,6 +136,7 @@ config:
         pim/group-manager:                  pimenrich/js/manager/group-manager
         pim/attribute-manager:              pimenrich/js/manager/attribute-manager
         pim/attribute-group-manager:        pimenrich/js/manager/attribute-group-manager
+        pim/history-item-manager:           pimenrich/js/manager/history-item-manager
 
         # Fetcher
         pim/fetcher-registry:               pimenrich/js/fetcher/fetcher-registry

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/routing.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/routing.yml
@@ -77,3 +77,7 @@ form_extensions:
 media_rest:
     resource: '@PimEnrichBundle/Resources/config/routing/media_rest.yml'
     prefix: /rest/media
+
+navigation_history_rest:
+    resource: '@PimEnrichBundle/Resources/config/routing/navigation_history.yml'
+    prefix: /rest/navigation-history

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/routing/navigation_history.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/routing/navigation_history.yml
@@ -1,0 +1,4 @@
+pim_enrich_navigation_history_rest_post:
+    path: /
+    defaults: { _controller: pim_enrich.controller.rest.navigation_history:postAction, _format: json }
+    methods: [POST]

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/manager/history-item-manager.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/manager/history-item-manager.js
@@ -1,0 +1,27 @@
+'use strict';
+/**
+ * @author    Damien Carcel <damien.carcel@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+define(
+    ['jquery', 'routing'],
+    function ($, Routing) {
+        return {
+            /**
+             * Saves a history item.
+             *
+             * @param {string} url
+             * @param {Object} title
+             */
+            save: function (url, title) {
+                return $.post(
+                    Routing.generate('pim_enrich_navigation_history_rest_post'),
+                    JSON.stringify({url: url, title: title}),
+                    null,
+                    'json'
+                );
+            }
+        };
+    }
+);

--- a/src/Pim/Bundle/EnrichBundle/Resources/views/Product/edit.html.twig
+++ b/src/Pim/Bundle/EnrichBundle/Resources/views/Product/edit.html.twig
@@ -53,8 +53,30 @@
                     </div>
                     <script>
                         require(
-                            ['jquery', 'pim/fetcher-registry', 'pim/form-builder', 'pim/product-manager', 'pim/user-context', 'pim/dialog', 'oro/mediator', 'pim/error', 'oro/navigation'],
-                            function($, FetcherRegistry, FormBuilder, ProductManager, UserContext, Dialog, mediator, Error, Navigation) {
+                            [
+                                'jquery',
+                                'pim/fetcher-registry',
+                                'pim/form-builder',
+                                'pim/product-manager',
+                                'pim/user-context',
+                                'pim/dialog',
+                                'oro/mediator',
+                                'pim/error',
+                                'oro/navigation',
+                                'pim/history-item-manager'
+                            ],
+                            function(
+                                $,
+                                FetcherRegistry,
+                                FormBuilder,
+                                ProductManager,
+                                UserContext,
+                                Dialog,
+                                mediator,
+                                Error,
+                                Navigation,
+                                HistoryItemManager
+                            ) {
                                 $(function() {
                                     FetcherRegistry.initialize().done(function () {
                                         ProductManager.get('{{ productId }}')
@@ -68,6 +90,7 @@
                                                 navTitle.params = {'%product.sku%': sku};
                                                 navigation.setPinButtonsData('title', navTitle);
                                                 navigation.setPinButtonsData('title-rendered-short', newTitle);
+                                                HistoryItemManager.save(navigation.url, navTitle);
 
                                                 FormBuilder.build(product.meta.form)
                                                     .then(function (form) {

--- a/src/Pim/Bundle/NavigationBundle/DependencyInjection/PimNavigationExtension.php
+++ b/src/Pim/Bundle/NavigationBundle/DependencyInjection/PimNavigationExtension.php
@@ -24,6 +24,9 @@ class PimNavigationExtension extends Extension
     public function load(array $configs, ContainerBuilder $container)
     {
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('entities.yml');
         $loader->load('providers.yml');
+        $loader->load('repositories.yml');
+        $loader->load('savers.yml');
     }
 }

--- a/src/Pim/Bundle/NavigationBundle/Resources/config/entities.yml
+++ b/src/Pim/Bundle/NavigationBundle/Resources/config/entities.yml
@@ -1,0 +1,2 @@
+parameters:
+    oro_navigation.entity.navigation_history_item.class: Oro\Bundle\NavigationBundle\Entity\NavigationHistoryItem

--- a/src/Pim/Bundle/NavigationBundle/Resources/config/repositories.yml
+++ b/src/Pim/Bundle/NavigationBundle/Resources/config/repositories.yml
@@ -1,0 +1,10 @@
+parameters:
+    oro_navigation.repository.navigation_history.class: Oro\Bundle\NavigationBundle\Entity\Repository\HistoryItemRepository
+
+services:
+    pim_navigation.repository.navigation_history:
+        class: '%oro_navigation.repository.navigation_history.class%'
+        factory: ['@doctrine.orm.entity_manager', 'getRepository']
+        arguments: ['%oro_navigation.entity.navigation_history_item.class%']
+        tags:
+            - { name: 'pim_repository' }

--- a/src/Pim/Bundle/NavigationBundle/Resources/config/savers.yml
+++ b/src/Pim/Bundle/NavigationBundle/Resources/config/savers.yml
@@ -1,0 +1,8 @@
+services:
+    pim_navigation.saver.navigation_history_item:
+        class: '%pim_catalog.saver.base.class%'
+        arguments:
+            - '@doctrine.orm.entity_manager'
+            - '@akeneo_storage_utils.saver.base_options_resolver'
+            - '@event_dispatcher'
+            - '%oro_navigation.entity.navigation_history_item.class%'


### PR DESCRIPTION
**Description**

In the history tab of the pinbar, after visiting a product page, one can see the text “Products %product.sku% | Edit” (see the screenshot below).

![image](https://cloud.githubusercontent.com/assets/5039018/15858916/214e6454-2cc3-11e6-8b3a-073298c1213b.png)

“%product.sku%” is not replaced by the real product SKU because the ProductController returns only the product ID (directly from the request), then all other product data are retrieved through AJAX requests.

This PR fixes this issue by providing to the template the product SKU (and only the SKU) in addition to the ID, so the history is correctly generated.

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | No
| Added Behats                      | Yes
| Changelog updated                 | Yes
| Review and 2 GTM                  | Pending
| Micro Demo to the PO (Story only) | N/A
| Migration script                  | No
| Tech Doc                          | No