### PR TITLE
Fix column headers selection in behat

### DIFF
--- a/features/Context/Page/Base/Grid.php
+++ b/features/Context/Page/Base/Grid.php
@@ -765,11 +765,21 @@ class Grid extends Index
      */
     protected function getColumnHeaders($withHidden = false, $withActions = true)
     {
-        $head    = $this->getGrid()->find('css', 'thead');
-        $headers = $head->findAll(
-            'css',
-            $withActions ? 'th' : 'th:not(.action-column):not(.select-all-header-cell)'
-        );
+        $head     = $this->getGrid()->find('css', 'thead');
+        $selector = '//th';
+        if (!$withActions) {
+            // This selector is equivalent to css selector
+            // ':not(.action-column):not(.select-all-header-cell):not(:has(input))'
+            // but we have to do it in xpath because :has() is neither supported by current
+            // browsers nor emulated by Selenium.
+            $selector .= '['.
+                'not(contains(@class, \'action-column\')) '.
+                'and not(contains(@class, \'select-all-header-cell\')) '.
+                'and not(input)'.
+            ']';
+        }
+
+        $headers = $head->findAll('xpath', $selector);
 
         if ($withHidden) {
             return $headers;

--- a/features/attribute/browse/view.feature
+++ b/features/attribute/browse/view.feature
@@ -9,6 +9,7 @@ Feature: View attributes
     And I am logged in as "Julia"
     And I am on the attributes page
 
+  @ce
   Scenario: Successfully view attributes
     Then the grid should contain 26 elements
     And I should see the columns Code, Label, Type, Scopable, Localizable and Group

--- a/features/enrich/variant-group/add_attributes_to_a_variant_group.feature
+++ b/features/enrich/variant-group/add_attributes_to_a_variant_group.feature
@@ -87,7 +87,7 @@ Feature: Add attributes to a variant group
     And I should see "EUR, USD" currencies on the Price price field
 
   @javascript @jira https://akeneo.atlassian.net/browse/PIM-5208
-  Scenario: View only attribute filters that are usable as grid filters and view varient axes in columns
+  Scenario: View only attribute filters that are usable as grid filters and view variant axes in columns
     Given the following attributes:
       | code                       | label-en_US                | type         | group  | useable_as_grid_filter |
       | high_heel_main_color       | High heel main color       | simpleselect | colors | yes                    |
@@ -108,5 +108,4 @@ Feature: Add attributes to a variant group
     When I am on the "high_heels" variant group page
     Then I should see the available filters High heel main color and High heel secondary fabric
     And I should not see the available filters High heel main fabric and High heel secondary color
-    And I should see the columns In group, Sku, High heel main color, Label, Family, Status, Complete, Created at and Updated at
-
+    And I should see the columns In group, Sku, High heel main color, High heel main fabric, Label, Family, Status, Complete, Created at and Updated at

--- a/features/enrich/variant-group/add_attributes_to_a_variant_group.feature
+++ b/features/enrich/variant-group/add_attributes_to_a_variant_group.feature
@@ -108,5 +108,5 @@ Feature: Add attributes to a variant group
     When I am on the "high_heels" variant group page
     Then I should see the available filters High heel main color and High heel secondary fabric
     And I should not see the available filters High heel main fabric and High heel secondary color
-    And I should see the columns In group, Sku, High heel main color, High heel main fabric, Label, Family, Status, Complete, Created at and Updated at
+    And I should see the columns In group, Sku, High heel main color, Label, Family, Status, Complete, Created at and Updated at
 

--- a/src/Pim/Bundle/DataGridBundle/Datagrid/Configuration/Product/ContextConfigurator.php
+++ b/src/Pim/Bundle/DataGridBundle/Datagrid/Configuration/Product/ContextConfigurator.php
@@ -137,9 +137,9 @@ class ContextConfigurator implements ConfiguratorInterface
     }
 
     /**
-     * Return useable attribute ids
+     * Return attribute ids to add to the conf
      *
-     * @param string[] $attributeCodes
+     * @param string[]|null $attributeCodes
      *
      * @return integer[]
      */
@@ -149,11 +149,23 @@ class ContextConfigurator implements ConfiguratorInterface
         // we need to add the variant group axes (even if they are not usable as grid filter)
         // as usable in the grid (to be displayed in the columns)
         $attributeIds = array_merge(
-            $this->attributeRepository->getAttributeIdsUseableInGrid($attributeCodes),
+            $this->getAttributeIdsUseableInGrid($attributeCodes),
             $this->getAttributeIdsFromProductGroupAxes()
         );
 
         return $attributeIds;
+    }
+
+    /**
+     * Return usable attribute ids
+     *
+     * @param string[]|null $attributeCodes
+     *
+     * @return integer[]
+     */
+    protected function getAttributeIdsUseableInGrid($attributeCodes = null)
+    {
+        return $this->attributeRepository->getAttributeIdsUseableInGrid($attributeCodes);
     }
 
     /**


### PR DESCRIPTION
In the variant group product grid there is a `th` without any class and with an `input` inside it, it shouldn't be selected because it breaks the columns count.

Also, this PR fixes the display of axis columns in the EE products grid of the variant group. I guess it was broken since https://github.com/akeneo/pim-community-dev/pull/3619 and never spotted due to the false positives in EE.