### PR TITLE
FileIterator: close reader only if not null

### DIFF
--- a/src/Pim/Component/Connector/Reader/File/FileIterator.php
+++ b/src/Pim/Component/Connector/Reader/File/FileIterator.php
@@ -146,7 +146,9 @@ class FileIterator implements FileIteratorInterface
      */
     public function __destruct()
     {
-        $this->reader->close();
+        if (null !== $this->reader) {
+            $this->reader->close();
+        }
 
         if (null !== $this->archivePath) {
             $fileSystem = new Filesystem();

--- a/src/Pim/Component/Connector/spec/Reader/File/FileIteratorSpec.php
+++ b/src/Pim/Component/Connector/spec/Reader/File/FileIteratorSpec.php
@@ -4,6 +4,7 @@ namespace spec\Pim\Component\Connector\Reader\File;
 
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
+use Symfony\Component\Filesystem\Exception\FileNotFoundException;
 
 class FileIteratorSpec extends ObjectBehavior
 {
@@ -14,6 +15,16 @@ class FileIteratorSpec extends ObjectBehavior
                 'fieldDelimiter' => ';'
             ]
         ]);
+    }
+
+    function it_throws_exception_with_invalid_filename()
+    {
+        $this->beConstructedWith('csv', $this->getPath() . DIRECTORY_SEPARATOR  . 'unknown_file.csv', [
+            'reader_options' => [
+                'fieldDelimiter' => ';'
+            ]
+        ]);
+        $this->shouldThrow(FileNotFoundException::class)->duringInstantiation();
     }
 
     function it_gets_current_row()


### PR DESCRIPTION
The internal reader can be null if an exception occured before its instanciation.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       |yes
| Added Behats                      |no
| Changelog updated                 |no
| Review and 2 GTM                  |yes

