### PR TITLE
PIM-5990: Fix persist order

### DIFF
--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -1,10 +1,20 @@
+# 1.5.x
+
+## Bug fixes
+
+- PIM-5990: Fix persist order causing issue on variant group import with associated products
+
 # 1.5.13 (2016-11-18)
+
+## Bug fixes
 
 - PIM-6005: Boost product export performances by loading less products at the same time
 - PIM-5995: Fix issue with product count on group save
 - PIM-6006: Fix small memory leak when iterating over products cursor
 
 # 1.5.12 (2016-11-04)
+
+## Bug fixes
 
 - PIM-5995: Fix issue with locale specific attributes added to variant groups
 

--- a/features/import/product_variant_group/import_variant_group_having_products.feature
+++ b/features/import/product_variant_group/import_variant_group_having_products.feature
@@ -1,0 +1,40 @@
+@javascript
+Feature: Execute an import of variant group having matching products
+  In order to update existing product information
+  As a product manager
+  I need to be able to import variant group having matching products
+
+  Background:
+    Given the "footwear" catalog configuration
+    And the following products:
+      | sku             | family  | categories        | size | color |
+      | sandal-white-37 | sandals | winter_collection | 37   | white |
+      | sandal-white-38 | sandals | winter_collection | 38   | white |
+      | sandal-white-39 | sandals | winter_collection | 39   | white |
+      | sandal-red-37   | sandals | winter_collection | 37   | red   |
+      | sandal-red-38   | sandals | winter_collection | 38   | red   |
+      | sandal-red-39   | sandals | winter_collection | 39   | red   |
+    And the following product groups:
+      | code    | label   | axis        | type    | products                                          |
+      | SANDAL  | Sandal  | size, color | VARIANT | sandal-white-37, sandal-white-38, sandal-white-39 |
+      | SANDAL2 | Sandal2 | size, color | VARIANT | sandal-red-37, sandal-red-38, sandal-red-39       |
+    And I am logged in as "Julia"
+
+  @jira https://akeneo.atlassian.net/browse/PIM-5990
+  Scenario: Import a variant group two times changes nothing
+    Given the following CSV file to import:
+      """
+      code;axis;type;name-en_US;description-en_US-tablet
+      SANDAL;size,color;VARIANT;Sandal;A description
+      SANDAL2;size,color;VARIANT;Sandal2;Another description
+      """
+    And the following job "footwear_variant_group_import" configuration:
+      | filePath | %file to import% |
+    When I am on the "footwear_variant_group_import" import job page
+    And I launch the import job
+    And I wait for the "footwear_variant_group_import" job to finish
+    Then I should see the text "Updated Products 6"
+    When I am on the "footwear_variant_group_import" import job page
+    And I launch the import job
+    And I wait for the "footwear_variant_group_import" job to finish
+    Then I should see the text "Updated Products 6"

--- a/src/Pim/Component/Connector/Writer/Doctrine/VariantGroupWriter.php
+++ b/src/Pim/Component/Connector/Writer/Doctrine/VariantGroupWriter.php
@@ -42,11 +42,11 @@ class VariantGroupWriter extends BaseWriter
      */
     public function write(array $variantGroups)
     {
+        parent::write($variantGroups);
+
         if ($this->isCopyValues()) {
             $this->copyValuesToProducts($variantGroups);
         }
-
-        parent::write($variantGroups);
     }
 
     /**


### PR DESCRIPTION
When you import a variant group having associated products, it raises this issue:

    VARIANT GROUP IMPORT A new entity was found through the relationship 'Pim\Component\Catalog\Model\Product#groups' that was not configured to cascade persist operations for entity: [oro_mug]. To solve this issue: Either explicitly call EntityManager#persist() on this unknown entity or configure cascade persist this association in the mapping for example @ManyToOne(..,cascade={"persist"}).

The issue is that there is some detach in the "copyValuesToProducts" method (this method updates the products with new values of Variant Groups).
To fix it, we use the same order than the GroupWriter:
https://github.com/akeneo/pim-community-dev/blob/master/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/GroupSaver.php#L121

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | n
| Added Behats                      | y
| Changelog updated                 | y
| Review and 2 GTM                  | TODO
| Migration script                  | n
| Tech Doc                          | n

