### PR TITLE
Clean decorator namespaces

### DIFF
--- a/features/Context/Page/Base/Form.php
+++ b/features/Context/Page/Base/Form.php
@@ -45,7 +45,7 @@ class Form extends Base
                 'Save'                            => ['css' => 'button.btn-submit'],
                 'Panel sidebar'                   => [
                     'css'        => '.edit-form > .content',
-                    'decorators' => ['Pim\Behat\Decorator\PageDecorator\PanelableDecorator']
+                    'decorators' => ['Pim\Behat\Decorator\Page\PanelableDecorator']
                 ]
             ],
             $this->elements

--- a/features/Context/Page/Base/Grid.php
+++ b/features/Context/Page/Base/Grid.php
@@ -26,7 +26,7 @@ class Grid extends Index
 
     protected $filterDecorators = [
         'tree' => [
-            'Pim\Behat\Decorator\TreeDecorator\JsTreeDecorator',
+            'Pim\Behat\Decorator\Tree\JsTreeDecorator',
             'Pim\Behat\Decorator\Grid\Filter\CategoryDecorator',
         ],
         'boolean' => [

--- a/features/Context/Page/Batch/Classify.php
+++ b/features/Context/Page/Batch/Classify.php
@@ -27,7 +27,7 @@ class Classify extends Wizard
                 'Category tree' => [
                     'css'        => '#trees',
                     'decorators' => [
-                        'Pim\Behat\Decorator\TreeDecorator\JsTreeDecorator'
+                        'Pim\Behat\Decorator\Tree\JsTreeDecorator'
                     ]
                 ],
             ]

--- a/features/Context/Page/Category/CategoryView.php
+++ b/features/Context/Page/Category/CategoryView.php
@@ -29,7 +29,7 @@ abstract class CategoryView extends Form
                 'Category tree'    => [
                     'css'        => '#tree',
                     'decorators' => [
-                        'Pim\Behat\Decorator\TreeDecorator\JsTreeDecorator'
+                        'Pim\Behat\Decorator\Tree\JsTreeDecorator'
                     ]
                 ],
                 'Tree select'      => ['css' => '#tree_select'],

--- a/features/Context/Page/Product/Edit.php
+++ b/features/Context/Page/Product/Edit.php
@@ -52,7 +52,7 @@ class Edit extends ProductEditForm
                 'Category tree'           => [
                     'css'        => '#trees',
                     'decorators' => [
-                        'Pim\Behat\Decorator\TreeDecorator\JsTreeDecorator'
+                        'Pim\Behat\Decorator\Tree\JsTreeDecorator'
                     ]
                 ],
                 'Copy actions'            => ['css' => '.copy-actions'],
@@ -64,14 +64,14 @@ class Edit extends ProductEditForm
                 'Attribute tab'           => [
                     'css'        => '.tab-container .object-attributes',
                     'decorators' => [
-                        'Pim\Behat\Decorator\TabDecorator\ComparableTabDecorator'
+                        'Pim\Behat\Decorator\Tab\ComparableTabDecorator'
                     ]
                 ],
                 'Comparison panel' => [
                     'css'        => '.tab-container .attribute-actions .attribute-copy-actions',
                     'decorators' => [
                         'Pim\Behat\Decorator\ContextSwitcherDecorator',
-                        'Pim\Behat\Decorator\TabElementDecorator\ComparisonPanelDecorator'
+                        'Pim\Behat\Decorator\TabElement\ComparisonPanelDecorator'
                     ]
                 ],
                 'Main context selector' => [

--- a/features/Pim/Behat/Context/NavigationContext.php
+++ b/features/Pim/Behat/Context/NavigationContext.php
@@ -63,7 +63,7 @@ class NavigationContext extends PimContext implements PageObjectAwareInterface
 
     /** @var array */
     protected $pageDecorators = [
-        'Pim\Behat\Decorator\PageDecorator\GridCapableDecorator',
+        'Pim\Behat\Decorator\Page\GridCapableDecorator',
     ];
 
     protected $elements = [

--- a/features/Pim/Behat/Decorator/Page/GridCapableDecorator.php
+++ b/features/Pim/Behat/Decorator/Page/GridCapableDecorator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Pim\Behat\Decorator\PageDecorator;
+namespace Pim\Behat\Decorator\Page;
 
 use Behat\Mink\Element\NodeElement;
 use Context\Spin\SpinCapableTrait;

--- a/features/Pim/Behat/Decorator/Page/PanelableDecorator.php
+++ b/features/Pim/Behat/Decorator/Page/PanelableDecorator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Pim\Behat\Decorator\PageDecorator;
+namespace Pim\Behat\Decorator\Page;
 
 use Behat\Mink\Exception\ElementNotFoundException;
 use Context\Spin\SpinCapableTrait;

--- a/features/Pim/Behat/Decorator/Tab/ComparableTabDecorator.php
+++ b/features/Pim/Behat/Decorator/Tab/ComparableTabDecorator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Pim\Behat\Decorator\TabDecorator;
+namespace Pim\Behat\Decorator\Tab;
 
 use Behat\Mink\Exception\ElementNotFoundException;
 use Context\Spin\SpinCapableTrait;

--- a/features/Pim/Behat/Decorator/TabElement/ComparisonPanelDecorator.php
+++ b/features/Pim/Behat/Decorator/TabElement/ComparisonPanelDecorator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Pim\Behat\Decorator\TabElementDecorator;
+namespace Pim\Behat\Decorator\TabElement;
 
 use Context\Spin\SpinCapableTrait;
 use Pim\Behat\Decorator\ElementDecorator;

--- a/features/Pim/Behat/Decorator/Tree/JsNodeDecorator.php
+++ b/features/Pim/Behat/Decorator/Tree/JsNodeDecorator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Pim\Behat\Decorator\TreeDecorator;
+namespace Pim\Behat\Decorator\Tree;
 
 use Behat\Mink\Element\NodeElement;
 use Context\Spin\SpinCapableTrait;

--- a/features/Pim/Behat/Decorator/Tree/JsTreeDecorator.php
+++ b/features/Pim/Behat/Decorator/Tree/JsTreeDecorator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Pim\Behat\Decorator\TreeDecorator;
+namespace Pim\Behat\Decorator\Tree;
 
 use Behat\Mink\Element\NodeElement;
 use Context\Spin\SpinCapableTrait;
@@ -24,7 +24,7 @@ class JsTreeDecorator extends ElementDecorator
             return $this->find('css', sprintf('li[data-code="%s"]', $nodeName));
         }, sprintf('Cannot find the node "%s"', $nodeName));
 
-        return $this->decorate($node, ['Pim\Behat\Decorator\TreeDecorator\JsNodeDecorator']);
+        return $this->decorate($node, ['Pim\Behat\Decorator\Tree\JsNodeDecorator']);
     }
 
     /**


### PR DESCRIPTION
Folders in `Pim\Behat\Decorator\` should not be suffixed by Decorator
Only classes have to be.


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       |
| Added Behats                      |
| Changelog updated                 |
| Review and 2 GTM                  |
| Micro Demo to the PO (Story only) |
| Migration script                  |
| Tech Doc                          |

