### PR TITLE
PIM-6038: Update 'update' product property in the Product Updater

### DIFF
--- a/src/Akeneo/Component/Batch/Model/JobExecution.php
+++ b/src/Akeneo/Component/Batch/Model/JobExecution.php
@@ -80,7 +80,7 @@ class JobExecution
         $this->setExitStatus(new ExitStatus(ExitStatus::UNKNOWN));
         $this->executionContext = new ExecutionContext();
         $this->stepExecutions = new ArrayCollection();
-        $this->createTime = new \DateTime();
+        $this->createTime = new \DateTime('now', new \DateTimeZone('UTC'));
         $this->failureExceptions = [];
     }
 

--- a/src/Pim/Component/Catalog/Updater/ProductUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/ProductUpdater.php
@@ -112,14 +112,20 @@ class ProductUpdater implements ObjectUpdaterInterface
             );
         }
 
+        $isProductUpdated = false;
+
         foreach ($data as $field => $values) {
             if (in_array($field, $this->supportedFields)) {
-                $this->updateProductFields($product, $field, $values);
+                $isProductUpdated |= $this->updateProductFields($product, $field, $values);
             } else {
-                $this->updateProductValues($product, $field, $values);
+                $isProductUpdated |= $this->updateProductValues($product, $field, $values);
             }
         }
-        $this->updateProductVariantValues($product, $data);
+        $isProductUpdated |= $this->updateProductVariantValues($product, $data);
+
+        if ($isProductUpdated) {
+            $product->setUpdated(new \Datetime('now', new \DateTimeZone('UTC')));
+        }
 
         return $this;
     }
@@ -130,10 +136,14 @@ class ProductUpdater implements ObjectUpdaterInterface
      * @param ProductInterface $product
      * @param string           $field
      * @param mixed            $value
+     *
+     * @return boolean whether the product has been updated
      */
     protected function updateProductFields(ProductInterface $product, $field, $value)
     {
         $this->propertySetter->setData($product, $field, $value);
+
+        return true;
     }
 
     /**
@@ -145,9 +155,12 @@ class ProductUpdater implements ObjectUpdaterInterface
      * @param ProductInterface $product
      * @param string           $attributeCode
      * @param array            $values
+     *
+     * @return boolean whether the product has been updated
      */
     protected function updateProductValues(ProductInterface $product, $attributeCode, array $values)
     {
+        $isValuesUpdated = false;
         $family = $product->getFamily();
         $authorizedCodes = (null !== $family) ? $family->getAttributeCodes() : [];
         $isFamilyAttribute = in_array($attributeCode, $authorizedCodes);
@@ -159,8 +172,11 @@ class ProductUpdater implements ObjectUpdaterInterface
             if ($isFamilyAttribute || $providedData || $hasValue) {
                 $options = ['locale' => $value['locale'], 'scope' => $value['scope']];
                 $this->propertySetter->setData($product, $attributeCode, $value['data'], $options);
+                $isValuesUpdated = true;
             }
         }
+
+        return $isValuesUpdated;
     }
 
     /**
@@ -169,6 +185,8 @@ class ProductUpdater implements ObjectUpdaterInterface
      *
      * @param ProductInterface $product
      * @param array            $data
+     *
+     * @return boolean whether the product has been updated.
      */
     protected function updateProductVariantValues(ProductInterface $product, array $data)
     {
@@ -185,5 +203,7 @@ class ProductUpdater implements ObjectUpdaterInterface
                 $this->templateUpdater->update($template, [$product]);
             }
         }
+
+        return $shouldEraseData;
     }
 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
*Problem: Export product updated since last export do not export recently imported (via job) products

In mongoDB product imports, we normalize the product values in a document property called `normalizedData`. The normalizedData is generated using a dedicated set of normalizers (see classes in the namespace `Pim\Bundle\CatalogBundle\MongoDB\Normalizer\NormalizedData`).

In the PIM, the 

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | :white_check_mark: :red_circle: :negative_squared_cross_mark: :clock1:
| Added Behats                      | :white_check_mark: :red_circle: :negative_squared_cross_mark: :clock1:
| Changelog updated                 | :white_check_mark: :red_circle: :negative_squared_cross_mark: :clock1:
| Review and 2 GTM                  | :white_check_mark: :red_circle: :negative_squared_cross_mark: :clock1:
| Micro Demo to the PO (Story only) | :white_check_mark: :red_circle: :negative_squared_cross_mark: :clock1:
| Migration script                  | :white_check_mark: :red_circle: :negative_squared_cross_mark: :clock1:
| Tech Doc                          | :white_check_mark: :red_circle: :negative_squared_cross_mark: :clock1:


:white_check_mark: Done and pass

:red_circle: Done but fail

:clock1: Done but pending

:negative_squared_cross_mark: Not needed
