### PR TITLE
PIM-6026: Use doctrine base writer for family mass edit

### DIFF
--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -1,3 +1,9 @@
+# 1.5.x
+
+## Bug fixes
+
+- PIM-6026: Fix an error on family mass edit that occurs when working on more families than the mass edit batch size
+
 # 1.5.14 (2016-12-01)
 
 ## Bug fixes

--- a/features/Context/DataGridContext.php
+++ b/features/Context/DataGridContext.php
@@ -1060,6 +1060,7 @@ class DataGridContext extends RawMinkContext implements PageObjectAwareInterface
 
     /**
      * @Then /^I select all products$/
+     * @When /^I select all families$/
      */
     public function iSelectAll()
     {

--- a/features/Context/FixturesContext.php
+++ b/features/Context/FixturesContext.php
@@ -156,13 +156,28 @@ class FixturesContext extends BaseFixturesContext
     }
 
     /**
+     * Generates a given number of families.
+     *
+     * @param int $familyNumber
+     *
+     * @Given /^([0-9]+) generated families$/
+     */
+    public function generatedFamilies($familyNumber)
+    {
+        for ($i = 1; $i <= $familyNumber; $i++) {
+            $familyCode = sprintf('family_%d', $i);
+            $this->createFamily($familyCode);
+        }
+    }
+
+    /**
      * @param TableNode $table
      *
      * @Given /^the following attribute groups?:$/
      */
     public function theFollowingAttributeGroups(TableNode $table)
     {
-        foreach ($table->getHash() as $index => $data) {
+        foreach ($table->getHash() as $data) {
             $this->createAttributeGroup($data);
         }
     }

--- a/features/Context/catalog/default/jobs.yml
+++ b/features/Context/catalog/default/jobs.yml
@@ -1,0 +1,36 @@
+jobs:
+    update_product_value:
+        connector: Akeneo Mass Edit Connector
+        alias:     update_product_value
+        label:     Mass update products
+        type:      mass_edit
+    add_product_value:
+        connector: Akeneo Mass Edit Connector
+        alias:     add_product_value
+        label:     Mass add products values
+        type:      mass_edit
+    edit_common_attributes:
+        connector: Akeneo Mass Edit Connector
+        alias:     edit_common_attributes
+        label:     Mass edit common product attributes
+        type:      mass_edit
+    set_attribute_requirements:
+        connector: Akeneo Mass Edit Connector
+        alias:     set_attribute_requirements
+        label:     Set family attribute requirements
+        type:      mass_edit
+    add_to_variant_group:
+        connector: Akeneo Mass Edit Connector
+        alias:     add_to_variant_group
+        label:     Mass add products to variant group
+        type:      mass_edit
+    csv_product_quick_export:
+        connector: Akeneo Mass Edit Connector
+        alias: csv_product_quick_export
+        label: CSV product quick export
+        type: quick_export
+        configuration:
+            delimiter:  ;
+            enclosure:  '"'
+            withHeader: true
+            filePath:   /tmp/products_export_%locale%_%scope%.csv

--- a/features/family/mass_edit_families.feature
+++ b/features/family/mass_edit_families.feature
@@ -51,21 +51,21 @@ Feature: Mass Edit Families
   Scenario: Successfully mass edit more than 10 families
     Given the "default" catalog configuration
     And the following families:
-    | code     |
-    | first    |
-    | second   |
-    | third    |
-    | fourth   |
-    | fifth    |
-    | sixth    |
-    | seventh  |
-    | eigth    |
-    | ninth    |
-    | tenth    |
-    | eleventh |
+      | code     |
+      | first    |
+      | second   |
+      | third    |
+      | fourth   |
+      | fifth    |
+      | sixth    |
+      | seventh  |
+      | eight    |
+      | ninth    |
+      | tenth    |
+      | eleventh |
     And I am logged in as "Julia"
     And I am on the families page
-    When I mass-edit families first, second, third, fourth, fifth, sixth, seventh, eigth, ninth, tenth and eleventh
+    When I mass-edit families first, second, third, fourth, fifth, sixth, seventh, eight, ninth, tenth and eleventh
     Then I should see "Mass Edit (11 families)"
 
   @jira https://akeneo.atlassian.net/browse/PIM-4203
@@ -76,3 +76,22 @@ Feature: Mass Edit Families
     When I sort by "label" value ascending
     And I mass-edit families boots, sneakers and sandals
     Then I should see "Mass Edit (3 families)"
+
+  @jira https://akeneo.atlassian.net/browse/PIM-6026
+  Scenario: Successfully mass edit more families than the batch size limit
+    Given the "default" catalog configuration
+    And 110 generated families
+    And the following attributes:
+      | code | label | type |
+      | name | Name  | text |
+    And I am logged in as "Julia"
+    And I am on the families page
+    When I select all families
+    And I press mass-edit button
+    And I choose the "Set attribute requirements" operation
+    And I display the Name attribute
+    And I move on to the next step
+    And I wait for the "set-attribute-requirements" mass-edit job to finish
+    Then I should see notification:
+      | type    | message                                              |
+      | success | Mass edit Set family attribute requirements finished |

--- a/src/Pim/Bundle/EnrichBundle/Connector/Reader/MassEdit/FilteredFamilyReader.php
+++ b/src/Pim/Bundle/EnrichBundle/Connector/Reader/MassEdit/FilteredFamilyReader.php
@@ -30,6 +30,9 @@ class FilteredFamilyReader extends AbstractConfigurableStepElement implements
     /** @var ArrayCollection */
     protected $families;
 
+    /** @var JobConfigurationRepositoryInterface */
+    protected $jobConfigurationRepo;
+
     /** @var FamilyRepositoryInterface */
     protected $familyRepository;
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/batch_jobs.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/batch_jobs.yml
@@ -45,7 +45,7 @@ connector:
                     services:
                         reader:    pim_enrich.connector.reader.mass_edit.family
                         processor: pim_enrich.connector.processor.mass_edit.family.set_requirements
-                        writer:    pim_base_connector.writer.doctrine
+                        writer:    pim_connector.writer.doctrine.family
         csv_product_quick_export:
             title: csv_product_quick_export
             type: quick_export


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When mass editing more than 100 families (default size of the batches in our batch jobs), following error occurs:
```
A new entity was found through the relationship 'Pim\Bundle\CatalogBundle\Entity\Family#attributeAsLabel' that was not
configured to cascade persist operations for entity: [libelle_article]. To solve this issue: Either explicitly call EntityManager#persist() on this unknown entity or configure cascade persist this association in the mapping for example @ManyToOne(..,cascade={"persist"}).
```

This is caused by our old CacheClearer that do not detach objects properly. This PR fix this bug by replacing, in the family mass edit job definition, the old `Pim\Bundle\BaseConnectorBundle\Writer\Doctrine\Writer` (that use this CacheClearer) by the new `Pim\Component\Connector\Writer\Doctrine\BaseWriter` (that use a new, better, ObjectDetacher).

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | :negative_squared_cross_mark:
| Added Behats                      | :white_check_mark:
| Changelog updated                 | :white_check_mark:
| Review and 2 GTM                  | :white_check_mark:
| Migration script                  |:negative_squared_cross_mark:
| Tech Doc                          | :negative_squared_cross_mark: