### PR TITLE
TIP-307: fix download pdf issue when using PHP7

### DIFF
--- a/src/Pim/Bundle/PdfGeneratorBundle/Resources/views/Product/renderPdf.html.twig
+++ b/src/Pim/Bundle/PdfGeneratorBundle/Resources/views/Product/renderPdf.html.twig
@@ -107,7 +107,11 @@
                                     {% set manualHeight = false %}
                                 {% else %}
                                     {% set content = product.getValue(attribute.code, locale, scope) %}
-                                    {% set manualHeight = attribute.label|length > (content.__toString()|length / 3) %}
+                                    {% if content != null %}
+                                        {% set manualHeight = attribute.label|length >(content.__toString()|length / 3) %}
+                                    {% else %}
+                                        {% set manualHeight = true %}
+                                    {% endif %}
                                 {% endif %}
 
                                 <div class="attributes"{% if manualHeight %} style="height: {{ (attribute.label|length / 30)|round(0, 'ceil') * 18 + 10 }}px"{% endif %}>


### PR DESCRIPTION
Following issue happens when using PHP7 (still experimental support for now).

![php7-issue](https://cloud.githubusercontent.com/assets/2104359/17101881/23f2afe2-5277-11e6-8718-7cfa0737a6ed.png)


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | N
| Added Behats                      | N
| Changelog updated                 | N
| Review and 2 GTM                  | ?
| Micro Demo to the PO (Story only) | N
| Migration script                  | N
| Tech Doc                          | N

