### PR TITLE
PIM-5987: Duplicate entities during import process

### DIFF
--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/steps.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/steps.yml
@@ -22,6 +22,7 @@ services:
             - '@pim_connector.reader.file.csv_attribute'
             - '@pim_connector.processor.denormalization.attribute'
             - '@pim_connector.writer.database.attribute'
+            - 1
 
     pim_connector.step.csv_attribute_option.import:
         class: '%pim_connector.step.item_step.class%'
@@ -32,6 +33,7 @@ services:
             - '@pim_connector.reader.file.csv_attribute_option'
             - '@pim_connector.processor.denormalization.attribute_option'
             - '@pim_connector.writer.database.attribute_option'
+            - 1
 
     pim_connector.step.csv_association_type.import:
         class: '%pim_connector.step.item_step.class%'
@@ -42,6 +44,7 @@ services:
             - '@pim_connector.reader.file.csv_association_type'
             - '@pim_connector.processor.denormalization.association_type'
             - '@pim_connector.writer.database.association_type'
+            - 1
 
     pim_connector.step.csv_family.import:
         class: '%pim_connector.step.item_step.class%'
@@ -52,6 +55,7 @@ services:
             - '@pim_connector.reader.file.csv_family'
             - '@pim_connector.processor.denormalization.family'
             - '@pim_connector.writer.database.family'
+            - 1
 
     pim_connector.step.csv_group.import:
         class: '%pim_connector.step.item_step.class%'
@@ -62,6 +66,7 @@ services:
             - '@pim_connector.reader.file.csv_group'
             - '@pim_connector.processor.denormalization.group'
             - '@pim_connector.writer.database.group'
+            - 1
 
     pim_connector.step.csv_product.import:
         class: '%pim_connector.step.item_step.class%'
@@ -115,6 +120,7 @@ services:
             - '@pim_connector.reader.file.csv_channel'
             - '@pim_connector.processor.denormalization.channel'
             - '@pim_connector.writer.database.channel'
+            - 1
 
     pim_connector.step.csv_locale_import.import:
         class: '%pim_connector.step.item_step.class%'
@@ -125,6 +131,7 @@ services:
             - '@pim_connector.reader.file.csv_locale'
             - '@pim_connector.processor.denormalization.locale'
             - '@pim_connector.writer.database.locale'
+            - 1
 
     pim_connector.step.csv_attribute_group_import.import:
         class: '%pim_connector.step.item_step.class%'
@@ -135,6 +142,7 @@ services:
             - '@pim_connector.reader.file.csv_attribute_group'
             - '@pim_connector.processor.denormalization.attribute_group'
             - '@pim_connector.writer.database.attribute_group'
+            - 1
 
     pim_connector.step.csv_currency_import.import:
         class: '%pim_connector.step.item_step.class%'
@@ -145,6 +153,7 @@ services:
             - '@pim_connector.reader.file.csv_currency'
             - '@pim_connector.processor.denormalization.currency'
             - '@pim_connector.writer.database.currency'
+            - 1
 
     pim_connector.step.csv_group_type_import.import:
         class: '%pim_connector.step.item_step.class%'
@@ -155,6 +164,7 @@ services:
             - '@pim_connector.reader.file.csv_group_type'
             - '@pim_connector.processor.denormalization.group_type'
             - '@pim_connector.writer.database.group_type'
+            - 1
 
     # CSV Export steps ------------------------------------------------------------------------------------------------
     pim_connector.step.csv_attribute.export:


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

**Description (for Contributor and Core Developer)**
This fix avoids to get Duplicate MySQL error and make sure validation is correctly done!

![image](https://cloud.githubusercontent.com/assets/2131005/21424964/80152f6c-c846-11e6-881d-288317d27b42.png)

It will probably impact performance negatively!

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | :white_check_mark: :red_circle: :negative_squared_cross_mark: :clock1:
| Added Behats                      | :white_check_mark: :red_circle: :negative_squared_cross_mark: :clock1:
| Changelog updated                 | :white_check_mark: :red_circle: :negative_squared_cross_mark: :clock1:
| Review and 2 GTM                  | :white_check_mark: :red_circle: :negative_squared_cross_mark: :clock1:
| Micro Demo to the PO (Story only) | :white_check_mark: :red_circle: :negative_squared_cross_mark: :clock1:
| Migration script                  | :white_check_mark: :red_circle: :negative_squared_cross_mark: :clock1:
| Tech Doc                          | :white_check_mark: :red_circle: :negative_squared_cross_mark: :clock1:


:white_check_mark: Done and pass

:red_circle: Done but fail

:clock1: Done but pending

:negative_squared_cross_mark: Not needed
