### PR TITLE
Example of eventstore events

### DIFF
--- a/src/Acme/Bundle/AppBundle/Resources/doc/index.md
+++ b/src/Acme/Bundle/AppBundle/Resources/doc/index.md
@@ -1,0 +1,129 @@
+EventStore event examples
+--------------------------
+I have an event subscriber exactly like yours.
+
+
+#### Example of a mass edit product: action change status. 
+I disabled 2 products. As you can see the change set is the previous from when I created the product. 
+```json
+{
+  "family": "sofa_variation",
+  "groups": [],
+  "variant_group": null,
+  "categories": [],
+  "enabled": false,
+  "values": {
+    "sku": [
+      {
+        "locale": null,
+        "scope": null,
+        "data": "TESTING-1"
+      }
+    ],
+    "variation_parent_product": [
+      {
+        "locale": null,
+        "scope": null,
+        "data": "UK-SKUMAGENTO000003"
+      }
+    ],
+    "main_color": [
+      {
+        "locale": null,
+        "scope": null,
+        "data": "black"
+      }
+    ]
+  },
+  "associations": [],
+  "sku": "TESTING-1",
+  "changeset": {
+    "sku": {
+      "old": "",
+      "new": "TESTING-1"
+    },
+    "family": {
+      "old": "",
+      "new": "sofa_variation"
+    },
+    "main_color": {
+      "old": "",
+      "new": "black"
+    },
+    "variation_parent_product": {
+      "old": "",
+      "new": "UK-SKUMAGENTO000003"
+    },
+    "enabled": {
+      "old": "",
+      "new": 1
+    }
+  },
+  "author": {
+    "name": "Iulian Popa",
+    "email": "iulian.popa@made.com"
+  }
+}
+```
+In the change set I should have just one change, something like this:
+```json
+"changeset": {
+    "enabled": {
+      "old": 1,
+      "new": 0
+    }
+}
+```
+But because the flush on the product is not done I got the wrong change set.
+Or maybe because the build of the version is triggered after post_save, maybe that is a problem.
+
+## Example of a mass edit product: action "Classify products in categories".
+ Again the change set is the previous one because the object is not flushed.
+```json
+{
+  "family": "sofa_variation",
+  "groups": [],
+  "variant_group": null,
+  "categories": [
+    "sofa"
+  ],
+  "enabled": true,
+  "values": {
+    "sku": [
+      {
+        "locale": null,
+        "scope": null,
+        "data": "TESTING-1"
+      }
+    ],
+    "variation_parent_product": [
+      {
+        "locale": null,
+        "scope": null,
+        "data": "UK-SKUMAGENTO000003"
+      }
+    ],
+    "main_color": [
+      {
+        "locale": null,
+        "scope": null,
+        "data": "black"
+      }
+    ]
+  },
+  "associations": [],
+  "sku": "TESTING-1",
+  "changeset": {
+    "enabled": {
+      "old": 1,
+      "new": 0
+    }
+  },
+  "author": {
+    "name": "Iulian Popa",
+    "email": "iulian.popa@made.com"
+  }
+}
+```
+I made some comments as an example on the Pim\Bundle\CatalogBundle\Doctrine\Common\Saver\ProductSaver.
+Please let me know if you have any questions.

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/ProductSaver.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/ProductSaver.php
@@ -83,7 +83,13 @@ class ProductSaver implements SaverInterface, BulkSaverInterface
         if (true === $options['recalculate']) {
             $this->completenessManager->generateMissingForProduct($product);
         }
-
+        /*
+         * A.
+         * If I listen for this event on mass edit I will not have in the $event->getEventType() the real changeset
+         * because the object was not flushed into the database.
+         * Also it's still not so clear for me why the post_save event should be dispatched if you didn't flush the
+         * object.
+         * */
         $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE, new GenericEvent($product, $options));
     }
 
@@ -103,13 +109,34 @@ class ProductSaver implements SaverInterface, BulkSaverInterface
         $itemOptions['flush'] = false;
 
         foreach ($products as $product) {
+            /*
+            B.
+            Here is where the save function is called multiple times for a batch when we use mass edit.
+            The function save will dispatch post_save events without flushing the changes into the database.
+
+            If saveAll function would not base on save function, everything should work as I expect:
+            - saveAll will flush every batch and dispatch the post_save_all event, which I am listening when I do imports
+            or mass edits.
+            - save will flush every time and dispatch the events with the correct change set.
+            */
             $this->save($product, $itemOptions);
         }
 
         if (true === $options['flush']) {
             $this->objectManager->flush();
         }
-
+        /*
+         * C.
+         * 1. If we listen for both post_save and post_save_all events all the events are duplicated right now.
+         * - From post_save I have the event with a wrong change set.
+         * - From post_save_all I have the correct event.
+         *
+         * 2. If I change the save function to dispatch the event post_save only when the object is flushed (as in my
+         * previous PR) and listen for both post_save and post_save_all, everything is awesome.
+         * The only issue in that case is that on mass edit "Edit common attributes"
+         * "PimEnterprise\Bundle\WorkflowBundle\Doctrine\Common\Saver\DelegatingProductSaver" does not raise
+         * "pre/post_save_all" events at all on saveAll function.
+         * */
         $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE_ALL, new GenericEvent($products, $options));
     }
 }


### PR DESCRIPTION
Hello @nidup 

Thank you very much for your response.
Yes I'm talking about the versioning change set and yes we use data from the $event->getEventType() directly.

- What is the format of the event you want to send? (paste sample json/xml please)

     We use json. I pasted in some example.

- Do you want to put only the updated product fields in this event or the whole product data?

     We want to put all the product data + the change set.

- How do you plan to build the content of this event in your listener/subscriber?

     We use Normalizers to build the content of the events that we send to EventStore. We extended your Pim\Bundle\TransformBundle\Normalizer\Structured\ProductNormalizer and perform some formatting on its response so we don't send data which is only important for PIM (like validation rules).

I added some examples and comments in "Pim\Bundle\CatalogBundle\Doctrine\Common\Saver\ProductSaver" class A. B. and C.
Please let me know what do you think.

Thank you,

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       |
| Added Behats                      |
| Changelog updated                 |
| Review and 2 GTM                  |
| Micro Demo to the PO (Story only) |
| Migration script                  |
| Tech Doc                          |

