### PR TITLE
Change the priority of reference data normalizer

### DIFF
--- a/src/Pim/Bundle/ReferenceDataBundle/Resources/config/serializers.yml
+++ b/src/Pim/Bundle/ReferenceDataBundle/Resources/config/serializers.yml
@@ -20,7 +20,7 @@ services:
     pim_reference_data.normalizer.reference_data:
         class: '%pim_reference_data.normalizer.reference_data.class%'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_serializer.normalizer, priority: 110 }
             - { name: pim_webservice.serializer.normalizer, priority: 90 }
 
     pim_reference_data.normalizer.flat.reference_data:


### PR DESCRIPTION
<3 Thanks for taking the time to contribute! You're awesome! <3

If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/CONTRIBUTING.md 

**Description (for Contributor and Core Developer)**

This PR fixes the normalization (for the PEF) of translatable reference data.

Previously, when you had a Translatable entity (implementing `TranslatableInterface`), it was normalized by `\Pim\Component\Catalog\Normalizer\Structured\TranslationNormalizer`. It resulted in an unexpected structure of JSON that could not be parsed by the Product Edit Form and lead to errors.

The proper normalizer to use is `\Pim\Component\ReferenceData\Normalizer\Structured\ReferenceDataNormalizer`. As both normlizers have the same priority, changing it to a higher one make this normalizer chosen first and JSON properly generated.

**Definition Of Done (for Core Developer only)**

| Q | A |
| --- | --- |
| Added Specs | No |
| Added Behats | No |
| Changelog updated | No |
| Review and 2 GTM | Pending |
| Micro Demo to the PO (Story only) | N/A |
| Migration script | No |
|  Tech Doc | No |
