### PR TITLE
PIM-5935: Fix unstable scenario about view all button in dashboard

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -2,6 +2,8 @@
 
 ## Bug fixes
 
+- PIM-5935: Fix view all button in dashboard
+
 # 1.6.0 (2016-08-30)
 
 ## Bug fixes

--- a/features/dashboard/display_last_operations_widget.feature
+++ b/features/dashboard/display_last_operations_widget.feature
@@ -39,7 +39,12 @@ Feature: Display last operations widget
 
   Scenario: Show job tracker
     Given a "footwear" catalog configuration
+    And the following job "csv_footwear_category_export" configuration:
+      | filePath | %tmp%/category_export/category_export.csv |
     And I am logged in as "Mary"
+    And I am on the "csv_footwear_category_export" export job page
+    And I launch the export job
+    And I wait for the "csv_footwear_category_export" job to finish
     When I am on the dashboard page
     And I follow "Show job tracker"
     Then I should be redirected on the job tracker page

--- a/src/Pim/Bundle/DashboardBundle/Resources/public/js/last-operations-widget.js
+++ b/src/Pim/Bundle/DashboardBundle/Resources/public/js/last-operations-widget.js
@@ -79,26 +79,15 @@ define(
             /**
              * {@inheritdoc}
              */
-            setElement: function () {
-                AbstractWidget.prototype.setElement.apply(this, arguments);
-
-                this._addShowTrackerBtn();
-
-                return this;
-            },
-
-            /**
-             * {@inheritdoc}
-             */
             _afterLoad: function () {
                 AbstractWidget.prototype._afterLoad.apply(this, arguments);
 
                 var $btn = this._getViewAllBtn();
 
-                if (_.isEmpty(this.data)) {
+                if (!_.isEmpty(this.data)) {
+                    this._addShowTrackerBtn();
+                } else if (0 > $btn.length) {
                     $btn.hide();
-                } else {
-                    $btn.show();
                 }
             },
 


### PR DESCRIPTION
The button was append before to know if we had data or not. Then if we had no data we hide it. That was the wrong way to do it. So, if the CI a little bit faster than usual, it has the time to clic on the button before we hide it -> the scenario pass.
Now, we wait to know if we have data or not to append the button, or to hide it if it is already here.
Scenario fixed.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | n
| Added Behats                      | y
| Changelog updated                 | n
| Review and 2 GTM                  |
| Micro Demo to the PO (Story only) |
| Migration script                  |
| Tech Doc                          |

