### PR TITLE
Dispatch POST_SAVE event only after flush

### DIFF
--- a/src/Akeneo/Bundle/StorageUtilsBundle/Doctrine/Common/Saver/BaseSaver.php
+++ b/src/Akeneo/Bundle/StorageUtilsBundle/Doctrine/Common/Saver/BaseSaver.php
@@ -66,15 +66,16 @@ class BaseSaver implements SaverInterface, BulkSaverInterface
         }
 
         $options = $this->optionsResolver->resolveSaveOptions($options);
+
         $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE, new GenericEvent($object, $options));
 
         $this->objectManager->persist($object);
 
         if (true === $options['flush']) {
             $this->objectManager->flush();
-        }
 
-        $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE, new GenericEvent($object, $options));
+            $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE, new GenericEvent($object, $options));
+        }
     }
 
     /**
@@ -96,8 +97,11 @@ class BaseSaver implements SaverInterface, BulkSaverInterface
             $this->save($object, $itemOptions);
         }
 
-        if (true === $allOptions['flush']) {
-            $this->objectManager->flush();
+        $this->objectManager->flush();
+
+        foreach ($objects as $object) {
+            $itemOptions = $this->optionsResolver->resolveSaveOptions($allOptions);
+            $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE, new GenericEvent($object, $itemOptions));
         }
 
         $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE_ALL, new GenericEvent($objects, $allOptions));

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/AttributeSaver.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/AttributeSaver.php
@@ -59,16 +59,17 @@ class AttributeSaver implements SaverInterface, BulkSaverInterface
             );
         }
 
+        $options = $this->optionsResolver->resolveSaveOptions($options);
+
         $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE, new GenericEvent($attribute));
 
-        $options = $this->optionsResolver->resolveSaveOptions($options);
         $this->objectManager->persist($attribute);
 
         if (true === $options['flush']) {
             $this->objectManager->flush();
-        }
 
-        $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE, new GenericEvent($attribute));
+            $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE, new GenericEvent($attribute));
+        }
     }
 
     /**
@@ -90,8 +91,10 @@ class AttributeSaver implements SaverInterface, BulkSaverInterface
             $this->save($attribute, $itemOptions);
         }
 
-        if (true === $allOptions['flush']) {
-            $this->objectManager->flush();
+        $this->objectManager->flush();
+
+        foreach ($attributes as $attribute) {
+            $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE, new GenericEvent($attribute));
         }
 
         $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE_ALL, new GenericEvent($attributes));

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/GroupSaver.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/GroupSaver.php
@@ -132,7 +132,9 @@ class GroupSaver implements SaverInterface, BulkSaverInterface
 
         $this->versionContext->unsetContextInfo($context);
 
-        $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE, new GenericEvent($group));
+        if (true === $options['flush']) {
+            $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE, new GenericEvent($group));
+        }
     }
 
     /**
@@ -154,8 +156,10 @@ class GroupSaver implements SaverInterface, BulkSaverInterface
             $this->save($group, $itemOptions);
         }
 
-        if (true === $allOptions['flush']) {
-            $this->objectManager->flush();
+        $this->objectManager->flush();
+
+        foreach ($groups as $group) {
+            $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE, new GenericEvent($group));
         }
 
         $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE_ALL, new GenericEvent($groups));

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/ProductSaver.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/ProductSaver.php
@@ -67,6 +67,7 @@ class ProductSaver implements SaverInterface, BulkSaverInterface
         }
 
         $options = $this->optionsResolver->resolveSaveOptions($options);
+
         $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE, new GenericEvent($product, $options));
 
         $this->completenessManager->schedule($product);
@@ -75,9 +76,9 @@ class ProductSaver implements SaverInterface, BulkSaverInterface
         if (true === $options['flush']) {
             $this->objectManager->flush();
             $this->completenessManager->generateMissingForProduct($product);
-        }
 
-        $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE, new GenericEvent($product, $options));
+            $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE, new GenericEvent($product, $options));
+        }
     }
 
     /**
@@ -89,10 +90,10 @@ class ProductSaver implements SaverInterface, BulkSaverInterface
             return;
         }
 
-        $options = $this->optionsResolver->resolveSaveAllOptions($options);
+        $allOptions = $this->optionsResolver->resolveSaveAllOptions($options);
         $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE_ALL, new GenericEvent($products, $options));
 
-        $itemOptions = $options;
+        $itemOptions = $allOptions;
         $itemOptions['flush'] = false;
 
         foreach ($products as $product) {
@@ -103,8 +104,11 @@ class ProductSaver implements SaverInterface, BulkSaverInterface
 
         foreach ($products as $product) {
             $this->completenessManager->generateMissingForProduct($product);
+
+            $productOptions = $this->optionsResolver->resolveSaveOptions($allOptions);
+            $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE, new GenericEvent($product, $productOptions));
         }
 
-        $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE_ALL, new GenericEvent($products, $options));
+        $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE_ALL, new GenericEvent($products, $allOptions));
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Saver/ProductSaver.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Saver/ProductSaver.php
@@ -105,6 +105,8 @@ class ProductSaver extends BaseProductSaver
             } else {
                 $productsToUpdate[] = $product;
             }
+
+            $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE, new GenericEvent($product, $options));
         }
 
         $insertDocs = $this->getDocsFromProducts($productsToInsert);
@@ -120,6 +122,8 @@ class ProductSaver extends BaseProductSaver
 
         foreach ($products as $product) {
             $this->completenessManager->generateMissingForProduct($product);
+
+            $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE, new GenericEvent($product, $options));
         }
 
         $versions = $this->bulkVersionBuilder->buildVersions($products);


### PR DESCRIPTION
Hello @nidup 

As promised I worked on Saver classes to dispatch POST_SAVE event only after flushing the entities into the database. 
I'm not sure if this is how you expected to be but please let me know if you think I could refactor more. 
I would like to remove the "flush" option for good, but I don't know if that's ok with you. Also I think I could remove also the "schedule" option if we remove the "flush".  
For now I just added the POST_SAVE event to be dispatched after flush so we could have the correct  versioning change set when the event is raised.
If this is fine with you maybe you could merge it and I could refactor further and remove the flush option into another PR. 
I saw you have a new "akeneo_storage_utils.saver.base_options_resolver". I would like to use it for all the savers, but remove the flush option from it too.
Let me know what you think.

Regards,

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       |
| Added Behats                      |
| Changelog updated                 |
| Review and 2 GTM                  |
| Micro Demo to the PO (Story only) |
| Migration script                  |
| Tech Doc                          |

