### PR TITLE
TIP-662: Remove unused WITH_REQUIRED_IDENTIFIER product import option

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -6,6 +6,7 @@
 - #5062: Fixed unit conversion for ElectricCharge, cheers @gplanchat!
 - #5294: Fixed infinite loading if no attribute is configured as a product identifier, cheers @gplanchat!
 - #5337: Fixed Widget Registry. Priority is now taken in account.
+- TIP-662: Removed the WITH_REQUIRED_IDENTIFIER option from the flatToStandard product converter.
 
 ## Functional improvements
 

--- a/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Product.php
+++ b/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Product.php
@@ -180,7 +180,7 @@ class Product implements ArrayConverterInterface
 
         $mappedItem = $this->mapFields($item, $options);
         $filteredItem = $this->filterFields($mappedItem, $options['with_associations']);
-        $this->validateItem($filteredItem, $options['with_required_identifier']);
+        $this->validateItem($filteredItem);
 
         $mergedItem = $this->columnsMerger->merge($filteredItem);
         $convertedItem = $this->convertItem($mergedItem, $options);
@@ -195,9 +195,6 @@ class Product implements ArrayConverterInterface
      */
     protected function prepareOptions(array $options)
     {
-        $options['with_required_identifier'] = isset($options['with_required_identifier']) ?
-            $options['with_required_identifier'] :
-            true;
         $options['with_associations'] = isset($options['with_associations']) ? $options['with_associations'] : true;
         $options['default_values'] = isset($options['default_values']) ? $options['default_values'] : [];
 
@@ -308,10 +305,10 @@ class Product implements ArrayConverterInterface
      * @param array $item
      * @param bool  $withRequiredSku
      */
-    protected function validateItem(array $item, $withRequiredSku)
+    protected function validateItem(array $item)
     {
-        $requiredFields = $withRequiredSku ? [$this->attrColumnsResolver->resolveIdentifierField()] : [];
-        $this->fieldChecker->checkFieldsPresence($item, $requiredFields);
+        $requiredField = $this->attrColumnsResolver->resolveIdentifierField();
+        $this->fieldChecker->checkFieldsPresence($item, [$requiredField]);
         $this->validateOptionalFields($item);
         $this->validateFieldValueTypes($item);
     }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
Removes unused WITH_REQUIRED_IDENTIFIER option from the flatToStandard converter because this option does not exists anymore in the job parameters option (for instance see https://github.com/akeneo/pim-community-dev/blob/5a5b1cb28288d9ab067c22f4dcb5f1c087d5fbd2/src/Pim/Component/Connector/Job/JobParameters/DefaultValuesProvider/ProductCsvImport.php#L37-L37).

It is neither used in EE.

[//]: <> (What does this Pull Request do? reference the related issue?)
The Identifier is definitely required for a job import. so we dropped the option from the converter inner workings.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | :negative_squared_cross_mark:
| Added Behats                      | :negative_squared_cross_mark:
| Changelog updated                 | :white_check_mark:
| Review and 2 GTM                  | :white_check_mark:
| Micro Demo to the PO (Story only) | :negative_squared_cross_mark:
| Migration script                  | :negative_squared_cross_mark: 
| Tech Doc                          | :negative_squared_cross_mark: 

:white_check_mark: Done and pass

:red_circle: Done but fail

:clock1: Done but pending

:negative_squared_cross_mark: Not needed
