### PR TITLE
GITHUB-5391: redo association type form

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -29,6 +29,7 @@
 - TIP-575: Rename FileIterator classes to FlatFileIterator and changes the reader/processor behavior to iterate over the item's position in the file instead of the item's line number in the file.
 - TIP-662: Removed the WITH_REQUIRED_IDENTIFIER option from `Pim\Component\Connector\ArrayConverter\FlatToStandard\Product` as it was not used anymore.
 - TIP-667: Introduce a product value factory service to instanciate product values.
+- GITHUB-5391: Redo association type edit form using backbonejs architecture and internal REST API
 
 ## BC breaks
 - Change the constructor of `Pim\Component\Catalog\Denormalizer\Standard\ProductValueDenormalizer` to add `Pim\Component\Catalog\Factory\ProductValueFactory`
@@ -123,3 +124,7 @@
 - Remove deprecated bundle "Oro\Bundle\UIBundle\OroUIBundle"
 - Remove deprecated bundle "Oro\Bundle\FormBundle\OroFormBundle"
 - Remove useless service and parameter: `pim_enrich_image` and `pim_enrich.form.type.image.class`
+- Change `Pim\Bundle\EnrichBundle\Normalizer\AssociationTypeNormalizer` constructor to add `versionManager` and `versionNormalizer`
+- Change `Pim\Bundle\EnrichBundle\Controller\Rest\AssociationTypeController` constructor to add `remover`, `updater`, `saver`, `validator` and `userContext`
+- Change `Pim\Bundle\EnrichBundle\Controller\AssociationTypeController` to remove `removeAction` and change `editAction`
+- Change association type route to use `code` instead of `id` for fetching

--- a/features/Context/NavigationContext.php
+++ b/features/Context/NavigationContext.php
@@ -68,13 +68,12 @@ class NavigationContext extends BaseNavigationContext
      * @param string $identifier
      *
      * @Given /^I edit the "([^"]*)" association type$/
+     * @Given /^I am on the "([^"]*)" association type page$/
      */
     public function iEditTheAssociationType($identifier)
     {
         $page   = 'AssociationType';
-        $getter = sprintf('get%s', $page);
-        $entity = $this->getFixturesContext()->$getter($identifier);
-        $this->openPage(sprintf('%s edit', $page), ['id' => $entity->getId()]);
+        $this->openPage(sprintf('%s edit', $page), ['code' => $identifier]);
     }
 
     /**
@@ -130,19 +129,6 @@ class NavigationContext extends BaseNavigationContext
     public function iAmOnTheGroupTypeEditPage($identifier)
     {
         $page   = 'GroupType';
-        $getter = sprintf('get%s', $page);
-        $entity = $this->getFixturesContext()->$getter($identifier);
-        $this->openPage(sprintf('%s edit', $page), ['id' => $entity->getId()]);
-    }
-
-    /**
-     * @param string $identifier
-     *
-     * @Given /^I am on the "([^"]*)" association type page$/
-     */
-    public function iAmOnTheAssociationTypeEditPage($identifier)
-    {
-        $page   = 'AssociationType';
         $getter = sprintf('get%s', $page);
         $entity = $this->getFixturesContext()->$getter($identifier);
         $this->openPage(sprintf('%s edit', $page), ['id' => $entity->getId()]);
@@ -244,7 +230,7 @@ class NavigationContext extends BaseNavigationContext
      */
     public function iShouldBeOnTheAssociationTypePage(AssociationTypeInterface $associationType)
     {
-        $expectedAddress = $this->getPage('AssociationType edit')->getUrl(['id' => $associationType->getId()]);
+        $expectedAddress = $this->getPage('AssociationType edit')->getUrl(['code' => $associationType->getCode()]);
         $this->assertAddress($expectedAddress);
     }
 

--- a/features/Context/Page/AssociationType/Edit.php
+++ b/features/Context/Page/AssociationType/Edit.php
@@ -16,5 +16,5 @@ class Edit extends Form
     /**
      * @var string
      */
-    protected $path = '/configuration/association-type/{id}/edit';
+    protected $path = '/configuration/association-type/{code}/edit';
 }

--- a/features/association-type/create_association_type.feature
+++ b/features/association-type/create_association_type.feature
@@ -10,14 +10,13 @@ Feature: Association type creation
     And I am on the association types page
     And I create a new association type
 
-  @skip
   Scenario: Successfully create an association type
     Then I should see the Code field
     When I fill in the following information in the popin:
       | Code | up_sell |
     And I press the "Save" button
     Then I should be on the "up_sell" association type page
-    And I should see "Edit association type - [up_sell]"
+    And I should see "up_sell"
 
   Scenario: Fail to create an association type with an empty or invalid code
     Given I press the "Save" button

--- a/features/association-type/display_association_type_history.feature
+++ b/features/association-type/display_association_type_history.feature
@@ -13,7 +13,7 @@ Feature: Display the association type history
       | Code | REPLACEMENT |
     And I press the "Save" button
     And I am on the association types page
-    Then I should see association type REPLACEMENT
+    Then I should see "REPLACEMENT"
     When I am on the "REPLACEMENT" association type page
     And I visit the "History" tab
     Then there should be 1 update

--- a/features/association-type/edit_association_type.feature
+++ b/features/association-type/edit_association_type.feature
@@ -23,7 +23,7 @@ Feature: Edit an association type
     When I fill in the following information:
       | English (United States) | My pack |
     And I click on the Akeneo logo
-    Then I should see a confirm dialog with the following content:
+    And I should see a confirm dialog with the following content:
       | title   | Are you sure you want to leave this page?                             |
       | content | You will lose changes to the association type if you leave this page. |
 
@@ -31,5 +31,5 @@ Feature: Edit an association type
   Scenario: Successfully display a message when there are unsaved changes
     Given I am on the "PACK" association type page
     When I fill in the following information:
-      | English (United States) | My pack |
+      | English (United States) | My new substitution |
     Then I should see "There are unsaved changes."

--- a/src/Pim/Bundle/EnrichBundle/Controller/AssociationTypeController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/AssociationTypeController.php
@@ -116,7 +116,7 @@ class AssociationTypeController
                 'status' => 1,
                 'url'    => $this->router->generate(
                     'pim_enrich_associationtype_edit',
-                    ['id' => $associationType->getId()]
+                    ['code' => $associationType->getCode()]
                 )
             ];
 
@@ -131,51 +131,17 @@ class AssociationTypeController
     /**
      * Edit an association type
      *
-     * @param int     $id
+     * @param string $code
      *
      * @Template
      * @AclAncestor("pim_enrich_associationtype_edit")
      *
      * @return array
      */
-    public function editAction($id)
+    public function editAction($code)
     {
-        $associationType = $this->assocTypeRepo->find($id);
-
-        if (!$associationType) {
-            throw new NotFoundHttpException(sprintf('%s entity not found', 'PimCatalogBundle:AssociationType'));
-        }
-
-        if ($this->assocTypeHandler->process($associationType)) {
-            $this->request->getSession()->getFlashBag()->add('success', new Message('flash.association type.updated'));
-
-            return new RedirectResponse($this->router->generate('pim_enrich_associationtype_edit', ['id' => $id]));
-        }
-        $usageCount = $this->assocRepository->countForAssociationType($associationType);
-
         return [
-            'form'       => $this->assocTypeForm->createView(),
-            'usageCount' => $usageCount
+            'code'       => $code
         ];
-    }
-
-    /**
-     * Remove an association type
-     *
-     * @param AssociationType $associationType
-     *
-     * @AclAncestor("pim_enrich_associationtype_remove")
-     *
-     * @return Response|RedirectResponse
-     */
-    public function removeAction(AssociationType $associationType)
-    {
-        $this->assocTypeRemover->remove($associationType);
-
-        if ($this->request->isXmlHttpRequest()) {
-            return new Response('', 204);
-        } else {
-            return new RedirectResponse($this->router->generate('pim_enrich_associationtype_index'));
-        }
     }
 }

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/AssociationTypeController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/AssociationTypeController.php
@@ -2,14 +2,25 @@
 
 namespace Pim\Bundle\EnrichBundle\Controller\Rest;
 
+use Akeneo\Component\StorageUtils\Remover\RemoverInterface;
+use Akeneo\Component\StorageUtils\Saver\SaverInterface;
+use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
+use Oro\Bundle\SecurityBundle\Annotation\AclAncestor;
+use Pim\Bundle\UserBundle\Context\UserContext;
+use Pim\Component\Catalog\Model\AssociationTypeInterface;
 use Pim\Component\Catalog\Repository\AssociationTypeRepositoryInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 /**
  * Association type controller
  *
  * @author    Filips Alpe <filips@akeneo.com>
+ * @author    Alexandr Jeliuc <alex@jeliuc.com>
  * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
@@ -21,20 +32,47 @@ class AssociationTypeController
     /** @var NormalizerInterface */
     protected $normalizer;
 
