### PR TITLE
PIM-5938: Use distinct translations for each import/export format

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -8,6 +8,7 @@
 - PIM-5940: Add a flash message in case of product export builder error
 - PIM-5922: Fix the scope switcher in variant group page grid
 - PIM-5959: Change wording of XLSX to Excel on mass actions
+- PIM-5938: Fix typos in import/export tooltips
 
 # 1.6.0 (2016-08-30)
 

--- a/src/Pim/Bundle/ConnectorBundle/Resources/translations/messages.en.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/translations/messages.en.yml
@@ -33,93 +33,142 @@ pim_connector:
 
     ## Import/export configuration fields (for readers, processors, writers)
     export:
-        delimiter:
-            label: Delimiter
-            help: One character used to set the field delimiter
-        enclosure:
-            label: Enclosure
-            help: One character used to set the field enclosure
-        lines_per_files:
-            label: Number of lines per file
-            help: Define the limit number of lines per file
-        withHeader:
-            label: With header
-            help: Whether or not to print the column name
-        with_media:
-            label: Export files and images
-            help: Whether or not to export product files and images
-        filePath:
-            label: File path
-            help: Where to write the generated file on the file system
-        channel:
-            label: Channel
-            help: The channel you want to export
-        locales:
-            label: Locales
-            help: The locales you want to export
-            validation:
-                not_blank: One locale must be selected, please choose a locale to export.
-        decimalSeparator:
-            label: Decimal separator
-            help: Determine the decimal separator
-        dateFormat:
-            label: Date format
-            help: Determine the format of date fields
-        header:
-            label: Header
-        families:
-            label: Family
-            help: The families you want to export
-            placeholder: Choose a family
+        csv:
+            delimiter:
+                label: Delimiter
+                help: One character used to set the field delimiter
+            enclosure:
+                label: Enclosure
+                help: One character used to set the field enclosure
+            withHeader:
+                label: With header
+                help: Whether or not to print the column name
+            with_media:
+                label: Export files and images
+                help: Whether or not to export product files and images
+            filePath:
+                label: File path
+                help: Where to write the generated file on the file system
+            decimalSeparator:
+                label: Decimal separator
+                help: Determine the decimal separator
+            dateFormat:
+                label: Date format
+                help: Determine the format of date fields
+        xlsx:
+            lines_per_files:
+                label: Number of lines per file
+                help: Define the limit number of lines per file
+            withHeader:
+                label: With header
+                help: Whether or not to print the column name
+            with_media:
+                label: Export files and images
+                help: Whether or not to export product files and images
+            filePath:
+                label: File path
+                help: Where to write the generated file on the file system
+            decimalSeparator:
+                label: Decimal separator
+                help: Determine the decimal separator
+            dateFormat:
+                label: Date format
+                help: Determine the format of date fields
+        yml:
+            filePath:
+                label: File path
+                help: Where to write the generated file on the file system
     import:
