### PR TITLE
 batch EnrichBundle edit sender e-mail address

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ php:
     - "5.5"
     - "5.6"
     - "7.0"
-    - "hhvm"
 
 # Allow to use container infrastructure
 sudo: false
@@ -19,6 +18,7 @@ cache:
     - $HOME/.composer/cache/files
 
 before_script:
+    - phpenv config-add travis.php.ini
     - echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
     - if [[ "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then phpenv config-rm xdebug.ini; fi
     - composer self-update --no-interaction

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/bundles/akeneo_batch.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/bundles/akeneo_batch.yml
@@ -1,3 +1,3 @@
 akeneo_batch:
-    sender_email:             'mailer@akeneo.com'
+    sender_email:             'batch@example.com'
     enable_mail_notification: true

--- a/travis.php.ini
+++ b/travis.php.ini
@@ -1,0 +1,1 @@
+memory_limit = 3072M


### PR DESCRIPTION
The Akeneo batch from the EnrichBundle is configured to send mail pretending to be from akeneo.com mail servers. This is a bad idea from a security point of view. 


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | no
| Added Behats                      | no
| Changelog updated                 | no
| Review and 2 GTM                  | yes
| Micro Demo to the PO (Story only) | no
| Migration script                  | no
| Tech Doc                          | no

