### PR TITLE
API-19: add a business exception in updaters for non existent fields

### DIFF
--- a/features/import/attribute/import_attributes.feature
+++ b/features/import/attribute/import_attributes.feature
@@ -136,7 +136,7 @@ Feature: Import attributes
     And I launch the import job
     And I wait for the "csv_footwear_attribute_import" job to finish
     Then I should see "skipped 1"
-    And I should see "attributeType must be filled."
+    And I should see "Property \"attribute_type\" expects a not empty value (for updater attribute)."
 
   Scenario: Successfully import and update existing attribute
     Given the "footwear" catalog configuration
@@ -172,7 +172,7 @@ Feature: Import attributes
     And I wait for the "csv_footwear_attribute_import" job to finish
     Then I should see "read lines 1"
     Then I should see "skipped 1"
-    Then I should see "Attribute expects a string with the format \"yyyy-mm-dd\" as data, \"2000/12/12\" given"
+    Then I should see "Property \"date_min\" expects a string with the format \"yyyy-mm-dd\" as data, \"2000/12/12\" given (for updater attribute)."
 
   Scenario: Fail to import attribute with invalid date
     Given the "footwear" catalog configuration
@@ -189,7 +189,7 @@ Feature: Import attributes
     And I wait for the "csv_footwear_attribute_import" job to finish
     Then I should see "read lines 1"
     Then I should see "skipped 1"
-    Then I should see "Invalid date, \"2000-99-12\" given"
+    Then I should see "Property \"date_min\" expects a string with the format \"yyyy-mm-dd\" as data, \"2000-99-12\" given (for updater attribute)."
 
   Scenario: Fail to import attribute with invalid data
     Given the "footwear" catalog configuration
@@ -208,7 +208,7 @@ Feature: Import attributes
     Then I should see "read lines 2"
     Then I should see "skipped 2"
     Then I should see "maxFileSize: This value should be a valid number.: not an int"
-    Then I should see "AttributeGroup \"not a group\" does not exist"
+    Then I should see "Property \"group\" expects a valid code. The attribute group does not exist, \"not a group\" given (for updater attribute)."
 
   Scenario: Successfully import new attribute
     Given the "footwear" catalog configuration

--- a/features/import/import_categories.feature
+++ b/features/import/import_categories.feature
@@ -47,8 +47,8 @@ Feature: Import categories
     When I am on the "csv_footwear_category_import" import job page
     And I launch the import job
     And I wait for the "csv_footwear_category_import" job to finish
-    Then I should see "The parent category \"clothes\" does not exist"
-    And I should see "The parent category \"clothes\" does not exist"
+    Then I should see "Property \"parent\" expects a valid category code. The category does not exist, \"clothes\" given (for updater category)."
+    And I should see "Property \"parent\" expects a valid category code. The category does not exist, \"tshirts\" given (for updater category)."
     And there should be the following categories:
       | code        | label       | parent    |
       | computers   | Computers   |           |

--- a/features/import/import_options.feature
+++ b/features/import/import_options.feature
@@ -67,7 +67,7 @@ Feature: Import options
     And I launch the import job
     And I wait for the "csv_footwear_option_import" job to finish
     Then I should see "skipped 1"
-    And I should see "Attribute \"unknown\" does not exist"
+    And I should see "Property \"attribute\" expects a valid attribute code. The attribute does not exist, \"unknown\" given (for updater attribute option)."
 
   @jira https://akeneo.atlassian.net/browse/PIM-3820
   Scenario: Import options with localizable label

--- a/features/import/product_group/import_groups.feature
+++ b/features/import/product_group/import_groups.feature
@@ -90,7 +90,7 @@ Feature: Import groups
     And I wait for the "csv_footwear_group_import" job to finish
     Then I should see "read lines 1"
     And I should see "skipped 1"
-    And I should see "Cannot process variant group \"New_VG\", only groups are accepted"
+    And I should see "Property \"type\" expects a valid group type. Cannot process variant group, only groups are accepted, \"New_VG\" given (for updater group)"
 
   Scenario: Skip the line if we encounter an existing variant group
     Given the following CSV file to import:
@@ -105,7 +105,7 @@ Feature: Import groups
     And I wait for the "csv_footwear_group_import" job to finish
     Then I should see "read lines 1"
     And I should see "skipped 1"
-    And I should see "Cannot process variant group \"AKENEO_TSHIRT\", only groups are accepted"
+    And I should see "Property \"type\" expects a valid group type. Cannot process variant group, only groups are accepted, \"AKENEO_TSHIRT\" given (for updater group)"
 
   Scenario: Skip the line if we try to set axis on a standard group
     Given the following CSV file to import:

--- a/features/import/product_group/xlsx/import_groups.feature
+++ b/features/import/product_group/xlsx/import_groups.feature
@@ -89,7 +89,7 @@ Feature: Import Xlsx groups
     And I wait for the "xlsx_footwear_group_import" job to finish
     Then I should see "read lines 1"
     And I should see "skipped 1"
-    And I should see "Cannot process variant group \"New_VG\", only groups are accepted"
+    And I should see "Property \"type\" expects a valid group type. Cannot process variant group, only groups are accepted, \"New_VG\" given (for updater group)"
 
   Scenario: Skip the line if we encounter an existing variant group
     Given the following XLSX file to import:
@@ -104,7 +104,7 @@ Feature: Import Xlsx groups
     And I wait for the "xlsx_footwear_group_import" job to finish
     Then I should see "read lines 1"
     And I should see "skipped 1"
-    And I should see "Cannot process variant group \"AKENEO_TSHIRT\", only groups are accepted"
+    And I should see "Property \"type\" expects a valid group type. Cannot process variant group, only groups are accepted, \"AKENEO_TSHIRT\" given (for updater group)."
 
   Scenario: Skip the line if we try to set axis on a standard group
     Given the following XLSX file to import:

--- a/features/import/product_variant_group/import_variant_group_with_invalid_properties.feature
+++ b/features/import/product_variant_group/import_variant_group_with_invalid_properties.feature
@@ -40,7 +40,7 @@ Feature: Execute an import with invalid properties
     When I am on the "csv_footwear_variant_group_import" import job page
     And I launch the import job
     And I wait for the "csv_footwear_variant_group_import" job to finish
-    Then I should see "Attributes: This property cannot be changed."
+    Then I should see "Property \"axes\" could not be modified, \"manufacturer,size\" given (for updater variant group)."
     And I should see "read lines 1"
     And I should see "Skipped 1"
     And there should be the following groups:
@@ -59,7 +59,7 @@ Feature: Execute an import with invalid properties
     When I am on the "csv_footwear_variant_group_import" import job page
     And I launch the import job
     And I wait for the "csv_footwear_variant_group_import" job to finish
-    Then I should see "Attributes: This property cannot be changed."
+    Then I should see "Property \"axes\" could not be modified, \"color\" given (for updater variant group)."
     And I should see "read lines 1"
     And I should see "Skipped 1"
     And there should be the following groups:

--- a/src/Akeneo/Component/Batch/Updater/JobInstanceUpdater.php
+++ b/src/Akeneo/Component/Batch/Updater/JobInstanceUpdater.php
@@ -6,6 +6,7 @@ use Akeneo\Component\Batch\Job\JobParameters;
 use Akeneo\Component\Batch\Job\JobParametersFactory;
 use Akeneo\Component\Batch\Job\JobRegistry;
 use Akeneo\Component\Batch\Model\JobInstance;
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Doctrine\Common\Util\ClassUtils;
 
@@ -42,11 +43,9 @@ class JobInstanceUpdater implements ObjectUpdaterInterface
     public function update($jobInstance, array $data, array $options = [])
     {
         if (!$jobInstance instanceof JobInstance) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    'Expects a "Akeneo\Component\Batch\Model\JobInstance", "%s" provided.',
-                    ClassUtils::getClass($jobInstance)
-                )
+            throw InvalidObjectException::objectExpected(
+                ClassUtils::getClass($jobInstance),
+                'Akeneo\Component\Batch\Model\JobInstance'
             );
         }
 

--- a/src/Akeneo/Component/Batch/spec/Updater/JobInstanceUpdaterSpec.php
+++ b/src/Akeneo/Component/Batch/spec/Updater/JobInstanceUpdaterSpec.php
@@ -7,6 +7,7 @@ use Akeneo\Component\Batch\Job\JobParameters;
 use Akeneo\Component\Batch\Job\JobParametersFactory;
 use Akeneo\Component\Batch\Job\JobRegistry;
 use Akeneo\Component\Batch\Model\JobInstance;
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
@@ -62,6 +63,11 @@ class JobInstanceUpdaterSpec extends ObjectBehavior
 
     function it_throw_an_exception_id_it_is_not_a_job_instance()
     {
-        $this->shouldThrow('\InvalidArgumentException')->during('update', [new \stdClass(), []]);
+        $this->shouldThrow(
+            InvalidObjectException::objectExpected(
+                'stdClass',
+                'Akeneo\Component\Batch\Model\JobInstance'
+            )
+        )->during('update', [new \stdClass(), []]);
     }
 }

--- a/src/Akeneo/Component/Classification/spec/Updater/CategoryUpdaterSpec.php
+++ b/src/Akeneo/Component/Classification/spec/Updater/CategoryUpdaterSpec.php
@@ -2,11 +2,12 @@
 
 namespace spec\Akeneo\Component\Classification\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
