### PR TITLE
Fix specs on CI

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -296,7 +296,8 @@
     </target>
 
     <target name="phpspec" description="Run specs with PhpSpec Dot formatter">
-        <exec executable="./phpspec-fix">
+        <exec executable="${basedir}/bin/phpspec">
+            <arg value="run" />
             <arg value="-fdot" />
             <arg value="--no-interaction" />
             <arg value="--ansi" />
@@ -304,7 +305,8 @@
     </target>
 
     <target name="phpspec-junit" description="Run specs with PhpSpec JUnit formatter">
-        <exec executable="./phpspec-fix" output="app/build/logs/phpspec/junit.xml">
+        <exec executable="${basedir}/bin/phpspec" output="app/build/logs/phpspec/junit.xml">
+            <arg value="run" />
             <arg value="-fjunit" />
             <arg value="--no-interaction" />
         </exec>


### PR DESCRIPTION
File `phpspec-fix` has been deleted on this PR https://github.com/akeneo/pim-community-dev/pull/4809, so all builds about specs are failed on CI