### PR TITLE
PIM-5929: Fix the validation issue indicator appearance on form tabs

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -6,6 +6,7 @@
 - PIM-5888: Fix an outline glitch on some buttons
 - PIM-5869: Allow any codes to be used for attributes
 - PIM-5915: Fix the import of localizable and scopable variant group attributes
+- PIM-5929: Fix the validation issue indicator appearance on form tabs
 
 ## Functional improvements
 

--- a/src/Pim/Bundle/UIBundle/Resources/public/css/form.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/css/form.less
@@ -17,8 +17,21 @@
   &.active a {
     border-bottom: 3px solid @textColor + #111;
   }
-  &:not(.active) a.error {
-    border-bottom: 3px solid @redDark;
+  a.error {
+    border-bottom: none;
+    color: @redDark;
+    font-weight: bold;
+    &:before {
+      display: inline-block;
+      margin-right: 5px;
+      font-family: 'FontAwesome';
+      font-style: normal;
+      text-decoration: inherit;
+      -webkit-font-smoothing: antialiased;
+      content: "\f06a";
+      text-indent: 0;
+      speak: none;
+    }
   }
 }
 


### PR DESCRIPTION
100% CSS fix. When validating a form, the indicator appearance which is displayed on the tabs with errors isn't clear. I adjusted it.

Before :
https://akeneo.atlassian.net/secure/attachment/28500/Screenshot_20160810_112115.png

After :
https://akeneo.atlassian.net/secure/attachment/28502/capture.jpg

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | N
| Added Behats                      | N
| Changelog updated                 | Y
| Review and 2 GTM                  | 
| Micro Demo to the PO (Story only) | Y
| Migration script                  | N
| Tech Doc                          | N

