### PR TITLE
TIP-539: allow the batches to have a working directory

### DIFF
--- a/features/Pim/Behat/Context/Domain/Spread/ExportProfilesContext.php
+++ b/features/Pim/Behat/Context/Domain/Spread/ExportProfilesContext.php
@@ -154,7 +154,7 @@ class ExportProfilesContext extends ImportExportContext
     public function exportDirectoryOfShouldContainTheFollowingMedia($code, TableNode $table)
     {
         $jobInstance = $this->getFixturesContext()->getJobInstance($code);
-        $path = $this->getMediaWorkingDirectory($jobInstance, $code, $jobInstance->getRawParameters()['filePath']);
+        $path = dirname($jobInstance->getRawParameters()['filePath']);
 
         $this->checkExportDirectoryFiles(true, $table, $path);
     }
@@ -170,7 +170,7 @@ class ExportProfilesContext extends ImportExportContext
     public function exportDirectoryOfShouldNotContainTheFollowingMedia($code, TableNode $table)
     {
         $jobInstance = $this->getFixturesContext()->getJobInstance($code);
-        $path = $this->getMediaWorkingDirectory($jobInstance, $code, $jobInstance->getRawParameters()['filePath']);
+        $path = dirname($jobInstance->getRawParameters()['filePath']);
 
         $this->checkExportDirectoryFiles(false, $table, $path);
     }
@@ -187,12 +187,6 @@ class ExportProfilesContext extends ImportExportContext
         if ($shouldBeInDirectory && !is_dir($path)) {
             throw $this->getMainContext()->createExpectationException(
                 sprintf('Directory "%s" doesn\'t exist', $path)
-            );
-        }
-
-        if (!$shouldBeInDirectory && is_dir($path)) {
-            throw $this->getMainContext()->createExpectationException(
-                sprintf('Directory "%s" exists, but it should not', $path)
             );
         }
 
@@ -230,25 +224,5 @@ class ExportProfilesContext extends ImportExportContext
         }
 
         return $filePath;
-    }
-
-    /**
-     * Build path of the working directory to import media in a specific directory.
-     * Will be extracted with TIP-539
-     *
-     * @param JobInstance $jobInstance
-     * @param string      $code
-     * @param string      $filePath
-     *
-     * @return string
-     */
-    protected function getMediaWorkingDirectory(JobInstance $jobInstance, $code, $filePath)
-    {
-        return dirname($filePath)
-               . DIRECTORY_SEPARATOR
-               . $code
-               . DIRECTORY_SEPARATOR
-               . $jobInstance->getJobExecutions()->first()->getId()
-               . DIRECTORY_SEPARATOR;
     }
 }

--- a/src/Akeneo/Component/Batch/Job/Job.php
+++ b/src/Akeneo/Component/Batch/Job/Job.php
@@ -4,11 +4,14 @@ namespace Akeneo\Component\Batch\Job;
 
 use Akeneo\Component\Batch\Event\EventInterface;
 use Akeneo\Component\Batch\Event\JobExecutionEvent;
+use Akeneo\Component\Batch\Item\ExecutionContext;
 use Akeneo\Component\Batch\Model\JobExecution;
 use Akeneo\Component\Batch\Model\StepExecution;
 use Akeneo\Component\Batch\Step\StepInterface;
 use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Filesystem\Exception\IOException;
+use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * Implementation of the {@link Job} interface.
@@ -33,6 +36,9 @@ class Job implements JobInterface
     /** @var array */
     protected $steps;
 
+    /** @var Filesystem */
+    protected $filesystem;
+
     /**
      * @param string                   $name
      * @param EventDispatcherInterface $eventDispatcher
@@ -49,6 +55,7 @@ class Job implements JobInterface
         $this->eventDispatcher = $eventDispatcher;
         $this->jobRepository = $jobRepository;
         $this->steps = $steps;
+        $this->filesystem = new Filesystem();
     }
 
     /**
@@ -133,10 +140,17 @@ class Job implements JobInterface
      * @param JobExecution $jobExecution
      *
      * @see Job#execute(JobExecution)
+     *
+     * A unique working directory is created before the execution of the job. It is deleted when the job is terminated.
+     * The working directory is created in the temporary filesystem. Its pathname is placed in the JobExecutionContext
+     * via the key {@link \Akeneo\Component\Batch\Job\JobInterface::WORKING_DIRECTORY_PARAMETER}
      */
     final public function execute(JobExecution $jobExecution)
     {
         try {
+            $workingDirectory = $this->createWorkingDirectory();
+            $jobExecution->getExecutionContext()->put(JobInterface::WORKING_DIRECTORY_PARAMETER, $workingDirectory);
+
             $this->dispatchJobExecutionEvent(EventInterface::BEFORE_JOB_EXECUTION, $jobExecution);
 
             if ($jobExecution->getStatus()->getValue() !== BatchStatus::STOPPING) {
@@ -169,7 +183,6 @@ class Job implements JobInterface
 
             $jobExecution->setEndTime(new \DateTime());
             $this->jobRepository->updateJobExecution($jobExecution);
-
         } catch (JobInterruptedException $e) {
             $jobExecution->setExitStatus($this->getDefaultExitStatusForFailure($e));
             $jobExecution->setStatus(
@@ -188,6 +201,11 @@ class Job implements JobInterface
             $this->jobRepository->updateJobExecution($jobExecution);
 
             $this->dispatchJobExecutionEvent(EventInterface::JOB_EXECUTION_FATAL_ERROR, $jobExecution);
+        } finally {
+            $workingDirectory = $jobExecution->getExecutionContext()->get(JobInterface::WORKING_DIRECTORY_PARAMETER);
+            if (null !== $workingDirectory) {
+                $this->deleteWorkingDirectory($workingDirectory);
+            }
         }
     }
 
@@ -316,5 +334,39 @@ class Job implements JobInterface
     private function updateStatus(JobExecution $jobExecution, $status)
     {
         $jobExecution->setStatus(new BatchStatus($status));
+    }
+
+    /**
+     * Create a unique working directory
+     *
+     * @return string the working directory path
+     */
+    private function createWorkingDirectory()
+    {
+        $path = sys_get_temp_dir() . DIRECTORY_SEPARATOR . uniqid('akeneo_batch_') . DIRECTORY_SEPARATOR;
+        try {
+            $this->filesystem->mkdir($path);
+        } catch (IOException $e) {
+            // this exception will be catched by {Job->execute()} and will set the batch as failed
+            throw new RuntimeErrorException(
+                sprintf('Unable to create the working directory "%s".', $path),
+                $e->getCode(),
+                $e
+            );
+        }
+
+        return $path;
+    }
+
+    /**
+     * Delete the working directory
+     *
+     * @param string $directory
+     */
+    private function deleteWorkingDirectory($directory)
+    {
+        if ($this->filesystem->exists($directory)) {
+            $this->filesystem->remove($directory);
+        }
     }
 }

--- a/src/Akeneo/Component/Batch/Job/JobInterface.php
+++ b/src/Akeneo/Component/Batch/Job/JobInterface.php
@@ -16,6 +16,8 @@ use Akeneo\Component\Batch\Model\JobExecution;
  */
 interface JobInterface
 {
+    const WORKING_DIRECTORY_PARAMETER = 'working_directory';
+
     /**
      * @return string the name of this job
      */

--- a/src/Pim/Bundle/EnrichBundle/Connector/Processor/QuickExport/ProductProcessor.php
+++ b/src/Pim/Bundle/EnrichBundle/Connector/Processor/QuickExport/ProductProcessor.php
@@ -3,6 +3,7 @@
 namespace Pim\Bundle\EnrichBundle\Connector\Processor\QuickExport;
 
 use Akeneo\Component\Batch\Item\DataInvalidItem;
+use Akeneo\Component\Batch\Job\JobInterface;
 use Akeneo\Component\Batch\Job\JobParameters;
 use Akeneo\Component\Batch\Model\StepExecution;
 use Akeneo\Component\StorageUtils\Detacher\ObjectDetacherInterface;
@@ -100,7 +101,9 @@ class ProductProcessor extends AbstractProcessor
         }
 
         if ($parameters->has('with_media') && $parameters->get('with_media')) {
-            $directory = $this->getWorkingDirectory($parameters->get('filePath'));
+            $directory = $this->stepExecution->getJobExecution()->getExecutionContext()
+                ->get(JobInterface::WORKING_DIRECTORY_PARAMETER);
+
             $this->fetchMedia($product, $directory);
         }
 
@@ -215,25 +218,5 @@ class ProductProcessor extends AbstractProcessor
 
         $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
         $this->tokenStorage->setToken($token);
-    }
-
-    /**
-     * Build path of the working directory to import media in a specific directory.
-     * Will be extracted with TIP-539
-     *
-     * @param string $filePath
-     *
-     * @return string
-     */
-    protected function getWorkingDirectory($filePath)
-    {
-        $jobExecution = $this->stepExecution->getJobExecution();
-
-        return dirname($filePath)
-               . DIRECTORY_SEPARATOR
-               . $jobExecution->getJobInstance()->getCode()
-               . DIRECTORY_SEPARATOR
-               . $jobExecution->getId()
-               . DIRECTORY_SEPARATOR;
     }
 }

--- a/src/Pim/Component/Connector/Processor/Normalization/ProductProcessor.php
+++ b/src/Pim/Component/Connector/Processor/Normalization/ProductProcessor.php
@@ -4,6 +4,7 @@ namespace Pim\Component\Connector\Processor\Normalization;
 
 use Akeneo\Component\Batch\Item\DataInvalidItem;
 use Akeneo\Component\Batch\Item\ItemProcessorInterface;
+use Akeneo\Component\Batch\Job\JobInterface;
 use Akeneo\Component\Batch\Job\JobParameters;
 use Akeneo\Component\Batch\Model\StepExecution;
 use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
@@ -93,7 +94,9 @@ class ProductProcessor implements ItemProcessorInterface, StepExecutionAwareInte
         }
 
         if ($parameters->has('with_media') && $parameters->get('with_media')) {
-            $directory = $this->getWorkingDirectory($parameters->get('filePath'));
+            $directory = $this->stepExecution->getJobExecution()->getExecutionContext()
+                ->get(JobInterface::WORKING_DIRECTORY_PARAMETER);
+
             $this->fetchMedia($product, $directory);
         }
 
@@ -175,25 +178,5 @@ class ProductProcessor implements ItemProcessorInterface, StepExecutionAwareInte
     {
         return isset($parameters->get('filters')['structure']['attributes'])
             && !empty($parameters->get('filters')['structure']['attributes']);
-    }
-
-    /**
-     * Build path of the working directory to import media in a specific directory.
-     * Will be extracted with TIP-539
-     *
-     * @param string $filePath
-     *
-     * @return string
-     */
-    protected function getWorkingDirectory($filePath)
-    {
-        $jobExecution = $this->stepExecution->getJobExecution();
-
-        return dirname($filePath)
-            . DIRECTORY_SEPARATOR
-            . $jobExecution->getJobInstance()->getCode()
-            . DIRECTORY_SEPARATOR
-            . $jobExecution->getId()
-            . DIRECTORY_SEPARATOR;
     }
 }