-        enabled:
-            label: Enable the product
-            help: Whether or not imported product should be enabled
-        categoriesColumn:
-            label: Categories column
-            help: Name of the categories column
-        familyColumn:
-            label: Family column
-            help: Name of the family column
-        groupsColumn:
-            label: Groups column
-            help: Name of the groups column
-        filePath:
-            label: File
-            help: The CSV file to import
-        yamlFilePath:
-            label: File
-            help: The YAML file to import
-        uploadAllowed:
-            label: Allow file upload
-            help: Whether or not to allow uploading the file directly
-        delimiter:
-            label: Delimiter
-            help: One character used to set the field delimiter for CSV file
-        enclosure:
-            label: Enclosure
-            help: One character used to set the field enclosure
-        escape:
-            label: Escape
-            help: One character used to set the field escape
-        circularRefsChecked:
-            label: Check circular references
-            help: If yes, data will be processed to make sure that there are no circular references between the categories
-        realTimeVersioning:
-            label: Real time history update
-            help: Means that the product history is automatically updated, can be switched off to improve performances
-        copyValuesToProducts:
-            label: Copy variant group values to products
-            help: Means that the products are automatically updated with variant group values, can be switched off to only update variant group
-        enabledComparison:
-            label: Compare values
-            help: Enable the comparison between original values and imported values. Can speed up import if imported values are very similar to original values
-        decimalSeparator:
-            label: Decimal separator
-            help: One character used to set the field separator for decimal
-        dateFormat:
-            label: Date format
-            help: Specify the format of any date columns in the file, e.g. here DD/MM/YYYY for a 30/04/2014 format.
+        csv:
+            enabled:
+                label: Enable the product
+                help: Whether or not imported product should be enabled
+            categoriesColumn:
+                label: Categories column
+                help: Name of the categories column
+            familyColumn:
+                label: Family column
+                help: Name of the family column
+            groupsColumn:
+                label: Groups column
+                help: Name of the groups column
+            filePath:
+                label: File
+                help: The CSV file to import
+            uploadAllowed:
+                label: Allow file upload
+                help: Whether or not to allow uploading the file directly
+            delimiter:
+                label: Delimiter
+                help: One character used to set the field delimiter for CSV file
+            enclosure:
+                label: Enclosure
+                help: One character used to set the field enclosure
+            escape:
+                label: Escape
+                help: One character used to set the field escape
+            circularRefsChecked:
+                label: Check circular references
+                help: If yes, data will be processed to make sure that there are no circular references between the categories
+            realTimeVersioning:
+                label: Real time history update
+                help: Means that the product history is automatically updated, can be switched off to improve performances
+            copyValuesToProducts:
+                label: Copy variant group values to products
+                help: Means that the products are automatically updated with variant group values, can be switched off to only update variant group
+            enabledComparison:
+                label: Compare values
+                help: Enable the comparison between original values and imported values. Can speed up import if imported values are very similar to original values
+            decimalSeparator:
+                label: Decimal separator
+                help: One character used to set the field separator for decimal
+            dateFormat:
+                label: Date format
+                help: Specify the format of any date columns in the file, e.g. here DD/MM/YYYY for a 30/04/2014 format.
+        xlsx:
+            enabled:
+                label: Enable the product
+                help: Whether or not imported product should be enabled
+            categoriesColumn:
+                label: Categories column
+                help: Name of the categories column
+            familyColumn:
+                label: Family column
+                help: Name of the family column
+            groupsColumn:
+                label: Groups column
+                help: Name of the groups column
+            filePath:
+                label: File
+                help: The XLSX file to import
+            uploadAllowed:
+                label: Allow file upload
+                help: Whether or not to allow uploading the file directly
+            circularRefsChecked:
+                label: Check circular references
+                help: If yes, data will be processed to make sure that there are no circular references between the categories
+            realTimeVersioning:
+                label: Real time history update
+                help: Means that the product history is automatically updated, can be switched off to improve performances
+            copyValuesToProducts:
+                label: Copy variant group values to products
+                help: Means that the products are automatically updated with variant group values, can be switched off to only update variant group
+            enabledComparison:
+                label: Compare values
+                help: Enable the comparison between original values and imported values. Can speed up import if imported values are very similar to original values
+            decimalSeparator:
+                label: Decimal separator
+                help: One character used to set the field separator for decimal
+            dateFormat:
+                label: Date format
+                help: Specify the format of any date columns in the file, e.g. here DD/MM/YYYY for a 30/04/2014 format.
+        yml:
+            filePath:
+                label: File
+                help: The YML file to import
+            uploadAllowed:
+                label: Allow file upload
+                help: Whether or not to allow uploading the file directly
 
 job_execution.summary:
     read:       read

--- a/src/Pim/Bundle/ImportExportBundle/JobParameters/FormConfigurationProvider/ProductCsvExport.php
+++ b/src/Pim/Bundle/ImportExportBundle/JobParameters/FormConfigurationProvider/ProductCsvExport.php
@@ -63,8 +63,8 @@ class ProductCsvExport implements FormConfigurationProviderInterface
             'with_media' => [
                 'type'    => 'switch',
                 'options' => [
-                    'label' => 'pim_connector.export.with_media.label',
-                    'help'  => 'pim_connector.export.with_media.help'
+                    'label' => 'pim_connector.export.csv.with_media.label',
+                    'help'  => 'pim_connector.export.csv.with_media.help'
                 ]
             ],
         ]);
@@ -84,8 +84,8 @@ class ProductCsvExport implements FormConfigurationProviderInterface
                     'choices'  => $this->decimalSeparators,
                     'required' => true,
                     'select2'  => true,
