### PR TITLE
PIM-5900: Remove accordions and unify ORO forms

### DIFF
--- a/features/Context/Page/Base/Form.php
+++ b/features/Context/Page/Base/Form.php
@@ -214,7 +214,7 @@ class Form extends Base
      */
     public function getSection($title)
     {
-        return $this->find('css', sprintf('div.accordion-heading:contains("%s")', $title));
+        return $this->find('css', sprintf('div.tabsection-title:contains("%s")', $title));
     }
 
     /**

--- a/features/Context/Page/Base/Form.php
+++ b/features/Context/Page/Base/Form.php
@@ -469,20 +469,20 @@ class Form extends Base
      *
      * @throws \InvalidArgumentException
      */
-    public function findFieldInAccordion($groupField, $field)
+    public function findFieldInTabSection($groupField, $field)
     {
-        $accordion = $this->find(
+        $tabSection = $this->find(
             'css',
-            sprintf('.accordion-heading a:contains("%s")', $groupField)
+            sprintf('.tabsection-title:contains("%s")', $groupField)
         );
 
-        if (!$accordion) {
+        if (!$tabSection) {
             throw new \InvalidArgumentException(
-                sprintf('Could not find accordion %s', $groupField)
+                sprintf('Could not find tab section "%s"', $groupField)
             );
         }
 
-        $accordionContent = $this->find('css', $accordion->getAttribute('href'));
+        $accordionContent = $tabSection->getParent()->find('css', '.tabsection-content');
 
         if (!$accordionContent->findField($field)) {
             throw new \InvalidArgumentException(

--- a/features/Context/WebUser.php
+++ b/features/Context/WebUser.php
@@ -1973,7 +1973,7 @@ class WebUser extends RawMinkContext
     public function iShouldSeeFields($groupField, TableNode $fields)
     {
         foreach ($fields->getRows() as $data) {
-            $this->getCurrentPage()->findFieldInAccordion($groupField, $data[0]);
+            $this->getCurrentPage()->findFieldInTabSection($groupField, $data[0]);
         }
     }
 

--- a/features/Pim/Behat/Decorator/ContextSwitcherDecorator.php
+++ b/features/Pim/Behat/Decorator/ContextSwitcherDecorator.php
@@ -22,7 +22,7 @@ class ContextSwitcherDecorator extends ElementDecorator
      */
     public function switchLocale($localeCode)
     {
-        $dropdown = $this->spin(function () use ($localeCode) {
+        $this->spin(function () use ($localeCode) {
             $dropdown = $this->find('css', $this->selectors['Locales dropdown']);
             if (null === $dropdown) {
                 return false;

--- a/src/Oro/Bundle/UIBundle/Resources/views/macros.html.twig
+++ b/src/Oro/Bundle/UIBundle/Resources/views/macros.html.twig
@@ -145,10 +145,12 @@
 #}
 {% macro scrollSubblock(title, data, isForm) %}
     <div>
-    {% if title|length %}<h5 class="user-fiedset"><span>{{ title|trans }}</span></h5>{% endif %}
-    {% for dataBlock in data %}
-        {{ dataBlock|raw }}
-    {% endfor %}
+    {% if title|length %}<div class="tabsection-title user-fiedset"><span>{{ title|trans }}</span></div>{% endif %}
+    <div class="tabsection-content">
+        {% for dataBlock in data %}
+            {{ dataBlock|raw }}
+        {% endfor %}
+    </div>
     </div>
     {#% if span %}
         </div>
@@ -171,9 +173,9 @@
 #}
 {% macro scrollBlock(blockId, title, subblocks, isForm, contentAttributes, useSubBlockDivider) %}
     {% set cols = subblocks|length %}
-    <div class="responsive-section">
-        <h4 class="scrollspy-title">{{ title|trans }}</h4>
+    <div class="tabsection responsive-section">
         <div id="{{ blockId }}" class="scrollspy-nav-target"></div>
+        <div class="tabsection-title scrollspy-title">{{ title|trans }}</div>
         <div class="row-fluid{% if (contentAttributes is defined and contentAttributes.class is defined and contentAttributes.class|length) %} {{ contentAttributes.class }}{% endif %}{% if cols > 1 and (useSubBlockDivider is not defined or useSubBlockDivider == true) %} row-fluid-divider{% endif %}" {{ _self.attributes(contentAttributes, ['class']) }}>
             {% if isForm is defined and isForm == true %}
                 <fieldset class="form-horizontal">
@@ -244,7 +246,7 @@
                 </div>
             </div>
         {% endif %}
-        <div data-spy="scroll" data-target="#{{ dataTarget }}" data-offset="1" class="scrollspy container-fluid scrollable-container{% if isForm %} form-container{% endif %}">
+        <div data-spy="scroll" data-target="#{{ dataTarget }}" data-offset="1" class="tabsections tab-content scrollspy container-fluid scrollable-container{% if isForm %} form-container{% endif %}">
             {% for scrollBlock in dataBlocks %}
                 {{ _self.scrollBlock("scroll-" ~ loop.index, scrollBlock.title, scrollBlock.subblocks, isForm, scrollBlock.content_attr is defined ? scrollBlock.content_attr : null, scrollBlock.useSubBlockDivider is defined ? scrollBlock.useSubBlockDivider : true) }}
             {% endfor %}

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/variant-group/form/properties/general.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/variant-group/form/properties/general.js
@@ -23,7 +23,7 @@ define([
         template
     ) {
         return BaseForm.extend({
-            className: 'accordion-group',
+            className: 'tabsection',
             template: _.template(template),
 
             /**

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/variant-group/form/properties/translation.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/variant-group/form/properties/translation.js
@@ -20,7 +20,7 @@ define([
         template
     ) {
         return BaseForm.extend({
-            className: 'accordion-group translation-container',
+            className: 'tabsection translation-container',
             template: _.template(template),
             events: {
                 'change .label-field': 'updateModel'

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/export/product/edit/content.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/export/product/edit/content.html
@@ -1,8 +1,8 @@
-<div class="accordion">
-    <div data-drop-zone="structure-filters" class="accordion-group">
+<div class="tabsections">
+    <div data-drop-zone="structure-filters" class="tabsection">
 
     </div>
-    <div data-drop-zone="data-filters" class="accordion-group">
+    <div data-drop-zone="data-filters" class="tabsection">
 
     </div>
 </div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/export/product/edit/content/data.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/export/product/edit/content/data.html
@@ -1,13 +1,8 @@
-<div class="accordion-heading clearfix">
+<div class="tabsection-title">
     <div class="pull-right" data-drop-zone="headings"></div>
-    <a class="accordion-toggle" data-toggle="collapse" href="#collapse-3-2">
-        <i class="icon-chevron-down"></i>
-        <%- __('pim_enrich.export.product.data.title') %>
-    </a>
+    <%- __('pim_enrich.export.product.data.title') %>
 </div>
-<div id="collapse-3-2" class="accordion-body in">
-    <div class="accordion-inner filter-wrapper">
-        <div class="control-group" data-drop-zone="product-filters"></div>
-        <div class="control-group filters"></div>
-    </div>
+<div class="tabsection-content">
+    <div class="control-group" data-drop-zone="product-filters"></div>
+    <div class="control-group filters"></div>
 </div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/export/product/edit/content/structure.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/export/product/edit/content/structure.html
@@ -1,11 +1,5 @@
-<div class="accordion-heading">
-    <a class="accordion-toggle" data-toggle="collapse" href="#collapse-3-1">
-        <i class="icon-chevron-down"></i>
-        <%- __('pim_enrich.export.product.structure.title') %>
-    </a>
+<div class="tabsection-title">
+    <%- __('pim_enrich.export.product.structure.title') %>
 </div>
-<div id="collapse-3-1" class="accordion-body in">
-    <div class="accordion-inner">
-        <div data-drop-zone="filters"></div>
-    </div>
+<div class="tabsection-content" data-drop-zone="filters">
 </div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/variant-group/tab/properties.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/variant-group/tab/properties.html
@@ -1,1 +1,1 @@
-<div class="accordion" data-drop-zone="accordion"></div>
+<div class="tabsections" data-drop-zone="accordion"></div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/variant-group/tab/properties/general.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/variant-group/tab/properties/general.html
@@ -1,42 +1,37 @@
-<div class="accordion-heading">
-    <a class="accordion-toggle" data-toggle="collapse">
-        <i class="icon-chevron-down"></i>
-        <%- sectionTitle %>
-    </a>
+<div class="tabsection-title">
+    <%- sectionTitle %>
 </div>
-<div class="accordion-body in">
-    <div class="accordion-inner">
-        <div class="control-group">
-            <label class="control-label required" for="pim_enrich_variant_group_form_code">
-                <%- codeLabel %> <em><%- __('pim_enrich.form.required') %></em>
-            </label>
-            <div class="controls">
-                <input type="text" id="pim_enrich_variant_group_form_code" readonly="readonly" disabled="disabled" required="required" class="input-large" value="<%- model.code %>">
-            </div>
+<div class="tabsection-content">
+    <div class="control-group">
+        <label class="control-label required" for="pim_enrich_variant_group_form_code">
+            <%- codeLabel %> <em><%- __('pim_enrich.form.required') %></em>
+        </label>
+        <div class="controls">
+            <input type="text" id="pim_enrich_variant_group_form_code" readonly="readonly" disabled="disabled" required="required" class="input-large" value="<%- model.code %>">
         </div>
+    </div>
 
-        <div class="control-group">
-            <label class="control-label required">
-                <%- typeLabel %> <em><%- __('pim_enrich.form.required') %></em>
-                </label>
-            <div class="controls">
-                <select id="pim_enrich_variant_group_form_type" readonly="readonly" disabled="disabled" class="select2 input-large">
-                    <option>[<%- model.type %>]</option>
-                </select>
-            </div>
-        </div>
-
-        <div class="control-group">
-            <label class="control-label required">
-                <%- axisLabel %> <em><%- __('pim_enrich.form.required') %></em>
+    <div class="control-group">
+        <label class="control-label required">
+            <%- typeLabel %> <em><%- __('pim_enrich.form.required') %></em>
             </label>
-            <div class="controls">
-                <select id="pim_enrich_variant_group_form_type" readonly="readonly" disabled="disabled" class="select2 input-large" multiple>
-                    <% _.each(model.axis, function (axis) { %>
-                        <option selected><%- axis %></option>
-                    <% }) %>
-                </select>
-            </div>
+        <div class="controls">
+            <select id="pim_enrich_variant_group_form_type" readonly="readonly" disabled="disabled" class="select2 input-large">
+                <option>[<%- model.type %>]</option>
+            </select>
+        </div>
+    </div>
+
+    <div class="control-group">
+        <label class="control-label required">
+            <%- axisLabel %> <em><%- __('pim_enrich.form.required') %></em>
+        </label>
+        <div class="controls">
+            <select id="pim_enrich_variant_group_form_type" readonly="readonly" disabled="disabled" class="select2 input-large" multiple>
+                <% _.each(model.axis, function (axis) { %>
+                    <option selected><%- axis %></option>
+                <% }) %>
+            </select>
         </div>
     </div>
 </div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/variant-group/tab/properties/translation.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/variant-group/tab/properties/translation.html
@@ -1,28 +1,23 @@
-<div class="accordion-heading">
-    <a class="accordion-toggle" data-toggle="collapse">
-        <i class="icon-chevron-down"></i>
-        <%- _.__('pim_enrich.form.variant_group.tab.properties.label_translations') %>
-    </a>
+<div class="tabsection-title">
+    <%- _.__('pim_enrich.form.variant_group.tab.properties.label_translations') %>
 </div>
-<div class="accordion-body in">
-    <div class="accordion-inner">
-        <% _.each(locales, function (locale) { %>
-        <div class="control-group">
-            <label for="pim_enrich_variant_group_form_label_<%- locale.code %>">
-                <%- locale.label %>
-            </label>
-            <div class="controls">
-                <input type="text" id="pim_enrich_variant_group_form_label_<%- locale.code %>" class="input-large label-field" data-locale="<%- locale.code %>" value="<%- model.labels[locale.code] %>">
-                <% if (errors[locale.code]) { %>
-                    <span class="validation-error">
-                        <i class="icon-warning-sign"></i>
-                        <span class="error-message"><%- errors[locale.code].message %></span>
-                    </span>
-                <% } %>
-                <div class="icons-container">
-                </div>
+<div class="tabsection-content">
+    <% _.each(locales, function (locale) { %>
+    <div class="control-group">
+        <label for="pim_enrich_variant_group_form_label_<%- locale.code %>">
+            <%- locale.label %>
+        </label>
+        <div class="controls">
+            <input type="text" id="pim_enrich_variant_group_form_label_<%- locale.code %>" class="input-large label-field" data-locale="<%- locale.code %>" value="<%- model.labels[locale.code] %>">
+            <% if (errors[locale.code]) { %>
+                <span class="validation-error">
+                    <i class="icon-warning-sign"></i>
+                    <span class="error-message"><%- errors[locale.code].message %></span>
+                </span>
+            <% } %>
+            <div class="icons-container">
             </div>
         </div>
-        <% }) %>
     </div>
+    <% }) %>
 </div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/views/AssociationType/Tab/property.html.twig
+++ b/src/Pim/Bundle/EnrichBundle/Resources/views/AssociationType/Tab/property.html.twig
@@ -1,5 +1,5 @@
 <div class="tab-pane tab-property {{ viewElement.loop.first ? 'active' : '' }}" id="{{ viewElement.alias|replace({' ': '-', '.': '-'})|lower }}">
-    {{ elements.accordion({
+    {{ elements.tabSections({
         'pane.accordion.general_properties': form_row(form.code),
         'pane.accordion.locale_values': form_row(form.label)
     }) }}

--- a/src/Pim/Bundle/EnrichBundle/Resources/views/Attribute/Tab/parameter.html.twig
+++ b/src/Pim/Bundle/EnrichBundle/Resources/views/Attribute/Tab/parameter.html.twig
@@ -22,7 +22,7 @@
     {% endset %}
 
     {{
-        elements.accordion({
+        elements.tabSections({
             'pane.accordion.general_parameters': view_elements('pim_enrich_attribute_form.general_parameters'),
             'pane.accordion.validation_parameters': validationParameters,
             'pane.accordion.backend_parameters': view_elements('pim_enrich_attribute_form.backend_parameters')

--- a/src/Pim/Bundle/EnrichBundle/Resources/views/Attribute/Tab/value.html.twig
+++ b/src/Pim/Bundle/EnrichBundle/Resources/views/Attribute/Tab/value.html.twig
@@ -23,5 +23,5 @@
         {% set accordionContent = accordionContent|merge({ 'pane.accordion.options': optionsContent }) %}
     {% endif %}
 
-    {{ elements.accordion(accordionContent, 2) }}
+    {{ elements.tabSections(accordionContent, 2) }}
 </div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/views/AttributeGroup/Tab/attribute.html.twig
+++ b/src/Pim/Bundle/EnrichBundle/Resources/views/AttributeGroup/Tab/attribute.html.twig
@@ -4,53 +4,58 @@
 %}
 {% set sortGranted = resource_granted('pim_enrich_attribute_sort') %}
 
-<div class="tab-pane tab-attribute {{ viewElement.loop.first ? 'active' : '' }}" id="{{ viewElement.alias|replace({' ': '-', '.': '-'})|lower }}">
-    <div id="attribute-buttons"></div>
-    <div class="clearfix"></div>
-    <table class="table groups">
-        <thead>
-            {% if sortGranted %}
-                <th>&nbsp;</th>
-            {% endif %}
-            <th>{{ 'Name'|trans }}</th>
-            <th>{{ 'Type'|trans }}</th>
-            <th>{{ 'Scope'|trans }}</th>
-            <th>{{ 'Localizable'|trans }}</th>
-            {% if removalGranted %}
-                <th>&nbsp;</th>
-            {% endif %}
-        </thead>
-            <tbody id="attributes-sortable">
-                {% for attribute in group.attributes %}
-                    <tr>
-                        {% if sortGranted %}
+<div class="tabsection tab-pane tab-attribute {{ viewElement.loop.first ? 'active' : '' }}" id="{{ viewElement.alias|replace({' ': '-', '.': '-'})|lower }}">
+    <div class="tabsection-title">
+        <div class="pull-right">
+            <div id="attribute-buttons"></div>
+        </div>
+    </div>
+    <div class="tabsection-content">
+        <table class="table groups">
+            <thead>
+                {% if sortGranted %}
+                    <th>&nbsp;</th>
+                {% endif %}
+                <th>{{ 'Name'|trans }}</th>
+                <th>{{ 'Type'|trans }}</th>
+                <th>{{ 'Scope'|trans }}</th>
+                <th>{{ 'Localizable'|trans }}</th>
+                {% if removalGranted %}
+                    <th>&nbsp;</th>
+                {% endif %}
+            </thead>
+                <tbody id="attributes-sortable">
+                    {% for attribute in group.attributes %}
+                        <tr>
+                            {% if sortGranted %}
+                                <td>
+                                    <span class="handle">
+                                        <i class="icon-reorder"></i>
+                                        <input name="{{ attribute.id }}" type="hidden" value="{{ attribute.sortOrder }}">
+                                    </span>
+                                </td>
+                            {% endif %}
+                            <td>{{ attribute.label }}</td>
+                            <td>{{ attribute.attributeType|trans }}</td>
+                            <td>{{ attribute.scopable ? 'Channel'|trans : 'Global'|trans }}</td>
                             <td>
-                                <span class="handle">
-                                    <i class="icon-reorder"></i>
-                                    <input name="{{ attribute.id }}" type="hidden" value="{{ attribute.sortOrder }}">
-                                </span>
+                                <input type="checkbox" disabled="disabled"{% if attribute.localizable %} checked="checked"{% endif %}>
                             </td>
-                        {% endif %}
-                        <td>{{ attribute.label }}</td>
-                        <td>{{ attribute.attributeType|trans }}</td>
-                        <td>{{ attribute.scopable ? 'Channel'|trans : 'Global'|trans }}</td>
-                        <td>
-                            <input type="checkbox" disabled="disabled"{% if attribute.localizable %} checked="checked"{% endif %}>
-                        </td>
-                        {% if removalGranted %}
-                            <td>
-                                <a {{ elements.deleteLinkAttributes(
-                                    path('pim_enrich_attributegroup_removeattribute', {'groupId': group.id, 'attributeId': attribute.id}),
-                                    path('pim_enrich_attributegroup_edit', {'id': group.id }),
-                                    'confirmation.attribute group.remove attribute'|trans({'%name%': attribute.label}),
-                                    'flash.attribute group.attribute removed'|trans
-                                ) }} class="remove-attribute">
-                                    <i class="icon-trash"></i>
-                                </a>
-                            </td>
-                        {% endif %}
-                    </tr>
-                {% endfor %}
-            </tbody>
-    </table>
+                            {% if removalGranted %}
+                                <td>
+                                    <a {{ elements.deleteLinkAttributes(
+                                        path('pim_enrich_attributegroup_removeattribute', {'groupId': group.id, 'attributeId': attribute.id}),
+                                        path('pim_enrich_attributegroup_edit', {'id': group.id }),
+                                        'confirmation.attribute group.remove attribute'|trans({'%name%': attribute.label}),
+                                        'flash.attribute group.attribute removed'|trans
+                                    ) }} class="remove-attribute">
+                                        <i class="icon-trash"></i>
+                                    </a>
+                                </td>
+                            {% endif %}
+                        </tr>
+                    {% endfor %}
+                </tbody>
+        </table>
+    </div>
 </div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/views/AttributeGroup/Tab/property.html.twig
+++ b/src/Pim/Bundle/EnrichBundle/Resources/views/AttributeGroup/Tab/property.html.twig
@@ -1,3 +1,3 @@
 <div class="tab-pane tab-property {{ viewElement.loop.first ? 'active' : '' }}" id="{{ viewElement.alias|replace({' ': '-', '.': '-'})|lower }}">
-    {{ elements.accordion({ 'pane.accordion.general_properties': form_row(form.code), 'pane.accordion.group_values': form_row(form.label) }) }}
+    {{ elements.tabSections({ 'pane.accordion.general_properties': form_row(form.code), 'pane.accordion.group_values': form_row(form.label) }) }}
 </div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/views/AttributeGroup/form.html.twig
+++ b/src/Pim/Bundle/EnrichBundle/Resources/views/AttributeGroup/form.html.twig
@@ -32,7 +32,7 @@
 
     {{ elements.form_navbar(view_element_aliases(form.vars.id ~ '.form_tab')) }}
 
-    <div class="tab-content">
+    <div class="tab-content tabsections">
         {{ elements.form_errors(form) }}
         {{ form_row(form.sort_order) }}
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/views/CategoryTree/Tab/property.html.twig
+++ b/src/Pim/Bundle/EnrichBundle/Resources/views/CategoryTree/Tab/property.html.twig
@@ -7,5 +7,5 @@
         {{ form_row(form.label) }}
     {% endset %}
 
-    {{ elements.accordion({ 'pane.accordion.general_properties': generalProperties, 'pane.accordion.node_values': nodeValues }) }}
+    {{ elements.tabSections({ 'pane.accordion.general_properties': generalProperties, 'pane.accordion.node_values': nodeValues }) }}
 </div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/views/Channel/Tab/property.html.twig
+++ b/src/Pim/Bundle/EnrichBundle/Resources/views/Channel/Tab/property.html.twig
@@ -11,7 +11,7 @@
             {{ form_row(conversionUnitForm) }}
         {% endfor %}
     {% endset %}
-    {{ elements.accordion({
+    {{ elements.tabSections({
         'pane.accordion.general_properties': generalProperties,
         'pim_enrich.channel.pick_conversion_unit': conversionOptions
     }) }}

--- a/src/Pim/Bundle/EnrichBundle/Resources/views/Family/Tab/attribute.html.twig
+++ b/src/Pim/Bundle/EnrichBundle/Resources/views/Family/Tab/attribute.html.twig
@@ -1,10 +1,13 @@
-<div class="tab-pane tab-attribute {{ viewElement.loop.first ? 'active' : '' }}" id="{{ viewElement.alias|replace({' ': '-', '.': '-'})|lower }}">
+<div class="tabsection tab-pane tab-attribute {{ viewElement.loop.first ? 'active' : '' }}" id="{{ viewElement.alias|replace({' ': '-', '.': '-'})|lower }}">
     {% if elements is not defined %}
         {% import 'PimUIBundle:Default:page_elements.html.twig' as elements %}
     {% endif %}
-    <div class="tab-content">
-        <div id="attribute-buttons"></div>
-
+    <div class="tabsection-title">
+        <div class="pull-right">
+            <div id="attribute-buttons"></div>
+        </div>
+    </div>
+    <div class="tabsection-content tab-content">
         {% set columnWidth = 85/(channels|length) %}
 
         <table class="table groups">

--- a/src/Pim/Bundle/EnrichBundle/Resources/views/Family/Tab/history.html.twig
+++ b/src/Pim/Bundle/EnrichBundle/Resources/views/Family/Tab/history.html.twig
@@ -1,1 +1,1 @@
-<div class="tab-pane tab-history {{ viewElement.loop.first ? 'active' : '' }}" id="{{ viewElement.alias|replace({' ': '-', '.': '-'})|lower }}" data-url="{{ path('pim_enrich_family_history', {id: form.vars.value.id}) }}"></div>
+<div class="tabsection tab-pane tab-history {{ viewElement.loop.first ? 'active' : '' }}" id="{{ viewElement.alias|replace({' ': '-', '.': '-'})|lower }}" data-url="{{ path('pim_enrich_family_history', {id: form.vars.value.id}) }}"></div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/views/Family/Tab/property.html.twig
+++ b/src/Pim/Bundle/EnrichBundle/Resources/views/Family/Tab/property.html.twig
@@ -1,4 +1,4 @@
-<div class="tab-pane tab-property {{ viewElement.loop.first ? 'active' : '' }}" id="{{ viewElement.alias|replace({' ': '-', '.': '-'})|lower }}">
+<div class="tabsection tab-pane tab-property {{ viewElement.loop.first ? 'active' : '' }}" id="{{ viewElement.alias|replace({' ': '-', '.': '-'})|lower }}">
     {% set generalProperties %}
         {{ form_row(form.code) }}
         {{ form_row(form.attributeAsLabel) }}

--- a/src/Pim/Bundle/EnrichBundle/Resources/views/Family/Tab/property.html.twig
+++ b/src/Pim/Bundle/EnrichBundle/Resources/views/Family/Tab/property.html.twig
@@ -4,7 +4,7 @@
         {{ form_row(form.attributeAsLabel) }}
     {% endset %}
 
-    {{ elements.accordion({
+    {{ elements.tabSections({
         'pane.accordion.general_properties': generalProperties,
         'pane.accordion.locale_values': form_row(form.label)
     }) }}

--- a/src/Pim/Bundle/EnrichBundle/Resources/views/Family/edit.html.twig
+++ b/src/Pim/Bundle/EnrichBundle/Resources/views/Family/edit.html.twig
@@ -43,7 +43,7 @@
 
         {{ elements.form_navbar(view_element_aliases(form.vars.id ~ '.form_tab')) }}
 
-        <div class="tab-content">
+        <div class="tabsections tab-content">
 
             {{ elements.form_errors(form) }}
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/views/Group/Tab/property.html.twig
+++ b/src/Pim/Bundle/EnrichBundle/Resources/views/Group/Tab/property.html.twig
@@ -6,7 +6,7 @@
             {{ form_row(form.attributes) }}
         {% endif %}
     {% endset %}
-    {{ elements.accordion({
+    {{ elements.tabSections({
         'pane.accordion.general_properties': generalProperties,
         'pane.accordion.label_translations': form_row(form.label)
     }) }}

--- a/src/Pim/Bundle/EnrichBundle/Resources/views/GroupType/Tab/property.html.twig
+++ b/src/Pim/Bundle/EnrichBundle/Resources/views/GroupType/Tab/property.html.twig
@@ -1,5 +1,5 @@
 <div class="tab-pane tab-property {{ viewElement.loop.first ? 'active' : '' }}" id="{{ viewElement.alias|replace({' ': '-', '.': '-'})|lower }}">
-    {{ elements.accordion({
+    {{ elements.tabSections({
         'pane.accordion.general_properties': form_row(form.code),
         'pane.accordion.locale_values': form_row(form.label)
     }) }}

--- a/src/Pim/Bundle/EnrichBundle/Resources/views/JobExecution/show.html.twig
+++ b/src/Pim/Bundle/EnrichBundle/Resources/views/JobExecution/show.html.twig
@@ -24,7 +24,7 @@
     <div class="container-fluid grid-container">
         <img src="{{ asset('bundles/pimimportexport/images/loading.gif') }}" alt="{{ 'Loading ...'|trans }}" class="transparent loading" />
         {{ elements.link('Refresh', path(refresh_route, { 'id': execution.id }), { icon: 'refresh', class: 'transparent loading btn-mini' }) }}
-        <table class="table table-bordered groups" id="job-execution">
+        <table class="table grid job-execution" id="job-execution">
             <thead>
                 <th>{{ 'Step'|trans|upper }}</th>
                 <th>{{ 'Status'|trans|upper }}</th>
@@ -53,14 +53,16 @@
                 <td><%= stepExecution.label %></td>
                 <td><%= stepExecution.status %></td>
                 <td>
-                    <table class="table-striped table-bordered table-hover">
-                        <% _.each(stepExecution.summary, function (value, key) { %>
-                            <tr>
-                                <td><%= key %></td>
-                                <td><%= value %></td>
-                            </tr>
-                        <% }); %>
-                    </table>
+                    <% if (_.size(stepExecution.summary) > 0) { %>
+                        <table class="table-striped table-bordered table-vertically-condensed">
+                            <% _.each(stepExecution.summary, function (value, key) { %>
+                                <tr>
+                                    <td><%= key %></td>
+                                    <td><%= value %></td>
+                                </tr>
+                            <% }); %>
+                        </table>
+                    <% } %>
                 </td>
                 <td><%= stepExecution.startedAt %></td>
                 <td><%= stepExecution.endedAt %></td>
@@ -70,33 +72,35 @@
             <% _.each(stepExecution.warnings, function (warning) { %>
                 <tr class="warning">
                     <td colspan="5">
-                        <span class="title">{{ 'warning.label'|trans }}</span>&nbsp;
-                        <ul>
-                            <% _.each(warning.reason.split("\n"), function(warningItem) { %>
-                                <% if (warningItem) { %>
-                                    <li><%= warningItem %></li>
-                                <% } %>
-                            <% }) %>
-                        </ul>
-                        <a class="data" href="#"
-                            data-display-label="<%= showLabel %>"
-                            data-hide-label="<%= hideLabel %>">
-                            <%= showLabel %>
-                        </a>
-                        <table class="hide table-striped table-bordered table-hover">
-                            <% _.each(warning.item, function (value, key) { %>
-                                <tr>
-                                    <td><%= key %></td>
-                                    <td>
-                                        <% if (typeof value === 'object') { %>
-                                            <%= JSON.stringify(value) %>
-                                        <% } else { %>
-                                            <%= value %>
-                                        <% } %>
-                                    </td>
-                                </tr>
-                            <% }); %>
-                        </table>
+                        <div>
+                            <span class="title">{{ 'warning.label'|trans }}</span>&nbsp;
+                            <ul>
+                                <% _.each(warning.reason.split("\n"), function(warningItem) { %>
+                                    <% if (warningItem) { %>
+                                        <li><%= warningItem %></li>
+                                    <% } %>
+                                <% }) %>
+                            </ul>
+                            <a class="data" href="#"
+                                data-display-label="<%= showLabel %>"
+                                data-hide-label="<%= hideLabel %>">
+                                <%= showLabel %>
+                            </a>
+                            <table class="hide table-striped table-bordered table-vertically-condensed">
+                                <% _.each(warning.item, function (value, key) { %>
+                                    <tr>
+                                        <td><%= key %></td>
+                                        <td>
+                                            <% if (typeof value === 'object') { %>
+                                                <%= JSON.stringify(value) %>
+                                            <% } else { %>
+                                                <%= value %>
+                                            <% } %>
+                                        </td>
+                                    </tr>
+                                <% }); %>
+                            </table>
+                        </div>
                     </td>
                 </tr>
             <% }); %>
@@ -105,8 +109,10 @@
             <% _.each(stepExecution.failures, function (failure) { %>
                 <tr class="error">
                     <td colspan="5">
-                        <span class="title"><%= stepExecution.label.toUpperCase() %></span>&nbsp;
-                        <%= failure %>
+                        <div>
+                            <span class="title"><%= stepExecution.label.toUpperCase() %></span>&nbsp;
+                            <%= failure %>
+                        </div>
                     </td>
                 </tr>
             <% }); %>
@@ -116,8 +122,10 @@
         <% _.each(jobExecution.failures, function (failure) { %>
             <tr class="error">
                 <td colspan="5">
-                    <span class="title"><%= jobExecution.label.toUpperCase() %></span>&nbsp;
-                    <%= failure %>
+                    <div>
+                        <span class="title"><%= jobExecution.label.toUpperCase() %></span>&nbsp;
+                        <%= failure %>
+                    </div>
                 </td>
             </tr>
         <% }); %>

--- a/src/Pim/Bundle/ImportExportBundle/Resources/views/JobExecution/show.html.twig
+++ b/src/Pim/Bundle/ImportExportBundle/Resources/views/JobExecution/show.html.twig
@@ -26,7 +26,7 @@
     <div class="container-fluid grid-container">
         <img src="{{ asset('bundles/pimimportexport/images/loading.gif') }}" alt="{{ 'Loading ...'|trans }}" class="transparent loading" />
         {{ elements.link('Refresh', path(refresh_route, { 'id': execution.id }), { icon: 'refresh', class: 'transparent loading btn-mini' }) }}
-        <table class="table table-bordered groups" id="job-execution">
+        <table class="table grid job-execution" id="job-execution">
             <thead>
                 <th>{{ 'Step' | trans | upper }}</th>
                 <th>{{ 'Status' | trans | upper }}</th>
@@ -55,14 +55,16 @@
                 <td><%= stepExecution.label %></td>
                 <td><%= stepExecution.status %></td>
                 <td>
-                    <table class="table-striped table-bordered table-hover">
-                        <% _.each(stepExecution.summary, function (value, key) { %>
-                            <tr>
-                                <td><%= key %></td>
-                                <td><%= value %></td>
-                            </tr>
-                        <% }); %>
-                    </table>
+                    <% if (_.size(stepExecution.summary) > 0) { %>
+                        <table class="table-striped table-bordered table-vertically-condensed">
+                            <% _.each(stepExecution.summary, function (value, key) { %>
+                                <tr>
+                                    <td><%= key %></td>
+                                    <td><%= value %></td>
+                                </tr>
+                            <% }); %>
+                        </table>
+                    <% } %>
                 </td>
                 <td><%= stepExecution.startedAt %></td>
                 <td><%= stepExecution.endedAt %></td>
@@ -72,33 +74,35 @@
             <% _.each(stepExecution.warnings, function (warning) { %>
                 <tr class="warning">
                     <td colspan="5">
-                        <span class="title">{{ 'warning.label'|trans }}</span>&nbsp;
-                        <ul>
-                            <% _.each(warning.reason.split("\n"), function(warningItem) { %>
-                                <% if (warningItem) { %>
-                                    <li><%= warningItem %></li>
-                                <% } %>
-                            <% }) %>
-                        </ul>
-                        <a class="data" href="#"
-                            data-display-label="<%= showLabel %>"
-                            data-hide-label="<%= hideLabel %>">
-                            <%= showLabel %>
-                        </a>
-                        <table class="hide table-striped table-bordered table-hover">
-                            <% _.each(warning.item, function (value, key) { %>
-                                <tr>
-                                    <td><%= key %></td>
-                                    <td>
-                                        <% if (typeof value === 'object') { %>
-                                            <%= JSON.stringify(value) %>
-                                        <% } else { %>
-                                            <%= value %>
-                                        <% } %>
-                                    </td>
-                                </tr>
-                            <% }); %>
-                        </table>
+                        <div>
+                            <span class="title">{{ 'warning.label'|trans }}</span>&nbsp;
+                            <ul>
+                                <% _.each(warning.reason.split("\n"), function(warningItem) { %>
+                                    <% if (warningItem) { %>
+                                        <li><%= warningItem %></li>
+                                    <% } %>
+                                <% }) %>
+                            </ul>
+                            <a class="data" href="#"
+                                data-display-label="<%= showLabel %>"
+                                data-hide-label="<%= hideLabel %>">
+                                <%= showLabel %>
+                            </a>
+                            <table class="hide table-striped table-bordered table-vertically-condensed">
+                                <% _.each(warning.item, function (value, key) { %>
+                                    <tr>
+                                        <td><%= key %></td>
+                                        <td>
+                                            <% if (typeof value === 'object') { %>
+                                                <%= JSON.stringify(value) %>
+                                            <% } else { %>
+                                                <%= value %>
+                                            <% } %>
+                                        </td>
+                                    </tr>
+                                <% }); %>
+                            </table>
+                        </div>
                     </td>
                 </tr>
             <% }); %>
@@ -107,8 +111,10 @@
             <% _.each(stepExecution.failures, function (failure) { %>
                 <tr class="error">
                     <td colspan="5">
-                        <span class="title"><%= stepExecution.label.toUpperCase() %></span>&nbsp;
-                        <%= failure %>
+                        <div>
+                            <span class="title"><%= stepExecution.label.toUpperCase() %></span>&nbsp;
+                            <%= failure %>
+                        </div>
                     </td>
                 </tr>
             <% }); %>
@@ -118,8 +124,10 @@
         <% _.each(jobExecution.failures, function (failure) { %>
             <tr class="error">
                 <td colspan="5">
-                    <span class="title"><%= jobExecution.label.toUpperCase() %></span>&nbsp;
-                    <%= failure %>
+                    <div>
+                        <span class="title"><%= jobExecution.label.toUpperCase() %></span>&nbsp;
+                        <%= failure %>
+                    </div>
                 </td>
             </tr>
         <% }); %>

--- a/src/Pim/Bundle/ImportExportBundle/Resources/views/JobProfile/Tab/property_edit.html.twig
+++ b/src/Pim/Bundle/ImportExportBundle/Resources/views/JobProfile/Tab/property_edit.html.twig
@@ -3,7 +3,7 @@
         {{ form_row(form.code) }}
         {{ form_row(form.label) }}
     {% endset %}
-    {{ elements.accordion({ 'pane.accordion.properties': properties }, 1) }}
+    {{ elements.tabSections({ 'pane.accordion.properties': properties }, 1) }}
 
     {% set globalSettings %}
         {% for field in form.parameters %}
@@ -12,5 +12,5 @@
             {% endif %}
         {% endfor %}
     {% endset %}
-    {{ elements.accordion({ 'pane.accordion.global_settings': globalSettings }, 2) }}
+    {{ elements.tabSections({ 'pane.accordion.global_settings': globalSettings }, 2) }}
 </div>

--- a/src/Pim/Bundle/ImportExportBundle/Resources/views/JobProfile/Tab/property_show.html.twig
+++ b/src/Pim/Bundle/ImportExportBundle/Resources/views/JobProfile/Tab/property_show.html.twig
@@ -15,6 +15,6 @@
                 </tbody>
             </table>
         {% endset %}
-        {{ elements.accordion({ 'pane.accordion.global_settings': globalSettings }, 1, true) }}
+        {{ elements.tabSections({ 'pane.accordion.global_settings': globalSettings }, 1, true) }}
     {% endblock parameters %}
 </div>

--- a/src/Pim/Bundle/UIBundle/Resources/public/css/buttons.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/css/buttons.less
@@ -339,6 +339,10 @@
       background-color: darken(@white, 10%);
     }
   }
+
+  label {
+    font-weight: normal;
+  }
 }
 
 .tab-header.attribute-actions {

--- a/src/Pim/Bundle/UIBundle/Resources/public/css/form.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/css/form.less
@@ -113,10 +113,25 @@
     .tabsection-title {
       background-color: @akeneoGreyLighter;
       line-height: 44px;
+      height: 44px;
       padding: 0 20px;
 
       .add-attribute .select2-container {
         margin: 0 5px 5px;
+      }
+
+      #locale-switcher .btn.dropdown-toggle {
+        background: white;
+        height: 30px;
+        line-height: 30px;
+        margin-top: -4px;
+
+        & > i {
+          background: @akeneoGreySuperLight;
+          height: 30px;
+          width: 30px;
+          line-height: 30px;
+        }
       }
     }
 
@@ -505,7 +520,7 @@ table i {
       font-weight: bold;
       color: @black;
       text-shadow: none;
-      background-color: @akeneoPurpleLighter;
+      background-color: @akeneoPurpleSuperLight;
     }
     > li {
       padding-right: 15px;
@@ -524,7 +539,6 @@ table i {
   .tab-pane h3 {
     padding-left: 20px;
     margin-top: 0;
-    background-color: @color-grey_tab;
     border-bottom: 1px solid @grayLighter;
   }
 }

--- a/src/Pim/Bundle/UIBundle/Resources/public/css/form.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/css/form.less
@@ -111,16 +111,20 @@
     border: 1px solid @akeneoGreyLighter;
 
     .tabsection-title {
-      background-color: @akeneoGreyLighter;
-      line-height: 44px;
-      height: 44px;
-      padding: 0 20px;
+      &:not(:empty) {
+        height: 44px;
+        padding: 0 20px;
+        background-color: @akeneoGreyLighter;
+        line-height: 44px;
+      }
+
 
       .add-attribute .select2-container {
         margin: 0 5px 5px;
       }
 
-      #locale-switcher .btn.dropdown-toggle {
+      #locale-switcher .btn.dropdown-toggle,
+      #attribute-buttons button {
         background: white;
         height: 30px;
         line-height: 30px;
@@ -294,13 +298,6 @@ div.btn-group > .has-switch {
   display: block;
 }
 
-#attribute-buttons {
-  float: right;
-  margin: 10px;
-  position: relative;
-  top: 4px;
-  margin-top: 0;
-}
 #channel-switcher {
   .dropdown-toggle {
     border-right: 0;

--- a/src/Pim/Bundle/UIBundle/Resources/public/css/form.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/css/form.less
@@ -126,6 +126,28 @@
   }
 }
 
+.oro-tab-form {
+  & > .tab-pane {
+    border: 1px solid @akeneoGreyLighter;
+    padding-bottom: 10px;
+
+    .control-group {
+      margin-left: 20px;
+      margin-top: 15px;
+    }
+  }
+}
+
+.tabsections.scrollspy {
+  .control-group {
+    margin-bottom: 0;
+
+    label {
+      width: 200px;
+    }
+  }
+}
+
 a.accordion-toggle {
   color: @textColor;
   text-decoration: none;

--- a/src/Pim/Bundle/UIBundle/Resources/public/css/form.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/css/form.less
@@ -106,8 +106,24 @@
   background-color: @greenDark
 }
 
-.scrollspy-title {
-  background-color: @color-grey_tab;
+.tabsections {
+  .tabsection {
+    border: 1px solid @akeneoGreyLighter;
+
+    .tabsection-title {
+      background-color: @akeneoGreyLighter;
+      line-height: 44px;
+      padding: 0 20px;
+
+      .add-attribute .select2-container {
+        margin: 0 5px 5px;
+      }
+    }
+
+    .tabsection-content {
+      padding: 20px 20px 10px;
+    }
+  }
 }
 
 a.accordion-toggle {

--- a/src/Pim/Bundle/UIBundle/Resources/public/css/form.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/css/form.less
@@ -249,6 +249,10 @@ th label {
   }
 }
 
+.table-vertically-condensed > tbody > tr > td {
+  padding: 5px 10px;
+}
+
 .table-striped tbody>tr:nth-child(even)>td,
 .table-light tbody tr {
   background-color: @backgroundColor-white;

--- a/src/Pim/Bundle/UIBundle/Resources/public/css/less/oro.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/css/less/oro.less
@@ -163,7 +163,14 @@ label, input, button, select, textarea {
     .controls {
       margin-left: 0;
 
-      input[type="text"], textarea {
+      input[type="text"],
+      input[type="password"],
+      input[type="date"],
+      input[type="number"],
+      input[type="email"],
+      input[type="url"],
+      input[type="search"],
+      textarea {
         width: @max-field-width;
         font-size: @font-size-12;
       }
@@ -768,9 +775,6 @@ textarea {
   line-height: 18px;
   padding: 10px 20px;
 }
-.scrollspy-nav-target {
-  height: 20px;
-}
 .oro-clearfix-width:after,
 .oro-clearfix:after {
   content: "";
@@ -910,9 +914,6 @@ select {
 
 .responsive-section .inner-grid {
   margin:-20px -20px 20px -20px;
-}
-.layout-content .responsive-section {
-  padding: 0 0 35px;
 }
 .container-fluid > .responsive-section .scrollspy-title {
   margin-left:0;

--- a/src/Pim/Bundle/UIBundle/Resources/public/css/less/oro.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/css/less/oro.less
@@ -390,7 +390,7 @@ select {
   display: inline-block;
   vertical-align: top;
   padding: 0 5px;
-  line-height: 32px;
+  line-height: 26px;
 }
 .grid-toolbar {
   /* FE */
@@ -765,15 +765,8 @@ textarea {
   display: none;
 }
 .scrollspy-title {
-  border:1px solid @grayLighter;
-  border-width:1px 0;
-  margin: 0 0 0 -20px;
-  color:lighten(@bodyColor,20%);
-  font-size: @font-size-13;
-  font-weight:normal;
-  text-shadow:0 1px 0 @white;
-  line-height:18px;
-  padding: 10px;
+  line-height: 18px;
+  padding: 10px 20px;
 }
 .scrollspy-nav-target {
   height: 20px;

--- a/src/Pim/Bundle/UIBundle/Resources/public/css/less/variables.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/css/less/variables.less
@@ -62,6 +62,7 @@
 
 // Reds
 @red:        #d36050;
+@redLight:   lighten(@red, 10%); // #dd8579
 @redLighter: lighten(@red, 30%); // #f2cfca
 @redDark:    darken(@red, 10%);  // #c04230
 @redDarker:  darken(@red, 20%);  // #973426
@@ -80,6 +81,7 @@
 
 // Yellows
 @yellow:        #f8b43f;
+@yellowLight:   lighten(@yellow, 10%); // #fac770
 @yellowLighter: lighten(@yellow, 30%); // #fdeed3
 @yellowDark:    darken(@yellow, 10%);  // #f6a10e
 @yellowDarker:  darken(@yellow, 20%);  // #ca8207

--- a/src/Pim/Bundle/UIBundle/Resources/public/css/pim.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/css/pim.less
@@ -644,12 +644,13 @@ h3.tab-header {
       .flex();
 
       & > .tab-pane {
-        padding-top: 15px;
-        padding-right: 20px;
-        margin-left: 20px;
         box-sizing: border-box;
         display: block;
         overflow: auto;
+
+        &.object-values {
+          padding: 15px 20px;
+        }
       }
 
       & > .tab-pane.association-type {
@@ -1672,10 +1673,6 @@ h3.tab-header {
 
 [data-type="pim-filter-attribute-metric"] .filter-input,
 [data-type="pim-filter-attribute-price-collection"] .filter-input {
-  .operator {
-    width: 100px;
-  }
-
   .value {
     width: 80px;
   }
@@ -1700,9 +1697,24 @@ h3.tab-header {
 [data-type="pim-filter-attribute-string"] .filter-input,
 [data-type="pim-filter-attribute-media"] .filter-input,
 [data-type="pim-filter-attribute-number"] .filter-input,
-[data-type="pim-filter-attribute-date"] .filter-input {
+[data-type="pim-filter-attribute-date"] .filter-input,
+[data-type="pim-filter-attribute-metric"] .filter-input,
+[data-type="pim-filter-attribute-price-collection"] .filter-input {
+  @operator-width: 100px;
   .operator {
-    width: 100px;
+    width: @operator-width;
+  }
+
+  .operator ~ input[type="text"],
+  .operator ~ input[type="password"],
+  .operator ~ input[type="date"],
+  .operator ~ input[type="number"],
+  .operator ~ input[type="email"],
+  .operator ~ input[type="url"],
+  .operator ~ input[type="search"],
+  .operator ~ .start-date-wrapper input[type="text"],
+  .operator + select + .select2-container {
+    width: @max-field-width - @operator-width;
   }
 }
 

--- a/src/Pim/Bundle/UIBundle/Resources/public/css/pim.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/css/pim.less
@@ -54,6 +54,7 @@ a:focus {
   background-color: @akeneoLight;
   color: @akeneoDarkBlue;
 }
+
 table.grid {
   margin-bottom: 20px;
 }
@@ -176,9 +177,33 @@ a.back-link i {
   padding-left: 5px;
 }
 
-/** Dashboard ********************************************************************************************************/
-hr.small {
-    margin: 4px 0;
+table.job-execution {
+  tr.error > td, tr.warning > td {
+    background: none;
+    border-top: none;
+    padding: 0 20px 10px;
+
+    & > div {
+      .border-radius(4px);
+      padding: 10px;
+      border-width: 1px;
+      border-style: solid;
+    }
+  }
+
+  tr.error > td > div {
+    background: @redLighter;
+    border-color: @redLight;
+  }
+
+  tr.warning > td > div {
+    background: @yellowLighter;
+    border-color: @yellowLight;
+  }
+
+  table.table-vertically-condensed {
+    width: 100%;
+  }
 }
 
 /** widgets **********************************************************************************************************/

--- a/src/Pim/Bundle/UIBundle/Resources/public/css/signin.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/css/signin.less
@@ -97,6 +97,9 @@
   .remember-me, .signin-help {
     float:left;
     width: 50%;
+    font-weight: normal;
+    font-size: @font-size-13;
+    
     input[type="checkbox"] {
       width: auto;
     }

--- a/src/Pim/Bundle/UIBundle/Resources/public/css/style.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/css/style.less
@@ -1,8 +1,5 @@
 .system-configuration-container {
   padding-top: 10px;
-  .scrollspy-title {
-    margin-left: -18px;
-  }
   .nav.nav-tabs > .active > a,
   .nav.nav-tabs > .active > a:hover,
   .nav.nav-tabs > .active > a:focus {

--- a/src/Pim/Bundle/UIBundle/Resources/public/lib/bootstrap/css/bootstrap.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/lib/bootstrap/css/bootstrap.less
@@ -2091,7 +2091,7 @@ table {
 
 .table-striped tbody > tr:nth-child(odd) > td,
 .table-striped tbody > tr:nth-child(odd) > th {
-  background-color: #f9f9f9;
+  background-color: @akeneoLight;
 }
 
 .table-hover tbody tr:hover > td,

--- a/src/Pim/Bundle/UIBundle/Resources/views/Default/page_elements.html.twig
+++ b/src/Pim/Bundle/UIBundle/Resources/views/Default/page_elements.html.twig
@@ -162,9 +162,7 @@
         {% for title, content in items %}
             {% if content|trim is not empty %}
                 <div class="tabsection">
-                    <div class="tabsection-title">
-                        {{ title|trans }}
-                    </div>
+                    <div class="tabsection-title">{{ title|trans }}</div>
                     <div class="tabsection-content {{ no_buffer ? 'unbuffered' : '' }}">
                         {{ content|raw }}
                     </div>

--- a/src/Pim/Bundle/UIBundle/Resources/views/Default/page_elements.html.twig
+++ b/src/Pim/Bundle/UIBundle/Resources/views/Default/page_elements.html.twig
@@ -156,6 +156,24 @@
     {% endif %}
 {% endmacro %}
 
+{% macro tabSections(items = {}, counter = 1, no_buffer = false, name = null) %}
+    {% set name = name ? name ~ '-' : '' %}
+    <div class="tabsections">
+        {% for title, content in items %}
+            {% if content|trim is not empty %}
+                <div class="tabsection">
+                    <div class="tabsection-title">
+                        {{ title|trans }}
+                    </div>
+                    <div class="tabsection-content {{ no_buffer ? 'unbuffered' : '' }}">
+                        {{ content|raw }}
+                    </div>
+                </div>
+            {% endif %}
+        {% endfor %}
+    </div>
+{% endmacro %}
+
 {% macro accordion(items = {}, counter = 1, no_buffer = false, name = null) %}
     {% set name = name ? name ~ '-' : '' %}
     <div class="accordion">

--- a/src/Pim/Bundle/UserBundle/Resources/views/Role/update.html.twig
+++ b/src/Pim/Bundle/UserBundle/Resources/views/Role/update.html.twig
@@ -100,7 +100,7 @@
 
         {{ elements.form_navbar(tabs, '') }}
 
-        <div class="row-fluid tab-content">
+        <div class="row-fluid tab-content oro-tab-form">
 
             {{ elements.form_errors(form) }}
 

--- a/src/Pim/Bundle/UserBundle/Resources/views/Role/update.html.twig
+++ b/src/Pim/Bundle/UserBundle/Resources/views/Role/update.html.twig
@@ -104,7 +104,7 @@
 
             {{ elements.form_errors(form) }}
 
-            <div class="tab-pane active buffer-top" id="general">
+            <div class="tab-pane active" id="general">
                 {{ form_row(form.label) }}
                 {% if form.owner is defined %}
                     {{ form_row(form.owner, {attr : { class: 'hide' }}) }}

--- a/src/Pim/Bundle/UserBundle/Resources/views/User/update.html.twig
+++ b/src/Pim/Bundle/UserBundle/Resources/views/User/update.html.twig
@@ -99,7 +99,7 @@
 
         {{ elements.form_navbar(view_element_aliases(form.vars.id ~ '.form_tab')) }}
 
-        <div class="row-fluid tab-content buffer-top">
+        <div class="row-fluid tab-content oro-tab-form">
             {{ elements.form_errors(form) }}
 
             {{ view_elements(form.vars.id ~ '.form_tab') }}


### PR DESCRIPTION
This PR

- removes accordions from tabs
- unify design with the "old" oro forms (Role + User forms)
- Change job-profile design

![screenshot from 2016-08-08 14 15 37](https://cloud.githubusercontent.com/assets/1590933/17479392/a4652654-5d72-11e6-814d-fb11d34ffed4.png)

![screenshot from 2016-08-08 14 14 17](https://cloud.githubusercontent.com/assets/1590933/17479370/8aef7076-5d72-11e6-95cb-314545c22c62.png)


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | n
| Added Behats                      | n
| Changelog updated                 | n
| Review and 2 GTM                  | TODO
| Micro Demo to the PO (Story only) |  n
| Migration script                  | n
| Tech Doc                          | n
