### PR TITLE
PIM-6027: Fix category filter for export builder

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -1,3 +1,9 @@
+# 1.6.X
+
+## Bug fixes
+
+- PIM-6027: Fix export builder filter on category with code as integer
+
 # 1.6.5 (2016-11-25)
 
 ## Bug fixes

--- a/features/export/product-export-builder/export_products_by_categories.feature
+++ b/features/export/product-export-builder/export_products_by_categories.feature
@@ -86,3 +86,30 @@ Feature: Export products from any given categories
     And I fill in the following information:
       | Channel | Mobile |
     Then I should see the text "All products"
+
+  @jira https://akeneo.atlassian.net/browse/PIM-6027
+  Scenario: Export the products from a tree using the UI with category code as integer
+    Given the following category:
+      | code | label_en_US | parent  |
+      | 1234 | 1234        | default |
+    And the following product:
+      | sku              | categories | family  |
+      | product_numbered | 1234       | default |
+    When I am on the "csv_product_export" export job edit page
+    And I visit the "Content" tab
+    Then I should see the text "All products"
+    When I press the "Select categories" button
+    Then I should see the text "Categories selection"
+    And I should see the text "Master catalog"
+    When I click on the "1234" category
+    And I press the "Confirm" button
+    Then I should see the text "one category selected"
+    When I press the "Save" button
+    And I am on the "csv_product_export" export job page
+    And I launch the export job
+    And I wait for the "csv_product_export" job to finish
+    Then exported file of "csv_product_export" should contain:
+      """
+      sku;categories;enabled;family;groups
+      product_numbered;1234;1;default;
+      """

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/product/category/selector.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/product/category/selector.js
@@ -73,7 +73,7 @@ define(
              * @param {Object} data
              */
             checkNode: function (data) {
-                var code = data.rslt.obj.data('code');
+                var code = String(data.rslt.obj.data('code'));
                 // All products case
                 if ('' === code) {
                     // Uncheck other nodes


### PR DESCRIPTION
**Description**

When you export products with filter on categories and some of these categories have an integer as code, you can't save your export.
This PR fixes this problem by parsing category code in String.

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | :no_entry_sign: 
| Added Behats                      | ☑️  
| Changelog updated                 | ☑️ 
| Review and 2 GTM                  | ☑️ 
| Migration script                  | :no_entry_sign: 
| Tech Doc                          | :no_entry_sign: 

