### PR TITLE
[SLA] Boost product export performances by loading less products at the same time

### DIFF
--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -1,5 +1,6 @@
 # 1.5.x
 
+- PIM-6005: Boost product export performances by loading less products at the same time
 - PIM-5995: Fix issue with product count on group save
 - PIM-6006: Fix small memory leak when iterating over products cursor
 

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/storage_driver/doctrine/orm.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/storage_driver/doctrine/orm.yml
@@ -25,7 +25,7 @@ parameters:
 
     pim_catalog.doctrine.query.cursor.class:               Akeneo\Bundle\StorageUtilsBundle\Doctrine\ORM\Cursor\Cursor
     pim_catalog.doctrine.cursor_factory.product.class:     Akeneo\Bundle\StorageUtilsBundle\Doctrine\ORM\Cursor\CursorFactory
-    pim_catalog.factory.product_cursor.page_size:          1000
+    pim_catalog.factory.product_cursor.page_size:          1
 
     pim_catalog.doctrine.query.sorter.base.class:          Pim\Bundle\CatalogBundle\Doctrine\ORM\Sorter\BaseSorter
     pim_catalog.doctrine.query.sorter.entity.class:        Pim\Bundle\CatalogBundle\Doctrine\ORM\Sorter\EntitySorter


### PR DESCRIPTION
### General points
* detected by a customer that has 60K products, 10M values in ORM
* this bug only occurs in ORM

### Boost product export performances by loading less products at the same time

Currently we fetches products 1000 by 1000 via [the cursor](https://github.com/akeneo/pim-community-dev/blob/1.5/src/Pim/Bundle/CatalogBundle/Resources/config/storage_driver/doctrine/orm.yml#L28). The cursor is internally used by the Product Query Builder.

When you have, let's say 200 values per product, that means you directly load 200 000 objects in memory. This leads to 2 problems: 
* it represents a big amount of memory (~750MB see below)
* the table of the garbage collector, which only has [10 000 entries](https://www.sitepoint.com/better-understanding-phps-garbage-collection/), is full (remember @BitOne's presentations :) )

The more a PHP process uses the memory, the less it's fast. We have the garbage collector double fee. It is constantly called.

To fix this problem, we decided with Benoit to fetch products one by one. So question, isn't it weird to have a cursor that fetches objects one by one? Actually we don't really care, this is purely an internal behavior. The only consequence is that we'll perform a MySQL query for each product. That may sounds really heavy and stupid but it's far better and faster to perform a really simple query per product rather than letting our cursor leak.

Note: we don't have this problem in Mongo as the cursor is handled directly by the Mongo driver :) (And as devs, we don't even know or have to care how this cursor works internally)


### A few measures, with the batch enhanced_product_export

(This export, like PIM 1.6, uses internally the cursor, contrary to the native export of the PIM 1.5)

Without this fix

nb products | memory | time
-----------------|------------|-----
1000 | 396MB | ~1 min 10 sec
2500 | 775MB | ~6 min
5000 | 783MB | ~15 min 30 sec
16000 | 783MB  | ~52 min
25000 | 783MB  | ~83 min


With this fix

nb products | memory | time
-----------------|------------|-----
1000 | 100MB | ~50 sec
2500 | 100MB | ~3 min
5000 | 100MB | ~7 min
16000 | 101MB  | ~25 min
25000 | 101MB  | ~41 min


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Changelog updated                 | Y
| Review and 2 GTM                  | -
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

