### PR TITLE
PIM-5924: Back button of an export edition should back to the export view

### DIFF
--- a/features/export/create_an_export.feature
+++ b/features/export/create_an_export.feature
@@ -17,7 +17,7 @@ Feature: Create an export
       | Label | Products export       |
       | Job   | Product export in CSV |
     And I press the "Save" button
-    Then I click back to grid
+    Then I click back
     And the grid should contain 1 element
     And I should see export profile PRODUCT_EXPORT
 

--- a/features/import/create_an_import.feature
+++ b/features/import/create_an_import.feature
@@ -17,7 +17,7 @@ Feature: Create an import
       | Label | Products import       |
       | Job   | Product import in CSV |
     And I press the "Save" button
-    Then I click back to grid
+    Then I click back
     And the grid should contain 2 element
     And I should see import profile PRODUCT_IMPORT
 

--- a/src/Pim/Bundle/ImportExportBundle/Resources/views/ExportProfile/edit.html.twig
+++ b/src/Pim/Bundle/ImportExportBundle/Resources/views/ExportProfile/edit.html.twig
@@ -2,6 +2,8 @@
 
 {% set actionRoute = path('pim_importexport_export_profile_edit', { 'id': form.vars.value.id }) %}
 
+{% set showRoute = path('pim_importexport_export_profile_show', { 'id': form.vars.value.id }) %}
+
 {% set entityName = 'export profile' %}
 {% set title = (entityName ~'.edit')|trans ~ ' - ' ~ form.vars.value.label %}
 {% set viewElementsAliases = form.vars.id ~ '.export.form_tab' %}

--- a/src/Pim/Bundle/ImportExportBundle/Resources/views/ImportProfile/edit.html.twig
+++ b/src/Pim/Bundle/ImportExportBundle/Resources/views/ImportProfile/edit.html.twig
@@ -2,6 +2,8 @@
 
 {% set actionRoute = path('pim_importexport_import_profile_edit', { 'id': form.vars.value.id }) %}
 
+{% set showRoute = path('pim_importexport_import_profile_show', { 'id': form.vars.value.id }) %}
+
 {% set entityName = 'import profile' %}
 {% set title = (entityName ~ '.edit')|trans ~ ' - ' ~ form.vars.value.label %}
 {% set viewElementsAliases = form.vars.id ~ '.import.form_tab' %}

--- a/src/Pim/Bundle/ImportExportBundle/Resources/views/JobProfile/edit.html.twig
+++ b/src/Pim/Bundle/ImportExportBundle/Resources/views/JobProfile/edit.html.twig
@@ -21,7 +21,7 @@
         {% endset %}
 
         {% set titleButtons %}
-            {{ elements.backLink(indexRoute) }}
+            {{ elements.backLink(showRoute, 'btn.back') }}
         {% endset %}
 
         {% set buttons %}


### PR DESCRIPTION
**Description**

Fix back button for the import/export profile edit page. Now clicking on back button display the job profile.

**Definition Of Done**


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | N
| Added Behats                      | N
| Changelog updated                 | N
| Review and 2 GTM                  | Y
| Micro Demo to the PO (Story only) | Y
| Migration script                  | N
| Tech Doc                          | N

