### PR TITLE
Update akeneo_batch.yml sender email

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-6376: Fix slow MongoDB queries when editing attribute options
+- GITHUB-5451: Update akeneo_batch.yml sender email, cheers @julienquetil!
 
 # 1.6.14 (2017-04-21)
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/bundles/akeneo_batch.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/bundles/akeneo_batch.yml
@@ -1,3 +1,3 @@
 akeneo_batch:
-    sender_email:             'batch@example.com'
+    sender_email:             '%mailer_from_address%'
     enable_mail_notification: true


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
When you get notification by mail after a batch import for example you didn't have the right sender defined in pim_parameters.yml n your mailbox. 

Not sure if it's "normal" or a miss, but in my mind it must use the master one.
