### PR TITLE
TIP-496: Use the standard format in imports

### DIFF
--- a/src/Pim/Component/Catalog/Updater/ChannelUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/ChannelUpdater.php
@@ -52,7 +52,7 @@ class ChannelUpdater implements ObjectUpdaterInterface
      *     },
      *     'locales': ['en_US'],
      *     'currencies': ['EUR', 'USD'],
-     *     'tree': 'master'
+     *     'category_tree': 'master'
      * }
      */
     public function update($channel, array $data, array $options = [])
@@ -86,8 +86,8 @@ class ChannelUpdater implements ObjectUpdaterInterface
             case 'code':
                 $channel->setCode($data);
                 break;
-            case 'tree':
-                $this->setTree($channel, $data);
+            case 'category_tree':
+                $this->setCategoryTree($channel, $data);
                 break;
             case 'locales':
                 $this->setLocales($channel, $data);
@@ -108,7 +108,7 @@ class ChannelUpdater implements ObjectUpdaterInterface
      * @param ChannelInterface $channel
      * @param string           $treeCode
      */
-    protected function setTree(ChannelInterface $channel, $treeCode)
+    protected function setCategoryTree(ChannelInterface $channel, $treeCode)
     {
         $category = $this->categoryRepository->findOneByIdentifier($treeCode);
         if (null === $category) {

--- a/src/Pim/Component/Catalog/Updater/CurrencyUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/CurrencyUpdater.php
@@ -20,9 +20,8 @@ class CurrencyUpdater implements ObjectUpdaterInterface
      *
      * Expected input format :
      * [
-     *     'code'      => 'USD',
-     *     'activated' => true,
-     *     ]
+     *     'code'    => 'USD',
+     *     'enabled' => true,
      * ]
      */
     public function update($currency, array $data, array $options = [])
@@ -52,7 +51,7 @@ class CurrencyUpdater implements ObjectUpdaterInterface
     {
         if ('code' == $field) {
             $currency->setCode($data);
-        } elseif ('activated' == $field) {
+        } elseif ('enabled' == $field) {
             $currency->setActivated($data);
         }
     }

--- a/src/Pim/Component/Catalog/Updater/FamilyUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/FamilyUpdater.php
@@ -98,7 +98,7 @@ class FamilyUpdater implements ObjectUpdaterInterface
             case 'labels':
                 $this->setLabels($family, $data);
                 break;
-            case 'requirements':
+            case 'attribute_requirements':
                 $this->setAttributeRequirements($family, $data);
                 break;
             case 'attributes':

--- a/src/Pim/Component/Catalog/Updater/VariantGroupUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/VariantGroupUpdater.php
@@ -74,7 +74,7 @@ class VariantGroupUpdater implements ObjectUpdaterInterface
      *         "en_US": "T-shirt very beautiful",
      *         "fr_FR": "T-shirt super beau"
      *     }
