### PR TITLE
Remove mass edit limit since it's now a background job

### DIFF
--- a/app/config/pim_parameters.yml
+++ b/app/config/pim_parameters.yml
@@ -28,7 +28,6 @@ parameters:
     installer_data:       PimInstallerBundle:icecat_demo_dev
 
     uservoice_key:                 ~
-    mass_edit_limit:               1000
     max_products_category_removal: 100
 
     # Product storage driver can be doctrine/orm or doctrine/mongodb-odm


### PR DESCRIPTION
**Description**

This parameter was used prior to have a background job to execute mass edit operations.

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
