### PR TITLE
TIP-400: PIM compatible with PHP 5.6

### DIFF
--- a/app/check.php
+++ b/app/check.php
@@ -12,7 +12,7 @@ echo '> PHP is using the following php.ini file:'.PHP_EOL;
 if ($iniPath) {
     echo_style('green', '  '.$iniPath);
 } else {
-    echo_style('warning', '  WARNING: No configuration file (php.ini) used by PHP!');
+    echo_style('yellow', '  WARNING: No configuration file (php.ini) used by PHP!');
 }
 
 echo PHP_EOL.PHP_EOL;

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     },
     "require": {
-        "php": ">=5.4.4",
+        "php": ">=5.6.0",
         "akeneo/measure-bundle": "0.5.0",
         "apy/jsfv-bundle": "2.0.1",
         "ass/xmlsecurity": "1.1.1",


### PR DESCRIPTION
As we upgraded PHP version from 5.4 to 5.6. We apply those modifications on travis and composer.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       |
| Added Behats                      |
| Changelog updated                 |
| Review and 2 GTM                  |
| Micro Demo to the PO (Story only) |
| Migration script                  |
| Tech Doc                          |
