### PR TITLE
TIP-667: Adds ProductValueFactory and replace hardcoded productValue instanciations

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -26,7 +26,7 @@
 - GITHUB-5380: Add `Pim\Component\User\Model\GroupInterface`
 - GITHUB-4696: Ping the server before updating job and step execution data to prevent "MySQL Server has gone away" issue cheers @qrz-io!
 - TIP-575: Rename FileIterator classes to FlatFileIterator and changes the reader/processor behavior to iterate over the item's position in the file instead of the item's line number in the file.
-- TIP-662: Removed the WITH_REQUIRED_IDENTIFIER option from the flatToStandard product converter.
+- TIP-662: Removed the WITH_REQUIRED_IDENTIFIER option from `Pim\Component\Connector\ArrayConverter\FlatToStandard\Product` as it was not used anymore.
 - TIP-667: Introduce a product value factory service to instanciate product values.
 
 ## BC breaks

--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -12,7 +12,8 @@
 - In the _Product Query Builder_, aka _PQB_, (`Pim\Component\Catalog\Query\ProductQueryBuilderInterface`), filtering products by the following filters is now deprecated: `categories.id`, `family.id`, `groups.id`. 
   Filters `categories`, `family` and `groups` have been introduced and the _PQB_ now uses them by default. The filters `categories.code`, `family.code` and `groups.code` are deprecated. 
   In the next version, the deprecated filters will be removed.
-- As it's not needed anymore to convert `codes` to `ids` in order to filter products, `Pim\Bundle\CatalogBundle\Doctrine\Common\Filter\ObjectIdResolver` and `Pim\Bundle\CatalogBundle\Doctrine\Common\Filter\ObjectIdResolverInterface` are now deprecated. 
+- As it's not needed anymore to convert `codes` to `ids` in order to filter products, `Pim\Bundle\CatalogBundle\Doctrine\Common\Filter\ObjectIdResolver` and `Pim\Bundle\CatalogBundle\Doctrine\Common\Filter\ObjectIdResolverInterface` are now deprecated.
+- Creating a product value with the ProductBuilder (`Pim\Component\Catalog\Denormalizer\Standard\ProductValueDenormalizer`) using the `createProductValue` function is now deprecated. It is advised to use the ProductValueFactory (`Pim\Component\Catalog\Factory\ProductValueFactory`) instead.
 
 ## Functional improvements
 

--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -6,8 +6,6 @@
 - GITHUB-5062: Fixed unit conversion for ElectricCharge, cheers @gplanchat!
 - GITHUB-5294: Fixed infinite loading if no attribute is configured as a product identifier, cheers @gplanchat!
 - GITHUB-5337: Fixed Widget Registry. Priority is now taken in account.
-- TIP-662: Removed the WITH_REQUIRED_IDENTIFIER option from the flatToStandard product converter.
-
 
 ## Deprecations
 
@@ -28,9 +26,12 @@
 - GITHUB-5380: Add `Pim\Component\User\Model\GroupInterface`
 - GITHUB-4696: Ping the server before updating job and step execution data to prevent "MySQL Server has gone away" issue cheers @qrz-io!
 - TIP-575: Rename FileIterator classes to FlatFileIterator and changes the reader/processor behavior to iterate over the item's position in the file instead of the item's line number in the file.
+- TIP-662: Removed the WITH_REQUIRED_IDENTIFIER option from the flatToStandard product converter.
+- TIP-667: Introduce a product value factory service to instanciate product values.
 
 ## BC breaks
-
+- Change the constructor of `Pim\Component\Catalog\Denormalizer\Standard\ProductValueDenormalizer` to add `Pim\Component\Catalog\Factory\ProductValueFactory`
+- Change the constructor of `Pim\Component\Catalog\Builder\ProductBuilder` to add `Pim\Component\Catalog\Factory\ProductValueFactory`
 - Add `getAllChildrenCodes` to `Akeneo\Component\Classification\Repository\CategoryRepositoryInterface` 
 - Change the constructor of `Pim\Bundle\FilterBundle\Filter\Product\InGroupFilter` to add `Pim\Bundle\CatalogBundle\Doctrine\Common\Filter\ObjectCodeResolver`
 - Remove WebServiceBundle

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/builders.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/builders.yml
@@ -13,6 +13,7 @@ services:
             - '@pim_catalog.repository.association_type'
             - '@event_dispatcher'
             - '@pim_catalog.resolver.attribute_values'
+            - '@pim_catalog.factory.product_value'
             - {'product': '%pim_catalog.entity.product.class%', 'product_value': '%pim_catalog.entity.product_value.class%', 'product_price': '%pim_catalog.entity.product_price.class%', 'association': '%pim_catalog.entity.association.class%'}
 
     pim_catalog.builder.product_template:

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/builders.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/builders.yml
@@ -14,7 +14,7 @@ services:
             - '@event_dispatcher'
             - '@pim_catalog.resolver.attribute_values'
             - '@pim_catalog.factory.product_value'
-            - {'product': '%pim_catalog.entity.product.class%', 'product_value': '%pim_catalog.entity.product_value.class%', 'product_price': '%pim_catalog.entity.product_price.class%', 'association': '%pim_catalog.entity.association.class%'}
+            - {'product': '%pim_catalog.entity.product.class%', 'product_price': '%pim_catalog.entity.product_price.class%', 'association': '%pim_catalog.entity.association.class%'}
 
     pim_catalog.builder.product_template:
         class: '%pim_catalog.builder.product_template.class%'

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/factories.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/factories.yml
@@ -95,6 +95,5 @@ services:
     pim_catalog.factory.product_value:
         class: '%pim_catalog.factory.product_value.class%'
         arguments:
