### PR TITLE
Bugfix: fix job name visibility checker to also check additional config

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -2,6 +2,7 @@
 
 ## Bug Fixes
 
+- #5038: Fixed job name visibility checker to also check additional config
 - #5062: Fixed unit conversion for ElectricCharge, cheers @gplanchat!
 - #5294: Fixed infinite loading if no attribute is configured as a product identifier, cheers @gplanchat!
 

--- a/src/Pim/Bundle/ImportExportBundle/ViewElement/Checker/JobNameVisibilityChecker.php
+++ b/src/Pim/Bundle/ImportExportBundle/ViewElement/Checker/JobNameVisibilityChecker.php
@@ -40,7 +40,7 @@ class JobNameVisibilityChecker implements VisibilityCheckerInterface
         $jobInstance = $context['jobInstance'];
 
         $jobNames = $this->jobNames;
-        if (isset ($config['job_names'])) {
+        if (isset($config['job_names'])) {
             $jobNames = array_merge($jobNames, $config['job_names']);
         }
 

--- a/src/Pim/Bundle/ImportExportBundle/ViewElement/Checker/JobNameVisibilityChecker.php
+++ b/src/Pim/Bundle/ImportExportBundle/ViewElement/Checker/JobNameVisibilityChecker.php
@@ -39,6 +39,11 @@ class JobNameVisibilityChecker implements VisibilityCheckerInterface
 
         $jobInstance = $context['jobInstance'];
 
-        return in_array($jobInstance->getJobName(), $this->jobNames);
+        $jobNames = $this->jobNames;
+        if (isset ($config['job_names'])) {
+            $jobNames = array_merge($jobNames, $config['job_names']);
+        }
+
+        return in_array($jobInstance->getJobName(), $jobNames);
     }
 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Check additional job_names supplied in the $config parameter of the job name visibility checker

| Q | A |
| --- | --- |
| Added Specs | no |
| Added Behats | no |
| Changelog updated | yes |
| Review and 2 GTM | no |
| Micro Demo to the PO (Story only) | no |
| Migration script | no |
|  Tech Doc | no |

Right now, additional job names supplied by $config are ignored. For instance, when adding a visibility checker to a custom job, the supplied job name will appear here in the $config variable. So also check that variable, together with the jobNames instance variable.
