### PR TITLE
PIM-5888: Fix button outline after click

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -51,6 +51,10 @@
 - TIP-255: Allow to select PQB filter on supported operator, to add new operators easily on existing fields/attribute types
 - PIM-5781: Introduce a new command to get system information from the command line
 
+## Bug fixes
+
+- PIM-5888: Fix an outline glitch on some buttons
+
 ## BC breaks
 
 - Move `Pim\Component\Connector\Writer\File\CsvWriter` to `Pim\Component\Connector\Writer\File\Csv\Writer`
@@ -374,7 +378,7 @@
 - Remove the class `Akeneo\Component\Batch\Connector\ConnectorRegistry`, please use `Akeneo\Component\Batch\Job\JobRegistry`
 - Remove the class `Akeneo\Component\Batch\Step\StepFactory` and related service '@akeneo_batch.step_factory'
 - Remove the class `Akeneo\Component\Batch\Job\JobFactory` and related service '@akeneo_batch.job_factory'
-- Remove method `setCharsetValidator()` from `Pim\Component\Connector\Step\ValidatorStep` 
+- Remove method `setCharsetValidator()` from `Pim\Component\Connector\Step\ValidatorStep`
 - Change constructor of `Pim\Component\Connector\Step\ValidatorStep` add `Pim\Component\Connector\Item\CharsetValidator` as last parameter
 - Change constructor of `Pim\Component\Connector\Step\TaskletStep` add `Pim\Component\Connector\Step\TaskletInterface` as last parameter
 - Change constructor of `Pim\Bundle\EnrichBundle\Connector\Step\MassEditStep` add `Pim\Bundle\EnrichBundle\Connector\Item\MassEdit\TemporaryFileCleaner` as last parameter

--- a/src/Pim/Bundle/UIBundle/Resources/public/css/buttons.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/css/buttons.less
@@ -67,6 +67,7 @@
   }
 
   &:hover, &:active, &:focus{
+    outline: none;
     background-image: none;
     border: none;
     box-shadow: none;


### PR DESCRIPTION
**Description**

Button for launching assets upload in EE do not come to its initial state after clicking. This also affect the login button and probably other ones, but these buttons are not visible long enough to see the glitch.

Here is a little set of screenshots of the login button to understand the problem:

- Initial state of the button

![initial](https://cloud.githubusercontent.com/assets/5039018/16762364/78e75a46-4824-11e6-8290-4eb0937551b0.png)

- clicking

![clicking](https://cloud.githubusercontent.com/assets/5039018/16762400/98d88262-4824-11e6-9cd8-fa3944ce1a08.png)

- after

![after](https://cloud.githubusercontent.com/assets/5039018/16762404/9cd3e00a-4824-11e6-8442-275de77dd389.png)

The "after" state should be the same than the "initial" one. This PR fixes this glitch.

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | N/A
| Added Behats                      | N/A
| Changelog updated                 | :white_check_mark:
| Review and 2 GTM                  | :white_check_mark:
| Migration script                  | N/A
| Tech Doc                          | N/A

