### PR TITLE
PIM-6017: Fix attribute options on localizable and scopable attribute…

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -6,6 +6,7 @@
 - PIM-6000: Fix migration from 1.5 on quick exports
 - #5198: Fix issue with the export builder time condition, cheers @Schwierig
 - #5192: Add upgrade script for missing export job, cheers @masmrlar!
+- PIM-6017: Fix attribute options on localizable and scopable attributes multi select
 
 # 1.6.4 (2016-10-20)
 

--- a/features/product/edit_product_with_localizable_and_scopable_attribute_options.feature
+++ b/features/product/edit_product_with_localizable_and_scopable_attribute_options.feature
@@ -11,11 +11,15 @@ Feature: Edit a product with localizable and scopable attribute options
       | rick_morty | 2014_collection |
     And the following attributes:
       | code   | label-en_US | label-fr_FR | label-de_DE | type         | group | scopable | localizable |
+      | multi  | Multi       | Multi       | Multi       | multiselect  | other | yes      | yes         |
       | simple | Simple      | Simple      | Simple      | simpleselect | other | yes      | yes         |
     And I am logged in as "Peter"
     And the following CSV file to import:
       """
       code;label-fr_FR;label-de_DE;label-en_US;attribute;sort_order
+      1;FR1;DE1;US1;multi;1
+      2;FR2;DE2;US2;multi;2
+      3;FR3;DE3;US3;multi;3
       1;FR1;DE1;US1;simple;1
       2;FR2;DE2;US2;simple;2
       """
@@ -37,3 +41,24 @@ Feature: Edit a product with localizable and scopable attribute options
     And I switch the scope to "print"
     When I switch the scope to "ecommerce"
     Then I should see the text "US2"
+
+  @jira https://akeneo.atlassian.net/browse/PIM-6017
+  Scenario: I edit a localizable and scopable multiselect attribute
+    Given I edit the "rick_morty" product
+    And I add available attribute Multi
+    And I switch the scope to "ecommerce"
+    And I switch the locale to "en_US"
+    And I change the "Multi" to "US1, US3"
+    And I switch the scope to "print"
+    And I change the Multi to "US2"
+    And I switch the locale to "de_DE"
+    And I change the Multi to "DE3, DE2"
+    When I save the product
+    Then I should see the flash message "Product successfully updated"
+    When I switch the scope to "ecommerce"
+    And I switch the locale to "en_US"
+    Then I should see the text "US1 US3"
+    When I switch the scope to "print"
+    Then I should see the text "US2"
+    When I switch the locale to "de_DE"
+    Then I should see the text "DE2 DE3"


### PR DESCRIPTION
<3 Thanks for taking the time to contribute! You're awesome! <3

**Description (for Contributor and Core Developer)**

Same issue as PIM-5989, but instead of simple select attributes, it's for multi select attributes.

The issue:

When you have localizable and scopable attribute with attribute options, then you:

- Create a scopable multiselect attribute 
- add 3 different options: 1, 2 and 3 with their translations 
- add it to a product. 
- save a different value for each scope, SAVE 
- change the scopes in the PEF and check the option displayed. 
- The options you selected are not displayed

Why just a behat ?

Actually, this issue has been fixed by PIM-6013. But Behats are only for the variant group part, not for the PEF.
There are no behat to test the edit of a multi select attribute (localizable and scopable).

This one do that.


**Definition Of Done (for Core Developer only)**


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | n
| Added Behats                      | y
| Changelog updated                 | y
| Review and 2 GTM                  | n
| Micro Demo to the PO (Story only) | n
| Migration script                  | n
| Tech Doc                          | n
