### PR TITLE
PIM-5928: Export products without media

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - #4879: Fix collision when using several popins on the same page, cheers @dimitri-koenig!
+- PIM-5928: Export products without media
 
 # 1.6.0-ALPHA2 (2016-08-23)
 

--- a/features/export/export_products_without_media.feature
+++ b/features/export/export_products_without_media.feature
@@ -1,0 +1,36 @@
+@javascript
+Feature: Export products without media
+  In order to re-import the product
+  As a product manager
+  I need to be able to export them without media
+
+  Background:
+    Given a "footwear" catalog configuration
+    And the following job "csv_footwear_product_export" configuration:
+      | filePath   | %tmp%/product_export/product_export.csv |
+      | with_media | no                                      |
+    And I am logged in as "Julia"
+
+  @jira https://akeneo.atlassian.net/browse/PIM-5928
+  Scenario: Successfully export products without media
+    Given the following products:
+      | sku      | family   | categories        | price          | size | color    | name-en_US |
+      | SNKRS-1B | sneakers | summer_collection | 50 EUR, 70 USD | 45   | black    | Model 1    |
+      | SNKRS-1R | sneakers | summer_collection | 50 EUR, 70 USD | 45   | red      | Model 1    |
+      | SNKRS-1C | sneakers | summer_collection | 55 EUR, 75 USD | 45   | charcoal | Model 1    |
+    And the following product values:
+      | product  | attribute | value                     |
+      | SNKRS-1R | side_view | %fixtures%/SNKRS-1R.png   |
+      | SNKRS-1C | side_view | %fixtures%/SNKRS-1C-s.png |
+      | SNKRS-1C | top_view  | %fixtures%/SNKRS-1C-t.png |
+    And I launched the completeness calculator
+    And I am on the "csv_footwear_product_export" export job page
+    When I launch the export job
+    And I wait for the "csv_footwear_product_export" job to finish
+    Then exported file of "csv_footwear_product_export" should contain:
+    """
+    sku;categories;color;description-en_US-mobile;enabled;family;groups;lace_color;manufacturer;name-en_US;price-EUR;price-USD;rating;size;weather_conditions
+    SNKRS-1B;summer_collection;black;;1;sneakers;;;;"Model 1";50.00;70.00;;45;
+    SNKRS-1R;summer_collection;red;;1;sneakers;;;;"Model 1";50.00;70.00;;45;
+    SNKRS-1C;summer_collection;charcoal;;1;sneakers;;;;"Model 1";55.00;75.00;;45;
+    """

--- a/src/Pim/Component/Connector/Processor/Normalization/ProductProcessor.php
+++ b/src/Pim/Component/Connector/Processor/Normalization/ProductProcessor.php
@@ -186,6 +186,6 @@ class ProductProcessor implements ItemProcessorInterface, StepExecutionAwareInte
     protected function areAttributesToFilter(JobParameters $parameters)
     {
         return isset($parameters->get('filters')['structure']['attributes'])
-        && !empty($parameters->get('filters')['structure']['attributes']);
+            && !empty($parameters->get('filters')['structure']['attributes']);
     }
 }

--- a/src/Pim/Component/Connector/Processor/Normalization/ProductProcessor.php
+++ b/src/Pim/Component/Connector/Processor/Normalization/ProductProcessor.php
@@ -98,6 +98,15 @@ class ProductProcessor implements ItemProcessorInterface, StepExecutionAwareInte
                 ->get(JobInterface::WORKING_DIRECTORY_PARAMETER);
 
             $this->fetchMedia($product, $directory);
+        } else {
+            $mediaAttributes = $this->attributeRepository->findMediaAttributeCodes();
+            $productStandard['values'] = array_filter(
+                $productStandard['values'],
+                function ($attributeCode) use ($mediaAttributes) {
+                    return !in_array($attributeCode, $mediaAttributes);
+                },
+                ARRAY_FILTER_USE_KEY
+            );
         }
 
         $this->detacher->detach($product);
@@ -177,6 +186,6 @@ class ProductProcessor implements ItemProcessorInterface, StepExecutionAwareInte
     protected function areAttributesToFilter(JobParameters $parameters)
     {
         return isset($parameters->get('filters')['structure']['attributes'])
-            && !empty($parameters->get('filters')['structure']['attributes']);
+        && !empty($parameters->get('filters')['structure']['attributes']);
     }
 }


### PR DESCRIPTION
When you export products without media we remove all media attributes from the generated file.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | yes
| Added Behats                      | yes
| Changelog updated                 | yes
| Review and 2 GTM                  | yes
| Micro Demo to the PO (Story only) | TODO
| Migration script                  |
| Tech Doc                          |

