### PR TITLE
PIM-6025: Allow changing locales on unique channel

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -5,6 +5,7 @@
 - PIM-6027: Fix export builder filter on category with code as integer
 - PIM-6018: Prevent the import of an attribute identifier if not usable as grid filter
 - PIM-6022: Fix shell command injection in mass-edit
+- PIM-6025: Fix a bug that prevents to completely change the channel's locales
 
 # 1.6.5 (2016-11-25)
 

--- a/features/channel/edit_channel.feature
+++ b/features/channel/edit_channel.feature
@@ -55,3 +55,18 @@ Feature: Edit a channel
     And  I am on the "tablet" channel page
     And I fill in the following information:
       | Longueur | Kilomètre |
+
+  @jira https://akeneo.atlassian.net/browse/PIM-6025
+  Scenario: Successfully replace a channel locale by another one when there is only one channel
+    Given I am logged in as "Peter"
+    And I am on the channels page
+    And I click on the "Delete" action of the row which contains "tablet"
+    And I confirm the deletion
+    And I am on the "mobile" channel page
+    When I change the "Locales" to "German (Germany)"
+    And I press the "Save" button
+    Then I should not see the text "There are unsaved changes."
+    When I am on the locales page
+    And I filter by "activated" with operator "equals" and value "yes"
+    Then the grid should contain 1 elements
+    And I should see locales "de_DE"

--- a/src/Pim/Bundle/EnrichBundle/EventListener/Storage/ChannelLocaleSubscriber.php
+++ b/src/Pim/Bundle/EnrichBundle/EventListener/Storage/ChannelLocaleSubscriber.php
@@ -104,8 +104,8 @@ class ChannelLocaleSubscriber implements EventSubscriberInterface
         foreach ($newLocales as $locale) {
             if (!$locale->hasChannel($channel)) {
                 $locale->addChannel($channel);
-                $updatedLocales[] = $locale;
             }
+            $updatedLocales[] = $locale;
         }
 
         if (!empty($updatedLocales)) {

--- a/src/Pim/Bundle/EnrichBundle/spec/EventListener/Storage/ChannelLocaleSubscriberSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/EventListener/Storage/ChannelLocaleSubscriberSpec.php
@@ -85,7 +85,7 @@ class ChannelLocaleSubscriberSpec extends ObjectBehavior
         $localeEn->removeChannel($channel)->shouldBeCalled();
         $localeEs->addChannel($channel)->shouldBeCalled();
 
-        $saver->saveAll([$localeEn, $localeEs])->shouldBeCalled();
+        $saver->saveAll([$localeEn, $localeFr, $localeEs])->shouldBeCalled();
 
         $this->updateChannel($event);
     }


### PR DESCRIPTION
**Description**

When having only one channel, if you remove all the locales from the channel, and add a new one, then you end with a critical error:

```
request.CRITICAL: Uncaught PHP Exception Symfony\Component\Debug\Exception\ContextErrorException: "Catchable Fatal Error: Argument 1 passed to Pim\Bundle\UserBundle\Entity\User::setCatalogLocale() must implement interface Pim\Component\Catalog\Model\LocaleInterface, boolean given, called in /home/docker/pim/src/Pim/Bundle/UserBundle/EventSubscriber/UserPreferencesSubscriber.php on line 220 and defined" at /home/docker/pim/src/Pim/Bundle/UserBundle/Entity/User.php line 908 {"exception":"[object] (Symfony\\Component\\Debug\\Exception\\ContextErrorException(code: 0): Catchable Fatal Error: Argument 1 passed to Pim\\Bundle\\UserBundle\\Entity\\User::setCatalogLocale() must implement interface Pim\\Component\\Catalog\\Model\\LocaleInterface, boolean given, called in /home/docker/pim/src/Pim/Bundle/UserBundle/EventSubscriber/UserPreferencesSubscriber.php on line 220 and defined at /home/docker/pim/src/Pim/Bundle/UserBundle/Entity/User.php:908)"} []
```

What happen is the following:
- The channel is updated, then passed to the channel saver.
- The `ChannelLocaleSubscriber` listen to the `PRE_SAVE` event of the channel saver, so the channel is **not yet persisted**.
- The `ChannelLocaleSubscriber` gets the locales from the channel, both previous ones and new one, and saves them (locale saver). **However**, the new locales are passed to the saver ONLY if they are not yet attached to the channel, which is not possible as it is a ManyToMany relation, so a `$channel->addLocale()` results in the locale being attached to the channel.
- So now, only the old locales are updated, not the new ones, and a `UserPreferenceSubscriber` listen to Doctrine `postFlush` event, removing the old locales from the user, and having nothing to add instead, which explain the PHP critical error above.
- After that, as the channel never had a chance to be saved, there is no active locales anymore in the PIM.

This PR fixes that problem by ensuring the new locale is correctly added in place of the old ones, by always being passed to the locale saver.

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | :white_check_mark:
| Added Behats                      | :white_check_mark:
| Changelog updated                 | :white_check_mark:
| Review and 2 GTM                  | :clock1:
| Micro Demo to the PO (Story only) | :negative_squared_cross_mark:
| Migration script                  | :negative_squared_cross_mark:
| Tech Doc                          | :negative_squared_cross_mark: