### PR TITLE
PIM-5926: When I go back in mass-classify products, I return to the mass-edit attributes

### DIFF
--- a/features/mass-action/classify_product.feature
+++ b/features/mass-action/classify_product.feature
@@ -18,6 +18,8 @@ Feature: Classify many products at once
     Given I select rows bigfoot and horseshoe
     And I press "Category Edit" on the "Bulk Actions" dropdown button
     And I choose the "Classify products in categories" operation
+    And I press the "Back" button
+    And I choose the "Classify products in categories" operation
     And I press the "2014 collection" button
     And I expand the "2014_collection" category
     And I click on the "winter_collection" category
@@ -31,6 +33,8 @@ Feature: Classify many products at once
   Scenario: Move several products to categories at once
     Given I select rows bigfoot and horseshoe
     And I press "Category Edit" on the "Bulk Actions" dropdown button
+    And I choose the "Move products to categories" operation
+    And I press the "Back" button
     And I choose the "Move products to categories" operation
     And I select the "2014 collection" tree
     And I expand the "2014_collection" category

--- a/features/mass-action/mass_actions_on_all_entities.feature
+++ b/features/mass-action/mass_actions_on_all_entities.feature
@@ -19,6 +19,8 @@ Feature: Apply a mass action on all entities
     And I select all entities
     And I press "Mass Edit" on the "Bulk Actions" dropdown button
     And I choose the "Edit common attributes" operation
+    And I press the "Back" button
+    And I choose the "Edit common attributes" operation
     And I display the Name attribute
     And I change the "Name" to "Same product"
     And I move on to the next step
@@ -39,6 +41,8 @@ Feature: Apply a mass action on all entities
     And I filter by "completeness" with operator "" and value "yes"
     When I select all entities
     And I press "Mass Edit" on the "Bulk Actions" dropdown button
+    And I choose the "Change the family of products" operation
+    And I press the "Back" button
     And I choose the "Change the family of products" operation
     And I change the Family to "Sandals"
     And I move on to the next step
@@ -71,6 +75,8 @@ Feature: Apply a mass action on all entities
     And I select all entities
     And I unselect row mega_boots
     When I press "Mass Edit" on the "Bulk Actions" dropdown button
+    And I choose the "Change status (enable / disable)" operation
+    And I press the "Back" button
     And I choose the "Change status (enable / disable)" operation
     And I disable the products
     And I wait for the "change-status" mass-edit job to finish

--- a/src/Pim/Bundle/EnrichBundle/Controller/MassEdit/AbstractMassEditController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/MassEdit/AbstractMassEditController.php
@@ -98,6 +98,7 @@ abstract class AbstractMassEditController
             if ($form->isValid()) {
                 $data = $form->getData();
                 $queryParams += ['operationAlias' => $data['operationAlias']];
+                $queryParams += ['operationGroup' => $operationGroup];
 
                 $configureRoute = $this
                     ->router
@@ -235,6 +236,7 @@ abstract class AbstractMassEditController
             'filters'    => json_encode($params['filters']),
             'dataLocale' => $request->get('dataLocale', null),
             'itemsCount' => $request->get('itemsCount'),
+            'operationGroup' => $request->get('operationGroup')
         ]);
 
         return $params;


### PR DESCRIPTION
**Description**

Fix the back button behaviour on mass-classify second step (configure)

**Definition Of Done**


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | N
| Added Behats                      | Y
| Changelog updated                 | N
| Review and 2 GTM                  | Y
| Micro Demo to the PO (Story only) | N
| Migration script                  | N
| Tech Doc                          | Y

