### PR TITLE
Moved \ArrayIterator to \Iterator type hints

### DIFF
--- a/src/Akeneo/Bundle/StorageUtilsBundle/Doctrine/ORM/Cursor/Cursor.php
+++ b/src/Akeneo/Bundle/StorageUtilsBundle/Doctrine/ORM/Cursor/Cursor.php
@@ -29,7 +29,7 @@ class Cursor extends AbstractCursor
     /** @var int */
     protected $count;
 
-    /** @var \ArrayIterator */
+    /** @var \Iterator */
     protected $entitiesPage;
 
     /** @var EntityManager */
@@ -185,7 +185,7 @@ class Cursor extends AbstractCursor
     /**
      * Get next entities batch from DB
      *
-     * @return \ArrayIterator
+     * @return \Iterator
      */
     protected function getNextEntitiesPage()
     {

--- a/src/Akeneo/Component/StorageUtils/Cursor/Paginator.php
+++ b/src/Akeneo/Component/StorageUtils/Cursor/Paginator.php
@@ -101,7 +101,12 @@ class Paginator implements PaginatorInterface
      */
     public function valid()
     {
-        return $this->pageNumber < $this->count();
+        if ($this->pageNumber < $this->count()) {
+            return true;
+        }
+
+        $this->pageData = false;
+        return false;
     }
 
     /**
@@ -119,29 +124,22 @@ class Paginator implements PaginatorInterface
      */
     public function count()
     {
-        return intval(ceil($this->cursor->count() / $this->pageSize));
+        return (int) ceil($this->cursor->count() / $this->pageSize);
     }
 
     /**
-     * @return array
+     * @return \Traversable
      */
     private function getNextDataPage()
     {
-        $result = [];
         $pageSize = 0;
         do {
             $current = $this->cursor->current();
             if (null !== $current && false !== $current) {
-                $result[] = $current;
+                yield $current;
             }
             $pageSize++;
             $this->cursor->next();
         } while ($pageSize < $this->pageSize && null !== $current && false !== $current);
-
-        if (empty($result)) {
-            return false;
-        }
-
-        return $result;
     }
 }

--- a/src/Akeneo/Component/StorageUtils/spec/Cursor/PaginatorSpec.php
+++ b/src/Akeneo/Component/StorageUtils/spec/Cursor/PaginatorSpec.php
@@ -38,9 +38,6 @@ class PaginatorSpec extends ObjectBehavior
             new Entity(13)
         ];
 
