### PR TITLE
Dispatch pre and post save events only when flush the object

### DIFF
--- a/src/Akeneo/Bundle/StorageUtilsBundle/Doctrine/Common/Saver/BaseSaver.php
+++ b/src/Akeneo/Bundle/StorageUtilsBundle/Doctrine/Common/Saver/BaseSaver.php
@@ -87,7 +87,7 @@ class BaseSaver implements SaverInterface, BulkSaverInterface
         }
 
         $allOptions = $this->optionsResolver->resolveSaveAllOptions($options);
-        $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE_ALL, new GenericEvent($objects, $allOptions));
+        $this->dispatchPreSaveEvent($objects, $allOptions);
 
         $itemOptions = $allOptions;
         $itemOptions['flush'] = false;
@@ -99,7 +99,29 @@ class BaseSaver implements SaverInterface, BulkSaverInterface
         if (true === $allOptions['flush']) {
             $this->objectManager->flush();
         }
+        $this->dispatchPostSaveEvent($objects, $allOptions);
 
-        $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE_ALL, new GenericEvent($objects, $allOptions));
+    }
+
+    /**
+     * @param object $objects
+     * @param array  $allOptions
+     */
+    protected function dispatchPreSaveEvent($objects, array $allOptions)
+    {
+        if (true === $allOptions['flush']) {
+            $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE_ALL, new GenericEvent($objects, $allOptions));
+        }
+    }
+
+    /**
+     * @param object $objects
+     * @param array  $allOptions
+     */
+    protected function dispatchPostSaveEvent($objects, array $allOptions)
+    {
+        if (true === $allOptions['flush']) {
+            $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE_ALL, new GenericEvent($objects, $allOptions));
+        }
     }
 }

--- a/src/Akeneo/Bundle/StorageUtilsBundle/Doctrine/Common/Saver/BaseSaver.php
+++ b/src/Akeneo/Bundle/StorageUtilsBundle/Doctrine/Common/Saver/BaseSaver.php
@@ -66,7 +66,8 @@ class BaseSaver implements SaverInterface, BulkSaverInterface
         }
 
         $options = $this->optionsResolver->resolveSaveOptions($options);
-        $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE, new GenericEvent($object, $options));
+
+        $this->dispatchPreSaveEvent($object, $options);
 
         $this->objectManager->persist($object);
 
@@ -74,7 +75,7 @@ class BaseSaver implements SaverInterface, BulkSaverInterface
             $this->objectManager->flush();
         }
 
-        $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE, new GenericEvent($object, $options));
+        $this->dispatchPostSaveEvent($object, $options);
     }
 
     /**
@@ -87,7 +88,8 @@ class BaseSaver implements SaverInterface, BulkSaverInterface
         }
 
         $allOptions = $this->optionsResolver->resolveSaveAllOptions($options);
-        $this->dispatchPreSaveEvent($objects, $allOptions);
+
+        $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE_ALL, new GenericEvent($objects, $allOptions));
 
         $itemOptions = $allOptions;
         $itemOptions['flush'] = false;
@@ -99,29 +101,33 @@ class BaseSaver implements SaverInterface, BulkSaverInterface
         if (true === $allOptions['flush']) {
             $this->objectManager->flush();
         }
-        $this->dispatchPostSaveEvent($objects, $allOptions);
 
+        $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE_ALL, new GenericEvent($objects, $allOptions));
     }
 
     /**
-     * @param object $objects
-     * @param array  $allOptions
+     * Dispatch pre save event if flush is true
+     *
+     * @param object $object
+     * @param array  $options
      */
-    protected function dispatchPreSaveEvent($objects, array $allOptions)
+    protected function dispatchPreSaveEvent($object, array $options)
     {
-        if (true === $allOptions['flush']) {
-            $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE_ALL, new GenericEvent($objects, $allOptions));
+        if (true === $options['flush']) {
+            $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE, new GenericEvent($object, $options));
         }
     }
 
     /**
-     * @param object $objects
-     * @param array  $allOptions
+     * Dispatch post save event if flush is true
+     *
+     * @param object $object
+     * @param array  $options
      */
-    protected function dispatchPostSaveEvent($objects, array $allOptions)
+    protected function dispatchPostSaveEvent($object, array $options)
     {
-        if (true === $allOptions['flush']) {
-            $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE_ALL, new GenericEvent($objects, $allOptions));
+        if (true === $options['flush']) {
+            $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE, new GenericEvent($object, $options));
         }
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/AttributeSaver.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/AttributeSaver.php
@@ -59,7 +59,7 @@ class AttributeSaver implements SaverInterface, BulkSaverInterface
             );
         }
 
-        $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE, new GenericEvent($attribute));
+        $this->dispatchPreSaveEvent($attribute, $options);
 
         $options = $this->optionsResolver->resolveSaveOptions($options);
         $this->objectManager->persist($attribute);
@@ -67,8 +67,7 @@ class AttributeSaver implements SaverInterface, BulkSaverInterface
         if (true === $options['flush']) {
             $this->objectManager->flush();
         }
