### PR TITLE
TIP-568: Improve performances on product import

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -4,6 +4,7 @@
 
 - PIM-5935: Fix view all button in dashboard
 - PIM-5945 : Fix tabs on user profile, DOM was not well structured
+- TIP-568: Detach version entity to improve performances on products import
 
 # 1.6.0 (2016-08-30)
 

--- a/src/Pim/Bundle/VersioningBundle/Manager/VersionManager.php
+++ b/src/Pim/Bundle/VersioningBundle/Manager/VersionManager.php
@@ -118,7 +118,8 @@ class VersionManager
         }
 
         if ($this->realTimeVersioning) {
-            $this->registry->getManagerForClass(ClassUtils::getClass($versionable))->refresh($versionable);
+            $manager = $this->registry->getManagerForClass(ClassUtils::getClass($versionable));
+            $manager->refresh($versionable);
 
             $createdVersions = $this->buildPendingVersions($versionable);
 
@@ -142,6 +143,10 @@ class VersionManager
                     $previousVersion,
                     $this->versionContext->getContextInfo(ClassUtils::getClass($versionable))
                 );
+
+            if (null !== $previousVersion) {
+                $manager->detach($previousVersion);
+            }
         } else {
             $createdVersions[] = $this->versionBuilder
                 ->createPendingVersion(


### PR DESCRIPTION
Detach the previous version to improve performances and fix a small memory leak when we import products already in database.

With the medium catalog, try to import 2500 products:

 | time | memory used
------ | ------ | ------
Before fix | 32 min | 447Mo
With fix | 23 min | 341Mo

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       |
| Added Behats                      |
| Changelog updated                 |
| Review and 2 GTM                  |
| Micro Demo to the PO (Story only) |
| Migration script                  |
| Tech Doc                          |

