### PR TITLE
Update Jenkinsfile test matrix

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -79,32 +79,32 @@ tasks['php-cs-fixer'] = {
             'phpdoc_order'
         ]
 
-        parallel 'php-cs-fixer-with-php-5.4': {
-            node('docker') {
-                deleteDir()
-                docker.image('carcel/php:5.4').inside {
-                    unstash "project_files"
-                    sh "composer global require friendsofphp/php-cs-fixer ^1.12"
-                    sh "/home/docker/.composer/vendor/friendsofphp/php-cs-fixer/php-cs-fixer fix features --dry-run -v --diff --level=psr2 --fixers=" + fixers.join(',')
-                    sh "/home/docker/.composer/vendor/friendsofphp/php-cs-fixer/php-cs-fixer fix src --dry-run -v --diff --level=psr2 --fixers=" + fixers.join(',')
-                }
-            }
-        },
-        'php-cs-fixer-with-php-5.5': {
-            node('docker') {
-                deleteDir()
-                docker.image('carcel/php:5.5').inside {
-                    unstash "project_files"
-                    sh "composer global require friendsofphp/php-cs-fixer ^1.12"
-                    sh "/home/docker/.composer/vendor/friendsofphp/php-cs-fixer/php-cs-fixer fix features --dry-run -v --diff --level=psr2 --fixers=" + fixers.join(',')
-                    sh "/home/docker/.composer/vendor/friendsofphp/php-cs-fixer/php-cs-fixer fix src --dry-run -v --diff --level=psr2 --fixers=" + fixers.join(',')
-                }
-            }
-        },
-        'php-cs-fixer-with-php-5.6': {
+        parallel 'php-cs-fixer-with-php-5.6': {
             node('docker') {
                 deleteDir()
                 docker.image('carcel/php:5.6').inside {
+                    unstash "project_files"
+                    sh "composer global require friendsofphp/php-cs-fixer ^1.12"
+                    sh "/home/docker/.composer/vendor/friendsofphp/php-cs-fixer/php-cs-fixer fix features --dry-run -v --diff --level=psr2 --fixers=" + fixers.join(',')
+                    sh "/home/docker/.composer/vendor/friendsofphp/php-cs-fixer/php-cs-fixer fix src --dry-run -v --diff --level=psr2 --fixers=" + fixers.join(',')
+                }
+            }
+        },
+        'php-cs-fixer-with-php-7.0': {
+            node('docker') {
+                deleteDir()
+                docker.image('carcel/php:7.0').inside {
+                    unstash "project_files"
+                    sh "composer global require friendsofphp/php-cs-fixer ^1.12"
+                    sh "/home/docker/.composer/vendor/friendsofphp/php-cs-fixer/php-cs-fixer fix features --dry-run -v --diff --level=psr2 --fixers=" + fixers.join(',')
+                    sh "/home/docker/.composer/vendor/friendsofphp/php-cs-fixer/php-cs-fixer fix src --dry-run -v --diff --level=psr2 --fixers=" + fixers.join(',')
+                }
+            }
+        },
+        'php-cs-fixer-with-php-7.1': {
+            node('docker') {
+                deleteDir()
+                docker.image('carcel/php:7.1').inside {
                     unstash "project_files"
                     sh "composer global require friendsofphp/php-cs-fixer ^1.12"
                     sh "/home/docker/.composer/vendor/friendsofphp/php-cs-fixer/php-cs-fixer fix features --dry-run -v --diff --level=psr2 --fixers=" + fixers.join(',')
@@ -130,69 +130,70 @@ tasks['grunt-codestyle'] = {
 
 tasks['phpunit'] = {
     stage('phpunit') {
-        parallel 'phpunit-with-php-5.4': {
-            node('docker') {
-                deleteDir()
-                docker.image('carcel/php:5.4').inside {
-                    unstash "project_files"
-                    sh "composer global require phpunit/phpunit 3.7.*"
-                    sh "/home/docker/.composer/vendor/phpunit/phpunit/composer/bin/phpunit -c app/phpunit.jenkins.xml --testsuite PIM_Unit_Test"
-                }
-            }
-        },
-        'phpunit-with-php-5.5': {
-            node('docker') {
-                deleteDir()
-                docker.image('carcel/php:5.5').inside {
-                    unstash "project_files"
-                    sh "composer global require phpunit/phpunit 3.7.*"
-                    sh "/home/docker/.composer/vendor/phpunit/phpunit/composer/bin/phpunit -c app/phpunit.jenkins.xml --testsuite PIM_Unit_Test"
-                }
-            }
-        },
-        'phpunit-with-php-5.6': {
+        parallel 'phpunit-with-php-5.6': {
             node('docker') {
                 deleteDir()
                 docker.image('carcel/php:5.6').inside {
+                    unstash "project_files"
+                    sh "composer global require phpunit/phpunit 3.7.*"
+                    sh "/home/docker/.composer/vendor/phpunit/phpunit/composer/bin/phpunit -c app/phpunit.jenkins.xml --testsuite PIM_Unit_Test"
+                }
+            }
+        },
+        'phpunit-with-php-7.0': {
+            node('docker') {
+                deleteDir()
+                docker.image('carcel/php:7.0').inside {
+                    unstash "project_files"
+                    sh "composer global require phpunit/phpunit 3.7.*"
+                    sh "/home/docker/.composer/vendor/phpunit/phpunit/composer/bin/phpunit -c app/phpunit.jenkins.xml --testsuite PIM_Unit_Test"
+                }
+            }
+        },
+        'phpunit-with-php-7.1': {
+            node('docker') {
+                deleteDir()
+                docker.image('carcel/php:7.1').inside {
                     unstash "project_files"
                     sh "composer global require phpunit/phpunit 3.7.*"
                     sh "/home/docker/.composer/vendor/phpunit/phpunit/composer/bin/phpunit -c app/phpunit.jenkins.xml --testsuite PIM_Unit_Test"
                 }
             }
         }
+
     }
 }
 
 tasks['phpspec'] = {
     stage('phpspec') {
-        parallel 'phpspec-with-php-5.4': {
-            node('docker') {
-                deleteDir()
-                docker.image('carcel/php:5.4').inside {
-                    unstash "project_files"
-                    sh "composer global require phpspec/phpspec 2.1.*"
-                    sh "composer global require akeneo/phpspec-skip-example-extension 1.1.*"
-                    sh "cp app/config/parameters.yml app/config/parameters_test.yml"
-                    sh "/home/docker/.composer/vendor/phpspec/phpspec/bin/phpspec run --no-interaction --format=dot"
-                }
-            }
-        },
-        'phpspec-with-php-5.5': {
-            node('docker') {
-                deleteDir()
-                docker.image('carcel/php:5.5').inside {
-                    unstash "project_files"
-                    sh "composer global require phpspec/phpspec 2.1.*"
-                    sh "composer global require akeneo/phpspec-skip-example-extension 1.1.*"
-                    sh "cp app/config/parameters.yml app/config/parameters_test.yml"
-                    sh "/home/docker/.composer/vendor/phpspec/phpspec/bin/phpspec run --no-interaction --format=dot"
-                }
-            }
-        },
-        'phpspec-with-php-5.6': {
+        parallel 'phpspec-with-php-5.6': {
             node('docker') {
                 deleteDir()
                 docker.image('carcel/php:5.6').inside {
+                    unstash "project_files"
+                    sh "composer global require phpspec/phpspec 2.1.*"
+                    sh "composer global require akeneo/phpspec-skip-example-extension 1.1.*"
+                    sh "cp app/config/parameters.yml app/config/parameters_test.yml"
+                    sh "/home/docker/.composer/vendor/phpspec/phpspec/bin/phpspec run --no-interaction --format=dot"
+                }
+            }
+        },
+        'phpspec-with-php-7.0': {
+            node('docker') {
+                deleteDir()
+                docker.image('carcel/php:7.0').inside {
+                    unstash "project_files"
+                    sh "composer global require phpspec/phpspec 2.1.*"
+                    sh "composer global require akeneo/phpspec-skip-example-extension 1.1.*"
+                    sh "cp app/config/parameters.yml app/config/parameters_test.yml"
+                    sh "/home/docker/.composer/vendor/phpspec/phpspec/bin/phpspec run --no-interaction --format=dot"
+                }
+            }
+        },
+        'phpspec-with-php-7.1': {
+            node('docker') {
+                deleteDir()
+                docker.image('carcel/php:7.1').inside {
                     unstash "project_files"
                     sh "composer global require phpspec/phpspec 2.1.*"
                     sh "composer global require akeneo/phpspec-skip-example-extension 1.1.*"


### PR DESCRIPTION
**Description**

Our current test matrix for Akeneo 1.6 is PHP 5.6, 7.0 and 7.1 for static analysis. This PR updates the Jenkinsfile to follow the same test matrix, and not the one of the previous Akeneo versions (PHP 5.4 to 5.6).

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | :negative_squared_cross_mark:
| Added Behats                      | :negative_squared_cross_mark:
| Changelog updated                 | :negative_squared_cross_mark:
| Review and 2 GTM                  | :clock1:
| Micro Demo to the PO (Story only) | :negative_squared_cross_mark:
| Migration script                  | :negative_squared_cross_mark:
| Tech Doc                          | :negative_squared_cross_mark:
