### PR TITLE
TIP-426: rename JobInstance parameter `rawConfiguration` to `rawParameters`

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -62,7 +62,7 @@
 
 ## BC breaks
 
-- Move namespace `Pim\Bundle\ImportExportBundle\Form\Type\JobInstanceType` to `Pim\Bundle\ImportExportBundle\Form\Type\JobInstanceFormType`
+- Rename `Pim\Bundle\ImportExportBundle\Form\Type\JobInstanceType` to `Pim\Bundle\ImportExportBundle\Form\Type\JobInstanceFormType`
 - Rename method `getRawConfiguration` to `getRawParameters` in `Akeneo\Component\Batch\Model\JobInstance`
 - Rename method `setRawConfiguration` to `setRawParameters` in `Akeneo\Component\Batch\Model\JobInstance`
 - Change constructor of `Akeneo\Component\Buffer\BufferInterface`. Add `$options` array as the second argument.

--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -62,6 +62,8 @@
 
 ## BC breaks
 
+- Rename method `getRawConfiguration` to `getRawParameters` in `Akeneo\Component\Batch\Model\JobInstance`
+- Rename method `setRawConfiguration` to `setRawParameters` in `Akeneo\Component\Batch\Model\JobInstance`
 - Change constructor of `Akeneo\Component\Buffer\BufferInterface`. Add `$options` array as the second argument.
 - Move `Pim\Component\Connector\Writer\File\CsvWriter` to `Pim\Component\Connector\Writer\File\Csv\Writer`
 - Move `Pim\Component\Connector\Writer\File\CsvProductWriter` to `Pim\Component\Connector\Writer\File\Csv\ProductWriter`

--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -62,6 +62,7 @@
 
 ## BC breaks
 
+- Move namespace `Pim\Bundle\ImportExportBundle\Form\Type\JobInstanceType` to `Pim\Bundle\ImportExportBundle\Form\Type\JobInstanceFormType`
 - Rename method `getRawConfiguration` to `getRawParameters` in `Akeneo\Component\Batch\Model\JobInstance`
 - Rename method `setRawConfiguration` to `setRawParameters` in `Akeneo\Component\Batch\Model\JobInstance`
 - Change constructor of `Akeneo\Component\Buffer\BufferInterface`. Add `$options` array as the second argument.

--- a/UPGRADE-1.6.md
+++ b/UPGRADE-1.6.md
@@ -331,4 +331,5 @@ Based on a PIM standard installation, execute the following command in your proj
     find ./src/ -type f -print0 | xargs -0 sed -i 's/Pim\\Component\\Connector\\Writer\\CsvProductWriter/Pim\\Component\\Connector\\Writer\\Csv\\ProductWriter/g'
     find ./src/ -type f -print0 | xargs -0 sed -i 's/Pim\\Component\\Connector\\Writer\\CsvVariantGroupWriter/Pim\\Component\\Connector\\Writer\\Csv\\VariantGroupWriter/g'
     find ./src/ -type f -print0 | xargs -0 sed -i 's/Pim\\Component\\Connector\\Writer\\YamlWriter/Pim\\Component\\Connector\\Writer\\Yaml\\Writer/g'
