### PR TITLE
PIM-5635 simple select reference data

### DIFF
--- a/features/Pim/Behat/Decorator/Field/Select2Decorator.php
+++ b/features/Pim/Behat/Decorator/Field/Select2Decorator.php
@@ -22,8 +22,8 @@ class Select2Decorator extends ElementDecorator
         $values = '' !== $value ? explode(',', $value) : [];
         $this->prune();
 
-        $widget = $this->getWidget();
         foreach ($values as $value) {
+            $widget = $this->getWidget();
             $value = trim($value);
 
             $this->getSession()->executeScript(
@@ -86,7 +86,7 @@ class Select2Decorator extends ElementDecorator
     {
         $openerElement = $this->find('css', '.select2-arrow');
         if (null === $openerElement) {
-            $openerElement = $this->find('css', '.select2-choices');
+            $openerElement = $this->find('css', '.select2-search-field');
         }
 
         $openerElement->click();

--- a/features/export/product-export-builder/export_products_by_simpleselect_reference_data.feature
+++ b/features/export/product-export-builder/export_products_by_simpleselect_reference_data.feature
@@ -1,27 +1,20 @@
 @javascript
-Feature: Export products according to multi select reference data values
+Feature: Export products according to simple select reference data values
   In order to use the enriched product data
   As a product manager
-  I need to be able to export the products according to their reference data values
+  I need to be able to export the products according to its selected reference data value
 
   Background:
     Given the "footwear" catalog configuration
     And the following reference data:
-      | type   | code         | label        |
-      | fabric | cashmerewool | Cashmerewool |
-      | fabric | neoprene     |              |
-      | fabric | silk         | Silk         |
+      | type  | code  | label |
+      | color | red   | Red   |
+      | color | green | Green |
     And the following products:
-      | sku    | family | name-en_US | sole_fabric            |
-      | HEEL-1 | heels  | The heel 1 | cashmerewool           |
-      | HEEL-2 | heels  | The heel 2 | cashmerewool           |
-      | HEEL-3 | heels  | The heel 3 | cashmerewool, neoprene |
-      | HEEL-4 | heels  | The heel 4 | neoprene               |
-      | HEEL-5 | heels  | The heel 5 | neoprene               |
-      | HEEL-6 | heels  | The heel 6 | silk                   |
-      | HEEL-7 | heels  | The heel 7 | silk                   |
-      | HEEL-8 | heels  | The heel 8 |                        |
-      | HEEL-9 | heels  | The heel 9 |                        |
+      | sku    | family | name-en_US | heel_color |
+      | HEEL-1 | heels  | The heel 1 | red        |
+      | HEEL-2 | heels  | The heel 2 | green      |
+      | HEEL-3 | heels  | The heel 3 |            |
     And the following jobs:
       | connector            | type   | alias              | code               | label              |
       | Akeneo CSV Connector | export | csv_product_export | csv_product_export | CSV product export |
@@ -32,73 +25,61 @@ Feature: Export products according to multi select reference data values
     Given I am logged in as "Julia"
     And I am on the "csv_product_export" export job edit page
     And I visit the "Content" tab
-    And I add available attributes Sole fabric
-    And I filter by "sole_fabric.code" with operator "In list" and value "Cashmerewool"
+    And I add available attributes Heel color
+    And I filter by "heel_color.code" with operator "In list" and value "Red"
     And I press the "Save" button
     When I launch the export job
     And I wait for the "csv_product_export" job to finish
     Then exported file of "csv_product_export" should contain:
       """
       sku;categories;color;description-en_US-mobile;enabled;family;groups;heel_color;manufacturer;name-en_US;price-EUR;price-USD;side_view;size;sole_color;sole_fabric;top_view
-      HEEL-1;;;;1;heels;;;;"The heel 1";;;;;;cashmerewool;
-      HEEL-2;;;;1;heels;;;;"The heel 2";;;;;;cashmerewool;
-      HEEL-3;;;;1;heels;;;;"The heel 3";;;;;;cashmerewool,neoprene;
+      HEEL-1;;;;1;heels;;red;;"The heel 1";;;;;;;
       """
 
-  Scenario: Export only the product values with multiple selected reference data values
+  Scenario: Export only the product values with selected reference data values
     Given I am logged in as "Julia"
     And I am on the "csv_product_export" export job edit page
     And I visit the "Content" tab
-    And I add available attributes Sole fabric
-    And I filter by "sole_fabric.code" with operator "In list" and value "Cashmerewool,Silk"
+    And I add available attributes Heel color
+    And I filter by "heel_color.code" with operator "In list" and value "Red,Green"
     And I press the "Save" button
     When I launch the export job
     And I wait for the "csv_product_export" job to finish
     Then exported file of "csv_product_export" should contain:
       """
       sku;categories;color;description-en_US-mobile;enabled;family;groups;heel_color;manufacturer;name-en_US;price-EUR;price-USD;side_view;size;sole_color;sole_fabric;top_view
-      HEEL-1;;;;1;heels;;;;"The heel 1";;;;;;cashmerewool;
-      HEEL-2;;;;1;heels;;;;"The heel 2";;;;;;cashmerewool;
-      HEEL-3;;;;1;heels;;;;"The heel 3";;;;;;cashmerewool,neoprene;
-      HEEL-6;;;;1;heels;;;;"The heel 6";;;;;;silk;
-      HEEL-7;;;;1;heels;;;;"The heel 7";;;;;;silk;
+      HEEL-1;;;;1;heels;;red;;"The heel 1";;;;;;;
+      HEEL-2;;;;1;heels;;green;;"The heel 2";;;;;;;
       """
 
   Scenario: Export only the product values without reference data values
     Given I am logged in as "Julia"
     And I am on the "csv_product_export" export job edit page
     And I visit the "Content" tab
-    And I add available attributes Sole fabric
-    And I filter by "sole_fabric.code" with operator "Empty" and value ""
+    And I add available attributes Heel color
+    And I filter by "heel_color.code" with operator "Empty" and value ""
     And I press the "Save" button
     When I launch the export job
     And I wait for the "csv_product_export" job to finish
     Then exported file of "csv_product_export" should contain:
       """
       sku;categories;color;description-en_US-mobile;enabled;family;groups;heel_color;manufacturer;name-en_US;price-EUR;price-USD;side_view;size;sole_color;sole_fabric;top_view
-      HEEL-8;;;;1;heels;;;;"The heel 8";;;;;;;
-      HEEL-9;;;;1;heels;;;;"The heel 9";;;;;;;
+      HEEL-3;;;;1;heels;;;;"The heel 3";;;;;;;
       """
 
-  Scenario: Export all the product values when no reference data is provided with operator IN LIST
+  Scenario: Export all the product values when no reference data is provided
     Given I am logged in as "Julia"
     And I am on the "csv_product_export" export job edit page
     And I visit the "Content" tab
-    And I add available attributes Sole fabric
-    And I filter by "sole_fabric.code" with operator "In list" and value ""
+    And I add available attributes Heel color
+    And I filter by "heel_color.code" with operator "In list" and value ""
     And I press the "Save" button
     When I launch the export job
     And I wait for the "csv_product_export" job to finish
     Then exported file of "csv_product_export" should contain:
       """
       sku;categories;color;description-en_US-mobile;enabled;family;groups;heel_color;manufacturer;name-en_US;price-EUR;price-USD;side_view;size;sole_color;sole_fabric;top_view
-      HEEL-1;;;;1;heels;;;;"The heel 1";;;;;;cashmerewool;
-      HEEL-2;;;;1;heels;;;;"The heel 2";;;;;;cashmerewool;
-      HEEL-3;;;;1;heels;;;;"The heel 3";;;;;;cashmerewool,neoprene;
-      HEEL-4;;;;1;heels;;;;"The heel 4";;;;;;neoprene;
-      HEEL-5;;;;1;heels;;;;"The heel 5";;;;;;neoprene;
-      HEEL-6;;;;1;heels;;;;"The heel 6";;;;;;silk;
-      HEEL-7;;;;1;heels;;;;"The heel 7";;;;;;silk;
-      HEEL-8;;;;1;heels;;;;"The heel 8";;;;;;;
-      HEEL-9;;;;1;heels;;;;"The heel 9";;;;;;;
+      HEEL-1;;;;1;heels;;red;;"The heel 1";;;;;;;
+      HEEL-2;;;;1;heels;;green;;"The heel 2";;;;;;;
+      HEEL-3;;;;1;heels;;;;"The heel 3";;;;;;;
       """

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_export_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_export_edit.yml
@@ -98,7 +98,7 @@ filters:
         pim_catalog_boolean:
             view: pim-filter-text
             # view: pim-filter-boolean
-        pim_reference_data_simpleselect: #to move in reference data bundle
-            view: pim-filter-simpleselect
+        pim_reference_data_simpleselect:
+            view: pim-filter-attribute-multiselect-reference-data
         pim_reference_data_multiselect:
             view: pim-filter-attribute-multiselect-reference-data

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_export_show.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_export_show.yml
@@ -96,6 +96,6 @@ filters:
             view: pim-filter-text
             # view: pim-filter-boolean
         pim_reference_data_simpleselect:
-            view: pim-filter-simpleselect
+            view: pim-filter-attribute-simpleselect-reference-data
         pim_reference_data_multiselect:
             view: pim-filter-attribute-multiselect-reference-data


### PR DESCRIPTION
**Title:** Adds support for simple select reference data in the export builder

**Description:**

The filter view for simple select reference data works the same as the multi select reference data.

The simple select reference data attribute types uses the multi select reference data view in the export builder. It supports the same operators "Empty" and "In list".

**Definition Of Done:**

| Q | A |
| --- | --- |
| Added Specs |  |
| Added Behats | Y |
| Changelog updated |  |
| Review and 2 GTM | N |
| Micro Demo to the PO (Story only) |  |
| Migration script |  |
|  Tech Doc |  |