+    /** @var RemoverInterface */
+    protected $remover;
+
+    /** @var ObjectUpdaterInterface */
+    protected $updater;
+
+    /** @var SaverInterface */
+    protected $saver;
+
+    /** @var ValidatorInterface */
+    protected $validator;
+
+    /** @var UserContext */
+    protected $userContext;
+
     /**
      * @param AssociationTypeRepositoryInterface $associationTypeRepo
      * @param NormalizerInterface                $normalizer
      */
     public function __construct(
         AssociationTypeRepositoryInterface $associationTypeRepo,
-        NormalizerInterface $normalizer
+        NormalizerInterface $normalizer,
+        RemoverInterface $remover,
+        ObjectUpdaterInterface $updater,
+        SaverInterface $saver,
+        ValidatorInterface $validator,
+        UserContext $userContext
     ) {
         $this->associationTypeRepo = $associationTypeRepo;
         $this->normalizer = $normalizer;
+        $this->remover = $remover;
+        $this->updater = $updater;
+        $this->saver = $saver;
+        $this->validator = $validator;
+        $this->userContext = $userContext;
     }
 
     /**
      * @return JsonResponse
+     *
+     * @AclAncestor("pim_enrich_associationtype_index")
      */
     public function indexAction()
     {
@@ -43,5 +81,98 @@ class AssociationTypeController
         $data = $this->normalizer->normalize($associationTypes, 'internal_api');
 
         return new JsonResponse($data);
+    }
+
+    /**
+     * @param string $identifier
+     *
+     * @return JsonResponse
+     *
+     * @AclAncestor("pim_enrich_associationtype_edit")
+     */
+    public function getAction($identifier)
+    {
+        $associationType = $this->getAssociationTypeOr404($identifier);
+
+        return new JsonResponse(
+            $this->normalizer->normalize($associationType, 'internal_api')
+        );
+    }
+
+    /**
+     * @param Request $request
+     *
+     * @return JsonResponse
+     *
+     * @AclAncestor("pim_enrich_associationtype_edit")
+     */
+    public function postAction(Request $request, $code)
+    {
+        $associationType = $this->getAssociationTypeOr404($code);
+
+        $data = json_decode($request->getContent(), true);
+        $this->updater->update($associationType, $data);
+
+        $violations = $this->validator->validate($associationType);
+
+        if (0 < $violations->count()) {
+            $errors = $this->normalizer->normalize(
+                $violations,
+                'internal_api'
+            );
+
+            return new JsonResponse($errors, 400);
+        }
+
+        $this->saver->save($associationType);
+
+        return new JsonResponse(
+            $this->normalizer->normalize(
+                $associationType,
+                'internal_api',
+                $this->userContext->toArray()
+            )
+        );
+    }
+
+    /**
+     * Remove action
+     *
+     * @param $code
+     *
+     * @return JsonResponse
+     *
+     * @AclAncestor("pim_enrich_associationtype_remove")
+     */
+    public function removeAction($code)
+    {
+        $associationType = $this->getAssociationTypeOr404($code);
+
+        $this->remover->remove($associationType);
+
+        return new JsonResponse(null, Response::HTTP_NO_CONTENT);
+    }
+
+    /**
+     * Finds association type by code or throws not found exception
+     *
+     * @param $code
+     *
+     * @throws NotFoundHttpException
+     *
+     * @return AssociationTypeInterface
+     */
+    private function getAssociationTypeOr404($code)
+    {
+        $associationType = $this->associationTypeRepo->findOneBy(
+            ['code' => $code]
+        );
+        if (null === $associationType) {
+            throw new NotFoundHttpException(
+                sprintf('Association type with code "%s" not found', $code)
+            );
+        }
+
+        return $associationType;
     }
 }

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/controllers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/controllers.yml
@@ -305,6 +305,11 @@ services:
         arguments:
             - '@pim_catalog.repository.association_type'
             - '@pim_internal_api_serializer'
+            - '@pim_catalog.remover.association_type'
+            - '@pim_catalog.updater.association_type'
+            - '@pim_catalog.saver.association_type'
+            - '@validator'
+            - '@pim_user.context.user'
 
     pim_enrich.controller.rest.attribute:
         class: '%pim_enrich.controller.rest.attribute.class%'

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/association_type.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/association_type.yml
@@ -1,21 +1,57 @@
 datagrid:
     association-type-grid:
-        extend: translatable-entity-grid
         options:
             entityHint: association type
+            locale_parameter: localeCode
         source:
+            type: pim_datasource_default
             acl_resource: pim_enrich_associationtype_index
             entity: '%pim_catalog.entity.association_type.class%'
+            repository_method: createDatagridQueryBuilder
+        columns:
+            code:
+                label: Code
+            label:
+                label: Label
         properties:
+            id: ~
             edit_link:
+                type: url
                 route: pim_enrich_associationtype_edit
+                params:
+                    - code
             delete_link:
-                route: pim_enrich_associationtype_remove
+                type: url
+                route: pim_enrich_associationtype_rest_remove
+                params:
+                    - code
+        actions:
+            edit:
+                type:      navigate
+                label:     Edit
+                icon:      edit
+                link:      edit_link
+                rowAction: true
+            delete:
+                type:  delete
+                label: Delete
+                icon:  trash
+                link:  delete_link
         sorters:
             columns:
+                label:
+                    data_name: label
                 code:
                     data_name: a.code
+            default:
+                code: '%oro_datagrid.extension.orm_sorter.class%::DIRECTION_ASC'
         filters:
             columns:
                 code:
+                    type:  string
+                    label: Code
                     data_name: a.code
