### PR TITLE
PIM-6008: Fix mass edit execution when using specials chars in text field edition

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -1,5 +1,8 @@
 # 1.4.27 (2016-08-31)
 
+## Bug fixes
+- PIM-6008: Fix mass edit execution when using specials chars in text field edition
+
 # 1.4.26 (2016-07-05)
 
 ## Bug fixes

--- a/features/Context/FixturesContext.php
+++ b/features/Context/FixturesContext.php
@@ -687,7 +687,7 @@ class FixturesContext extends BaseFixturesContext
      * @param string $identifier
      * @param string $value
      *
-     * @Given /^the (\w+) (\w+) (\w+) of "([^"]*)" should be "([^"]*)"$/
+     * @Given /^the (\w+) (\w+) (\w+) of "([^"]*)" should be "(.*)"$/
      */
     public function theScopableOfShouldBe($lang, $scope, $attribute, $identifier, $value)
     {

--- a/features/Context/WebUser.php
+++ b/features/Context/WebUser.php
@@ -924,7 +924,7 @@ class WebUser extends RawMinkContext
      *
      *
      * @When /^I change the (?P<field>\w+) to "([^"]*)"$/
-     * @When /^I change the "(?P<field>[^"]*)" to "([^"]*)"$/
+     * @When /^I change the "(?P<field>[^"]*)" to "(.*)"$/
      * @When /^I change the (?P<language>\w+) (?P<field>\w+) to "(?P<value>[^"]*)"$/
      * @When /^I change the (?P<field>\w+) to an invalid value$/
      */

--- a/features/mass-action/edit_common_attributes.feature
+++ b/features/mass-action/edit_common_attributes.feature
@@ -89,3 +89,19 @@ Feature: Edit common attributes of many products at once
     And the english tablet Description of "boots" should be "Bar"
     And the english mobile Description of "pump" should be "Foo"
     And the english tablet Description of "pump" should be "Bar"
+
+  @jira https://akeneo.atlassian.net/browse/PIM-6008
+  Scenario: Successfully mass edit scoped product values with special chars
+    Given I set product "pump" family to "boots"
+    When I mass-edit products boots and pump
+    And I choose the "Edit common attributes" operation
+    And I display the Description attribute
+    And I change the Description to "&$@(B°ar'<"
+    And I switch the scope to "mobile"
+    And I change the "Description" to ">§€")F*o'o"
+    And I move on to the next step
+    And I wait for the "edit-common-attributes" mass-edit job to finish
+    Then the english mobile Description of "boots" should be ">§€")F*o'o"
+    And the english tablet Description of "boots" should be "&$@(B°ar'<"
+    And the english mobile Description of "pump" should be ">§€")F*o'o"
+    And the english tablet Description of "pump" should be "&$@(B°ar'<"

--- a/src/Pim/Bundle/EnrichBundle/MassEditAction/Operation/EditCommonAttributes.php
+++ b/src/Pim/Bundle/EnrichBundle/MassEditAction/Operation/EditCommonAttributes.php
@@ -242,7 +242,7 @@ class EditCommonAttributes extends AbstractMassEditOperation
             }
         }
 
-        $this->values = json_encode($data);
+        $this->values = json_encode($data, JSON_HEX_APOS);
     }
 
     /**


### PR DESCRIPTION
PIM-6008: Fix mass edit execution when using specials chars in text field edition

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | N
| Added Behats                      | Y
| Changelog updated                 | Y
| Review and 2 GTM                  | Y
| Micro Demo to the PO (Story only) | N
| Migration script                  | N
| Tech Doc                          | N

…ield edition