### PR TITLE
PIM-5933: fix Attribute flat to standard converter

### DIFF
--- a/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Attribute.php
+++ b/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Attribute.php
@@ -58,12 +58,21 @@ class Attribute implements ArrayConverterInterface
      */
     protected function convertFields($field, $booleanFields, $data, $convertedItem)
     {
+        if (false !== strpos($field, 'label-', 0)) {
+            $labelTokens = explode('-', $field);
+            $labelLocale = $labelTokens[1];
+            $convertedItem['labels'][$labelLocale] = $data;
+
+            return $convertedItem;
+        }
+
+        if (in_array($field, $booleanFields)) {
+            $convertedItem[$field] = (bool) $data;
+
+            return $convertedItem;
+        }
+
         switch ($field) {
-            case false !== strpos($field, 'label-', 0):
-                $labelTokens = explode('-', $field);
-                $labelLocale = $labelTokens[1];
-                $convertedItem['labels'][$labelLocale] = $data;
-                break;
             case 'type':
                 $convertedItem['attribute_type'] = $data;
                 break;
@@ -80,9 +89,6 @@ class Attribute implements ArrayConverterInterface
             case 'options':
             case 'available_locales':
                 $convertedItem[$field] = ('' === $data) ? [] : explode(',', $data);
-                break;
-            case in_array($field, $booleanFields):
-                $convertedItem[$field] = (bool) $data;
                 break;
             case 'date_min':
             case 'date_max':

--- a/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Attribute.php
+++ b/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Attribute.php
@@ -62,42 +62,51 @@ class Attribute implements ArrayConverterInterface
             $labelTokens = explode('-', $field);
             $labelLocale = $labelTokens[1];
             $convertedItem['labels'][$labelLocale] = $data;
-
             return $convertedItem;
         }
 
-        if (in_array($field, $booleanFields)) {
+        if ($field === 'type') {
+            $convertedItem['attribute_type'] = $data;
+            return $convertedItem;
+        }
+
+        if ($field === 'number_min' ||
+            $field === 'number_max' ||
+            $field === 'max_file_size'
+        ) {
+            $convertedItem[$field] = ('' === $data) ? null : (float) $data;
+            return $convertedItem;
+        }
+
+        if ($field === 'sort_order' ||
+            $field === 'max_characters' ||
+            $field === 'minimum_input_length'
+        ) {
+            $convertedItem[$field] = ('' === $data) ? null : (int) $data;
+            return $convertedItem;
+        }
+
+        if ($field === 'options' ||
+            $field === 'available_locales'
+        ) {
+            $convertedItem[$field] = ('' === $data) ? [] : explode(',', $data);
+            return $convertedItem;
+        }
+
+        if ($field === 'date_min' ||
+            $field === 'date_max' ||
+            $field === 'reference_data_name'
+        ) {
+            $convertedItem[$field] = ('' === $data) ? null : $data;
+            return $convertedItem;
+        }
+
+        if (in_array($field, $booleanFields, true)) {
             $convertedItem[$field] = (bool) $data;
-
             return $convertedItem;
         }
 
-        switch ($field) {
-            case 'type':
-                $convertedItem['attribute_type'] = $data;
-                break;
-            case 'number_min':
-            case 'number_max':
-            case 'max_file_size':
-                $convertedItem[$field] = ('' === $data) ? null : (float) $data;
-                break;
-            case 'sort_order':
-            case 'max_characters':
-            case 'minimum_input_length':
-                $convertedItem[$field] = ('' === $data) ? null : (int) $data;
-                break;
-            case 'options':
-            case 'available_locales':
-                $convertedItem[$field] = ('' === $data) ? [] : explode(',', $data);
-                break;
-            case 'date_min':
-            case 'date_max':
-            case 'reference_data_name':
-                $convertedItem[$field] = ('' === $data) ? null : $data;
-                break;
-            default:
-                $convertedItem[$field] = (string) $data;
-        }
+        $convertedItem[$field] = (string) $data;
 
         return $convertedItem;
     }

--- a/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Attribute.php
+++ b/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Attribute.php
@@ -62,44 +62,30 @@ class Attribute implements ArrayConverterInterface
             $labelTokens = explode('-', $field);
             $labelLocale = $labelTokens[1];
             $convertedItem['labels'][$labelLocale] = $data;
-        }
-
-        elseif ($field === 'type') {
+        } elseif ($field === 'type') {
             $convertedItem['attribute_type'] = $data;
-        }
-
-        elseif ($field === 'number_min' ||
+        } elseif ($field === 'number_min' ||
             $field === 'number_max' ||
             $field === 'max_file_size'
         ) {
             $convertedItem[$field] = ('' === $data) ? null : (float) $data;
-        }
-
-        elseif ($field === 'sort_order' ||
+        } elseif ($field === 'sort_order' ||
             $field === 'max_characters' ||
             $field === 'minimum_input_length'
         ) {
             $convertedItem[$field] = ('' === $data) ? null : (int) $data;
-        }
-
-        elseif ($field === 'options' ||
+        } elseif ($field === 'options' ||
             $field === 'available_locales'
         ) {
             $convertedItem[$field] = ('' === $data) ? [] : explode(',', $data);
-        }
-
-        elseif ($field === 'date_min' ||
+        } elseif ($field === 'date_min' ||
             $field === 'date_max' ||
             $field === 'reference_data_name'
         ) {
             $convertedItem[$field] = ('' === $data) ? null : $data;
-        }
-
-        elseif (in_array($field, $booleanFields, true)) {
+        } elseif (in_array($field, $booleanFields, true)) {
             $convertedItem[$field] = (bool) $data;
-        }
-
-        else {
+        } else {
             $convertedItem[$field] = (string) $data;
         }
 

