### PR TITLE
Fixed unit conversion for ElectricCharge + typo in MeasureBundle

### DIFF
--- a/src/Akeneo/Bundle/MeasureBundle/Resources/config/measure.yml
+++ b/src/Akeneo/Bundle/MeasureBundle/Resources/config/measure.yml
@@ -276,25 +276,25 @@ measures_config:
                 convert: [{'mul': 1}]
                 symbol: Ah
             MILLICOULOMB:
-                convert: [{'mul': 3600000}]
+                convert: [{'div': 3600000}]
                 symbol: mC
-            CENTIOULOMB:
-                convert: [{'mul': 360000}]
+            CENTICOULOMB:
+                convert: [{'div': 360000}]
                 symbol: cC
             DECICOULOMB:
-                convert: [{'mul': 36000}]
+                convert: [{'div': 36000}]
                 symbol: dC
             COULOMB:
-                convert: [{'mul': 3600}]
+                convert: [{'div': 3600}]
                 symbol: C
             DEKACOULOMB:
-                convert: [{'mul': 360}]
+                convert: [{'div': 360}]
                 symbol: daC
             HECTOCOULOMB:
-                convert: [{'mul': 36}]
+                convert: [{'div': 36}]
                 symbol: hC
             KILOCOULOMB:
-                convert: [{'mul': 3.6}]
+                convert: [{'div': 3.6}]
                 symbol: kC
     Duration:
         standard: SECOND


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

See #5062

Fixed typo for `CENTICOULOMB` and fixed ElectricCharge conversions

**Definition Of Done (for Core Developer only)**


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       |
| Added Behats                      |
| Changelog updated                 |
| Review and 2 GTM                  |
| Micro Demo to the PO (Story only) |
| Migration script                  |
| Tech Doc                          |

Fixed typo on CENTICOULOMB unit