### PR TITLE
PIM-5973: Fix association between products with new association types

### DIFF
--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 PIM-5985: Fix the import of localizable and scopable variant group attributes (backport of PIM-5915)
+PIM-5973: Fix association between products with new association types
 
 # 1.5.9 (2016-09-27)
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/associations.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/associations.js
@@ -102,10 +102,12 @@ define(
                 });
 
                 _.each(this.datagrids, function (datagrid) {
+                    mediator.clear('datagrid:selectModel:' + datagrid.name);
                     mediator.on('datagrid:selectModel:' + datagrid.name, function (model) {
                         this.selectModel(model, datagrid);
                     }.bind(this));
 
+                    mediator.clear('datagrid:unselectModel:' + datagrid.name);
                     mediator.on('datagrid:unselectModel:' + datagrid.name, function (model) {
                         this.unselectModel(model, datagrid);
                     }.bind(this));


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

**Bug description :** 

- Go to the association tab in the PEF (for any product)
- Go to the association type page
- Add an association type
- Return to the association tab in the PEF (for any product)
- Try to associate a product to another one with the new association added juste before and save it : it fails

**Why this bug occurs :** 

When you open the association tab in the PEF, a javascript instance of the association type form is loaded.

This instance is bind to the mediator in order to listen when you check/uncheck checkboxes to associate a product to another one. This instance has a model, and this model contains association types.

Then, if you add a new association type, and you return to the association type PEF, you will not be able to associate the product with another one, with the new association type.

You will get a javascript error in the console.

In fact, the second time you navigate on the association tab int the PEF, a new javascript instance of the association type form is created.
This instance is bind to the mediator as well. The instance's model contains every association types + the new one created just before.

But the first instance is still bind to the mediator, and this instance's model does not contain the new association type.

So, when you check a checkbox, the mediator propagates the event at first to the old instance.
And it fails because the new association type is missing in the model of the old instance.

**Fix :** 

Unbind the old instance from the mediator when a new instance of the association type form is created.

**Behat :** 

Can't test it with Behat because this problem does not occur when the page is refreshed after the creation of the new association type (and that's the case with Behat).

**Definition Of Done (for Core Developer only)**


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | n
| Added Behats                      | n
| Changelog updated                 | y
| Review and 2 GTM                  | n
| Micro Demo to the PO (Story only) | n
| Migration script                  | n
| Tech Doc                          | n
