### PR TITLE
Throw exceptions on fixture-file problems, fixes #5213

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -81,7 +81,8 @@
         "sensiolabs/behat-page-object-extension": "1.0.1",
         "phpspec/phpspec": "2.4.*",
         "akeneo/phpspec-skip-example-extension": "1.2.*",
-        "akeneo/php-coupling-detector": "dev-master"
+        "akeneo/php-coupling-detector": "dev-master",
+        "mikey179/vfsStream": "~1.6.4"
     },
     "suggest": {
         "doctrine/mongodb-odm-bundle": "In order to activate the MongoDB support within Akeneo",

--- a/src/Pim/Bundle/InstallerBundle/FixtureLoader/ConfigurationRegistry.php
+++ b/src/Pim/Bundle/InstallerBundle/FixtureLoader/ConfigurationRegistry.php
@@ -76,9 +76,7 @@ class ConfigurationRegistry implements ConfigurationRegistryInterface
         $ordered = [];
 
         foreach ($filePaths as $filePath) {
-            if (!is_dir($filePath)) {
-                $this->setFixtures($ordered, $filePath);
-            }
+            $this->setFixtures($ordered, $filePath);
         }
 
         ksort($ordered);
@@ -130,7 +128,12 @@ class ConfigurationRegistry implements ConfigurationRegistryInterface
      */
     protected function setFixtures(array &$ordered, $filePath)
     {
+        if (!is_file($filePath)) {
+            throw new \InvalidArgumentException(sprintf('Error, not a file: "%s"', $filePath));
+        }
+
         $pathInfo = pathinfo($filePath);
+        $fixturesFound = 0;
         foreach ($this->getConfiguration() as $fixtureName => $fixtureConfig) {
             if (!isset($fixtureConfig[$pathInfo['extension']])) {
                 continue;
@@ -150,6 +153,10 @@ class ConfigurationRegistry implements ConfigurationRegistryInterface
                 'name'      => $fixtureName,
                 'extension' => $pathInfo['extension']
             ];
+            $fixturesFound++;
+        }
+        if (0 === $fixturesFound) {
+            throw new \UnexpectedValueException(sprintf('Can not identify file as fixture: "%s"', $filePath));
         }
     }
 

--- a/src/Pim/Bundle/InstallerBundle/Tests/Unit/FixtureLoader/ConfigurationRegistryTest.php
+++ b/src/Pim/Bundle/InstallerBundle/Tests/Unit/FixtureLoader/ConfigurationRegistryTest.php
@@ -2,6 +2,8 @@
 
 namespace Pim\Bundle\InstallerBundle\Tests\Unit\FixtureLoader;
 
+use org\bovigo\vfs\vfsStream;
+
 /**
  * Tests related class
  *
@@ -167,41 +169,56 @@ class ConfigurationRegistryTest extends \PHPUnit_Framework_TestCase
 
     public function testGetFixtures()
     {
+        $root = vfsStream::setup('root/tmp');
+        $filePaths = [
+            $root->url() . '/tmp/entity1.format1',
+            $root->url() . '/tmp/entity1.format2',
+            $root->url() . '/tmp/entity2.format2',
+        ];
+        array_map('touch', $filePaths);
+
         $this->assertEquals(
             [
                 [
                     'name'      => 'entity1.step2',
                     'extension' => 'format1',
-                    'path'      => '/tmp/entity1.format1'
+                    'path'      => 'vfs://root/tmp/entity1.format1'
                 ],
                 [
                     'name'      => 'entity1.step2',
                     'extension' => 'format2',
-                    'path'      => '/tmp/entity1.format2'
+                    'path'      => 'vfs://root/tmp/entity1.format2'
                 ],
                 [
                     'name'      => 'entity2',
                     'extension' => 'format2',
-                    'path'      => '/tmp/entity2.format2'
+                    'path'      => 'vfs://root/tmp/entity2.format2'
                 ],
                 [
                     'name'      => 'entity1',
                     'extension' => 'format1',
-                    'path'      => '/tmp/entity1.format1'
+                    'path'      => 'vfs://root/tmp/entity1.format1'
                 ],
                 [
                     'name'      => 'entity1',
                     'extension' => 'format2',
-                    'path'      => '/tmp/entity1.format2'
+                    'path'      => 'vfs://root/tmp/entity1.format2'
                 ],
             ],
-            $this->configurationRegistry->getFixtures(
-                [
-                    '/tmp/entity1.format1',
-                    '/tmp/entity1.format2',
-                    '/tmp/entity2.format2'
-                ]
-            )
+            $this->configurationRegistry->getFixtures($filePaths)
+        );
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage Error, not a file: "/tmp/entity1.format1"
+     */
+    public function testThrowException()
+    {
+        $this->configurationRegistry->getFixtures(
+            [
+                '/tmp/entity1.format1',
+            ]
         );
     }
 }


### PR DESCRIPTION
<3 Thanks for taking the time to contribute! You're awesome! <3

If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/CONTRIBUTING.md 

**Description (for Contributor and Core Developer)**

If a file giving as fixture parameter is not found within the file-system
or could not be identified as actual fixture then treat it as an exception.

Additionally give an exception message that informs about the cause of it
and which path is the culprit.

Refs:

- Command: pim:installer:load-fixtures

- #5213

- #1878

**Definition Of Done (for Core Developer only)**

| Q | A
| --------------------------------- | ---
| Added Specs                       |
| Added Behats                      |
| Changelog updated                 |
| Review and 2 GTM                  |
| Micro Demo to the PO (Story only) |
| Migration script                  |
| Tech Doc                          |