### PR TITLE
Fix SSL translation

### DIFF
--- a/src/Pim/Bundle/UserBundle/Resources/translations/messages.en.yml
+++ b/src/Pim/Bundle/UserBundle/Resources/translations/messages.en.yml
@@ -68,7 +68,7 @@ Business Units: Business Units
 Email synchronization settings: Email synchronization settings
 Host: Host
 Port: Port
-Ssl: Ssl
+Ssl: SSL
 Last logged in: Last logged in
 Login count: Login count
 Additional Information: Additional Information


### PR DESCRIPTION
Fix remark from Crowdin

Exact acronym is "SSL", not "Ssl".

https://crowdin.com/translate/akeneo/291/en-hu#7107