### PR TITLE
PIM-5635: Add media filter on product export builder

### DIFF
--- a/features/Context/Page/Base/Grid.php
+++ b/features/Context/Page/Base/Grid.php
@@ -121,6 +121,10 @@ class Grid extends Index
             'Pim\Behat\Decorator\Export\Filter\BaseDecorator',
             'Pim\Behat\Decorator\Export\Filter\Select2Decorator',
         ],
+        'pim-filter-attribute-media' => [
+            'Pim\Behat\Decorator\Export\Filter\BaseDecorator',
+            'Pim\Behat\Decorator\Export\Filter\MediaDecorator',
+        ],
     ];
 
     /**

--- a/features/Pim/Behat/Decorator/Export/Filter/MediaDecorator.php
+++ b/features/Pim/Behat/Decorator/Export/Filter/MediaDecorator.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Pim\Behat\Decorator\Export\Filter;
+
+use Context\Spin\SpinCapableTrait;
+use Pim\Behat\Decorator\ElementDecorator;
+
+/**
+ * Decorator dedicated to metric attribute type.
+ */
+class MediaDecorator extends ElementDecorator
+{
+    use SpinCapableTrait;
+
+    /**
+     * Sets operator and value in the filter
+     *
+     * @param string $operator
+     * @param string $value
+     */
+    public function filter($operator, $value)
+    {
+        $operatorField = $this->spin(function () {
+            return $this->find('css', '.select2-container.operator');
+        }, 'Cannot find the media operator field');
+
+        $operatorField = $this->decorate(
+            $operatorField,
+            ['Pim\Behat\Decorator\Field\Select2Decorator']
+        );
+        $operatorField->setValue($operator);
+
+        if ('' !== $value) {
+            $field = $this->spin(function () {
+                return $this->find('css', '[name="filter-value"]');
+            }, 'Cannot find the media data field');
+
+            $field->setValue($value);
+            $this->getSession()->executeScript(
+                sprintf(
+                    '$(\'.filter-item[data-name="%s"][data-type="%s"] [name="filter-value"]\').trigger(\'change\')',
+                    $this->getAttribute('data-name'),
+                    $this->getAttribute('data-type')
+                )
+            );
+        }
+    }
+}