-                    'label'    => 'pim_connector.export.decimalSeparator.label',
-                    'help'     => 'pim_connector.export.decimalSeparator.help'
+                    'label'    => 'pim_connector.export.csv.decimalSeparator.label',
+                    'help'     => 'pim_connector.export.csv.decimalSeparator.help'
                 ]
             ],
             'dateFormat' => [
@@ -94,8 +94,8 @@ class ProductCsvExport implements FormConfigurationProviderInterface
                     'choices'  => $this->dateFormats,
                     'required' => true,
                     'select2'  => true,
-                    'label'    => 'pim_connector.export.dateFormat.label',
-                    'help'     => 'pim_connector.export.dateFormat.help',
+                    'label'    => 'pim_connector.export.csv.dateFormat.label',
+                    'help'     => 'pim_connector.export.csv.dateFormat.help',
                 ]
             ],
         ];

--- a/src/Pim/Bundle/ImportExportBundle/JobParameters/FormConfigurationProvider/ProductCsvImport.php
+++ b/src/Pim/Bundle/ImportExportBundle/JobParameters/FormConfigurationProvider/ProductCsvImport.php
@@ -63,8 +63,8 @@ class ProductCsvImport implements FormConfigurationProviderInterface
                     'choices'  => $this->decimalSeparators,
                     'required' => true,
                     'select2'  => true,
-                    'label'    => 'pim_connector.export.decimalSeparator.label',
-                    'help'     => 'pim_connector.export.decimalSeparator.help'
+                    'label'    => 'pim_connector.import.csv.decimalSeparator.label',
+                    'help'     => 'pim_connector.import.csv.decimalSeparator.help'
                 ]
             ],
             'dateFormat' => [
@@ -73,47 +73,47 @@ class ProductCsvImport implements FormConfigurationProviderInterface
                     'choices'  => $this->dateFormats,
                     'required' => true,
                     'select2'  => true,
-                    'label'    => 'pim_connector.export.dateFormat.label',
-                    'help'     => 'pim_connector.export.dateFormat.help',
+                    'label'    => 'pim_connector.import.csv.dateFormat.label',
+                    'help'     => 'pim_connector.import.csv.dateFormat.help',
                 ]
             ],
             'enabled' => [
                 'type'    => 'switch',
                 'options' => [
-                    'label' => 'pim_connector.import.enabled.label',
-                    'help'  => 'pim_connector.import.enabled.help'
+                    'label' => 'pim_connector.import.csv.enabled.label',
+                    'help'  => 'pim_connector.import.csv.enabled.help'
                 ]
             ],
             'categoriesColumn' => [
                 'options' => [
-                    'label' => 'pim_connector.import.categoriesColumn.label',
-                    'help'  => 'pim_connector.import.categoriesColumn.help'
+                    'label' => 'pim_connector.import.csv.categoriesColumn.label',
+                    'help'  => 'pim_connector.import.csv.categoriesColumn.help'
                 ]
             ],
             'familyColumn' => [
                 'options' => [
-                    'label' => 'pim_connector.import.familyColumn.label',
-                    'help'  => 'pim_connector.import.familyColumn.help'
+                    'label' => 'pim_connector.import.csv.familyColumn.label',
+                    'help'  => 'pim_connector.import.csv.familyColumn.help'
                 ]
             ],
             'groupsColumn' => [
                 'options' => [
-                    'label' => 'pim_connector.import.groupsColumn.label',
-                    'help'  => 'pim_connector.import.groupsColumn.help'
+                    'label' => 'pim_connector.import.csv.groupsColumn.label',
+                    'help'  => 'pim_connector.import.csv.groupsColumn.help'
                 ]
             ],
             'enabledComparison' => [
                 'type'    => 'switch',
                 'options' => [
-                    'label' => 'pim_connector.import.enabledComparison.label',
-                    'help'  => 'pim_connector.import.enabledComparison.help'
+                    'label' => 'pim_connector.import.csv.enabledComparison.label',
+                    'help'  => 'pim_connector.import.csv.enabledComparison.help'
                 ]
             ],
             'realTimeVersioning' => [
                 'type'    => 'switch',
                 'options' => [
-                    'label' => 'pim_connector.import.realTimeVersioning.label',
-                    'help'  => 'pim_connector.import.realTimeVersioning.help'
+                    'label' => 'pim_connector.import.csv.realTimeVersioning.label',
+                    'help'  => 'pim_connector.import.csv.realTimeVersioning.help'
                 ]
             ]
         ];