+                label:
+                    type: string
+                    label: Label
+                    data_name: translation.label

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/association_type.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/association_type.yml
@@ -1,0 +1,114 @@
+extensions:
+    pim-association-type-edit-form:
+        module: pim/form/common/edit-form
+
+    pim-association-type-edit-form-cache-invalidator:
+        module: pim/cache-invalidator
+        parent: pim-association-type-edit-form
+        position: 1000
+
+    pim-association-type-edit-form-form-tabs:
+        module: pim/form/common/form-tabs
+        parent: pim-association-type-edit-form
+        targetZone: content
+        position: 90
+
+    pim-association-type-edit-form-label:
+        module: pim/form/common/label
+        parent: pim-association-type-edit-form
+        targetZone: title
+        position: 110
+
+    pim-association-type-edit-form-back-to-grid:
+        module: pim/form/common/back-to-grid
+        parent: pim-association-type-edit-form
+        targetZone: back
+        aclResourceId: pim_enrich_associationtype_index
+        position: 80
+        config:
+            backUrl: pim_enrich_associationtype_index
+
+    pim-association-type-edit-form-delete:
+        module: pim/association-type-edit-form/delete
+        parent: pim-association-type-edit-form
+        targetZone: buttons
+        aclResourceId: pim_enrich_associationtype_remove
+        position: 100
+        config:
+            trans:
+                title: confirmation.remove.association_type
+                content: pim_enrich.confirmation.delete_item
+                success: flash.association_type.removed
+                fail: error.removing.association_type
+            redirect: pim_enrich_associationtype_index
+
+    pim-association-type-edit-form-save-buttons:
+        module: pim/form/common/save-buttons
+        parent: pim-association-type-edit-form
+        targetZone: buttons
+        position: 100
+
+    pim-association-type-edit-form-save:
+        module: pim/association-type-edit-form/save
+        parent: pim-association-type-edit-form
+        targetZone: buttons
+        position: 0
+
+    pim-association-type-edit-form-state:
+        module: pim/form/common/state
+        parent: pim-association-type-edit-form
+        targetZone: state
+        position: 900
+        config:
+            entity: pim_enrich.entity.association_type.title
+
+    pim-association-type-edit-form-created:
+        module: pim/form/common/meta/created
+        parent: pim-association-type-edit-form
+        targetZone: meta
+        position: 90
+        config:
+            label: pim_enrich.entity.association_type.meta.created
+            labelBy: pim_enrich.entity.association_type.meta.created_by
+
+    pim-association-type-edit-form-updated:
+        module: pim/form/common/meta/updated
+        parent: pim-association-type-edit-form
+        targetZone: meta
+        position: 100
+        config:
+            label: pim_enrich.entity.association_type.meta.updated
+            labelBy: pim_enrich.entity.association_type.meta.updated_by
+
+    pim-association-type-edit-form-properties:
+        module: pim/common/tab/properties
+        parent: pim-association-type-edit-form-form-tabs
+        targetZone: container
+        position: 100
+        config:
+            label: 'pim_enrich.form.association_type.tab.properties.title'
+
+    pim-association-type-edit-form-properties-general:
+        module: pim/association-type-edit-form/properties/general
+        parent: pim-association-type-edit-form-properties
+        targetZone: accordion
+        position: 100
+
+    pim-association-type-edit-form-properties-translation:
+        module: pim/common/properties/translation
+        parent: pim-association-type-edit-form-properties
+        targetZone: accordion
+        position: 110
+        config:
+            label: 'pim_enrich.form.association_type.tab.properties.label_translations'
+            fieldBaseId: 'pim_enrich_association_type_form_label_'
+
+    pim-association-type-edit-form-history:
+        module: pim/common/tab/history
+        parent: pim-association-type-edit-form-form-tabs
+        targetZone: container
+        aclResourceId: pim_enrich_associationtype_history
+        position: 120
+        config:
+            class: 'association_type'
+            title: 'pim_enrich.form.association_type.tab.history.title'

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/normalizers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/normalizers.yml
@@ -87,6 +87,8 @@ services:
         class: '%pim_enrich.normalizer.association_type.class%'
         arguments:
             - '@pim_serializer'
+            - '@pim_versioning.manager.version'
+            - '@pim_enrich.normalizer.version'
         tags:
             - { name: pim_internal_api_serializer.normalizer }
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
@@ -33,12 +33,17 @@ config:
         pim/variant-group-manager:
             urls:
                 get: pim_enrich_variant_group_rest_get
+
+        pim/remover/association-type:
+            url: pim_enrich_associationtype_rest_remove
         pim/remover/variant-group:
             url: pim_enrich_variant_group_rest_remove
         pim/remover/group:
             url: pim_enrich_group_rest_remove
         pim/remover/product:
             url: pim_enrich_product_rest_remove
+        pim/saver/association-type:
+            url: pim_enrich_associationtype_rest_post
         pim/saver/variant-group:
             url: pim_enrich_variant_group_rest_post
         pim/saver/product:
@@ -48,6 +53,12 @@ config:
         pim/fetcher-registry:
             fetchers:
                 default: pim/base-fetcher
+                association-type:
+                    module: pim/base-fetcher
+                    options:
+                        urls:
+                            list: pim_enrich_associationtype_rest_index
+                            get: pim_enrich_associationtype_rest_get
                 attribute-group:
                     module: pim/base-fetcher
                     options:
@@ -86,11 +97,6 @@ config:
                     options:
                         urls:
                             list: pim_enrich_currency_rest_index
-                association-type:
-                    module: pim/base-fetcher
-                    options:
-                        urls:
-                            list: pim_enrich_associationtype_rest_index
                 product-completeness:
                     module: pim/completeness-fetcher
                     options:
@@ -172,16 +178,18 @@ config:
         pim/variant-group-fetcher: pimenrich/js/fetcher/variant-group-fetcher
 
         # Remover
-        pim/remover/base:          pimenrich/js/remover/base-remover
-        pim/remover/product:       pimenrich/js/remover/product-remover
-        pim/remover/variant-group: pimenrich/js/remover/variant-group-remover
-        pim/remover/group:         pimenrich/js/remover/group-remover
+        pim/remover/base:               pimenrich/js/remover/base-remover
+        pim/remover/association-type:   pimenrich/js/remover/association-type-remover
+        pim/remover/product:            pimenrich/js/remover/product-remover
+        pim/remover/variant-group:      pimenrich/js/remover/variant-group-remover
+        pim/remover/group:              pimenrich/js/remover/group-remover
 
         # Saver
