### PR TITLE
TIP-611: Ease override of AttributeColumnInfoExtractor and AttributeColumnsResolver

### DIFF
--- a/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Product/AttributeColumnInfoExtractor.php
+++ b/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Product/AttributeColumnInfoExtractor.php
@@ -143,26 +143,11 @@ class AttributeColumnInfoExtractor
      */
     protected function checkFieldNameTokens(AttributeInterface $attribute, $fieldName, array $explodedFieldName)
     {
-        // the expected number of tokens in a field may vary,
-        //  - with the current price import, the currency can be optionally present in the header,
-        //  - with the current metric import, a "-unit" field can be added in the header,
-        //
-        // To avoid BC break, we keep the support in this fix, a next minor version could contain only the
-        // support of currency code in the header and metric in a single field
         $isLocalizable = $attribute->isLocalizable();
         $isScopable = $attribute->isScopable();
         $isPrice = 'prices' === $attribute->getBackendType();
-        $isMetric = 'metric' === $attribute->getBackendType();
 
-        $expectedSize = 1;
-        $expectedSize = $isLocalizable ? $expectedSize + 1 : $expectedSize;
-        $expectedSize = $isScopable ? $expectedSize + 1 : $expectedSize;
-
-        if ($isMetric || $isPrice) {
-            $expectedSize = [$expectedSize, $expectedSize + 1];
-        } else {
-            $expectedSize = [$expectedSize];
-        }
+        $expectedSize = $this->calculateExpectedSize($attribute);
 
         $nbTokens = count($explodedFieldName);
         if (!in_array($nbTokens, $expectedSize)) {
@@ -185,6 +170,39 @@ class AttributeColumnInfoExtractor
         if ($isLocalizable) {
             $this->checkForLocaleSpecificValue($attribute, $explodedFieldName);
         }
+    }
+
+    /**
+     * Calculates the expected size of the field with the attribute and its properties locale, scope, etc.
+     *
+     * @param AttributeInterface $attribute
+     *
+     * @return int
+     */
+    protected function calculateExpectedSize(AttributeInterface $attribute)
+    {
+        // the expected number of tokens in a field may vary,
+        //  - with the current price import, the currency can be optionally present in the header,
+        //  - with the current metric import, a "-unit" field can be added in the header,
+        //
+        // To avoid BC break, we keep the support in this fix, a next minor version could contain only the
+        // support of currency code in the header and metric in a single field
+        $isLocalizable = $attribute->isLocalizable();
+        $isScopable = $attribute->isScopable();
+        $isPrice = 'prices' === $attribute->getBackendType();
+        $isMetric = 'metric' === $attribute->getBackendType();
+
+        $expectedSize = 1;
+        $expectedSize = $isLocalizable ? $expectedSize + 1 : $expectedSize;
+        $expectedSize = $isScopable ? $expectedSize + 1 : $expectedSize;
+
+        if ($isMetric || $isPrice) {
+            $expectedSize = [$expectedSize, $expectedSize + 1];
+        } else {
+            $expectedSize = [$expectedSize];
+        }
+
+        return $expectedSize;
     }
 
     /**

--- a/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Product/AttributeColumnsResolver.php
+++ b/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Product/AttributeColumnsResolver.php
@@ -26,7 +26,7 @@ class AttributeColumnsResolver
     protected $valuesResolver;
 
     /** @var array */
-    protected $attributesFields;
+    protected $attributesFields = [];
 
     /** @var string */
     protected $identifierField;
@@ -70,7 +70,8 @@ class AttributeColumnsResolver
             $currencyCodes = $this->currencyRepository->getActivatedCurrencyCodes();
             $values = $this->valuesResolver->resolveEligibleValues($attributes);
             foreach ($values as $value) {
-                $this->resolveAttributeField($value, $currencyCodes);
+                $fields = $this->resolveAttributeField($value, $currencyCodes);
+                $this->attributesFields = array_merge($this->attributesFields, $fields);
             }
         }
 
