### PR TITLE
PIM-5952: Add default message in empty family filter

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -10,6 +10,7 @@
 - PIM-5959: Change wording of XLSX to Excel on mass actions
 - PIM-5938: Fix typos in import/export tooltips
 - PIM-5966: Fix style about category filter on product export builder
+- PIM-5952: Add the information "No condition on families" in the family field of the Export Builder
 
 # 1.6.0 (2016-08-30)
 

--- a/features/Context/Page/Base/Form.php
+++ b/features/Context/Page/Base/Form.php
@@ -26,12 +26,8 @@ class Form extends Base
 
         $this->elements = array_merge(
             [
-                'Tabs'                            => ['css' => '#form-navbar'],
-                'Oro tabs'                        => ['css' => '.navbar.scrollspy-nav'],
                 'Dialog'                          => ['css' => 'div.modal'],
-                'Form tabs'                       => ['css' => '.nav-tabs.form-tabs'],
                 'Associations list'               => ['css' => '.associations-list'],
-                'Active tab'                      => ['css' => '.form-horizontal .tab-pane.active'],
                 'Groups'                          => ['css' => '.tab-groups'],
                 'Form Groups'                     => ['css' => '.group-selector'],
                 'Validation errors'               => ['css' => '.validation-tooltip'],
@@ -65,82 +61,6 @@ class Form extends Base
     public function saveAndClose()
     {
         $this->pressButton('Save and close');
-    }
-
-    /**
-     * Visit the specified tab
-     *
-     * @param string $tab
-     */
-    public function visitTab($tab)
-    {
-        $tabs = $this->getPageTabs();
-
-        $tabDom = $this->spin(function () use ($tabs, $tab) {
-            return $tabs->findLink($tab);
-        }, sprintf('Could not find a tab named "%s"', $tab));
-
-        $this->spin(function () {
-            $loading = $this->find('css', '#loading-wrapper');
-
-            return null === $loading || !$loading->isVisible();
-        }, sprintf('Could not visit tab %s because of loading wrapper', $tab));
-
-        $this->spin(function () use ($tabDom) {
-            $tabDom->click();
-
-            return $tabDom->getParent()->hasClass('active') || $tabDom->getParent()->hasClass('tab-scrollable');
-        }, sprintf('Cannot switch to the tab %s', $tab));
-    }
-
-    /**
-     * Get the tabs in the current page
-     *
-     * @return NodeElement[]
-     */
-    public function getTabs()
-    {
-        $tabs = $this->spin(function () {
-            return $this->find('css', $this->elements['Tabs']['css']);
-        }, sprintf('Cannot find "%s" element', $this->elements['Tabs']['css']));
-
-        if (null === $tabs) {
-            $tabs = $this->getElement('Oro tabs');
-        }
-
-        return $tabs->findAll('css', 'a');
-    }
-
-    /**
-     * Get the form tab containg $tab text
-     *
-     * @param string $tab
-     *
-     * @return NodeElement|null
-     */
-    public function getFormTab($tab)
-    {
-        $tabs = $this->getPageTabs();
-
-        try {
-            $node = $this->spin(function () use ($tabs, $tab) {
-                return $tabs->find('css', sprintf('a:contains("%s")', $tab));
-            }, sprintf('Cannot find form tab "%s"', $tab));
-        } catch (\Exception $e) {
-            $node = null;
-        }
-
-        return $node;
-    }
-
-    /**
-     * Get the specified tab
-     *
-     * @return NodeElement
-     */
-    public function getTab($tab)
-    {
-        return $this->find('css', sprintf('a:contains("%s")', $tab));
     }
 
     /**
@@ -840,25 +760,5 @@ class Form extends Base
 
         $field = $this->findPriceField($label->labelContent, $label->subLabelContent);
         $field->setValue($value);
-    }
-
-    /**
-     * Returns the tabs of the current page, if any.
-     *
-     * @return NodeElement
-     */
-    protected function getPageTabs()
-    {
-        return $this->spin(function () {
-            $tabs = $this->find('css', $this->elements['Tabs']['css']);
-            if (null === $tabs) {
-                $tabs = $this->find('css', $this->elements['Oro tabs']['css']);
-            }
-            if (null === $tabs) {
-                $tabs = $this->find('css', $this->elements['Form tabs']['css']);
-            }
-
-            return $tabs;
-        }, 'Cannot find any tabs in this page');
     }
 }

--- a/features/Pim/Behat/Context/JobContext.php
+++ b/features/Pim/Behat/Context/JobContext.php
@@ -8,10 +8,13 @@ use Akeneo\Component\Batch\Job\JobRegistry;
 use Akeneo\Component\Batch\Model\JobInstance;
 use Behat\Behat\Context\Step;
 use Behat\Gherkin\Node\TableNode;
+use Context\Spin\SpinCapableTrait;
 use Symfony\Component\Validator\ConstraintViolationInterface;
 
 class JobContext extends PimContext
 {
+    use SpinCapableTrait;
+
     /**
      * @param string    $code
      * @param TableNode $table
@@ -104,14 +107,14 @@ class JobContext extends PimContext
      * @param string      $action
      * @param JobInstance $job
      *
-     * @return \Behat\Behat\Context\Step\Then
+     * @return Step\Then
      *
      * @When /^I should not be able to (launch|edit) the ("([^"]*)" (export|import) job)$/
      */
     public function iShouldNotBeAbleToAccessTheJob($action, JobInstance $job)
     {
         $this->currentPage = sprintf("%s %s", ucfirst($job->getType()), $action);
-        $page              = $this->getCurrentPage()->open(['id' => $job->getId()]);
+        $this->getCurrentPage()->open(['id' => $job->getId()]);
 
         return new Step\Then('I should see "403 Forbidden"');
     }
@@ -124,6 +127,22 @@ class JobContext extends PimContext
     public function iTryToCreateAnUnknownJob($jobType)
     {
         $this->getNavigationContext()->openPage(sprintf('%s creation', ucfirst($jobType)));
+    }
+
+    /**
+     * @param string $label
+     * @param string $message
+     *
+     * @Then /^the export content field "([^"]*)" should contain "([^"]*)"$/
+     */
+    public function theExportContentFieldShouldContain($label, $message)
+    {
+        $page = $this->getCurrentPage();
+        $field = $this->spin(function () use ($label, $page) {
+            return $page->find('css', sprintf('[data-name="%s"] .select2-default', $label));
+        }, sprintf('Field "%s" not found.', $label));
+
+        assertEquals($field->getValue(), $message);
     }
 
     /**

--- a/features/export/product-export-builder/export_products_by_families.feature
+++ b/features/export/product-export-builder/export_products_by_families.feature
@@ -67,3 +67,14 @@ Feature: Export products according to their families
     SNKRS-5;summer_collection;;;1;boots;;;;;"Black boots";;;;;;;;;
     SNKRS-6;summer_collection;;;1;boots;;;;;"Black boots";;;;;;;;;
     """
+
+  @jira https://akeneo.atlassian.net/browse/PIM-5952
+  Scenario: Display default messages when no family are selected
+    Given the following job "csv_footwear_product_export" configuration:
+      | filePath | %tmp%/product_export/product_export.csv |
+    When I am on the "csv_footwear_product_export" export job edit page
+    And I visit the "Content" tab
+    Then the export content field "family.code" should contain "No condition on families"
+    When I am on the "csv_footwear_product_export" export job page
+    And I visit the "Content" tab
+    Then the export content field "family.code" should contain "No condition on families"

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/product/family.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/product/family.js
@@ -1,16 +1,16 @@
 'use strict';
 
 define([
-        'underscore',
-        'oro/translator',
-        'pim/filter/filter',
-        'routing',
-        'text!pim/template/filter/product/family',
-        'pim/fetcher-registry',
-        'pim/user-context',
-        'pim/i18n',
-        'jquery.select2'
-    ], function (_, __, BaseFilter, Routing, template, fetcherRegistry, userContext, i18n) {
+    'underscore',
+    'oro/translator',
+    'pim/filter/filter',
+    'routing',
+    'text!pim/template/filter/product/family',
+    'pim/fetcher-registry',
+    'pim/user-context',
+    'pim/i18n',
+    'jquery.select2'
+], function (_, __, BaseFilter, Routing, template, fetcherRegistry, userContext, i18n) {
     return BaseFilter.extend({
         shortname: 'family',
         config: {},
@@ -27,6 +27,7 @@ define([
 
             this.selectOptions = {
                 allowClear: true,
+                containerCss: {width: 500},
                 multiple: true,
                 ajax: {
                     url: Routing.generate(this.config.url),

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/metric-field.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/metric-field.js
@@ -8,13 +8,13 @@
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 define([
-        'jquery',
-        'pim/field',
-        'underscore',
-        'pim/fetcher-registry',
-        'text!pim/template/product/field/metric',
-        'pim/initselect2'
-        ], function ($, Field, _, FetcherRegistry, fieldTemplate, initSelect2) {
+    'jquery',
+    'pim/field',
+    'underscore',
+    'pim/fetcher-registry',
+    'text!pim/template/product/field/metric',
+    'pim/initselect2'
+], function ($, Field, _, FetcherRegistry, fieldTemplate, initSelect2) {
     return Field.extend({
         fieldTemplate: _.template(fieldTemplate),
         events: {

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
@@ -380,7 +380,7 @@ pim_enrich:
                         "NOT IN": Not in list
                         EMPTY: Products that don't have a family
                         "NOT EMPTY": Products that have a family
-                    empty_selection: Select a family
+                    empty_selection: No condition on families
                 updated:
                     title: Time condition
                     operators:


### PR DESCRIPTION
**Description**

In the product export builder, the field of the family filter is empty if no family are selected. This is confusing because the user don't know what the empty field means.

This PR fixes this problem by adding two default message: one when showing the export profile in read only, another when editing the export profile.

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | N/A
| Added Behats                      | :white_check_mark:
| Changelog updated                 | :white_check_mark:
| Review and 2 GTM                  | :white_check_mark:
| Micro Demo to the PO (Story only) | :white_check_mark:
| Migration script                  | N/A
| Tech Doc                          | N/A