### PR TITLE
PIM-5965: Fix default product export filters order

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -11,6 +11,7 @@
 - PIM-5938: Fix typos in import/export tooltips
 - PIM-5966: Fix style about category filter on product export builder
 - PIM-5952: Add the information "No condition on families" in the family field of the Export Builder
+- PIM-5965: Fix the display order of the default product export filters
 
 # 1.6.0 (2016-08-30)
 

--- a/features/Pim/Behat/Context/JobContext.php
+++ b/features/Pim/Behat/Context/JobContext.php
@@ -146,6 +146,19 @@ class JobContext extends PimContext
     }
 
     /**
+     * @param string $filters
+     *
+     * @Then /^I should see the ordered filters (.*)$/
+     */
+    public function iShouldSeeTheOrderedFilters($filters)
+    {
+        $expectedOrderedFilters = $this->getMainContext()->listToArray($filters);
+        $currentOrderedFilters = $this->getOrderedFilters();
+
+        assertEquals($expectedOrderedFilters, $currentOrderedFilters);
+    }
+
+    /**
      * @param string   $code
      * @param int|null $number
      *
@@ -227,5 +240,22 @@ class JobContext extends PimContext
         $archives = $archiver->getArchives($jobExecution);
 
         return $archives;
+    }
+
+    /**
+     * Gets currently displayed export filters, ordered.
+     *
+     * return string[]
+     */
+    protected function getOrderedFilters()
+    {
+        $filters = $this->getCurrentPage()->findAll('css', '.filters .filter-item');
+        $currentFilters = [];
+
+        foreach ($filters as $filter) {
+            $currentFilters[] = $filter->getAttribute('data-name');
+        }
+
+        return $currentFilters;
     }
 }

--- a/features/export/edit_an_export.feature
+++ b/features/export/edit_an_export.feature
@@ -67,3 +67,15 @@ Feature: Edit an export
     When I fill in the following information:
       | Label | My export |
     Then I should see "There are unsaved changes."
+
+  @jira https://akeneo.atlassian.net/browse/PIM-5965
+  Scenario: Successfully display export filter in expected order
+    Given I am on the "csv_footwear_product_export" export job page
+    When I visit the "Content" tab
+    Then I should see the ordered filters family.code, enabled, completeness, updated, categories.code and sku
+    When I am on the "csv_footwear_product_export" export job edit page
+    And I visit the "Content" tab
+    Then I should see the ordered filters family.code, enabled, completeness, updated, categories.code and sku
+    When I add available attributes Name
+    And I add available attributes Weight
+    Then I should see the ordered filters family.code, enabled, completeness, updated, categories.code, name, weight and sku

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/filter/product/family.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/filter/product/family.html
@@ -3,6 +3,6 @@
     name="filter-value"
     type="hidden"
     value="<%- value ? value : '' %>"
-    data-placeholder="<%- __('pim_enrich.export.product.filter.' + shortname + '.empty_selection') %>"
+    data-placeholder="<%- __('pim_enrich.export.product.filter.' + shortname + '.' + (isEditable ? 'empty_selection' : 'empty_selection_readonly')) %>"
     <%- isEditable ? '' : 'disabled' %>
 />

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/filter/product/family.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/filter/product/family.html
@@ -3,6 +3,6 @@
     name="filter-value"
     type="hidden"
     value="<%- value ? value : '' %>"
-    data-placeholder="<%- __('pim_enrich.export.product.filter.' + shortname + '.' + (isEditable ? 'empty_selection' : 'empty_selection_readonly')) %>"
+    data-placeholder="<%- __('pim_enrich.export.product.filter.' + shortname + '.empty_selection') %>"
     <%- isEditable ? '' : 'disabled' %>
 />


### PR DESCRIPTION
**Description**

Product export builder comes with a set of default filters, that cannot be removed. Those filters should always be in this order:

- family
- status
- complete
- update
- category
- product identifier

Other filters should be alphabetically sorted, but **the product identifier should always stay at the end of the list**.

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | N/A
| Added Behats                      | :white_check_mark:
| Changelog updated                 | :white_check_mark:
| Review and 2 GTM                  | :white_check_mark:
| Micro Demo to the PO (Story only) | :white_check_mark:
| Migration script                  | N/A
| Tech Doc                          | N/A