--- a/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Attribute.php
+++ b/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Attribute.php
@@ -62,51 +62,46 @@ class Attribute implements ArrayConverterInterface
             $labelTokens = explode('-', $field);
             $labelLocale = $labelTokens[1];
             $convertedItem['labels'][$labelLocale] = $data;
-            return $convertedItem;
         }
 
-        if ($field === 'type') {
+        elseif ($field === 'type') {
             $convertedItem['attribute_type'] = $data;
-            return $convertedItem;
         }
 
-        if ($field === 'number_min' ||
+        elseif ($field === 'number_min' ||
             $field === 'number_max' ||
             $field === 'max_file_size'
         ) {
             $convertedItem[$field] = ('' === $data) ? null : (float) $data;
-            return $convertedItem;
         }
 
-        if ($field === 'sort_order' ||
+        elseif ($field === 'sort_order' ||
             $field === 'max_characters' ||
             $field === 'minimum_input_length'
         ) {
             $convertedItem[$field] = ('' === $data) ? null : (int) $data;
-            return $convertedItem;
         }
 
-        if ($field === 'options' ||
+        elseif ($field === 'options' ||
             $field === 'available_locales'
         ) {
             $convertedItem[$field] = ('' === $data) ? [] : explode(',', $data);
-            return $convertedItem;
         }
 
-        if ($field === 'date_min' ||
+        elseif ($field === 'date_min' ||
             $field === 'date_max' ||
             $field === 'reference_data_name'
         ) {
             $convertedItem[$field] = ('' === $data) ? null : $data;
-            return $convertedItem;
         }
 
-        if (in_array($field, $booleanFields, true)) {
+        elseif (in_array($field, $booleanFields, true)) {
             $convertedItem[$field] = (bool) $data;
-            return $convertedItem;
         }
 
-        $convertedItem[$field] = (string) $data;
+        else {
+            $convertedItem[$field] = (string) $data;
+        }
 
         return $convertedItem;
     }

--- a/src/Pim/Component/Connector/spec/ArrayConverter/FlatToStandard/AttributeSpec.php
+++ b/src/Pim/Component/Connector/spec/ArrayConverter/FlatToStandard/AttributeSpec.php
@@ -140,4 +140,20 @@ class AttributeSpec extends ObjectBehavior
             'number_max'     => 15.0,
         ]);
     }
+
+    function it_does_not_convert_empty_keys()
+    {
+        $item = [
+            '' => 'foo',
+            0 => 'bar',
+        ];
+
+        $result = [
+            'labels' => [],
+            '' => 'foo',
+            0 => 'bar',
+        ];
+
+        $this->convert($item)->shouldReturn($result);
+    }
 }


### PR DESCRIPTION
Testing an expression in case is evil :angry: 

For example, `case false !== strpos($field, 'label-', 0)` will match with `$field = 0` :scream: 

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       |yes
| Added Behats                      |no
| Changelog updated                 |no
| Review and 2 GTM                  |yes