-        pim/saver/base:          pimenrich/js/saver/base-saver
-        pim/saver/product:       pimenrich/js/saver/product-saver
-        pim/saver/variant-group: pimenrich/js/saver/variant-group-saver
-        pim/saver/group:         pimenrich/js/saver/group-saver
+        pim/saver/base:             pimenrich/js/saver/base-saver
+        pim/saver/association-type: pimenrich/js/saver/association-type-saver
+        pim/saver/product:          pimenrich/js/saver/product-saver
+        pim/saver/variant-group:    pimenrich/js/saver/variant-group-saver
+        pim/saver/group:            pimenrich/js/saver/group-saver
 
         # Generator
         pim/media-url-generator:  pimenrich/js/generator/media-url-generator
@@ -194,11 +202,13 @@ config:
 
         pim/form: pimenrich/js/product/form
 
+        # Association type
+        pim/association-type-edit-form/delete:                 pimenrich/js/association-type/form/delete
+        pim/association-type-edit-form/save:                   pimenrich/js/association-type/form/save
+        pim/association-type-edit-form/properties/general:     pimenrich/js/association-type/form/properties/general
+
         # Variant group
         pim/variant-group-edit-form/save: pimenrich/js/variant-group/form/save
-
-        # Group
-        pim/group-edit-form/save: pimenrich/js/group/form/save
 
         # Product
         pim/product-edit-form/product-label:               pimenrich/js/product/form/product-label
@@ -290,6 +300,7 @@ config:
         pim/group-edit-form/delete:                 pimenrich/js/group/form/delete
         pim/group-edit-form/properties/general:     pimenrich/js/group/form/properties/general
         pim/group-edit-form/meta/product-count:     pimenrich/js/group/form/meta/product-count
+        pim/group-edit-form/save:                   pimenrich/js/group/form/save
 
         # Common
         pim/common/tab/history:            pimenrich/js/form/common/tab/history
@@ -372,6 +383,8 @@ config:
         pim/template/form/tab/attribute/attribute-group-selector: pimenrich/templates/form/tab/attributes/attribute-group-selector.html
         pim/template/form/tab/attribute/copy:                     pimenrich/templates/form/tab/attributes/copy.html
         pim/template/form/tab/attribute/copy-field:               pimenrich/templates/form/tab/attributes/copy-field.html
+
+        pim/template/association-type/tab/properties/general:     pimenrich/templates/association-type/tab/properties/general.html
 
         pim/template/product/tab/categories:                 pimenrich/templates/product/tab/categories.html
         pim/template/product/tab/attribute/validation-error: pimenrich/templates/product/tab/attributes/validation-error.html

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/routing/associationtype.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/routing/associationtype.yml
@@ -1,5 +1,5 @@
 pim_enrich_associationtype_index:
-    path: /.{_format}
+    path: /
     defaults: { _controller: pim_enrich.controller.association_type:indexAction, _format: html }
     requirements:
         _format: html|json
@@ -9,21 +9,36 @@ pim_enrich_associationtype_create:
     defaults: { _controller: pim_enrich.controller.association_type:createAction }
 
 pim_enrich_associationtype_edit:
-    path: /{id}/edit
+    path: /{code}/edit
     defaults: { _controller: pim_enrich.controller.association_type:editAction }
     requirements:
-        id: \d+
-
-pim_enrich_associationtype_remove:
-    path: /{id}/remove
-    defaults: { _controller: pim_enrich.controller.association_type:removeAction }
-    requirements:
-        id: \d+
-    methods: [DELETE]
+        code: '[a-zA-Z0-9_]+'
 
 pim_enrich_associationtype_rest_index:
-    path: /rest.{_format}
+    path: /rest
     defaults: { _controller: pim_enrich.controller.rest.association_type:indexAction, _format: json }
+    methods: [GET]
+
+pim_enrich_associationtype_rest_get:
+    path: /rest/{identifier}
+    defaults: { _controller: pim_enrich.controller.rest.association_type:getAction, _format: json }
     methods: [GET]
     requirements:
         _format: json
