### PR TITLE
PIM-5635: Order filters in product export builder

### DIFF
--- a/features/export/edit_an_export.feature
+++ b/features/export/edit_an_export.feature
@@ -29,13 +29,13 @@ Feature: Edit an export
     And I uncheck the "With header" switch
     When I visit the "Content" tab
     Then I should see the Channel, Locales fields
-    Then I should see the filters enabled, completeness, updated, sku and family.code
+    Then I should see the filters enabled, completeness, updated, identifier and family.code
     And I fill in the following information:
       | Channel | Tablet |
     Then I filter by "enabled" with operator "" and value "Disabled"
     And I filter by "family.code" with operator "" and value "Boots"
     And I filter by "completeness" with operator "Not complete on all selected locales" and value ""
-    And I filter by "sku" with operator "" and value "identifier1 identifier2,identifier3, identifier4"
+    And I filter by "identifier" with operator "" and value "identifier1 identifier2,identifier3, identifier4"
     When I press the "Save" button
     Then I should see the text "File path file.csv"
     And I should see the text "Delimiter |"

--- a/features/export/product-export-builder/export_products_by_metrics.feature
+++ b/features/export/product-export-builder/export_products_by_metrics.feature
@@ -35,7 +35,7 @@ Feature: Export products according to metric attribute filter
     When I am on the "csv_footwear_product_export" export job edit page
     And I visit the "Content" tab
     And I add available attributes Length
-    And I filter by "length" with operator "=" and value "20 cm"
+    And I filter by "length" with operator "Is equal to" and value "20 cm"
     And I press "Save"
     Then I should not see the text "There are unsaved changes"
     When I am on the "csv_footwear_product_export" export job page

--- a/features/export/product-export-builder/export_products_by_price_collections.feature
+++ b/features/export/product-export-builder/export_products_by_price_collections.feature
@@ -35,7 +35,7 @@ Feature: Export products according to price attribute filter
     And I am on the "csv_footwear_product_export" export job edit page
     And I visit the "Content" tab
     When I add available attributes Price
-    And I filter by "price" with operator "=" and value "30 USD"
+    And I filter by "price" with operator "Is equal to" and value "30 USD"
     And I press "Save"
     Then I should not see the text "There are unsaved changes"
     When I am on the "csv_footwear_product_export" export job page

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/filters.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/filters.yml
@@ -42,11 +42,13 @@ extensions:
         config:
             operators:
                 - "="
+                - "!="
                 - ">="
                 - ">"
                 - "<="
                 - "<"
                 - EMPTY
+                - NOT EMPTY
 
     pim-filter-attribute-number:
         module: pim/filter/attribute/number
@@ -66,6 +68,7 @@ extensions:
         config:
             operators:
                 - "="
+                - "!="
                 - ">="
                 - "<="
                 - ">"

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_export_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_export_edit.yml
@@ -38,20 +38,23 @@ extensions:
         config:
             filters:
                 -
+                    field: family
+                    view: pim-filter-product-family
+                -
                     field: enabled
                     view: pim-filter-product-enabled
                 -
                     field: completeness
                     view: pim-filter-product-completeness
                 -
-                    field: family
-                    view: pim-filter-product-family
-                -
                     field: updated
                     view: pim-filter-product-updated
                 -
                     field: categories
                     view: pim-filter-product-category
+                -
+                    field: identifier
+                    view: pim-filter-product-identifier
 
     pim-product-export-edit-content-default-attribute-filters:
         module: pim/export/product/edit/content/data/default-attribute-filters

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_export_show.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_export_show.yml
@@ -48,20 +48,23 @@ extensions:
         config:
             filters:
                 -
+                    field: family
+                    view: pim-filter-product-family
+                -
                     field: enabled
                     view: pim-filter-product-enabled
                 -
                     field: completeness
                     view: pim-filter-product-completeness
                 -
-                    field: family
-                    view: pim-filter-product-family
-                -
                     field: updated
                     view: pim-filter-product-updated
                 -
                     field: categories
                     view: pim-filter-product-category
