### PR TITLE
Add missing job set_attribute_requirements

### DIFF
--- a/upgrades/schema/Version_1_6_20161114150000_add_missing_set_attribute_requirements_job.php
+++ b/upgrades/schema/Version_1_6_20161114150000_add_missing_set_attribute_requirements_job.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Pim\Upgrade\Schema;
+
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Add the missing set_attribute_requirements job
+ *
+ * @author   Thomas Neumann <thomas.neumann@aoe.com
+ * @license  none none
+ */
+class Version_1_6_20161114150000_add_missing_set_attribute_requirements_job extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->write('(re-)create set_attribute_requirements job');
+        $this->addSql("DELETE FROM akeneo_batch_job_instance WHERE code = 'set_attribute_requirements';");
+        $this->addSql(<<< SQL
+            INSERT INTO `akeneo_batch_job_instance`
+              (`code`, `label`, `job_name`, `status`, `connector`, `type`, `raw_parameters`)
+            VALUES
+              (
+                'set_attribute_requirements',
+                'Set Attribute Requirements',
+                'set_attribute_requirements',
+                '0',
+                'Akeneo Mass Edit Connector',
+                'mass_edit',
+                'a:2:{s:7:\"filters\";a:0:{}s:7:\"actions\";a:0:{}}'
+              )
+            ;
+SQL
+        );
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        $this->throwIrreversibleMigrationException();
+    }
+}

--- a/upgrades/schema/Version_1_6_20161114150000_add_missing_set_attribute_requirements_job.php
+++ b/upgrades/schema/Version_1_6_20161114150000_add_missing_set_attribute_requirements_job.php
@@ -2,7 +2,6 @@
 
 namespace Pim\Upgrade\Schema;
 
-
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
 


### PR DESCRIPTION
Hi,

the mass-edit for families does not work (the final completion step fails).
Reason for this is the missing background job 'set_attribute_requirements'. This PR adds the missing job in a migration script. An existing job with the same code will be removed as it may be created manually.

The bug can be reproduces by using the mass edit functionality of families (mass-adding attributes).
The last completion step fails.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | N
| Added Behats                      | N
| Changelog updated                 | N
| Review and 2 GTM                  | Y
| Micro Demo to the PO (Story only) | N
| Migration script                  | Y
| Tech Doc                          | N


