### PR TITLE
PIM-6018: Import identifier attribute only if usable as grid filter

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-6027: Fix export builder filter on category with code as integer
+- PIM-6018: Prevent the import of an attribute identifier if not usable as grid filter
 
 # 1.6.5 (2016-11-25)
 

--- a/features/import/attribute/import_identifier.feature
+++ b/features/import/attribute/import_identifier.feature
@@ -1,0 +1,22 @@
+@javascript
+Feature: Import identifier attributes
+  In order to reuse the attributes of my products
+  As a product manager
+  I need to be able to import identifier attributes
+
+  @jira https://akeneo.atlassian.net/browse/PIM-6018
+  Scenario: Successfully import attributes in CSV
+    Given the "footwear" catalog configuration
+    And I am logged in as "Julia"
+    And the following CSV file to import:
+      """
+      type;code;label-en_US;group;unique;useable_as_grid_filter;allowed_extensions;metric_family;default_metric_unit;reference_data_name;localizable;scopable;required;sort_order;label-fr_FR;max_characters;number_min;number_max;decimals_allowed;negative_allowed;max_file_size
+      pim_catalog_identifier;sku;SKU;info;1;0;;;;;0;0;1;1;;;;;;;
+      """
+    And the following job "csv_footwear_attribute_import" configuration:
+      | filePath | %file to import% |
+    When I am on the "csv_footwear_attribute_import" import job page
+    And I launch the import job
+    And I wait for the "csv_footwear_attribute_import" job to finish
+    Then I should see the text "skipped 1"
+    And I should see the text "\"sku\" is an identifier attribute, it must be usable as grid filter"

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/validation/attribute.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/validation/attribute.yml
@@ -3,6 +3,7 @@ Pim\Bundle\CatalogBundle\Entity\Attribute:
         - Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity: code
         - Pim\Component\Catalog\Validator\Constraints\SingleIdentifierAttribute: ~
         - Pim\Component\Catalog\Validator\Constraints\IsReferenceDataConfigured: ~
+        - Pim\Component\Catalog\Validator\Constraints\IsIdentifierUsableAsGridFilter: ~
         - Pim\Component\Catalog\Validator\Constraints\Immutable:
             properties:
                 - code

--- a/src/Pim/Component/Catalog/Validator/Constraints/IsIdentifierUsableAsGridFilter.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/IsIdentifierUsableAsGridFilter.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Pim\Component\Catalog\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @author    Damien Carcel (damien.carcel@akeneo.com)
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class IsIdentifierUsableAsGridFilter extends Constraint
+{
+    /** @var string */
+    public $message = '"%code%" is an identifier attribute, it must be usable as grid filter';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTargets()
+    {
+        return self::CLASS_CONSTRAINT;
+    }
+}

--- a/src/Pim/Component/Catalog/Validator/Constraints/IsIdentifierUsableAsGridFilterValidator.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/IsIdentifierUsableAsGridFilterValidator.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Pim\Component\Catalog\Validator\Constraints;
+
+use Pim\Component\Catalog\AttributeTypes;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ * @author    Damien Carcel (damien.carcel@akeneo.com)
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class IsIdentifierUsableAsGridFilterValidator extends ConstraintValidator
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function validate($attribute, Constraint $constraint)
+    {
+        if ($attribute instanceof AttributeInterface &&
+            AttributeTypes::IDENTIFIER === $attribute->getAttributeType() &&
+            !$attribute->isUseableAsGridFilter()
+        ) {
+            $this->context
+                ->buildViolation($constraint->message)
+                ->setParameter('%code%', $attribute->getCode())
+                ->addViolation();
+        }
+    }
+}

--- a/src/Pim/Component/Catalog/spec/Validator/Constraints/IsIdentifierUsableAsGridFilterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Validator/Constraints/IsIdentifierUsableAsGridFilterSpec.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace spec\Pim\Component\Catalog\Validator\Constraints;
+
+use Pim\Component\Catalog\Validator\Constraints\IsIdentifierUsableAsGridFilter;
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\Validator\Constraint;
+
+class IsIdentifierUsableAsGridFilterSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(IsIdentifierUsableAsGridFilter::class);
+    }
+
+    function it_has_message()
+    {
+        $this->message->shouldBe('"%code%" is an identifier attribute, it must be usable as grid filter');
+    }
+
+    function it_is_a_validator_constraint()
+    {
+        $this->shouldBeAnInstanceOf(Constraint::class);
+    }
+}

--- a/src/Pim/Component/Catalog/spec/Validator/Constraints/IsIdentifierUsableAsGridFilterValidatorSpec.php
+++ b/src/Pim/Component/Catalog/spec/Validator/Constraints/IsIdentifierUsableAsGridFilterValidatorSpec.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace spec\Pim\Component\Catalog\Validator\Constraints;
+
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Validator\Constraints\IsIdentifierUsableAsGridFilter;
+use Pim\Component\Catalog\Validator\Constraints\IsIdentifierUsableAsGridFilterValidator;
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
+
+class IsIdentifierUsableAsGridFilterValidatorSpec extends ObjectBehavior
+{
+    function let(ExecutionContextInterface $context)
+    {
+        $this->initialize($context);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(IsIdentifierUsableAsGridFilterValidator::class);
+    }
+
+    function it_builds_a_violation_for_identifier_not_usable_as_grid_filter(
+        $context,
+        AttributeInterface $attribute,
+        IsIdentifierUsableAsGridFilter $constraint,
+        ConstraintViolationBuilderInterface $violation
+    ) {
+        $attribute->getAttributeType()->willReturn('pim_catalog_identifier');
+        $attribute->isUseableAsGridFilter()->willReturn(false);
+        $attribute->getCode()->shouldBeCalled()->willReturn('foobar');
+
+        $context->buildViolation($constraint->message)->shouldBeCalled()->willReturn($violation);
+        $violation->setParameter('%code%', 'foobar')->shouldBeCalled()->willReturn($violation);
+        $violation->addViolation()->shouldBeCalled();
+
+        $this->validate($attribute, $constraint);
+    }
+
+    function it_does_not_build_a_violation_for_identifier_usable_as_grid_filter(
+        $context,
+        AttributeInterface $attribute,
+        IsIdentifierUsableAsGridFilter $constraint
+    ) {
+        $attribute->getAttributeType()->willReturn('pim_catalog_identifier');
+        $attribute->isUseableAsGridFilter()->willReturn(true);
+
+        $attribute->getCode()->shouldNotBeCalled();
+        $context->buildViolation($constraint->message)->shouldNotBeCalled();
+
+        $this->validate($attribute, $constraint);
+    }
+}


### PR DESCRIPTION
**Description**

If a user import an identifier attribute with "useable_as_grid_filter" set to 0, the import works fine but the corresponding filter isn't available anymore on the product grid.

This fix adds a validation on attribute that prevents an identifier to be not usable as grid filter.

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | 🔲 
| Added Behats                      | ☑️ 
| Changelog updated                 | ☑️ 
| Review and 2 GTM                  | 🔲 
| Migration script                  | 🚫 
| Tech Doc                          | 🚫 