### PR TITLE
PIM-5862: The default custom view does not display the product grid correctly for new user

### DIFF
--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - TIP-307: Fix issues with Mongo 2.6
+- PIM-5862: Fix product grid display on a custom user view
 
 # 1.5.8 (2016-08-25)
 

--- a/src/Pim/Bundle/DataGridBundle/Resources/views/Datagrid/_views.html.twig
+++ b/src/Pim/Bundle/DataGridBundle/Resources/views/Datagrid/_views.html.twig
@@ -97,6 +97,7 @@ require(
                     });
                 });
             });
+            activateView(activeViewId);
         }
 
         var truncateTitle = function(title) {


### PR DESCRIPTION
Fix default display of a product grid when the user have a custom view in his settings.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | N
| Added Behats                      | N
| Changelog updated                 | Y
| Review and 2 GTM                  | Y
| Micro Demo to the PO (Story only) | N
| Migration script                  | N
| Tech Doc                          | N
