### PR TITLE
Fix coverage of specs on CI

### DIFF
--- a/app/phpspec.jenkins-coverage.yml
+++ b/app/phpspec.jenkins-coverage.yml
@@ -1,7 +1,0 @@
-formatter.name: dot
-extensions:
-    - Akeneo\SkipExampleExtension
-    - PhpSpec\Extension\CodeCoverageExtension
-code_coverage:
-    format: php
-    output: app/build/coverage-parts/phpspec.php

--- a/bin/merge-coverage
+++ b/bin/merge-coverage
@@ -1,6 +1,10 @@
 #!/usr/bin/env php
 
 <?php
+
+use SebastianBergmann\CodeCoverage\Report\Clover;
+use SebastianBergmann\CodeCoverage\Report\Html\Facade;
+
 /**
  * Require PHP_CodeCoverage objects from the files passed on the command line,
  * combines them into a single coverage object and creates Clover and HTML reports of the
@@ -27,9 +31,9 @@ foreach (array_slice($argv, 1) as $filename) {
 }
 
 print "Generating code coverage report in clover format ...";
-$writer = new PHP_CodeCoverage_Report_Clover();
+$writer = new Clover();
 $writer->process($codeCoverage, 'app/build/coverage-parts/report.xml');
 
 print "\nGenerating code coverage report in HTML format ...";
-$writer = new PHP_CodeCoverage_Report_HTML();
+$writer = new Facade();
 $writer->process($codeCoverage, 'app/build/coverage');

--- a/build.xml
+++ b/build.xml
@@ -244,6 +244,21 @@
             <arg value="3.0.*@dev" />
         </exec>
 
+        <replace
+                file="${basedir}/phpspec.yml.dist"
+                token="suites:"
+                failOnNoReplacements="true"
+        >
+            <replacevalue><![CDATA[formatter.name: dot
+extensions:
+    Akeneo\SkipExampleExtension: ~
+    PhpSpecCodeCoverage\CodeCoverageExtension: ~
+code_coverage:
+    format: php
+    output: app/build/coverage-parts/phpspec.php
+suites:]]></replacevalue>
+        </replace>
+
         <!--
             As long as composer does not provide an option to ignore platform dependency,
             it must be executed with the xdebug extension activated
@@ -275,8 +290,6 @@
             <arg value="-d zend_extension=${xdebug_path}/xdebug.so" />
             <arg value="${basedir}/bin/phpspec" />
             <arg value="run" />
-            <arg value="-c" />
-            <arg path="${basedir}/app/phpspec.jenkins-coverage.yml" />
         </exec>
 
         <exec executable="php">

--- a/build.xml
+++ b/build.xml
@@ -241,7 +241,7 @@
             <arg value="require" />
             <arg value="--no-update" />
             <arg value="henrikbjorn/phpspec-code-coverage" />
-            <arg value="1.0.*@dev" />
+            <arg value="3.0.*@dev" />
         </exec>
 
         <!--

--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
         "box/spout": "2.5.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "3.7.*",
+        "phpunit/phpunit": "5.4.*",
         "squizlabs/php_codesniffer": "2.*",
         "pdepend/pdepend": "2.1.*",
         "phpmd/phpmd": "1.*",

--- a/phpspec.yml.dist
+++ b/phpspec.yml.dist
@@ -91,22 +91,22 @@ suites:
         spec_path: src/Pim/Component/Catalog
         src_path: src/Pim/Component/Catalog
 
-    ## Akeneo Bundles
+    ## Pim Bundles
     AnalyticsBundle:
         namespace: Pim\Bundle\AnalyticsBundle
         psr4_prefix: Pim\Bundle\AnalyticsBundle
         spec_path: src/Pim/Bundle/AnalyticsBundle
         src_path: src/Pim/Bundle/AnalyticsBundle
-    BaseConnectorBundle:
-        namespace: Pim\Bundle\BaseConnectorBundle
-        psr4_prefix: Pim\Bundle\BaseConnectorBundle
-        spec_path: src/Pim/Bundle/BaseConnectorBundle
-        src_path: src/Pim/Bundle/BaseConnectorBundle
     CatalogBundle:
         namespace: Pim\Bundle\CatalogBundle
         psr4_prefix: Pim\Bundle\CatalogBundle
         spec_path: src/Pim/Bundle/CatalogBundle
         src_path: src/Pim/Bundle/CatalogBundle
+    ConnectorBundle:
+        namespace: Pim\Bundle\ConnectorBundle
+        psr4_prefix: Pim\Bundle\ConnectorBundle
+        spec_path: src/Pim/Bundle/ConnectorBundle
+        src_path: src/Pim/Bundle/ConnectorBundle
     DashboardBundle:
         namespace: Pim\Bundle\DashboardBundle
         psr4_prefix: Pim\Bundle\DashboardBundle

--- a/src/Akeneo/Bundle/StorageUtilsBundle/spec/Doctrine/SmartManagerRegistrySpec.php
+++ b/src/Akeneo/Bundle/StorageUtilsBundle/spec/Doctrine/SmartManagerRegistrySpec.php
@@ -46,9 +46,6 @@ class SmartManagerRegistrySpec extends ObjectBehavior
         $odmRegistry,
         $customRegistry
     ) {
-        if (!class_exists('Doctrine\ODM\MongoDB\MongoDBException', false)) {
-            throw new SkippingException('Mongo ODM is not installed');
-        }
         $ormRegistry->getAliasNamespace('foo')->willThrow(new ORMException());
         $odmRegistry->getAliasNamespace('foo')->willThrow(new MongoDBException());
         $customRegistry->getAliasNamespace('foo')->willReturn('\Foo');
@@ -61,9 +58,6 @@ class SmartManagerRegistrySpec extends ObjectBehavior
         $odmRegistry,
         $customRegistry
     ) {
-        if (!class_exists('Doctrine\ODM\MongoDB\MongoDBException', false)) {
-            throw new SkippingException('Mongo ODM is not installed');
-        }
         $ormRegistry->getAliasNamespace('foo')->willThrow(new ORMException());
         $odmRegistry->getAliasNamespace('foo')->willThrow(new MongoDBException());
         $customRegistry->getAliasNamespace('foo')->willThrow(new ORMException());

--- a/src/Oro/Bundle/AsseticBundle/Tests/Unit/DependencyInjection/OroAsseticExtensionTest.php
+++ b/src/Oro/Bundle/AsseticBundle/Tests/Unit/DependencyInjection/OroAsseticExtensionTest.php
@@ -31,7 +31,7 @@ class OroAsseticExtensionTest extends \PHPUnit_Framework_TestCase
     {
         $extension = new OroAsseticExtension();
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerBuilder');
 
         $container->expects($this->once())
             ->method('getParameter')

--- a/src/Oro/Bundle/AsseticBundle/Tests/Unit/Factory/OroAssetManagerTest.php
+++ b/src/Oro/Bundle/AsseticBundle/Tests/Unit/Factory/OroAssetManagerTest.php
@@ -131,7 +131,7 @@ class OroAssetManagerTest extends \PHPUnit_Framework_TestCase
 
     protected function createMockResource($name, $content)
     {
-        $result = $this->getMock('Assetic\Factory\Resource\ResourceInterface');
+        $result = $this->createMock('Assetic\Factory\Resource\ResourceInterface');
 
         $result->expects($this->once())
             ->method('getContent')

--- a/src/Oro/Bundle/ConfigBundle/Tests/Unit/Config/ConfigManagerTest.php
+++ b/src/Oro/Bundle/ConfigBundle/Tests/Unit/Config/ConfigManagerTest.php
@@ -67,7 +67,7 @@ class ConfigManagerTest extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped('Doctrine Common has to be installed for this test to run.');
         }
 
-        $this->om = $this->getMock('Doctrine\Common\Persistence\ObjectManager');
+        $this->om = $this->createMock('Doctrine\Common\Persistence\ObjectManager');
         $this->object = new ConfigManager($this->om, $this->settings);
     }
 
@@ -105,7 +105,7 @@ class ConfigManagerTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetDefaultSettings()
     {
-        $object = $this->getMock(
+        $object = $this->createMock(
             'Oro\Bundle\ConfigBundle\Config\ConfigManager',
             ['loadStoredSettings'],
             [$this->om, $this->settings]
@@ -124,7 +124,7 @@ class ConfigManagerTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetSettingsByForm()
     {
-        $object = $this->getMock(
+        $object = $this->createMock(
             'Oro\Bundle\ConfigBundle\Config\ConfigManager',
             ['get'],
             [$this->om, $this->settings]
@@ -165,7 +165,7 @@ class ConfigManagerTest extends \PHPUnit_Framework_TestCase
             ],
         ];
 
-        $object = $this->getMock(
+        $object = $this->createMock(
             'Oro\Bundle\ConfigBundle\Config\ConfigManager',
             ['getChanged'],
             [$this->om, $this->settings]
@@ -180,7 +180,7 @@ class ConfigManagerTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo($settings))
             ->will($this->returnValue($changes));
 
-        $configMock = $this->getMock('Oro\Bundle\ConfigBundle\Entity\Config');
+        $configMock = $this->createMock('Oro\Bundle\ConfigBundle\Entity\Config');
         $configMock->expects($this->once())
             ->method('getOrCreateValue')
             ->will($this->returnValue(new ConfigValue()));
@@ -232,7 +232,7 @@ class ConfigManagerTest extends \PHPUnit_Framework_TestCase
             ],
         ];
 
-        $object = $this->getMock(
+        $object = $this->createMock(
             'Oro\Bundle\ConfigBundle\Config\ConfigManager',
             ['get'],
             [$this->om, $this->settings]

--- a/src/Oro/Bundle/ConfigBundle/Tests/Unit/Config/UserConfigManagerTest.php
+++ b/src/Oro/Bundle/ConfigBundle/Tests/Unit/Config/UserConfigManagerTest.php
@@ -38,14 +38,14 @@ class UserConfigManagerTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->om = $this->getMock('Doctrine\Common\Persistence\ObjectManager');
+        $this->om = $this->createMock('Doctrine\Common\Persistence\ObjectManager');
         $this->object = new UserConfigManager($this->om, $this->settings);
 
-        $this->tokenStorage = $this->getMock('Symfony\Component\Security\Core\TokenStorageInterface');
-        $this->group1 = $this->getMock('Oro\Bundle\UserBundle\Entity\Group');
-        $this->group2 = $this->getMock('Oro\Bundle\UserBundle\Entity\Group');
+        $this->tokenStorage = $this->createMock('Symfony\Component\Security\Core\TokenStorageInterface');
+        $this->group1 = $this->createMock('Oro\Bundle\UserBundle\Entity\Group');
+        $this->group2 = $this->createMock('Oro\Bundle\UserBundle\Entity\Group');
 
-        $token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
+        $token = $this->createMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
         $user = new User();
 
         $this->tokenStorage
@@ -73,7 +73,7 @@ class UserConfigManagerTest extends \PHPUnit_Framework_TestCase
             ->addGroup($this->group1)
             ->addGroup($this->group2);
 
-        $this->object = $this->getMock(
+        $this->object = $this->createMock(
             'Oro\Bundle\ConfigBundle\Config\UserConfigManager',
             ['loadStoredSettings'],
             [$this->om, $this->settings]

--- a/src/Oro/Bundle/ConfigBundle/Tests/Unit/DependencyInjection/OroConfigExtensionTest.php
+++ b/src/Oro/Bundle/ConfigBundle/Tests/Unit/DependencyInjection/OroConfigExtensionTest.php
@@ -22,7 +22,7 @@ class OroConfigExtensionTest extends \PHPUnit_Framework_TestCase
         $extension = new OroConfigExtension();
         $configs = [];
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerBuilder');
         $container->expects($this->any())
             ->method('setParameter')
             ->will(

--- a/src/Oro/Bundle/ConfigBundle/Tests/Unit/Entity/Repository/ConfigRepositoryTest.php
+++ b/src/Oro/Bundle/ConfigBundle/Tests/Unit/Entity/Repository/ConfigRepositoryTest.php
@@ -27,7 +27,7 @@ class ConfigRepositoryTest extends \PHPUnit_Framework_TestCase
             ->setMethods([])
             ->getMock();
 
-        $this->repository = $this->getMock(
+        $this->repository = $this->createMock(
             'Oro\Bundle\ConfigBundle\Entity\Repository\ConfigRepository',
             ['findOneBy'],
             [
@@ -63,7 +63,7 @@ class ConfigRepositoryTest extends \PHPUnit_Framework_TestCase
         ];
 
         if ($isScope) {
-            $value = $this->getMock('Oro\Bundle\ConfigBundle\Entity\ConfigValue');
+            $value = $this->createMock('Oro\Bundle\ConfigBundle\Entity\ConfigValue');
             $value->expects($this->once())
                 ->method('getSection')
                 ->will($this->returnValue('oro_user'));
@@ -74,7 +74,7 @@ class ConfigRepositoryTest extends \PHPUnit_Framework_TestCase
                 ->method('getValue')
                 ->will($this->returnValue('test'));
 
-            $scope = $this->getMock('Oro\Bundle\ConfigBundle\Entity\Config');
+            $scope = $this->createMock('Oro\Bundle\ConfigBundle\Entity\Config');
             $scope->expects($this->once())
                 ->method('getValues')
                 ->will($this->returnValue([$value]));

--- a/src/Oro/Bundle/DataGridBundle/Tests/Unit/Datagrid/BuilderTest.php
+++ b/src/Oro/Bundle/DataGridBundle/Tests/Unit/Datagrid/BuilderTest.php
@@ -27,7 +27,7 @@ class BuilderTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->eventDispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcher');
+        $this->eventDispatcher = $this->createMock('Symfony\Component\EventDispatcher\EventDispatcher');
         $this->securityFacade = $this->getMockBuilder('Oro\Bundle\SecurityBundle\SecurityFacade')
             ->disableOriginalConstructor()->getMock();
     }

--- a/src/Oro/Bundle/FilterBundle/Tests/Unit/Twig/AbstractExtensionTestCase.php
+++ b/src/Oro/Bundle/FilterBundle/Tests/Unit/Twig/AbstractExtensionTestCase.php
@@ -52,7 +52,7 @@ class AbstractExtensionTestCase extends \PHPUnit_Framework_TestCase
 
     public function testGetFunctions()
     {
-        $twigNode = $this->getMock('\Twig_Node');
+        $twigNode = $this->createMock('\Twig_Node');
 
         $actualFunctions = $this->extension->getFunctions();
 

--- a/src/Oro/Bundle/FilterBundle/Tests/Unit/Twig/RenderHeaderExtensionTest.php
+++ b/src/Oro/Bundle/FilterBundle/Tests/Unit/Twig/RenderHeaderExtensionTest.php
@@ -56,7 +56,7 @@ class RenderHeaderExtensionTest extends AbstractExtensionTestCase
             ->with($blockName, [])
             ->will($this->returnValue($blockHtml));
 
-        $environment = $this->getMock('\Twig_Environment', ['loadTemplate']);
+        $environment = $this->createMock('\Twig_Environment', ['loadTemplate']);
         $environment->expects($this->once())
             ->method('loadTemplate')
             ->with($templateName)

--- a/src/Oro/Bundle/FilterBundle/Tests/Unit/Twig/RenderLayoutExtensionTest.php
+++ b/src/Oro/Bundle/FilterBundle/Tests/Unit/Twig/RenderLayoutExtensionTest.php
@@ -109,7 +109,7 @@ class RenderLayoutExtensionTest extends AbstractExtensionTestCase
                 ->will($this->returnValue(self::TEST_BLOCK_HTML));
         }
 
-        $environment = $this->getMock('\Twig_Environment', ['loadTemplate']);
+        $environment = $this->createMock('\Twig_Environment', ['loadTemplate']);
         $environment->expects($this->any())
             ->method('loadTemplate')
             ->with(self::TEST_TEMPLATE_NAME)

--- a/src/Oro/Bundle/NavigationBundle/Tests/Unit/Command/TitleIndexUpdateCommandTest.php
+++ b/src/Oro/Bundle/NavigationBundle/Tests/Unit/Command/TitleIndexUpdateCommandTest.php
@@ -20,7 +20,7 @@ class TitleIndexUpdateCommandTest extends \PHPUnit_Framework_TestCase
     {
         $this->command = new TitleIndexUpdateCommand();
 
-        $this->container = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+        $this->container = $this->createMock('Symfony\Component\DependencyInjection\ContainerBuilder');
         $this->command->setContainer($this->container);
     }
 
@@ -38,10 +38,10 @@ class TitleIndexUpdateCommandTest extends \PHPUnit_Framework_TestCase
      */
     public function testExecute($data)
     {
-        $input = $this->getMock('Symfony\Component\Console\Input\InputInterface');
-        $output = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
+        $input = $this->createMock('Symfony\Component\Console\Input\InputInterface');
+        $output = $this->createMock('Symfony\Component\Console\Output\OutputInterface');
 
-        $route = $this->getMock('Symfony\Component\Routing\Route', [], ['/user/show/{id}']);
+        $route = $this->createMock('Symfony\Component\Routing\Route', [], ['/user/show/{id}']);
 
         $route->expects($this->once())
             ->method('getRequirements')
@@ -52,19 +52,19 @@ class TitleIndexUpdateCommandTest extends \PHPUnit_Framework_TestCase
             ->with('_controller')
             ->will($this->returnValue(''));
 
-        $routerCollection = $this->getMock('Symfony\Component\Routing\RouteCollection');
+        $routerCollection = $this->createMock('Symfony\Component\Routing\RouteCollection');
 
         $routerCollection->expects($this->once())
             ->method('all')
             ->will($this->returnValue([$route]));
 
-        $router = $this->getMock('Symfony\Component\Routing\RouterInterface');
+        $router = $this->createMock('Symfony\Component\Routing\RouterInterface');
 
         $router->expects($this->once())
             ->method('getRouteCollection')
             ->will($this->returnValue($routerCollection));
 
-        $titleService = $this->getMock('Oro\Bundle\NavigationBundle\Provider\TitleServiceInterface');
+        $titleService = $this->createMock('Oro\Bundle\NavigationBundle\Provider\TitleServiceInterface');
         $titleService->expects($this->once())
             ->method('update');
 

--- a/src/Oro/Bundle/NavigationBundle/Tests/Unit/DependencyInjection/OroNavigationExtensionTest.php
+++ b/src/Oro/Bundle/NavigationBundle/Tests/Unit/DependencyInjection/OroNavigationExtensionTest.php
@@ -11,7 +11,7 @@ class OroNavigationExtensionTest extends \PHPUnit_Framework_TestCase
         $extension = new OroNavigationExtension();
 
         $configs = [];
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerBuilder');
 
         $container->expects($this->any())
             ->method('getParameter')

--- a/src/Oro/Bundle/NavigationBundle/Tests/Unit/Entity/Builder/HistoryItemBuilderTest.php
+++ b/src/Oro/Bundle/NavigationBundle/Tests/Unit/Entity/Builder/HistoryItemBuilderTest.php
@@ -29,11 +29,11 @@ class HistoryItemBuilderTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->tokenStorage = $this->getMock('Symfony\Component\Security\Core\TokenStorageInterface');
+        $this->tokenStorage = $this->createMock('Symfony\Component\Security\Core\TokenStorageInterface');
         $this->em = $this->getMockBuilder('Doctrine\ORM\EntityManager')
             ->disableOriginalConstructor()
             ->getMock();
-        $this->factory = $this->getMock('Oro\Bundle\NavigationBundle\Entity\Builder\ItemFactory');
+        $this->factory = $this->createMock('Oro\Bundle\NavigationBundle\Entity\Builder\ItemFactory');
         $this->builder = new HistoryItemBuilder($this->em, $this->factory);
     }
 
