### PR TITLE
StorageUtils events specialization

### DIFF
--- a/src/Akeneo/Bundle/StorageUtilsBundle/Doctrine/Common/Remover/BaseRemover.php
+++ b/src/Akeneo/Bundle/StorageUtilsBundle/Doctrine/Common/Remover/BaseRemover.php
@@ -2,6 +2,7 @@
 
 namespace Akeneo\Bundle\StorageUtilsBundle\Doctrine\Common\Remover;
 
+use Akeneo\Component\StorageUtils\Event\BulkRemoveEvent;
 use Akeneo\Component\StorageUtils\Event\RemoveEvent;
 use Akeneo\Component\StorageUtils\Remover\BulkRemoverInterface;
 use Akeneo\Component\StorageUtils\Remover\RemoverInterface;
@@ -72,7 +73,7 @@ class BaseRemover implements RemoverInterface, BulkRemoverInterface
         foreach ($objects as $object) {
             $this->validateObject($object);
 
-            $this->eventDispatcher->dispatch(StorageEvents::PRE_REMOVE, new RemoveEvent($object, $object->getId(), $options));
+            $this->eventDispatcher->dispatch(StorageEvents::PRE_REMOVE, new BulkRemoveEvent($object, $object->getId(), $options));
 
             $this->objectManager->remove($object);
         }
@@ -80,7 +81,7 @@ class BaseRemover implements RemoverInterface, BulkRemoverInterface
         $this->objectManager->flush();
 
         foreach ($objects as $object) {
-            $this->eventDispatcher->dispatch(StorageEvents::POST_REMOVE, new RemoveEvent($object, $object->getId(), $options));
+            $this->eventDispatcher->dispatch(StorageEvents::POST_REMOVE, new BulkRemoveEvent($object, $object->getId(), $options));
         }
     }
 

--- a/src/Akeneo/Bundle/StorageUtilsBundle/Doctrine/Common/Saver/BaseSaver.php
+++ b/src/Akeneo/Bundle/StorageUtilsBundle/Doctrine/Common/Saver/BaseSaver.php
@@ -2,13 +2,14 @@
 
 namespace Akeneo\Bundle\StorageUtilsBundle\Doctrine\Common\Saver;
 
+use Akeneo\Component\StorageUtils\Event\BulkSaveEvent;
+use Akeneo\Component\StorageUtils\Event\SaveEvent;
 use Akeneo\Component\StorageUtils\Saver\BulkSaverInterface;
 use Akeneo\Component\StorageUtils\Saver\SaverInterface;
 use Akeneo\Component\StorageUtils\StorageEvents;
 use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\Common\Util\ClassUtils;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\EventDispatcher\GenericEvent;
 
 /**
  * Base saver, declared as different services for different classes
@@ -50,13 +51,13 @@ class BaseSaver implements SaverInterface, BulkSaverInterface
     {
         $this->validateObject($object);
 
-        $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE, new GenericEvent($object, $options));
+        $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE, new SaveEvent($object, $options));
 
         $this->objectManager->persist($object);
 
         $this->objectManager->flush();
 
-        $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE, new GenericEvent($object, $options));
+        $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE, new SaveEvent($object, $options));
     }
 
     /**
@@ -68,13 +69,12 @@ class BaseSaver implements SaverInterface, BulkSaverInterface
             return;
         }
 
-        $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE_ALL, new GenericEvent($objects, $options));
-
+        $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE_ALL, new BulkSaveEvent($objects, $options));
 
         foreach ($objects as $object) {
             $this->validateObject($object);
 
-            $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE, new GenericEvent($object, $options));
+            $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE, new BulkSaveEvent($object, $options));
 
             $this->objectManager->persist($object);
         }
@@ -82,10 +82,10 @@ class BaseSaver implements SaverInterface, BulkSaverInterface
         $this->objectManager->flush();
 
         foreach ($objects as $object) {
-            $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE, new GenericEvent($object, $options));
+            $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE, new BulkSaveEvent($object, $options));
         }
 
-        $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE_ALL, new GenericEvent($objects, $options));
+        $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE_ALL, new BulkSaveEvent($objects, $options));
     }
 
     /**

--- a/src/Akeneo/Component/StorageUtils/Event/BulkRemoveEvent.php
+++ b/src/Akeneo/Component/StorageUtils/Event/BulkRemoveEvent.php
@@ -12,7 +12,7 @@ use Symfony\Component\EventDispatcher\GenericEvent;
  * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class RemoveEvent extends GenericEvent implements SubjectAwareInterface, StorageEventInterface
+class BulkRemoveEvent extends GenericEvent implements SubjectAwareInterface, StorageEventInterface
 {
     use SubjectIdAwareTrait;
 
@@ -33,6 +33,6 @@ class RemoveEvent extends GenericEvent implements SubjectAwareInterface, Storage
      */
     public function isBulk()
     {
-        return false;
+        return true;
     }
 }