--- a/src/Pim/Bundle/ImportExportBundle/JobParameters/FormConfigurationProvider/ProductXlsxExport.php
+++ b/src/Pim/Bundle/ImportExportBundle/JobParameters/FormConfigurationProvider/ProductXlsxExport.php
@@ -62,8 +62,8 @@ class ProductXlsxExport implements FormConfigurationProviderInterface
             'with_media' => [
                 'type'    => 'switch',
                 'options' => [
-                    'label' => 'pim_connector.export.with_media.label',
-                    'help'  => 'pim_connector.export.with_media.help'
+                    'label' => 'pim_connector.export.xlsx.with_media.label',
+                    'help'  => 'pim_connector.export.xlsx.with_media.help'
                 ]
             ],
         ]);
@@ -83,8 +83,8 @@ class ProductXlsxExport implements FormConfigurationProviderInterface
                     'choices'  => $this->decimalSeparators,
                     'required' => true,
                     'select2'  => true,
-                    'label'    => 'pim_connector.export.decimalSeparator.label',
-                    'help'     => 'pim_connector.export.decimalSeparator.help'
+                    'label'    => 'pim_connector.export.xlsx.decimalSeparator.label',
+                    'help'     => 'pim_connector.export.xlsx.decimalSeparator.help'
                 ]
             ],
             'dateFormat' => [
@@ -93,15 +93,15 @@ class ProductXlsxExport implements FormConfigurationProviderInterface
                     'choices'  => $this->dateFormats,
                     'required' => true,
                     'select2'  => true,
-                    'label'    => 'pim_connector.export.dateFormat.label',
-                    'help'     => 'pim_connector.export.dateFormat.help',
+                    'label'    => 'pim_connector.export.xlsx.dateFormat.label',
+                    'help'     => 'pim_connector.export.xlsx.dateFormat.help',
                 ]
             ],
             'linesPerFile' => [
                 'type'    => 'integer',
                 'options' => [
-                    'label' => 'pim_connector.export.lines_per_files.label',
-                    'help'  => 'pim_connector.export.lines_per_files.help',
+                    'label' => 'pim_connector.export.xlsx.lines_per_files.label',
+                    'help'  => 'pim_connector.export.xlsx.lines_per_files.help',
                 ]
             ],
         ];

--- a/src/Pim/Bundle/ImportExportBundle/JobParameters/FormConfigurationProvider/SimpleCsvExport.php
+++ b/src/Pim/Bundle/ImportExportBundle/JobParameters/FormConfigurationProvider/SimpleCsvExport.php
@@ -33,27 +33,27 @@ class SimpleCsvExport implements FormConfigurationProviderInterface
         return [
             'filePath' => [
                 'options' => [
-                    'label' => 'pim_connector.export.filePath.label',
-                    'help'  => 'pim_connector.export.filePath.help'
+                    'label' => 'pim_connector.export.csv.filePath.label',
+                    'help'  => 'pim_connector.export.csv.filePath.help'
                 ]
             ],
             'delimiter' => [
                 'options' => [
-                    'label' => 'pim_connector.export.delimiter.label',
-                    'help'  => 'pim_connector.export.delimiter.help'
+                    'label' => 'pim_connector.export.csv.delimiter.label',
+                    'help'  => 'pim_connector.export.csv.delimiter.help'
                 ]
             ],
             'enclosure' => [
                 'options' => [
-                    'label' => 'pim_connector.export.enclosure.label',
-                    'help'  => 'pim_connector.export.enclosure.help'
+                    'label' => 'pim_connector.export.csv.enclosure.label',
+                    'help'  => 'pim_connector.export.csv.enclosure.help'
                 ]
             ],
             'withHeader' => [
                 'type'    => 'switch',
                 'options' => [
-                    'label' => 'pim_connector.export.withHeader.label',
-                    'help'  => 'pim_connector.export.withHeader.help'
+                    'label' => 'pim_connector.export.csv.withHeader.label',
+                    'help'  => 'pim_connector.export.csv.withHeader.help'
                 ]
             ],
         ];

