### PR TITLE
PIM-5991: Add the focus into wysiwig field

### DIFF
--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-6026: Fix an error on family mass edit that occurs when working on more families than the mass edit batch size
+- PIM-5991: Focus on wysiwig field when clicking on the product edit form completeness link
 
 # 1.5.14 (2016-12-01)
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/textarea-field.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/textarea-field.js
@@ -23,15 +23,27 @@ define(
             events: {
                 'change .field-input:first textarea': 'updateModel'
             },
+
+            /**
+             * @inheritDoc
+             */
             renderInput: function (context) {
                 return this.fieldTemplate(context);
             },
+
+            /**
+             * @inheritDoc
+             */
             updateModel: function () {
                 var data = this.$('.field-input:first textarea:first').val();
                 data = '' === data ? this.attribute.empty_value : data;
 
                 this.setCurrentValue(data);
             },
+
+            /**
+             * @inheritDoc
+             */
             setFocus: function () {
                 this.$('.field-input:first textarea').focus();
             }

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/wysiwyg-field.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/wysiwyg-field.js
@@ -1,6 +1,6 @@
 'use strict';
 /**
- * Textarea field
+ * Wysiwyg field
  *
  * @author    Julien Sanchez <julien@akeneo.com>
  * @author    Filips Alpe <filips@akeneo.com>
@@ -24,9 +24,17 @@ define(
             events: {
                 'change .field-input:first textarea:first': 'updateModel'
             },
+
+            /**
+             * @inheritDoc
+             */
             renderInput: function (context) {
                 return this.fieldTemplate(context);
             },
+
+            /**
+             * @inheritDoc
+             */
             postRender: function () {
                 this.$('textarea').summernote({
                     disableResizeEditor: true,
@@ -40,11 +48,22 @@ define(
                     ]
                 }).on('summernote.blur', this.updateModel.bind(this));
             },
+
+            /**
+             * @inheritDoc
+             */
             updateModel: function () {
                 var data = this.$('.field-input:first textarea:first').code();
                 data = '' === data ? this.attribute.empty_value : data;
 
                 this.setCurrentValue(data);
+            },
+
+            /**
+             * @inheritDoc
+             */
+            setFocus: function () {
+                this.$('.field-input:first .note-editable').trigger('focus');
             }
         });
     }


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) 

**Description (for Contributor and Core Developer)**

[//]: <> (What does this Pull Request do? reference the related issue?)

Create a textarea attribute and enable wysiwyg mode. 
Add the attribute to a family and mark it as required for completeness. 
Edit a product of the family. 
Open the completeness tab. 
Click on the link corresponding to the empty wysiwyg field. 
Add the focus into the concerned field

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       |:negative_squared_cross_mark:
| Added Behats                      | :negative_squared_cross_mark:
| Changelog updated                 | :white_check_mark:
| Review and 2 GTM                  | :white_check_mark:
| Micro Demo to the PO (Story only) | :negative_squared_cross_mark:
| Migration script                  |  :negative_squared_cross_mark:
| Tech Doc                          | :negative_squared_cross_mark:


:white_check_mark: Done and pass

:red_circle: Done but fail

:clock1: Done but pending

:negative_squared_cross_mark: Not needed

