### PR TITLE
TIP-663: use codes as default in the PQB

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -23,6 +23,7 @@
 
 ## BC breaks
 
+- Add `getAllChildrenCodes` to `Akeneo\Component\Classification\Repository\CategoryRepositoryInterface` 
 - Change the constructor of `Pim\Bundle\FilterBundle\Filter\Product\InGroupFilter` to add `Pim\Bundle\CatalogBundle\Doctrine\Common\Filter\ObjectCodeResolver`
 - Remove WebServiceBundle
 - Remove `wsse_secured` firewall in security.yml

--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -2,11 +2,19 @@
 
 ## Bug Fixes
 
-- #5038: Fixed job name visibility checker to also check additional config
-- #5062: Fixed unit conversion for ElectricCharge, cheers @gplanchat!
-- #5294: Fixed infinite loading if no attribute is configured as a product identifier, cheers @gplanchat!
-- #5337: Fixed Widget Registry. Priority is now taken in account.
+- GITHUB-5038: Fixed job name visibility checker to also check additional config
+- GITHUB-5062: Fixed unit conversion for ElectricCharge, cheers @gplanchat!
+- GITHUB-5294: Fixed infinite loading if no attribute is configured as a product identifier, cheers @gplanchat!
+- GITHUB-5337: Fixed Widget Registry. Priority is now taken in account.
 - TIP-662: Removed the WITH_REQUIRED_IDENTIFIER option from the flatToStandard product converter.
+
+
+## Deprecations
+
+- In the _Product Query Builder_, aka _PQB_, (`Pim\Component\Catalog\Query\ProductQueryBuilderInterface`), filtering products by the following filters is now deprecated: `categories.id`, `family.id`, `groups.id`. 
+  Filters `categories`, `family` and `groups` have been introduced and the _PQB_ now uses them by default. The filters `categories.code`, `family.code` and `groups.code` are deprecated. 
+  In the next version, the deprecated filters will be removed.
+- As it's not needed anymore to convert `codes` to `ids` in order to filter products, `Pim\Bundle\CatalogBundle\Doctrine\Common\Filter\ObjectIdResolver` and `Pim\Bundle\CatalogBundle\Doctrine\Common\Filter\ObjectIdResolverInterface` are now deprecated. 
 
 ## Functional improvements
 
@@ -17,8 +25,8 @@
 
 ## Technical improvements
 
-- #5380: Add `Pim\Component\User\Model\GroupInterface`
-- #4696: Ping the server before updating job and step execution data to prevent "MySQL Server has gone away" issue cheers @qrz-io!
+- GITHUB-5380: Add `Pim\Component\User\Model\GroupInterface`
+- GITHUB-4696: Ping the server before updating job and step execution data to prevent "MySQL Server has gone away" issue cheers @qrz-io!
 - TIP-575: Rename FileIterator classes to FlatFileIterator and changes the reader/processor behavior to iterate over the item's position in the file instead of the item's line number in the file.
 
 ## BC breaks

--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -23,6 +23,7 @@
 
 ## BC breaks
 
+- Change the constructor of `Pim\Bundle\FilterBundle\Filter\Product\InGroupFilter` to add `Pim\Bundle\CatalogBundle\Doctrine\Common\Filter\ObjectCodeResolver`
 - Remove WebServiceBundle
 - Remove `wsse_secured` firewall in security.yml
 - Change the constructor of `Pim\Component\Connector\Writer\File\Yaml\Writer` to add `Pim\Component\Connector\ArrayConverter\ArrayConverterInterface`

--- a/features/Context/catalog/apparel/jobs.yml
+++ b/features/Context/catalog/apparel/jobs.yml
@@ -45,7 +45,7 @@ jobs:
                         operator: '='
                         value: true
                     -
-                        field: categories.code
+                        field: categories
                         operator: 'IN CHILDREN'
                         value: ['2014_collection']
                     -
@@ -76,7 +76,7 @@ jobs:
                         operator: '='
                         value: true
                     -
-                        field: categories.code
+                        field: categories
                         operator: 'IN CHILDREN'
                         value: ['2013_collection']
                     -
@@ -104,7 +104,7 @@ jobs:
                         operator: '='
                         value: true
                     -
-                        field: categories.code
+                        field: categories
                         operator: 'IN CHILDREN'
                         value: ['2013_collection']
                     -
@@ -133,7 +133,7 @@ jobs:
                         operator: '='
                         value: true
                     -
-                        field: categories.code
+                        field: categories
                         operator: 'IN CHILDREN'
                         value: ['2015_collection']
                     -

--- a/features/Context/catalog/footwear/attribute_options.csv
+++ b/features/Context/catalog/footwear/attribute_options.csv
@@ -25,6 +25,7 @@ size;43;43;9
 size;44;44;10
 size;45;45;11
 size;46;46;12
+size;60;60;13
 color;white;White;1
 color;black;Black;2
 color;blue;Blue;3

--- a/features/Context/catalog/footwear/jobs.yml
+++ b/features/Context/catalog/footwear/jobs.yml
@@ -33,7 +33,7 @@ jobs:
                         operator: '='
                         value: true
                     -
-                        field: categories.code
+                        field: categories
                         operator: 'IN CHILDREN'
                         value: ['2014_collection']
                     -

--- a/features/export/edit_an_export.feature
+++ b/features/export/edit_an_export.feature
@@ -29,11 +29,11 @@ Feature: Edit an export
     And I uncheck the "With header" switch
     When I visit the "Content" tab
     Then I should see the Channel, Locales fields
-    Then I should see the filters enabled, completeness, updated, sku and family.code
+    Then I should see the filters enabled, completeness, updated, sku and family
     And I fill in the following information:
       | Channel | Tablet |
     Then I filter by "enabled" with operator "" and value "Disabled"
-    And I filter by "family.code" with operator "" and value "Boots"
+    And I filter by "family" with operator "" and value "Boots"
     And I filter by "completeness" with operator "Not complete on all selected locales" and value ""
     And I filter by "sku" with operator "" and value "identifier1 identifier2,identifier3 ,identifier4"
     Then I press the "Save" button
@@ -72,10 +72,10 @@ Feature: Edit an export
   Scenario: Successfully display export filter in expected order
     Given I am on the "csv_footwear_product_export" export job page
     When I visit the "Content" tab
-    Then I should see the ordered filters family.code, enabled, completeness, updated, categories and sku
+    Then I should see the ordered filters family, enabled, completeness, updated, categories and sku
     When I am on the "csv_footwear_product_export" export job edit page
     And I visit the "Content" tab
-    Then I should see the ordered filters family.code, enabled, completeness, updated, categories and sku
+    Then I should see the ordered filters family, enabled, completeness, updated, categories and sku
     When I add available attributes Name
     And I add available attributes Weight
-    Then I should see the ordered filters family.code, enabled, completeness, updated, categories, name, weight and sku
+    Then I should see the ordered filters family, enabled, completeness, updated, categories, name, weight and sku

--- a/features/export/edit_an_export.feature
+++ b/features/export/edit_an_export.feature
@@ -72,10 +72,10 @@ Feature: Edit an export
   Scenario: Successfully display export filter in expected order
     Given I am on the "csv_footwear_product_export" export job page
     When I visit the "Content" tab
-    Then I should see the ordered filters family.code, enabled, completeness, updated, categories.code and sku
+    Then I should see the ordered filters family.code, enabled, completeness, updated, categories and sku
     When I am on the "csv_footwear_product_export" export job edit page
     And I visit the "Content" tab
-    Then I should see the ordered filters family.code, enabled, completeness, updated, categories.code and sku
+    Then I should see the ordered filters family.code, enabled, completeness, updated, categories and sku
     When I add available attributes Name
     And I add available attributes Weight
-    Then I should see the ordered filters family.code, enabled, completeness, updated, categories.code, name, weight and sku
+    Then I should see the ordered filters family.code, enabled, completeness, updated, categories, name, weight and sku

--- a/features/export/ensure_acl.feature
+++ b/features/export/ensure_acl.feature
@@ -31,7 +31,7 @@ Feature: Ensures acl are respected on the export profile tabs
     And I save the role
     When I am on the "csv_footwear_product_export" export job edit page
     Then I should not see the text "General properties"
-    When I filter by "family.code" with operator "" and value "Boots"
+    When I filter by "family" with operator "" and value "Boots"
     And I press the "Save" button
     Then I should see the text "Boots"
 

--- a/features/export/export_options.feature
+++ b/features/export/export_options.feature
@@ -41,6 +41,7 @@ Feature: Export options
     size;44;10;44
     size;45;11;45
     size;46;12;46
+    size;60;13;60
     color;white;1;White
     color;black;2;Black
     color;blue;3;Blue

--- a/features/export/export_products.feature
+++ b/features/export/export_products.feature
@@ -72,7 +72,7 @@ Feature: Export products
     Given an "apparel" catalog configuration
     And the following job "tablet_product_export" configuration:
       | filePath | %tmp%/tablet_product_export/tablet_product_export.csv |
-      | filters  | {"structure": {"locales": ["en_US", "en_GB"], "scope": "tablet"},"data":[{"field":"completeness","operator":"=","value":100}, {"field":"categories.code","operator":"IN","value":["men_2013"]}]} |
+      | filters  | {"structure": {"locales": ["en_US", "en_GB"], "scope": "tablet"},"data":[{"field":"completeness","operator":"=","value":100}, {"field":"categories","operator":"IN","value":["men_2013"]}]} |
     And the following products:
       | sku          | family  | categories                   | price                 | size   | color | manufacturer     | material | country_of_manufacture |
       | tshirt-white | tshirts | men_2013, men_2014, men_2015 | 10 EUR, 15 USD, 9 GBP | size_M | white | american_apparel | cotton   | usa                    |
@@ -102,7 +102,7 @@ Feature: Export products
     Given an "apparel" catalog configuration
     And the following job "tablet_product_export" configuration:
       | filePath | %tmp%/tablet_product_export/tablet_product_export.csv |
-      | filters  | {"structure": {"locales": ["en_US", "en_GB"], "scope": "tablet"},"data":[{"field":"completeness","operator":"=","value":100}, {"field":"categories.code","operator":"IN CHILDREN","value":["2013_collection"]}]} |
+      | filters  | {"structure": {"locales": ["en_US", "en_GB"], "scope": "tablet"},"data":[{"field":"completeness","operator":"=","value":100}, {"field":"categories","operator":"IN CHILDREN","value":["2013_collection"]}]} |
     And the following attributes:
       | code                      | type | localizable | available_locales |
       | locale_specific_attribute | text | yes         | en_US,fr_FR       |

--- a/features/export/product-export-builder/export_products_by_categories.feature
+++ b/features/export/product-export-builder/export_products_by_categories.feature
@@ -47,7 +47,7 @@ Feature: Export products from any given categories
   @skip
   Scenario: Export the products from a tree
     Given the following job "csv_product_export" configuration:
-      | filters | {"structure": {"locales": ["en_US"], "scope": "ecommerce"}, "data": [{"field": "categories.code", "operator": "IN", "value": ["toys_games", "dolls", "women"]}, {"field": "completeness", "operator": ">=", "value": 100,"context":{"locales":["en_US"]}}]} |
+      | filters | {"structure": {"locales": ["en_US"], "scope": "ecommerce"}, "data": [{"field": "categories", "operator": "IN", "value": ["toys_games", "dolls", "women"]}, {"field": "completeness", "operator": ">=", "value": 100,"context":{"locales":["en_US"]}}]} |
     When I am on the "csv_product_export" export job page
     And I launch the export job
     And I wait for the "csv_product_export" job to finish

--- a/features/export/product-export-builder/export_products_by_families.feature
+++ b/features/export/product-export-builder/export_products_by_families.feature
@@ -24,7 +24,7 @@ Feature: Export products according to their families
   Scenario: Export only products in boots family
     Given the following job "csv_footwear_product_export" configuration:
       | filePath | %tmp%/product_export/product_export.csv                                                                                            |
-      | filters  | {"structure": {"locales": ["en_US"], "scope": "mobile"}, "data": [{"field": "family.code", "operator": "IN", "value": ["boots"]}]} |
+      | filters  | {"structure": {"locales": ["en_US"], "scope": "mobile"}, "data": [{"field": "family", "operator": "IN", "value": ["boots"]}]} |
     When I am on the "csv_footwear_product_export" export job page
     And I launch the export job
     And I wait for the "csv_footwear_product_export" job to finish
@@ -38,7 +38,7 @@ Feature: Export products according to their families
   Scenario: Export only products in boots and high heels family
     Given the following job "csv_footwear_product_export" configuration:
       | filePath | %tmp%/product_export/product_export.csv |
-      | filters  | {"structure": {"locales": ["en_US"], "scope": "mobile"}, "data": [{"field": "family.code", "operator": "IN", "value": ["boots", "heels"]}]} |
+      | filters  | {"structure": {"locales": ["en_US"], "scope": "mobile"}, "data": [{"field": "family", "operator": "IN", "value": ["boots", "heels"]}]} |
     When I am on the "csv_footwear_product_export" export job page
     And I launch the export job
     And I wait for the "csv_footwear_product_export" job to finish
@@ -74,7 +74,7 @@ Feature: Export products according to their families
       | filePath | %tmp%/product_export/product_export.csv |
     When I am on the "csv_footwear_product_export" export job edit page
     And I visit the "Content" tab
