### PR TITLE
TIP-482: move localization from processors to array conversion

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -46,6 +46,7 @@
 
 ## BC breaks
 
+- Change constructor of `Pim\Component\Connector\Processor\Denormalization\ProductProcessor`. Remove argument `Pim\Component\Catalog\Localization\Localizer\AttributeConverterInterface`.
 - Add method `findPotentiallyPurgeableBy` to interface `Pim\Bundle\VersioningBundle\Repository\VersionRepositoryInterface`
 - Add method `getNewestVersionIdForResource` to interface `Pim\Bundle\VersioningBundle\Repository\VersionRepositoryInterface`
 - Move `Pim\Component\Connector\Writer\Doctrine` to `Pim\Component\Connector\Writer\Database`

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/NumberFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/NumberFilter.php
@@ -57,10 +57,7 @@ class NumberFilter extends AbstractAttributeFilter implements AttributeFilterInt
     ) {
         $this->checkLocaleAndScope($attribute, $locale, $scope, 'number');
 
-        if (null !== $value &&
-            !is_int($value) &&
-            !is_float($value)
-        ) {
+        if (null !== $value && !is_numeric($value)) {
             throw InvalidArgumentException::numericExpected($attribute->getCode(), 'filter', 'number', gettype($value));
         }
 

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/NumberFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/NumberFilter.php
@@ -50,7 +50,7 @@ class NumberFilter extends AbstractAttributeFilter implements AttributeFilterInt
     ) {
         $this->checkLocaleAndScope($attribute, $locale, $scope, 'number');
 
-        if (!is_numeric($value) && null !== $value) {
+        if (null !== $value && !is_numeric($value)) {
             throw InvalidArgumentException::numericExpected($attribute->getCode(), 'filter', 'number', gettype($value));
         }
 

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/NumberFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/NumberFilterSpec.php
@@ -155,8 +155,5 @@ class NumberFilterSpec extends ObjectBehavior
 
         $this->shouldThrow(InvalidArgumentException::numericExpected('number_code', 'filter', 'number', gettype('WRONG')))
             ->during('addAttributeFilter', [$attribute, '=', 'WRONG']);
-
-        $this->shouldThrow(InvalidArgumentException::numericExpected('number_code', 'filter', 'number', gettype('42')))
-            ->during('addAttributeFilter', [$attribute, '=', '42']);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/NumberFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/NumberFilterSpec.php
@@ -136,6 +136,7 @@ class NumberFilterSpec extends ObjectBehavior
     function it_throws_an_exception_if_value_is_not_a_numeric(AttributeInterface $attribute)
     {
         $attribute->getCode()->willReturn('number_code');
-        $this->shouldThrow(InvalidArgumentException::numericExpected('number_code', 'filter', 'number', gettype('WRONG')))->during('addAttributeFilter', [$attribute, '=', 'WRONG']);
+        $this->shouldThrow(InvalidArgumentException::numericExpected('number_code', 'filter', 'number', gettype('WRONG')))
+            ->during('addAttributeFilter', [$attribute, '=', 'WRONG']);
     }
 }

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/array_converters.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/array_converters.yml
@@ -2,6 +2,7 @@ parameters:
     pim_connector.array_converter.flat_to_standard.attribute_option.class:                        Pim\Component\Connector\ArrayConverter\FlatToStandard\AttributeOption
     pim_connector.array_converter.flat_to_standard.attribute.class:                               Pim\Component\Connector\ArrayConverter\FlatToStandard\Attribute
     pim_connector.array_converter.flat_to_standard.product.class:                                 Pim\Component\Connector\ArrayConverter\FlatToStandard\Product
+    pim_connector.array_converter.flat_to_standard.product_delocalized.class:                     Pim\Component\Connector\ArrayConverter\FlatToStandard\ProductDelocalized
     pim_connector.array_converter.flat_to_standard.product_association.class:                     Pim\Component\Connector\ArrayConverter\FlatToStandard\ProductAssociation
     pim_connector.array_converter.flat_to_standard.variant_group.class:                           Pim\Component\Connector\ArrayConverter\FlatToStandard\VariantGroup
     pim_connector.array_converter.flat_to_standard.group.class:                                   Pim\Component\Connector\ArrayConverter\FlatToStandard\Group
@@ -125,6 +126,12 @@ services:
             - '@pim_connector.array_converter.flat_to_standard.product.columns_merger'
             - '@pim_connector.array_converter.flat_to_standard.product.columns_mapper'
             - '@pim_connector.array_convertor.checker.fields_requirement'
+
+    pim_connector.array_converter.flat_to_standard.product_delocalized:
+        class: '%pim_connector.array_converter.flat_to_standard.product_delocalized.class%'
+        arguments:
+            - '@pim_connector.array_converter.flat_to_standard.product'
+            - '@pim_catalog.localization.localizer.converter'
 
     pim_connector.array_converter.flat_to_standard.product_association:
         class: '%pim_connector.array_converter.flat_to_standard.product_association.class%'

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/readers.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/readers.yml
@@ -142,7 +142,7 @@ services:
         class: '%pim_connector.reader.file.csv_product.class%'
         arguments:
             - '@pim_connector.reader.file.csv_iterator_factory'
-            - '@pim_connector.array_converter.flat_to_standard.product'
+            - '@pim_connector.array_converter.flat_to_standard.product_delocalized'
             - '@pim_connector.reader.file.media_path_transformer'
 
     pim_connector.reader.file.csv_user:
@@ -174,7 +174,7 @@ services:
        class: '%pim_connector.reader.file.xlsx_product.class%'
        arguments:
            - '@pim_connector.reader.file.xlsx_iterator_factory'
-           - '@pim_connector.array_converter.flat_to_standard.product'
+           - '@pim_connector.array_converter.flat_to_standard.product_delocalized'
            - '@pim_connector.reader.file.media_path_transformer'
 
     pim_connector.reader.file.xlsx_association_type:

--- a/src/Pim/Component/Connector/ArrayConverter/FieldsRequirementChecker.php
+++ b/src/Pim/Component/Connector/ArrayConverter/FieldsRequirementChecker.php
@@ -2,7 +2,8 @@
 
 namespace Pim\Component\Connector\ArrayConverter;
 
-use Pim\Component\Connector\Exception\ArrayConversionException;
+use Pim\Component\Connector\Exception\DataArrayConversionException;
+use Pim\Component\Connector\Exception\StructureArrayConversionException;
 
 /**
  * Simple validator to check if required fields are present and filled.
@@ -19,13 +20,13 @@ class FieldsRequirementChecker
      * @param array $item
      * @param array $fields
      *
-     * @throws ArrayConversionException
+     * @throws StructureArrayConversionException
      */
     public function checkFieldsPresence(array $item, array $fields)
     {
         foreach ($fields as $field) {
             if (!in_array($field, array_keys($item))) {
-                throw new ArrayConversionException(
+                throw new StructureArrayConversionException(
                     sprintf(
                         'Field "%s" is expected, provided fields are "%s"',
                         $field,
@@ -42,13 +43,13 @@ class FieldsRequirementChecker
      * @param array $item
      * @param array $fields
      *
-     * @throws ArrayConversionException
+     * @throws DataArrayConversionException
      */
     public function checkFieldsFilling(array $item, array $fields)
     {
         foreach ($fields as $field) {
             if ('' == $item[$field]) {
-                throw new ArrayConversionException(
+                throw new DataArrayConversionException(
                     sprintf(
                         'Field "%s" must be filled',
                         $field

--- a/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/AttributeOption.php
+++ b/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/AttributeOption.php
@@ -5,7 +5,7 @@ namespace Pim\Component\Connector\ArrayConverter\FlatToStandard;
 use Pim\Component\Catalog\Repository\LocaleRepositoryInterface;
 use Pim\Component\Connector\ArrayConverter\ArrayConverterInterface;
 use Pim\Component\Connector\ArrayConverter\FieldsRequirementChecker;
-use Pim\Component\Connector\Exception\ArrayConversionException;
+use Pim\Component\Connector\Exception\StructureArrayConversionException;
 
 /**
  * Convert flat format to standard format for attribute option
@@ -86,7 +86,7 @@ class AttributeOption implements ArrayConverterInterface
     /**
      * @param array $item
      *
-     * @throws ArrayConversionException
+     * @throws StructureArrayConversionException
      */
     protected function validate(array $item)
     {
@@ -102,7 +102,7 @@ class AttributeOption implements ArrayConverterInterface
 
         foreach (array_keys($item) as $field) {
             if (!in_array($field, $authorizedFields)) {
-                throw new ArrayConversionException(
+                throw new StructureArrayConversionException(
                     sprintf(
                         'Field "%s" is provided, authorized fields are: "%s"',
                         $field,

--- a/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Group.php
+++ b/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Group.php
@@ -5,7 +5,7 @@ namespace Pim\Component\Connector\ArrayConverter\FlatToStandard;
 use Pim\Component\Catalog\Repository\LocaleRepositoryInterface;
 use Pim\Component\Connector\ArrayConverter\ArrayConverterInterface;
 use Pim\Component\Connector\ArrayConverter\FieldsRequirementChecker;
-use Pim\Component\Connector\Exception\ArrayConversionException;
+use Pim\Component\Connector\Exception\StructureArrayConversionException;
 
 /**
  * Group Flat Converter
@@ -110,7 +110,7 @@ class Group implements ArrayConverterInterface
      * @param array $item
      * @param array $authorizedFields
      *
-     * @throws ArrayConversionException
+     * @throws StructureArrayConversionException
      */
     protected function validateAuthorizedFields(array $item, array $authorizedFields)
     {
@@ -121,7 +121,7 @@ class Group implements ArrayConverterInterface
 
         foreach (array_keys($item) as $field) {
             if (!in_array($field, $authorizedFields)) {
-                throw new ArrayConversionException(
+                throw new StructureArrayConversionException(
                     sprintf(
                         'Field "%s" is provided, authorized fields are: "%s"',
                         $field,

--- a/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Product.php
+++ b/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Product.php
@@ -11,7 +11,8 @@ use Pim\Component\Connector\ArrayConverter\FlatToStandard\Product\ColumnsMapper;
 use Pim\Component\Connector\ArrayConverter\FlatToStandard\Product\ColumnsMerger;
 use Pim\Component\Connector\ArrayConverter\FlatToStandard\Product\FieldConverter;
 use Pim\Component\Connector\ArrayConverter\FlatToStandard\Product\ValueConverter\ValueConverterRegistryInterface;
-use Pim\Component\Connector\Exception\ArrayConversionException;
+use Pim\Component\Connector\Exception\DataArrayConversionException;
+use Pim\Component\Connector\Exception\StructureArrayConversionException;
 
 /**
  * Product Converter
@@ -310,8 +311,6 @@ class Product implements ArrayConverterInterface
     /**
      * @param array $item
      * @param bool  $withRequiredSku
-     *
-     * @throws ArrayConversionException
      */
     protected function validateItem(array $item, $withRequiredSku)
     {
@@ -324,7 +323,7 @@ class Product implements ArrayConverterInterface
     /**
      * @param array $item
      *
-     * @throws ArrayConversionException
+     * @throws StructureArrayConversionException
      */
     protected function validateOptionalFields(array $item)
     {
@@ -344,14 +343,14 @@ class Product implements ArrayConverterInterface
         if (0 < count($unknownFields)) {
             $message = count($unknownFields) > 1 ? 'The fields "%s" do not exist' : 'The field "%s" does not exist';
 
-            throw new ArrayConversionException(sprintf($message, implode(', ', $unknownFields)));
+            throw new StructureArrayConversionException(sprintf($message, implode(', ', $unknownFields)));
         }
     }
 
     /**
      * @param array $item
      *
-     * @throws ArrayConversionException
+     * @throws DataArrayConversionException
      */
     protected function validateFieldValueTypes(array $item)
     {
@@ -359,7 +358,7 @@ class Product implements ArrayConverterInterface
 
         foreach ($item as $field => $value) {
             if (in_array($field, $stringFields) && !is_string($value)) {
-                throw new ArrayConversionException(
+                throw new DataArrayConversionException(
                     sprintf('The field "%s" should contain a string, "%s" provided', $field, $value)
                 );
             }

--- a/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Product.php
+++ b/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Product.php
@@ -15,7 +15,11 @@ use Pim\Component\Connector\Exception\DataArrayConversionException;
 use Pim\Component\Connector\Exception\StructureArrayConversionException;
 
 /**
- * Product Converter
+ * Convert a Product from Flat to Standard structure.
+ * This conversion does not result in the standard format, as the values are not delocalized here.
+ *
+ * To get a real standardized from the flat format, please
+ * see {@link \Pim\Component\Connector\ArrayConverter\FlatToStandard\ProductDelocalized }
  *
  * @author    Julien Sanchez <julien@akeneo.com>
  * @copyright 2015 Akeneo SAS (http://www.akeneo.com)

--- a/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/ProductDelocalized.php
+++ b/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/ProductDelocalized.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Pim\Component\Connector\ArrayConverter\FlatToStandard;
+
+use Pim\Component\Catalog\Localization\Localizer\AttributeConverterInterface;
+use Pim\Component\Connector\ArrayConverter\ArrayConverterInterface;
+use Pim\Component\Connector\Exception\DataArrayConversionException;
+
+/**
+ * Convert a Product from Flat to Standard format with delocalized values.
+ *
+ * @author    Julien Janvier <jjanvier@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ProductDelocalized implements ArrayConverterInterface
+{
+    /** @var ArrayConverterInterface */
+    protected $converter;
+
+    /** @var AttributeConverterInterface */
+    protected $delocalizer;
+
+    /**
+     * @param ArrayConverterInterface     $converter
+     * @param AttributeConverterInterface $delocalizer
+     */
+    public function __construct(ArrayConverterInterface $converter, AttributeConverterInterface $delocalizer)
+    {
+        $this->converter   = $converter;
+        $this->delocalizer = $delocalizer;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function convert(array $item, array $options = [])
+    {
+        $standardizedItem = $this->converter->convert($item, $options);
+        $delocalizedItem = $this->delocalizer->convertToDefaultFormats($standardizedItem, $options);
+
+        $violations = $this->delocalizer->getViolations();
+
+        if ($violations->count() > 0) {
+            throw new DataArrayConversionException(
+                'An error occurred during the delocalization of the product.',
+                0,
+                null,
+                $violations
+            );
+        }
+
+        return $delocalizedItem;
+    }
+}

--- a/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/VariantGroup.php
+++ b/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/VariantGroup.php
@@ -6,7 +6,7 @@ use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
 use Pim\Component\Catalog\Repository\LocaleRepositoryInterface;
 use Pim\Component\Connector\ArrayConverter\ArrayConverterInterface;
 use Pim\Component\Connector\ArrayConverter\FieldsRequirementChecker;
-use Pim\Component\Connector\Exception\ArrayConversionException;
+use Pim\Component\Connector\Exception\StructureArrayConversionException;
 
 /**
  * Variant group Flat Converter
@@ -156,7 +156,7 @@ class VariantGroup implements ArrayConverterInterface
      * @param array $item
      * @param array $authorizedFields
      *
-     * @throws ArrayConversionException
+     * @throws StructureArrayConversionException
      */
     protected function validateAuthorizedFields(array $item, array $authorizedFields)
     {
@@ -167,7 +167,7 @@ class VariantGroup implements ArrayConverterInterface
 
         foreach (array_keys($item) as $field) {
             if (!in_array($field, $authorizedFields) && !$this->isAttribute($field)) {
-                throw new ArrayConversionException(
+                throw new StructureArrayConversionException(
                     sprintf(
                         'Field "%s" is provided, authorized fields are: "%s"',
                         $field,

--- a/src/Pim/Component/Connector/Exception/ArrayConversionException.php
+++ b/src/Pim/Component/Connector/Exception/ArrayConversionException.php
@@ -2,6 +2,8 @@
 
 namespace Pim\Component\Connector\Exception;
 
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+
 /**
  * Exception which may be thrown when we convert an array
  *
@@ -11,4 +13,25 @@ namespace Pim\Component\Connector\Exception;
  */
 class ArrayConversionException extends \LogicException
 {
+    /** @var ConstraintViolationListInterface */
+    protected $violations;
+
+    public function __construct(
+        $message,
+        $code = 0,
+        \Exception $previous = null,
+        ConstraintViolationListInterface $violations = null
+    ) {
+        $this->violations = $violations;
+
+        parent::__construct($message, $code, $previous);
+    }
+
+    /**
+     * @return ConstraintViolationListInterface
+     */
+    public function getViolations()
+    {
+        return $this->violations;
+    }
 }

--- a/src/Pim/Component/Connector/Exception/ArrayConversionException.php
+++ b/src/Pim/Component/Connector/Exception/ArrayConversionException.php
@@ -2,10 +2,8 @@
 
 namespace Pim\Component\Connector\Exception;
 
-use Symfony\Component\Validator\ConstraintViolationListInterface;
-
 /**
- * Exception which may be thrown when we convert an array
+ * Exception thrown during a conversion of an array
  *
  * @author    Nicolas Dupont <nicolas@akeneo.com>
  * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
@@ -13,25 +11,4 @@ use Symfony\Component\Validator\ConstraintViolationListInterface;
  */
 class ArrayConversionException extends \LogicException
 {
-    /** @var ConstraintViolationListInterface */
-    protected $violations;
-
-    public function __construct(
-        $message,
-        $code = 0,
-        \Exception $previous = null,
-        ConstraintViolationListInterface $violations = null
-    ) {
-        $this->violations = $violations;
-
-        parent::__construct($message, $code, $previous);
-    }
-
-    /**
-     * @return ConstraintViolationListInterface
-     */
-    public function getViolations()
-    {
-        return $this->violations;
-    }
 }

--- a/src/Pim/Component/Connector/Exception/DataArrayConversionException.php
+++ b/src/Pim/Component/Connector/Exception/DataArrayConversionException.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Pim\Component\Connector\Exception;
+
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+
+/**
+ * Exception thrown during a conversion of an array.
+ * Related to a data problem, for example, a property has not been filled as expected.
+ *
+ * @author    Julien Janvier <jjanvier@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class DataArrayConversionException extends ArrayConversionException
+{
+    /** @var ConstraintViolationListInterface */
+    protected $violations;
+
+    /**
+     * @param string                                $message
+     * @param int                                   $code
+     * @param \Exception|null                       $previous
+     * @param ConstraintViolationListInterface|null $violations
+     */
+    public function __construct(
+        $message,
+        $code = 0,
+        \Exception $previous = null,
+        ConstraintViolationListInterface $violations = null
+    ) {
+        $this->violations = $violations;
+
+        parent::__construct($message, $code, $previous);
+    }
+
+    /**
+     * @return ConstraintViolationListInterface
+     */
+    public function getViolations()
+    {
+        return $this->violations;
+    }
+}

--- a/src/Pim/Component/Connector/Exception/InvalidItemFromViolationsException.php
+++ b/src/Pim/Component/Connector/Exception/InvalidItemFromViolationsException.php
@@ -1,7 +1,6 @@
 <?php
 
-
-namespace Pim\Component\Connector\Item;
+namespace Pim\Component\Connector\Exception;
 
 use Akeneo\Component\Batch\Item\InvalidItemException as BaseInvalidItemException;
 use Pim\Component\Catalog\Model\ProductPriceInterface;
@@ -9,13 +8,14 @@ use Symfony\Component\Validator\ConstraintViolationInterface;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
 
 /**
- * Extends the InvalidItemExceptionFromViolations to be able to build one from a Symfony constraints violations list.
+ * Extends the {@link  Akeneo\Component\Batch\Item\InvalidItemException}
+ * to be able to build one from a Symfony constraints violations list.
  *
  * @author    Julien Janvier <jjanvier@akeneo.com>
  * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class InvalidItemExceptionFromViolations extends BaseInvalidItemException
+class InvalidItemFromViolationsException extends BaseInvalidItemException
 {
     /** @var ConstraintViolationListInterface */
     protected $violations;
@@ -61,5 +61,4 @@ class InvalidItemExceptionFromViolations extends BaseInvalidItemException
 
         parent::__construct(implode("\n", $errors), $item, $messageParameters, $code, $previous);
     }
-
 }

--- a/src/Pim/Component/Connector/Exception/StructureArrayConversionException.php
+++ b/src/Pim/Component/Connector/Exception/StructureArrayConversionException.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Pim\Component\Connector\Exception;
+
+/**
+ * Exception thrown during a conversion of an array.
+ * Related to a structure problem, for example, an unknown property has been provided as input.
+ *
+ * @author    Julien Janvier <jjanvier@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class StructureArrayConversionException extends ArrayConversionException
+{
+}

--- a/src/Pim/Component/Connector/Item/InvalidItemExceptionFromViolations.php
+++ b/src/Pim/Component/Connector/Item/InvalidItemExceptionFromViolations.php
@@ -1,0 +1,65 @@
+<?php
+
+
+namespace Pim\Component\Connector\Item;
+
+use Akeneo\Component\Batch\Item\InvalidItemException as BaseInvalidItemException;
+use Pim\Component\Catalog\Model\ProductPriceInterface;
+use Symfony\Component\Validator\ConstraintViolationInterface;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+
+/**
+ * Extends the InvalidItemExceptionFromViolations to be able to build one from a Symfony constraints violations list.
+ *
+ * @author    Julien Janvier <jjanvier@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class InvalidItemExceptionFromViolations extends BaseInvalidItemException
+{
+    /** @var ConstraintViolationListInterface */
+    protected $violations;
+
+    /**
+     * @param ConstraintViolationListInterface|null $violations
+     * @param array                                 $item
+     * @param array                                 $messageParameters
+     * @param int                                   $code
+     * @param \Exception|null                       $previous
+     */
+    public function __construct(
+        ConstraintViolationListInterface $violations,
+        array $item,
+        array $messageParameters = [],
+        $code = 0,
+        \Exception $previous = null
+    ) {
+        $this->violations = $violations;
+
+        $errors = [];
+        /** @var ConstraintViolationInterface $violation */
+        foreach ($violations as $violation) {
+            // TODO: re-format the message, property path doesn't exist for class constraint
+            // TODO: for instance cf VariantGroupAxis
+            $invalidValue = $violation->getInvalidValue();
+            if ($invalidValue instanceof ProductPriceInterface) {
+                $invalidValue = sprintf('%s %s', $invalidValue->getData(), $invalidValue->getCurrency());
+            } elseif (is_object($invalidValue) && method_exists($invalidValue, '__toString')) {
+                $invalidValue = (string)$invalidValue;
+            } elseif (is_object($invalidValue)) {
+                $invalidValue = get_class($invalidValue);
+            } elseif (is_array($invalidValue)) {
+                $invalidValue = implode(', ', $invalidValue);
+            }
+            $errors[] = sprintf(
+                "%s: %s: %s\n",
+                $violation->getPropertyPath(),
+                $violation->getMessage(),
+                $invalidValue
+            );
+        }
+
+        parent::__construct(implode("\n", $errors), $item, $messageParameters, $code, $previous);
+    }
+
+}

--- a/src/Pim/Component/Connector/Processor/Denormalization/AbstractProcessor.php
+++ b/src/Pim/Component/Connector/Processor/Denormalization/AbstractProcessor.php
@@ -8,8 +8,8 @@ use Akeneo\Component\Batch\Item\ItemProcessorInterface;
 use Akeneo\Component\Batch\Model\StepExecution;
 use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
+use Pim\Component\Connector\Exception\InvalidItemFromViolationsException;
 use Pim\Component\Connector\Exception\MissingIdentifierException;
-use Pim\Component\Connector\Item\InvalidItemExceptionFromViolations;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
 
 /**
@@ -113,6 +113,6 @@ abstract class AbstractProcessor extends AbstractConfigurableStepElement impleme
             $this->stepExecution->incrementSummaryInfo('skip');
         }
 
-        throw new InvalidItemExceptionFromViolations($violations, $item, [], 0, $previousException);
+        throw new InvalidItemFromViolationsException($violations, $item, [], 0, $previousException);
     }
 }

--- a/src/Pim/Component/Connector/Reader/File/Csv/ProductReader.php
+++ b/src/Pim/Component/Connector/Reader/File/Csv/ProductReader.php
@@ -58,12 +58,17 @@ class ProductReader extends Reader
         $jobParameters = $this->stepExecution->getJobParameters();
 
         return [
+            // for the array converters
             'mapping'           => [
                 $jobParameters->get('familyColumn')     => 'family',
                 $jobParameters->get('categoriesColumn') => 'categories',
                 $jobParameters->get('groupsColumn')     => 'groups'
             ],
-            'with_associations' => false
+            'with_associations' => false,
+
+            // for the delocalization
+            'decimal_separator' => $jobParameters->get('decimalSeparator'),
+            'date_format'       => $jobParameters->get('dateFormat')
         ];
     }
 }

--- a/src/Pim/Component/Connector/Reader/File/Csv/Reader.php
+++ b/src/Pim/Component/Connector/Reader/File/Csv/Reader.php
@@ -10,7 +10,7 @@ use Akeneo\Component\Batch\Model\StepExecution;
 use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
 use Pim\Component\Connector\ArrayConverter\ArrayConverterInterface;
 use Pim\Component\Connector\Exception\DataArrayConversionException;
-use Pim\Component\Connector\Item\InvalidItemExceptionFromViolations;
+use Pim\Component\Connector\Exception\InvalidItemFromViolationsException;
 use Pim\Component\Connector\Reader\File\FileIteratorFactory;
 use Pim\Component\Connector\Reader\File\FileIteratorInterface;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -118,7 +118,7 @@ class Reader extends AbstractConfigurableStepElement implements
      * @param DataArrayConversionException $exception
      *
      * @throws InvalidItemException
-     * @throws InvalidItemExceptionFromViolations
+     * @throws InvalidItemFromViolationsException
      */
     protected function skipItemFromConversionException(array $item, DataArrayConversionException $exception)
     {
@@ -127,7 +127,7 @@ class Reader extends AbstractConfigurableStepElement implements
         }
 
         if (null !== $exception->getViolations()) {
-            throw new InvalidItemExceptionFromViolations($exception->getViolations(), $item, [], 0, $exception);
+            throw new InvalidItemFromViolationsException($exception->getViolations(), $item, [], 0, $exception);
         }
 
         throw new InvalidItemException($exception->getMessage(), $item, [], 0, $exception);

--- a/src/Pim/Component/Connector/Reader/File/Csv/Reader.php
+++ b/src/Pim/Component/Connector/Reader/File/Csv/Reader.php
@@ -75,7 +75,7 @@ class Reader extends AbstractConfigurableStepElement implements
         $item = $this->fileIterator->current();
 
         if (null === $item) {
-           return null;
+            return null;
         }
 
         try {

--- a/src/Pim/Component/Connector/Reader/File/Xlsx/ProductReader.php
+++ b/src/Pim/Component/Connector/Reader/File/Xlsx/ProductReader.php
@@ -55,23 +55,20 @@ class ProductReader extends Reader
      */
     protected function getArrayConverterOptions()
     {
-        return [
-            'mapping'           => $this->getMapping(),
-            'with_associations' => false
-        ];
-    }
-
-    /**
-     * @return array
-     */
-    protected function getMapping()
-    {
         $jobParameters = $this->stepExecution->getJobParameters();
 
         return [
-            $jobParameters->get('familyColumn')     => 'family',
-            $jobParameters->get('categoriesColumn') => 'categories',
-            $jobParameters->get('groupsColumn')     => 'groups'
+            // for the array converters
+            'mapping'           => [
+                $jobParameters->get('familyColumn')     => 'family',
+                $jobParameters->get('categoriesColumn') => 'categories',
+                $jobParameters->get('groupsColumn')     => 'groups'
+            ],
+            'with_associations' => false,
+
+            // for the delocalization
+            'decimal_separator' => $jobParameters->get('decimalSeparator'),
+            'date_format'       => $jobParameters->get('dateFormat')
         ];
     }
 }

--- a/src/Pim/Component/Connector/Reader/File/Xlsx/Reader.php
+++ b/src/Pim/Component/Connector/Reader/File/Xlsx/Reader.php
@@ -10,7 +10,7 @@ use Akeneo\Component\Batch\Model\StepExecution;
 use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
 use Pim\Component\Connector\ArrayConverter\ArrayConverterInterface;
 use Pim\Component\Connector\Exception\DataArrayConversionException;
-use Pim\Component\Connector\Item\InvalidItemExceptionFromViolations;
+use Pim\Component\Connector\Exception\InvalidItemFromViolationsException;
 use Pim\Component\Connector\Reader\File\FileIteratorFactory;
 use Pim\Component\Connector\Reader\File\FileIteratorInterface;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -113,7 +113,7 @@ class Reader extends AbstractConfigurableStepElement implements
      * @param DataArrayConversionException $exception
      *
      * @throws InvalidItemException
-     * @throws InvalidItemExceptionFromViolations
+     * @throws InvalidItemFromViolationsException
      */
     protected function skipItemFromConversionException(array $item, DataArrayConversionException $exception)
     {
@@ -122,7 +122,7 @@ class Reader extends AbstractConfigurableStepElement implements
         }
 
         if (null !== $exception->getViolations()) {
-            throw new InvalidItemExceptionFromViolations($exception->getViolations(), $item, [], 0, $exception);
+            throw new InvalidItemFromViolationsException($exception->getViolations(), $item, [], 0, $exception);
         }
 
         throw new InvalidItemException($exception->getMessage(), $item, [], 0, $exception);

--- a/src/Pim/Component/Connector/Reader/File/Xlsx/Reader.php
+++ b/src/Pim/Component/Connector/Reader/File/Xlsx/Reader.php
@@ -4,13 +4,15 @@ namespace Pim\Component\Connector\Reader\File\Xlsx;
 
 use Akeneo\Component\Batch\Item\AbstractConfigurableStepElement;
 use Akeneo\Component\Batch\Item\FlushableInterface;
+use Akeneo\Component\Batch\Item\InvalidItemException;
 use Akeneo\Component\Batch\Item\ItemReaderInterface;
 use Akeneo\Component\Batch\Model\StepExecution;
 use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
 use Pim\Component\Connector\ArrayConverter\ArrayConverterInterface;
+use Pim\Component\Connector\Exception\DataArrayConversionException;
+use Pim\Component\Connector\Item\InvalidItemExceptionFromViolations;
 use Pim\Component\Connector\Reader\File\FileIteratorFactory;
 use Pim\Component\Connector\Reader\File\FileIteratorInterface;
-use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\Validator\Constraints as Assert;
 
 /**
@@ -67,7 +69,17 @@ class Reader extends AbstractConfigurableStepElement implements
 
         $item = $this->fileIterator->current();
 
-        return (null === $item) ? null : $this->converter->convert($item, $this->getArrayConverterOptions());
+        if (null === $item) {
+            return null;
+        }
+
+        try {
+            $item = $this->converter->convert($item, $this->getArrayConverterOptions());
+        } catch (DataArrayConversionException $e) {
+            $this->skipItemFromConversionException($item, $e);
+        }
+
+        return $item;
     }
 
     /**
@@ -94,5 +106,25 @@ class Reader extends AbstractConfigurableStepElement implements
     protected function getArrayConverterOptions()
     {
         return [];
+    }
+
+    /**
+     * @param array                        $item
+     * @param DataArrayConversionException $exception
+     *
+     * @throws InvalidItemException
+     * @throws InvalidItemExceptionFromViolations
+     */
+    protected function skipItemFromConversionException(array $item, DataArrayConversionException $exception)
+    {
+        if (null !== $this->stepExecution) {
+            $this->stepExecution->incrementSummaryInfo('skip');
+        }
+
+        if (null !== $exception->getViolations()) {
+            throw new InvalidItemExceptionFromViolations($exception->getViolations(), $item, [], 0, $exception);
+        }
+
+        throw new InvalidItemException($exception->getMessage(), $item, [], 0, $exception);
     }
 }

--- a/src/Pim/Component/Connector/Reader/File/Yaml/Reader.php
+++ b/src/Pim/Component/Connector/Reader/File/Yaml/Reader.php
@@ -10,7 +10,7 @@ use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
 use Pim\Bundle\BaseConnectorBundle\Reader\File\FileReader;
 use Pim\Component\Connector\ArrayConverter\ArrayConverterInterface;
 use Pim\Component\Connector\Exception\DataArrayConversionException;
-use Pim\Component\Connector\Item\InvalidItemExceptionFromViolations;
+use Pim\Component\Connector\Exception\InvalidItemFromViolationsException;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Yaml\Yaml;
 
@@ -168,7 +168,7 @@ class Reader extends FileReader implements
      * @param DataArrayConversionException $exception
      *
      * @throws InvalidItemException
-     * @throws InvalidItemExceptionFromViolations
+     * @throws InvalidItemFromViolationsException
      */
     protected function skipItemFromConversionException(array $item, DataArrayConversionException $exception)
     {
@@ -177,7 +177,7 @@ class Reader extends FileReader implements
         }
 
         if (null !== $exception->getViolations()) {
-            throw new InvalidItemExceptionFromViolations($exception->getViolations(), $item, [], 0, $exception);
+            throw new InvalidItemFromViolationsException($exception->getViolations(), $item, [], 0, $exception);
         }
 
         throw new InvalidItemException($exception->getMessage(), $item, [], 0, $exception);

--- a/src/Pim/Component/Connector/spec/ArrayConverter/FieldsRequirementCheckerSpec.php
+++ b/src/Pim/Component/Connector/spec/ArrayConverter/FieldsRequirementCheckerSpec.php
@@ -14,35 +14,35 @@ class FieldsRequirementCheckerSpec extends ObjectBehavior
     function it_does_not_raise_exception_when_there_is_no_required_fields()
     {
         $this
-            ->shouldNotThrow('Pim\Component\Connector\Exception\ArrayConversionException')
+            ->shouldNotThrow('Pim\Component\Connector\Exception\StructureArrayConversionException')
             ->during('checkFieldsPresence', [['foo' => 'bar'], []]);
     }
 
     function it_does_not_raise_exception_when_all_required_fields_are_filled()
     {
         $this
-            ->shouldNotThrow('Pim\Component\Connector\Exception\ArrayConversionException')
+            ->shouldNotThrow('Pim\Component\Connector\Exception\StructureArrayConversionException')
             ->during('checkFieldsPresence', [['foo' => 'bar'], ['foo']]);
     }
 
     function it_should_raise_exception_when_a_required_field_is_blank()
     {
         $this
-            ->shouldThrow('Pim\Component\Connector\Exception\ArrayConversionException')
+            ->shouldThrow('Pim\Component\Connector\Exception\DataArrayConversionException')
             ->during('checkFieldsFilling', [['foo' => ''], ['foo']]);
     }
 
     function it_should_raise_exception_when_a_required_field_is_null()
     {
         $this
-            ->shouldThrow('Pim\Component\Connector\Exception\ArrayConversionException')
+            ->shouldThrow('Pim\Component\Connector\Exception\DataArrayConversionException')
             ->during('checkFieldsFilling', [['foo' => null], ['foo']]);
     }
 
     function it_should_raise_exception_when_a_required_field_is_not_present()
     {
         $this
-            ->shouldThrow('Pim\Component\Connector\Exception\ArrayConversionException')
+            ->shouldThrow('Pim\Component\Connector\Exception\StructureArrayConversionException')
             ->during('checkFieldsPresence', [['foo' => 'bar'], ['baz']]);
     }
 }

--- a/src/Pim/Component/Connector/spec/ArrayConverter/FlatToStandard/AttributeOptionSpec.php
+++ b/src/Pim/Component/Connector/spec/ArrayConverter/FlatToStandard/AttributeOptionSpec.php
@@ -59,10 +59,10 @@ class AttributeOptionSpec extends ObjectBehavior
 
         $fieldChecker
             ->checkFieldsPresence($item, ['attribute', 'code'])
-            ->willThrow('Pim\Component\Connector\Exception\ArrayConversionException');
+            ->willThrow('Pim\Component\Connector\Exception\StructureArrayConversionException');
 
         $this
-            ->shouldThrow('Pim\Component\Connector\Exception\ArrayConversionException')
+            ->shouldThrow('Pim\Component\Connector\Exception\StructureArrayConversionException')
             ->during('convert', [$item]);
     }
 
@@ -71,7 +71,7 @@ class AttributeOptionSpec extends ObjectBehavior
         $localeRepository->getActivatedLocaleCodes()->willReturn(['de_DE', 'en_US', 'fr_FR']);
 
         $this
-            ->shouldThrow('Pim\Component\Connector\Exception\ArrayConversionException')
+            ->shouldThrow('Pim\Component\Connector\Exception\StructureArrayConversionException')
             ->during(
                 'convert',
                 [

--- a/src/Pim/Component/Connector/spec/ArrayConverter/FlatToStandard/ProductDelocalizedSpec.php
+++ b/src/Pim/Component/Connector/spec/ArrayConverter/FlatToStandard/ProductDelocalizedSpec.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace spec\Pim\Component\Connector\ArrayConverter\FlatToStandard;
+
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Localization\Localizer\AttributeConverterInterface;
+use Pim\Component\Connector\ArrayConverter\ArrayConverterInterface;
+use Prophecy\Argument;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+
+class ProductDelocalizedSpec extends ObjectBehavior
+{
+    function let(ArrayConverterInterface $converter, AttributeConverterInterface $delocalizer)
+    {
+        $this->beConstructedWith($converter, $delocalizer);
+    }
+
+    function it_converts($converter, $delocalizer, ConstraintViolationListInterface $violations)
+    {
+        $converter->convert(['the item'], ['the options'])->willReturn(['the item standardized']);
+        $delocalizer->convertToDefaultFormats(['the item standardized'], ['the options'])
+            ->willReturn(['the item standardized and delocalized']);
+
+        $delocalizer->getViolations()->willReturn($violations);
+        $violations->count()->willReturn(0);
+
+        $this->convert(['the item'], ['the options'])->shouldReturn(['the item standardized and delocalized']);
+    }
+
+    function it_throws_an_exception_in_case_of_conversion_error(
+        $converter,
+        $delocalizer,
+        ConstraintViolationListInterface $violations
+    ) {
+        $converter->convert(['the item'], ['the options'])->willReturn(['the item standardized']);
+        $delocalizer->convertToDefaultFormats(['the item standardized'], ['the options'])
+            ->willReturn(['the item standardized and delocalized']);
+
+        $delocalizer->getViolations()->willReturn($violations);
+        $violations->count()->willReturn(3);
+
+        $this->shouldThrow('Pim\Component\Connector\Exception\DataArrayConversionException')
+            ->during('convert', [['the item'], ['the options']]);
+    }
+}

--- a/src/Pim/Component/Connector/spec/ArrayConverter/FlatToStandard/ProductSpec.php
+++ b/src/Pim/Component/Connector/spec/ArrayConverter/FlatToStandard/ProductSpec.php
@@ -13,7 +13,7 @@ use Pim\Component\Connector\ArrayConverter\FlatToStandard\Product\ColumnsMapper;
 use Pim\Component\Connector\ArrayConverter\FlatToStandard\Product\ColumnsMerger;
 use Pim\Component\Connector\ArrayConverter\FlatToStandard\Product\AssociationColumnsResolver;
 use Pim\Component\Connector\ArrayConverter\FlatToStandard\Product\AttributeColumnsResolver;
-use Pim\Component\Connector\Exception\ArrayConversionException;
+use Pim\Component\Connector\Exception\StructureArrayConversionException;
 use Prophecy\Argument;
 
 class ProductSpec extends ObjectBehavior
@@ -298,7 +298,7 @@ class ProductSpec extends ObjectBehavior
         $converterRegistry->getConverter(Argument::any())->willReturn(null);
 
         $this->shouldThrow(
-            new ArrayConversionException('The fields "unknown_field, other_unknown_field" do not exist')
+            new StructureArrayConversionException('The fields "unknown_field, other_unknown_field" do not exist')
         )->during(
             'convert',
             [$item],
@@ -335,7 +335,7 @@ class ProductSpec extends ObjectBehavior
         $converterRegistry->getConverter(Argument::any())->willReturn(null);
 
         $this->shouldThrow(
-            new ArrayConversionException('The fields "unknown-products, unknown-groups" do not exist')
+            new StructureArrayConversionException('The fields "unknown-products, unknown-groups" do not exist')
         )->during(
             'convert',
             [$item],

--- a/src/Pim/Component/Connector/spec/Processor/Denormalization/ProductProcessorSpec.php
+++ b/src/Pim/Component/Connector/spec/Processor/Denormalization/ProductProcessorSpec.php
@@ -11,8 +11,6 @@ use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Builder\ProductBuilderInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Comparator\Filter\ProductFilterInterface;
-use Pim\Component\Connector\ArrayConverter\ArrayConverterInterface;
-use Pim\Component\Catalog\Localization\Localizer\AttributeConverterInterface;
 use Prophecy\Argument;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationList;
@@ -28,8 +26,7 @@ class ProductProcessorSpec extends ObjectBehavior
         ValidatorInterface $productValidator,
         StepExecution $stepExecution,
         ObjectDetacherInterface $productDetacher,
-        ProductFilterInterface $productFilter,
-        AttributeConverterInterface $localizedConverter
+        ProductFilterInterface $productFilter
     ) {
         $this->beConstructedWith(
             $productRepository,
@@ -37,8 +34,7 @@ class ProductProcessorSpec extends ObjectBehavior
             $productUpdater,
             $productValidator,
             $productDetacher,
-            $productFilter,
-            $localizedConverter
+            $productFilter
         );
         $this->setStepExecution($stepExecution);
     }
@@ -55,7 +51,6 @@ class ProductProcessorSpec extends ObjectBehavior
         $productUpdater,
         $productValidator,
         $productFilter,
-        $localizedConverter,
         $stepExecution,
         ProductInterface $product,
         ConstraintViolationListInterface $violationList,
@@ -127,11 +122,6 @@ class ProductProcessorSpec extends ObjectBehavior
             ]
         ];
 
-        $localizedConverter->convertToDefaultFormats(array_merge($convertedData, ['enabled' => true]), [
-            'decimal_separator' => '.',
-            'date_format'       => 'yyyy-MM-dd'
-        ])->willReturn($convertedData);
-        $localizedConverter->getViolations()->willReturn($violationList);
         $productFilter->filter($product, $filteredData)->willReturn($filteredData);
 
         $productUpdater
@@ -152,7 +142,6 @@ class ProductProcessorSpec extends ObjectBehavior
         $productUpdater,
         $productValidator,
         $productFilter,
-        $localizedConverter,
         $stepExecution,
         ProductInterface $product,
         ConstraintViolationListInterface $violationList,
@@ -201,12 +190,6 @@ class ProductProcessorSpec extends ObjectBehavior
             ]
         ];
 
-        $localizedConverter->convertToDefaultFormats(array_merge($convertedData, ['enabled' => true]), [
-            'decimal_separator' => '.',
-            'date_format'       => 'yyyy-MM-dd'
-        ])->willReturn($convertedData);
-        $localizedConverter->getViolations()->willReturn($violationList);
-
         $preFilteredData = $filteredData = [
             'family' => 'Tshirt',
             'name' => [
@@ -251,7 +234,6 @@ class ProductProcessorSpec extends ObjectBehavior
         $productUpdater,
         $productValidator,
         $productFilter,
-        $localizedConverter,
         $stepExecution,
         ProductInterface $product,
         ConstraintViolationListInterface $violationList,
@@ -300,12 +282,6 @@ class ProductProcessorSpec extends ObjectBehavior
             ]
         ];
 
-        $localizedConverter->convertToDefaultFormats(array_merge($convertedData, ['enabled' => true]), [
-            'decimal_separator' => '.',
-            'date_format'       => 'yyyy-MM-dd'
-        ])->willReturn($convertedData);
-        $localizedConverter->getViolations()->willReturn($violationList);
-
         $filteredData = [
             'family' => 'Tshirt',
             'name' => [
@@ -350,7 +326,6 @@ class ProductProcessorSpec extends ObjectBehavior
         $productUpdater,
         $productValidator,
         $productFilter,
-        $localizedConverter,
         $stepExecution,
         ProductInterface $product,
         ConstraintViolationListInterface $violationList,
@@ -370,7 +345,7 @@ class ProductProcessorSpec extends ObjectBehavior
 
         $productBuilder->createProduct('tshirt', 'Tshirt')->willReturn($product);
 
-        $convertedData =                 [
+        $convertedData = [
             'sku' => [
                 [
                     'locale' => null,
@@ -397,14 +372,9 @@ class ProductProcessorSpec extends ObjectBehavior
                     'scope' =>  'mobile',
                     'data' => 'My description'
                 ]
-            ]
+            ],
+            'enabled' => true
         ];
-
-        $localizedConverter->convertToDefaultFormats(array_merge($convertedData, ['enabled' => true]), [
-            'decimal_separator' => '.',
-            'date_format'       => 'yyyy-MM-dd'
-        ])->willReturn($convertedData);
-        $localizedConverter->getViolations()->willReturn($violationList);
 
         $filteredData = [
             'family' => 'Tshirt',
@@ -426,7 +396,8 @@ class ProductProcessorSpec extends ObjectBehavior
                     'scope' =>  'mobile',
                     'data' => 'My description'
                 ]
-            ]
+            ],
+            'enabled' => true
         ];
 
         $productFilter->filter($product, $filteredData)->willReturn($filteredData);
@@ -446,9 +417,7 @@ class ProductProcessorSpec extends ObjectBehavior
 
     function it_skips_a_product_when_identifier_is_empty(
         $productRepository,
-        $localizedConverter,
         $stepExecution,
-        ConstraintViolationListInterface $violationList,
         JobParameters $jobParameters
     ) {
         $stepExecution->getJobParameters()->willReturn($jobParameters);
@@ -473,12 +442,6 @@ class ProductProcessorSpec extends ObjectBehavior
             'family' => 'Tshirt',
         ];
 
-        $localizedConverter->convertToDefaultFormats(array_merge($convertedData, ['enabled' => true]), [
-            'decimal_separator' => '.',
-            'date_format'       => 'yyyy-MM-dd'
-        ])->willReturn($convertedData);
-        $localizedConverter->getViolations()->willReturn($violationList);
-
         $stepExecution->incrementSummaryInfo('skip')->shouldBeCalled();
 
         $this
@@ -495,7 +458,6 @@ class ProductProcessorSpec extends ObjectBehavior
         $productUpdater,
         $productDetacher,
         $productFilter,
-        $localizedConverter,
         $stepExecution,
         ProductInterface $product,
         ConstraintViolationListInterface $violationList,
@@ -542,14 +504,9 @@ class ProductProcessorSpec extends ObjectBehavior
                     'scope' =>  'mobile',
                     'data' => 'My description'
                 ]
-            ]
+            ],
+            'enabled' => true
         ];
-
-        $localizedConverter->convertToDefaultFormats(array_merge($convertedData, ['enabled' => true]), [
-            'decimal_separator' => '.',
-            'date_format'       => 'yyyy-MM-dd'
-        ])->willReturn($convertedData);
-        $localizedConverter->getViolations()->willReturn($violationList);
 
         $filteredData = [
             'family' => 'Tshirt',
@@ -571,7 +528,8 @@ class ProductProcessorSpec extends ObjectBehavior
                     'scope' =>  'mobile',
                     'data' => 'My description'
                 ]
-            ]
+            ],
+            'enabled' => true
         ];
 
         $productFilter->filter($product, $filteredData)->willReturn($filteredData);
@@ -598,7 +556,6 @@ class ProductProcessorSpec extends ObjectBehavior
         $productValidator,
         $productDetacher,
         $productFilter,
-        $localizedConverter,
         $stepExecution,
         ProductInterface $product,
         ConstraintViolationListInterface $violationList,
@@ -645,14 +602,9 @@ class ProductProcessorSpec extends ObjectBehavior
                     'scope' =>  'mobile',
                     'data' => 'My description'
                 ]
-            ]
+            ],
+            'enabled' => true
         ];
-
-        $localizedConverter->convertToDefaultFormats(array_merge($convertedData, ['enabled' => true]), [
-            'decimal_separator' => '.',
-            'date_format'       => 'yyyy-MM-dd'
-        ])->willReturn($convertedData);
-        $localizedConverter->getViolations()->willReturn($violationList);
 
         $filteredData = [
             'family' => 'Tshirt',
@@ -674,7 +626,8 @@ class ProductProcessorSpec extends ObjectBehavior
                     'scope' =>  'mobile',
                     'data' => 'My description'
                 ]
-            ]
+            ],
+            'enabled' => true
         ];
 
         $productFilter->filter($product, $filteredData)->willReturn($filteredData);
@@ -704,7 +657,6 @@ class ProductProcessorSpec extends ObjectBehavior
         $productUpdater,
         $productDetacher,
         $productFilter,
-        $localizedConverter,
         $stepExecution,
         ProductInterface $product,
         ConstraintViolationListInterface $violationList,
@@ -753,12 +705,6 @@ class ProductProcessorSpec extends ObjectBehavior
             ]
         ];
 
-        $localizedConverter->convertToDefaultFormats(array_merge($convertedData, ['enabled' => true]), [
-            'decimal_separator' => '.',
-            'date_format'       => 'yyyy-MM-dd'
-        ])->willReturn($convertedData);
-        $localizedConverter->getViolations()->willReturn($violationList);
-
         $filteredData = [
             'family' => 'Tshirt',
             'name' => [
@@ -795,230 +741,11 @@ class ProductProcessorSpec extends ObjectBehavior
             ->shouldReturn(null);
     }
 
-    function it_updates_an_existing_product_with_localized_value(
-        $productRepository,
-        $productUpdater,
-        $productValidator,
-        $productFilter,
-        $localizedConverter,
-        $stepExecution,
-        ProductInterface $product,
-        ConstraintViolationListInterface $violationList,
-        JobParameters $jobParameters
-    ) {
-        $stepExecution->getJobParameters()->willReturn($jobParameters);
-        $jobParameters->get('enabledComparison')->willReturn(true);
-        $jobParameters->get('familyColumn')->willReturn('family');
-        $jobParameters->get('categoriesColumn')->willReturn('categories');
-        $jobParameters->get('groupsColumn')->willReturn('groups');
-        $jobParameters->get('enabled')->willReturn(true);
-        $jobParameters->get('decimalSeparator')->willReturn(',');
-        $jobParameters->get('dateFormat')->willReturn('dd/MM/yyyy');
-
-        $productRepository->getIdentifierProperties()->willReturn(['sku']);
-        $productRepository->findOneByIdentifier(Argument::any())->willReturn($product);
-        $product->getId()->willReturn(42);
-
-        $postConverterData = $convertedData = [
-            'sku' => [
-                [
-                    'locale' => null,
-                    'scope'  =>  null,
-                    'data'   => 'tshirt'
-                ],
-            ],
-            'number' => [
-                [
-                    'locale' => null,
-                    'scope'  =>  null,
-                    'data'   => '10,45'
-                ]
-            ],
-            'date' => [
-                [
-                    'locale' => null,
-                    'scope'  =>  null,
-                    'data'   => '20/10/2015'
-                ]
-            ]
-        ];
-
-        $filteredData = [
-            'number' => [
-                [
-                    'locale' => null,
-                    'scope' =>  null,
-                    'data' => '10.45'
-                ]
-            ],
-            'date' => [
-                [
-                    'locale' => null,
-                    'scope'  =>  null,
-                    'data'   => '2015-10-20'
-                ]
-            ]
-        ];
-
-        $postConverterData['number'][0]['data'] = '10.45';
-        $postConverterData['date'][0]['data'] = '2015-10-20';
-        $localizedConverter->convertToDefaultFormats(array_merge($convertedData, ['enabled' => true]), [
-            'decimal_separator' => ',',
-            'date_format'       => 'dd/MM/yyyy'
-        ])->willReturn($postConverterData);
-        $localizedConverter->getViolations()->willReturn($violationList);
-
-        $productFilter->filter($product, $filteredData)->willReturn($filteredData);
-
-        $productUpdater
-            ->update($product, $filteredData)
-            ->shouldBeCalled();
-
-        $productValidator
-            ->validate($product)
-            ->willReturn($violationList);
-
-        $this
-            ->process($convertedData)
-            ->shouldReturn($product);
-    }
-
-    function it_skips_a_product_if_format_of_localized_attribute_is_not_expected(
-        $localizedConverter,
-        $productRepository,
-        $stepExecution,
-        ProductInterface $product,
-        JobParameters $jobParameters
-    ) {
-        $stepExecution->getJobParameters()->willReturn($jobParameters);
-        $jobParameters->get('enabledComparison')->willReturn(true);
-        $jobParameters->get('familyColumn')->willReturn('family');
-        $jobParameters->get('categoriesColumn')->willReturn('categories');
-        $jobParameters->get('groupsColumn')->willReturn('groups');
-        $jobParameters->get('enabled')->willReturn(true);
-        $jobParameters->get('decimalSeparator')->willReturn('.');
-        $jobParameters->get('dateFormat')->willReturn('yyyy-MM-dd');
-
-        $productRepository->getIdentifierProperties()->willReturn(['sku']);
-        $productRepository->findOneByIdentifier(Argument::any())->willReturn($product);
-        $product->getId()->willReturn(42);
-
-        $convertedData = [
-            'sku' => [
-                [
-                    'locale' => null,
-                    'scope'  =>  null,
-                    'data'   => 'tshirt'
-                ],
-            ],
-            'number' => [
-                [
-                    'locale' => null,
-                    'scope'  =>  null,
-                    'data'   => '10,45'
-                ]
-            ]
-        ];
-
-        $data = $convertedData;
-        $data['number'][0]['data'] = '10.45';
-        $localizedConverter->convertToDefaultFormats(array_merge($convertedData, ['enabled' => true]), [
-            'decimal_separator' => '.',
-            'date_format'       => 'yyyy-MM-dd'
-        ])->willReturn($data);
-
-        $violation = new ConstraintViolation(Argument::any(), Argument::any(), [], $product, 'number', '10,45');
-        $violations = new ConstraintViolationList([$violation]);
-        $localizedConverter->getViolations()->willReturn($violations);
-
-        $stepExecution->incrementSummaryInfo('skip')->shouldBeCalled();
-
-        $this
-            ->shouldThrow('Akeneo\Component\Batch\Item\InvalidItemException')
-            ->during(
-                'process',
-                [$convertedData]
-            );
-    }
-
-    function it_skips_a_product_when_there_is_nothing_to_update_with_localized_value(
-        $productRepository,
-        $productBuilder,
-        $productUpdater,
-        $productFilter,
-        $localizedConverter,
-        $stepExecution,
-        ProductInterface $product,
-        ConstraintViolationListInterface $violationList,
-        JobParameters $jobParameters
-    ) {
-        $stepExecution->getJobParameters()->willReturn($jobParameters);
-        $jobParameters->get('enabledComparison')->willReturn(true);
-        $jobParameters->get('familyColumn')->willReturn('family');
-        $jobParameters->get('categoriesColumn')->willReturn('categories');
-        $jobParameters->get('groupsColumn')->willReturn('groups');
-        $jobParameters->get('enabled')->willReturn(true);
-        $jobParameters->get('decimalSeparator')->willReturn(',');
-        $jobParameters->get('dateFormat')->willReturn('yyyy-MM-dd');
-
-        $productRepository->getIdentifierProperties()->willReturn(['sku']);
-        $productRepository->findOneByIdentifier('tshirt')->willReturn(false);
-        $product->getId()->willReturn(42);
-
-        $productBuilder->createProduct('tshirt', null)->willReturn($product);
-
-        $postConvertedData = $convertedData = [
-            'sku' => [
-                [
-                    'locale' => null,
-                    'scope' =>  null,
-                    'data' => 'tshirt'
-                ],
-            ],
-            'number' => [
-                [
-                    'locale' => null,
-                    'scope' =>  null,
-                    'data' => '10,45'
-                ],
-            ]
-        ];
-
-        $postConvertedData['number'][0]['data'] = '10.45';
-        $localizedConverter->convertToDefaultFormats(array_merge($convertedData, ['enabled' => true]), [
-            'decimal_separator' => ',',
-            'date_format'       => 'yyyy-MM-dd'
-        ])->willReturn($postConvertedData);
-        $localizedConverter->getViolations()->willReturn($violationList);
-
-        $filteredData = [
-            'number' => [
-                [
-                    'locale' => null,
-                    'scope' =>  null,
-                    'data' => '10.45'
-                ],
-            ]
-        ];
-
-        $productFilter->filter($product, $filteredData)->willReturn([]);
-
-        $stepExecution->incrementSummaryInfo('product_skipped_no_diff')->shouldBeCalled();
-
-        $productUpdater
-            ->update($product, $filteredData)->shouldNotBeCalled();
-
-        $this
-            ->process($convertedData)
-            ->shouldReturn(null);
-    }
-
     function it_updates_an_existing_product_and_does_not_change_his_state(
         $productRepository,
         $productUpdater,
         $productValidator,
         $productFilter,
-        $localizedConverter,
         $stepExecution,
         ProductInterface $product,
         ConstraintViolationListInterface $violationList,
@@ -1091,12 +818,6 @@ class ProductProcessorSpec extends ObjectBehavior
             ],
             'enabled' => false,
         ];
-
-        $localizedConverter->convertToDefaultFormats($convertedData, [
-            'decimal_separator' => '.',
-            'date_format'       => 'yyyy-MM-dd'
-        ])->willReturn($convertedData);
-        $localizedConverter->getViolations()->willReturn($violationList);
 
         $productFilter->filter($product, $filteredData)->willReturn($filteredData);
 
@@ -1119,7 +840,6 @@ class ProductProcessorSpec extends ObjectBehavior
         $productUpdater,
         $productValidator,
         $productFilter,
-        $localizedConverter,
         $stepExecution,
         ProductInterface $product,
         ConstraintViolationListInterface $violationList,
@@ -1156,11 +876,6 @@ class ProductProcessorSpec extends ObjectBehavior
             'enabled' => true
         ];
 
-        $localizedConverter->convertToDefaultFormats($convertedData, [
-            'decimal_separator' => '.',
-            'date_format'       => 'yyyy-MM-dd'
-        ])->willReturn($convertedData);
-        $localizedConverter->getViolations()->willReturn($violationList);
         $productFilter->filter($product, $filteredData)->willReturn($filteredData);
 
         $productUpdater

--- a/src/Pim/Component/Connector/spec/Reader/File/Csv/ProductReaderSpec.php
+++ b/src/Pim/Component/Connector/spec/Reader/File/Csv/ProductReaderSpec.php
@@ -11,7 +11,7 @@ use Pim\Component\Connector\Reader\File\FileIteratorInterface;
 use Pim\Component\Connector\Reader\File\MediaPathTransformer;
 use Prophecy\Argument;
 
-class ProductReaderSpec extends ObjectBehavior
+class  ProductReaderSpec extends ObjectBehavior
 {
     function let(
         FileIteratorFactory $fileIteratorFactory,
@@ -19,7 +19,7 @@ class ProductReaderSpec extends ObjectBehavior
         MediaPathTransformer $mediaPath,
         StepExecution $stepExecution
     ) {
-        $this->beConstructedWith($fileIteratorFactory, $converter, $mediaPath, ['.', ','], ['Y-m-d', 'd-m-Y']);
+        $this->beConstructedWith($fileIteratorFactory, $converter, $mediaPath);
         $this->setStepExecution($stepExecution);
     }
 
@@ -49,6 +49,8 @@ class ProductReaderSpec extends ObjectBehavior
         $jobParameters->get('familyColumn')->willReturn('family');
         $jobParameters->get('categoriesColumn')->willReturn('category');
         $jobParameters->get('groupsColumn')->willReturn('group');
+        $jobParameters->get('decimalSeparator')->willReturn('.');
+        $jobParameters->get('dateFormat')->willReturn('YYYY-mm-dd');
 
         $data = [
             'sku'          => 'SKU-001',
@@ -86,7 +88,9 @@ class ProductReaderSpec extends ObjectBehavior
                 'category' => 'categories',
                 'group' => 'groups'
             ],
-            'with_associations' => false
+            'with_associations' => false,
+            'decimal_separator' => '.',
+            'date_format'       => 'YYYY-mm-dd',
         ])->willReturn($absolutePath);
 
         $this->read()->shouldReturn($absolutePath);

--- a/src/Pim/Component/Connector/spec/Reader/File/Csv/ReaderSpec.php
+++ b/src/Pim/Component/Connector/spec/Reader/File/Csv/ReaderSpec.php
@@ -6,9 +6,11 @@ use Akeneo\Component\Batch\Job\JobParameters;
 use Akeneo\Component\Batch\Model\StepExecution;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Connector\ArrayConverter\ArrayConverterInterface;
+use Pim\Component\Connector\Exception\DataArrayConversionException;
 use Pim\Component\Connector\Reader\File\FileIteratorFactory;
 use Pim\Component\Connector\Reader\File\FileIteratorInterface;
 use Prophecy\Argument;
+use Symfony\Component\Validator\ConstraintViolationList;
 
 class ReaderSpec extends ObjectBehavior
 {
@@ -55,6 +57,45 @@ class ReaderSpec extends ObjectBehavior
         $converter->convert($data, Argument::any())->willReturn($data);
 
         $this->read()->shouldReturn($data);
+    }
+
+    function it_skips_an_item_in_case_of_conversion_error(
+        $fileIteratorFactory,
+        $converter,
+        $stepExecution,
+        FileIteratorInterface $fileIterator,
+        JobParameters $jobParameters
+    ) {
+        $filePath = $this->getPath() . DIRECTORY_SEPARATOR  . 'with_media.csv';
+
+        $stepExecution->getJobParameters()->willReturn($jobParameters);
+        $jobParameters->get('enclosure')->willReturn('"');
+        $jobParameters->get('delimiter')->willReturn(';');
+        $jobParameters->get('filePath')->willReturn($filePath);
+
+        $data = [
+            'sku'  => 'SKU-001',
+            'name' => 'door',
+        ];
+
+        $fileIteratorFactory->create($filePath, [
+            'fieldDelimiter' => ';',
+            'fieldEnclosure' => '"',
+        ])->willReturn($fileIterator);
+
+        $fileIterator->rewind()->shouldBeCalled();
+        $fileIterator->next()->shouldBeCalled();
+        $fileIterator->valid()->willReturn(true);
+        $fileIterator->current()->willReturn($data);
+
+        $stepExecution->incrementSummaryInfo('read_lines')->shouldBeCalled();
+
+        $stepExecution->incrementSummaryInfo("skip")->shouldBeCalled();
+        $converter->convert($data, Argument::any())->willThrow(
+            new DataArrayConversionException('message', 0, null, new ConstraintViolationList())
+        );
+
+        $this->shouldThrow('Pim\Component\Connector\Item\InvalidItemExceptionFromViolations')->during('read');
     }
 
     private function getPath()

--- a/src/Pim/Component/Connector/spec/Reader/File/Csv/ReaderSpec.php
+++ b/src/Pim/Component/Connector/spec/Reader/File/Csv/ReaderSpec.php
@@ -95,7 +95,7 @@ class ReaderSpec extends ObjectBehavior
             new DataArrayConversionException('message', 0, null, new ConstraintViolationList())
         );
 
-        $this->shouldThrow('Pim\Component\Connector\Item\InvalidItemExceptionFromViolations')->during('read');
+        $this->shouldThrow('Pim\Component\Connector\Exception\InvalidItemFromViolationsException')->during('read');
     }
 
     private function getPath()

--- a/src/Pim/Component/Connector/spec/Reader/File/Xlsx/ProductReaderSpec.php
+++ b/src/Pim/Component/Connector/spec/Reader/File/Xlsx/ProductReaderSpec.php
@@ -28,7 +28,7 @@ class ProductReaderSpec extends ObjectBehavior
         $this->shouldHaveType('Pim\Component\Connector\Reader\File\Xlsx\ProductReader');
     }
 
-    function it_is_a_csv_reader()
+    function it_is_a_xlsx_reader()
     {
         $this->shouldHaveType('Pim\Component\Connector\Reader\File\Xlsx\Reader');
     }
@@ -48,6 +48,8 @@ class ProductReaderSpec extends ObjectBehavior
         $jobParameters->get('familyColumn')->willReturn('family');
         $jobParameters->get('categoriesColumn')->willReturn('categories');
         $jobParameters->get('groupsColumn')->willReturn('groups');
+        $jobParameters->get('decimalSeparator')->willReturn('.');
+        $jobParameters->get('dateFormat')->willReturn('YYYY-mm-dd');
 
         $fileIteratorFactory->create($filePath)->willReturn($fileIterator);
 
@@ -86,6 +88,8 @@ class ProductReaderSpec extends ObjectBehavior
                 'groups'     => 'groups',
             ],
             'with_associations' => false,
+            'decimal_separator' => '.',
+            'date_format'       => 'YYYY-mm-dd',
         ];
 
         $fileIterator->rewind()->shouldBeCalled();

--- a/src/Pim/Component/Connector/spec/Reader/File/Xlsx/ReaderSpec.php
+++ b/src/Pim/Component/Connector/spec/Reader/File/Xlsx/ReaderSpec.php
@@ -93,7 +93,7 @@ class ReaderSpec extends ObjectBehavior
             new DataArrayConversionException('message', 0, null, new ConstraintViolationList())
         );
 
-        $this->shouldThrow('Pim\Component\Connector\Item\InvalidItemExceptionFromViolations')->during('read');
+        $this->shouldThrow('Pim\Component\Connector\Exception\InvalidItemFromViolationsException')->during('read');
     }
 
 

--- a/src/Pim/Component/Connector/spec/Reader/File/Xlsx/ReaderSpec.php
+++ b/src/Pim/Component/Connector/spec/Reader/File/Xlsx/ReaderSpec.php
@@ -6,9 +6,11 @@ use Akeneo\Component\Batch\Job\JobParameters;
 use Akeneo\Component\Batch\Model\StepExecution;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Connector\ArrayConverter\ArrayConverterInterface;
+use Pim\Component\Connector\Exception\DataArrayConversionException;
 use Pim\Component\Connector\Reader\File\FileIteratorFactory;
 use Pim\Component\Connector\Reader\File\FileIteratorInterface;
 use Prophecy\Argument;
+use Symfony\Component\Validator\ConstraintViolationList;
 
 class ReaderSpec extends ObjectBehavior
 {
@@ -21,7 +23,7 @@ class ReaderSpec extends ObjectBehavior
         $this->setStepExecution($stepExecution);
     }
 
-    function it_read_csv_file(
+    function it_read_xlsx_file(
         $fileIteratorFactory,
         $converter,
         $stepExecution,
@@ -54,4 +56,45 @@ class ReaderSpec extends ObjectBehavior
 
         $this->read()->shouldReturn($data);
     }
+
+    function it_skips_an_item_in_case_of_conversion_error(
+        $fileIteratorFactory,
+        $converter,
+        $stepExecution,
+        FileIteratorInterface $fileIterator,
+        JobParameters $jobParameters
+    ) {
+        $filePath = __DIR__ . DIRECTORY_SEPARATOR .
+            DIRECTORY_SEPARATOR . 'features' .
+            DIRECTORY_SEPARATOR . 'Context' .
+            DIRECTORY_SEPARATOR . 'fixtures' .
+            DIRECTORY_SEPARATOR . 'product_with_carriage_return.xlsx';
+
+        $stepExecution->getJobParameters()->willReturn($jobParameters);
+        $jobParameters->get('filePath')->willReturn($filePath);
+
+        $data = [
+            'sku'  => 'SKU-001',
+            'name' => 'door',
+        ];
+
+        $fileIteratorFactory->create($filePath)->willReturn($fileIterator);
+
+        $fileIterator->rewind()->shouldBeCalled();
+        $fileIterator->next()->shouldBeCalled();
+        $fileIterator->valid()->willReturn(true);
+        $fileIterator->current()->willReturn($data);
+        $converter->convert($data, Argument::any())->willReturn($data);
+
+        $stepExecution->incrementSummaryInfo('read_lines')->shouldBeCalled();
+
+        $stepExecution->incrementSummaryInfo("skip")->shouldBeCalled();
+        $converter->convert($data, Argument::any())->willThrow(
+            new DataArrayConversionException('message', 0, null, new ConstraintViolationList())
+        );
+
+        $this->shouldThrow('Pim\Component\Connector\Item\InvalidItemExceptionFromViolations')->during('read');
+    }
+
+
 }

--- a/src/Pim/Component/Connector/spec/Reader/File/Yaml/ReaderSpec.php
+++ b/src/Pim/Component/Connector/spec/Reader/File/Yaml/ReaderSpec.php
@@ -84,7 +84,7 @@ class ReaderSpec extends ObjectBehavior
             new DataArrayConversionException('message', 0, null, new ConstraintViolationList())
         );
 
-        $this->shouldThrow('Pim\Component\Connector\Item\InvalidItemExceptionFromViolations')->during('read');
+        $this->shouldThrow('Pim\Component\Connector\Exception\InvalidItemFromViolationsException')->during('read');
     }
 
     function it_reads_entities_from_a_yml_file_one_by_one(


### PR DESCRIPTION
What's done here:
* now we can create an InvalidItemException from a constraint violation list (before it was done in the ProductProcessor)
* ArrayConversionException has specialized into StructureArrayConversionException and DataArrayConversionException 
* regular conversion errors are now catched  to in the readers (via the DataArrayConversionException) to skip the item (StructureArrayConversionException and regular ArrayConversionException are still catch by the BatchBundle itself to stop the process)
* a ProductDelocalizer array converter has been introduced to correctly convert the product from Flat to Standard (in the standard format, data are delocalized) => that means the product processor now receives the "standard" format as input

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Y
| Added Behats                      | -
| Changelog updated                 | Y
| Review and 2 GTM                  | 
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -
