### PR TITLE
TIP-477: call key "identifier" from the product standard format

### DIFF
--- a/src/Pim/Component/Connector/Writer/File/Csv/ProductWriter.php
+++ b/src/Pim/Component/Connector/Writer/File/Csv/ProductWriter.php
@@ -44,8 +44,6 @@ class ProductWriter extends AbstractItemMediaWriter implements
      */
     protected function getItemIdentifier(array $product)
     {
-        $attributeCode = $this->attributeRepository->getIdentifierCode();
-
-        return current($product['values'][$attributeCode])['data'];
+        return $product['identifier'];
     }
 }

--- a/src/Pim/Component/Connector/Writer/File/Xlsx/ProductWriter.php
+++ b/src/Pim/Component/Connector/Writer/File/Xlsx/ProductWriter.php
@@ -37,8 +37,6 @@ class ProductWriter extends AbstractItemMediaWriter implements
      */
     protected function getItemIdentifier(array $product)
     {
-        $attributeCode = $this->attributeRepository->getIdentifierCode();
-
-        return current($product['values'][$attributeCode])['data'];
+        return $product['identifier'];
     }
 }

--- a/src/Pim/Component/Connector/spec/Writer/File/Csv/ProductWriterSpec.php
+++ b/src/Pim/Component/Connector/spec/Writer/File/Csv/ProductWriterSpec.php
@@ -76,6 +76,7 @@ class ProductWriterSpec extends ObjectBehavior
         $jobParameters->get('with_media')->willReturn(true);
 
         $productStandard1 = [
+            'identifier' => 'jackets',
             'enabled'    => true,
             'categories' => ['2015_clothes', '2016_clothes'],
             'groups'     => [],
@@ -135,6 +136,7 @@ class ProductWriterSpec extends ObjectBehavior
         ];
 
         $productStandard2 = [
+            'identifier' => 'sweaters',
             'type'   => 'product',
             'labels' => [
                 'en_US' => 'Sweaters',
@@ -183,7 +185,6 @@ class ProductWriterSpec extends ObjectBehavior
 
         $bufferFactory->create()->willReturn($flatRowBuffer);
 
-        $attributeRepository->getIdentifierCode()->willReturn('sku');
         $attributeRepository->getAttributeTypeByCodes(['sku', 'description', 'media'])
             ->willReturn(['media' => 'pim_catalog_image']);
         $attributeRepository->getAttributeTypeByCodes(['sku', 'media'])

--- a/src/Pim/Component/Connector/spec/Writer/File/Xlsx/ProductWriterSpec.php
+++ b/src/Pim/Component/Connector/spec/Writer/File/Xlsx/ProductWriterSpec.php
@@ -76,6 +76,7 @@ class ProductWriterSpec extends ObjectBehavior
         $jobParameters->get('with_media')->willReturn(true);
 
         $productStandard1 = [
+            'identifier' => 'jackets',
             'enabled'    => true,
             'categories' => ['2015_clothes', '2016_clothes'],
             'groups'     => [],
@@ -135,6 +136,7 @@ class ProductWriterSpec extends ObjectBehavior
         ];
 
         $productStandard2 = [
+            'identifier' => 'sweaters',
             'type'   => 'product',
             'labels' => [
                 'en_US' => 'Sweaters',
@@ -184,7 +186,6 @@ class ProductWriterSpec extends ObjectBehavior
 
         $bufferFactory->create()->willReturn($flatRowBuffer);
 
-        $attributeRepository->getIdentifierCode()->willReturn('sku');
         $attributeRepository->getAttributeTypeByCodes(['sku', 'description', 'media'])
             ->willReturn(['media' => 'pim_catalog_image']);
         $attributeRepository->getAttributeTypeByCodes(['sku', 'media'])


### PR DESCRIPTION
use the key "identifier" in the product standard format introduced in a previous PR

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       |
| Added Behats                      |
| Changelog updated                 |
| Review and 2 GTM                  |
| Micro Demo to the PO (Story only) |
| Migration script                  |
| Tech Doc                          |