--- a/src/Pim/Component/Connector/Processor/Normalization/VariantGroupProcessor.php
+++ b/src/Pim/Component/Connector/Processor/Normalization/VariantGroupProcessor.php
@@ -4,6 +4,7 @@ namespace Pim\Component\Connector\Processor\Normalization;
 
 use Akeneo\Component\Batch\Item\DataInvalidItem;
 use Akeneo\Component\Batch\Item\ItemProcessorInterface;
+use Akeneo\Component\Batch\Job\JobInterface;
 use Akeneo\Component\Batch\Job\JobParameters;
 use Akeneo\Component\Batch\Model\StepExecution;
 use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
@@ -70,7 +71,9 @@ class VariantGroupProcessor implements ItemProcessorInterface, StepExecutionAwar
         $parameters = $this->stepExecution->getJobParameters();
 
         if ($parameters->has('with_media') && $parameters->get('with_media')) {
-            $directory = $this->getWorkingDirectory($parameters->get('filePath'));
+            $directory = $this->stepExecution->getJobExecution()->getExecutionContext()
+                ->get(JobInterface::WORKING_DIRECTORY_PARAMETER);
+
             $this->fetchMedia($variantGroup, $directory);
         }
 
@@ -107,25 +110,5 @@ class VariantGroupProcessor implements ItemProcessorInterface, StepExecutionAwar
         foreach ($this->mediaFetcher->getErrors() as $error) {
             $this->stepExecution->addWarning($error['message'], [], new DataInvalidItem($error['media']));
         }
-    }
-
-    /**
-     * Build path of the working directory to import media in a specific directory.
-     * Will be extracted with TIP-539
-     *
-     * @param string $filePath
-     *
-     * @return string
-     */
-    protected function getWorkingDirectory($filePath)
-    {
-        $jobExecution = $this->stepExecution->getJobExecution();
-
-        return dirname($filePath)
-            . DIRECTORY_SEPARATOR
-            . $jobExecution->getJobInstance()->getCode()
-            . DIRECTORY_SEPARATOR
-            . $jobExecution->getId()
-            . DIRECTORY_SEPARATOR;
     }
 }

--- a/src/Pim/Component/Connector/Writer/File/AbstractItemMediaWriter.php
+++ b/src/Pim/Component/Connector/Writer/File/AbstractItemMediaWriter.php
@@ -5,6 +5,7 @@ namespace Pim\Component\Connector\Writer\File;
 use Akeneo\Component\Batch\Item\FlushableInterface;
 use Akeneo\Component\Batch\Item\InitializableInterface;
 use Akeneo\Component\Batch\Item\ItemWriterInterface;
+use Akeneo\Component\Batch\Job\JobInterface;
 use Akeneo\Component\Batch\Job\JobParameters;
 use Akeneo\Component\Batch\Model\StepExecution;
 use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
@@ -105,9 +106,11 @@ abstract class AbstractItemMediaWriter implements
         $converterOptions = $this->getConverterOptions($parameters);
 
         $flatItems = [];
+        $directory = $this->stepExecution->getJobExecution()->getExecutionContext()
+            ->get(JobInterface::WORKING_DIRECTORY_PARAMETER);
+
         foreach ($items as $item) {
             if ($parameters->has('with_media') && $parameters->get('with_media')) {
-                $directory = $this->getWorkingDirectory($parameters->get('filePath'));
                 $item = $this->resolveMediaPaths($item, $directory);
             }
 
@@ -281,25 +284,5 @@ abstract class AbstractItemMediaWriter implements
         }
 
         return $options;
-    }
-
-    /**
-     * Build path of the working directory to import media in a specific directory.
-     * Will be extracted with TIP-539
-     *
-     * @param string $filePath
-     *
-     * @return string
-     */
-    protected function getWorkingDirectory($filePath)
-    {
-        $jobExecution = $this->stepExecution->getJobExecution();
-
-        return dirname($filePath)
-               . DIRECTORY_SEPARATOR
-               . $jobExecution->getJobInstance()->getCode()
-               . DIRECTORY_SEPARATOR
-               . $jobExecution->getId()
-               . DIRECTORY_SEPARATOR;
     }
 }

--- a/src/Pim/Component/Connector/Writer/File/AbstractItemMediaWriter.php
+++ b/src/Pim/Component/Connector/Writer/File/AbstractItemMediaWriter.php
@@ -141,6 +141,8 @@ abstract class AbstractItemMediaWriter implements
         foreach ($writtenFiles as $writtenFile) {
             $this->writtenFiles[$writtenFile] = basename($writtenFile);
         }
+
+        $this->exportMedias();
     }
 
     /**
@@ -284,5 +286,31 @@ abstract class AbstractItemMediaWriter implements
         }
 
         return $options;
+    }
+
+    /**
+     * Export medias from the working directory to the output expected directory.
+     *
+     * Basically, we first remove the content of /path/where/my/user/expects/the/export/files/.
+     * (This path can exist of an export was launched previously)
+     *
+     * Then we copy /path/of/the/working/directory/files/ to /path/where/my/user/expects/the/export/files/.
+     */
+    protected function exportMedias()
+    {
+        $outputDirectory = dirname($this->getPath());
+        $workingDirectory = $this->stepExecution->getJobExecution()->getExecutionContext()
+            ->get(JobInterface::WORKING_DIRECTORY_PARAMETER);
+
+        $outputFilesDirectory = $outputDirectory . DIRECTORY_SEPARATOR . 'files';
+        $workingFilesDirectory = $workingDirectory . 'files';
+
+        if ($this->localFs->exists($outputFilesDirectory)) {
+            $this->localFs->remove($outputFilesDirectory);
+        }
+
+        if ($this->localFs->exists($workingFilesDirectory)) {
+            $this->localFs->mirror($workingFilesDirectory, $outputFilesDirectory);
+        }
     }
 }

