### PR TITLE
API-57: upgrade FOSRestBundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "dompdf/dompdf" : "0.6.1",
         "escapestudios/wsse-authentication-bundle": "2.0.2",
         "friendsofsymfony/jsrouting-bundle": "1.5.4",
-        "friendsofsymfony/rest-bundle": "0.12.0",
+        "friendsofsymfony/rest-bundle": "2.1.1",
         "gedmo/doctrine-extensions":"v2.4.3",
         "incenteev/composer-parameter-handler": "2.1.1",
         "jms/serializer": "1.0.0",

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/bundles/fos_rest.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/bundles/fos_rest.yml
@@ -4,13 +4,13 @@ fos_rest:
         default_engine: php
         formats:
             json: true
-            xml: true
     format_listener:
-        prefer_extension: true
+        rules:
+            - { path: '^/', priorities: ['html', 'json'], fallback_format: html, prefer_extension: true }
+            - { path: '^/api', priorities: ['json'], fallback_format: json, prefer_extension: true }
     body_listener:
         decoders:
             json: fos_rest.decoder.json
-            xml: fos_rest.decoder.xml
     routing_loader:
         default_format: json
     exception:


### PR DESCRIPTION
- Upgrade bundle
- Remove unsupported xml format for the API

(Initially, we wanted to remove this bundle as we thought it was useless. But it's still used for the oro navigation and quite usefull to call exceptions in the good format depending on the URI)

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | :negative_squared_cross_mark:
| Added Behats                      | :negative_squared_cross_mark:
| Changelog updated                 | :negative_squared_cross_mark:
| Review and 2 GTM                  | 
| Micro Demo to the PO (Story only) | :negative_squared_cross_mark:
| Migration script                  | :negative_squared_cross_mark:
| Tech Doc                          | :negative_squared_cross_mark:


:white_check_mark: Done and pass

:red_circle: Done but fail

:clock1: Done but pending

:negative_squared_cross_mark: Not needed