+use Akeneo\Component\StorageUtils\Exception\UnknownPropertyException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use PhpSpec\ObjectBehavior;
 use Pim\Bundle\CatalogBundle\Entity\CategoryTranslation;
 use Akeneo\Component\Classification\Model\CategoryInterface;
-use Prophecy\Argument;
 
 class CategoryUpdaterSpec extends ObjectBehavior
 {
@@ -28,8 +29,9 @@ class CategoryUpdaterSpec extends ObjectBehavior
     function it_throws_an_exception_when_trying_to_update_anything_else_than_a_category()
     {
         $this->shouldThrow(
-            new \InvalidArgumentException(
-                'Expects a "Akeneo\Component\Classification\Model\CategoryInterface", "stdClass" provided.'
+            InvalidObjectException::objectExpected(
+                'stdClass',
+                'Akeneo\Component\Classification\Model\CategoryInterface'
             )
         )->during(
             'update',
@@ -54,5 +56,17 @@ class CategoryUpdaterSpec extends ObjectBehavior
         ];
 
         $this->update($category, $values, []);
+    }
+
+    function it_throws_an_exception_when_trying_to_update_a_non_existent_field(CategoryInterface $category) {
+        $values = [
+            'non_existent_field' => 'field',
+            'code'               => 'mycode',
+            'parent'             => 'master',
+        ];
+
+        $this
+            ->shouldThrow(new UnknownPropertyException('non_existent_field'))
+            ->during('update', [$category, $values, []]);
     }
 }

--- a/src/Akeneo/Component/StorageUtils/Exception/ImmutablePropertyException.php
+++ b/src/Akeneo/Component/StorageUtils/Exception/ImmutablePropertyException.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Akeneo\Component\StorageUtils\Exception;
+
+/**
+ * Immutable property exception the updater can throw when updating a property which can't be modified.
+ *
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ImmutablePropertyException extends ObjectUpdaterException
+{
+    /** @var string */
+    protected $propertyName;
+
+    /** @var string */
+    protected $propertyValue;
+
+    /**
+     * @param string          $propertyName
+     * @param string          $propertyValue
+     * @param string          $message
+     * @param \Exception|null $previous
+     * @param int             $code
+     */
+    public function __construct($propertyName, $propertyValue, $message = '', $code = 0, \Exception $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+        $this->propertyName = $propertyName;
+    }
+
+    /**
+     * @param $propertyName
+     * @param $propertyValue
+     * @param $action
+     * @param $type
+     *
+     * @return ImmutablePropertyException
+     */
+    public static function immutableProperty($propertyName, $propertyValue, $action, $type)
+    {
+        return new self(
+            $propertyName,
+            $propertyValue,
+            sprintf(
+                'Property "%s" could not be modified, "%s" given (for %s %s).',
+                $propertyName,
+                $propertyValue,
+                $action,
+                $type
+            )
+        );
+    }
+
+    /**
+     * @return string
+     */
+    public function getPropertyName()
+    {
+        return $this->propertyName;
+    }
+}

--- a/src/Akeneo/Component/StorageUtils/Exception/InvalidObjectException.php
+++ b/src/Akeneo/Component/StorageUtils/Exception/InvalidObjectException.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Akeneo\Component\StorageUtils\Exception;
+
+/**
+ * Invalid object exception the updater can throw when updating
+ * an object which could not be handle by the updater.
+ *
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class InvalidObjectException extends ObjectUpdaterException
+{
+    /* @var string */
+    protected $objectClassName;
+
+    /* @var string */
+    protected $expectedClassName;
+
+    /**
+     * @param string     $objectClassName
+     * @param int        $expectedClassName
+     * @param string     $message
+     * @param int        $code
+     * @param \Exception $previous
+     */
+    public function __construct($objectClassName, $expectedClassName, $message = '', $code = 0, \Exception $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+        $this->objectClassName   = $objectClassName;
+        $this->expectedClassName = $expectedClassName;
+    }
+
+    /**
+     * @param $objectClassName
+     * @param $expectedClassName
+     *
+     * @return InvalidObjectException
+     */
+    public static function objectExpected($objectClassName, $expectedClassName)
+    {
+        return new self(
+            $objectClassName,
+            $expectedClassName,
+            sprintf(
+                'Expects a "%s", "%s" provided.',
+                $expectedClassName,
+                $objectClassName
+            )
+        );
+    }
+
+    /**
+     * @return string
+     */
+    public function getObjectClassName()
+    {
+        return $this->objectClassName;
+    }
+
+    /**
+     * @return string
+     */
+    public function getExpectedClassName()
+    {
+        return $this->expectedClassName;
+    }
+}

--- a/src/Akeneo/Component/StorageUtils/Exception/InvalidPropertyException.php
+++ b/src/Akeneo/Component/StorageUtils/Exception/InvalidPropertyException.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace Akeneo\Component\StorageUtils\Exception;
+
+/**
+ *
+ * Invalid property exception the updater can throw when updating a property which is invalid.
+ *
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class InvalidPropertyException extends ObjectUpdaterException
+{
+    const EXPECTED_CODE = 100;
+    const DATE_EXPECTED_CODE = 101;
+    const BOOLEAN_EXPECTED_CODE = 102;
+    const FLOAT_EXPECTED_CODE = 103;
+    const INTEGER_EXPECTED_CODE = 104;
+    const NUMERIC_EXPECTED_CODE = 105;
+    const STRING_EXPECTED_CODE = 106;
+    const ARRAY_EXPECTED_CODE = 108;
+    const ARRAY_OF_ARRAYS_EXPECTED_CODE = 109;
+
+    const NOT_EMPTY_VALUE_EXPECTED_CODE = 200;
+
+    const VALID_ENTITY_CODE_EXPECTED_CODE = 300;
+    const VALID_GROUP_TYPE_EXPECTED_CODE = 301;
+
+    /** @var string */
+    protected $propertyName;
+
+    /** @var string */
+    protected $propertyValue;
+
+    /**
+     * @param string          $propertyName
+     * @param int             $propertyValue
+     * @param string          $message
+     * @param int             $code
+     * @param \Exception|null $previous
+     */
+    public function __construct($propertyName, $propertyValue, $message = '', $code = 0, \Exception $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+        $this->propertyName  = $propertyName;
+        $this->propertyValue = $propertyValue;
+    }
+
+    /**
+     * Build an exception when the data is empty.
+     *
+     * @param $propertyName
+     * @param $action
+     * @param $type
+     *
+     * @return InvalidPropertyException
+     */
+    public static function valueNotEmptyExpected($propertyName, $action, $type)
+    {
+        $err = 'Property "%s" expects a not empty value (for %s %s).';
+
+        return new self(
+            $propertyName,
+            null,
+            sprintf($err, $propertyName, $action, $type),
+            self::NOT_EMPTY_VALUE_EXPECTED_CODE
+        );
+    }
+
+    /**
+     * Build an exception when the data is an invalid entity code.
+     *
+     * @param $propertyName
+     * @param $key
+     * @param $because
+     * @param $action
+     * @param $type
+     * @param $propertyValue
+     *
+     * @return InvalidPropertyException
+     */
+    public static function validEntityCodeExpected($propertyName, $key, $because, $action, $type, $propertyValue)
+    {
+        $err = 'Property "%s" expects a valid %s. %s, "%s" given (for %s %s).';
+
+        return new self(
+            $propertyName,
+            $propertyValue,
+            sprintf($err, $propertyName, $key, $because, $propertyValue, $action, $type),
+            self::VALID_ENTITY_CODE_EXPECTED_CODE
+        );
+    }
+
+    /**
+     * Build an exception when the date is invalid.
+     *
+     * @param $propertyName
+     * @param $format
+     * @param $action
+     * @param $type
+     * @param $propertyValue
+     *
+     * @return InvalidPropertyException
+     */
+    public static function dateExpected($propertyName, $format, $action, $type, $propertyValue)
+    {
+        $err = 'Property "%s" expects a string with the format "%s" as data, "%s" given (for %s %s).';
+
+        return new self(
+            $propertyName,
+            $propertyValue,
+            sprintf($err, $propertyName, $format, $propertyValue, $action, $type),
+            self::DATE_EXPECTED_CODE
+        );
+    }
+
+    /**
+     * Build an exception when the group type is invalid or is not allowed.
+     *
+     * @param $propertyName
+     * @param $because
+     * @param $action
+     * @param $type
+     * @param $propertyValue
+     *
+     * @return InvalidPropertyException
+     */
+    public static function validGroupTypeExpected($propertyName, $because, $action, $type, $propertyValue)
+    {
+        $err = 'Property "%s" expects a valid group type. %s, "%s" given (for %s %s).';
+
+        return new self(
+            $propertyName,
+            $propertyValue,
+            sprintf($err, $propertyName, $because, $propertyValue, $action, $type),
+            self::VALID_GROUP_TYPE_EXPECTED_CODE
+        );
+    }
+}

