### PR TITLE
Fix multi-select attribute option search

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/multi-select-field.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/multi-select-field.js
@@ -81,8 +81,7 @@ define(
                                 return {
                                     search: term,
                                     options: {
-                                        limit: 20,
-                                        page: page
+                                        locale: UserContext.get('catalogLocale')
                                     }
                                 };
                             }.bind(this),


### PR DESCRIPTION
After an update from Akeneo 1.5.8 to Akeneo 1.5.9 the multi-select attributes doesn't work as expected in the PEF anymore: When clicking on the attribute, we only get one option with the wrong translation.

This PR fixes the issue.