### PR TITLE
PIM-5918: Fix conflict between saver instances

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
@@ -12,10 +12,6 @@ config:
         translator:
             exports: Translator
 
-    map:
-        '*':
-            pim/saver/variant-group:   pim/saver/base
-
     config:
         # Forwarded events from mediator
         pim/form/common/edit-form:

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/remover/product-remover.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/remover/product-remover.js
@@ -11,8 +11,7 @@ define([
         module,
         Routing
     ) {
-        return _.extend(BaseRemover, {
-
+        return _.extend({}, BaseRemover, {
             /**
              * {@inheritdoc}
              */

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/remover/variant-group-remover.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/remover/variant-group-remover.js
@@ -11,8 +11,7 @@ define([
         module,
         Routing
     ) {
-        return _.extend(BaseRemover, {
-
+        return _.extend({}, BaseRemover, {
             /**
              * {@inheritdoc}
              */

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/saver/product-saver.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/saver/product-saver.js
@@ -11,8 +11,7 @@ define([
         module,
         Routing
     ) {
-        return _.extend(BaseSaver, {
-
+        return _.extend({}, BaseSaver, {
             /**
              * {@inheritdoc}
              */

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/saver/variant-group-saver.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/saver/variant-group-saver.js
@@ -11,8 +11,7 @@ define([
         module,
         Routing
     ) {
-        return _.extend(BaseSaver, {
-
+        return _.extend({}, BaseSaver, {
             /**
              * {@inheritdoc}
              */


### PR DESCRIPTION
We used to extend the savers the bad way. Saver instances were modified by reference inside requirejs, so you could have for example a product saver on the variant group form.
I fixed also the removers, same issue.