### PR TITLE
PIM-5977: Fix missing products in the variant group edit form

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - #4987: Fix hardcoded image URLs in the dashboard, cheers @julienanquetil!
+- PIM-5978 : Fix missing products in the variant group edit form
 
 # 1.6.3 (2016-09-22)
 

--- a/features/enrich/variant-group/edit_variant_browse_products.feature
+++ b/features/enrich/variant-group/edit_variant_browse_products.feature
@@ -14,30 +14,43 @@ Feature: Edit a variant group adding/removing products
       | code  | label | type         | useable_as_grid_filter |
       | color | Color | simpleselect | yes                    |
       | size  | Size  | simpleselect | yes                    |
-    And the following "color" attribute options: Yellow, Blue, Green and Red
+    And the following "color" attribute options: Yellow, Blue, Green, Pink and Red
     And the following "size" attribute options: XS, S, M, L and XL
-    And the following products:
-      | sku    | family    | color | size |
-      | MUG_1  | mug       | Red   | XL   |
-      | MUG_2  | mug       | Green |      |
-      | MUG_3  | mug       |       | S    |
-      | POSTIT | furniture | Blue  | M    |
     And the following product groups:
-      | code   | label      | axis        | type    |
-      | MUG    | MUG Akeneo | color       | VARIANT |
-      | POSTIT | Postit     | color, size | VARIANT |
+      | code       | label      | axis        | type    |
+      | MUG        | MUG Akeneo | color       | VARIANT |
+      | POSTIT     | Postit     | color, size | VARIANT |
+      | CROSS_SELL | Cross sell |             | X_SELL |
+    And the following products:
+      | sku    | groups          | family    | color  | size |
+      | MUG_A1 |                 | mug       |        |      |
+      | MUG_A2 |                 | mug       | Red    | XL   |
+      | MUG_A3 |                 | mug       | Green  |      |
+      | MUG_A4 |                 | mug       |        | S    |
+      | MUG_B1 | MUG             | mug       | Yellow | M    |
+      | MUG_B2 | MUG             | mug       | Blue   |      |
+      | MUG_C1 | CROSS_SELL      | mug       |        |      |
+      | MUG_C2 | CROSS_SELL      | mug       | Yellow | M    |
+      | MUG_C3 | CROSS_SELL      | mug       | Red    |      |
+      | MUG_C4 | CROSS_SELL      | mug       |        | XL   |
+      | MUG_D1 | CROSS_SELL, MUG | mug       | Green  | L    |
+      | MUG_D2 | CROSS_SELL, MUG | mug       | Pink   |      |
+      | POSTIT |                 | furniture | Blue   | M    |
     And I am logged in as "Julia"
 
   Scenario: Successfully display the product datagrid when I edit a variant group
     Given I am on the "MUG" variant group page
-    Then the grid should contain 3 elements
-    And I should see products MUG_1, MUG_2 and POSTIT
-    And I should not see product MUG_3
+    Then the grid should contain 9 elements
+    And I should see products MUG_A2, MUG_A3, MUG_B1, MUG_B2, MUG_C2, MUG_C3, MUG_D1, MUG_D2 and POSTIT
+    And I should not see product MUG_A1, MUG_A4, MUG_C1 and MUG_C4
+    And the rows "MUG_B1, MUG_B2, MUG_D1 and MUG_D2" should be checked
+    And the rows "MUG_A2, MUG_A3, MUG_C2, MUG_C3 and POSTIT" should not be checked
     And I should see the columns In group, SKU, Color, Label, Family, Status, Complete, Created at and Updated at
 
   Scenario: Successfully display the product datagrid when I edit a variant group with 2 axes
     Given I am on the "POSTIT" variant group page
-    Then the grid should contain 2 elements
-    And I should see products MUG_1 and POSTIT
-    And I should not see products MUG_2 and MUG_3
+    Then the grid should contain 3 elements
+    And I should see products MUG_A2, MUG_C2 and POSTIT
+    And I should not see products MUG_A1, MUG_A3, MUG_A4, MUG_B1, MUG_B2, MUG_C1, MUG_C3, MUG_C4, MUG_D1 and MUG_D2
+    And the rows "MUG_A2, MUG_C2 and POSTIT" should not be checked
     And I should see the columns In group, SKU, Color, Size, Label, Family, Status, Complete, Created at and Updated at


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

In Mysql storage only, when a product is in a group (not a variant group), this one is not visible anymore in the variant group edit form,
even if the product has the axis (and, therefore, is eligible to the variant group).

When you take off the product from the group, this one is visible in  the variant group edit form.

The SQL request to know the eligible products was wrong.

**Definition Of Done (for Core Developer only)**


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | n
| Added Behats                      | y
| Changelog updated                 | y
| Review and 2 GTM                  | n
| Micro Demo to the PO (Story only) | n
| Migration script                  | n
| Tech Doc                          | n