--- a/src/Akeneo/Component/StorageUtils/Exception/ObjectUpdaterException.php
+++ b/src/Akeneo/Component/StorageUtils/Exception/ObjectUpdaterException.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Akeneo\Component\StorageUtils\Exception;
+
+/**
+ * Object updater exception the updater can throw when performing an action.
+ *
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ObjectUpdaterException extends \LogicException
+{
+}

--- a/src/Akeneo/Component/StorageUtils/Exception/UnknownPropertyException.php
+++ b/src/Akeneo/Component/StorageUtils/Exception/UnknownPropertyException.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Akeneo\Component\StorageUtils\Exception;
+
+/**
+ * Unknown property exception the updater can throw when updating value on an unknown property.
+ *
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class UnknownPropertyException extends ObjectUpdaterException
+{
+    /** @var string */
+    protected $propertyName;
+
+    /**
+     * @param string          $propertyName
+     * @param string          $message
+     * @param \Exception|null $previous
+     * @param int             $code
+     */
+    public function __construct($propertyName, $message = '', $code = 0, \Exception $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+        $this->propertyName = $propertyName;
+    }
+
+    /**
+     * @param string $propertyName
+     * @param string $previous
+     *
+     * @return UnknownPropertyException
+     */
+    public static function unknownProperty($propertyName, $previous)
+    {
+        return new self(
+            $propertyName,
+            sprintf(
+                'Property "%s" does not exist.',
+                $propertyName
+            ),
+            0,
+            $previous
+        );
+    }
+
+    /**
+     * @return string
+     */
+    public function getPropertyName()
+    {
+        return $this->propertyName;
+    }
+}

--- a/src/Akeneo/Component/StorageUtils/Updater/ObjectUpdaterInterface.php
+++ b/src/Akeneo/Component/StorageUtils/Updater/ObjectUpdaterInterface.php
@@ -2,6 +2,8 @@
 
 namespace Akeneo\Component\StorageUtils\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\ObjectUpdaterException;
+
 /**
  * Updates an object with a set of data
  *
@@ -18,7 +20,7 @@ interface ObjectUpdaterInterface
      * @param array  $data    The data to update
      * @param array  $options The options to use
      *
-     * @throws \InvalidArgumentException
+     * @throws ObjectUpdaterException
      *
      * @return ObjectUpdaterInterface
      */

--- a/src/Pim/Bundle/DataGridBundle/Updater/DatagridViewUpdater.php
+++ b/src/Pim/Bundle/DataGridBundle/Updater/DatagridViewUpdater.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Bundle\DataGridBundle\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Doctrine\Common\Util\ClassUtils;
 use Pim\Bundle\DataGridBundle\Entity\DatagridView;
@@ -22,12 +23,9 @@ class DatagridViewUpdater implements ObjectUpdaterInterface
     public function update($datagridView, array $data, array $options = [])
     {
         if (!$datagridView instanceof DatagridView) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    'Expects a "%s", "%s" provided.',
-                    DatagridView::class,
-                    ClassUtils::getClass($datagridView)
-                )
+            throw InvalidObjectException::objectExpected(
+                ClassUtils::getClass($datagridView),
+                DatagridView::class
             );
         }
 

--- a/src/Pim/Component/Catalog/Updater/AttributeGroupUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/AttributeGroupUpdater.php
@@ -2,6 +2,8 @@
 
 namespace Pim\Component\Catalog\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Doctrine\Common\Util\ClassUtils;
@@ -54,11 +56,9 @@ class AttributeGroupUpdater implements ObjectUpdaterInterface
     public function update($attributeGroup, array $data, array $options = [])
     {
         if (!$attributeGroup instanceof AttributeGroupInterface) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    'Expects a "Pim\Component\Catalog\Model\AttributeGroupInterface", "%s" provided.',
-                    ClassUtils::getClass($attributeGroup)
-                )
+            throw InvalidObjectException::objectExpected(
+                ClassUtils::getClass($attributeGroup),
+                'Pim\Component\Catalog\Model\AttributeGroupInterface'
             );
         }
 
@@ -74,7 +74,7 @@ class AttributeGroupUpdater implements ObjectUpdaterInterface
      * @param string                  $field
      * @param mixed                   $data
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidPropertyException
      */
     protected function setData($attributeGroup, $field, $data)
     {
@@ -105,6 +105,8 @@ class AttributeGroupUpdater implements ObjectUpdaterInterface
     /**
      * @param AttributeGroupInterface $attributeGroup
      * @param string[]                $data
+     *
+     * @throws InvalidPropertyException
      */
     protected function setAttributes(AttributeGroupInterface $attributeGroup, array $data)
     {
@@ -123,10 +125,14 @@ class AttributeGroupUpdater implements ObjectUpdaterInterface
         foreach ($data as $attributeCode) {
             $attribute = $this->findAttribute($attributeCode);
             if (null === $attribute) {
-                throw new \InvalidArgumentException(sprintf(
-                    'Attribute with "%s" code does not exist',
+                throw InvalidPropertyException::validEntityCodeExpected(
+                    'attributes',
+                    'attribute code',
+                    'The attribute does not exist',
+                    'updater',
+                    'attribute group',
                     $attributeCode
-                ));
+                );
             }
             $attributeGroup->addAttribute($attribute);
         }

--- a/src/Pim/Component/Catalog/Updater/AttributeOptionUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/AttributeOptionUpdater.php
@@ -2,7 +2,10 @@
 
 namespace Pim\Component\Catalog\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
+use Doctrine\Common\Util\ClassUtils;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\AttributeOptionInterface;
 use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
@@ -45,11 +48,9 @@ class AttributeOptionUpdater implements ObjectUpdaterInterface
     public function update($attributeOption, array $data, array $options = [])
     {
         if (!$attributeOption instanceof AttributeOptionInterface) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    'Expects a "Pim\Component\Catalog\Model\AttributeOptionInterface", "%s" provided.',
-                    ClassUtils::getClass($attributeOption)
-                )
+            throw InvalidObjectException::objectExpected(
+                ClassUtils::getClass($attributeOption),
+                'Pim\Component\Catalog\Model\AttributeOptionInterface'
             );
         }
 
@@ -70,7 +71,7 @@ class AttributeOptionUpdater implements ObjectUpdaterInterface
      * @param string                   $field
      * @param mixed                    $data
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidPropertyException
      */
     protected function setData(AttributeOptionInterface $attributeOption, $field, $data)
     {
@@ -83,7 +84,14 @@ class AttributeOptionUpdater implements ObjectUpdaterInterface
             if (null !== $attribute) {
                 $attributeOption->setAttribute($attribute);
             } else {
-                throw new \InvalidArgumentException(sprintf('Attribute "%s" does not exist', $data));
+                throw InvalidPropertyException::validEntityCodeExpected(
+                    'attribute',
+                    'attribute code',
+                    'The attribute does not exist',
+                    'updater',
+                    'attribute option',
+                    $data
+                );
             }
         }
 

--- a/src/Pim/Component/Catalog/Updater/AttributeUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/AttributeUpdater.php
@@ -2,6 +2,9 @@
 
 namespace Pim\Component\Catalog\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\UnknownPropertyException;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Doctrine\Common\Util\ClassUtils;
 use Pim\Component\Catalog\AttributeTypeRegistry;
@@ -9,6 +12,7 @@ use Pim\Component\Catalog\Model\AttributeGroupInterface;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Repository\AttributeGroupRepositoryInterface;
 use Pim\Component\Catalog\Repository\LocaleRepositoryInterface;
+use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 
@@ -55,11 +59,9 @@ class AttributeUpdater implements ObjectUpdaterInterface
     public function update($attribute, array $data, array $options = [])
     {
         if (!$attribute instanceof AttributeInterface) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    'Expects a "Pim\Component\Catalog\Model\AttributeInterface", "%s" provided.',
-                    ClassUtils::getClass($attribute)
-                )
+            throw InvalidObjectException::objectExpected(
+                ClassUtils::getClass($attribute),
+                'Pim\Component\Catalog\Model\AttributeInterface'
             );
         }
 
@@ -75,7 +77,8 @@ class AttributeUpdater implements ObjectUpdaterInterface
      * @param string             $field
      * @param mixed              $data
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidPropertyException
+     * @throws UnknownPropertyException
      */
     protected function setData(AttributeInterface $attribute, $field, $data)
     {
@@ -93,12 +96,12 @@ class AttributeUpdater implements ObjectUpdaterInterface
                 $this->setAvailableLocales($attribute, $field, $data);
                 break;
             case 'date_min':
-                $this->validateDateFormat($data);
+                $this->validateDateFormat('date_min', $data);
                 $date = $this->getDate($data);
                 $attribute->setDateMin($date);
                 break;
             case 'date_max':
-                $this->validateDateFormat($data);
+                $this->validateDateFormat('date_max', $data);
                 $date = $this->getDate($data);
                 $attribute->setDateMax($date);
                 break;
@@ -106,7 +109,7 @@ class AttributeUpdater implements ObjectUpdaterInterface
                 $attribute->setAllowedExtensions(implode(',', $data));
                 break;
             default:
-                $this->accessor->setValue($attribute, $field, $data);
+                $this->setValue($attribute, $field, $data);
         }
     }
 
@@ -120,6 +123,22 @@ class AttributeUpdater implements ObjectUpdaterInterface
         $attributeGroup = $this->attrGroupRepo->findOneByIdentifier($code);
 
         return $attributeGroup;
+    }
+
+    /**
+     * @param $attribute
+     * @param $field
+     * @param $data
+     *
+     * @throws UnknownPropertyException
+     */
+    protected function setValue($attribute, $field, $data)
+    {
+        try {
+            $this->accessor->setValue($attribute, $field, $data);
+        } catch (NoSuchPropertyException $e) {
+            throw UnknownPropertyException::unknownProperty($field, $e);
+        }
     }
 
     /**
@@ -141,6 +160,8 @@ class AttributeUpdater implements ObjectUpdaterInterface
      * @param AttributeInterface $attribute
      * @param string             $field
      * @param array              $availableLocaleCodes
+     *
+     * @throw UnknownPropertyException
      */
     protected function setAvailableLocales(AttributeInterface $attribute, $field, array $availableLocaleCodes)
     {
@@ -152,14 +173,14 @@ class AttributeUpdater implements ObjectUpdaterInterface
             }
         }
 
