### PR TITLE
PIM-5490: Minor fixes

### DIFF
--- a/features/localization/product/display_localized_history.feature
+++ b/features/localization/product/display_localized_history.feature
@@ -5,34 +5,46 @@ Feature: Display the localized product history
   I need to have show localized values
 
   Background:
-    Given a "default" catalog configuration
+    Given a "footwear" catalog configuration
     And the following attributes:
       | code   | label  | label-fr_FR | type   | decimals_allowed | negative_allowed | default_metric_unit | metric_family | group |
       | number | Number | Nombre      | number | true             | false            |                     |               | other |
       | metric | Metric | Metrique    | metric | true             | true             | GRAM                | Weight        | other |
       | price  | Price  | Prix        | prices | true             | false            |                     |               | other |
-    And the following products:
-      | sku      | price                | metric       | number  |
-      | boots    | 20.80 EUR, 25.35 USD | 12.1234 GRAM | 98.7654 |
-    And the history of the product "boots" has been built
+    And I am logged in as "admin"
+    And the following CSV file to import:
+      """
+      sku;price-EUR;price-USD;metric;metric-unit;number
+      boots;20.80;25.35;12.1234;GRAM;98.7654
+      """
+    And the following job "csv_footwear_product_import" configuration:
+      | filePath | %file to import% |
+    When I am on the "csv_footwear_product_import" import job page
+    And I launch the import job
+    And I wait for the "csv_footwear_product_import" job to finish
+    And I logout
 
   Scenario: Display french-format product history numbers
     Given I am logged in as "Julien"
-    And I edit the "boots" product
+    And I am on the products page
+    And I click on the "boots" row
+    And I wait to be on the "boots" product page
     When I open the history
     Then there should be 1 update
     And I should see history:
-      | version | property      | value     |
-      | 1       | SKU           | boots     |
-      | 1       | Metrique      | 12,1234   |
-      | 1       | Metrique unit | Gramme    |
-      | 1       | Nombre        | 98,7654   |
-      | 1       | Prix EUR      | 20,80 €   |
-      | 1       | Prix USD      | 25,35 $US |
+      | version | property    | value     |
+      | 1       | SKU         | boots     |
+      | 1       | Metric      | 12,1234   |
+      | 1       | Metric unit | Gramme    |
+      | 1       | Number      | 98,7654   |
+      | 1       | Price EUR   | 20,80 €   |
+      | 1       | Price USD   | 25,35 $US |
 
   Scenario: Display english-format product history numbers
     Given I am logged in as "Julia"
-    And I edit the "boots" product
+    And I am on the products page
+    And I click on the "boots" row
+    And I wait to be on the "boots" product page
     When I open the history
     Then there should be 1 update
     And I should see history:

--- a/src/Pim/Bundle/DataGridBundle/Resources/translations/jsmessages.en.yml
+++ b/src/Pim/Bundle/DataGridBundle/Resources/translations/jsmessages.en.yml
@@ -61,9 +61,9 @@ pim_datagrid:
         remove_column:     Remove
     mass_action:
         delete:
-            confirm_title:   Delete confirmation.
+            confirm_title:   Delete confirmation
             confirm_ok:      OK
-            empty_selection: No product selected.
+            empty_selection: No product selected
 
 # Quick export
 pim.grid.mass_action.quick_export.title: Quick Export


### PR DESCRIPTION
**Description**

This very tiny PR removes useless punctuation on two translations.
This is before all for consistency with other popins in Akeneo.

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | N/A
| Added Behats                      | N/A
| Changelog updated                 | N/A
| Review and 2 GTM                  | :white_check_mark: 
| Micro Demo to the PO (Story only) | N/A
| Migration script                  | N/A
| Tech Doc                          | N/A