-            - '@pim_catalog.repository.channel'
-            - '@pim_catalog.repository.locale'
+            - '@pim_catalog.validator.helper.attribute'
             - '%pim_catalog.entity.product_value.class%'

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/factories.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/factories.yml
@@ -7,6 +7,7 @@ parameters:
     pim_catalog.factory.group_type.class:            Pim\Component\Catalog\Factory\GroupTypeFactory
     pim_catalog.factory.currency.class:              Pim\Component\Catalog\Factory\CurrencyFactory
     pim_catalog.factory.product_template.class:      Pim\Component\Catalog\Factory\ProductTemplateFactory
+    pim_catalog.factory.product_value.class:         Pim\Component\Catalog\Factory\ProductValueFactory
 
 services:
     pim_catalog.factory.family:
@@ -90,3 +91,8 @@ services:
         class: '%pim_catalog.factory.product_template.class%'
         arguments:
             - '%pim_catalog.entity.product_template.class%'
+
+    pim_catalog.factory.product_value:
+        class: '%pim_catalog.factory.product_value.class%'
+        arguments:
+            - '%pim_catalog.entity.product_value.class%'

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/factories.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/factories.yml
@@ -95,4 +95,6 @@ services:
     pim_catalog.factory.product_value:
         class: '%pim_catalog.factory.product_value.class%'
         arguments:
+            - '@pim_catalog.repository.channel'
+            - '@pim_catalog.repository.locale'
             - '%pim_catalog.entity.product_value.class%'

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/serializers.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/serializers.yml
@@ -50,7 +50,7 @@ services:
     pim_catalog.denormalizer.standard.product_value:
         class: '%pim_catalog.denormalizer.standard.product_value.class%'
         arguments:
-            - '%pim_catalog.entity.product_value.class%'
+            - '@pim_catalog.factory.product_value'
         tags:
             - { name: pim_serializer.normalizer, priority: 90 }
 

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/serializers.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/serializers.yml
@@ -51,6 +51,7 @@ services:
         class: '%pim_catalog.denormalizer.standard.product_value.class%'
         arguments:
             - '@pim_catalog.factory.product_value'
+            - '%pim_catalog.entity.product_value.class%'
         tags:
             - { name: pim_serializer.normalizer, priority: 90 }
 

--- a/src/Pim/Bundle/VersioningBundle/Denormalizer/Flat/ProductValue/PricesDenormalizer.php
+++ b/src/Pim/Bundle/VersioningBundle/Denormalizer/Flat/ProductValue/PricesDenormalizer.php
@@ -82,9 +82,7 @@ class PricesDenormalizer extends AbstractValueDenormalizer
      */
     protected function addPriceForCurrency(ProductValueInterface $value, $data, $currency)
     {
-        $priceValue = $this->productBuilder->addPriceForCurrency($value, $currency);
-        $priceValue->setCurrency($currency);
-        $priceValue->setData($data);
+        $priceValue = $this->productBuilder->addPriceForCurrencyWithData($value, $currency, $data);
         $value->addPrice($priceValue);
     }
 

