### PR TITLE
Pim 5984: Optimization on product import when iterating on each existing attributes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ php:
     - "5.5"
     - "5.6"
     - "7.0"
-    - "hhvm"
 
 # Allow to use container infrastructure
 sudo: false
@@ -14,6 +13,7 @@ cache:
     - $HOME/.composer/cache/files
 
 before_install:
+    - phpenv config-add travis.php.ini
     - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then
         phpenv config-rm xdebug.ini;
       fi

--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -5,6 +5,7 @@ clear
 - PIM-5777: Fix attribute refresh when locale change in Product Edit Form
 - TIP-307: Fix issues with Mongo 2.6
 - PIM-5862: Fix product grid display on a custom user view
+- PIM-5984: Optimization on product import when iterating on each existing attributes
 
 # 1.5.8 (2016-08-25)
 

--- a/src/Pim/Bundle/CatalogBundle/Manager/AttributeValuesResolver.php
+++ b/src/Pim/Bundle/CatalogBundle/Manager/AttributeValuesResolver.php
@@ -73,7 +73,10 @@ class AttributeValuesResolver
                     'scope'     => null
                 ];
             }
-            $values = array_merge($values, $this->filterExpectedValues($attribute, $requiredValues));
+            $expectedValues = $this->filterExpectedValues($attribute, $requiredValues);
+            foreach ($expectedValues as $expectedValue) {
+                $values[] = $expectedValue;
+            }
         }
 
         return $values;

--- a/travis.php.ini
+++ b/travis.php.ini
@@ -1,0 +1,1 @@
+memory_limit = 3072M


### PR DESCRIPTION
Optimization requested by a customer

When importing products, the import job fetch all attributes and iterate on each of them. The problem is there is an array_merge method in this foreach loop and it's very time consuming when there are plenty of attributes in the database.

As an example, with 14000 attributes, the loop takes about 10 minutes, and only 8 second with the optimization.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Covered by existing one
| Added Behats                      | Covered by existing ones
| Changelog updated                 | Y
| Review and 2 GTM                  |
| Micro Demo to the PO (Story only) | N
| Migration script                  | N
| Tech Doc                          | N
