### PR TITLE
AMS-10: Make the create button from view selector extensible

### DIFF
--- a/features/Context/DataGridContext.php
+++ b/features/Context/DataGridContext.php
@@ -1019,9 +1019,9 @@ class DataGridContext extends RawMinkContext implements PageObjectAwareInterface
     public function iCreateTheView(TableNode $table)
     {
         $this->getCurrentPage()->getViewSelector()->click();
+        $this->getCurrentPage()->clickCreateOnButton("Create view");
 
         return [
-            new Step\Then('I press the "Create view" button'),
             new Step\Then('I fill in the following information in the popin:', $table),
             new Step\Then('I press the "OK" button')
         ];

--- a/features/Pim/Behat/Decorator/Page/GridCapableDecorator.php
+++ b/features/Pim/Behat/Decorator/Page/GridCapableDecorator.php
@@ -51,6 +51,18 @@ class GridCapableDecorator extends ElementDecorator
     }
 
     /**
+     * @param string $button
+     */
+    public function clickCreateOnButton($button)
+    {
+        $button = $this->spin(function () use ($button) {
+            return $this->find('css', sprintf('.create-button:contains("%s")', $button));
+        }, sprintf('Button "%s" not found.', $button));
+
+        $button->click();
+    }
+
+    /**
      * Returns available views in the datagrid view selector.
      *
      * @return array

--- a/features/datagrid/datagrid_views.feature
+++ b/features/datagrid/datagrid_views.feature
@@ -17,6 +17,7 @@ Feature: Datagrid views
   Scenario: Successfully display the default view
     Then I should see the text "Default view"
 
+  @skip-activity-manager
   Scenario: Successfully create a new view
     Given I filter by "family" with operator "in list" and value "Sneakers"
     And I create the view:
@@ -34,6 +35,7 @@ Feature: Datagrid views
     When I apply the "Default view" view
     Then I should see products black-boots, purple-sneakers and black-sneakers
 
+  @skip-activity-manager
   Scenario: Successfully update a view
     Given I filter by "family" with operator "in list" and value "Boots"
     And I create the view:
@@ -53,6 +55,7 @@ Feature: Datagrid views
     And I should see products purple-sneakers and black-sneakers
     But I should not see product black-boots
 
+  @skip-activity-manager
   Scenario: Successfully delete a view
     Given I filter by "family" with operator "in list" and value "Boots"
     And I create the view:
@@ -79,6 +82,7 @@ Feature: Datagrid views
     When I am on the attributes page
     Then the page size should be 50
 
+  @skip-activity-manager
   Scenario: Successfully choose my default view
     Given I filter by "family" with operator "in list" and value "Sneakers"
     And I create the view:
@@ -107,6 +111,7 @@ Feature: Datagrid views
     When I press the "Reset" button
     Then I should see products black-boots, purple-sneakers and black-sneakers
 
+  @skip-activity-manager
   Scenario: Successfully remove my default view
     Given I filter by "family" with operator "in list" and value "Sneakers"
     And I create the view:

--- a/src/Pim/Bundle/DataGridBundle/Resources/translations/jsmessages.en.yml
+++ b/src/Pim/Bundle/DataGridBundle/Resources/translations/jsmessages.en.yml
@@ -87,7 +87,8 @@ grid.view_selector:
     default_view: Default view
     save_changes: Save this view
     remove: Delete this view
-    create: Create view
+    create_view: Create view
+    create: Create
     search: Search
     views: Views
     placeholder: Name of new view

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/grid_view_selector.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/grid_view_selector.yml
@@ -11,6 +11,12 @@ extensions:
         targetZone: buttons
         position: 100
 
+    pim-grid-view-selector-footer-create-view:
+        module: pim/grid/view-selector/footer/create/view
+        parent: pim-grid-view-selector-footer-create
+        targetZone: action-list
+        position: 100
+
     pim-grid-view-selector-line:
         module: pim/grid/view-selector/line
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
@@ -338,6 +338,7 @@ config:
         pim/grid/view-selector: pimenrich/js/grid/view-selector
         pim/grid/view-selector/footer: pimenrich/js/grid/view-selector-footer
         pim/grid/view-selector/footer/create: pimenrich/js/grid/view-selector-footer-create
+        pim/grid/view-selector/footer/create/view: pimenrich/js/grid/view-selector-footer-create-view
         pim/grid/view-selector/line: pimenrich/js/grid/view-selector-line
         pim/grid/view-selector/line/remove: pimenrich/js/grid/view-selector-line-remove
         pim/grid/view-selector/save: pimenrich/js/grid/view-selector-save
@@ -444,6 +445,7 @@ config:
         pim/template/grid/view-selector: pimenrich/templates/grid/view-selector.html
         pim/template/grid/view-selector/footer: pimenrich/templates/grid/view-selector-footer.html
         pim/template/grid/view-selector/footer/create: pimenrich/templates/grid/view-selector-footer-create.html
+        pim/template/grid/view-selector/footer/create/view: pimenrich/templates/grid/view-selector-footer-create-view.html
         pim/template/grid/view-selector/line: pimenrich/templates/grid/view-selector-line.html
         pim/template/grid/view-selector/line/remove: pimenrich/templates/grid/view-selector-line-remove.html
         pim/template/grid/view-selector/save: pimenrich/templates/grid/view-selector-save.html

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/grid/view-selector-footer-create-view.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/grid/view-selector-footer-create-view.js
@@ -1,0 +1,122 @@
+'use strict';
+
+/**
+ * Create view button extension for the Datagrid footer View Selector.
+ *
+ * Contains a "create" button to allow the user to create a view from the current
+ * state of the grid (regarding filters and columns).
+ *
+ * @author    Adrien Petremann <adrien.petremann@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+define(
+    [
+        'jquery',
+        'underscore',
+        'oro/translator',
+        'pim/form',
+        'backbone',
+        'text!pim/template/grid/view-selector/footer/create/view',
+        'pim/dialog',
+        'routing',
+        'pim/datagrid/state',
+        'pim/saver/datagrid-view',
+        'oro/messenger'
+    ],
+    function (
+        $,
+        _,
+        __,
+        BaseForm,
+        Backbone,
+        template,
+        Dialog,
+        Routing,
+        DatagridState,
+        DatagridViewSaver,
+        messenger
+    ) {
+        return BaseForm.extend({
+            template: _.template(template),
+            tagName: 'span',
+            className: 'action',
+            events: {
+                'click [data-action="prompt-create-view"]': 'promptCreateView'
+            },
+
+            /**
+             * {@inheritdoc}
+             */
+            render: function () {
+                this.$el.html(this.template({
+                    viewButtonTitle: __('grid.view_selector.create_view')
+                }));
+
+                return this;
+            },
+
+            /**
+             * Prompt the view creation modal.
+             */
+            promptCreateView: function () {
+                this.getRoot().trigger('grid:view-selector:close-selector');
+
+                var placeholder = __('grid.view_selector.placeholder');
+                var modal = new Backbone.BootstrapModal({
+                    title: __('grid.view_selector.choose_label'),
+                    content: '<input name="new-view-label" type="text" placeholder="' + placeholder + '">',
+                    okText: __('OK'),
+                    cancelText: __('Cancel')
+                });
+                modal.open();
+
+                var $submitButton = modal.$el.find('.ok').hide();
+
+                modal.on('ok', this.saveView.bind(this, modal));
+                modal.on('cancel', function () {
+                    modal.remove();
+                }.bind(this));
+                modal.$('input[name="new-view-label"]').on('input', function (event) {
+                    var label = event.target.value;
+
+                    if (!label.length) {
+                        $submitButton.hide();
+                    } else {
+                        $submitButton.show();
+                    }
+                });
+                modal.$('input[name="new-view-label"]').on('keypress', function (event) {
+                    if (13 === (event.keyCode || event.which) && event.target.value.length) {
+                        $submitButton.trigger('click');
+                    }
+                });
+            },
+
+            /**
+             * Save the current Datagrid view in database and triggers an event to the parent
+             * to select it.
+             *
+             * @param {object} modal
+             */
+            saveView: function (modal) {
+                var gridState = DatagridState.get(this.getRoot().gridAlias, ['filters', 'columns']);
+                var newView = {
+                    filters: gridState.filters,
+                    columns: gridState.columns,
+                    label: modal.$('input[name="new-view-label"]').val()
+                };
+
+                DatagridViewSaver.save(newView, this.getRoot().gridAlias)
+                    .done(function (response) {
+                        this.getRoot().trigger('grid:view-selector:view-created', response.id);
+                    }.bind(this))
+                    .fail(function (response) {
+                        _.each(response.responseJSON, function (error) {
+                            messenger.notificationFlashMessage('error', error);
+                        });
+                    });
+            }
+        });
+    }
+);

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/grid/view-selector-footer-create-view.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/grid/view-selector-footer-create-view.html
@@ -1,0 +1,3 @@
+<span class="select-view-action-list" data-action="prompt-create-view">
+    <%- viewButtonTitle %>
+</span>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/grid/view-selector-footer-create.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/grid/view-selector-footer-create.html
@@ -1,3 +1,16 @@
-<button class="btn btn-primary pull-right icons-holder-text" data-action="prompt-creation" type="button">
-    <i class="icon-plus"></i> <%- buttonTitle %>
-</button>
+<% if (!isMultiple) { %>
+    <div class="btn btn-primary pull-right icons-holder-text create-button">
+        <i class="icon-plus"></i><span data-drop-zone="action-list"></span>
+    </div>
+<% } else if (isMultiple) { %>
+    <div class="btn-group create-group">
+        <div class="btn-primary dropdown-toggle action btn create-button create-dropdown" data-toggle="dropdown">
+            <%- createButtonTitle %>
+        </div>
+        <div class="btn dropdown-toggle create-carret" data-toggle="dropdown">
+            <span class="caret"></span>
+        </div>
+
+        <ul class="dropdown-menu AknDropdown-menu--alignRight" data-drop-zone="action-list"></ul>
+    </div>
+<% } %>

