### PR TITLE
TIP-474: Stabilize most randomish behat scenarios

### DIFF
--- a/features/Context/AssertionContext.php
+++ b/features/Context/AssertionContext.php
@@ -711,25 +711,6 @@ class AssertionContext extends RawMinkContext
     }
 
     /**
-     * @param PyStringNode $text
-     *
-     * @throws ResponseTextException
-     * @throws \Exception
-     *
-     * @Then /^I should see the sequential edit progression:$/
-     */
-    public function iShouldSeeTheSequentialEditProgression(PyStringNode $text)
-    {
-        $this->getCurrentPage()->waitForProgressionBar();
-
-        $this->spin(function () use ($text) {
-            $this->assertSession()->pageTextContains((string) $text);
-
-            return true;
-        }, sprintf('Cannot find text "%s" in Sequential edit progression', (string) $text));
-    }
-
-    /**
      * Checks that avatar was not the default one
      *
      * @Then /^I should not see the default avatar$/

--- a/features/Context/Page/Product/Edit.php
+++ b/features/Context/Page/Product/Edit.php
@@ -626,18 +626,6 @@ class Edit extends ProductEditForm
     }
 
     /**
-     * @throws \Exception
-     *
-     * @return string
-     */
-    public function waitForProgressionBar()
-    {
-        $this->spin(function () {
-            return $this->getElement('Progress bar');
-        }, 'Cannot find Progress bar element');
-    }
-
-    /**
      * Find an attribute group in the nav
      *
      * @param string $group

--- a/features/localization/product/display_localized_history_of_complex_prices.feature
+++ b/features/localization/product/display_localized_history_of_complex_prices.feature
@@ -11,10 +11,12 @@ Feature: Display the localized product history for complex prices
       | localized_price | localized_price | localized_price | prices | yes              | no               | other | fr_FR, en_US | yes         | no       |
       | scoped_price    | scoped_price    | scoped_price    | prices | yes              | no               | other |              | no          | yes      |
       | complex_price   | complex_price   | complex_price   | prices | yes              | no               | other | fr_FR, en_US | yes         | yes      |
-    And the following products:
-      | sku      |
-      | sandal   |
     And I am logged in as "admin"
+    And I am on the products page
+    And I create a new product
+    And I fill in the following information in the popin:
+      | SKU | sandal |
+    And I press the "Save" button in the popin
     And I edit the "sandal" product
     And I add available attributes localized_price, scoped_price and complex_price
     And I change the "localized_price" to "0.12 EUR"

--- a/features/navigation/browse_navigation_history.feature
+++ b/features/navigation/browse_navigation_history.feature
@@ -14,6 +14,8 @@ Feature: Browse the history in the history tab of the pinbar
   @jira https://akeneo.atlassian.net/browse/PIM-5828
   Scenario: Add pages to the pinbar
     Given I am on the "pineapple" product page
+    And I click back to grid
+    And I am on the family index page
     And I am on the home page
     When I click on the pin bar dot menu
     And I press the "History" button

--- a/features/product/sequential_edit/sequential_edit.feature
+++ b/features/product/sequential_edit/sequential_edit.feature
@@ -42,24 +42,18 @@ Feature: Edit sequentially some products
       Given I sort by "SKU" value ascending
       And I select rows white_sandal, boot and sneaker
       When I press sequential-edit button
-      And I should see the sequential edit progression:
-        """
-        1 / 3 products
-        """
+      Then I should be on the product "boot" edit page
+      And I should see the text "1 / 3 products"
       When I am on the products page
       And I select rows white_sandal, blue_sandal, boot and sneaker
       And I press sequential-edit button
-      And I should see the sequential edit progression:
-        """
-        1 / 4 products
-        """
+      Then I should be on the product "blue_sandal" edit page
+      And I should see the text "1 / 4 products"
       When I fill in the following information:
         | Name | A new name |
       And I press the "Save and next" button
-      And I should see the sequential edit progression:
-        """
-        2 / 4 products
-        """
+      Then I should be on the product "boot" edit page
+      And I should see the text "2 / 4 products"
 
     @jira https://akeneo.atlassian.net/browse/PIM-4672
     Scenario: Keep product grid sorting order in sequential edit


### PR DESCRIPTION
# Description

This PR stabilize our most unstable behat scenarios. Those scenarios was requiring at least 1.5 retry to pass. Here are the impacted scenarios:

| Feature | Line | Average attempts
| ---------- | ------ | ------------------------
| navigation/browse_navigation_history.feature | 15 | 2.2000
| product/sequential_edit/sequential_edit.feature | 41 | 2.0714
| localization/product/display_localized_history_of_complex_prices.feature | 41 | 1.7857
| export/product-export-builder/export_products_by_metric.feature | 32 | 1.5

# Definition of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | N/A
| Added Behats                      | :white_check_mark: 
| Changelog updated                 | N/A
| Review and 2 GTM                  | :ballot_box_with_check: 
| Micro Demo to the PO (Story only) | N/A
| Migration script                  | N/A
| Tech Doc                          | N/A