--- a/src/Pim/Component/Connector/spec/Processor/Normalization/ProductProcessorSpec.php
+++ b/src/Pim/Component/Connector/spec/Processor/Normalization/ProductProcessorSpec.php
@@ -3,6 +3,8 @@
 namespace spec\Pim\Component\Connector\Processor\Normalization;
 
 use Akeneo\Component\Batch\Item\DataInvalidItem;
+use Akeneo\Component\Batch\Item\ExecutionContext;
+use Akeneo\Component\Batch\Job\JobInterface;
 use Akeneo\Component\Batch\Job\JobParameters;
 use Akeneo\Component\Batch\Model\JobExecution;
 use Akeneo\Component\Batch\Model\JobInstance;
@@ -122,7 +124,8 @@ class ProductProcessorSpec extends ObjectBehavior
         JobExecution $jobExecution,
         JobInstance $jobInstance,
         ProductValueInterface $identifier,
-        ArrayCollection $valuesCollection
+        ArrayCollection $valuesCollection,
+        ExecutionContext $executionContext
     ) {
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $jobParameters->get('filePath')->willReturn('/my/path/product.csv');
@@ -148,7 +151,9 @@ class ProductProcessorSpec extends ObjectBehavior
         $jobExecution->getJobInstance()->willReturn($jobInstance);
         $jobExecution->getId()->willReturn(100);
         $jobInstance->getCode()->willReturn('csv_product_export');
-        $directory = '/my/path/csv_product_export/100/';
+
+        $jobExecution->getExecutionContext()->willReturn($executionContext);
+        $executionContext->get(JobInterface::WORKING_DIRECTORY_PARAMETER)->willReturn('/working/directory/');
 
         $productStandard = [
             'values' => [
@@ -168,7 +173,7 @@ class ProductProcessorSpec extends ObjectBehavior
         $normalizer->normalize($product, 'json', ['channels' => ['foobar'], 'locales' => ['en_US']])
             ->willReturn($productStandard);
 
-        $mediaFetcher->fetchAll($valuesCollection, $directory, 'AKIS_XS')->shouldBeCalled();
+        $mediaFetcher->fetchAll($valuesCollection, '/working/directory/', 'AKIS_XS')->shouldBeCalled();
         $mediaFetcher->getErrors()->willReturn([]);
 
         $this->process($product)->shouldReturn($productStandard);
@@ -190,7 +195,8 @@ class ProductProcessorSpec extends ObjectBehavior
         JobExecution $jobExecution,
         JobInstance $jobInstance,
         ProductValueInterface $identifier,
-        ArrayCollection $valuesCollection
+        ArrayCollection $valuesCollection,
+        ExecutionContext $executionContext
     ) {
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $jobParameters->get('filePath')->willReturn('/my/path/product.csv');
@@ -216,7 +222,9 @@ class ProductProcessorSpec extends ObjectBehavior
         $jobExecution->getJobInstance()->willReturn($jobInstance);
         $jobExecution->getId()->willReturn(100);
         $jobInstance->getCode()->willReturn('csv_product_export');
-        $directory = '/my/path/csv_product_export/100/';
+
+        $jobExecution->getExecutionContext()->willReturn($executionContext);
+        $executionContext->get(JobInterface::WORKING_DIRECTORY_PARAMETER)->willReturn('/working/directory/');
 
         $productStandard = [
             'values' => [
@@ -231,7 +239,7 @@ class ProductProcessorSpec extends ObjectBehavior
         $normalizer->normalize($product, 'json', ['channels' => ['foobar'], 'locales' => ['en_US']])
             ->willReturn($productStandard);
 
-        $mediaFetcher->fetchAll($valuesCollection, $directory, 'AKIS_XS')->shouldBeCalled();
+        $mediaFetcher->fetchAll($valuesCollection, '/working/directory/', 'AKIS_XS')->shouldBeCalled();
         $mediaFetcher->getErrors()->willReturn(
             [
                 [

--- a/src/Pim/Component/Connector/spec/Processor/Normalization/VariantGroupProcessorSpec.php
+++ b/src/Pim/Component/Connector/spec/Processor/Normalization/VariantGroupProcessorSpec.php
@@ -3,6 +3,8 @@
 namespace spec\Pim\Component\Connector\Processor\Normalization;
 
 use Akeneo\Component\Batch\Item\DataInvalidItem;
+use Akeneo\Component\Batch\Item\ExecutionContext;
+use Akeneo\Component\Batch\Job\JobInterface;
 use Akeneo\Component\Batch\Job\JobParameters;
 use Akeneo\Component\Batch\Model\JobExecution;
 use Akeneo\Component\Batch\Model\JobInstance;
@@ -103,7 +105,8 @@ class VariantGroupProcessorSpec extends ObjectBehavior
         ProductValueInterface $productValue,
         JobParameters $jobParameters,
         JobExecution $jobExecution,
-        JobInstance $jobInstance
+        JobInstance $jobInstance,
+        ExecutionContext $executionContext
     ) {
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $jobParameters->get('filePath')->willReturn('my/path/variant_group.csv');
@@ -119,7 +122,9 @@ class VariantGroupProcessorSpec extends ObjectBehavior
         $jobExecution->getJobInstance()->willReturn($jobInstance);
         $jobExecution->getId()->willReturn(100);
         $jobInstance->getCode()->willReturn('csv_variant_group_export');
-        $directory = 'my/path/csv_variant_group_export/100/';
+
+        $jobExecution->getExecutionContext()->willReturn($executionContext);
+        $executionContext->get(JobInterface::WORKING_DIRECTORY_PARAMETER)->willReturn('/working/directory/');
 
         $variantStandard = [
             'code' => 'my_variant_group',
@@ -145,7 +150,7 @@ class VariantGroupProcessorSpec extends ObjectBehavior
 
         $productTemplate->getValuesData()->willReturn($variantStandard['values']);
         $productTemplate->getValues()->willReturn($emptyCollection);
-        $mediaFetcher->fetchAll($emptyCollection, $directory, 'my_variant_group')->shouldBeCalled();
+        $mediaFetcher->fetchAll($emptyCollection, '/working/directory/', 'my_variant_group')->shouldBeCalled();
         $mediaFetcher->getErrors()->willReturn([]);
 
         $variantGroupUpdater->update($variantGroup, ['values' => $variantStandard['values']])->shouldBeCalled();
@@ -170,7 +175,8 @@ class VariantGroupProcessorSpec extends ObjectBehavior
         ProductValueInterface $productValue2,
         JobParameters $jobParameters,
         JobExecution $jobExecution,
-        JobInstance $jobInstance
+        JobInstance $jobInstance,
+        ExecutionContext $executionContext
     ) {
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $jobParameters->get('filePath')->willReturn('my/path/variant_group.csv');
@@ -188,7 +194,9 @@ class VariantGroupProcessorSpec extends ObjectBehavior
         $jobExecution->getJobInstance()->willReturn($jobInstance);
         $jobExecution->getId()->willReturn(100);
         $jobInstance->getCode()->willReturn('csv_variant_group_export');
-        $directory = 'my/path/csv_variant_group_export/100/';
+
+        $jobExecution->getExecutionContext()->willReturn($executionContext);
+        $executionContext->get(JobInterface::WORKING_DIRECTORY_PARAMETER)->willReturn('/working/directory/');
 
         $values = [
             'picture' => [
@@ -220,7 +228,7 @@ class VariantGroupProcessorSpec extends ObjectBehavior
         $variantGroupUpdater->update($variantGroup, ['values' => $variantStandard['values']])->shouldBeCalled();
         $productTemplate->getValuesData()->willReturn($variantStandard['values']);
         $productTemplate->getValues()->willReturn($productValueCollection);
-        $mediaFetcher->fetchAll($productValueCollection, $directory, 'my_variant_group')->shouldBeCalled();
+        $mediaFetcher->fetchAll($productValueCollection, '/working/directory/', 'my_variant_group')->shouldBeCalled();
         $mediaFetcher->getErrors()->willReturn([]);
 
         $this->process($variantGroup)->shouldReturn($variantStandard);
@@ -243,7 +251,8 @@ class VariantGroupProcessorSpec extends ObjectBehavior
         ProductValueInterface $productValue2,
         JobParameters $jobParameters,
         JobExecution $jobExecution,
-        JobInstance $jobInstance
+        JobInstance $jobInstance,
+        ExecutionContext $executionContext
     ) {
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $jobParameters->get('filePath')->willReturn('my/path/variant_group.csv');
@@ -261,7 +270,9 @@ class VariantGroupProcessorSpec extends ObjectBehavior
         $jobExecution->getJobInstance()->willReturn($jobInstance);
         $jobExecution->getId()->willReturn(100);
         $jobInstance->getCode()->willReturn('csv_variant_group_export');
-        $directory = 'my/path/csv_variant_group_export/100/';
+
+        $jobExecution->getExecutionContext()->willReturn($executionContext);
+        $executionContext->get(JobInterface::WORKING_DIRECTORY_PARAMETER)->willReturn('/working/directory/');
 
         $values = [
             'picture' => [
@@ -288,7 +299,7 @@ class VariantGroupProcessorSpec extends ObjectBehavior
         $variantGroupUpdater->update($variantGroup, ['values' => $variantStandard['values']])->shouldBeCalled();
         $productTemplate->getValuesData()->willReturn($variantStandard['values']);
         $productTemplate->getValues()->willReturn($productValueCollection);
-        $mediaFetcher->fetchAll($productValueCollection, $directory, 'my_variant_group')->shouldBeCalled();
+        $mediaFetcher->fetchAll($productValueCollection, '/working/directory/', 'my_variant_group')->shouldBeCalled();
         $mediaFetcher->getErrors()->willReturn(
             [
                 [

--- a/src/Pim/Component/Connector/spec/Writer/File/Csv/ProductWriterSpec.php
+++ b/src/Pim/Component/Connector/spec/Writer/File/Csv/ProductWriterSpec.php
@@ -2,6 +2,8 @@
 
 namespace spec\Pim\Component\Connector\Writer\File\Csv;
 
+use Akeneo\Component\Batch\Item\ExecutionContext;
+use Akeneo\Component\Batch\Job\JobInterface;
 use Akeneo\Component\Batch\Job\JobParameters;
 use Akeneo\Component\Batch\Model\JobExecution;
 use Akeneo\Component\Batch\Model\JobInstance;
@@ -59,10 +61,12 @@ class ProductWriterSpec extends ObjectBehavior
         StepExecution $stepExecution,
         JobParameters $jobParameters,
         JobExecution $jobExecution,
-        JobInstance $jobInstance
+        JobInstance $jobInstance,
+        ExecutionContext $executionContext
     ) {
         $this->setStepExecution($stepExecution);
         $stepExecution->getJobParameters()->willReturn($jobParameters);
+        $stepExecution->getJobExecution()->willReturn($jobExecution);
         $jobParameters->get('withHeader')->willReturn(true);
         $jobParameters->get('filePath')->willReturn($this->directory . 'product.csv');
         $jobParameters->has('ui_locale')->willReturn(false);
@@ -119,7 +123,8 @@ class ProductWriterSpec extends ObjectBehavior
                         'locale' => null,
                         'scope'  => null,
                         'data'   => [
-                            'filePath' => 'a/b/c/d/it_s_the_filename.jpg',
+                            // the file paths are resolved before the conversion to the standard format
+                            'filePath' => 'files/jackets/media/it\'s the filename.jpg',
                         ]
                     ]
                 ]
@@ -136,7 +141,7 @@ class ProductWriterSpec extends ObjectBehavior
             'description-en_US-mobile'    => 'Simple description',
             'description-fr_FR-ecommerce' => 'Une description merveilleuse...',
             'description-fr_FR-mobile'    => 'Une simple description',
-            'media'                       => 'a/b/c/d/it_s_the_filename.jpg',
+            'media'                       => 'files/jackets/media/it\'s the filename.jpg',
         ];
 
         $productStandard2 = [
@@ -175,11 +180,14 @@ class ProductWriterSpec extends ObjectBehavior
 
         $items = [$productStandard1, $productStandard2];
 
-        $stepExecution->getJobExecution()->willReturn($jobExecution);
         $jobExecution->getJobInstance()->willReturn($jobInstance);
         $jobExecution->getId()->willReturn(100);
         $jobInstance->getCode()->willReturn('csv_product_export');
-        $productPathMedia1 = $this->directory . 'csv_product_export/100/files/jackets/media/';
+
+        $jobExecution->getExecutionContext()->willReturn($executionContext);
+        $executionContext->get(JobInterface::WORKING_DIRECTORY_PARAMETER)->willReturn($this->directory);
+
+        $productPathMedia1 = $this->directory . 'files/jackets/media/';
         $originalFilename = "it's the filename.jpg";
 
         $this->filesystem->mkdir($productPathMedia1);
@@ -222,10 +230,13 @@ class ProductWriterSpec extends ObjectBehavior
         $bufferFactory,
         FlatItemBuffer $flatRowBuffer,
         StepExecution $stepExecution,
-        JobParameters $jobParameters
+        JobParameters $jobParameters,
+        JobExecution $jobExecution,
+        ExecutionContext $executionContext
     ) {
         $this->setStepExecution($stepExecution);
         $stepExecution->getJobParameters()->willReturn($jobParameters);
+        $stepExecution->getJobExecution()->willReturn($jobExecution);
         $jobParameters->get('withHeader')->willReturn(true);
         $jobParameters->get('filePath')->willReturn($this->directory . 'product.csv');
         $jobParameters->has('ui_locale')->willReturn(false);
@@ -253,8 +264,8 @@ class ProductWriterSpec extends ObjectBehavior
                         'locale' => null,
                         'scope'  => null,
                         'data'   => [
-                            'filePath' => 'a/b/c/d/it_s_the_filename.jpg',
-                        ]
+                            // the file paths are resolved before the conversion to the standard format
+                            'filePath' => 'files/jackets/media/it\'s the filename.jpg',                        ]
                     ]
                 ]
             ]
@@ -271,6 +282,9 @@ class ProductWriterSpec extends ObjectBehavior
         ];
 
         $items = [$productStandard];
+
+        $jobExecution->getExecutionContext()->willReturn($executionContext);
+        $executionContext->get(JobInterface::WORKING_DIRECTORY_PARAMETER)->willReturn($this->directory);
 
         $bufferFactory->create()->willReturn($flatRowBuffer);
 

--- a/src/Pim/Component/Connector/spec/Writer/File/Csv/ProductWriterSpec.php
+++ b/src/Pim/Component/Connector/spec/Writer/File/Csv/ProductWriterSpec.php
@@ -306,11 +306,17 @@ class ProductWriterSpec extends ObjectBehavior
         $flusher,
         FlatItemBuffer $flatRowBuffer,
         StepExecution $stepExecution,
-        JobParameters $jobParameters
+        JobParameters $jobParameters,
+        JobExecution $jobExecution,
+        ExecutionContext $executionContext
     ) {
         $this->setStepExecution($stepExecution);
 
         $flusher->setStepExecution($stepExecution)->shouldBeCalled();
+
+        $stepExecution->getJobExecution()->willReturn($jobExecution);
+        $jobExecution->getExecutionContext()->willReturn($executionContext);
+        $executionContext->get(JobInterface::WORKING_DIRECTORY_PARAMETER)->willReturn($this->directory);
 
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $jobParameters->has('linesPerFile')->willReturn(false);

--- a/src/Pim/Component/Connector/spec/Writer/File/Csv/VariantGroupWriterSpec.php
+++ b/src/Pim/Component/Connector/spec/Writer/File/Csv/VariantGroupWriterSpec.php
@@ -2,6 +2,8 @@
 
 namespace spec\Pim\Component\Connector\Writer\File\Csv;
 
+use Akeneo\Component\Batch\Item\ExecutionContext;
+use Akeneo\Component\Batch\Job\JobInterface;
 use Akeneo\Component\Batch\Job\JobParameters;
 use Akeneo\Component\Batch\Model\JobExecution;
 use Akeneo\Component\Batch\Model\JobInstance;
@@ -59,7 +61,8 @@ class VariantGroupWriterSpec extends ObjectBehavior
         StepExecution $stepExecution,
         JobParameters $jobParameters,
         JobExecution $jobExecution,
-        JobInstance $jobInstance
+        JobInstance $jobInstance,
+        ExecutionContext $executionContext
     ) {
         $this->setStepExecution($stepExecution);
         $stepExecution->getJobParameters()->willReturn($jobParameters);
@@ -85,7 +88,7 @@ class VariantGroupWriterSpec extends ObjectBehavior
                         'locale' => null,
                         'scope'  => null,
                         'data' => [
-                            'filePath' => 'a/b/c/d/it_s_the_filename.jpg',
+                            'filePath' => 'files/jackets/media/it\'s the filename.jpg',
                         ]
                     ]
                 ]
@@ -98,7 +101,7 @@ class VariantGroupWriterSpec extends ObjectBehavior
             'type'        => 'variant',
             'label-en_US' => 'Jacket',
             'label-en_GB' => 'Jacket',
-            'media'       => 'files/jackets/media/it\'s the filaname.jpg'
+            'media'       => 'files/jackets/media/it\'s the filename.jpg'
         ];
 
         $variantStandard2 = [
@@ -136,7 +139,11 @@ class VariantGroupWriterSpec extends ObjectBehavior
         $jobExecution->getJobInstance()->willReturn($jobInstance);
         $jobExecution->getId()->willReturn(100);
         $jobInstance->getCode()->willReturn('csv_variant_group_export');
-        $variantPathMedia1 = $this->directory . 'csv_variant_group_export/100/files/jackets/media/';
+
+        $jobExecution->getExecutionContext()->willReturn($executionContext);
+        $executionContext->get(JobInterface::WORKING_DIRECTORY_PARAMETER)->willReturn($this->directory);
+
+        $variantPathMedia1 = $this->directory . 'files/jackets/media/';
         $originalFilename = "it's the filename.jpg";
 
         $this->filesystem->mkdir($variantPathMedia1);
@@ -174,9 +181,12 @@ class VariantGroupWriterSpec extends ObjectBehavior
         $bufferFactory,
         FlatItemBuffer $flatRowBuffer,
         StepExecution $stepExecution,
-        JobParameters $jobParameters
+        JobParameters $jobParameters,
+        JobExecution $jobExecution,
+        ExecutionContext $executionContext
     ) {
         $this->setStepExecution($stepExecution);
+        $stepExecution->getJobExecution()->willReturn($jobExecution);
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $jobParameters->get('withHeader')->willReturn(true);
         $jobParameters->get('filePath')->willReturn($this->directory . 'variant_group.csv');
@@ -213,10 +223,13 @@ class VariantGroupWriterSpec extends ObjectBehavior
             'type'        => 'variant',
             'label-en_US' => 'Jacket',
             'label-en_GB' => 'Jacket',
-            'media'       => 'files/jackets/media/it\'s the filaname.jpg'
+            'media'       => 'files/jackets/media/it\'s the filename.jpg'
         ];
 
         $items = [$variantStandard1];
+
+        $jobExecution->getExecutionContext()->willReturn($executionContext);
+        $executionContext->get(JobInterface::WORKING_DIRECTORY_PARAMETER)->willReturn(null);
 
         $bufferFactory->create()->willReturn($flatRowBuffer);
 

--- a/src/Pim/Component/Connector/spec/Writer/File/Csv/VariantGroupWriterSpec.php
+++ b/src/Pim/Component/Connector/spec/Writer/File/Csv/VariantGroupWriterSpec.php
@@ -251,11 +251,17 @@ class VariantGroupWriterSpec extends ObjectBehavior
         $flusher,
         FlatItemBuffer $flatRowBuffer,
         StepExecution $stepExecution,
-        JobParameters $jobParameters
+        JobParameters $jobParameters,
+        JobExecution $jobExecution,
+        ExecutionContext $executionContext
     ) {
         $this->setStepExecution($stepExecution);
 
         $flusher->setStepExecution($stepExecution)->shouldBeCalled();
+
+        $stepExecution->getJobExecution()->willReturn($jobExecution);
+        $jobExecution->getExecutionContext()->willReturn($executionContext);
+        $executionContext->get(JobInterface::WORKING_DIRECTORY_PARAMETER)->willReturn($this->directory);
 
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $jobParameters->has('linesPerFile')->willReturn(false);

--- a/src/Pim/Component/Connector/spec/Writer/File/Xlsx/ProductWriterSpec.php
+++ b/src/Pim/Component/Connector/spec/Writer/File/Xlsx/ProductWriterSpec.php
@@ -309,11 +309,17 @@ class ProductWriterSpec extends ObjectBehavior
         $flusher,
         FlatItemBuffer $flatRowBuffer,
         StepExecution $stepExecution,
-        JobParameters $jobParameters
+        JobParameters $jobParameters,
+        JobExecution $jobExecution,
+        ExecutionContext $executionContext
     ) {
         $this->setStepExecution($stepExecution);
 
         $flusher->setStepExecution($stepExecution)->shouldBeCalled();
+
+        $stepExecution->getJobExecution()->willReturn($jobExecution);
+        $jobExecution->getExecutionContext()->willReturn($executionContext);
+        $executionContext->get(JobInterface::WORKING_DIRECTORY_PARAMETER)->willReturn($this->directory);
 
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $jobParameters->has('linesPerFile')->willReturn(false);

--- a/src/Pim/Component/Connector/spec/Writer/File/Xlsx/VariantGroupWriterSpec.php
+++ b/src/Pim/Component/Connector/spec/Writer/File/Xlsx/VariantGroupWriterSpec.php
@@ -2,6 +2,8 @@
 
 namespace spec\Pim\Component\Connector\Writer\File\Xlsx;
 
+use Akeneo\Component\Batch\Item\ExecutionContext;
+use Akeneo\Component\Batch\Job\JobInterface;
 use Akeneo\Component\Batch\Job\JobParameters;
 use Akeneo\Component\Batch\Model\JobExecution;
 use Akeneo\Component\Batch\Model\JobInstance;
@@ -59,7 +61,8 @@ class VariantGroupWriterSpec extends ObjectBehavior
         StepExecution $stepExecution,
         JobParameters $jobParameters,
         JobExecution $jobExecution,
-        JobInstance $jobInstance
+        JobInstance $jobInstance,
+        ExecutionContext $executionContext
     ) {
         $this->setStepExecution($stepExecution);
         $stepExecution->getJobParameters()->willReturn($jobParameters);
@@ -98,7 +101,7 @@ class VariantGroupWriterSpec extends ObjectBehavior
             'type'        => 'variant',
             'label-en_US' => 'Jacket',
             'label-en_GB' => 'Jacket',
-            'media'       => 'files/jackets/media/it\'s the filaname.jpg'
+            'media'       => 'files/jackets/media/it\'s the filename.jpg'
         ];
 
         $variantStandard2 = [
@@ -135,7 +138,11 @@ class VariantGroupWriterSpec extends ObjectBehavior
         $jobExecution->getJobInstance()->willReturn($jobInstance);
         $jobExecution->getId()->willReturn(100);
         $jobInstance->getCode()->willReturn('csv_variant_group_export');
-        $variantPathMedia1 = $this->directory . 'csv_variant_group_export/100/files/jackets/media/';
+
+        $jobExecution->getExecutionContext()->willReturn($executionContext);
+        $executionContext->get(JobInterface::WORKING_DIRECTORY_PARAMETER)->willReturn($this->directory);
+
+        $variantPathMedia1 = $this->directory . 'files/jackets/media/';
         $originalFilename = "it's the filename.jpg";
 
         $this->filesystem->mkdir($variantPathMedia1);
@@ -175,9 +182,12 @@ class VariantGroupWriterSpec extends ObjectBehavior
         $bufferFactory,
         FlatItemBuffer $flatRowBuffer,
         StepExecution $stepExecution,
-        JobParameters $jobParameters
+        JobParameters $jobParameters,
+        JobExecution $jobExecution,
+        ExecutionContext $executionContext
     ) {
         $this->setStepExecution($stepExecution);
+        $stepExecution->getJobExecution()->willReturn($jobExecution);
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $jobParameters->get('withHeader')->willReturn(true);
         $jobParameters->get('filePath')->willReturn($this->directory . 'variant_group.xlsx');
@@ -214,10 +224,13 @@ class VariantGroupWriterSpec extends ObjectBehavior
             'type'        => 'variant',
             'label-en_US' => 'Jacket',
             'label-en_GB' => 'Jacket',
-            'media'       => 'files/jackets/media/it\'s the filaname.jpg'
+            'media'       => 'files/jackets/media/it\'s the filename.jpg'
         ];
 
         $items = [$variantStandard1];
+
+        $jobExecution->getExecutionContext()->willReturn($executionContext);
+        $executionContext->get(JobInterface::WORKING_DIRECTORY_PARAMETER)->willReturn(null);
 
         $bufferFactory->create()->willReturn($flatRowBuffer);
 

--- a/src/Pim/Component/Connector/spec/Writer/File/Xlsx/VariantGroupWriterSpec.php
+++ b/src/Pim/Component/Connector/spec/Writer/File/Xlsx/VariantGroupWriterSpec.php
@@ -252,11 +252,17 @@ class VariantGroupWriterSpec extends ObjectBehavior
         $flusher,
         FlatItemBuffer $flatRowBuffer,
         StepExecution $stepExecution,
-        JobParameters $jobParameters
+        JobParameters $jobParameters,
+        JobExecution $jobExecution,
+        ExecutionContext $executionContext
     ) {
         $this->setStepExecution($stepExecution);
 
         $flusher->setStepExecution($stepExecution)->shouldBeCalled();
+
+        $stepExecution->getJobExecution()->willReturn($jobExecution);
+        $jobExecution->getExecutionContext()->willReturn($executionContext);
+        $executionContext->get(JobInterface::WORKING_DIRECTORY_PARAMETER)->willReturn($this->directory);
 
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $jobParameters->has('linesPerFile')->willReturn(false);


### PR DESCRIPTION
This PR adds the possibility to have a working directory for batches. Within this directory you can do whatever you want (download files, create temporary files etc..). This working directory is easily accessible from your reader/processor/writer/step without having to write the same specific logic each time.

This working directory is automatically created before the job starts and is automatically destroyed once the job is terminated.

Then, in your step you can retrieve the working directory via the job execution context:
```
$workingDir = $jobExecution->getExecutionContext()->get(JobInterface::WORKING_DIRECTORY_PARAMETER);
```

What's done here:
- [x] fix batch job status when an exception is thown during `BEFORE_JOB_EXECUTION` or `AFTER_JOB_EXECUTION` (previously, the batch remained in the `started` status)
- [x] implement the working directory feature in the Batch
- [x] use this working directory for the products exports (to have a directory where we fetch the medias)
- [x] use this working directory for the quick products exports (to have a directory where we fetch the medias)
- [x] use this working directory for the variant group exports (to have a directory where we fetch the medias)

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | - 
| Changelog updated                 | -
| Review and 2 GTM                  |
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | we should do a cookbook
