### PR TITLE
PIM-5968: Fix back translation for attribute options when value is null

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -1,8 +1,9 @@
-# 1.6.
+# 1.6.x
 
 ## Bug fixes
 
 - PIM-5964: Index category labels by locale code in channel normalization
+- PIM-5968: Fix default translation for attribute options when value is null
 
 ## Functionnal improvements
 

--- a/features/attribute/option/import_attribute_options.feature
+++ b/features/attribute/option/import_attribute_options.feature
@@ -1,0 +1,36 @@
+Feature: Import attribute options
+  In order to define choices for a choice attribute
+  As a product manager
+  I need to import options for attributes
+
+  Background:
+    Given the "footwear" catalog configuration
+    And I am logged in as "Julia"
+    And I am on the attributes page
+    And I create a "Simple select" attribute
+    And I fill in the following information:
+      | Code            | fruit |
+      | Attribute group | Other |
+    And I save the attribute
+
+  @javascript
+  Scenario: Successfully show default translation when blank text
+    Given the following CSV file to import:
+      """
+      code;attribute;sort_order;label-en_US
+      kiwi;fruit;0;
+      """
+    And the following job "csv_footwear_option_import" configuration:
+      | filePath | %file to import% |
+    And I am on the "csv_footwear_option_import" import job page
+    And I launch the import job
+    And I wait for the "csv_footwear_option_import" job to finish
+    And I am on the products page
+    And I create a new product
+    And I fill in the following information in the popin:
+      | SKU | caterpillar |
+    And I press the "Save" button in the popin
+    And I am on the "caterpillar" product page
+    When I add available attributes fruit
+    And I change the "[fruit]" to "[kiwi]"
+    Then I should see the text "[kiwi]"

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/AttributeOptionRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/AttributeOptionRepository.php
@@ -75,9 +75,10 @@ class AttributeOptionRepository extends EntityRepository implements
                 $autoSorting = $row['properties']['autoOptionSorting'];
             }
 
+            $isLabelBlank = (null === $row['label']) || ('' === $row['label']);
             $results[] = [
                 'id'   => (isset($options['type']) && 'code' === $options['type']) ? $row['code'] : $row['id'],
-                'text' => null !== $row['label'] ? $row['label'] : sprintf('[%s]', $row['code'])
+                'text' => $isLabelBlank ? sprintf('[%s]', $row['code']) : $row['label'],
             ];
         }
 
@@ -101,7 +102,7 @@ class AttributeOptionRepository extends EntityRepository implements
     public function getOptionLabel($object, $dataLocale)
     {
         foreach ($object->getOptionValues() as $value) {
-            if ($dataLocale === $value->getLocale() && null !== $value->getValue()) {
+            if ($dataLocale === $value->getLocale() && null !== $value->getValue() && '' !== $value->getValue()) {
                 return $value->getValue();
             }
         }


### PR DESCRIPTION
This little PR fixes the fact than when you import attribute_options without any labels, the value is set to "null", and no label is displayed at all.

*DISCLAIMER*

This is not the best fix. The good solution is to split the AjaxOptionController and to drop all but the SearchableRepositoryInterface to be able to use Normalizers for each options. @momoss begins to create a new one in 1.5, but we can not split all the AjaxOptionController.
The next step of this PR is to make a rework of this in "master" to avoid any BC break.


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | n
| Added Behats                      | y
| Changelog updated                 | y
| Review and 2 GTM                  | TODO
| Micro Demo to the PO (Story only) | n
| Migration script                  | n
| Tech Doc                          | n