--- a/src/Akeneo/Component/StorageUtils/Event/BulkSaveEvent.php
+++ b/src/Akeneo/Component/StorageUtils/Event/BulkSaveEvent.php
@@ -12,20 +12,15 @@ use Symfony\Component\EventDispatcher\GenericEvent;
  * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class RemoveEvent extends GenericEvent implements SubjectAwareInterface, StorageEventInterface
+class BulkSaveEvent extends GenericEvent implements StorageEventInterface
 {
-    use SubjectIdAwareTrait;
-
     /**
      * @param mixed $subject
-     * @param int   $subjectId
      * @param array $arguments
      */
-    public function __construct($subject, $subjectId, array $arguments = [])
+    public function __construct($subject, array $arguments = [])
     {
         parent::__construct($subject, $arguments);
-
-        $this->setSubjectId($subjectId);
     }
 
     /**
@@ -33,6 +28,6 @@ class RemoveEvent extends GenericEvent implements SubjectAwareInterface, Storage
      */
     public function isBulk()
     {
-        return false;
+        return true;
     }
 }

--- a/src/Akeneo/Component/StorageUtils/Event/SaveEvent.php
+++ b/src/Akeneo/Component/StorageUtils/Event/SaveEvent.php
@@ -12,20 +12,15 @@ use Symfony\Component\EventDispatcher\GenericEvent;
  * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class RemoveEvent extends GenericEvent implements SubjectAwareInterface, StorageEventInterface
+class SaveEvent extends GenericEvent implements StorageEventInterface
 {
-    use SubjectIdAwareTrait;
-
     /**
      * @param mixed $subject
-     * @param int   $subjectId
      * @param array $arguments
      */
-    public function __construct($subject, $subjectId, array $arguments = [])
+    public function __construct($subject, array $arguments = [])
     {
         parent::__construct($subject, $arguments);
-
-        $this->setSubjectId($subjectId);
     }
 
     /**

--- a/src/Akeneo/Component/StorageUtils/Event/StorageEventInterface.php
+++ b/src/Akeneo/Component/StorageUtils/Event/StorageEventInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Akeneo\Component\StorageUtils\Event;
+
+/**
+ * Storage event interface
+ *
+ * @author    Julien Sanchez <julien@akeneo.com>
+ * @author    Grégory Planchat <gregory@kiboko.fr>
+ * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface StorageEventInterface extends \ArrayAccess, \IteratorAggregate
+{
+    /**
+     * @return bool
+     */
+    public function isBulk();
+}

--- a/src/Akeneo/Component/StorageUtils/Event/SubjectAwareInterface.php
+++ b/src/Akeneo/Component/StorageUtils/Event/SubjectAwareInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Akeneo\Component\StorageUtils\Event;
+
+/**
+ * Remove envent
+ *
+ * @author    Julien Sanchez <julien@akeneo.com>
+ * @author    Grégory Planchat <gregory@kiboko.fr>
+ * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface SubjectAwareInterface
+{
+    /**
+     * Getter for subject property.
+     *
+     * @return mixed $subject The observer subject.
+     */
+    public function getSubject();
+
+    /**
+     * Get subject id
+     *
+     * @return int
+     */
+    public function getSubjectId();
+}

--- a/src/Akeneo/Component/StorageUtils/Event/SubjectIdAwareTrait.php
+++ b/src/Akeneo/Component/StorageUtils/Event/SubjectIdAwareTrait.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Akeneo\Component\StorageUtils\Event;
+
+/**
+ * Remove envent
+ *
+ * @author    Julien Sanchez <julien@akeneo.com>
+ * @author    Grégory Planchat <gregory@kiboko.fr>
+ * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+trait SubjectIdAwareTrait
+{
+    /** @var int */
+    protected $subjectId;
+    
+    /**
+     * Get subject id
+     *
+     * @param int $subjectId
+     */
+    protected function setSubjectId($subjectId)
+    {
+        $this->subjectId = $subjectId;
+    }
+
+    /**
+     * Get subject id
+     *
+     * @return int
+     */
+    public function getSubjectId()
+    {
+        return $this->subjectId;
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/AttributeSaver.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/AttributeSaver.php
@@ -2,6 +2,8 @@
 
 namespace Pim\Bundle\CatalogBundle\Doctrine\Common\Saver;
 
+use Akeneo\Component\StorageUtils\Event\BulkSaveEvent;
+use Akeneo\Component\StorageUtils\Event\SaveEvent;
 use Akeneo\Component\StorageUtils\Saver\BulkSaverInterface;
 use Akeneo\Component\StorageUtils\Saver\SaverInterface;
 use Akeneo\Component\StorageUtils\StorageEvents;
@@ -9,7 +11,6 @@ use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\Common\Util\ClassUtils;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\EventDispatcher\GenericEvent;
 
 /**
  * Attribute saver
@@ -45,13 +46,13 @@ class AttributeSaver implements SaverInterface, BulkSaverInterface
     {
         $this->validateAttribute($attribute);
 
-        $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE, new GenericEvent($attribute, $options));
+        $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE, new SaveEvent($attribute, $options));
 
         $this->objectManager->persist($attribute);
 
         $this->objectManager->flush();
 
-        $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE, new GenericEvent($attribute, $options));
+        $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE, new SaveEvent($attribute, $options));
     }
 
     /**
@@ -63,12 +64,12 @@ class AttributeSaver implements SaverInterface, BulkSaverInterface
             return;
         }
 
-        $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE_ALL, new GenericEvent($attributes, $options));
+        $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE_ALL, new BulkSaveEvent($attributes, $options));
 
         foreach ($attributes as $attribute) {
             $this->validateAttribute($attribute);
 
-            $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE, new GenericEvent($attribute, $options));
+            $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE, new BulkSaveEvent($attribute, $options));
 
             $this->objectManager->persist($attribute);
         }
@@ -76,10 +77,10 @@ class AttributeSaver implements SaverInterface, BulkSaverInterface
         $this->objectManager->flush();
 
         foreach ($attributes as $attribute) {
-            $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE, new GenericEvent($attribute, $options));
+            $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE, new BulkSaveEvent($attribute, $options));
         }
 
-        $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE_ALL, new GenericEvent($attributes, $options));
+        $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE_ALL, new BulkSaveEvent($attributes, $options));
     }
 
     /**
@@ -90,7 +91,8 @@ class AttributeSaver implements SaverInterface, BulkSaverInterface
         if (!$attribute instanceof AttributeInterface) {
             throw new \InvalidArgumentException(
                 sprintf(
-                    'Expects a "Pim\Component\Catalog\Model\AttributeInterface", "%s" provided.',
+                    'Expects a "%s", "%s" provided.',
+                    AttributeInterface::class,
                     ClassUtils::getClass($attribute)
                 )
             );

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/GroupSaver.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/GroupSaver.php
@@ -2,9 +2,9 @@
 
 namespace Pim\Bundle\CatalogBundle\Doctrine\Common\Saver;
 
+use Akeneo\Component\StorageUtils\Detacher\BulkObjectDetacherInterface;
 use Akeneo\Component\StorageUtils\Event\BulkSaveEvent;
 use Akeneo\Component\StorageUtils\Event\SaveEvent;
-use Akeneo\Component\StorageUtils\Detacher\BulkObjectDetacherInterface;
 use Akeneo\Component\StorageUtils\Saver\BulkSaverInterface;
 use Akeneo\Component\StorageUtils\Saver\SaverInterface;
 use Akeneo\Component\StorageUtils\Saver\SavingOptionsResolverInterface;

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Saver/ProductSaver.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Saver/ProductSaver.php
@@ -3,6 +3,8 @@
 namespace Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Saver;
 
 use Akeneo\Bundle\StorageUtilsBundle\MongoDB\MongoObjectsFactory;
+use Akeneo\Component\StorageUtils\Event\BulkSaveEvent;
+use Akeneo\Component\StorageUtils\Event\SaveEvent;
 use Akeneo\Component\StorageUtils\Saver\BulkSaverInterface;
 use Akeneo\Component\StorageUtils\StorageEvents;
 use Akeneo\Component\Versioning\BulkVersionBuilderInterface;
@@ -89,7 +91,7 @@ class ProductSaver extends BaseProductSaver
             return;
         }
 
-        $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE_ALL, new GenericEvent($products, $options));
+        $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE_ALL, new BulkSaveEvent($products, $options));
 
         $productsToInsert = [];
         $productsToUpdate = [];
@@ -102,7 +104,7 @@ class ProductSaver extends BaseProductSaver
                 $productsToUpdate[] = $product;
             }
 
-            $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE, new GenericEvent($product, $options));
+            $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE, new BulkSaveEvent($product, $options));
         }
 
         $insertDocs = $this->getDocsFromProducts($productsToInsert);
@@ -119,13 +121,13 @@ class ProductSaver extends BaseProductSaver
         foreach ($products as $product) {
             $this->completenessManager->generateMissingForProduct($product);
 
-            $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE, new GenericEvent($product, $options));
+            $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE, new BulkSaveEvent($product, $options));
         }
 
         $versions = $this->bulkVersionBuilder->buildVersions($products);
         $this->versionSaver->saveAll($versions);
 
-        $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE_ALL, new GenericEvent($products, $options));
+        $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE_ALL, new BulkSaveEvent($products, $options));
     }
 
     /**

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/Common/Saver/ProductSaverSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/Common/Saver/ProductSaverSpec.php
@@ -82,7 +82,7 @@ class ProductSaverSpec extends ObjectBehavior
         $objectManager->persist(Argument::any())->shouldNotBeCalled();
 
         $this
-            ->shouldThrow(new \InvalidArgumentException('Expects a Pim\Component\Catalog\Model\ProductInterface, "stdClass" provided'))
+            ->shouldThrow(new \InvalidArgumentException('Expects a "Pim\Component\Catalog\Model\ProductInterface", "stdClass" provided'))
             ->duringSave($otherObject);
     }
 }


### PR DESCRIPTION
Specializes the `StorageUtils` component's events, helping third-party developers to know if the events are bulk or unitary save/delete.

It adds 2 interfaces :
- `Akeneo\Component\StorageUtils\Event\StorageEventInterface`
- `Akeneo\Component\StorageUtils\Event\SubjectAwareInterface`

It also adds 1 trait :
- `Akeneo\Component\StorageUtils\Event\SubjectIdAwareTrait`

And 4 concrete event classes :
- `Akeneo\Component\StorageUtils\Event\BulkRemoveEvent`
- `Akeneo\Component\StorageUtils\Event\BulkSaveEvent`
- `Akeneo\Component\StorageUtils\Event\RemoveEvent` (existed already, changed the code)
- `Akeneo\Component\StorageUtils\Event\SaveEvent`

**Definition Of Done (for Core Developer only)**

| Q | A |
| --- | --- |
| Added Specs |  |
| Added Behats |  |
| Changelog updated |  |
| Review and 2 GTM |  |
| Micro Demo to the PO (Story only) |  |
| Migration script |  |
|  Tech Doc |  |