+        identifier: '[a-zA-Z0-9_]+'
+
+pim_enrich_associationtype_rest_post:
+    path: /rest/{code}
+    defaults: { _controller: pim_enrich.controller.rest.association_type:postAction, _format: json }
+    methods: [POST]
+    requirements:
+        _format: json
+        code: '[a-zA-Z0-9_]+'
+
+pim_enrich_associationtype_rest_remove:
+    path: /rest/{code}
+    defaults: { _controller: pim_enrich.controller.rest.association_type:removeAction, _format: json }
+    methods: [DELETE]
+    requirements:
+        _format: json
+        code: '[a-zA-Z0-9_]+'

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/association-type/form/delete.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/association-type/form/delete.js
@@ -1,0 +1,14 @@
+'use strict';
+
+/**
+ * Delete extension for association type
+ *
+ * @author    Alexandr Jeliuc <alex@jeliuc.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+define(['pim/form/common/delete', 'pim/remover/association-type'], function (DeleteForm, AssociationTypeRemover) {
+    return DeleteForm.extend({
+        remover: AssociationTypeRemover
+    });
+});

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/association-type/form/properties/general.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/association-type/form/properties/general.js
@@ -1,0 +1,46 @@
+'use strict';
+
+/**
+ * Module used to display the generals properties of an association type
+ *
+ * @author    Alexandr Jeliuc <alex@jeliuc.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+define([
+        'underscore',
+        'oro/translator',
+        'pim/form',
+        'pim/fetcher-registry',
+        'text!pim/template/association-type/tab/properties/general',
+        'jquery.select2'
+    ],
+    function (
+        _,
+        __,
+        BaseForm,
+        FetcherRegistry,
+        template
+    ) {
+        return BaseForm.extend({
+            className: 'tabsection',
+            template: _.template(template),
+
+            /**
+             * {@inheritdoc}
+             */
+            render: function () {
+                this.$el.html(this.template({
+                    model: this.getFormData(),
+                    sectionTitle: __('pim_enrich.form.association_type.tab.properties.general'),
+                    codeLabel: __('pim_enrich.form.association_type.tab.properties.code'),
+                    __: __
+                }));
+
+                this.$el.find('select.select2').select2({});
+
+                this.renderExtensions();
+            }
+        });
+    }
+);

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/association-type/form/save.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/association-type/form/save.js
@@ -1,0 +1,83 @@
+'use strict';
+
+/**
+ * Save extension for association type
+ *
+ * @author    Alexandr Jeliuc <alex@jeliuc.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+define(
+    [
+        'jquery',
+        'underscore',
+        'oro/translator',
+        'pim/form/common/save',
+        'oro/messenger',
+        'pim/saver/association-type',
+        'pim/field-manager',
+        'pim/i18n',
+        'pim/user-context'
+    ],
+    function (
+        $,
+        _,
+        __,
+        BaseSave,
+        messenger,
+        AssociationTypeSaver,
+        FieldManager,
+        i18n,
+        UserContext
+    ) {
+        return BaseSave.extend({
+            updateSuccessMessage: __('pim_enrich.entity.association_type.info.update_successful'),
+            updateFailureMessage: __('pim_enrich.entity.association_type.info.update_failed'),
+
+            /**
+             * {@inheritdoc}
+             */
+            save: function () {
+                var group = $.extend(true, {}, this.getFormData());
+
+                delete group.meta;
+
+                var notReadyFields = FieldManager.getNotReadyFields();
+
+                if (0 < notReadyFields.length) {
+                    var fieldLabels = _.map(notReadyFields, function (field) {
+                        return i18n.getLabel(
+                            field.attribute.label,
+                            UserContext.get('catalogLocale'),
+                            field.attribute.code
+                        );
+                    });
+
+                    messenger.notificationFlashMessage(
+                        'error',
+                        __(
+                            'pim_enrich.entity.association_type.info.field_not_ready',
+                            {'fields': fieldLabels.join(', ')}
+                        )
+                    );
+
+                    return;
+                }
+
+                this.showLoadingMask();
+                this.getRoot().trigger('pim_enrich:form:entity:pre_save');
+
+                return AssociationTypeSaver
+                    .save(group.code, group)
+                    .then(function (data) {
+                        this.postSave();
+
+                        this.setData(data);
+                        this.getRoot().trigger('pim_enrich:form:entity:post_fetch', data);
+                    }.bind(this))
+                    .fail(this.fail.bind(this))
+                    .always(this.hideLoadingMask.bind(this));
+            }
+        });
+    }
+);

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/properties/translation.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/properties/translation.js
@@ -78,6 +78,7 @@ define([
                         label: this.config.label,
                         fieldBaseId: this.config.fieldBaseId
                     }));
+                    this.delegateEvents();
                 }.bind(this));
 
                 this.renderExtensions();

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/remover/association-type-remover.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/remover/association-type-remover.js
@@ -1,0 +1,30 @@
+'use strict';
+
+/**
+ * Module to remove association type
+ *
+ * @author    Alexandr Jeliuc <alex@jeliuc.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+define([
+        'underscore',
+        'pim/remover/base',
+        'module',
+        'routing'
+    ], function (
+        _,
+        BaseRemover,
+        module,
+        Routing
+    ) {
+        return _.extend({}, BaseRemover, {
+            /**
+             * {@inheritdoc}
+             */
+            getUrl: function (code) {
+                return Routing.generate(module.config().url, {code: code});
+            }
+        });
+    }
+);

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/saver/association-type-saver.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/saver/association-type-saver.js
@@ -1,0 +1,30 @@
+'use strict';
+
+/**
+ * Module to save association type
+ *
+ * @author    Alexandr Jeliuc <alex@jeliuc.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+define([
+        'underscore',
+        'pim/saver/base',
+        'module',
+        'routing'
+    ], function (
+        _,
+        BaseSaver,
+        module,
+        Routing
+    ) {
+        return _.extend({}, BaseSaver, {
+            /**
+             * {@inheritdoc}
+             */
+            getUrl: function (code) {
+                return Routing.generate(module.config().url, {code: code});
+            }
+        });
+    }
+);

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/association-type/tab/properties/general.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/association-type/tab/properties/general.html
@@ -1,0 +1,17 @@
+<div class="tabsection-title">
+    <%- sectionTitle %>
+</div>
+<div class="tabsection-content">
+    <div class="AknFormContainer AknFormContainer--withPadding">
+        <div class="AknFieldContainer">
+            <div class="AknFieldContainer-header">
+                <label class="control-label required" for="pim_enrich_association_type_form_code">
+                    <%- codeLabel %> <em><%- __('pim_enrich.form.required') %></em>
+                </label>
+            </div>
+            <div class="AknFieldContainer-inputContainer">
+                <input id="pim_enrich_association_type_form_code" class="AknTextField" type="text" readonly disabled required value="<%- model.code %>">
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
@@ -2,7 +2,7 @@
 confirmation:
     remove:
         item:             Are you sure you want to delete this item?