-    Then the export content field "family.code" should contain "No condition on families"
+    Then the export content field "family" should contain "No condition on families"
     When I am on the "csv_footwear_product_export" export job page
     And I visit the "Content" tab
-    Then the export content field "family.code" should contain "No condition on families"
+    Then the export content field "family" should contain "No condition on families"

--- a/features/export/product-export-builder/export_products_with_attributes.feature
+++ b/features/export/product-export-builder/export_products_with_attributes.feature
@@ -140,7 +140,7 @@ Feature: Export products with only selected attributes
       | HEEL-2 | high_heels | The blue heels | Blue            | Orange               | 2014_collection |
     And the following job "csv_footwear_product_export" configuration:
       | filePath | %tmp%/product_export/product_export.csv |
-      | filters  | {"structure": {"locales": ["en_US"], "scope": "mobile", "attributes": ["high_heel_color", "high_heel_color_sole"]}, "data": [{"field": "family.code", "operator": "IN", "value": ["high_heels"]}]} |
+      | filters  | {"structure": {"locales": ["en_US"], "scope": "mobile", "attributes": ["high_heel_color", "high_heel_color_sole"]}, "data": [{"field": "family", "operator": "IN", "value": ["high_heels"]}]} |
     When I am on the "csv_footwear_product_export" export job page
     And I launch the export job
     And I wait for the "csv_footwear_product_export" job to finish

--- a/features/export/xlsx/export_options.feature
+++ b/features/export/xlsx/export_options.feature
@@ -42,6 +42,7 @@ Feature: Export options in XSLX
       | size               | 44          | 10         | 44          |
       | size               | 45          | 11         | 45          |
       | size               | 46          | 12         | 46          |
+      | size               | 60          | 13         | 60          |
       | color              | white       | 1          | White       |
       | color              | black       | 2          | Black       |
       | color              | blue        | 3          | Blue        |

--- a/features/filter/category.feature
+++ b/features/filter/category.feature
@@ -14,11 +14,11 @@ Feature: Filter on category
       | BOOTRXS | 2014_collection, summer_collection |
     Then I should get the following results for the given filters:
       | filter                                                                                               | result                           |
-      | [{"field":"categories.code", "operator":"IN",                 "value": ["winter_boots", "sandals"]}] | ["BOOTBXS", "BOOTWXS", "BOOTBS"] |
-      | [{"field":"categories.code", "operator":"NOT IN",             "value": ["winter_boots"]}]            | ["BOOTBS", "BOOTBL", "BOOTRXS"]  |
-      | [{"field":"categories.code", "operator":"UNCLASSIFIED",       "value": []}]                          | ["BOOTBL"]                       |
-      | [{"field":"categories.code", "operator":"IN OR UNCLASSIFIED", "value": ["sandals"]}]                 | ["BOOTBS", "BOOTBL", "BOOTWXS"]  |
-      | [{"field":"categories.code", "operator":"IN CHILDREN",        "value": ["summer_collection"]}]       | ["BOOTBS", "BOOTRXS", "BOOTWXS"] |
-      | [{"field":"categories.code", "operator":"NOT IN CHILDREN",    "value": ["winter_collection"]}]       | ["BOOTBS", "BOOTBL", "BOOTRXS"]  |
-      | [{"field":"categories.code", "operator":"NOT IN CHILDREN",    "value": ["winter_collection"]}, {"field":"categories.code", "operator":"IN", "value": ["sandals"]}] | ["BOOTBS"] |
-      | [{"field":"categories.code", "operator":"NOT IN CHILDREN",    "value": ["winter_collection"]}, {"field":"categories.code", "operator":"IN OR UNCLASSIFIED", "value": ["sandals"]}] | ["BOOTBS", "BOOTBL"] |
+      | [{"field":"categories", "operator":"IN",                 "value": ["winter_boots", "sandals"]}] | ["BOOTBXS", "BOOTWXS", "BOOTBS"] |
+      | [{"field":"categories", "operator":"NOT IN",             "value": ["winter_boots"]}]            | ["BOOTBS", "BOOTBL", "BOOTRXS"]  |
+      | [{"field":"categories", "operator":"UNCLASSIFIED",       "value": []}]                          | ["BOOTBL"]                       |
+      | [{"field":"categories", "operator":"IN OR UNCLASSIFIED", "value": ["sandals"]}]                 | ["BOOTBS", "BOOTBL", "BOOTWXS"]  |
+      | [{"field":"categories", "operator":"IN CHILDREN",        "value": ["summer_collection"]}]       | ["BOOTBS", "BOOTRXS", "BOOTWXS"] |
+      | [{"field":"categories", "operator":"NOT IN CHILDREN",    "value": ["winter_collection"]}]       | ["BOOTBS", "BOOTBL", "BOOTRXS"]  |
+      | [{"field":"categories", "operator":"NOT IN CHILDREN",    "value": ["winter_collection"]}, {"field":"categories", "operator":"IN", "value": ["sandals"]}] | ["BOOTBS"] |
+      | [{"field":"categories", "operator":"NOT IN CHILDREN",    "value": ["winter_collection"]}, {"field":"categories", "operator":"IN OR UNCLASSIFIED", "value": ["sandals"]}] | ["BOOTBS", "BOOTBL"] |

--- a/features/filter/family.feature
+++ b/features/filter/family.feature
@@ -14,7 +14,7 @@ Feature: Filter on family
       | BOOTRXS |          |
     Then I should get the following results for the given filters:
       | filter                                                                            | result                            |
-      | [{"field":"family.code", "operator":"IN",        "value": ["boots", "heels"]}]    | ["BOOTBXS", "HEELXXL"]            |
-      | [{"field":"family.code", "operator":"NOT IN",    "value": ["heels", "sneakers"]}] | ["BOOTBXS", "BOOTBL", "BOOTRXS"]  |
-      | [{"field":"family.code", "operator":"EMPTY",     "value": null}]                  | ["BOOTBL", "BOOTRXS"]             |
-      | [{"field":"family.code", "operator":"NOT EMPTY", "value": null}]                  | ["BOOTBXS", "HEELXXL", "SNEAKXS"] |
+      | [{"field":"family", "operator":"IN",        "value": ["boots", "heels"]}]    | ["BOOTBXS", "HEELXXL"]            |
+      | [{"field":"family", "operator":"NOT IN",    "value": ["heels", "sneakers"]}] | ["BOOTBXS", "BOOTBL", "BOOTRXS"]  |
+      | [{"field":"family", "operator":"EMPTY",     "value": null}]                  | ["BOOTBL", "BOOTRXS"]             |
+      | [{"field":"family", "operator":"NOT EMPTY", "value": null}]                  | ["BOOTBXS", "HEELXXL", "SNEAKXS"] |

--- a/features/filter/group.feature
+++ b/features/filter/group.feature
@@ -14,7 +14,7 @@ Feature: Filter on groups
       | BOOT   |                    |
     Then I should get the following results for the given filters:
       | filter                                                                               | result                                |
-      | [{"field":"groups.code", "operator":"IN",        "value": ["substitute", "upsell"]}] | ["TSHIRT", "JACKET", "SWEAT"]         |
-      | [{"field":"groups.code", "operator":"NOT IN",    "value": ["substitute", "upsell"]}] | ["PANT", "BOOT"]                      |
-      | [{"field":"groups.code", "operator":"EMPTY",     "value": null}]                     | ["BOOT"]                              |
-      | [{"field":"groups.code", "operator":"NOT EMPTY", "value": null}]                     | ["TSHIRT", "JACKET", "SWEAT", "PANT"] |
+      | [{"field":"groups", "operator":"IN",        "value": ["substitute", "upsell"]}] | ["TSHIRT", "JACKET", "SWEAT"]         |
+      | [{"field":"groups", "operator":"NOT IN",    "value": ["substitute", "upsell"]}] | ["PANT", "BOOT"]                      |
+      | [{"field":"groups", "operator":"EMPTY",     "value": null}]                     | ["BOOT"]                              |
+      | [{"field":"groups", "operator":"NOT EMPTY", "value": null}]                     | ["TSHIRT", "JACKET", "SWEAT", "PANT"] |

--- a/src/Akeneo/Bundle/ClassificationBundle/Doctrine/ORM/Repository/CategoryRepository.php
+++ b/src/Akeneo/Bundle/ClassificationBundle/Doctrine/ORM/Repository/CategoryRepository.php
@@ -169,7 +169,7 @@ class CategoryRepository extends NestedTreeRepository implements
             $codes[] = $category['code'];
         }
 
-       return $codes;
+        return $codes;
     }
 
     /**

--- a/src/Akeneo/Bundle/ClassificationBundle/Doctrine/ORM/Repository/CategoryRepository.php
+++ b/src/Akeneo/Bundle/ClassificationBundle/Doctrine/ORM/Repository/CategoryRepository.php
@@ -175,6 +175,34 @@ class CategoryRepository extends NestedTreeRepository implements
     /**
      * {@inheritdoc}
      */
