### PR TITLE
PHP7 and APCu #4829

### DIFF
--- a/app/PimRequirements.php
+++ b/app/PimRequirements.php
@@ -50,6 +50,12 @@ class PimRequirements extends OroRequirements
             'Make sure the <strong>exec()</strong> function is not disabled in php.ini'
         );
 
+        $this->addPimRequirement(
+            function_exists('apcu_store'),
+            'Extension php5-apcu should be installed',
+            'Install and enable <strong>php5-apcu</strong>'
+        );
+
         // Check directories
         foreach ($directoriesToCheck as $directoryToCheck) {
             $this->addPimRequirement(

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "apy/jsfv-bundle": "2.0.1",
         "ass/xmlsecurity": "1.1.1",
         "doctrine/annotations": "1.2.6",
-        "doctrine/cache": "1.3.1",
+        "doctrine/cache": "1.6.0",
         "doctrine/common": "2.4.2",
         "doctrine/data-fixtures": "1.0.0",
         "doctrine/doctrine-bundle": "1.2.0",

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ArrayApcCache.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ArrayApcCache.php
@@ -2,14 +2,19 @@
 
 namespace Pim\Bundle\CatalogBundle\Doctrine;
 
-use Doctrine\Common\Cache\ApcCache;
+use Doctrine\Common\Cache\ApcuCache;
 use Doctrine\Common\Cache\ArrayCache;
 use Doctrine\Common\Cache\Cache;
 
 /**
- * Proxy for ApcCache in http mode and ArrayCache in command line mode
+ * Proxy for ApcuCache with a fall back on ArrayCache when using cli mode.
  *
- * This class replaces Doctrine\Common\Cache\ApcCache in the configuration
+ * In http mode, apc is enabled by default.
+ *
+ * In command line mode, apc is disabled by default, we advise to enable it with the option apc.enable_cli=1.
+ *
+ * This class replaces Doctrine\Common\Cache\ApcCache in the configuration, defined in doctrine/doctrine-bundle with
+ * the parameter "doctrine.orm.cache.apc.class"
  *
  * @author    Antoine Guigan <antoine@akeneo.com>
  * @copyright 2013 Akeneo SAS (http://www.akeneo.com)
@@ -17,19 +22,14 @@ use Doctrine\Common\Cache\Cache;
  */
 class ArrayApcCache implements Cache
 {
-    /**
-     * @var Cache
-     */
+    /** @var Cache */
     protected $cache;
 
-    /**
-     * Constructor
-     */
+    /** Constructor */
     public function __construct()
     {
-        $this->cache = ('cli' === php_sapi_name())
-            ? new ArrayCache()
-            : new ApcCache();
+        $cliModeWithDisabledApc = ('cli' === php_sapi_name() && ini_get('apc.enable_cli') !== '1');
+        $this->cache = $cliModeWithDisabledApc ? new ArrayCache() : new ApcuCache();
     }
 
     /**


### PR DESCRIPTION
When installing the PIM master with PHP7 + php-apcu, the PIM is not usable in web, in prod mode due to the following issue:

```PHP Fatal error:  Uncaught Symfony\\Component\\Debug\\Exception\\FatalThrowableError: Fatal error: Call to undefined function Doctrine\\Common\\Cache\\apc_fetch() in /home/nico/git/pim-ce-16-orm/vendor/doctrine/cache/lib/Doctrine/Common/Cache/ApcCache.php:41\nStack trace:\n#0 /home/nico/git/pim-ce-16-orm/vendor/doctrine/cache/lib/Doctrine/Common/Cache/CacheProvider.php(212): Doctrine\\Common\\Cache\\ApcCache->doFetch('DoctrineNamespa...')\n#1 /home/nico/git/pim-ce-16-orm/vendor/doctrine/cache/lib/Doctrine/Common/Cache/CacheProvider.php(185): Doctrine\\Common\\Cache\\CacheProvider->getNamespaceVersion()\n#2 /home/nico/git/pim-ce-16-orm/vendor/doctrine/cache/lib/Doctrine/Common/Cache/CacheProvider.php(78): Doctrine\\Common\\Cache\\CacheProvider->getNamespacedId('Pim\\\\Bundle\\\\Cata...')\n#3 /home/nico/git/pim-ce-16-orm/src/Pim/Bundle/CatalogBundle/Doctrine/ArrayApcCache.php(56): Doctrine\\Common\\Cache\\CacheProvider->fetch('Pim\\\\Bundle\\\\Cata...')\n#4 /home/nico/git/pim-ce-16-orm/vendor/doctrine/common/lib/Doctrine/Common/Persistence/Mapping/AbstractClass in /home/nico/git/pim-ce-16-orm/vendor/doctrine/cache/lib/Doctrine/Common/Cache/ApcCache.php on line 41```

This is related to the replacement of doctrine.orm.cache.apc.class to use our own class via `    doctrine.orm.cache.apc.class: Pim\Bundle\CatalogBundle\Doctrine\ArrayApcCache` this class delegates to `Doctrine\Common\Cache\ApcCache` when in web mode and to `Doctrine\Common\Cache\ArrayCache` in cli mode.

This parameter is originally defined in `doctrine/bundle` with `<parameter key="doctrine.orm.cache.apc.class">Doctrine\Common\Cache\ApcCache</parameter>`.

It worked with Debian because we install the package php7.0-apcu-bc cf https://docs.akeneo.com/master/developer_guide/installation/system_requirements/setup_requirements_debian8_php7.html this package is not available in Ubuntu xenial (16.04LTS) and now in PHP7, there is no more default backward compatibility support for apc cf http://php.net/manual/de/apcu.installation.php 

Our doctrine/cache dependency natively supports APCu since the v1.6.0 cf https://github.com/doctrine/cache/releases/tag/v1.6.0 for now we use the v1.3.1.

After discussion with @BitOne,
 - we bump doctrine/cache to v1.6
 - always use ApcuCache class in http mode
 - when used in cli, use ApcuCache when apc.enable_cli enabled and fallback on ArrayCache when disable
 - change the documentation to ask to enable apcu in cli mode

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | N
| Added Behats                      | N
| Changelog updated                 | Y
| Review and 2 GTM                  | ?
| Micro Demo to the PO (Story only) |
| Migration script                  | N
| Tech Doc                          | N