+    find ./src/ -type f -print0 | xargs -0 sed -i 's/Pim\\Bundle\\ImportExportBundle\\Form\\Type\\JobInstanceType/Pim\\Bundle\\ImportExportBundle\\Form\\Type\\JobInstanceFormType/g'
 ```

--- a/features/Context/FixturesContext.php
+++ b/features/Context/FixturesContext.php
@@ -884,7 +884,7 @@ class FixturesContext extends BaseFixturesContext
     {
         $configuration = $this
             ->getJobInstance($code)
-            ->getRawConfiguration();
+            ->getRawParameters();
 
         $path = dirname($configuration['filePath']);
 

--- a/features/Pim/Behat/Context/Domain/Collect/ImportProfilesContext.php
+++ b/features/Pim/Behat/Context/Domain/Collect/ImportProfilesContext.php
@@ -150,7 +150,7 @@ class ImportProfilesContext extends ImportExportContext
     {
         $jobInstance = $this->getMainContext()->getSubcontext('fixtures')->getJobInstance($code);
         $jobExecution = $jobInstance->getJobExecutions()->first();
-        $fileType = $jobInstance->getRawConfiguration()['invalid_items_file_format'];
+        $fileType = $jobInstance->getRawParameters()['invalid_items_file_format'];
 
         $filePath = $this->getMainContext()->getSubcontext('job')->getJobInstancePath($code);
         $filePath = sprintf(

--- a/features/Pim/Behat/Context/Domain/ImportExportContext.php
+++ b/features/Pim/Behat/Context/Domain/ImportExportContext.php
@@ -112,7 +112,7 @@ class ImportExportContext extends PimContext
      */
     protected function getCsvJobConfiguration($code)
     {
-        $config = $this->getFixturesContext()->getJobInstance($code)->getRawConfiguration();
+        $config = $this->getFixturesContext()->getJobInstance($code)->getRawParameters();
         $config['delimiter'] = isset($config['delimiter']) ? $config['delimiter'] : ';';
         $config['enclosure'] = isset($config['enclosure']) ? $config['enclosure'] : '"';
         $config['escape'] = isset($config['escape']) ? $config['escape'] : '\\';
@@ -127,7 +127,7 @@ class ImportExportContext extends PimContext
      */
     protected function getXlsxJobConfiguration($code)
     {
-        return $this->getFixturesContext()->getJobInstance($code)->getRawConfiguration();
+        return $this->getFixturesContext()->getJobInstance($code)->getRawParameters();
     }
 
     /**

--- a/features/Pim/Behat/Context/Domain/Spread/ExportProfilesContext.php
+++ b/features/Pim/Behat/Context/Domain/Spread/ExportProfilesContext.php
@@ -162,7 +162,7 @@ class ExportProfilesContext extends ImportExportContext
      */
     protected function checkExportDirectoryFiles($code, $shouldBeInDirectory, TableNode $table)
     {
-        $config = $this->getFixturesContext()->getJobInstance($code)->getRawConfiguration();
+        $config = $this->getFixturesContext()->getJobInstance($code)->getRawParameters();
 
         $path = dirname($config['filePath']);
 

--- a/features/Pim/Behat/Context/JobContext.php
+++ b/features/Pim/Behat/Context/JobContext.php
@@ -21,7 +21,7 @@ class JobContext extends PimContext
     public function theFollowingJobConfiguration($code, TableNode $table)
     {
         $jobInstance   = $this->getFixturesContext()->getJobInstance($code);
-        $configuration = $jobInstance->getRawConfiguration();
+        $configuration = $jobInstance->getRawParameters();
 
         foreach ($table->getRowsHash() as $property => $value) {
             $value = $this->replacePlaceholders($value);
@@ -67,7 +67,7 @@ class JobContext extends PimContext
                 )
             );
         }
-        $jobInstance->setRawConfiguration($jobParams->all());
+        $jobInstance->setRawParameters($jobParams->all());
 
         $saver = $this->getMainContext()->getContainer()->get('akeneo_batch.saver.job_instance');
         $saver->save($jobInstance);

--- a/src/Akeneo/Bundle/BatchBundle/Command/BatchCommand.php
+++ b/src/Akeneo/Bundle/BatchBundle/Command/BatchCommand.php
@@ -92,10 +92,10 @@ class BatchCommand extends ContainerAwareCommand
         $job = $this->getJobRegistry()->get($jobInstance->getJobName());
         $jobParamsFactory = $this->getJobParametersFactory();
         if ($config = $input->getOption('config')) {
-            $rawConfiguration = $this->decodeConfiguration($config);
-            $jobParameters = $jobParamsFactory->create($job, $rawConfiguration);
+            $rawParameters = $this->decodeConfiguration($config);
+            $jobParameters = $jobParamsFactory->create($job, $rawParameters);
         } else {
-            $jobParameters = $jobParamsFactory->create($job, $jobInstance->getRawConfiguration());
+            $jobParameters = $jobParamsFactory->create($job, $jobInstance->getRawParameters());
         }
         $validator = $this->getValidator();
 

--- a/src/Akeneo/Bundle/BatchBundle/Command/CreateJobCommand.php
+++ b/src/Akeneo/Bundle/BatchBundle/Command/CreateJobCommand.php
@@ -63,7 +63,7 @@ class CreateJobCommand extends ContainerAwareCommand
         $jobInstance->setJobName($jobName);
         $jobInstance->setCode($code);
         $jobInstance->setLabel($label);
-        $jobInstance->setRawConfiguration($rawConfig);
+        $jobInstance->setRawParameters($rawConfig);
 
         /** @var JobInterface */
         $job = $this->getJobRegistry()->get($jobInstance->getJobName());
@@ -80,7 +80,7 @@ class CreateJobCommand extends ContainerAwareCommand
 
         /** @var JobParameters $jobParameters */
         $jobParameters = $this->getJobParametersFactory()->create($job, $rawConfig);
-        $jobInstance->setRawConfiguration($jobParameters->all());
+        $jobInstance->setRawParameters($jobParameters->all());
 
         $violations = $this->getJobParametersValidator()->validate($job, $jobParameters);
         if (count($violations) > 0) {

--- a/src/Akeneo/Bundle/BatchBundle/Launcher/SimpleJobLauncher.php
+++ b/src/Akeneo/Bundle/BatchBundle/Launcher/SimpleJobLauncher.php
@@ -116,7 +116,7 @@ class SimpleJobLauncher implements JobLauncherInterface
     protected function createJobExecution(JobInstance $jobInstance, UserInterface $user)
     {
         $job = $this->jobRegistry->get($jobInstance->getJobName());
-        $jobParameters = $this->jobParametersFactory->create($job, $jobInstance->getRawConfiguration());
+        $jobParameters = $this->jobParametersFactory->create($job, $jobInstance->getRawParameters());
         $jobExecution = $this->jobRepository->createJobExecution($jobInstance, $jobParameters);
         $jobExecution->setUser($user->getUsername());
         $this->jobRepository->updateJobExecution($jobExecution);

--- a/src/Akeneo/Bundle/BatchBundle/Resources/config/model/doctrine/JobInstance.orm.yml
+++ b/src/Akeneo/Bundle/BatchBundle/Resources/config/model/doctrine/JobInstance.orm.yml
@@ -35,9 +35,9 @@ Akeneo\Component\Batch\Model\JobInstance:
             type: string
             length: 255
             column: connector
-        rawConfiguration:
+        rawParameters:
             type: array
-            column: rawConfiguration
+            column: raw_parameters
         type:
             type: string
             length: 255

--- a/src/Akeneo/Component/Batch/Model/JobInstance.php
+++ b/src/Akeneo/Component/Batch/Model/JobInstance.php
@@ -59,7 +59,7 @@ class JobInstance
     protected $type;
 
     /** @var array */
-    protected $rawConfiguration = [];
+    protected $rawParameters = [];
 
     /** @var Collection|JobExecution[] */
     protected $jobExecutions;
@@ -218,29 +218,55 @@ class JobInstance
     }
 
     /**
-     * This configuration can be used to create a JobParameters, stored like this in a legacy way
-     * TODO TIP-426: we should rename this configuration to rawParameters
+     * This parameters can be used to create a JobParameters, stored like this in a legacy way
      *
-     * @param array $configuration
+     * @param array $parameters
      *
      * @return JobInstance
      */
-    public function setRawConfiguration($configuration)
+    public function setRawParameters($parameters)
     {
-        $this->rawConfiguration = $configuration;
+        $this->rawParameters = $parameters;
 
         return $this;
     }
 
     /**
-     * This configuration can be used to create a JobParameters, stored like this in a legacy way
-     * TODO TIP-426: we should rename this configuration to rawParameters
+     * This parameters can be used to create a JobParameters, stored like this in a legacy way
      *
      * @return array
      */
+    public function getRawParameters()
+    {
+        return $this->rawParameters;
+    }
+
+    /**
+     * This configuration can be used to create a JobParameters, stored like this in a legacy way
+     *
+     * @param array $configuration
+     *
+     * @return JobInstance
+     *
+     * @deprecated will be removed in 1.7, this has been used to set the job instance parameters (configuration), we
+     *             must use $jobInstance->setRawParameters()
+     */
+    public function setRawConfiguration($configuration)
+    {
+        trigger_error('please use $jobInstance->setRawParameters() instead', E_USER_NOTICE);
+    }
+
+    /**
+     * This parameters can be used to create a JobParameters, stored like this in a legacy way
+     *
+     * @return array
+     *
+     * @deprecated will be removed in 1.7, this has been used to get the job instance parameters (configuration), we
+     *             must use $jobInstance->getRawParameters()
+     */
     public function getRawConfiguration()
     {
-        return $this->rawConfiguration;
+        trigger_error('please use $jobInstance->getRawParameters() instead', E_USER_NOTICE);
     }
 
     /**

--- a/src/Akeneo/Component/Batch/Model/JobInstance.php
+++ b/src/Akeneo/Component/Batch/Model/JobInstance.php
@@ -220,13 +220,13 @@ class JobInstance
     /**
      * This parameters can be used to create a JobParameters, stored like this in a legacy way
      *
-     * @param array $parameters
+     * @param array $rawParameters
      *
      * @return JobInstance
      */
-    public function setRawParameters($parameters)
+    public function setRawParameters($rawParameters)
     {
-        $this->rawParameters = $parameters;
+        $this->rawParameters = $rawParameters;
 
         return $this;
     }

--- a/src/Akeneo/Component/Batch/Normalizer/Structured/JobInstanceNormalizer.php
+++ b/src/Akeneo/Component/Batch/Normalizer/Structured/JobInstanceNormalizer.php
@@ -54,6 +54,6 @@ class JobInstanceNormalizer implements NormalizerInterface
      */
     protected function normalizeConfiguration(JobInstance $job)
     {
-        return $job->getRawConfiguration();
+        return $job->getRawParameters();
     }
 }

--- a/src/Akeneo/Component/Batch/Updater/JobInstanceUpdater.php
+++ b/src/Akeneo/Component/Batch/Updater/JobInstanceUpdater.php
@@ -81,7 +81,7 @@ class JobInstanceUpdater implements ObjectUpdaterInterface
                 $job = $this->jobRegistry->get($jobInstance->getJobName());
                 /** @var JobParameters $jobParameters */
                 $jobParameters = $this->jobParametersFactory->create($job, $data);
-                $jobInstance->setRawConfiguration($jobParameters->all());
+                $jobInstance->setRawParameters($jobParameters->all());
                 break;
             case 'code':
                 $jobInstance->setCode($data);

--- a/src/Akeneo/Component/Batch/spec/Normalizer/Structured/JobInstanceNormalizerSpec.php
+++ b/src/Akeneo/Component/Batch/spec/Normalizer/Structured/JobInstanceNormalizerSpec.php
@@ -30,7 +30,7 @@ class JobInstanceNormalizerSpec extends ObjectBehavior
         $jobinstance->getLabel()->willReturn('Product export');
         $jobinstance->getConnector()->willReturn('myconnector');
         $jobinstance->getType()->willReturn('EXPORT');
-        $jobinstance->getRawConfiguration()->willReturn(
+        $jobinstance->getRawParameters()->willReturn(
             [
                 'delimiter' => ';'
             ]

--- a/src/Akeneo/Component/Batch/spec/Updater/JobInstanceUpdaterSpec.php
+++ b/src/Akeneo/Component/Batch/spec/Updater/JobInstanceUpdaterSpec.php
@@ -43,7 +43,7 @@ class JobInstanceUpdaterSpec extends ObjectBehavior
         $jobInstance->setCode('fixtures_currency_csv')->shouldBeCalled();
         $jobInstance->setConnector('Data fixtures')->shouldBeCalled();
         $jobInstance->setLabel('Currencies data fixtures')->shouldBeCalled();
-        $jobInstance->setRawConfiguration([
+        $jobInstance->setRawParameters([
             'filePath' => 'currencies.csv',
         ])->shouldBeCalled();
         $jobInstance->setType('type')->shouldBeCalled();

--- a/src/Pim/Bundle/DataGridBundle/Controller/ProductExportController.php
+++ b/src/Pim/Bundle/DataGridBundle/Controller/ProductExportController.php
@@ -85,9 +85,9 @@ class ProductExportController
             throw new \RuntimeException(sprintf('Jobinstance "%s" is not well configured', $jobCode));
         }
 
-        $filters          = $this->gridFilterAdapter->adapt($this->request);
-        $rawConfiguration = $jobInstance->getRawConfiguration();
-        $mainContext      = $this->getContextParameters();
+        $filters       = $this->gridFilterAdapter->adapt($this->request);
+        $rawParameters = $jobInstance->getRawParameters();
+        $mainContext   = $this->getContextParameters();
 
         $dynamicConfiguration = [
             'filters'     => $filters,
@@ -110,7 +110,7 @@ class ProductExportController
             );
         }
 
-        $configuration = array_merge($rawConfiguration, $dynamicConfiguration);
+        $configuration = array_merge($rawParameters, $dynamicConfiguration);
 
         $this->jobLauncher->launch($jobInstance, $this->getUser(), $configuration);
 

--- a/src/Pim/Bundle/ImportExportBundle/Controller/JobProfileController.php
+++ b/src/Pim/Bundle/ImportExportBundle/Controller/JobProfileController.php
@@ -14,7 +14,7 @@ use Pim\Bundle\EnrichBundle\Flash\Message;
 use Pim\Bundle\EnrichBundle\Form\Type\UploadType;
 use Pim\Bundle\ImportExportBundle\Entity\Repository\JobInstanceRepository;
 use Pim\Bundle\ImportExportBundle\Event\JobProfileEvents;
-use Pim\Bundle\ImportExportBundle\Form\Type\JobInstanceType;
+use Pim\Bundle\ImportExportBundle\Form\Type\JobInstanceFormType;
 use Pim\Bundle\ImportExportBundle\JobTemplate\JobTemplateProviderInterface;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -45,8 +45,8 @@ class JobProfileController
     /** @var string */
     protected $jobType;
 
-    /** @var JobInstanceType */
-    protected $jobInstanceType;
+    /** @var JobInstanceFormType */
+    protected $jobInstanceFormType;
 
     /** @var JobInstanceFactory */
     protected $jobInstanceFactory;
@@ -101,7 +101,7 @@ class JobProfileController
      * @param ValidatorInterface           $validator
      * @param EventDispatcherInterface     $eventDispatcher
      * @param JobRegistry                  $jobRegistry
-     * @param JobInstanceType              $jobInstanceType
+     * @param JobInstanceFormType          $jobInstanceFormType
      * @param JobInstanceFactory           $jobInstanceFactory
      * @param JobLauncherInterface         $simpleJobLauncher
      * @param EntityManagerInterface       $entityManager
@@ -120,7 +120,7 @@ class JobProfileController
         ValidatorInterface $validator,
         EventDispatcherInterface $eventDispatcher,
         JobRegistry $jobRegistry,
-        JobInstanceType $jobInstanceType,
+        JobInstanceFormType $jobInstanceFormType,
         JobInstanceFactory $jobInstanceFactory,
         JobLauncherInterface $simpleJobLauncher,
         EntityManagerInterface $entityManager,
@@ -134,8 +134,8 @@ class JobProfileController
         $this->jobRegistry           = $jobRegistry;
         $this->jobType               = $jobType;
 
-        $this->jobInstanceType       = $jobInstanceType;
-        $this->jobInstanceType->setJobType($this->jobType);
+        $this->jobInstanceFormType       = $jobInstanceFormType;
+        $this->jobInstanceFormType->setJobType($this->jobType);
 
         $this->jobInstanceFactory    = $jobInstanceFactory;
         $this->simpleJobLauncher     = $simpleJobLauncher;
@@ -163,7 +163,7 @@ class JobProfileController
     public function createAction(Request $request)
     {
         $jobInstance = $this->jobInstanceFactory->createJobInstance($this->getJobType());
-        $form = $this->formFactory->create($this->jobInstanceType, $jobInstance);
+        $form = $this->formFactory->create($this->jobInstanceFormType, $jobInstance);
 
         if ($request->isMethod('POST')) {
             $form->handleRequest($request);
@@ -216,7 +216,7 @@ class JobProfileController
 
         $this->eventDispatcher->dispatch(JobProfileEvents::PRE_SHOW, new GenericEvent($jobInstance));
 
-        $form = $this->formFactory->create($this->jobInstanceType, $jobInstance, ['disabled' => true]);
+        $form = $this->formFactory->create($this->jobInstanceFormType, $jobInstance, ['disabled' => true]);
         $uploadAllowed = false;
         $uploadForm = null;
 
@@ -261,7 +261,7 @@ class JobProfileController
 
         $this->eventDispatcher->dispatch(JobProfileEvents::PRE_EDIT, new GenericEvent($jobInstance));
 
-        $form = $this->formFactory->create($this->jobInstanceType, $jobInstance);
+        $form = $this->formFactory->create($this->jobInstanceFormType, $jobInstance);
 
         if ($request->isMethod('POST')) {
             $form->handleRequest($request);

--- a/src/Pim/Bundle/ImportExportBundle/Controller/JobProfileController.php
+++ b/src/Pim/Bundle/ImportExportBundle/Controller/JobProfileController.php
@@ -131,26 +131,26 @@ class JobProfileController
         JobParametersValidator $jobParametersValidator,
         $jobType
     ) {
-        $this->jobRegistry           = $jobRegistry;
-        $this->jobType               = $jobType;
+        $this->jobRegistry            = $jobRegistry;
+        $this->jobType                = $jobType;
 
-        $this->jobInstanceFormType       = $jobInstanceFormType;
+        $this->jobInstanceFormType    = $jobInstanceFormType;
         $this->jobInstanceFormType->setJobType($this->jobType);
 
-        $this->jobInstanceFactory    = $jobInstanceFactory;
-        $this->simpleJobLauncher     = $simpleJobLauncher;
-        $this->formFactory           = $formFactory;
-        $this->request               = $request;
-        $this->router                = $router;
-        $this->templating            = $templating;
-        $this->eventDispatcher       = $eventDispatcher;
-        $this->validator             = $validator;
-        $this->entityManager         = $entityManager;
-        $this->jobInstanceRepository = $jobInstanceRepository;
-        $this->jobTemplateProvider   = $jobTemplateProvider;
-        $this->jobParametersFactory  = $jobParametersFactory;
+        $this->jobInstanceFactory     = $jobInstanceFactory;
+        $this->simpleJobLauncher      = $simpleJobLauncher;
+        $this->formFactory            = $formFactory;
+        $this->request                = $request;
+        $this->router                 = $router;
+        $this->templating             = $templating;
+        $this->eventDispatcher        = $eventDispatcher;
+        $this->validator              = $validator;
+        $this->entityManager          = $entityManager;
+        $this->jobInstanceRepository  = $jobInstanceRepository;
+        $this->jobTemplateProvider    = $jobTemplateProvider;
+        $this->jobParametersFactory   = $jobParametersFactory;
         $this->jobParametersValidator = $jobParametersValidator;
-        $this->tokenStorage          = $tokenStorage;
+        $this->tokenStorage           = $tokenStorage;
     }
 
     /**

--- a/src/Pim/Bundle/ImportExportBundle/Controller/JobProfileController.php
+++ b/src/Pim/Bundle/ImportExportBundle/Controller/JobProfileController.php
@@ -171,7 +171,7 @@ class JobProfileController
             if ($form->isValid()) {
                 $job = $this->jobRegistry->get($jobInstance->getJobName());
                 $jobParameters = $this->jobParametersFactory->create($job);
-                $jobInstance->setRawConfiguration($jobParameters->all());
+                $jobInstance->setRawParameters($jobParameters->all());
 
                 $this->entityManager->persist($jobInstance);
                 $this->entityManager->flush();
@@ -220,8 +220,8 @@ class JobProfileController
         $uploadAllowed = false;
         $uploadForm = null;
 
-        $rawConfiguration = $jobInstance->getRawConfiguration();
-        if (isset($rawConfiguration['uploadAllowed']) && true === $rawConfiguration['uploadAllowed']) {
+        $rawParameters = $jobInstance->getRawParameters();
+        if (isset($rawParameters['uploadAllowed']) && true === $rawParameters['uploadAllowed']) {
             $uploadAllowed = true;
             $uploadForm = $this->createUploadForm()->createView();
         }
@@ -399,9 +399,9 @@ class JobProfileController
      */
     protected function validateJobInstance(JobInstance $jobInstance, array $validationGroups)
     {
-        $rawConfiguration = $jobInstance->getRawConfiguration();
+        $rawParameters = $jobInstance->getRawParameters();
         $job = $this->jobRegistry->get($jobInstance->getJobName());
-        $jobParameters = $this->jobParametersFactory->create($job, $rawConfiguration);
+        $jobParameters = $this->jobParametersFactory->create($job, $rawParameters);
 
         /** @var ConstraintViolationListInterface $jobParamsViolations */
         $jobParamsViolations = $this->jobParametersValidator->validate(
@@ -430,7 +430,7 @@ class JobProfileController
     {
         $this->eventDispatcher->dispatch(JobProfileEvents::PRE_EXECUTE, new GenericEvent($jobInstance));
 
-        $configuration = $jobInstance->getRawConfiguration();
+        $configuration = $jobInstance->getRawParameters();
         $configuration['send_email'] = true;
         $jobExecution = $this->simpleJobLauncher
             ->launch($jobInstance, $this->tokenStorage->getToken()->getUser(), $configuration);
@@ -483,9 +483,9 @@ class JobProfileController
 
         $uploadedFile = $fileInfo->getUploadedFile();
         $file = $uploadedFile->move(sys_get_temp_dir(), $uploadedFile->getClientOriginalName());
-        $rawConfiguration = $jobInstance->getRawConfiguration();
-        $rawConfiguration['filePath'] = $file->getRealPath();
-        $jobInstance->setRawConfiguration($rawConfiguration);
+        $rawParameters = $jobInstance->getRawParameters();
+        $rawParameters['filePath'] = $file->getRealPath();
+        $jobInstance->setRawParameters($rawParameters);
 
         return true;
     }

--- a/src/Pim/Bundle/ImportExportBundle/Form/Type/JobInstanceFormType.php
+++ b/src/Pim/Bundle/ImportExportBundle/Form/Type/JobInstanceFormType.php
@@ -20,7 +20,7 @@ use Symfony\Component\Translation\TranslatorInterface;
  * @copyright 2013 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class JobInstanceType extends AbstractType
+class JobInstanceFormType extends AbstractType
 {
     /** @var JobRegistry $jobRegistry */
     protected $jobRegistry;
@@ -90,7 +90,7 @@ class JobInstanceType extends AbstractType
      *
      * @param string $jobType
      *
-     * @return JobInstanceType
+     * @return JobInstanceFormType
      */
     public function setJobType($jobType)
     {
@@ -114,7 +114,7 @@ class JobInstanceType extends AbstractType
      *
      * @param FormBuilderInterface $builder
      *
-     * @return JobInstanceType
+     * @return JobInstanceFormType
      */
     protected function addCodeField(FormBuilderInterface $builder)
     {
@@ -130,7 +130,7 @@ class JobInstanceType extends AbstractType
      *
      * @param FormBuilderInterface $builder
      *
-     * @return JobInstanceType
+     * @return JobInstanceFormType
      */
     protected function addLabelField(FormBuilderInterface $builder)
     {
@@ -144,7 +144,7 @@ class JobInstanceType extends AbstractType
      *
      * @param FormBuilderInterface $builder
      *
-     * @return JobInstanceType
+     * @return JobInstanceFormType
      */
     protected function addConnectorField(FormBuilderInterface $builder)
     {
@@ -167,7 +167,7 @@ class JobInstanceType extends AbstractType
      *
      * @param FormBuilderInterface $builder
      *
-     * @return JobInstanceType
+     * @return JobInstanceFormType
      */
     protected function addJobNameField(FormBuilderInterface $builder)
     {
@@ -201,7 +201,7 @@ class JobInstanceType extends AbstractType
      *
      * @param FormBuilderInterface $builder
      *
-     * @return JobInstanceType
+     * @return JobInstanceFormType
      */
     protected function addJobConfigurationField(FormBuilderInterface $builder)
     {

--- a/src/Pim/Bundle/ImportExportBundle/Form/Type/JobInstanceType.php
+++ b/src/Pim/Bundle/ImportExportBundle/Form/Type/JobInstanceType.php
@@ -205,22 +205,21 @@ class JobInstanceType extends AbstractType
      */
     protected function addJobConfigurationField(FormBuilderInterface $builder)
     {
-        // TODO: TIP-426: rename this field to parameters
         $jobName = $builder->getData()->getJobName();
 
         if (null !== $jobName) {
             $job = $this->jobRegistry->get($jobName);
             $builder
                 ->add(
-                    'configuration',
+                    'parameters',
                     'pim_import_export_job_parameters',
                     [
                         'required'      => true,
                         'by_reference'  => false,
-                        'property_path' => 'rawConfiguration',
+                        'property_path' => 'rawParameters',
                     ]
                 )
-                ->get('configuration')
+                ->get('parameters')
                 ->addModelTransformer(new ConfigurationToJobParametersTransformer(
                     $this->jobParametersFactory,
                     $job

--- a/src/Pim/Bundle/ImportExportBundle/Resources/config/form_types.yml
+++ b/src/Pim/Bundle/ImportExportBundle/Resources/config/form_types.yml
@@ -1,5 +1,5 @@
 parameters:
-    pim_import_export.form.type.job_instance.class: Pim\Bundle\ImportExportBundle\Form\Type\JobInstanceType
+    pim_import_export.form.type.job_instance.class: Pim\Bundle\ImportExportBundle\Form\Type\JobInstanceFormType
     pim_import_export.form.type.job_parameters.class: Pim\Bundle\ImportExportBundle\Form\Type\JobParametersType
     pim_import_export.form.type.product_export.locale_choice.class: Pim\Bundle\ImportExportBundle\Form\Type\JobParameter\LocaleChoiceType
     pim_import_export.form.type.updated_since_parameter.class: Pim\Bundle\ImportExportBundle\Form\Type\JobParameter\UpdatedSinceType

--- a/src/Pim/Bundle/ImportExportBundle/Resources/views/JobProfile/Tab/job_content.html.twig
+++ b/src/Pim/Bundle/ImportExportBundle/Resources/views/JobProfile/Tab/job_content.html.twig
@@ -1,6 +1,6 @@
 <div id="{{ viewElement.alias|replace({' ': '-', '.': '-'})|lower }}" class="job-profile-content-tab tab-pane buffer-top">
     {% set filtersSettings %}
-        {% for field in form.configuration %}
+        {% for field in form.parameters %}
             {% if field.vars.attr['data-tab'] is defined and 'content' == field.vars.attr['data-tab'] %}
                 {{ form_row(field) }}
             {% endif %}
@@ -15,8 +15,8 @@
 
                 $(function () {
                     LocaleSelector.init(
-                        '#{{ form.configuration.channel.vars.id }}',
-                        '#{{ form.configuration.locales.vars.id }}'
+                        '#{{ form.parameters.channel.vars.id }}',
+                        '#{{ form.parameters.locales.vars.id }}'
                     );
                 });
             }

--- a/src/Pim/Bundle/ImportExportBundle/Resources/views/JobProfile/Tab/property_edit.html.twig
+++ b/src/Pim/Bundle/ImportExportBundle/Resources/views/JobProfile/Tab/property_edit.html.twig
@@ -8,7 +8,7 @@
     {{ elements.accordion({ 'pane.accordion.properties': properties }, 1) }}
 
     {% set globalSettings %}
-        {% for field in form.configuration %}
+        {% for field in form.parameters %}
             {% if field.vars.attr['data-tab'] is not defined %}
                 {{ form_row(field) }}
             {% endif %}

--- a/src/Pim/Bundle/ImportExportBundle/Resources/views/JobProfile/Tab/property_show.html.twig
+++ b/src/Pim/Bundle/ImportExportBundle/Resources/views/JobProfile/Tab/property_show.html.twig
@@ -1,12 +1,12 @@
 {% form_theme form 'PimImportExportBundle:JobProfile/Tab:_form_theme.html.twig' %}
 
 <div id="{{ viewElement.alias|replace({' ': '-', '.': '-'})|lower }}" class="tab-pane buffer-top active">
-    {% block configuration %}
+    {% block parameters %}
         {% set globalSettings %}
             <table class="configuration">
                 <thead></thead>
                 <tbody>
-                {% for element in form.configuration %}
+                {% for element in form.parameters %}
                     {% if element.vars.attr['data-tab'] is not defined %}
                     <tr>
                         <td><b>{{ element.vars.label|trans }}</b></td>
@@ -18,5 +18,5 @@
             </table>
         {% endset %}
         {{ elements.accordion({ 'pane.accordion.global_settings': globalSettings }, 1, true) }}
-    {% endblock configuration %}
+    {% endblock parameters %}
 </div>

--- a/src/Pim/Bundle/ImportExportBundle/Validator/Constraints/UpdatedSinceStrategyValidator.php
+++ b/src/Pim/Bundle/ImportExportBundle/Validator/Constraints/UpdatedSinceStrategyValidator.php
@@ -27,7 +27,7 @@ class UpdatedSinceStrategyValidator extends ConstraintValidator
             throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\UpdateSinceStrategy');
         }
 
-        $strategy = $constraint->jobInstance->getRawConfiguration()['updated_since_strategy'];
+        $strategy = $constraint->jobInstance->getRawParameters()['updated_since_strategy'];
         if (empty($value) && $constraint->strategy === $strategy) {
             $this->context->buildViolation($constraint->message)->addViolation();
         }

--- a/src/Pim/Bundle/ImportExportBundle/spec/Validator/Constraints/UpdatedSinceStrategyValidatorSpec.php
+++ b/src/Pim/Bundle/ImportExportBundle/spec/Validator/Constraints/UpdatedSinceStrategyValidatorSpec.php
@@ -34,7 +34,7 @@ class UpdatedSinceStrategyValidatorSpec extends ObjectBehavior
         JobInstance $jobInstance,
         \Pim\Bundle\ImportExportBundle\Validator\Constraints\UpdatedSinceDate $constraint
     ) {
-        $jobInstance->getRawConfiguration()->willReturn([
+        $jobInstance->getRawParameters()->willReturn([
             'updated_since_strategy' => 'since_date',
         ]);
         $constraint->jobInstance = $jobInstance;
@@ -50,7 +50,7 @@ class UpdatedSinceStrategyValidatorSpec extends ObjectBehavior
         UpdatedSinceDate $constraint,
         ConstraintViolationBuilderInterface $constraintViolationBuilder
     ) {
-        $jobInstance->getRawConfiguration()->willReturn([
+        $jobInstance->getRawParameters()->willReturn([
             'updated_since_strategy' => 'since_date',
         ]);
 
@@ -69,7 +69,7 @@ class UpdatedSinceStrategyValidatorSpec extends ObjectBehavior
         UpdatedSinceNDays $constraint,
         ConstraintViolationBuilderInterface $constraintViolationBuilder
     ) {
-        $jobInstance->getRawConfiguration()->willReturn([
+        $jobInstance->getRawParameters()->willReturn([
             'updated_since_strategy' => 'since_n_days',
         ]);
 

--- a/src/Pim/Bundle/InstallerBundle/FixtureLoader/JobInstancesConfigurator.php
+++ b/src/Pim/Bundle/InstallerBundle/FixtureLoader/JobInstancesConfigurator.php
@@ -45,7 +45,7 @@ class JobInstancesConfigurator
             throw new \Exception(sprintf('Path "%s" not found', $installerDataPath));
         }
         foreach ($jobInstances as $jobInstance) {
-            $configuration = $jobInstance->getRawConfiguration();
+            $configuration = $jobInstance->getRawParameters();
             $configuration['filePath'] = sprintf('%s%s', $installerDataPath, $configuration['filePath']);
             if (!is_readable($configuration['filePath'])) {
                 throw new \Exception(
@@ -56,7 +56,7 @@ class JobInstancesConfigurator
                     )
                 );
             }
-            $jobInstance->setRawConfiguration($configuration);
+            $jobInstance->setRawParameters($configuration);
             $configuredJobInstances[] = $jobInstance;
         }
 
@@ -77,7 +77,7 @@ class JobInstancesConfigurator
     {
         $counter = 0;
         foreach ($jobInstances as $jobInstance) {
-            $configuration = $jobInstance->getRawConfiguration();
+            $configuration = $jobInstance->getRawParameters();
             if (!isset($replacePaths[$configuration['filePath']])) {
                 throw new \Exception(sprintf('No replacement path for "%s"', $configuration['filePath']));
             }
@@ -94,7 +94,7 @@ class JobInstancesConfigurator
                         )
                     );
                 }
-                $configuredJobInstance->setRawConfiguration($configuration);
+                $configuredJobInstance->setRawParameters($configuration);
                 $configuredJobInstances[] = $configuredJobInstance;
             }
         }

--- a/src/Pim/Bundle/InstallerBundle/spec/FixtureLoader/JobInstancesConfiguratorSpec.php
+++ b/src/Pim/Bundle/InstallerBundle/spec/FixtureLoader/JobInstancesConfiguratorSpec.php
@@ -20,8 +20,8 @@ class JobInstancesConfiguratorSpec extends ObjectBehavior
         $myInstallerPath = dirname($myFilePath);
         $myFileName = str_replace($myInstallerPath, '', $myFilePath);
         $pathProvider->getFixturesPath()->willReturn($myInstallerPath);
-        $instance->getRawConfiguration()->willReturn(['filePath' => $myFileName]);
-        $instance->setRawConfiguration(['filePath' => $myInstallerPath.$myFileName])->shouldBeCalled();
+        $instance->getRawParameters()->willReturn(['filePath' => $myFileName]);
+        $instance->setRawParameters(['filePath' => $myInstallerPath.$myFileName])->shouldBeCalled();
 
         $this->configureJobInstancesWithInstallerData([$instance]);
     }
@@ -38,8 +38,8 @@ class JobInstancesConfiguratorSpec extends ObjectBehavior
             ]
         ];
         $instance->getCode()->willReturn('my_original_code');
-        $instance->getRawConfiguration()->willReturn(['filePath' => $myFileName]);
-        $instance->setRawConfiguration(['filePath' => $myReplacementFilePath])->shouldBeCalled();
+        $instance->getRawParameters()->willReturn(['filePath' => $myFileName]);
+        $instance->setRawParameters(['filePath' => $myReplacementFilePath])->shouldBeCalled();
         $instance->setCode('my_original_code0')->shouldBeCalled();
 
         $configuredInstances = $this->configureJobInstancesWithReplacementPaths([$instance], $replacementPaths);
@@ -57,12 +57,12 @@ class JobInstancesConfiguratorSpec extends ObjectBehavior
             $myFileName  => [$myReplacementFileCommunity, $myReplacementFileEnterprise]
         ];
         $instance->getCode()->willReturn('my_original_code');
-        $instance->getRawConfiguration()->willReturn(['filePath' => $myFileName]);
-        $instance->setRawConfiguration(['filePath' => $myReplacementFileCommunity])->shouldBeCalled();
+        $instance->getRawParameters()->willReturn(['filePath' => $myFileName]);
+        $instance->setRawParameters(['filePath' => $myReplacementFileCommunity])->shouldBeCalled();
         $instance->setCode('my_original_code0')->shouldBeCalled();
 
-        $instance->getRawConfiguration()->willReturn(['filePath' => $myFileName]);
-        $instance->setRawConfiguration(['filePath' => $myReplacementFileEnterprise])->shouldBeCalled();
+        $instance->getRawParameters()->willReturn(['filePath' => $myFileName]);
+        $instance->setRawParameters(['filePath' => $myReplacementFileEnterprise])->shouldBeCalled();
         $instance->setCode('my_original_code1')->shouldBeCalled();
 
         $configuredInstances = $this->configureJobInstancesWithReplacementPaths([$instance], $replacementPaths);

--- a/src/Pim/Component/Connector/Normalizer/Flat/JobInstanceNormalizer.php
+++ b/src/Pim/Component/Connector/Normalizer/Flat/JobInstanceNormalizer.php
@@ -22,7 +22,7 @@ class JobInstanceNormalizer extends BaseNormalizer
      */
     protected function normalizeConfiguration(JobInstance $job)
     {
-        $configuration = json_encode($job->getRawConfiguration());
+        $configuration = json_encode($job->getRawParameters());
 
         return $configuration;
     }

--- a/src/Pim/Component/Connector/Processor/Denormalization/JobInstanceProcessor.php
+++ b/src/Pim/Component/Connector/Processor/Denormalization/JobInstanceProcessor.php
@@ -93,10 +93,10 @@ class JobInstanceProcessor extends AbstractProcessor
             $this->skipItemWithConstraintViolations($item, $violations);
         }
 
-        $rawConfiguration = $entity->getRawConfiguration();
-        if (!empty($rawConfiguration)) {
+        $rawParameters = $entity->getRawParameters();
+        if (!empty($rawParameters)) {
             $job = $this->jobRegistry->get($entity->getJobName());
-            $parameters = $this->jobParamsFactory->create($job, $rawConfiguration);
+            $parameters = $this->jobParamsFactory->create($job, $rawParameters);
             $violations = $this->jobParamsValidator->validate($job, $parameters);
             if ($violations->count() > 0) {
                 $this->objectDetacher->detach($entity);

--- a/src/Pim/Component/Connector/spec/Normalizer/Flat/JobInstanceNormalizerSpec.php
+++ b/src/Pim/Component/Connector/spec/Normalizer/Flat/JobInstanceNormalizerSpec.php
@@ -30,7 +30,7 @@ class JobInstanceNormalizerSpec extends ObjectBehavior
         $jobinstance->getLabel()->willReturn('Product export');
         $jobinstance->getConnector()->willReturn('myconnector');
         $jobinstance->getType()->willReturn('EXPORT');
-        $jobinstance->getRawConfiguration()->willReturn(
+        $jobinstance->getRawParameters()->willReturn(
             [
                 'delimiter' => ';'
             ]

--- a/upgrades/schema/Version_1_6_20160714195239_jobinstance_rawConfiguration_to_raw_parameters.php
+++ b/upgrades/schema/Version_1_6_20160714195239_jobinstance_rawConfiguration_to_raw_parameters.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Pim\Upgrade\Schema;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Rename JobInstance rawConfiguration to rawParameters
+ */
+class Version_1_6_20160714195239_jobinstance_rawConfiguration_to_raw_parameters extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->addSql('ALTER TABLE akeneo_batch_job_instance CHANGE rawConfiguration raw_parameters longtext COLLATE utf8_unicode_ci NOT NULL COMMENT \'(DC2Type:array)\'');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        $this->throwIrreversibleMigrationException();
+    }
+}


### PR DESCRIPTION
Rename rawConfiguration to rawParameters:
 - changes the field name in JobInstance ''raw_configuration" to "raw_parameters"
 - keeps the old getRawConfiguration as deprecated 
 - introduces a getRawParameters / setRawParameters
 - add update schema scripts in CE and EE
 - replace all reference of getRawConfiguration by getRawParameters
 - rename JobInstanceType in JobInstanceFormType

With this PR on akeneo-labs/DataGeneratorBundle/pull/39 

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | N
| Added Behats                      | N
| Changelog updated                 | Y
| Review and 2 GTM                  |
| Micro Demo to the PO (Story only) | N
| Migration script                  | Y
| Tech Doc                          | N
