### PR TITLE
Detach read items on export job

### DIFF
--- a/src/Akeneo/Component/Batch/Step/ItemStep.php
+++ b/src/Akeneo/Component/Batch/Step/ItemStep.php
@@ -118,6 +118,7 @@ class ItemStep extends AbstractStep
             }
 
             $processedItem = $this->process($readItem);
+            unset($readItem);
             if (null !== $processedItem) {
                 $itemsToWrite[] = $processedItem;
                 $writeCount++;

--- a/src/Pim/Bundle/EnrichBundle/Connector/Processor/QuickExport/ProductProcessor.php
+++ b/src/Pim/Bundle/EnrichBundle/Connector/Processor/QuickExport/ProductProcessor.php
@@ -9,6 +9,7 @@ use Akeneo\Component\Batch\Model\StepExecution;
 use Akeneo\Component\StorageUtils\Detacher\ObjectDetacherInterface;
 use Pim\Bundle\EnrichBundle\Connector\Processor\AbstractProcessor;
 use Pim\Component\Catalog\Builder\ProductBuilderInterface;
+use Pim\Component\Catalog\Model\AssociationInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
 use Pim\Component\Catalog\Repository\ChannelRepositoryInterface;
@@ -107,7 +108,7 @@ class ProductProcessor extends AbstractProcessor
             $this->fetchMedia($product, $directory);
         }
 
-        $this->detacher->detach($product);
+        $this->detachProduct($product);
 
         return $productStandard;
     }
@@ -218,5 +219,25 @@ class ProductProcessor extends AbstractProcessor
 
         $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
         $this->tokenStorage->setToken($token);
+    }
+
+
+    /**
+     * Detach $product and its associations
+     *
+     * @param ProductInterface $product
+     *
+     * @return void
+     */
+    protected function detachProduct(ProductInterface $product)
+    {
+        $this->detacher->detach($product);
+        /** @var AssociationInterface $association */
+        $associations = $product->getAssociations();
+        foreach ($associations as $association) {
+            foreach ($association->getProducts() as $associatedProduct) {
+                $this->detacher->detach($associatedProduct);
+            }
+        }
     }
 }

--- a/src/Pim/Component/Connector/Processor/Normalization/ProductProcessor.php
+++ b/src/Pim/Component/Connector/Processor/Normalization/ProductProcessor.php
@@ -10,6 +10,7 @@ use Akeneo\Component\Batch\Model\StepExecution;
 use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
 use Akeneo\Component\StorageUtils\Detacher\ObjectDetacherInterface;
 use Pim\Component\Catalog\Builder\ProductBuilderInterface;
+use Pim\Component\Catalog\Model\AssociationInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
 use Pim\Component\Catalog\Repository\ChannelRepositoryInterface;
@@ -109,7 +110,7 @@ class ProductProcessor implements ItemProcessorInterface, StepExecutionAwareInte
             );
         }
 
-        $this->detacher->detach($product);
+        $this->detachProduct($product);
 
         return $productStandard;
     }
@@ -187,5 +188,24 @@ class ProductProcessor implements ItemProcessorInterface, StepExecutionAwareInte
     {
         return isset($parameters->get('filters')['structure']['attributes'])
             && !empty($parameters->get('filters')['structure']['attributes']);
+    }
+
+    /**
+     * Detach $product and its associations
+     *
+     * @param ProductInterface $product
+     *
+     * @return void
+     */
+    protected function detachProduct(ProductInterface $product)
+    {
+        $this->detacher->detach($product);
+        /** @var AssociationInterface $association */
+        $associations = $product->getAssociations();
+        foreach ($associations as $association) {
+            foreach ($association->getProducts() as $associatedProduct) {
+                $this->detacher->detach($associatedProduct);
+            }
+        }
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Added Specs | N |
| Added Behats | N |
| Changelog updated | N |
| Review and 2 GTM | N |
| Micro Demo to the PO (Story only) | N |
| Migration script | N |
|  Tech Doc | N |

The memory consumption of export jobs constantly increases if products
with associations are exported.

The fix detaches the read items together with their associations and
products collected in the associations.
