### PR TITLE
Update file according to sf2.7 #4937

### DIFF
--- a/web/app.php
+++ b/web/app.php
@@ -1,17 +1,8 @@
 <?php
 
-use Symfony\Component\ClassLoader\ApcClassLoader;
 use Symfony\Component\HttpFoundation\Request;
 
 $loader = require_once __DIR__.'/../app/bootstrap.php.cache';
-
-// Use APC for autoloading to improve performance.
-// Change 'sf2' to a unique prefix in order to prevent cache key conflicts
-// with other applications also using APC.
-/*
-$loader = new ApcClassLoader('sf2', $loader);
-$loader->register(true);
-*/
 
 require_once __DIR__.'/../app/AppKernel.php';
 //require_once __DIR__.'/../app/AppCache.php';
@@ -19,6 +10,9 @@ require_once __DIR__.'/../app/AppKernel.php';
 $kernel = new AppKernel('prod', false);
 $kernel->loadClassCache();
 //$kernel = new AppCache($kernel);
+
+// When using the HttpCache, you need to call the method in your front controller instead of relying on the configuration parameter
+//Request::enableHttpMethodParameterOverride();
 $request = Request::createFromGlobals();
 $response = $kernel->handle($request);
 $response->send();


### PR DESCRIPTION
| Q                                 | A
| --------------------------------- | ---
| Review and 2 GTM                  | No


This PR add missing lines in the web/app.php file that we forgot to add when we upgrade from sf2.3 to sf2.7. If this line is not added it doesn't work with the APC cache.
