### PR TITLE
Call validation on family mass edit

### DIFF
--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -1,3 +1,9 @@
+# 1.5.16
+
+## Bug fixes
+- Call validation on family mass edit
+
+
 # 1.5.15 (2016-12-13)
 
 ## Bug fixes

--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -1,8 +1,8 @@
-# 1.5.16
+# 1.5.x
 
 ## Bug fixes
-- Call validation on family mass edit
 
+- Call validation on family mass edit
 
 # 1.5.15 (2016-12-13)
 

--- a/spec/Pim/Bundle/EnrichBundle/Connector/Processor/MassEdit/Family/SetAttributeRequirementsSpec.php
+++ b/spec/Pim/Bundle/EnrichBundle/Connector/Processor/MassEdit/Family/SetAttributeRequirementsSpec.php
@@ -4,6 +4,7 @@ namespace spec\Pim\Bundle\EnrichBundle\Connector\Processor\MassEdit\Family;
 
 use Akeneo\Component\Batch\Model\JobExecution;
 use Akeneo\Component\Batch\Model\StepExecution;
+use Akeneo\Component\StorageUtils\Detacher\ObjectDetacherInterface;
 use PhpSpec\ObjectBehavior;
 use Pim\Bundle\CatalogBundle\Factory\AttributeRequirementFactory;
 use Pim\Component\Catalog\Model\AttributeInterface;
@@ -23,13 +24,17 @@ class SetAttributeRequirementsSpec extends ObjectBehavior
         JobConfigurationRepositoryInterface $jobConfigurationRepo,
         AttributeRepositoryInterface $attributeRepository,
         ChannelRepositoryInterface $channelRepository,
-        AttributeRequirementFactory $factory
+        AttributeRequirementFactory $factory,
+        ValidatorInterface $validator,
+        ObjectDetacherInterface $detacher
     ) {
         $this->beConstructedWith(
             $jobConfigurationRepo,
             $attributeRepository,
             $channelRepository,
-            $factory
+            $factory,
+            $validator,
+            $detacher
         );
     }
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/connector/processors.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/connector/processors.yml
@@ -37,6 +37,8 @@ services:
             - '@pim_catalog.repository.attribute'
             - '@pim_catalog.repository.channel'
             - '@pim_catalog.factory.attribute_requirement'
+            - '@validator'
+            - '@akeneo_storage_utils.doctrine.object_detacher'
 
     pim_enrich.connector.processor.mass_edit.product.add_to_variant_group:
         class: %pim_enrich.connector.processor.mass_edit.product.add_to_variant_group.class%

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/messages.en.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/messages.en.yml
@@ -967,6 +967,7 @@ job_execution.summary:
     skip:               Skipped
     skipped_products:   Skipped products
     skipped_attributes: Skipped attributes
+    skipped_families:   Skipped families
 
 pim_mass_edit_execution_show:  Mass edit executions | Details
 


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

**Description (for Contributor and Core Developer)**
This PR calls the validation during family mass action! Today families are saved in DB without being validated.

![image](https://cloud.githubusercontent.com/assets/2131005/21356730/f7fb71aa-c6d2-11e6-932d-2751636417ad.png)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | :white_check_mark:
| Added Behats                      | :negative_squared_cross_mark:
| Changelog updated                 | :white_check_mark:
| Review and 2 GTM                  | :clock1:
| Micro Demo to the PO (Story only) | :negative_squared_cross_mark:
| Migration script                  | :negative_squared_cross_mark:
| Tech Doc                          | :negative_squared_cross_mark:


:white_check_mark: Done and pass

:red_circle: Done but fail

:clock1: Done but pending

:negative_squared_cross_mark: Not needed
