### PR TITLE
TIP-568: reduce time import of products

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/CompletenessGenerator.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/CompletenessGenerator.php
@@ -272,7 +272,7 @@ MISSING_SQL;
     /**
      * Get the sql query to insert completeness
      *
-     * @param array
+     * @param array $criteria
      *
      * @return string
      */

--- a/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Product.php
+++ b/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Product.php
@@ -251,8 +251,8 @@ class Product implements ArrayConverterInterface
                 $value = $this->convertValue($column, $value);
             }
 
-            if (null !== $value) {
-                $convertedItem = $this->mergeValueToResult($convertedItem, $value);
+            if (!empty($value)) {
+                $convertedItem = $this->mergeValueToItem($convertedItem, $value);
             }
         }
 
@@ -292,24 +292,24 @@ class Product implements ArrayConverterInterface
     }
 
     /**
-     * Merge the structured value inside the passed collection
+     * Merge the structured value inside the passed item
      *
-     * @param array $collection The collection in which we add the element
-     * @param array $value      The structured value to add to the collection
+     * @param array $item   The item in which we add the element
+     * @param array $value  The structured value to add to the collection
      *
      * @return array
      */
-    protected function mergeValueToResult(array $collection, array $value)
+    protected function mergeValueToItem(array $item, array $value)
     {
         foreach ($value as $code => $data) {
-            if (array_key_exists($code, $collection)) {
-                $collection[$code] = array_merge_recursive($collection[$code], $data);
+            if (array_key_exists($code, $item)) {
+                $item[$code] = array_merge_recursive($item[$code], $data);
             } else {
-                $collection[$code] = $data;
+                $item[$code] = $data;
             }
         }
 
-        return $collection;
+        return $item;
     }
 
     /**

--- a/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Product.php
+++ b/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Product.php
@@ -295,7 +295,7 @@ class Product implements ArrayConverterInterface
      * Merge the structured value inside the passed item
      *
      * @param array $item   The item in which we add the element
-     * @param array $value  The structured value to add to the collection
+     * @param array $value  The structured value to add to the item
      *
      * @return array
      */

--- a/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Product.php
+++ b/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Product.php
@@ -337,9 +337,12 @@ class Product implements ArrayConverterInterface
             $this->getOptionalAssociationFields()
         );
 
+        // index $optionalFields by keys to improve performances
+        $optionalFields = array_combine($optionalFields, $optionalFields);
         $unknownFields = [];
