### PR TITLE
PIM-5963: be able to install PIM on MySQL 5.7

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -1,3 +1,9 @@
+# 1.6.x
+
+## Bug fixes
+
+- PIM-5963: Fix installation on MySQL 5.7
+
 # 1.6.1 (2016-09-01)
 
 ## Bug fixes

--- a/features/product/completeness/display_completeness_with_selects.feature
+++ b/features/product/completeness/display_completeness_with_selects.feature
@@ -1,6 +1,6 @@
 @javascript
-Feature: Display the completeness of a product with reference data
-  In order to see the completeness of a product with reference data in the catalog
+Feature: Display the completeness of a product with simple or multi selects
+  In order to see the completeness of a product with simple or multi selects in the catalog
   As a product manager
   I need to be able to display the completeness of a product
 
@@ -9,22 +9,27 @@ Feature: Display the completeness of a product with reference data
     And I add the "french" locale to the "tablet" channel
     And I add the "french" locale to the "mobile" channel
     And the following attributes:
-      | code        | label       | localizable | scopable | type                        | reference_data_name |
-      | heel_fabric | Heel fabric | yes         | yes      | reference_data_multiselect  | fabrics             |
-      | main_fabric | Main fabric | no          | yes      | reference_data_multiselect  | fabrics             |
-      | main_color  | Main color  | yes         | no       | reference_data_simpleselect | color               |
+      | code         | label        | localizable | scopable | type         |
+      | braid_color  | Braid color  | no          | no       | simpleselect |
+      | braid_fabric | Braid fabric | no          | no       | multiselect  |
+      | heel_fabric  | Heel fabric  | yes         | yes      | multiselect  |
+      | main_fabric  | Main fabric  | no          | yes      | multiselect  |
+      | main_color   | Main color   | yes         | no       | simpleselect |
     And the following family:
-      | code      | attributes                                                         | requirements-tablet                      | requirements-mobile                      |
-      | highheels | sku, heel_color, sole_fabric, heel_fabric, main_fabric, main_color | sku, heel_color, sole_fabric, main_color | sku,heel_fabric, main_fabric, main_color |
+      | code      | attributes                                                           | requirements-tablet                        | requirements-mobile                       |
+      | highheels | sku, braid_color, braid_fabric, heel_fabric, main_fabric, main_color | sku, braid_color, braid_fabric, main_color | sku, heel_fabric, main_fabric, main_color |
     And I am logged in as "Julia"
-    And the following "main_fabric" attribute reference data: PVC, Nylon, Neoprene, Spandex, Wool, Kevlar, Jute
-    And the following "main_color" attribute reference data: Red, Green, Light green, Blue, Yellow, Cyan, Magenta, Black, White
+    And the following "braid_fabric" attribute options: PVC, Nylon, Neoprene, Spandex, Wool, Kevlar, Jute
+    And the following "braid_color" attribute options: Red, Green, Emerald, Blue, Yellow, Cyan, Magenta, Black, White
+    And the following "main_fabric" attribute options: PVC, Nylon, Neoprene, Spandex, Wool, Kevlar, Jute
+    And the following "main_color" attribute options: Red, Green, Emerald, Blue, Yellow, Cyan, Magenta, Black, White
+    And the following "heel_fabric" attribute options: PVC, Nylon, Neoprene, Spandex, Wool, Kevlar, Jute
     And the following products:
-      | sku         | family    | heel_color | sole_fabric | heel_fabric-en_US-mobile | heel_fabric-fr_FR-mobile | heel_fabric-en_US-tablet | heel_fabric-fr_FR-tablet | main_fabric-mobile | main_fabric-tablet | main_color-fr_FR | main_color-en_US |
-      | red-heels   | highheels |            | Spandex     |                          | Neoprene,Jute            |                          |                          | PVC                |                    | Red              |                  |
-      | black-heels | highheels | Black      | Wool        |                          |                          | Nylon                    | Kevlar,Jute              |                    | Nylon              |                  | Black            |
-      | green-heels | highheels | Green      | PVC         |                          |                          |                          |                          |                    |                    | Green            | Light green      |
-      | high-heels  | highheels |            |             |                          |                          |                          |                          |                    |                    |                  |                  |
+      | sku         | family    | braid_color | braid_fabric | heel_fabric-en_US-mobile | heel_fabric-fr_FR-mobile | heel_fabric-en_US-tablet | heel_fabric-fr_FR-tablet | main_fabric-mobile | main_fabric-tablet | main_color-fr_FR | main_color-en_US |
+      | red-heels   | highheels |             | Spandex      |                          | Neoprene,Jute            |                          |                          | PVC                |                    | Red              |                  |
+      | black-heels | highheels | Black       | Wool         |                          |                          | Nylon                    | Kevlar,Jute              |                    | Nylon              |                  | Black            |
+      | green-heels | highheels | Green       | PVC          |                          |                          |                          |                          |                    |                    | Green            | Emerald          |
+      | high-heels  | highheels |             |              |                          |                          |                          |                          |                    |                    |                  |                  |
     And I launched the completeness calculator
 
   Scenario: Successfully display the completeness of the products with reference data

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/CompletenessGenerator.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/CompletenessGenerator.php
@@ -295,45 +295,38 @@ MISSING_SQL;
     protected function getMainSqlPart()
     {
         return <<<MAIN_SQL
-            INSERT INTO pim_catalog_completeness (
-                locale_id, channel_id, product_id, ratio, missing_count, required_count
-            )
-            SELECT
-                l.id AS locale_id, c.id AS channel_id, p.id AS product_id,
-                (
-                    COUNT(distinct v.id)
-                    / (
-                        SELECT count(*)
-                        FROM pim_catalog_attribute_requirement r
-                        LEFT JOIN pim_catalog_attribute_locale al ON al.attribute_id = r.attribute_id
-                        WHERE family_id = p.family_id
-                            AND channel_id = c.id
-                            AND r.required = true
-                            AND (al.locale_id = l.id OR al.locale_id IS NULL)
-                    )
-                    * 100
-                ) AS ratio,
-                (
-                    (
-                        SELECT count(*)
-                        FROM pim_catalog_attribute_requirement r
-                        LEFT JOIN pim_catalog_attribute_locale al ON al.attribute_id = r.attribute_id
-                        WHERE family_id = p.family_id
-                            AND channel_id = c.id
-                            AND r.required = true
-                            AND (al.locale_id = l.id OR al.locale_id IS NULL)
-                    ) - COUNT(distinct v.id)
-                ) AS missing_count,
-                (
-                    SELECT count(*)
+    INSERT INTO pim_catalog_completeness (
+        locale_id, channel_id, product_id, ratio, missing_count, required_count
+    )
+    SELECT
+        locale_id,
+        channel_id,
+        product_id,
+        (req_values_filled / required_count * 100) as ratio,
+        (required_count - req_values_filled) as missing_count,
+        required_count
+    FROM (
+        SELECT
+            values_filled.locale_id,
+            values_filled.channel_id,
+            values_filled.product_id,
+            values_filled.req_values_filled,
+            (
+                SELECT COUNT(*)
                     FROM pim_catalog_attribute_requirement r
                     LEFT JOIN pim_catalog_attribute_locale al ON al.attribute_id = r.attribute_id
-                    WHERE family_id = p.family_id
-                        AND channel_id = c.id
-                        AND r.required = true
-                        AND (al.locale_id = l.id OR al.locale_id IS NULL)
-                ) AS required_count
-
+                    WHERE r.family_id = values_filled.family_id
+                        AND r.channel_id = values_filled.channel_id
+                        AND r.required = TRUE
+                        AND (al.locale_id = values_filled.locale_id OR al.locale_id IS NULL)
+            ) AS required_count
+        FROM (
+            SELECT
+                l.id AS locale_id,
+                c.id AS channel_id,
+                p.id AS product_id,
+                p.family_id AS family_id,
+                COUNT(DISTINCT v.id) AS req_values_filled
             FROM %missing_completeness% AS m
             JOIN pim_catalog_channel c ON c.id = m.channel_id
             JOIN pim_catalog_locale l ON l.id = m.locale_id
@@ -350,7 +343,6 @@ MISSING_SQL;
                 AND cp.channel_id = c.id
                 AND cp.locale_id = l.id
             LEFT JOIN pim_catalog_attribute_locale al ON al.attribute_id = v.attribute_id
-
             WHERE (
                 %product_value_conditions%
                 %extra_conditions%
@@ -358,8 +350,9 @@ MISSING_SQL;
             )
             AND (al.locale_id = l.id OR al.locale_id IS NULL)
             AND r.required = true
-
             GROUP BY p.id, c.id, l.id
+        ) AS values_filled
+    ) AS results
 MAIN_SQL;
     }
 


### PR DESCRIPTION
Due to [this completeness optimization](https://github.com/akeneo/pim-community-dev/pull/4863), the PIM is not installable anymore on MySQL 5.7

Officially we don't support MySQL 5.7, but the latest Ubuntu ships with it. Which means a lot of devs will not understand why the PIM is not installable on their LAMP machine...

The problem is that (since the beginning of the PIM) the completeness is calculated thanks to a SQL request than is not SQL92 compliant: we select data that is not aggregated. MySQL 5.6 and 5.5 were not so strict and authorized such behaviors. MySQL 5.7 is less permissive, which leads to a problem to calculate the _required_count_ and the _ratio_.

The first commit fixes the problem. This fix is gracefully provided by your beloved CTO.
The second commit adds Behat on completeness calculation with select attribute types. The next person who will have to modify the completeness will be happy to have them :) It's like a little bit of sugar on top of the completeness cake :cake: .

**Edit: this patch has no impact on performances.**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | Y
| Changelog updated                  | Y
| Review and 2 GTM                  | 
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | https://github.com/akeneo/pim-docs/pull/384
