### PR TITLE
Fix glitch on flash messages

### DIFF
--- a/src/Pim/Bundle/UIBundle/Resources/public/css/less/oro.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/css/less/oro.less
@@ -1008,6 +1008,8 @@ select:focus:invalid:focus {
   overflow: hidden;
 }
 .flash-messages-frame {
+  position: fixed;
+  top: 74px;
   left: 25%;
   z-index: 500;
   width: 50%;


### PR DESCRIPTION
This PR fixes a regression between 1.5 and 1.6 on flash messages display.

Before the PR:
![before](https://cloud.githubusercontent.com/assets/659491/18199917/bfa4699a-7102-11e6-8e52-cc3337055241.png)

After:
![after](https://cloud.githubusercontent.com/assets/659491/18199925/c9fa6bd8-7102-11e6-9ad9-e9d0e3d5d162.png)
