### PR TITLE
PIM-5852: Fix attribute option import order

### DIFF
--- a/features/Context/FixturesContext.php
+++ b/features/Context/FixturesContext.php
@@ -456,9 +456,30 @@ class FixturesContext extends BaseFixturesContext
             );
             $option->setLocale('en_US');
             assertEquals($data['label-en_US'], (string) $option);
+            $this->detach($option);
         }
     }
 
+    /**
+     * @param TableNode $table
+     *
+     * @Then /^there should be the following options with this order:$/
+     */
+    public function thereShouldBeTheFollowingOptionsWithThisOrder(TableNode $table)
+    {
+        foreach ($table->getHash() as $i => $data) {
+            $attribute = $this->getEntityOrException('Attribute', ['code' => $data['attribute']]);
+            $option    = $this->getEntityOrException(
+                'AttributeOption',
+                ['code' => $data['code'], 'attribute' => $attribute]
+            );
+            $option->setLocale('en_US');
+            assertEquals($i+1, $option->getSortOrder());
+            assertEquals($data['code'], $option->getCode());
+            assertEquals($data['label-en_US'], $option->getOptionValue()->getValue());
+            $this->detach($option);
+        }
+    }
     /**
      * @param TableNode $table
      *

--- a/features/Context/FixturesContext.php
+++ b/features/Context/FixturesContext.php
@@ -474,7 +474,13 @@ class FixturesContext extends BaseFixturesContext
                 ['code' => $data['code'], 'attribute' => $attribute]
             );
             $option->setLocale('en_US');
-            assertEquals($i+1, $option->getSortOrder());
+
+            if (!isset($data['sort_order'])) {
+                assertEquals($i+1, $option->getSortOrder());
+            } else {
+                assertEquals($data['sort_order'], $option->getSortOrder());
+            }
+
             assertEquals($data['code'], $option->getCode());
             assertEquals($data['label-en_US'], $option->getOptionValue()->getValue());
             $this->detach($option);

--- a/features/Pim/Behat/Context/FixturesContext.php
+++ b/features/Pim/Behat/Context/FixturesContext.php
@@ -279,4 +279,14 @@ class FixturesContext extends PimContext
             $this->getSmartRegistry()->getManagerForClass(get_class($object))->refresh($object);
         }
     }
+
+    /**
+     * @param $object
+     */
+    public function detach($object)
+    {
+        if (is_object($object)) {
+            $this->getSmartRegistry()->getManagerForClass(get_class($object))->detach($object);
+        }
+    }
 }

--- a/features/import/import_options.feature
+++ b/features/import/import_options.feature
@@ -171,3 +171,36 @@ Feature: Import options
       | brand     | TimberLand  | TimberLand  |
       | brand     | Nike        | Nike        |
       | brand     | Caterpillar | Caterpillar |
+
+  @jira https://akeneo.atlassian.net/browse/PIM-5682
+    Scenario: Successfully update options without sort order
+      Given the "footwear" catalog configuration
+      And I am logged in as "Julia"
+      Then there should be the following options with this order:
+        | attribute          | code  | label-en_US |
+        | weather_conditions | dry   | Dry         |
+        | weather_conditions | wet   | Wet         |
+        | weather_conditions | hot   | Hot         |
+        | weather_conditions | cold  | Cold        |
+        | weather_conditions | snowy | Snowy       |
+      And the following XLSX file to import:
+      """
+      attribute;code;label-en_US
+      weather_conditions;wet;Watery
+      weather_conditions;dry;Rainy
+      weather_conditions;cold;Very cold
+      weather_conditions;snowy;Snow
+      weather_conditions;hot;Sunny
+      """
+      And the following job "xlsx_footwear_option_import" configuration:
+        | filePath | %file to import% |
+      When I am on the "xlsx_footwear_option_import" import job page
+      And I launch the import job
+      And I wait for the "xlsx_footwear_option_import" job to finish
+      Then there should be the following options with this order:
+        | attribute          | code  | label-en_US |
+        | weather_conditions | dry   | Rainy       |
+        | weather_conditions | wet   | Watery      |
+        | weather_conditions | hot   | Sunny       |
+        | weather_conditions | cold  | Very cold   |
+        | weather_conditions | snowy | Snow        |

--- a/features/import/import_options.feature
+++ b/features/import/import_options.feature
@@ -204,3 +204,36 @@ Feature: Import options
         | weather_conditions | hot   | Sunny       |
         | weather_conditions | cold  | Very cold   |
         | weather_conditions | snowy | Snow        |
+
+    @jira https://akeneo.atlassian.net/browse/PIM-5682
+  Scenario: Successfully update options with sort order
+    Given the "footwear" catalog configuration
+    And I am logged in as "Julia"
+    Then there should be the following options with this order:
+      | attribute          | code  | label-en_US | sort_order |
+      | weather_conditions | dry   | Dry         | 1          |
+      | weather_conditions | wet   | Wet         | 2          |
+      | weather_conditions | hot   | Hot         | 3          |
+      | weather_conditions | cold  | Cold        | 4          |
+      | weather_conditions | snowy | Snowy       | 5          |
+    And the following XLSX file to import:
+      """
+      attribute;code;label-en_US;sort_order
+      weather_conditions;cold;Very cold;5
+      weather_conditions;dry;Rainy;2
+      weather_conditions;snowy;Snow;1
+      weather_conditions;hot;Sunny;4
+      weather_conditions;wet;Watery;3
+      """
+    And the following job "xlsx_footwear_option_import" configuration:
+      | filePath | %file to import% |
+    When I am on the "xlsx_footwear_option_import" import job page
+    And I launch the import job
+    And I wait for the "xlsx_footwear_option_import" job to finish
+    Then there should be the following options with this order:
+      | attribute          | code  | label-en_US | sort_ order |
+      | weather_conditions | snowy | Snow        | 1           |
+      | weather_conditions | dry   | Rainy       | 2           |
+      | weather_conditions | wet   | Watery      | 3           |
+      | weather_conditions | hot   | Sunny       | 4           |
+      | weather_conditions | cold  | Very cold   | 5           |

--- a/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/AttributeOption.php
+++ b/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/AttributeOption.php
@@ -75,10 +75,9 @@ class AttributeOption implements ArrayConverterInterface
                 $convertedItem[$field] = $data;
             }
         }
-        if (!isset($convertedItem['sort_order'])) {
-            $convertedItem['sort_order'] = 1;
+        if (isset($convertedItem['sort_order'])) {
+            $convertedItem['sort_order'] = (int) $convertedItem['sort_order'];
         }
-        $convertedItem['sort_order'] = (int) $convertedItem['sort_order'];
 
         return $convertedItem;
     }


### PR DESCRIPTION
Fixes the `ArrayConverter/FlatToStandard/AttributeOption` to update attribute option information without ordering when none is specified.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | no
| Added Behats                      | yes
| Changelog updated                 | no 
| Review and 2 GTM                  | no 
| Micro Demo to the PO (Story only) | -
| Migration script                  | - 
| Tech Doc                          | -