--- a/src/Pim/Bundle/VersioningBundle/spec/Denormalizer/Flat/ProductValue/PricesDenormalizerSpec.php
+++ b/src/Pim/Bundle/VersioningBundle/spec/Denormalizer/Flat/ProductValue/PricesDenormalizerSpec.php
@@ -30,22 +30,14 @@ class PricesDenormalizerSpec extends ObjectBehavior
         ProductPriceInterface $productPriceEur,
         ProductPriceInterface $productPriceUsd
     ) {
-        $productBuilder->addPriceForCurrency($priceValue, 'EUR')
+        $productBuilder->addPriceForCurrencyWithData($priceValue, 'EUR', '100')
             ->willReturn($productPriceEur)
-            ->shouldBeCalled();
-        $productPriceEur->setCurrency('EUR')
-            ->shouldBeCalled();
-        $productPriceEur->setData('100')
             ->shouldBeCalled();
         $priceValue->addPrice($productPriceEur)
             ->shouldBeCalled();
 
-        $productBuilder->addPriceForCurrency($priceValue, 'USD')
+        $productBuilder->addPriceForCurrencyWithData($priceValue, 'USD', '25')
             ->willReturn($productPriceUsd)
-            ->shouldBeCalled();
-        $productPriceUsd->setCurrency('USD')
-            ->shouldBeCalled();
-        $productPriceUsd->setData('25')
             ->shouldBeCalled();
         $priceValue->addPrice($productPriceUsd)
             ->shouldBeCalled();
@@ -65,32 +57,20 @@ class PricesDenormalizerSpec extends ObjectBehavior
         ProductPriceInterface $productPriceEur,
         ProductPriceInterface $productPriceUsd
     ) {
-        $productBuilder->addPriceForCurrency($priceValue, 'EUR')
+        $productBuilder->addPriceForCurrencyWithData($priceValue, 'EUR', '120.00')
             ->willReturn($productPriceEur)
-            ->shouldBeCalled();
-        $productPriceEur->setCurrency('EUR')
-            ->shouldBeCalled();
-        $productPriceEur->setData('120.00')
             ->shouldBeCalled();
         $priceValue->addPrice($productPriceEur)
             ->shouldBeCalled();
 
-        $productBuilder->addPriceForCurrency($priceValue, 'USD')
+        $productBuilder->addPriceForCurrencyWithData($priceValue, 'USD', '145.40')
             ->willReturn($productPriceUsd)
-            ->shouldBeCalled();
-        $productPriceUsd->setCurrency('USD')
-            ->shouldBeCalled();
-        $productPriceUsd->setData('145.40')
             ->shouldBeCalled();
         $priceValue->addPrice($productPriceUsd)
             ->shouldBeCalled();
 
-        $productBuilder->addPriceForCurrency($priceValue, 'CHF')
+        $productBuilder->addPriceForCurrencyWithData($priceValue, 'CHF', '100')
             ->willReturn($productPriceUsd)
-            ->shouldBeCalled();
-        $productPriceUsd->setCurrency('CHF')
-            ->shouldBeCalled();
-        $productPriceUsd->setData('100')
             ->shouldBeCalled();
         $priceValue->addPrice($productPriceUsd)
             ->shouldBeCalled();
@@ -107,7 +87,7 @@ class PricesDenormalizerSpec extends ObjectBehavior
         ProductPriceInterface $price,
         ArrayCollection $priceCollection
     ) {
-        $productBuilder->addPriceForCurrency(Argument::cetera())->willReturn($price);
+        $productBuilder->addPriceForCurrencyWithData(Argument::cetera())->willReturn($price);
         $priceValue->addPrice($price)->shouldBeCalled();
         $priceValue->getPrices()->willReturn($priceCollection);
 

--- a/src/Pim/Component/Catalog/Builder/ProductBuilder.php
+++ b/src/Pim/Component/Catalog/Builder/ProductBuilder.php
@@ -225,7 +225,7 @@ class ProductBuilder implements ProductBuilderInterface
         $locale = null,
         $scope = null
     ) {
-        $productValue = $this->productValueFactory->create($attribute, $locale, $scope);
+        $productValue = $this->productValueFactory->create($attribute, $scope, $locale);
         $product->addValue($productValue);
 
         return $productValue;

--- a/src/Pim/Component/Catalog/Builder/ProductBuilder.php
+++ b/src/Pim/Component/Catalog/Builder/ProductBuilder.php
@@ -225,19 +225,17 @@ class ProductBuilder implements ProductBuilderInterface
         $locale = null,
         $scope = null
     ) {
-        $productValue = $this->productValueFactory->createEmpty($attribute, $locale, $scope);
+        $productValue = $this->productValueFactory->create($attribute, $locale, $scope);
         $product->addValue($productValue);
 
         return $productValue;
     }
     /**
      * {@inheritdoc}
-     *
-     * @deprecated will be removed in 1.8. Please use ProductValueFactory::createEmpty instead.
      */
     public function createProductValue(AttributeInterface $attribute, $locale = null, $scope = null)
     {
-        return $this->productValueFactory->createEmpty($attribute, $locale, $scope);
+        return $this->productValueFactory->create($attribute, $locale, $scope);
     }
 
     /**

--- a/src/Pim/Component/Catalog/Builder/ProductBuilderInterface.php
+++ b/src/Pim/Component/Catalog/Builder/ProductBuilderInterface.php
@@ -137,6 +137,8 @@ interface ProductBuilderInterface
      * @param string             $scope
      *
      * @return ProductValueInterface
+     *
+     * @deprecated will be removed in 1.8. Please use ProductValueFactory::create instead.
      */
     public function createProductValue(AttributeInterface $attribute, $locale = null, $scope = null);
 }

--- a/src/Pim/Component/Catalog/Builder/ProductBuilderInterface.php
+++ b/src/Pim/Component/Catalog/Builder/ProductBuilderInterface.php
@@ -74,16 +74,26 @@ interface ProductBuilderInterface
     public function removeAttributeFromProduct(ProductInterface $product, AttributeInterface $attribute);
 
     /**
+     * Add a product price with currency to the value. If the price already exists, it is returned.
+     *
+     * @param ProductValueInterface $value
+     * @param string                $currency
+     *
+     * @return null|ProductPriceInterface
+     */
+    public function addPriceForCurrency(ProductValueInterface $value, $currency);
+
+    /**
      * Add a product price with currency and data to the value. If the price already exists, its data is
      * updated and it is returned.
      *
      * @param ProductValueInterface $value
      * @param string                $currency
-     * @param float|int             $data
+     * @param float|int             $amount
      *
      * @return null|ProductPriceInterface
      */
-    public function addPriceForCurrencyWithData(ProductValueInterface $value, $currency, $data);
+    public function addPriceForCurrencyWithData(ProductValueInterface $value, $currency, $amount);
 
     /**
      * Remove extra prices that are not in the currencies passed in arguments
@@ -118,4 +128,15 @@ interface ProductBuilderInterface
         $locale = null,
         $scope = null
     );
+
+    /**
+     * Create a productValue
+     *
+     * @param AttributeInterface $attribute
+     * @param string             $locale
+     * @param string             $scope
+     *
+     * @return ProductValueInterface
+     */
+    public function createProductValue(AttributeInterface $attribute, $locale = null, $scope = null);
 }

