### PR TITLE
Remove legacy optional dependencies to flysystem #5129

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,6 @@
         "kriswallsmith/assetic": "1.1.3",
         "leafo/lessphp": "0.5.0",
         "league/flysystem": "1.0.11",
-        "league/flysystem-sftp": "1.0.5",
         "league/flysystem-ziparchive": "1.0.2",
         "liip/imagine-bundle": "1.3.0",
         "imagine/imagine": "0.6.2",


### PR DESCRIPTION
We introduced "league/flysystem-sftp" in v1.4 and we don't even use it, the namespace is not use either in CE and EE, I dropped it here and run the full CI without encountering any issue.

The real issue behing this is the following one https://github.com/akeneo/pim-community-dev/issues/5129 concerning the v1.6 where we would need to bump or remove this dep.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | N
| Added Behats                      | N
| Changelog updated                 | Y
| Review and 2 GTM                  | ?
| Micro Demo to the PO (Story only) | N
| Migration script                  | N
| Tech Doc                          | N

