### PR TITLE
PIM-5536: Inconsistency on search fields

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -6,6 +6,7 @@
 - PIM-5982: Missing job instance parameters when using custom configuration in command line
 - PIM-5978: Fix missing products in the variant group edit form
 - PIM-5893: Fix products and assets category display issue on Firefox
+- PIM-5536 : Fix search of an attribute by its code
 
 # 1.6.3 (2016-09-22)
 

--- a/features/Context/DataGridContext.php
+++ b/features/Context/DataGridContext.php
@@ -143,6 +143,33 @@ class DataGridContext extends RawMinkContext implements PageObjectAwareInterface
     }
 
     /**
+     * @param string $text
+     *
+     * @Then /^I type "([^"]*)" in the manage filter input$/
+     */
+    public function iTypeInTheManageFilterInput($text)
+    {
+        $this->datagrid->typeInManageFilterInput($text);
+    }
+
+
+    /**
+     * @param string $title
+     *
+     * @Then /^I could see "([^"]*)" in the manage filters list$/
+     */
+    public function iCouldSeeInTheManageFiltersList($title)
+    {
+        $filterElement = $this->datagrid->getElement('Manage filters')->find('css', sprintf('input[title="%s"]', $title));
+
+        if($filterElement == null || !$filterElement->isVisible()) {
+            throw $this->createExpectationException(
+                sprintf('Expecting "%s" to be displayed in the filters list', $title)
+            );
+        }
+    }
+
+    /**
      * @param string    $code
      * @param TableNode $table
      *

--- a/features/Context/DataGridContext.php
+++ b/features/Context/DataGridContext.php
@@ -162,7 +162,7 @@ class DataGridContext extends RawMinkContext implements PageObjectAwareInterface
     {
         $filterElement = $this->datagrid->getElement('Manage filters')->find('css', sprintf('input[title="%s"]', $title));
 
-        if($filterElement == null || !$filterElement->isVisible()) {
+        if ($filterElement == null || !$filterElement->isVisible()) {
             throw $this->createExpectationException(
                 sprintf('Expecting "%s" to be displayed in the filters list', $title)
             );

--- a/features/Context/Page/Base/Grid.php
+++ b/features/Context/Page/Base/Grid.php
@@ -734,7 +734,8 @@ class Grid extends Index
      *
      * @param string $text
      */
