### PR TITLE
File import/export: add iterator options in the DI

### DIFF
--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/readers.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/readers.yml
@@ -176,6 +176,7 @@ services:
             - '@pim_connector.reader.file.csv_iterator_factory'
             - '@pim_connector.array_converter.flat_to_standard.product_delocalized'
             - '@pim_connector.reader.file.media_path_transformer'
+            - []
 
     pim_connector.reader.file.csv_user:
         class: '%pim_connector.reader.file.csv.class%'
@@ -208,6 +209,7 @@ services:
            - '@pim_connector.reader.file.xlsx_iterator_factory'
            - '@pim_connector.array_converter.flat_to_standard.product_delocalized'
            - '@pim_connector.reader.file.media_path_transformer'
+           - []
 
     pim_connector.reader.file.xlsx_association_type:
         class: '%pim_connector.reader.file.xlsx.class%'

--- a/src/Pim/Component/Connector/Archiver/CsvInvalidItemWriter.php
+++ b/src/Pim/Component/Connector/Archiver/CsvInvalidItemWriter.php
@@ -40,8 +40,10 @@ class CsvInvalidItemWriter extends AbstractInvalidItemWriter
         $delimiter = $jobParameters->get('delimiter');
         $enclosure = $jobParameters->get('enclosure');
         $fileIterator = $this->fileIteratorFactory->create($filePath, [
-            'fieldDelimiter' => $delimiter,
-            'fieldEnclosure' => $enclosure
+            'reader_options' => [
+                'fieldDelimiter' => $delimiter,
+                'fieldEnclosure' => $enclosure,
+            ]
         ]);
         $fileIterator->rewind();
 

--- a/src/Pim/Component/Connector/Reader/File/Csv/ProductReader.php
+++ b/src/Pim/Component/Connector/Reader/File/Csv/ProductReader.php
@@ -28,16 +28,18 @@ class ProductReader extends Reader implements
     protected $mediaPathTransformer;
 
     /**
-     * @param FileIteratorFactory     $fileIteratorFactory,
+     * @param FileIteratorFactory     $fileIteratorFactory ,
      * @param ArrayConverterInterface $converter
      * @param MediaPathTransformer    $mediaPathTransformer
+     * @param array                   $options
      */
     public function __construct(
         FileIteratorFactory $fileIteratorFactory,
         ArrayConverterInterface $converter,
-        MediaPathTransformer $mediaPathTransformer
+        MediaPathTransformer $mediaPathTransformer,
+        array $options = []
     ) {
-        parent::__construct($fileIteratorFactory, $converter);
+        parent::__construct($fileIteratorFactory, $converter, $options);
 
         $this->mediaPathTransformer = $mediaPathTransformer;
     }

--- a/src/Pim/Component/Connector/Reader/File/Csv/ProductReader.php
+++ b/src/Pim/Component/Connector/Reader/File/Csv/ProductReader.php
@@ -28,7 +28,7 @@ class ProductReader extends Reader implements
     protected $mediaPathTransformer;
 
     /**
-     * @param FileIteratorFactory     $fileIteratorFactory ,
+     * @param FileIteratorFactory     $fileIteratorFactory
      * @param ArrayConverterInterface $converter
      * @param MediaPathTransformer    $mediaPathTransformer
      * @param array                   $options

--- a/src/Pim/Component/Connector/Reader/File/Csv/Reader.php
+++ b/src/Pim/Component/Connector/Reader/File/Csv/Reader.php
@@ -36,14 +36,22 @@ class Reader implements ItemReaderInterface, StepExecutionAwareInterface, Flusha
     /** @var StepExecution */
     protected $stepExecution;
 
+    /** @var array */
+    protected $options;
+
     /**
      * @param FileIteratorFactory     $fileIteratorFactory
      * @param ArrayConverterInterface $converter
+     * @param array                   $options
      */
