### PR TITLE
PIM-5954: Change order of bulk actions in product grid

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product.yml
@@ -96,6 +96,32 @@ datagrid:
             quick_export:
                 label: pim_datagrid.mass_action_group.quick_export.label
         mass_actions:
+            mass_edit:
+                type: edit
+                acl_resource: pim_enrich_mass_edit
+                label: pim.grid.mass_action.mass_edit
+                handler: product_mass_edit
+                route: pim_enrich_mass_edit_product_action_choose
+                launcherOptions:
+                    group: bulk_actions
+            sequential_edit:
+                type: edit
+                acl_resource: pim_enrich_product_edit_attributes
+                label: pim.grid.mass_action.sequential_edit
+                handler: sequential_edit
+                route: pim_enrich_mass_edit_action_sequential_edit
+                launcherOptions:
+                    group: bulk_actions
+            category_edit:
+                type: edit
+                acl_resource: pim_enrich_mass_edit
+                label: pim.grid.mass_action.category_edit
+                handler: product_mass_edit
+                route: pim_enrich_mass_edit_product_action_choose
+                route_parameters:
+                    operationGroup: category-edit
+                launcherOptions:
+                    group: bulk_actions
             delete:
                 type: delete
                 label: pim.grid.mass_action.delete
@@ -109,32 +135,6 @@ datagrid:
                     success: pim_datagrid.mass_action.delete.success
                     error: pim_datagrid.mass_action.delete.error
                     empty_selection: pim_datagrid.mass_action.delete.empty_selection
-                launcherOptions:
-                    group: bulk_actions
-            mass_edit:
-                type: edit
-                acl_resource: pim_enrich_mass_edit
-                label: pim.grid.mass_action.mass_edit
-                handler: product_mass_edit
-                route: pim_enrich_mass_edit_product_action_choose
-                launcherOptions:
-                    group: bulk_actions
-            category_edit:
-                type: edit
-                acl_resource: pim_enrich_mass_edit
-                label: pim.grid.mass_action.category_edit
-                handler: product_mass_edit
-                route: pim_enrich_mass_edit_product_action_choose
-                route_parameters:
-                    operationGroup: category-edit
-                launcherOptions:
-                    group: bulk_actions
-            sequential_edit:
-                type: edit
-                acl_resource: pim_enrich_product_edit_attributes
-                label: pim.grid.mass_action.sequential_edit
-                handler: sequential_edit
-                route: pim_enrich_mass_edit_action_sequential_edit
                 launcherOptions:
                     group: bulk_actions
             quick_export_grid_context_xlsx:


### PR DESCRIPTION
**Description**

Previously, the first action was "Delete". It's confusing as it's not the main action in a day-to-day work.

The mass action order now is:
- Mass Edit
- Sequential Edit
- Category Edit
- Delete

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | N/A
| Added Behats                      | N/A
| Changelog updated                 | N/A
| Review and 2 GTM                  | :white_check_mark:
| Micro Demo to the PO (Story only) | :white_check_mark:
| Migration script                  | N/A
| Tech Doc                          | N/A