### PR TITLE
Remove useless test as there is already @require on spec

### DIFF
--- a/src/Akeneo/Bundle/StorageUtilsBundle/spec/Doctrine/SmartManagerRegistrySpec.php
+++ b/src/Akeneo/Bundle/StorageUtilsBundle/spec/Doctrine/SmartManagerRegistrySpec.php
@@ -46,9 +46,6 @@ class SmartManagerRegistrySpec extends ObjectBehavior
         $odmRegistry,
         $customRegistry
     ) {
-        if (!class_exists('Doctrine\ODM\MongoDB\MongoDBException', false)) {
-            throw new SkippingException('Mongo ODM is not installed');
-        }
         $ormRegistry->getAliasNamespace('foo')->willThrow(new ORMException());
         $odmRegistry->getAliasNamespace('foo')->willThrow(new MongoDBException());
         $customRegistry->getAliasNamespace('foo')->willReturn('\Foo');
@@ -61,9 +58,6 @@ class SmartManagerRegistrySpec extends ObjectBehavior
         $odmRegistry,
         $customRegistry
     ) {
-        if (!class_exists('Doctrine\ODM\MongoDB\MongoDBException', false)) {
-            throw new SkippingException('Mongo ODM is not installed');
-        }
         $ormRegistry->getAliasNamespace('foo')->willThrow(new ORMException());
         $odmRegistry->getAliasNamespace('foo')->willThrow(new MongoDBException());
         $customRegistry->getAliasNamespace('foo')->willThrow(new ORMException());


### PR DESCRIPTION
add SkipException is useless as there is already `@require Doctrine\ODM\MongoDB\MongoDBException` on spec.

Add SkipException make this build red however all specs are ok
http://core-ci.akeneo.com/view/PIM%20-%201.6/job/pim-community-dev-1-6-spec/572/console
