### PR TITLE
SDS-614: Fix CSS encoding weird chars

### DIFF
--- a/src/Pim/Bundle/UIBundle/Resources/public/css/pim.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/css/pim.less
@@ -1775,7 +1775,7 @@ h3.tab-header {
   display: inline-block;
 }
 
- // SDS-614: custom fix: allow to display correctly tree with large children count 
-.jstree > ul > li:last-child { 
-  padding-bottom: 80px ;
+// SDS-614: custom fix: allow to display correctly tree with large children count
+.jstree > ul > li:last-child {
+  padding-bottom: 80px;
 }


### PR DESCRIPTION
Git diff :

```
-<U+2028>// SDS-614: custom fix: allow to display correctly tree with large children count<U+2028>
-.jstree > ul > li:last-child {<U+2028>
-  padding-bottom: 80px<U+2028>;

+// SDS-614: custom fix: allow to display correctly tree with large children count
+.jstree > ul > li:last-child {
+  padding-bottom: 80px;
```
