### PR TITLE
Fix default file path in export

### DIFF
--- a/src/Pim/Component/Connector/Job/JobParameters/DefaultValuesProvider/ProductCsvExport.php
+++ b/src/Pim/Component/Connector/Job/JobParameters/DefaultValuesProvider/ProductCsvExport.php
@@ -57,7 +57,12 @@ class ProductCsvExport implements DefaultValuesProviderInterface
         $parameters['decimalSeparator'] = LocalizerInterface::DEFAULT_DECIMAL_SEPARATOR;
         $parameters['dateFormat'] = LocalizerInterface::DEFAULT_DATE_FORMAT;
         $parameters['with_media'] = true;
-        $parameters['filePath'] = sys_get_temp_dir() . 'csv_products_export.csv';
+
+        $basePath = sys_get_temp_dir();
+        if (substr($basePath, -1) !== DIRECTORY_SEPARATOR) {
+            $basePath = $basePath . DIRECTORY_SEPARATOR;
+        }
+        $parameters['filePath'] = $basePath . 'csv_products_export.csv';
 
         $defaultChannel = $this->channelRepository->getFullChannels()[0];
         $defaultLocaleCode = $this->localeRepository->getActivatedLocaleCodes()[0];

--- a/src/Pim/Component/Connector/Job/JobParameters/DefaultValuesProvider/ProductCsvExport.php
+++ b/src/Pim/Component/Connector/Job/JobParameters/DefaultValuesProvider/ProductCsvExport.php
@@ -59,7 +59,7 @@ class ProductCsvExport implements DefaultValuesProviderInterface
         $parameters['with_media'] = true;
 
         $basePath = sys_get_temp_dir();
-        if (substr($basePath, -1) !== DIRECTORY_SEPARATOR) {
+        if (DIRECTORY_SEPARATOR !== substr($basePath, -1)) {
             $basePath = $basePath . DIRECTORY_SEPARATOR;
         }
         $parameters['filePath'] = $basePath . 'csv_products_export.csv';

--- a/src/Pim/Component/Connector/Job/JobParameters/DefaultValuesProvider/ProductXlsxExport.php
+++ b/src/Pim/Component/Connector/Job/JobParameters/DefaultValuesProvider/ProductXlsxExport.php
@@ -57,8 +57,13 @@ class ProductXlsxExport implements DefaultValuesProviderInterface
         $parameters['decimalSeparator'] = LocalizerInterface::DEFAULT_DECIMAL_SEPARATOR;
         $parameters['dateFormat'] = LocalizerInterface::DEFAULT_DATE_FORMAT;
         $parameters['with_media'] = true;
-        $parameters['filePath'] = sys_get_temp_dir() . 'csv_products_export.xlsx';
         $parameters['linesPerFile'] = 10000;
+
+        $basePath = sys_get_temp_dir();
+        if (substr($basePath, -1) !== DIRECTORY_SEPARATOR) {
+            $basePath = $basePath . DIRECTORY_SEPARATOR;
+        }
+        $parameters['filePath'] = $basePath . 'xlsx_products_export.xlsx';
 
         $defaultChannel = $this->channelRepository->getFullChannels()[0];
         $defaultLocaleCode = $this->localeRepository->getActivatedLocaleCodes()[0];

--- a/src/Pim/Component/Connector/Job/JobParameters/DefaultValuesProvider/ProductXlsxExport.php
+++ b/src/Pim/Component/Connector/Job/JobParameters/DefaultValuesProvider/ProductXlsxExport.php
@@ -60,7 +60,7 @@ class ProductXlsxExport implements DefaultValuesProviderInterface
         $parameters['linesPerFile'] = 10000;
 
         $basePath = sys_get_temp_dir();
-        if (substr($basePath, -1) !== DIRECTORY_SEPARATOR) {
+        if (DIRECTORY_SEPARATOR !== substr($basePath, -1)) {
             $basePath = $basePath . DIRECTORY_SEPARATOR;
         }
         $parameters['filePath'] = $basePath . 'xlsx_products_export.xlsx';


### PR DESCRIPTION
Fixes a bug introduced in PIM-5897. 

- as `sys_get_temp_dir()` does not return a trailing '/' in os X and does in linux (see http://php.net/manual/en/function.sys-get-temp-dir.php#80690)

**Definition Of Done (for Core Developer only)**


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Changelog updated                 | -
| Review and 2 GTM                  | Y
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

