### PR TITLE
PIM-6031: Deleted families are still visible on the product grid

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -1,3 +1,9 @@
+# 1.6.x
+
+## Bug fixes
+
+- PIM-6031: Deleted families are still visible on the product grid
+
 # 1.6.6 (2016-12-08)
 
 ## Bug fixes

--- a/features/family/delete_family.feature
+++ b/features/family/delete_family.feature
@@ -13,21 +13,30 @@ Feature: Delete a family
     Then I should see family boots
     When I click on the "Delete" action of the row which contains "boots"
     And I confirm the deletion
-    Then I should not see family boots
+    Then I should be on the families page
+    But I should not see family boots
 
   Scenario: Successfully delete a family from the edit page
     Given I edit the "sneakers" family
     When I press the "Delete" button
     And I confirm the deletion
-    Then the grid should contain 4 elements
-    And I should not see family sneakers
+    Then I should be on the families page
+    And the grid should contain 4 elements
+    But I should not see family sneakers
 
+  @jira https://akeneo.atlassian.net/browse/PIM-6031
   Scenario: Successfully delete a family used by a product
     Given the following product:
       | sku | family   |
       | foo | sneakers |
-    And I edit the "sneakers" family
-    When I press the "Delete" button
+    When I am on the products page
+    And I display the columns SKU, Family
+    Then I should see the text "sneakers"
+    When I edit the "sneakers" family
+    And I press the "Delete" button
     And I confirm the deletion
+    And I am on the products page
+    And I display the columns SKU, Family
+    Then I should not see the text "sneakers"
     When I edit the "foo" product
     Then I should see "Family: None"

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/QueryGenerator/FamilyDeletedQueryGenerator.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/QueryGenerator/FamilyDeletedQueryGenerator.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\QueryGenerator;
+
+/**
+ * Family deleted query generator
+ *
+ * @author    Anael Chardan <anael.chardan@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class FamilyDeletedQueryGenerator extends AbstractQueryGenerator
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function generateQuery($entity, $field, $oldValue, $newValue)
+    {
+        return [
+            [
+                ['normalizedData.family.code' => $entity->getCode()],
+                ['$unset'                     => ['normalizedData.family' => '']],
+                ['multiple'                   => true]
+            ]
+        ];
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/storage_driver/doctrine/mongodb-odm.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/storage_driver/doctrine/mongodb-odm.yml
@@ -42,6 +42,7 @@ parameters:
     pim_catalog.mongodb_odm_query_generator.attribute_as_label_updated.class:    Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\QueryGenerator\AttributeAsLabelUpdatedQueryGenerator
     pim_catalog.mongodb_odm_query_generator.channel_deleted.class:               Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\QueryGenerator\ChannelDeletedQueryGenerator
     pim_catalog.mongodb_odm_query_generator.attribute_deleted.class:             Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\QueryGenerator\AttributeDeletedQueryGenerator
+    pim_catalog.mongodb_odm_query_generator.family_deleted.class:                Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\QueryGenerator\FamilyDeletedQueryGenerator
     pim_catalog.mongodb_odm_query_generator.family_label_updated.class:          Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\QueryGenerator\FamilyLabelUpdatedQueryGenerator
     pim_catalog.mongodb_odm_query_generator.option_code_updated.class:           Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\QueryGenerator\OptionCodeUpdatedQueryGenerator
     pim_catalog.mongodb_odm_query_generator.option_deleted.class:                Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\QueryGenerator\OptionDeletedQueryGenerator
@@ -368,6 +369,14 @@ services:
         parent: pim_catalog.mongodb_odm_query_generator.abstract_normalized_data
         arguments:
             - '%pim_catalog.entity.attribute.class%'
+        tags:
+            - { name: pim_catalog.mongodb_odm_query_generator }
+
+    pim_catalog.mongodb_odm_query_generator.family_deleted:
+        class: '%pim_catalog.mongodb_odm_query_generator.family_deleted.class%'
+        parent: pim_catalog.mongodb_odm_query_generator.abstract_normalized_data
+        arguments:
+            - '%pim_catalog.entity.family.class%'
         tags:
             - { name: pim_catalog.mongodb_odm_query_generator }
 

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/QueryGenerator/FamilyDeletedQueryGeneratorSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/QueryGenerator/FamilyDeletedQueryGeneratorSpec.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace spec\Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\QueryGenerator;
+
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\NamingUtility;
+use Pim\Bundle\CatalogBundle\Entity\Family;
+use Pim\Component\Catalog\Model\FamilyInterface;
+
+class FamilyDeletedQueryGeneratorSpec extends ObjectBehavior
+{
+    public function let(NamingUtility $namingUtility)
+    {
+        $this->beConstructedWith($namingUtility, Family::class);
+    }
+
+    public function it_generates_a_query_to_delete_product_family(FamilyInterface $family)
+    {
+        $family->getCode()->willReturn(42);
+        $this->generateQuery($family, '', '', '')->shouldReturn([
+            [
+                ['normalizedData.family.code' => 42],
+                ['$unset' => ['normalizedData.family' => '']],
+                ['multiple' => true]
+            ]
+        ]);
+    }
+}


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) 

**Description (for Contributor and Core Developer)**

As the family is stored directly on the product in mongoDb, we have to delete it when the family itself is deleted :)

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | :white_check_mark:
| Added Behats                      | :white_check_mark:
| Changelog updated                 | :white_check_mark:
| Review and 2 GTM                  | :clock1:
| Micro Demo to the PO (Story only) |  :negative_squared_cross_mark:
| Migration script                  |  :negative_squared_cross_mark: 
| Tech Doc                          |  :negative_squared_cross_mark:


:white_check_mark: Done and pass

:red_circle: Done but fail

:clock1: Done but pending

:negative_squared_cross_mark: Not needed
