### PR TITLE
TIP-559: Rework exports: last enhancements

### DIFF
--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/archiving.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/archiving.yml
@@ -1,7 +1,7 @@
 parameters:
     pim_connector.event_listener.archivist.class:                 Pim\Bundle\ConnectorBundle\EventListener\JobExecutionArchivist
     pim_connector.event_listener.invalid_items_collector.class:   Pim\Bundle\ConnectorBundle\EventListener\InvalidItemsCollector
-    pim_connector.factory.zip_filesystem.class:                   Pim\Component\Connector\Filesystem\ZipFilesystemFactory
+    pim_connector.factory.zip_filesystem.class:                   Pim\Component\Connector\Archiver\ZipFilesystemFactory
     pim_connector.archiver.file_reader_archiver.class:            Pim\Component\Connector\Archiver\FileReaderArchiver
     pim_connector.archiver.file_writer_archiver.class:            Pim\Component\Connector\Archiver\FileWriterArchiver
     pim_connector.archiver.archivable_file_writer_archiver.class: Pim\Component\Connector\Archiver\ArchivableFileWriterArchiver

--- a/src/Pim/Bundle/EnrichBundle/Connector/Job/JobParameters/ConstraintCollectionProvider/ProductQuickExport.php
+++ b/src/Pim/Bundle/EnrichBundle/Connector/Job/JobParameters/ConstraintCollectionProvider/ProductQuickExport.php
@@ -41,9 +41,11 @@ class ProductQuickExport implements ConstraintCollectionProviderInterface
         $baseConstraint = $this->simpleConstraint->getConstraintCollection();
         $constraintFields = $baseConstraint->fields;
         $constraintFields['filters'] = new NotBlank(['groups' => 'Execution']);
-        $constraintFields['mainContext'] = new NotBlank(['groups' => 'Execution']);
         $constraintFields['selected_properties'] = null;
         $constraintFields['with_media'] = new Type('bool');
+        $constraintFields['locale'] = new NotBlank(['groups' => 'Execution']);
+        $constraintFields['scope'] = new NotBlank(['groups' => 'Execution']);
+        $constraintFields['ui_locale'] = new NotBlank(['groups' => 'Execution']);
 
         return new Collection(['fields' => $constraintFields]);
     }

--- a/src/Pim/Bundle/EnrichBundle/Connector/Job/JobParameters/DefaultValuesProvider/ProductQuickExport.php
+++ b/src/Pim/Bundle/EnrichBundle/Connector/Job/JobParameters/DefaultValuesProvider/ProductQuickExport.php
@@ -37,9 +37,11 @@ class ProductQuickExport implements DefaultValuesProviderInterface
     {
         $parameters = $this->simpleProvider->getDefaultValues();
         $parameters['filters'] = null;
-        $parameters['mainContext'] = null;
         $parameters['selected_properties'] = null;
         $parameters['with_media'] = true;
+        $parameters['locale'] = null;
+        $parameters['scope'] = null;
+        $parameters['ui_locale'] = null;
 
         return $parameters;
     }

--- a/src/Pim/Bundle/EnrichBundle/Connector/Processor/QuickExport/ProductProcessor.php
+++ b/src/Pim/Bundle/EnrichBundle/Connector/Processor/QuickExport/ProductProcessor.php
@@ -172,15 +172,13 @@ class ProductProcessor extends AbstractProcessor
      */
     protected function getNormalizerContext(JobParameters $parameters)
     {
-        $mainContext = $parameters->get('mainContext');
-
-        if (!isset($mainContext['scope'])) {
+        if (!$parameters->has('scope')) {
             throw new \InvalidArgumentException('No channel found');
         }
 
         $normalizerContext = [
-            'channels'     => [$mainContext['scope']],
-            'locales'      => $this->getLocaleCodes($mainContext['scope']),
+            'channels'     => [$parameters->get('scope')],
+            'locales'      => $this->getLocaleCodes($parameters->get('scope')),
             'filter_types' => [
                 'pim.transform.product_value.structured',
                 'pim.transform.product_value.structured.quick_export'

--- a/src/Pim/Component/Connector/Archiver/ArchivableFileWriterArchiver.php
+++ b/src/Pim/Component/Connector/Archiver/ArchivableFileWriterArchiver.php
@@ -7,7 +7,6 @@ use Akeneo\Component\Batch\Job\JobRegistry;
 use Akeneo\Component\Batch\Model\JobExecution;
 use Akeneo\Component\Batch\Step\ItemStep;
 use League\Flysystem\Filesystem;
-use Pim\Component\Connector\Filesystem\ZipFilesystemFactory;
 use Pim\Component\Connector\Writer\File\ArchivableWriterInterface;
 
 /**

--- a/src/Pim/Component/Connector/Archiver/ZipFilesystemFactory.php
+++ b/src/Pim/Component/Connector/Archiver/ZipFilesystemFactory.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Pim\Component\Connector\Filesystem;
+namespace Pim\Component\Connector\Archiver;
 
 use League\Flysystem\Filesystem;
 use League\Flysystem\ZipArchive\ZipArchiveAdapter;

--- a/src/Pim/Component/Connector/Writer/File/AbstractFileWriter.php
+++ b/src/Pim/Component/Connector/Writer/File/AbstractFileWriter.php
@@ -6,7 +6,6 @@ use Akeneo\Component\Batch\Item\ItemWriterInterface;
 use Akeneo\Component\Batch\Model\StepExecution;
 use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
 use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Abstract file writer to handle file naming and configuration-related logic.
@@ -18,27 +17,14 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 abstract class AbstractFileWriter implements ItemWriterInterface, StepExecutionAwareInterface
 {
-    /** @var OptionsResolver */
-    protected $filePathResolver;
-
     /** @var StepExecution */
     protected $stepExecution;
-
-    /** @var array */
-    protected $filePathResolverOptions;
 
     /** @var Filesystem */
     protected $localFs;
 
     public function __construct()
     {
-        $this->filePathResolver = new OptionsResolver();
-        $this->filePathResolver->setRequired('parameters');
-        $this->filePathResolver->setAllowedTypes('parameters', 'array');
-
-        $this->filePathResolverOptions = [
-            'parameters' => ['%datetime%' => date('Y-m-d_H:i:s')]
-        ];
         $this->localFs = new Filesystem();
     }
 
@@ -50,18 +36,8 @@ abstract class AbstractFileWriter implements ItemWriterInterface, StepExecutionA
     public function getPath()
     {
         $parameters = $this->stepExecution->getJobParameters();
-        $filePath = $parameters->get('filePath');
 
-        if ($parameters->has('mainContext')) {
-            $mainContext = $parameters->get('mainContext');
-            foreach ($mainContext as $key => $value) {
-                $this->filePathResolverOptions['parameters']['%' . $key . '%'] = $value;
-            }
-        }
-
-        $options = $this->filePathResolver->resolve($this->filePathResolverOptions);
-
-        return strtr($filePath, $options['parameters']);
+        return $parameters->get('filePath');
     }
 
     /**

--- a/src/Pim/Component/Connector/Writer/File/AbstractItemMediaWriter.php
+++ b/src/Pim/Component/Connector/Writer/File/AbstractItemMediaWriter.php
@@ -13,7 +13,6 @@ use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
 use Pim\Component\Connector\ArrayConverter\ArrayConverterInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
-use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * @author    Marie Bochu <marie.bochu@akeneo.com>
@@ -44,14 +43,8 @@ abstract class AbstractItemMediaWriter implements
     /** @var string[] */
     protected $mediaAttributeTypes;
 
-    /** @var OptionsResolver */
-    protected $filePathResolver;
-
     /** @var StepExecution */
     protected $stepExecution;
-
-    /** @var array */
-    protected $filePathResolverOptions;
 
     /** @var Filesystem */
     protected $localFs;
@@ -84,14 +77,6 @@ abstract class AbstractItemMediaWriter implements
         $this->attributeRepository = $attributeRepository;
         $this->mediaAttributeTypes = $mediaAttributeTypes;
         $this->fileExporterPath = $fileExporterPath;
-
-        $this->filePathResolver = new OptionsResolver();
-        $this->filePathResolver->setRequired('parameters');
-        $this->filePathResolver->setAllowedTypes('parameters', 'array');
-
-        $this->filePathResolverOptions = [
-            'parameters' => ['%datetime%' => date('Y-m-d_H:i:s')]
-        ];
 
         $this->localFs = new Filesystem();
     }
@@ -163,18 +148,8 @@ abstract class AbstractItemMediaWriter implements
     public function getPath()
     {
         $parameters = $this->stepExecution->getJobParameters();
-        $filePath = $parameters->get('filePath');
 
-        if ($parameters->has('mainContext')) {
-            $mainContext = $parameters->get('mainContext');
-            foreach ($mainContext as $key => $value) {
-                $this->filePathResolverOptions['parameters']['%' . $key . '%'] = $value;
-            }
-        }
-
-        $options = $this->filePathResolver->resolve($this->filePathResolverOptions);
-
-        return strtr($filePath, $options['parameters']);
+        return $parameters->get('filePath');
     }
 
     /**
@@ -301,8 +276,8 @@ abstract class AbstractItemMediaWriter implements
             $options['date_format'] = $parameters->get('dateFormat');
         }
 
-        if ($parameters->has('mainContext') && isset($parameters->get('mainContext')['ui_locale'])) {
-            $options['locale'] = $parameters->get('mainContext')['ui_locale'];
+        if ($parameters->has('ui_locale')) {
+            $options['locale'] = $parameters->get('ui_locale');
         }
 
         return $options;

--- a/src/Pim/Component/Connector/spec/Archiver/ArchivableFileWriterArchiverSpec.php
+++ b/src/Pim/Component/Connector/spec/Archiver/ArchivableFileWriterArchiverSpec.php
@@ -12,7 +12,7 @@ use Akeneo\Component\Batch\Step\ItemStep;
 use League\Flysystem\Adapter\Local as LocalAdapter;
 use League\Flysystem\Filesystem;
 use PhpSpec\ObjectBehavior;
-use Pim\Component\Connector\Filesystem\ZipFilesystemFactory;
+use Pim\Component\Connector\Archiver\ZipFilesystemFactory;
 use Pim\Component\Connector\Writer\File\Csv\Writer;
 use Prophecy\Argument;
 

--- a/src/Pim/Component/Connector/spec/Archiver/ZipFilesystemFactorySpec.php
+++ b/src/Pim/Component/Connector/spec/Archiver/ZipFilesystemFactorySpec.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace spec\Pim\Component\Connector\Filesystem;
+namespace spec\Pim\Component\Connector\Archiver;
 
 use PhpSpec\ObjectBehavior;
 

--- a/src/Pim/Component/Connector/spec/Writer/File/Csv/ProductWriterSpec.php
+++ b/src/Pim/Component/Connector/spec/Writer/File/Csv/ProductWriterSpec.php
@@ -65,7 +65,7 @@ class ProductWriterSpec extends ObjectBehavior
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $jobParameters->get('withHeader')->willReturn(true);
         $jobParameters->get('filePath')->willReturn($this->directory . 'product.csv');
-        $jobParameters->has('mainContext')->willReturn(false);
+        $jobParameters->has('ui_locale')->willReturn(false);
         $jobParameters->has('decimalSeparator')->willReturn(false);
         $jobParameters->has('dateFormat')->willReturn(false);
         $jobParameters->has('with_media')->willReturn(true);
@@ -228,7 +228,7 @@ class ProductWriterSpec extends ObjectBehavior
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $jobParameters->get('withHeader')->willReturn(true);
         $jobParameters->get('filePath')->willReturn($this->directory . 'product.csv');
-        $jobParameters->has('mainContext')->willReturn(false);
+        $jobParameters->has('ui_locale')->willReturn(false);
         $jobParameters->has('decimalSeparator')->willReturn(false);
         $jobParameters->has('dateFormat')->willReturn(false);
         $jobParameters->has('with_media')->willReturn(true);
@@ -303,7 +303,7 @@ class ProductWriterSpec extends ObjectBehavior
         $jobParameters->get('delimiter')->willReturn(';');
         $jobParameters->get('enclosure')->willReturn('"');
         $jobParameters->get('filePath')->willReturn('my/file/path/foo');
-        $jobParameters->has('mainContext')->willReturn(false);
+        $jobParameters->has('ui_locale')->willReturn(false);
 
         $bufferFactory->create()->willReturn($flatRowBuffer);
         $flusher->flush(
@@ -315,17 +315,5 @@ class ProductWriterSpec extends ObjectBehavior
 
         $this->initialize();
         $this->flush();
-    }
-
-    function it_builds_the_path(StepExecution $stepExecution, JobParameters $jobParameters)
-    {
-        $options = ['date' => '2015-01-01'];
-        $this->setStepExecution($stepExecution);
-        $stepExecution->getJobParameters()->willReturn($jobParameters);
-        $jobParameters->has('mainContext')->willReturn(true);
-        $jobParameters->get('mainContext')->willReturn($options);
-        $jobParameters->get('filePath')->willReturn($this->directory . 'product_%date%.csv');
-
-        $this->getPath()->shouldReturn($this->directory . 'product_2015-01-01.csv');
     }
 }

--- a/src/Pim/Component/Connector/spec/Writer/File/Csv/VariantGroupWriterSpec.php
+++ b/src/Pim/Component/Connector/spec/Writer/File/Csv/VariantGroupWriterSpec.php
@@ -65,7 +65,7 @@ class VariantGroupWriterSpec extends ObjectBehavior
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $jobParameters->get('withHeader')->willReturn(true);
         $jobParameters->get('filePath')->willReturn($this->directory . 'variant_group.csv');
-        $jobParameters->has('mainContext')->willReturn(false);
+        $jobParameters->has('ui_locale')->willReturn(false);
         $jobParameters->has('decimalSeparator')->willReturn(false);
         $jobParameters->has('dateFormat')->willReturn(false);
         $jobParameters->has('with_media')->willReturn(true);
@@ -180,7 +180,7 @@ class VariantGroupWriterSpec extends ObjectBehavior
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $jobParameters->get('withHeader')->willReturn(true);
         $jobParameters->get('filePath')->willReturn($this->directory . 'variant_group.csv');
-        $jobParameters->has('mainContext')->willReturn(false);
+        $jobParameters->has('ui_locale')->willReturn(false);
         $jobParameters->has('decimalSeparator')->willReturn(false);
         $jobParameters->has('dateFormat')->willReturn(false);
         $jobParameters->has('with_media')->willReturn(true);
@@ -249,7 +249,7 @@ class VariantGroupWriterSpec extends ObjectBehavior
         $jobParameters->get('delimiter')->willReturn(';');
         $jobParameters->get('enclosure')->willReturn('"');
         $jobParameters->get('filePath')->willReturn('my/file/path/foo');
-        $jobParameters->has('mainContext')->willReturn(false);
+        $jobParameters->has('ui_locale')->willReturn(false);
 
         $bufferFactory->create()->willReturn($flatRowBuffer);
         $flusher->flush(
@@ -261,17 +261,5 @@ class VariantGroupWriterSpec extends ObjectBehavior
 
         $this->initialize();
         $this->flush();
-    }
-
-    function it_builds_the_path(StepExecution $stepExecution, JobParameters $jobParameters)
-    {
-        $options = ['date' => '2015-01-01'];
-        $this->setStepExecution($stepExecution);
-        $stepExecution->getJobParameters()->willReturn($jobParameters);
-        $jobParameters->has('mainContext')->willReturn(true);
-        $jobParameters->get('mainContext')->willReturn($options);
-        $jobParameters->get('filePath')->willReturn($this->directory . 'variant_group_%date%.csv');
-
-        $this->getPath()->shouldReturn($this->directory . 'variant_group_2015-01-01.csv');
     }
 }

--- a/src/Pim/Component/Connector/spec/Writer/File/Csv/WriterSpec.php
+++ b/src/Pim/Component/Connector/spec/Writer/File/Csv/WriterSpec.php
@@ -42,7 +42,7 @@ class WriterSpec extends ObjectBehavior
         $this->setStepExecution($stepExecution);
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $jobParameters->get('filePath')->willReturn('my/file/path/foo');
-        $jobParameters->has('mainContext')->willReturn(false);
+        $jobParameters->has('ui_locale')->willReturn(false);
         $jobParameters->get('withHeader')->willReturn(true);
 
         $groups = [
@@ -120,7 +120,7 @@ class WriterSpec extends ObjectBehavior
         $jobParameters->get('delimiter')->willReturn(';');
         $jobParameters->get('enclosure')->willReturn('"');
         $jobParameters->get('filePath')->willReturn('my/file/path/foo');
-        $jobParameters->has('mainContext')->willReturn(false);
+        $jobParameters->has('ui_locale')->willReturn(false);
 
         $bufferFactory->create()->willReturn($flatRowBuffer);
 

--- a/src/Pim/Component/Connector/spec/Writer/File/Xlsx/ProductWriterSpec.php
+++ b/src/Pim/Component/Connector/spec/Writer/File/Xlsx/ProductWriterSpec.php
@@ -65,7 +65,7 @@ class ProductWriterSpec extends ObjectBehavior
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $jobParameters->get('withHeader')->willReturn(true);
         $jobParameters->get('filePath')->willReturn($this->directory . 'product.xlsx');
-        $jobParameters->has('mainContext')->willReturn(false);
+        $jobParameters->has('ui_locale')->willReturn(false);
         $jobParameters->has('decimalSeparator')->willReturn(false);
         $jobParameters->has('dateFormat')->willReturn(false);
         $jobParameters->has('with_media')->willReturn(true);
@@ -230,7 +230,7 @@ class ProductWriterSpec extends ObjectBehavior
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $jobParameters->get('withHeader')->willReturn(true);
         $jobParameters->get('filePath')->willReturn($this->directory . 'product.xlsx');
-        $jobParameters->has('mainContext')->willReturn(false);
+        $jobParameters->has('ui_locale')->willReturn(false);
         $jobParameters->has('decimalSeparator')->willReturn(false);
         $jobParameters->has('dateFormat')->willReturn(false);
         $jobParameters->has('with_media')->willReturn(true);
@@ -305,7 +305,7 @@ class ProductWriterSpec extends ObjectBehavior
         $jobParameters->get('delimiter')->willReturn(';');
         $jobParameters->get('enclosure')->willReturn('"');
         $jobParameters->get('filePath')->willReturn('my/file/path/foo');
-        $jobParameters->has('mainContext')->willReturn(false);
+        $jobParameters->has('ui_locale')->willReturn(false);
 
         $bufferFactory->create()->willReturn($flatRowBuffer);
         $flusher->flush(
@@ -317,18 +317,5 @@ class ProductWriterSpec extends ObjectBehavior
 
         $this->initialize();
         $this->flush();
-    }
-
-    function it_builds_the_path(StepExecution $stepExecution, JobParameters $jobParameters)
-    {
-        $options = ['date' => '2015-01-01'];
-        $this->setStepExecution($stepExecution);
-        $stepExecution->getJobParameters()->willReturn($jobParameters);
-        $jobParameters->has('mainContext')->willReturn(true);
-        $jobParameters->get('mainContext')->willReturn($options);
-        $jobParameters->get('filePath')->willReturn($this->directory . 'product_%date%.xlsx');
-
-
-        $this->getPath()->shouldReturn($this->directory . 'product_2015-01-01.xlsx');
     }
 }

--- a/src/Pim/Component/Connector/spec/Writer/File/Xlsx/VariantGroupWriterSpec.php
+++ b/src/Pim/Component/Connector/spec/Writer/File/Xlsx/VariantGroupWriterSpec.php
@@ -65,7 +65,7 @@ class VariantGroupWriterSpec extends ObjectBehavior
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $jobParameters->get('withHeader')->willReturn(true);
         $jobParameters->get('filePath')->willReturn($this->directory . 'variant_group.xlsx');
-        $jobParameters->has('mainContext')->willReturn(false);
+        $jobParameters->has('ui_locale')->willReturn(false);
         $jobParameters->has('decimalSeparator')->willReturn(false);
         $jobParameters->has('dateFormat')->willReturn(false);
         $jobParameters->has('with_media')->willReturn(true);
@@ -181,7 +181,7 @@ class VariantGroupWriterSpec extends ObjectBehavior
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $jobParameters->get('withHeader')->willReturn(true);
         $jobParameters->get('filePath')->willReturn($this->directory . 'variant_group.xlsx');
-        $jobParameters->has('mainContext')->willReturn(false);
+        $jobParameters->has('ui_locale')->willReturn(false);
         $jobParameters->has('decimalSeparator')->willReturn(false);
         $jobParameters->has('dateFormat')->willReturn(false);
         $jobParameters->has('with_media')->willReturn(true);
@@ -250,7 +250,7 @@ class VariantGroupWriterSpec extends ObjectBehavior
         $jobParameters->get('delimiter')->willReturn(';');
         $jobParameters->get('enclosure')->willReturn('"');
         $jobParameters->get('filePath')->willReturn('my/file/path/foo');
-        $jobParameters->has('mainContext')->willReturn(false);
+        $jobParameters->has('ui_locale')->willReturn(false);
 
         $bufferFactory->create()->willReturn($flatRowBuffer);
         $flusher->flush(
@@ -262,17 +262,5 @@ class VariantGroupWriterSpec extends ObjectBehavior
 
         $this->initialize();
         $this->flush();
-    }
-
-    function it_builds_the_path(StepExecution $stepExecution, JobParameters $jobParameters)
-    {
-        $options = ['date' => '2015-01-01'];
-        $this->setStepExecution($stepExecution);
-        $stepExecution->getJobParameters()->willReturn($jobParameters);
-        $jobParameters->has('mainContext')->willReturn(true);
-        $jobParameters->get('mainContext')->willReturn($options);
-        $jobParameters->get('filePath')->willReturn($this->directory . 'variant_group_%date%.xlsx');
-
-        $this->getPath()->shouldReturn($this->directory . 'variant_group_2015-01-01.xlsx');
     }
 }

--- a/src/Pim/Component/Connector/spec/Writer/File/Xlsx/WriterSpec.php
+++ b/src/Pim/Component/Connector/spec/Writer/File/Xlsx/WriterSpec.php
@@ -48,7 +48,7 @@ class WriterSpec extends ObjectBehavior
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $jobParameters->get('withHeader')->willReturn(true);
         $jobParameters->get('filePath')->willReturn(true);
-        $jobParameters->has('mainContext')->willReturn(false);
+        $jobParameters->has('ui_locale')->willReturn(false);
 
         $groups = [
             [
@@ -122,7 +122,7 @@ class WriterSpec extends ObjectBehavior
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $jobParameters->get('linesPerFile')->willReturn(2);
         $jobParameters->get('filePath')->willReturn('my/file/path/foo');
-        $jobParameters->has('mainContext')->willReturn(false);
+        $jobParameters->has('ui_locale')->willReturn(false);
 
         $bufferFactory->create()->willReturn($flatRowBuffer);
 

--- a/upgrades/schema/Version_1_6_20160722155535_quick_export.php
+++ b/upgrades/schema/Version_1_6_20160722155535_quick_export.php
@@ -32,6 +32,10 @@ class Version_1_6_20160722155535_quick_export extends AbstractMigration
         $parameters = unserialize($job['raw_parameters']);
         $parameters['with_media'] = true;
 
+        if (array_key_exists('mainContext', $parameters)) {
+            unset($parameters['mainContext']);
+        }
+
         $this->connection->update(
             'akeneo_batch_job_instance',
             ['raw_parameters' => serialize($parameters)],


### PR DESCRIPTION
- [x] remove `mainContext` in the processors/writers and `filePathResolverOptions` in writers (it's only need for quick export)
- [x] build path file for quick export before launch the job
- [x] move Pim\Component\Connector\Filesystem\ZipFilesystemFactory to archivers as it's only used here