--- a/src/Pim/Component/Catalog/Builder/ProductBuilderInterface.php
+++ b/src/Pim/Component/Catalog/Builder/ProductBuilderInterface.php
@@ -74,16 +74,6 @@ interface ProductBuilderInterface
     public function removeAttributeFromProduct(ProductInterface $product, AttributeInterface $attribute);
 
     /**
-     * Add a product price with currency to the value. If the price already exists, it is returned.
-     *
-     * @param ProductValueInterface $value
-     * @param string                $currency
-     *
-     * @return null|ProductPriceInterface
-     */
-    public function addPriceForCurrency(ProductValueInterface $value, $currency);
-
-    /**
      * Add a product price with currency and data to the value. If the price already exists, its data is
      * updated and it is returned.
      *
@@ -128,15 +118,4 @@ interface ProductBuilderInterface
         $locale = null,
         $scope = null
     );
-
-    /**
-     * Create a productValue
-     *
-     * @param AttributeInterface $attribute
-     * @param string             $locale
-     * @param string             $scope
-     *
-     * @return ProductValueInterface
-     */
-    public function createProductValue(AttributeInterface $attribute, $locale = null, $scope = null);
 }

--- a/src/Pim/Component/Catalog/Denormalizer/Standard/ProductValueDenormalizer.php
+++ b/src/Pim/Component/Catalog/Denormalizer/Standard/ProductValueDenormalizer.php
@@ -29,10 +29,12 @@ class ProductValueDenormalizer implements SerializerAwareInterface, Denormalizer
 
     /**
      * @param ProductValueFactory $productValueFactory
+     * @param string              $entityClass
      */
-    public function __construct(ProductValueFactory $productValueFactory)
+    public function __construct(ProductValueFactory $productValueFactory, $entityClass)
     {
         $this->productValueFactory = $productValueFactory;
+        $this->entityClass = $entityClass;
     }
 
     /**

--- a/src/Pim/Component/Catalog/Denormalizer/Standard/ProductValueDenormalizer.php
+++ b/src/Pim/Component/Catalog/Denormalizer/Standard/ProductValueDenormalizer.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Component\Catalog\Denormalizer\Standard;
 
+use Pim\Component\Catalog\Factory\ProductValueFactory;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
@@ -23,12 +24,15 @@ class ProductValueDenormalizer implements SerializerAwareInterface, Denormalizer
     /** @var SerializerInterface */
     protected $serializer;
 
+    /** @var ProductValueFactory */
+    protected $productValueFactory;
+
     /**
-     * @param string $entityClass
+     * @param ProductValueFactory $productValueFactory
      */
