### PR TITLE
Fix quick export of all products

### DIFF
--- a/features/mass-action/quick_export.feature
+++ b/features/mass-action/quick_export.feature
@@ -14,7 +14,29 @@ Feature: Quick export many products from datagrid
       | pump     |          | summer_collection | Pump          | 15 EUR, 20 USD | 41   | blue  | ddd |
     And I am logged in as "Julia"
 
-  Scenario: Successfully quick export products as a CSV file
+  Scenario: Successfully quick export all products as a CSV file
+    Given I am on the products page
+    When I select all entities
+    And I press "CSV (All attributes)" on the "Quick Export" dropdown button
+    And I wait for the "csv_product_quick_export" quick export to finish
+    And I am on the dashboard page
+    Then I should have 1 new notification
+    And I should see notification:
+      | type    | message                                        |
+      | success | Quick export CSV product quick export finished |
+    When I go on the last executed job resume of "csv_product_quick_export"
+    Then I should see the text "COMPLETED"
+    And the name of the exported file of "csv_product_quick_export" should be "products_export_en_US_tablet.csv"
+    And exported file of "csv_product_quick_export" should contain:
+    """
+    sku;123;categories;color;description-en_US-tablet;enabled;family;groups;lace_color;manufacturer;name-en_US;price-EUR;price-USD;rating;side_view;size;top_view;weather_conditions
+    boots;aaa;winter_collection;black;;1;boots;;;;"Amazing boots";20;25;;;40;;
+    sneakers;bbb;summer_collection;white;;1;sneakers;;;;Sneakers;50;60;;;42;;
+    sandals;ccc;summer_collection;red;;1;sandals;;;;Sandals;5;5;;;40;;
+    pump;ddd;summer_collection;blue;;1;;;;;Pump;15;20;;;41;;
+    """
+
+  Scenario: Successfully quick export selected products as a CSV file
     Given I am on the products page
     When I select rows boots, sneakers
     And I press "CSV (All attributes)" on the "Quick Export" dropdown button
@@ -34,7 +56,7 @@ Feature: Quick export many products from datagrid
     sneakers;bbb;summer_collection;white;;1;sneakers;;;;Sneakers;50;60;;;42;;
     """
 
-  Scenario: Successfully quick export products as a XSLX file
+  Scenario: Successfully quick export selected products as a XSLX file
     Given I am on the products page
     When I select rows boots, sneakers
     And I press "XLSX (All attributes)" on the "Quick Export" dropdown button

--- a/src/Pim/Bundle/EnrichBundle/Connector/Job/JobParameters/ConstraintCollectionProvider/ProductQuickExport.php
+++ b/src/Pim/Bundle/EnrichBundle/Connector/Job/JobParameters/ConstraintCollectionProvider/ProductQuickExport.php
@@ -40,7 +40,7 @@ class ProductQuickExport implements ConstraintCollectionProviderInterface
     {
         $baseConstraint = $this->simpleConstraint->getConstraintCollection();
         $constraintFields = $baseConstraint->fields;
-        $constraintFields['filters'] = new NotBlank(['groups' => 'Execution']);
+        $constraintFields['filters'] = [];
         $constraintFields['selected_properties'] = null;
         $constraintFields['with_media'] = new Type('bool');
         $constraintFields['locale'] = new NotBlank(['groups' => 'Execution']);

--- a/src/Pim/Bundle/EnrichBundle/Connector/Processor/QuickExport/ProductProcessor.php
+++ b/src/Pim/Bundle/EnrichBundle/Connector/Processor/QuickExport/ProductProcessor.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Bundle\EnrichBundle\Connector\Processor\QuickExport;
 
+use Akeneo\Component\Batch\Item\DataInvalidItem;
 use Akeneo\Component\Batch\Job\JobParameters;
 use Akeneo\Component\Batch\Model\StepExecution;
 use Akeneo\Component\StorageUtils\Detacher\ObjectDetacherInterface;
@@ -159,7 +160,7 @@ class ProductProcessor extends AbstractProcessor
         $this->mediaFetcher->fetchAll($product->getValues(), $directory, $identifier);
 
         foreach ($this->mediaFetcher->getErrors() as $error) {
-            $this->stepExecution->addWarning($error['message'], [], $error['media']);
+            $this->stepExecution->addWarning($error['message'], [], new DataInvalidItem($error['media']));
         }
     }
 

--- a/upgrades/schema/Version_1_6_20160722155535_quick_export.php
+++ b/upgrades/schema/Version_1_6_20160722155535_quick_export.php
@@ -21,34 +21,26 @@ class Version_1_6_20160722155535_quick_export extends AbstractMigration
      */
     public function up(Schema $schema)
     {
-        $query = <<<SQL
-SELECT code, raw_parameters 
-FROM akeneo_batch_job_instance 
-WHERE code IN (
-  "csv_product_quick_export", 
-  "csv_product_grid_context_quick_export", 
-  "xlsx_product_quick_export", 
-  "xlsx_product_grid_context_quick_export"
-)
-SQL;
+        $query = 'SELECT code, raw_parameters FROM akeneo_batch_job_instance WHERE code = "csv_product_quick_export"';
         $stmt = $this->connection->prepare($query);
         $stmt->execute();
-        $jobs = $stmt->fetchAll();
-
-        foreach ($jobs as $job) {
-            $parameters = unserialize($job['raw_parameters']);
-            $parameters['with_media'] = true;
-
-            if (array_key_exists('mainContext', $parameters)) {
-                unset($parameters['mainContext']);
-            }
-
-            $this->connection->update(
-                'akeneo_batch_job_instance',
-                ['raw_parameters' => serialize($parameters)],
-                ['code'           => $job['code']]
-            );
+        $job = $stmt->fetch();
+        if (null === $job) {
+            throw new \Exception('Job "csv_product_quick_export" cannot be found');
         }
+
+        $parameters = unserialize($job['raw_parameters']);
+        $parameters['with_media'] = true;
+
+        if (array_key_exists('mainContext', $parameters)) {
+            unset($parameters['mainContext']);
+        }
+
+        $this->connection->update(
+            'akeneo_batch_job_instance',
+            ['raw_parameters' => serialize($parameters)],
+            ['code'           => 'csv_product_quick_export']
+        );
     }
 
     /**


### PR DESCRIPTION
**Issue:**

When we select all entities in the product grid and quick export, the job fails because the job parameter "filters" is an empty array.

The PIM fails to validate the constraint NotBlank on this job parameter.

**Solution:**

Set the same constraint as the CSV Product export for the "filters" jobParameter

___

**This PR also contains:**

- Fixes an issue with the quick export when a warning would be thrown about a media not found.
- Reverts the quick-export migrations (seen with @aRn0D) 

___

**Definition Of Done (for Core Developer only)**


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | yes
| Changelog updated                 | -
| Review and 2 GTM                  | yes
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -
