### PR TITLE
Added "replace" configuration in the composer.json file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -84,6 +84,23 @@
         "doctrine/mongodb-odm-bundle": "In order to activate the MongoDB support within Akeneo",
         "akeneo/catalogs": "In order to install one of the Akeneo catalogs"
     },
+    "replace": {
+        "oro/translation-bundle": "1.0-dev",
+        "oro/navigation-bundle": "1.0-dev",
+        "oro/requirejs-bundle": "1.0-dev",
+        "oro/security-bundle": "1.0-dev",
+        "oro/assetic-bundle": "1.0-dev",
+        "oro/filter-bundle": "1.0-dev",
+        "oro/config-bundle": "1.0-dev",
+        "oro/user-bundle": "1.0-dev",
+        "oro/form-bundle": "1.0-dev",
+        "oro/ui-bundle": "1.0.0-alpha",
+        "akeneo/storage-utils": "0.6.0-dev",
+        "akeneo/batch": "0.6.0-dev",
+        "akeneo/storage-utils-bundle": "0.6.0-dev",
+        "akeneo/measure-bundle": "0.6.0-dev",
+        "akeneo/batch-bundle": "0.6.0-dev"
+    },
     "scripts": {
         "post-install-cmd": [
             "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters",


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Splitted repos aren't easy to use as dependencies. If you create a bundle or a component that would only require `akeneo/batch`, there is no use to require the whole `akeneo/pim-community-dev` repo, at least if you want it to work with anything else than Akeneo.

I can create a bundle (independent from Akeneo) with this `composer.json` content :

```json
    "repositories": [
        {
            "type": "git",
            "url": "git@github.com:akeneo/batch.git"
        }
    ],
    "require": {
        "doctrine/common": "~2.4",
        "doctrine/orm": "~2.4",
        "akeneo/batch": "0.6.x-dev",
        "symfony/dependency-injection": "~2.7.0",
        "symfony/config": "~2.7.0",
        "symfony/http-kernel": "~2.7.0"
    },
```

The bundle will work perfectly in any Symfony application... except Akeneo.

Those lines fixes this for the batch component, I also did it for other components and bundles in the same situation in this repo.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       |  :negative_squared_cross_mark:
| Added Behats                      | :negative_squared_cross_mark:
| Changelog updated                 | 
| Review and 2 GTM                  |
| Micro Demo to the PO (Story only) | :negative_squared_cross_mark:
| Migration script                  | :negative_squared_cross_mark:
| Tech Doc                          | :negative_squared_cross_mark:

