### PR TITLE
PIM-5566: fix decimals in history grid

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -5,6 +5,7 @@
 - PIM-5964: Index category labels by locale code in channel normalization
 - PIM-5968: Fix default translation for attribute options when value is null
 - PIM-5897: fix the does not contain filter to filter on product without product values
+- PIM-5566: Fix version number displayed as decimals
 
 ## Functionnal improvements
 

--- a/features/versioning/ensure_versioning_on_family.feature
+++ b/features/versioning/ensure_versioning_on_family.feature
@@ -19,3 +19,4 @@ Feature: Ensure versioning on family
     Then I should not see the text "There are unsaved changes."
     When I visit the "History" tab
     Then there should be 2 updates
+    And I should not see the text "2.00"

--- a/src/Pim/Bundle/DataGridBundle/Resources/config/requirejs.yml
+++ b/src/Pim/Bundle/DataGridBundle/Resources/config/requirejs.yml
@@ -39,6 +39,7 @@ config:
         oro/datagrid/date-cell:                 pimdatagrid/js/datagrid/cell/date-cell
         oro/datagrid/datetime-cell:             pimdatagrid/js/datagrid/cell/datetime-cell
         oro/datagrid/number-cell:               pimdatagrid/js/datagrid/cell/number-cell
+        oro/datagrid/integer-cell:              pimdatagrid/js/datagrid/cell/integer-cell
         oro/datagrid/select-cell:               pimdatagrid/js/datagrid/cell/select-cell
         oro/datagrid/select-row-cell:           pimdatagrid/js/datagrid/cell/select-row-cell
         oro/datagrid/string-cell:               pimdatagrid/js/datagrid/cell/string-cell

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid-builder.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid-builder.js
@@ -18,7 +18,7 @@ define(function (require) {
         cellModuleName = 'oro/datagrid/{{type}}-cell',
         actionModuleName = 'oro/datagrid/{{type}}-action',
         cellTypes = {
-            integer:   'number',
+            integer:   'integer',
             decimal:   'number',
             percent:   'number'
         },

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/cell/integer-cell.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/cell/integer-cell.js
@@ -1,0 +1,36 @@
+/* global define */
+define(['underscore', 'backgrid'],
+    function(_, Backgrid) {
+        'use strict';
+
+        /**
+         * Integer column cell.
+         *
+         * @export  oro/datagrid/integer-cell
+         * @class   oro.datagrid.NumberCell
+         * @extends Backgrid.NumberCell
+         */
+        return Backgrid.NumberCell.extend({
+            /** @property {String} */
+            style: 'decimal',
+
+            /**
+             * {@inheritdoc}
+             */
+            initialize: function () {
+                this.decimals = 0;
+
+                Backgrid.NumberCell.prototype.initialize.apply(this, arguments);
+            },
+
+            /**
+             * @inheritDoc
+             */
+            enterEditMode: function (e) {
+                if (this.column.get("editable")) {
+                    e.stopPropagation();
+                }
+                return Backgrid.NumberCell.prototype.enterEditMode.apply(this, arguments);
+            }
+        });
+    });


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Before this fix, the version numbers were displayed as decimals. This PR fixes this bug.

**Definition Of Done (for Core Developer only)**


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | NA
| Added Behats                      | Y
| Changelog updated                 | N
| Review and 2 GTM                  | N
| Micro Demo to the PO (Story only) | NA
| Migration script                  | NA
| Tech Doc                          | NA