-    public function __construct(FileIteratorFactory $fileIteratorFactory, ArrayConverterInterface $converter)
-    {
+    public function __construct(
+        FileIteratorFactory $fileIteratorFactory,
+        ArrayConverterInterface $converter,
+        array $options = []
+    ) {
         $this->fileIteratorFactory = $fileIteratorFactory;
         $this->converter           = $converter;
+        $this->options             = $options;
     }
 
     /**
@@ -57,10 +65,16 @@ class Reader implements ItemReaderInterface, StepExecutionAwareInterface, Flusha
             $filePath = $jobParameters->get('filePath');
             $delimiter = $jobParameters->get('delimiter');
             $enclosure = $jobParameters->get('enclosure');
-            $this->fileIterator = $this->fileIteratorFactory->create($filePath, [
-                'fieldDelimiter' => $delimiter,
-                'fieldEnclosure' => $enclosure
-            ]);
+            $defaultOptions = [
+                'reader_options' => [
+                    'fieldDelimiter' => $delimiter,
+                    'fieldEnclosure' => $enclosure,
+                ],
+            ];
+            $this->fileIterator = $this->fileIteratorFactory->create(
+                $filePath,
+                array_merge($defaultOptions, $this->options)
+            );
             $this->fileIterator->rewind();
         }
 

--- a/src/Pim/Component/Connector/Reader/File/Csv/VariantGroupReader.php
+++ b/src/Pim/Component/Connector/Reader/File/Csv/VariantGroupReader.php
@@ -25,16 +25,18 @@ class VariantGroupReader extends Reader implements
     protected $mediaPathTransformer;
 
     /**
-     * @param FileIteratorFactory     $fileIteratorFactory,
+     * @param FileIteratorFactory     $fileIteratorFactory ,
      * @param ArrayConverterInterface $converter
      * @param MediaPathTransformer    $mediaPathTransformer
+     * @param array                   $options
      */
     public function __construct(
         FileIteratorFactory $fileIteratorFactory,
         ArrayConverterInterface $converter,
-        MediaPathTransformer $mediaPathTransformer
+        MediaPathTransformer $mediaPathTransformer,
+        array $options = []
     ) {
-        parent::__construct($fileIteratorFactory, $converter);
+        parent::__construct($fileIteratorFactory, $converter, $options);
 
         $this->mediaPathTransformer = $mediaPathTransformer;
     }

--- a/src/Pim/Component/Connector/Reader/File/Csv/VariantGroupReader.php
+++ b/src/Pim/Component/Connector/Reader/File/Csv/VariantGroupReader.php
@@ -25,7 +25,7 @@ class VariantGroupReader extends Reader implements
     protected $mediaPathTransformer;
 
     /**
-     * @param FileIteratorFactory     $fileIteratorFactory ,
+     * @param FileIteratorFactory     $fileIteratorFactory
      * @param ArrayConverterInterface $converter
      * @param MediaPathTransformer    $mediaPathTransformer
      * @param array                   $options

--- a/src/Pim/Component/Connector/Reader/File/FileIterator.php
+++ b/src/Pim/Component/Connector/Reader/File/FileIterator.php
@@ -66,7 +66,9 @@ class FileIterator implements FileIteratorInterface
         }
 
         $this->reader = ReaderFactory::create($type);
-        $this->setReaderOptions($options);
+        if (isset($options['reader_options'])) {
+            $this->setReaderOptions($options['reader_options']);
+        }
         $this->reader->open($this->filePath);
         $this->reader->getSheetIterator()->rewind();
 
@@ -207,13 +209,13 @@ class FileIterator implements FileIteratorInterface
     /**
      * Add options to Spout reader
      *
-     * @param array $options
+     * @param array $readerOptions
      *
      * @throws \InvalidArgumentException
      */
-    protected function setReaderOptions(array $options = [])
+    protected function setReaderOptions(array $readerOptions = [])
     {
-        foreach ($options as $name => $option) {
+        foreach ($readerOptions as $name => $option) {
             $setter = 'set' . ucfirst($name);
             if (method_exists($this->reader, $setter)) {
                 $this->reader->$setter($option);

--- a/src/Pim/Component/Connector/Reader/File/Xlsx/ProductReader.php
+++ b/src/Pim/Component/Connector/Reader/File/Xlsx/ProductReader.php
@@ -30,14 +30,16 @@ class ProductReader extends Reader implements
     /**
      * @param FileIteratorFactory     $fileIteratorFactory
      * @param ArrayConverterInterface $converter
+     * @param array                   $options
      * @param MediaPathTransformer    $mediaPathTransformer
      */
     public function __construct(
         FileIteratorFactory $fileIteratorFactory,
         ArrayConverterInterface $converter,
-        MediaPathTransformer $mediaPathTransformer
+        MediaPathTransformer $mediaPathTransformer,
+        array $options = []
     ) {
-        parent::__construct($fileIteratorFactory, $converter);
+        parent::__construct($fileIteratorFactory, $converter, $options);
 
         $this->mediaPathTransformer = $mediaPathTransformer;
     }

--- a/src/Pim/Component/Connector/Reader/File/Xlsx/Reader.php
+++ b/src/Pim/Component/Connector/Reader/File/Xlsx/Reader.php
@@ -36,14 +36,22 @@ class Reader implements ItemReaderInterface, StepExecutionAwareInterface, Flusha
     /** @var StepExecution */
     protected $stepExecution;
 
+    /** @var array */
+    protected $options;
+
     /**
      * @param FileIteratorFactory     $fileIteratorFactory
      * @param ArrayConverterInterface $converter
+     * @param array                   $options
      */
-    public function __construct(FileIteratorFactory $fileIteratorFactory, ArrayConverterInterface $converter)
-    {
+    public function __construct(
+        FileIteratorFactory $fileIteratorFactory,
+        ArrayConverterInterface $converter,
+        array $options = []
+    ) {
         $this->fileIteratorFactory = $fileIteratorFactory;
         $this->converter           = $converter;
+        $this->options             = $options;
     }
 
     /**
@@ -55,7 +63,7 @@ class Reader implements ItemReaderInterface, StepExecutionAwareInterface, Flusha
         if (null === $this->fileIterator) {
             $jobParameters = $this->stepExecution->getJobParameters();
             $filePath = $jobParameters->get('filePath');
-            $this->fileIterator = $this->fileIteratorFactory->create($filePath);
+            $this->fileIterator = $this->fileIteratorFactory->create($filePath, $this->options);
             $this->fileIterator->rewind();
         }
 

--- a/src/Pim/Component/Connector/spec/Reader/File/Csv/ProductReaderSpec.php
+++ b/src/Pim/Component/Connector/spec/Reader/File/Csv/ProductReaderSpec.php
@@ -60,8 +60,10 @@ class  ProductReaderSpec extends ObjectBehavior
         ];
 
         $fileIteratorFactory->create($filePath, [
-            'fieldDelimiter' => ';',
-            'fieldEnclosure' => '"',
+            'reader_options' => [
+                'fieldDelimiter' => ';',
+                'fieldEnclosure' => '"',
+            ]
         ])->willReturn($fileIterator);
 
         $fileIterator->getHeaders()->willReturn(['sku', 'name', 'view', 'manual-fr_FR']);

--- a/src/Pim/Component/Connector/spec/Reader/File/Csv/ReaderSpec.php
+++ b/src/Pim/Component/Connector/spec/Reader/File/Csv/ReaderSpec.php
@@ -43,8 +43,10 @@ class ReaderSpec extends ObjectBehavior
         ];
 
         $fileIteratorFactory->create($filePath, [
-            'fieldDelimiter' => ';',
-            'fieldEnclosure' => '"',
+            'reader_options' => [
+                'fieldDelimiter' => ';',
+                'fieldEnclosure' => '"',
+            ]
         ])->willReturn($fileIterator);
 
         $fileIterator->getHeaders()->willReturn(['sku', 'name']);
@@ -81,8 +83,10 @@ class ReaderSpec extends ObjectBehavior
         $stepExecution->getSummaryInfo('read_lines')->shouldBeCalled();
 
         $fileIteratorFactory->create($filePath, [
-            'fieldDelimiter' => ';',
-            'fieldEnclosure' => '"',
+            'reader_options' => [
+                'fieldDelimiter' => ';',
+                'fieldEnclosure' => '"',
+            ]
         ])->willReturn($fileIterator);
 
         $fileIterator->getHeaders()->willReturn(['sku', 'name']);

--- a/src/Pim/Component/Connector/spec/Reader/File/FileIteratorSpec.php
+++ b/src/Pim/Component/Connector/spec/Reader/File/FileIteratorSpec.php
@@ -10,7 +10,9 @@ class FileIteratorSpec extends ObjectBehavior
     function let()
     {
         $this->beConstructedWith('csv', $this->getPath() . DIRECTORY_SEPARATOR  . 'with_media.csv', [
-            'fieldDelimiter' => ';'
+            'reader_options' => [
+                'fieldDelimiter' => ';'
+            ]
         ]);
     }
 
@@ -51,7 +53,9 @@ Est'
     function it_gets_current_row_from_an_archive()
     {
         $this->beConstructedWith('csv', $this->getPath() . DIRECTORY_SEPARATOR  . 'caterpillar_import.zip', [
-            'fieldDelimiter' => ';'
+            'reader_options' => [
+                'fieldDelimiter' => ';'
+            ]
         ]);
 
         $this->rewind();

--- a/src/Pim/Component/Connector/spec/Reader/File/Xlsx/ProductReaderSpec.php
+++ b/src/Pim/Component/Connector/spec/Reader/File/Xlsx/ProductReaderSpec.php
@@ -51,7 +51,7 @@ class ProductReaderSpec extends ObjectBehavior
         $jobParameters->get('decimalSeparator')->willReturn('.');
         $jobParameters->get('dateFormat')->willReturn('YYYY-mm-dd');
 
-        $fileIteratorFactory->create($filePath)->willReturn($fileIterator);
+        $fileIteratorFactory->create($filePath, [])->willReturn($fileIterator);
 
         $item = [
             'sku'          => 'SKU-001',

--- a/src/Pim/Component/Connector/spec/Reader/File/Xlsx/ReaderSpec.php
+++ b/src/Pim/Component/Connector/spec/Reader/File/Xlsx/ReaderSpec.php
@@ -44,7 +44,7 @@ class ReaderSpec extends ObjectBehavior
             'name' => 'door',
         ];
 
-        $fileIteratorFactory->create($filePath)->willReturn($fileIterator);
+        $fileIteratorFactory->create($filePath, [])->willReturn($fileIterator);
 
         $fileIterator->getHeaders()->willReturn(['sku', 'name']);
         $fileIterator->rewind()->shouldBeCalled();
@@ -81,7 +81,7 @@ class ReaderSpec extends ObjectBehavior
 
         $stepExecution->getSummaryInfo('read_lines')->shouldBeCalled();
 
-        $fileIteratorFactory->create($filePath)->willReturn($fileIterator);
+        $fileIteratorFactory->create($filePath, [])->willReturn($fileIterator);
 
         $fileIterator->getHeaders()->willReturn(['sku', 'name']);
         $fileIterator->rewind()->shouldBeCalled();


### PR DESCRIPTION
This PR add the possibilty to configure file iterators from the DI by injecting factory options.

For example, a XLSX file iterator could need read (or skip) a specific worksheet configured in the DI.
If i want options to be injected in my custom file iterator, i need the factory to inject them.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       |no
| Added Behats                      |no
| Changelog updated                 |no
| Review and 2 GTM                  |yes
