### PR TITLE
PIM-5862: Fix product grid display on a custom user view

### DIFF
--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -7,6 +7,7 @@
 - PIM-6013: Fix attribute options on localizable and scopable attributes simple select and multi select
 - PIM-6002: Fix characters escapment with usage of quote in attribute option
 - PIM-5997: Restrict to 25 characters the role label
+- PIM-5862: Fix product grid display on a custom user view
 
 # 1.5.13 (2016-11-18)
 

--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -44,7 +44,6 @@
 
 - PIM-5777: Fix attribute refresh when locale change in Product Edit Form
 - TIP-307: Fix issues with Mongo 2.6
-- PIM-5862: Fix product grid display on a custom user view
 
 # 1.5.8 (2016-08-25)
 

--- a/features/Context/DataGridContext.php
+++ b/features/Context/DataGridContext.php
@@ -412,7 +412,7 @@ class DataGridContext extends RawMinkContext implements PageObjectAwareInterface
      */
     public function iDisplayTheColumns($gridLabel, $columns)
     {
-        $currentColumns = $this->datagrid->getColumnLabels();
+        $currentColumns = $this->datagrid->getCurrentColumnLabels();
         $expectedColumns = $this->getMainContext()->listToArray($columns);
 
         $currentColumns = array_map('strtolower', $currentColumns);
@@ -422,8 +422,8 @@ class DataGridContext extends RawMinkContext implements PageObjectAwareInterface
         $columnsToRemove = array_diff($currentColumns, $expectedColumns);
 
         $this->datagrid->openColumnsPopin();
-        $this->datagrid->showColumns($columnsToAdd);
-        $this->datagrid->hideColumns($columnsToRemove);
+        $this->datagrid->addColumns($columnsToAdd);
+        $this->datagrid->removeColumns($columnsToRemove);
         $this->datagrid->validateColumnsPopin();
     }
 
@@ -439,8 +439,6 @@ class DataGridContext extends RawMinkContext implements PageObjectAwareInterface
         $columns = $this->getMainContext()->listToArray($columns);
 
         $expectedColumns = count($columns);
