### PR TITLE
PIM-5958: In the tab "Content" of an export profile, the tooltip for the field "attributes" does not appear on mouse over

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 
+- PIM-5958: Fix tooltip for the field "attributes" in the tab "Content" of an export profile
 - PIM-5963: Fix installation on MySQL 5.7
 
 # 1.6.1 (2016-09-01)

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/export/product/edit/content/structure/attributes.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/export/product/edit/content/structure/attributes.js
@@ -76,6 +76,7 @@ define(
 
                 this.delegateEvents();
 
+                this.$('[data-toggle="tooltip"]').tooltip();
                 this.renderExtensions();
             },
 


### PR DESCRIPTION
**Description**

Enable tooltip for field "attributes"

**Definition Of Done**


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | N
| Added Behats                      | N
| Changelog updated                 | N
| Review and 2 GTM                  | N
| Micro Demo to the PO (Story only) | N
| Migration script                  | N
| Tech Doc                          | N
