### PR TITLE
PIM-5976: fix group products saving regression

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -4,8 +4,9 @@
 
 - PIM-5964: Index category labels by locale code in channel normalization
 - PIM-5968: Fix default translation for attribute options when value is null
-- PIM-5897: fix the does not contain filter to filter on product without product values
+- PIM-5897: Fix the does not contain filter to filter on product without product values
 - PIM-5566: Fix version number displayed as decimals
+- PIM-5976: Fix adding products to a group (regression following variant group ajaxification)
 
 ## Functionnal improvements
 

--- a/features/product-group/add_products.feature
+++ b/features/product-group/add_products.feature
@@ -1,0 +1,26 @@
+@javascript
+Feature: Add products to a group
+  In order to manage existing groups for the catalog
+  As a product manager
+  I need to be able to add products to a group
+
+  Background:
+    Given the "footwear" catalog configuration
+    And the following product groups:
+      | code       | label      | type  |
+      | CROSS_SELL | Cross Sell | XSELL |
+    And the following products:
+      | sku             | family  | categories        | size | color |
+      | sandal-white-37 | sandals | winter_collection | 37   | white |
+      | sandal-white-38 | sandals | winter_collection | 38   | white |
+      | sandal-white-39 | sandals | winter_collection | 39   | white |
+    And I am logged in as "Julia"
+
+  Scenario: Successfully add products in groups
+    Given I am on the "CROSS_SELL" product group page
+    And I should see products sandal-white-37 and sandal-white-38
+    And I check the row "sandal-white-37"
+    And I check the row "sandal-white-38"
+    And I save the group
+    Then the row "sandal-white-37" should be checked
+    And the row "sandal-white-38" should be checked

--- a/features/product-group/remove_products.feature
+++ b/features/product-group/remove_products.feature
@@ -1,0 +1,26 @@
+@javascript
+Feature: Remove products from a group
+  In order to manage existing groups for the catalog
+  As a product manager
+  I need to be able to remove products from a group
+
+  Background:
+    Given the "footwear" catalog configuration
+    And the following product groups:
+      | code       | label      | type  |
+      | CROSS_SELL | Cross Sell | XSELL |
+    And the following products:
+      | sku             | groups     | family  | categories        | size | color |
+      | sandal-white-37 | CROSS_SELL | sandals | winter_collection | 37   | white |
+      | sandal-white-38 | CROSS_SELL | sandals | winter_collection | 38   | white |
+      | sandal-white-39 | CROSS_SELL | sandals | winter_collection | 39   | white |
+    And I am logged in as "Julia"
+
+  @jira https://akeneo.atlassian.net/browse/PIM-3736
+  Scenario: Successfully remove a product from the group
+    Given I am on the "CROSS_SELL" product group page
+    Then the grid should contain 3 elements
+    When I uncheck the row "sandal-white-37"
+    And I press the "Save" button
+    Then I should see "Products: 2"
+    And the row "sandal-white-37" should not be checked

--- a/src/Pim/Bundle/EnrichBundle/Form/DataTransformer/EntityToIdentifierTransformer.php
+++ b/src/Pim/Bundle/EnrichBundle/Form/DataTransformer/EntityToIdentifierTransformer.php
@@ -107,8 +107,15 @@ class EntityToIdentifierTransformer implements DataTransformerInterface
             if (!is_array($value)) {
                 throw new UnexpectedTypeException($value, 'array');
             }
-
-            return $this->repository->findBy([$this->identifierProperty => $value]);
+            // PIM-5976: in GroupType, we use the pim_object_identifier field type which rely on product repository,
+            // the findBy(['id' => [1, 2]) does not work properly with Mongodb, the following patch workaround this
+            // Ideally, we should revamp the group management screen to use the same stack than the variant group and
+            // avoid to use this transformer
+            if ('id' === $this->identifierProperty && method_exists($this->repository, 'findByIds')) {
+                return $this->repository->findByIds($value);
+            } else {
+                return $this->repository->findBy([$this->identifierProperty => $value]);
+            }
         }
 
         return $this->repository->findOneBy([$this->identifierProperty => $value]);

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product_group.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product_group.yml
@@ -8,8 +8,8 @@ datagrid:
                 dataField: id
                 columnName: is_checked
                 selectors:
-                    included: '#added_objects'
-                    excluded: '#removed_objects'
+                    included: '#appendProducts'
+                    excluded: '#removeProducts'
         source:
             acl_resource:      pim_enrich_product_index
             type:              pim_datasource_product


### PR DESCRIPTION
Fixed with this PR : Regression since 1.6, products cannot be added to groups anymore via Enrich < Group

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | N
| Added Behats                      | Y
| Changelog updated                 | Y
| Review and 2 GTM                  | Y
| Micro Demo to the PO (Story only) |
| Migration script                  |
| Tech Doc                          |

