### PR TITLE
PIM-6041 and PIM-6047: Fixed Channel normalizer

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -4,6 +4,8 @@
 
 - PIM-6033: Fix validation issue when you add a blank attribute option line
 - PIM-6042: Successfully import product associations without removing already existing associations when option "compare values" is set to true
+- PIM-6041: Fix wrong conversion units output for channel export profiles csv and xlsx
+- PIM-6047: Do not export conversion units of channels if no conversion is set
 
 # 1.6.7 (2016-12-20)
 

--- a/features/export/export_channels.feature
+++ b/features/export/export_channels.feature
@@ -1,14 +1,34 @@
+@javascript
 Feature: Export channels
   In order to be able to access and modify channels data outside PIM
   As an administrator
   I need to be able to export channels
 
-  @javascript
   Scenario: Successfully export channels
     Given a "footwear" catalog configuration
     And the following job "csv_footwear_channel_export" configuration:
       | filePath | %tmp%/channel_export/channel_export.csv |
     And I am logged in as "Julia"
+    And I am on the "csv_footwear_channel_export" export job page
+    When I launch the export job
+    And I wait for the "csv_footwear_channel_export" job to finish
+    Then I should see "Read 2"
+    And I should see "Written 2"
+    And exported file of "csv_footwear_channel_export" should contain:
+    """
+    code;label;conversion_units;currencies;locales;tree
+    mobile;Mobile;;EUR;en_US;2014_collection
+    tablet;Tablet;;USD,EUR;en_US;2014_collection
+    """
+
+  @jira https://akeneo.atlassian.net/browse/PIM-6047
+  Scenario: Do not export empty conversion units of channels
+    Given a "footwear" catalog configuration
+    And the following job "csv_footwear_channel_export" configuration:
+      | filePath | %tmp%/channel_export/channel_export.csv |
+    And I am logged in as "Julia"
+    And I edit the "mobile" channel
+    And I press the "Save" button
     And I am on the "csv_footwear_channel_export" export job page
     When I launch the export job
     And I wait for the "csv_footwear_channel_export" job to finish

--- a/features/import/import_channels.feature
+++ b/features/import/import_channels.feature
@@ -21,6 +21,34 @@ Feature: Import channels
       | code | label | currencies | locales           | tree            | conversion_units                                                                                 |
       | site | Site  | EUR,USD    | de_DE,en_US,hy_AM | 2014_collection | weight: GRAM, maximum_scan_size: KILOMETER, display_diagonal: DEKAMETER, viewing_area: DEKAMETER |
 
+  @jira https://akeneo.atlassian.net/browse/PIM-6041
+  Scenario: Successfully import channel do not create empty conversion unit
+    Given the "footwear" catalog configuration
+    And I am logged in as "Julia"
+    And the following CSV file to import:
+      """
+      code;label;currencies;locales;tree;conversion_units
+      mobile;Mobile app;EUR,USD;en_US,fr_FR;2014_collection;
+      """
+    And the following job "csv_footwear_channel_import" configuration:
+      | filePath | %file to import% |
+    And the following job "csv_footwear_channel_export" configuration:
+      | filePath | %tmp%/channel_export/channel_export.csv |
+    When I am on the "csv_footwear_channel_import" import job page
+    And I launch the import job
+    And I wait for the "csv_footwear_channel_import" job to finish
+    And I am on the "csv_footwear_channel_export" export job page
+    When I launch the export job
+    And I wait for the "csv_footwear_channel_export" job to finish
+    Then I should see "Read 2"
+    And I should see "Written 2"
+    And exported file of "csv_footwear_channel_export" should contain:
+    """
+    code;label;conversion_units;currencies;locales;tree
+    mobile;"Mobile app";;USD,EUR;en_US,fr_FR;2014_collection
+    tablet;Tablet;;USD,EUR;en_US;2014_collection
+    """
+
   Scenario: Successfully update existing channel and add a new one
     Given the "footwear" catalog configuration
     And I am logged in as "Julia"