-
-        $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE, new GenericEvent($attribute));
+        $this->dispatchPostSaveEvent($attribute, $options);
     }
 
     /**
@@ -95,5 +94,27 @@ class AttributeSaver implements SaverInterface, BulkSaverInterface
         }
 
         $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE_ALL, new GenericEvent($attributes));
+    }
+
+    /**
+     * @param object $attribute
+     * @param array  $options
+     */
+    protected function dispatchPreSaveEvent($attribute, array $options)
+    {
+        if (true === $options['flush']) {
+            $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE, new GenericEvent($attribute));
+        }
+    }
+
+    /**
+     * @param object $attribute
+     * @param array  $options
+     */
+    protected function dispatchPostSaveEvent($attribute, array $options)
+    {
+        if (true === $options['flush']) {
+            $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE, new GenericEvent($attribute));
+        }
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/AttributeSaver.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/AttributeSaver.php
@@ -59,9 +59,10 @@ class AttributeSaver implements SaverInterface, BulkSaverInterface
             );
         }
 
+        $options = $this->optionsResolver->resolveSaveOptions($options);
+
         $this->dispatchPreSaveEvent($attribute, $options);
 
-        $options = $this->optionsResolver->resolveSaveOptions($options);
         $this->objectManager->persist($attribute);
 
         if (true === $options['flush']) {
@@ -97,6 +98,8 @@ class AttributeSaver implements SaverInterface, BulkSaverInterface
     }
 
     /**
+     * Dispatch pre save event if flush is true
+     *
      * @param object $attribute
      * @param array  $options
      */
@@ -108,6 +111,8 @@ class AttributeSaver implements SaverInterface, BulkSaverInterface
     }
 
     /**
+     * Dispatch post save event if flush is true
+     *
      * @param object $attribute
      * @param array  $options
      */

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/FamilySaver.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/FamilySaver.php
@@ -66,14 +66,16 @@ class FamilySaver implements SaverInterface, BulkSaverInterface
             );
         }
 
+        $options = $this->optionsResolver->resolveSaveOptions($options);
+
         $this->dispatchPreSaveEvent($family, $options);
 
-        $options = $this->optionsResolver->resolveSaveOptions($options);
         $this->objectManager->persist($family);
 
         if (true === $options['flush']) {
             $this->objectManager->flush();
         }
+
         if (true === $options['schedule']) {
             $this->completenessManager->scheduleForFamily($family);
         }
@@ -90,9 +92,10 @@ class FamilySaver implements SaverInterface, BulkSaverInterface
             return;
         }
 
+        $allOptions = $this->optionsResolver->resolveSaveAllOptions($options);
+
         $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE_ALL, new GenericEvent($families));
 
-        $allOptions = $this->optionsResolver->resolveSaveAllOptions($options);
         $itemOptions = $allOptions;
         $itemOptions['flush'] = false;
 
@@ -108,6 +111,8 @@ class FamilySaver implements SaverInterface, BulkSaverInterface
     }
 
     /**
+     * Dispatch pre save event if flush is true
+     *
      * @param object $family
      * @param array  $options
      */
@@ -119,6 +124,8 @@ class FamilySaver implements SaverInterface, BulkSaverInterface
     }
 
     /**
+     * Dispatch post save event if flush is true
+     *
      * @param object $family
      * @param array  $options
      */

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/FamilySaver.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/FamilySaver.php
@@ -66,10 +66,11 @@ class FamilySaver implements SaverInterface, BulkSaverInterface
             );
         }
 
-        $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE, new GenericEvent($family));
+        $this->dispatchPreSaveEvent($family, $options);
 
         $options = $this->optionsResolver->resolveSaveOptions($options);
         $this->objectManager->persist($family);
+
         if (true === $options['flush']) {
             $this->objectManager->flush();
         }
@@ -77,7 +78,7 @@ class FamilySaver implements SaverInterface, BulkSaverInterface
             $this->completenessManager->scheduleForFamily($family);
         }
 
-        $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE, new GenericEvent($family));
+        $this->dispatchPostSaveEvent($family, $options);
     }
 
     /**
@@ -104,5 +105,27 @@ class FamilySaver implements SaverInterface, BulkSaverInterface
         }
 
         $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE_ALL, new GenericEvent($families));
+    }
+
+    /**
+     * @param object $family
+     * @param array  $options
+     */
+    protected function dispatchPreSaveEvent($family, array $options)
+    {
+        if (true === $options['flush']) {
+            $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE, new GenericEvent($family));
+        }
+    }
+
+    /**
+     * @param object $family
+     * @param array  $options
+     */
+    protected function dispatchPostSaveEvent($family, array $options)
+    {
+        if (true === $options['flush']) {
+            $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE, new GenericEvent($family));
+        }
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/GroupSaver.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/GroupSaver.php
@@ -93,9 +93,9 @@ class GroupSaver implements SaverInterface, BulkSaverInterface
             );
         }
 
-        $this->dispatchPreSaveEvent($group, $options);
-
         $options = $this->optionsResolver->resolveSaveOptions($options);
