### PR TITLE
PIM-5855: Attribute Length generates issues in Product Grid

### DIFF
--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -1,3 +1,9 @@
+# 1.5.*
+
+## Bug fixes
+
+- PIM-5855: Attribute Length generates issues in Product Grid
+
 # 1.5.5 (2016-06-16)
 
 - PIM-5711: Don't create empty attribute translations if attributes are imported with empty labels

--- a/features/datagrid/display_many_datagrid_filters.feature
+++ b/features/datagrid/display_many_datagrid_filters.feature
@@ -12,3 +12,21 @@ Feature: Display many datagrid filters
     When I show the filter "Attribute 499"
     And I filter by "Attribute 499" with value "Option 1 for attribute 499"
     Then I should be on the products page
+
+  @jira https://akeneo.atlassian.net/browse/PIM-5855
+  Scenario: Check that a non metric attribute named "length" do not break the grid
+    Given the "default" catalog configuration
+    And the following families:
+      | code      | label-en_US |
+      | guitar    | Guitar      |
+    And the following products:
+      | sku        | family |
+      | les-paul   | guitar |
+      | telecaster | guitar |
+    And the following attributes:
+      | code   | label  | type |
+      | length | length | text |
+    When I am logged in as "Mary"
+    And I am on the products page
+    Then I should see product les-paul
+    And I should see product telecaster

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/collection-filters-manager.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/collection-filters-manager.js
@@ -117,7 +117,7 @@ function(_, FiltersManager) {
             _.each(this.filters, function(filter, name) {
                 var shortName = '__' + name,
                     filterState;
-                if (_.has(state, name)) {
+                if (_.has(state, name) && 0 !== _​.size(state)) {
                     filterState = state[name];
                     if (!_.isObject(filterState)) {
                         filterState = {


### PR DESCRIPTION
Having a text attribute Length usable as grid filter breaks the product grid.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | no
| Added Behats                      | yes
| Changelog updated                 | yes
| Review and 2 GTM                  | yes
| Micro Demo to the PO (Story only) | no
| Migration script                  | no
| Tech Doc                          | no

