### PR TITLE
Pim-5037: Fix missing directory separator in default path for product export

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -8,6 +8,7 @@
 - PIM-5566: Fix version number displayed as decimals
 - PIM-5976: Fix adding products to a group (regression following variant group ajaxification)
 - PIM-5975 & #5016: Fix attribute groups order not kept in product edit form, cheers @julienanquetil!
+- PIM-5037 Fix missing directory separator in default path for product export
 
 ## Functionnal improvements
 

--- a/src/Pim/Component/Connector/Job/JobParameters/DefaultValuesProvider/ProductCsvExport.php
+++ b/src/Pim/Component/Connector/Job/JobParameters/DefaultValuesProvider/ProductCsvExport.php
@@ -57,7 +57,7 @@ class ProductCsvExport implements DefaultValuesProviderInterface
         $parameters['decimalSeparator'] = LocalizerInterface::DEFAULT_DECIMAL_SEPARATOR;
         $parameters['dateFormat'] = LocalizerInterface::DEFAULT_DATE_FORMAT;
         $parameters['with_media'] = true;
-        $parameters['filePath'] = sys_get_temp_dir() . 'csv_products_export.csv';
+        $parameters['filePath'] = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'csv_products_export.csv';
 
         $channels = $this->channelRepository->getFullChannels();
         $defaultChannelCode = (0 !== count($channels)) ? $channels[0]->getCode() : null;

--- a/src/Pim/Component/Connector/Job/JobParameters/DefaultValuesProvider/ProductXlsxExport.php
+++ b/src/Pim/Component/Connector/Job/JobParameters/DefaultValuesProvider/ProductXlsxExport.php
@@ -57,7 +57,7 @@ class ProductXlsxExport implements DefaultValuesProviderInterface
         $parameters['decimalSeparator'] = LocalizerInterface::DEFAULT_DECIMAL_SEPARATOR;
         $parameters['dateFormat'] = LocalizerInterface::DEFAULT_DATE_FORMAT;
         $parameters['with_media'] = true;
-        $parameters['filePath'] = sys_get_temp_dir() . 'csv_products_export.xlsx';
+        $parameters['filePath'] = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'csv_products_export.xlsx';
         $parameters['linesPerFile'] = 10000;
 
         $channels = $this->channelRepository->getFullChannels();


### PR DESCRIPTION
added missing directory separator to the default filePath 

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | no
| Added Behats                      | no
| Changelog updated                 | yes
| Review and 2 GTM                  | no
| Migration script                  | no
| Tech Doc                          | no