-
-        $this->wait('$("table.grid").length > 0');
 
         $countColumns = $this->datagrid->countColumns();
         if ($expectedColumns !== $countColumns) {
@@ -1131,7 +1129,7 @@ class DataGridContext extends RawMinkContext implements PageObjectAwareInterface
      */
     public function iCreateTheView(TableNode $table)
     {
-        $button = $this->spin(function () {
+        $createViewButton = $this->spin(function () {
             $button = $this->getCurrentPage()->find('css', '#create-view');
             if (null !== $button && $button->isVisible()) {
                 return $button;
@@ -1140,8 +1138,8 @@ class DataGridContext extends RawMinkContext implements PageObjectAwareInterface
             return false;
         }, 'Create view button not found');
 
-        $this->spin(function () use ($button) {
-            $button->click();
+        $this->spin(function () use ($createViewButton) {
+            $createViewButton->click();
             $modalHeader = $this->getCurrentPage()->find(
                 'css',
                 '.modal-header:contains("Choose a label for the view")'

--- a/features/Context/Page/Base/Grid.php
+++ b/features/Context/Page/Base/Grid.php
@@ -813,6 +813,20 @@ class Grid extends Index
     }
 
     /**
+     * Return the labels of current columns
+     *
+     * @return string[]
+     */
+    public function getColumnLabels()
+    {
+        $headers = $this->getColumnHeaders(false, false);
+
+        return array_map(function (NodeElement $column) {
+            return  $column->getText();
+        }, $headers);
+    }
+
+    /**
      * Get rows
      *
      * @return NodeElement[]
@@ -922,13 +936,33 @@ class Grid extends Index
     }
 
     /**
-     * Hide a grid column
+     * Show grid columns
      *
-     * @param string $column
+     * @param string[] $columns
      */
-    public function hideColumn($column)
+    public function showColumns($columns)
     {
-        return $this->getElement('Configuration Popin')->hideColumn($column);
+        return $this->getElement('Configuration Popin')->showColumns($columns);
+    }
+
+    /**
+     * Hide grid columns
+     *
+     * @param string[] $columns
+     */
+    public function hideColumns($columns)
+    {
+        return $this->getElement('Configuration Popin')->hideColumns($columns);
+    }
+
+    /**
+     * Validate the columns selection
+     *
+     * @param string[] $columns
+     */
+    public function validateColumnsPopin()
+    {
+        $this->getElement('Configuration Popin')->apply();
     }
 
     /**

--- a/features/Context/Page/Element/ConfigurationPopin.php
+++ b/features/Context/Page/Element/ConfigurationPopin.php
@@ -2,6 +2,9 @@
 
 namespace Context\Page\Element;
 
+use Behat\Mink\Element\NodeElement;
+use Context\Spin\SpinCapableTrait;
+use Context\Spin\TimeoutException;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Element;
 
 /**
@@ -13,85 +16,92 @@ use SensioLabs\Behat\PageObjectExtension\PageObject\Element;
  */
 class ConfigurationPopin extends Element
 {
-    /** @var array */
+    use SpinCapableTrait;
+
     protected $selector = ['css' => '.modal'];
 
     /**
-     * Hide a column by dragging to the bucket
-     *
-     * @param string $label
+     * @param string[] $labels
      */
-    public function hideColumn($label)
+    public function showColumns($labels)
     {
-        $this->getColumn($label)->dragTo($this->getBucket());
-        $this->apply();
+        $searchInput = $this->spin(function () {
+            return $this->find('css', 'input[type="search"]');
+        });
+
+        $dropZone = $this->spin(function () {
+            return $this->find('css', '#column-selection');
+        }, sprintf('Cannot find the drop zone'));
+
+        foreach ($labels as $label) {
+            $searchInput->setValue($label);
+            $item = $this->getItemForLabel($label);
+            $this->dragElementTo($item, $dropZone);
+        }
     }
 
     /**
-     * Move a column
-     *
-     * @param string $source
-     * @param string $target
+     * @param string[] $labels
      */
-    public function moveColumn($source, $target)
+    public function hideColumns($labels)
     {
-        $this->getColumn($source)->dragTo($this->getColumn($target));
-        $this->apply();
-    }
+        $dropZone = $this->spin(function () {
+            return $this->find('css', '#column-list');
+        }, sprintf('Cannot find the drop zone'));
 
-    /**
-     * Get the whole columns container or a specific item
-     *
-     * @param string $label
-     *
-     * @return Element
-     *
-     * @throw ElementNotFoundException
-     */
-    protected function getColumn($label = null)
-    {
-        if ($label) {
-            $column = $this->find('css', sprintf('#columns li:contains("%s")', $label));
-        } else {
-            $column = $this->find('css', '#columns');
+        foreach ($labels as $label) {
+            $item = $this->getItemForLabel($label);
+            $this->dragElementTo($item, $dropZone);
         }
-
-        if (!$column) {
-            throw new \Exception('Columns container is not available');
-        }
-
-        return $column;
-    }
-
-    /**
-     * Get the whole bucket container or a specific item
-     *
-     * @param string $label
-     *
-     * @return Element
-     *
-     * @throw ElementNotFoundException
-     */
-    protected function getBucket($label = null)
-    {
-        if ($label) {
-            $bucket = $this->find('css', sprintf('#bucket li:contains("%s")', $label));
-        } else {
-            $bucket = $this->find('css', '#bucket');
-        }
-
-        if (!$bucket) {
-            throw new \Exception('Bucket container is not available');
-        }
-
-        return $bucket;
     }
 
     /**
      * Apply the configuration
      */
-    protected function apply()
+    public function apply()
     {
-        $this->find('css', '.btn.ok')->click();
+        $this->find('css', '.ok')->click();
+    }
+
+    /**
+     * Drags an element on another one.
+     * Works better than the standard dragTo.
+     *
+     * @param $element
+     * @param $dropZone
+     */
+    protected function dragElementTo($element, $dropZone)
+    {
+        $session = $this->getSession()->getDriver()->getWebDriverSession();
+
+        $from = $session->element('xpath', $element->getXpath());
+        $to = $session->element('xpath', $dropZone->getXpath());
+
+        $session->moveto(['element' => $from->getID()]);
+        $session->buttondown('');
+        $session->moveto(['element' => $to->getID()]);
+        $session->buttonup('');
+    }
+
+    /**
+     * @param string $label
+     *
+     * @throws TimeoutException
+     *
+     * @return NodeElement
+     */
+    protected function getItemForLabel($label)
+    {
+        return $this->spin(function () use ($label) {
+            $items = $this->findAll('css', 'li');
+
+            foreach ($items as $item) {
+                if (strtolower($label) === strtolower($item->getText())) {
+                    return $item;
+                }
+            }
+
+            return false;
+        }, sprintf('Cannot find the column "%s" in the list', $label));
     }
 }

--- a/features/Context/Page/Element/ConfigurationPopin.php
+++ b/features/Context/Page/Element/ConfigurationPopin.php
@@ -23,7 +23,7 @@ class ConfigurationPopin extends Element
     /**
      * @param string[] $labels
      */
-    public function showColumns($labels)
+    public function addColumns($labels)
     {
         $searchInput = $this->spin(function () {
             return $this->find('css', 'input[type="search"]');
@@ -43,7 +43,7 @@ class ConfigurationPopin extends Element
     /**
      * @param string[] $labels
      */
-    public function hideColumns($labels)
+    public function removeColumns($labels)
     {
         $dropZone = $this->spin(function () {
             return $this->find('css', '#column-list');
@@ -93,7 +93,7 @@ class ConfigurationPopin extends Element
     protected function getItemForLabel($label)
     {
         return $this->spin(function () use ($label) {
-            $items = $this->findAll('css', 'li');
+            $items = $this->findAll('css', '.ui-sortable-handle');
 
             foreach ($items as $item) {
                 if (strtolower($label) === strtolower($item->getText())) {

--- a/features/Context/Spin/SpinCapableTrait.php
+++ b/features/Context/Spin/SpinCapableTrait.php
@@ -42,7 +42,7 @@ trait SpinCapableTrait
             $looping = true;
         } while (
             microtime(true) < $end &&
-            !$result &&
+            (null === $result || false === $result || [] === $result) &&
             !$previousException instanceof TimeoutException
         );
 
@@ -50,7 +50,7 @@ trait SpinCapableTrait
             $message = (null !== $previousException) ? $previousException->getMessage() : 'no message';
         }
 
-        if (!$result) {
+        if (null === $result || false === $result || [] === $result) {
             $infos = sprintf('Spin : timeout of %d excedeed, with message : %s', $timeout, $message);
             throw new TimeoutException($infos, 0, $previousException);
         }

--- a/features/datagrid/datagrid_views.feature
+++ b/features/datagrid/datagrid_views.feature
@@ -7,18 +7,19 @@ Feature: Datagrid views
   Background:
     Given a "footwear" catalog configuration
     And the following products:
-      | sku             | family   |
-      | purple-sneakers | sneakers |
-      | black-sneakers  | sneakers |
-      | black-boots     | boots    |
+      | sku             | family   | name-en_US      |
+      | purple-sneakers | sneakers | Purple sneakers |
+      | black-sneakers  | sneakers | Black sneakers  |
+      | black-boots     | boots    | Black boots     |
     And I am logged in as "Mary"
-    And I am on the products page
 
   Scenario: Successfully display the default view
+    Given I am on the products page
     Then I should see the text "Views Default view"
 
   Scenario: Successfully create a new view
-    Given I filter by "Family" with value "Sneakers"
+    Given I am on the products page
+    And I filter by "Family" with value "Sneakers"
     And I create the view:
       | label | Sneakers only |
     Then I should be on the products page
@@ -28,14 +29,16 @@ Feature: Datagrid views
     But I should not see product black-boots
 
   Scenario: Successfully apply a view
-    Given I filter by "Family" with value "Boots"
+    Given I am on the products page
+    And I filter by "Family" with value "Boots"
     Then I should see product black-boots
     But I should not see products purple-sneakers and black-sneakers
     When I apply the "Default view" view
     Then I should see products black-boots, purple-sneakers and black-sneakers
 
   Scenario: Successfully update a view
-    Given I filter by "Family" with value "Boots"
+    Given I am on the products page
+    And I filter by "Family" with value "Boots"
     And I create the view:
       | label | Some shoes |
     Then I should be on the products page
@@ -54,7 +57,8 @@ Feature: Datagrid views
     But I should not see product black-boots
 
   Scenario: Successfully delete a view
-    Given I filter by "Family" with value "Boots"
+    Given I am on the products page
+    And I filter by "Family" with value "Boots"
     And I create the view:
       | label | Boots only |
     Then I should be on the products page
@@ -71,8 +75,9 @@ Feature: Datagrid views
     And I should see products black-boots, purple-sneakers and black-sneakers
 
   Scenario: Keep view per page
+    Given I am on the products page
     When I change the page size to 25
-    Given I am on the attributes page
+    And I am on the attributes page
     And I change the page size to 50
     When I am on the products page
     Then page size should be 25
@@ -80,7 +85,8 @@ Feature: Datagrid views
     Then page size should be 50
 
   Scenario: Successfully choose my default view
-    Given I filter by "Family" with value "Sneakers"
+    Given I am on the products page
+    And I filter by "Family" with value "Sneakers"
     And I create the view:
       | label | Sneakers only |
     Then I should be on the products page
@@ -106,7 +112,8 @@ Feature: Datagrid views
     Then I should see products black-boots, purple-sneakers and black-sneakers
 
   Scenario: Successfully remove my default view
-    Given I filter by "Family" with value "Sneakers"
+    Given I am on the products page
+    And I filter by "Family" with value "Sneakers"
     And I create the view:
       | label | Sneakers only |
     Then I should be on the products page
@@ -126,3 +133,36 @@ Feature: Datagrid views
     And I should see the flash message "Datagrid view successfully removed"
     And I should see the text "Views Default view"
     But I should not see the text "Sneakers only"
+
+  Scenario: Successfully display values in grid when using a custom default view
+    Given I am on the products page
+    And I display the columns SKU, Name and Family
+    Then I should see the text "purple-sneakers"
+    When I create the view:
+      | label | With name |
+    Then I should be on the products page
+    And I should see a flash message "Datagrid view successfully created"
+    When I am on my profile page
+    And I press the "Edit" button
+    And I visit the "Additional" tab
+    Then I should see the text "Default product grid view"
+    When I fill in the following information:
+      | Default product grid view | With name |
+    And I press the "Save" button
+    And I am on the products page
+    And I logout
+    And I am logged in as "Mary"
+    And I am on the products page
+    And I filter by "category" with value "unclassified"
+    Then the row "purple-sneakers" should contain:
+      | column | value           |
+      | Name   | Purple sneakers |
+      | Family | Sneakers        |
+    And the row "black-sneakers" should contain:
+      | column | value          |
+      | Name   | Black sneakers |
+      | Family | Sneakers       |
+    And the row "black-boots" should contain:
+      | column | value       |
+      | Name   | Black boots |
+      | Family | Boots       |

--- a/features/enrich/variant-group/edit_variant_group_attribute_value.feature
+++ b/features/enrich/variant-group/edit_variant_group_attribute_value.feature
@@ -100,7 +100,7 @@ Feature: Editing attribute values of a variant group also updates products
     Then the product "boot" should have the following values:
       | rating | [5] |
 
-  Scenario: Change a pim_catalog_simpleselect attribute of a variant group
+  Scenario: Change a pim_catalog_simpleselect locale specific attribute of a variant group
     Given I set the "English (United States), French (France)" locales to the "mobile" channel
     And I am on the "simple_select_local_specific" attribute page
     And I visit the "Values" tab

--- a/features/localization/product/datagrid/display_localized_dates.feature
+++ b/features/localization/product/datagrid/display_localized_dates.feature
@@ -18,6 +18,8 @@ Feature: Localize dates in the product grid
       | column          | value      |
       | Destocking date | 01/31/2015 |
 
+  # https://akeneo.atlassian.net/browse/PIM-6020
+  @skip
   Scenario: Successfully show French format numbers for French UI
     Given I am logged in as "Julien"
     When I am on the products page
@@ -30,8 +32,8 @@ Feature: Localize dates in the product grid
     Given I am logged in as "Julia"
     And I add the "french" locale to the "mobile" channel
     And I am on the products page
-    And I display the columns SKU, Destocking date
     When I switch the locale to "fr_FR"
+    And I display the columns [sku], [destocking_date]
     Then the row "sandals" should contain:
       | column            | value      |
-      | [Destocking_date] | 01/31/2015 |
+      | [destocking_date] | 01/31/2015 |

--- a/features/localization/product/datagrid/display_localized_dates.feature
+++ b/features/localization/product/datagrid/display_localized_dates.feature
@@ -13,7 +13,7 @@ Feature: Localize dates in the product grid
   Scenario: Successfully show English format dates for English UI
     Given I am logged in as "Julia"
     When I am on the products page
-    And I display the columns sku, destocking_date
+    And I display the columns SKU, Destocking date
     Then the row "sandals" should contain:
       | column          | value      |
       | Destocking date | 01/31/2015 |
@@ -21,7 +21,7 @@ Feature: Localize dates in the product grid
   Scenario: Successfully show French format numbers for French UI
     Given I am logged in as "Julien"
     When I am on the products page
-    And I display the columns sku, destocking_date
+    And I display the columns SKU, Destocking date
     Then the row "sandals" should contain:
       | column          | value      |
       | Destocking date | 31/01/2015 |
@@ -30,7 +30,7 @@ Feature: Localize dates in the product grid
     Given I am logged in as "Julia"
     And I add the "french" locale to the "mobile" channel
     And I am on the products page
-    And I display the columns sku, destocking_date
+    And I display the columns SKU, Destocking date
     When I switch the locale to "fr_FR"
     Then the row "sandals" should contain:
       | column            | value      |

--- a/features/localization/product/datagrid/display_localized_numbers.feature
+++ b/features/localization/product/datagrid/display_localized_numbers.feature
@@ -16,7 +16,7 @@ Feature: Localize numbers in the product grid
   Scenario: Successfully show English format numbers for English UI
     Given I am logged in as "Julia"
     When I am on the products page
-    And I display the columns sku, big_price, rate_sale and weight
+    And I display the columns SKU, Big price, Rate sale and Weight
     Then the row "sandals" should contain:
       | column       | value                |
       | big_price    | $1,000.12, €1,000.01 |
@@ -26,7 +26,7 @@ Feature: Localize numbers in the product grid
   Scenario: Successfully show French format numbers for French UI
     Given I am logged in as "Julien"
     When I am on the products page
-    And I display the columns sku, big_price, rate_sale and weight
+    And I display the columns SKU, Big price, Rate sale and Weight
     Then the row "sandals" should contain:
       | column       | value                    |
       | big_price    | 1 000,12 $US, 1 000,01 € |
@@ -37,7 +37,7 @@ Feature: Localize numbers in the product grid
     Given I am logged in as "Julia"
     And I add the "french" locale to the "mobile" channel
     And I am on the products page
-    And I display the columns sku, big_price, rate_sale and weight
+    And I display the columns SKU, Big price, Rate sale and Weight
     When I switch the locale to "fr_FR"
     Then the row "sandals" should contain:
       | column        | value                |

--- a/features/localization/product/datagrid/display_localized_numbers.feature
+++ b/features/localization/product/datagrid/display_localized_numbers.feature
@@ -8,7 +8,7 @@ Feature: Localize numbers in the product grid
     Given a "footwear" catalog configuration
     And the following attributes:
       | code      | label     | type   | decimals_allowed | label-fr_FR | useable_as_grid_filter |
-      | big_price | big_price | prices | yes              | big_price   | yes                    |
+      | big_price | Big price | prices | yes              | Gros prix   | yes                    |
     And the following products:
       | sku     | big_price                | rate_sale    | weight             |
       | sandals | 1000.12 USD, 1000.01 EUR | 1000.1234    | 1000.3456 KILOGRAM |
@@ -16,31 +16,33 @@ Feature: Localize numbers in the product grid
   Scenario: Successfully show English format numbers for English UI
     Given I am logged in as "Julia"
     When I am on the products page
-    And I display the columns SKU, Big price, Rate sale and Weight
+    And I display the columns SKU, Big price, Rate of sale and Weight
     Then the row "sandals" should contain:
       | column       | value                |
-      | big_price    | $1,000.12, €1,000.01 |
-      | Rate of Sale | 1,000.1234           |
-      | weight       | 1,000.3456 Kilogram  |
+      | Big price    | $1,000.12, €1,000.01 |
+      | Rate of sale | 1,000.1234           |
+      | Weight       | 1,000.3456 Kilogram  |
 
+  # https://akeneo.atlassian.net/browse/PIM-6020
+  @skip
   Scenario: Successfully show French format numbers for French UI
     Given I am logged in as "Julien"
     When I am on the products page
-    And I display the columns SKU, Big price, Rate sale and Weight
+    And I display the columns SKU, Big price, Rate of sale and Weight
     Then the row "sandals" should contain:
       | column       | value                    |
-      | big_price    | 1 000,12 $US, 1 000,01 € |
-      | Rate of Sale | 1 000,1234               |
-      | weight       | 1 000,3456 Kilogramme    |
+      | Big price    | 1 000,12 $US, 1 000,01 € |
+      | Rate of sale | 1 000,1234               |
+      | Weight       | 1 000,3456 Kilogramme    |
 
   Scenario: Successfully show English format numbers for French catalog
     Given I am logged in as "Julia"
     And I add the "french" locale to the "mobile" channel
     And I am on the products page
-    And I display the columns SKU, Big price, Rate sale and Weight
-    When I switch the locale to "fr_FR"
+    And I switch the locale to "fr_FR"
+    When I display the columns [sku], Gros prix, Taux de vente and Poids
     Then the row "sandals" should contain:
       | column        | value                |
-      | big_price     | $1,000.12, €1,000.01 |
+      | Gros prix     | $1,000.12, €1,000.01 |
       | Taux de vente | 1,000.1234           |
       | Poids         | 1,000.3456 Kilogram  |

--- a/features/product/browse_products_by_locale_and_scope.feature
+++ b/features/product/browse_products_by_locale_and_scope.feature
@@ -19,7 +19,7 @@ Feature: Browse products by locale and scope
       | postit | furniture | Post it    | Etiquette  | My ecommerce description    | Ma description ecommerce    | Ma description mobile    | large.jpeg      | small.jpeg   |
     And I am logged in as "Mary"
     And I am on the products page
-    And I display the columns sku, name, image, description and family
+    And I display the columns SKU, Name, Image, Description and Family
 
   @skip
   Scenario: Successfully display english data on products page

--- a/features/product/choose_and_order_products_grid_columns.feature
+++ b/features/product/choose_and_order_products_grid_columns.feature
@@ -27,7 +27,7 @@ Feature: Choose and order product grids columns
     Then I should see the columns Sku, Family, Status, Complete, Created At, Updated At, Groups
 
   Scenario: Successfully hide removed attribute column that was previously selected to be displayed
-    Given I display the columns sku, family and name
+    Given I display the columns SKU, Family and Name
     When I've removed the "name" attribute
     And I am on the products page
     Then I should see the columns Sku and Family
@@ -38,7 +38,7 @@ Feature: Choose and order product grids columns
       | sku     | name-en_US | categories        |
       | sandal1 | sandal one | summer_collection |
       | sandal2 | sandal two | summer_collection |
-    And I display the columns sku, family and name
+    And I display the columns SKU, Family and Name
     Then I should see the columns Sku, Family and Name
     Then I should be able to use the following filters:
       | filter   | value             | result                 |

--- a/features/product/choose_and_order_products_grid_columns.feature
+++ b/features/product/choose_and_order_products_grid_columns.feature
@@ -39,7 +39,8 @@ Feature: Choose and order product grids columns
       | sandal1 | sandal one | summer_collection |
       | sandal2 | sandal two | summer_collection |
     And I display the columns SKU, Family and Name
-    Then I should see the columns Sku, Family and Name
-    Then I should be able to use the following filters:
+    And I am on the products page
+    Then I should see the columns SKU, Family and Name
+    And I should be able to use the following filters:
       | filter   | value             | result                 |
       | category | summer_collection | sandal one, sandal two |

--- a/features/product/date.feature
+++ b/features/product/date.feature
@@ -16,7 +16,7 @@ Feature: Check that imported date is properly displayed
 
   Scenario: Successfully display a date in the grid (PIM-2971)
     Given I am on the products page
-    And I display the columns sku, family, release, complete, created and updated
+    And I display the columns SKU, Family, Release, Complete, Created at and Updated at
     Then the row "postit" should contain:
      | column  | value      |
      | release | 05/01/2014 |

--- a/features/product/display_attributes_in_the_grid.feature
+++ b/features/product/display_attributes_in_the_grid.feature
@@ -19,7 +19,7 @@ Feature: Display product attributes in the grid
       | boots    | lacoste      | cloudy              |
     And I am logged in as "Mary"
     And I am on the products page
-    When I display the columns sku, manufacturer and weather_conditions
+    When I display the columns SKU, Manufacturer and Weather conditions
     Then the row "sneakers" should contain:
       | column             | value                     |
       | Manufacturer       | [Converse]                |
@@ -45,7 +45,8 @@ Feature: Display product attributes in the grid
       | sandals  |                       | %fixtures%/akeneo2.jpg |
     And I am logged in as "Mary"
     And I am on the products page
-    When I display the columns sku, side_view and top_view
+    When I display the columns SKU, Side view and Top view
+    And I wait 60 seconds
     Then the row "sneakers" should contain the images:
       | column    | title      |
       | Side view | akeneo.jpg |

--- a/features/product/display_attributes_in_the_grid.feature
+++ b/features/product/display_attributes_in_the_grid.feature
@@ -46,7 +46,6 @@ Feature: Display product attributes in the grid
     And I am logged in as "Mary"
     And I am on the products page
     When I display the columns SKU, Side view and Top view
-    And I wait 60 seconds
     Then the row "sneakers" should contain the images:
       | column    | title      |
       | Side view | akeneo.jpg |

--- a/features/product/edit_product_and_action.feature
+++ b/features/product/edit_product_and_action.feature
@@ -11,7 +11,7 @@ Feature: Product edition clicking on another action
       | sandal | sandals |
     And I am logged in as "Mary"
     And I am on the products page
-    And I display the columns sku, name, image, description and family
+    And I display the columns SKU, Name, Image, Description and Family
 
   Scenario: Successfully edit a product and back to the grid
     Given I am on the "sandal" product page

--- a/features/product/edit_product_and_action.feature
+++ b/features/product/edit_product_and_action.feature
@@ -11,7 +11,7 @@ Feature: Product edition clicking on another action
       | sandal | sandals |
     And I am logged in as "Mary"
     And I am on the products page
-    And I display the columns SKU, Name, Image, Description and Family
+    And I display the columns SKU, Name, Description and Family
 
   Scenario: Successfully edit a product and back to the grid
     Given I am on the "sandal" product page

--- a/features/product/filtering/filter_products_per_text_fields.feature
+++ b/features/product/filtering/filter_products_per_text_fields.feature
@@ -20,7 +20,7 @@ Feature: Filter products by text field
       | 13572541 | Canon 5D + EF 24-105 F5L IS    |
       | 135-2541 | Canon 5D + EF 25-15 FL         |
     When I am on the products page
-    And I display the columns sku, name, family, complete, created and updated
+    And I display the columns SKU, Name, Family, Complete, Created at and Updated at
     Then the grid should contain 5 elements
     And I should see products "HP LA2206xc + WF722A", "Canon 5D + EF 24-105 F4L IS", "Canon 5D + EF 24-105mm f/4L IS" and "Canon 5D + EF 24-105 F5L IS"
     And I should be able to use the following filters:

--- a/features/product/sorting/sort_products_per_attribute.feature
+++ b/features/product/sorting/sort_products_per_attribute.feature
@@ -37,5 +37,5 @@ Feature: Sort products per attributes
     And I press the "Save" button
     And I am on the products page
     And the grid should contain 5 elements
-    And I display the columns sku, label, family, status, complete, created, updated, groups and handmade
+    And I display the columns SKU, Label, Family, Status, Complete, Created at, Updated at, Groups and Handmade
     And I should be able to sort the rows by Handmade

--- a/features/reference-data/product/display_reference_data_in_the_grid.feature
+++ b/features/reference-data/product/display_reference_data_in_the_grid.feature
@@ -25,7 +25,7 @@ Feature: Display reference data in the grid
       | high-heels | sole_fabric | cashmerewool, neoprene |
       | high-heels | sole_color  | red                    |
     And I am on the products page
-    When I display the columns sku, sole_color and sole_fabric
+    When I display the columns SKU, Sole color and Sole fabric
     Then the row "high-heels" should contain:
       | column      | value                    |
       | Sole color  | Red                      |
@@ -50,7 +50,7 @@ Feature: Display reference data in the grid
       | high-heels | cap_color   | Purple        | tablet | en_US  |
       | high-heels | cap_color   | Orange        | mobile | en_US  |
     And I am on the products page
-    When I display the columns sku, cap_color and lace_fabric
+    When I display the columns SKU, Cap color and Lace fabric
     Then the row "high-heels" should contain:
       | column      | value         |
       | Cap color   | Purple        |

--- a/features/reference-data/product/sorting/sort_products_per_reference_data.feature
+++ b/features/reference-data/product/sorting/sort_products_per_reference_data.feature
@@ -23,5 +23,5 @@ Feature: Sort products
   Scenario: Successfully sort products by simple reference data
     Given I am on the products page
     And the grid should contain 2 elements
-    And I display the columns sku, sole_color, heel_color and sole_fabric
+    And I display the columns SKU, Sole color, Heel color and Sole fabric
     And I sort by "Sole color" value ascending

--- a/src/Pim/Bundle/DataGridBundle/Repository/DatagridViewRepositoryInterface.php
+++ b/src/Pim/Bundle/DataGridBundle/Repository/DatagridViewRepositoryInterface.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Bundle\DataGridBundle\Repository;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Pim\Bundle\UserBundle\Entity\UserInterface;
 
 /**
@@ -27,6 +28,8 @@ interface DatagridViewRepositoryInterface
      *
      * @param UserInterface $user
      * @param string        $alias
+     *
+     * @return ArrayCollection
      */
     public function findDatagridViewByUserAndAlias(UserInterface $user, $alias);
 }

--- a/src/Pim/Bundle/DataGridBundle/Resources/views/Datagrid/_views.html.twig
+++ b/src/Pim/Bundle/DataGridBundle/Resources/views/Datagrid/_views.html.twig
@@ -97,7 +97,6 @@ require(
                     });
                 });
             });
-            activateView(activeViewId);
         }
 
         var truncateTitle = function(title) {

--- a/src/Pim/Bundle/DataGridBundle/Resources/views/Datagrid/_views.html.twig
+++ b/src/Pim/Bundle/DataGridBundle/Resources/views/Datagrid/_views.html.twig
@@ -79,6 +79,10 @@ require(
             activeViewId = $activeView.val();
         }
 
+        if (null === DatagridState.get('{{ alias }}', 'view') && 0 !== +activeViewId) {
+            activateView(activeViewId);
+        }
+
         var activeViewLabel = $activeView.text();
 
         var $removeLink = $('#remove-view');


### PR DESCRIPTION
This PR:
- Reverts https://github.com/akeneo/pim-community-dev/pull/4948 because it caused a regression (PIM-6007)
- Provides a fix for the original bug without regression (hopefully)
- Really tests the grid columns selectors popin (because it wasn't the case, nope)
- Adds behats stabilization and fix some incoherent ones
- Fixes the spin method behaviour

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | n/a
| Added Behats                      | yes
| Changelog updated                 | yes
| Review and 2 GTM                  | 
| Micro Demo to the PO (Story only) | n/a
| Migration script                  | n/a
| Tech Doc                          |