### PR TITLE
Remove useless "league/flysystem-sftp" dependency to fix #5129

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -7,6 +7,7 @@
 - PIM-5978: Fix missing products in the variant group edit form
 - PIM-5893: Fix products and assets category display issue on Firefox
 - PIM-5536 : Fix search of an attribute by its code
+- #5129: Remove useless "league/flysystem-sftp" dependency, if you use "League\Flysystem\Sftp\SftpAdapter" in your own project code, please add this dependency in the composer.json of your project, cheers @mathewrapid!
 
 # 1.6.3 (2016-09-22)
 

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,6 @@
         "kriswallsmith/assetic": "1.1.3",
         "leafo/lessphp": "0.5.0",
         "league/flysystem": "1.0.11",
-        "league/flysystem-sftp": "1.0.5",
         "league/flysystem-ziparchive": "1.0.2",
         "liip/imagine-bundle": "1.3.0",
         "imagine/imagine": "0.6.2",


### PR DESCRIPTION
We introduced "league/flysystem-sftp" in v1.4 and we don't even use it, the namespace is not use either in CE and EE, I dropped it here and run the full CI without encountering any issue on master https://github.com/akeneo/pim-community-dev/pull/5136.

The real issue behing this is the following one #5129 concerning the v1.6 where we would need to bump or remove this dep.

Changing our composer.json in an already released version is a very very very sensitive topic, even for bumping to the last patch in this case, it's doable because we don't use this lib into our own code, the only impact is to properly add it in project when using it for real.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | N
| Added Behats                      | N
| Changelog updated                 | Y
| Review and 2 GTM                  | ?
| Micro Demo to the PO (Story only) | N
| Migration script                  | N
| Tech Doc                          | N