+    public function getCategoryIdsByCodes(array $categoriesCodes)
+    {
+        if (empty($categoriesCodes)) {
+            return [];
+        }
+
+        $meta = $this->getClassMetadata();
+        $config = $this->listener->getConfiguration($this->_em, $meta->name);
+
+        $qb = $this->_em->createQueryBuilder();
+        $qb->select('node.id')
+            ->from($config['useObjectClass'], 'node')
+            ->where('node.code IN (:categoriesCodes)');
+
+        $qb->setParameter('categoriesCodes', $categoriesCodes);
+
+        $categories = $qb->getQuery()->execute(null, AbstractQuery::HYDRATE_SCALAR);
+        $ids = [];
+        foreach ($categories as $category) {
+            $ids[] = (int) $category['id'];
+        }
+
+        return $ids;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function findOneByIdentifier($code)
     {
         return $this->findOneBy(['code' => $code]);

--- a/src/Akeneo/Bundle/ClassificationBundle/Doctrine/ORM/Repository/CategoryRepository.php
+++ b/src/Akeneo/Bundle/ClassificationBundle/Doctrine/ORM/Repository/CategoryRepository.php
@@ -154,6 +154,27 @@ class CategoryRepository extends NestedTreeRepository implements
     /**
      * {@inheritdoc}
      */
+    public function getAllChildrenCodes(CategoryInterface $parent, $includeNode = false)
+    {
+        $categoryQb = $this->getAllChildrenQueryBuilder($parent, $includeNode);
+        $rootAlias = current($categoryQb->getRootAliases());
+        $rootEntity = current($categoryQb->getRootEntities());
+        $categoryQb->select($rootAlias.'.code');
+        $categoryQb->resetDQLPart('from');
+        $categoryQb->from($rootEntity, $rootAlias, $rootAlias.'.id');
+
+        $categories = $categoryQb->getQuery()->execute(null, AbstractQuery::HYDRATE_SCALAR);
+        $codes = [];
+        foreach ($categories as $category) {
+            $codes[] = $category['code'];
+        }
+
+       return $codes;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function findOneByIdentifier($code)
     {
         return $this->findOneBy(['code' => $code]);

--- a/src/Akeneo/Component/Classification/Repository/CategoryRepositoryInterface.php
+++ b/src/Akeneo/Component/Classification/Repository/CategoryRepositoryInterface.php
@@ -79,6 +79,15 @@ interface CategoryRepositoryInterface extends
     public function getAllChildrenCodes(CategoryInterface $parent, $includeNode = false);
 
     /**
+     * Return the categories IDs from their codes. The categories are not hydrated.
+     *
+     * @param array $codes
+     *
+     * @return array
+     */
+    public function getCategoryIdsByCodes(array $codes);
+
+    /**
      * Get children from a parent id
      *
      * @param int $parentId

--- a/src/Akeneo/Component/Classification/Repository/CategoryRepositoryInterface.php
+++ b/src/Akeneo/Component/Classification/Repository/CategoryRepositoryInterface.php
@@ -69,6 +69,16 @@ interface CategoryRepositoryInterface extends
     public function getAllChildrenIds(CategoryInterface $parent, $includeNode = false);
 
     /**
+     * Shortcut to get all children codes
+     *
+     * @param CategoryInterface $parent      the parent
+     * @param bool              $includeNode true to include actual node in query result
+     *
+     * @return string[]
+     */
+    public function getAllChildrenCodes(CategoryInterface $parent, $includeNode = false);
+
+    /**
      * Get children from a parent id
      *
      * @param int $parentId

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Filter/ObjectCodeResolver.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Filter/ObjectCodeResolver.php
@@ -36,8 +36,8 @@ class ObjectCodeResolver
      * @param array              $ids
      * @param AttributeInterface $attribute
      *
-     * @return array
      * @throws ObjectNotFoundException
+     * @return array
      */
     public function getCodesFromIds($entityName, array $ids, AttributeInterface $attribute = null)
     {

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Filter/ObjectCodeResolver.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Filter/ObjectCodeResolver.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\Doctrine\Common\Filter;
+
+use Doctrine\Common\Persistence\ManagerRegistry;
+use Pim\Component\Catalog\Exception\ObjectNotFoundException;
+use Pim\Component\Catalog\Model\AttributeInterface;
+
+/**
+ * Object code resolver
+ *
+ * @author    Julien Janvier <j.janvier@gmail.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ObjectCodeResolver
+{
+    /** @var ManagerRegistry */
+    protected $managerRegistry;
+
+    /** @var array */
+    protected $fieldMapping = [];
+
+    /**
+     * @param ManagerRegistry $managerRegistry
+     */
+    public function __construct(ManagerRegistry $managerRegistry)
+    {
+        $this->managerRegistry = $managerRegistry;
+    }
+
+    /**
+     * Get codes for the given ids
+     *
+     * @param string             $entityName
+     * @param array              $ids
+     * @param AttributeInterface $attribute
+     *
+     * @return array
+     * @throws ObjectNotFoundException
+     */
+    public function getCodesFromIds($entityName, array $ids, AttributeInterface $attribute = null)
+    {
+        if (!isset($this->fieldMapping[$entityName])) {
+            throw new \InvalidArgumentException(sprintf('The class %s cannot be found', $entityName));
+        }
+
+        $repository = $this->managerRegistry
+            ->getManagerForClass($this->fieldMapping[$entityName])
+            ->getRepository($this->fieldMapping[$entityName]);
+
+        $codes = [];
+        foreach ($ids as $id) {
+            $entity = $repository->findOneBy(['id' => $id]);
+
+            if (null === $entity) {
+                throw new ObjectNotFoundException(
+                    sprintf('Object "%s" with id "%s" does not exist', $entityName, $id)
+                );
+            }
+
+            $code = $entity->getCode();
+            if (null !== $attribute) {
+                $code = $attribute->getCode() . '.' . $code;
+            }
+
+            $codes[] = $code;
+        }
+
+        return $codes;
+    }
+
+    /**
+     * Add a mapping to the field mapping
+     *
+     * @param string $entityName
+     * @param string $className
+     */
+    public function addFieldMapping($entityName, $className)
+    {
+        $this->fieldMapping[$entityName] = $className;
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Filter/ObjectIdResolver.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Filter/ObjectIdResolver.php
@@ -12,6 +12,9 @@ use Pim\Component\Catalog\Model\AttributeInterface;
  * @author    Julien Sanchez <julien@akeneo.com>
  * @copyright 2014 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *
+ * @deprecated will be removed in 1.8. The filters will only handle identifiers. No more IDs.
+ * @deprecated Which means we won't have to convert IDs <=> codes.
  */
 class ObjectIdResolver implements ObjectIdResolverInterface
 {

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Filter/ObjectIdResolverInterface.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Filter/ObjectIdResolverInterface.php
@@ -10,6 +10,9 @@ use Pim\Component\Catalog\Model\AttributeInterface;
  * @author    Julien Sanchez <julien@akeneo.com>
  * @copyright 2014 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *
+ * @deprecated will be removed in 1.8. The filters will only handle identifiers. No more IDs.
+ * @deprecated Which means we won't have to convert IDs <=> codes.
  */
 interface ObjectIdResolverInterface
 {

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/GroupSaver.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/GroupSaver.php
@@ -172,7 +172,7 @@ class GroupSaver implements SaverInterface, BulkSaverInterface
 
         if (null !== $group->getId()) {
             $pqb = $this->productQueryBuilderFactory->create();
-            $pqb->addFilter('groups.id', Operators::IN_LIST, [$group->getId()]);
+            $pqb->addFilter('groups.code', Operators::IN_LIST, [$group->getCode()]);
             $oldProducts = $pqb->execute();
             foreach ($oldProducts as $oldProduct) {
                 if (!in_array($oldProduct->getId(), $productToUpdateIds)) {

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/GroupSaver.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/GroupSaver.php
@@ -172,7 +172,7 @@ class GroupSaver implements SaverInterface, BulkSaverInterface
 
         if (null !== $group->getId()) {
             $pqb = $this->productQueryBuilderFactory->create();
-            $pqb->addFilter('groups.code', Operators::IN_LIST, [$group->getCode()]);
+            $pqb->addFilter('groups', Operators::IN_LIST, [$group->getCode()]);
             $oldProducts = $pqb->execute();
             foreach ($oldProducts as $oldProduct) {
                 if (!in_array($oldProduct->getId(), $productToUpdateIds)) {

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/GroupRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/GroupRepository.php
@@ -220,8 +220,13 @@ class GroupRepository extends EntityRepository implements GroupRepositoryInterfa
      */
     public function getOptions($dataLocale, $collectionId = null, $search = '', array $options = [])
     {
+        $selectDQL = sprintf(
+            'o.%s as id, COALESCE(NULLIF(t.label, \'\'), CONCAT(\'[\', o.code, \']\')) as text',
+            isset($options['type']) && 'code' === $options['type'] ? 'code' : 'id'
+        );
+
         $qb = $this->createQueryBuilder('o')
-            ->select('o.id as id, COALESCE(NULLIF(t.label, \'\'), CONCAT(\'[\', o.code, \']\')) as text')
+            ->select($selectDQL)
             ->leftJoin('o.translations', 't', 'WITH', 't.locale=:locale')
             ->addOrderBy('text', 'ASC')
             ->setParameter('locale', $dataLocale);

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
@@ -7,6 +7,7 @@ parameters:
     pim_catalog.query.filter.attribute_dumper.class:            Pim\Bundle\CatalogBundle\Command\ProductQueryHelp\AttributeFilterDumper
     pim_catalog.doctrine.query.filter.category.class:           Pim\Bundle\CatalogBundle\Doctrine\Common\Filter\CategoryFilter
     pim_catalog.doctrine.query.filter.object_id_resolver.class: Pim\Bundle\CatalogBundle\Doctrine\Common\Filter\ObjectIdResolver
+    pim_catalog.doctrine.query.filter.object_code_resolver.class: Pim\Bundle\CatalogBundle\Doctrine\Common\Filter\ObjectCodeResolver
     pim_catalog.doctrine.query.filter.dummy.class:              Pim\Bundle\CatalogBundle\Doctrine\Common\Filter\DummyFilter
 
 services:
@@ -43,6 +44,16 @@ services:
     # PQB common utils
     pim_catalog.doctrine.query.filter.object_id_resolver:
         class: '%pim_catalog.doctrine.query.filter.object_id_resolver.class%'
+        arguments:
+            - '@akeneo_storage_utils.doctrine.smart_manager_registry'
+        calls:
+            - [ addFieldMapping, ['family', '%pim_catalog.entity.family.class%']]
+            - [ addFieldMapping, ['option', '%pim_catalog.entity.attribute_option.class%']]
+            - [ addFieldMapping, ['category', '%pim_catalog.entity.category.class%']]
+            - [ addFieldMapping, ['group', '%pim_catalog.entity.group.class%']]
+
+    pim_catalog.doctrine.query.filter.object_code_resolver:
+        class: '%pim_catalog.doctrine.query.filter.object_code_resolver.class%'
         arguments:
             - '@akeneo_storage_utils.doctrine.smart_manager_registry'
         calls:

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
@@ -107,7 +107,7 @@ services:
         class: '%pim_catalog.doctrine.query.filter.groups.class%'
         arguments:
             - '@pim_catalog.doctrine.query.filter.object_id_resolver'
-            - ['groups.id', 'groups.code']
+            - ['groups', 'groups.id', 'groups.code']
             - ['IN', 'NOT IN', 'EMPTY', 'NOT EMPTY']
         tags:
             - { name: 'pim_catalog.doctrine.query.filter', priority: 30 }

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
@@ -69,7 +69,7 @@ services:
             - '@pim_catalog.repository.category'
             - '@pim_catalog.repository.product_category'
             - '@pim_catalog.doctrine.query.filter.object_id_resolver'
-            - ['categories.id', 'categories.code']
+            - ['categories', 'categories.id', 'categories.code']
             - ['IN', 'NOT IN', 'UNCLASSIFIED', 'IN OR UNCLASSIFIED', 'IN CHILDREN', 'NOT IN CHILDREN']
         tags:
             - { name: 'pim_catalog.doctrine.query.filter', priority: 30 }

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
@@ -98,7 +98,7 @@ services:
         class: '%pim_catalog.doctrine.query.filter.family.class%'
         arguments:
             - '@pim_catalog.doctrine.query.filter.object_id_resolver'
-            - ['family.id', 'family.code']
+            - ['family', 'family.id', 'family.code']
             - ['IN', 'NOT IN' ,'EMPTY', 'NOT EMPTY']
         tags:
             - { name: 'pim_catalog.doctrine.query.filter', priority: 30 }

--- a/src/Pim/Bundle/CatalogBundle/spec/Command/ProductQueryHelp/FieldFilterDumperSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Command/ProductQueryHelp/FieldFilterDumperSpec.php
@@ -32,7 +32,7 @@ class FieldFilterDumperSpec extends ObjectBehavior
         $output->writeln(Argument::any())->shouldBeCalled();
 
         $operators = ['IN', 'NOT IN', 'EMPTY', 'NOT EMPTY'];
-        $fields = ['groups.id', 'groups.code'];
+        $fields = ['groups.id', 'groups'];
         $registry->getFieldFilters()->willReturn([$groupFilter]);
         $groupFilter->getOperators()->willReturn($operators);
         $groupFilter->getFields()->willReturn($fields);
@@ -44,7 +44,7 @@ class FieldFilterDumperSpec extends ObjectBehavior
             return 'groups.id' === $param[0][0] &&
                 'IN, NOT IN, EMPTY, NOT EMPTY' === $param[0][1] &&
                 false !== strpos($param[0][2], 'FieldFilterInterface') &&
-                'groups.code' === $param[1][0] &&
+                'groups' === $param[1][0] &&
                 'IN, NOT IN, EMPTY, NOT EMPTY' === $param[1][1] &&
                 false !== strpos($param[1][2], 'FieldFilterInterface');
         }))->shouldBeCalled();

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/Common/Filter/DummyFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/Common/Filter/DummyFilterSpec.php
@@ -33,7 +33,7 @@ class DummyFilterSpec extends ObjectBehavior
         $this->supportsField('categories')->shouldReturn(false);
         $this->supportsField('enabled')->shouldReturn(true);
         $this->supportsField('completeness')->shouldReturn(true);
-        $this->supportsField('family.code')->shouldReturn(false);
+        $this->supportsField('family')->shouldReturn(false);
     }
 
     function it_checks_if_attribute_is_supported(

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/Common/Filter/ObjectCodeResolverSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/Common/Filter/ObjectCodeResolverSpec.php
@@ -10,7 +10,7 @@ use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\AttributeOptionInterface;
 use Pim\Component\Catalog\Model\FamilyInterface;
 
-class ObjectIdResolverSpec extends ObjectBehavior
+class ObjectCodeResolverSpec extends ObjectBehavior
 {
     function let(ManagerRegistry $managerRegistry)
     {
@@ -19,7 +19,7 @@ class ObjectIdResolverSpec extends ObjectBehavior
         $this->addFieldMapping('option', 'optionClass');
     }
 
-    function it_gets_ids_from_codes(
+    function it_gets_codes_from_ids(
         $managerRegistry,
         ObjectManager $manager,
         ObjectRepository $repository,
@@ -30,18 +30,18 @@ class ObjectIdResolverSpec extends ObjectBehavior
         $managerRegistry->getManagerForClass('familyClass')->willReturn($manager);
         $manager->getRepository('familyClass')->willReturn($repository);
 
-        $repository->findOneBy(['code' => 'camcorders'])->willReturn($camcorders);
-        $repository->findOneBy(['code' => 'shirt'])->willReturn($shirt);
-        $repository->findOneBy(['code' => 'men'])->willReturn($men);
+        $repository->findOneBy(['id' => 12])->willReturn($camcorders);
+        $repository->findOneBy(['id' => 56])->willReturn($shirt);
+        $repository->findOneBy(['id' => 123])->willReturn($men);
 
-        $camcorders->getId()->willReturn(2);
-        $shirt->getId()->willReturn(12);
-        $men->getId()->willReturn(32);
+        $camcorders->getCode()->willReturn('camcorders');
+        $shirt->getCode()->willReturn('shirt');
+        $men->getCode()->willReturn('men');
 
-        $this->getIdsFromCodes('family', ['camcorders', 'shirt', 'men'])->shouldReturn([2, 12, 32]);
+        $this->getCodesFromIds('family', [12, 56, 123])->shouldReturn(['camcorders', 'shirt', 'men']);
     }
 
-    function it_gets_ids_from_codes_with_attribute(
+    function it_gets_codes_from_ids_with_attribute(
         $managerRegistry,
         ObjectManager $manager,
         ObjectRepository $repository,
@@ -50,17 +50,17 @@ class ObjectIdResolverSpec extends ObjectBehavior
     ) {
         $managerRegistry->getManagerForClass('optionClass')->willReturn($manager);
         $manager->getRepository('optionClass')->willReturn($repository);
-        $attribute->getId()->willReturn(12);
+        $attribute->getCode()->willReturn('an_option');
 
-        $repository->findOneBy(['code' => 'purple', 'attribute' => 12])->willReturn($purple);
-        $purple->getId()->willReturn(2);
+        $repository->findOneBy(['id' => 12])->willReturn($purple);
+        $purple->getCode()->willReturn('purple');
 
-        $this->getIdsFromCodes('option', ['purple'], $attribute)->shouldReturn([2]);
+        $this->getCodesFromIds('option', [12], $attribute)->shouldReturn(['an_option.purple']);
     }
 
     function it_throws_an_exception_if_the_call_mapping_is_not_well_set()
     {
-        $this->shouldThrow('\InvalidArgumentException')->during('getIdsFromCodes', ['group', ['mug']]);
+        $this->shouldThrow('\InvalidArgumentException')->during('getCodesFromIds', ['group', ['mug']]);
     }
 
     function it_throws_an_exception_if_one_of_the_elements_is_not_found(
@@ -72,14 +72,14 @@ class ObjectIdResolverSpec extends ObjectBehavior
         $managerRegistry->getManagerForClass('familyClass')->willReturn($manager);
         $manager->getRepository('familyClass')->willReturn($repository);
 
-        $repository->findOneBy(['code' => 'camcorders'])->willReturn($camcorders);
-        $repository->findOneBy(['code' => 'shirt'])->willReturn(null);
+        $repository->findOneBy(['id' => 23])->willReturn($camcorders);
+        $repository->findOneBy(['id' => 56])->willReturn(null);
 
-        $camcorders->getId()->willReturn(2);
+        $camcorders->getCode()->willReturn('camcorders');
 
         $this->shouldThrow('\Pim\Component\Catalog\Exception\ObjectNotFoundException')->during(
-            'getIdsFromCodes',
-            ['family', ['camcorders', 'shirt', 'men']]
+            'getCodesFromIds',
+            ['family', [23, 56, 123]]
         );
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/Common/Saver/GroupSaverSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/Common/Saver/GroupSaverSpec.php
@@ -131,7 +131,7 @@ class GroupSaverSpec extends ObjectBehavior
         );
 
         $pqbFactory->create()->willReturn($pqb);
-        $pqb->addFilter('groups.code', 'IN', ['foo'])->shouldBeCalled();
+        $pqb->addFilter('groups', 'IN', ['foo'])->shouldBeCalled();
         $pqb->execute()->willReturn([$removedProduct]);
 
         $group->getProducts()->willReturn(new ArrayCollection([]));

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/Common/Saver/GroupSaverSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/Common/Saver/GroupSaverSpec.php
@@ -3,16 +3,16 @@
 namespace spec\Pim\Bundle\CatalogBundle\Doctrine\Common\Saver;
 
 use Akeneo\Component\StorageUtils\Detacher\BulkObjectDetacherInterface;
-use Akeneo\Component\StorageUtils\StorageEvents;
 use Akeneo\Component\StorageUtils\Saver\BulkSaverInterface;
 use Akeneo\Component\StorageUtils\Saver\SavingOptionsResolverInterface;
+use Akeneo\Component\StorageUtils\StorageEvents;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Persistence\ObjectManager;
 use PhpSpec\ObjectBehavior;
 use Pim\Bundle\CatalogBundle\Entity\GroupType;
+use Pim\Bundle\VersioningBundle\Manager\VersionContext;
 use Pim\Component\Catalog\Manager\ProductTemplateApplierInterface;
 use Pim\Component\Catalog\Manager\ProductTemplateMediaManager;
-use Pim\Bundle\VersioningBundle\Manager\VersionContext;
 use Pim\Component\Catalog\Model\GroupInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Model\ProductTemplateInterface;
@@ -131,13 +131,14 @@ class GroupSaverSpec extends ObjectBehavior
         );
 
         $pqbFactory->create()->willReturn($pqb);
-        $pqb->addFilter('groups.id', 'IN', [42])->shouldBeCalled();
+        $pqb->addFilter('groups.code', 'IN', ['foo'])->shouldBeCalled();
         $pqb->execute()->willReturn([$removedProduct]);
 
         $group->getProducts()->willReturn(new ArrayCollection([]));
         $group->getType()->willReturn($type);
         $group->getCode()->willReturn('my_code');
         $group->getId()->willReturn(42);
+        $group->getCode()->willReturn('foo');
 
         $objectManager->persist($group)->shouldBeCalled();
         $objectManager->flush()->shouldBeCalled();

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/FamilyFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/FamilyFilterSpec.php
@@ -156,10 +156,10 @@ class FamilyFilterSpec extends ObjectBehavior
             ->during('addFieldFilter', ['family', 'IN', 'not an array']);
     }
 
-    function it_throws_an_exception_if_content_of_array_is_not_string_or_empty()
+    function it_throws_an_exception_if_content_of_array_is_not_string_or_numeric_or_empty()
     {
-        $this->shouldThrow(InvalidArgumentException::stringExpected('family', 'filter', 'family', gettype(1)))
-            ->during('addFieldFilter', ['family', 'IN', ['a_code', 1]]);
+        $this->shouldThrow(InvalidArgumentException::stringExpected('family', 'filter', 'family', gettype(false)))
+            ->during('addFieldFilter', ['family', 'IN', ['a_code', false]]);
     }
 
     function it_returns_supported_fields()

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/FamilyFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/FamilyFilterSpec.php
@@ -35,6 +35,33 @@ class FamilyFilterSpec extends ObjectBehavior
         $this->supportsOperator('FAKE')->shouldReturn(false);
     }
 
+    function it_adds_a_filter_on_codes_by_default($qb, $objectIdResolver)
+    {
+        $qb->field('family')->shouldBeCalled()->willReturn($qb);
+        $qb->in([12, 56])->shouldBeCalled();
+        $objectIdResolver->getIdsFromCodes('family', ['foo', 'bar'])->willReturn([12, 56]);
+
+        $this->addFieldFilter('family', 'IN', ['foo', 'bar']);
+    }
+
+    function it_adds_a_filter_on_codes($qb, $objectIdResolver)
+    {
+        $qb->field('family')->shouldBeCalled()->willReturn($qb);
+        $qb->in([12, 56])->shouldBeCalled();
+        $objectIdResolver->getIdsFromCodes('family', ['foo', 'bar'])->willReturn([12, 56]);
+
+        $this->addFieldFilter('family.code', 'IN', ['foo', 'bar']);
+    }
+
+    function it_adds_a_filter_on_ids($qb, $objectIdResolver)
+    {
+        $qb->field('family')->shouldBeCalled()->willReturn($qb);
+        $qb->in([12, 56])->shouldBeCalled();
+        $objectIdResolver->getIdsFromCodes(Argument::cetera())->shouldNotBeCalled();
+
+        $this->addFieldFilter('family.id', 'IN', [12, 56]);
+    }
+
     function it_adds_an_in_filter_on_an_id_field_in_the_query($qb)
     {
         $qb->field('family')
@@ -129,10 +156,10 @@ class FamilyFilterSpec extends ObjectBehavior
             ->during('addFieldFilter', ['family', 'IN', 'not an array']);
     }
 
-    function it_throws_an_exception_if_content_of_array_is_not_integer_or_empty()
+    function it_throws_an_exception_if_content_of_array_is_not_string_or_empty()
     {
-        $this->shouldThrow(InvalidArgumentException::numericExpected('family', 'filter', 'family', gettype('WRONG')))
-            ->during('addFieldFilter', ['family', 'IN', [1, 2, 'WRONG']]);
+        $this->shouldThrow(InvalidArgumentException::stringExpected('family', 'filter', 'family', gettype(1)))
+            ->during('addFieldFilter', ['family', 'IN', ['a_code', 1]]);
     }
 
     function it_returns_supported_fields()

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/FamilyFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/FamilyFilterSpec.php
@@ -17,7 +17,7 @@ class FamilyFilterSpec extends ObjectBehavior
     {
         $this->beConstructedWith(
             $objectIdResolver,
-            ['family.id', 'family.code'],
+            ['family.id', 'family'],
             ['IN', 'NOT IN', 'EMPTY', 'NOT EMPTY']
         );
         $this->setQueryBuilder($qb);
@@ -83,7 +83,7 @@ class FamilyFilterSpec extends ObjectBehavior
             ->willReturn($qb);
         $qb->in([12, 13])->shouldBeCalled();
 
-        $this->addFieldFilter('family.code', 'IN', ['shoes', 'ties']);
+        $this->addFieldFilter('family', 'IN', ['shoes', 'ties']);
     }
 
     function it_adds_a_not_in_filter_on_an_id_field_in_the_query($qb)
@@ -107,7 +107,7 @@ class FamilyFilterSpec extends ObjectBehavior
             ->willReturn($qb);
         $qb->notIn([12, 13])->shouldBeCalled();
 
-        $this->addFieldFilter('family.code', 'NOT IN', ['shoes', 'ties']);
+        $this->addFieldFilter('family', 'NOT IN', ['shoes', 'ties']);
     }
 
     function it_adds_an_empty_filter_on_an_id_field_in_the_query($qb)
@@ -127,7 +127,7 @@ class FamilyFilterSpec extends ObjectBehavior
             ->willReturn($qb);
         $qb->exists(false)->shouldBeCalled();
 
-        $this->addFieldFilter('family.code', 'EMPTY', null);
+        $this->addFieldFilter('family', 'EMPTY', null);
     }
 
     function it_adds_a_not_empty_filter_on_an_id_field_in_the_query($qb)
@@ -147,7 +147,7 @@ class FamilyFilterSpec extends ObjectBehavior
             ->willReturn($qb);
         $qb->exists(true)->shouldBeCalled();
 
-        $this->addFieldFilter('family.code', 'NOT EMPTY', null);
+        $this->addFieldFilter('family', 'NOT EMPTY', null);
     }
 
     function it_throws_an_exception_if_value_is_not_an_array()
@@ -164,6 +164,6 @@ class FamilyFilterSpec extends ObjectBehavior
 
     function it_returns_supported_fields()
     {
-        $this->getFields()->shouldReturn(['family.id', 'family.code']);
+        $this->getFields()->shouldReturn(['family.id', 'family']);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/GroupsFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/GroupsFilterSpec.php
@@ -17,7 +17,7 @@ class GroupsFilterSpec extends ObjectBehavior
     {
         $this->beConstructedWith(
             $objectIdResolver,
-            ['groups.id', 'groups.code'],
+            ['groups.id', 'groups'],
             ['IN', 'NOT IN', 'EMPTY', 'NOT EMPTY']
         );
         $this->setQueryBuilder($qb);
@@ -47,7 +47,7 @@ class GroupsFilterSpec extends ObjectBehavior
         $qb->in([12, 13])->shouldBeCalled();
         $objectIdResolver->getIdsFromCodes('group', ['foo', 'bar'])->willReturn([12, 13]);
 
-        $this->addFieldFilter('groups.code', 'IN', ['foo', 'bar']);
+        $this->addFieldFilter('groups', 'IN', ['foo', 'bar']);
     }
 
     function it_adds_a_filter_on_ids($qb, $objectIdResolver)
@@ -82,7 +82,7 @@ class GroupsFilterSpec extends ObjectBehavior
             ->willReturn($qb);
         $qb->in([12, 13])->shouldBeCalled();
 
-        $this->addFieldFilter('groups.code', 'IN', ['upsell', 'related']);
+        $this->addFieldFilter('groups', 'IN', ['upsell', 'related']);
     }
 
     function it_adds_a_not_in_filter_on_an_id_field_in_the_query($qb)
@@ -106,7 +106,7 @@ class GroupsFilterSpec extends ObjectBehavior
             ->willReturn($qb);
         $qb->notIn([12, 13])->shouldBeCalled();
 
-        $this->addFieldFilter('groups.code', 'NOT IN', ['upsell', 'related']);
+        $this->addFieldFilter('groups', 'NOT IN', ['upsell', 'related']);
     }
 
     function it_adds_an_empty_filter_on_an_id_field_in_the_query($qb)
@@ -126,7 +126,7 @@ class GroupsFilterSpec extends ObjectBehavior
             ->willReturn($qb);
         $qb->size(0)->shouldBeCalled();
 
-        $this->addFieldFilter('groups.code', 'EMPTY', null);
+        $this->addFieldFilter('groups', 'EMPTY', null);
     }
 
     function it_adds_a_not_empty_filter_on_an_id_field_in_the_query($qb)
@@ -140,7 +140,7 @@ class GroupsFilterSpec extends ObjectBehavior
     {
         $qb->where('this.groupIds.length > 0')->shouldBeCalled();
 
-        $this->addFieldFilter('groups.code', 'NOT EMPTY', null);
+        $this->addFieldFilter('groups', 'NOT EMPTY', null);
     }
 
     function it_throws_an_exception_if_value_is_not_an_array()
@@ -160,6 +160,6 @@ class GroupsFilterSpec extends ObjectBehavior
 
     function it_returns_supported_fields()
     {
-        $this->getFields()->shouldReturn(['groups.id', 'groups.code']);
+        $this->getFields()->shouldReturn(['groups.id', 'groups']);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/GroupsFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/GroupsFilterSpec.php
@@ -6,6 +6,7 @@ use Doctrine\ODM\MongoDB\Query\Builder;
 use PhpSpec\ObjectBehavior;
 use Pim\Bundle\CatalogBundle\Doctrine\Common\Filter\ObjectIdResolverInterface;
 use Pim\Component\Catalog\Exception\InvalidArgumentException;
+use Prophecy\Argument;
 
 /**
  * @require Doctrine\ODM\MongoDB\Query\Builder
@@ -25,6 +26,39 @@ class GroupsFilterSpec extends ObjectBehavior
     function it_is_a_field_filter()
     {
         $this->shouldImplement('Pim\Component\Catalog\Query\Filter\FieldFilterInterface');
+    }
+
+    function it_adds_a_filter_on_codes_by_default($qb, $objectIdResolver)
+    {
+        $qb->field('groupIds')
+            ->shouldBeCalled()
+            ->willReturn($qb);
+        $qb->in([12, 13])->shouldBeCalled();
+        $objectIdResolver->getIdsFromCodes('group', ['foo', 'bar'])->willReturn([12, 13]);
+
+        $this->addFieldFilter('groups', 'IN', ['foo', 'bar']);
+    }
+
+    function it_adds_a_filter_on_codes($qb, $objectIdResolver)
+    {
+        $qb->field('groupIds')
+            ->shouldBeCalled()
+            ->willReturn($qb);
+        $qb->in([12, 13])->shouldBeCalled();
+        $objectIdResolver->getIdsFromCodes('group', ['foo', 'bar'])->willReturn([12, 13]);
+
+        $this->addFieldFilter('groups.code', 'IN', ['foo', 'bar']);
+    }
+
+    function it_adds_a_filter_on_ids($qb, $objectIdResolver)
+    {
+        $qb->field('groupIds')
+            ->shouldBeCalled()
+            ->willReturn($qb);
+        $qb->in([12, 13])->shouldBeCalled();
+        $objectIdResolver->getIdsFromCodes(Argument::cetera())->shouldNotBeCalled();
+
+        $this->addFieldFilter('groups.id', 'IN', [12, 13]);
     }
 
     function it_adds_an_in_filter_on_an_id_field_in_the_query($qb)
@@ -119,6 +153,9 @@ class GroupsFilterSpec extends ObjectBehavior
     {
         $this->shouldThrow(InvalidArgumentException::numericExpected('groups', 'filter', 'groups', gettype('WRONG')))
             ->during('addFieldFilter', ['groups.id', 'IN', [1, 2, 'WRONG']]);
+
+        $this->shouldThrow(InvalidArgumentException::stringExpected('groups', 'filter', 'groups', gettype(1)))
+            ->during('addFieldFilter', ['groups', 'IN', ['a_code', 1]]);
     }
 
     function it_returns_supported_fields()

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/GroupsFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/GroupsFilterSpec.php
@@ -149,13 +149,13 @@ class GroupsFilterSpec extends ObjectBehavior
             ->during('addFieldFilter', ['groups.id', 'IN', 'not an array']);
     }
 
-    function it_throws_an_exception_if_content_of_array_is_not_integer_or_empty()
+    function it_throws_an_exception_if_content_of_array_is_not_string_or_numeric_or_empty()
     {
         $this->shouldThrow(InvalidArgumentException::numericExpected('groups', 'filter', 'groups', gettype('WRONG')))
             ->during('addFieldFilter', ['groups.id', 'IN', [1, 2, 'WRONG']]);
 
-        $this->shouldThrow(InvalidArgumentException::stringExpected('groups', 'filter', 'groups', gettype(1)))
-            ->during('addFieldFilter', ['groups', 'IN', ['a_code', 1]]);
+        $this->shouldThrow(InvalidArgumentException::stringExpected('groups', 'filter', 'groups', gettype(false)))
+            ->during('addFieldFilter', ['groups', 'IN', ['a_code', false]]);
     }
 
     function it_returns_supported_fields()

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/FamilyFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/FamilyFilterSpec.php
@@ -34,7 +34,7 @@ class FamilyFilterSpec extends ObjectBehavior
         $this->supportsOperator('FAKE')->shouldReturn(false);
     }
 
-    function it_adds_a_in_filter_on_a_field_in_the_query($qb, Expr $expr)
+    function it_adds_a_filter_on_codes_by_default($qb, $objectIdResolver, Expr $expr)
     {
         $qb->getRootAlias()->willReturn('f');
         $qb->leftJoin('f.family', Argument::any())->willReturn($qb);
@@ -43,7 +43,52 @@ class FamilyFilterSpec extends ObjectBehavior
         $expr->in(Argument::any(), [1, 2])->willReturn('filterfamily.id IN (1, 2)');
         $qb->expr()->willReturn($expr);
 
-        $this->addFieldFilter('family', 'IN', [1, 2]);
+        $objectIdResolver->getIdsFromCodes('family', ['foo', 'bar'])->willReturn([1, 2]);
+
+        $this->addFieldFilter('family', 'IN', ['foo', 'bar']);
+
+    }
+
+    function it_adds_a_filter_on_codes($qb, $objectIdResolver, Expr $expr)
+    {
+        $qb->getRootAlias()->willReturn('f');
+        $qb->leftJoin('f.family', Argument::any())->willReturn($qb);
+        $qb->andWhere('filterfamily.id IN (1, 2)')->willReturn($qb);
+
+        $expr->in(Argument::any(), [1, 2])->willReturn('filterfamily.id IN (1, 2)');
+        $qb->expr()->willReturn($expr);
+
+        $objectIdResolver->getIdsFromCodes('family', ['foo', 'bar'])->willReturn([1, 2]);
+
+        $this->addFieldFilter('family.code', 'IN', ['foo', 'bar']);
+    }
+
+    function it_adds_a_filter_on_ids($qb, $objectIdResolver, Expr $expr)
+    {
+        $qb->getRootAlias()->willReturn('f');
+        $qb->leftJoin('f.family', Argument::any())->willReturn($qb);
+        $qb->andWhere('filterfamily.id IN (1, 2)')->willReturn($qb);
+
+        $expr->in(Argument::any(), [1, 2])->willReturn('filterfamily.id IN (1, 2)');
+        $qb->expr()->willReturn($expr);
+
+        $objectIdResolver->getIdsFromCodes(Argument::cetera())->shouldNotBeCalled();
+
+        $this->addFieldFilter('family.id', 'IN', [1, 2]);
+    }
+
+    function it_adds_a_in_filter_on_a_field_in_the_query($qb, $objectIdResolver, Expr $expr)
+    {
+        $qb->getRootAlias()->willReturn('f');
+        $qb->leftJoin('f.family', Argument::any())->willReturn($qb);
+        $qb->andWhere('filterfamily.id IN (1, 2)')->willReturn($qb);
+
+        $expr->in(Argument::any(), [1, 2])->willReturn('filterfamily.id IN (1, 2)');
+        $qb->expr()->willReturn($expr);
+
+        $objectIdResolver->getIdsFromCodes('family', ['foo', 'bar'])->willReturn([1, 2]);
+
+        $this->addFieldFilter('family', 'IN', ['foo', 'bar']);
     }
 
     function it_adds_an_empty_filter_on_a_field_in_the_query($qb, Expr $expr)
@@ -58,7 +103,7 @@ class FamilyFilterSpec extends ObjectBehavior
         $this->addFieldFilter('family', 'EMPTY', null);
     }
 
-    function it_adds_a_not_in_filter_on_a_field_in_the_query($qb, Expr $expr)
+    function it_adds_a_not_in_filter_on_a_field_in_the_query($qb, $objectIdResolver, Expr $expr)
     {
         $qb->getRootAlias()->willReturn('f');
         $qb->leftJoin('f.family', Argument::any())->willReturn($qb);
@@ -72,7 +117,9 @@ class FamilyFilterSpec extends ObjectBehavior
             ->shouldBeCalled()
             ->willReturn('filterfamily.id NOT IN(3)'.'filterfamily.id IS NULL');
 
-        $this->addFieldFilter('family', 'NOT IN', [3]);
+        $objectIdResolver->getIdsFromCodes('family', ['foo'])->willReturn([3]);
+
+        $this->addFieldFilter('family', 'NOT IN', ['foo']);
     }
 
     function it_adds_a_not_empty_filter_on_a_field_in_the_query($qb, Expr $expr)
@@ -98,8 +145,8 @@ class FamilyFilterSpec extends ObjectBehavior
         $this->shouldThrow(InvalidArgumentException::arrayExpected('family', 'filter', 'family', gettype('WRONG')))->during('addFieldFilter', ['family', 'IN', 'WRONG']);
     }
 
-    function it_throws_an_exception_if_values_in_array_are_not_integers()
+    function it_throws_an_exception_if_values_in_array_are_not_strings()
     {
-        $this->shouldThrow(InvalidArgumentException::arrayExpected('family', 'filter', 'family', gettype('WRONG')))->during('addFieldFilter', ['family', 'IN', 'WRONG']);
+        $this->shouldThrow(InvalidArgumentException::stringExpected('family', 'filter', 'family', gettype(1)))->during('addFieldFilter', ['family', 'IN', [1]]);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/FamilyFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/FamilyFilterSpec.php
@@ -60,7 +60,7 @@ class FamilyFilterSpec extends ObjectBehavior
 
         $objectIdResolver->getIdsFromCodes('family', ['foo', 'bar'])->willReturn([1, 2]);
 
-        $this->addFieldFilter('family.code', 'IN', ['foo', 'bar']);
+        $this->addFieldFilter('family', 'IN', ['foo', 'bar']);
     }
 
     function it_adds_a_filter_on_ids($qb, $objectIdResolver, Expr $expr)

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/FamilyFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/FamilyFilterSpec.php
@@ -145,8 +145,8 @@ class FamilyFilterSpec extends ObjectBehavior
         $this->shouldThrow(InvalidArgumentException::arrayExpected('family', 'filter', 'family', gettype('WRONG')))->during('addFieldFilter', ['family', 'IN', 'WRONG']);
     }
 
-    function it_throws_an_exception_if_values_in_array_are_not_strings()
+    function it_throws_an_exception_if_values_in_array_are_not_strings_or_numerics()
     {
-        $this->shouldThrow(InvalidArgumentException::stringExpected('family', 'filter', 'family', gettype(1)))->during('addFieldFilter', ['family', 'IN', [1]]);
+        $this->shouldThrow(InvalidArgumentException::stringExpected('family', 'filter', 'family', gettype(false)))->during('addFieldFilter', ['family', 'IN', [false]]);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/GroupsFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/GroupsFilterSpec.php
@@ -60,7 +60,7 @@ class GroupsFilterSpec extends ObjectBehavior
 
         $objectIdResolver->getIdsFromCodes('group', ['foo', 'bar'])->willReturn([1, 2]);
 
-        $this->addFieldFilter('groups.code', 'IN', ['foo', 'bar']);
+        $this->addFieldFilter('groups', 'IN', ['foo', 'bar']);
     }
 
     function it_adds_a_filter_on_ids($qb, $objectIdResolver, Expr $expr)

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/GroupsFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/GroupsFilterSpec.php
@@ -35,6 +35,48 @@ class GroupsFilterSpec extends ObjectBehavior
         $this->getFields()->shouldReturn(['groups']);
     }
 
+    function it_adds_a_filter_on_codes_by_default($qb, $objectIdResolver, Expr $expr)
+    {
+        $qb->getRootAlias()->willReturn('f');
+        $qb->leftJoin('f.groups', Argument::any())->willReturn($qb);
+        $qb->andWhere('filtergroups.id IN (1, 2)')->willReturn($qb);
+
+        $expr->in(Argument::any(), [1, 2])->willReturn('filtergroups.id IN (1, 2)');
+        $qb->expr()->willReturn($expr);
+
+        $objectIdResolver->getIdsFromCodes('group', ['foo', 'bar'])->willReturn([1, 2]);
+
+        $this->addFieldFilter('groups', 'IN', ['foo', 'bar']);
+    }
+
+    function it_adds_a_filter_on_codes($qb, $objectIdResolver, Expr $expr)
+    {
+        $qb->getRootAlias()->willReturn('f');
+        $qb->leftJoin('f.groups', Argument::any())->willReturn($qb);
+        $qb->andWhere('filtergroups.id IN (1, 2)')->willReturn($qb);
+
+        $expr->in(Argument::any(), [1, 2])->willReturn('filtergroups.id IN (1, 2)');
+        $qb->expr()->willReturn($expr);
+
+        $objectIdResolver->getIdsFromCodes('group', ['foo', 'bar'])->willReturn([1, 2]);
+
+        $this->addFieldFilter('groups.code', 'IN', ['foo', 'bar']);
+    }
+
+    function it_adds_a_filter_on_ids($qb, $objectIdResolver, Expr $expr)
+    {
+        $qb->getRootAlias()->willReturn('f');
+        $qb->leftJoin('f.groups', Argument::any())->willReturn($qb);
+        $qb->andWhere('filtergroups.id IN (1, 2)')->willReturn($qb);
+
+        $expr->in(Argument::any(), [1, 2])->willReturn('filtergroups.id IN (1, 2)');
+        $qb->expr()->willReturn($expr);
+
+        $objectIdResolver->getIdsFromCodes(Argument::cetera())->shouldNotBeCalled();
+
+        $this->addFieldFilter('groups.id', 'IN', [1, 2]);
+    }
+
     function it_adds_a_in_filter_on_a_field_in_the_query($qb, Expr $expr)
     {
         $qb->getRootAlias()->willReturn('f');
@@ -110,8 +152,8 @@ class GroupsFilterSpec extends ObjectBehavior
         $this->shouldThrow(InvalidArgumentException::arrayExpected('groups', 'filter', 'groups', gettype('WRONG')))->during('addFieldFilter', ['groups', 'IN', 'WRONG']);
     }
 
-    function it_throws_an_exception_if_values_in_array_are_not_integers()
+    function it_throws_an_exception_if_values_in_array_are_not_strings()
     {
-        $this->shouldThrow(InvalidArgumentException::arrayExpected('groups', 'filter', 'groups', gettype('WRONG')))->during('addFieldFilter', ['groups', 'IN', 'WRONG']);
+        $this->shouldThrow(InvalidArgumentException::stringExpected('groups', 'filter', 'groups', gettype(1)))->during('addFieldFilter', ['groups', 'IN', [1]]);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/GroupsFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/GroupsFilterSpec.php
@@ -152,8 +152,8 @@ class GroupsFilterSpec extends ObjectBehavior
         $this->shouldThrow(InvalidArgumentException::arrayExpected('groups', 'filter', 'groups', gettype('WRONG')))->during('addFieldFilter', ['groups', 'IN', 'WRONG']);
     }
 
-    function it_throws_an_exception_if_values_in_array_are_not_strings()
+    function it_throws_an_exception_if_values_in_array_are_not_strings_or_numerics()
     {
-        $this->shouldThrow(InvalidArgumentException::stringExpected('groups', 'filter', 'groups', gettype(1)))->during('addFieldFilter', ['groups', 'IN', [1]]);
+        $this->shouldThrow(InvalidArgumentException::stringExpected('groups', 'filter', 'groups', gettype(false)))->during('addFieldFilter', ['groups', 'IN', [false]]);
     }
 }

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/filter.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/filter.js
@@ -49,7 +49,7 @@ define([
         },
 
         /**
-         * Sets the filter code  (code: 'categories', field: 'categories.code')
+         * Sets the filter code  (code: 'categories', field: 'categories')
          *
          * @param {string} code
          */
@@ -58,7 +58,7 @@ define([
         },
 
         /**
-         * Gets the filter code (code: 'categories', field: 'categories.code')
+         * Gets the filter code (code: 'categories', field: 'categories')
          *
          * @return {string}
          */
@@ -67,7 +67,7 @@ define([
         },
 
         /**
-         * Sets the field code on which this filter operates. (code: 'categories', field: 'categories.code')
+         * Sets the field code on which this filter operates. (code: 'categories', field: 'categories')
          *
          * @param {string} field
          */
@@ -79,7 +79,7 @@ define([
         },
 
         /**
-         * Gets the field code on which this filter operates.  (code: 'categories', field: 'categories.code')
+         * Gets the field code on which this filter operates.  (code: 'categories', field: 'categories')
          *
          * @return {string}
          */

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/product/category.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/product/category.js
@@ -30,7 +30,7 @@ define([
         configure: function () {
             this.listenTo(this, 'channel:update:after', this.channelUpdated.bind(this));
             this.listenTo(this.getRoot(), 'pim_enrich:form:entity:pre_update', function (data) {
-                _.defaults(data, {field: this.getCode() + '.code', operator: 'IN CHILDREN', value: []});
+                _.defaults(data, {field: this.getCode(), operator: 'IN CHILDREN', value: []});
             }.bind(this));
 
             return BaseFilter.prototype.configure.apply(this, arguments);

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/product/family.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/product/family.js
@@ -82,7 +82,7 @@ define([
          */
         configure: function () {
             this.listenTo(this.getRoot(), 'pim_enrich:form:entity:pre_update', function (data) {
-                _.defaults(data, {field: this.getCode() + '.code', operator: '='});
+                _.defaults(data, {field: this.getCode(), operator: '='});
             }.bind(this));
 
             return BaseFilter.prototype.configure.apply(this, arguments);

--- a/src/Pim/Bundle/FilterBundle/Filter/CategoryFilter.php
+++ b/src/Pim/Bundle/FilterBundle/Filter/CategoryFilter.php
@@ -113,8 +113,8 @@ class CategoryFilter extends NumberFilter
     {
         $tree = $this->categoryRepo->find($data['treeId']);
         if ($tree) {
-            $categoryIds = $this->getAllChildrenIds($tree);
-            $this->util->applyFilter($ds, 'categories.id', 'NOT IN', $categoryIds);
+            $categoryCodes = $this->getAllChildrenCodes($tree);
+            $this->util->applyFilter($ds, 'categories.code', 'NOT IN', $categoryCodes);
 
             return true;
         }
@@ -140,12 +140,12 @@ class CategoryFilter extends NumberFilter
 
         if ($category) {
             if ($data['includeSub']) {
-                $categoryIds = $this->getAllChildrenIds($category);
+                $categoryCodes = $this->getAllChildrenCodes($category);
             } else {
-                $categoryIds = [];
+                $categoryCodes = [];
             }
-            $categoryIds[] = $category->getId();
-            $this->util->applyFilter($ds, 'categories.id', 'IN', $categoryIds);
+            $categoryCodes[] = $category->getCode();
+            $this->util->applyFilter($ds, 'categories.code', 'IN', $categoryCodes);
 
             return true;
         }
@@ -154,17 +154,15 @@ class CategoryFilter extends NumberFilter
     }
 
     /**
-     * Get children category ids
+     * Get children category codes
      *
      * @param CategoryInterface $category
      *
-     * @return integer[]
+     * @return string[]
      */
-    protected function getAllChildrenIds(CategoryInterface $category)
+    protected function getAllChildrenCodes(CategoryInterface $category)
     {
-        $categoryIds = $this->categoryRepo->getAllChildrenIds($category);
-
-        return $categoryIds;
+        return $this->categoryRepo->getAllChildrenCodes($category);
     }
 
     /**

--- a/src/Pim/Bundle/FilterBundle/Filter/CategoryFilter.php
+++ b/src/Pim/Bundle/FilterBundle/Filter/CategoryFilter.php
@@ -114,7 +114,7 @@ class CategoryFilter extends NumberFilter
         $tree = $this->categoryRepo->find($data['treeId']);
         if ($tree) {
             $categoryCodes = $this->getAllChildrenCodes($tree);
-            $this->util->applyFilter($ds, 'categories.code', 'NOT IN', $categoryCodes);
+            $this->util->applyFilter($ds, 'categories', 'NOT IN', $categoryCodes);
 
             return true;
         }
@@ -145,7 +145,7 @@ class CategoryFilter extends NumberFilter
                 $categoryCodes = [];
             }
             $categoryCodes[] = $category->getCode();
-            $this->util->applyFilter($ds, 'categories.code', 'IN', $categoryCodes);
+            $this->util->applyFilter($ds, 'categories', 'IN', $categoryCodes);
 
             return true;
         }

--- a/src/Pim/Bundle/FilterBundle/Filter/Product/FamilyFilter.php
+++ b/src/Pim/Bundle/FilterBundle/Filter/Product/FamilyFilter.php
@@ -27,9 +27,9 @@ class FamilyFilter extends AjaxChoiceFilter
         }
 
         if (Operators::IS_EMPTY === strtoupper($data['type'])) {
-            $this->util->applyFilter($dataSource, 'family.code', Operators::IS_EMPTY, null);
+            $this->util->applyFilter($dataSource, 'family', Operators::IS_EMPTY, null);
         } else {
-            $this->util->applyFilter($dataSource, 'family.code', Operators::IN_LIST, $data['value']);
+            $this->util->applyFilter($dataSource, 'family', Operators::IN_LIST, $data['value']);
         }
 
         return true;

--- a/src/Pim/Bundle/FilterBundle/Filter/Product/GroupsFilter.php
+++ b/src/Pim/Bundle/FilterBundle/Filter/Product/GroupsFilter.php
@@ -53,8 +53,8 @@ class GroupsFilter extends AjaxChoiceFilter
             return false;
         }
 
-        $ids = $data['value'];
-        $this->util->applyFilter($ds, 'groups.id', 'IN', $ids);
+        $codes = $data['value'];
+        $this->util->applyFilter($ds, 'groups.code', 'IN', $codes);
 
         return true;
     }
@@ -71,7 +71,10 @@ class GroupsFilter extends AjaxChoiceFilter
                 'choice_url_params' => [
                     'class'        => $this->groupClass,
                     'dataLocale'   => $this->userContext->getCurrentLocaleCode(),
-                    'collectionId' => null
+                    'collectionId' => null,
+                    'options'      => [
+                        'type' => 'code',
+                    ],
                 ]
             ]
         );

--- a/src/Pim/Bundle/FilterBundle/Filter/Product/GroupsFilter.php
+++ b/src/Pim/Bundle/FilterBundle/Filter/Product/GroupsFilter.php
@@ -54,7 +54,7 @@ class GroupsFilter extends AjaxChoiceFilter
         }
 
         $codes = $data['value'];
-        $this->util->applyFilter($ds, 'groups.code', 'IN', $codes);
+        $this->util->applyFilter($ds, 'groups', 'IN', $codes);
 
         return true;
     }

--- a/src/Pim/Bundle/FilterBundle/Filter/Product/InGroupFilter.php
+++ b/src/Pim/Bundle/FilterBundle/Filter/Product/InGroupFilter.php
@@ -62,7 +62,7 @@ class InGroupFilter extends BooleanFilter
         $groupCodes = $this->codeResolver->getCodesFromIds('group', [$groupId]);
 
         $operator = ($data['value'] === BooleanFilterType::TYPE_YES) ? 'IN' : 'NOT IN';
-        $this->util->applyFilter($ds, 'groups.code', $operator, $groupCodes);
+        $this->util->applyFilter($ds, 'groups', $operator, $groupCodes);
 
         return true;
     }

--- a/src/Pim/Bundle/FilterBundle/Filter/Product/InGroupFilter.php
+++ b/src/Pim/Bundle/FilterBundle/Filter/Product/InGroupFilter.php
@@ -6,6 +6,7 @@ use Oro\Bundle\FilterBundle\Datasource\FilterDatasourceAdapterInterface;
 use Oro\Bundle\FilterBundle\Filter\BooleanFilter;
 use Oro\Bundle\FilterBundle\Filter\FilterUtility;
 use Oro\Bundle\FilterBundle\Form\Type\Filter\BooleanFilterType;
+use Pim\Bundle\CatalogBundle\Doctrine\Common\Filter\ObjectCodeResolver;
 use Pim\Bundle\DataGridBundle\Datagrid\Request\RequestParametersExtractorInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 
@@ -18,10 +19,11 @@ use Symfony\Component\Form\FormFactoryInterface;
  */
 class InGroupFilter extends BooleanFilter
 {
-    /**
-     * @var RequestParametersExtractorInterface
-     */
+    /** @var RequestParametersExtractorInterface */
     protected $extractor;
+
+    /** @var ObjectCodeResolver */
+    protected $codeResolver;
 
     /**
      * Constructor
@@ -29,14 +31,17 @@ class InGroupFilter extends BooleanFilter
      * @param FormFactoryInterface                $factory
      * @param FilterUtility                       $util
      * @param RequestParametersExtractorInterface $extractor
+     * @param ObjectCodeResolver                  $codeResolver
      */
     public function __construct(
         FormFactoryInterface $factory,
         FilterUtility $util,
-        RequestParametersExtractorInterface $extractor
+        RequestParametersExtractorInterface $extractor,
+        ObjectCodeResolver $codeResolver
     ) {
         parent::__construct($factory, $util);
         $this->extractor = $extractor;
+        $this->codeResolver = $codeResolver;
     }
 
     /**
@@ -54,9 +59,10 @@ class InGroupFilter extends BooleanFilter
             throw new \LogicException('The current product group must be configured');
         }
 
-        $value = [$groupId];
+        $groupCodes = $this->codeResolver->getCodesFromIds('group', [$groupId]);
+
         $operator = ($data['value'] === BooleanFilterType::TYPE_YES) ? 'IN' : 'NOT IN';
-        $this->util->applyFilter($ds, 'groups.id', $operator, $value);
+        $this->util->applyFilter($ds, 'groups.code', $operator, $groupCodes);
 
         return true;
     }

--- a/src/Pim/Bundle/FilterBundle/Filter/ProductValue/ChoiceFilter.php
+++ b/src/Pim/Bundle/FilterBundle/Filter/ProductValue/ChoiceFilter.php
@@ -107,7 +107,10 @@ class ChoiceFilter extends AjaxChoiceFilter
                 'choice_url_params' => [
                     'class'        => $this->optionRepoClass,
                     'dataLocale'   => $this->userContext->getCurrentLocaleCode(),
-                    'collectionId' => $attribute->getId()
+                    'collectionId' => $attribute->getId(),
+                    'options'      => [
+                        'type' => 'code',
+                    ],
                 ]
             ]
         );

--- a/src/Pim/Bundle/FilterBundle/Resources/config/filters.yml
+++ b/src/Pim/Bundle/FilterBundle/Resources/config/filters.yml
@@ -98,6 +98,7 @@ services:
             - '@form.factory'
             - '@pim_filter.product_utility'
             - '@pim_datagrid.datagrid.request.parameters_extractor'
+            - '@pim_catalog.doctrine.query.filter.object_code_resolver'
         tags:
             - { name: oro_filter.extension.orm_filter.filter, type: product_in_group }
 

--- a/src/Pim/Bundle/FilterBundle/spec/Filter/CategoryFilterSpec.php
+++ b/src/Pim/Bundle/FilterBundle/spec/Filter/CategoryFilterSpec.php
@@ -2,11 +2,11 @@
 
 namespace spec\Pim\Bundle\FilterBundle\Filter;
 
-use PhpSpec\ObjectBehavior;
-use Pim\Component\Catalog\Model\CategoryInterface;
 use Akeneo\Component\Classification\Repository\CategoryRepositoryInterface;
+use PhpSpec\ObjectBehavior;
 use Pim\Bundle\FilterBundle\Datasource\FilterDatasourceAdapterInterface;
 use Pim\Bundle\FilterBundle\Filter\ProductFilterUtility;
+use Pim\Component\Catalog\Model\CategoryInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 
 class CategoryFilterSpec extends ObjectBehavior
@@ -37,8 +37,8 @@ class CategoryFilterSpec extends ObjectBehavior
     ) {
         $tree->getId()->willReturn(1);
         $categoryRepo->find(1)->willReturn($tree);
-        $categoryRepo->getAllChildrenIds($tree)->willReturn([2, 3]);
-        $utility->applyFilter($datasource, 'categories.id', 'NOT IN', [2, 3])->shouldBeCalled();
+        $categoryRepo->getAllChildrenCodes($tree)->willReturn(['bar', 'baz']);
+        $utility->applyFilter($datasource, 'categories.code', 'NOT IN', ['bar', 'baz'])->shouldBeCalled();
 
         $this->apply($datasource, ['value' => ['categoryId' => -1, 'treeId' => 1]]);
     }
@@ -50,8 +50,8 @@ class CategoryFilterSpec extends ObjectBehavior
         CategoryInterface $category
     ) {
         $categoryRepo->find(42)->willReturn($category);
-        $category->getId()->willReturn(42);
-        $utility->applyFilter($datasource, 'categories.id', 'IN', [42])->shouldBeCalled();
+        $category->getCode()->willReturn('foo');
+        $utility->applyFilter($datasource, 'categories.code', 'IN', ['foo'])->shouldBeCalled();
 
         $this->apply($datasource, ['value' => ['categoryId' => 42], 'type' => false]);
     }
@@ -63,11 +63,11 @@ class CategoryFilterSpec extends ObjectBehavior
         CategoryInterface $category
     ) {
         $categoryRepo->find(42)->willReturn($category);
-        $category->getId()->willReturn(42);
+        $category->getCode()->willReturn('foo');
         $categoryRepo->find(42)->willReturn($category);
-        $categoryRepo->getAllChildrenIds($category)->willReturn([2, 3]);
+        $categoryRepo->getAllChildrenCodes($category)->willReturn(['bar', 'baz']);
 
-        $utility->applyFilter($datasource, 'categories.id', 'IN', [2, 3, 42])->shouldBeCalled();
+        $utility->applyFilter($datasource, 'categories.code', 'IN', ['bar', 'baz', 'foo'])->shouldBeCalled();
 
         $this->apply($datasource, ['value' => ['categoryId' => 42], 'type' => true]);
     }

--- a/src/Pim/Bundle/FilterBundle/spec/Filter/CategoryFilterSpec.php
+++ b/src/Pim/Bundle/FilterBundle/spec/Filter/CategoryFilterSpec.php
@@ -38,7 +38,7 @@ class CategoryFilterSpec extends ObjectBehavior
         $tree->getId()->willReturn(1);
         $categoryRepo->find(1)->willReturn($tree);
         $categoryRepo->getAllChildrenCodes($tree)->willReturn(['bar', 'baz']);
-        $utility->applyFilter($datasource, 'categories.code', 'NOT IN', ['bar', 'baz'])->shouldBeCalled();
+        $utility->applyFilter($datasource, 'categories', 'NOT IN', ['bar', 'baz'])->shouldBeCalled();
 
         $this->apply($datasource, ['value' => ['categoryId' => -1, 'treeId' => 1]]);
     }
@@ -51,7 +51,7 @@ class CategoryFilterSpec extends ObjectBehavior
     ) {
         $categoryRepo->find(42)->willReturn($category);
         $category->getCode()->willReturn('foo');
-        $utility->applyFilter($datasource, 'categories.code', 'IN', ['foo'])->shouldBeCalled();
+        $utility->applyFilter($datasource, 'categories', 'IN', ['foo'])->shouldBeCalled();
 
         $this->apply($datasource, ['value' => ['categoryId' => 42], 'type' => false]);
     }
@@ -67,7 +67,7 @@ class CategoryFilterSpec extends ObjectBehavior
         $categoryRepo->find(42)->willReturn($category);
         $categoryRepo->getAllChildrenCodes($category)->willReturn(['bar', 'baz']);
 
-        $utility->applyFilter($datasource, 'categories.code', 'IN', ['bar', 'baz', 'foo'])->shouldBeCalled();
+        $utility->applyFilter($datasource, 'categories', 'IN', ['bar', 'baz', 'foo'])->shouldBeCalled();
 
         $this->apply($datasource, ['value' => ['categoryId' => 42], 'type' => true]);
     }

--- a/src/Pim/Bundle/FilterBundle/spec/Filter/Product/FamilyFilterSpec.php
+++ b/src/Pim/Bundle/FilterBundle/spec/Filter/Product/FamilyFilterSpec.php
@@ -23,7 +23,7 @@ class FamilyFilterSpec extends ObjectBehavior
         FilterDatasourceAdapterInterface $datasource,
         $utility
     ) {
-        $utility->applyFilter($datasource, 'family.code', 'IN', [2, 3])->shouldBeCalled();
+        $utility->applyFilter($datasource, 'family', 'IN', [2, 3])->shouldBeCalled();
 
         $this->apply($datasource, ['type' => null, 'value' => [2, 3]]);
     }

--- a/src/Pim/Bundle/FilterBundle/spec/Filter/Product/GroupsFilterSpec.php
+++ b/src/Pim/Bundle/FilterBundle/spec/Filter/Product/GroupsFilterSpec.php
@@ -24,8 +24,8 @@ class GroupsFilterSpec extends ObjectBehavior
         FilterDatasourceAdapterInterface $datasource,
         $utility
     ) {
-        $utility->applyFilter($datasource, 'groups.id', 'IN', [2, 3])->shouldBeCalled();
+        $utility->applyFilter($datasource, 'groups.code', 'IN', ['foo', 'bar'])->shouldBeCalled();
 
-        $this->apply($datasource, ['type' => null, 'value' => [2, 3]]);
+        $this->apply($datasource, ['type' => null, 'value' => ['foo', 'bar']]);
     }
 }

--- a/src/Pim/Bundle/FilterBundle/spec/Filter/Product/GroupsFilterSpec.php
+++ b/src/Pim/Bundle/FilterBundle/spec/Filter/Product/GroupsFilterSpec.php
@@ -24,7 +24,7 @@ class GroupsFilterSpec extends ObjectBehavior
         FilterDatasourceAdapterInterface $datasource,
         $utility
     ) {
-        $utility->applyFilter($datasource, 'groups.code', 'IN', ['foo', 'bar'])->shouldBeCalled();
+        $utility->applyFilter($datasource, 'groups', 'IN', ['foo', 'bar'])->shouldBeCalled();
 
         $this->apply($datasource, ['type' => null, 'value' => ['foo', 'bar']]);
     }

--- a/src/Pim/Bundle/FilterBundle/spec/Filter/Product/InGroupFilterSpec.php
+++ b/src/Pim/Bundle/FilterBundle/spec/Filter/Product/InGroupFilterSpec.php
@@ -34,7 +34,7 @@ class InGroupFilterSpec extends ObjectBehavior
         $extractor->getDatagridParameter('currentGroup')->willReturn(12);
         $codeResolver->getCodesFromIds('group', [12])->willReturn(['foo']);
 
-        $utility->applyFilter($datasource, 'groups.code', 'IN', ['foo'])->shouldBeCalled();
+        $utility->applyFilter($datasource, 'groups', 'IN', ['foo'])->shouldBeCalled();
 
         $this->apply($datasource, ['type' => null, 'value' => 1]);
     }

--- a/src/Pim/Bundle/FilterBundle/spec/Filter/Product/InGroupFilterSpec.php
+++ b/src/Pim/Bundle/FilterBundle/spec/Filter/Product/InGroupFilterSpec.php
@@ -3,6 +3,7 @@
 namespace spec\Pim\Bundle\FilterBundle\Filter\Product;
 
 use PhpSpec\ObjectBehavior;
+use Pim\Bundle\CatalogBundle\Doctrine\Common\Filter\ObjectCodeResolver;
 use Pim\Bundle\DataGridBundle\Datagrid\Request\RequestParametersExtractorInterface;
 use Pim\Bundle\FilterBundle\Datasource\FilterDatasourceAdapterInterface;
 use Pim\Bundle\FilterBundle\Filter\ProductFilterUtility;
@@ -13,9 +14,10 @@ class InGroupFilterSpec extends ObjectBehavior
     function let(
         FormFactoryInterface $factory,
         ProductFilterUtility $utility,
-        RequestParametersExtractorInterface $extractor
+        RequestParametersExtractorInterface $extractor,
+        ObjectCodeResolver $codeResolver
     ) {
-        $this->beConstructedWith($factory, $utility, $extractor);
+        $this->beConstructedWith($factory, $utility, $extractor, $codeResolver);
     }
 
     function it_is_an_oro_choice_filter()
@@ -24,12 +26,15 @@ class InGroupFilterSpec extends ObjectBehavior
     }
 
     function it_applies_a_filter_on_product_when_its_in_an_expected_group(
-        FilterDatasourceAdapterInterface $datasource,
         $utility,
+        $codeResolver,
+        FilterDatasourceAdapterInterface $datasource,
         RequestParametersExtractorInterface $extractor
     ) {
         $extractor->getDatagridParameter('currentGroup')->willReturn(12);
-        $utility->applyFilter($datasource, 'groups.id', 'IN', [12])->shouldBeCalled();
+        $codeResolver->getCodesFromIds('group', [12])->willReturn(['foo']);
+
+        $utility->applyFilter($datasource, 'groups.code', 'IN', ['foo'])->shouldBeCalled();
 
         $this->apply($datasource, ['type' => null, 'value' => 1]);
     }

--- a/src/Pim/Bundle/FilterBundle/spec/Filter/ProductValue/ChoiceFilterSpec.php
+++ b/src/Pim/Bundle/FilterBundle/spec/Filter/ProductValue/ChoiceFilterSpec.php
@@ -118,7 +118,10 @@ class ChoiceFilterSpec extends ObjectBehavior
             'choice_url_params' => [
                 'class'        => 'attributeOptionClass',
                 'dataLocale'   => null,
-                'collectionId' => null
+                'collectionId' => null,
+                'options'      => [
+                    'type' => 'code',
+                ],
             ]
         ])->willReturn($form);
 

--- a/src/Pim/Bundle/InstallerBundle/Resources/fixtures/icecat_demo_dev/jobs.yml
+++ b/src/Pim/Bundle/InstallerBundle/Resources/fixtures/icecat_demo_dev/jobs.yml
@@ -34,7 +34,7 @@ jobs:
                         operator: '='
                         value: true
                     -
-                        field: categories.code
+                        field: categories
                         operator: 'IN CHILDREN'
                         value: ['master']
                     -
@@ -262,7 +262,7 @@ jobs:
                         operator: '='
                         value: true
                     -
-                        field: categories.code
+                        field: categories
                         operator: 'IN CHILDREN'
                         value: ['master']
                     -

--- a/src/Pim/Bundle/ReferenceDataBundle/DataGrid/Filter/ReferenceDataFilter.php
+++ b/src/Pim/Bundle/ReferenceDataBundle/DataGrid/Filter/ReferenceDataFilter.php
@@ -62,7 +62,10 @@ class ReferenceDataFilter extends ChoiceFilter
                 'choice_url_params' => [
                     'class'        => $referenceData->getClass(),
                     'dataLocale'   => $this->userContext->getCurrentLocaleCode(),
-                    'collectionId' => $attribute->getId()
+                    'collectionId' => $attribute->getId(),
+                    'options'      => [
+                        'type' => 'code',
+                    ],
                 ]
             ]
         );

--- a/src/Pim/Bundle/ReferenceDataBundle/spec/Doctrine/MongoDB/Filter/ReferenceDataFilterSpec.php
+++ b/src/Pim/Bundle/ReferenceDataBundle/spec/Doctrine/MongoDB/Filter/ReferenceDataFilterSpec.php
@@ -39,8 +39,9 @@ class ReferenceDataFilterSpec extends ObjectBehavior
         $this->supportsOperator('FAKE')->shouldReturn(false);
     }
 
-    function it_adds_a_filter_with_ids_to_the_query(
+    function it_adds_a_filter_by_default_with_codes_to_the_query(
         $attrValidatorHelper,
+        $idResolver,
         Builder $qb,
         AttributeInterface $attribute,
         Expr $expr
@@ -53,6 +54,35 @@ class ReferenceDataFilterSpec extends ObjectBehavior
         $attribute->isScopable()->willReturn(false);
         $attribute->getBackendType()->willReturn('reference_data_option');
         $attribute->getCode()->willReturn('color');
+        $attribute->getReferenceDataName()->willReturn('ref_data_color');
+
+        $idResolver->resolve('ref_data_color', ['red', 'blue'])->willReturn([118, 270]);
+
+        $qb->expr()->willReturn($expr);
+        $expr->field('normalizedData.color.id')->shouldBeCalled()->willReturn($expr);
+        $expr->in([118, 270])->shouldBeCalled()->willReturn($expr);
+        $qb->addAnd($expr)->shouldBeCalled();
+
+        $this->addAttributeFilter($attribute, 'IN', ['red', 'blue'], null, null, ['field' => 'color']);
+    }
+
+    function it_adds_a_filter_with_ids_to_the_query(
+        $attrValidatorHelper,
+        $idResolver,
+        Builder $qb,
+        AttributeInterface $attribute,
+        Expr $expr
+    ) {
+        $attrValidatorHelper->validateLocale($attribute, Argument::any())->shouldBeCalled();
+        $attrValidatorHelper->validateScope($attribute, Argument::any())->shouldBeCalled();
+
+        $attribute->getId()->willReturn(42);
+        $attribute->isLocalizable()->willReturn(false);
+        $attribute->isScopable()->willReturn(false);
+        $attribute->getBackendType()->willReturn('reference_data_option');
+        $attribute->getCode()->willReturn('color');
+
+        $idResolver->resolve(Argument::cetera())->shouldNotBeCalled();
 
         $qb->expr()->willReturn($expr);
         $expr->field('normalizedData.color.id')->shouldBeCalled()->willReturn($expr);

--- a/src/Pim/Bundle/ReferenceDataBundle/spec/Doctrine/MongoDB/Filter/ReferenceDataFilterSpec.php
+++ b/src/Pim/Bundle/ReferenceDataBundle/spec/Doctrine/MongoDB/Filter/ReferenceDataFilterSpec.php
@@ -39,7 +39,7 @@ class ReferenceDataFilterSpec extends ObjectBehavior
         $this->supportsOperator('FAKE')->shouldReturn(false);
     }
 
-    function it_adds_a_filter_to_the_query(
+    function it_adds_a_filter_with_ids_to_the_query(
         $attrValidatorHelper,
         Builder $qb,
         AttributeInterface $attribute,
@@ -59,7 +59,7 @@ class ReferenceDataFilterSpec extends ObjectBehavior
         $expr->in([118, 270])->shouldBeCalled()->willReturn($expr);
         $qb->addAnd($expr)->shouldBeCalled();
 
-        $this->addAttributeFilter($attribute, 'IN', [118, 270], null, null, ['field' => 'color']);
+        $this->addAttributeFilter($attribute, 'IN', [118, 270], null, null, ['field' => 'color.id']);
     }
 
     function it_adds_a_filter_with_codes_to_the_query(
@@ -119,9 +119,9 @@ class ReferenceDataFilterSpec extends ObjectBehavior
         )
             ->during('addAttributeFilter', [$attribute, '=', $value, null, null, ['field' => 'color']]);
 
-        $value = ['foo'];
+        $value = [false];
         $this->shouldThrow(
-            InvalidArgumentException::numericExpected('color', 'filter', 'reference_data', 'string')
+            InvalidArgumentException::stringExpected('color', 'filter', 'reference_data', 'boolean')
         )
             ->during('addAttributeFilter', [$attribute, '=', $value, null, null, ['field' => 'color']]);
     }

--- a/src/Pim/Bundle/ReferenceDataBundle/spec/Doctrine/ORM/Filter/ReferenceDataFilterSpec.php
+++ b/src/Pim/Bundle/ReferenceDataBundle/spec/Doctrine/ORM/Filter/ReferenceDataFilterSpec.php
@@ -41,8 +41,9 @@ class ReferenceDataFilterSpec extends ObjectBehavior
         $this->supportsOperator('FAKE')->shouldReturn(false);
     }
 
-    function it_adds_a_filter_with_ids_to_the_query(
+    function it_adds_a_filter_by_default_with_codes_to_the_query(
         $qb,
+        $idResolver,
         $attrValidatorHelper,
         AttributeInterface $attribute
     ) {
@@ -55,6 +56,42 @@ class ReferenceDataFilterSpec extends ObjectBehavior
         $attribute->getBackendType()->willReturn('reference_data_option');
         $attribute->getReferenceDataName()->willReturn('color');
         $attribute->getCode()->willReturn('color');
+
+        $idResolver->resolve('color', ['red', 'blue'])->willReturn([1, 2]);
+
+        $qb->getRootAliases()->willReturn(['r']);
+        $qb->expr()->willReturn(new Expr());
+
+        $qb->innerJoin('r.values', Argument::any(), 'WITH', Argument::any())->shouldBeCalled();
+        $qb
+            ->innerJoin(
+                Argument::any(),
+                Argument::any(),
+                'WITH',
+                Argument::any()
+            )
+            ->shouldBeCalled();
+
+        $this->addAttributeFilter($attribute, 'IN', ['red', 'blue'], null, null, ['field' => 'color']);
+    }
+
+    function it_adds_a_filter_with_ids_to_the_query(
+        $qb,
+        $idResolver,
+        $attrValidatorHelper,
+        AttributeInterface $attribute
+    ) {
+        $attrValidatorHelper->validateLocale($attribute, Argument::any())->shouldBeCalled();
+        $attrValidatorHelper->validateScope($attribute, Argument::any())->shouldBeCalled();
+
+        $attribute->getId()->willReturn(42);
+        $attribute->isLocalizable()->willReturn(false);
+        $attribute->isScopable()->willReturn(false);
+        $attribute->getBackendType()->willReturn('reference_data_option');
+        $attribute->getReferenceDataName()->willReturn('color');
+        $attribute->getCode()->willReturn('color');
+
+        $idResolver->resolve(Argument::cetera())->shouldNotBeCalled();
 
         $qb->getRootAliases()->willReturn(['r']);
         $qb->expr()->willReturn(new Expr());

--- a/src/Pim/Bundle/ReferenceDataBundle/spec/Doctrine/ORM/Filter/ReferenceDataFilterSpec.php
+++ b/src/Pim/Bundle/ReferenceDataBundle/spec/Doctrine/ORM/Filter/ReferenceDataFilterSpec.php
@@ -69,7 +69,7 @@ class ReferenceDataFilterSpec extends ObjectBehavior
             )
             ->shouldBeCalled();
 
-        $this->addAttributeFilter($attribute, 'IN', [1, 2], null, null, ['field' => 'color']);
+        $this->addAttributeFilter($attribute, 'IN', [1, 2], null, null, ['field' => 'color.id']);
     }
 
     function it_adds_a_filter_with_codes_to_the_query(
@@ -139,9 +139,9 @@ class ReferenceDataFilterSpec extends ObjectBehavior
         )
             ->during('addAttributeFilter', [$attribute, '=', $value, null, null, ['field' => 'color']]);
 
-        $value = ['foo'];
+        $value = [false];
         $this->shouldThrow(
-            InvalidArgumentException::numericExpected('color', 'filter', 'reference_data', 'string')
+            InvalidArgumentException::stringExpected('color', 'filter', 'reference_data', 'boolean')
         )
             ->during('addAttributeFilter', [$attribute, '=', $value, null, null, ['field' => 'color']]);
     }

--- a/src/Pim/Component/Catalog/Query/Filter/FieldFilterHelper.php
+++ b/src/Pim/Component/Catalog/Query/Filter/FieldFilterHelper.php
@@ -41,7 +41,7 @@ class FieldFilterHelper
      *
      * @return string
      */
-    public static function getProperty($field, $default = 'id')
+    public static function getProperty($field, $default = 'code')
     {
         $fieldData = explode('.', $field);
 
@@ -84,9 +84,7 @@ class FieldFilterHelper
     public static function checkIdentifier($field, $value, $filter)
     {
         $invalidIdField = static::hasProperty($field) && static::getProperty($field) === 'id' && !is_numeric($value);
-        $invalidDefaultField = !static::hasProperty($field) && !is_numeric($value);
-
-        if ($invalidIdField || $invalidDefaultField) {
+        if ($invalidIdField) {
             throw InvalidArgumentException::numericExpected(
                 static::getCode($field),
                 'filter',
@@ -95,8 +93,9 @@ class FieldFilterHelper
             );
         }
 
+        $invalidDefaultField = !static::hasProperty($field) && !is_string($value);
         $invalidStringField = static::hasProperty($field) && static::getProperty($field) !== 'id' && !is_string($value);
-        if ($invalidStringField) {
+        if ($invalidDefaultField || $invalidStringField) {
             throw InvalidArgumentException::stringExpected(static::getCode($field), 'filter', $filter, gettype($value));
         }
     }

--- a/src/Pim/Component/Catalog/Query/Filter/FieldFilterHelper.php
+++ b/src/Pim/Component/Catalog/Query/Filter/FieldFilterHelper.php
@@ -93,8 +93,10 @@ class FieldFilterHelper
             );
         }
 
-        $invalidDefaultField = !static::hasProperty($field) && !is_string($value);
-        $invalidStringField = static::hasProperty($field) && static::getProperty($field) !== 'id' && !is_string($value);
+        $invalidDefaultField = !static::hasProperty($field) && !is_string($value) && !is_numeric($value);
+        $invalidStringField = static::hasProperty($field) && static::getProperty($field) !== 'id' &&
+            !is_string($value) && !is_numeric($value);
+
         if ($invalidDefaultField || $invalidStringField) {
             throw InvalidArgumentException::stringExpected(static::getCode($field), 'filter', $filter, gettype($value));
         }

--- a/src/Pim/Component/Catalog/Repository/GroupRepositoryInterface.php
+++ b/src/Pim/Component/Catalog/Repository/GroupRepositoryInterface.php
@@ -54,7 +54,12 @@ interface GroupRepositoryInterface extends IdentifiableObjectRepositoryInterface
     public function createAssociationDatagridQueryBuilder();
 
     /**
-     * {@inheritdoc}
+     * @param string $dataLocale
+     * @param int    $collectionId
+     * @param string $search
+     * @param array  $options
+     *
+     * @return array
      */
     public function getOptions($dataLocale, $collectionId = null, $search = '', array $options = []);
 

--- a/src/Pim/Component/Connector/Job/JobParameters/DefaultValuesProvider/ProductCsvExport.php
+++ b/src/Pim/Component/Connector/Job/JobParameters/DefaultValuesProvider/ProductCsvExport.php
@@ -77,7 +77,7 @@ class ProductCsvExport implements DefaultValuesProviderInterface
                     'value'    => 100,
                 ],
                 [
-                    'field'    => 'categories.code',
+                    'field'    => 'categories',
                     'operator' => Operators::IN_CHILDREN_LIST,
                     'value'    => []
                 ]

--- a/src/Pim/Component/Connector/Job/JobParameters/DefaultValuesProvider/ProductXlsxExport.php
+++ b/src/Pim/Component/Connector/Job/JobParameters/DefaultValuesProvider/ProductXlsxExport.php
@@ -78,7 +78,7 @@ class ProductXlsxExport implements DefaultValuesProviderInterface
                     'value'    => 100,
                 ],
                 [
-                    'field'    => 'categories.code',
+                    'field'    => 'categories',
                     'operator' => Operators::IN_CHILDREN_LIST,
                     'value'    => []
                 ]

--- a/src/Pim/Component/Connector/spec/Reader/Database/ProductReaderSpec.php
+++ b/src/Pim/Component/Connector/spec/Reader/Database/ProductReaderSpec.php
@@ -2,21 +2,13 @@
 
 namespace spec\Pim\Component\Connector\Reader\Database;
 
-use Akeneo\Component\Batch\Job\BatchStatus;
 use Akeneo\Component\Batch\Job\JobParameters;
-use Akeneo\Component\Batch\Job\JobRepositoryInterface;
-use Akeneo\Component\Batch\Model\JobExecution;
-use Akeneo\Component\Batch\Model\JobInstance;
 use Akeneo\Component\Batch\Model\StepExecution;
 use Akeneo\Component\StorageUtils\Cursor\CursorInterface;
 use Akeneo\Component\StorageUtils\Detacher\ObjectDetacherInterface;
 use PhpSpec\ObjectBehavior;
-use Pim\Bundle\CatalogBundle\Doctrine\ORM\Repository\AttributeRepository;
-use Pim\Component\Catalog\AttributeTypes;
 use Pim\Component\Catalog\Converter\MetricConverter;
 use Pim\Component\Catalog\Manager\CompletenessManager;
-use Pim\Component\Catalog\Model\AttributeInterface;
-use Pim\Component\Catalog\Model\CategoryInterface;
 use Pim\Component\Catalog\Model\ChannelInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Query\ProductQueryBuilderFactoryInterface;
@@ -70,7 +62,7 @@ class ProductReaderSpec extends ObjectBehavior
                     'value'    => true
                 ],
                 [
-                    'field'    => 'family.code',
+                    'field'    => 'family',
                     'operator' => 'IN',
                     'value'    => [
                         'camcorder'


### PR DESCRIPTION
The end goal of this PR is to use the filters `categories`, `family` and `groups` instead of `categories.id`, `categories.code`, `family.id`, `family.code`, groups.id` and `groups.code`.

Is has been done following this process:
* the PQB now filters by codes by default for `categories`, `groups` and `family`. Internally, it may use the IDs. I didn't touch the internal behavior, that was not the goal of this PR.
* as a consequence, `categories.id`, `groups.id` and  `family.id` have been deprecated
* the filters `categories`, `groups` and  `family` have been introduced and used everywhere possible
* as a consequence, `categories.code`, `groups.code` and  `family.code` have also been deprecated. They are no longer used in the application.


| Q                                 | A
| --------------------------------- | ---
| CI | blue 
| Added Specs                       | Y
| Added Behats                      |  -
| Changelog updated                 | Y
| Review and 2 GTM                  | :clock1:
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | https://github.com/akeneo/pim-docs/pull/443

