### PR TITLE
Ignore integrity constraint violations

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/CompletenessGenerator.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/CompletenessGenerator.php
@@ -282,7 +282,7 @@ MISSING_SQL;
     protected function getMainSqlPart()
     {
         return <<<MAIN_SQL
-            INSERT IGNORE INTO pim_catalog_completeness (
+            REPLACE pim_catalog_completeness (
                 locale_id, channel_id, product_id, ratio, missing_count, required_count
             )
             SELECT

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/CompletenessGenerator.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/CompletenessGenerator.php
@@ -282,7 +282,7 @@ MISSING_SQL;
     protected function getMainSqlPart()
     {
         return <<<MAIN_SQL
-            INSERT INTO pim_catalog_completeness (
+            INSERT IGNORE INTO pim_catalog_completeness (
                 locale_id, channel_id, product_id, ratio, missing_count, required_count
             )
             SELECT


### PR DESCRIPTION
When running 2 completeness calculations executed at the same time you may get integrity constraint violations (see #4659).

This PR use REPLACE instead of INSERT INTO. REPLACE works exactly like INSERT, except that if an old row in the table has the same value as a new row for a PRIMARY KEY or a UNIQUE index, the old row is deleted before the new row is inserted.

There still may be errors with dropped `complete_price`, `missing_completeness` tables, but it defuse the problem of concurrent completeness calculations. 