--- a/src/Pim/Bundle/ImportExportBundle/JobParameters/FormConfigurationProvider/SimpleCsvImport.php
+++ b/src/Pim/Bundle/ImportExportBundle/JobParameters/FormConfigurationProvider/SimpleCsvImport.php
@@ -33,33 +33,33 @@ class SimpleCsvImport implements FormConfigurationProviderInterface
         return [
             'filePath' => [
                 'options' => [
-                    'label' => 'pim_connector.import.filePath.label',
-                    'help'  => 'pim_connector.import.filePath.help'
+                    'label' => 'pim_connector.import.csv.filePath.label',
+                    'help'  => 'pim_connector.import.csv.filePath.help'
                 ]
             ],
             'uploadAllowed' => [
                 'type'    => 'switch',
                 'options' => [
-                    'label' => 'pim_connector.import.uploadAllowed.label',
-                    'help'  => 'pim_connector.import.uploadAllowed.help'
+                    'label' => 'pim_connector.import.csv.uploadAllowed.label',
+                    'help'  => 'pim_connector.import.csv.uploadAllowed.help'
                 ]
             ],
             'delimiter' => [
                 'options' => [
-                    'label' => 'pim_connector.import.delimiter.label',
-                    'help'  => 'pim_connector.import.delimiter.help'
+                    'label' => 'pim_connector.import.csv.delimiter.label',
+                    'help'  => 'pim_connector.import.csv.delimiter.help'
                 ]
             ],
             'enclosure' => [
                 'options' => [
-                    'label' => 'pim_connector.import.enclosure.label',
-                    'help'  => 'pim_connector.import.enclosure.help'
+                    'label' => 'pim_connector.import.csv.enclosure.label',
+                    'help'  => 'pim_connector.import.csv.enclosure.help'
                 ]
             ],
             'escape' => [
                 'options' => [
-                    'label' => 'pim_connector.import.escape.label',
-                    'help'  => 'pim_connector.import.escape.help'
+                    'label' => 'pim_connector.import.csv.escape.label',
+                    'help'  => 'pim_connector.import.csv.escape.help'
                 ]
             ],
         ];

--- a/src/Pim/Bundle/ImportExportBundle/JobParameters/FormConfigurationProvider/SimpleXlsxExport.php
+++ b/src/Pim/Bundle/ImportExportBundle/JobParameters/FormConfigurationProvider/SimpleXlsxExport.php
@@ -33,22 +33,22 @@ class SimpleXlsxExport implements FormConfigurationProviderInterface
         return [
             'filePath' => [
                 'options' => [
-                    'label' => 'pim_connector.export.filePath.label',
-                    'help'  => 'pim_connector.export.filePath.help'
+                    'label' => 'pim_connector.export.xlsx.filePath.label',
+                    'help'  => 'pim_connector.export.xlsx.filePath.help'
                 ]
             ],
             'linesPerFile' => [
                 'type'    => 'integer',
                 'options' => [
-                    'label' => 'pim_connector.export.lines_per_files.label',
-                    'help'  => 'pim_connector.export.lines_per_files.help',
+                    'label' => 'pim_connector.export.xlsx.lines_per_files.label',
+                    'help'  => 'pim_connector.export.xlsx.lines_per_files.help',
                 ]
             ],
             'withHeader' => [
                 'type'    => 'switch',
                 'options' => [
-                    'label' => 'pim_connector.export.withHeader.label',
-                    'help'  => 'pim_connector.export.withHeader.help'
+                    'label' => 'pim_connector.export.xlsx.withHeader.label',
+                    'help'  => 'pim_connector.export.xlsx.withHeader.help'
                 ]
             ],
         ];

--- a/src/Pim/Bundle/ImportExportBundle/JobParameters/FormConfigurationProvider/SimpleXlsxImport.php
+++ b/src/Pim/Bundle/ImportExportBundle/JobParameters/FormConfigurationProvider/SimpleXlsxImport.php
@@ -33,15 +33,15 @@ class SimpleXlsxImport implements FormConfigurationProviderInterface
         return [
             'filePath' => [
                 'options' => [
-                    'label' => 'pim_connector.import.filePath.label',
-                    'help'  => 'pim_connector.import.filePath.help'
+                    'label' => 'pim_connector.import.xlsx.filePath.label',
+                    'help'  => 'pim_connector.import.xlsx.filePath.help'
                 ]
             ],
             'uploadAllowed' => [
                 'type'    => 'switch',
                 'options' => [
-                    'label' => 'pim_connector.import.uploadAllowed.label',
-                    'help'  => 'pim_connector.import.uploadAllowed.help'
+                    'label' => 'pim_connector.import.xlsx.uploadAllowed.label',
+                    'help'  => 'pim_connector.import.xlsx.uploadAllowed.help'
                 ]
             ],
         ];

--- a/src/Pim/Bundle/ImportExportBundle/JobParameters/FormConfigurationProvider/SimpleYamlExport.php
+++ b/src/Pim/Bundle/ImportExportBundle/JobParameters/FormConfigurationProvider/SimpleYamlExport.php
@@ -33,8 +33,8 @@ class SimpleYamlExport implements FormConfigurationProviderInterface
         return [
             'filePath' => [
                 'options' => [
-                    'label' => 'pim_connector.import.filePath.label',
-                    'help'  => 'pim_connector.import.filePath.help'
+                    'label' => 'pim_connector.export.yml.filePath.label',
+                    'help'  => 'pim_connector.export.yml.filePath.help'
                 ]
             ],
         ];