-     *     "axis": ["main_color", "secondary_color"],
+     *     "axes": ["main_color", "secondary_color"],
      *     "type": "VARIANT",
      *     "values": {
      *         "main_color": "white",
@@ -134,7 +134,7 @@ class VariantGroupUpdater implements ObjectUpdaterInterface
                 $this->setLabels($variantGroup, $data);
                 break;
 
-            case 'axis':
+            case 'axes':
                 $this->setAxes($variantGroup, $data);
                 break;
 
@@ -392,8 +392,8 @@ class VariantGroupUpdater implements ObjectUpdaterInterface
     }
 
     /**
-     * @param GroupInterface $group
-     * @param array          $labels
+     * @param GroupInterface $variantGroup
+     * @param array          $productIds
      */
     protected function setProducts(GroupInterface $variantGroup, array $productIds)
     {

--- a/src/Pim/Component/Catalog/spec/Updater/ChannelUpdaterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/ChannelUpdaterSpec.php
@@ -57,14 +57,14 @@ class ChannelUpdaterSpec extends ObjectBehavior
         ChannelTranslationInterface $channelTranslation
     ) {
         $values = [
-            'code'  => 'ecommerce',
-            'labels' => [
+            'code'             => 'ecommerce',
+            'labels'           => [
                 'fr_FR' => 'Tablette',
                 'en_US' => 'Tablet',
             ],
-            'locales'    => ['en_US', 'fr_FR'],
-            'currencies' => ['EUR', 'USD'],
-            'tree'       => 'master_catalog',
+            'locales'          => ['en_US', 'fr_FR'],
+            'currencies'       => ['EUR', 'USD'],
+            'category_tree'    => 'master_catalog',
             'conversion_units' => [
                 'weight' => 'GRAM'
             ],
@@ -106,12 +106,12 @@ class ChannelUpdaterSpec extends ObjectBehavior
         CurrencyInterface $eur
     ) {
         $values = [
-            'code'       => 'ecommerce',
-            'tree'       => 'unknown',
-            'labels'     => [
+            'code'          => 'ecommerce',
+            'category_tree' => 'unknown',
+            'labels'        => [
                 'fr_FR' => 'E-commerce',
             ],
-            'locales'    => ['fr_FR'],
+            'locales'       => ['fr_FR'],
             'currencies' => ['EUR']
         ];
         $categoryRepository->findOneByIdentifier('unknown')->willReturn(null);
@@ -133,10 +133,10 @@ class ChannelUpdaterSpec extends ObjectBehavior
         CurrencyInterface $eur
     ) {
         $values = [
-            'code'       => 'ecommerce',
-            'locales'    => ['unknown'],
-            'currencies' => ['EUR'],
-            'tree'       => 'tree',
+            'code'          => 'ecommerce',
+            'locales'       => ['unknown'],
+            'currencies'    => ['EUR'],
+            'category_tree' => 'tree',
         ];
         $categoryRepository->findOneByIdentifier('tree')->willReturn($tree);
         $localeRepository->findOneByIdentifier('unknown')->willReturn(null);
@@ -155,11 +155,11 @@ class ChannelUpdaterSpec extends ObjectBehavior
         LocaleInterface $frFR
     ) {
         $values = [
-            'code'       => 'ecommerce',
-            'locales'    => ['fr_FR'],
-            'currencies' => ['unknown'],
-            'tree'       => 'tree',
-            'labels'     => [
+            'code'          => 'ecommerce',
+            'locales'       => ['fr_FR'],
+            'currencies'    => ['unknown'],
+            'category_tree' => 'tree',
+            'labels'        => [
                 'fr_FR' => 'E-commerce',
             ],
         ];

--- a/src/Pim/Component/Catalog/spec/Updater/CurrencyUpdaterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/CurrencyUpdaterSpec.php
@@ -35,8 +35,8 @@ class CurrencyUpdaterSpec extends ObjectBehavior
         $currency->setActivated(true)->shouldBeCalled();
 
         $this->update($currency, [
-            'code' => 'USD',
-            'activated' => true
+            'code'    => 'USD',
+            'enabled' => true
         ], []);
     }
 }

--- a/src/Pim/Component/Catalog/spec/Updater/FamilyUpdaterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/FamilyUpdaterSpec.php
@@ -75,14 +75,14 @@ class FamilyUpdaterSpec extends ObjectBehavior
         ChannelInterface $printChannel
     ) {
         $values = [
-            'code'                => 'mycode',
-            'attributes'          => ['sku', 'name', 'description', 'price'],
-            'attribute_as_label'  => 'name',
-            'requirements'        => [
+            'code'                   => 'mycode',
+            'attributes'             => ['sku', 'name', 'description', 'price'],
+            'attribute_as_label'     => 'name',
+            'attribute_requirements' => [
                 'mobile' => ['sku', 'name'],
                 'print'  => ['name', 'description'],
             ],
-            'labels'              => [
+            'labels'                 => [
                 'fr_FR' => 'Moniteurs',
                 'en_US' => 'PC Monitors',
             ],
@@ -192,8 +192,8 @@ class FamilyUpdaterSpec extends ObjectBehavior
         ChannelInterface $printChannel
     ) {
         $values = [
-            'code' => 'mycode',
-            'requirements' => []
+            'code'                   => 'mycode',
+            'attribute_requirements' => []
         ];
         $family->getAttributeRequirements()->willReturn([$skuMobileRqrmt, $skuPrintRqrmt]);
         $skuMobileRqrmt->getAttribute()->willReturn($skuAttribute);
@@ -229,8 +229,8 @@ class FamilyUpdaterSpec extends ObjectBehavior
         ChannelInterface $printChannel
     ) {
         $values = [
-            'code' => 'mycode',
-            'requirements' => [
+            'code'                   => 'mycode',
+            'attribute_requirements' => [
                 'print' => ['name', 'description']
             ]
         ];
@@ -274,14 +274,14 @@ class FamilyUpdaterSpec extends ObjectBehavior
         AttributeInterface $priceAttribute
     ) {
         $data = [
-            'code'                => 'mycode',
-            'attributes'          => ['sku', 'name', 'description', 'price'],
-            'attribute_as_label'  => 'name',
-            'requirements'        => [
+            'code'                   => 'mycode',
+            'attributes'             => ['sku', 'name', 'description', 'price'],
+            'attribute_as_label'     => 'name',
+            'attribute_requirements' => [
                 'mobile' => ['sku', 'name'],
                 'print'  => ['sku', 'name', 'description'],
             ],
-            'labels'              => [
+            'labels'                 => [
                 'fr_FR' => 'Moniteurs',
                 'en_US' => 'PC Monitors',
             ],
@@ -304,8 +304,8 @@ class FamilyUpdaterSpec extends ObjectBehavior
         FamilyInterface $family
     ) {
         $data = [
-            'code'                => 'mycode',
-            'requirements'        => [
+            'code'                   => 'mycode',
+            'attribute_requirements' => [
                 'mobile' => ['sku', 'name'],
                 'print'  => ['sku', 'name', 'description'],
             ]

--- a/src/Pim/Component/Catalog/spec/Updater/VariantGroupUpdaterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/VariantGroupUpdaterSpec.php
@@ -108,7 +108,7 @@ class VariantGroupUpdaterSpec extends ObjectBehavior
 
         $values = [
             'code'         => 'mycode',
-            'axis'         => ['main_color', 'secondary_color'],
+            'axes'         => ['main_color', 'secondary_color'],
             'type'         => 'VARIANT',
             'labels'       => [
                 'fr_FR' => 'T-shirt super beau',
@@ -161,7 +161,7 @@ class VariantGroupUpdaterSpec extends ObjectBehavior
 
         $values = [
             'code'     => 'mycode',
-            'axis'     => [],
+            'axes'     => [],
             'type'     => 'VARIANT',
             'labels'   => [],
             'values'   => [],
@@ -192,7 +192,7 @@ class VariantGroupUpdaterSpec extends ObjectBehavior
 
         $values = [
             'code' => 'mycode',
-            'axis' => ['unknown', 'secondary_color'],
+            'axes' => ['unknown', 'secondary_color'],
         ];
 
         $this->shouldThrow(new \InvalidArgumentException('Attribute "unknown" does not exist'))
@@ -209,7 +209,7 @@ class VariantGroupUpdaterSpec extends ObjectBehavior
 
         $values = [
             'code' => 'mycode',
-            'axis' => ['main_color'],
+            'axes' => ['main_color'],
         ];
 
         $this->shouldThrow(new \InvalidArgumentException('Attributes: This property cannot be changed.'))

--- a/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Category.php
+++ b/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Category.php
@@ -77,7 +77,7 @@ class Category implements ArrayConverterInterface
             $labelLocale = $labelTokens[1];
             $convertedItem['labels'][$labelLocale] = $data;
         } elseif ('code' === $field) {
-            $convertedItem[$field] = (string)$data;
+            $convertedItem[$field] = (string) $data;
         } elseif ('parent' === $field) {
             $convertedItem[$field] = '' === $data ? null : $data;
         }

--- a/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Channel.php
+++ b/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Channel.php
@@ -50,12 +50,12 @@ class Channel implements ArrayConverterInterface
      *      ],
      *     'locales'          => ['en_US', 'fr_FR'],
      *     'currencies'       => ['EUR', 'USD'],
-     *     'tree'             => 'master_catalog',
+     *     'category_tree'    => 'master_catalog',
      *     'conversion_units' => [
-     *          'weight' => 'GRAM',
+     *          'weight'            => 'GRAM',
      *          'maximum_scan_size' => 'KILOMETER',
-     *          'display_diagonal' => 'DEKAMETER',
-     *          'viewing_area' => 'DEKAMETER'
+     *          'display_diagonal'  => 'DEKAMETER',
+     *          'viewing_area'      => 'DEKAMETER'
      *      ]
      */
     public function convert(array $item, array $options = [])
@@ -88,6 +88,8 @@ class Channel implements ArrayConverterInterface
             $convertedItem[$field] = explode(',', $data);
         } elseif ('conversion_units' === $field) {
             $convertedItem[$field] = $this->convertUnits($data);
+        } elseif ('tree' === $field) {
+            $convertedItem['category_tree'] = $data;
         } else {
             $convertedItem[$field] = $data;
         }

--- a/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Currency.php
+++ b/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Currency.php
@@ -38,8 +38,8 @@ class Currency implements ArrayConverterInterface
      *
      * After:
      * [
-     *     'code'      => 'USD',
-     *     'activated' => true,
+     *     'code'    => 'USD',
+     *     'enabled' => true,
      * ]
      */
     public function convert(array $item, array $options = [])
@@ -67,7 +67,7 @@ class Currency implements ArrayConverterInterface
         if ('code' === $field) {
             $convertedItem[$field] = $data;
         } elseif ('activated' === $field) {
-            $convertedItem[$field] = (bool) $data;
+            $convertedItem['enabled'] = (bool) $data;
         }
 
         return $convertedItem;

--- a/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Family.php
+++ b/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Family.php
@@ -43,14 +43,14 @@ class Family implements ArrayConverterInterface
      *
      * After:
      * [
-     *      'code'                => 'pc_monitors',
-     *      'attributes'          => ['sku', 'name', 'description', 'price'],
-     *      'attribute_as_label'  => 'name',
-     *      'requirements' => [
+     *      'code'                   => 'pc_monitors',
+     *      'attributes'             => ['sku', 'name', 'description', 'price'],
+     *      'attribute_as_label'     => 'name',
+     *      'attribute_requirements' => [
      *          'mobile' => ['sku', 'name'],
      *          'print'  => ['sku', 'name', 'description'],
      *      ],
-     *      'labels' => [
+     *      'labels'                 => [
      *          'fr_FR' => 'Moniteurs',
      *          'en_US' => 'PC Monitors',
      *      ],
@@ -61,7 +61,7 @@ class Family implements ArrayConverterInterface
         $this->fieldChecker->checkFieldsPresence($item, ['code']);
         $this->fieldChecker->checkFieldsFilling($item, ['code']);
 
-        $convertedItem = ['labels' => [], 'requirements' => []];
+        $convertedItem = ['labels' => [], 'attribute_requirements' => []];
         foreach ($item as $field => $data) {
             $convertedItem = $this->convertField($convertedItem, $field, $data);
         }
@@ -85,7 +85,7 @@ class Family implements ArrayConverterInterface
         } elseif ('' !== $data && false !== strpos($field, 'requirements-', 0)) {
             $requirementsTokens = explode('-', $field);
             $requirementsLocale = $requirementsTokens[1];
-            $convertedItem['requirements'][$requirementsLocale] = explode(',', $data);
+            $convertedItem['attribute_requirements'][$requirementsLocale] = explode(',', $data);
         } elseif ('' !== $data) {
             switch ($field) {
                 case 'code':

--- a/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Locale.php
+++ b/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Locale.php
@@ -32,8 +32,8 @@ class Locale implements ArrayConverterInterface
      *
      * Before:
      * [
-     *     'code'    => 'en_US',
-     *     'enabled' => 1,
+     *     'code'      => 'en_US',
+     *     'activated' => 1,
      * ]
      *
      * After:

--- a/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/VariantGroup.php
+++ b/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/VariantGroup.php
@@ -72,7 +72,7 @@ class VariantGroup implements ArrayConverterInterface
      *         "en_US": "T-shirt very beautiful",
      *         "fr_FR": "T-shirt super beau"
      *     }
-     *     "axis": ["main_color", "secondary_color"],
+     *     "axes": ["main_color", "secondary_color"],
      *     "type": "VARIANT",
      *     "values": {
      *         "main_color": "white",
@@ -129,7 +129,7 @@ class VariantGroup implements ArrayConverterInterface
                     $convertedItem[$field] = $data;
                     break;
                 case 'axis':
-                    $convertedItem[$field] = explode(',', $data);
+                    $convertedItem['axes'] = explode(',', $data);
                     break;
                 default:
                     $convertedItem['values'][$field] = $data;

--- a/src/Pim/Component/Connector/spec/ArrayConverter/FlatToStandard/ChannelSpec.php
+++ b/src/Pim/Component/Connector/spec/ArrayConverter/FlatToStandard/ChannelSpec.php
@@ -32,19 +32,19 @@ class ChannelSpec extends ObjectBehavior
         ];
 
         $result = [
-            'labels' => [
+            'labels'           => [
                 'fr_FR' => 'Ecommerce',
                 'en_US' => 'Ecommerce',
             ],
-            'code'       => 'ecommerce',
-            'locales'    => ['en_US', 'fr_FR'],
-            'currencies' => ['EUR', 'USD'],
-            'tree'       => 'master_catalog',
+            'code'             => 'ecommerce',
+            'locales'          => ['en_US', 'fr_FR'],
+            'currencies'       => ['EUR', 'USD'],
+            'category_tree'    => 'master_catalog',
             'conversion_units' => [
-                'weight' => 'GRAM',
+                'weight'            => 'GRAM',
                 'maximum_scan_size' => 'KILOMETER',
-                'display_diagonal' => 'DEKAMETER',
-                'viewing_area' => 'DEKAMETER'
+                'display_diagonal'  => 'DEKAMETER',
+                'viewing_area'      => 'DEKAMETER'
             ]
         ];
 

--- a/src/Pim/Component/Connector/spec/ArrayConverter/FlatToStandard/CurrencySpec.php
+++ b/src/Pim/Component/Connector/spec/ArrayConverter/FlatToStandard/CurrencySpec.php
@@ -21,11 +21,11 @@ class CurrencySpec extends ObjectBehavior
 
     function it_converts_an_activated_item_to_standard_format()
     {
-        $this->convert(['code' => 'USD', 'activated' => 1])->shouldReturn(['code' => 'USD', 'activated' => true]);
+        $this->convert(['code' => 'USD', 'activated' => 1])->shouldReturn(['code' => 'USD', 'enabled' => true]);
     }
 
     function it_converts_a_disabled_item_to_standard_format()
     {
-        $this->convert(['code' => 'USD', 'activated' => 0])->shouldReturn(['code' => 'USD', 'activated' => false]);
+        $this->convert(['code' => 'USD', 'activated' => 0])->shouldReturn(['code' => 'USD', 'enabled' => false]);
     }
 }

--- a/src/Pim/Component/Connector/spec/ArrayConverter/FlatToStandard/VariantGroupSpec.php
+++ b/src/Pim/Component/Connector/spec/ArrayConverter/FlatToStandard/VariantGroupSpec.php
@@ -80,7 +80,7 @@ class VariantGroupSpec extends ObjectBehavior
                 'en_US' => 'T-shirt very beautiful',
             ],
             'code'    => 'mycode',
-            'axis'    => ['main_color', 'secondary_color'],
+            'axes'    => ['main_color', 'secondary_color'],
             'type'    => 'VARIANT',
             'values'  => $convertedValues
         ]);


### PR DESCRIPTION
Last PR about the standard format in imports (a previous PR has been [done](https://github.com/akeneo/pim-community-dev/pull/5096) about the standard format but mainly for products) 

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       |
| Added Behats                      |
| Changelog updated                 |
| Review and 2 GTM                  |
| Micro Demo to the PO (Story only) |
| Migration script                  |
| Tech Doc                          |
