### PR TITLE
[WIP][POC] PIM-5809: ajaxify the export builder content tab

### DIFF
--- a/src/Pim/Bundle/BaseConnectorBundle/Processor/ProductToFlatArrayProcessor.php
+++ b/src/Pim/Bundle/BaseConnectorBundle/Processor/ProductToFlatArrayProcessor.php
@@ -59,7 +59,7 @@ class ProductToFlatArrayProcessor extends AbstractConfigurableStepElement implem
     public function process($product)
     {
         $parameters = $this->stepExecution->getJobParameters();
-        $channelCode = $parameters->get('channel');
+        $channelCode = json_decode($parameters->get('filters'), true)['structure']['scope'];
         $contextChannel = $this->channelRepository->findOneByIdentifier($channelCode);
         $this->productBuilder->addMissingProductValues(
             $product,
@@ -106,7 +106,7 @@ class ProductToFlatArrayProcessor extends AbstractConfigurableStepElement implem
 
         $normalizerContext = [
             'scopeCode'         => $channel->getCode(),
-            'localeCodes'       => array_intersect($channel->getLocaleCodes(), $parameters->get('locales')),
+            'localeCodes'       => array_intersect($channel->getLocaleCodes(), json_decode($parameters->get('filters'), true)['structure']['locales']),
             'decimal_separator' => $decimalSeparator,
             'date_format'       => $dateFormat,
         ];

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/AbstractAttributeFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/AbstractAttributeFilter.php
@@ -31,16 +31,16 @@ abstract class AbstractAttributeFilter extends AbstractFilter implements Attribu
      */
     protected function checkLocaleAndScope(AttributeInterface $attribute, $locale, $scope, $type)
     {
-        try {
-            $this->attrValidatorHelper->validateLocale($attribute, $locale);
-            $this->attrValidatorHelper->validateScope($attribute, $scope);
-        } catch (\LogicException $e) {
-            throw InvalidArgumentException::expectedFromPreviousException(
-                $e,
-                $attribute->getCode(),
-                'filter',
-                $type
-            );
-        }
+        // try {
+        //     $this->attrValidatorHelper->validateLocale($attribute, $locale);
+        //     $this->attrValidatorHelper->validateScope($attribute, $scope);
+        // } catch (\LogicException $e) {
+        //     throw InvalidArgumentException::expectedFromPreviousException(
+        //         $e,
+        //         $attribute->getCode(),
+        //         'filter',
+        //         $type
+        //     );
+        // }
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Join/ValueJoin.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Join/ValueJoin.php
@@ -43,20 +43,20 @@ class ValueJoin
     {
         $condition = $joinAlias.'.attribute = '.$attribute->getId();
 
-        if ($attribute->isLocalizable() && null === $locale) {
-            throw new \InvalidArgumentException(
-                sprintf('Cannot prepare condition on localizable attribute "%s" without locale', $attribute->getCode())
-            );
-        }
+        // if ($attribute->isLocalizable() && null === $locale) {
+        //     throw new \InvalidArgumentException(
+        //         sprintf('Cannot prepare condition on localizable attribute "%s" without locale', $attribute->getCode())
+        //     );
+        // }
         if ($attribute->isLocalizable()) {
             $condition .= ' AND '.$joinAlias.'.locale = '.$this->qb->expr()->literal($locale);
         }
 
-        if ($attribute->isScopable() && null === $scope) {
-            throw new \InvalidArgumentException(
-                sprintf('Cannot prepare condition on scopable attribute "%s" without scope', $attribute->getCode())
-            );
-        }
+        // if ($attribute->isScopable() && null === $scope) {
+        //     throw new \InvalidArgumentException(
+        //         sprintf('Cannot prepare condition on scopable attribute "%s" without scope', $attribute->getCode())
+        //     );
+        // }
         if ($attribute->isScopable()) {
             $condition .= ' AND '.$joinAlias.'.scope = '.$this->qb->expr()->literal($scope);
         }

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/FamilyController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/FamilyController.php
@@ -51,9 +51,16 @@ class FamilyController
      */
     public function indexAction(Request $request)
     {
+        $options = $request->query->get('options', ['limit' => 20]);
+
+        if ($request->request->has('identifiers')) {
+            $this->familySearchableRepo->findBySearch();
+            $options['identifiers'] = explode(',', $request->request->get('identifiers'));
+        }
+
         $families = $this->familySearchableRepo->findBySearch(
             $request->query->get('search'),
-            $request->query->get('options', ['limit' => 20])
+            $options
         );
 
         $normalizedFamilies = [];

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/FormExtensionController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/FormExtensionController.php
@@ -33,7 +33,8 @@ class FormExtensionController
         return new JsonResponse(
             [
                 'extensions'       => $this->extensionProvider->getExtensions(),
-                'attribute_fields' => $this->extensionProvider->getAttributeFields()
+                'attribute_fields' => $this->extensionProvider->getAttributeFields(),
+                'filters'          => $this->extensionProvider->getFilters()
             ]
         );
     }

--- a/src/Pim/Bundle/EnrichBundle/DependencyInjection/Compiler/RegisterFormExtensionsPass.php
+++ b/src/Pim/Bundle/EnrichBundle/DependencyInjection/Compiler/RegisterFormExtensionsPass.php
@@ -33,6 +33,7 @@ class RegisterFormExtensionsPass implements CompilerPassInterface
 
         $extensionConfig = [];
         $attributeFields = [];
+        $filters         = [];
         $files = $this->listConfigFiles($container);
 
         foreach ($files as $file) {
@@ -43,6 +44,9 @@ class RegisterFormExtensionsPass implements CompilerPassInterface
             if (isset($config['attribute_fields']) && is_array($config['attribute_fields'])) {
                 $attributeFields = array_merge($attributeFields, $config['attribute_fields']);
             }
+            if (isset($config['filters']) && is_array($config['filters'])) {
+                $filters = array_merge($filters, $config['filters']);
+            }
             $container->addResource(new FileResource($file->getPathName()));
         }
 
@@ -52,6 +56,10 @@ class RegisterFormExtensionsPass implements CompilerPassInterface
 
         foreach ($attributeFields as $attributeType => $module) {
             $providerDefinition->addMethodCall('addAttributeField', [$attributeType, $module]);
+        }
+
+        foreach ($filters as $filter => $module) {
+            $providerDefinition->addMethodCall('addFilter', [$filter, $module]);
         }
     }
 

--- a/src/Pim/Bundle/EnrichBundle/Provider/FormExtensionProvider.php
+++ b/src/Pim/Bundle/EnrichBundle/Provider/FormExtensionProvider.php
@@ -19,6 +19,9 @@ class FormExtensionProvider
     /** @var array */
     protected $attributeFields = [];
 
+    /** @var array */
+    protected $filters = [];
+
     /** @var SecurityFacade */
     protected $securityFacade;
 
@@ -90,5 +93,22 @@ class FormExtensionProvider
     public function getAttributeFields()
     {
         return $this->attributeFields;
+    }
+
+    /**
+     * @param string $filter
+     * @param string $config
+     */
+    public function addFilter($filter, $config)
+    {
+        $this->filters[$filter] = $config;
+    }
+
+    /**
+     * @return array
+     */
+    public function getFilters()
+    {
+        return $this->filters;
     }
 }

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/filters.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/filters.yml
@@ -16,3 +16,6 @@ extensions:
 
     pim-filter-product-updated:
         module: pim/filter/product/updated
+
+    pim-filter-simpleselect:
+        module: pim/filter/simpleselect

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/filters.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/filters.yml
@@ -10,3 +10,6 @@ extensions:
                 - NOT IN
                 - EMPTY
                 - NOT EMPTY
+
+    pim-filter-product-enabled:
+        module: pim/filter/product/enabled

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/filters.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/filters.yml
@@ -1,3 +1,12 @@
 extensions:
     pim-filter-text:
         module: pim/filter/text
+
+    pim-filter-product-family:
+        module: pim/filter/product/family
+        config:
+            operators: #Maybe we can create a method to get that from the back (not sure)
+                - IN
+                - NOT IN
+                - EMPTY
+                - NOT EMPTY

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/filters.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/filters.yml
@@ -1,0 +1,3 @@
+extensions:
+    pim-filter-text:
+        module: pim/filter/text

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/filters.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/filters.yml
@@ -13,3 +13,6 @@ extensions:
 
     pim-filter-product-enabled:
         module: pim/filter/product/enabled
+
+    pim-filter-product-updated:
+        module: pim/filter/product/updated

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_export_product_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_export_product_edit.yml
@@ -39,8 +39,11 @@ extensions:
                     field: completeness
                     view: pim-filter-text
                 -
-                    field: family
+                    field: family.code
                     view: pim-filter-product-family
+                -
+                    field: updated
+                    view: pim-filter-product-updated
 
     pim-product-export-edit-content-data-add-filter:
         module: pim/product-edit-form/attributes/add-attribute #to change

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_export_product_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_export_product_edit.yml
@@ -33,8 +33,8 @@ extensions:
         config:
             filters:
                 -
-                    field: status
-                    view: pim-filter-text
+                    field: enabled
+                    view: pim-filter-product-enabled
                 -
                     field: completeness
                     view: pim-filter-text

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_export_product_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_export_product_edit.yml
@@ -40,7 +40,7 @@ extensions:
                     view: pim-filter-text
                 -
                     field: family
-                    view: pim-filter-text
+                    view: pim-filter-product-family
 
     pim-product-export-edit-content-data-add-filter:
         module: pim/product-edit-form/attributes/add-attribute #to change

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_export_product_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_export_product_edit.yml
@@ -75,8 +75,7 @@ filters:
             view: pim-filter-text
             # view: pim-filter-multiselect
         pim_catalog_simpleselect:
-            view: pim-filter-text
-            # view: pim-filter-simpleselect
+            view: pim-filter-simpleselect
         pim_catalog_date:
             view: pim-filter-text
             # view: pim-filter-date
@@ -84,8 +83,7 @@ filters:
             view: pim-filter-text
             # view: pim-filter-boolean
         pim_reference_data_simpleselect: #to move in reference data bundle
-            view: pim-filter-text
-            # view: pim-filter-simpleselect
+            view: pim-filter-simpleselect
         pim_reference_data_multiselect:
             view: pim-filter-text
             # view: pim-filter-multiselect

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_export_product_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_export_product_edit.yml
@@ -1,0 +1,90 @@
+extensions:
+    pim-product-export-edit-content:
+        module: pim/export/product/edit/content
+
+    pim-product-export-edit-content-structure:
+        module: pim/export/product/edit/content/structure
+        parent: pim-product-export-edit-content
+        targetZone: structure-filters
+        position: 100
+
+    pim-product-export-edit-content-structure-scope:
+        module: pim/export/product/edit/content/structure/scope
+        parent: pim-product-export-edit-content-structure
+        targetZone: filters
+        position: 90
+
+    pim-product-export-edit-content-structure-locales:
+        module: pim/export/product/edit/content/structure/locales
+        parent: pim-product-export-edit-content-structure
+        targetZone: filters
+        position: 100
+
+    pim-product-export-edit-content-structure-attributes:
+        module: pim/export/product/edit/content/structure/attributes
+        parent: pim-product-export-edit-content-structure
+        targetZone: filters
+        position: 110
+
+    pim-product-export-edit-content-data:
+        module: pim/export/product/edit/content/data
+        parent: pim-product-export-edit-content
+        targetZone: data-filters
+        config:
+            filters:
+                -
+                    field: status
+                    view: pim-filter-text
+                -
+                    field: completeness
+                    view: pim-filter-text
+                -
+                    field: family
+                    view: pim-filter-text
+
+    pim-product-export-edit-content-data-add-filter:
+        module: pim/product-edit-form/attributes/add-attribute #to change
+        parent: pim-product-export-edit-content-data
+        targetZone: headings
+
+filters:
+    pim-product-export-edit-content:
+        pim_catalog_text:
+            view: pim-filter-text
+        pim_catalog_number:
+            view: pim-filter-text
+            # view: pim-filter-number
+        pim_catalog_textarea:
+            view: pim-filter-text
+        pim_catalog_identifier:
+            view: pim-filter-text
+        pim_catalog_metric:
+            view: pim-filter-text
+            # view: pim-filter-metric
+        pim_catalog_price_collection:
+            view: pim-filter-text
+            # view: pim-filter-price
+        pim_catalog_image:
+            view: pim-filter-text
+        pim_catalog_file:
+            view: pim-filter-text
+        pim_catalog_multiselect:
+            view: pim-filter-text
+            # view: pim-filter-multiselect
+        pim_catalog_simpleselect:
+            view: pim-filter-text
+            # view: pim-filter-simpleselect
+        pim_catalog_date:
+            view: pim-filter-text
+            # view: pim-filter-date
+        pim_catalog_boolean:
+            view: pim-filter-text
+            # view: pim-filter-boolean
+        pim_reference_data_simpleselect: #to move in reference data bundle
+            view: pim-filter-text
+            # view: pim-filter-simpleselect
+        pim_reference_data_multiselect:
+            view: pim-filter-text
+            # view: pim-filter-multiselect
+
+#Lorsqu'on ajoute un attribute il regarde son type normalizé. il fait appel au configProvider->getFilters() à partir de là il récupère son module et le load avec le form registry

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
@@ -199,7 +199,8 @@ config:
         pim/export/product/edit/content/structure:                 pimenrich/js/export/product/edit/content/structure
 
         # Filters
-        pim/filter/text: pimenrich/js/filter/text
+        pim/filter/text:           pimenrich/js/filter/text
+        pim/filter/product/family: pimenrich/js/filter/product/family
 
         # Product edit form
         pim/product-edit-form:              pimenrich/js/product/edit-form
@@ -298,4 +299,5 @@ config:
         pim/template/export/product/edit/content/structure/attributes: pimenrich/templates/export/product/edit/content/structure/attributes.html
 
         # Filters
-        pim/template/filter/text: pimenrich/templates/filter/text
+        pim/template/filter/text:           pimenrich/templates/filter/text.html
+        pim/template/filter/product/family: pimenrich/templates/filter/product/family.html

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
@@ -203,6 +203,7 @@ config:
         pim/filter/text:            pimenrich/js/filter/text
         pim/filter/product/family:  pimenrich/js/filter/product/family
         pim/filter/product/enabled: pimenrich/js/filter/product/enabled
+        pim/filter/product/updated: pimenrich/js/filter/product/updated
 
         # Product edit form
         pim/product-edit-form:              pimenrich/js/product/edit-form
@@ -304,3 +305,4 @@ config:
         pim/template/filter/text:            pimenrich/templates/filter/text.html
         pim/template/filter/product/family:  pimenrich/templates/filter/product/family.html
         pim/template/filter/product/enabled: pimenrich/templates/filter/product/enabled.html
+        pim/template/filter/product/updated: pimenrich/templates/filter/product/updated.html

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
@@ -199,8 +199,10 @@ config:
         pim/export/product/edit/content/structure:                 pimenrich/js/export/product/edit/content/structure
 
         # Filters
-        pim/filter/text:           pimenrich/js/filter/text
-        pim/filter/product/family: pimenrich/js/filter/product/family
+        pim/filter/filter:          pimenrich/js/filter/filter
+        pim/filter/text:            pimenrich/js/filter/text
+        pim/filter/product/family:  pimenrich/js/filter/product/family
+        pim/filter/product/enabled: pimenrich/js/filter/product/enabled
 
         # Product edit form
         pim/product-edit-form:              pimenrich/js/product/edit-form
@@ -299,5 +301,6 @@ config:
         pim/template/export/product/edit/content/structure/attributes: pimenrich/templates/export/product/edit/content/structure/attributes.html
 
         # Filters
-        pim/template/filter/text:           pimenrich/templates/filter/text.html
-        pim/template/filter/product/family: pimenrich/templates/filter/product/family.html
+        pim/template/filter/text:            pimenrich/templates/filter/text.html
+        pim/template/filter/product/family:  pimenrich/templates/filter/product/family.html
+        pim/template/filter/product/enabled: pimenrich/templates/filter/product/enabled.html

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
@@ -201,6 +201,7 @@ config:
         # Filters
         pim/filter/filter:          pimenrich/js/filter/filter
         pim/filter/text:            pimenrich/js/filter/text
+        pim/filter/simpleselect:    pimenrich/js/filter/simpleselect
         pim/filter/product/family:  pimenrich/js/filter/product/family
         pim/filter/product/enabled: pimenrich/js/filter/product/enabled
         pim/filter/product/updated: pimenrich/js/filter/product/updated
@@ -303,6 +304,7 @@ config:
 
         # Filters
         pim/template/filter/text:            pimenrich/templates/filter/text.html
+        pim/template/filter/simpleselect:    pimenrich/templates/filter/simpleselect.html
         pim/template/filter/product/family:  pimenrich/templates/filter/product/family.html
         pim/template/filter/product/enabled: pimenrich/templates/filter/product/enabled.html
         pim/template/filter/product/updated: pimenrich/templates/filter/product/updated.html

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
@@ -191,6 +191,16 @@ config:
         pim/product-edit-form/download-pdf:                        pimenrich/js/product/form/download-pdf
         pim/product-edit-form/back-to-grid:                        pimenrich/js/product/form/back-to-grid
 
+        pim/export/product/edit/content/structure/scope:           pimenrich/js/export/product/edit/content/structure/scope
+        pim/export/product/edit/content/structure/locales:         pimenrich/js/export/product/edit/content/structure/locales
+        pim/export/product/edit/content/structure/attributes:      pimenrich/js/export/product/edit/content/structure/attributes
+        pim/export/product/edit/content:                           pimenrich/js/export/product/edit/content
+        pim/export/product/edit/content/data:                      pimenrich/js/export/product/edit/content/data
+        pim/export/product/edit/content/structure:                 pimenrich/js/export/product/edit/content/structure
+
+        # Filters
+        pim/filter/text: pimenrich/js/filter/text
+
         # Product edit form
         pim/product-edit-form:              pimenrich/js/product/edit-form
         pim/field-manager:                  pimenrich/js/product/field-manager
@@ -278,3 +288,14 @@ config:
         pim/template/attribute/add-attribute-footer:                 pimenrich/templates/attribute/add-attribute-footer.html
         pim/template/i18n/flag:                                      pimenrich/templates/i18n/flag.html
         pim/template/error/error:                                    pimenrich/templates/error/error.html
+
+        # Exports
+        pim/template/export/product/edit/content:                      pimenrich/templates/export/product/edit/content.html
+        pim/template/export/product/edit/content/data:                 pimenrich/templates/export/product/edit/content/data.html
+        pim/template/export/product/edit/content/structure:            pimenrich/templates/export/product/edit/content/structure.html
+        pim/template/export/product/edit/content/structure/scope:      pimenrich/templates/export/product/edit/content/structure/scope.html
+        pim/template/export/product/edit/content/structure/locales:    pimenrich/templates/export/product/edit/content/structure/locales.html
+        pim/template/export/product/edit/content/structure/attributes: pimenrich/templates/export/product/edit/content/structure/attributes.html
+
+        # Filters
+        pim/template/filter/text: pimenrich/templates/filter/text

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/export/product/edit/content.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/export/product/edit/content.js
@@ -1,0 +1,65 @@
+'use strict';
+/**
+ * Content form
+ *
+ * @author    Julien Sanchez <julien@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+define(
+    [
+        'module',
+        'underscore',
+        'backbone',
+        'text!pim/template/export/product/edit/content',
+        'pim/form',
+        'oro/mediator',
+        'pim/fetcher-registry',
+        'pim/field-manager'
+    ],
+    function (
+        module,
+        _,
+        Backbone,
+        template,
+        BaseForm,
+        mediator,
+        FetcherRegistry,
+        FieldManager
+    ) {
+        return BaseForm.extend({
+            template: _.template(template),
+            configure: function () {
+                mediator.clear('pim_enrich:form');
+                Backbone.Router.prototype.once('route', this.unbindEvents);
+
+                if (_.has(module.config(), 'forwarded-events')) {
+                    this.forwardMediatorEvents(module.config()['forwarded-events']);
+                }
+
+                return BaseForm.prototype.configure.apply(this, arguments);
+            },
+            render: function () {
+                if (!this.configured) {
+                    return this;
+                }
+                this.getRoot().trigger('pim_enrich:form:render:before');
+
+                this.$el.html(
+                    this.template({})
+                );
+
+                this.renderExtensions();
+
+                this.getRoot().trigger('pim_enrich:form:render:after');
+            },
+            unbindEvents: function () {
+                mediator.clear('pim_enrich:form');
+            },
+            clearCache: function () {
+                FetcherRegistry.clearAll();
+                this.render();
+            }
+        });
+    }
+);

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/export/product/edit/content/data.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/export/product/edit/content/data.js
@@ -31,7 +31,7 @@ define(
                 //change that after variant group merge
                 this.config = config || {
                     filters: [
-                        {field: 'enabled', view: 'pim-filter-text'},
+                        {field: 'enabled', view: 'pim-filter-product-enabled'},
                         {field: 'completeness', view: 'pim-filter-text'},
                         {field: 'family.code', view: 'pim-filter-product-family'}
                     ]

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/export/product/edit/content/data.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/export/product/edit/content/data.js
@@ -33,7 +33,7 @@ define(
                     filters: [
                         {field: 'enabled', view: 'pim-filter-text'},
                         {field: 'completeness', view: 'pim-filter-text'},
-                        {field: 'family.code', view: 'pim-filter-text'}
+                        {field: 'family.code', view: 'pim-filter-product-family'}
                     ]
                 };
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/export/product/edit/content/data.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/export/product/edit/content/data.js
@@ -33,7 +33,8 @@ define(
                     filters: [
                         {field: 'enabled', view: 'pim-filter-product-enabled'},
                         {field: 'completeness', view: 'pim-filter-text'},
-                        {field: 'family.code', view: 'pim-filter-product-family'}
+                        {field: 'family.code', view: 'pim-filter-product-family'},
+                        {field: 'updated', view: 'pim-filter-product-updated'}
                     ]
                 };
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/export/product/edit/content/data.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/export/product/edit/content/data.js
@@ -89,7 +89,8 @@ define(
                             filterConfig = {
                                 field: attribute.code,
                                 view: config[attribute.type].view,
-                                removable: true
+                                removable: true,
+                                context: {attribute: attribute}
                             };
                         }
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/export/product/edit/content/data.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/export/product/edit/content/data.js
@@ -1,0 +1,155 @@
+'use strict';
+/**
+ * Data section
+ *
+ * @author    Julien Sanchez <julien@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+define(
+    [
+        'underscore',
+        'text!pim/template/export/product/edit/content/data',
+        'pim/form',
+        'pim/fetcher-registry',
+        'pim/form-config-provider',
+        'pim/form-builder'
+    ],
+    function (
+        _,
+        template,
+        BaseForm,
+        fetcherRegistry,
+        configProvider,
+        formBuilder
+    ) {
+        return BaseForm.extend({
+            filterDataCollection: [],
+            filterViews: {},
+            template: _.template(template),
+            initialize: function (config) {
+                //change that after variant group merge
+                this.config = config || {
+                    filters: [
+                        {field: 'enabled', view: 'pim-filter-text'},
+                        {field: 'completeness', view: 'pim-filter-text'},
+                        {field: 'family.code', view: 'pim-filter-text'}
+                    ]
+                };
+
+
+                BaseForm.prototype.initialize.apply(this, arguments);
+            },
+            configure: function () {
+                this.onExtensions('add-attribute:add', function (event) {
+                    this.addFilters(event.codes);
+                }.bind(this));
+
+                $.when.apply($, _.map(this.config.filters, function (filter) {
+                    return this.addFilterView(filter.view, filter.field, false);
+                }.bind(this))).then(function () {
+                    this.render();
+                }.bind(this));
+
+                this.listenTo(this.getRoot(), 'pim_enrich:form:entity:post_update', this.updateFiltersData.bind(this));
+
+                BaseForm.prototype.configure.apply(this, arguments);
+            },
+            render: function () {
+                if (!this.configured) {
+                    return this;
+                }
+
+                this.$el.html(
+                    this.template({})
+                );
+
+                _.each(this.filterViews, function (filterView) {
+                    this.$('.filters').append(filterView.render().$el);
+                }.bind(this));
+
+                this.renderExtensions();
+            },
+            addFilters: function (fields) {
+                var fields = _.without(fields, _.keys(this.filterViews));
+
+                return $.when(
+                    fetcherRegistry.getFetcher('attribute').fetchByIdentifiers(fields),
+                    configProvider.getFilters(this.getRoot().code)
+                ).then(function (attributes, config) {
+                    return $.when.apply($, _.map(fields, function (field) {
+                        var attribute = _.findWhere(attributes, {code: field})
+                        var filterConfig = {};
+
+                        if (undefined === attribute) {
+                            filterConfig = _.findWhere(this.config.filters, {field: field});
+                            filterConfig.removable = false;
+                        } else {
+                            filterConfig = {
+                                field: attribute.code,
+                                view: config[attribute.type].view,
+                                removable: true
+                            };
+                        }
+
+                        return this.addFilterView(filterConfig.view, filterConfig.field, filterConfig.removable);
+                    }.bind(this)));
+                }.bind(this)).then(function () {
+                    this.render();
+                }.bind(this));
+            },
+            addFilterView: function (viewCode, fieldCode, removable) {
+                return formBuilder.build(viewCode).then(function(view) {
+                    view.setField(fieldCode);
+                    view.setRemovable(removable);
+
+                    return view;
+                }).then(function (filterView) {
+                    var filterData = _.findWhere(this.filterDataCollection, {field: filterView.getField()});
+                    if (null !== filterData) {
+                        filterView.setData(filterData);
+                    }
+
+                    this.listenTo(filterView, 'pim_enrich:form:entity:post_update', this.updateModel.bind(this));
+                    this.listenTo(filterView, 'filter:remove', this.removeFilter.bind(this));
+
+                    this.filterViews[filterView.getField()] = filterView;
+
+                    return filterView;
+                }.bind(this));
+            },
+            updateModel: function () {
+                this.filterDataCollection = [];
+
+                _.each(this.filterViews, function (filterView, code) {
+                    if (!_.isEmpty(filterView.getFormData())) {
+                        this.filterDataCollection.push(filterView.getFormData());
+                    }
+                }.bind(this));
+
+                var formData = this.getFormData();
+                formData.data = this.filterDataCollection;
+                this.setData(formData);
+            },
+            updateFiltersData: function () {
+                var fields = _.map(this.getFormData()['data'], function (filter) {
+                    return filter.field;
+                });
+
+                this.addFilters(fields).then(function () {
+                    _.each(this.getFormData()['data'], function (filterData) {
+                        var filterView = this.filterViews[filterData.field];
+
+                        filterView.setData(filterData, {silent: true}).render();
+                    }.bind(this));
+                }.bind(this));
+            },
+            removeFilter: function (field) {
+                delete this.filterViews[field];
+                this.updateModel();
+
+                this.render();
+            }
+        });
+    }
+);

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/export/product/edit/content/structure.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/export/product/edit/content/structure.js
@@ -1,0 +1,32 @@
+'use strict';
+/**
+ * Structure section
+ *
+ * @author    Julien Sanchez <julien@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+define(
+    [
+        'text!pim/template/export/product/edit/content/structure',
+        'pim/form'
+    ],
+    function (
+        template,
+        BaseForm
+    ) {
+        return BaseForm.extend({
+            template: _.template(template),
+            render: function () {
+                if (!this.configured) {
+                    return this;
+                }
+                this.$el.html(
+                    this.template({})
+                );
+
+                this.renderExtensions();
+            }
+        });
+    }
+);

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/export/product/edit/content/structure/attributes.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/export/product/edit/content/structure/attributes.js
@@ -1,0 +1,44 @@
+'use strict';
+/**
+ * Attributes structure filter
+ *
+ * @author    Julien Sanchez <julien@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+define(
+    [
+        'text!pim/template/export/product/edit/content/structure/attributes',
+        'pim/form'
+    ],
+    function (
+        template,
+        BaseForm
+    ) {
+        return BaseForm.extend({
+            template: _.template(template),
+            events: {
+                'change input': 'updateModel'
+            },
+            render: function () {
+                if (!this.configured) {
+                    return this;
+                }
+                this.$el.html(
+                    this.template({
+                        attributes: this.getFormData().structure.attributes || []
+                    })
+                );
+
+                this.delegateEvents();
+
+                this.renderExtensions();
+            },
+            updateModel: function() {
+                var data = this.getFormData();
+                data.structure.attributes = JSON.parse(event.target.value);
+                this.setData(data);
+            }
+        });
+    }
+);

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/export/product/edit/content/structure/locales.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/export/product/edit/content/structure/locales.js
@@ -1,0 +1,42 @@
+'use strict';
+/**
+ * Locale structure filter
+ *
+ * @author    Julien Sanchez <julien@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+define(
+    [
+        'text!pim/template/export/product/edit/content/structure/locales',
+        'pim/form'
+    ],
+    function (
+        template,
+        BaseForm
+    ) {
+        return BaseForm.extend({
+            template: _.template(template),
+            events: {
+                'change input': 'updateModel'
+            },
+            render: function () {
+                if (!this.configured) {
+                    return this;
+                }
+                this.$el.html(
+                    this.template({
+                        locales: this.getFormData().structure.locales || []
+                    })
+                );
+
+                this.renderExtensions();
+            },
+            updateModel: function() {
+                var data = this.getFormData();
+                data.structure.locales = JSON.parse(event.target.value);
+                this.setData(data);
+            }
+        });
+    }
+);

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/export/product/edit/content/structure/locales.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/export/product/edit/content/structure/locales.js
@@ -11,7 +11,7 @@ define(
         'text!pim/template/export/product/edit/content/structure/locales',
         'pim/form',
         'pim/fetcher-registry',
-        'pim/initselect2'
+        'jquery.select2'
     ],
     function (
         template,

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/export/product/edit/content/structure/locales.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/export/product/edit/content/structure/locales.js
@@ -9,33 +9,81 @@
 define(
     [
         'text!pim/template/export/product/edit/content/structure/locales',
-        'pim/form'
+        'pim/form',
+        'pim/fetcher-registry',
+        'pim/initselect2'
     ],
     function (
         template,
-        BaseForm
+        BaseForm,
+        fetcherRegistry
     ) {
         return BaseForm.extend({
             template: _.template(template),
-            events: {
-                'change input': 'updateModel'
+            configure: function () {
+                this.listenTo(this.getRoot(), 'channel:update:after', this.channelUpdated.bind(this));
+
+                return BaseForm.prototype.configure.apply(this, arguments);
             },
             render: function () {
                 if (!this.configured) {
                     return this;
                 }
-                this.$el.html(
-                    this.template({
-                        locales: this.getFormData().structure.locales || []
-                    })
-                );
 
-                this.renderExtensions();
+                var defaultLocalesPromise = (new $.Deferred()).resolve();
+                if (_.isEmpty(this.getLocales())) {
+                    defaultLocalesPromise = this.setDefaultLocales();
+                }
+
+                $.when(
+                    fetcherRegistry.getFetcher('channel').fetch(this.getFormData().structure.scope),
+                    defaultLocalesPromise
+                ).then(function (scope) {
+                    this.$el.html(
+                        this.template({
+                            locales: this.getLocales(),
+                            availableLocales: scope.locales
+                        })
+                    );
+
+                    this.$('.select2').select2().on('change', this.updateModel.bind(this));
+
+                    this.renderExtensions();
+                }.bind(this));
+
+                return this;
             },
-            updateModel: function() {
+            updateModel: function (event) {
+                this.setLocales($(event.target).val());
+            },
+            setLocales: function (codes) {
                 var data = this.getFormData();
-                data.structure.locales = JSON.parse(event.target.value);
+                var before = data.structure.locales;
+
+                data.structure.locales = codes;
                 this.setData(data);
+
+                if (before !== codes) {
+                    this.getRoot().trigger('locales:update:after', codes);
+                }
+            },
+            getLocales: function () {
+                return this.getFormData().structure.locales;
+            },
+            channelUpdated: function () {
+                this.setDefaultLocales()
+                    .then(function () {
+                        this.render();
+                    }.bind(this));
+            },
+            setDefaultLocales: function () {
+                return fetcherRegistry.getFetcher('channel')
+                    .fetch(this.getFormData().structure.scope)
+                    .then(function (scope) {
+                        this.setLocales(scope.locales);
+
+                        return;
+                    }.bind(this));
             }
         });
     }

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/export/product/edit/content/structure/scope.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/export/product/edit/content/structure/scope.js
@@ -12,7 +12,7 @@ define(
         'pim/form',
         'pim/fetcher-registry',
         'pim/user-context',
-        'pim/initselect2'
+        'jquery.select2'
     ],
     function (
         template,

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/export/product/edit/content/structure/scope.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/export/product/edit/content/structure/scope.js
@@ -1,0 +1,42 @@
+'use strict';
+/**
+ * Scope structure filter
+ *
+ * @author    Julien Sanchez <julien@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+define(
+    [
+        'text!pim/template/export/product/edit/content/structure/scope',
+        'pim/form'
+    ],
+    function (
+        template,
+        BaseForm
+    ) {
+        return BaseForm.extend({
+            template: _.template(template),
+            events: {
+                'change input': 'updateModel'
+            },
+            render: function () {
+                if (!this.configured) {
+                    return this;
+                }
+                this.$el.html(
+                    this.template({
+                        scope: this.getFormData().structure.scope || ''
+                    })
+                );
+
+                this.renderExtensions();
+            },
+            updateModel: function() {
+                var data = this.getFormData();
+                data.structure.scope = JSON.parse(event.target.value);
+                this.setData(data);
+            }
+        });
+    }
+);

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/filter.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/filter.js
@@ -1,0 +1,43 @@
+/* global console */
+'use strict';
+
+define([
+        'pim/form',
+    ], function (BaseForm) {
+    return BaseForm.extend({
+        removable: false,
+        setField: function (field) {
+            var data = this.getFormData();
+            data.field = field;
+            this.setData(data, {silent: true});
+        },
+        getField: function () {
+            return this.getFormData().field;
+        },
+        setOperator: function (operator) {
+            var data = this.getFormData();
+            data.operator = operator;
+            this.setData(data, {silent: true});
+        },
+        getOperator: function () {
+            return this.getFormData().operator;
+        },
+        setValue: function (value) {
+            var data = this.getFormData();
+            data.value = value;
+            this.setData(data, {silent: true});
+        },
+        getValue: function () {
+            return this.getFormData().value;
+        },
+        setRemovable: function (removable) {
+            this.removable = removable;
+        },
+        isRemovable: function () {
+            return this.removable;
+        },
+        removeFilter: function () {
+            this.trigger('filter:remove', this.getField());
+        }
+    });
+});

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/product/enabled.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/product/enabled.js
@@ -1,0 +1,61 @@
+/* global console */
+'use strict';
+
+define([
+        'pim/filter/filter',
+        'routing',
+        'text!pim/template/filter/product/enabled',
+        'pim/fetcher-registry',
+        'pim/user-context',
+        'pim/i18n',
+        'jquery.select2'
+    ], function (BaseFilter, Routing, template, fetcherRegistry, userContext, i18n, initSelect2) {
+    return BaseFilter.extend({
+        template: _.template(template),
+        removable: false,
+        events: {
+            'change [name="filter-value"]': 'updateState',
+            'click .remove': 'removeFilter'
+        },
+        render: function () {
+            this.$el.empty();
+
+            if (undefined === this.getValue()) {
+                this.setValue('');
+            }
+
+            this.$el.append(this.template({
+                field: this.getField(),
+                operator: this.getOperator(),
+                value: this.getValue(),
+                removable: this.isRemovable()
+            }));
+
+            this.$('[name="filter-value"]').select2();
+
+            this.delegateEvents();
+
+            return this;
+        },
+        updateState: function () {
+            var value = this.$('[name="filter-value"]').val();
+            switch (value) {
+                case 'all':
+                    value = null;
+                    break;
+                case 'true':
+                    value = true;
+                    break;
+                case 'false':
+                    value = false;
+                    break;
+            }
+
+            this.setData({
+                field: this.getField(),
+                operator: null === value ? '' : '=', //Maybe we should add an applyable parameter to disable a filter if we don't want to apply it instead of setting an empty operator
+                value: value
+            });
+        }
+    });
+});

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/product/enabled.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/product/enabled.js
@@ -2,6 +2,8 @@
 'use strict';
 
 define([
+        'underscore',
+        'oro/translator',
         'pim/filter/filter',
         'routing',
         'text!pim/template/filter/product/enabled',
@@ -9,7 +11,7 @@ define([
         'pim/user-context',
         'pim/i18n',
         'jquery.select2'
-    ], function (BaseFilter, Routing, template, fetcherRegistry, userContext, i18n, initSelect2) {
+    ], function (_, __, BaseFilter, Routing, template, fetcherRegistry, userContext, i18n, initSelect2) {
     return BaseFilter.extend({
         template: _.template(template),
         removable: false,
@@ -25,6 +27,7 @@ define([
             }
 
             this.$el.append(this.template({
+                __: __,
                 field: this.getField(),
                 operator: this.getOperator(),
                 value: this.getValue(),

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/product/enabled.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/product/enabled.js
@@ -1,6 +1,8 @@
 /* global console */
 'use strict';
 
+//Should be reworked to be a boolean filter
+
 define([
         'underscore',
         'oro/translator',

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/product/family.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/product/family.js
@@ -1,0 +1,142 @@
+/* global console */
+'use strict';
+
+define([
+        'pim/form',
+        'routing',
+        'text!pim/template/filter/product/family',
+        'pim/fetcher-registry',
+        'pim/user-context',
+        'pim/i18n',
+        'jquery.select2'
+    ], function (BaseForm, Routing, template, fetcherRegistry, userContext, i18n, initSelect2) {
+    return BaseForm.extend({
+        template: _.template(template),
+        removable: false,
+        events: {
+            'change [name="filter-operator"], [name="filter-value"]': 'updateState',
+            'click .remove': 'removeFilter'
+        },
+        initialize: function () {
+            this.config = { //To remove
+                operators: [
+                    'IN',
+                    'NOT IN',
+                    'EMPTY',
+                    'NOT EMPTY'
+                ],
+                url: 'pim_enrich_family_rest_index'
+            };
+
+            this.selectOptions = {
+                allowClear: true,
+                multiple: true,
+                ajax: {
+                    url: Routing.generate(this.config.url),
+                    quietMillis: 250,
+                    cache: true,
+                    data: function (term, page) {
+                        return {
+                            search: term,
+                            options: {
+                                limit: 20,
+                                page: page,
+                                locale: userContext.get('uiLocale')
+                            }
+                        };
+                    },
+                    results: function (families) {
+                        var data = {
+                            more: 20 === _.keys(families).length,
+                            results: []
+                        };
+                        _.each(families, function (value, key) {
+                            data.results.push({
+                                id: key,
+                                text: i18n.getLabel(value.label, userContext.get('uiLocale'), value.code)
+                            });
+                        });
+
+                        return data;
+                    }
+                },
+                initSelection: function (element, callback) {
+                    var families = this.getFormData().value;
+                    if (null !== families) {
+                        fetcherRegistry.getFetcher('family')
+                            .fetchByIdentifiers(families)
+                            .then(function (families) {
+                                callback(_.map(families, function (family) {
+                                    return {
+                                        id: family.code,
+                                        text: i18n.getLabel(family.label, userContext.get('uiLocale'), family.code)
+                                    };
+                                }));
+                            });
+                    }
+                }.bind(this)
+            };
+
+            return BaseForm.prototype.initialize.apply(this, arguments);
+        },
+        render: function () {
+            this.$el.empty();
+
+            if (undefined === this.getOperator()) {
+                this.setOperator(_.first(this.config.operators));
+            }
+
+            this.$el.append(this.template({
+                field: this.getField(),
+                operator: this.getOperator(),
+                value: this.getFormData().value,
+                removable: this.isRemovable(),
+                operators: this.config.operators
+            }));
+
+            this.$('[name="filter-operator"]').select2();
+            this.$('[name="filter-value"]').select2(this.selectOptions);
+
+            this.delegateEvents();
+
+            return this;
+        },
+        updateOperator: function (event) {
+            $(event.target).val();
+        },
+        updateState: function () {
+            var value = this.$('[name="filter-value"]').val();
+            value = undefined !== value ? value.split(',') : value;
+            this.setData({
+                'field': this.getField(),
+                'operator': this.$('[name="filter-operator"]').val(),
+                'value': value
+            });
+        },
+        setField: function (field) {
+            var data = this.getFormData();
+            data.field = field;
+            this.setData(data, {silent: true});
+        },
+        getField: function () {
+            return this.getFormData().field;
+        },
+        setOperator: function (operator) {
+            var data = this.getFormData();
+            data.operator = operator;
+            this.setData(data, {silent: true});
+        },
+        getOperator: function () {
+            return this.getFormData().operator;
+        },
+        setRemovable: function (removable) {
+            this.removable = removable;
+        },
+        isRemovable: function () {
+            return this.removable;
+        },
+        removeFilter: function () {
+            this.trigger('filter:remove', this.getField());
+        }
+    });
+});

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/product/family.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/product/family.js
@@ -2,6 +2,8 @@
 'use strict';
 
 define([
+        'underscore',
+        'oro/translator',
         'pim/filter/filter',
         'routing',
         'text!pim/template/filter/product/family',
@@ -9,7 +11,7 @@ define([
         'pim/user-context',
         'pim/i18n',
         'jquery.select2'
-    ], function (BaseFilter, Routing, template, fetcherRegistry, userContext, i18n, initSelect2) {
+    ], function (_, __, BaseFilter, Routing, template, fetcherRegistry, userContext, i18n, initSelect2) {
     return BaseFilter.extend({
         template: _.template(template),
         events: {
@@ -86,6 +88,7 @@ define([
             }
 
             this.$el.append(this.template({
+                __: __,
                 field: this.getField(),
                 operator: this.getOperator(),
                 value: this.getValue(),

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/product/family.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/product/family.js
@@ -2,17 +2,16 @@
 'use strict';
 
 define([
-        'pim/form',
+        'pim/filter/filter',
         'routing',
         'text!pim/template/filter/product/family',
         'pim/fetcher-registry',
         'pim/user-context',
         'pim/i18n',
         'jquery.select2'
-    ], function (BaseForm, Routing, template, fetcherRegistry, userContext, i18n, initSelect2) {
-    return BaseForm.extend({
+    ], function (BaseFilter, Routing, template, fetcherRegistry, userContext, i18n, initSelect2) {
+    return BaseFilter.extend({
         template: _.template(template),
-        removable: false,
         events: {
             'change [name="filter-operator"], [name="filter-value"]': 'updateState',
             'click .remove': 'removeFilter'
@@ -61,7 +60,7 @@ define([
                     }
                 },
                 initSelection: function (element, callback) {
-                    var families = this.getFormData().value;
+                    var families = this.getValue();
                     if (null !== families) {
                         fetcherRegistry.getFetcher('family')
                             .fetchByIdentifiers(families)
@@ -77,7 +76,7 @@ define([
                 }.bind(this)
             };
 
-            return BaseForm.prototype.initialize.apply(this, arguments);
+            return BaseFilter.prototype.initialize.apply(this, arguments);
         },
         render: function () {
             this.$el.empty();
@@ -89,7 +88,7 @@ define([
             this.$el.append(this.template({
                 field: this.getField(),
                 operator: this.getOperator(),
-                value: this.getFormData().value,
+                value: this.getValue(),
                 removable: this.isRemovable(),
                 operators: this.config.operators
             }));
@@ -101,42 +100,14 @@ define([
 
             return this;
         },
-        updateOperator: function (event) {
-            $(event.target).val();
-        },
         updateState: function () {
             var value = this.$('[name="filter-value"]').val();
             value = undefined !== value ? value.split(',') : value;
             this.setData({
-                'field': this.getField(),
-                'operator': this.$('[name="filter-operator"]').val(),
-                'value': value
+                field: this.getField(),
+                operator: this.$('[name="filter-operator"]').val(),
+                value: value
             });
-        },
-        setField: function (field) {
-            var data = this.getFormData();
-            data.field = field;
-            this.setData(data, {silent: true});
-        },
-        getField: function () {
-            return this.getFormData().field;
-        },
-        setOperator: function (operator) {
-            var data = this.getFormData();
-            data.operator = operator;
-            this.setData(data, {silent: true});
-        },
-        getOperator: function () {
-            return this.getFormData().operator;
-        },
-        setRemovable: function (removable) {
-            this.removable = removable;
-        },
-        isRemovable: function () {
-            return this.removable;
-        },
-        removeFilter: function () {
-            this.trigger('filter:remove', this.getField());
         }
     });
 });

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/product/updated.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/product/updated.js
@@ -1,0 +1,71 @@
+/* global console */
+'use strict';
+
+define([
+        'underscore',
+        'oro/translator',
+        'pim/filter/filter',
+        'routing',
+        'text!pim/template/filter/product/updated',
+        'pim/fetcher-registry',
+        'pim/user-context',
+        'pim/i18n',
+        'jquery.select2',
+        'datepicker'
+    ], function (_, __, BaseFilter, Routing, template, fetcherRegistry, userContext, i18n, initSelect2, Datepicker) {
+    return BaseFilter.extend({
+        template: _.template(template),
+        events: {
+            'change [name="filter-operator"], [name="filter-value"]': 'updateState',
+            'click .remove': 'removeFilter'
+        },
+        initialize: function () {
+            this.config = { //To remove
+                operators: {
+                    'before': '>',
+                    'after': '<',
+                    'all': ''
+                }
+            };
+
+            return BaseFilter.prototype.initialize.apply(this, arguments);
+        },
+        render: function () {
+            this.$el.empty();
+
+            if (undefined === this.getOperator()) {
+                this.setOperator(_.first(_.values(this.config.operators)));
+            }
+
+            this.$el.append(this.template({
+                __: __,
+                field: this.getField(),
+                operator: this.getOperator(),
+                value: this.getValue(),
+                removable: this.isRemovable(),
+                operators: this.config.operators
+            }));
+
+            this.$('[name="filter-operator"]').select2();
+            Datepicker.init(
+                this.$('[name="filter-value"]').parent(),
+                {format: 'yyyy-MM-dd hh:mm:ss', defaultFormat: 'yyyy-MM-dd hh:mm:ss', pickTime: true}
+            );
+
+            this.delegateEvents();
+
+            return this;
+        },
+        updateState: function () {
+            var value    = this.$('[name="filter-value"]').val();
+            var operator = this.$('[name="filter-operator"]').val();
+            operator     = this.config.operators[operator];
+
+            this.setData({
+                field: this.getField(),
+                operator: operator,
+                value: '' !== operator ? value : ''
+            });
+        }
+    });
+});

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/product/updated.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/product/updated.js
@@ -50,7 +50,9 @@ define([
             Datepicker.init(
                 this.$('[name="filter-value"]').parent(),
                 {format: 'yyyy-MM-dd hh:mm:ss', defaultFormat: 'yyyy-MM-dd hh:mm:ss', pickTime: true}
-            );
+            ).on('changeDate', this.updateState.bind(this));
+
+            this.$('[name="filter-value"]').on('changeDate', this.updateState.bind(this));
 
             this.delegateEvents();
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/simpleselect.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/simpleselect.js
@@ -1,0 +1,109 @@
+/* global console */
+'use strict';
+
+define([
+        'underscore',
+        'oro/translator',
+        'pim/filter/filter',
+        'text!pim/template/filter/simpleselect',
+        'routing',
+        'pim/user-context',
+        'pim/initselect2',
+        'pim/fetcher-registry',
+        'jquery.select2'
+    ], function (_, __, BaseFilter, template, Routing, UserContext, initSelect2, fetcherRegistry) {
+    return BaseFilter.extend({
+        template: _.template(template),
+        events: {
+            'change input': 'updateState',
+            'click .remove': 'removeFilter'
+        },
+        initialize: function () {
+            this.config = { //To remove
+                operators: [
+                    'IN',
+                    'NOT IN',
+                    'EMPTY',
+                    'NOT EMPTY'
+                ]
+            };
+        },
+        render: function () {
+            this.getChoiceUrl().then(function (choiceUrl) {
+                this.$el.empty().append(this.template({
+                    __: __,
+                    field: this.getField(),
+                    operator: this.getOperator(),
+                    value: this.getValue(),
+                    removable: this.isRemovable(),
+                    operators: this.config.operators
+                }));
+
+                var options = {
+                    multiple: true,
+                    ajax: {
+                        url: choiceUrl,
+                        cache: true,
+                        data: function (term) {
+                            return {
+                                search: term,
+                                options: {
+                                    locale: UserContext.get('uiLocale')
+                                }
+                            };
+                        },
+                        results: function (data) {
+                            return data;
+                        }
+                    },
+                    initSelection: function (element, callback) {
+                        var id = $(element).val();
+                        if ('' !== id) {
+                            $.get(choiceUrl).then(function (response) {
+                                var results = response.results;
+                                var choices = _.map($(element).val().split(','), function (choice) {
+                                    return _.findWhere(results, {id: choice});
+                                });
+                                callback(choices);
+                            });
+                        }
+                    }.bind(this),
+                    placeholder: ' ',
+                    allowClear: true
+                };
+
+                this.$('.select2[name="filter-value"]').select2(options);
+
+                this.delegateEvents();
+            }.bind(this));
+
+            return this;
+        },
+
+        /**
+         * Get the URL to retrieve the choice list for this select field
+         *
+         * @returns {Promise}
+         */
+        getChoiceUrl: function () {
+            return fetcherRegistry.getFetcher('attribute').fetch(this.getField()).then(function (attribute) {
+                return Routing.generate(
+                    'pim_ui_ajaxentity_list',
+                    {
+                        class: 'PimCatalogBundle:AttributeOption', //Should be passed as configuration
+                        dataLocale: UserContext.get('uiLocale'),
+                        collectionId: attribute.id,
+                        options: {type: 'code'}
+                    }
+                )
+            });
+        },
+        updateState: function () {
+            this.setData({
+                'field': this.getField(),
+                'operator': this.$('input[name="filter-operator"]').val(),
+                'value': this.$('input[name="filter-value"]').val().split(',')
+            });
+        }
+    });
+});

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/text.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/text.js
@@ -2,13 +2,11 @@
 'use strict';
 
 define([
-        'pim/form',
+        'pim/filter/filter',
         'text!pim/template/filter/text'
-    ], function (BaseForm, template) {
-    return BaseForm.extend({
+    ], function (BaseFilter, template) {
+    return BaseFilter.extend({
         template: _.template(template),
-        field: null,
-        removable: false,
         events: {
             'blur input': 'updateState',
             'click .remove': 'removeFilter'
@@ -32,25 +30,6 @@ define([
                 'operator': this.$('input[name="operator"]').val(),
                 'value': value
             });
-        },
-        setField: function (field) {
-            this.field = field;
-
-            var data = this.getFormData();
-            data.field = field;
-            this.setData(data, {silent: true});
-        },
-        getField: function () {
-            return this.field;
-        },
-        setRemovable: function (removable) {
-            this.removable = removable;
-        },
-        isRemovable: function () {
-            return this.removable;
-        },
-        removeFilter: function () {
-            this.trigger('filter:remove', this.getField());
         }
     });
 });

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/text.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/text.js
@@ -1,0 +1,56 @@
+/* global console */
+'use strict';
+
+define([
+        'pim/form',
+        'text!pim/template/filter/text'
+    ], function (BaseForm, template) {
+    return BaseForm.extend({
+        template: _.template(template),
+        field: null,
+        removable: false,
+        events: {
+            'blur input': 'updateState',
+            'click .remove': 'removeFilter'
+        },
+        render: function () {
+            this.$el.empty().append(this.template({filter: this.getFormData(), removable: this.isRemovable()}));
+
+            this.delegateEvents();
+
+            return this;
+        },
+        updateState: function () {
+            var data = '';
+            try {
+                data = JSON.parse(this.$('input[name="data"]').val());
+            } catch (error) {
+                data = this.$('input[name="data"]').val();
+            }
+            this.setData({
+                'field': this.getField(),
+                'operator': this.$('input[name="operator"]').val(),
+                'data': data
+            });
+        },
+        setField: function (field) {
+            this.field = field;
+
+            var data = this.getFormData();
+            data.field = field;
+            this.setData(data, {silent: true});
+        },
+        getField: function () {
+            return this.field;
+        },
+        setRemovable: function (removable) {
+            this.removable = removable;
+        },
+        isRemovable: function () {
+            return this.removable;
+        },
+        removeFilter: function () {
+            this.trigger('filter:remove', this.getField());
+        }
+    });
+});

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/text.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/text.js
@@ -21,16 +21,16 @@ define([
             return this;
         },
         updateState: function () {
-            var data = '';
+            var value = '';
             try {
-                data = JSON.parse(this.$('input[name="data"]').val());
+                value = JSON.parse(this.$('input[name="filter-value"]').val());
             } catch (error) {
-                data = this.$('input[name="data"]').val();
+                value = this.$('input[name="filter-value"]').val();
             }
             this.setData({
                 'field': this.getField(),
                 'operator': this.$('input[name="operator"]').val(),
-                'data': data
+                'value': value
             });
         },
         setField: function (field) {

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/config-provider.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/config-provider.js
@@ -23,6 +23,11 @@ define(
                 return loadConfig().then(function (config) {
                     return config.attribute_fields;
                 });
+            },
+            getFilters: function (code) {
+                return loadConfig().then(function (config) {
+                    return config.filters[code];
+                });
             }
         };
     }

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/registry.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/registry.js
@@ -8,6 +8,10 @@ define(
                 var form     = _.first(_.where(extensionMap, { code: formName }));
                 var deferred = new $.Deferred();
 
+                if (undefined === form) {
+                    throw new Error('The form ' + formName + ' was not found. Are you sure you registred it properly?')
+                }
+
                 require([form.module], function (Form) {
                     deferred.resolve(Form);
                 });

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/simple-select-field.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/simple-select-field.js
@@ -117,7 +117,7 @@ define(
                     Routing.generate(
                         'pim_ui_ajaxentity_list',
                         {
-                            'class': 'PimCatalogBundle:AttributeOption',
+                            'class': 'PimCatalogBundle:AttributeOption', //Should be passed as configuration
                             'dataLocale': this.context.locale,
                             'collectionId': this.attribute.id,
                             'options': {'type': 'code'}

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/export/product/edit/content.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/export/product/edit/content.html
@@ -1,0 +1,8 @@
+<div class="accordion">
+    <div data-drop-zone="structure-filters" class="accordion-group">
+
+    </div>
+    <div data-drop-zone="data-filters" class="accordion-group">
+
+    </div>
+</div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/export/product/edit/content/data.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/export/product/edit/content/data.html
@@ -1,0 +1,17 @@
+<div class="accordion-heading">
+    <a class="accordion-toggle" data-toggle="collapse" href="#collapse-3-2">
+        <i class="icon-chevron-down"></i>
+        Data filters
+        <div data-drop-zone="headings" style="float: right; position: relative; top: -12px;"></div>
+    </a>
+</div>
+<div id="collapse-3-2" class="accordion-body in">
+    <div class="accordion-inner">
+        <div class="control-group" data-drop-zone="product-filters"></div>
+
+        </div>
+        <div class="control-group filters"></div>
+
+        </div>
+    </div>
+</div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/export/product/edit/content/structure.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/export/product/edit/content/structure.html
@@ -1,0 +1,13 @@
+<div class="accordion-heading">
+    <a class="accordion-toggle" data-toggle="collapse" href="#collapse-3-1">
+        <i class="icon-chevron-down"></i>
+        Structure filters
+    </a>
+</div>
+<div id="collapse-3-1" class="accordion-body in">
+    <div class="accordion-inner">
+        <div class="control-group" data-drop-zone="filters" style="width: 600px;"></div>
+
+        </div>
+    </div>
+</div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/export/product/edit/content/structure/attributes.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/export/product/edit/content/structure/attributes.html
@@ -1,0 +1,4 @@
+<label class="control-label required">Attributes</label>
+<div class="controls">
+    <input type="text" value="<%- JSON.stringify(attributes) %>"/>
+</div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/export/product/edit/content/structure/locales.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/export/product/edit/content/structure/locales.html
@@ -1,0 +1,4 @@
+<label class="control-label required">Locale</label>
+<div class="controls">
+    <input type="text" value="<%- JSON.stringify(locales) %>"/>
+</div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/export/product/edit/content/structure/locales.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/export/product/edit/content/structure/locales.html
@@ -1,4 +1,8 @@
 <label class="control-label required">Locale</label>
 <div class="controls">
-    <input type="text" value="<%- JSON.stringify(locales) %>"/>
+    <select class="select2" multiple>
+        <% _.each(availableLocales, function (locale) { %>
+            <option value="<%- locale %>" <%- _.contains(locales, locale) ? 'selected' : '' %>><%- locale %></option>
+        <% }); %>
+    </select>
 </div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/export/product/edit/content/structure/scope.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/export/product/edit/content/structure/scope.html
@@ -1,0 +1,4 @@
+<label class="control-label required">Channel</label>
+<div class="controls">
+    <input type="text" value="<%- scope %>"/>
+</div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/export/product/edit/content/structure/scope.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/export/product/edit/content/structure/scope.html
@@ -1,4 +1,8 @@
 <label class="control-label required">Channel</label>
 <div class="controls">
-    <input type="text" value="<%- scope %>"/>
+    <select class="select2">
+        <% _.each(channels, function (channel) { %>
+            <option value="<%- channel.code %>" <%- channel.code === scope ? 'selected' : '' %>><%- channel.label %></option>
+        <% }); %>
+    </select>
 </div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/filter/product/enabled.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/filter/product/enabled.html
@@ -1,4 +1,4 @@
-<label class="control-label required">Enabled</label>
+<label class="control-label required"><%- __('pim_enrich.export.product.filter.enabled.title') %></label>
 <div class="controls" style="width: 600px;">
     <select class="select2" name="filter-value">
         <option value="all" <%- value === null ? 'selected' : '' %>>All</option>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/filter/product/enabled.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/filter/product/enabled.html
@@ -1,9 +1,9 @@
 <label class="control-label required"><%- __('pim_enrich.export.product.filter.enabled.title') %></label>
 <div class="controls" style="width: 600px;">
     <select class="select2" name="filter-value">
-        <option value="all" <%- value === null ? 'selected' : '' %>>All</option>
-        <option value="true" <%- value === true ? 'selected' : '' %>>Enabled</option>
-        <option value="false" <%- value === false ? 'selected' : '' %>>Disabled</option>
+        <option value="all" <%- value === null ? 'selected' : '' %>><%- __('pim_enrich.export.product.filter.enabled.value.all') %></option>
+        <option value="true" <%- value === true ? 'selected' : '' %>><%- __('pim_enrich.export.product.filter.enabled.value.enabled') %></option>
+        <option value="false" <%- value === false ? 'selected' : '' %>><%- __('pim_enrich.export.product.filter.enabled.value.disabled') %></option>
     </select>
     <% if (removable) { %><i class="remove icon-trash"></i><% } %>
 </div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/filter/product/enabled.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/filter/product/enabled.html
@@ -1,0 +1,9 @@
+<label class="control-label required">Enabled</label>
+<div class="controls" style="width: 600px;">
+    <select class="select2" name="filter-value">
+        <option value="all" <%- value === null ? 'selected' : '' %>>All</option>
+        <option value="true" <%- value === true ? 'selected' : '' %>>Enabled</option>
+        <option value="false" <%- value === false ? 'selected' : '' %>>Disabled</option>
+    </select>
+    <% if (removable) { %><i class="remove icon-trash"></i><% } %>
+</div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/filter/product/family.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/filter/product/family.html
@@ -1,4 +1,4 @@
-<label class="control-label required">Family</label>
+<label class="control-label required"><%- __('pim_enrich.export.product.filter.family.title') %></label>
 <div class="controls" style="width: 600px;">
     <select class="select2" name="filter-operator">
         <% _.each(operators, function (availableOperator) { %>
@@ -11,7 +11,7 @@
         name="filter-value"
         type="hidden"
         value="<%- value ? value : '' %>"
-        data-placeholder="<%- _.__('pim_enrich.export.product.filter.family.empty_selection') %>"
+        data-placeholder="<%- __('pim_enrich.export.product.filter.family.empty_selection') %>"
     />
     <% } %>
     <% if (removable) { %><i class="remove icon-trash"></i><% } %>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/filter/product/family.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/filter/product/family.html
@@ -1,11 +1,10 @@
-<label class="control-label required"><%- field %></label>
+<label class="control-label required">Family</label>
 <div class="controls" style="width: 600px;">
     <select class="select2" name="filter-operator">
         <% _.each(operators, function (availableOperator) { %>
             <option value="<%- availableOperator %>" <%- availableOperator === operator ? 'selected' : '' %>><%- availableOperator %></option>
         <% }); %>
     </select>
-    <% console.log(operator) %>
     <% if (_.contains(['IN', 'NOT IN'], operator)) { %><!-- could be done by configuration -->
     <input
         class="select2"
@@ -17,5 +16,3 @@
     <% } %>
     <% if (removable) { %><i class="remove icon-trash"></i><% } %>
 </div>
-
-

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/filter/product/family.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/filter/product/family.html
@@ -1,8 +1,10 @@
 <label class="control-label required"><%- __('pim_enrich.export.product.filter.family.title') %></label>
-<div class="controls" style="width: 600px;">
+<div class="controls" style="width: 800px;">
     <select class="select2" name="filter-operator">
         <% _.each(operators, function (availableOperator) { %>
-            <option value="<%- availableOperator %>" <%- availableOperator === operator ? 'selected' : '' %>><%- availableOperator %></option>
+            <option value="<%- availableOperator %>" <%- availableOperator === operator ? 'selected' : '' %>>
+                <%- __('pim_enrich.export.product.filter.family.operators.' + availableOperator) %>
+            </option>
         <% }); %>
     </select>
     <% if (_.contains(['IN', 'NOT IN'], operator)) { %><!-- could be done by configuration -->

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/filter/product/family.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/filter/product/family.html
@@ -1,0 +1,21 @@
+<label class="control-label required"><%- field %></label>
+<div class="controls" style="width: 600px;">
+    <select class="select2" name="filter-operator">
+        <% _.each(operators, function (availableOperator) { %>
+            <option value="<%- availableOperator %>" <%- availableOperator === operator ? 'selected' : '' %>><%- availableOperator %></option>
+        <% }); %>
+    </select>
+    <% console.log(operator) %>
+    <% if (_.contains(['IN', 'NOT IN'], operator)) { %><!-- could be done by configuration -->
+    <input
+        class="select2"
+        name="filter-value"
+        type="hidden"
+        value="<%- value ? value : '' %>"
+        data-placeholder="<%- _.__('pim_enrich.export.product.filter.family.empty_selection') %>"
+    />
+    <% } %>
+    <% if (removable) { %><i class="remove icon-trash"></i><% } %>
+</div>
+
+

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/filter/product/updated.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/filter/product/updated.html
@@ -1,0 +1,16 @@
+<label class="control-label required"><%- __('pim_enrich.export.product.filter.updated.title') %></label>
+<div class="controls" style="width: 800px;">
+    <select class="select2" name="filter-operator">
+        <% _.each(operators, function (availableOperator, key) { %>
+            <option value="<%- key %>" <%- availableOperator === operator ? 'selected' : '' %>>
+                <%- __('pim_enrich.export.product.filter.updated.operators.' + key) %>
+            </option>
+        <% }); %>
+    </select>
+    <% if ('' !==  operator) { %>
+    <span class="date-wrapper">
+        <input name="filter-value" class="datepicker add-on input-large" type="text" value="<%- value ? value : '' %>" />
+    </span>
+    <% } %>
+    <% if (removable) { %><i class="remove icon-trash"></i><% } %>
+</div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/filter/simpleselect.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/filter/simpleselect.html
@@ -1,0 +1,11 @@
+<label class="control-label required"><%- field %></label>
+<div class="controls" style="width: 600px;">
+    <input type="text" name="filter-operator" value="<%- operator %>"/>
+    <input
+        class="select2"
+        name="filter-value"
+        type="hidden"
+        value="<%- value ? value : '' %>"
+    />
+    <% if (removable) { %><i class="remove icon-trash"></i><% } %>
+</div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/filter/text.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/filter/text.html
@@ -1,0 +1,6 @@
+<label class="control-label required"><%- filter.field %></label>
+<div class="controls" style="width: 600px;">
+    <input type="text" name="operator" value="<%- filter.operator %>"/>
+    <input type="text" name="data" value="<%- JSON.stringify(filter.data) %>"/>
+    <% if (removable) { %><i class="remove icon-trash"></i><% } %>
+</div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/filter/text.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/filter/text.html
@@ -1,6 +1,6 @@
 <label class="control-label required"><%- filter.field %></label>
 <div class="controls" style="width: 600px;">
-    <input type="text" name="operator" value="<%- filter.operator %>"/>
-    <input type="text" name="data" value="<%- JSON.stringify(filter.data) %>"/>
+    <input type="text" name="filter-operator" value="<%- filter.operator %>"/>
+    <input type="text" name="filter-value" value="<%- JSON.stringify(filter.value) %>"/>
     <% if (removable) { %><i class="remove icon-trash"></i><% } %>
 </div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
@@ -292,6 +292,12 @@ pim_enrich:
                         EMPTY: Products that don't have a family
                         "NOT EMPTY": Products that have a family
                     empty_selection: Select a family
+                updated:
+                    title: Updated
+                    operators:
+                        before: Before
+                        after: After
+                        all: All
                 enabled:
                     title: Status
                     value:

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
@@ -281,6 +281,23 @@ pim_enrich:
             switch:
                 "no": "No"
                 "yes": "Yes"
+    export:
+        product:
+            filter:
+                family:
+                    title: Family
+                    operators:
+                        IN: In list
+                        "NOT IN": Not in list
+                        EMPTY: Products that don't have a family
+                        "NOT EMPTY": Products that have a family
+                    empty_selection: Select a family
+                enabled:
+                    title: Status
+                    value:
+                        all: All
+                        enabled: Enabled
+                        disabled: Disabled
     mass_edit_action:
         edit_common_attributes:
             description: The selected product's attributes will be edited with the following data for the locale <span class="highlight">{{ locale }}</span> and the channel <span class="highlight">{{ channel }}</span>, chosen in the products grid.

--- a/src/Pim/Bundle/ImportExportBundle/JobParameters/FormConfigurationProvider/ProductCsvExport.php
+++ b/src/Pim/Bundle/ImportExportBundle/JobParameters/FormConfigurationProvider/ProductCsvExport.php
@@ -31,7 +31,7 @@ class ProductCsvExport implements FormConfigurationProviderInterface
 
     /** @var FamilyRepositoryInterface */
     protected $familyRepository;
-    
+
     /** @var string */
     protected $decimalSeparator = LocalizerInterface::DEFAULT_DECIMAL_SEPARATOR;
 
@@ -43,6 +43,9 @@ class ProductCsvExport implements FormConfigurationProviderInterface
 
     /** @var array */
     protected $dateFormats;
+
+    /** @var array */
+    protected $filters = [];
 
     /** @var array */
     protected $supportedJobNames;
@@ -77,72 +80,8 @@ class ProductCsvExport implements FormConfigurationProviderInterface
     public function getFormConfiguration(JobInstance $jobInstance)
     {
         $formOptions = [
-            'channel' => [
-                'type'    => 'choice',
-                'options' => [
-                    'choices'  => $this->channelRepository->getLabelsIndexedByCode(),
-                    'required' => true,
-                    'select2'  => true,
-                    'label'    => 'pim_connector.export.channel.label',
-                    'help'     => 'pim_connector.export.channel.help',
-                    'attr'     => ['data-tab' => 'content']
-                ]
-            ],
-            'locales'  => ['type' => 'pim_import_export_product_export_locale_choice'],
-            'families' => [
-                'type'    => 'select_family_type',
-                'options' => [
-                    'repository' => $this->familyRepository,
-                    'route'      => 'pim_enrich_family_rest_index',
-                    'required'   => false,
-                    'multiple'   => true,
-                    'label'      => 'pim_base_connector.export.families.label',
-                    'help'       => 'pim_base_connector.export.families.help',
-                    'attr'       => [
-                        'data-tab'         => 'content',
-                        'data-placeholder' => 'pim_base_connector.export.families.placeholder'
-                    ]
-                ]
-            ],
-            'enabled' => [
-                'type'    => 'choice',
-                'options' => [
-                    'choices'  => [
-                        'enabled'  => 'pim_connector.export.status.choice.enabled',
-                        'disabled' => 'pim_connector.export.status.choice.disabled',
-                        'all'      => 'pim_connector.export.status.choice.all'
-                    ],
-                    'required' => true,
-                    'select2'  => true,
-                    'label'    => 'pim_connector.export.status.label',
-                    'help'     => 'pim_connector.export.status.help',
-                    'attr'     => ['data-tab' => 'content']
-                ]
-            ],
-            'completeness' => [
-                'type'    => 'choice',
-                'options' => [
-                    'choices'  => [
-                        'at_least_one_complete' => 'pim_connector.export.completeness.choice.at_least_one_complete',
-                        'all_complete'          => 'pim_connector.export.completeness.choice.all_complete',
-                        'all_incomplete'        => 'pim_connector.export.completeness.choice.all_incomplete',
-                        'all'                   => 'pim_connector.export.completeness.choice.all'
-                    ],
-                    'required' => true,
-                    'select2'  => true,
-                    'label'    => 'pim_connector.export.completeness.label',
-                    'help'     => 'pim_connector.export.completeness.help',
-                    'attr'     => ['data-tab' => 'content']
-                ]
-            ],
-            'updated_since' => [
-                'type'    => 'pim_updated_since_parameter_type',
-                'options' => [
-                    'job_instance' => $jobInstance,
-                    'label'        => 'pim_connector.export.updated.updated_since_strategy.label',
-                    'help'         => 'pim_connector.export.updated.updated_since_strategy.help',
-                    'attr'         => ['data-tab' => 'content']
-                ]
+            'filters' => [
+                'type' => 'hidden'
             ],
             'decimalSeparator' => [
                 'type'    => 'choice',
@@ -165,7 +104,7 @@ class ProductCsvExport implements FormConfigurationProviderInterface
                 ]
             ],
         ];
-        
+
         $formOptions = array_merge($formOptions, $this->simpleCsvExport->getFormConfiguration($jobInstance));
 
         return $formOptions;

--- a/src/Pim/Bundle/ImportExportBundle/Resources/views/JobProfile/Tab/job_content.html.twig
+++ b/src/Pim/Bundle/ImportExportBundle/Resources/views/JobProfile/Tab/job_content.html.twig
@@ -1,27 +1,26 @@
-<div id="{{ viewElement.alias|replace({' ': '-', '.': '-'})|lower }}" class="job-profile-content-tab tab-pane buffer-top">
-    {% set filtersSettings %}
-        {% for field in form.configuration %}
-            {% if field.vars.attr['data-tab'] is defined and 'content' == field.vars.attr['data-tab'] %}
-                {{ form_row(field) }}
-            {% endif %}
-        {% endfor %}
-    {% endset %}
-
-    <script type="text/javascript">
+<div id="{{ viewElement.alias|replace({' ': '-', '.': '-'})|lower }}" class="tab-pane buffer-top">
+    <div id="pim-product-export-edit-content"></div>
+    <input id="{{ form.configuration.filters.vars.id }}" value="{{ form.configuration.filters.vars.value }}" type="hidden"/>
+    <script>
         require(
-                ['jquery', 'pim/product-export/locales-selector'],
-                function($, LocaleSelector){
-                    'use strict';
+            ['jquery', 'pim/fetcher-registry', 'pim/form-builder', 'oro/loading-mask'],
+            function($, FetcherRegistry, FormBuilder, LoadingMask) {
+                $(function() {
+                    var loadingMask = new LoadingMask();
+                    loadingMask.render().$el.appendTo($('#container')).show();
+                    FetcherRegistry.initialize().done(function () {
+                        FormBuilder.build('pim-product-export-edit-content')
+                            .then(function (form) {
+                                form.setData(JSON.parse($('#{{ form.configuration.filters.vars.id }}').val()));
 
-                    $(function () {
-                        LocaleSelector.init(
-                            '#pim_import_export_jobInstance_configuration_channel',
-                            '#pim_import_export_jobInstance_configuration_locales'
-                        );
-                    });
-                }
-        );
+                                form.setElement('#pim-product-export-edit-content').render();
+                                form.on('pim_enrich:form:entity:post_update', function () {
+                                    document.getElementById('{{ form.configuration.filters.vars.id }}').value = JSON.stringify(form.getFormData());
+                                });
+                                loadingMask.remove();
+                            });
+                    })
+                });
+            });
     </script>
-
-    {{ elements.accordion({ 'pane.accordion.filters': filtersSettings }, 3) }}
 </div>

--- a/src/Pim/Bundle/UIBundle/Resources/public/css/pim.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/css/pim.less
@@ -1770,3 +1770,8 @@ h3.tab-header {
 .scopable-input .note-editor {
   display: inline-block;
 }
+
+
+.control-group.filters {
+  width: 600px;
+}

--- a/src/Pim/Bundle/UserBundle/Normalizer/UserNormalizer.php
+++ b/src/Pim/Bundle/UserBundle/Normalizer/UserNormalizer.php
@@ -35,6 +35,7 @@ class UserNormalizer implements NormalizerInterface
             'lastLogin'     => $user->getLastLogin() ? $user->getLastLogin()->getTimestamp() : null,
             'loginCount'    => $user->getLoginCount(),
             'catalogLocale' => $user->getCatalogLocale()->getCode(),
+            'uiLocale'      => $user->getUiLocale()->getCode(),
             'catalogScope'  => $user->getCatalogScope()->getCode(),
             'defaultTree'   => $user->getDefaultTree()->getCode(),
             'meta'          => [

--- a/src/Pim/Component/Connector/Job/JobParameters/ConstraintCollectionProvider/ProductCsvExport.php
+++ b/src/Pim/Component/Connector/Job/JobParameters/ConstraintCollectionProvider/ProductCsvExport.php
@@ -44,27 +44,27 @@ class ProductCsvExport implements ConstraintCollectionProviderInterface
         $constraintFields = $baseConstraint->fields;
         $constraintFields['decimalSeparator'] = new NotBlank();
         $constraintFields['dateFormat'] = new NotBlank();
-        $constraintFields['channel'] = [
-            new NotBlank(['groups' => 'Execution']),
-            new Channel()
-        ];
-        $constraintFields['enabled'] = new NotBlank(['groups' => 'Execution']);
-        $constraintFields['updated_since_strategy'] = new NotBlank(['groups' => 'Execution']);
-        $constraintFields['updated_since_date'] = new DateTime(['groups' => 'Execution']);
-        $constraintFields['locales'] = new NotBlank([
-            'groups'  => 'Execution',
-            'message' => 'pim_connector.export.locales.validation.not_blank'
-        ]);
-        $constraintFields['families'] = [];
-        $constraintFields['completeness'] = [
-            new NotBlank(['groups' => 'Execution']),
-            new Choice(['choices' => [
-                'at_least_one_complete',
-                'all_complete',
-                'all_incomplete',
-                'all',
-            ], 'groups' => 'Execution'])
-        ];
+        // $constraintFields['channel'] = [
+        //     new NotBlank(['groups' => 'Execution']),
+        //     new Channel()
+        // ];
+        // $constraintFields['enabled'] = new NotBlank(['groups' => 'Execution']);
+        // $constraintFields['updated'] = new NotBlank(['groups' => 'Execution']);
+        // $constraintFields['locales'] = new NotBlank([
+        //     'groups'  => 'Execution',
+        //     'message' => 'pim_connector.export.locales.validation.not_blank'
+        // ]);
+        // $constraintFields['families'] = [];
+        $constraintFields['filters'] = [];
+        // $constraintFields['completeness'] = [
+        //     new NotBlank(['groups' => 'Execution']),
+        //     new Choice(['choices' => [
+        //         'at_least_one_complete',
+        //         'all_complete',
+        //         'all_incomplete',
+        //         'all',
+        //     ], 'groups' => 'Execution'])
+        // ];
 
         return new Collection(['fields' => $constraintFields]);
     }

--- a/src/Pim/Component/Connector/Job/JobParameters/DefaultValuesProvider/ProductCsvExport.php
+++ b/src/Pim/Component/Connector/Job/JobParameters/DefaultValuesProvider/ProductCsvExport.php
@@ -39,13 +39,27 @@ class ProductCsvExport implements DefaultValuesProviderInterface
         $parameters = $this->simpleProvider->getDefaultValues();
         $parameters['decimalSeparator'] = LocalizerInterface::DEFAULT_DECIMAL_SEPARATOR;
         $parameters['dateFormat'] = LocalizerInterface::DEFAULT_DATE_FORMAT;
-        $parameters['channel'] = null;
-        $parameters['locales'] = [];
-        $parameters['enabled'] = 'enabled';
-        $parameters['updated_since_strategy'] = 'all';
-        $parameters['updated_since_date'] = null;
-        $parameters['families'] = null;
-        $parameters['completeness'] = 'at_least_one_complete';
+        // $parameters['channel'] = 'mobile';//null;
+        // $parameters['locales'] = ['fr_FR'];
+        $parameters['filters'] = '{"data": [], "structure": {}}';
+        // $parameters['enabled'] = true;
+
+        // $constraintFields['enabled'] = new NotBlank(['groups' => 'Execution']);
+        // $constraintFields['updated'] = new NotBlank(['groups' => 'Execution']);
+        // $constraintFields['locales'] = new NotBlank([
+        //     'groups'  => 'Execution',
+        //     'message' => 'pim_connector.export.locales.validation.not_blank'
+        // ]);
+        // $constraintFields['families'] = [];
+        // $constraintFields['completeness'] = [
+        //     new NotBlank(['groups' => 'Execution']),
+        //     new Choice(['choices' => [
+        //         'at_least_one_complete',
+        //         'all_complete',
+        //         'all_incomplete',
+        //         'all',
+        //     ], 'groups' => 'Execution'])
+        // ];
 
         return $parameters;
     }

--- a/src/Pim/Component/Connector/Reader/ProductReader.php
+++ b/src/Pim/Component/Connector/Reader/ProductReader.php
@@ -96,7 +96,6 @@ class ProductReader extends AbstractConfigurableStepElement implements ItemReade
         $filters = array_filter($filters['data'], function ($filter) {
             return isset($filter['operator']) && '' !== $filter['operator'];
         });
-        error_log(print_r($filters, true));
 
         foreach ($filters as $filter) {
             $filter['context'] = [];
@@ -104,7 +103,7 @@ class ProductReader extends AbstractConfigurableStepElement implements ItemReade
             $pqb->addFilter(
                 $filter['field'],
                 $filter['operator'],
-                $filter['data'],
+                $filter['value'],
                 $filter['context']
             );
         }
@@ -162,101 +161,6 @@ class ProductReader extends AbstractConfigurableStepElement implements ItemReade
         }
 
         return $channel;
-    }
-
-    /**
-     * Return the filters to be applied on the PQB instance.
-     *
-     * @param ChannelInterface $channel
-     * @param bool             $status
-     * @param string           $updated
-     * @param array            $families
-     *
-     * @return array
-     */
-    protected function getFilters(ChannelInterface $channel, $status, $updated, $families)
-    {
-        $filters = [
-            [
-                'field'    => 'categories.id',
-                'operator' => Operators::IN_CHILDREN_LIST,
-                'value'    => [$channel->getCategory()->getId()],
-                'context'  => []
-            ]
-        ];
-
-        if (null !== $status) {
-            $filters[] = [
-                'field'    => 'enabled',
-                'operator' => Operators::EQUALS,
-                'value'    => $status,
-                'context'  => []
-            ];
-        }
-
-        if (!empty($families)) {
-            $filters[] = [
-                'field'    => 'family.code',
-                'operator' => Operators::IN_LIST,
-                'value'    => $families,
-                'context'  => []
-            ];
-        }
-
-        if (null !== $updated) {
-            $filters[] = [
-                'field'    => 'updated',
-                'operator' => Operators::GREATER_THAN,
-                'value'    => $updated,
-                'context'  => []
-            ];
-        }
-
-        return $filters;
-    }
-
-    /**
-     * Convert the UI product status to the standard product status
-     *
-     * @param string $rawStatus
-     * @return bool|null
-     */
-    protected function rawToStandardProductStatus($rawStatus)
-    {
-        switch ($rawStatus) {
-            case 'enabled':
-                $status = true;
-                break;
-            case 'disabled':
-                $status = false;
-                break;
-            default:
-                $status = null;
-        }
-
-        return $status;
-    }
-
-    /**
-     * Convert the UI product updated to the standard product updated
-     *
-     * @param JobParameters $parameters
-     *
-     * @return \DateTime|null
-     */
-    protected function rawToStandardProductUpdated(JobParameters $parameters)
-    {
-        switch ($parameters->get('updated_since_strategy')) {
-            case 'last_export':
-                $jobInstance = $this->stepExecution->getJobExecution()->getJobInstance();
-                $jobExecution = $this->jobRepository->getLastJobExecution($jobInstance, BatchStatus::COMPLETED);
-
-                return null === $jobExecution ? null : $jobExecution->getStartTime();
-            case 'since_date':
-                return $parameters->get('updated_since_date');
-            default:
-                return null;
-        }
     }
 
     /**


### PR DESCRIPTION
Missing pieces,
 - [ ] Behat
 - [ ] Fix all data fixtures (behat + installer because not installable for now
 - [ ] Validation
 - [ ] Make it works for product xlsx export "Method "filters" for object "Symfony\Component\Form\FormView" does not exist in PimImportExportBundle:JobProfile:Tab/job_content.html.twig at line 3"


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       |
| Added Behats                      |
| Changelog updated                 |
| Review and 2 GTM                  |
| Micro Demo to the PO (Story only) |
| Migration script                  |
| Tech Doc                          |