--- a/src/Pim/Bundle/ImportExportBundle/JobParameters/FormConfigurationProvider/SimpleYamlImport.php
+++ b/src/Pim/Bundle/ImportExportBundle/JobParameters/FormConfigurationProvider/SimpleYamlImport.php
@@ -33,15 +33,15 @@ class SimpleYamlImport implements FormConfigurationProviderInterface
         return [
             'filePath' => [
                 'options' => [
-                    'label' => 'pim_connector.import.filePath.label',
-                    'help'  => 'pim_connector.import.filePath.help'
+                    'label' => 'pim_connector.import.yml.filePath.label',
+                    'help'  => 'pim_connector.import.yml.filePath.help'
                 ]
             ],
             'uploadAllowed' => [
                 'type'    => 'switch',
                 'options' => [
-                    'label' => 'pim_connector.import.uploadAllowed.label',
-                    'help'  => 'pim_connector.import.uploadAllowed.help'
+                    'label' => 'pim_connector.import.yml.uploadAllowed.label',
+                    'help'  => 'pim_connector.import.yml.uploadAllowed.help'
                 ]
             ],
         ];

--- a/src/Pim/Bundle/ImportExportBundle/JobParameters/FormConfigurationProvider/VariantGroupCsvExport.php
+++ b/src/Pim/Bundle/ImportExportBundle/JobParameters/FormConfigurationProvider/VariantGroupCsvExport.php
@@ -63,8 +63,8 @@ class VariantGroupCsvExport implements FormConfigurationProviderInterface
                     'choices'  => $this->decimalSeparators,
                     'required' => true,
                     'select2'  => true,
-                    'label'    => 'pim_connector.export.decimalSeparator.label',
-                    'help'     => 'pim_connector.export.decimalSeparator.help'
+                    'label'    => 'pim_connector.export.csv.decimalSeparator.label',
+                    'help'     => 'pim_connector.export.csv.decimalSeparator.help'
                 ]
             ],
             'dateFormat' => [
@@ -73,8 +73,8 @@ class VariantGroupCsvExport implements FormConfigurationProviderInterface
                     'choices'  => $this->dateFormats,
                     'required' => true,
                     'select2'  => true,
-                    'label'    => 'pim_connector.export.dateFormat.label',
-                    'help'     => 'pim_connector.export.dateFormat.help',
+                    'label'    => 'pim_connector.export.csv.dateFormat.label',
+                    'help'     => 'pim_connector.export.csv.dateFormat.help',
                 ]
             ],
         ];

--- a/src/Pim/Bundle/ImportExportBundle/JobParameters/FormConfigurationProvider/VariantGroupCsvImport.php
+++ b/src/Pim/Bundle/ImportExportBundle/JobParameters/FormConfigurationProvider/VariantGroupCsvImport.php
@@ -63,8 +63,8 @@ class VariantGroupCsvImport implements FormConfigurationProviderInterface
                     'choices'  => $this->decimalSeparators,
                     'required' => true,
                     'select2'  => true,
-                    'label'    => 'pim_connector.export.decimalSeparator.label',
-                    'help'     => 'pim_connector.export.decimalSeparator.help'
+                    'label'    => 'pim_connector.import.csv.decimalSeparator.label',
+                    'help'     => 'pim_connector.import.csv.decimalSeparator.help'
                 ]
             ],
             'dateFormat' => [
@@ -73,15 +73,15 @@ class VariantGroupCsvImport implements FormConfigurationProviderInterface
                     'choices'  => $this->dateFormats,
                     'required' => true,
                     'select2'  => true,
-                    'label'    => 'pim_connector.export.dateFormat.label',
-                    'help'     => 'pim_connector.export.dateFormat.help',
+                    'label'    => 'pim_connector.import.csv.dateFormat.label',
+                    'help'     => 'pim_connector.import.csv.dateFormat.help',
                 ]
             ],
             'copyValues' => [
                 'type'    => 'switch',
                 'options' => [
-                    'label' => 'pim_connector.import.copyValuesToProducts.label',
-                    'help'  => 'pim_connector.import.copyValuesToProducts.help'
+                    'label' => 'pim_connector.import.csv.copyValuesToProducts.label',
+                    'help'  => 'pim_connector.import.csv.copyValuesToProducts.help'
                 ]
             ]
         ];