-        $page1 = array_slice($data, 0, 10);
-        $page2 = array_slice($data, 10, 10);
-
         $iterator = new \ArrayIterator($data);
 
         $cursor->count()->will(function() use($iterator) {

--- a/src/Akeneo/Component/StorageUtils/spec/Cursor/PaginatorSpec.php
+++ b/src/Akeneo/Component/StorageUtils/spec/Cursor/PaginatorSpec.php
@@ -22,7 +22,7 @@ class PaginatorSpec extends ObjectBehavior
 
     function it_iterate_by_page_over_cursor(CursorInterface $cursor)
     {
-        $page1 = [
+        $data = [
             new Entity(1),
             new Entity(2),
             new Entity(3),
@@ -32,37 +32,45 @@ class PaginatorSpec extends ObjectBehavior
             new Entity(7),
             new Entity(8),
             new Entity(9),
-            new Entity(10)
+            new Entity(10),
+            new Entity(11),
+            new Entity(12),
+            new Entity(13)
         ];
-        $page2 = [new Entity(11), new Entity(12), new Entity(13)];
-        $data = array_merge($page1, $page2);
 
-        $cursor->count()->shouldBeCalled()->willReturn(13);
-        $cursor->next()->shouldBeCalled()->will(function () use ($cursor, &$data) {
-            $item = array_shift($data);
-            if ($item === null) {
-                $item = false;
-            }
-            $cursor->current()->willReturn($item);
+        $page1 = array_slice($data, 0, 10);
+        $page2 = array_slice($data, 10, 10);
+
+        $iterator = new \ArrayIterator($data);
+
+        $cursor->count()->will(function() use($iterator) {
+            return $iterator->count();
         });
-        $cursor->rewind()->shouldBeCalled()->will(function () use ($cursor, &$data, $page1, $page2) {
-            $data = array_merge($page1, $page2);
-            $item = array_shift($data);
-            if ($item === null) {
-                $item = false;
-            }
-            $cursor->current()->willReturn($item);
+        $cursor->current()->will(function() use($iterator) {
+            return $iterator->current();
+        });
+        $cursor->next()->will(function() use($iterator) {
+            $iterator->next();
+        });
+        $cursor->key()->will(function() use($iterator) {
+            return $iterator->key();
+        });
+        $cursor->valid()->will(function() use($iterator) {
+            return $iterator->valid();
+        });
+        $cursor->rewind()->will(function() use($iterator) {
+            $iterator->rewind();
         });
 
         // for each call sequence
         $this->rewind()->shouldReturn(null);
         $this->valid()->shouldReturn(true);
-        $this->current()->shouldReturn($page1);
+        $this->current()->shouldReturnAnInstanceOf(\Traversable::class);
         $this->key()->shouldReturn(0);
 
         $this->next()->shouldReturn(null);
         $this->valid()->shouldReturn(true);
-        $this->current()->shouldReturn($page2);
+        $this->current()->shouldReturnAnInstanceOf(\Traversable::class);
         $this->key()->shouldReturn(1);
 
         $this->next()->shouldReturn(null);
@@ -76,8 +84,8 @@ class PaginatorSpec extends ObjectBehavior
         $this->rewind()->shouldReturn(null);
         $this->valid()->shouldReturn(true);
         $this->valid()->shouldReturn(true);
-        $this->current()->shouldReturn($page1);
-        $this->current()->shouldReturn($page1);
+        $this->current()->shouldReturnAnInstanceOf(\Traversable::class);
+        $this->current()->shouldReturnAnInstanceOf(\Traversable::class);
         $this->key()->shouldReturn(0);
         $this->key()->shouldReturn(0);
     }

--- a/src/Oro/Bundle/SecurityBundle/Acl/Persistence/AclPrivilegeRepository.php
+++ b/src/Oro/Bundle/SecurityBundle/Acl/Persistence/AclPrivilegeRepository.php
@@ -445,7 +445,7 @@ class AclPrivilegeRepository
      */
     protected function sortPrivileges(ArrayCollection &$privileges)
     {
-        /** @var \ArrayIterator $iterator */
+        /** @var \Iterator $iterator */
         $iterator = $privileges->getIterator();
         $iterator->uasort(
             function (AclPrivilege $a, AclPrivilege $b) {

--- a/src/Pim/Component/Connector/Reader/Database/AbstractReader.php
+++ b/src/Pim/Component/Connector/Reader/Database/AbstractReader.php
@@ -22,7 +22,7 @@ abstract class AbstractReader implements ItemReaderInterface, InitializableInter
     /** @var StepExecution */
     protected $stepExecution;
 
-    /** @var \ArrayIterator */
+    /** @var \Iterator */
     protected $results;
 
     /**
@@ -61,7 +61,7 @@ abstract class AbstractReader implements ItemReaderInterface, InitializableInter
     }
 
     /**
-     * @return \ArrayIterator
+     * @return \Iterator
      */
     abstract protected function getResults();
 }

--- a/src/Pim/Component/Connector/Reader/File/Yaml/Reader.php
+++ b/src/Pim/Component/Connector/Reader/File/Yaml/Reader.php
@@ -37,7 +37,7 @@ class Reader implements ItemReaderInterface, StepExecutionAwareInterface, Flusha
     /** @var StepExecution */
     protected $stepExecution;
 
-    /** @var \ArrayIterator */
+    /** @var \Iterator */
     protected $yaml;
 
     /**


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

I changed some return type hints of connector methods using `\ArrayIterator`, I instead replaced them with `\Iterator`.

Now, you can use `\Generator`s... or whatever iterator you desire.

**Definition Of Done (for Core Developer only)**

| Q | A |
| --- | --- |
| Added Specs |  |
| Added Behats |  |
| Changelog updated |  |
| Review and 2 GTM |  |
| Micro Demo to the PO (Story only) |  |
| Migration script |  |
|  Tech Doc |  |