-        $this->accessor->setValue($attribute, $field, $locales);
+        $this->setValue($attribute, $field, $locales);
     }
 
     /**
      * @param AttributeInterface $attribute
      * @param string             $data
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidPropertyException
      */
     protected function setGroup(AttributeInterface $attribute, $data)
     {
@@ -167,18 +188,31 @@ class AttributeUpdater implements ObjectUpdaterInterface
         if (null !== $attributeGroup) {
             $attribute->setGroup($attributeGroup);
         } else {
-            throw new \InvalidArgumentException(sprintf('AttributeGroup "%s" does not exist', $data));
+            throw InvalidPropertyException::validEntityCodeExpected(
+                'group',
+                'code',
+                'The attribute group does not exist',
+                'updater',
+                'attribute',
+                $data
+            );
         }
     }
 
     /**
-     * @param AttributeInterface $attribute
-     * @param string|null        $data
+     * @param $attribute
+     * @param $data
+     *
+     * @throws InvalidPropertyException
      */
     protected function setType($attribute, $data)
     {
         if (('' === $data) || (null === $data)) {
-            throw new \InvalidArgumentException('attributeType must be filled.');
+            throw InvalidPropertyException::valueNotEmptyExpected(
+                'attribute_type',
+                'updater',
+                'attribute'
+            );
         }
 
         try {
@@ -187,7 +221,14 @@ class AttributeUpdater implements ObjectUpdaterInterface
             $attribute->setBackendType($attributeType->getBackendType());
             $attribute->setUnique($attributeType->isUnique());
         } catch (\LogicException $exception) {
-            throw new \InvalidArgumentException(sprintf('AttributeType "%s" does not exist.', $data));
+            throw InvalidPropertyException::validEntityCodeExpected(
+                'attribute_type',
+                'attribute type',
+                'The attribute type does not exist',
+                'updater',
+                'attribute',
+                $data
+            );
         }
     }
 
@@ -201,11 +242,12 @@ class AttributeUpdater implements ObjectUpdaterInterface
      * - "2015-45-31"
      * - "not a date"
      *
+     * @param string $field
      * @param string $data
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidPropertyException
      */
