### PR TITLE
PIM-5421: Fix categories selector in the export builder when the channel change

### DIFF
--- a/features/export/product-export-builder/export_products_by_categories.feature
+++ b/features/export/product-export-builder/export_products_by_categories.feature
@@ -78,3 +78,8 @@ Feature: Export products from any given categories
       toys_games;toys_games;1;default;
       action_figures;action_figures;1;default;
       """
+    When I am on the "csv_product_export" export job edit page
+    And I visit the "Content" tab
+    And I fill in the following information:
+      | Channel | Mobile |
+    Then I should see the text "Categories All products"

--- a/src/Pim/Bundle/ImportExportBundle/Resources/public/js/product-export/categories-selector.js
+++ b/src/Pim/Bundle/ImportExportBundle/Resources/public/js/product-export/categories-selector.js
@@ -44,7 +44,7 @@ define(
                 });
 
                 $('#' + this.$el.data('channel-input')).bind('change', function () {
-                    this.attributes.categories.clear();
+                    this.attributes.categories = [];
                     this.trigger('change:categories');
                 }.bind(this));
             },


### PR DESCRIPTION
# Description
We introduced a bug recently when we merged the product export builder "select categories" feature. A case was not covered by any test so when we changed the code it was not tested (and have not been tested manually after the code review have been fixed)

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | N/A
| Added Behats                      | :white_check_mark: 
| Changelog updated                 | N/A
| Review and 2 GTM                  | :white_check_mark: 
| Micro Demo to the PO (Story only) | :white_check_mark: 
| Migration script                  | N/A
| Tech Doc                          | N/A