### PR TITLE
Travis CI: disable Xdebug does not crash Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,7 @@ before_script:
 
 before_install:
     - phpenv config-add travis.php.ini
-    - if [ "$TRAVIS_PHP_VERSION" != "7.1" ]; then
-        phpenv config-rm xdebug.ini;
-      fi;
+    - phpenv config-rm xdebug.ini
     - echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
     - composer self-update --no-interaction
     - if [ "$TRAVIS_PHP_VERSION" = "5.6" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_script:
 
 before_install:
     - phpenv config-add travis.php.ini
-    - phpenv config-rm xdebug.ini
+    - phpenv config-rm xdebug.ini || echo "xdebug not available for PHP $TRAVIS_PHP_VERSION"
     - echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
     - composer self-update --no-interaction
     - if [ "$TRAVIS_PHP_VERSION" = "5.6" ]; then


### PR DESCRIPTION
If xdebug is not activated for a PHP version, disabling xdebug should not crash the build.
As a bonus, we don't have to check for specific PHP versions and the build will not take 10 minutes! ;)