### PR TITLE
CI fix: absolute path for symfony console

### DIFF
--- a/features/Context/CommandContext.php
+++ b/features/Context/CommandContext.php
@@ -9,6 +9,7 @@ use Pim\Bundle\CatalogBundle\Command\QueryProductCommand;
 use Pim\Bundle\CatalogBundle\Command\UpdateProductCommand;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Process\PhpExecutableFinder;
 
 /**
  * Context for commands
@@ -223,7 +224,10 @@ class CommandContext extends PimContext
      */
     public function iRun($command)
     {
-        $command = $this->replacePlaceholders($command);
-        $this->output = shell_exec('php app/console ' . $command);
+        $pathFinder   = new PhpExecutableFinder();
+        $php          = $pathFinder->find();
+        $rootDir      = $this->getRootDir();
+        $command      = $this->replacePlaceholders($command);
+        $this->output = shell_exec(sprintf('%s %s/console %s', $php, $rootDir, $command));
     }
 }

--- a/features/Pim/Behat/Context/PimContext.php
+++ b/features/Pim/Behat/Context/PimContext.php
@@ -126,4 +126,12 @@ class PimContext extends RawMinkContext implements KernelAwareInterface
     {
         $this->getMainContext()->wait($condition);
     }
+
+    /**
+     * @return string
+     */
+    protected function getRootDir()
+    {
+        return $this->kernel->getRootDir();
+    }
 }


### PR DESCRIPTION
Fix for CI :  Launch symfony commands via console absolute path.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       |
| Added Behats                      |
| Changelog updated                 |
| Review and 2 GTM                  |
| Micro Demo to the PO (Story only) |
| Migration script                  |
| Tech Doc                          |