--- a/src/Pim/Bundle/ImportExportBundle/JobParameters/FormConfigurationProvider/VariantGroupXlsxExport.php
+++ b/src/Pim/Bundle/ImportExportBundle/JobParameters/FormConfigurationProvider/VariantGroupXlsxExport.php
@@ -63,8 +63,8 @@ class VariantGroupXlsxExport implements FormConfigurationProviderInterface
                     'choices'  => $this->decimalSeparators,
                     'required' => true,
                     'select2'  => true,
-                    'label'    => 'pim_connector.export.decimalSeparator.label',
-                    'help'     => 'pim_connector.export.decimalSeparator.help'
+                    'label'    => 'pim_connector.export.xlsx.decimalSeparator.label',
+                    'help'     => 'pim_connector.export.xlsx.decimalSeparator.help'
                 ]
             ],
             'dateFormat' => [
@@ -73,15 +73,15 @@ class VariantGroupXlsxExport implements FormConfigurationProviderInterface
                     'choices'  => $this->dateFormats,
                     'required' => true,
                     'select2'  => true,
-                    'label'    => 'pim_connector.export.dateFormat.label',
-                    'help'     => 'pim_connector.export.dateFormat.help',
+                    'label'    => 'pim_connector.export.xlsx.dateFormat.label',
+                    'help'     => 'pim_connector.export.xlsx.dateFormat.help',
                 ]
             ],
             'linesPerFile' => [
                 'type'    => 'integer',
                 'options' => [
-                    'label' => 'pim_connector.export.lines_per_files.label',
-                    'help'  => 'pim_connector.export.lines_per_files.help',
+                    'label' => 'pim_connector.export.xlsx.lines_per_files.label',
+                    'help'  => 'pim_connector.export.xlsx.lines_per_files.help',
                 ]
             ],
         ];

--- a/src/Pim/Bundle/ImportExportBundle/spec/JobParameters/FormConfigurationProvider/ProductCsvExportSpec.php
+++ b/src/Pim/Bundle/ImportExportBundle/spec/JobParameters/FormConfigurationProvider/ProductCsvExportSpec.php
@@ -51,8 +51,8 @@ class ProductCsvExportSpec extends ObjectBehavior
                     'choices'  => [','],
                     'required' => true,
                     'select2'  => true,
-                    'label'    => 'pim_connector.export.decimalSeparator.label',
-                    'help'     => 'pim_connector.export.decimalSeparator.help'
+                    'label'    => 'pim_connector.export.csv.decimalSeparator.label',
+                    'help'     => 'pim_connector.export.csv.decimalSeparator.help'
                 ]
             ],
             'dateFormat' => [
@@ -61,8 +61,8 @@ class ProductCsvExportSpec extends ObjectBehavior
                     'choices'  => ['yyyy-MM-dd', 'dd/MM/yyyy'],
                     'required' => true,
                     'select2'  => true,
-                    'label'    => 'pim_connector.export.dateFormat.label',
-                    'help'     => 'pim_connector.export.dateFormat.help',
+                    'label'    => 'pim_connector.export.csv.dateFormat.label',
+                    'help'     => 'pim_connector.export.csv.dateFormat.help',
                 ]
             ]
         ];
@@ -70,29 +70,29 @@ class ProductCsvExportSpec extends ObjectBehavior
         $exportConfig = [
             'filePath' => [
                 'options' => [
-                    'label' => 'pim_connector.export.filePath.label',
-                    'help'  => 'pim_connector.export.filePath.help'
+                    'label' => 'pim_connector.export.csv.filePath.label',
+                    'help'  => 'pim_connector.export.csv.filePath.help'
                 ]
             ],
             'linesPerFile' => [
                 'type'    => 'integer',
                 'options' => [
-                    'label' => 'pim_connector.export.lines_per_files.label',
-                    'help'  => 'pim_connector.export.lines_per_files.help',
+                    'label' => 'pim_connector.export.csv.lines_per_files.label',
+                    'help'  => 'pim_connector.export.csv.lines_per_files.help',
                 ]
             ],
             'withHeader' => [
                 'type'    => 'switch',
                 'options' => [
-                    'label' => 'pim_connector.export.withHeader.label',
-                    'help'  => 'pim_connector.export.withHeader.help'
+                    'label' => 'pim_connector.export.csv.withHeader.label',
+                    'help'  => 'pim_connector.export.csv.withHeader.help'
                 ]
             ],
             'with_media' => [
                 'type'    => 'switch',
                 'options' => [
-                    'label' => 'pim_connector.export.with_media.label',
-                    'help'  => 'pim_connector.export.with_media.help'
+                    'label' => 'pim_connector.export.csv.with_media.label',
+                    'help'  => 'pim_connector.export.csv.with_media.help'
                 ]
             ],
         ];

