### PR TITLE
PIM-5850: Update help for akeneo:batch:job command

### DIFF
--- a/src/Akeneo/Bundle/BatchBundle/Command/BatchCommand.php
+++ b/src/Akeneo/Bundle/BatchBundle/Command/BatchCommand.php
@@ -38,8 +38,7 @@ class BatchCommand extends ContainerAwareCommand
                 'c',
                 InputOption::VALUE_REQUIRED,
                 'Override job configuration (formatted as json. ie: ' .
-                'php app/console akeneo:batch:job -c \'[{"reader":{"filePath":"/tmp/foo.csv"}}]\' ' .
-                'acme_product_import)'
+                'php app/console akeneo:batch:job -c "{\"filePath\":\"/tmp/foo.csv\"}" acme_product_import)'
             )
             ->addOption(
                 'email',
@@ -68,7 +67,11 @@ class BatchCommand extends ContainerAwareCommand
         }
 
         $code = $input->getArgument('code');
-        $jobInstance = $this->getJobManager()->getRepository('Akeneo\Component\Batch\Model\JobInstance')->findOneByCode($code);
+        $jobInstance = $this
+            ->getJobManager()
+            ->getRepository('Akeneo\Component\Batch\Model\JobInstance')
+            ->findOneByCode($code);
+
         if (!$jobInstance) {
             throw new \InvalidArgumentException(sprintf('Could not find job instance "%s".', $code));
         }


### PR DESCRIPTION
**Description**

Help for the "config" option is wrong. It currently displays the following message:

```-c, --config=CONFIG      Override job configuration (formatted as json. ie: php app/console akeneo:batch:job -c '[{"reader":{"filePath":"/tmp/foo.csv"}}]' acme_product_import)```

The JSON syntax is wrong and should be `"{\"filePath\":\"/tmp/foo.csv\"}"`

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | No
| Added Behats                      | No
| Changelog updated                 | No
| Review and 2 GTM                  | Pending
| Micro Demo to the PO (Story only) | N/A
| Migration script                  | No
| Tech Doc                          | No