--- a/src/Pim/Component/Catalog/Normalizer/Structured/ChannelNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Structured/ChannelNormalizer.php
@@ -124,7 +124,9 @@ class ChannelNormalizer implements NormalizerInterface
     {
         $result = [];
         foreach ($channel->getConversionUnits() as $family => $unit) {
-            $result[] = sprintf('%s: %s', $family, $unit);
+            if (!empty($unit)) {
+                $result[] = sprintf('%s: %s', $family, $unit);
+            }
         }
 
         return implode(', ', $result);

--- a/src/Pim/Component/Catalog/spec/Normalizer/Structured/ChannelNormalizerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Normalizer/Structured/ChannelNormalizerSpec.php
@@ -54,7 +54,8 @@ class ChannelNormalizerSpec extends ObjectBehavior
         $channel->getConversionUnits()->willReturn(
             [
                 'Weight' => 'Kilogram',
-                'Size' => 'Centimeter'
+                'Size' => '',
+                'Length' => 'Centimeter',
             ]
         );
 
@@ -71,8 +72,9 @@ class ChannelNormalizerSpec extends ObjectBehavior
                         'en_US' => 'label'
                     ],
                 ],
-                'conversion_units' => 'Weight: Kilogram, Size: Centimeter'
+                'conversion_units' => 'Weight: Kilogram, Length: Centimeter'
             ]
         );
     }
 }
+

--- a/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Channel.php
+++ b/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Channel.php
@@ -5,6 +5,7 @@ namespace Pim\Component\Connector\ArrayConverter\FlatToStandard;
 use Pim\Component\Connector\ArrayConverter\ArrayConverterInterface;
 use Pim\Component\Connector\ArrayConverter\FieldsRequirementChecker;
 use Pim\Component\Connector\Exception\ArrayConversionException;
+use Pim\Component\Connector\Exception\StructureArrayConversionException;
 
 /**
  * Channel Flat to Standard format Converter
@@ -100,7 +101,7 @@ class Channel implements ArrayConverterInterface
      */
     protected function convertUnits($flatUnits)
     {
-        $units = explode(',', $flatUnits);
+        $units = array_filter(explode(',', $flatUnits));
 
         $formattedUnits = [];
         foreach ($units as $unit) {

--- a/src/Pim/Component/Connector/spec/ArrayConverter/FlatToStandard/ChannelSpec.php
+++ b/src/Pim/Component/Connector/spec/ArrayConverter/FlatToStandard/ChannelSpec.php
@@ -46,4 +46,9 @@ class ChannelSpec extends ObjectBehavior
 
         $this->convert($item)->shouldReturn($result);
     }
+
+    function it_converts_empty_conversion_units()
+    {
+        $this->convert(['conversion_units' => ''])->shouldReturn(['conversion_units' => []]);
+    }
 }


### PR DESCRIPTION
| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | :white_check_mark:
| Added Behats                      | :white_check_mark:
| Changelog updated                 | :white_check_mark:
| Review and 2 GTM                  | :white_check_mark:
| Micro Demo to the PO (Story only) | In progress
| Migration script                  | :negative_squared_cross_mark:
| Tech Doc                          | :negative_squared_cross_mark:

# Notes

About the import issue, here is what we have when creating a channel from fixtures for example:
```
mysql> select * from pim_catalog_channel;
+----+-------------+-----------+-----------+-----------------+
| id | category_id | code      | label     | conversionUnits |
+----+-------------+-----------+-----------+-----------------+
|  3 |           1 | ecommerce | Ecommerce | a:0:{}          |
+----+-------------+-----------+-----------+-----------------+
```
And here is the same after we save it from the UI:
```
mysql> select * from pim_catalog_channel;
+----+-------------+-----------+-----------+--------------------------------------------------------------------------------------------------+
| id | category_id | code      | label     | conversionUnits                                                                                  |
+----+-------------+-----------+-----------+--------------------------------------------------------------------------------------------------+
|  3 |           1 | ecommerce | Ecommerce | a:4:{s:6:"weight";N;s:17:"maximum_scan_size";N;s:16:"display_diagonal";N;s:12:"viewing_area";N;} |
+----+-------------+-----------+-----------+--------------------------------------------------------------------------------------------------+
```

For the FlatToStandard issue, exploding an empty string creates an empty array which creates a ": " string at the export. Here is what was generated in the database
```
mysql> select * from pim_catalog_channel;
+----+-------------+-----------+-----------+--------------------------------------------------------------------------------------------------+
| id | category_id | code      | label     | conversionUnits                                                                                  |
+----+-------------+-----------+-----------+--------------------------------------------------------------------------------------------------+
|  3 |           1 | ecommerce | Ecommerce | a:1:{s:0:"";s:0:"";} |
+----+-------------+-----------+-----------+--------------------------------------------------------------------------------------------------+
```

Both issues were generating a bug when trying to export / import / export again channels.