-    public function __construct($entityClass)
+    public function __construct(ProductValueFactory $productValueFactory)
     {
-        $this->entityClass = $entityClass;
+        $this->productValueFactory = $productValueFactory;
     }
 
     /**
@@ -54,18 +58,15 @@ class ProductValueDenormalizer implements SerializerAwareInterface, Denormalizer
 
         $data = $data + ['locale' => null, 'scope' => null, 'data' => null];
 
-        $value = new $this->entityClass();
-        $value->setAttribute($attribute);
-        $value->setLocale($data['locale']);
-        $value->setScope($data['scope']);
+        $productValue = $this->productValueFactory->createEmpty($attribute, $data['scope'], $data['locale']);
 
         $valueData = $this->serializer->denormalize($data['data'], $attribute->getAttributeType(), $format, $context);
 
         if (null !== $valueData) {
-            $value->setData($valueData);
+            $productValue->setData($valueData);
         }
 
-        return $value;
+        return $productValue;
     }
 
     /**

--- a/src/Pim/Component/Catalog/Denormalizer/Standard/ProductValueDenormalizer.php
+++ b/src/Pim/Component/Catalog/Denormalizer/Standard/ProductValueDenormalizer.php
@@ -60,7 +60,7 @@ class ProductValueDenormalizer implements SerializerAwareInterface, Denormalizer
 
         $data = $data + ['locale' => null, 'scope' => null, 'data' => null];
 
-        $productValue = $this->productValueFactory->createEmpty($attribute, $data['scope'], $data['locale']);
+        $productValue = $this->productValueFactory->create($attribute, $data['scope'], $data['locale']);
 
         $valueData = $this->serializer->denormalize($data['data'], $attribute->getAttributeType(), $format, $context);
 

--- a/src/Pim/Component/Catalog/Factory/ProductValueFactory.php
+++ b/src/Pim/Component/Catalog/Factory/ProductValueFactory.php
@@ -48,8 +48,9 @@ class ProductValueFactory
      * @param string             $channelCode
      * @param string             $localeCode
      *
-     * @return ProductValueInterface
+     * @throws \LogicException
      *
+     * @return ProductValueInterface
      */
     public function create(AttributeInterface $attribute, $channelCode, $localeCode)
     {

--- a/src/Pim/Component/Catalog/Factory/ProductValueFactory.php
+++ b/src/Pim/Component/Catalog/Factory/ProductValueFactory.php
@@ -58,7 +58,7 @@ class ProductValueFactory
      * @return ProductValueInterface
      *
      */
-    public function createEmpty(AttributeInterface $attribute, $channelCode, $localeCode)
+    public function create(AttributeInterface $attribute, $channelCode, $localeCode)
     {
         if ($attribute->isScopable()) {
             if (null === $channelCode) {

--- a/src/Pim/Component/Catalog/Factory/ProductValueFactory.php
+++ b/src/Pim/Component/Catalog/Factory/ProductValueFactory.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Pim\Component\Catalog\Factory;
+
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\ProductValueInterface;
+
+class ProductValueFactory
+{
+    /** @var string */
+    private $productValueClass;
+
+    /**
+     * @param string $productValueClass
+     */
+    public function __construct($productValueClass)
+    {
+        if (!class_exists($productValueClass)) {
+            throw new \InvalidArgumentException(
+                sprintf('The product value class "%s" does not exist.', $productValueClass)
+            );
+        }
+
+        $this->productValueClass = $productValueClass;
+    }
+
+    public function createEmpty(AttributeInterface $attribute, $channelCode, $localeCode)
+    {
+        /** @var ProductValueInterface $value */
+        $value = new $this->productValueClass();
+        $value->setAttribute($attribute);
+        $value->setScope($channelCode);
+        $value->setLocale($localeCode);
+
+        return $value;
+    }
+}

--- a/src/Pim/Component/Catalog/Factory/ProductValueFactory.php
+++ b/src/Pim/Component/Catalog/Factory/ProductValueFactory.php
@@ -4,17 +4,39 @@ namespace Pim\Component\Catalog\Factory;
 
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\ProductValueInterface;
+use Pim\Component\Catalog\Repository\ChannelRepositoryInterface;
+use Pim\Component\Catalog\Repository\LocaleRepositoryInterface;
 
+/**
+ * Factory that creates empty product values
+ *
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
 class ProductValueFactory
 {
+    /** @var ChannelRepositoryInterface */
+    protected $channelRepository;
+
+    /** @var LocaleRepositoryInterface */
+    protected $localeRepository;
+
     /** @var string */
     private $productValueClass;
 
     /**
-     * @param string $productValueClass
+     * @param ChannelRepositoryInterface $channelRepository
+     * @param LocaleRepositoryInterface  $localeRepository
+     * @param string                     $productValueClass
      */
-    public function __construct($productValueClass)
-    {
+    public function __construct(
+        ChannelRepositoryInterface $channelRepository,
+        LocaleRepositoryInterface $localeRepository,
+        $productValueClass
+    ) {
+        $this->channelRepository = $channelRepository;
+        $this->localeRepository = $localeRepository;
         if (!class_exists($productValueClass)) {
             throw new \InvalidArgumentException(
                 sprintf('The product value class "%s" does not exist.', $productValueClass)
@@ -24,8 +46,38 @@ class ProductValueFactory
         $this->productValueClass = $productValueClass;
     }
 
+    /**
+     * This method effectively creates an empty product value while checking the provided localeCode and ChannelCode
+     * exists.
+     * The Data for this product value should be set in a second time using ProductValue::setData method.
+     *
+     * @param AttributeInterface $attribute
+     * @param string             $channelCode
+     * @param string             $localeCode
+     *
+     * @return ProductValueInterface
+     *
+     */
     public function createEmpty(AttributeInterface $attribute, $channelCode, $localeCode)
     {
+        if ($attribute->isScopable() && null === $this->channelRepository->findOneByIdentifier($channelCode)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'A scope must be provided to create a value for the scopable attribute %s',
+                    $attribute->getCode()
+                )
+            );
+        }
+
+        if ($attribute->isLocalizable() && null === $this->localeRepository->findOneByIdentifier($localeCode)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'A locale must be provided to create a value for the localizable attribute %s',
+                    $attribute->getCode()
+                )
+            );
+        }
+
         /** @var ProductValueInterface $value */
         $value = new $this->productValueClass();
         $value->setAttribute($attribute);

--- a/src/Pim/Component/Catalog/Factory/ProductValueFactory.php
+++ b/src/Pim/Component/Catalog/Factory/ProductValueFactory.php
@@ -60,22 +60,45 @@ class ProductValueFactory
      */
     public function createEmpty(AttributeInterface $attribute, $channelCode, $localeCode)
     {
-        if ($attribute->isScopable() && null === $this->channelRepository->findOneByIdentifier($channelCode)) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    'A scope must be provided to create a value for the scopable attribute %s',
-                    $attribute->getCode()
-                )
-            );
+        if ($attribute->isScopable()) {
+            if (null === $channelCode) {
+                throw new \InvalidArgumentException(
+                    sprintf(
+                        'A channel code must be provided to create a value for the scopable attribute "%s"',
+                        $attribute->getCode()
+                    )
+                );
+            }
+            if (!in_array($channelCode, $this->channelRepository->getChannelCodes())) {
+                throw new \InvalidArgumentException(
+                    sprintf(
+                        'A valid channel code must be provided to create a value for the scopable attribute "%s", "%s" given',
+                        $attribute->getCode(),
+                        $channelCode
+                    )
+                );
+            }
         }
 
-        if ($attribute->isLocalizable() && null === $this->localeRepository->findOneByIdentifier($localeCode)) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    'A locale must be provided to create a value for the localizable attribute %s',
-                    $attribute->getCode()
-                )
-            );
+        if ($attribute->isLocalizable()) {
+            if (null === $localeCode) {
+                throw new \InvalidArgumentException(
+                    sprintf(
+                        'A locale code must be provided to create a value for the localizable attribute "%s"',
+                        $attribute->getCode()
+                    )
+                );
+
+            }
+            if (!in_array($localeCode, $this->localeRepository->getActivatedLocaleCodes())) {
+                throw new \InvalidArgumentException(
+                    sprintf(
+                        'An activated locale code must be provided to create a value for the localizable attribute "%s", "%s" given',
+                        $attribute->getCode(),
+                        $localeCode
+                    )
+                );
+            }
         }
 
         /** @var ProductValueInterface $value */

--- a/src/Pim/Component/Catalog/spec/Builder/ProductBuilderSpec.php
+++ b/src/Pim/Component/Catalog/spec/Builder/ProductBuilderSpec.php
@@ -64,7 +64,7 @@ class ProductBuilderSpec extends ObjectBehavior
 
         $productValue->getAttribute()->willReturn($skuAttribute);
         $productValue->setEntity(Argument::type(self::PRODUCT_CLASS))->shouldBeCalled();
-        $productValueFactory->createEmpty($skuAttribute, null, null)
+        $productValueFactory->create($skuAttribute, null, null)
             ->willReturn($productValue);
 
         $eventDispatcher->dispatch(ProductEvents::CREATE, Argument::any());
@@ -99,7 +99,7 @@ class ProductBuilderSpec extends ObjectBehavior
         $productValue->setData('mysku')->shouldBeCalled();
         $productValue->setEntity(Argument::type(self::PRODUCT_CLASS))->shouldBeCalled();
         $productValue->getAttribute()->willReturn($skuAttribute);
-        $productValueFactory->createEmpty($skuAttribute, null, null)
+        $productValueFactory->create($skuAttribute, null, null)
             ->willReturn($productValue);
 
         $this->createProduct('mysku', 'tshirt')->shouldReturnAnInstanceOf(self::PRODUCT_CLASS);
@@ -194,7 +194,7 @@ class ProductBuilderSpec extends ObjectBehavior
         $product->addValue(Argument::any())->shouldBeCalledTimes(6);
 
         // Create 6 empty product values and add them to the product
-        $productValueFactory->createEmpty(Argument::cetera())
+        $productValueFactory->create(Argument::cetera())
             ->shouldBeCalledTimes(6)
             ->willReturn(new $valueClass());
         $product->addValue(Argument::any())->shouldBeCalledTimes(6);
@@ -223,7 +223,7 @@ class ProductBuilderSpec extends ObjectBehavior
         $size->isLocalizable()->willReturn(false);
         $size->isScopable()->willReturn(false);
 
-        $productValueFactory->createEmpty($size, null, null)->willReturn(new $valueClass());
+        $productValueFactory->create($size, null, null)->willReturn(new $valueClass());
 
         $product->addValue(Argument::any())->shouldBeCalled();
 

--- a/src/Pim/Component/Catalog/spec/Denormalizer/Standard/ProductValueDenormalizerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Denormalizer/Standard/ProductValueDenormalizerSpec.php
@@ -3,16 +3,20 @@
 namespace spec\Pim\Component\Catalog\Denormalizer\Standard;
 
 use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Factory\ProductValueFactory;
 use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\ProductValueInterface;
 use Prophecy\Argument;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\SerializerInterface;
 
 class ProductValueDenormalizerSpec extends ObjectBehavior
 {
-    function let(SerializerInterface $serializer)
+    const VALUE_CLASS = 'Pim\Component\Catalog\Model\ProductValue';
+
+    function let(SerializerInterface $serializer, ProductValueFactory $productValueFactory)
     {
-        $this->beConstructedWith('Pim\Component\Catalog\Model\ProductValue');
+        $this->beConstructedWith($productValueFactory, self::VALUE_CLASS);
 
         $serializer->implement('Symfony\Component\Serializer\Normalizer\DenormalizerInterface');
         $this->setSerializer($serializer);
@@ -31,16 +35,16 @@ class ProductValueDenormalizerSpec extends ObjectBehavior
 
     function it_supports_denormalization_of_product_values_from_json()
     {
-        $this->supportsDenormalization([], 'Pim\Component\Catalog\Model\ProductValue', 'standard')->shouldReturn(true);
+        $this->supportsDenormalization([], self::VALUE_CLASS, 'standard')->shouldReturn(true);
         $this->supportsDenormalization([], 'Product', 'standard')->shouldReturn(false);
-        $this->supportsDenormalization([], 'Pim\Component\Catalog\Model\ProductValue', 'csv')->shouldReturn(false);
+        $this->supportsDenormalization([], self::VALUE_CLASS, 'csv')->shouldReturn(false);
     }
 
     function it_requires_attribute_to_be_passed_in_the_context()
     {
         $this
             ->shouldThrow(new InvalidArgumentException('Attribute must be passed in the context'))
-            ->duringDenormalize([], 'Pim\Component\Catalog\Model\ProductValue', 'standard', []);
+            ->duringDenormalize([], self::VALUE_CLASS, 'standard', []);
 
         $this
             ->shouldThrow(
@@ -48,33 +52,41 @@ class ProductValueDenormalizerSpec extends ObjectBehavior
                     'Attribute must be an instance of Pim\Component\Catalog\Model\AttributeInterface, string given'
                 )
             )
-            ->duringDenormalize([], 'Pim\Component\Catalog\Model\ProductValue', 'standard', ['attribute' => 'foo']);
+            ->duringDenormalize([], self::VALUE_CLASS, 'standard', ['attribute' => 'foo']);
     }
 
-    function it_denormalizes_json_into_product_values($serializer, AttributeInterface $attribute)
-    {
+    function it_denormalizes_json_into_product_values(
+        $serializer,
+        $productValueFactory,
+        AttributeInterface $attribute,
+        ProductValueInterface $productValue
+    ) {
         $attribute->getAttributeType()->willReturn('pim_catalog_text');
         $attribute->getBackendType()->willReturn('text');
         $attribute->isBackendTypeReferenceData()->willReturn(false);
 
         $serializer
-            ->denormalize(null, 'pim_catalog_text', 'standard', Argument::type('array'))
+            ->denormalize(null, 'pim_catalog_text', 'standard', ['attribute' => $attribute])
             ->shouldBeCalled()
             ->willReturn('foo');
 
-        $value = $this->denormalize(
+        $productValue->setData('foo')->shouldBeCalled();
+        $productValueFactory->createEmpty($attribute, null, null)->willReturn($productValue);
+
+        $this->denormalize(
             [],
-            'Pim\Component\Catalog\Model\ProductValue',
+            self::VALUE_CLASS,
             'standard',
             ['attribute' => $attribute]
         );
-
-        $value->shouldBeAnInstanceOf('Pim\Component\Catalog\Model\ProductValue');
-        $value->getData()->shouldReturn('foo');
     }
 
-    function it_sets_the_locale_and_scope_when_denormalizing_values($serializer, AttributeInterface $attribute)
-    {
+    function it_sets_the_locale_and_scope_when_denormalizing_values(
+        $serializer,
+        $productValueFactory,
+        AttributeInterface $attribute,
+        ProductValueInterface $productValue
+    ) {
         $attribute->getAttributeType()->willReturn('pim_catalog_number');
         $attribute->getBackendType()->willReturn('decimal');
         $attribute->isBackendTypeReferenceData()->willReturn(false);
@@ -86,16 +98,14 @@ class ProductValueDenormalizerSpec extends ObjectBehavior
             ->shouldBeCalled()
             ->willReturn(1);
 
-        $value = $this->denormalize(
+        $productValue->setData(1)->shouldBeCalled();
+        $productValueFactory->createEmpty($attribute, 'ecommerce', 'en_US')->willReturn($productValue);
+
+        $this->denormalize(
             ['data' => 1, 'locale' => 'en_US', 'scope' => 'ecommerce'],
-            'Pim\Component\Catalog\Model\ProductValue',
+            self::VALUE_CLASS,
             'standard',
             ['attribute' => $attribute]
         );
-
-        $value->shouldBeAnInstanceOf('Pim\Component\Catalog\Model\ProductValue');
-        $value->getData()->shouldReturn(1);
-        $value->getLocale()->shouldReturn('en_US');
-        $value->getScope()->shouldReturn('ecommerce');
     }
 }

--- a/src/Pim/Component/Catalog/spec/Denormalizer/Standard/ProductValueDenormalizerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Denormalizer/Standard/ProductValueDenormalizerSpec.php
@@ -71,7 +71,7 @@ class ProductValueDenormalizerSpec extends ObjectBehavior
             ->willReturn('foo');
 
         $productValue->setData('foo')->shouldBeCalled();
-        $productValueFactory->createEmpty($attribute, null, null)->willReturn($productValue);
+        $productValueFactory->create($attribute, null, null)->willReturn($productValue);
 
         $this->denormalize(
             [],
@@ -99,7 +99,7 @@ class ProductValueDenormalizerSpec extends ObjectBehavior
             ->willReturn(1);
 
         $productValue->setData(1)->shouldBeCalled();
-        $productValueFactory->createEmpty($attribute, 'ecommerce', 'en_US')->willReturn($productValue);
+        $productValueFactory->create($attribute, 'ecommerce', 'en_US')->willReturn($productValue);
 
         $this->denormalize(
             ['data' => 1, 'locale' => 'en_US', 'scope' => 'ecommerce'],

--- a/src/Pim/Component/Catalog/spec/Factory/ProductValueFactorySpec.php
+++ b/src/Pim/Component/Catalog/spec/Factory/ProductValueFactorySpec.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace spec\Pim\Component\Catalog\Factory;
+
+use Pim\Component\Catalog\Factory\ProductValueFactory;
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\ChannelInterface;
+use Pim\Component\Catalog\Model\LocaleInterface;
+use Pim\Component\Catalog\Model\ProductValue;
+use Prophecy\Argument;
+
+class ProductValueFactorySpec extends ObjectBehavior
+{
+    function let()
+    {
+        $this->beConstructedWith(ProductValue::class);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(ProductValueFactory::class);
+    }
+
+    function it_creates_a_simple_empty_product_value(
+        AttributeInterface $attribute
+    ) {
+        $attribute->getCode()->willReturn('simple_attribute');
+        $attribute->getBackendType()->willReturn('text');
+        $attribute->isBackendTypeReferenceData()->willReturn(false);
+
+        $productValue = $this->createEmpty(
+            $attribute,
+            null,
+            null
+        );
+        $productValue->shouldReturnAnInstanceOf(ProductValue::class);
+        $productValue->shouldHaveAttribute('simple_attribute');
+        $productValue->shouldNotBeLocalizable();
+        $productValue->shouldNotBeScopable();
+        $productValue->shouldBeEmpty();
+    }
+
+    function it_creates_a_simple_localizable_and_scopable_empty_product_value(
+        AttributeInterface $attribute
+    ) {
+        $attribute->getCode()->willReturn('simple_attribute');
+        $attribute->isScopable()->willReturn(true);
+        $attribute->isLocalizable()->willReturn(true);
+        $attribute->getBackendType()->willReturn('text');
+        $attribute->isBackendTypeReferenceData()->willReturn(false);
+
+        $productValue = $this->createEmpty(
+            $attribute,
+            'ecommerce',
+            'en_US'
+        );
+        $productValue->shouldReturnAnInstanceOf(ProductValue::class);
+        $productValue->shouldHaveAttribute('simple_attribute');
+        $productValue->shouldBeLocalizable();
+        $productValue->shouldHaveLocale('en_US');
+        $productValue->shouldBeScopable();
+        $productValue->shouldHaveChannel('ecommerce');
+        $productValue->shouldBeEmpty();
+    }
+
+    public function getMatchers()
+    {
+        return [
+            'haveAttribute' => function ($subject, $attributeCode) {
+                return $subject->getAttribute()->getCode() === $attributeCode;
+            },
+            'beLocalizable' => function ($subject) {
+                return null !== $subject->getLocale();
+            },
+            'haveLocale' => function ($subject, $localeCode) {
+                return $localeCode === $subject->getLocale();
+            },
+            'beScopable' => function ($subject) {
+                return null !== $subject->getScope();
+            },
+            'haveChannel' => function ($subject, $channelCode) {
+                return $channelCode === $subject->getScope();
+            },
+            'beEmpty' => function ($subject) {
+                return null === $subject->getData();
+            },
+        ];
+    }
+}

--- a/src/Pim/Component/Catalog/spec/Factory/ProductValueFactorySpec.php
+++ b/src/Pim/Component/Catalog/spec/Factory/ProductValueFactorySpec.php
@@ -30,7 +30,7 @@ class ProductValueFactorySpec extends ObjectBehavior
         $attribute->getBackendType()->willReturn('text');
         $attribute->isBackendTypeReferenceData()->willReturn(false);
 
-        $productValue = $this->createEmpty(
+        $productValue = $this->create(
             $attribute,
             null,
             null
@@ -59,7 +59,7 @@ class ProductValueFactorySpec extends ObjectBehavior
         $channelRepository->getChannelCodes()->willReturn(['ecommerce']);
         $localeRepository->getActivatedLocaleCodes()->willReturn(['en_US']);
 
-        $productValue = $this->createEmpty(
+        $productValue = $this->create(
             $attribute,
             'ecommerce',
             'en_US'
@@ -82,7 +82,7 @@ class ProductValueFactorySpec extends ObjectBehavior
         $attribute->isScopable()->willReturn(true);
         $channelRepository->getChannelCodes()->willReturn(['ecommerce', 'mobile']);
 
-        $this->shouldThrow('\InvalidArgumentException')->duringCreateEmpty(
+        $this->shouldThrow('\InvalidArgumentException')->duringCreate(
             $attribute,
             'mail',
             'en_US'
@@ -97,7 +97,7 @@ class ProductValueFactorySpec extends ObjectBehavior
         $attribute->isScopable()->willReturn(true);
         $channelRepository->getChannelCodes()->willReturn(['ecommerce', 'mobile']);
 
-        $this->shouldThrow('\InvalidArgumentException')->duringCreateEmpty(
+        $this->shouldThrow('\InvalidArgumentException')->duringCreate(
             $attribute,
             null,
             'en_US'
@@ -113,7 +113,7 @@ class ProductValueFactorySpec extends ObjectBehavior
         $attribute->isLocalizable()->willReturn(true);
         $localeRepository->getActivatedLocaleCodes()->willReturn(['fr_FR']);
 
-        $this->shouldThrow('\InvalidArgumentException')->duringCreateEmpty(
+        $this->shouldThrow('\InvalidArgumentException')->duringCreate(
             $attribute,
             'mail',
             'en_US'
@@ -129,7 +129,7 @@ class ProductValueFactorySpec extends ObjectBehavior
         $attribute->isLocalizable()->willReturn(true);
         $localeRepository->getActivatedLocaleCodes()->shouldNotBeCalled();
 
-        $this->shouldThrow('\InvalidArgumentException')->duringCreateEmpty(
+        $this->shouldThrow('\InvalidArgumentException')->duringCreate(
             $attribute,
             'mail',
             null


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This PR introduces a ProductValue factory which responsibility is to solely create product values.

~This factory checks for the attribute localizable, scopable properties as well as if the locale we want the product value to be created is activated or if the scope exists.~

This factory relies on the AttributeValidatorHelper in order to check if the product value can be created within the scope and locale requested.

This simplifies our codebase as those checks were made in different layers.

This factory is being injected everywhere product values were created with new ProductValue() (eg, the ProductBuilder).

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | :white_check_mark:
| Added Behats                      | :negative_squared_cross_mark:
| Changelog updated                 | :white_check_mark:
| Review and 2 GTM                  | :white_check_mark:
| Micro Demo to the PO (Story only) | :white_check_mark:
| Migration script                  | :red_circle:
| Tech Doc                          | :negative_squared_cross_mark:


:white_check_mark: Done and pass

:red_circle: Done but fail

:clock1: Done but pending

:negative_squared_cross_mark: Not needed