--- a/features/export/product-export-builder/export_products_by_files.feature
+++ b/features/export/product-export-builder/export_products_by_files.feature
@@ -1,0 +1,69 @@
+@javascript
+Feature: Export products according to file media attribute
+  In order to export specific products
+  As a product manager
+  I need to be able to export the products according to file attribute values
+
+  Background:
+    Given an "apparel" catalog configuration
+    And the following family:
+      | code    | requirements-ecommerce |
+      | rangers | sku, name              |
+    And the following products:
+      | sku        | enabled | family  | categories      | image                     | attachment            |
+      | SNKRS-1C-s | 1       | sandals | 2015_collection | %fixtures%/SNKRS-1C-s.png | %fixtures%/akeneo.txt |
+      | SNKRS-1C-t | 1       | sandals | 2015_collection | %fixtures%/SNKRS-1C-t.png | %fixtures%/akeneo.txt |
+      | SNKRS-1R   | 1       | sandals | 2015_collection | %fixtures%/SNKRS-1R.png   |                       |
+      | SNKRS-1S   | 1       | sandals | 2015_collection |                           | %fixtures%/akeneo2.txt|
+    And I am logged in as "Julia"
+
+  Scenario: Successfully export products by their file values without using the UI
+    Given the following job "ecommerce_product_export" configuration:
+      | filePath | %tmp%/product_export/product_export.csv |
+      | filters  | {"structure":{"locales":["en_US"],"scope":"ecommerce"},"data":[{"field": "attachment", "operator": "=", "value": "akeneo.txt"}]} |
+    When I am on the "ecommerce_product_export" export job page
+    And I launch the export job
+    And I wait for the "ecommerce_product_export" job to finish
+    Then exported file of "ecommerce_product_export" should contain:
+    """
+    sku;attachment;categories;description-en_US-ecommerce;enabled;family;groups;image;name-en_US;price-EUR;price-GBP;price-USD
+    SNKRS-1C-s;files/SNKRS-1C-s/attachment/akeneo.txt;2015_collection;;1;sandals;;files/SNKRS-1C-s/image/SNKRS-1C-s.png;;;;
+    SNKRS-1C-t;files/SNKRS-1C-t/attachment/akeneo.txt;2015_collection;;1;sandals;;files/SNKRS-1C-t/image/SNKRS-1C-t.png;;;;
+    """
+
+  Scenario: Successfully export products according to file value start
+    Given the following job "ecommerce_product_export" configuration:
+      | filePath | %tmp%/product_export/product_export.csv |
+    And I am on the "ecommerce_product_export" export job edit page
+    And I visit the "Content" tab
+    When I add available attributes Attachment
+    And I filter by "attachment" with operator "Starts with" and value "akeneo.t"
+    And I press "Save"
+    Then I should not see the text "There are unsaved changes"
+    When I am on the "ecommerce_product_export" export job page
+    And I launch the export job
+    And I wait for the "ecommerce_product_export" job to finish
+    Then exported file of "ecommerce_product_export" should contain:
+    """
+    sku;attachment;categories;description-de_DE-ecommerce;description-en_GB-ecommerce;description-en_US-ecommerce;description-fr_FR-ecommerce;enabled;family;groups;image;name-de_DE;name-en_GB;name-en_US;name-fr_FR;price-EUR;price-GBP;price-USD
+    SNKRS-1C-s;files/SNKRS-1C-s/attachment/akeneo.txt;2015_collection;;;;;1;sandals;;files/SNKRS-1C-s/image/SNKRS-1C-s.png;;;;;;;
+    SNKRS-1C-t;files/SNKRS-1C-t/attachment/akeneo.txt;2015_collection;;;;;1;sandals;;files/SNKRS-1C-t/image/SNKRS-1C-t.png;;;;;;;
+    """
+
+  Scenario: Successfully export products with empty file values
+    Given the following job "ecommerce_product_export" configuration:
+      | filePath | %tmp%/product_export/product_export.csv |
+    And I am on the "ecommerce_product_export" export job edit page
+    And I visit the "Content" tab
+    When I add available attributes Attachment
+    And I filter by "attachment" with operator "Is empty" and value ""
+    And I press "Save"
+    Then I should not see the text "There are unsaved changes"
+    When I am on the "ecommerce_product_export" export job page
+    And I launch the export job
+    And I wait for the "ecommerce_product_export" job to finish
+    Then exported file of "ecommerce_product_export" should contain:
+    """
+    sku;attachment;categories;description-de_DE-ecommerce;description-en_GB-ecommerce;description-en_US-ecommerce;description-fr_FR-ecommerce;enabled;family;groups;image;name-de_DE;name-en_GB;name-en_US;name-fr_FR;price-EUR;price-GBP;price-USD
+    SNKRS-1R;;2015_collection;;;;;1;sandals;;files/SNKRS-1R/image/SNKRS-1R.png;;;;;;;
+    """

