### PR TITLE
PIM-6033: Fix validation issue when you add an empty attribute option

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -1,3 +1,9 @@
+# 1.6.x
+
+## Bug fixes
+
+- PIM-6033: Fix validation issue when you add a blank attribute option line
+
 # 1.6.7 (2016-12-20)
 
 ## Bug fixes

--- a/features/Context/Page/Attribute/Creation.php
+++ b/features/Context/Page/Attribute/Creation.php
@@ -2,6 +2,7 @@
 
 namespace Context\Page\Attribute;
 
+use Behat\Mink\Element\NodeElement;
 use Context\Page\Base\Form;
 
 /**
@@ -58,22 +59,54 @@ class Creation extends Form
     public function addOption($name, array $labels = [])
     {
         if (null === $this->getElement('attribute_option_table')->find('css', '.attribute_option_code')) {
-            $this->getElement('add_option_button')->click();
-
-            $this->spin(function () {
-                return $this->getElement('attribute_option_table')->find('css', '.attribute_option_code');
-            }, 'The click on new option has not added a new line.');
+            $this->createOption();
         }
 
-        $rows = $this->getOptionsElement();
-        $row  = end($rows);
+        $this->fillLastOption($name, $labels);
+        $this->saveLastOption();
+    }
+
+    public function createOption()
+    {
+        $this->spin(function () {
+            $this->getElement('add_option_button')->click();
+
+            return true;
+        }, 'Cannot add a new attribute option');
+
+        $this->spin(function () {
+            return $this->getElement('attribute_option_table')->find('css', '.attribute_option_code');
+        }, 'The click on new option has not added a new line.');
+    }
+
+    /**
+     * @param string $name
+     * @param array  $labels
+     */
+    public function fillLastOption($name, $labels = [])
+    {
+        $row = $this->getLastOption();
 
         $row->find('css', '.attribute_option_code')->setValue($name);
 
         foreach ($labels as $locale => $label) {
             $row->find('css', sprintf('.attribute-option-value[data-locale="%s"]', $locale))->setValue($label);
         }
-        $row->find('css', '.btn.update-row')->click();
+    }
+
+    public function saveLastOption()
+    {
+        $this->getLastOption()->find('css', '.btn.update-row')->click();
+    }
+
+    /**
+     * @return NodeElement
+     */
+    protected function getLastOption()
+    {
+        $rows = $this->getOptionsElement();
+
+        return end($rows);
     }
 
     /**

--- a/features/Context/WebUser.php
+++ b/features/Context/WebUser.php
@@ -1276,6 +1276,33 @@ class WebUser extends RawMinkContext
     }
 
     /**
+     * @param TableNode $table
+     *
+     * @When /^I add an empty attribute option$/
+     * @When /^I add the following attribute option:$/
+     */
+    public function iAddAnOptionRow(TableNode $table = null)
+    {
+        $this->getCurrentPage()->createOption();
+
+        if (null !== $table) {
+            $values = $table->getRowsHash();
+            $code = $values['Code'];
+            unset($values['Code']);
+
+            $this->getCurrentPage()->fillLastOption($code, $values);
+        }
+    }
+
+    /**
+     * @When /^I update the last attribute option$/
+     */
+    public function iUpdateTheLastAttributeOption()
+    {
+        $this->getCurrentPage()->saveLastOption();
+    }
+
+    /**
      * @param string $oldOptionName
      * @param string $newOptionName
      *

--- a/features/attribute/option/create_attribute_options.feature
+++ b/features/attribute/option/create_attribute_options.feature
@@ -7,25 +7,49 @@ Feature: Create attribute options
   Background:
     Given the "default" catalog configuration
     And I am logged in as "Julia"
-    And I am on the attributes page
+
+  Scenario: Successfully create some attribute options
+    Given I am on the attributes page
     And I create a "Simple select" attribute
     And I fill in the following information:
       | Code            | size  |
       | Attribute group | Other |
     And I visit the "Values" tab
     Then I should see the "Options" section
-    Then I should see "To manage options, please save the attribute first"
-    And I save the attribute
-    Then I should see the flash message "Attribute successfully created"
-    And I check the "Automatic option sorting" switch
-
-  Scenario: Successfully create some attribute options
-    Given I create the following attribute options:
+    And I should see "To manage options, please save the attribute first"
+    When I save the attribute
+    Then I should not see the text "There are unsaved changes."
+    When I check the "Automatic option sorting" switch
+    And I create the following attribute options:
       | Code  |
       | red   |
       | blue  |
       | green |
-    Then I should see "green"
+    Then I should see the text "green"
     And I save the attribute
-    Then I should see the flash message "Attribute successfully updated"
-    Then I should see "green"
+    And I should see the flash message "Attribute successfully updated"
+    And I should see the text "green"
+
+  @jira https://akeneo.atlassian.net/browse/PIM-6033
+  Scenario: Successfully create several empty attribute options but save only filled options
+    Given the following attributes:
+      | code | type         | localizable | scopable | group |
+      | size | simpleselect | no          | no       | other |
+    And I am on the "size" attribute page
+    When I visit the "Values" tab
+    And I create the following attribute options:
+      | Code  |
+      | red   |
+      | blue  |
+      | green |
+    And I add the following attribute option:
+      | Code  | Grey |
+      | en_US | Grey |
+      | fr_FR | Gris |
+    And I update the last attribute option
+    And I add an empty attribute option
+    And I add an empty attribute option
+    And I add an empty attribute option
+    And I save the attribute
+    Then the Options section should contain 4 options
+

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/pim-attributeoptionview.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/pim-attributeoptionview.js
@@ -412,7 +412,11 @@ define(
                     }
                 }
 
-                this.currentlyEditedItemView = attributeOptionRow;
+                if (attributeOptionRow.model.id)
+                {
+                    this.currentlyEditedItemView = attributeOptionRow;
+                }
+
                 this.updateEditionStatus();
 
                 return true;


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) 

**Description (for Contributor and Core Developer)**

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       |  :negative_squared_cross_mark:
| Added Behats                      | :white_check_mark:
| Changelog updated                 | :white_check_mark:
| Review and 2 GTM                  | :clock1:
| Micro Demo to the PO (Story only) | :clock1:
| Migration script                  | :negative_squared_cross_mark:
| Tech Doc                          |  :negative_squared_cross_mark:


:white_check_mark: Done and pass

:red_circle: Done but fail

:clock1: Done but pending

:negative_squared_cross_mark: Not needed
