### PR TITLE
PIM-5635: Add context on filters

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
@@ -225,9 +225,9 @@ config:
         pim/export/product/edit/content/structure/attributes:           pimenrich/js/export/product/edit/content/structure/attributes
         pim/export/product/edit/content/structure/attributes-selector:  pimenrich/js/export/product/edit/content/structure/attributes-selector
         pim/export/product/edit/content/data:                           pimenrich/js/export/product/edit/content/data
+        pim/export/product/edit/content/data/add-filter:                pimenrich/js/export/product/edit/content/data/add-filter
         pim/export/product/edit/content/data/default-attribute-filters: pimenrich/js/export/product/edit/content/data/default-attribute-filters
         pim/export/product/edit/content/data/help:                      pimenrich/js/export/product/edit/content/data/help
-        pim/export/product/edit/content/data/add-filter:                pimenrich/js/export/product/edit/content/data/add-filter
 
         # Filters
         pim/filter/filter:                     pimenrich/js/filter/filter
@@ -240,6 +240,7 @@ config:
         pim/filter/product/category:           pimenrich/js/filter/product/category
         pim/filter/product/category/selector:  pimenrich/js/filter/product/category/selector
         pim/filter/product/identifier:         pimenrich/js/filter/product/identifier
+        pim/filter/attribute/attribute:        pimenrich/js/filter/attribute/attribute
         pim/filter/attribute/boolean:          pimenrich/js/filter/attribute/boolean
         pim/filter/attribute/string:           pimenrich/js/filter/attribute/string
         pim/filter/attribute/metric:           pimenrich/js/filter/attribute/metric

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/export/product/edit/content/data/help.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/export/product/edit/content/data/help.js
@@ -19,7 +19,7 @@ define([
         template: _.template(template),
 
         /**
-         * {@inherit}
+         * {@inheritdoc}
          */
         configure: function () {
             this.listenTo(this.getRoot(), 'pim_enrich:form:filter:extension:add', this.addFilterExtension.bind(this));

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/attribute/attribute.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/attribute/attribute.js
@@ -1,0 +1,202 @@
+/**
+ * Abstract attribute filter
+ *
+ * @author    Yohan Blain <yohan.blain@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+
+'use strict';
+
+define([
+    'jquery',
+    'underscore',
+    'oro/translator',
+    'pim/filter/filter',
+    'pim/fetcher-registry',
+    'pim/i18n',
+    'pim/product-edit-form/scope-switcher',
+    'pim/product-edit-form/locale-switcher'
+], function (
+    $,
+    _,
+    __,
+    BaseFilter,
+    FetcherRegistry,
+    i18n,
+    ScopeSwitcher,
+    LocaleSwitcher
+) {
+    return BaseFilter.extend({
+        /**
+         * Sets the scope code on which this filter operates.
+         *
+         * @param {string} scope
+         */
+        setScope: function (scope) {
+            var context = this.getFormData().context || {};
+            context.scope = scope;
+
+            this.setData({context: context});
+        },
+
+        /**
+         * Gets the scope code on which this filter operates.
+         *
+         * @return {string}
+         */
+        getScope: function () {
+            if (undefined === this.getFormData().context) {
+                return null;
+            }
+
+            return this.getFormData().context.scope;
+        },
+
+        /**
+         * Sets the locale code on which this filter operates.
+         *
+         * @param {string} locale
+         */
+        setLocale: function (locale) {
+            var context = this.getFormData().context || {};
+            context.locale = locale;
+
+            this.setData({context: context});
+        },
+
+        /**
+         * Gets the locale code on which this filter operates.
+         *
+         * @return {string}
+         */
+        getLocale: function () {
+            if (undefined === this.getFormData().context) {
+                return null;
+            }
+
+            return this.getFormData().context.locale;
+        },
+
+        /**
+         * {@inheritdoc}
+         */
+        renderElements: function () {
+            FetcherRegistry.getFetcher('attribute')
+                .fetch(this.getField())
+                .then(function (attribute) {
+                    if (this.isEditable()) {
+                        this.addContextDropdowns(attribute);
+                    } else {
+                        this.addContextLabels(attribute);
+                    }
+                }.bind(this))
+                .then(function () {
+                    BaseFilter.prototype.renderElements.apply(this, arguments);
+                }.bind(this));
+        },
+
+        /**
+         * Adds the context dropdown to the filter in edit mode according to attribute information.
+         *
+         * @param {Object} attribute
+         */
+        addContextDropdowns: function (attribute) {
+            if (attribute.scopable) {
+                var scopeSwitcher = new ScopeSwitcher();
+
+                this.listenTo(
+                    scopeSwitcher,
+                    'pim_enrich:form:scope_switcher:pre_render',
+                    function (scopeEvent) {
+                        if (this.getScope()) {
+                            scopeEvent.scopeCode = this.getScope();
+                        }
+                    }
+                );
+
+                this.listenTo(
+                    scopeSwitcher,
+                    'pim_enrich:form:scope_switcher:change',
+                    function (scopeEvent) {
+                        this.setScope(scopeEvent.scopeCode);
+                    }
+                );
+
+                this.addElement(
+                    'after-input',
+                    'scope-switcher',
+                    scopeSwitcher.render().$el
+                );
+            }
+
+            if (attribute.localizable) {
+                var localeSwitcher = new LocaleSwitcher();
+
+                this.listenTo(
+                    localeSwitcher,
+                    'pim_enrich:form:locale_switcher:pre_render',
+                    function (localeEvent) {
+                        if (this.getLocale()) {
+                            localeEvent.localeCode = this.getLocale();
+                        }
+                    }
+                );
+
+                this.listenTo(
+                    localeSwitcher,
+                    'pim_enrich:form:locale_switcher:change',
+                    function (localeEvent) {
+                        this.setLocale(localeEvent.localeCode);
+                    }
+                );
+
+                this.addElement(
+                    'after-input',
+                    'locale-switcher',
+                    localeSwitcher.render().$el
+                );
+            }
+        },
+
+        /**
+         * Adds the context labels to the filter in view mode according to attribute information.
+         *
+         * @param {Object} attribute
+         */
+        addContextLabels: function (attribute) {
+            var promises = [];
+
+            if (attribute.scopable && this.getScope()) {
+                promises.push(FetcherRegistry.getFetcher('channel')
+                    .fetch(this.getScope())
+                    .then(function (channel) {
+                        return $('<span>').html(channel.label);
+                    })
+                );
+            }
+
+            if (attribute.localizable && this.getLocale()) {
+                promises.push(
+                    $.Deferred()
+                        .resolve($('<span>').html(i18n.getFlag(this.getLocale())))
+                        .promise()
+                );
+            }
+
+            $.when.apply($, promises)
+                .then(function () {
+                    var container = $('<span class="filter-context">');
+                    _.each(_.toArray(arguments), function (item) {
+                        container.append(item);
+                    });
+
+                    this.addElement(
+                        'after-input',
+                        'filter-context',
+                        container
+                    );
+                }.bind(this));
+        }
+    });
+});

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/attribute/attribute.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/attribute/attribute.js
@@ -102,6 +102,8 @@ define([
          * @param {Object} attribute
          */
         addContextDropdowns: function (attribute) {
+            var container = $('<span class="filter-context">');
+
             if (attribute.scopable) {
                 var scopeSwitcher = new ScopeSwitcher();
 
@@ -112,7 +114,7 @@ define([
                         if (this.getScope()) {
                             scopeEvent.scopeCode = this.getScope();
                         }
-                    }
+                    }.bind(this)
                 );
 
                 this.listenTo(
@@ -120,14 +122,10 @@ define([
                     'pim_enrich:form:scope_switcher:change',
                     function (scopeEvent) {
                         this.setScope(scopeEvent.scopeCode);
-                    }
+                    }.bind(this)
                 );
 
-                this.addElement(
-                    'after-input',
-                    'scope-switcher',
-                    scopeSwitcher.render().$el
-                );
+                container.append(scopeSwitcher.render().$el);
             }
 
             if (attribute.localizable) {
@@ -140,7 +138,7 @@ define([
                         if (this.getLocale()) {
                             localeEvent.localeCode = this.getLocale();
                         }
-                    }
+                    }.bind(this)
                 );
 
                 this.listenTo(
@@ -148,15 +146,17 @@ define([
                     'pim_enrich:form:locale_switcher:change',
                     function (localeEvent) {
                         this.setLocale(localeEvent.localeCode);
-                    }
+                    }.bind(this)
                 );
 
-                this.addElement(
-                    'after-input',
-                    'locale-switcher',
-                    localeSwitcher.render().$el
-                );
+                container.append(localeSwitcher.render().$el);
             }
+
+            this.addElement(
+                'after-input',
+                'filter-context',
+                container
+            );
         },
 
         /**

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/attribute/boolean.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/attribute/boolean.js
@@ -11,7 +11,7 @@ define([
     'jquery',
     'underscore',
     'oro/translator',
-    'pim/filter/filter',
+    'pim/filter/attribute/attribute',
     'pim/fetcher-registry',
     'pim/user-context',
     'pim/i18n',

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/attribute/date.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/attribute/date.js
@@ -4,7 +4,7 @@ define([
     'jquery',
     'underscore',
     'oro/translator',
-    'pim/filter/filter',
+    'pim/filter/attribute/attribute',
     'text!pim/template/filter/attribute/date',
     'pim/fetcher-registry',
     'pim/user-context',

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/attribute/media.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/attribute/media.js
@@ -4,7 +4,7 @@ define([
     'jquery',
     'underscore',
     'oro/translator',
-    'pim/filter/filter',
+    'pim/filter/attribute/attribute',
     'pim/fetcher-registry',
     'pim/user-context',
     'pim/i18n',

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/attribute/metric.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/attribute/metric.js
@@ -4,7 +4,7 @@ define([
     'jquery',
     'underscore',
     'oro/translator',
-    'pim/filter/filter',
+    'pim/filter/attribute/attribute',
     'pim/fetcher-registry',
     'pim/user-context',
     'pim/i18n',

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/attribute/number.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/attribute/number.js
@@ -4,7 +4,7 @@ define([
     'jquery',
     'underscore',
     'oro/translator',
-    'pim/filter/filter',
+    'pim/filter/attribute/attribute',
     'pim/fetcher-registry',
     'pim/user-context',
     'pim/i18n',

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/attribute/price-collection.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/attribute/price-collection.js
@@ -4,7 +4,7 @@ define([
     'jquery',
     'underscore',
     'oro/translator',
-    'pim/filter/filter',
+    'pim/filter/attribute/attribute',
     'pim/fetcher-registry',
     'pim/user-context',
     'pim/i18n',

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/attribute/select.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/attribute/select.js
@@ -5,7 +5,7 @@ define([
     'underscore',
     'oro/translator',
     'routing',
-    'pim/filter/filter',
+    'pim/filter/attribute/attribute',
     'pim/fetcher-registry',
     'pim/user-context',
     'pim/i18n',

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/attribute/string.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/attribute/string.js
@@ -4,7 +4,7 @@ define([
     'jquery',
     'underscore',
     'oro/translator',
-    'pim/filter/filter',
+    'pim/filter/attribute/attribute',
     'pim/fetcher-registry',
     'pim/user-context',
     'pim/i18n',

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/product/category.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/product/category.js
@@ -17,7 +17,7 @@ define([
     return BaseFilter.extend({
         shortname: 'category',
         template: _.template(template),
-        className: 'category-filter',
+        className: 'control-group filter-item category-filter',
         events: {
             'click button': 'openSelector'
         },

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/product/category/selector.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/product/category/selector.js
@@ -21,9 +21,7 @@ define(
         'jquery.jstree'
     ],
     function ($, _, Backbone, Routing, __, LoadingMask, i18n, FetcherRegistry, UserContext, template) {
-
         return Backbone.View.extend({
-
             template: _.template(template),
 
             config: {

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes.js
@@ -84,6 +84,14 @@ define(
                 this.onExtensions('copy:copy-fields:after', this.render.bind(this));
                 this.onExtensions('copy:select:after', this.render.bind(this));
                 this.onExtensions('copy:context:change', this.render.bind(this));
+                this.onExtensions('pim_enrich:form:scope_switcher:pre_render', this.initScope.bind(this));
+                this.onExtensions('pim_enrich:form:locale_switcher:pre_render', this.initLocale.bind(this));
+                this.onExtensions('pim_enrich:form:scope_switcher:change', function (event) {
+                    this.setScope(event.scopeCode);
+                }.bind(this));
+                this.onExtensions('pim_enrich:form:locale_switcher:change', function (event) {
+                    this.setLocale(event.localeCode);
+                }.bind(this));
 
                 return BaseForm.prototype.configure.apply(this, arguments);
             },
@@ -305,6 +313,19 @@ define(
             },
 
             /**
+             * Initialize  the scope if there is none, or modify it by reference if there is already one
+             *
+             * @param {Object} event
+             */
+            initScope: function (event) {
+                if (undefined === this.getScope()) {
+                    this.setScope(event.scopeCode, {silent: true});
+                } else {
+                    event.scopeCode = this.getScope();
+                }
+            },
+
+            /**
              * Set the current scope
              *
              * @param {String} scope
@@ -316,12 +337,22 @@ define(
 
             /**
              * Get the current scope
-             *
-             * @param {String} scope
-             * @param {Object} options
              */
             getScope: function () {
                 return UserContext.get('catalogScope');
+            },
+
+            /**
+             * Initialize  the locale if there is none, or modify it by reference if there is already one
+             *
+             * @param {Object} event
+             */
+            initLocale: function (event) {
+                if (undefined === this.getLocale()) {
+                    this.setLocale(event.localeCode, {silent: true});
+                } else {
+                    event.localeCode = this.getLocale();
+                }
             },
 
             /**
@@ -336,9 +367,6 @@ define(
 
             /**
              * Get the current locale
-             *
-             * @param {String} locale
-             * @param {Object} options
              */
             getLocale: function () {
                 return UserContext.get('catalogLocale');

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes/copy.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes/copy.js
@@ -64,6 +64,15 @@ define(
 
                 this.listenTo(this.getRoot(), 'pim_enrich:form:field:extension:add', this.addFieldExtension);
 
+                this.onExtensions('pim_enrich:form:scope_switcher:pre_render', this.initScope.bind(this));
+                this.onExtensions('pim_enrich:form:locale_switcher:pre_render', this.initLocale.bind(this));
+                this.onExtensions('pim_enrich:form:scope_switcher:change', function (event) {
+                    this.setScope(event.scopeCode);
+                }.bind(this));
+                this.onExtensions('pim_enrich:form:locale_switcher:change', function (event) {
+                    this.setLocale(event.localeCode);
+                }.bind(this));
+
                 return BaseForm.prototype.configure.apply(this, arguments);
             },
 
@@ -183,6 +192,19 @@ define(
             },
 
             /**
+             * Initialize  the locale if there is none, or modify it by reference if there is already one
+             *
+             * @param {Object} event
+             */
+            initLocale: function (event) {
+                if (undefined === this.getLocale()) {
+                    this.setLocale(event.localeCode);
+                } else {
+                    event.localeCode = this.getLocale();
+                }
+            },
+
+            /**
              * Change the locale for copy context
              *
              * @param {string} locale
@@ -199,6 +221,19 @@ define(
              */
             getLocale: function () {
                 return this.locale;
+            },
+
+            /**
+             * Initialize  the scope if there is none, or modify it by reference if there is already one
+             *
+             * @param {Object} event
+             */
+            initScope: function (event) {
+                if (undefined === this.getScope()) {
+                    this.setScope(event.scopeCode);
+                } else {
+                    event.scopeCode = this.getScope();
+                }
             },
 
             /**

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/locale-switcher.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/locale-switcher.js
@@ -25,10 +25,13 @@ define(
             render: function () {
                 this.getDisplayedLocales()
                     .done(function (locales) {
+                        var params = { localeCode: locales[0].code };
+                        this.trigger('pim_enrich:form:locale_switcher:pre_render', params);
+
                         this.$el.html(
                             this.template({
                                 locales: locales,
-                                currentLocale: _.findWhere(locales, {code: this.getParent().getLocale()}),
+                                currentLocale: _.findWhere(locales, {code: params.localeCode}),
                                 i18n: i18n
                             })
                         );
@@ -53,7 +56,10 @@ define(
              * @param {Object} event
              */
             changeLocale: function (event) {
-                this.getParent().setLocale(event.currentTarget.dataset.locale);
+                this.trigger('pim_enrich:form:locale_switcher:change', {
+                    localeCode: event.currentTarget.dataset.locale
+                });
+
                 this.render();
             }
         });

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/scope-switcher.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/scope-switcher.js
@@ -29,11 +29,10 @@ define(
                 FetcherRegistry.getFetcher('channel')
                     .fetchAll()
                     .done(function (channels) {
-                        if (!this.getParent().getScope()) {
-                            this.getParent().setScope(channels[0].code, {silent: true});
-                        }
+                        var params = { scopeCode: channels[0].code };
+                        this.trigger('pim_enrich:form:scope_switcher:pre_render', params);
 
-                        var scope = _.findWhere(channels, { code: this.getParent().getScope() });
+                        var scope = _.findWhere(channels, { code: params.scopeCode });
 
                         this.$el.html(
                             this.template({
@@ -54,7 +53,10 @@ define(
              * @param {Event} event
              */
             changeScope: function (event) {
-                this.getParent().setScope(event.currentTarget.dataset.scope);
+                this.trigger('pim_enrich:form:scope_switcher:change', {
+                    scopeCode: event.currentTarget.dataset.scope
+                });
+
                 this.render();
             }
         });

--- a/src/Pim/Bundle/UIBundle/Resources/public/css/form.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/css/form.less
@@ -1322,15 +1322,3 @@ button.view-button {
 .tabbable.properties .accordion, .tabbable.history .grid-drop {
   width: 100%;
 }
-
-.job-profile-content-tab {
-  .control-group {
-    max-width: 900px;
-    .control-label.required {
-      font-weight: bold;
-    }
-    .filter-input {
-      display: inline-block;
-    }
-  }
-}

--- a/src/Pim/Bundle/UIBundle/Resources/public/css/pim.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/css/pim.less
@@ -1782,9 +1782,49 @@ h3.tab-header {
   justify-content: space-between;
 }
 
+/** PEB*** ************************************************************************************************************/
+
+.job-profile-content-tab {
+  .control-group {
+    max-width: 900px;
+
+    .control-label.required {
+      font-weight: bold;
+    }
+
+    .filter-input {
+      display: inline-block;
+    }
+
+    .filter-context {
+      display: inline-block;
+      vertical-align: middle;
+
+      .btn-group + .btn-group {
+        margin-left: 3px;
+      }
+
+      .btn {
+        height: 32px;
+      }
+
+      > span {
+        padding: 0 4px;
+        vertical-align: middle;
+
+        .language {
+          padding: 0;
+          color: inherit;
+        }
+      }
+    }
+  }
+}
+
 .input-like {
-  padding: 0 3px 10px 3px;
+  padding: 2px 3px;
   width: 300px;
+  border: 1px solid @color-ddd;
   box-sizing: content-box;
 
   &.disabled {
@@ -1793,6 +1833,7 @@ h3.tab-header {
 
   .form-control {
     line-height: 28px;
+    font-size: @font-size-11em;
     padding-left: 7px;
   }
 }
@@ -1825,7 +1866,7 @@ h3.tab-header {
 
 .attributes .input-like, [data-type="pim-filter-product-category"] .filter-input .input-like {
     padding: 2px 2px 2px 0;
-    margin: 0 0 10px 5px;
+    margin: 0 0 10px 0;
     border: 1px solid #ddd;
     box-sizing: border-box;
 }


### PR DESCRIPTION
The goal is to have that next to the filters:

![context](https://cloud.githubusercontent.com/assets/659491/17249840/1172793c-55a2-11e6-8d25-26f294e2b792.png)

The locale and scope are saved and sent to the PQB for filtering.
Dropdowns are the same used in PEF, mass edit, etc.

TODO: unskip related behats