--- a/features/export/product-export-builder/export_products_by_images.feature
+++ b/features/export/product-export-builder/export_products_by_images.feature
@@ -1,0 +1,69 @@
+@javascript
+Feature: Export products according to image media attribute
+  In order to export specific products
+  As a product manager
+  I need to be able to export the products according to image attribute values
+
+  Background:
+    Given an "apparel" catalog configuration
+    And the following family:
+      | code    | requirements-ecommerce |
+      | rangers | sku, name              |
+    And the following products:
+      | sku        | enabled | family  | categories      | image                     | attachment             |
+      | SNKRS-1C-s | 1       | sandals | 2015_collection | %fixtures%/SNKRS-1C-s.png | %fixtures%/akeneo.txt  |
+      | SNKRS-1C-t | 1       | sandals | 2015_collection | %fixtures%/SNKRS-1C-t.png | %fixtures%/akeneo.txt  |
+      | SNKRS-1R   | 1       | sandals | 2015_collection | %fixtures%/SNKRS-1R.png   |                        |
+      | SNKRS-1S   | 1       | sandals | 2015_collection |                           | %fixtures%/akeneo2.txt |
+    And I am logged in as "Julia"
+
+  Scenario: Successfully export products by their image values without using the UI
+    Given the following job "ecommerce_product_export" configuration:
+      | filePath | %tmp%/product_export/product_export.csv |
+      | filters  | {"structure":{"locales":["en_US"],"scope":"ecommerce"},"data":[{"field": "image", "operator": "=", "value": "SNKRS-1C-s.png"}]} |
+    When I am on the "ecommerce_product_export" export job page
+    And I launch the export job
+    And I wait for the "ecommerce_product_export" job to finish
+    Then exported file of "ecommerce_product_export" should contain:
+    """
+    sku;attachment;categories;description-en_US-ecommerce;enabled;family;groups;image;name-en_US;price-EUR;price-GBP;price-USD
+    SNKRS-1C-s;files/SNKRS-1C-s/attachment/akeneo.txt;2015_collection;;1;sandals;;files/SNKRS-1C-s/image/SNKRS-1C-s.png;;;;
+    """
+
+  Scenario: Successfully export products which contains partial image value
+    Given the following job "ecommerce_product_export" configuration:
+      | filePath | %tmp%/product_export/product_export.csv |
+    And I am on the "ecommerce_product_export" export job edit page
+    And I visit the "Content" tab
+    When I add available attributes Image
+    And I filter by "image" with operator "Contains" and value "KRS-1"
+    And I press "Save"
+    Then I should not see the text "There are unsaved changes"
+    When I am on the "ecommerce_product_export" export job page
+    And I launch the export job
+    And I wait for the "ecommerce_product_export" job to finish
+    Then exported file of "ecommerce_product_export" should contain:
+    """
+    sku;attachment;categories;description-de_DE-ecommerce;description-en_GB-ecommerce;description-en_US-ecommerce;description-fr_FR-ecommerce;enabled;family;groups;image;name-de_DE;name-en_GB;name-en_US;name-fr_FR;price-EUR;price-GBP;price-USD
+    SNKRS-1C-s;files/SNKRS-1C-s/attachment/akeneo.txt;2015_collection;;;;;1;sandals;;files/SNKRS-1C-s/image/SNKRS-1C-s.png;;;;;;;
+    SNKRS-1C-t;files/SNKRS-1C-t/attachment/akeneo.txt;2015_collection;;;;;1;sandals;;files/SNKRS-1C-t/image/SNKRS-1C-t.png;;;;;;;
+    SNKRS-1R;;2015_collection;;;;;1;sandals;;files/SNKRS-1R/image/SNKRS-1R.png;;;;;;;
+    """
+
+  Scenario: Successfully export products with empty image values
+    Given the following job "ecommerce_product_export" configuration:
+      | filePath | %tmp%/product_export/product_export.csv |
+    And I am on the "ecommerce_product_export" export job edit page
+    And I visit the "Content" tab
+    When I add available attributes Image
+    And I filter by "image" with operator "Is empty" and value ""
+    And I press "Save"
+    Then I should not see the text "There are unsaved changes"
+    When I am on the "ecommerce_product_export" export job page
+    And I launch the export job
+    And I wait for the "ecommerce_product_export" job to finish
+    Then exported file of "ecommerce_product_export" should contain:
+    """
+    sku;attachment;categories;description-de_DE-ecommerce;description-en_GB-ecommerce;description-en_US-ecommerce;description-fr_FR-ecommerce;enabled;family;groups;image;name-de_DE;name-en_GB;name-en_US;name-fr_FR;price-EUR;price-GBP;price-USD
+    SNKRS-1S;files/SNKRS-1S/attachment/akeneo2.txt;2015_collection;;;;;1;sandals;;;;;;;;;
+    """

--- a/features/export/product-export-builder/export_products_by_metrics.feature
+++ b/features/export/product-export-builder/export_products_by_metrics.feature
@@ -53,7 +53,7 @@ Feature: Export products according to metric attribute filter
     When I am on the "csv_footwear_product_export" export job edit page
     And I visit the "Content" tab
     And I add available attributes Length
-    Then I filter by "length" with operator "Empty" and value ""
+    Then I filter by "length" with operator "Is empty" and value ""
     And I press "Save"
     And I should not see the text "There are unsaved changes"
     When I am on the "csv_footwear_product_export" export job page

--- a/features/export/product-export-builder/export_products_by_multiselect_reference_data.feature
+++ b/features/export/product-export-builder/export_products_by_multiselect_reference_data.feature
@@ -50,7 +50,7 @@ Feature: Export products according to multi select reference data values
     And I am on the "csv_product_export" export job edit page
     And I visit the "Content" tab
     And I add available attributes Sole fabric
-    And I filter by "sole_fabric.code" with operator "Empty" and value ""
+    And I filter by "sole_fabric.code" with operator "Is empty" and value ""
     And I press the "Save" button
     When I launch the export job
     And I wait for the "csv_product_export" job to finish