@@ -42,7 +42,7 @@ class HistoryItemBuilderTest extends \PHPUnit_Framework_TestCase
         $itemBuilder = $this->builder;
 
         //$user = $this->tokenStorage->getToken()->getUser();
-        $user = $this->getMock('\Pim\Bundle\UserBundle\Entity\UserInterface');
+        $user = $this->createMock('\Pim\Bundle\UserBundle\Entity\UserInterface');
         $params = [
             'title' => 'kldfjs;jasf',
             'url'   => 'some url',

--- a/src/Oro/Bundle/NavigationBundle/Tests/Unit/Entity/PinbarTabTest.php
+++ b/src/Oro/Bundle/NavigationBundle/Tests/Unit/Entity/PinbarTabTest.php
@@ -8,7 +8,7 @@ class PinbarTabTest extends \PHPUnit_Framework_TestCase
 {
     public function testSetMaximizedNotEmpty()
     {
-        $item = $this->getMock('Oro\Bundle\NavigationBundle\Entity\NavigationItem');
+        $item = $this->createMock('Oro\Bundle\NavigationBundle\Entity\NavigationItem');
 
         $pinbarTab = new PinbarTab();
         $pinbarTab->setItem($item);
@@ -19,7 +19,7 @@ class PinbarTabTest extends \PHPUnit_Framework_TestCase
 
     public function testSetMaximizedEmpty()
     {
-        $item = $this->getMock('Oro\Bundle\NavigationBundle\Entity\NavigationItem');
+        $item = $this->createMock('Oro\Bundle\NavigationBundle\Entity\NavigationItem');
 
         $pinbarTab = new PinbarTab();
         $pinbarTab->setItem($item);
@@ -30,7 +30,7 @@ class PinbarTabTest extends \PHPUnit_Framework_TestCase
 
     public function testSetGet()
     {
-        $item = $this->getMock('Oro\Bundle\NavigationBundle\Entity\NavigationItem');
+        $item = $this->createMock('Oro\Bundle\NavigationBundle\Entity\NavigationItem');
 
         $pinbarTab = new PinbarTab();
         $pinbarTab->setItem($item);
@@ -40,7 +40,7 @@ class PinbarTabTest extends \PHPUnit_Framework_TestCase
 
     public function testDoPrePersist()
     {
-        $item = $this->getMock('Oro\Bundle\NavigationBundle\Entity\NavigationItem');
+        $item = $this->createMock('Oro\Bundle\NavigationBundle\Entity\NavigationItem');
 
         $pinbarTab = new PinbarTab();
         $pinbarTab->setItem($item);
@@ -52,7 +52,7 @@ class PinbarTabTest extends \PHPUnit_Framework_TestCase
     public function testSetValues()
     {
         $values = ['maximized' => '2022-02-02 22:22:22', 'url' => '/'];
-        $item = $this->getMock('Oro\Bundle\NavigationBundle\Entity\NavigationItem');
+        $item = $this->createMock('Oro\Bundle\NavigationBundle\Entity\NavigationItem');
         $item->expects($this->once())
             ->method('setValues')
             ->with($values);
@@ -70,8 +70,8 @@ class PinbarTabTest extends \PHPUnit_Framework_TestCase
 
     public function testGetUser()
     {
-        $user = $this->getMock('stdClass');
-        $item = $this->getMock('Oro\Bundle\NavigationBundle\Entity\NavigationItem');
+        $user = $this->createMock('stdClass');
+        $item = $this->createMock('Oro\Bundle\NavigationBundle\Entity\NavigationItem');
         $item->expects($this->once())
             ->method('getUser')
             ->will($this->returnValue($user));

--- a/src/Oro/Bundle/NavigationBundle/Tests/Unit/Event/RequestTitleListenerTest.php
+++ b/src/Oro/Bundle/NavigationBundle/Tests/Unit/Event/RequestTitleListenerTest.php
@@ -14,7 +14,7 @@ class RequestTitleListenerTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->titleService = $this->getMock('Oro\Bundle\NavigationBundle\Provider\TitleServiceInterface');
+        $this->titleService = $this->createMock('Oro\Bundle\NavigationBundle\Provider\TitleServiceInterface');
     }
 
     /**
@@ -69,7 +69,7 @@ class RequestTitleListenerTest extends \PHPUnit_Framework_TestCase
      */
     private function getRequest($invokeTimes)
     {
-        $request = $this->getMock('Symfony\Component\HttpFoundation\Request');
+        $request = $this->createMock('Symfony\Component\HttpFoundation\Request');
 
         $request->expects($this->exactly($invokeTimes))
             ->method('getRequestFormat')

--- a/src/Oro/Bundle/NavigationBundle/Tests/Unit/Event/ResponseHashnavListenerTest.php
+++ b/src/Oro/Bundle/NavigationBundle/Tests/Unit/Event/ResponseHashnavListenerTest.php
@@ -46,8 +46,8 @@ class ResponseHashnavListenerTest extends \PHPUnit_Framework_TestCase
             ->method('getResponse')
             ->will($this->returnValue($this->response));
 
-        $this->tokenStorage = $this->getMock('Symfony\Component\Security\Core\TokenStorageInterface');
-        $this->templating = $this->getMock('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
+        $this->tokenStorage = $this->createMock('Symfony\Component\Security\Core\TokenStorageInterface');
+        $this->templating = $this->createMock('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
         $this->listener = new ResponseHashnavListener($this->tokenStorage, $this->templating);
     }
 

--- a/src/Oro/Bundle/NavigationBundle/Tests/Unit/Event/ResponseHistoryListenerTest.php
+++ b/src/Oro/Bundle/NavigationBundle/Tests/Unit/Event/ResponseHistoryListenerTest.php
@@ -54,13 +54,13 @@ class ResponseHistoryListenerTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->factory = $this->getMock('Oro\Bundle\NavigationBundle\Entity\Builder\ItemFactory');
-        $this->tokenStorage = $this->getMock('Symfony\Component\Security\Core\TokenStorageInterface');
+        $this->factory = $this->createMock('Oro\Bundle\NavigationBundle\Entity\Builder\ItemFactory');
+        $this->tokenStorage = $this->createMock('Symfony\Component\Security\Core\TokenStorageInterface');
 
         $user = new User();
         $user->setEmail('some@email.com');
 
-        $token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
+        $token = $this->createMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
         $token->expects($this->exactly(2))
             ->method('getUser')
             ->will($this->returnValue($user));
@@ -69,7 +69,7 @@ class ResponseHistoryListenerTest extends \PHPUnit_Framework_TestCase
             ->method('getToken')
             ->will($this->returnValue($token));
 
-        $this->item = $this->getMock('Oro\Bundle\NavigationBundle\Entity\NavigationHistoryItem');
+        $this->item = $this->createMock('Oro\Bundle\NavigationBundle\Entity\NavigationHistoryItem');
 
         $this->serializedTitle = json_encode(['titleTemplate' => 'Test title template']);
     }
@@ -138,7 +138,7 @@ class ResponseHistoryListenerTest extends \PHPUnit_Framework_TestCase
         $em->expects($this->never())
             ->method('getRepository');
 
-        $titleService = $this->getMock('Oro\Bundle\NavigationBundle\Provider\TitleServiceInterface');
+        $titleService = $this->createMock('Oro\Bundle\NavigationBundle\Provider\TitleServiceInterface');
 
         $listener = new ResponseHistoryListener($this->factory, $this->tokenStorage, $em, $titleService);
         $listener->onResponse($event);
@@ -179,7 +179,7 @@ class ResponseHistoryListenerTest extends \PHPUnit_Framework_TestCase
      */
     private function getRequest()
     {
-        $this->request = $this->getMock('Symfony\Component\HttpFoundation\Request');
+        $this->request = $this->createMock('Symfony\Component\HttpFoundation\Request');
 
         $this->request->expects($this->once())
             ->method('getRequestFormat')
@@ -204,7 +204,7 @@ class ResponseHistoryListenerTest extends \PHPUnit_Framework_TestCase
      */
     private function getResponse()
     {
-        $response = $this->getMock('Symfony\Component\HttpFoundation\Response');
+        $response = $this->createMock('Symfony\Component\HttpFoundation\Response');
 
         $response->expects($this->once())
             ->method('getStatusCode')
@@ -215,7 +215,7 @@ class ResponseHistoryListenerTest extends \PHPUnit_Framework_TestCase
 
     public function getTitleService()
     {
-        $this->titleService = $this->getMock('Oro\Bundle\NavigationBundle\Provider\TitleServiceInterface');
+        $this->titleService = $this->createMock('Oro\Bundle\NavigationBundle\Provider\TitleServiceInterface');
         $this->titleService->expects($this->once())
             ->method('getSerialized')
             ->will($this->returnValue($this->serializedTitle));

--- a/src/Oro/Bundle/NavigationBundle/Tests/Unit/Menu/Matcher/Voter/RequestVoterTest.php
+++ b/src/Oro/Bundle/NavigationBundle/Tests/Unit/Menu/Matcher/Voter/RequestVoterTest.php
@@ -11,12 +11,12 @@ class RequestVoterTest extends \PHPUnit_Framework_TestCase
     {
         $uri = 'test.uri';
 
-        $request = $this->getMock('Symfony\Component\HttpFoundation\Request');
+        $request = $this->createMock('Symfony\Component\HttpFoundation\Request');
         $request->expects($this->once())
             ->method('getRequestUri')
             ->will($this->returnValue($uri));
 
-        $itemMock = $this->getMock('Knp\Menu\ItemInterface');
+        $itemMock = $this->createMock('Knp\Menu\ItemInterface');
         $itemMock->expects($this->exactly(2))
             ->method('getUri')
             ->will($this->returnValue($uri));

--- a/src/Oro/Bundle/NavigationBundle/Tests/Unit/Menu/Matcher/Voter/RoutePatternVoterTest.php
+++ b/src/Oro/Bundle/NavigationBundle/Tests/Unit/Menu/Matcher/Voter/RoutePatternVoterTest.php
@@ -9,7 +9,7 @@ class RoutePatternVoterTest extends \PHPUnit_Framework_TestCase
 {
     public function testMatchingWithoutRequest()
     {
-        $item = $this->getMock('Knp\Menu\ItemInterface');
+        $item = $this->createMock('Knp\Menu\ItemInterface');
         $item->expects($this->never())->method('getExtra');
 
         $voter = new RoutePatternVoter();
@@ -28,7 +28,7 @@ class RoutePatternVoterTest extends \PHPUnit_Framework_TestCase
      */
     public function testMatching($route, array $parameters, $itemRoutes, array $itemsRoutesParameters, $expected)
     {
-        $item = $this->getMock('Knp\Menu\ItemInterface');
+        $item = $this->createMock('Knp\Menu\ItemInterface');
         $item->expects($this->any())
             ->method('getExtra')
             ->will(

--- a/src/Oro/Bundle/NavigationBundle/Tests/Unit/Menu/NavigationHistoryBuilderTest.php
+++ b/src/Oro/Bundle/NavigationBundle/Tests/Unit/Menu/NavigationHistoryBuilderTest.php
@@ -33,18 +33,18 @@ class NavigationHistoryBuilderTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->tokenStorage = $this->getMock('Symfony\Component\Security\Core\TokenStorageInterface');
+        $this->tokenStorage = $this->createMock('Symfony\Component\Security\Core\TokenStorageInterface');
         $this->em = $this->getMockBuilder('Doctrine\ORM\EntityManager')
             ->disableOriginalConstructor()
             ->getMock();
-        $this->factory = $this->getMock('Oro\Bundle\NavigationBundle\Entity\Builder\ItemFactory');
+        $this->factory = $this->createMock('Oro\Bundle\NavigationBundle\Entity\Builder\ItemFactory');
 
         $this->builder = $this->getMockBuilder('Oro\Bundle\NavigationBundle\Menu\NavigationHistoryBuilder')
             ->setConstructorArgs([$this->tokenStorage, $this->em, $this->factory])
             ->setMethods(['getMenuManipulator'])
             ->getMock();
 
-        $this->manipulator = $this->getMock('Knp\Menu\Util\MenuManipulator');
+        $this->manipulator = $this->createMock('Knp\Menu\Util\MenuManipulator');
         $this->builder->expects($this->any())->method('getMenuManipulator')
             ->will($this->returnValue($this->manipulator));
     }
@@ -61,7 +61,7 @@ class NavigationHistoryBuilderTest extends \PHPUnit_Framework_TestCase
             ->method('getId')
             ->will($this->returnValue($userId));
 
-        $token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
+        $token = $this->createMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
         $token->expects($this->once())
             ->method('getUser')
             ->will($this->returnValue($user));
@@ -70,7 +70,7 @@ class NavigationHistoryBuilderTest extends \PHPUnit_Framework_TestCase
             ->method('getToken')
             ->will($this->returnValue($token));
 
-        $item = $this->getMock('Oro\Bundle\NavigationBundle\Entity\NavigationItemInterface');
+        $item = $this->createMock('Oro\Bundle\NavigationBundle\Entity\NavigationItemInterface');
         $this->factory->expects($this->once())
             ->method('createItem')
             ->with($type, [])
@@ -96,11 +96,11 @@ class NavigationHistoryBuilderTest extends \PHPUnit_Framework_TestCase
 
         $menu = $this->getMockBuilder('Knp\Menu\MenuItem')->disableOriginalConstructor()->getMock();
 
-        $childMock = $this->getMock('Knp\Menu\ItemInterface');
+        $childMock = $this->createMock('Knp\Menu\ItemInterface');
         $childMock2 = clone $childMock;
         $children = [$childMock, $childMock2];
 
-        $matcher = $this->getMock('\Knp\Menu\Matcher\Matcher');
+        $matcher = $this->createMock('\Knp\Menu\Matcher\Matcher');
         $matcher->expects($this->once())
             ->method('isCurrent')
             ->will($this->returnValue(true));

--- a/src/Oro/Bundle/NavigationBundle/Tests/Unit/Menu/NavigationItemBuilderTest.php
+++ b/src/Oro/Bundle/NavigationBundle/Tests/Unit/Menu/NavigationItemBuilderTest.php
@@ -28,17 +28,17 @@ class NavigationItemBuilderTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->tokenStorage = $this->getMock('Symfony\Component\Security\Core\TokenStorageInterface');
+        $this->tokenStorage = $this->createMock('Symfony\Component\Security\Core\TokenStorageInterface');
         $this->em = $this->getMockBuilder('Doctrine\ORM\EntityManager')
             ->disableOriginalConstructor()
             ->getMock();
-        $this->factory = $this->getMock('Oro\Bundle\NavigationBundle\Entity\Builder\ItemFactory');
+        $this->factory = $this->createMock('Oro\Bundle\NavigationBundle\Entity\Builder\ItemFactory');
         $this->builder = new NavigationItemBuilder($this->tokenStorage, $this->em, $this->factory);
     }
 
     public function testBuildAnonUser()
     {
-        $token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
+        $token = $this->createMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
         $token->expects($this->once())
             ->method('getUser')
             ->will($this->returnValue('anon.'));
@@ -69,7 +69,7 @@ class NavigationItemBuilderTest extends \PHPUnit_Framework_TestCase
             ->method('getId')
             ->will($this->returnValue(1));
 
-        $token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
+        $token = $this->createMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
         $token->expects($this->once())
             ->method('getUser')
             ->will($this->returnValue($user));
@@ -78,7 +78,7 @@ class NavigationItemBuilderTest extends \PHPUnit_Framework_TestCase
             ->method('getToken')
             ->will($this->returnValue($token));
 
-        $item = $this->getMock('Oro\Bundle\NavigationBundle\Entity\NavigationItemInterface');
+        $item = $this->createMock('Oro\Bundle\NavigationBundle\Entity\NavigationItemInterface');
         $this->factory->expects($this->once())
             ->method('createItem')
             ->with($type, [])

--- a/src/Oro/Bundle/NavigationBundle/Tests/Unit/Menu/NavigationMostviewedBuilderTest.php
+++ b/src/Oro/Bundle/NavigationBundle/Tests/Unit/Menu/NavigationMostviewedBuilderTest.php
@@ -29,11 +29,11 @@ class NavigationMostviewedBuilderTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->tokenStorage = $this->getMock('Symfony\Component\Security\Core\TokenStorageInterface');
+        $this->tokenStorage = $this->createMock('Symfony\Component\Security\Core\TokenStorageInterface');
         $this->em = $this->getMockBuilder('Doctrine\ORM\EntityManager')
             ->disableOriginalConstructor()
             ->getMock();
-        $this->factory = $this->getMock('Oro\Bundle\NavigationBundle\Entity\Builder\ItemFactory');
+        $this->factory = $this->createMock('Oro\Bundle\NavigationBundle\Entity\Builder\ItemFactory');
 
         $this->builder = new NavigationMostviewedBuilder($this->tokenStorage, $this->em, $this->factory);
     }
@@ -51,7 +51,7 @@ class NavigationMostviewedBuilderTest extends \PHPUnit_Framework_TestCase
             ->method('getId')
             ->will($this->returnValue($userId));
 
-        $token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
+        $token = $this->createMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
         $token->expects($this->once())
             ->method('getUser')
             ->will($this->returnValue($user));
@@ -60,7 +60,7 @@ class NavigationMostviewedBuilderTest extends \PHPUnit_Framework_TestCase
             ->method('getToken')
             ->will($this->returnValue($token));
 
-        $item = $this->getMock('Oro\Bundle\NavigationBundle\Entity\NavigationItemInterface');
+        $item = $this->createMock('Oro\Bundle\NavigationBundle\Entity\NavigationItemInterface');
         $this->factory->expects($this->once())
             ->method('createItem')
             ->with($type, [])

--- a/src/Oro/Bundle/NavigationBundle/Tests/Unit/OroNavigationBundleTest.php
+++ b/src/Oro/Bundle/NavigationBundle/Tests/Unit/OroNavigationBundleTest.php
@@ -7,7 +7,7 @@ class OroNavigationBundleTest extends \PHPUnit_Framework_TestCase
 {
     public function testBuild()
     {
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerBuilder');
         $container->expects($this->once())
             ->method('addCompilerPass')
             ->with(

--- a/src/Oro/Bundle/NavigationBundle/Tests/Unit/Provider/TitleServiceTest.php
+++ b/src/Oro/Bundle/NavigationBundle/Tests/Unit/Provider/TitleServiceTest.php
@@ -110,7 +110,7 @@ class TitleServiceTest extends \PHPUnit_Framework_TestCase
     {
         $data = 'test data';
 
-        $storedTitleMock = $this->getMock('Oro\Bundle\NavigationBundle\Title\StoredTitle');
+        $storedTitleMock = $this->createMock('Oro\Bundle\NavigationBundle\Title\StoredTitle');
 
         $this->serializer->expects($this->once())
             ->method('deserialize')
@@ -190,7 +190,7 @@ class TitleServiceTest extends \PHPUnit_Framework_TestCase
             ->method('getRepository')
             ->will($this->returnValue($this->repository));
 
-        $entityMock = $this->getMock('Oro\Bundle\NavigationBundle\Entity\Title');
+        $entityMock = $this->createMock('Oro\Bundle\NavigationBundle\Entity\Title');
 
         $this->repository->expects($this->once())
             ->method('findOneBy')
@@ -271,7 +271,7 @@ class TitleServiceTest extends \PHPUnit_Framework_TestCase
             ->method('getRepository')
             ->will($this->returnValue($this->repository));
 
-        $entityMock = $this->getMock('Oro\Bundle\NavigationBundle\Entity\Title');
+        $entityMock = $this->createMock('Oro\Bundle\NavigationBundle\Entity\Title');
 
         $entityMock->expects($this->once())
             ->method('getRoute')
@@ -307,7 +307,7 @@ class TitleServiceTest extends \PHPUnit_Framework_TestCase
         $this->userConfigManager->expects($this->at(2))->method('get')
             ->with('oro_navigation.title_delimiter')->will($this->returnValue('/'));
 
-        $entityMock = $this->getMock('Oro\Bundle\NavigationBundle\Entity\Title');
+        $entityMock = $this->createMock('Oro\Bundle\NavigationBundle\Entity\Title');
 
         $entityMock->expects($this->exactly(2))
             ->method('getRoute')

--- a/src/Oro/Bundle/NavigationBundle/Tests/Unit/Title/TitleReader/AnnotationsReaderTest.php
+++ b/src/Oro/Bundle/NavigationBundle/Tests/Unit/Title/TitleReader/AnnotationsReaderTest.php
@@ -27,16 +27,16 @@ class AnnotationsReaderTest extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped('Doctrine Common has to be installed for this test to run.');
         }
 
-        $this->testBundle = $this->getMock(
+        $this->testBundle = $this->createMock(
             'Symfony\Bundle\FrameworkBundle\FrameworkBundle'
         );
 
-        $this->kernelMock = $this->getMock(
+        $this->kernelMock = $this->createMock(
             'Symfony\Component\HttpKernel\KernelInterface',
             []
         );
 
-        $this->annotationReader = $this->getMock(
+        $this->annotationReader = $this->createMock(
             'Doctrine\Common\Annotations\AnnotationReader'
         );
     }
@@ -57,7 +57,7 @@ class AnnotationsReaderTest extends \PHPUnit_Framework_TestCase
             ->method('getBundles')
             ->will($this->returnValue([$this->testBundle]));
 
-        $routeMock = $this->getMock('Symfony\Component\Routing\Route', [], ['/user/show/{id}']);
+        $routeMock = $this->createMock('Symfony\Component\Routing\Route', [], ['/user/show/{id}']);
 
         $routeMock->expects($this->once())
             ->method('getDefault')

--- a/src/Oro/Bundle/NavigationBundle/Tests/Unit/Title/TranslationExtractorTest.php
+++ b/src/Oro/Bundle/NavigationBundle/Tests/Unit/Title/TranslationExtractorTest.php
@@ -33,7 +33,7 @@ class TranslationExtractorTest extends \PHPUnit_Framework_TestCase
         $route = $this->getMockBuilder('Symfony\Component\Routing\Route')
             ->disableOriginalConstructor()
             ->getMock();
-        $routeCollection = $this->getMock('Symfony\Component\Routing\RouteCollection');
+        $routeCollection = $this->createMock('Symfony\Component\Routing\RouteCollection');
         $routeCollection
             ->expects($this->once())
             ->method('all')

--- a/src/Oro/Bundle/NavigationBundle/Tests/Unit/Twig/TitleExtensionTest.php
+++ b/src/Oro/Bundle/NavigationBundle/Tests/Unit/Twig/TitleExtensionTest.php
@@ -18,7 +18,7 @@ class TitleExtensionTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->service = $this->getMock('Oro\Bundle\NavigationBundle\Provider\TitleServiceInterface');
+        $this->service = $this->createMock('Oro\Bundle\NavigationBundle\Provider\TitleServiceInterface');
         $this->extension = new TitleExtension($this->service);
     }
 

--- a/src/Oro/Bundle/NavigationBundle/Tests/Unit/Twig/TitleNodeTest.php
+++ b/src/Oro/Bundle/NavigationBundle/Tests/Unit/Twig/TitleNodeTest.php
@@ -26,7 +26,7 @@ class TitleNodeTest extends \PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
-        $this->node = $this->getMock('Twig_Node');
+        $this->node = $this->createMock('Twig_Node');
         $this->compiler = $this->getMockBuilder('Twig_Compiler')
             ->disableOriginalConstructor()
             ->getMock();

--- a/src/Oro/Bundle/NavigationBundle/Tests/Unit/Twig/TitleSetTokenParserTest.php
+++ b/src/Oro/Bundle/NavigationBundle/Tests/Unit/Twig/TitleSetTokenParserTest.php
@@ -11,7 +11,7 @@ class TitleSetTokenParserTest extends \PHPUnit_Framework_TestCase
      */
     public function testParsing()
     {
-        $node = $this->getMock('Twig_Node');
+        $node = $this->createMock('Twig_Node');
 
         $exprParser = $this->getMockBuilder('Twig_ExpressionParser')
                            ->disableOriginalConstructor()

--- a/src/Oro/Bundle/RequireJSBundle/Tests/Unit/DependencyInjection/OroRequireJSExtensionTest.php
+++ b/src/Oro/Bundle/RequireJSBundle/Tests/Unit/DependencyInjection/OroRequireJSExtensionTest.php
@@ -30,7 +30,7 @@ class OroRequireJSExtensionTest extends \PHPUnit_Framework_TestCase
     {
         $actualParameters = [];
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerBuilder');
         $container->expects($this->any())
             ->method('setParameter')
             ->will(

--- a/src/Oro/Bundle/RequireJSBundle/Tests/Unit/Provider/ConfigTest.php
+++ b/src/Oro/Bundle/RequireJSBundle/Tests/Unit/Provider/ConfigTest.php
@@ -20,7 +20,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
             'kernel.bundles' => ['Oro\Bundle\RequireJSBundle\Tests\Unit\Fixtures\TestBundle']
         ];
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $container->expects($this->any())
             ->method('getParameter')
             ->will($this->returnCallback(
@@ -29,7 +29,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
                 }
             ));
 
-        $templating = $this->getMock('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
+        $templating = $this->createMock('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
         $templating->expects($this->any())
             ->method('render')
             ->will($this->returnArgument(1));
@@ -52,7 +52,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
 
         $expected['config']['paths']['oro/test2'] = 'orotest/js/test2';
 
-        $cache = $this->getMock('\Doctrine\Common\Cache\PhpFileCache', [], [], '', false);
+        $cache = $this->createMock('\Doctrine\Common\Cache\PhpFileCache', [], [], '', false);
         $cache->expects($this->any())
             ->method('fetch')
             ->will($this->returnValue($expected));

--- a/src/Oro/Bundle/RequireJSBundle/Tests/Unit/Twig/OroRequireJSExtensionTest.php
+++ b/src/Oro/Bundle/RequireJSBundle/Tests/Unit/Twig/OroRequireJSExtensionTest.php
@@ -17,12 +17,12 @@ class OroRequireJSExtensionTest extends \PHPUnit_Framework_TestCase
 
     public function testGetFunctions()
     {
-        $configProvider = $this->getMock('Oro\Bundle\RequireJSBundle\Provider\Config', [], [], '', false);
+        $configProvider = $this->createMock('Oro\Bundle\RequireJSBundle\Provider\Config', [], [], '', false);
         $configProvider->expects($this->any())
             ->method('getMainConfig')
             ->will($this->returnValue($this->functions['get_requirejs_config']));
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $container->expects($this->any())
             ->method('getParameter')
             ->will($this->returnValueMap($this->parameters));
@@ -51,7 +51,7 @@ class OroRequireJSExtensionTest extends \PHPUnit_Framework_TestCase
 
     public function testGetName()
     {
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $extension = new OroRequireJSExtension($container);
         $this->assertEquals('requirejs_extension', $extension->getName());
     }

--- a/src/Oro/Bundle/SecurityBundle/Tests/Unit/Acl/Cache/AclCacheTest.php
+++ b/src/Oro/Bundle/SecurityBundle/Tests/Unit/Acl/Cache/AclCacheTest.php
@@ -14,7 +14,7 @@ class AclCacheTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->cacheProvider = $this->getMock('Doctrine\Common\Cache\CacheProvider', [
+        $this->cacheProvider = $this->createMock('Doctrine\Common\Cache\CacheProvider', [
             'deleteAll', 'doFetch', 'doContains', 'doSave', 'doDelete', 'doFlush', 'doGetStats'
         ]
         );

--- a/src/Oro/Bundle/SecurityBundle/Tests/Unit/Acl/Dbal/MutableAclProviderTest.php
+++ b/src/Oro/Bundle/SecurityBundle/Tests/Unit/Acl/Dbal/MutableAclProviderTest.php
@@ -44,7 +44,7 @@ class MutableAclProviderTest extends \PHPUnit_Framework_TestCase
                 )
             );
 
-        $strategy = $this->getMock('Symfony\Component\Security\Acl\Model\PermissionGrantingStrategyInterface');
+        $strategy = $this->createMock('Symfony\Component\Security\Acl\Model\PermissionGrantingStrategyInterface');
 
         $this->provider = new MutableAclProvider(
             $this->connection,

--- a/src/Oro/Bundle/SecurityBundle/Tests/Unit/Acl/Domain/ObjectIdAccessorTest.php
+++ b/src/Oro/Bundle/SecurityBundle/Tests/Unit/Acl/Domain/ObjectIdAccessorTest.php
@@ -11,7 +11,7 @@ class ObjectIdAccessorTest extends \PHPUnit_Framework_TestCase
     {
         $accessor = new ObjectIdAccessor();
 
-        $obj = $this->getMock('Symfony\Component\Security\Acl\Model\DomainObjectInterface');
+        $obj = $this->createMock('Symfony\Component\Security\Acl\Model\DomainObjectInterface');
         $obj
             ->expects($this->once())
             ->method('getObjectIdentifier')

--- a/src/Oro/Bundle/SecurityBundle/Tests/Unit/Acl/Domain/RootBasedAclWrapperTest.php
+++ b/src/Oro/Bundle/SecurityBundle/Tests/Unit/Acl/Domain/RootBasedAclWrapperTest.php
@@ -29,9 +29,9 @@ class RootBasedAclWrapperTest extends \PHPUnit_Framework_TestCase
         $sid1 = new RoleSecurityIdentity('sid1');
         $sid2 = new RoleSecurityIdentity('sid2');
 
-        $ace = $this->getMock('Symfony\Component\Security\Acl\Model\EntryInterface');
-        $rootAce1 = $this->getMock('Symfony\Component\Security\Acl\Model\EntryInterface');
-        $rootAce2 = $this->getMock('Symfony\Component\Security\Acl\Model\EntryInterface');
+        $ace = $this->createMock('Symfony\Component\Security\Acl\Model\EntryInterface');
+        $rootAce1 = $this->createMock('Symfony\Component\Security\Acl\Model\EntryInterface');
+        $rootAce2 = $this->createMock('Symfony\Component\Security\Acl\Model\EntryInterface');
 
         $ace->expects($this->any())
             ->method('getSecurityIdentity')
@@ -61,9 +61,9 @@ class RootBasedAclWrapperTest extends \PHPUnit_Framework_TestCase
         $sid1 = new RoleSecurityIdentity('sid1');
         $sid2 = new RoleSecurityIdentity('sid2');
 
-        $ace = $this->getMock('Symfony\Component\Security\Acl\Model\EntryInterface');
-        $rootAce1 = $this->getMock('Symfony\Component\Security\Acl\Model\EntryInterface');
-        $rootAce2 = $this->getMock('Symfony\Component\Security\Acl\Model\EntryInterface');
+        $ace = $this->createMock('Symfony\Component\Security\Acl\Model\EntryInterface');
+        $rootAce1 = $this->createMock('Symfony\Component\Security\Acl\Model\EntryInterface');
+        $rootAce2 = $this->createMock('Symfony\Component\Security\Acl\Model\EntryInterface');
 
         $ace->expects($this->any())
             ->method('getSecurityIdentity')
@@ -92,7 +92,7 @@ class RootBasedAclWrapperTest extends \PHPUnit_Framework_TestCase
 
     public function testGetObjectAces()
     {
-        $ace = $this->getMock('Symfony\Component\Security\Acl\Model\EntryInterface');
+        $ace = $this->createMock('Symfony\Component\Security\Acl\Model\EntryInterface');
 
         $obj = new RootBasedAclWrapper($this->acl, $this->rootAcl);
         $this->acl->expects($this->once())
@@ -105,7 +105,7 @@ class RootBasedAclWrapperTest extends \PHPUnit_Framework_TestCase
 
     public function testGetObjectFieldAces()
     {
-        $ace = $this->getMock('Symfony\Component\Security\Acl\Model\EntryInterface');
+        $ace = $this->createMock('Symfony\Component\Security\Acl\Model\EntryInterface');
 
         $obj = new RootBasedAclWrapper($this->acl, $this->rootAcl);
         $this->acl->expects($this->once())
@@ -176,7 +176,7 @@ class RootBasedAclWrapperTest extends \PHPUnit_Framework_TestCase
     {
         $sid = new RoleSecurityIdentity('sid1');
 
-        $strategy = $this->getMock('Symfony\Component\Security\Acl\Model\PermissionGrantingStrategyInterface');
+        $strategy = $this->createMock('Symfony\Component\Security\Acl\Model\PermissionGrantingStrategyInterface');
 
         $obj = $this->getMockBuilder('Oro\Bundle\SecurityBundle\Acl\Domain\RootBasedAclWrapper')
             ->setConstructorArgs([$this->acl, $this->rootAcl])
@@ -204,7 +204,7 @@ class RootBasedAclWrapperTest extends \PHPUnit_Framework_TestCase
     {
         $sid = new RoleSecurityIdentity('sid1');
 
-        $strategy = $this->getMock('Symfony\Component\Security\Acl\Model\PermissionGrantingStrategyInterface');
+        $strategy = $this->createMock('Symfony\Component\Security\Acl\Model\PermissionGrantingStrategyInterface');
 
         $obj = $this->getMockBuilder('Oro\Bundle\SecurityBundle\Acl\Domain\RootBasedAclWrapper')
             ->setConstructorArgs([$this->acl, $this->rootAcl])

--- a/src/Oro/Bundle/SecurityBundle/Tests/Unit/Acl/Persistence/AbstractAclManagerTest.php
+++ b/src/Oro/Bundle/SecurityBundle/Tests/Unit/Acl/Persistence/AbstractAclManagerTest.php
@@ -26,7 +26,7 @@ class AbstractAclManagerTest extends \PHPUnit_Framework_TestCase
             $this->manager->getSid('ROLE_TEST')
         );
 
-        $src = $this->getMock('Symfony\Component\Security\Core\Role\RoleInterface');
+        $src = $this->createMock('Symfony\Component\Security\Core\Role\RoleInterface');
         $src->expects($this->once())
             ->method('getRole')
             ->will($this->returnValue('ROLE_TEST'));
@@ -35,7 +35,7 @@ class AbstractAclManagerTest extends \PHPUnit_Framework_TestCase
             $this->manager->getSid($src)
         );
 
-        $src = $this->getMock('Symfony\Component\Security\Core\User\UserInterface');
+        $src = $this->createMock('Symfony\Component\Security\Core\User\UserInterface');
         $src->expects($this->once())
             ->method('getUsername')
             ->will($this->returnValue('Test'));
@@ -44,11 +44,11 @@ class AbstractAclManagerTest extends \PHPUnit_Framework_TestCase
             $this->manager->getSid($src)
         );
 
-        $user = $this->getMock('Symfony\Component\Security\Core\User\UserInterface');
+        $user = $this->createMock('Symfony\Component\Security\Core\User\UserInterface');
         $user->expects($this->once())
             ->method('getUsername')
             ->will($this->returnValue('Test'));
-        $src = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
+        $src = $this->createMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
         $src->expects($this->once())
             ->method('getUser')
             ->will($this->returnValue($user));

--- a/src/Oro/Bundle/SecurityBundle/Tests/Unit/Acl/Persistence/AceManipulationHelperTest.php
+++ b/src/Oro/Bundle/SecurityBundle/Tests/Unit/Acl/Persistence/AceManipulationHelperTest.php
@@ -16,7 +16,7 @@ class AceManipulationHelperTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->acl = $this->getMock('Symfony\Component\Security\Acl\Model\MutableAclInterface');
+        $this->acl = $this->createMock('Symfony\Component\Security\Acl\Model\MutableAclInterface');
         $this->manipulator = new AceManipulationHelper();
     }
 
@@ -26,20 +26,20 @@ class AceManipulationHelperTest extends \PHPUnit_Framework_TestCase
      */
     public function testSetPermissionShouldCallUpdateAceForAce3($type, $field)
     {
-        $sid = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
+        $sid = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
         $replace = true;
         $granting = true;
         $mask = 123;
         $strategy = 'any';
 
-        $aceSid1 = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
+        $aceSid1 = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
         $aceGranting1 = $granting;
         $aceMask1 = $mask;
         $aceStrategy1 = $strategy;
 
-        $aceSid2 = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
+        $aceSid2 = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
 
-        $aceSid3 = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
+        $aceSid3 = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
         $aceGranting3 = $granting;
         $aceMask3 = 789;
         $aceStrategy3 = $strategy;
@@ -116,15 +116,15 @@ class AceManipulationHelperTest extends \PHPUnit_Framework_TestCase
      */
     public function testSetPermissionShouldCallInsertAce($type, $field)
     {
-        $sid = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
+        $sid = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
         $replace = false;
         $granting = true;
         $mask = 123;
         $strategy = 'any';
 
-        $aceSid1 = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
+        $aceSid1 = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
 
-        $aceSid2 = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
+        $aceSid2 = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
         $aceGranting2 = $granting;
         $aceMask2 = $mask;
         $aceStrategy2 = 'all';
@@ -199,19 +199,19 @@ class AceManipulationHelperTest extends \PHPUnit_Framework_TestCase
      */
     public function testDeletePermission($type, $field)
     {
-        $sid = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
+        $sid = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
         $granting = true;
         $mask = 123;
         $strategy = 'any';
 
-        $aceSid1 = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
+        $aceSid1 = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
         $aceGranting1 = true;
         $aceMask1 = 123;
         $aceStrategy1 = 'equal';
 
-        $aceSid2 = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
+        $aceSid2 = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
 
-        $aceSid3 = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
+        $aceSid3 = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
         $aceGranting3 = $granting;
         $aceMask3 = $mask;
         $aceStrategy3 = $strategy;
@@ -268,10 +268,10 @@ class AceManipulationHelperTest extends \PHPUnit_Framework_TestCase
      */
     public function testDeleteAllPermissions($type, $field)
     {
-        $sid = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
+        $sid = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
 
-        $aceSid1 = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
-        $aceSid2 = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
+        $aceSid1 = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
+        $aceSid2 = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
         $ace1 = $this->getAce($aceSid1);
         $ace2 = $this->getAce($aceSid2);
 
@@ -340,7 +340,7 @@ class AceManipulationHelperTest extends \PHPUnit_Framework_TestCase
     public function testInsertAce($type, $field)
     {
         $index = 1;
-        $sid = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
+        $sid = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
         $granting = true;
         $mask = 123;
         $strategy = 'any';
@@ -444,7 +444,7 @@ class AceManipulationHelperTest extends \PHPUnit_Framework_TestCase
         $getMaskCallCount = 1,
         $getStrategyCallCount = 1
     ) {
-        $ace = $this->getMock('Symfony\Component\Security\Acl\Model\EntryInterface');
+        $ace = $this->createMock('Symfony\Component\Security\Acl\Model\EntryInterface');
         $ace->expects($this->once())
             ->method('getSecurityIdentity')
             ->will($this->returnValue($sid));

--- a/src/Oro/Bundle/SecurityBundle/Tests/Unit/Acl/Persistence/AclManagerSidTest.php
+++ b/src/Oro/Bundle/SecurityBundle/Tests/Unit/Acl/Persistence/AclManagerSidTest.php
@@ -37,7 +37,7 @@ class AclManagerSidTest extends \PHPUnit_Framework_TestCase
 
     public function testUpdateSid()
     {
-        $sid = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
+        $sid = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
         $this->aclProvider->expects($this->once())
             ->method('updateSecurityIdentity')
             ->with($this->identicalTo($sid), $this->equalTo('old'));
@@ -47,7 +47,7 @@ class AclManagerSidTest extends \PHPUnit_Framework_TestCase
 
     public function testDeleteSid()
     {
-        $sid = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
+        $sid = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
         $this->aclProvider->expects($this->once())
             ->method('deleteSecurityIdentity')
             ->with($this->identicalTo($sid));

--- a/src/Oro/Bundle/SecurityBundle/Tests/Unit/Acl/Persistence/AclManagerTest.php
+++ b/src/Oro/Bundle/SecurityBundle/Tests/Unit/Acl/Persistence/AclManagerTest.php
@@ -39,7 +39,7 @@ class AclManagerTest extends \PHPUnit_Framework_TestCase
                 ->disableOriginalConstructor()
                 ->getMock();
 
-        $this->extension = $this->getMock('Oro\Bundle\SecurityBundle\Acl\Extension\AclExtensionInterface');
+        $this->extension = $this->createMock('Oro\Bundle\SecurityBundle\Acl\Extension\AclExtensionInterface');
         $this->extension->expects($this->any())->method('getExtensionKey')->will($this->returnValue('entity'));
         $this->extension->expects($this->any())->method('getServiceBits')->will($this->returnValue(0));
         $this->extensionSelector = $this->getMockBuilder('Oro\Bundle\SecurityBundle\Acl\Extension\AclExtensionSelector')
@@ -128,7 +128,7 @@ class AclManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testSetPermissionForNewAclIfGetAcesCalledBefore()
     {
-        $sid = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
+        $sid = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
         $oid = new ObjectIdentity('entity', 'Acme\Test');
         $granting = true;
         $mask = 123;
@@ -152,13 +152,13 @@ class AclManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testSetPermissionForRootOid()
     {
-        $sid = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
+        $sid = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
         $oid = new ObjectIdentity('entity', ObjectIdentityFactory::ROOT_IDENTITY_TYPE);
         $granting = true;
         $mask = 123;
         $strategy = 'any';
 
-        $acl = $this->getMock('Symfony\Component\Security\Acl\Model\MutableAclInterface');
+        $acl = $this->createMock('Symfony\Component\Security\Acl\Model\MutableAclInterface');
         $this->aclProvider->expects($this->once())
             ->method('findAcl')
             ->with($this->identicalTo($oid))
@@ -185,13 +185,13 @@ class AclManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testSetPermissionForDomainObject()
     {
-        $sid = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
+        $sid = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
         $oid = new ObjectIdentity(123, 'Acme\Test');
         $granting = true;
         $mask = 123;
         $strategy = 'any';
 
-        $acl = $this->getMock('Symfony\Component\Security\Acl\Model\MutableAclInterface');
+        $acl = $this->createMock('Symfony\Component\Security\Acl\Model\MutableAclInterface');
         $this->aclProvider->expects($this->once())
             ->method('findAcl')
             ->with($this->identicalTo($oid))
@@ -218,13 +218,13 @@ class AclManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testSetPermissionForEntityClass()
     {
-        $sid = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
+        $sid = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
         $oid = new ObjectIdentity('entity', 'Acme\Test');
         $granting = true;
         $mask = 123;
         $strategy = 'any';
 
-        $acl = $this->getMock('Symfony\Component\Security\Acl\Model\MutableAclInterface');
+        $acl = $this->createMock('Symfony\Component\Security\Acl\Model\MutableAclInterface');
         $this->aclProvider->expects($this->once())
             ->method('findAcl')
             ->with($this->identicalTo($oid))
@@ -255,7 +255,7 @@ class AclManagerTest extends \PHPUnit_Framework_TestCase
      */
     public function testSetFieldPermissionForRootOid()
     {
-        $sid = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
+        $sid = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
         $oid = new ObjectIdentity('entity', ObjectIdentityFactory::ROOT_IDENTITY_TYPE);
         $granting = true;
         $mask = 123;
@@ -267,14 +267,14 @@ class AclManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testSetFieldPermissionForDomainObject()
     {
-        $sid = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
+        $sid = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
         $oid = new ObjectIdentity(123, 'Acme\Test');
         $granting = true;
         $mask = 123;
         $strategy = 'any';
         $field = 'TestField';
 
-        $acl = $this->getMock('Symfony\Component\Security\Acl\Model\MutableAclInterface');
+        $acl = $this->createMock('Symfony\Component\Security\Acl\Model\MutableAclInterface');
         $this->aclProvider->expects($this->once())
             ->method('findAcl')
             ->with($this->identicalTo($oid))
@@ -301,14 +301,14 @@ class AclManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testSetFieldPermissionForEntityClass()
     {
-        $sid = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
+        $sid = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
         $oid = new ObjectIdentity('entity', 'Acme\Test');
         $granting = true;
         $mask = 123;
         $strategy = 'any';
         $field = 'TestField';
 
-        $acl = $this->getMock('Symfony\Component\Security\Acl\Model\MutableAclInterface');
+        $acl = $this->createMock('Symfony\Component\Security\Acl\Model\MutableAclInterface');
         $this->aclProvider->expects($this->once())
             ->method('findAcl')
             ->with($this->identicalTo($oid))
@@ -336,13 +336,13 @@ class AclManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testDeletePermissionForRootOid()
     {
-        $sid = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
+        $sid = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
         $oid = new ObjectIdentity('entity', ObjectIdentityFactory::ROOT_IDENTITY_TYPE);
         $granting = true;
         $mask = 123;
         $strategy = 'any';
 
-        $acl = $this->getMock('Symfony\Component\Security\Acl\Model\MutableAclInterface');
+        $acl = $this->createMock('Symfony\Component\Security\Acl\Model\MutableAclInterface');
         $this->aclProvider->expects($this->once())
             ->method('findAcl')
             ->with($this->identicalTo($oid))
@@ -364,13 +364,13 @@ class AclManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testDeletePermissionForDomainObject()
     {
-        $sid = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
+        $sid = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
         $oid = new ObjectIdentity(123, 'Acme\Test');
         $granting = true;
         $mask = 123;
         $strategy = 'any';
 
-        $acl = $this->getMock('Symfony\Component\Security\Acl\Model\MutableAclInterface');
+        $acl = $this->createMock('Symfony\Component\Security\Acl\Model\MutableAclInterface');
         $this->aclProvider->expects($this->once())
             ->method('findAcl')
             ->with($this->identicalTo($oid))
@@ -392,13 +392,13 @@ class AclManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testDeletePermissionForEntityClass()
     {
-        $sid = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
+        $sid = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
         $oid = new ObjectIdentity('entity', 'Acme\Test');
         $granting = true;
         $mask = 123;
         $strategy = 'any';
 
-        $acl = $this->getMock('Symfony\Component\Security\Acl\Model\MutableAclInterface');
+        $acl = $this->createMock('Symfony\Component\Security\Acl\Model\MutableAclInterface');
         $this->aclProvider->expects($this->once())
             ->method('findAcl')
             ->with($this->identicalTo($oid))
@@ -424,7 +424,7 @@ class AclManagerTest extends \PHPUnit_Framework_TestCase
      */
     public function testDeleteFieldPermissionForRootOid()
     {
-        $sid = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
+        $sid = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
         $oid = new ObjectIdentity('entity', ObjectIdentityFactory::ROOT_IDENTITY_TYPE);
         $granting = true;
         $mask = 123;
@@ -436,14 +436,14 @@ class AclManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testDeleteFieldPermissionForDomainObject()
     {
-        $sid = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
+        $sid = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
         $oid = new ObjectIdentity(123, 'Acme\Test');
         $granting = true;
         $mask = 123;
         $strategy = 'any';
         $field = 'TestField';
 
-        $acl = $this->getMock('Symfony\Component\Security\Acl\Model\MutableAclInterface');
+        $acl = $this->createMock('Symfony\Component\Security\Acl\Model\MutableAclInterface');
         $this->aclProvider->expects($this->once())
             ->method('findAcl')
             ->with($this->identicalTo($oid))
@@ -465,14 +465,14 @@ class AclManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testDeleteFieldPermissionForEntityClass()
     {
-        $sid = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
+        $sid = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
         $oid = new ObjectIdentity('entity', 'Acme\Test');
         $granting = true;
         $mask = 123;
         $strategy = 'any';
         $field = 'TestField';
 
-        $acl = $this->getMock('Symfony\Component\Security\Acl\Model\MutableAclInterface');
+        $acl = $this->createMock('Symfony\Component\Security\Acl\Model\MutableAclInterface');
         $this->aclProvider->expects($this->once())
             ->method('findAcl')
             ->with($this->identicalTo($oid))
@@ -495,10 +495,10 @@ class AclManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testDeleteAllPermissionsForRootOid()
     {
-        $sid = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
+        $sid = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
         $oid = new ObjectIdentity('entity', ObjectIdentityFactory::ROOT_IDENTITY_TYPE);
 
-        $acl = $this->getMock('Symfony\Component\Security\Acl\Model\MutableAclInterface');
+        $acl = $this->createMock('Symfony\Component\Security\Acl\Model\MutableAclInterface');
         $this->aclProvider->expects($this->once())
             ->method('findAcl')
             ->with($this->identicalTo($oid))
@@ -517,10 +517,10 @@ class AclManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testDeleteAllPermissionsForDomainObject()
     {
-        $sid = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
+        $sid = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
         $oid = new ObjectIdentity(123, 'Acme\Test');
 
-        $acl = $this->getMock('Symfony\Component\Security\Acl\Model\MutableAclInterface');
+        $acl = $this->createMock('Symfony\Component\Security\Acl\Model\MutableAclInterface');
         $this->aclProvider->expects($this->once())
             ->method('findAcl')
             ->with($this->identicalTo($oid))
@@ -539,10 +539,10 @@ class AclManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testDeleteAllPermissionsForEntityClass()
     {
-        $sid = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
+        $sid = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
         $oid = new ObjectIdentity('entity', 'Acme\Test');
 
-        $acl = $this->getMock('Symfony\Component\Security\Acl\Model\MutableAclInterface');
+        $acl = $this->createMock('Symfony\Component\Security\Acl\Model\MutableAclInterface');
         $this->aclProvider->expects($this->once())
             ->method('findAcl')
             ->with($this->identicalTo($oid))
@@ -565,7 +565,7 @@ class AclManagerTest extends \PHPUnit_Framework_TestCase
      */
     public function testDeleteAllFieldPermissionsForRootOid()
     {
-        $sid = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
+        $sid = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
         $oid = new ObjectIdentity('entity', ObjectIdentityFactory::ROOT_IDENTITY_TYPE);
         $field = 'TestField';
 
@@ -574,11 +574,11 @@ class AclManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testDeleteAllFieldPermissionsForDomainObject()
     {
-        $sid = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
+        $sid = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
         $oid = new ObjectIdentity(123, 'Acme\Test');
         $field = 'TestField';
 
-        $acl = $this->getMock('Symfony\Component\Security\Acl\Model\MutableAclInterface');
+        $acl = $this->createMock('Symfony\Component\Security\Acl\Model\MutableAclInterface');
         $this->aclProvider->expects($this->once())
             ->method('findAcl')
             ->with($this->identicalTo($oid))
@@ -597,11 +597,11 @@ class AclManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testDeleteAllFieldPermissionsForEntityClass()
     {
-        $sid = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
+        $sid = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
         $oid = new ObjectIdentity('entity', 'Acme\Test');
         $field = 'TestField';
 
-        $acl = $this->getMock('Symfony\Component\Security\Acl\Model\MutableAclInterface');
+        $acl = $this->createMock('Symfony\Component\Security\Acl\Model\MutableAclInterface');
         $this->aclProvider->expects($this->once())
             ->method('findAcl')
             ->with($this->identicalTo($oid))
@@ -621,7 +621,7 @@ class AclManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testSetPermissionForRootOidNoAcl()
     {
-        $sid = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
+        $sid = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
         $oid = new ObjectIdentity('entity', ObjectIdentityFactory::ROOT_IDENTITY_TYPE);
         $granting = true;
         $mask = 123;
@@ -642,7 +642,7 @@ class AclManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testSetPermissionForDomainObjectNoAcl()
     {
-        $sid = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
+        $sid = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
         $oid = new ObjectIdentity(123, 'Acme\Test');
         $granting = true;
         $mask = 123;
@@ -663,7 +663,7 @@ class AclManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testSetPermissionForEntityClassNoAcl()
     {
-        $sid = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
+        $sid = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
         $oid = new ObjectIdentity('entity', 'Acme\Test');
         $granting = true;
         $mask = 123;
@@ -684,7 +684,7 @@ class AclManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testSetFieldPermissionForDomainObjectNoAcl()
     {
-        $sid = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
+        $sid = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
         $oid = new ObjectIdentity(123, 'Acme\Test');
         $granting = true;
         $mask = 123;
@@ -706,7 +706,7 @@ class AclManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testSetFieldPermissionForEntityClassNoAcl()
     {
-        $sid = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
+        $sid = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
         $oid = new ObjectIdentity('entity', 'Acme\Test');
         $granting = true;
         $mask = 123;
@@ -728,7 +728,7 @@ class AclManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testDeletePermissionForRootOidNoAcl()
     {
-        $sid = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
+        $sid = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
         $oid = new ObjectIdentity('entity', ObjectIdentityFactory::ROOT_IDENTITY_TYPE);
         $granting = true;
         $mask = 123;
@@ -746,7 +746,7 @@ class AclManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testDeletePermissionForDomainObjectNoAcl()
     {
-        $sid = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
+        $sid = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
         $oid = new ObjectIdentity(123, 'Acme\Test');
         $granting = true;
         $mask = 123;
@@ -764,7 +764,7 @@ class AclManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testDeletePermissionForEntityClassNoAcl()
     {
-        $sid = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
+        $sid = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
         $oid = new ObjectIdentity('entity', 'Acme\Test');
         $granting = true;
         $mask = 123;
@@ -782,7 +782,7 @@ class AclManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testDeleteFieldPermissionForDomainObjectNoAcl()
     {
-        $sid = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
+        $sid = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
         $oid = new ObjectIdentity(123, 'Acme\Test');
         $granting = true;
         $mask = 123;
@@ -801,7 +801,7 @@ class AclManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testDeleteFieldPermissionForEntityClassNoAcl()
     {
-        $sid = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
+        $sid = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
         $oid = new ObjectIdentity('entity', 'Acme\Test');
         $granting = true;
         $mask = 123;
@@ -820,7 +820,7 @@ class AclManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testDeleteAllPermissionsForRootOidNoAcl()
     {
-        $sid = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
+        $sid = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
         $oid = new ObjectIdentity('entity', ObjectIdentityFactory::ROOT_IDENTITY_TYPE);
 
         $this->setItem($oid, BatchItem::STATE_CREATE);
@@ -835,7 +835,7 @@ class AclManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testDeleteAllPermissionsForDomainObjectNoAcl()
     {
-        $sid = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
+        $sid = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
         $oid = new ObjectIdentity(123, 'Acme\Test');
 
         $this->setItem($oid, BatchItem::STATE_CREATE);
@@ -850,7 +850,7 @@ class AclManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testDeleteAllPermissionsForEntityClassNoAcl()
     {
-        $sid = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
+        $sid = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
         $oid = new ObjectIdentity('entity', 'Acme\Test');
 
         $this->setItem($oid, BatchItem::STATE_CREATE);
@@ -865,7 +865,7 @@ class AclManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testDeleteAllFieldPermissionsForDomainObjectNoAcl()
     {
-        $sid = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
+        $sid = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
         $oid = new ObjectIdentity(123, 'Acme\Test');
         $field = 'TestField';
 
@@ -881,7 +881,7 @@ class AclManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testDeleteAllFieldPermissionsForEntityClassNoAcl()
     {
-        $sid = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
+        $sid = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
         $oid = new ObjectIdentity('entity', 'Acme\Test');
         $field = 'TestField';
 
@@ -902,12 +902,12 @@ class AclManagerTest extends \PHPUnit_Framework_TestCase
         $oid3 = new ObjectIdentity('Acme\Test3', 'entity');
         $oid4 = new ObjectIdentity('Acme\Test4', 'entity');
 
-        $newItemSid = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
+        $newItemSid = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
         $newItem = new BatchItem($oid2, BatchItem::STATE_CREATE);
         $newItem->addAce(AclManager::OBJECT_ACE, 'TestField', $newItemSid, true, 123, 'all', true);
 
-        $updateItemAcl = $this->getMock('Symfony\Component\Security\Acl\Model\MutableAclInterface');
-        $deleteItemAcl = $this->getMock('Symfony\Component\Security\Acl\Model\MutableAclInterface');
+        $updateItemAcl = $this->createMock('Symfony\Component\Security\Acl\Model\MutableAclInterface');
+        $deleteItemAcl = $this->createMock('Symfony\Component\Security\Acl\Model\MutableAclInterface');
 
         $this->setItems(
             [
@@ -923,7 +923,7 @@ class AclManagerTest extends \PHPUnit_Framework_TestCase
         $this->aclProvider->expects($this->once())
             ->method('commit');
 
-        $acl = $this->getMock('Symfony\Component\Security\Acl\Model\MutableAclInterface');
+        $acl = $this->createMock('Symfony\Component\Security\Acl\Model\MutableAclInterface');
         $this->aclProvider->expects($this->once())
             ->method('createAcl')
             ->with($this->identicalTo($oid2))

--- a/src/Oro/Bundle/SecurityBundle/Tests/Unit/Acl/Persistence/AclPrivilegeRepositoryTest.php
+++ b/src/Oro/Bundle/SecurityBundle/Tests/Unit/Acl/Persistence/AclPrivilegeRepositoryTest.php
@@ -38,7 +38,7 @@ class AclPrivilegeRepositoryTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->extension = $this->getMock('Oro\Bundle\SecurityBundle\Acl\Extension\AclExtensionInterface');
+        $this->extension = $this->createMock('Oro\Bundle\SecurityBundle\Acl\Extension\AclExtensionInterface');
         $this->extension->expects($this->any())
             ->method('getObjectIdentity')
             ->will(
@@ -148,7 +148,7 @@ class AclPrivilegeRepositoryTest extends \PHPUnit_Framework_TestCase
     {
         $thisLink = $this;
 
-        $sid = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
+        $sid = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
         $sid->expects($this->any())->method('equals')->will($this->returnValue(true));
 
         $extensionKey = 'test';
@@ -156,20 +156,20 @@ class AclPrivilegeRepositoryTest extends \PHPUnit_Framework_TestCase
             'Acme\Class1',
             'Acme\Class2',
         ];
-        $class1 = $this->getMock('Oro\Bundle\SecurityBundle\Acl\Extension\AclClassInfo');
+        $class1 = $this->createMock('Oro\Bundle\SecurityBundle\Acl\Extension\AclClassInfo');
         $class1->expects($this->once())->method('getClassName')->will($this->returnValue($classes[0]));
         $class1->expects($this->once())->method('getGroup')->will($this->returnValue('SomeGroup'));
         $class1->expects($this->once())->method('getLabel')->will($this->returnValue('Class 1'));
-        $class2 = $this->getMock('Oro\Bundle\SecurityBundle\Acl\Extension\AclClassInfo');
+        $class2 = $this->createMock('Oro\Bundle\SecurityBundle\Acl\Extension\AclClassInfo');
         $class2->expects($this->once())->method('getClassName')->will($this->returnValue($classes[1]));
         $class2->expects($this->once())->method('getGroup')->will($this->returnValue('SomeGroup'));
         $class2->expects($this->once())->method('getLabel')->will($this->returnValue('Class 2'));
 
         $rootOid = new ObjectIdentity($extensionKey, ObjectIdentityFactory::ROOT_IDENTITY_TYPE);
-        $rootAcl = $this->getMock('Symfony\Component\Security\Acl\Model\AclInterface');
+        $rootAcl = $this->createMock('Symfony\Component\Security\Acl\Model\AclInterface');
 
         $oid1 = new ObjectIdentity($extensionKey, $classes[0]);
-        $oid1Acl = $this->getMock('Symfony\Component\Security\Acl\Model\AclInterface');
+        $oid1Acl = $this->createMock('Symfony\Component\Security\Acl\Model\AclInterface');
         $oid2 = new ObjectIdentity($extensionKey, $classes[1]);
 
         $oidsWithRoot = [$rootOid, $oid2, $oid1];
@@ -550,7 +550,7 @@ class AclPrivilegeRepositoryTest extends \PHPUnit_Framework_TestCase
             ]
         );
 
-        $sid = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
+        $sid = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
         $this->initSavePrivileges($extensionKey, $rootOid);
 
         $this->setExpectationsForGetAces([]);
@@ -600,7 +600,7 @@ class AclPrivilegeRepositoryTest extends \PHPUnit_Framework_TestCase
             ]
         );
 
-        $sid = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
+        $sid = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
         $this->initSavePrivileges($extensionKey, $rootOid);
 
         $this->setExpectationsForGetAces([]);
@@ -660,7 +660,7 @@ class AclPrivilegeRepositoryTest extends \PHPUnit_Framework_TestCase
             ]
         );
 
-        $sid = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
+        $sid = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
         $this->initSavePrivileges($extensionKey, $rootOid);
 
         $this->setExpectationsForGetAces(
@@ -721,7 +721,7 @@ class AclPrivilegeRepositoryTest extends \PHPUnit_Framework_TestCase
 
     public function getAce($mask, $sid = null)
     {
-        $ace = $this->getMock('Symfony\Component\Security\Acl\Model\EntryInterface');
+        $ace = $this->createMock('Symfony\Component\Security\Acl\Model\EntryInterface');
         $ace->expects($this->any())->method('isGranting')->will($this->returnValue(true));
         $ace->expects($this->any())->method('getMask')->will($this->returnValue($mask));
         if ($sid !== null) {

--- a/src/Oro/Bundle/SecurityBundle/Tests/Unit/Acl/Voter/AclVoterTest.php
+++ b/src/Oro/Bundle/SecurityBundle/Tests/Unit/Acl/Voter/AclVoterTest.php
@@ -12,18 +12,18 @@ class AclVoterTest extends \PHPUnit_Framework_TestCase
         $selector = $this->getMockBuilder('Oro\Bundle\SecurityBundle\Acl\Extension\AclExtensionSelector')
             ->disableOriginalConstructor()
             ->getMock();
-        $permissionMap = $this->getMock('Symfony\Component\Security\Acl\Permission\PermissionMapInterface');
+        $permissionMap = $this->createMock('Symfony\Component\Security\Acl\Permission\PermissionMapInterface');
         $voter = new AclVoter(
-            $this->getMock('Symfony\Component\Security\Acl\Model\AclProviderInterface'),
-            $this->getMock('Symfony\Component\Security\Acl\Model\ObjectIdentityRetrievalStrategyInterface'),
-            $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityRetrievalStrategyInterface'),
+            $this->createMock('Symfony\Component\Security\Acl\Model\AclProviderInterface'),
+            $this->createMock('Symfony\Component\Security\Acl\Model\ObjectIdentityRetrievalStrategyInterface'),
+            $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityRetrievalStrategyInterface'),
             $permissionMap
         );
         $voter->setAclExtensionSelector($selector);
 
-        $token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
+        $token = $this->createMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
         $object = new \stdClass();
-        $extension = $this->getMock('Oro\Bundle\SecurityBundle\Acl\Extension\AclExtensionInterface');
+        $extension = $this->createMock('Oro\Bundle\SecurityBundle\Acl\Extension\AclExtensionInterface');
         $extension->expects($this->once())
             ->method('getAccessLevel')
             ->with($this->equalTo(1))

--- a/src/Oro/Bundle/SecurityBundle/Tests/Unit/EventListener/ControllerListenerTest.php
+++ b/src/Oro/Bundle/SecurityBundle/Tests/Unit/EventListener/ControllerListenerTest.php
@@ -36,8 +36,8 @@ class ControllerListenerTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $logger = $this->getMock('Psr\Log\LoggerInterface');
-        $this->tokenStorage = $this->getMock('Symfony\Component\Security\Core\TokenStorageInterface');
+        $logger = $this->createMock('Psr\Log\LoggerInterface');
+        $this->tokenStorage = $this->createMock('Symfony\Component\Security\Core\TokenStorageInterface');
         $this->annotationProvider = $this->getMockBuilder('Oro\Bundle\SecurityBundle\Metadata\AclAnnotationProvider')
             ->disableOriginalConstructor()
             ->getMock();
@@ -61,7 +61,7 @@ class ControllerListenerTest extends \PHPUnit_Framework_TestCase
     public function testInterceptWithNoAnnotation()
     {
         $event = new FilterControllerEvent(
-            $this->getMock('Symfony\Component\HttpKernel\HttpKernelInterface'),
+            $this->createMock('Symfony\Component\HttpKernel\HttpKernelInterface'),
             [new TestDomainObject(), $this->methodName],
             $this->request,
             HttpKernelInterface::MASTER_REQUEST
@@ -90,7 +90,7 @@ class ControllerListenerTest extends \PHPUnit_Framework_TestCase
     public function testInterceptAccessGranted()
     {
         $event = new FilterControllerEvent(
-            $this->getMock('Symfony\Component\HttpKernel\HttpKernelInterface'),
+            $this->createMock('Symfony\Component\HttpKernel\HttpKernelInterface'),
             [new TestDomainObject(), $this->methodName],
             $this->request,
             HttpKernelInterface::MASTER_REQUEST
@@ -138,7 +138,7 @@ class ControllerListenerTest extends \PHPUnit_Framework_TestCase
     public function testInterceptAccessGrantedWithIgnoreClassAcl()
     {
         $event = new FilterControllerEvent(
-            $this->getMock('Symfony\Component\HttpKernel\HttpKernelInterface'),
+            $this->createMock('Symfony\Component\HttpKernel\HttpKernelInterface'),
             [new TestDomainObject(), $this->methodName],
             $this->request,
             HttpKernelInterface::MASTER_REQUEST
@@ -171,7 +171,7 @@ class ControllerListenerTest extends \PHPUnit_Framework_TestCase
     public function testInterceptAccessGrantedWithoutClassAcl()
     {
         $event = new FilterControllerEvent(
-            $this->getMock('Symfony\Component\HttpKernel\HttpKernelInterface'),
+            $this->createMock('Symfony\Component\HttpKernel\HttpKernelInterface'),
             [new TestDomainObject(), $this->methodName],
             $this->request,
             HttpKernelInterface::MASTER_REQUEST
@@ -211,7 +211,7 @@ class ControllerListenerTest extends \PHPUnit_Framework_TestCase
     public function testInterceptAccessGrantedByClassAcl()
     {
         $event = new FilterControllerEvent(
-            $this->getMock('Symfony\Component\HttpKernel\HttpKernelInterface'),
+            $this->createMock('Symfony\Component\HttpKernel\HttpKernelInterface'),
             [new TestDomainObject(), $this->methodName],
             $this->request,
             HttpKernelInterface::MASTER_REQUEST
@@ -252,7 +252,7 @@ class ControllerListenerTest extends \PHPUnit_Framework_TestCase
     public function testInterceptAccessDeniedByClassAcl()
     {
         $event = new FilterControllerEvent(
-            $this->getMock('Symfony\Component\HttpKernel\HttpKernelInterface'),
+            $this->createMock('Symfony\Component\HttpKernel\HttpKernelInterface'),
             [new TestDomainObject(), $this->methodName],
             $this->request,
             HttpKernelInterface::MASTER_REQUEST
@@ -303,7 +303,7 @@ class ControllerListenerTest extends \PHPUnit_Framework_TestCase
     public function testInterceptAccessDeniedByMethodAcl()
     {
         $event = new FilterControllerEvent(
-            $this->getMock('Symfony\Component\HttpKernel\HttpKernelInterface'),
+            $this->createMock('Symfony\Component\HttpKernel\HttpKernelInterface'),
             [new TestDomainObject(), $this->methodName],
             $this->request,
             HttpKernelInterface::MASTER_REQUEST
@@ -339,7 +339,7 @@ class ControllerListenerTest extends \PHPUnit_Framework_TestCase
     public function testInterceptAccessDenied()
     {
         $event = new FilterControllerEvent(
-            $this->getMock('Symfony\Component\HttpKernel\HttpKernelInterface'),
+            $this->createMock('Symfony\Component\HttpKernel\HttpKernelInterface'),
             [new TestDomainObject(), $this->methodName],
             $this->request,
             HttpKernelInterface::MASTER_REQUEST
@@ -371,7 +371,7 @@ class ControllerListenerTest extends \PHPUnit_Framework_TestCase
     public function testInterceptAccessDeniedForInternalAction()
     {
         $event = new FilterControllerEvent(
-            $this->getMock('Symfony\Component\HttpKernel\HttpKernelInterface'),
+            $this->createMock('Symfony\Component\HttpKernel\HttpKernelInterface'),
             [new TestDomainObject(), $this->methodName],
             $this->request,
             HttpKernelInterface::SUB_REQUEST

--- a/src/Oro/Bundle/SecurityBundle/Tests/Unit/Metadata/AclAnnotationProviderTest.php
+++ b/src/Oro/Bundle/SecurityBundle/Tests/Unit/Metadata/AclAnnotationProviderTest.php
@@ -28,7 +28,7 @@ class AclAnnotationProviderTest extends \PHPUnit_Framework_TestCase
             true,
             ['fetch', 'save', 'delete', 'deleteAll']
         );
-        $this->loader = $this->getMock('Oro\Bundle\SecurityBundle\Annotation\Loader\AclAnnotationLoaderInterface');
+        $this->loader = $this->createMock('Oro\Bundle\SecurityBundle\Annotation\Loader\AclAnnotationLoaderInterface');
         $this->provider = new AclAnnotationProvider($this->cache);
         $this->provider->addLoader($this->loader);
     }

--- a/src/Oro/Bundle/SecurityBundle/Tests/Unit/SecurityFacadeTest.php
+++ b/src/Oro/Bundle/SecurityBundle/Tests/Unit/SecurityFacadeTest.php
@@ -26,7 +26,7 @@ class SecurityFacadeTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->tokenStorage = $this->getMock('Symfony\Component\Security\Core\TokenStorageInterface');
+        $this->tokenStorage = $this->createMock('Symfony\Component\Security\Core\TokenStorageInterface');
         $this->annotationProvider =
             $this->getMockBuilder('Oro\Bundle\SecurityBundle\Metadata\AclAnnotationProvider')
                 ->disableOriginalConstructor()
@@ -35,7 +35,7 @@ class SecurityFacadeTest extends \PHPUnit_Framework_TestCase
             $this->getMockBuilder('Oro\Bundle\SecurityBundle\Acl\Domain\ObjectIdentityFactory')
                 ->disableOriginalConstructor()
                 ->getMock();
-        $this->logger = $this->getMock('Psr\Log\LoggerInterface');
+        $this->logger = $this->createMock('Psr\Log\LoggerInterface');
 
         $this->facade = new SecurityFacade(
             $this->tokenStorage,

--- a/src/Oro/Bundle/TranslationBundle/Tests/Unit/Controller/ControllerTest.php
+++ b/src/Oro/Bundle/TranslationBundle/Tests/Unit/Controller/ControllerTest.php
@@ -71,7 +71,7 @@ class ControllerTest extends \PHPUnit_Framework_TestCase
      */
     public function testRenderJsTranslationContent($params, $expected)
     {
-        $templating = $this->getMock('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
+        $templating = $this->createMock('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
         $templating
             ->expects($this->any())
             ->method('render')

--- a/src/Oro/Bundle/TranslationBundle/Tests/Unit/Translation/TranslatorTest.php
+++ b/src/Oro/Bundle/TranslationBundle/Tests/Unit/Translation/TranslatorTest.php
@@ -181,7 +181,7 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
     {
         $messages = $this->messages;
         $obj = $this;
-        $loader = $this->getMock('Symfony\Component\Translation\Loader\LoaderInterface');
+        $loader = $this->createMock('Symfony\Component\Translation\Loader\LoaderInterface');
         $loader
             ->expects($this->any())
             ->method('load')
@@ -204,7 +204,7 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
      */
     protected function getContainer($loader)
     {
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $container
             ->expects($this->any())
             ->method('get')

--- a/src/Oro/Bundle/UIBundle/Tests/Unit/DependencyInjection/OroUIExtensionTest.php
+++ b/src/Oro/Bundle/UIBundle/Tests/Unit/DependencyInjection/OroUIExtensionTest.php
@@ -11,7 +11,7 @@ class OroUIExtensionTest extends \PHPUnit_Framework_TestCase
 
     public function testLoad()
     {
-        $this->container = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+        $this->container = $this->createMock('Symfony\Component\DependencyInjection\ContainerBuilder');
 
         $this->container->expects($this->once())
             ->method('getParameter')

--- a/src/Oro/Bundle/UIBundle/Tests/Unit/Route/RouterTest.php
+++ b/src/Oro/Bundle/UIBundle/Tests/Unit/Route/RouterTest.php
@@ -15,7 +15,7 @@ class RouterTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->request = $this->getMock('Symfony\Component\HttpFoundation\Request');
+        $this->request = $this->createMock('Symfony\Component\HttpFoundation\Request');
         $this->route = $this->getMockBuilder('Symfony\Bundle\FrameworkBundle\Routing\Router')
             ->disableOriginalConstructor()
             ->getMock();

--- a/src/Oro/Bundle/UserBundle/Tests/Unit/Entity/EventListener/UploadedImageSubscriberTest.php
+++ b/src/Oro/Bundle/UserBundle/Tests/Unit/Entity/EventListener/UploadedImageSubscriberTest.php
@@ -56,7 +56,7 @@ class UploadedImageSubscriberTest extends \PHPUnit_Framework_TestCase
         $fileName = md5(time()) . '.jpg';
         $uploadDir = 'uploads/post-remove-test';
 
-        $entity = $this->getMock('Oro\Bundle\UserBundle\Entity\EntityUploadedImageInterface');
+        $entity = $this->createMock('Oro\Bundle\UserBundle\Entity\EntityUploadedImageInterface');
         $this->assertImageRemoveConditions($entity, $fileName, $uploadDir);
 
         $this->getSubscriber()->postRemove($this->getEvent($entity));
@@ -78,7 +78,7 @@ class UploadedImageSubscriberTest extends \PHPUnit_Framework_TestCase
 
     public function testPrePersist()
     {
-        $entity = $this->getMock('Oro\Bundle\UserBundle\Entity\EntityUploadedImageInterface');
+        $entity = $this->createMock('Oro\Bundle\UserBundle\Entity\EntityUploadedImageInterface');
         $this->assertImageUpdate($entity);
 
         $this->getSubscriber()->prePersist($this->getEvent($entity));
@@ -108,7 +108,7 @@ class UploadedImageSubscriberTest extends \PHPUnit_Framework_TestCase
         $fileName = md5(time()) . '.jpg';
         $uploadDir = 'uploads/pre-update-test';
 
-        $entity = $this->getMock('Oro\Bundle\UserBundle\Entity\EntityUploadedImageInterface');
+        $entity = $this->createMock('Oro\Bundle\UserBundle\Entity\EntityUploadedImageInterface');
         $this->assertImageRemoveConditions($entity, $fileName, $uploadDir);
         $this->assertImageUpdate($entity);
 
@@ -140,7 +140,7 @@ class UploadedImageSubscriberTest extends \PHPUnit_Framework_TestCase
 
     public function testHandleImageUploadNoImage()
     {
-        $entity = $this->getMock('Oro\Bundle\UserBundle\Entity\EntityUploadedImageInterface');
+        $entity = $this->createMock('Oro\Bundle\UserBundle\Entity\EntityUploadedImageInterface');
         $entity->expects($this->never())
             ->method('getUploadDir');
         $entity->expects($this->exactly(2))
@@ -155,7 +155,7 @@ class UploadedImageSubscriberTest extends \PHPUnit_Framework_TestCase
     public function testPostUpdate()
     {
         $uploadDir = 'uploads/image-upload-test';
-        $entity = $this->getMock('Oro\Bundle\UserBundle\Entity\EntityUploadedImageInterface');
+        $entity = $this->createMock('Oro\Bundle\UserBundle\Entity\EntityUploadedImageInterface');
         $this->assertImageUploadPreconditions($entity, $uploadDir);
         $this->getSubscriber()->postUpdate($this->getEvent($entity));
         $this->assertFileExists($this->getUploadRootDir() . DIRECTORY_SEPARATOR . $uploadDir);
@@ -164,7 +164,7 @@ class UploadedImageSubscriberTest extends \PHPUnit_Framework_TestCase
     public function testPostPersist()
     {
         $uploadDir = 'uploads/image-upload-test';
-        $entity = $this->getMock('Oro\Bundle\UserBundle\Entity\EntityUploadedImageInterface');
+        $entity = $this->createMock('Oro\Bundle\UserBundle\Entity\EntityUploadedImageInterface');
         $this->assertImageUploadPreconditions($entity, $uploadDir);
         $this->getSubscriber()->postPersist($this->getEvent($entity));
         $this->assertFileExists($this->getUploadRootDir() . DIRECTORY_SEPARATOR . $uploadDir);

--- a/src/Oro/Bundle/UserBundle/Tests/Unit/Entity/Manager/GroupManagerTest.php
+++ b/src/Oro/Bundle/UserBundle/Tests/Unit/Entity/Manager/GroupManagerTest.php
@@ -23,7 +23,7 @@ class GroupManagerTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->repository = $this->getMock(
+        $this->repository = $this->createMock(
             'Doctrine\Common\Persistence\ObjectRepository',
             ['find', 'findAll', 'findBy', 'findOneBy', 'getClassName', 'getUserQueryBuilder']
         );

--- a/src/Oro/Bundle/UserBundle/Tests/Unit/Entity/Manager/RoleManagerTest.php
+++ b/src/Oro/Bundle/UserBundle/Tests/Unit/Entity/Manager/RoleManagerTest.php
@@ -23,7 +23,7 @@ class RoleManagerTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->repository = $this->getMock(
+        $this->repository = $this->createMock(
             'Doctrine\Common\Persistence\ObjectRepository',
             ['find', 'findAll', 'findBy', 'findOneBy', 'getClassName', 'getUserQueryBuilder']
         );

--- a/src/Oro/Bundle/UserBundle/Tests/Unit/Entity/UserManagerTest.php
+++ b/src/Oro/Bundle/UserBundle/Tests/Unit/Entity/UserManagerTest.php
@@ -40,10 +40,10 @@ class UserManagerTest extends \PHPUnit_Framework_TestCase
         }
 
         $ef = new EncoderFactory([static::USER_CLASS => new MessageDigestPasswordEncoder('sha512')]);
-        $class = $this->getMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
+        $class = $this->createMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
 
-        $this->om = $this->getMock('Doctrine\Common\Persistence\ObjectManager');
-        $this->repository = $this->getMock('Doctrine\Common\Persistence\ObjectRepository');
+        $this->om = $this->createMock('Doctrine\Common\Persistence\ObjectManager');
+        $this->repository = $this->createMock('Doctrine\Common\Persistence\ObjectRepository');
 
         $this->om
             ->expects($this->any())

--- a/src/Oro/Bundle/UserBundle/Tests/Unit/Form/Type/ChangePasswordTypeTest.php
+++ b/src/Oro/Bundle/UserBundle/Tests/Unit/Form/Type/ChangePasswordTypeTest.php
@@ -29,7 +29,7 @@ class ChangePasswordTypeTest extends FormIntegrationTestCase
      */
     public function testBuildForm()
     {
-        $builder = $this->getMock('Symfony\Component\Form\Test\FormBuilderInterface');
+        $builder = $this->createMock('Symfony\Component\Form\Test\FormBuilderInterface');
         $options = [];
 
         $builder->expects($this->once())
@@ -48,7 +48,7 @@ class ChangePasswordTypeTest extends FormIntegrationTestCase
      */
     public function testSetDefaultOptions()
     {
-        $resolver = $this->getMock('Symfony\Component\OptionsResolver\OptionsResolverInterface');
+        $resolver = $this->createMock('Symfony\Component\OptionsResolver\OptionsResolverInterface');
         $resolver->expects($this->once())
             ->method('setDefaults')
             ->with($this->isType('array'));

--- a/src/Oro/Bundle/UserBundle/Tests/Unit/Security/UserProviderTest.php
+++ b/src/Oro/Bundle/UserBundle/Tests/Unit/Security/UserProviderTest.php
@@ -27,9 +27,9 @@ class UserProviderTest extends \PHPUnit_Framework_TestCase
         }
 
         $ef = new EncoderFactory([static::USER_CLASS => new MessageDigestPasswordEncoder('sha512')]);
-        $class = $this->getMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
-        $om = $this->getMock('Doctrine\Common\Persistence\ObjectManager');
-        $repository = $this->getMock('Doctrine\Common\Persistence\ObjectRepository');
+        $class = $this->createMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
+        $om = $this->createMock('Doctrine\Common\Persistence\ObjectManager');
+        $repository = $this->createMock('Doctrine\Common\Persistence\ObjectRepository');
 
         $om->expects($this->any())
             ->method('getRepository')
@@ -41,7 +41,7 @@ class UserProviderTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo(static::USER_CLASS))
             ->will($this->returnValue($class));
 
-        $this->userManager = $this->getMock(
+        $this->userManager = $this->createMock(
             'Oro\Bundle\UserBundle\Entity\UserManager',
             ['findUserBy', 'findUserByUsernameOrEmail', 'getClass'],
             [static::USER_CLASS, $om, $ef]
@@ -79,7 +79,7 @@ class UserProviderTest extends \PHPUnit_Framework_TestCase
             ->method('getId')
             ->will($this->returnValue(123));
 
-        $refreshedUser = $this->getMock('Pim\Bundle\UserBundle\Entity\UserInterface');
+        $refreshedUser = $this->createMock('Pim\Bundle\UserBundle\Entity\UserInterface');
 
         $this->userManager
             ->expects($this->once())
@@ -95,7 +95,7 @@ class UserProviderTest extends \PHPUnit_Framework_TestCase
      */
     public function testRefreshDeleted()
     {
-        $user = $this->getMock('Pim\Bundle\UserBundle\Entity\UserInterface');
+        $user = $this->createMock('Pim\Bundle\UserBundle\Entity\UserInterface');
 
         $this->userManager
             ->expects($this->once())

--- a/src/Pim/Bundle/EnrichBundle/Tests/Unit/Form/Subscriber/AddAttributeRequirementsSubscriberTest.php
+++ b/src/Pim/Bundle/EnrichBundle/Tests/Unit/Form/Subscriber/AddAttributeRequirementsSubscriberTest.php
@@ -120,7 +120,7 @@ class AddAttributeRequirementsSubscriberTest extends \PHPUnit_Framework_TestCase
      */
     private function getAttributeRequirementMock($attribute, $channel = null)
     {
-        $requirement = $this->getMock('Pim\Bundle\CatalogBundle\Entity\AttributeRequirement');
+        $requirement = $this->createMock('Pim\Bundle\CatalogBundle\Entity\AttributeRequirement');
 
         $requirement->expects($this->any())
             ->method('getAttribute')
@@ -164,7 +164,7 @@ class AddAttributeRequirementsSubscriberTest extends \PHPUnit_Framework_TestCase
      */
     private function getChannelMock($code)
     {
-        $channel = $this->getMock('Pim\Bundle\CatalogBundle\Entity\Channel');
+        $channel = $this->createMock('Pim\Bundle\CatalogBundle\Entity\Channel');
 
         $channel->expects($this->any())
             ->method('getCode')
@@ -181,7 +181,7 @@ class AddAttributeRequirementsSubscriberTest extends \PHPUnit_Framework_TestCase
      */
     private function getAttributeMock($code, $type = null)
     {
-        $attribute = $this->getMock('Pim\Bundle\CatalogBundle\Entity\Attribute');
+        $attribute = $this->createMock('Pim\Bundle\CatalogBundle\Entity\Attribute');
 
         $attribute->expects($this->any())
             ->method('getCode')
@@ -225,7 +225,7 @@ class AddAttributeRequirementsSubscriberTest extends \PHPUnit_Framework_TestCase
      */
     protected function getFamilyMock(array $requirements)
     {
-        $family = $this->getMock('Pim\Bundle\CatalogBundle\Entity\Family');
+        $family = $this->createMock('Pim\Bundle\CatalogBundle\Entity\Family');
 
         $family->expects($this->any())
             ->method('getAttributeRequirements')

--- a/src/Pim/Bundle/EnrichBundle/Tests/Unit/Form/Subscriber/FilterLocaleValueSubscriberTest.php
+++ b/src/Pim/Bundle/EnrichBundle/Tests/Unit/Form/Subscriber/FilterLocaleValueSubscriberTest.php
@@ -151,7 +151,7 @@ class FilterLocaleValueSubscriberTest extends \PHPUnit_Framework_TestCase
      */
     private function getProductValueMock($attribute, $locale)
     {
-        $value = $this->getMock('Pim\Component\Catalog\Model\ProductValue');
+        $value = $this->createMock('Pim\Component\Catalog\Model\ProductValue');
 
         $value->expects($this->any())
             ->method('getAttribute')
@@ -171,7 +171,7 @@ class FilterLocaleValueSubscriberTest extends \PHPUnit_Framework_TestCase
      */
     private function getAttributeMock($localizable = true)
     {
-        $attribute = $this->getMock('Pim\Bundle\CatalogBundle\Entity\Attribute');
+        $attribute = $this->createMock('Pim\Bundle\CatalogBundle\Entity\Attribute');
 
         $attribute->expects($this->any())
             ->method('isLocalizable')

--- a/src/Pim/Bundle/EnrichBundle/Tests/Unit/Form/Type/AbstractFormTypeTest.php
+++ b/src/Pim/Bundle/EnrichBundle/Tests/Unit/Form/Type/AbstractFormTypeTest.php
@@ -89,12 +89,12 @@ abstract class AbstractFormTypeTest extends TypeTestCase
             ->addTypeExtension(new FormTypeSelect2Extension())
             ->addTypeExtension(
                 new FormTypeValidatorExtension(
-                    $this->getMock('Symfony\Component\Validator\ValidatorInterface')
+                    $this->createMock('Symfony\Component\Validator\ValidatorInterface')
                 )
             )
             ->addType(
                 new TranslatableFieldType(
-                    $this->getMock('Symfony\Component\Validator\ValidatorInterface'),
+                    $this->createMock('Symfony\Component\Validator\ValidatorInterface'),
                     $this->getUserContextMock(),
                     $this->getLocaleHelperMock()
                 )
@@ -140,7 +140,7 @@ abstract class AbstractFormTypeTest extends TypeTestCase
      */
     protected function getObjectManagerMock()
     {
-        return $this->getMock('Doctrine\Common\Persistence\ObjectManager');
+        return $this->createMock('Doctrine\Common\Persistence\ObjectManager');
     }
 
     /**
@@ -150,7 +150,7 @@ abstract class AbstractFormTypeTest extends TypeTestCase
      */
     protected function getEventDispatcherInterfaceMock()
     {
-        return $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        return $this->createMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
     }
 
     /**

--- a/src/Pim/Bundle/UIBundle/Tests/Unit/Form/Transformer/AjaxEntityTransformerFactoryTest.php
+++ b/src/Pim/Bundle/UIBundle/Tests/Unit/Form/Transformer/AjaxEntityTransformerFactoryTest.php
@@ -15,7 +15,7 @@ class AjaxEntityTransformerFactoryTest extends \PHPUnit_Framework_TestCase
 {
     public function testCreate()
     {
-        $doctrine = $this->getMock('Symfony\Bridge\Doctrine\RegistryInterface');
+        $doctrine = $this->createMock('Symfony\Bridge\Doctrine\RegistryInterface');
         $transformerClass = 'Pim\Bundle\UIBundle\Form\Transformer\AjaxEntityTransformer';
         $options = [
             'class' => 'class'
@@ -24,7 +24,7 @@ class AjaxEntityTransformerFactoryTest extends \PHPUnit_Framework_TestCase
             ->method('getRepository')
             ->with($this->equalTo('class'))
             ->will(
-                $this->returnValue($this->getMock('Pim\Bundle\UIBundle\Entity\Repository\OptionRepositoryInterface'))
+                $this->returnValue($this->createMock('Pim\Bundle\UIBundle\Entity\Repository\OptionRepositoryInterface'))
             );
 
         $factory = new AjaxEntityTransformerFactory($doctrine, $transformerClass);

--- a/src/Pim/Bundle/UIBundle/Tests/Unit/Form/Transformer/AjaxEntityTransformerTest.php
+++ b/src/Pim/Bundle/UIBundle/Tests/Unit/Form/Transformer/AjaxEntityTransformerTest.php
@@ -17,7 +17,7 @@ class AjaxEntityTransformerTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->repository = $this->getMock('Pim\Bundle\UIBundle\Entity\Repository\OptionRepositoryInterface');
+        $this->repository = $this->createMock('Pim\Bundle\UIBundle\Entity\Repository\OptionRepositoryInterface');
         $this->repository->expects($this->any())
             ->method('getOption')
             ->will(

--- a/src/Pim/Bundle/UIBundle/Tests/Unit/Form/Type/AjaxEntityTypeTest.php
+++ b/src/Pim/Bundle/UIBundle/Tests/Unit/Form/Type/AjaxEntityTypeTest.php
@@ -42,7 +42,7 @@ class AjaxEntityTypeTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->router = $this->getMock('Symfony\Component\Routing\RouterInterface');
+        $this->router = $this->createMock('Symfony\Component\Routing\RouterInterface');
         $this->router->expects($this->any())
             ->method('generate')
             ->will(


### PR DESCRIPTION
Since we updated "phpspec/phpspec" to 3.0, build on our CI to test corevage does not work.

- [x] Update phpunit to `5.4.*` (not the last version because of one of these requirements is php >= 7.0) 
- [x] Fix phpunit tests
- [x] Add all suites test to calculate the coverage