### PR TITLE
Media migration memory consumption

### DIFF
--- a/upgrades/1.3-1.4/common/MediaMigration.php
+++ b/upgrades/1.3-1.4/common/MediaMigration.php
@@ -93,14 +93,8 @@ class MediaMigration
      */
     public function storeLocalMedias()
     {
-        // enable the garbage collector
-        gc_enable();
-
         /** @var \Doctrine\ORM\EntityManagerInterface $em */
-        $em = null;
-        if (!$this->upgradeHelper->areProductsStoredInMongo()) {
-            $em = $this->container->get('doctrine.orm.entity_manager');
-        };
+        $em = $this->container->get('doctrine.orm.entity_manager');
 
         $this->output->writeln(sprintf('Storing medias located in <comment>%s</comment> to the catalog filesystem...', $this->mediaDirectory));
 
@@ -116,30 +110,17 @@ class MediaMigration
                 ['old_file_key' => $file->getFilename()],
                 ['id'           => $fileInfo->getId()]
             );
-            // detach and unset if products are not stored in Mongo
-            if (null !== $em) {
-                $em->detach($fileInfo);
-            }
+            $em->detach($fileInfo);
             unset($fileInfo);
             unset($file);
 
             if (0 == $count % $batch) {
-                // flush / clear / gc
-                if (null !== $em) {
-                    $em->flush();
-                    $em->clear();
-                    gc_collect_cycles();
-                }
+                $em->clear();
             }
             $count++;
         }
 
-        // flush / clear / gc finally
-        if (null !== $em) {
-            $em->flush();
-            $em->clear();
-            gc_collect_cycles();
-        }
+        $em->clear();
     }
 
     /**

--- a/upgrades/1.3-1.4/common/MediaMigration.php
+++ b/upgrades/1.3-1.4/common/MediaMigration.php
@@ -99,7 +99,7 @@ class MediaMigration
         /** @var \Doctrine\ORM\EntityManagerInterface $em */
         $em = null;
         if (!$this->upgradeHelper->areProductsStoredInMongo()) {
-            $this->container->get('doctrine.orm.entity_manager');
+            $em = $this->container->get('doctrine.orm.entity_manager');
         };
 
         $this->output->writeln(sprintf('Storing medias located in <comment>%s</comment> to the catalog filesystem...', $this->mediaDirectory));


### PR DESCRIPTION
With big amount of media files managed by the PIM, the media migration from version 1.3 to 1.6 is slow (and slows down during the migration process) and its quite memory consuming.

The issue is in upgrades/1.3-1.4/common/MediaMigration.php::storeLocalMedias

The foreach loop does not detach the $fileInfo entities from the entity manager.
Detaching the entities and regular flushing/clearing the entity manager helps the garbage collector to keep the memory usage low and speeds up the migration process as the entity manager does not handle the detached entities (as long as they are not reattached anymore).

| Q | A |
| --- | --- |
| Added Specs | N |
| Added Behats | N |
| Changelog updated | N |
| Review and 2 GTM | N |
| Micro Demo to the PO (Story only) | N |
| Migration script | N |
|  Tech Doc | N |