--- a/features/export/product-export-builder/export_products_by_price_collections.feature
+++ b/features/export/product-export-builder/export_products_by_price_collections.feature
@@ -53,7 +53,7 @@ Feature: Export products according to price attribute filter
     And I am on the "csv_footwear_product_export" export job edit page
     And I visit the "Content" tab
     When I add available attributes Price
-    And I filter by "price" with operator "Empty" and value ""
+    And I filter by "price" with operator "Is empty" and value ""
     And I press "Save"
     Then I should not see the text "There are unsaved changes"
     When I am on the "csv_footwear_product_export" export job page

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/filters.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/filters.yml
@@ -80,3 +80,14 @@ extensions:
             operators:
                 - IN
                 - EMPTY
+
+    pim-filter-attribute-media:
+        module:  pim/filter/attribute/media
+        config:
+            operators:
+                - CONTAINS
+                - DOES NOT CONTAIN
+                - "="
+                - STARTS WITH
+                - ENDS WITH
+                - EMPTY

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_export_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_export_edit.yml
@@ -80,9 +80,9 @@ filters:
         pim_catalog_price_collection:
             view: pim-filter-attribute-price-collection
         pim_catalog_image:
-            view: pim-filter-text
+            view: pim-filter-attribute-media
         pim_catalog_file:
-            view: pim-filter-text
+            view: pim-filter-attribute-media
         pim_catalog_multiselect:
             view: pim-filter-text
             # view: pim-filter-multiselect

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_export_show.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_export_show.yml
@@ -81,9 +81,9 @@ filters:
         pim_catalog_price_collection:
             view: pim-filter-attribute-price-collection
         pim_catalog_image:
-            view: pim-filter-text
+            view: pim-filter-attribute-media
         pim_catalog_file:
-            view: pim-filter-text
+            view: pim-filter-attribute-media
         pim_catalog_multiselect:
             view: pim-filter-text
             # view: pim-filter-multiselect

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
@@ -229,24 +229,25 @@ config:
         pim/export/product/edit/content/data/add-filter:                pimenrich/js/export/product/edit/content/data/add-filter
 
         # Filters
-        pim/filter/filter: pimenrich/js/filter/filter
-        pim/filter/text: pimenrich/js/filter/text
-        pim/filter/simpleselect: pimenrich/js/filter/simpleselect
-        pim/filter/product/family: pimenrich/js/filter/product/family
-        pim/filter/product/enabled: pimenrich/js/filter/product/enabled
-        pim/filter/product/updated: pimenrich/js/filter/product/updated
-        pim/filter/product/completeness: pimenrich/js/filter/product/completeness
-        pim/filter/product/category: pimenrich/js/filter/product/category
-        pim/filter/product/category/selector: pimenrich/js/filter/product/category/selector
-        pim/filter/product/identifier: pimenrich/js/filter/product/identifier
-        pim/filter/attribute/metric: pimenrich/js/filter/attribute/metric
-        pim/filter/attribute/string: pimenrich/js/filter/attribute/string
-        pim/filter/attribute/price-collection: pimenrich/js/filter/attribute/price-collection
+        pim/filter/filter:                               pimenrich/js/filter/filter
+        pim/filter/text:                                 pimenrich/js/filter/text
+        pim/filter/simpleselect:                         pimenrich/js/filter/simpleselect
+        pim/filter/product/family:                       pimenrich/js/filter/product/family
+        pim/filter/product/enabled:                      pimenrich/js/filter/product/enabled
+        pim/filter/product/updated:                      pimenrich/js/filter/product/updated
+        pim/filter/product/completeness:                 pimenrich/js/filter/product/completeness
+        pim/filter/product/category:                     pimenrich/js/filter/product/category
+        pim/filter/product/category/selector:            pimenrich/js/filter/product/category/selector
+        pim/filter/product/identifier:                   pimenrich/js/filter/product/identifier
+        pim/filter/attribute/metric:                     pimenrich/js/filter/attribute/metric
+        pim/filter/attribute/boolean:                    pimenrich/js/filter/attribute/boolean
+        pim/filter/attribute/string:                     pimenrich/js/filter/attribute/string
+        pim/filter/attribute/price-collection:           pimenrich/js/filter/attribute/price-collection
         pim/filter/attribute/multiselect-reference-data: pimenrich/js/filter/attribute/multiselect-reference-data