+                -
+                    field: identifier
+                    view: pim-filter-product-identifier
 
     pim-product-export-show-content-default-attribute-filters:
         module: pim/export/product/edit/content/data/default-attribute-filters

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/export/product/edit/content/data.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/export/product/edit/content/data.js
@@ -83,8 +83,18 @@ define(
                     var filtersContainer = this.$('.filters');
                     filtersContainer.empty();
 
-                    _.each(this.filterViews, function (filterView) {
-                        filtersContainer.append(filterView.render().$el);
+                    var keys = _.keys(this.filterViews).sort();
+                    var fieldViews = _.pluck(this.config.filters, 'view');
+
+                    _.each(fieldViews, function (view) {
+                        var key = _.findKey(this.filterViews, {type: view});
+                        filtersContainer.append(this.filterViews[key].render().$el);
+                    }.bind(this));
+
+                    _.each(keys, function (key) {
+                        if (!_.contains(fieldViews, this.filterViews[key].type)) {
+                            filtersContainer.append(this.filterViews[key].render().$el);
+                        }
                     }.bind(this));
 
                     this.renderExtensions();

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
@@ -409,12 +409,14 @@ pim_enrich:
                     help: Identifiers of products you want to export separated by commas, spaces or line breaks
                 metric:
                     operators:
-                        "=": "="
-                        ">=": ">="
-                        ">": ">"
-                        "<=": "<="
-                        "<": "<"
+                        "=": Is equal to
+                        "!=": Is not equal to
+                        ">=": Greater than or equals
+                        ">": Greater than
+                        "<=": Lower than or equals
+                        "<": Lower than
                         EMPTY: Is empty
+                        NOT EMPTY: Is not empty
                 string:
                     operators:
                         ALL: All
@@ -424,18 +426,22 @@ pim_enrich:
                         STARTS WITH: Starts with
                         ENDS WITH: Ends with
                         EMPTY: Is empty
+                        NOT EMPTY: Is not empty
                 price-collection:
                     operators:
-                        "=": "="
-                        ">=": ">="
-                        "<=": "<="
-                        ">": ">"
-                        "<": "<"
+                        "=": Is equal to
+                        "!=": Is not equal to
+                        ">=": Greater than or equals
+                        ">": Greater than
+                        "<=": Lower than or equals
+                        "<": Lower than
                         EMPTY: Is empty
+                        NOT EMPTY: Is not empty
                 multi_select:
                     operators:
                         IN: In list
                         EMPTY: Is empty
+                        NOT EMPTY: Is not empty
                 media:
                     operators:
                         CONTAINS: Contains
@@ -444,6 +450,7 @@ pim_enrich:
                         STARTS WITH: Starts with
                         ENDS WITH: Ends with
                         EMPTY: Is empty
+                        NOT EMPTY: Is not empty
                 date:
                     operators:
                         ">": Greater than
@@ -456,11 +463,11 @@ pim_enrich:
                         NOT EMPTY: Is not empty
                 number:
                     operators:
-                        "=": Is equals to
-                        "!=": Is not equals to
-                        ">=": Greater or equals than
+                        "=": Is equal to
+                        "!=": Is not equal to
+                        ">=": Greater than or equals
                         ">": Greater than
-                        "<=": Lower or equals than
+                        "<=": Lower than or equals
                         "<": Lower than
                         EMPTY: Is empty
                         NOT EMPTY: Is not empty


### PR DESCRIPTION
**Description**

The fields of the data filters, in the “content” tab of the product export, were ordered randomly. This PR intends to display them in a predefined order.

First are rendered the filters of the product “fields” plus the identifier in this precise order:
- family
- status
- complete
- update
- category
- sku

Then are rendered the attribute filters, alphabetically ordered.

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | N/A
| Added Behats                      | N/A
| Changelog updated                 | N/A
| Review and 2 GTM                  | :white_check_mark:
| Micro Demo to the PO (Story only) | N/A
| Migration script                  | N/A
| Tech Doc                          | N/A