### PR TITLE
PIM-5798: manage permission on export profiles tabs

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -60,6 +60,7 @@
 - PIM-5109: As Peter, I would like to choose the products attributes to export
 - PIM-5634: As Peter, I would like to filter on a list attribute to export products
 - PIM-5635: As Peter, I would like to filter on all attributes types to export products
+- PIM-5798: As Peter, I would like to manage permission on "Content" tab
 
 ### User Productivity
 
@@ -481,3 +482,4 @@
 - Remove argument `Akeneo\Component\StorageUtils\Saver\SavingOptionsResolverInterface` from `CatalogBundle\Doctrine\Common\Saver\ProductSaver`
 - Remove argument `Akeneo\Component\StorageUtils\Saver\SavingOptionsResolverInterface` from `CatalogBundle\Doctrine\MongoDBODM\Saver\ProductSaver`
 - Remove class `Pim\Bundle\CatalogBundle\Doctrine\Common\Saver\ProductSavingOptionsResolver`
+- Change constructor of `Pim\Bundle\ImportExportBundle\Form\Type\JobInstanceFormType`, add `Oro\Bundle\SecurityBundle\SecurityFacade` as last parameter

--- a/UPGRADE-1.6.md
+++ b/UPGRADE-1.6.md
@@ -2,14 +2,14 @@
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents
+**Table of Contents:**
 
 - [Disclaimer](#disclaimer)
 - [Migrate your system requirements](#migrate-your-system-requirements)
   - [PHP 5.6 as minimum version and PHP 7 in experimental mode](#php-56-as-minimum-version-and-php-7-in-experimental-mode)
 - [Migrate your standard project](#migrate-your-standard-project)
 - [Migrate your custom code](#migrate-your-custom-code)
-  - [Global updates for any projects](#global-updates-for-any-projects)
+  - [Global updates for any project](#global-updates-for-any-project)
     - [Update references to moved `Pim\Bundle\CatalogBundle\AttributeType\AbstractAttributeType` constants](#update-references-to-moved-pim%5Cbundle%5Ccatalogbundle%5Cattributetype%5Cabstractattributetype-constants)
     - [Update references to moved `Pim\Component\Catalog` business classes](#update-references-to-moved-pim%5Ccomponent%5Ccatalog-business-classes)
     - [Update references to moved `PimEnterprise\Component\Catalog` business classes](#update-references-to-moved-pimenterprise%5Ccomponent%5Ccatalog-business-classes)
@@ -988,6 +988,19 @@ You can now notice a `filters` key containing `data` and `structure`.
 We provide doctrine migrations to handle this change in your existing data.
 
 In case you have custom products export using the native processor, you may need to update this migration script to update your job instances.
+
+#### Updates to access the "Content" and "General Property" tab in the export job profiles
+
+In order to access the "Content" and "General Property" tabs for already existing user roles. An admin has to set access to those roles.
+
+Go to the role profile and activate the following permissions situated in the "Permission" tab and the "Export Profile" section:
+
+- "Show an export profile general properties"
+- "Edit an export profile general properties"
+- "Show an export profile content"
+- "Edit an export profile content"
+
+If you want to display the "Content" tab for you custom product export job profiles, you can follow the cookbook "Configure the job profile" in the documentation (https://docs.akeneo.com/master/cookbook/import_export/create-custom-step.html#configure-the-job-profile).
 
 ### Updates for projects adding custom Mass Edit Action
 

--- a/features/Context/Page/Dashboard/Index.php
+++ b/features/Context/Page/Dashboard/Index.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Context\Page\Dashboard;
+
+use Context\Page\Base\Base;
+
+/**
+ * Dashboard page
+ *
+ * @author    Romain Monceau <romain@akeneo.com>
+ * @copyright 2013 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class Index extends Base
+{
+    /**
+     * @var string
+     */
+    protected $path = '/';
+
+    /**
+     * Get the channel completeness ratio inside the completeness widget
+     *
+     * @param string $channel
+     *
+     * @return string
+     */
+    public function getChannelCompleteness($channel)
+    {
+        return $this->getElement('Completeness Widget')->getChannelCompleteness($channel);
+    }
+
+    /**
+     * Get the localized channel completeness ratio inside the completeness widget
+     *
+     * @param string $channel
+     * @param string $locale
+     *
+     * @return string
+     */
+    public function getLocalizedChannelCompleteness($channel, $locale)
+    {
+        return $this->getElement('Completeness Widget')->getLocalizedChannelCompleteness($channel, $locale);
+    }
+}

--- a/features/export/edit_an_export.feature
+++ b/features/export/edit_an_export.feature
@@ -21,11 +21,11 @@ Feature: Edit an export
     Given I am on the "csv_footwear_product_export" export job edit page
     Then I should see the Delimiter, Enclosure, With header, File path and Decimal separator fields
     And I fill in the following information:
-      | Delimiter         | \|         |
-      | Enclosure         | '          |
-      | File path         | file.csv   |
-      | Decimal separator | ,          |
-      | Date format       | yyyy-MM-dd |
+      | Delimiter         | \|            |
+      | Enclosure         | '             |
+      | File path         | /tmp/file.csv |
+      | Decimal separator | ,             |
+      | Date format       | yyyy-MM-dd    |
     And I uncheck the "With header" switch
     When I visit the "Content" tab
     Then I should see the Channel, Locales fields
@@ -36,8 +36,9 @@ Feature: Edit an export
     And I filter by "family.code" with operator "" and value "Boots"
     And I filter by "completeness" with operator "Not complete on all selected locales" and value ""
     And I filter by "sku" with operator "" and value "identifier1 identifier2,identifier3 ,identifier4"
-    When I press the "Save" button
-    Then I should see the text "File path file.csv"
+    Then I press the "Save" button
+    When I visit the "General" tab
+    Then I should see the text "File path /tmp/file.csv"
     And I should see the text "Delimiter |"
     And I should see the text "Enclosure '"
     And I should see the text "With header No"

--- a/features/export/ensure_acl.feature
+++ b/features/export/ensure_acl.feature
@@ -1,0 +1,44 @@
+@javascript
+Feature: Ensures acl are respected on the export profile tabs
+  In order to give more access to export configuration (content part) for Julia, without giving her all the settings access (Properties tab)
+  As peter
+  I would like to manage permissions on the export profile tabs
+
+  Background:
+    Given a "footwear" catalog configuration
+    And I am logged in as "Julia"
+    And I am on the "Catalog manager" role page
+    And I visit the "Permissions" tab
+
+  Scenario: Disable show general property right
+    Given I revoke rights to resources Show an export profile general properties
+    And I grant rights to resources Show an export profile content
+    And I save the role
+    When I am on the "csv_footwear_product_export" export job page
+    Then I should not see the text "General properties"
+
+  Scenario: Disable show general property and show content tab
+    Given I revoke rights to resources Show an export profile general properties
+    And I revoke rights to resources Show an export profile content
+    And I save the role
+    When I am on the "csv_footwear_product_export" export job page
+    Then I should not see the text "General properties"
+    And I should not see the text "Content"
+
+  Scenario: Disable edit general property right and update Content tab
+    Given I revoke rights to resources Edit an export profile general properties
+    And I grant rights to resources Edit an export profile content
+    And I save the role
+    When I am on the "csv_footwear_product_export" export job edit page
+    Then I should not see the text "General properties"
+    When I filter by "family.code" with operator "" and value "Boots"
+    And I press the "Save" button
+    Then I should see the text "Boots"
+
+  Scenario: Disable edit general property and show content tab read rights
+    Given I revoke rights to resources Edit an export profile general properties
+    And I revoke rights to resources Edit an export profile content
+    And I save the role
+    When I am on the "csv_footwear_product_export" export job edit page
+    Then I should not see the text "General properties"
+    And I should not see the text "Content"

--- a/features/import/edit_an_import.feature
+++ b/features/import/edit_an_import.feature
@@ -22,20 +22,20 @@ Feature: Edit an import
     Given I am on the "csv_footwear_product_import" import job edit page
     Then I should see the File, Allow file upload, Delimiter, Enclosure, Escape, Enable the product, Categories column, Family column, Groups column, Real time history update, Decimal separator, Date format fields
     When I fill in the following information:
-      | File               | file.csv   |
-      | Delimiter          | \|         |
-      | Enclosure          | '          |
-      | Escape             | \\         |
-      | Categories column  | cat        |
-      | Family column      | fam        |
-      | Groups column      | grp        |
-      | Decimal separator  | .          |
-      | Date format        | yyyy-MM-dd |
+      | File              | /tmp/file.csv |
+      | Delimiter         | \|            |
+      | Enclosure         | '             |
+      | Escape            | \\            |
+      | Categories column | cat           |
+      | Family column     | fam           |
+      | Groups column     | grp           |
+      | Decimal separator | .             |
+      | Date format       | yyyy-MM-dd    |
     And I uncheck the "Allow file upload" switch
     And I uncheck the "Enable the product" switch
     And I uncheck the "Real time history update" switch
     And I press the "Save" button
-    Then I should see the text "File file.csv"
+    Then I should see the text "File /tmp/file.csv"
     And I should see "Allow file upload No"
     And I should see "Delimiter |"
     And I should see "Enclosure '"

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/archiving.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/archiving.yml
@@ -54,6 +54,7 @@ services:
             - '@pim_connector.writer.file.invalid_items_csv'
             - '@pim_connector.reader.file.csv_iterator_factory'
             - '@oneup_flysystem.archivist_filesystem'
+            - '@pim_connector.job.job_parameters.default_values_provider.product_csv_export'
             - 'csv'
         tags:
             - { name: pim_connector.archiver }
@@ -65,6 +66,7 @@ services:
             - '@pim_connector.writer.file.invalid_items_xlsx'
             - '@pim_connector.reader.file.xlsx_iterator_factory'
             - '@oneup_flysystem.archivist_filesystem'
+            - '@pim_connector.job.job_parameters.default_values_provider.product_xslx_export'
             - 'xlsx'
         tags:
             - { name: pim_connector.archiver }

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/job_defaults.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/job_defaults.yml
@@ -47,6 +47,8 @@ services:
         class: '%pim_connector.job.job_parameters.default_values_provider.product_csv_export.class%'
         arguments:
             - '@pim_connector.job.job_parameters.default_values_provider.simple_csv_export'
+            - '@pim_catalog.repository.channel'
+            - '@pim_catalog.repository.locale'
             -
                 - 'csv_product_export'
         tags:
@@ -56,6 +58,8 @@ services:
         class: '%pim_connector.job.job_parameters.default_values_provider.product_xlsx_export.class%'
         arguments:
             - '@pim_connector.job.job_parameters.default_values_provider.simple_xlsx_export'
+            - '@pim_catalog.repository.channel'
+            - '@pim_catalog.repository.locale'
             -
                 - 'xlsx_product_export'
         tags:

--- a/src/Pim/Bundle/ImportExportBundle/Controller/JobProfileController.php
+++ b/src/Pim/Bundle/ImportExportBundle/Controller/JobProfileController.php
@@ -263,9 +263,9 @@ class JobProfileController
 
         $this->eventDispatcher->dispatch(JobProfileEvents::PRE_EDIT, new GenericEvent($jobInstance));
 
-        $form = $this->formFactory->create($this->jobInstanceFormType, $jobInstance);
+        $form = $this->formFactory->create($this->jobInstanceFormType, $jobInstance, ['method' => 'PATCH']);
 
-        if ($request->isMethod('POST')) {
+        if ($request->isMethod('PATCH')) {
             $form->handleRequest($request);
             if ($form->isValid()) {
                 $this->entityManager->persist($jobInstance);

--- a/src/Pim/Bundle/ImportExportBundle/Form/Type/JobParametersType.php
+++ b/src/Pim/Bundle/ImportExportBundle/Form/Type/JobParametersType.php
@@ -120,10 +120,8 @@ class JobParametersType extends AbstractType implements DataMapperInterface
 
                 $data = $event->getData();
 
-                foreach (array_keys($configs) as $parameter) {
-                    if ('filters' === $parameter) {
-                        $data[$parameter] = json_decode($data[$parameter], true);
-                    }
+                if (isset($configs['filters']) && isset($data['filters'])) {
+                    $data['filters'] = json_decode($data['filters'], true);
                 }
 
                 $event->setData($data);

--- a/src/Pim/Bundle/ImportExportBundle/Resources/config/acl.yml
+++ b/src/Pim/Bundle/ImportExportBundle/Resources/config/acl.yml
@@ -23,9 +23,25 @@ pim_importexport_export_profile_launch:
     type: action
     label: pim_importexport.acl.export_profile.launch
     group_name: pim_importexport.acl_group.export
+pim_importexport_export_profile_property_show:
+    type: action
+    label: pim_importexport.acl.export_profile.property_show
+    group_name: pim_importexport.acl_group.export
+pim_importexport_export_profile_property_edit:
+    type: action
+    label: pim_importexport.acl.export_profile.property_edit
+    group_name: pim_importexport.acl_group.export
 pim_importexport_export_profile_history:
     type: action
     label: pim_importexport.acl.export_profile.history
+    group_name: pim_importexport.acl_group.export
+pim_importexport_export_profile_content_show:
+    type: action
+    label: pim_importexport.acl.export_profile.content_show
+    group_name: pim_importexport.acl_group.export
+pim_importexport_export_profile_content_edit:
+    type: action
+    label: pim_importexport.acl.export_profile.content_edit
     group_name: pim_importexport.acl_group.export
 
 # Import

--- a/src/Pim/Bundle/ImportExportBundle/Resources/config/form_types.yml
+++ b/src/Pim/Bundle/ImportExportBundle/Resources/config/form_types.yml
@@ -11,6 +11,7 @@ services:
             - '@translator'
             - '@pim_import_export.job_label.translated_label_provider'
             - '@akeneo_batch.job_parameters_factory'
+            - '@oro_security.security_facade'
         tags:
             - { name: form.type, alias: pim_import_export_job_instance }
 

--- a/src/Pim/Bundle/ImportExportBundle/Resources/config/view_elements/job_profile.yml
+++ b/src/Pim/Bundle/ImportExportBundle/Resources/config/view_elements/job_profile.yml
@@ -48,6 +48,8 @@ services:
        arguments:
            - 'pim_import_export.job_profile.tab.property'
            - '%pim_import_export.view_element.job_profile.tab.property_show.template%'
+       calls:
+           - [ addVisibilityChecker, ['@pim_enrich.view_element.visibility_checker.acl', {acl: 'pim_importexport_export_profile_property_show'}] ]
        tags:
            - { name: pim_enrich.view_element, type: pim_import_export_jobInstance.export, position: 90 }
 
@@ -58,6 +60,7 @@ services:
            - '%pim_import_export.view_element.job_profile.tab.job_content.template%'
        calls:
            - [ addVisibilityChecker, ['@pim_import_export.view_element.visibility_checker.job_name'] ]
+           - [ addVisibilityChecker, ['@pim_enrich.view_element.visibility_checker.acl', {acl: 'pim_importexport_export_profile_content_show'}] ]
        tags:
            - { name: pim_enrich.view_element, type: pim_import_export_jobInstance.export, position: 100 }
 
@@ -76,6 +79,8 @@ services:
        arguments:
            - 'pim_import_export.job_profile.tab.property'
            - '%pim_import_export.view_element.job_profile.tab.property_edit.template%'
+       calls:
+           - [ addVisibilityChecker, ['@pim_enrich.view_element.visibility_checker.acl', {acl: 'pim_importexport_export_profile_property_edit'}] ]
        tags:
            - { name: pim_enrich.view_element, type: pim_import_export_jobInstance.export.form_tab, position: 90 }
 
@@ -87,6 +92,7 @@ services:
            - '%pim_import_export.view_element.job_profile.tab.job_content.template%'
        calls:
            - [ addVisibilityChecker, ['@pim_import_export.view_element.visibility_checker.job_name'] ]
+           - [ addVisibilityChecker, ['@pim_enrich.view_element.visibility_checker.acl', {acl: 'pim_importexport_export_profile_content_edit'}] ]
        tags:
            - { name: pim_enrich.view_element, type: pim_import_export_jobInstance.export.form_tab, position: 100 }
 

--- a/src/Pim/Bundle/ImportExportBundle/Resources/translations/messages.en.yml
+++ b/src/Pim/Bundle/ImportExportBundle/Resources/translations/messages.en.yml
@@ -80,7 +80,11 @@ pim_importexport:
             edit: Edit an export profile
             remove: Remove an export profile
             launch: Launch an export profile
+            property_edit: Edit an export profile general properties
+            property_show: Show an export profile general properties
             history: View export profile history
+            content_edit: Edit an export profile content
+            content_show: Show an export profile content
         import_profile:
             index: View import profiles list
             create: Create an import profile

--- a/src/Pim/Bundle/ImportExportBundle/Resources/views/JobProfile/Tab/history.html.twig
+++ b/src/Pim/Bundle/ImportExportBundle/Resources/views/JobProfile/Tab/history.html.twig
@@ -1,3 +1,3 @@
-<div id="{{ viewElement.alias|replace({' ': '-', '.': '-'})|lower }}" class="tab-pane">
+<div id="{{ viewElement.alias|replace({' ': '-', '.': '-'})|lower }}" class="tab-pane  {{ viewElement.loop.first ? 'active' : '' }}">
     {{ dataGrid.renderHistoryGrid(form.vars.value) }}
 </div>

--- a/src/Pim/Bundle/ImportExportBundle/Resources/views/JobProfile/Tab/job_content.html.twig
+++ b/src/Pim/Bundle/ImportExportBundle/Resources/views/JobProfile/Tab/job_content.html.twig
@@ -1,4 +1,4 @@
-<div id="{{ viewElement.alias|replace({' ': '-', '.': '-'})|lower }}" class="job-profile-content-tab tab-pane">
+<div id="{{ viewElement.alias|replace({' ': '-', '.': '-'})|lower }}" class="job-profile-content-tab tab-pane {{ viewElement.loop.first ? 'active' : '' }}">
     <div id="pim-product-export-edit-content" class="form-horizontal"></div>
     <input id="{{ form.parameters.filters.vars.id }}" name="{{ form.parameters.filters.vars.full_name }}" value="{{ form.parameters.filters.vars.value|json_encode }}" type="hidden"/>
     <input id="{{ form.parameters.filters.vars.id }}_errors" type="hidden" value="{{ errors|default([])|json_encode }}">

--- a/src/Pim/Bundle/ImportExportBundle/Resources/views/JobProfile/create.html.twig
+++ b/src/Pim/Bundle/ImportExportBundle/Resources/views/JobProfile/create.html.twig
@@ -13,7 +13,6 @@
         'data-button-cancel': 'btn.cancel'|trans|capitalize
     }
 }) }}
-    {{ JSFV(form) }}
 
 <script type="text/javascript">
     require(

--- a/src/Pim/Bundle/ImportExportBundle/Resources/views/JobProfile/edit.html.twig
+++ b/src/Pim/Bundle/ImportExportBundle/Resources/views/JobProfile/edit.html.twig
@@ -4,7 +4,6 @@
 
 {% block content %}
 
-    {{ JSFV(form) }}
     {{ form_start(form, {
         'action': actionRoute,
         'attr': {

--- a/src/Pim/Component/Connector/Archiver/AbstractInvalidItemWriter.php
+++ b/src/Pim/Component/Connector/Archiver/AbstractInvalidItemWriter.php
@@ -5,6 +5,7 @@ namespace Pim\Component\Connector\Archiver;
 use Akeneo\Component\Batch\Item\InvalidItemInterface;
 use Akeneo\Component\Batch\Item\ItemWriterInterface;
 use Akeneo\Component\Batch\Job\JobParameters;
+use Akeneo\Component\Batch\Job\JobParameters\DefaultValuesProviderInterface;
 use Akeneo\Component\Batch\Model\JobExecution;
 use Doctrine\Common\Collections\ArrayCollection;
 use League\Flysystem\Filesystem;
@@ -36,28 +37,33 @@ abstract class AbstractInvalidItemWriter extends AbstractFilesystemArchiver
     /** @var FileIteratorFactory */
     protected $fileIteratorFactory;
 
+    /** @var DefaultValuesProviderInterface */
+    protected $defaultValuesProvider;
+
     /** @var int */
     protected $batchSize = 100;
 
-
     /**
-     * @param InvalidItemsCollector $collector
-     * @param ItemWriterInterface   $writer
-     * @param FileIteratorFactory   $fileIteratorFactory
-     * @param Filesystem Filesystem $filesystem
-     * @param string                $invalidItemFileFormat
+     * @param InvalidItemsCollector          $collector
+     * @param ItemWriterInterface            $writer
+     * @param FileIteratorFactory            $fileIteratorFactory
+     * @param Filesystem                     $filesystem
+     * @param DefaultValuesProviderInterface $defaultValuesProvider
+     * @param string                         $invalidItemFileFormat
      */
     public function __construct(
         InvalidItemsCollector $collector,
         ItemWriterInterface $writer,
         FileIteratorFactory $fileIteratorFactory,
         Filesystem $filesystem,
+        DefaultValuesProviderInterface $defaultValuesProvider,
         $invalidItemFileFormat
     ) {
         $this->collector = $collector;
         $this->writer = $writer;
         $this->fileIteratorFactory = $fileIteratorFactory;
         $this->filesystem = $filesystem;
+        $this->defaultValuesProvider = $defaultValuesProvider;
         $this->invalidItemFileFormat = $invalidItemFileFormat;
     }
 

--- a/src/Pim/Component/Connector/Archiver/CsvInvalidItemWriter.php
+++ b/src/Pim/Component/Connector/Archiver/CsvInvalidItemWriter.php
@@ -61,8 +61,7 @@ class CsvInvalidItemWriter extends AbstractInvalidItemWriter
         $fileKey = strtr($this->getRelativeArchivePath($jobExecution), ['%filename%' => 'invalid_items.csv']);
         $this->filesystem->put($fileKey, '');
 
-        $provider = new ProductCsvExport(new SimpleCsvExport([]), []);
-        $writeParams = $provider->getDefaultValues();
+        $writeParams = $this->defaultValuesProvider->getDefaultValues();
         $writeParams['filePath'] = $this->filesystem->getAdapter()->getPathPrefix() . $fileKey;
         $writeParams['withHeader'] = true;
 

--- a/src/Pim/Component/Connector/Archiver/XlsxInvalidItemWriter.php
+++ b/src/Pim/Component/Connector/Archiver/XlsxInvalidItemWriter.php
@@ -46,8 +46,7 @@ class XlsxInvalidItemWriter extends AbstractInvalidItemWriter
         $fileKey = strtr($this->getRelativeArchivePath($jobExecution), ['%filename%' => 'invalid_items.xlsx']);
         $this->filesystem->put($fileKey, '');
 
-        $provider = new ProductXlsxExport(new SimpleXlsxExport([]), []);
-        $writeParams = $provider->getDefaultValues();
+        $writeParams = $this->defaultValuesProvider->getDefaultValues();
         $writeParams['filePath'] = $this->filesystem->getAdapter()->getPathPrefix() . $fileKey;
         $writeParams['withHeader'] = true;
 

--- a/src/Pim/Component/Connector/Job/JobParameters/ConstraintCollectionProvider/ProductCsvExport.php
+++ b/src/Pim/Component/Connector/Job/JobParameters/ConstraintCollectionProvider/ProductCsvExport.php
@@ -44,29 +44,41 @@ class ProductCsvExport implements ConstraintCollectionProviderInterface
     {
         $baseConstraint = $this->simpleProvider->getConstraintCollection();
         $constraintFields = $baseConstraint->fields;
-        $constraintFields['decimalSeparator'] = new NotBlank();
-        $constraintFields['dateFormat'] = new NotBlank();
-        $constraintFields['filters'] = [new FilterData(), new Collection(
+        $constraintFields['decimalSeparator'] = new NotBlank(['groups' => ['Default', 'FileConfiguration']]);
+        $constraintFields['dateFormat'] = new NotBlank(['groups' => ['Default', 'FileConfiguration']]);
+        $constraintFields['with_media'] = new Type(
             [
-                'fields' => [
-                    'structure' => [
-                        new FilterStructureLocale(),
-                        new Collection(
-                            [
-                                'fields' => [
-                                    'locales'    => new NotBlank(),
-                                    'scope'      => new Channel(),
-                                    'attributes' => new FilterStructureAttribute(),
-                                ],
-                                'allowMissingFields' => true,
-                            ]
-                        ),
-                    ],
-                ],
-                'allowExtraFields' => true,
+                'type'   => 'bool',
+                'groups' => ['Default', 'FileConfiguration'],
             ]
-        )];
-        $constraintFields['with_media'] = new Type('bool');
+        );
+        $constraintFields['filters'] = [
+            new FilterData(['groups' => ['Default', 'DataFilters']]),
+            new Collection(
+                [
+                    'fields'           => [
+                        'structure' => [
+                            new FilterStructureLocale(['groups' => ['Default', 'DataFilters']]),
+                            new Collection(
+                                [
+                                    'fields'             => [
+                                        'locales'    => new NotBlank(['groups' => ['Default', 'DataFilters']]),
+                                        'scope'      => new Channel(['groups' => ['Default', 'DataFilters']]),
+                                        'attributes' => new FilterStructureAttribute(
+                                            [
+                                                'groups' => ['Default', 'DataFilters'],
+                                            ]
+                                        ),
+                                    ],
+                                    'allowMissingFields' => true,
+                                ]
+                            ),
+                        ],
+                    ],
+                    'allowExtraFields' => true,
+                ]
+            ),
+        ];
 
         return new Collection(['fields' => $constraintFields]);
     }

--- a/src/Pim/Component/Connector/Job/JobParameters/ConstraintCollectionProvider/ProductXlsxExport.php
+++ b/src/Pim/Component/Connector/Job/JobParameters/ConstraintCollectionProvider/ProductXlsxExport.php
@@ -44,29 +44,42 @@ class ProductXlsxExport implements ConstraintCollectionProviderInterface
     {
         $baseConstraint = $this->simpleProvider->getConstraintCollection();
         $constraintFields = $baseConstraint->fields;
-        $constraintFields['decimalSeparator'] = new NotBlank();
-        $constraintFields['dateFormat'] = new NotBlank();
-        $constraintFields['filters'] = [new FilterData(), new Collection(
+        $constraintFields['decimalSeparator'] = new NotBlank(['groups' => ['Default', 'FileConfiguration']]);
+        $constraintFields['dateFormat'] = new NotBlank(['groups' => ['Default', 'FileConfiguration']]);
+        $constraintFields['with_media'] = new Type(
             [
-                'fields' => [
-                    'structure' => [
-                        new FilterStructureLocale(),
-                        new Collection(
-                            [
-                                'fields' => [
-                                    'locales'    => new NotBlank(),
-                                    'scope'      => new Channel(),
-                                    'attributes' => new FilterStructureAttribute(),
-                                ],
-                                'allowMissingFields' => true,
-                            ]
-                        ),
-                    ],
-                ],
-                'allowExtraFields' => true,
+                'type'   => 'bool',
+                'groups' => ['Default', 'FileConfiguration'],
             ]
-        )];
-        $constraintFields['with_media'] = new Type('bool');
+        );
+        $constraintFields['filters'] = [
+            new FilterData(['groups' => ['Default', 'DataFilters']]),
+            new Collection(
+                [
+                    'fields'           => [
+                        'structure' => [
+                            new FilterStructureLocale(['groups' => ['Default', 'DataFilters']]),
+                            new Collection(
+                                [
+                                    'fields'             => [
+                                        'locales'    => new NotBlank(['groups' => ['Default', 'DataFilters']]),
+                                        'scope'      => new Channel(['groups' => ['Default', 'DataFilters']]),
+                                        'attributes' => new FilterStructureAttribute([
+                                            'groups' => [
+                                                'Default',
+                                                'DataFilters',
+                                            ],
+                                        ]),
+                                    ],
+                                    'allowMissingFields' => true,
+                                ]
+                            ),
+                        ],
+                    ],
+                    'allowExtraFields' => true,
+                ]
+            )
+        ];
 
         return new Collection(['fields' => $constraintFields]);
     }

--- a/src/Pim/Component/Connector/Job/JobParameters/ConstraintCollectionProvider/SimpleCsvExport.php
+++ b/src/Pim/Component/Connector/Job/JobParameters/ConstraintCollectionProvider/SimpleCsvExport.php
@@ -38,32 +38,39 @@ class SimpleCsvExport implements ConstraintCollectionProviderInterface
         return new Collection(
             [
                 'fields' => [
-                    'filePath' => [
-                        new NotBlank(['groups' => 'Execution']),
-                        new WritableDirectory(['groups' => 'Execution'])
+                    'filePath'   => [
+                        new NotBlank(['groups' => ['Execution', 'FileConfiguration']]),
+                        new WritableDirectory(['groups' => ['Execution', 'FileConfiguration']]),
                     ],
-                    'delimiter' => [
-                        new NotBlank(),
+                    'delimiter'  => [
+                        new NotBlank(['groups' => ['Default', 'FileConfiguration']]),
                         new Choice(
                             [
                                 'choices' => [",", ";", "|"],
-                                'message' => 'The value must be one of , or ; or |'
+                                'message' => 'The value must be one of , or ; or |',
+                                'groups'  => ['Default', 'FileConfiguration'],
                             ]
-                        )
+                        ),
                     ],
-                    'enclosure' => [
+                    'enclosure'  => [
                         [
-                            new NotBlank(),
+                            new NotBlank(['groups' => ['Default', 'FileConfiguration']]),
                             new Choice(
                                 [
                                     'choices' => ['"', "'"],
-                                    'message' => 'The value must be one of " or \''
+                                    'message' => 'The value must be one of " or \'',
+                                    'groups'  => ['Default', 'FileConfiguration'],
                                 ]
-                            )
-                        ]
+                            ),
+                        ],
                     ],
-                    'withHeader' => new Type('bool'),
-                ]
+                    'withHeader' => new Type(
+                        [
+                            'type'   => 'bool',
+                            'groups' => ['Default', 'FileConfiguration'],
+                        ]
+                    ),
+                ],
             ]
         );
     }

--- a/src/Pim/Component/Connector/Job/JobParameters/ConstraintCollectionProvider/SimpleXlsxExport.php
+++ b/src/Pim/Component/Connector/Job/JobParameters/ConstraintCollectionProvider/SimpleXlsxExport.php
@@ -40,15 +40,25 @@ class SimpleXlsxExport implements ConstraintCollectionProviderInterface
             [
                 'fields' => [
                     'filePath'     => [
-                        new NotBlank(['groups' => 'Execution']),
-                        new WritableDirectory(['groups' => 'Execution'])
+                        new NotBlank(['groups' => ['Execution', 'FileConfiguration']]),
+                        new WritableDirectory(['groups' => ['Execution', 'FileConfiguration']]),
                     ],
-                    'withHeader'   => new Type('bool'),
+                    'withHeader'   => new Type(
+                        [
+                            'type'   => 'bool',
+                            'groups' => ['Default', 'FileConfiguration'],
+                        ]
+                    ),
                     'linesPerFile' => [
-                        new NotBlank(),
-                        new GreaterThan(1)
-                    ]
-                ]
+                        new NotBlank(['groups' => ['Default', 'FileConfiguration']]),
+                        new GreaterThan(
+                            [
+                                'value'  => 1,
+                                'groups' => ['Default', 'FileConfiguration'],
+                            ]
+                        ),
+                    ],
+                ],
             ]
         );
     }

--- a/src/Pim/Component/Connector/spec/Job/JobParameters/DefaultValuesProvider/ProductCsvExportSpec.php
+++ b/src/Pim/Component/Connector/spec/Job/JobParameters/DefaultValuesProvider/ProductCsvExportSpec.php
@@ -5,13 +5,21 @@ namespace spec\Pim\Component\Connector\Job\JobParameters\DefaultValuesProvider;
 use Akeneo\Component\Batch\Job\JobInterface;
 use Akeneo\Component\Batch\Job\JobParameters\DefaultValuesProviderInterface;
 use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Model\CategoryInterface;
+use Pim\Component\Catalog\Model\ChannelInterface;
+use Pim\Component\Catalog\Model\LocaleInterface;
+use Pim\Component\Catalog\Repository\ChannelRepositoryInterface;
+use Pim\Component\Catalog\Repository\LocaleRepositoryInterface;
 use Prophecy\Argument;
 
 class ProductCsvExportSpec extends ObjectBehavior
 {
-    function let(DefaultValuesProviderInterface $decoratedProvider)
-    {
-        $this->beConstructedWith($decoratedProvider, ['my_supported_job_name']);
+    function let(
+        DefaultValuesProviderInterface $decoratedProvider,
+        ChannelRepositoryInterface $channelRepository,
+        LocaleRepositoryInterface $localeRepository
+    ) {
+        $this->beConstructedWith($decoratedProvider, $channelRepository, $localeRepository, ['my_supported_job_name']);
     }
 
     function it_is_a_provider()
@@ -19,8 +27,19 @@ class ProductCsvExportSpec extends ObjectBehavior
         $this->shouldImplement('Akeneo\Component\Batch\Job\JobParameters\DefaultValuesProviderInterface');
     }
 
-    function it_provides_default_values($decoratedProvider)
-    {
+    function it_provides_default_values(
+        $decoratedProvider,
+        ChannelRepositoryInterface $channelRepository,
+        LocaleRepositoryInterface $localeRepository,
+        LocaleInterface $locale,
+        ChannelInterface $channel
+    ) {
+        $channel->getCode()->willReturn('channel_code');
+        $channelRepository->getFullChannels()->willReturn([$channel]);
+
+        $locale->getCode()->willReturn('locale_code');
+        $localeRepository->getActivatedLocaleCodes()->willReturn([$locale]);
+
         $decoratedProvider->getDefaultValues()->willReturn(['decoratedParam' => true]);
         $this->getDefaultValues()->shouldReturnWellFormedDefaultValues();
     }
@@ -38,6 +57,7 @@ class ProductCsvExportSpec extends ObjectBehavior
                 return true === $parameters['decoratedParam'] &&
                     '.' === $parameters['decimalSeparator'] &&
                     'yyyy-MM-dd' === $parameters['dateFormat'] &&
+                    is_string($parameters['filePath']) &&
                     true === $parameters['with_media'] &&
                     is_array($parameters['filters']) &&
                     is_array($parameters['filters']['data']) &&

--- a/src/Pim/Component/Connector/spec/Job/JobParameters/DefaultValuesProvider/ProductXlsxExportSpec.php
+++ b/src/Pim/Component/Connector/spec/Job/JobParameters/DefaultValuesProvider/ProductXlsxExportSpec.php
@@ -5,13 +5,21 @@ namespace spec\Pim\Component\Connector\Job\JobParameters\DefaultValuesProvider;
 use Akeneo\Component\Batch\Job\JobInterface;
 use Akeneo\Component\Batch\Job\JobParameters\DefaultValuesProviderInterface;
 use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Model\CategoryInterface;
+use Pim\Component\Catalog\Model\ChannelInterface;
+use Pim\Component\Catalog\Model\LocaleInterface;
+use Pim\Component\Catalog\Repository\ChannelRepositoryInterface;
+use Pim\Component\Catalog\Repository\LocaleRepositoryInterface;
 use Prophecy\Argument;
 
 class ProductXlsxExportSpec extends ObjectBehavior
 {
-    function let(DefaultValuesProviderInterface $decoratedProvider)
-    {
-        $this->beConstructedWith($decoratedProvider, ['my_supported_job_name']);
+    function let(
+        DefaultValuesProviderInterface $decoratedProvider,
+        ChannelRepositoryInterface $channelRepository,
+        LocaleRepositoryInterface $localeRepository
+    ) {
+        $this->beConstructedWith($decoratedProvider, $channelRepository, $localeRepository, ['my_supported_job_name']);
     }
 
     function it_is_a_provider()
@@ -19,8 +27,19 @@ class ProductXlsxExportSpec extends ObjectBehavior
         $this->shouldImplement('Akeneo\Component\Batch\Job\JobParameters\DefaultValuesProviderInterface');
     }
 
-    function it_provides_default_values($decoratedProvider)
-    {
+    function it_provides_default_values(
+        $decoratedProvider,
+        ChannelRepositoryInterface $channelRepository,
+        LocaleRepositoryInterface $localeRepository,
+        LocaleInterface $locale,
+        ChannelInterface $channel
+    ) {
+        $channel->getCode()->willReturn('channel_code');
+        $channelRepository->getFullChannels()->willReturn([$channel]);
+
+        $locale->getCode()->willReturn('locale_code');
+        $localeRepository->getActivatedLocaleCodes()->willReturn([$locale]);
+
         $decoratedProvider->getDefaultValues()->willReturn(['decoratedParam' => true]);
         $this->getDefaultValues()->shouldReturnWellFormedDefaultValues();
     }
@@ -38,6 +57,7 @@ class ProductXlsxExportSpec extends ObjectBehavior
                 return true === $parameters['decoratedParam'] &&
                     '.' === $parameters['decimalSeparator'] &&
                     'yyyy-MM-dd' === $parameters['dateFormat'] &&
+                    is_string($parameters['filePath']) &&
                     true === $parameters['with_media'] &&
                     10000 === $parameters['linesPerFile'] &&
                     is_array($parameters['filters']) &&


### PR DESCRIPTION
Add four separate rights for the job profile tabs:
- Access the "General properties" in Show profile
- Access the "General properties" in Edit profile
- Access the "Content" in Show profile
- Access the "Content" in Edit profile

Moved the product export job names for the visibility checker of the content tab into a pim_parameter instead of the definition of service.
___
Problems:
- When one of the tabs (or both) are not shown, the submission of the form on save is incomplete (because possibly half of the form was not shown to the user). Hence, the need for a "Patch" form submission instead of POST (which would erase information about the job profile) coupled with validation groups.
- When a user has no rights over the edit "content" and "general properties" tab. The user is still able to create a new job profile. We need to make sure all default values are set for the job profile to be saved and run by the user without any further configuration.

___
Todolist: 
- [X] Setup ACL for both tabs and make sure the tabs are shown independently
- [X] Removes the JSVF validation
- [X] Use group validation and PATCH on the form to update parts of the job profiles
- [X] Test that creating a new job profile without any rights on "General" and "Content" is working and that the job can be run afterwards
    - [X] Set additional default values for properties: "filePath", "scope" and "locale" 
- [X] Introducing validation groups to validate the job profiles:
    - [X] FileConfiguration: for settings concerning the file format (ex : delimiter, number of lines, DateFormat)
    - [X] DataFilters: the configuration of filters on the job profile


**Definition Of Done (for Core Developer only)**


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | Y
| Changelog updated                 | Y
| Review and 2 GTM                  | Y
| Micro Demo to the PO (Story only) | Y
| Migration script                  | -
| Tech Doc                          | -
