### PR TITLE
PIM-5915: Partial update on Variant Groups remove existing data

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -5,6 +5,7 @@
 - PIM-5854: The family code is not displayed at all in the product grid when no family labels
 - PIM-5888: Fix an outline glitch on some buttons
 - PIM-5869: Allow any codes to be used for attributes
+- PIM-5915: Fix the import of localizable and scopable variant group attributes
 
 ## Functional improvements
 

--- a/features/import/product_variant_group/import_variant_group_with_scopable_or_localizable_data.feature
+++ b/features/import/product_variant_group/import_variant_group_with_scopable_or_localizable_data.feature
@@ -1,0 +1,34 @@
+@javascript
+Feature: Execute an import with scopable or localizable data
+  In order to update existing product information
+  As a product manager
+  I need to be able to import variant group values in product values
+
+  Background:
+    Given the "footwear" catalog configuration
+    And the following product groups:
+      | code   | label  | axis        | type    |
+      | SANDAL | Sandal | size, color | VARIANT |
+    And I am logged in as "Julia"
+
+  Scenario: Avoid data loss when importing variant group localizable/scopable values
+    Given I am on the "SANDAL" variant group page
+    And I visit the "Attributes" tab
+    And I add available attributes Description
+    And I change the Description for scope tablet and locale en_US to "original description tablet"
+    And I change the Description for scope mobile and locale en_US to "original description mobile"
+    And I save the variant group
+    And the following CSV file to import:
+      """
+        label-en_US;axis;code;description-en_US-tablet;type
+        Sandal;color,size;SANDAL;"new description tablet";VARIANT
+      """
+    And the following job "csv_footwear_variant_group_import" configuration:
+      | filePath | %file to import% |
+    And I am on the "csv_footwear_variant_group_import" import job page
+    And I launch the import job
+    And I wait for the "csv_footwear_variant_group_import" job to finish
+    And I am on the "SANDAL" variant group page
+    And I visit the "Attributes" tab
+    Then the field Description for locale "en_US" and scope "tablet" should contain "new description tablet"
+    And the field Description for locale "en_US" and scope "mobile" should contain "original description mobile"


### PR DESCRIPTION
Fix for an issue when importing variant group : the PIM deletes existing values and replaces them by the imported one's. For the scoped and/or localized attributes, it can cause data loss when processing a partial import.

**Example**

I have an attribute "description" on a variant group with this existing values : 
```
Array
(
    [0] => Array
        (
            [locale] => en_US
            [scope] => ecommerce
            [data] => desc US
        )

    [2] => Array
        (
            [locale] => de_DE
            [scope] => ecommerce
            [data] => desc DE
        )
)
```
I process an import with only this value for the attribute "description" :
```
Array
(
    [description] => Array
        (
            [0] => Array
                (
                    [locale] => en_US
                    [scope] => ecommerce
                    [data] => desc EN import
                )
        )
)
```
The en_US value will be updated but the de_DE value will be deleted from the database.

**Fix**

I replaced the array_merge method by a custom one in order to merge properly original values (extisting values) and new values (imported values).

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Y
| Added Behats                      | Y
| Changelog updated                 | Y
| Review and 2 GTM                  |
| Micro Demo to the PO (Story only) | N
| Migration script                  | N
| Tech Doc                          | N