+
         foreach (array_keys($item) as $field) {
-            if (!in_array($field, $optionalFields)) {
+            if (!isset($optionalFields[$field])) {
                 $unknownFields[] = $field;
             }
         }

--- a/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Product/AssociationColumnsResolver.php
+++ b/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Product/AssociationColumnsResolver.php
@@ -31,7 +31,6 @@ class AssociationColumnsResolver
     public function __construct(AssociationTypeRepositoryInterface $repository)
     {
         $this->assocTypeRepository = $repository;
-        $this->assocFieldsCache    = [];
     }
 
     /**
@@ -41,7 +40,7 @@ class AssociationColumnsResolver
      */
     public function resolveAssociationColumns()
     {
-        if (empty($this->assocFieldsCache)) {
+        if (null === $this->assocFieldsCache) {
             $fieldNames = [];
             $assocTypes = $this->assocTypeRepository->findAll();
             foreach ($assocTypes as $assocType) {

--- a/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Product/ValueConverter/ValueConverterRegistry.php
+++ b/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Product/ValueConverter/ValueConverterRegistry.php
@@ -14,19 +14,15 @@ class ValueConverterRegistry implements ValueConverterRegistryInterface
     /** @var ValueConverterInterface[] */
     protected $converters = [];
 
+    /** @var ValueConverterInterface[] */
+    protected $convertersByAttributeType = [];
+
     /**
      * {@inheritdoc}
      */
-    public function register(ValueConverterInterface $converter, $priority)
+    public function register(ValueConverterInterface $converter)
     {
-        $priority = (int)$priority;
-        if (!isset($this->converters[$priority])) {
-            $this->converters[$priority] = $converter;
-        } else {
-            $this->register($converter, ++$priority);
-        }
-
-        ksort($this->converters);
+        $this->converters[] = $converter;
 
         return $this;
     }
@@ -36,8 +32,14 @@ class ValueConverterRegistry implements ValueConverterRegistryInterface
      */
     public function getConverter($attributeType)
     {
+        if (isset($this->convertersByAttributeType[$attributeType])) {
+            return $this->convertersByAttributeType[$attributeType];
+        }
+
         foreach ($this->converters as $converter) {
             if ($converter->supportsField($attributeType)) {
+                $this->convertersByAttributeType[$attributeType] = $converter;
+
                 return $converter;
             }
         }

--- a/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Product/ValueConverter/ValueConverterRegistryInterface.php
+++ b/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Product/ValueConverter/ValueConverterRegistryInterface.php
@@ -15,11 +15,10 @@ interface ValueConverterRegistryInterface
      * Register a converter.
      *
      * @param ValueConverterInterface $converter
-     * @param int                     $priority FIFO order : converter with lower priority is inspected first.
      *
      * @return ValueConverterRegistry
      */
-    public function register(ValueConverterInterface $converter, $priority);
+    public function register(ValueConverterInterface $converter);
 
     /**
      * @param string $attributeType

--- a/src/Pim/Component/Connector/spec/ArrayConverter/FlatToStandard/Product/AssociationColumnsResolverSpec.php
+++ b/src/Pim/Component/Connector/spec/ArrayConverter/FlatToStandard/Product/AssociationColumnsResolverSpec.php
@@ -31,7 +31,7 @@ class AssociationColumnsResolverSpec extends ObjectBehavior
         );
     }
 
-    function it_cache_the_associations_even_without_results($assocTypeRepo)
+    function it_caches_the_associations_even_without_results($assocTypeRepo)
     {
         $assocTypeRepo->findAll()->willReturn([])->shouldBeCalledTimes(1);
         $this->resolveAssociationColumns()->shouldReturn([]);

--- a/src/Pim/Component/Connector/spec/ArrayConverter/FlatToStandard/Product/AssociationColumnsResolverSpec.php
+++ b/src/Pim/Component/Connector/spec/ArrayConverter/FlatToStandard/Product/AssociationColumnsResolverSpec.php
@@ -30,4 +30,11 @@ class AssociationColumnsResolverSpec extends ObjectBehavior
             ]
         );
     }
+
+    function it_cache_the_associations_even_without_results($assocTypeRepo)
+    {
+        $assocTypeRepo->findAll()->willReturn([])->shouldBeCalledTimes(1);
+        $this->resolveAssociationColumns()->shouldReturn([]);
+        $this->resolveAssociationColumns()->shouldReturn([]);
+    }
 }

--- a/src/Pim/Component/Connector/spec/ArrayConverter/FlatToStandard/ProductSpec.php
+++ b/src/Pim/Component/Connector/spec/ArrayConverter/FlatToStandard/ProductSpec.php
@@ -247,7 +247,7 @@ class ProductSpec extends ObjectBehavior
             ],
             'associations' => [
                 'X_SELL' => [
-                    'groups' => ['group-A'],
+                    'groups'   => ['group-A'],
                     'products' => ['sku-A', 'sku-B'],
                 ],
             ]


### PR DESCRIPTION
This PR aims to reduce the time of product imports. There are two axes of improvements in this PR:

1. reduce the time spent in the completeness calculation. Adding the completeness calculation during the save of a product has a huge impact on computer with non SSD drives.
2. reduce the time spent in greedy methods (lot of CPU time) or methods that are called a very lot of times 

Note: this PR treats only the import of new products. We currently have a memory leak on the import of MongoDB updated products. @skeleton is taking care of that :)

Note: the benchmarks you'll see below have been realized on the _core-perf_ machine.

## The state of products import before this PR

Internally, we changed quite a lot of things between the products import 1.5 and the products import master:
* the processors now receives the standard format
* which means the readers transform flat format to standard format (and delocalize data)
* spout is used to read CSV/XLSX
* *the completeness is now calculated at each save*
* and a few more..

Those changes make difficult to analyse with blackfire what's better or worse than before, because the paths of the graphs are totally different.

![mongo](https://cloud.githubusercontent.com/assets/3691804/17889198/660cb0b6-692f-11e6-9e05-43c490b27bbe.png)

Calculating the completeness at each save has no impact on the MongoDB imports. That's because, by design, the MongoDB completeness is simple to caclulate. Even better, our changes tend to improve a little bit (~10%) the import time.

![orm](https://cloud.githubusercontent.com/assets/3691804/17889200/6782f428-692f-11e6-9d88-072299344d5c.png)

On ORM, that's a different story! The completeness calculation has a huge impact on the time to import. And the more the table grows, the more the completeness calculation is greedy. For 500 products, the master import is ~2.2 times slower while for 10 000 products it's ~2.7 times slower.

You can see in orange the master without the completeness calculation. We import products on the same time basis that what we had on 1.5. 

## The ORM completeness improvements
 
The ORM completeness was, by design, effective for the calculation of a lot of products at the same time. Each time the completeness was calculated we:

1. created a temporary table with all missing completeness (for the set of products we selected)
2. created a temporary table with all complete (for the set of products we selected)
3. performed a complicated query that joins on those two tables

Creating the temporary tables consumes a lot of IO waits on non SSD disks (like what we have on the core-perf server). *A lot!* The impact are much less important on machines with SSD disks.

So basically, what's done in this PR is that when we calculate the completeness for one product (ie: each time we save a product), we do not create those temporary tables. We just join on the data we need.
The temporary tables are still used when we calculate the completeness of a vast amount of products at the same time (completeness:calculate command, change attribute requirements of a family etc...). Without those temporary tables, the completeness calculations takes too much memory for a vast number of products.


## The others minor improvements

Other improvements consist of:
* caching things that are called a lot of times during an import (example: 1 000 products imported => 1 000 000 calls to the method)
   * really cache the association columns resolver
   * cache the value converter registry
* improving the code of greedy methods
   * do not use `in_array` in the product flat to standard array converter

## The state of products import after this PR

This PR (green dots, branch tweak_completeness) improves performances of products import. 

![mongo](https://cloud.githubusercontent.com/assets/3691804/17960916/0e02f580-6aa9-11e6-9ff4-39dc65e093db.png)

On MongoDB this branch is slightly faster than 1.5 and master due to the caching improvements and code simplifications.

![orm](https://cloud.githubusercontent.com/assets/3691804/17960923/16573796-6aa9-11e6-917f-d55e5894e95a.png)

On ORM this branch allows us to have the same timings that the 1.5 branch, even if we do calculate the completeness. We are ~65% faster than the current master. Please keep in mind that these branch is particularly effective for non SSD drives. On SSD drives, the gain will be lower, but still significant.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Y
| Added Behats                      | -
| Changelog updated                 | -
| Review and 2 GTM                  |
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -
