### PR TITLE
Fix failing behat on localized history

### DIFF
--- a/features/Context/WebUser.php
+++ b/features/Context/WebUser.php
@@ -192,7 +192,9 @@ class WebUser extends RawMinkContext
             return false;
         }, 'Cannot expand history');
 
-        $this->wait();
+        $this->spin(function () {
+            return $this->getCurrentPage()->find('css', 'div.full-panel div.panels');
+        }, 'History as full panel can not be found.');
     }
 
     /**

--- a/features/localization/product/display_localized_history.feature
+++ b/features/localization/product/display_localized_history.feature
@@ -5,30 +5,40 @@ Feature: Display the localized product history
   I need to have show localized values
 
   Background:
-    Given a "default" catalog configuration
+    Given a "footwear" catalog configuration
     And the following attributes:
       | code   | label  | label-fr_FR | type   | decimals_allowed | negative_allowed | default_metric_unit | metric_family | group |
       | number | Number | Nombre      | number | true             | false            |                     |               | other |
       | metric | Metric | Metrique    | metric | true             | true             | GRAM                | Weight        | other |
       | price  | Price  | Prix        | prices | true             | false            |                     |               | other |
-    And the following products:
-      | sku      | price                | metric       | number  |
-      | boots    | 20.80 EUR, 25.35 USD | 12.1234 GRAM | 98.7654 |
-    And the history of the product "boots" has been built
+    And I am logged in as "admin"
+    And the following CSV file to import:
+      """
+      sku;price-EUR;price-USD;metric;metric-unit;number
+      boots;20.80;25.35;12.1234;GRAM;98.7654
+      """
+    And the following job "csv_footwear_product_import" configuration:
+      | filePath | %file to import% |
+    When I am on the "csv_footwear_product_import" import job page
+    And I launch the import job
+    And I wait for the "csv_footwear_product_import" job to finish
+    And I logout
 
   Scenario: Display french-format product history numbers
     Given I am logged in as "Julien"
-    And I edit the "boots" product
+    And I am on the products page
+    And I click on the "boots" row
+    And I wait to be on the "boots" product page
     When I open the history
     Then there should be 1 update
     And I should see history:
-      | version | property      | value     |
-      | 1       | SKU           | boots     |
-      | 1       | Metrique      | 12,1234   |
-      | 1       | Metrique unit | Gramme    |
-      | 1       | Nombre        | 98,7654   |
-      | 1       | Prix EUR      | 20,80 €   |
-      | 1       | Prix USD      | 25,35 $US |
+      | version | property    | value     |
+      | 1       | SKU         | boots     |
+      | 1       | Metric      | 12,1234   |
+      | 1       | Metric unit | Gramme    |
+      | 1       | Number      | 98,7654   |
+      | 1       | Price EUR   | 20,80 €   |
+      | 1       | Price USD   | 25,35 $US |
 
   Scenario: Display english-format product history numbers
     Given I am logged in as "Julia"


### PR DESCRIPTION
# Wut

- Replace methods with correct spin (removes wait)
- Fix test replacing "following products" with import to be sure history is well constructed

## Warning

If you read in details, this PR changes field language of the history. This is due to a bug in the history language. I created another card in Jira for this specific bug, but the main behavior does not change in this PR (the fields in the history are displayed with the catalogLocale, not the userLocale).
