### PR TITLE
PIM-5854: The family code is not displayed at all in the product grid when no family labels

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -1,6 +1,10 @@
 
 # 1.6.x
 
+## Bug fixes
+
+- PIM-5854: The family code is not displayed at all in the product grid when no family labels
+
 ## Functional improvements
 
 - PIM-5664: It is now possible to purge jobs executions history

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/AttributeRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/AttributeRepository.php
@@ -155,7 +155,7 @@ class AttributeRepository extends EntityRepository implements
     {
         $query = $this->findAllAxesQB()
             ->select('a.id')
-            ->addSelect('COALESCE(t.label, CONCAT(\'[\', a.code, \']\')) as label')
+            ->addSelect('COALESCE(NULLIF(t.label, \'\'), CONCAT(\'[\', a.code, \']\')) as label')
             ->leftJoin('a.translations', 't')
             ->andWhere('t.locale = :locale')
             ->setParameter('locale', $locale)
@@ -216,8 +216,8 @@ class AttributeRepository extends EntityRepository implements
         $results = $qb->getQuery()->execute([], AbstractQuery::HYDRATE_ARRAY);
 
         if ($withLabel) {
-            $labelExpr = 'COALESCE(trans.label, CONCAT(CONCAT(\'[\', att.code), \']\'))';
-            $groupLabelExpr = 'COALESCE(gtrans.label, CONCAT(CONCAT(\'[\', g.code), \']\'))';
+            $labelExpr = 'COALESCE(NULLIF(trans.label, \'\'), CONCAT(CONCAT(\'[\', att.code), \']\'))';
+            $groupLabelExpr = 'COALESCE(NULLIF(gtrans.label, \'\'), CONCAT(CONCAT(\'[\', g.code), \']\'))';
 
             $qb = $this->_em->createQueryBuilder()
                 ->select('att.code', sprintf('%s as label', $labelExpr))

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/GroupRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/GroupRepository.php
@@ -221,7 +221,7 @@ class GroupRepository extends EntityRepository implements GroupRepositoryInterfa
     public function getOptions($dataLocale, $collectionId = null, $search = '', array $options = [])
     {
         $qb = $this->createQueryBuilder('o')
-            ->select('o.id as id, COALESCE(t.label, CONCAT(\'[\', o.code, \']\')) as text')
+            ->select('o.id as id, COALESCE(t.label, \'\'), CONCAT(\'[\', o.code, \']\')) as text')
             ->leftJoin('o.translations', 't', 'WITH', 't.locale=:locale')
             ->addOrderBy('text', 'ASC')
             ->setParameter('locale', $dataLocale);

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/GroupRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/GroupRepository.php
@@ -221,7 +221,7 @@ class GroupRepository extends EntityRepository implements GroupRepositoryInterfa
     public function getOptions($dataLocale, $collectionId = null, $search = '', array $options = [])
     {
         $qb = $this->createQueryBuilder('o')
-            ->select('o.id as id, COALESCE(t.label, \'\'), CONCAT(\'[\', o.code, \']\')) as text')
+            ->select('o.id as id, COALESCE(NULLIF(t.label, \'\'), CONCAT(\'[\', o.code, \']\')) as text')
             ->leftJoin('o.translations', 't', 'WITH', 't.locale=:locale')
             ->addOrderBy('text', 'ASC')
             ->setParameter('locale', $dataLocale);

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Sorter/FamilySorter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Sorter/FamilySorter.php
@@ -49,7 +49,7 @@ class FamilySorter implements FieldSorterInterface
             ->leftJoin($rootAlias.'.family', $family)
             ->leftJoin($family.'.translations', $trans, 'WITH', $trans.'.locale = :dataLocale');
         $this->qb
-            ->addSelect('COALESCE('.$trans.'.label, CONCAT(\'[\', '.$family.'.code, \']\')) as '.$field);
+            ->addSelect('COALESCE(NULLIF('.$trans.'.label, \'\'), CONCAT(\'[\', '.$family.'.code, \']\')) as '.$field);
 
         $this->qb->addOrderBy($field, $direction);
 

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Repository/AttributeRepositorySpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Repository/AttributeRepositorySpec.php
@@ -64,7 +64,7 @@ class AttributeRepositorySpec extends ObjectBehavior
         $em->createQueryBuilder()->willReturn($queryBuilder);
         $queryBuilder->select('a')->willReturn($queryBuilder);
         $queryBuilder->select('a.id')->willReturn($queryBuilder);
-        $queryBuilder->addSelect('COALESCE(t.label, CONCAT(\'[\', a.code, \']\')) as label')->willReturn($queryBuilder);
+        $queryBuilder->addSelect('COALESCE(NULLIF(t.label, \'\'), CONCAT(\'[\', a.code, \']\')) as label')->willReturn($queryBuilder);
         $queryBuilder->from('attribute', 'a')->willReturn($queryBuilder);
         $queryBuilder->leftJoin('a.translations', 't')->willReturn($queryBuilder);
         $queryBuilder->andWhere($in)->willReturn($queryBuilder);

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Sorter/FamilySorterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Sorter/FamilySorterSpec.php
@@ -46,7 +46,7 @@ class FamilySorterSpec extends ObjectBehavior
         ;
         $qb
             ->addSelect(
-                'COALESCE(sorterfamilyTranslations.label, CONCAT(\'[\', sorterfamily.code, \']\')) as sorterfamilyLabel'
+                'COALESCE(NULLIF(sorterfamilyTranslations.label, \'\'), CONCAT(\'[\', sorterfamily.code, \']\')) as sorterfamilyLabel'
             )
             ->shouldBeCalled()
             ->willReturn($qb)

--- a/src/Pim/Bundle/DataGridBundle/Extension/Selector/Orm/Product/FamilySelector.php
+++ b/src/Pim/Bundle/DataGridBundle/Extension/Selector/Orm/Product/FamilySelector.php
@@ -24,9 +24,7 @@ class FamilySelector implements SelectorInterface
 
         $datasource->getQueryBuilder()
             ->leftJoin($rootAlias.'.family', 'family')
-            ->leftJoin('family.translations', 'ft', 'WITH', 'ft.locale = :dataLocale');
-
-        $datasource->getQueryBuilder()
-            ->addSelect('COALESCE(ft.label, CONCAT(\'[\', family.code, \']\')) as familyLabel');
+            ->leftJoin('family.translations', 'ft', 'WITH', 'ft.locale = :dataLocale')
+            ->addSelect('COALESCE(NULLIF(ft.label, \'\'), CONCAT(\'[\', family.code, \']\')) as familyLabel');
     }
 }

--- a/src/Pim/Bundle/DataGridBundle/spec/Extension/Selector/Orm/Product/FamilySelectorSpec.php
+++ b/src/Pim/Bundle/DataGridBundle/spec/Extension/Selector/Orm/Product/FamilySelectorSpec.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace spec\Pim\Bundle\DataGridBundle\Extension\Selector\Orm\Product;
+
+use Doctrine\ORM\QueryBuilder;
+use Oro\Bundle\DataGridBundle\Datagrid\Common\DatagridConfiguration;
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\DataGridBundle\Datasource\DatasourceInterface;
+use Prophecy\Argument;
+
+class FamilySelectorSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Pim\Bundle\DataGridBundle\Extension\Selector\Orm\Product\FamilySelector');
+    }
+
+    function it_is_a_selector()
+    {
+        $this->shouldImplement('Pim\Bundle\DataGridBundle\Extension\Selector\SelectorInterface');
+    }
+
+    function it_applies_a_selector(
+        DatasourceInterface $datasource, 
+        DatagridConfiguration $configuration,
+        QueryBuilder $queryBuilder
+    ) {
+        $datasource->getQueryBuilder()->willReturn($queryBuilder);
+        $queryBuilder->getRootAlias()->willReturn('p');
+
+        $queryBuilder->leftJoin('p.family', 'family')->willReturn($queryBuilder);
+        $queryBuilder->leftJoin('family.translations', 'ft', 'WITH', 'ft.locale = :dataLocale')->willReturn($queryBuilder);
+        $queryBuilder->addSelect('COALESCE(NULLIF(ft.label, \'\'), CONCAT(\'[\', family.code, \']\')) as familyLabel')->shouldBeCalled();
+    
+        $this->apply($datasource, $configuration);
+    }
+}

--- a/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/AttributeGroupRepository.php
+++ b/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/AttributeGroupRepository.php
@@ -31,7 +31,7 @@ class AttributeGroupRepository extends EntityRepository implements TranslatedLab
     {
         $queryBuilder = $this->createQueryBuilder('g')
             ->select('g.code')
-            ->addSelect('COALESCE(t.label, CONCAT(\'[\', g.code, \']\')) as label')
+            ->addSelect('COALESCE(NULLIF(t.label, \'\'), CONCAT(\'[\', g.code, \']\')) as label')
             ->leftJoin('g.translations', 't', 'WITH', 't.locale = :locale')
             ->setParameter('locale', $this->userContext->getCurrentLocaleCode())
             ->orderBy('t.label')

--- a/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/AttributeRepository.php
+++ b/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/AttributeRepository.php
@@ -36,8 +36,8 @@ class AttributeRepository extends EntityRepository implements TranslatedLabelsPr
     {
         $queryBuilder = $this->createQueryBuilder('a')
             ->select('a.id')
-            ->addSelect('COALESCE(at.label, CONCAT(\'[\', a.code, \']\')) as attribute_label')
-            ->addSelect('COALESCE(gt.label, CONCAT(\'[\', g.code, \']\')) as group_label')
+            ->addSelect('COALESCE(NULLIF(at.label, \'\'), CONCAT(\'[\', a.code, \']\')) as attribute_label')
+            ->addSelect('COALESCE(NULLIF(gt.label, \'\'), CONCAT(\'[\', g.code, \']\')) as group_label')
             ->leftJoin('a.translations', 'at', 'WITH', 'at.locale = :locale_code')
             ->leftJoin('a.group', 'g')
             ->leftJoin('g.translations', 'gt', 'WITH', 'gt.locale = :locale_code')

--- a/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/CategoryRepository.php
+++ b/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/CategoryRepository.php
@@ -31,7 +31,7 @@ class CategoryRepository extends NestedTreeRepository implements TranslatedLabel
     {
         $query = $this->childrenQueryBuilder(null, true, 'created', 'DESC')
             ->select('node.id')
-            ->addSelect('COALESCE(t.label, CONCAT(\'[\', node.code, \']\')) as label')
+            ->addSelect('COALESCE(NULLIF(t.label, \'\'), CONCAT(\'[\', node.code, \']\')) as label')
             ->leftJoin('node.translations', 't', 'WITH', 't.locale = :locale')
             ->setParameter('locale', $this->userContext->getCurrentLocaleCode())
             ->orderBy('t.label')

--- a/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/FamilyRepository.php
+++ b/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/FamilyRepository.php
@@ -36,7 +36,7 @@ class FamilyRepository extends EntityRepository implements TranslatedLabelsProvi
     {
         $query = $this->createQueryBuilder('f')
             ->select('f.id')
-            ->addSelect('COALESCE(ft.label, CONCAT(\'[\', f.code, \']\')) as label')
+            ->addSelect('COALESCE(NULLIF(ft.label, \'\'), CONCAT(\'[\', f.code, \']\')) as label')
             ->leftJoin('f.translations', 'ft', 'WITH', 'ft.locale = :locale_code')
             ->orderBy('label')
             ->setParameter('locale_code', $this->userContext->getCurrentLocaleCode())

--- a/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/GroupRepository.php
+++ b/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/GroupRepository.php
@@ -36,7 +36,7 @@ class GroupRepository extends EntityRepository implements TranslatedLabelsProvid
     {
         $queryBuilder = $this->createQueryBuilder('g')
             ->select('g.id')
-            ->addSelect('COALESCE(t.label, CONCAT(\'[\', g.code, \']\')) as label')
+            ->addSelect('COALESCE(NULLIF(t.label, \'\'), CONCAT(\'[\', g.code, \']\')) as label')
             ->leftJoin('g.translations', 't', 'WITH', 't.locale = :locale')
             ->setParameter('locale', $this->userContext->getCurrentLocaleCode())
             ->orderBy('t.label')

--- a/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/GroupTypeRepository.php
+++ b/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/GroupTypeRepository.php
@@ -36,7 +36,7 @@ class GroupTypeRepository extends EntityRepository implements TranslatedLabelsPr
     {
         $queryBuilder = $this->createQueryBuilder('g')
             ->select('g.id')
-            ->addSelect('COALESCE(t.label, CONCAT(\'[\', g.code, \']\')) as label')
+            ->addSelect('COALESCE(NULLIF(t.label, \'\'), CONCAT(\'[\', g.code, \']\')) as label')
             ->leftJoin('g.translations', 't', 'WITH', 't.locale = :locale')
             ->setParameter('locale', $this->userContext->getCurrentLocaleCode())
             ->orderBy('t.label');

--- a/src/Pim/Bundle/EnrichBundle/spec/Doctrine/ORM/Repository/AttributeGroupRepositorySpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Doctrine/ORM/Repository/AttributeGroupRepositorySpec.php
@@ -42,7 +42,7 @@ class AttributeGroupRepositorySpec extends ObjectBehavior
         $em->createQueryBuilder()->willReturn($queryBuilder);
         $queryBuilder->select('g')->willReturn($queryBuilder);
         $queryBuilder->select('g.code')->willReturn($queryBuilder);
-        $queryBuilder->addSelect('COALESCE(t.label, CONCAT(\'[\', g.code, \']\')) as label')->willReturn($queryBuilder);
+        $queryBuilder->addSelect('COALESCE(NULLIF(t.label, \'\'), CONCAT(\'[\', g.code, \']\')) as label')->willReturn($queryBuilder);
         $queryBuilder->from('attribute_group', 'g')->willReturn($queryBuilder);
         $queryBuilder->leftJoin('g.translations', 't', 'WITH', 't.locale = :locale')->willReturn($queryBuilder);
         $queryBuilder->setParameter('locale', 'en_US')->willReturn($queryBuilder);

--- a/src/Pim/Bundle/EnrichBundle/spec/Doctrine/ORM/Repository/AttributeRepositorySpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Doctrine/ORM/Repository/AttributeRepositorySpec.php
@@ -46,8 +46,8 @@ class AttributeRepositorySpec extends ObjectBehavior
         $em->createQueryBuilder()->willReturn($queryBuilder);
         $queryBuilder->select('a')->willReturn($queryBuilder);
         $queryBuilder->select('a.id')->willReturn($queryBuilder);
-        $queryBuilder->addSelect('COALESCE(at.label, CONCAT(\'[\', a.code, \']\')) as attribute_label')->willReturn($queryBuilder);
-        $queryBuilder->addSelect('COALESCE(gt.label, CONCAT(\'[\', g.code, \']\')) as group_label')->willReturn($queryBuilder);
+        $queryBuilder->addSelect('COALESCE(NULLIF(at.label, \'\'), CONCAT(\'[\', a.code, \']\')) as attribute_label')->willReturn($queryBuilder);
+        $queryBuilder->addSelect('COALESCE(NULLIF(gt.label, \'\'), CONCAT(\'[\', g.code, \']\')) as group_label')->willReturn($queryBuilder);
         $queryBuilder->from('attribute', 'a')->willReturn($queryBuilder);
         $queryBuilder->leftJoin('a.translations', 'at', 'WITH', 'at.locale = :locale_code')->willReturn($queryBuilder);
         $queryBuilder->leftJoin('a.group', 'g')->willReturn($queryBuilder);

--- a/src/Pim/Bundle/EnrichBundle/spec/Doctrine/ORM/Repository/FamilyRepositorySpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Doctrine/ORM/Repository/FamilyRepositorySpec.php
@@ -42,7 +42,7 @@ class FamilyRepositorySpec extends ObjectBehavior
         $em->createQueryBuilder()->willReturn($queryBuilder);
         $queryBuilder->select('f')->willReturn($queryBuilder);
         $queryBuilder->select('f.id')->willReturn($queryBuilder);
-        $queryBuilder->addSelect('COALESCE(ft.label, CONCAT(\'[\', f.code, \']\')) as label')->willReturn($queryBuilder);
+        $queryBuilder->addSelect('COALESCE(NULLIF(ft.label, \'\'), CONCAT(\'[\', f.code, \']\')) as label')->willReturn($queryBuilder);
         $queryBuilder->from('family', 'f')->willReturn($queryBuilder);
         $queryBuilder->leftJoin('f.translations', 'ft', 'WITH', 'ft.locale = :locale_code')->willReturn($queryBuilder);
         $queryBuilder->orderBy('label')->willReturn($queryBuilder);

--- a/src/Pim/Bundle/EnrichBundle/spec/Doctrine/ORM/Repository/GroupRepositorySpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Doctrine/ORM/Repository/GroupRepositorySpec.php
@@ -42,7 +42,7 @@ class GroupRepositorySpec extends ObjectBehavior
         $em->createQueryBuilder()->willReturn($queryBuilder);
         $queryBuilder->select('g')->willReturn($queryBuilder);
         $queryBuilder->select('g.id')->willReturn($queryBuilder);
-        $queryBuilder->addSelect('COALESCE(t.label, CONCAT(\'[\', g.code, \']\')) as label')->willReturn($queryBuilder);
+        $queryBuilder->addSelect('COALESCE(NULLIF(t.label, \'\'), CONCAT(\'[\', g.code, \']\')) as label')->willReturn($queryBuilder);
         $queryBuilder->from('group', 'g')->willReturn($queryBuilder);
         $queryBuilder->leftJoin('g.translations', 't', 'WITH', 't.locale = :locale')->willReturn($queryBuilder);
         $queryBuilder->setParameter('locale', 'en_US')->willReturn($queryBuilder);

--- a/src/Pim/Bundle/EnrichBundle/spec/Doctrine/ORM/Repository/GroupTypeRepositorySpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Doctrine/ORM/Repository/GroupTypeRepositorySpec.php
@@ -42,7 +42,7 @@ class GroupTypeRepositorySpec extends ObjectBehavior
         $em->createQueryBuilder()->willReturn($queryBuilder);
         $queryBuilder->select('g')->willReturn($queryBuilder);
         $queryBuilder->select('g.id')->willReturn($queryBuilder);
-        $queryBuilder->addSelect('COALESCE(t.label, CONCAT(\'[\', g.code, \']\')) as label')->willReturn($queryBuilder);
+        $queryBuilder->addSelect('COALESCE(NULLIF(t.label, \'\'), CONCAT(\'[\', g.code, \']\')) as label')->willReturn($queryBuilder);
         $queryBuilder->from('group_type', 'g')->willReturn($queryBuilder);
         $queryBuilder->leftJoin('g.translations', 't', 'WITH', 't.locale = :locale')->willReturn($queryBuilder);
         $queryBuilder->andWhere('g.variant = :is_variant')->willReturn($queryBuilder);


### PR DESCRIPTION
When you create families using the csv_family_import and if you do not set any family labels, the family code is not displayed in the product grid. We should display the family code between brackets like everywhere else in the UI.

This happens only when you create families through imports. During CSV import, we import empties values instead of null values. 

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | yes
| Added Behats                      |  no
| Changelog updated                 | yes 
| Review and 2 GTM                  | yes
| Micro Demo to the PO (Story only) | no
| Migration script                  | no
| Tech Doc                          | no
