### PR TITLE
PIM-6019: Successfully import products without removing already existing associations when option "compare values" is disabled

### DIFF
--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -1,3 +1,9 @@
+# 1.5.x
+
+## Bug fixes
+
+- PIM-6019: Successfully import products without removing already existing associations when option "compare values" is disabled
+
 # 1.5.15 (2016-12-13)
 
 ## Bug fixes

--- a/features/Context/DataGridContext.php
+++ b/features/Context/DataGridContext.php
@@ -878,7 +878,9 @@ class DataGridContext extends RawMinkContext implements PageObjectAwareInterface
 
         foreach ($rows as $row) {
             $gridRow  = $this->datagrid->getRow($row);
-            $checkbox = $gridRow->find('css', 'td.boolean-cell input[type="checkbox"]:not(:disabled)');
+            $checkbox = $this->spin(function () use ($gridRow) {
+                return $gridRow->find('css', 'td.boolean-cell input[type="checkbox"]:not(:disabled)');
+            });
 
             if (!$checkbox) {
                 throw $this->createExpectationException(sprintf('Unable to find a checkbox for row %s', $row));

--- a/features/import/product/import_products_with_associations.feature
+++ b/features/import/product/import_products_with_associations.feature
@@ -131,3 +131,27 @@ Feature: Execute a job
     And I visit the "Associations" tab
     And I visit the "Cross sell" group
     Then I should see "0 products and 0 groups"
+
+  @jira https://akeneo.atlassian.net/browse/PIM-6019
+  Scenario: Successfully import product without remove already existing associations when option "compare values" is set to false
+    Given the following product:
+      | sku     | name-en_US |
+      | SKU-001 | sku-001    |
+      | SKU-002 | sku-002    |
+    When I edit the "SKU-001" product
+    And I visit the "Associations" tab
+    And I visit the "Cross sell" group
+    And I check the rows "SKU-002"
+    And I save the product
+    And the following CSV file to import:
+      """
+      sku
+      SKU-001
+      """
+    And the following job "footwear_product_import" configuration:
+      | filePath          | %file to import% |
+      | enabledComparison | no               |
+    And I am on the "footwear_product_import" import job page
+    And I launch the import job
+    And I wait for the "footwear_product_import" job to finish
+    Then I should see the text "skipped product (no associations detected)"

--- a/src/Pim/Bundle/ConnectorBundle/Resources/translations/messages.en.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/translations/messages.en.yml
@@ -173,3 +173,4 @@ job_execution.summary:
         title: File encoding:
         skipped: skipped, extension in white list
     product_skipped_no_diff: skipped product (no differences)
+    product_skipped_no_associations: skipped product (no associations detected)

--- a/src/Pim/Bundle/InstallerBundle/Resources/config/fixtures_jobs.yml
+++ b/src/Pim/Bundle/InstallerBundle/Resources/config/fixtures_jobs.yml
@@ -126,7 +126,7 @@ jobs:
                 - 'picture'
             enabledComparison: true
             decimalSeparator: .
-            dateFormat: Y-m-d
+            dateFormat: yyyy-MM-dd
 
     fixtures_job_yml:
         order: 100

--- a/src/Pim/Bundle/InstallerBundle/Resources/fixtures/icecat_demo_dev/jobs.yml
+++ b/src/Pim/Bundle/InstallerBundle/Resources/fixtures/icecat_demo_dev/jobs.yml
@@ -16,7 +16,7 @@ jobs:
             groupsColumn:       groups
             realTimeVersioning: true
             decimalSeparator: .
-            dateFormat: Y-m-d
+            dateFormat: yyyy-MM-dd
     csv_product_export:
         connector: Akeneo CSV Connector
         alias:     csv_product_export

--- a/src/Pim/Component/Connector/Processor/Denormalization/ProductAssociationProcessor.php
+++ b/src/Pim/Component/Connector/Processor/Denormalization/ProductAssociationProcessor.php
@@ -93,6 +93,11 @@ class ProductAssociationProcessor extends AbstractProcessor
 
                 return null;
             }
+        } elseif (!$this->hasImportedAssociations($convertedItem)) {
+            $this->detachProduct($product);
+            $this->stepExecution->incrementSummaryInfo('product_skipped_no_associations');
+
+            return null;
         }
 
         try {
@@ -234,5 +239,27 @@ class ProductAssociationProcessor extends AbstractProcessor
     protected function detachProduct(ProductInterface $product)
     {
         $this->detacher->detach($product);
+    }
+
+    /**
+     * It there association(s) in new values ?
+     *
+     * @param array $convertedItem
+     *
+     * @return bool
+     */
+    protected function hasImportedAssociations(array $convertedItem)
+    {
+        if (!isset($convertedItem['associations'])) {
+            return false;
+        }
+
+        foreach ($convertedItem['associations'] as $association) {
+            if (!empty($association['products']) || !empty($association['groups'])) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) 

**Description (for Contributor and Core Developer)**

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | :white_check_mark:
| Added Behats                      | :white_check_mark:
| Changelog updated                 | :white_check_mark:
| Review and 2 GTM                  | :clock1:
| Micro Demo to the PO (Story only) | :negative_squared_cross_mark:
| Migration script                  | :negative_squared_cross_mark:
| Tech Doc                          | :negative_squared_cross_mark:


:white_check_mark: Done and pass

:red_circle: Done but fail

:clock1: Done but pending

:negative_squared_cross_mark: Not needed