--- a/src/Pim/Bundle/UIBundle/Resources/public/css/pim.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/css/pim.less
@@ -1213,6 +1213,16 @@ h3.tab-header {
       cursor: pointer;
     }
   }
+
+  .ui-multiselect-footer {
+    .btn-primary {
+      padding-right: 10px;
+    }
+
+    .icons-holder-text {
+      position: relative;
+    }
+  }
 }
 
 .form-field .select2-container {

--- a/src/Pim/Bundle/UIBundle/Resources/public/css/select2.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/css/select2.less
@@ -249,7 +249,7 @@ a.select2-choice {
       line-height: 30px;
       color: @color-form-info;
     }
-    .btn-primary {
+    .btn-primary:not(.create-dropdown) {
       padding: 0 10px 0 38px;
       overflow: hidden;
 
@@ -264,6 +264,47 @@ a.select2-choice {
         background-color: @greenDark;
         border-top-left-radius: 2px;
         border-bottom-left-radius: 2px;
+      }
+
+      i:not(.create-dropdown) {
+        width: 34px;
+        height: 34px;
+      }
+    }
+    .create-group {
+      display: flex;
+
+      .dropdown-menu .create-action {
+        line-height: 32px;
+        padding-left: 10px;
+
+        &:hover {
+          background-color: @akeneoLight;
+        }
+
+        .action, .select-view-action-list {
+          display: inline-block;
+          width: 100%;
+        }
+      }
+    }
+    .create-carret {
+      background-color: @greenDark;
+      background-image: none;
+
+      &:hover {
+        background-color: @greenDark;
+        background-image: none;
+      }
+
+      .caret {
+        background-color: @greenDark;
+        border-top: 4px solid @white;
+
+        &:hover {
+          background-color: @greenDark;
+          background-image: none;
+        }
       }
     }
   }


### PR DESCRIPTION
Now the create button is render as a single button if there is only one extension. If there is more than one extension, it is a dropdown with the list of possible actions.


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | no
| Added Behats                      | yes
| Changelog updated                 | no
| Review and 2 GTM                  |
| Micro Demo to the PO (Story only) |
| Migration script                  |
| Tech Doc                          |

