### PR TITLE
PIM-5896: Fix reference data name validation when creating a referenc…

### DIFF
--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-5767: Issue with filter "in list" when SKU contains dashes (-)
+- PIM-5896: Fix reference data name validation when creating a reference data simple/multi-select attribute
 
 # 1.5.7 (2016-07-19)
 

--- a/features/reference-data/attribute/add_attribute_with_reference_data_name.feature
+++ b/features/reference-data/attribute/add_attribute_with_reference_data_name.feature
@@ -1,0 +1,28 @@
+@javascript
+Feature: Perform form validation when creating a reference data attribute
+  In order to check the "reference data name" field is filled
+  As a product manager
+  I need to be sure I have selected the "reference data name" for the attribute I'm creating
+
+  Background:
+    Given the "footwear" catalog configuration
+    And I am logged in as "Julia"
+    And I am on the attributes page
+
+  @jira https://akeneo.atlassian.net/browse/PIM-5896
+  Scenario: Avoid creation of a simple reference data when field reference data name is not filled
+    Given I create a "Reference data simple select" attribute
+    And I fill in the following information:
+      | Code            | mycolor |
+      | Attribute group | Other   |
+    When I save the attribute
+    Then I should see validation error "This value should not be blank."
+
+  @jira https://akeneo.atlassian.net/browse/PIM-5896
+  Scenario: Avoid creation of a multiple reference data when field reference data name is not filled
+    Given I create a "Reference data multi select" attribute
+    And I fill in the following information:
+      | Code            | mycolor |
+      | Attribute group | Other   |
+    When I save the attribute
+    Then I should see validation error "This value should not be blank."

--- a/spec/Pim/Bundle/CatalogBundle/Validator/Constraints/NotBlankPropertiesSpec.php
+++ b/spec/Pim/Bundle/CatalogBundle/Validator/Constraints/NotBlankPropertiesSpec.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace spec\Pim\Bundle\CatalogBundle\Validator\Constraints;
+
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\Validator\Constraint;
+
+class NotBlankPropertiesSpec extends ObjectBehavior
+{
+    function let()
+    {
+        $this->beConstructedWith(['properties' => ['my_property']]);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Pim\Bundle\CatalogBundle\Validator\Constraints\NotBlankProperties');
+    }
+
+    function it_is_a_validator_constraint()
+    {
+        $this->shouldBeAnInstanceOf('Symfony\Component\Validator\Constraint');
+    }
+
+    function it_has_message()
+    {
+        $this->message->shouldBeEqualTo('This value should not be blank.');
+    }
+
+    function it_has_class_target()
+    {
+        $this->getTargets()->shouldBe(Constraint::CLASS_CONSTRAINT);
+    }
+
+    function it_has_default_option_equal_to_properties()
+    {
+        $this->getDefaultOption()->shouldBe('properties');
+    }
+
+    function it_has_required_options_contain_properties()
+    {
+        $this->getRequiredOptions()->shouldBe(['properties']);
+    }
+}

