### PR TITLE
Remove navigation specific methods

### DIFF
--- a/features/Context/NavigationContext.php
+++ b/features/Context/NavigationContext.php
@@ -40,30 +40,6 @@ class NavigationContext extends BaseNavigationContext
     }
 
     /**
-     * @Given /^I edit my profile$/
-     */
-    public function iAmOnMyProfileEditPage()
-    {
-        $this->openPage('User profile edit');
-    }
-
-    /**
-     * @Given /^I am on my profile page$/
-     */
-    public function iAmOnMyProfilePage()
-    {
-        $this->openPage('User profile show');
-    }
-
-    /**
-     * @Given /^I edit the system configuration$/
-     */
-    public function iAmOnTheSystemEditPage()
-    {
-        $this->openPage('System index');
-    }
-
-    /**
      * @param string $identifier
      *
      * @Given /^I edit the "([^"]*)" user group$/

--- a/features/datagrid/datagrid_views.feature
+++ b/features/datagrid/datagrid_views.feature
@@ -85,7 +85,7 @@ Feature: Datagrid views
       | label | Sneakers only |
     Then I should be on the products page
     And I should see the flash message "Datagrid view successfully created"
-    When I am on my profile page
+    When I am on the User profile show page
     And I press the "Edit" button
     Then I should see the text "Edit user - Mary Smith"
     When I visit the "Additional" tab
@@ -113,7 +113,7 @@ Feature: Datagrid views
       | label | Sneakers only |
     Then I should be on the products page
     And I should see the flash message "Datagrid view successfully created"
-    When I am on my profile page
+    When I am on the User profile show page
     And I press the "Edit" button
     Then I should see the text "Edit user - Mary Smith"
     When I visit the "Additional" tab

--- a/features/locale/change_system_locale.feature
+++ b/features/locale/change_system_locale.feature
@@ -22,13 +22,6 @@ Feature: Change system locale
 
   Scenario: Successfully display a localized login form according to the system locale
     Given I am on the System index page
-    And I select German locale
-    When I save the configuration
-    Then I should see the text "Successfully updated"
-    When I logout
-    Then I should see the "Anmelden" button
-    When I am logged in as "Julia"
-    And I am on the System index page
     And I select French locale
     And I save the configuration
     Then I should see the text "Successfully updated"

--- a/features/locale/change_system_locale.feature
+++ b/features/locale/change_system_locale.feature
@@ -5,32 +5,32 @@ Feature: Change system locale
   I need to be able to change the locale of the pim without changing user locales
 
   Background:
-    Given the "apparel" catalog configuration
+    Given the "default" catalog configuration
     And I am logged in as "Peter"
 
   Scenario: Successfully change pim locale without changing current user locales
-    Given I edit the system configuration
+    Given I am on the System index page
     And I select French locale
     And I save the configuration
     Then the user "Peter" should have "en" locale
     And the user "Julia" should have "en" locale
 
   Scenario: Should only see translated locales
-    Given I edit the system configuration
+    Given I am on the System index page
     Then I should see English locale option
     And I should not see Breton locale option
 
   Scenario: Successfully display a localized login form according to the system locale
-    Given I edit the system configuration
-    And I select de_DE locale
-    And I save the configuration
+    Given I am on the System index page
+    And I select German locale
+    When I save the configuration
     Then I should see the text "Successfully updated"
-    Then I logout
+    When I logout
     Then I should see the "Anmelden" button
     When I am logged in as "Julia"
-    And I edit the system configuration
-    And I select fr_FR locale
+    And I am on the System index page
+    And I select French locale
     And I save the configuration
     Then I should see the text "Successfully updated"
-    Then I logout
-    Then I should see the "Connexion" button
+    And I logout
+    And I should see the "Connexion" button

--- a/features/locale/change_user_locale.feature
+++ b/features/locale/change_user_locale.feature
@@ -9,7 +9,7 @@ Feature: Change user locale
     And I am logged in as "Peter"
 
   Scenario: Successfully change my locale
-    Given I edit my profile
+    Given I am on the User profile edit page
     Then I visit the "Interfaces" tab
     And I fill in the following information:
      | UI locale | French (France) |
@@ -27,7 +27,7 @@ Feature: Change user locale
     Then I should not see the text "Collecter"
 
   Scenario: Should only see translated locales
-    Given I edit my profile
+    Given I am on the User profile edit page
     And I visit the "Interfaces" tab
     Then I should see English locale option
     And I should not see Breton locale option

--- a/features/localization/product/edit_product.feature
+++ b/features/localization/product/edit_product.feature
@@ -60,7 +60,7 @@ Feature: Edit a product with localized attributes
       | date | 2015-12-01 |
 
   Scenario: Switching locale should change the displayed format
-    When I edit my profile
+    When I am on the User profile edit page
     And I visit the "Interfaces" tab
     And I fill in the following information:
       | Langage de l'interface | anglais (Royaume-Uni) |

--- a/features/user/show_user.feature
+++ b/features/user/show_user.feature
@@ -15,7 +15,7 @@ Feature: Show a user
     And I should see "en_US"
 
   Scenario: Successfully show my locale
-    Given I am on my profile page
+    Given I am on the User profile show page
     And I visit the "Interfaces" tab
     Then I should see "Ui locale"
     And I should see "en_US"


### PR DESCRIPTION
This PR:

- Removes navigation specific methods to replace by "I am on the xxx page"
- Change I select xxx locale to use label instead of identifier