### PR TITLE
PIM-5869: Allow any codes to be used for attributes

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -4,6 +4,7 @@
 
 - PIM-5854: The family code is not displayed at all in the product grid when no family labels
 - PIM-5888: Fix an outline glitch on some buttons
+- PIM-5869: Allow any codes to be used for attributes
 
 ## Functional improvements
 

--- a/features/datagrid/display_many_datagrid_filters.feature
+++ b/features/datagrid/display_many_datagrid_filters.feature
@@ -9,6 +9,24 @@ Feature: Display many datagrid filters
     And 500 filterable simple select attributes with 5 options per attribute
     And I am logged in as "Mary"
     And I am on the products page
-    When I show the filter "attribute_499"
-    And I filter by "attribute_499" with operator "in list" and value "Option 1 for attribute 499"
+    When I show the filter "Attribute 499"
+    And I filter by "Attribute 499" with value "Option 1 for attribute 499"
     Then I should be on the products page
+
+  @jira https://akeneo.atlassian.net/browse/PIM-5869
+  Scenario: Check that a non metric attribute named "length" do not break the grid
+    Given the "default" catalog configuration
+    And the following families:
+      | code      | label-en_US |
+      | guitar    | Guitar      |
+    And the following products:
+      | sku        | family |
+      | les-paul   | guitar |
+      | telecaster | guitar |
+    And the following attributes:
+      | code   | label  | type |
+      | length | length | text |
+    When I am logged in as "Mary"
+    And I am on the products page
+    Then I should see product les-paul
+    And I should see product telecaster

--- a/features/datagrid/display_many_datagrid_filters.feature
+++ b/features/datagrid/display_many_datagrid_filters.feature
@@ -9,8 +9,8 @@ Feature: Display many datagrid filters
     And 500 filterable simple select attributes with 5 options per attribute
     And I am logged in as "Mary"
     And I am on the products page
-    When I show the filter "Attribute 499"
-    And I filter by "Attribute 499" with value "Option 1 for attribute 499"
+    When I show the filter "attribute_499"
+    And I filter by "attribute_499" with operator "in list" and value "Option 1 for attribute 499"
     Then I should be on the products page
 
   @jira https://akeneo.atlassian.net/browse/PIM-5869

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/collection-filters-manager.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/collection-filters-manager.js
@@ -117,7 +117,7 @@ function(_, FiltersManager) {
             _.each(this.filters, function(filter, name) {
                 var shortName = '__' + name,
                     filterState;
-                if (_.has(state, name)) {
+                if (_.has(state, name) && 0 !== _.size(state)) {
                     filterState = state[name];
                     if (!_.isObject(filterState)) {
                         filterState = {


### PR DESCRIPTION
**Description**

Previously some reserved keywords like "length" break the display of the product grid. This fix allow any codes to be used for attributes.

**Definition Of Done**


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | N
| Added Behats                      | Y
| Changelog updated                 | Y
| Review and 2 GTM                  | Y
| Micro Demo to the PO (Story only) | NA
| Migration script                  | NA
| Tech Doc                          | NA