-        association type: Are you sure you want to delete this association type?
+        association_type: Are you sure you want to delete this association type?
         attribute:        Are you sure you want to delete this attribute?
         family:           Are you sure you want to delete this family?
         product:          Are you sure you want to delete this product?
@@ -35,7 +35,7 @@ pim_datagrid:
 flash:
     item:
         removed: Item successfully removed
-    association type:
+    association_type:
         removed: Association type successfully removed
     attribute:
         removed: Attribute successfully removed
@@ -65,7 +65,7 @@ error:
         product: No attribute is configured as a product identifier or you don't have the rights to edit it.
     removing:
         item:             Cannot delete this item
-        association type: Cannot delete this association type
+        association_type: Cannot delete this association type
         attribute:        Cannot delete this attribute
         family:           Cannot delete this family
         product:          Cannot delete this product
@@ -218,6 +218,20 @@ pim_enrich:
                     family: Choose a family
                     save: Save
                     cancel: Cancel
+        association_type:
+            info:
+                deletion_successful: Association type successfully deleted.
+                deletion_failed: Association type could not be deleted.
+                update_successful: Association type successfully updated.
+                update_failed: The association type could not be updated.
+                field_not_ready: The association type cannot be saved right now. The following fields are not ready: {{ fields }}
+            meta:
+                created: Created
+                created_by: Created by
+                updated: Updated
+                updated_by: Updated by
+            btn:
+                save: Save
         attribute_option:
             code: Code
             label: Label
@@ -327,6 +341,15 @@ pim_enrich:
             mass_edit:
                 select_attributes: Select attributes
                 select: Select
+        association_type:
+            tab:
+                properties:
+                    title: Properties
+                    general: General properties
+                    code: Code
+                    label_translations: Label translations
+                history:
+                    title: History
         attribute_option:
             flash:
                 option_created: Attribute option successfully created

--- a/src/Pim/Bundle/EnrichBundle/Resources/views/AssociationType/edit.html.twig
+++ b/src/Pim/Bundle/EnrichBundle/Resources/views/AssociationType/edit.html.twig
@@ -1,48 +1,62 @@
 {% extends 'PimEnrichBundle::layout.html.twig' %}
-{% import 'PimDataGridBundle::macros.html.twig' as dataGrid %}
+{% import 'PimUIBundle:Default:page_elements.html.twig' as elements %}
 
-{% oro_title_set({ params: { '%association type.label%': form.vars.value.label } }) %}
-
-{% block content %}
-    {{ JSFV(form) }}
-    {{ form_start(form, {
-        'action': path('pim_enrich_associationtype_edit', { id: form.vars.value.id}),
-        'attr': {
-            'data-updated-title': 'confirmation.leave'|trans,
-            'data-updated-message': 'confirmation.discard changes'|trans({ '%entity%': 'association type.title'|trans })
-        }
-    }) }}
-
-        {% set title = 'association type.edit'|trans ~ ' - ' ~ form.vars.value.label %}
-
-        {% set confirmationMessage = 'confirmation.remove.association type'|trans({ '%name%': form.vars.value.label }) %}
-        {% if usageCount %}
-            {% set confirmationMessage = confirmationMessage ~ '<br />' ~ 'info.association type.remove from products'|trans({ '%count%': usageCount }) %}
-        {% endif %}
-        {% set titleButtons %}
-            {{ elements.backLink(path('pim_enrich_associationtype_index')) }}
-        {% endset %}
-        {% set buttons %}
-            {{ elements.deleteLink(
-                path('pim_enrich_associationtype_remove', { id: form.vars.value.id }),
-                'pim_enrich_associationtype_remove',
-                path('pim_enrich_associationtype_index'),
-                confirmationMessage,
-                'flash.association type.removed'|trans,
-                '',
-                'AknButtonList-item'
-            ) }}
-            {{ elements.submitBtn('', 'ok', 'AknButtonList-item') }}
-        {% endset %}
-
-        {{ elements.page_header(title, buttons, null, null, null, titleButtons, elements.updated(form.vars.id)) }}
-
-        <div class="AknTabContainer">
-            {{ elements.form_navbar(view_element_aliases(form.vars.id ~ '.form_tab')) }}
-            <div class="AknTabContainer-content tab-content">
-                {{ elements.form_errors(form) }}
-                {{ view_elements(form.vars.id ~ '.form_tab') }}
+{% block main %}
+    <div id="main">
+        {% block before_content %}
+            <div class="BreadcrumbContainer">
+                <div id="breadcrumb">
+                    {% block breadcrumb %}
+                        {% placeholder breadcrumb %}
+                    {% endblock breadcrumb %}
+                </div>
+                {{ elements.flashMessagesContainer() }}
+                {% placeholder pin_button %}
             </div>
