### PR TITLE
PIM-5995: fix product count on update for variant groups

### DIFF
--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -1,3 +1,7 @@
+# 1.5.x
+
+- PIM-5995: Fix issue with product count on group save
+
 # 1.5.12 (2016-11-04)
 
 - PIM-5995: Fix issue with locale specific attributes added to variant groups

--- a/features/enrich/variant-group/add_products.feature
+++ b/features/enrich/variant-group/add_products.feature
@@ -28,7 +28,8 @@ Feature: Add products to a variant group
     And I check the row "sandal-white-37"
     And I check the row "sandal-white-38"
     And I press the "Save" button
-    Then the rows "sandal-white-37 and sandal-white-38" should be checked
+    Then I should see the text "Products: 2"
+    And the rows "sandal-white-37 and sandal-white-38" should be checked
     And the product "sandal-white-37" should have the following value:
       | name-en_US   | EN name     |
       | comment      | New comment |

--- a/features/enrich/variant-group/edit_attributes_of_a_variant_group.feature
+++ b/features/enrich/variant-group/edit_attributes_of_a_variant_group.feature
@@ -72,7 +72,8 @@ Feature: Edit attributes of a variant group
     Then the field ecommerce Description should contain "British ecommerce description"
     And the field tablet Description should contain "British tablet description"
 
-  @skip temporary disabling Behat
+  # Temporary disabling Behat
+  @skip
   Scenario: Display a message when variant group has no attributes
     Given I am on the "jackets" variant group page
     And I visit the "Attributes" tab

--- a/src/Pim/Bundle/EnrichBundle/Form/Handler/GroupHandler.php
+++ b/src/Pim/Bundle/EnrichBundle/Form/Handler/GroupHandler.php
@@ -3,6 +3,7 @@
 namespace Pim\Bundle\EnrichBundle\Form\Handler;
 
 use Akeneo\Component\StorageUtils\Saver\SaverInterface;
+use Doctrine\Common\Persistence\ObjectManager;
 use Pim\Bundle\CatalogBundle\Repository\ProductRepositoryInterface;
 use Pim\Component\Catalog\Localization\Localizer\AttributeConverterInterface;
 use Pim\Component\Catalog\Model\GroupInterface;
@@ -33,6 +34,9 @@ class GroupHandler implements HandlerInterface
     /** @var AttributeConverterInterface */
     protected $localizedConverter;
 
+    /** @var ObjectManager */
+    protected $objectManager;
+
     /**
      * Constructor for handler
      *
@@ -41,19 +45,22 @@ class GroupHandler implements HandlerInterface
      * @param SaverInterface              $groupSaver
      * @param ProductRepositoryInterface  $productRepository
      * @param AttributeConverterInterface $localizedConverter
+     * @param ObjectManager               $objectManager
      */
     public function __construct(
         FormInterface $form,
         Request $request,
         SaverInterface $groupSaver,
         ProductRepositoryInterface $productRepository,
-        AttributeConverterInterface $localizedConverter
+        AttributeConverterInterface $localizedConverter,
+        ObjectManager $objectManager = null
     ) {
         $this->form               = $form;
         $this->request            = $request;
         $this->groupSaver         = $groupSaver;
         $this->productRepository  = $productRepository;
         $this->localizedConverter = $localizedConverter;
+        $this->objectManager      = $objectManager;
     }
 
     /**
@@ -103,6 +110,10 @@ class GroupHandler implements HandlerInterface
             $this->convertLocalizedValues($group);
         }
         $this->groupSaver->save($group, $options);
+
+        if (null !== $this->objectManager && $group->getId()) {
+            $this->objectManager->refresh($group);
+        }
     }
 
     /**

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/handlers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/handlers.yml
@@ -36,6 +36,7 @@ services:
             - '@pim_catalog.saver.group'
             - '@pim_catalog.repository.product'
             - '@pim_catalog.localization.localizer.converter'
+            - '@doctrine.orm.entity_manager'
 
     pim_enrich.form.handler.variant_group:
         class: %pim_enrich.form.handler.group.class%
@@ -46,6 +47,7 @@ services:
             - '@pim_catalog.saver.group'
             - '@pim_catalog.repository.product'
             - '@pim_catalog.localization.localizer.converter'
+            - '@doctrine.orm.entity_manager'
 
     pim_enrich.form.handler.group_type:
         class: %pim_enrich.form.handler.base.class%


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Bug: the product count is not updated after group save (work after refresh).

By refreshing the group after persist the product count is updated.

**Definition Of Done (for Core Developer only)**


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Y
| Added Behats                      | Y
| Changelog updated                 | N
| Review and 2 GTM                  | N
| Micro Demo to the PO (Story only) | N
| Migration script                  | N
| Tech Doc                          | N