+
+        $this->dispatchPreSaveEvent($group, $options);
 
         $this->versionContext->addContextInfo(
             sprintf('Comes from variant group %s', $group->getCode()),
@@ -138,9 +138,10 @@ class GroupSaver implements SaverInterface, BulkSaverInterface
             return;
         }
 
+        $allOptions = $this->optionsResolver->resolveSaveAllOptions($options);
+
         $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE_ALL, new GenericEvent($groups));
 
-        $allOptions = $this->optionsResolver->resolveSaveAllOptions($options);
         $itemOptions = $allOptions;
         $itemOptions['flush'] = false;
 
@@ -184,6 +185,8 @@ class GroupSaver implements SaverInterface, BulkSaverInterface
     }
 
     /**
+     * Dispatch pre save event if flush is true
+     *
      * @param object $group
      * @param array  $options
      */
@@ -195,6 +198,8 @@ class GroupSaver implements SaverInterface, BulkSaverInterface
     }
 
     /**
+     * Dispatch post save event if flush is true
+     *
      * @param object $group
      * @param array  $options
      */

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/GroupSaver.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/GroupSaver.php
@@ -93,7 +93,7 @@ class GroupSaver implements SaverInterface, BulkSaverInterface
             );
         }
 
-        $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE, new GenericEvent($group));
+        $this->dispatchPreSaveEvent($group, $options);
 
         $options = $this->optionsResolver->resolveSaveOptions($options);
 
@@ -126,7 +126,7 @@ class GroupSaver implements SaverInterface, BulkSaverInterface
             $this->removeProducts($options['remove_products']);
         }
 
-        $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE, new GenericEvent($group));
+        $this->dispatchPostSaveEvent($group, $options);
     }
 
     /**
@@ -181,5 +181,27 @@ class GroupSaver implements SaverInterface, BulkSaverInterface
         $template = $group->getProductTemplate();
         $products = $group->getProducts()->toArray();
         $this->productTplApplier->apply($template, $products);
+    }
+
+    /**
+     * @param object $group
+     * @param array  $options
+     */
+    protected function dispatchPreSaveEvent($group, array $options)
+    {
+        if (true === $options['flush']) {
+            $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE, new GenericEvent($group));
+        }
+    }
+
+    /**
+     * @param object $group
+     * @param array  $options
+     */
+    protected function dispatchPostSaveEvent($group, array $options)
+    {
+        if (true === $options['flush']) {
+            $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE, new GenericEvent($group));
+        }
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/ProductSaver.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/ProductSaver.php
@@ -97,6 +97,7 @@ class ProductSaver implements SaverInterface, BulkSaverInterface
         }
 
         $options = $this->optionsResolver->resolveSaveAllOptions($options);
+
         $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE_ALL, new GenericEvent($products, $options));
 
         $itemOptions = $options;
@@ -114,6 +115,8 @@ class ProductSaver implements SaverInterface, BulkSaverInterface
     }
 
     /**
+     * Dispatch pre save event if flush is true
+     *
      * @param object $product
      * @param array  $options
      */
@@ -125,6 +128,8 @@ class ProductSaver implements SaverInterface, BulkSaverInterface
     }
 
     /**
+     * Dispatch post save event if flush is true
+     *
      * @param object $product
      * @param array  $options
      */

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/ProductSaver.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/ProductSaver.php
@@ -67,8 +67,8 @@ class ProductSaver implements SaverInterface, BulkSaverInterface
         }
 
         $options = $this->optionsResolver->resolveSaveOptions($options);
-        $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE, new GenericEvent($product, $options));
 
+        $this->dispatchPreSaveEvent($product, $options);
 
         $this->objectManager->persist($product);
 
@@ -84,7 +84,7 @@ class ProductSaver implements SaverInterface, BulkSaverInterface
             $this->completenessManager->generateMissingForProduct($product);
         }
 
-        $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE, new GenericEvent($product, $options));
+        $this->dispatchPostSaveEvent($product, $options);
     }
 
     /**
@@ -111,5 +111,27 @@ class ProductSaver implements SaverInterface, BulkSaverInterface
         }
 
         $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE_ALL, new GenericEvent($products, $options));
+    }
+
+    /**
+     * @param object $product
+     * @param array  $options
+     */
+    protected function dispatchPreSaveEvent($product, array $options)
+    {
+        if (true === $options['flush']) {
+            $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE, new GenericEvent($product, $options));
+        }
+    }
+
+    /**
+     * @param object $product
+     * @param array  $options
+     */
+    protected function dispatchPostSaveEvent($product, array $options)
+    {
+        if (true === $options['flush']) {
+            $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE, new GenericEvent($product, $options));
+        }
     }
 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Dispatch pre and post save events only when flush the object in the database. 
If those changes will be approved the "PimEnterprise\Bundle\WorkflowBundle\Doctrine\Common\Saver\DelegatingProductSaver" saveAll function should dispatch the PRE_SAVE_ALL and POST_SAVE_ALL events.

**Definition Of Done (for Core Developer only)**


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       |
| Added Behats                      |
| Changelog updated                 |
| Review and 2 GTM                  |
| Micro Demo to the PO (Story only) |
| Migration script                  |
| Tech Doc                          |

…abase