--- a/spec/Pim/Bundle/CatalogBundle/Validator/Constraints/NotBlankPropertiesValidatorSpec.php
+++ b/spec/Pim/Bundle/CatalogBundle/Validator/Constraints/NotBlankPropertiesValidatorSpec.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace spec\Pim\Bundle\CatalogBundle\Validator\Constraints;
+
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\CatalogBundle\Entity\Attribute;
+use Pim\Bundle\CatalogBundle\Validator\Constraints\NotBlankProperties;
+use Prophecy\Argument;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
+
+class NotBlankPropertiesValidatorSpec extends ObjectBehavior
+{
+    function let(ExecutionContextInterface $context)
+    {
+        $this->initialize($context);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Pim\Bundle\CatalogBundle\Validator\Constraints\NotBlankPropertiesValidator');
+    }
+
+    function it_validates_not_blank_property_value(
+        $context,
+        NotBlankProperties $constraint,
+        Attribute $value
+    ) {
+        $constraint->properties = ['my_property'];
+
+        $value
+            ->getProperties()
+            ->willReturn(['my_property' => 'not_blank_value']);
+
+        $context
+            ->buildViolation(Argument::any())
+            ->shouldNotBeCalled();
+
+        $this->validate($value, $constraint);
+    }
+
+    function it_does_not_validate_blank_property_value(
+        $context,
+        NotBlankProperties $constraint,
+        ConstraintViolationBuilderInterface $violation,
+        Attribute $value
+    ) {
+        $constraint->properties = ['my_property'];
+
+        $value
+            ->getProperties()
+            ->willReturn(['my_property' => null]);
+
+        $context
+            ->buildViolation($constraint->message)
+            ->shouldBeCalled()
+            ->willReturn($violation);
+
+        $this->validate($value, $constraint);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/validation/attribute.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/validation/attribute.yml
@@ -21,6 +21,9 @@ Pim\Bundle\CatalogBundle\Entity\Attribute:
                 - pim_catalog_number
                 - pim_catalog_price_collection
                 - pim_catalog_metric
+        - Pim\Bundle\CatalogBundle\Validator\Constraints\NotBlankProperties:
+            properties:
+                - reference_data_name
     properties:
         attributeType:
             - NotBlank: ~
@@ -82,7 +85,6 @@ Pim\Bundle\CatalogBundle\Entity\Attribute:
                     - pim_catalog_price_collection
                     - pim_catalog_multiselect
                     - pim_catalog_simpleselect
-
                     - pim_catalog_file
                     - pim_catalog_image
                     - pim_catalog_boolean

--- a/src/Pim/Bundle/CatalogBundle/Validator/Constraints/NotBlankProperties.php
+++ b/src/Pim/Bundle/CatalogBundle/Validator/Constraints/NotBlankProperties.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Constraint to check if properties are not left blank
+ *
+ * @author    Fabien Lemoine <fabien.lemoine@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class NotBlankProperties extends Constraint
+{
+    /** @var string */
+    public $message = 'This value should not be blank.';
+
+    /** @var array */
+    public $properties = [];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTargets()
+    {
+        return self::CLASS_CONSTRAINT;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultOption()
+    {
+        return 'properties';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRequiredOptions()
+    {
+        return ['properties'];
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Validator/Constraints/NotBlankPropertiesValidator.php
+++ b/src/Pim/Bundle/CatalogBundle/Validator/Constraints/NotBlankPropertiesValidator.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ * Validator to check if properties are not left blank
+ *
+ * @author    Fabien Lemoine <fabien.lemoine@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class NotBlankPropertiesValidator extends ConstraintValidator
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function validate($value, Constraint $constraint)
+    {
+        $properties = $constraint->properties;
+        $values = $value->getProperties();
+
+        foreach ($properties as $propertyCode) {
+            if (array_key_exists($propertyCode, $values) && null === $values[$propertyCode]) {
+                $this->context->buildViolation($constraint->message)->addViolation();
+            }
+        }
+    }
+}

--- a/src/Pim/Bundle/JsFormValidationBundle/Generator/FormValidationScriptGenerator.php
+++ b/src/Pim/Bundle/JsFormValidationBundle/Generator/FormValidationScriptGenerator.php
@@ -139,17 +139,18 @@ class FormValidationScriptGenerator extends BaseFormValidationScriptGenerator
             $dispatcher->dispatch(JsfvEvents::preProcess, $preProcessEvent);
             // @codingStandardsIgnoreEnd
 
-            if (!empty($metadata->constraints)) {
-                foreach ($metadata->constraints as $constraint) {
+            if ($metadata->hasConstraints()) {
+                foreach ($metadata->getConstraints() as $constraint) {
                     $constraintName = $this->getConstraintName($constraint);
-                    if ($constraintName == 'UniqueEntity') {
+                    if ('UniqueEntity' == $constraintName) {
                         if (is_array($constraint->fields)) {
                             //It has not been implemented yet
                         } elseif (is_string($constraint->fields)) {
-                            if (!isset($aConstraints[$constraint->fields])) {
-                                $aConstraints[$constraint->fields] = [];
-                            }
                             $aConstraints[$constraint->fields][] = $constraint;
+                        }
+                    } elseif ('NotBlankProperties' == $constraintName) {
+                        foreach ($constraint->properties as $property) {
+                            $aConstraints[$property][] = $constraint;
                         }
                     }
                 }
@@ -160,7 +161,6 @@ class FormValidationScriptGenerator extends BaseFormValidationScriptGenerator
          * PIM-4443: we removed the original $metadata->getters implementation to avoid issues with
          * cascade validation and getter (validation of the code of the attribute group of an attribute)
          */
-
         if (isset($entityName)) {
             $constraintsTarget = $metadata->properties;
         } else {
@@ -209,6 +209,16 @@ class FormValidationScriptGenerator extends BaseFormValidationScriptGenerator
                     }
                     // we look through each field constraint
                     foreach ($constraintList as $constraint) {
+                        $this->addFieldConstraint(
+                            $formField,
+                            $fieldsConstraints,
+                            $constraint
+                        );
+                    }
+                } elseif ('reference_data_name' === $formField->vars['name'] &&
+                    !empty($aConstraints[$formField->vars['name']])
+                ) {
+                    foreach ($aConstraints[$formField->vars['name']] as $constraint) {
                         $this->addFieldConstraint(
                             $formField,
                             $fieldsConstraints,

--- a/src/Pim/Bundle/JsFormValidationBundle/Resources/views/Constraints/NotBlankPropertiesValidator.js.twig
+++ b/src/Pim/Bundle/JsFormValidationBundle/Resources/views/Constraints/NotBlankPropertiesValidator.js.twig
@@ -1,0 +1,10 @@
+function NotBlankProperties(field, params)
+{
+    var value = field && field.nodeName ? $(field).val() : field;
+
+    if (isNotDefined(value)) {
+        return getComputeMessage(params.message);
+    }
+
+    return true;
+}


### PR DESCRIPTION
When creating a simple select or multi select reference data attribute, form validation was not performed on the mandatory field "reference data name". I fixed that.

The point is "Reference data name" is a non mapped field. 
- I created a custom validator for properties and use it for this field.
- I created specific code in the "JsFormValidationBundle/Generator/FormValidationScriptGenerator.php" in order to enable frontend validation.
- There is no phpspec for "FormValidationScriptGenerator.php" so I didn't create it. 

The attribute creation form and his formTypes will be replaced by a "PEF like form" in the near future.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Y
| Added Behats                      | Y
| Changelog updated                 | Y
| Review and 2 GTM                  | Y
| Micro Demo to the PO (Story only) | N
| Migration script                  | N
| Tech Doc                          | N

…e data simple/multi-select attribute