### PR TITLE
PIM-5767: Issue with filter "in list" when SKU contains dashes (-)

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -5,6 +5,7 @@
 
 - PIM-5854: The family code is not displayed at all in the product grid when no family labels
 - PIM-5888: Fix an outline glitch on some buttons
+- PIM-5767: Issue with filter "in list" when SKU contains dashes (-)
 
 ## Functional improvements
 

--- a/features/product/filtering/filter_products_per_text_fields.feature
+++ b/features/product/filtering/filter_products_per_text_fields.feature
@@ -18,9 +18,10 @@ Feature: Filter products by text field
       | 13605290 | Canon 5D + EF 24-105 F4L IS    |
       | 13378171 | Canon 5D + EF 24-105mm f/4L IS |
       | 13572541 | Canon 5D + EF 24-105 F5L IS    |
+      | 135-2541 | Canon 5D + EF 25-15 FL         |
     When I am on the products page
     And I display the columns sku, name, family, complete, created and updated
-    Then the grid should contain 4 elements
+    Then the grid should contain 5 elements
     And I should see products "HP LA2206xc + WF722A", "Canon 5D + EF 24-105 F4L IS", "Canon 5D + EF 24-105mm f/4L IS" and "Canon 5D + EF 24-105 F5L IS"
     And I should be able to use the following filters:
       | filter | operator         | value                | result                                                                                      |
@@ -34,6 +35,8 @@ Feature: Filter products by text field
       | name   | does not contain | Canon                | HP LA2206xc + WF722A                                                                        |
       | name   | is equal to      | Canon 5D + EF 24-105 |                                                                                             |
       | name   | contains         | f/4L                 | Canon 5D + EF 24-105mm f/4L IS                                                              |
+      | sku    | is equal to      | 135-2541             | 135-2541                                                                                    |
+      | sku    | in list          | 135-2541, 13572541   | 135-2541, 13572541                                                                          |
 
   Scenario: Successfully filter products by empty value for text and textarea attributes
     Given the following attributes:

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/StringFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/StringFilter.php
@@ -117,16 +117,16 @@ class StringFilter extends AbstractAttributeFilter implements AttributeFilterInt
     {
         switch ($operator) {
             case Operators::STARTS_WITH:
-                $value = new \MongoRegex(sprintf('/^%s/i', $value));
+                $value = new \MongoRegex(sprintf('/^%s/i', preg_quote($value)));
                 break;
             case Operators::ENDS_WITH:
-                $value = new \MongoRegex(sprintf('/%s$/i', $value));
+                $value = new \MongoRegex(sprintf('/%s$/i', preg_quote($value)));
                 break;
             case Operators::CONTAINS:
-                $value = new \MongoRegex(sprintf('/%s/i', $value));
+                $value = new \MongoRegex(sprintf('/%s/i', preg_quote($value)));
                 break;
             case Operators::DOES_NOT_CONTAIN:
-                $value = new \MongoRegex(sprintf('/^((?!%s).)*$/i', $value));
+                $value = new \MongoRegex(sprintf('/^((?!%s).)*$/i', preg_quote($value)));
                 break;
         }
 

--- a/src/Pim/Bundle/FilterBundle/Filter/ProductValue/StringFilter.php
+++ b/src/Pim/Bundle/FilterBundle/Filter/ProductValue/StringFilter.php
@@ -69,8 +69,6 @@ class StringFilter extends OroStringFilter
             return $data;
         }
 
-        $data['value'] = preg_quote($data['value']);
-
         if (null === $data['value'] || '' === $data['value']) {
             return false;
         }


### PR DESCRIPTION
On the product grid, you cannot filter on SKU attribute containing a dash -.

ORM: filter on sku “in list”
MongDB : filter on sku “in list” and “is equal to”

`preg_quote` add a \ before -, doctrine do the same so you got sku like `my\\-sku` 

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | no
| Added Behats                      | yes
| Changelog updated                 | yes
| Review and 2 GTM                  | yes
| Micro Demo to the PO (Story only) | no 
| Migration script                  | no 
| Tech Doc                          | no

Related issues :
https://github.com/akeneo/pim-community-dev/issues/4630
https://github.com/akeneo/pim-community-dev/issues/4435 