### PR TITLE
[PIM-5989] Fix attribute options on localizable and scopable attribute simple select

### DIFF
--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-5990: Fix persist order causing issue on variant group import with associated products
+- PIM-5989: Fix attribute options on localizable and scopable attributes simple select
 
 # 1.5.13 (2016-11-18)
 

--- a/features/product/edit_product_with_localizable_and_scopable_attribute_options.feature
+++ b/features/product/edit_product_with_localizable_and_scopable_attribute_options.feature
@@ -1,0 +1,39 @@
+@javascript
+Feature: Edit a product with localizable and scopable attribute options
+  In order to enrich the catalog
+  As a regular user
+  I need to be able to edit a product with localizable and scopable attribute options
+
+  Background:
+    Given the "apparel" catalog configuration
+    And the following products:
+      | sku        | categories      |
+      | rick_morty | 2014_collection |
+    And the following attributes:
+      | code   | label-en_US | label-fr_FR | label-de_DE | type         | group | scopable | localizable |
+      | simple | Simple      | Simple      | Simple      | simpleselect | other | yes      | yes         |
+    And I am logged in as "Peter"
+    And the following CSV file to import:
+      """
+      code;label-fr_FR;label-de_DE;label-en_US;attribute;sort_order
+      1;FR1;DE1;US1;simple;1
+      2;FR2;DE2;US2;simple;2
+      """
+    And the following job "option_import" configuration:
+      | filePath      | %file to import% |
+    And I am on the "option_import" import job page
+    And I launch the import job
+    And I wait for the "option_import" job to finish
+
+  @jira https://akeneo.atlassian.net/browse/PIM-5989
+  Scenario: I should not lost data when switching scope on scopable and localizable simple select
+    Given I edit the "rick_morty" product
+    And I add available attribute Simple
+    And I change the Simple to "US1"
+    When I save the product
+    Then I should see the flash message "Product successfully updated"
+    Given I switch the scope to "ecommerce"
+    And I change the Simple to "US2"
+    And I switch the scope to "print"
+    When I switch the scope to "ecommerce"
+    Then I should see the text "US2"

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/simple-select-field.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/simple-select-field.js
@@ -107,7 +107,7 @@ define(
                             var id = $(element).val();
                             if ('' !== id) {
                                 if (null === this.choicePromise) {
-                                    this.choicePromise = $.get(choiceUrl, {options: {identifiers: [id]}});
+                                    this.choicePromise = $.get(choiceUrl);
                                 }
 
                                 this.choicePromise.then(function (response) {


### PR DESCRIPTION
Apply a fix of @ahocquard 
This fix can not be cherry-picked because it was done during a merge.

The issue:
When you have localizable and scopable attribute with attribute options, then you:
- save an attribute option
- set an attribute option for another scope
- swith scope then go back to the first one
- the value disappears !

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | n
| Added Behats                      | y
| Changelog updated                 | y
| Review and 2 GTM                  | TODO
| Migration script                  | n
| Tech Doc                          | n