### PR TITLE
Fix issue #SDS-741 Import do not change product update date correctly

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/MongoDB/Normalizer/Document/ProductNormalizer.php
+++ b/src/Pim/Bundle/CatalogBundle/MongoDB/Normalizer/Document/ProductNormalizer.php
@@ -84,7 +84,8 @@ class ProductNormalizer implements NormalizerInterface, SerializerAwareInterface
             $data['created'] = $this->mongoFactory->createMongoDate();
         }
 
-        $data['updated'] = $this->mongoFactory->createMongoDate();
+        $product->setUpdated(new \DateTime());
+        $data['updated'] = $this->normalizer->normalize($product->getUpdated(), self::FORMAT, $context);
 
         if (null !== $product->getFamily()) {
             $data['family'] = $product->getFamily()->getId();


### PR DESCRIPTION
```
| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | no
| Added Behats                      | no
| Changelog updated                 | no
| Review and 2 GTM                  | no
| Migration scripts                 | no
| Tech Doc                          | no

```
**Description**

Fix it by changing «updated» data into $product when normalize it with MongoDB as storage engine, to have same correct value into `updated` and `normalizedData`>`updated` data. Without this fix,  `normalizedData`>`updated` contains previous updated date of product !

NB: may the part `$product->setUpdated(new \DateTime());` should not be called here… but before normalization ?! I did it cause of `$data['updated'] = […]` set.
I'm open to discuss about this little point if needed :-)