### PR TITLE
PIM-5964: Index category labels by locale code in channel normalization

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -1,3 +1,9 @@
+# 1.6.
+
+## Bug fixes
+
+- PIM-5964: Index category labels by locale code in channel normalization
+
 # 1.6.2 (2016-09-02)
 
 ## Bug fixes

--- a/features/export/product-export-builder/export_products_by_categories.feature
+++ b/features/export/product-export-builder/export_products_by_categories.feature
@@ -65,6 +65,7 @@ Feature: Export products from any given categories
     Then I should see the text "All products"
     When I press the "Select categories" button
     Then I should see the text "Categories selection"
+    And I should see the text "Master catalog"
     When I click on the "toys_games" category
     And I expand the "toys_games" category
     And I click on the "action_figures" category

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/product/category/selector.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/product/category/selector.js
@@ -144,7 +144,6 @@ define(
                     FetcherRegistry.getFetcher('channel')
                         .fetch(this.attributes.channel)
                         .then(function (channel) {
-
                             this.currentTree = channel.category;
 
                             this.$el.html(this.template({

--- a/src/Pim/Component/Catalog/Normalizer/Structured/ChannelNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Structured/ChannelNormalizer.php
@@ -103,10 +103,7 @@ class ChannelNormalizer implements NormalizerInterface
         $labels = [];
 
         foreach ($translations as $translation) {
-            $labels[] = [
-                'locale' => $translation->getLocale(),
-                'label'  => $translation->getLabel(),
-            ];
+            $labels[$translation->getLocale()] = $translation->getLabel();
         }
 
         return [

--- a/src/Pim/Component/Catalog/spec/Normalizer/Structured/ChannelNormalizerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Normalizer/Structured/ChannelNormalizerSpec.php
@@ -68,7 +68,7 @@ class ChannelNormalizerSpec extends ObjectBehavior
                     'id' => 42,
                     'code' => 'master',
                     'labels' => [
-                        ['locale' => 'en_US', 'label' => 'label']
+                        'en_US' => 'label'
                     ],
                 ],
                 'conversion_units' => 'Weight: Kilogram, Size: Centimeter'


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Channel normalization before the PR:
```
[
    "code" => "ecommerce",
    "label" => "Ecommerce",
    "currencies" => [...],
    "locales" => [...],
    "category" => [
        "id" => 1,
        "code" => "master",
        "labels" => [
            ["locale" => "en_US", "label" => "Master catalog"],
            ["locale" => "de_DE", "label" => "Hauptkatalog"],
            ["locale" => "fr_FR", "label" => "Catalogue principal"]
        ]
    ],
    "conversion_units" => ""
]
```
and after:
```
[
    "code" => "ecommerce",
    "label" => "Ecommerce",
    "currencies" => [...],
    "locales" => [...],
    "category" => [
        "id" => 1,
        "code" => "master",
        "labels" => [
            "en_US" => "Master catalog",
            "de_DE" => "Hauptkatalog",
            "fr_FR" => "Catalogue principal"
        ]
    ],
    "conversion_units" => ""
]
```
This change allows to use the [i18n](https://github.com/akeneo/pim-community-dev/blob/1.6/src/Pim/Bundle/EnrichBundle/Resources/public/js/i18n.js#L22) module easily to get localized labels in front.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | yes
| Added Behats                      | yes
| Changelog updated                 | 
| Review and 2 GTM                  | 
| Micro Demo to the PO (Story only) | 
| Migration script                  | n/a
| Tech Doc                          | n/a

