### PR TITLE
Pim 5982: Missing job instance parameters when using custom configuration in command line

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - #4987: Fix hardcoded image URLs in the dashboard, cheers @julienanquetil!
+- PIM-5982: Missing job instance parameters when using custom configuration in command line
 
 # 1.6.3 (2016-09-22)
 

--- a/features/Context/CommandContext.php
+++ b/features/Context/CommandContext.php
@@ -217,4 +217,13 @@ class CommandContext extends PimContext
     {
         return $this->getMainContext()->getSubcontext('fixtures');
     }
+
+    /**
+     * @When /^I run '([^\']*)'$/
+     */
+    public function iRun($command)
+    {
+        $command = $this->replacePlaceholders($command);
+        $this->output = shell_exec('php app/console ' . $command);
+    }
 }

--- a/features/export/execute_an_export.feature
+++ b/features/export/execute_an_export.feature
@@ -34,3 +34,9 @@ Feature: Execute a job
     Then I should see "Execution details"
     And file "%tmp%/product_export/product_export.csv" should exist
     And an email to "Julia@example.com" should have been sent
+
+  @ce @jira https://akeneo.atlassian.net/browse/PIM-5982
+  Scenario: Successfully launch an export with custom parameters
+    When I run 'akeneo:batch:job csv_product_export -c "{\"filePath\": \"%tmp%/productCustomConfig.csv\"}"'
+    Then file "%tmp%/productCustomConfig.csv" should exist
+    And file "%tmp%/productCustomConfig.csv" should contain 113 rows

--- a/src/Akeneo/Bundle/BatchBundle/Command/BatchCommand.php
+++ b/src/Akeneo/Bundle/BatchBundle/Command/BatchCommand.php
@@ -91,12 +91,11 @@ class BatchCommand extends ContainerAwareCommand
 
         $job = $this->getJobRegistry()->get($jobInstance->getJobName());
         $jobParamsFactory = $this->getJobParametersFactory();
+        $rawParameters = $jobInstance->getRawParameters();
         if ($config = $input->getOption('config')) {
-            $rawParameters = $this->decodeConfiguration($config);
-            $jobParameters = $jobParamsFactory->create($job, $rawParameters);
-        } else {
-            $jobParameters = $jobParamsFactory->create($job, $jobInstance->getRawParameters());
+            $rawParameters = array_merge($rawParameters, $this->decodeConfiguration($config));
         }
+        $jobParameters = $jobParamsFactory->create($job, $rawParameters);
         $validator = $this->getValidator();
 
         // Override mail notifier recipient email


### PR DESCRIPTION
Fix for an issue with exports in command line mode.

The job instance parameters were lost if the user use a custom config.

As an example, if an user run an export with a custom file path like this :

app/console akeneo:batch:job csv_product_export -c "{\"filePath\": \"/custom/path/products.csv\"}"

The other job instance parameters are ignored, including the tree to export, so that the generated file is empty.

I solve that with a simple array_merge between default job parameters and user provided parameters.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | N
| Added Behats                      | Y
| Changelog updated                 |  Y
| Review and 2 GTM                  |
| Micro Demo to the PO (Story only) | N
| Migration script                  | N
| Tech Doc                          | N