+        {% endblock before_content %}
+        <div class="hash-loading-mask"></div>
+        <div id="container">
+            {% block page_container %}
+                {% block content %}
+                    {% placeholder content_before %}
+                    <div id="association-type-edit-form">
+
+                    </div>
+                    <script>
+                        require(
+                            ['jquery', 'pim/fetcher-registry', 'pim/form-builder', 'pim/user-context', 'pim/dialog', 'oro/mediator', 'pim/error', 'oro/navigation'],
+                            function($, FetcherRegistry, FormBuilder, UserContext, Dialog, mediator, Error, Navigation) {
+                                $(function() {
+                                    FetcherRegistry.initialize().done(function () {
+                                        FetcherRegistry.getFetcher('association-type').fetch('{{ code }}', {cached: false, generateMissing: true})
+                                            .then(function (associationType) {
+                                                var label    = _.escape(associationType.labels[UserContext.get('catalogLocale')]);
+                                                var newTitle = document.title.replace('%association type.label%', label);
+
+                                                document.title  = newTitle;
+                                                var navigation  = Navigation.getInstance();
+                                                var navTitle    = navigation.getPinButtonsData('title');
+                                                navTitle.params = {'%association type.label%': label};
+                                                navigation.setPinButtonsData('title', navTitle);
+                                                navigation.setPinButtonsData('title-rendered-short', newTitle);
+
+                                                FormBuilder.build(associationType.meta.form)
+                                                    .then(function (form) {
+                                                        form.setData(associationType);
+                                                        mediator.trigger('pim_enrich:form:entity:post_fetch', associationType);
+                                                        form.setElement('#association-type-edit-form').render();
+                                                    });
+                                            }).fail(function(response, textStatus, errorThrown) {
+                                            var errorView = new Error(response.responseJSON.message, response.status);
+                                            errorView.setElement('#association-type-edit-form').render();
+                                        });
+                                    })
+                                });
+                            });
+                    </script>
+                    {% placeholder content_after %}
+                {% endblock content %}
+            {% endblock page_container %}
         </div>
-    {{ form_end(form) }}
-{% endblock %}
+    </div>
+{% endblock main %}

--- a/src/Pim/Bundle/EnrichBundle/spec/Form/Type/AssociationTypeTypeSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Form/Type/AssociationTypeTypeSpec.php
@@ -54,3 +54,4 @@ class AssociationTypeTypeSpec extends ObjectBehavior
         )->shouldHaveBeenCalled();
     }
 }
+

--- a/src/Pim/Bundle/EnrichBundle/spec/Normalizer/AssociationTypeNormalizerSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Normalizer/AssociationTypeNormalizerSpec.php
@@ -3,14 +3,22 @@
 namespace spec\Pim\Bundle\EnrichBundle\Normalizer;
 
 use PhpSpec\ObjectBehavior;
+use Pim\Bundle\VersioningBundle\Manager\VersionManager;
 use Pim\Component\Catalog\Model\AssociationTypeInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class AssociationTypeNormalizerSpec extends ObjectBehavior
 {
-    public function let(NormalizerInterface $normalizer)
-    {
-        $this->beConstructedWith($normalizer);
+    public function let(
+        NormalizerInterface $normalizer,
+        VersionManager $versionManager,
+        NormalizerInterface $versionNormalizer
+    ) {
+        $this->beConstructedWith(
+            $normalizer,
+            $versionManager,
+            $versionNormalizer
+        );
     }
 
     public function it_adds_the_attribute_id_to_the_normalized_association_type($normalizer, AssociationTypeInterface $variant)
@@ -18,7 +26,20 @@ class AssociationTypeNormalizerSpec extends ObjectBehavior
         $normalizer->normalize($variant, 'standard', [])->willReturn(['code' => 'variant']);
         $variant->getId()->willReturn(12);
 
-        $this->normalize($variant, 'internal_api', [])->shouldReturn(['code' => 'variant', 'id' => 12]);
+        $this->normalize($variant, 'internal_api', [])
+            ->shouldReturn(
+                [
+                    'code' => 'variant',
+                    'id' => 12,
+                    'meta' => [
+                        'id' => 12,
+                        'form' => "pim-association-type-edit-form",
+                        'model_type' => "association_type",
+                        'created' => null,
+                        'updated' => null,
+                    ]
+                ]
+            );
     }
 
     public function it_supports_association_types_and_internal_api(AssociationTypeInterface $variant)


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) 

**Description (for Contributor and Core Developer)**

See #5391 
- upgrade AssociationType controller
- upgrade AssociationType rest controller
- create association type form extensions
- update requirejs.yml
- implement association type edit form js module and html template
- implement association type save form and saver js modules
- implement association type delete form and remover js modules
- upgrade association type normalizer
- update specs
- update translations
- update behats
- fix translations form event bug
- review fixes

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | :white_check_mark:
| Added Behats                      | :white_check_mark:
| Changelog updated                 | :clock1:
| Review and 2 GTM                  | :white_check_mark:
| Micro Demo to the PO (Story only) | :negative_squared_cross_mark:
| Migration script                  | :negative_squared_cross_mark:
| Tech Doc                          | :negative_squared_cross_mark:


:white_check_mark: Done and pass

:red_circle: Done but fail

:clock1: Done but pending

:negative_squared_cross_mark: Not needed