--- a/src/Pim/Bundle/ImportExportBundle/spec/JobParameters/FormConfigurationProvider/ProductXlsxExportSpec.php
+++ b/src/Pim/Bundle/ImportExportBundle/spec/JobParameters/FormConfigurationProvider/ProductXlsxExportSpec.php
@@ -42,28 +42,28 @@ class ProductXlsxExportSpec extends ObjectBehavior
             'linesPerFile' => [
                 'type'    => 'integer',
                 'options' => [
-                    'label' => 'pim_connector.export.lines_per_files.label',
-                    'help'  => 'pim_connector.export.lines_per_files.help',
+                    'label' => 'pim_connector.export.xlsx.lines_per_files.label',
+                    'help'  => 'pim_connector.export.xlsx.lines_per_files.help',
                 ]
             ],
             'filePath' => [
                 'options' => [
-                    'label' => 'pim_connector.export.filePath.label',
-                    'help'  => 'pim_connector.export.filePath.help'
+                    'label' => 'pim_connector.export.xlsx.filePath.label',
+                    'help'  => 'pim_connector.export.xlsx.filePath.help'
                 ]
             ],
             'withHeader' => [
                 'type'    => 'switch',
                 'options' => [
-                    'label' => 'pim_connector.export.withHeader.label',
-                    'help'  => 'pim_connector.export.withHeader.help'
+                    'label' => 'pim_connector.export.xlsx.withHeader.label',
+                    'help'  => 'pim_connector.export.xlsx.withHeader.help'
                 ]
             ],
             'with_media' => [
                 'type'    => 'switch',
                 'options' => [
-                    'label' => 'pim_connector.export.with_media.label',
-                    'help'  => 'pim_connector.export.with_media.help'
+                    'label' => 'pim_connector.export.xlsx.with_media.label',
+                    'help'  => 'pim_connector.export.xlsx.with_media.help'
                 ]
             ],
         ];
@@ -83,8 +83,8 @@ class ProductXlsxExportSpec extends ObjectBehavior
                     'choices'  => [',', ';'],
                     'required' => true,
                     'select2'  => true,
-                    'label'    => 'pim_connector.export.decimalSeparator.label',
-                    'help'     => 'pim_connector.export.decimalSeparator.help'
+                    'label'    => 'pim_connector.export.xlsx.decimalSeparator.label',
+                    'help'     => 'pim_connector.export.xlsx.decimalSeparator.help'
                 ]
             ],
             'dateFormat' => [
@@ -93,15 +93,15 @@ class ProductXlsxExportSpec extends ObjectBehavior
                     'choices'  => ['yyyy-MM-dd', 'dd/MM/yyyy'],
                     'required' => true,
                     'select2'  => true,
-                    'label'    => 'pim_connector.export.dateFormat.label',
-                    'help'     => 'pim_connector.export.dateFormat.help',
+                    'label'    => 'pim_connector.export.xlsx.dateFormat.label',
+                    'help'     => 'pim_connector.export.xlsx.dateFormat.help',
                 ]
             ],
             'linesPerFile' => [
                 'type'    => 'integer',
                 'options' => [
-                    'label' => 'pim_connector.export.lines_per_files.label',
-                    'help'  => 'pim_connector.export.lines_per_files.help',
+                    'label' => 'pim_connector.export.xlsx.lines_per_files.label',
+                    'help'  => 'pim_connector.export.xlsx.lines_per_files.help',
                 ]
             ],
         ];


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This PR:
- fixes some tooltips in XLSX jobs containing mentions to CSV
- fixes some tooltips in export jobs containing import descriptions
- cleans unused translation keys

Concretely, I duplicated all translation keys for xlsx and yml and remove/fix when needed (for example xlsx jobs don't need the "delimiter" key).

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | n/a
| Added Behats                      | n/a
| Changelog updated                 | yes
| Review and 2 GTM                  |
| Micro Demo to the PO (Story only) |
| Migration script                  | n/a
| Tech Doc                          | n/a

