### PR TITLE
[AMS-116]Update datagrid creator with username

### DIFF
--- a/src/Pim/Bundle/DataGridBundle/Controller/Rest/DatagridViewController.php
+++ b/src/Pim/Bundle/DataGridBundle/Controller/Rest/DatagridViewController.php
@@ -174,7 +174,7 @@ class DatagridViewController
             $creation = true;
             $datagridView = $this->factory->create();
 
-            $view['owner'] = $this->tokenStorage->getToken()->getUser();
+            $view['owner'] = $this->tokenStorage->getToken()->getUser()->getUsername();
             $view['datagrid_alias'] = $alias;
         }
 

--- a/src/Pim/Bundle/DataGridBundle/Resources/config/updaters.yml
+++ b/src/Pim/Bundle/DataGridBundle/Resources/config/updaters.yml
@@ -4,3 +4,5 @@ parameters:
 services:
     pim_datagrid.updater.datagrid_view:
         class: '%pim_datagrid.updater.datagrid_view.class%'
+        arguments:
+            - '@pim_user.repository.user'

--- a/src/Pim/Bundle/DataGridBundle/Updater/DatagridViewUpdater.php
+++ b/src/Pim/Bundle/DataGridBundle/Updater/DatagridViewUpdater.php
@@ -2,10 +2,11 @@
 
 namespace Pim\Bundle\DataGridBundle\Updater;
 
+use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Doctrine\Common\Util\ClassUtils;
 use Pim\Bundle\DataGridBundle\Entity\DatagridView;
-use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
  * Update the datagrid view properties
@@ -16,6 +17,17 @@ use Symfony\Component\PropertyAccess\PropertyAccess;
  */
 class DatagridViewUpdater implements ObjectUpdaterInterface
 {
+    /** @var IdentifiableObjectRepositoryInterface */
+    protected $userRepository;
+
+    /**
+     * @param IdentifiableObjectRepositoryInterface $userRepository
+     */
+    public function __construct(IdentifiableObjectRepositoryInterface $userRepository)
+    {
+        $this->userRepository = $userRepository;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -52,7 +64,8 @@ class DatagridViewUpdater implements ObjectUpdaterInterface
                 $datagridView->setLabel($value);
                 break;
             case 'owner':
-                $datagridView->setOwner($value);
+                $user = $this->userRepository->findOneByIdentifier($value);
+                $datagridView->setOwner($user);
                 break;
             case 'datagrid_alias':
                 $datagridView->setDatagridAlias($value);

--- a/src/Pim/Bundle/DataGridBundle/spec/Updater/DatagridViewUpdaterSpec.php
+++ b/src/Pim/Bundle/DataGridBundle/spec/Updater/DatagridViewUpdaterSpec.php
@@ -2,14 +2,20 @@
 
 namespace spec\Pim\Bundle\DataGridBundle\Updater;
 
+use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Pim\Bundle\DataGridBundle\Entity\DatagridView;
 use Pim\Bundle\DataGridBundle\Updater\DatagridViewUpdater;
 use PhpSpec\ObjectBehavior;
-use Pim\Bundle\UserBundle\Entity\User;
+use Pim\Bundle\UserBundle\Entity\UserInterface;
 
 class DatagridViewUpdaterSpec extends ObjectBehavior
 {
+    function let(IdentifiableObjectRepositoryInterface $userRepository)
+    {
+        $this->beConstructedWith($userRepository);
+    }
+
     function it_is_initializable()
     {
         $this->shouldHaveType(DatagridViewUpdater::class);
@@ -20,13 +26,15 @@ class DatagridViewUpdaterSpec extends ObjectBehavior
         $this->shouldImplement(ObjectUpdaterInterface::class);
     }
 
-    function it_throws_an_exception_if_the_given_object_is_not_a_datagrid(User $user)
+    function it_throws_an_exception_if_the_given_object_is_not_a_datagrid(UserInterface $user)
     {
         $this->shouldThrow('\InvalidArgumentException')->during('update', [$user, []]);
     }
 
-    function it_updates_the_data_grid_property(DatagridView $datagridView, User $user)
+    function it_updates_the_data_grid_property($userRepository, DatagridView $datagridView, UserInterface $user)
     {
+        $userRepository->findOneByIdentifier('julia')->willreturn($user);
+
         $datagridView->setLabel('My view')->shouldBeCalled();
         $datagridView->setOwner($user)->shouldBeCalled();
         $datagridView->setType(DatagridView::TYPE_PUBLIC)->shouldBeCalled();
@@ -35,7 +43,7 @@ class DatagridViewUpdaterSpec extends ObjectBehavior
         $datagridView->setFilters('my filter as string')->shouldBeCalled();
 
         $this->update($datagridView, [
-            'owner' => $user,
+            'owner' => 'julia',
             'type' => DatagridView::TYPE_PUBLIC,
             'datagrid_alias' => 'product-grid',
             'label' => 'My view',


### PR DESCRIPTION
`DatagridViewUpdater` can update the datagrid's owner with its username or an user object. 

Related to https://github.com/akeneo/pim-enterprise-dev/pull/2356

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | :white_check_mark:
| Added Behats                      | :negative_squared_cross_mark: 
| Changelog updated                 | :negative_squared_cross_mark:
| Review and 2 GTM                  | :clock1:
| Micro Demo to the PO (Story only) | :negative_squared_cross_mark: 
| Migration script                  | :negative_squared_cross_mark: 
| Tech Doc                          | :negative_squared_cross_mark: 


:white_check_mark: Done and pass

:red_circle: Done but fail

:clock1: Done but pending

:negative_squared_cross_mark: Not needed