-    protected function validateDateFormat($data)
+    protected function validateDateFormat($field, $data)
     {
         if (null === $data) {
             return;
@@ -214,12 +256,22 @@ class AttributeUpdater implements ObjectUpdaterInterface
         try {
             new \DateTime($data);
         } catch (\Exception $e) {
-            throw new \InvalidArgumentException(sprintf('Invalid date, "%s" given', $data), 0, $e);
+            throw InvalidPropertyException::dateExpected(
+                $field,
+                'yyyy-mm-dd',
+                'updater',
+                'attribute',
+                $data
+            );
         }
 
         if (!preg_match('/^\d{4}-\d{2}-\d{2}/', $data)) {
-            throw new \InvalidArgumentException(
-                sprintf('Attribute expects a string with the format "yyyy-mm-dd" as data, "%s" given', $data)
+            throw InvalidPropertyException::dateExpected(
+                $field,
+                'yyyy-mm-dd',
+                'updater',
+                'attribute',
+                $data
             );
         }
     }

--- a/src/Pim/Component/Catalog/Updater/ChannelUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/ChannelUpdater.php
@@ -2,6 +2,8 @@
 
 namespace Pim\Component\Catalog\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Doctrine\Common\Util\ClassUtils;
@@ -58,11 +60,9 @@ class ChannelUpdater implements ObjectUpdaterInterface
     public function update($channel, array $data, array $options = [])
     {
         if (!$channel instanceof ChannelInterface) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    'Expects a "Pim\Component\Catalog\Model\ChannelInterface", "%s" provided.',
-                    ClassUtils::getClass($channel)
-                )
+            throw InvalidObjectException::objectExpected(
+                ClassUtils::getClass($channel),
+                'Pim\Component\Catalog\Model\ChannelInterface'
             );
         }
 
@@ -78,7 +78,7 @@ class ChannelUpdater implements ObjectUpdaterInterface
      * @param string           $field
      * @param mixed            $data
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidPropertyException
      */
     protected function setData(ChannelInterface $channel, $field, $data)
     {
@@ -107,12 +107,21 @@ class ChannelUpdater implements ObjectUpdaterInterface
     /**
      * @param ChannelInterface $channel
      * @param string           $treeCode
+     *
+     * @throws InvalidPropertyException
      */
     protected function setCategoryTree(ChannelInterface $channel, $treeCode)
     {
         $category = $this->categoryRepository->findOneByIdentifier($treeCode);
         if (null === $category) {
-            throw new \InvalidArgumentException(sprintf('Category with "%s" code does not exist', $treeCode));
+            throw InvalidPropertyException::validEntityCodeExpected(
+                'category_tree',
+                'code',
+                'The category does not exist',
+                'updater',
+                'channel',
+                $treeCode
+            );
         }
         $channel->setCategory($category);
     }
@@ -120,6 +129,8 @@ class ChannelUpdater implements ObjectUpdaterInterface
     /**
      * @param ChannelInterface $channel
      * @param array            $currencyCodes
+     *
+     * @throws InvalidPropertyException
      */
     protected function setCurrencies(ChannelInterface $channel, array $currencyCodes)
     {
@@ -127,7 +138,14 @@ class ChannelUpdater implements ObjectUpdaterInterface
         foreach ($currencyCodes as $currencyCode) {
             $currency = $this->currencyRepository->findOneByIdentifier($currencyCode);
             if (null === $currency) {
-                throw new \InvalidArgumentException(sprintf('Currency with "%s" code does not exist', $currencyCode));
+                throw InvalidPropertyException::validEntityCodeExpected(
+                    'currencies',
+                    'code',
+                    'The currency does not exist',
+                    'updater',
+                    'channel',
+                    $currencyCode
+                );
             }
 
             $currencies[] = $currency;
@@ -139,6 +157,8 @@ class ChannelUpdater implements ObjectUpdaterInterface
     /**
      * @param ChannelInterface $channel
      * @param array            $localeCodes
+     *
+     * @throws InvalidPropertyException
      */
     protected function setLocales(ChannelInterface $channel, array $localeCodes)
     {
@@ -146,7 +166,14 @@ class ChannelUpdater implements ObjectUpdaterInterface
         foreach ($localeCodes as $localeCode) {
             $locale = $this->localeRepository->findOneByIdentifier($localeCode);
             if (null === $locale) {
-                throw new \InvalidArgumentException(sprintf('Locale with "%s" code does not exist', $localeCode));
+                throw InvalidPropertyException::validEntityCodeExpected(
+                    'locales',
+                    'code',
+                    'The locale does not exist',
+                    'updater',
+                    'channel',
+                    $localeCode
+                );
             }
 
             $locales[] = $locale;

--- a/src/Pim/Component/Catalog/Updater/CurrencyUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/CurrencyUpdater.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Component\Catalog\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Doctrine\Common\Util\ClassUtils;
 use Pim\Component\Catalog\Model\CurrencyInterface;
@@ -27,11 +28,9 @@ class CurrencyUpdater implements ObjectUpdaterInterface
     public function update($currency, array $data, array $options = [])
     {
         if (!$currency instanceof CurrencyInterface) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    'Expects a "Pim\Component\Catalog\Model\CurrencyInterface", "%s" provided.',
-                    ClassUtils::getClass($currency)
-                )
+            throw InvalidObjectException::objectExpected(
+                ClassUtils::getClass($currency),
+                'Pim\Component\Catalog\Model\CurrencyInterface'
             );
         }
 

--- a/src/Pim/Component/Catalog/Updater/GroupTypeUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/GroupTypeUpdater.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Component\Catalog\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Doctrine\Common\Util\ClassUtils;
 use Pim\Component\Catalog\Model\GroupTypeInterface;
@@ -31,11 +32,9 @@ class GroupTypeUpdater implements ObjectUpdaterInterface
     public function update($groupType, array $data, array $options = [])
     {
         if (!$groupType instanceof GroupTypeInterface) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    'Expects a "Pim\Component\Catalog\Model\GroupTypeInterface", "%s" provided.',
-                    ClassUtils::getClass($groupType)
-                )
+            throw InvalidObjectException::objectExpected(
+                ClassUtils::getClass($groupType),
+                'Pim\Component\Catalog\Model\GroupTypeInterface'
             );
         }
 

--- a/src/Pim/Component/Catalog/Updater/GroupUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/GroupUpdater.php
@@ -2,6 +2,8 @@
 
 namespace Pim\Component\Catalog\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Doctrine\Common\Util\ClassUtils;
 use Pim\Component\Catalog\Model\GroupInterface;
@@ -58,11 +60,9 @@ class GroupUpdater implements ObjectUpdaterInterface
     public function update($group, array $data, array $options = [])
     {
         if (!$group instanceof GroupInterface) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    'Expects a "Pim\Component\Catalog\Model\GroupInterface", "%s" provided.',
-                    ClassUtils::getClass($group)
-                )
+            throw InvalidObjectException::objectExpected(
+                ClassUtils::getClass($group),
+                'Pim\Component\Catalog\Model\GroupInterface'
             );
         }
 
@@ -77,6 +77,8 @@ class GroupUpdater implements ObjectUpdaterInterface
      * @param GroupInterface $group
      * @param string         $field
      * @param mixed          $data
+     *
+     * @throws InvalidPropertyException
      */
     protected function setData(GroupInterface $group, $field, $data)
     {
@@ -112,21 +114,31 @@ class GroupUpdater implements ObjectUpdaterInterface
      * @param GroupInterface $group
      * @param string         $type
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidPropertyException
      */
     protected function setType(GroupInterface $group, $type)
     {
         $groupType = $this->groupTypeRepository->findOneByIdentifier($type);
 
         if (null === $groupType) {
-            throw new \InvalidArgumentException(sprintf('Type "%s" does not exist', $type));
+            throw InvalidPropertyException::validEntityCodeExpected(
+                'type',
+                'group type',
+                'The group type does not exist',
+                'updater',
+                'group',
+                $type
+            );
         }
 
         if ($groupType->isVariant()) {
-            throw new \InvalidArgumentException(sprintf(
-                'Cannot process variant group "%s", only groups are accepted',
-                $group->getCode()
-            ));
+            throw InvalidPropertyException::validGroupTypeExpected(
+                'type',
+                'Cannot process variant group, only groups are accepted',
+                'updater',
+                'group',
+                $type
+            );
         }
 
         $group->setType($groupType);
@@ -149,7 +161,7 @@ class GroupUpdater implements ObjectUpdaterInterface
      * @param GroupInterface $group
      * @param string[]       $attributeCodes
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidPropertyException
      */
     protected function setAxis(GroupInterface $group, array $attributeCodes)
     {
@@ -157,7 +169,14 @@ class GroupUpdater implements ObjectUpdaterInterface
         foreach ($attributeCodes as $attributeCode) {
             $attribute = $this->attributeRepository->findOneByIdentifier($attributeCode);
             if (null === $attribute) {
-                throw new \InvalidArgumentException(sprintf('Attribute "%s" does not exist', $attributeCode));
+                throw InvalidPropertyException::validEntityCodeExpected(
+                    'axis',
+                    'attribute code',
+                    'The attribute does not exist',
+                    'updater',
+                    'group',
+                    $attributeCode
+                );
             }
             $attributes[] = $attribute;
         }
@@ -166,7 +185,7 @@ class GroupUpdater implements ObjectUpdaterInterface
 
     /**
      * @param GroupInterface $group
-     * @param array          $labels
+     * @param array          $productIds
      */
     protected function setProducts(GroupInterface $group, array $productIds)
     {

--- a/src/Pim/Component/Catalog/Updater/LocaleUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/LocaleUpdater.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Component\Catalog\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Doctrine\Common\Util\ClassUtils;
 use Pim\Component\Catalog\Model\LocaleInterface;
@@ -26,11 +27,9 @@ class LocaleUpdater implements ObjectUpdaterInterface
     public function update($locale, array $data, array $options = [])
     {
         if (!$locale instanceof LocaleInterface) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    'Expects a "Pim\Component\Catalog\Model\LocaleInterface", "%s" provided.',
-                    ClassUtils::getClass($locale)
-                )
+            throw InvalidObjectException::objectExpected(
+                ClassUtils::getClass($locale),
+                'Pim\Component\Catalog\Model\LocaleInterface'
             );
         }
 
@@ -45,8 +44,6 @@ class LocaleUpdater implements ObjectUpdaterInterface
      * @param LocaleInterface $locale
      * @param string          $field
      * @param mixed           $data
-     *
-     * @throws \InvalidArgumentException
      */
     protected function setData(LocaleInterface $locale, $field, $data)
     {

--- a/src/Pim/Component/Catalog/Updater/ProductUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/ProductUpdater.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Component\Catalog\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Akeneo\Component\StorageUtils\Updater\PropertySetterInterface;
 use Doctrine\Common\Util\ClassUtils;
@@ -112,11 +113,9 @@ class ProductUpdater implements ObjectUpdaterInterface
     public function update($product, array $data, array $options = [])
     {
         if (!$product instanceof ProductInterface) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    'Expects a "Pim\Component\Catalog\Model\ProductInterface", "%s" provided.',
-                    ClassUtils::getClass($product)
-                )
+            throw InvalidObjectException::objectExpected(
+                ClassUtils::getClass($product),
+                'Pim\Component\Catalog\Model\ProductInterface'
             );
         }
 

--- a/src/Pim/Component/Catalog/Updater/VariantGroupUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/VariantGroupUpdater.php
@@ -2,6 +2,8 @@
 
 namespace Pim\Component\Catalog\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\ImmutablePropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
@@ -97,11 +99,9 @@ class VariantGroupUpdater implements ObjectUpdaterInterface
     public function update($variantGroup, array $data, array $options = [])
     {
         if (!$variantGroup instanceof GroupInterface) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    'Expects a "Pim\Component\Catalog\Model\GroupInterface", "%s" provided.',
-                    ClassUtils::getClass($variantGroup)
-                )
+            throw InvalidPropertyException::objectExpected(
+                ClassUtils::getClass($variantGroup),
+                'Pim\Component\Catalog\Model\GroupInterface'
             );
         }
 
@@ -117,7 +117,8 @@ class VariantGroupUpdater implements ObjectUpdaterInterface
      * @param string         $field
      * @param mixed          $data
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidPropertyException
+     * @throws ImmutablePropertyException
      */
     protected function setData(GroupInterface $variantGroup, $field, $data)
     {
@@ -161,7 +162,7 @@ class VariantGroupUpdater implements ObjectUpdaterInterface
      * @param GroupInterface $variantGroup
      * @param string         $type
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidPropertyException
      */
     protected function setType(GroupInterface $variantGroup, $type)
     {
@@ -169,15 +170,20 @@ class VariantGroupUpdater implements ObjectUpdaterInterface
         if (null !== $groupType) {
             $variantGroup->setType($groupType);
         } else {
-            throw new \InvalidArgumentException(sprintf('Type "%s" does not exist', $type));
+            throw InvalidPropertyException::validEntityCodeExpected(
+                'type',
+                'group type',
+                'The group type does not exist',
+                'updater',
+                'variant group',
+                $type
+            );
         }
     }
 
     /**
      * @param GroupInterface $variantGroup
      * @param array          $labels
-     *
-     * @throws \InvalidArgumentException
      */
     protected function setLabels(GroupInterface $variantGroup, array $labels)
     {
@@ -192,13 +198,19 @@ class VariantGroupUpdater implements ObjectUpdaterInterface
      * @param GroupInterface $variantGroup
      * @param array          $axes
      *
-     * @throws \InvalidArgumentException
+     * @throws ImmutablePropertyException
+     * @throws InvalidPropertyException
      */
     protected function setAxes(GroupInterface $variantGroup, array $axes)
     {
         if (null !== $variantGroup->getId()) {
             if (array_diff($this->getOriginalAxes($variantGroup->getAxisAttributes()), array_values($axes))) {
-                throw new \InvalidArgumentException('Attributes: This property cannot be changed.');
+                throw ImmutablePropertyException::immutableProperty(
+                    'axes',
+                    implode(',', $axes),
+                    'updater',
+                    'variant group'
+                );
             }
         }
 
@@ -207,7 +219,14 @@ class VariantGroupUpdater implements ObjectUpdaterInterface
             if (null !== $attribute) {
                 $variantGroup->addAxisAttribute($attribute);
             } else {
-                throw new \InvalidArgumentException(sprintf('Attribute "%s" does not exist', $axis));
+                throw InvalidPropertyException::validEntityCodeExpected(
+                    'axes',
+                    'attribute code',
+                    'The attribute does not exist',
+                    'updater',
+                    'variant group',
+                    $axis
+                );
             }
         }
     }

--- a/src/Pim/Component/Catalog/spec/Updater/AssociationTypeUpdaterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/AssociationTypeUpdaterSpec.php
@@ -2,6 +2,8 @@
 
 namespace spec\Pim\Component\Catalog\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
+use Akeneo\Component\StorageUtils\Exception\UnknownPropertyException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use PhpSpec\ObjectBehavior;
 use Pim\Bundle\CatalogBundle\Entity\AssociationTypeTranslation;
@@ -27,8 +29,9 @@ class AssociationTypeUpdaterSpec extends ObjectBehavior
     function it_throws_an_exception_when_trying_to_update_anything_else_than_an_association_type()
     {
         $this->shouldThrow(
-            new \InvalidArgumentException(
-                'Expects a "Pim\Component\Catalog\Model\AssociationTypeInterface", "stdClass" provided.'
+            InvalidObjectException::objectExpected(
+                'stdClass',
+                'Pim\Component\Catalog\Model\AssociationTypeInterface'
             )
         )->during(
             'update',
@@ -54,5 +57,16 @@ class AssociationTypeUpdaterSpec extends ObjectBehavior
         ];
 
         $this->update($associationType, $values, []);
+    }
+
+    function it_throws_an_exception_when_trying_to_update_a_non_existent_field(AssociationTypeInterface $associationType) {
+        $values = [
+            'non_existent_field' => 'field',
+            'code'               => 'mycode',
+        ];
+
+        $this
+            ->shouldThrow(new UnknownPropertyException('non_existent_field', 'Property "non_existent_field" does not exist.'))
+            ->during('update', [$associationType, $values, []]);
     }
 }

--- a/src/Pim/Component/Catalog/spec/Updater/AttributeGroupUpdaterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/AttributeGroupUpdaterSpec.php
@@ -2,6 +2,8 @@
 
 namespace spec\Pim\Component\Catalog\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Model\AttributeGroupInterface;
@@ -33,8 +35,9 @@ class AttributeGroupUpdaterSpec extends ObjectBehavior
     function it_throw_an_exception_when_trying_to_update_anything_else_than_an_attribute_group()
     {
         $this->shouldThrow(
-            new \InvalidArgumentException(
-                'Expects a "Pim\Component\Catalog\Model\AttributeGroupInterface", "stdClass" provided.'
+            InvalidObjectException::objectExpected(
+                'stdClass',
+                'Pim\Component\Catalog\Model\AttributeGroupInterface'
             )
         )->during(
             'update',
@@ -99,7 +102,16 @@ class AttributeGroupUpdaterSpec extends ObjectBehavior
         $attributeGroup->getAttributes()->willReturn([]);
 
         $attributeRepository->findOneByIdentifier('foo')->willReturn(null);
-        $this->shouldThrow(new \InvalidArgumentException('Attribute with "foo" code does not exist'))
+
+        $this->shouldThrow(
+            InvalidPropertyException::validEntityCodeExpected(
+               'attributes',
+               'attribute code',
+               'The attribute does not exist',
+               'updater',
+               'attribute group',
+               'foo'
+            ))
             ->during('update', [$attributeGroup, $values]);
     }
 

--- a/src/Pim/Component/Catalog/spec/Updater/AttributeOptionUpdaterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/AttributeOptionUpdaterSpec.php
@@ -2,6 +2,8 @@
 
 namespace spec\Pim\Component\Catalog\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\AttributeOptionInterface;
@@ -24,6 +26,19 @@ class AttributeOptionUpdaterSpec extends ObjectBehavior
     function it_is_a_updater()
     {
         $this->shouldImplement('Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface');
+    }
+
+    function it_throw_an_exception_when_trying_to_update_anything_else_than_an_attribute_option()
+    {
+        $this->shouldThrow(
+            InvalidObjectException::objectExpected(
+                'stdClass',
+                'Pim\Component\Catalog\Model\AttributeOptionInterface'
+            )
+        )->during(
+            'update',
+            [new \stdClass(), []]
+        );
     }
 
     function it_updates_all_fields_on_a_new_attribute_option(
@@ -66,7 +81,16 @@ class AttributeOptionUpdaterSpec extends ObjectBehavior
         $attributeOption->setCode('mycode')->shouldBeCalled();
         $attributeRepository->findOneByIdentifier('myattribute')->willReturn(null);
 
-        $this->shouldThrow('\InvalidArgumentException')->during(
+        $this->shouldThrow(
+            InvalidPropertyException::validEntityCodeExpected(
+                'attribute',
+                'attribute code',
+                'The attribute does not exist',
+                'updater',
+                'attribute option',
+                'myattribute'
+            )
+        )->during(
             'update',
             [
                 $attributeOption,

--- a/src/Pim/Component/Catalog/spec/Updater/ChannelUpdaterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/ChannelUpdaterSpec.php
@@ -2,6 +2,8 @@
 
 namespace spec\Pim\Component\Catalog\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use PhpSpec\ObjectBehavior;
 use Pim\Bundle\CatalogBundle\Entity\ChannelTranslation;
@@ -35,8 +37,9 @@ class ChannelUpdaterSpec extends ObjectBehavior
     function it_throws_an_exception_when_trying_to_update_anything_else_than_a_channel()
     {
         $this->shouldThrow(
-            new \InvalidArgumentException(
-                'Expects a "Pim\Component\Catalog\Model\ChannelInterface", "stdClass" provided.'
+            InvalidObjectException::objectExpected(
+                'stdClass',
+                'Pim\Component\Catalog\Model\ChannelInterface'
             )
         )->during(
             'update',
@@ -120,8 +123,19 @@ class ChannelUpdaterSpec extends ObjectBehavior
 
         $channel->setCode('ecommerce')->shouldBeCalled();
 
-        $this->shouldThrow(new \InvalidArgumentException(sprintf('Category with "%s" code does not exist', 'unknown')))
-            ->during('update', [$channel, $values]);
+        $this->shouldThrow(
+            InvalidPropertyException::validEntityCodeExpected(
+                'category_tree',
+                'code',
+                'The category does not exist',
+                'updater',
+                'channel',
+                'unknown'
+            )
+        )->during(
+            'update',
+            [$channel, $values]
+        );
     }
 
     function it_throws_an_exception_if_locale_not_found(
@@ -142,8 +156,19 @@ class ChannelUpdaterSpec extends ObjectBehavior
         $localeRepository->findOneByIdentifier('unknown')->willReturn(null);
         $currencyRepository->findOneByIdentifier('EUR')->willReturn($eur);
 
-        $this->shouldThrow(new \InvalidArgumentException(sprintf('Locale with "%s" code does not exist', 'unknown')))
-            ->during('update', [$channel, $values]);
+        $this->shouldThrow(
+            InvalidPropertyException::validEntityCodeExpected(
+                'locales',
+                'code',
+                'The locale does not exist',
+                'updater',
+                'channel',
+                'unknown'
+            )
+        )->during(
+            'update',
+            [$channel, $values]
+        );
     }
 
     function it_throws_an_exception_if_currency_not_found(
@@ -167,7 +192,15 @@ class ChannelUpdaterSpec extends ObjectBehavior
         $localeRepository->findOneByIdentifier('fr_FR')->willReturn($frFR);
         $currencyRepository->findOneByIdentifier('unknown')->willReturn(null);
 
-        $this->shouldThrow(new \InvalidArgumentException(sprintf('Currency with "%s" code does not exist', 'unknown')))
-            ->during('update', [$channel, $values]);
+        $this->shouldThrow(
+            InvalidPropertyException::validEntityCodeExpected(
+                'currencies',
+                'code',
+                'The currency does not exist',
+                'updater',
+                'channel',
+                'unknown'
+            )
+        )->during('update', [$channel, $values]);
     }
 }

--- a/src/Pim/Component/Catalog/spec/Updater/CurrencyUpdaterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/CurrencyUpdaterSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Pim\Component\Catalog\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Model\CurrencyInterface;
 
@@ -20,8 +21,9 @@ class CurrencyUpdaterSpec extends ObjectBehavior
     function it_throw_an_exception_when_trying_to_update_anything_else_than_an_attribute_group()
     {
         $this->shouldThrow(
-            new \InvalidArgumentException(
-                'Expects a "Pim\Component\Catalog\Model\CurrencyInterface", "stdClass" provided.'
+            InvalidObjectException::objectExpected(
+                'stdClass',
+                'Pim\Component\Catalog\Model\CurrencyInterface'
             )
         )->during(
             'update',

--- a/src/Pim/Component/Catalog/spec/Updater/GroupTypeUpdaterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/GroupTypeUpdaterSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Pim\Component\Catalog\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Model\GroupTypeInterface;
 
@@ -20,8 +21,9 @@ class GroupTypeUpdaterSpec extends ObjectBehavior
     function it_throw_an_exception_when_trying_to_update_anything_else_than_a_group_type()
     {
         $this->shouldThrow(
-            new \InvalidArgumentException(
-                'Expects a "Pim\Component\Catalog\Model\GroupTypeInterface", "stdClass" provided.'
+            InvalidObjectException::objectExpected(
+                'stdClass',
+                'Pim\Component\Catalog\Model\GroupTypeInterface'
             )
         )->during(
             'update',

--- a/src/Pim/Component/Catalog/spec/Updater/GroupUpdaterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/GroupUpdaterSpec.php
@@ -2,6 +2,8 @@
 
 namespace spec\Pim\Component\Catalog\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use PhpSpec\ObjectBehavior;
 use Pim\Bundle\CatalogBundle\Entity\GroupTranslation;
 use Pim\Component\Catalog\Model\AttributeInterface;
@@ -37,8 +39,9 @@ class GroupUpdaterSpec extends ObjectBehavior
     function it_throws_an_exception_when_trying_to_update_anything_else_than_a_variant_group()
     {
         $this->shouldThrow(
-            new \InvalidArgumentException(
-                'Expects a "Pim\Component\Catalog\Model\GroupInterface", "stdClass" provided.'
+            InvalidObjectException::objectExpected(
+                'stdClass',
+                'Pim\Component\Catalog\Model\GroupInterface'
             )
         )->during(
             'update',
@@ -92,18 +95,48 @@ class GroupUpdaterSpec extends ObjectBehavior
         $this->update($group, $values, []);
     }
 
-    function it_throws_an_error_if_type_is_unknown(GroupInterface $group)
+    function it_throws_an_error_if_type_is_unknown($groupTypeRepository, GroupInterface $group)
     {
         $group->setCode('mycode')->shouldBeCalled();
-        $group->getId()->willReturn(null);
+        $groupTypeRepository->findOneByIdentifier('UNKNOWN')->willReturn(null);
 
         $values = [
             'code' => 'mycode',
             'type' => 'UNKNOWN',
         ];
 
-        $this->shouldThrow(new \InvalidArgumentException('Type "UNKNOWN" does not exist'))
-            ->during('update', [$group, $values, []]);
+        $this->shouldThrow(
+            InvalidPropertyException::validEntityCodeExpected(
+                'type',
+                'group type',
+                'The group type does not exist',
+                'updater',
+                'group',
+                'UNKNOWN'
+            )
+        )->during('update', [$group, $values, []]);
+    }
+
+    function it_throws_an_error_if_it_is_a_variant_group_type($groupTypeRepository, GroupInterface $group, GroupTypeInterface $groupType)
+    {
+        $group->setCode('mycode')->shouldBeCalled();
+        $groupTypeRepository->findOneByIdentifier('variant_group_type')->willReturn($groupType);
+        $groupType->isVariant()->willReturn(true);
+
+        $values = [
+            'code' => 'mycode',
+            'type' => 'variant_group_type',
+        ];
+
+        $this->shouldThrow(
+            InvalidPropertyException::validGroupTypeExpected(
+                'type',
+                'Cannot process variant group, only groups are accepted',
+                'updater',
+                'group',
+                'variant_group_type'
+            )
+        )->during('update', [$group, $values, []]);
     }
 
     function it_throws_an_exception_if_attribute_is_unknown($attributeRepository, GroupInterface $group)
@@ -117,7 +150,15 @@ class GroupUpdaterSpec extends ObjectBehavior
             'axis' => ['foo']
         ];
 
-        $this->shouldThrow(new \InvalidArgumentException('Attribute "foo" does not exist'))
-            ->during('update', [$group, $values, []]);
+        $this->shouldThrow(
+            InvalidPropertyException::validEntityCodeExpected(
+                'axis',
+                'attribute code',
+                'The attribute does not exist',
+                'updater',
+                'group',
+                'foo'
+            )
+        )->during('update', [$group, $values, []]);
     }
 }

--- a/src/Pim/Component/Catalog/spec/Updater/LocaleUpdaterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/LocaleUpdaterSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Pim\Component\Catalog\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Model\LocaleInterface;
 use Prophecy\Argument;
@@ -21,8 +22,9 @@ class LocaleUpdaterSpec extends ObjectBehavior
     function it_throws_an_exception_when_trying_to_update_anything_else_than_a_locale()
     {
         $this->shouldThrow(
-            new \InvalidArgumentException(
-                'Expects a "Pim\Component\Catalog\Model\LocaleInterface", "stdClass" provided.'
+            InvalidObjectException::objectExpected(
+                'stdClass',
+                'Pim\Component\Catalog\Model\LocaleInterface'
             )
         )->during(
             'update',

--- a/src/Pim/Component/Catalog/spec/Updater/ProductUpdaterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/ProductUpdaterSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Pim\Component\Catalog\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
 use Akeneo\Component\StorageUtils\Updater\PropertySetterInterface;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Model\ProductInterface;
@@ -32,8 +33,11 @@ class ProductUpdaterSpec extends ObjectBehavior
 
     function it_throws_an_exception_when_trying_to_update_anything_else_than_a_product()
     {
-        $this->shouldThrow(new \InvalidArgumentException('Expects a "Pim\Component\Catalog\Model\ProductInterface", "stdClass" provided.'))->during(
-            'update', [new \stdClass(), []]
+        $this->shouldThrow(
+            InvalidObjectException::objectExpected(
+                'stdClass',
+                'Pim\Component\Catalog\Model\ProductInterface'
+            )
         );
     }
 

--- a/src/Pim/Component/Catalog/spec/Updater/VariantGroupUpdaterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/VariantGroupUpdaterSpec.php
@@ -2,6 +2,9 @@
 
 namespace spec\Pim\Component\Catalog\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\ImmutablePropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Doctrine\Common\Collections\ArrayCollection;
 use PhpSpec\ObjectBehavior;
@@ -53,8 +56,11 @@ class VariantGroupUpdaterSpec extends ObjectBehavior
 
     function it_throws_an_exception_when_trying_to_update_anything_else_than_a_variant_group()
     {
-        $this->shouldThrow(new \InvalidArgumentException('Expects a "Pim\Component\Catalog\Model\GroupInterface", "stdClass" provided.'))->during(
-            'update', [new \stdClass(), []]
+        $this->shouldThrow(
+            InvalidObjectException::objectExpected(
+                'stdClass',
+                'Pim\Component\Catalog\Model\GroupInterface'
+            )
         );
     }
 
@@ -181,8 +187,16 @@ class VariantGroupUpdaterSpec extends ObjectBehavior
             'type' => 'UNKNOWN',
         ];
 
-        $this->shouldThrow(new \InvalidArgumentException('Type "UNKNOWN" does not exist'))
-            ->during('update', [$variantGroup, $values, []]);
+        $this->shouldThrow(
+            InvalidPropertyException::validEntityCodeExpected(
+                'type',
+                'group type',
+                'The group type does not exist',
+                'updater',
+                'variant group',
+                'UNKNOWN'
+            )
+        )->during('update', [$variantGroup, $values, []]);
     }
 
     function it_throws_an_error_if_axis_is_unknown(GroupInterface $variantGroup)
@@ -195,8 +209,16 @@ class VariantGroupUpdaterSpec extends ObjectBehavior
             'axes' => ['unknown', 'secondary_color'],
         ];
 
-        $this->shouldThrow(new \InvalidArgumentException('Attribute "unknown" does not exist'))
-            ->during('update', [$variantGroup, $values, []]);
+        $this->shouldThrow(
+            InvalidPropertyException::validEntityCodeExpected(
+                'axes',
+                'attribute code',
+                'The attribute does not exist',
+                'updater',
+                'variant group',
+                'unknown'
+            )
+        )->during('update', [$variantGroup, $values, []]);
     }
 
     function it_throws_an_error_if_axis_is_updated(GroupInterface $variantGroup)
@@ -212,8 +234,14 @@ class VariantGroupUpdaterSpec extends ObjectBehavior
             'axes' => ['main_color'],
         ];
 
-        $this->shouldThrow(new \InvalidArgumentException('Attributes: This property cannot be changed.'))
-            ->during('update', [$variantGroup, $values, []]);
+        $this->shouldThrow(
+            ImmutablePropertyException::immutableProperty(
+                'axes',
+                'main_color',
+                'updater',
+                'variant group'
+            )
+        )->during('update', [$variantGroup, $values, []]);
     }
 
     function it_merges_original_and_new_values(

--- a/src/Pim/Component/Connector/Processor/Denormalization/JobInstanceProcessor.php
+++ b/src/Pim/Component/Connector/Processor/Denormalization/JobInstanceProcessor.php
@@ -10,6 +10,7 @@ use Akeneo\Component\Batch\Job\JobRegistry;
 use Akeneo\Component\Batch\Model\JobInstance;
 use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
 use Akeneo\Component\StorageUtils\Detacher\ObjectDetacherInterface;
+use Akeneo\Component\StorageUtils\Exception\ObjectUpdaterException;
 use Akeneo\Component\StorageUtils\Factory\SimpleFactoryInterface;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
@@ -85,6 +86,8 @@ class JobInstanceProcessor extends AbstractProcessor implements ItemProcessorInt
 
         try {
             $this->updater->update($entity, $item);
+        } catch (ObjectUpdaterException $exception) {
+            $this->skipItemWithMessage($item, $exception->getMessage(), $exception);
         } catch (\InvalidArgumentException $exception) {
             $this->skipItemWithMessage($item, $exception->getMessage(), $exception);
         }

--- a/src/Pim/Component/Connector/Processor/Denormalization/Processor.php
+++ b/src/Pim/Component/Connector/Processor/Denormalization/Processor.php
@@ -5,6 +5,7 @@ namespace Pim\Component\Connector\Processor\Denormalization;
 use Akeneo\Component\Batch\Item\ItemProcessorInterface;
 use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
 use Akeneo\Component\StorageUtils\Detacher\ObjectDetacherInterface;
+use Akeneo\Component\StorageUtils\Exception\ObjectUpdaterException;
 use Akeneo\Component\StorageUtils\Factory\SimpleFactoryInterface;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
@@ -63,6 +64,8 @@ class Processor extends AbstractProcessor implements ItemProcessorInterface, Ste
 
         try {
             $this->updater->update($entity, $item);
+        } catch (ObjectUpdaterException $exception) {
+            $this->skipItemWithMessage($item, $exception->getMessage(), $exception);
         } catch (\InvalidArgumentException $exception) {
             $this->skipItemWithMessage($item, $exception->getMessage(), $exception);
         }

--- a/src/Pim/Component/Connector/Processor/Denormalization/ProductAssociationProcessor.php
+++ b/src/Pim/Component/Connector/Processor/Denormalization/ProductAssociationProcessor.php
@@ -5,6 +5,7 @@ namespace Pim\Component\Connector\Processor\Denormalization;
 use Akeneo\Component\Batch\Item\ItemProcessorInterface;
 use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
 use Akeneo\Component\StorageUtils\Detacher\ObjectDetacherInterface;
+use Akeneo\Component\StorageUtils\Exception\ObjectUpdaterException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Pim\Component\Catalog\Comparator\Filter\ProductFilterInterface;
@@ -104,6 +105,9 @@ class ProductAssociationProcessor extends AbstractProcessor implements
 
         try {
             $this->updateProduct($product, $item);
+        } catch (ObjectUpdaterException $exception) {
+            $this->detachProduct($product);
+            $this->skipItemWithMessage($item, $exception->getMessage(), $exception);
         } catch (\InvalidArgumentException $exception) {
             $this->detachProduct($product);
             $this->skipItemWithMessage($item, $exception->getMessage(), $exception);
@@ -133,7 +137,7 @@ class ProductAssociationProcessor extends AbstractProcessor implements
      * @param ProductInterface $product
      * @param array            $item
      *
-     * @throws \InvalidArgumentException
+     * @throws ObjectUpdaterException
      */
     protected function updateProduct(ProductInterface $product, array $item)
     {

--- a/src/Pim/Component/Connector/Processor/Denormalization/ProductProcessor.php
+++ b/src/Pim/Component/Connector/Processor/Denormalization/ProductProcessor.php
@@ -5,6 +5,7 @@ namespace Pim\Component\Connector\Processor\Denormalization;
 use Akeneo\Component\Batch\Item\ItemProcessorInterface;
 use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
 use Akeneo\Component\StorageUtils\Detacher\ObjectDetacherInterface;
+use Akeneo\Component\StorageUtils\Exception\ObjectUpdaterException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Pim\Component\Catalog\Builder\ProductBuilderInterface;
@@ -107,6 +108,9 @@ class ProductProcessor extends AbstractProcessor implements ItemProcessorInterfa
 
         try {
             $this->updateProduct($product, $filteredItem);
+        } catch (ObjectUpdaterException $exception) {
+            $this->detachProduct($product);
+            $this->skipItemWithMessage($item, $exception->getMessage(), $exception);
         } catch (\InvalidArgumentException $exception) {
             $this->detachProduct($product);
             $this->skipItemWithMessage($item, $exception->getMessage(), $exception);
@@ -192,7 +196,7 @@ class ProductProcessor extends AbstractProcessor implements ItemProcessorInterfa
      * @param ProductInterface $product
      * @param array            $filteredItem
      *
-     * @throws \InvalidArgumentException
+     * @throws ObjectUpdaterException
      */
     protected function updateProduct(ProductInterface $product, array $filteredItem)
     {

--- a/src/Pim/Component/User/Updater/GroupUpdater.php
+++ b/src/Pim/Component/User/Updater/GroupUpdater.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Component\User\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Doctrine\Common\Util\ClassUtils;
 use Pim\Component\User\Model\GroupInterface;
@@ -26,11 +27,9 @@ class GroupUpdater implements ObjectUpdaterInterface
     public function update($group, array $data, array $options = [])
     {
         if (!$group instanceof GroupInterface) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    'Expects a "Pim\Component\User\Model\GroupInterface", "%s" provided.',
-                    ClassUtils::getClass($group)
-                )
+            throw InvalidObjectException::objectExpected(
+                ClassUtils::getClass($group),
+                'Pim\Component\User\Model\GroupInterface'
             );
         }
 

--- a/src/Pim/Component/User/Updater/RoleUpdater.php
+++ b/src/Pim/Component/User/Updater/RoleUpdater.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Component\User\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Doctrine\Common\Util\ClassUtils;
 use Oro\Bundle\SecurityBundle\Acl\Persistence\AclManager;
@@ -40,11 +41,9 @@ class RoleUpdater implements ObjectUpdaterInterface
     public function update($role, array $data, array $options = [])
     {
         if (!$role instanceof Role) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    'Expects a "Oro\Bundle\UserBundle\Entity\Role", "%s" provided.',
-                    ClassUtils::getClass($role)
-                )
+            throw InvalidObjectException::objectExpected(
+                ClassUtils::getClass($role),
+                'Oro\Bundle\UserBundle\Entity\Role'
             );
         }
 

--- a/src/Pim/Component/User/Updater/UserUpdater.php
+++ b/src/Pim/Component/User/Updater/UserUpdater.php
@@ -3,6 +3,7 @@
 namespace Pim\Component\User\Updater;
 
 use Akeneo\Component\Classification\Model\CategoryInterface;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Doctrine\Common\Util\ClassUtils;
@@ -81,11 +82,9 @@ class UserUpdater implements ObjectUpdaterInterface
     public function update($user, array $data, array $options = [])
     {
         if (!$user instanceof UserInterface) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    'Expects a "Pim\Bundle\UserBundle\Entity\UserInterface", "%s" provided.',
-                    ClassUtils::getClass($user)
-                )
+            throw InvalidObjectException::objectExpected(
+                ClassUtils::getClass($user),
+                'Pim\Bundle\UserBundle\Entity\UserInterface'
             );
         }
 
@@ -105,7 +104,7 @@ class UserUpdater implements ObjectUpdaterInterface
      * @param string        $field
      * @param mixed         $data
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidPropertyException
      */
     protected function setData(UserInterface $user, $field, $data)
     {
@@ -143,10 +142,10 @@ class UserUpdater implements ObjectUpdaterInterface
                 $user->setEmailNotifications($data);
                 break;
             case 'catalog_locale':
-                $user->setCatalogLocale($this->findLocale($data));
+                $user->setCatalogLocale($this->findLocale('catalog_locale', $data));
                 break;
             case 'user_locale':
-                $user->setUiLocale($this->findLocale($data));
+                $user->setUiLocale($this->findLocale('user_locale', $data));
                 break;
             case 'catalog_scope':
                 $user->setCatalogScope($this->findChannel($data));
@@ -179,30 +178,49 @@ class UserUpdater implements ObjectUpdaterInterface
     /**
      * @param string $code
      *
-     * @return CategoryInterface|null
+     * @throws InvalidPropertyException
+     *
+     * @return CategoryInterface
      */
     protected function findCategory($code)
     {
         $category = $this->categoryRepository->findOneByIdentifier($code);
 
         if (null === $category) {
-            throw new \InvalidArgumentException(sprintf('Category %s was not found', $code));
+            throw InvalidPropertyException::validEntityCodeExpected(
+                'default_tree',
+                'category code',
+                'The category does not exist',
+                'updater',
+                'user',
+                $code
+            );
         }
 
         return $category;
     }
 
     /**
-     * @param string $code
+     * @param $field
+     * @param $code
      *
-     * @return LocaleInterface|null
+     * @throws InvalidPropertyException
+     *
+     * @return LocaleInterface
      */
-    protected function findLocale($code)
+    protected function findLocale($field, $code)
     {
         $locale = $this->localeRepository->findOneByIdentifier($code);
 
         if (null === $locale) {
-            throw new \InvalidArgumentException(sprintf('Locale %s was not found', $code));
+            throw InvalidPropertyException::validEntityCodeExpected(
+                $field,
+                'locale code',
+                'The locale does not exist',
+                'updater',
+                'user',
+                $code
+            );
         }
 
         return $locale;
@@ -211,6 +229,8 @@ class UserUpdater implements ObjectUpdaterInterface
     /**
      * @param string $code
      *
+     * @throws InvalidPropertyException
+     *
      * @return ChannelInterface|null
      */
     protected function findChannel($code)
@@ -218,7 +238,14 @@ class UserUpdater implements ObjectUpdaterInterface
         $channel = $this->channelRepository->findOneByIdentifier($code);
 
         if (null === $channel) {
-            throw new \InvalidArgumentException(sprintf('Channel %s was not found', $code));
+            throw InvalidPropertyException::validEntityCodeExpected(
+                'catalog_scope',
+                'channel code',
+                'The channel does not exist',
+                'updater',
+                'user',
+                $code
+            );
         }
 
         return $channel;
@@ -227,14 +254,23 @@ class UserUpdater implements ObjectUpdaterInterface
     /**
      * @param string $code
      *
-     * @return Role|null
+     * @throws InvalidPropertyException
+     *
+     * @return Role
      */
     protected function findRole($code)
     {
         $role = $this->roleRepository->findOneByIdentifier($code);
 
         if (null === $role) {
-            throw new \InvalidArgumentException(sprintf('Role %s was not found', $code));
+            throw InvalidPropertyException::validEntityCodeExpected(
+                'roles',
+                'role',
+                'The role does not exist',
+                'updater',
+                'user',
+                $code
+            );
         }
 
         return $role;
@@ -243,14 +279,23 @@ class UserUpdater implements ObjectUpdaterInterface
     /**
      * @param string $code
      *
-     * @return GroupInterface|null
+     * @throws InvalidPropertyException
+     *
+     * @return GroupInterface
      */
     protected function findGroup($code)
     {
         $group = $this->groupRepository->findOneByIdentifier($code);
 
         if (null === $group) {
-            throw new \InvalidArgumentException(sprintf('Group %s was not found', $code));
+            throw InvalidPropertyException::validEntityCodeExpected(
+                'groups',
+                'group',
+                'The group does not exist',
+                'updater',
+                'user',
+                $code
+            );
         }
 
         return $group;


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) 

**Description (for Contributor and Core Developer)**

In the API, we need to have specific error messages when we update non existent fields. 
For example : 

> "Property "%s" does not exist. Check the standard format documentation.


An exception "NoSuchPropertyException was already raised by Symfony. Unfortunately, this exception has just a message :


> "Cannot read property "%s" from an array. Maybe you intended to write the property path as "[%s]" instead"

If we want to get the property in a controller (for a custom message as above), it's not possible without a regex parsing the error message in NoSuchPropertyException... and that's dirty :)

This PR resolve that problem by raising business exception directly in the updaters, with a property which is accessible in the exception.

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | :white_check_mark: 
| Added Behats                      | :red_circle: 
| Changelog updated                 | :clock1:
| Review and 2 GTM                  |  :red_circle:
| Micro Demo to the PO (Story only) |
| Migration script                  | 
| Tech Doc                          | 


:white_check_mark: Done and pass

:red_circle: Done but fail

:clock1: Done but pending

:negative_squared_cross_mark: Not needed
