### PR TITLE
Remove require-mongo as this dependency is already in composer.json

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -5,15 +5,15 @@
 
     <target name="build" depends="prepare,composer,vendors,setupdb,fixtures,lint,phploc,pdepend,phpmd-ci,phpcs-ci,phpcpd,phpdox,phpunit,phpspec,phpcb"/>
 
-    <target name="build-phpunit" depends="prepare,composer,require-mongo,vendors-no-scripts,phpunit,phpspec,phpspec-junit"/>
+    <target name="build-phpunit" depends="prepare,composer,vendors-no-scripts,phpunit,phpspec,phpspec-junit"/>
 
-    <target name="build-coverage" depends="prepare,composer,require-mongo,coverage"/>
+    <target name="build-coverage" depends="prepare,composer,coverage"/>
 
     <target name="build-behat" depends="prepare,composer,vendors,install-all-behat,behat"/>
 
     <target name="build-behat-deprecated" depends="prepare-deprecated-behat,prepare,composer,vendors,install-all-behat,behat"/>
 
-    <target name="build-behat-mongo" depends="prepare,composer,require-mongo,activate-mongo,vendors,install-all-behat,behat"/>
+    <target name="build-behat-mongo" depends="prepare,composer,activate-mongo,vendors,install-all-behat,behat"/>
 
     <target name="build-code-quality" depends="prepare,lint,phploc,pdepend,phpmd-ci,php-cs-fixer,phpcpd,phpdoc"/>
 
@@ -354,15 +354,6 @@
         <exec executable="bash">
             <arg value="-c"/>
             <arg value="curl -sS https://getcomposer.org/installer | php"/>
-        </exec>
-    </target>
-
-    <target name="require-mongo" description="Require the mongo bundle">
-        <exec executable="${basedir}/composer.phar" failonerror="true">
-            <arg value="require" />
-            <arg value="--no-update" />
-            <arg value="doctrine/mongodb-odm-bundle" />
-            <arg value="v3.0.1" />
         </exec>
     </target>
 


### PR DESCRIPTION
Remove useless `require-mongo` as this dependency is already in our composer.json.


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       |
| Added Behats                      |
| Changelog updated                 |
| Review and 2 GTM                  |
| Micro Demo to the PO (Story only) |
| Migration script                  |
| Tech Doc                          |

