### PR TITLE
PIM-6013: fix simple and multi select cache

### DIFF
--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -4,6 +4,7 @@
 
 - PIM-5990: Fix persist order causing issue on variant group import with associated products
 - PIM-5989: Fix attribute options on localizable and scopable attributes simple select
+- PIM-6013: Fix attribute options on localizable and scopable attributes simple select and multi select
 
 # 1.5.13 (2016-11-18)
 

--- a/features/attribute/option/sort_attribute_options.feature
+++ b/features/attribute/option/sort_attribute_options.feature
@@ -1,5 +1,5 @@
 @javascript
-Feature: Sortd attribute options
+Feature: Sort attribute options
   In order to define choices for a choice attribute
   As a product manager
   I need to sort options for attributes of type "Multi select" and "Simple select"

--- a/features/enrich/variant-group/edit_variant_group_attribute_value.feature
+++ b/features/enrich/variant-group/edit_variant_group_attribute_value.feature
@@ -37,8 +37,10 @@ Feature: Editing attribute values of a variant group also updates products
       | sku  | groups            | color | size |
       | boot | caterpillar_boots | black | 40   |
     And the following attributes:
-      | code                  | label-en_US           | type | group | allowedExtensions    |
-      | technical_description | Technical description | file | media | gif,png,jpeg,jpg,txt |
+      | code                         | label-en_US           | label-fr_FR           | type         | group     | allowedExtensions    | localizable | available_locales |
+      | technical_description        | Technical description | Description technique | file         | media     | gif,png,jpeg,jpg,txt |             |                   |
+      | simple_select_local_specific | Simple                | Simple                | simpleselect | marketing |                      | yes         | fr_FR,en_US       |
+      | multi_select_local_specific  | Multi                 | Multi                 | multiselect  | marketing |                      | yes         | fr_FR,en_US       |
     And I am logged in as "Julia"
     And I am on the "caterpillar_boots" variant group page
     And I visit the "Attributes" tab
@@ -97,6 +99,32 @@ Feature: Editing attribute values of a variant group also updates products
     And I should see the flash message "Variant group successfully updated"
     Then the product "boot" should have the following values:
       | rating | [5] |
+
+  Scenario: Change a pim_catalog_simpleselect attribute of a variant group
+    Given I set the "English (United States), French (France)" locales to the "mobile" channel
+    And I am on the "simple_select_local_specific" attribute page
+    And I visit the "Values" tab
+    And I create the following attribute options:
+      | Code  |
+      | red   |
+      | blue  |
+      | green |
+    When I am on the "caterpillar_boots" variant group page
+    And I visit the "Attributes" tab
+    And I visit the "Marketing" group
+    And I add available attributes Simple
+    And I change the "Simple" to "red"
+    And I save the variant group
+    And I switch the locale to "fr_FR"
+    When I change the "Simple" to "blue"
+    And I save the variant group
+    Then I should see the flash message "Variant group successfully updated"
+    When I am on the "boot" product page
+    And I visit the "Marketing" group
+    And I switch the scope to "mobile"
+    Then I should see the text "[red]"
+    When I switch the locale to "fr_FR"
+    Then I should see the text "[blue]"
 
   Scenario: Change a pim_catalog_text attribute of a variant group
     When I change the "Name" to "In a galaxy far far away"

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/multi-select-field.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/multi-select-field.js
@@ -18,12 +18,26 @@ define(
         'pim/security-context',
         'pim/initselect2',
         'pim/user-context',
-        'pim/i18n'
+        'pim/i18n',
+        'pim/attribute-manager'
     ],
-    function ($, Field, _, fieldTemplate, Routing, createOption, SecurityContext, initSelect2, UserContext, i18n) {
+    function (
+        $,
+        Field,
+        _,
+        fieldTemplate,
+        Routing,
+        createOption,
+        SecurityContext,
+        initSelect2,
+        UserContext,
+        i18n,
+        AttributeManager
+    ) {
         return Field.extend({
             fieldTemplate: _.template(fieldTemplate),
             choicePromise: null,
+            promiseIdentifiers: null,
             events: {
                 'change .field-input:first input.select-field': 'updateModel',
                 'click .add-attribute-option': 'createOption'
@@ -106,12 +120,20 @@ define(
                             }.bind(this)
                         },
                         initSelection: function (element, callback) {
-                            if (null === this.choicePromise) {
+                            var identifiers = AttributeManager.getValue(
+                                this.model.attributes.values,
+                                this.attribute,
+                                UserContext.get('catalogLocale'),
+                                UserContext.get('catalogScope')
+                            ).data;
+
+                            if (null === this.choicePromise || this.promiseIdentifiers !== identifiers) {
                                 this.choicePromise = $.get(choiceUrl, {
                                     options: {
-                                        identifiers: this.model.attributes.values[0].data
+                                        identifiers: identifiers
                                     }
                                 });
+                                this.promiseIdentifiers = identifiers;
                             }
 
                             this.choicePromise.then(function (results) {

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/simple-select-field.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/simple-select-field.js
@@ -24,6 +24,7 @@ define(
         return Field.extend({
             fieldTemplate: _.template(fieldTemplate),
             choicePromise: null,
+            promiseIdentifier: null,
             events: {
                 'change .field-input:first input[type="hidden"].select-field': 'updateModel',
                 'click .add-attribute-option': 'createOption'
@@ -106,8 +107,9 @@ define(
                         initSelection: function (element, callback) {
                             var id = $(element).val();
                             if ('' !== id) {
-                                if (null === this.choicePromise) {
-                                    this.choicePromise = $.get(choiceUrl);
+                                if (null === this.choicePromise || this.promiseIdentifier !== id) {
+                                    this.choicePromise = $.get(choiceUrl, {options: {identifiers: [id]}});
+                                    this.promiseIdentifier = id;
                                 }
 
                                 this.choicePromise.then(function (response) {


### PR DESCRIPTION
**Description**

With locale specific attributes and if you use a variant group there we a problem with the select and multi select fields.

In this PR we fix the cache management in simple/multiselect fields.

**Definition Of Done (for Core Developer only)**


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | NA
| Added Behats                      | Y
| Changelog updated                 | N
| Review and 2 GTM                  | N
| Micro Demo to the PO (Story only) | N
| Migration script                  | NA
| Tech Doc                          | NA
