### PR TITLE
[SLA] PIM-6006: fix small memory leak when iterating over products cursor

### DIFF
--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -1,6 +1,7 @@
 # 1.5.x
 
 - PIM-5995: Fix issue with product count on group save
+- PIM-6006: Fix small memory leak when iterating over products cursor
 
 # 1.5.12 (2016-11-04)
 

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/ProductRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/ProductRepository.php
@@ -169,8 +169,9 @@ class ProductRepository extends EntityRepository implements
         $this->addJoinToValueTables($qb);
         $rootAlias = current($qb->getRootAliases());
         $qb->andWhere(
-            $qb->expr()->in($rootAlias.'.id', $ids)
+            $qb->expr()->in($rootAlias.'.id', ':product_ids')
         );
+        $qb->setParameter('product_ids', $ids);
 
         return $qb->getQuery()->execute();
     }


### PR DESCRIPTION
### General points

* detected by a customer that has 60K products, 10M values in ORM
* this bug only occurs in ORM

### Fix small memory leak when iterating over products cursor

When using the method `execute()` of the product query builder, a `Akeneo\Component\StorageUtils\Cursor\CursorInterface` is created is created. Each time a new page of the cursor is loaded, the method `findByIds` of the `ProductRepository` is called.

Doctrine internally caches all DQL queries. Imagine we call the method `findByIds` 3 times, with the following paramteters:
1. `[1,2,3]`
2. `[8,9]`
3. `[11,22,33,44]`

Before this fix, Doctrine would have cache the following DQLs:
1. `SELECT p FROM Product p WHERE p.id IN (1)` #(1) represents [1,2,3]
2. `SELECT p FROM Product p WHERE p.id IN (2)` #(2) represents [8,9]
3. `SELECT p FROM Product p WHERE p.id IN (3)` #(3) represents [11,22,33,44]

It would have cached one different DQL per call. Which results in a small memory leak. During an export, we call this method a few bunch of times.

With this fix, Doctrine will only cache one time the following DQL `SELECT p FROM Product p WHERE p.id IN (:product_ids)`.

# We should always use the `setParameter` method of the query builder. We should never directly set the parameters!

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Changelog updated                 | Y
| Review and 2 GTM                  | 
| Micro Demo to the PO (Story only) |
| Migration script                  |
| Tech Doc                          |
