### PR TITLE
Use User GroupInterface and not Group entity (decoupling)

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -119,3 +119,4 @@
 - Change route from `pim_user_user_rest_get` to `pim_user_user_rest_get_current`. Route `pim_user_user_rest_get` now fetch a user the given username.
 - Remove classes `Oro\Bundle\UserBundle\Entity\Manager\GroupManager` and `Oro\Bundle\UserBundle\Entity\Manager\RoleManager`
 - Remove services `oro_user.role_manager` and `oro_user.group_manager`
+- Update classes and services to use the interface `Pim\Component\User\Model\GroupInterface`in place of `Oro\Bundle\UserBundle\Entity\Group`

--- a/src/Oro/Bundle/UserBundle/Entity/Repository/GroupRepository.php
+++ b/src/Oro/Bundle/UserBundle/Entity/Repository/GroupRepository.php
@@ -3,17 +3,17 @@ namespace Oro\Bundle\UserBundle\Entity\Repository;
 
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\QueryBuilder;
-use Oro\Bundle\UserBundle\Entity\Group;
+use Pim\Component\User\Model\GroupInterface;
 
 class GroupRepository extends EntityRepository
 {
     /**
      * Get user query builder
      *
-     * @param  Group        $group
+     * @param  GroupInterface $group
      * @return QueryBuilder
      */
-    public function getUserQueryBuilder(Group $group)
+    public function getUserQueryBuilder(GroupInterface $group)
     {
         return $this->_em->createQueryBuilder()
             ->select('u')

--- a/src/Oro/Bundle/UserBundle/Form/Handler/GroupHandler.php
+++ b/src/Oro/Bundle/UserBundle/Form/Handler/GroupHandler.php
@@ -3,8 +3,8 @@
 namespace Oro\Bundle\UserBundle\Form\Handler;
 
 use Doctrine\Common\Persistence\ObjectManager;
-use Oro\Bundle\UserBundle\Entity\Group;
 use Pim\Bundle\UserBundle\Entity\UserInterface;
+use Pim\Component\User\Model\GroupInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -40,10 +40,10 @@ class GroupHandler
     /**
      * Process form
      *
-     * @param  Group $entity
-     * @return bool  True on successfull processing, false otherwise
+     * @param  GroupInterface $entity
+     * @return bool           True on successfull processing, false otherwise
      */
-    public function process(Group $entity)
+    public function process(GroupInterface $entity)
     {
         $this->form->setData($entity);
 
@@ -65,11 +65,11 @@ class GroupHandler
     /**
      * "Success" form handler
      *
-     * @param Group           $entity
+     * @param GroupInterface  $entity
      * @param UserInterface[] $appendUsers
      * @param UserInterface[] $removeUsers
      */
-    protected function onSuccess(Group $entity, array $appendUsers, array $removeUsers)
+    protected function onSuccess(GroupInterface $entity, array $appendUsers, array $removeUsers)
     {
         $this->appendUsers($entity, $appendUsers);
         $this->removeUsers($entity, $removeUsers);
@@ -80,10 +80,10 @@ class GroupHandler
     /**
      * Append users to group
      *
-     * @param Group           $group
+     * @param GroupInterface  $group
      * @param UserInterface[] $users
      */
-    protected function appendUsers(Group $group, array $users)
+    protected function appendUsers(GroupInterface $group, array $users)
     {
         /** @var $user UserInterface */
         foreach ($users as $user) {
@@ -95,10 +95,10 @@ class GroupHandler
     /**
      * Remove users from group
      *
-     * @param Group          $group
+     * @param GroupInterface  $group
      * @param UserInterface[] $users
      */
-    protected function removeUsers(Group $group, array $users)
+    protected function removeUsers(GroupInterface $group, array $users)
     {
         /** @var $user UserInterface */
         foreach ($users as $user) {

--- a/src/Pim/Bundle/UserBundle/Entity/User.php
+++ b/src/Pim/Bundle/UserBundle/Entity/User.php
@@ -6,7 +6,6 @@ use DateTime;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
-use Oro\Bundle\UserBundle\Entity\Group;
 use Oro\Bundle\UserBundle\Entity\Role;
 use Oro\Bundle\UserBundle\Entity\UserApi;
 use Pim\Bundle\CatalogBundle\Entity\Channel;
@@ -15,6 +14,7 @@ use Pim\Bundle\DataGridBundle\Entity\DatagridView;
 use Pim\Component\Catalog\Model\CategoryInterface;
 use Pim\Component\Catalog\Model\ChannelInterface;
 use Pim\Component\Catalog\Model\LocaleInterface;
+use Pim\Component\User\Model\GroupInterface;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 /**
@@ -110,7 +110,7 @@ class User implements UserInterface
     /** @var Role[] */
     protected $roles;
 
-    /** @var Group[] */
+    /** @var GroupInterface[] */
     protected $groups;
 
     /** @var string */
@@ -641,7 +641,7 @@ class User implements UserInterface
     {
         $roles = $this->roles->toArray();
 
-        /** @var Group $group */
+        /** @var GroupInterface $group */
         foreach ($this->getGroups() as $group) {
             $roles = array_merge($roles, $group->getRoles()->toArray());
         }
@@ -790,7 +790,7 @@ class User implements UserInterface
     /**
      * {@inheritdoc}
      */
-    public function addGroup(Group $group)
+    public function addGroup(GroupInterface $group)
     {
         if (!$this->getGroups()->contains($group)) {
             $this->getGroups()->add($group);
@@ -802,7 +802,7 @@ class User implements UserInterface
     /**
      * {@inheritdoc}
      */
-    public function removeGroup(Group $group)
+    public function removeGroup(GroupInterface $group)
     {
         if ($this->getGroups()->contains($group)) {
             $this->getGroups()->removeElement($group);

--- a/src/Pim/Bundle/UserBundle/Entity/UserInterface.php
+++ b/src/Pim/Bundle/UserBundle/Entity/UserInterface.php
@@ -6,13 +6,13 @@ use DateTime;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Oro\Bundle\UserBundle\Entity\EntityUploadedImageInterface;
-use Oro\Bundle\UserBundle\Entity\Group;
 use Oro\Bundle\UserBundle\Entity\Role;
 use Oro\Bundle\UserBundle\Entity\UserApi;
 use Pim\Bundle\DataGridBundle\Entity\DatagridView;
 use Pim\Component\Catalog\Model\CategoryInterface;
 use Pim\Component\Catalog\Model\ChannelInterface;
 use Pim\Component\Catalog\Model\LocaleInterface;
+use Pim\Component\User\Model\GroupInterface;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\Security\Core\User\AdvancedUserInterface;
 
@@ -388,18 +388,18 @@ interface UserInterface extends AdvancedUserInterface, \Serializable, EntityUplo
     public function hasGroup($name);
 
     /**
-     * @param  Group $group
+     * @param  GroupInterface $group
      *
      * @return UserInterface
      */
-    public function addGroup(Group $group);
+    public function addGroup(GroupInterface $group);
 
     /**
-     * @param  Group $group
+     * @param  GroupInterface $group
      *
      * @return UserInterface
      */
-    public function removeGroup(Group $group);
+    public function removeGroup(GroupInterface $group);
 
     /**
      * Get groups ids

--- a/src/Pim/Bundle/UserBundle/EventSubscriber/GroupSubscriber.php
+++ b/src/Pim/Bundle/UserBundle/EventSubscriber/GroupSubscriber.php
@@ -2,9 +2,9 @@
 
 namespace Pim\Bundle\UserBundle\EventSubscriber;
 
-use Oro\Bundle\UserBundle\Entity\Group;
 use Oro\Bundle\UserBundle\OroUserEvents;
 use Pim\Bundle\UserBundle\Entity\User;
+use Pim\Component\User\Model\GroupInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
@@ -57,7 +57,7 @@ class GroupSubscriber implements EventSubscriberInterface
      */
     protected function checkDefaultGroup(GenericEvent $event)
     {
-        /** @var Group $group */
+        /** @var GroupInterface $group */
         $group = $event->getSubject();
 
         if (strtolower(User::GROUP_DEFAULT) === strtolower($group->getName())) {

--- a/src/Pim/Component/User/Updater/GroupUpdater.php
+++ b/src/Pim/Component/User/Updater/GroupUpdater.php
@@ -4,7 +4,7 @@ namespace Pim\Component\User\Updater;
 
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Doctrine\Common\Util\ClassUtils;
-use Oro\Bundle\UserBundle\Entity\Group;
+use Pim\Component\User\Model\GroupInterface;
 
 /**
  * Updates a group
@@ -25,10 +25,10 @@ class GroupUpdater implements ObjectUpdaterInterface
      */
     public function update($group, array $data, array $options = [])
     {
-        if (!$group instanceof Group) {
+        if (!$group instanceof GroupInterface) {
             throw new \InvalidArgumentException(
                 sprintf(
-                    'Expects a "Oro\Bundle\UserBundle\Entity\Group", "%s" provided.',
+                    'Expects a "Pim\Component\User\Model\GroupInterface", "%s" provided.',
                     ClassUtils::getClass($group)
                 )
             );
@@ -42,13 +42,13 @@ class GroupUpdater implements ObjectUpdaterInterface
     }
 
     /**
-     * @param Group $group
-     * @param string        $field
-     * @param mixed         $data
+     * @param GroupInterface $group
+     * @param string         $field
+     * @param mixed          $data
      *
      * @throws \InvalidArgumentException
      */
-    protected function setData(Group $group, $field, $data)
+    protected function setData(GroupInterface $group, $field, $data)
     {
         switch ($field) {
             case 'name':

--- a/src/Pim/Component/User/Updater/UserUpdater.php
+++ b/src/Pim/Component/User/Updater/UserUpdater.php
@@ -6,13 +6,13 @@ use Akeneo\Component\Classification\Model\CategoryInterface;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Doctrine\Common\Util\ClassUtils;
-use Oro\Bundle\UserBundle\Entity\Group;
 use Oro\Bundle\UserBundle\Entity\Role;
 use Oro\Bundle\UserBundle\Entity\UserApi;
 use Oro\Bundle\UserBundle\Entity\UserManager;
 use Pim\Bundle\UserBundle\Entity\UserInterface;
 use Pim\Component\Catalog\Model\ChannelInterface;
 use Pim\Component\Catalog\Model\LocaleInterface;
+use Pim\Component\User\Model\GroupInterface;
 
 /**
  * Updates an user
@@ -243,7 +243,7 @@ class UserUpdater implements ObjectUpdaterInterface
     /**
      * @param string $code
      *
-     * @return Group|null
+     * @return GroupInterface|null
      */
     protected function findGroup($code)
     {


### PR DESCRIPTION
[//]: <> (What does this Pull Request do? reference the related issue?)

Most of our business code (components) depends on Oro/UserBundle because using the user Group entity, an interface has been introduced by @aRn0D this PR uses this interface and not the concret entity allowing to decouple all our code from Oro/UserBundle and prepare / allow a future rewriting of this part.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | :negative_squared_cross_mark:
| Added Behats                      | :negative_squared_cross_mark:
| Changelog updated                 | :white_check_mark:
| Review and 2 GTM                  | :clock1:
| Micro Demo to the PO (Story only) |:negative_squared_cross_mark:
| Migration script                  | :negative_squared_cross_mark:
| Tech Doc                          | :negative_squared_cross_mark:


:white_check_mark: Done and pass

:red_circle: Done but fail

:clock1: Done but pending

:negative_squared_cross_mark: Not needed