-    public function typeInManageFilterInput($text) {
+    public function typeInManageFilterInput($text)
+    {
         $manageFilters = $this->getElement('Manage filters');
         if (!$manageFilters->isVisible()) {
             $this->clickFiltersList();

--- a/features/Context/Page/Base/Grid.php
+++ b/features/Context/Page/Base/Grid.php
@@ -730,6 +730,22 @@ class Grid extends Index
     }
 
     /**
+     * Set the content of filter search
+     *
+     * @param string $text
+     */
+    public function typeInManageFilterInput($text) {
+        $manageFilters = $this->getElement('Manage filters');
+        if (!$manageFilters->isVisible()) {
+            $this->clickFiltersList();
+        }
+
+        $manageFilters
+            ->find('css', 'input')
+            ->setValue($text);
+    }
+
+    /**
      * Select a row
      *
      * @param string $value

--- a/features/datagrid/display_many_datagrid_filters.feature
+++ b/features/datagrid/display_many_datagrid_filters.feature
@@ -4,38 +4,11 @@ Feature: Display many datagrid filters
   As a regular user
   I need to be able to use the datagrid with many filters
 
-  Scenario: Successfully display the datagrid with 500 filters
-    Given the "default" catalog configuration
-    And 500 filterable simple select attributes with 5 options per attribute
-    And I am logged in as "Mary"
-    And I am on the products page
-    When I show the filter "attribute_499"
-    And I filter by "attribute_499" with operator "in list" and value "Option 1 for attribute 499"
-    Then I should be on the products page
-
-  @jira https://akeneo.atlassian.net/browse/PIM-5869
-  Scenario: Check that a non metric attribute named "length" do not break the grid
-    Given the "default" catalog configuration
-    And the following families:
-      | code      | label-en_US |
-      | guitar    | Guitar      |
-    And the following products:
-      | sku        | family |
-      | les-paul   | guitar |
-      | telecaster | guitar |
-    And the following attributes:
-      | code   | label  | type |
-      | length | length | text |
-    When I am logged in as "Mary"
-    And I am on the products page
-    Then I should see product les-paul
-    And I should see product telecaster
-
   @jira https://akeneo.atlassian.net/browse/PIM-5536
   Scenario: Successfully search an attribute from its code
     Given the "apparel" catalog configuration
     And I am logged in as "Mary"
     And I am on the products page
-    When I show the filter "number_in_stock"
-    Then I should not see the filters Number in stock
+    When I type "number_in_stock" in the manage filter input
+    And I could see "Number in stock" in the manage filters list
 

--- a/features/datagrid/display_many_datagrid_filters.feature
+++ b/features/datagrid/display_many_datagrid_filters.feature
@@ -4,6 +4,33 @@ Feature: Display many datagrid filters
   As a regular user
   I need to be able to use the datagrid with many filters
 
+  Scenario: Successfully display the datagrid with 500 filters
+    Given the "default" catalog configuration
+    And 500 filterable simple select attributes with 5 options per attribute
+    And I am logged in as "Mary"
+    And I am on the products page
+    When I show the filter "attribute_499"
+    And I filter by "attribute_499" with operator "in list" and value "Option 1 for attribute 499"
+    Then I should be on the products page
+
+  @jira https://akeneo.atlassian.net/browse/PIM-5869
+  Scenario: Check that a non metric attribute named "length" do not break the grid
+    Given the "default" catalog configuration
+    And the following families:
+      | code      | label-en_US |
+      | guitar    | Guitar      |
+    And the following products:
+      | sku        | family |
+      | les-paul   | guitar |
+      | telecaster | guitar |
+    And the following attributes:
+      | code   | label  | type |
+      | length | length | text |
+    When I am logged in as "Mary"
+    And I am on the products page
+    Then I should see product les-paul
+    And I should see product telecaster
+
   @jira https://akeneo.atlassian.net/browse/PIM-5536
   Scenario: Successfully search an attribute from its code
     Given the "apparel" catalog configuration

--- a/features/datagrid/display_many_datagrid_filters.feature
+++ b/features/datagrid/display_many_datagrid_filters.feature
@@ -30,3 +30,12 @@ Feature: Display many datagrid filters
     And I am on the products page
     Then I should see product les-paul
     And I should see product telecaster
+
+  @jira https://akeneo.atlassian.net/browse/PIM-5536
+  Scenario: Successfully search an attribute from its code
+    Given the "apparel" catalog configuration
+    And I am logged in as "Mary"
+    And I am on the products page
+    When I show the filter "number_in_stock"
+    Then I should not see the filters Number in stock
+

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/lib/multiselect/jquery.multiselect.filter.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/lib/multiselect/jquery.multiselect.filter.js
@@ -117,7 +117,18 @@
         var regex = new RegExp(term.replace(rEscape, "\\$&"), 'gi');
 
         this._trigger("filter", e, $.map(cache, function(v, i) {
+          var found = false;
           if(v.search(regex) !== -1) {
+            found = true;
+          } else {
+            // look for 'value' attibute if innerHTML doesn't match
+            var val = rows.eq(i).find('input').attr('value');
+            if(val.search(regex) !== -1) {
+              found = true;
+            }
+          }
+
+          if(found) {
             rows.eq(i).show();
             return inputs.get(i);
           }


### PR DESCRIPTION
**Description**

On the product grid, it is not possible to search for an attribute's code.
For a complete explanation please see : https://akeneo.atlassian.net/browse/PIM-5536

Solution : The problem is due to `jquery.multiselect.js` which only autocomplete on the `innerHTML` (the attribute's label) and not the `value` attribute of the `<option>` tag (the attribute's code). As a quick fix, we decided with @nidup to fix the library to allow autocomplete on both `innerHTML` and `value` attribute. This has no side effect. A better approach would be to replace multiselect plugin by select2 but the refactoring is huge.

Here is an example with an attribue which code is "Attribute" and label is "Nom" :

![image](https://cloud.githubusercontent.com/assets/55890/19438706/93f239fc-947b-11e6-95f5-779dcb86eee2.png)

![image](https://cloud.githubusercontent.com/assets/55890/19438783/cb44c956-947b-11e6-9f73-d902e31c9265.png)


**Definition Of Done**


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       |
| Added Behats                      | X
| Changelog updated                 | X
| Review and 2 GTM                  | X
| Micro Demo to the PO (Story only) | X
| Migration script                  |
| Tech Doc                          |