### PR TITLE
PIM-6035: Fix an issue with locale switcher

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Filter/ChainedFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Filter/ChainedFilter.php
@@ -30,6 +30,10 @@ class ChainedFilter implements CollectionFilterInterface, ObjectFilterInterface
             }
         }
 
+        if (is_array($collection)) {
+            $collection = array_values($collection);
+        }
+
         return $collection;
     }
 


### PR DESCRIPTION
**Description**

On a product page, when the user does not have access to the first locale in the locale switcher, the product information cannot load, and a JavaScript error appear in the browser console: 
`Error: locale-switcher.js:28 Uncaught TypeError: Cannot read property 'code' of undefined Pim/Bundle/EnrichBundle/Resources/public/js/product/form/locale-switcher.js line 28`

This PR fixes the problem by resetting the indexes of the array containing the filtered locales.
As this bug can only occur in Enterprise Edition, functional testing is performed in `pim-enterprise-dev` repository.

**Definition Of Done)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | :negative_squared_cross_mark:
| Added Behats                      | :negative_squared_cross_mark:
| Changelog updated                 | :negative_squared_cross_mark:
| Review and 2 GTM                  | :clock1:
| Micro Demo to the PO (Story only) | :negative_squared_cross_mark:
| Migration script                  | :negative_squared_cross_mark:
| Tech Doc                          | :negative_squared_cross_mark:
