### PR TITLE
PIM-5955: Fix CSS for Select2 on mass edit

### DIFF
--- a/src/Pim/Bundle/UIBundle/Resources/public/css/pim.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/css/pim.less
@@ -1346,7 +1346,6 @@ h3.tab-header {
   .border-radius(0);
   .box-sizing();
   max-width: @max-field-width;
-  display: block;
 
   .select2-choice {
     line-height: 30px;


### PR DESCRIPTION
Mass edit with "select2" attributes were broken, due to a bad CSS (unreachable select2 clicking zone)
This PR fixes it.


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | n
| Added Behats                      | n
| Changelog updated                 | n
| Review and 2 GTM                  | n
| Micro Demo to the PO (Story only) | n
| Migration script                  | n
| Tech Doc                          | n
