### PR TITLE
Remove obsolete "behat/common-contexts"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,6 @@
         "phpmd/phpmd": "1.*",
         "behat/behat": "2.5.5",
         "kriswallsmith/buzz": ">=0.5",
-        "behat/common-contexts": "1.2.0",
         "behat/gherkin":"2.3.5",
         "behat/mink":"1.7.1",
         "behat/mink-browserkit-driver": "1.3.2",


### PR DESCRIPTION
I broke the PIM ( :kissing_heart: ) when I upgraded phpunit, the obsolete package "behat/common-contexts" is not compatible with our new version. I remove it and add usefull methods in `features/Context/WebApiContext`.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       |
| Added Behats                      |
| Changelog updated                 |
| Review and 2 GTM                  |
| Micro Demo to the PO (Story only) |
| Migration script                  |
| Tech Doc                          |