@@ -88,18 +89,20 @@ class AttributeColumnsResolver
         $field = $this->resolveFlatAttributeName($value['attribute'], $value['locale'], $value['scope']);
 
         if (AttributeTypes::PRICE_COLLECTION === $value['type']) {
-            $this->attributesFields[] = $field;
+            $fields[] = $field;
             foreach ($currencyCodes as $currencyCode) {
                 $currencyField = sprintf('%s-%s', $field, $currencyCode);
-                $this->attributesFields[] = $currencyField;
+                $fields[] = $currencyField;
             }
         } elseif (AttributeTypes::METRIC === $value['type']) {
-            $this->attributesFields[] = $field;
+            $fields[] = $field;
             $metricField = sprintf('%s-%s', $field, 'unit');
-            $this->attributesFields[] = $metricField;
+            $fields[] = $metricField;
         } else {
-            $this->attributesFields[] = $field;
+            $fields[] = $field;
         }
+
+        return $fields;
     }
 
     /**

--- a/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Product/AttributeColumnsResolver.php
+++ b/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Product/AttributeColumnsResolver.php
@@ -70,25 +70,36 @@ class AttributeColumnsResolver
             $currencyCodes = $this->currencyRepository->getActivatedCurrencyCodes();
             $values = $this->valuesResolver->resolveEligibleValues($attributes);
             foreach ($values as $value) {
-                $field = $this->resolveFlatAttributeName($value['attribute'], $value['locale'], $value['scope']);
-
-                if (AttributeTypes::PRICE_COLLECTION === $value['type']) {
-                    $this->attributesFields[] = $field;
-                    foreach ($currencyCodes as $currencyCode) {
-                        $currencyField = sprintf('%s-%s', $field, $currencyCode);
-                        $this->attributesFields[] = $currencyField;
-                    }
-                } elseif (AttributeTypes::METRIC === $value['type']) {
-                    $this->attributesFields[] = $field;
-                    $metricField = sprintf('%s-%s', $field, 'unit');
-                    $this->attributesFields[] = $metricField;
-                } else {
-                    $this->attributesFields[] = $field;
-                }
+                $this->resolveAttributeField($value, $currencyCodes);
             }
         }
 
         return $this->attributesFields;
+    }
+
+    /**
+     * Resolves the attribute field name
+     *
+     * @param array $value
+     * @param array $currencyCodes
+     */
+    protected function resolveAttributeField(array $value, array $currencyCodes)
+    {
+        $field = $this->resolveFlatAttributeName($value['attribute'], $value['locale'], $value['scope']);
+
+        if (AttributeTypes::PRICE_COLLECTION === $value['type']) {
+            $this->attributesFields[] = $field;
+            foreach ($currencyCodes as $currencyCode) {
+                $currencyField = sprintf('%s-%s', $field, $currencyCode);
+                $this->attributesFields[] = $currencyField;
+            }
+        } elseif (AttributeTypes::METRIC === $value['type']) {
+            $this->attributesFields[] = $field;
+            $metricField = sprintf('%s-%s', $field, 'unit');
+            $this->attributesFields[] = $metricField;
+        } else {
+            $this->attributesFields[] = $field;
+        }
     }
 
     /**

--- a/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Product/AttributeColumnsResolver.php
+++ b/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Product/AttributeColumnsResolver.php
@@ -71,7 +71,9 @@ class AttributeColumnsResolver
             $values = $this->valuesResolver->resolveEligibleValues($attributes);
             foreach ($values as $value) {
                 $fields = $this->resolveAttributeField($value, $currencyCodes);
-                $this->attributesFields = array_merge($this->attributesFields, $fields);
+                foreach ($fields as $field) {
+                    $this->attributesFields[] = $field;
+                }
             }
         }
 

--- a/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Product/AttributeColumnsResolver.php
+++ b/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Product/AttributeColumnsResolver.php
@@ -85,6 +85,8 @@ class AttributeColumnsResolver
      *
      * @param array $value
      * @param array $currencyCodes
+     *
+     * @return array
      */
     protected function resolveAttributeField(array $value, array $currencyCodes)
     {


### PR DESCRIPTION
This PR eases the override exploding methods to extend in protected sub-method. It has been done for attribute types.
It does not contain any BC.

| Q | A |
| --- | --- |
| Added Specs | N/A |
| Added Behats | N/A |
| Changelog updated | N/A |
| Review and 2 GTM |  |
| Micro Demo to the PO (Story only) | N/A |
| Migration script | N/A |
|  Tech Doc | N/A |