-        pim/filter/attribute/boolean: pimenrich/js/filter/attribute/boolean
+        pim/filter/attribute/media:                      pimenrich/js/filter/attribute/media
 
         # Product edit form
-        pim/field-manager:                  pimenrich/js/product/field-manager
+        pim/field-manager: pimenrich/js/product/field-manager
 
         # Product create form
         pim/product-create:      pimenrich/js/product/create/create
@@ -387,18 +388,19 @@ config:
         pim/template/export/product/edit/content/structure/attributes: pimenrich/templates/export/product/edit/content/structure/attributes.html
 
         # Filters
-        pim/template/filter/filter: pimenrich/templates/filter/filter.html
-        pim/template/filter/text: pimenrich/templates/filter/text.html
-        pim/template/filter/simpleselect: pimenrich/templates/filter/simpleselect.html
-        pim/template/filter/product/family: pimenrich/templates/filter/product/family.html
-        pim/template/filter/product/enabled: pimenrich/templates/filter/product/enabled.html
-        pim/template/filter/product/updated: pimenrich/templates/filter/product/updated.html
-        pim/template/filter/product/completeness: pimenrich/templates/filter/product/completeness.html
-        pim/template/filter/product/category: pimenrich/templates/filter/product/category.html
-        pim/template/filter/product/category/selector: pimenrich/templates/filter/product/category/selector.html
-        pim/template/filter/product/identifier: pimenrich/templates/filter/product/identifier.html
-        pim/template/filter/attribute/boolean: pimenrich/templates/filter/attribute/boolean.html
-        pim/template/filter/attribute/metric: pimenrich/templates/filter/attribute/metric.html
-        pim/template/filter/attribute/string: pimenrich/templates/filter/attribute/string.html
-        pim/template/filter/attribute/price-collection: pimenrich/templates/filter/attribute/price-collection.html
+        pim/template/filter/filter:                               pimenrich/templates/filter/filter.html
+        pim/template/filter/text:                                 pimenrich/templates/filter/text.html
+        pim/template/filter/simpleselect:                         pimenrich/templates/filter/simpleselect.html
+        pim/template/filter/product/family:                       pimenrich/templates/filter/product/family.html
+        pim/template/filter/product/enabled:                      pimenrich/templates/filter/product/enabled.html
+        pim/template/filter/product/updated:                      pimenrich/templates/filter/product/updated.html
+        pim/template/filter/product/completeness:                 pimenrich/templates/filter/product/completeness.html
+        pim/template/filter/product/category:                     pimenrich/templates/filter/product/category.html
+        pim/template/filter/product/category/selector:            pimenrich/templates/filter/product/category/selector.html
+        pim/template/filter/product/identifier:                   pimenrich/templates/filter/product/identifier.html
+        pim/template/filter/attribute/boolean:                    pimenrich/templates/filter/attribute/boolean.html
+        pim/template/filter/attribute/metric:                     pimenrich/templates/filter/attribute/metric.html
+        pim/template/filter/attribute/string:                     pimenrich/templates/filter/attribute/string.html
+        pim/template/filter/attribute/price-collection:           pimenrich/templates/filter/attribute/price-collection.html
         pim/template/filter/attribute/multiselect-reference-data: pimenrich/templates/filter/attribute/multiselect-reference-data.html
