### PR TITLE
TIP-298: bump dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -77,7 +77,7 @@
         "behat/mink-selenium2-driver": "1.3.1",
         "behat/symfony2-extension": "1.1.2",
         "behat/transliterator":"1.0.1",
-        "doctrine/mongodb-odm-bundle": "3.0.1",
+        "doctrine/mongodb-odm-bundle": "3.2.0",
         "sensiolabs/behat-page-object-extension": "1.0.1",
         "phpspec/phpspec": "3.0.0",
         "akeneo/phpspec-skip-example-extension": "2.0.0",

--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
         "sensio/framework-extra-bundle": "~3.0,>=3.0.2",
         "sensio/generator-bundle": "2.3.5",
         "symfony/assetic-bundle": "2.3.1",
-        "symfony/icu": "1.1.0",
+        "symfony/intl": "3.1.2",
         "symfony/monolog-bundle": "2.10.0",
         "symfony/swiftmailer-bundle": "2.3.8",
         "symfony/symfony": "2.7.2",


### PR DESCRIPTION
## symfony/icu

symfony/icu has been deprecated in favor of symfony/intl

##  doctrine/mongodb-odm-bundle

Why this change?

### 1. it has no impacts on perf 

done with 3 local measures on `pim:install:db`

before this change
* pim:install:db -e prod  65.19s user 1.08s system 77% cpu 1:25.41 total
* pim:install:db -e prod  63.59s user 0.89s system 77% cpu 1:23.13 total
* pim:install:db -e prod  65.61s user 1.08s system 76% cpu 1:27.72 total

after this change
* pim:install:db -e prod  64.32s user 1.04s system 77% cpu 1:24.76 total
* pim:install:db -e prod  63.08s user 0.94s system 77% cpu 1:22.70 total
* pim:install:db -e prod  63.98s user 0.90s system 77% cpu 1:23.44 total

### 2. it opens the gates towards PHP7
* to be able to make the PIM works with Mongo and PHP7, we need to have `doctrine/mongodb-odm:1.1.0` (see https://github.com/doctrine/mongodb-odm/releases/tag/1.1.0)
* our current version of `doctrine/mongodb-odm-bundle` requires `doctrine/mongodb-odm: ~1.0.0-beta10@dev` (see https://github.com/doctrine/DoctrineMongoDBBundle/blob/3.0.1/composer.json#L15). Which means we can have only `1.0.0-beta10 >= doctrine/mongodb-odm > 1.1` (see https://getcomposer.org/doc/articles/versions.md#tilde). So we have to bump `doctrine/mongodb-odm-bundle` to be able to install the `1.1` version.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Changelog updated                 | -
| Review and 2 GTM                  | 
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | https://github.com/akeneo/pim-docs/pull/349

