### PR TITLE
Ping the server before updating job and step execution data

### DIFF
--- a/src/Akeneo/Bundle/BatchBundle/Job/DoctrineJobRepository.php
+++ b/src/Akeneo/Bundle/BatchBundle/Job/DoctrineJobRepository.php
@@ -7,6 +7,7 @@ use Akeneo\Component\Batch\Model\JobExecution;
 use Akeneo\Component\Batch\Model\JobInstance;
 use Akeneo\Component\Batch\Model\StepExecution;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DBALException;
 use Doctrine\ORM\EntityManager;
 
 /**
@@ -95,6 +96,7 @@ class DoctrineJobRepository implements JobRepositoryInterface
      */
     public function updateJobExecution(JobExecution $jobExecution)
     {
+        $this->checkConnection();
         $this->jobManager->persist($jobExecution);
         $this->jobManager->flush($jobExecution);
     }
@@ -104,7 +106,40 @@ class DoctrineJobRepository implements JobRepositoryInterface
      */
     public function updateStepExecution(StepExecution $stepExecution)
     {
+        $this->checkConnection();
         $this->jobManager->persist($stepExecution);
         $this->jobManager->flush($stepExecution);
+    }
+
+    /**
+     * Ping the Server, if not available then reset the connection.
+     * @author Cristian Quiroz <cq@amp.co>
+     */
+    public function checkConnection()
+    {
+        $connection = $this->jobManager->getConnection();
+        if ($this->pingConnection($connection) === false) {
+            $connection->close();
+            $connection->connect();
+        }
+    }
+
+    /**
+     * Pings the server, returns false if it's not available.
+     * There is a ping() method in Doctrine\DBAL\Connection in the doctrine/dbal package
+     * as of 2.5.0, but  we are currently on 2.4.x
+     * @return bool
+     * @author Cristian Quiroz <cq@amp.co>
+     */
+    private function pingConnection()
+    {
+        $connection = $this->jobManager->getConnection();
+        $connection->connect();
+        try {
+            $connection->query($connection->getDatabasePlatform()->getDummySelectSQL());
+            return true;
+        } catch (DBALException $e) {
+            return false;
+        }
     }
 }

--- a/src/Akeneo/Bundle/BatchBundle/Job/DoctrineJobRepository.php
+++ b/src/Akeneo/Bundle/BatchBundle/Job/DoctrineJobRepository.php
@@ -118,7 +118,7 @@ class DoctrineJobRepository implements JobRepositoryInterface
     public function checkConnection()
     {
         $connection = $this->jobManager->getConnection();
-        if ($this->pingConnection($connection) === false) {
+        if ($this->pingConnection() === false) {
             $connection->close();
             $connection->connect();
         }
@@ -131,7 +131,7 @@ class DoctrineJobRepository implements JobRepositoryInterface
      * @return bool
      * @author Cristian Quiroz <cq@amp.co>
      */
-    private function pingConnection()
+    protected function pingConnection()
     {
         $connection = $this->jobManager->getConnection();
         $connection->connect();


### PR DESCRIPTION
During import and export jobs the MySQL server can become unavailable (because of timeouts, for example) and the connection will throw `The EntityManager is closed` and `MySQL Server has gone away` exceptions.

This is particularly troublesome for installations with Mongo, because the MySQL connection can be left untouched for large amounts of time, and then used to update Step and Job execution data. In this case, even though the product data was imported/exported successfully, the job will be marked as failed because the exception gets thrown at the moment of saving information about it.

To solve this, we can ensure our connection is alive by pinging the server and attempting to reconnect if it has become unavailable. 

Note: doctrine/dbal implements a [ping() method in 2.5](https://github.com/doctrine/dbal/blob/abbdfd1cff43a7b99d027af3be709bc8fc7d4769/lib/Doctrine/DBAL/Connection.php#L1571) but since Akeneo is using an older version, this PR adds a method to the doctrine job repository to do the same. Incidentally, in the comment for the ping method, doctrine recommends that it is used to ensure the server is available, like this PR is doing.

Note2: These PHP Warnings will still be issued if the server has indeed become unavailble:
```
PHP Warning:  PDO::query(): MySQL server has gone away in /var/www/html/akeneo/vendor/doctrine/dbal/lib/Doctrine/DBAL/Connection.php on line 801
PHP Warning:  PDO::query(): Error reading result set's header in /var/www/html/akeneo/vendor/doctrine/dbal/lib/Doctrine/DBAL/Connection.php on line 801
```