### PR TITLE
AMS-3: Make view selector footer extensible

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/grid/view-selector-footer.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/grid/view-selector-footer.js
@@ -49,6 +49,8 @@ define(
                     buttonTitle: __('grid.view_selector.create')
                 }));
 
+                this.renderExtensions();
+
                 return this;
             },
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/grid/view-selector-footer.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/grid/view-selector-footer.html
@@ -1,5 +1,5 @@
 <div class="ui-multiselect-footer">
-    <span class="left-footer"></span>
+    <span class="left-footer" data-drop-zone="left-footer"></span>
     <button class="btn btn-primary pull-right icons-holder-text" data-action="prompt-creation" type="button">
         <i class="icon-plus"></i> <%- buttonTitle %>
     </button>


### PR DESCRIPTION
This PR make the view selector footer extensible by adding a data drop zone in template and rendering extensions.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | no need
| Added Behats                      | no need
| Changelog updated                 | no need
| Review and 2 GTM                  | 
| Micro Demo to the PO (Story only) | no functional update
| Migration script                  |
| Tech Doc                          |

