### PR TITLE
[ON HOLD] PIM-6037: Prevent association code to be an integer

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -6,6 +6,7 @@
 - GITHUB-5062: Fixed unit conversion for ElectricCharge, cheers @gplanchat!
 - GITHUB-5294: Fixed infinite loading if no attribute is configured as a product identifier, cheers @gplanchat!
 - GITHUB-5337: Fixed Widget Registry. Priority is now taken in account.
+- PIM-6037: Prevent association type code to be only numeric
 
 ## Deprecations
 

--- a/features/Context/DataGridContext.php
+++ b/features/Context/DataGridContext.php
@@ -5,7 +5,6 @@ namespace Context;
 use Behat\Behat\Context\Step;
 use Behat\Behat\Context\Step\Then;
 use Behat\Gherkin\Node\TableNode;
-use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Exception\ExpectationException;
 use Behat\MinkExtension\Context\RawMinkContext;
 use Context\Page\Base\Grid;

--- a/features/association-type/create_association_type.feature
+++ b/features/association-type/create_association_type.feature
@@ -12,7 +12,7 @@ Feature: Association type creation
 
   @skip
   Scenario: Successfully create an association type
-    Then I should see the Code field
+    Given I should see the Code field
     When I fill in the following information in the popin:
       | Code | up_sell |
     And I press the "Save" button
@@ -25,7 +25,7 @@ Feature: Association type creation
     When I fill in the following information in the popin:
       | Code | =( |
     And I press the "Save" button
-    Then I should see validation error "Association type code may contain only letters, numbers and underscores"
+    Then I should see validation error "Association type code may contain only letters, numbers and underscores (numbers only are not allowed)"
 
   Scenario: Fail to create an association type with an already used code
     Given the following association type:
@@ -35,3 +35,10 @@ Feature: Association type creation
       | Code | cross_sell |
     And I press the "Save" button
     Then I should see validation error "This value is already used."
+
+  @jira https://akeneo.atlassian.net/browse/PIM-6037
+  Scenario: Fail to create an association type with a numeric code
+    Given I fill in the following information in the popin:
+      | Code | 1234 |
+    When I press the "Save" button
+    Then I should see validation error "Association type code may contain only letters, numbers and underscores (numbers only are not allowed)"

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/validation/associationType.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/validation/associationType.yml
@@ -8,8 +8,8 @@ Pim\Bundle\CatalogBundle\Entity\AssociationType:
         code:
             - NotBlank: ~
             - Regex:
-                pattern: /^[a-zA-Z0-9_]+$/
-                message: Association type code may contain only letters, numbers and underscores
+                pattern: /^(?![0-9]*$)[a-zA-Z0-9_]+$/
+                message: Association type code may contain only letters, numbers and underscores (numbers only are not allowed)
             - Length:
                 max: 100
         translations:

--- a/src/Pim/Component/Catalog/Updater/Setter/AssociationFieldSetter.php
+++ b/src/Pim/Component/Catalog/Updater/Setter/AssociationFieldSetter.php
@@ -122,8 +122,9 @@ class AssociationFieldSetter extends AbstractFieldSetter
      * Set products and groups to associations
      *
      * @param ProductInterface $product
+     * @param array            $data
      */
-    protected function setProductsAndGroupsToAssociations(ProductInterface $product, $data)
+    protected function setProductsAndGroupsToAssociations(ProductInterface $product, array $data)
     {
         foreach ($data as $typeCode => $items) {
             $association = $product->getAssociationForTypeCode($typeCode);
@@ -149,7 +150,7 @@ class AssociationFieldSetter extends AbstractFieldSetter
      * @param AssociationInterface $association
      * @param array                $productsIdentifiers
      */
-    protected function setAssociatedProducts(AssociationInterface $association, $productsIdentifiers)
+    protected function setAssociatedProducts(AssociationInterface $association, array $productsIdentifiers)
     {
         foreach ($productsIdentifiers as $productIdentifier) {
             $associatedProduct = $this->productRepository->findOneByIdentifier($productIdentifier);
@@ -170,7 +171,7 @@ class AssociationFieldSetter extends AbstractFieldSetter
      * @param AssociationInterface $association
      * @param array                $groupsCodes
      */
-    protected function setAssociatedGroups(AssociationInterface $association, $groupsCodes)
+    protected function setAssociatedGroups(AssociationInterface $association, array $groupsCodes)
     {
         foreach ($groupsCodes as $groupCode) {
             $associatedGroup = $this->groupRepository->findOneByIdentifier($groupCode);


### PR DESCRIPTION
**Description**



**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | :negative_squared_cross_mark:
| Added Behats                      | :white_check_mark:
| Changelog updated                 | :white_check_mark:
| Review and 2 GTM                  | :clock1:
| Micro Demo to the PO (Story only) | :clock1:
| Migration script                  | :negative_squared_cross_mark:
| Tech Doc                          | :negative_squared_cross_mark:
