### PR TITLE
PIM-5910: fix a wrong use of NotImplementedException

### DIFF
--- a/spec/Pim/Bundle/NotificationBundle/EventSubscriber/JobExecutionNotifierSpec.php
+++ b/spec/Pim/Bundle/NotificationBundle/EventSubscriber/JobExecutionNotifierSpec.php
@@ -2,8 +2,7 @@
 
 namespace spec\Pim\Bundle\NotificationBundle\EventSubscriber;
 
-use Akeneo\Component\Batch\Model\JobExecution
-    ;
+use Akeneo\Component\Batch\Model\JobExecution;
 use Akeneo\Component\Batch\Model\JobInstance;
 use Akeneo\Component\Batch\Model\StepExecution;
 use Akeneo\Component\Batch\Event\JobExecutionEvent;

--- a/spec/Pim/Bundle/NotificationBundle/EventSubscriber/JobExecutionNotifierSpec.php
+++ b/spec/Pim/Bundle/NotificationBundle/EventSubscriber/JobExecutionNotifierSpec.php
@@ -52,11 +52,7 @@ class JobExecutionNotifierSpec extends ObjectBehavior
         );
     }
 
-    function it_does_not_notify_if_job_execution_has_no_user(
-        $event,
-        $jobExecution,
-        $manager
-    ) {
+    function it_does_not_notify_if_job_execution_has_no_user($event, $jobExecution, $manager) {
         $jobExecution->getUser()->willReturn(null);
 
         $jobExecution->getStatus()->shouldNotBeCalled();
@@ -65,11 +61,8 @@ class JobExecutionNotifierSpec extends ObjectBehavior
         $this->afterJobExecution($event);
     }
 
-    function it_notifies_a_user_of_the_completion_of_job_execution(
-        $event,
-        $user,
-        $manager
-    ) {
+    function it_notifies_a_user_of_the_completion_of_job_execution($event, $user, $manager)
+    {
         $manager
             ->notify(
                 [$user],
@@ -87,13 +80,8 @@ class JobExecutionNotifierSpec extends ObjectBehavior
         $this->afterJobExecution($event);
     }
 
-    function it_notifies_a_user_of_the_completion_of_a_mass_edit_job_execution(
-        $event,
-        $user,
-        $manager,
-        $jobInstance,
-        $jobExecution
-    ) {
+    function it_notifies_a_user_of_the_completion_of_a_mass_edit_job_execution($event, $user, $manager, $jobInstance, $jobExecution)
+    {
         $manager
             ->notify(
                 [$user],
@@ -115,12 +103,8 @@ class JobExecutionNotifierSpec extends ObjectBehavior
         $this->afterJobExecution($event);
     }
 
-    function it_notifies_a_user_of_the_completion_of_job_execution_which_has_encountered_a_warning(
-        $event,
-        $warnings,
-        $user,
-        $manager
-    ) {
+    function it_notifies_a_user_of_the_completion_of_job_execution_which_has_encountered_a_warning($event, $warnings, $user, $manager)
+    {
         $warnings->count()->willReturn(2);
 
         $manager
@@ -140,12 +124,8 @@ class JobExecutionNotifierSpec extends ObjectBehavior
         $this->afterJobExecution($event);
     }
 
-    function it_notifies_a_user_of_the_completion_of_job_execution_which_has_encountered_an_error(
-        $event,
-        $user,
-        $status,
-        $manager
-    ) {
+    function it_notifies_a_user_of_the_completion_of_job_execution_which_has_encountered_an_error($event, $user, $status, $manager)
+    {
         $status->isUnsuccessful()->willReturn(true);
 
         $manager

--- a/spec/Pim/Bundle/NotificationBundle/EventSubscriber/JobExecutionNotifierSpec.php
+++ b/spec/Pim/Bundle/NotificationBundle/EventSubscriber/JobExecutionNotifierSpec.php
@@ -52,7 +52,8 @@ class JobExecutionNotifierSpec extends ObjectBehavior
         );
     }
 
-    function it_does_not_notify_if_job_execution_has_no_user($event, $jobExecution, $manager) {
+    function it_does_not_notify_if_job_execution_has_no_user($event, $jobExecution, $manager)
+    {
         $jobExecution->getUser()->willReturn(null);
 
         $jobExecution->getStatus()->shouldNotBeCalled();

--- a/spec/Pim/Bundle/NotificationBundle/EventSubscriber/JobExecutionNotifierSpec.php
+++ b/spec/Pim/Bundle/NotificationBundle/EventSubscriber/JobExecutionNotifierSpec.php
@@ -2,7 +2,8 @@
 
 namespace spec\Pim\Bundle\NotificationBundle\EventSubscriber;
 
-use Akeneo\Component\Batch\Model\JobExecution;
+use Akeneo\Component\Batch\Model\JobExecution
+    ;
 use Akeneo\Component\Batch\Model\JobInstance;
 use Akeneo\Component\Batch\Model\StepExecution;
 use Akeneo\Component\Batch\Event\JobExecutionEvent;
@@ -52,8 +53,11 @@ class JobExecutionNotifierSpec extends ObjectBehavior
         );
     }
 
-    function it_does_not_notify_if_job_execution_has_no_user($event, $jobExecution, $manager)
-    {
+    function it_does_not_notify_if_job_execution_has_no_user(
+        $event,
+        $jobExecution,
+        $manager
+    ) {
         $jobExecution->getUser()->willReturn(null);
 
         $jobExecution->getStatus()->shouldNotBeCalled();
@@ -62,8 +66,11 @@ class JobExecutionNotifierSpec extends ObjectBehavior
         $this->afterJobExecution($event);
     }
 
-    function it_notifies_a_user_of_the_completion_of_job_execution($event, $user, $manager)
-    {
+    function it_notifies_a_user_of_the_completion_of_job_execution(
+        $event,
+        $user,
+        $manager
+    ) {
         $manager
             ->notify(
                 [$user],
@@ -81,8 +88,13 @@ class JobExecutionNotifierSpec extends ObjectBehavior
         $this->afterJobExecution($event);
     }
 
-    function it_notifies_a_user_of_the_completion_of_a_mass_edit_job_execution($event, $user, $manager, $jobInstance, $jobExecution)
-    {
+    function it_notifies_a_user_of_the_completion_of_a_mass_edit_job_execution(
+        $event,
+        $user,
+        $manager,
+        $jobInstance,
+        $jobExecution
+    ) {
         $manager
             ->notify(
                 [$user],
@@ -152,5 +164,20 @@ class JobExecutionNotifierSpec extends ObjectBehavior
             ->shouldBeCalled();
 
         $this->afterJobExecution($event);
+    }
+
+    function it_fails_to_notify_a_user_of_the_completion_of_job_execution_because_job_type_is_unknown(
+        $event,
+        JobExecution $jobExecution,
+        JobInstance $jobInstance
+    ) {
+        $event->getJobExecution()->willReturn($jobExecution);
+
+        $jobExecution->getJobInstance()->willReturn($jobInstance);
+        $jobInstance->getType()->willReturn('unknown');
+
+        $this->shouldThrow(
+            new \RuntimeException('Unable to generate a notification: job type "unknown" unknown')
+        )->during('afterJobExecution', [$event]);
     }
 }

--- a/src/Pim/Bundle/NotificationBundle/EventSubscriber/JobExecutionNotifier.php
+++ b/src/Pim/Bundle/NotificationBundle/EventSubscriber/JobExecutionNotifier.php
@@ -104,7 +104,7 @@ class JobExecutionNotifier implements EventSubscriberInterface
 
             default:
                 throw new \RuntimeException(
-                    sprintf('Unable to generate a notification: job "%s" unknown', $type)
+                    sprintf('Unable to generate a notification: job type "%s" unknown', $type)
                 );
                 break;
         }

--- a/src/Pim/Bundle/NotificationBundle/EventSubscriber/JobExecutionNotifier.php
+++ b/src/Pim/Bundle/NotificationBundle/EventSubscriber/JobExecutionNotifier.php
@@ -7,7 +7,6 @@ use Akeneo\Component\Batch\Event\JobExecutionEvent;
 use Akeneo\Component\Batch\Model\JobExecution;
 use Akeneo\Component\Batch\Model\JobInstance;
 use Pim\Bundle\NotificationBundle\Manager\NotificationManager;
-use RuntimeException;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 
@@ -104,8 +103,8 @@ class JobExecutionNotifier implements EventSubscriberInterface
                 break;
 
             default:
-                throw new RuntimeException(
-                    sprintf('Impossible to generate a notification for this unknown type : "%s"', $type)
+                throw new \RuntimeException(
+                    sprintf('Unable to generate a notification: job "%s" unknown', $type)
                 );
                 break;
         }

--- a/src/Pim/Bundle/NotificationBundle/EventSubscriber/JobExecutionNotifier.php
+++ b/src/Pim/Bundle/NotificationBundle/EventSubscriber/JobExecutionNotifier.php
@@ -7,8 +7,8 @@ use Akeneo\Component\Batch\Event\JobExecutionEvent;
 use Akeneo\Component\Batch\Model\JobExecution;
 use Akeneo\Component\Batch\Model\JobInstance;
 use Pim\Bundle\NotificationBundle\Manager\NotificationManager;
+use RuntimeException;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\Intl\Exception\NotImplementedException;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
@@ -104,7 +104,7 @@ class JobExecutionNotifier implements EventSubscriberInterface
                 break;
 
             default:
-                throw new NotImplementedException(
+                throw new RuntimeException(
                     sprintf('Impossible to generate a notification for this unknown type : "%s"', $type)
                 );
                 break;


### PR DESCRIPTION
**Description**

Replace a wrong usage of NotImplementedExcption (from Symony intl extension) by a simple RuntimeException.

**Definition Of Done**


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Y
| Added Behats                      | N
| Changelog updated                 | N
| Review and 2 GTM                  | Y
| Micro Demo to the PO (Story only) | N
| Migration script                  | N
| Tech Doc                          | N

