### PR TITLE
PIM-6002: Fix characters escapment with usage of quote in attribute option

### DIFF
--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -5,6 +5,7 @@
 - PIM-5990: Fix persist order causing issue on variant group import with associated products
 - PIM-5989: Fix attribute options on localizable and scopable attributes simple select
 - PIM-6013: Fix attribute options on localizable and scopable attributes simple select and multi select
+- PIM-6002: Fix characters escapment with usage of quote in attribute option
 
 # 1.5.13 (2016-11-18)
 

--- a/features/attribute/option/edit_attribute_options_02.feature
+++ b/features/attribute/option/edit_attribute_options_02.feature
@@ -46,3 +46,15 @@ Feature: Edit attribute options
     And I edit the "green" option and turn it to "yellow"
     Then I should see "yellow"
     Then I should not see "green"
+
+  @jira https://akeneo.atlassian.net/browse/PIM-6002
+  Scenario: Successfully edit an attribute option value containing a quote
+    Given I create the following attribute options:
+      | Code  | en_US |
+      | red   | r"ed  |
+      | blue  | blue  |
+      | green | green |
+    And I save the attribute
+    And I wait for options to load
+    And I edit the code "red" to turn it to "red" and cancel
+    Then I should see the text "r\"ed"

--- a/features/enrich/variant-group/edit_variant_group_attribute_value.feature
+++ b/features/enrich/variant-group/edit_variant_group_attribute_value.feature
@@ -115,6 +115,7 @@ Feature: Editing attribute values of a variant group also updates products
     And I add available attributes Simple
     And I change the "Simple" to "red"
     And I save the variant group
+    And I wait for the options to load
     And I switch the locale to "fr_FR"
     When I change the "Simple" to "blue"
     And I save the variant group

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/pim-attributeoptionview.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/pim-attributeoptionview.js
@@ -58,7 +58,7 @@ define(
                 '<td class="field-cell">' +
                     '<% if (item.optionValues[locale]) { %>' +
                         '<input type="text" class="attribute-option-value exclude" data-locale="<%= locale %>" ' +
-                            'value="<%= item.optionValues[locale].value %>"/>' +
+                            'value="<%- item.optionValues[locale].value %>"/>' +
                     '<% } else { %>' +
                         '<input type="text" class="attribute-option-value exclude" data-locale="<%= locale %>" ' +
                             'value=""/>' +


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

The usage of quotes in attribute options truncated the rest of the value when editing.

**Definition Of Done (for Core Developer only)**


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | N
| Added Behats                      | Y
| Changelog updated                 | Y
| Review and 2 GTM                  | N
| Micro Demo to the PO (Story only) | N
| Migration script                  | N
| Tech Doc                          | N

CI -> https://core-ci.akeneo.com/view/All/job/dci_behat/7397/
