### PR TITLE
PIM-5997: Restrict to 25 characters the role label

### DIFF
--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -6,6 +6,7 @@
 - PIM-5989: Fix attribute options on localizable and scopable attributes simple select
 - PIM-6013: Fix attribute options on localizable and scopable attributes simple select and multi select
 - PIM-6002: Fix characters escapment with usage of quote in attribute option
+- PIM-5997: Restrict to 25 characters the role label
 
 # 1.5.13 (2016-11-18)
 

--- a/features/user/create_edit_and_delete_role.feature
+++ b/features/user/create_edit_and_delete_role.feature
@@ -39,3 +39,8 @@ Feature: Create and delete a user role
       | Role |  |
     When I save the role
     Then I should see validation tooltip "This value should not be blank."
+    When I edit the "Administrator" user role
+    And I fill in the following information:
+      | Role | ThisIsARoleLabelWith27Chars |
+    When I save the role
+    Then I should see validation tooltip "This value is too long. It should have 25 characters or less."

--- a/src/Oro/Bundle/UserBundle/Resources/config/validation.yml
+++ b/src/Oro/Bundle/UserBundle/Resources/config/validation.yml
@@ -46,7 +46,7 @@ Oro\Bundle\UserBundle\Entity\Role:
         label:
             - NotBlank:     ~
             - Length:
-                max:        30
+                max:        25
 
 Oro\Bundle\UserBundle\Entity\Group:
     constraints:


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

The code generated from the label must be less than 30 characters (Generated from the label mean all in caps and '_' instead of spaces and add ROLE_ at the beginning of the label so 5 chars more than the label)

**Definition Of Done (for Core Developer only)**


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | N
| Added Behats                      | Y
| Changelog updated                 | Y
| Review and 2 GTM                  | N
| Micro Demo to the PO (Story only) | N
| Migration script                  | N
| Tech Doc                          | N

CI -> https://core-ci.akeneo.com/view/All/job/dci_behat/7407/
