### PR TITLE
PIM-5863: Fix row selection in association grid

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 - PIM-5820: Fix product value filtering by channel and locale in structured product normalizer
 - PIM-5687: Fix an issue that prevented the removal of a product from a variant group in MongoDB
+- PIM-5863: Fix an issue that prevented the association of multiple products at once in the association tab
 
 # 1.4.24 (2016-05-10)
 

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/listener/oro-column-form-listener.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/listener/oro-column-form-listener.js
@@ -40,6 +40,7 @@ function($, _, __, mediator, Modal, AbstractListener) {
 
             this.$gridContainer.on('preExecute:refresh:' + this.gridName, this._onExecuteRefreshAction.bind(this));
             this.$gridContainer.on('preExecute:reset:' + this.gridName, this._onExecuteResetAction.bind(this));
+            mediator.on('grid_load:complete', this._restoreState.bind(this));
 
             this._clearState();
             this._restoreState();
@@ -114,8 +115,6 @@ function($, _, __, mediator, Modal, AbstractListener) {
             if (this.selectors.excluded) {
                 $(this.selectors.excluded).val(excluded.join(','));
             }
-            mediator.trigger('datagrid:setParam:' + this.gridName, 'data_in', included);
-            mediator.trigger('datagrid:setParam:' + this.gridName, 'data_not_in', excluded);
         },
 
         /**
@@ -149,8 +148,6 @@ function($, _, __, mediator, Modal, AbstractListener) {
                 this.set('excluded', excluded)
             }
             if (included || excluded) {
-                mediator.trigger('datagrid:setParam:' + this.gridName, 'data_in', included);
-                mediator.trigger('datagrid:setParam:' + this.gridName, 'data_not_in', excluded);
                 mediator.trigger('datagrid:restoreState:' + this.gridName, this.columnName, this.dataField, included, excluded);
             }
          },


### PR DESCRIPTION
This patch prevents the association grid from sending/getting all checked rows into/from the backend and uses the state saved into the DOM instead (hidden input).

When the grid loads the "oro-column-listener" restores the state (column checked and unchecked during the session) from the DOM and applies it to the grid.

**Definition Of Done **

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Changelog updated                 | yes
| Review and 2 GTM                  | yes

