### PR TITLE
SDS-614: categories are not visible

### DIFF
--- a/src/Pim/Bundle/UIBundle/Resources/public/css/pim.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/css/pim.less
@@ -1774,3 +1774,8 @@ h3.tab-header {
 .scopable-input .note-editor {
   display: inline-block;
 }
+
+ // custom fix: allow to display correctly tree with large children count 
+.jstree > ul > li:last-child { 
+  padding-bottom: 80px ;
+}

--- a/src/Pim/Bundle/UIBundle/Resources/public/css/pim.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/css/pim.less
@@ -1775,7 +1775,7 @@ h3.tab-header {
   display: inline-block;
 }
 
- // custom fix: allow to display correctly tree with large children count 
+ // SDS-614: custom fix: allow to display correctly tree with large children count 
 .jstree > ul > li:last-child { 
   padding-bottom: 80px ;
 }


### PR DESCRIPTION
**Description**

When we had lot of categories, the last children were not visible on some browsers. The problem is that jsTree doesn't handle large amount of children very well (I think they do some calculation in javascript for height/padding). A custom fix is to add extra padding for the last children using CSS.

Note: we use an old version of jsTree (1.0-rc3). The current is 3.3.1. We need to update this later.