+        pim/template/filter/attribute/media:                      pimenrich/templates/filter/attribute/media.html

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/attribute/media.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/attribute/media.js
@@ -1,0 +1,101 @@
+'use strict';
+
+define([
+    'jquery',
+    'underscore',
+    'oro/translator',
+    'pim/filter/filter',
+    'pim/fetcher-registry',
+    'pim/user-context',
+    'pim/i18n',
+    'text!pim/template/filter/attribute/media',
+    'jquery.select2'
+], function (
+    $,
+    _,
+    __,
+    BaseFilter,
+    FetcherRegistry,
+    UserContext,
+    i18n,
+    template
+) {
+    return BaseFilter.extend({
+        shortname: 'media',
+        template: _.template(template),
+        events: {
+            'change [name="filter-value"], [name="filter-operator"]': 'updateState'
+        },
+
+        /**
+         * {@inheritdoc}
+         */
+        initialize: function (config) {
+            this.config = config.config;
+
+            return BaseFilter.prototype.initialize.apply(this, arguments);
+        },
+
+        /**
+         * {@inheritdoc}
+         */
+        isEmpty: function () {
+            return 'EMPTY' !== this.getOperator() &&
+                (undefined === this.getValue() || '' === this.getValue());
+        },
+
+        /**
+         * {@inheritdoc}
+         */
+        renderInput: function (templateContext) {
+            var value = this.getValue();
+
+            if (undefined === value) {
+                value = '';
+            }
+
+            return this.template(_.extend({}, templateContext, {
+                __: __,
+                value: value,
+                field: this.getField(),
+                operator: this.getOperator(),
+                operators: this.config.operators
+            }));
+        },
+
+        /**
+         * {@inheritdoc}
+         */
+        postRender: function () {
+            this.$('.operator').select2({minimumResultsForSearch: -1});
+        },
+
+        /**
+         * {@inheritdoc}
+         */
+        getTemplateContext: function () {
+            return $.when(
+                BaseFilter.prototype.getTemplateContext.apply(this, arguments),
+                FetcherRegistry.getFetcher('attribute').fetch(this.getField())
+            ).then(function (templateContext, attribute) {
+                return _.extend({}, templateContext, {
+                    label: i18n.getLabel(attribute.labels, UserContext.get('uiLocale'), attribute.code)
+                });
+            }.bind(this));
+        },
+
+        /**
+         * {@inheritdoc}
+         */
+        updateState: function () {
+            var value = this.$('[name="filter-value"]').val();
+            var operator = this.$('[name="filter-operator"]').val();
+
+            this.setData({
+                field: this.getField(),
+                operator: operator,
+                value: value
+            });
+        }
+    });
+});

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/filter/attribute/media.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/filter/attribute/media.html
@@ -1,0 +1,11 @@
+<select class="select2 operator" <%- editable ? '' : 'disabled' %> name="filter-operator">
+    <% _.each(operators, function (operatorChoice) { %>
+        <option value="<%- operatorChoice %>"<%- operator === operatorChoice ? ' selected' : '' %>>
+            <%- __('pim_enrich.export.product.filter.media.operators.' + operatorChoice) %>
+        </option>
+    <% }); %>
+</select>
+
+<% if ('EMPTY' !== operator) { %>
+    <input type="text" name="filter-value" class="value" value="<%- value %>" <%- editable ? '' : 'disabled' %>>
+<% } %>

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
@@ -397,7 +397,7 @@ pim_enrich:
                         ">": ">"
                         "<=": "<="
                         "<": "<"
-                        EMPTY: "Empty"
+                        EMPTY: Is empty
                 string:
                     operators:
                         ALL: All
@@ -414,11 +414,19 @@ pim_enrich:
                         "<=": "<="
                         ">": ">"
                         "<": "<"
-                        EMPTY: "Empty"
+                        EMPTY: Is empty
                 multi_select:
                     operators:
                         IN: In list
-                        EMPTY: Empty
+                        EMPTY: Is empty
+                media:
+                    operators:
+                        CONTAINS: Contains
+                        DOES NOT CONTAIN: Does not contain
+                        "=": Is equal to
+                        STARTS WITH: Starts with
+                        ENDS WITH: Ends with
+                        EMPTY: Is empty
     mass_edit_action:
         edit_common_attributes:
             description: The selected product's attributes will be edited with the following data for the locale <span class="highlight">{{ locale }}</span> and the channel <span class="highlight">{{ channel }}</span>, chosen in the products grid.

--- a/src/Pim/Bundle/UIBundle/Resources/public/css/pim.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/css/pim.less
@@ -1810,7 +1810,7 @@ h3.tab-header {
   }
 
   .value {
-    width: 95px;
+    width: 94px;
   }
 
   .unit, .currency {
@@ -1819,13 +1819,14 @@ h3.tab-header {
 }
 
 [data-type="pim-filter-attribute-multiselect-reference-data"] .filter-input,
-[data-type="pim-filter-attribute-string"] .filter-input {
+[data-type="pim-filter-attribute-string"] .filter-input,
+[data-type="pim-filter-attribute-media"] .filter-input {
   .operator {
     width: 100px;
   }
 
   .value {
-    width: 200px;
+    width: 197px;
   }
 }
 


### PR DESCRIPTION
**Description**

Adds media filter on product export builder. This filter works both on media and file attribute types.

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | N/A
| Added Behats                      | :white_check_mark:
| Changelog updated                 | N/A
| Review and 2 GTM                  | :white_check_mark:
| Micro Demo to the PO (Story only) | N/A
| Migration script                  | N/A
| Tech Doc                          | N/A