### PR TITLE
WIP Fix identifiers import duplication

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -6,7 +6,7 @@
 - GITHUB-5062: Fixed unit conversion for ElectricCharge, cheers @gplanchat!
 - GITHUB-5294: Fixed infinite loading if no attribute is configured as a product identifier, cheers @gplanchat!
 - GITHUB-5337: Fixed Widget Registry. Priority is now taken in account.
-- PIM-5897: Introducing a BulkIdentifierBag class used to keep track of the entities identifiers imported (avoiding to import duplicated entities).
+- PIM-5897: Introducing a BulkSimpleIdentifierBag and BulkCompositeIdentifierBag classes used to keep track of the entities processed (avoiding to import duplicated entities).
 
 ## Deprecations
 
@@ -34,6 +34,7 @@
 - GITHUB-5391: Redo association type edit form using backbonejs architecture and internal REST API
 - TIP-652: Redo the import/export screens in new PEF architecture
 - TIP-682: Update to Symfony 2.7.23
+- PIM-5897: Denormalization processors now check if the item's identifier has already been processed within the job lifetime using the BulkIdentifierBagInterface implementations.
 
 ## BC breaks
 - Change the constructor of `Pim\Component\Catalog\Denormalizer\Standard\ProductValueDenormalizer` to add `Pim\Component\Catalog\Factory\ProductValueFactory`

--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -6,6 +6,7 @@
 - GITHUB-5062: Fixed unit conversion for ElectricCharge, cheers @gplanchat!
 - GITHUB-5294: Fixed infinite loading if no attribute is configured as a product identifier, cheers @gplanchat!
 - GITHUB-5337: Fixed Widget Registry. Priority is now taken in account.
+- PIM-5897: Introducing a BulkIdentifierBag class used to keep track of the entities identifiers imported (avoiding to import duplicated entities).
 
 ## Deprecations
 

--- a/features/Context/FixturesContext.php
+++ b/features/Context/FixturesContext.php
@@ -102,6 +102,7 @@ class FixturesContext extends BaseFixturesContext
         }
 
         $converter = $this->getContainer()->get('pim_connector.array_converter.flat_to_standard.product');
+
         $processor = $this->getContainer()->get('pim_connector.processor.denormalization.product');
 
         $jobExecution = new JobExecution();
@@ -388,6 +389,11 @@ class FixturesContext extends BaseFixturesContext
         $attributeBulks = [];
         $attributeConverter = $this->getContainer()->get('pim_connector.array_converter.flat_to_standard.attribute');
         $attributeProcessor = $this->getContainer()->get('pim_connector.processor.denormalization.attribute');
+
+        $dummyJobExecution = new JobExecution();
+        $dummyStepExecution = new StepExecution('', $dummyJobExecution);
+        $attributeProcessor->setStepExecution($dummyStepExecution);
+
         foreach ($attributeData as $index => $data) {
             $convertedData = $attributeConverter->convert($data);
             $attribute = $attributeProcessor->process($convertedData);
@@ -401,6 +407,11 @@ class FixturesContext extends BaseFixturesContext
         $optionsBulks = [];
         $optionConverter = $this->getContainer()->get('pim_connector.array_converter.flat_to_standard.attribute_option');
         $optionProcessor = $this->getContainer()->get('pim_connector.processor.denormalization.attribute_option');
+
+        $dummyJobExecution = new JobExecution();
+        $dummyStepExecution = new StepExecution('', $dummyJobExecution);
+        $optionProcessor->setStepExecution($dummyStepExecution);
+
         foreach ($optionData as $index => $data) {
             $convertedData = $optionConverter->convert($data);
             $option = $optionProcessor->process($convertedData);
@@ -1711,6 +1722,11 @@ class FixturesContext extends BaseFixturesContext
         $convertedData = $converter->convert($data);
 
         $processor = $this->getContainer()->get('pim_connector.processor.denormalization.attribute');
+
+        $dummyJobExecution = new JobExecution();
+        $dummyStepExecution = new StepExecution('', $dummyJobExecution);
+        $processor->setStepExecution($dummyStepExecution);
+
         $attribute = $processor->process($convertedData);
 
         $familiesToPersist = [];
@@ -1783,6 +1799,11 @@ class FixturesContext extends BaseFixturesContext
 
         $converter = $this->getContainer()->get('pim_connector.array_converter.flat_to_standard.category');
         $processor = $this->getContainer()->get('pim_connector.processor.denormalization.category');
+
+        $dummyJobExecution = new JobExecution();
+        $dummyStepExecution = new StepExecution('', $dummyJobExecution);
+        $processor->setStepExecution($dummyStepExecution);
+
         $convertedData = $converter->convert($data);
         $category = $processor->process($convertedData);
 
@@ -2030,6 +2051,10 @@ class FixturesContext extends BaseFixturesContext
         $converter = $this->getContainer()->get('pim_connector.array_converter.flat_to_standard.family');
         $processor = $this->getContainer()->get('pim_connector.processor.denormalization.family');
 
+        $dummyJobExecution = new JobExecution();
+        $dummyStepExecution = new StepExecution('', $dummyJobExecution);
+        $processor->setStepExecution($dummyStepExecution);
+
         $convertedData = $converter->convert($data);
         $family = $processor->process($convertedData);
         $this->getFamilySaver()->save($family);
@@ -2050,8 +2075,15 @@ class FixturesContext extends BaseFixturesContext
             $data = ['code' => $data];
         }
 
+
+
         $converter = $this->getContainer()->get('pim_connector.array_converter.flat_to_standard.attribute_group');
         $processor = $this->getContainer()->get('pim_connector.processor.denormalization.attribute_group');
+
+        $dummyJobExecution = new JobExecution();
+        $dummyStepExecution = new StepExecution('', $dummyJobExecution);
+        $processor->setStepExecution($dummyStepExecution);
+
         $convertedData = $converter->convert($data);
         $attributeGroup = $processor->process($convertedData);
         $this->getContainer()->get('pim_catalog.saver.attribute_group')->save($attributeGroup);

--- a/features/import/attribute/import_attributes.feature
+++ b/features/import/attribute/import_attributes.feature
@@ -199,15 +199,17 @@ Feature: Import attributes
       type;code;label-de_DE;label-en_US;label-fr_FR;group;unique;useable_as_grid_filter;allowed_extensions;metric_family;default_metric_unit;reference_data_name;localizable;scopable;available_locales;sort_order;max_characters;validation_rule;validation_regexp;wysiwyg_enabled;number_min;number_max;decimals_allowed;negative_allowed;date_min;date_max;metric_family;default_metric_unit;max_file_size;allowed_extensions
       pim_catalog_image;media_code;Meine große Code;My awesome code;Mon super code;marketing;0;1;;family;;;0;0;en_US,fr_FR;3;300;validation_rule;;1;3;5;true;true;2000-08-08;2015-08-08;;EUR;not an int;jpg
       pim_catalog_image;media_code;Meine große Code;My awesome code;Mon super code;not a group;0;1;;family;;;0;0;en_US,fr_FR;3;300;validation_rule;;1;3;5;true;true;2000-08-08;2015-08-08;;EUR;not an int;jpg
+      pim_catalog_image;media_code_2;Meine große Code;My awesome code;Mon super code;not a group;0;1;;family;;;0;0;en_US,fr_FR;3;300;validation_rule;;1;3;5;true;true;2000-08-08;2015-08-08;;EUR;not an int;jpg
       """
     And the following job "csv_footwear_attribute_import" configuration:
       | filePath | %file to import% |
     When I am on the "csv_footwear_attribute_import" import job page
     And I launch the import job
     And I wait for the "csv_footwear_attribute_import" job to finish
-    Then I should see "read lines 2"
-    Then I should see "skipped 2"
+    Then I should see "read lines 3"
+    Then I should see "skipped 3"
     Then I should see "maxFileSize: This value should be a valid number.: not an int"
+    Then I should see "An item with the identifier \"media_code\" has already been processed."
     Then I should see "Property \"group\" expects a valid code. The attribute group does not exist, \"not a group\" given (for updater attribute)."
 
   Scenario: Successfully import new attribute

--- a/features/import/import_invalid_csv_data.feature
+++ b/features/import/import_invalid_csv_data.feature
@@ -198,3 +198,47 @@ Feature: Handle import of invalid CSV data
       code;type;label-en_US;axis
       caterpil ar;VARIANT;Caterpillar;color,size
       """
+
+  Scenario: From a product CSV import, the job does not import duplicated products
+    Given the following CSV file to import:
+      """
+      sku;family
+      SKU-002;sneakers
+      SKU-003;sneakers
+      SKU-003;sneakers
+      SKU-005;boots
+      """
+    And the following job "csv_footwear_product_import" configuration:
+      | filePath | %file to import% |
+    And I am logged in as "Julia"
+    And I am on the "csv_footwear_product_import" export job page
+    And I launch the "csv_footwear_product_import" import job
+    And I wait for the "csv_footwear_product_import" job to finish
+    Then I should see the text "Download invalid data"
+    And the invalid data file of "csv_footwear_product_import" should contain:
+      """
+      sku;family
+      SKU-003;sneakers
+      """
+
+  Scenario: From an attribute CSV import, the job does not import duplicated attributes
+    Given the following CSV file to import:
+      """
+      type;code;label-en_US;group;unique;useable_as_grid_filter;allowed_extensions;metric_family;default_metric_unit;reference_data_name;localizable;scopable;required;sort_order;label-fr_FR;max_characters;number_min;number_max;decimals_allowed;negative_allowed;max_file_size
+      pim_catalog_text;name;Name;info;0;1;;;;;1;0;0;2;;;;;;;
+      pim_catalog_text;comment;Comment;other;0;1;;;;;0;0;0;7;;255;;;;;
+      pim_catalog_text;comment;Comment;other;0;1;;;;;0;0;0;7;;255;;;;;
+      pim_catalog_multiselect;weather_conditions;"Weather conditions";info;0;1;;;;;0;0;0;4;;;;;;;
+      """
+    And the following job "csv_footwear_attribute_import" configuration:
+      | filePath | %file to import% |
+    And I am logged in as "Julia"
+    And I am on the "csv_footwear_attribute_import" export job page
+    And I launch the "csv_footwear_attribute_import" import job
+    And I wait for the "csv_footwear_attribute_import" job to finish
+    Then I should see the text "Download invalid data"
+    And the invalid data file of "csv_footwear_attribute_import" should contain:
+      """
+      type;code;label-en_US;group;unique;useable_as_grid_filter;allowed_extensions;metric_family;default_metric_unit;reference_data_name;localizable;scopable;required;sort_order;label-fr_FR;max_characters;number_min;number_max;decimals_allowed;negative_allowed;max_file_size
+      pim_catalog_text;comment;Comment;other;0;1;;;;;0;0;0;7;;255;;;;;
+      """

--- a/features/import/product/import_products_with_invalid_data.feature
+++ b/features/import/product/import_products_with_invalid_data.feature
@@ -292,7 +292,7 @@ Feature: Execute a job
     And I launch the import job
     And I wait for the "csv_footwear_product_import" job to finish
     Then there should be 1 product
-    And I should see "The value SKU-001 is already set on another product for the unique attribute sku"
+    And I should see "An item with the identifier \"SKU-001\" has already been processed."
     And the product "SKU-001" should have the following value:
       | name-en_US | high heels |
 

--- a/src/Akeneo/Bundle/BatchBundle/EventListener/ResetBulkIdentifierBagSubscriber.php
+++ b/src/Akeneo/Bundle/BatchBundle/EventListener/ResetBulkIdentifierBagSubscriber.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Akeneo\Bundle\BatchBundle\EventListener;
+
+use Akeneo\Component\Batch\Event\EventInterface;
+use Akeneo\Component\Batch\Event\JobExecutionEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Given a job execution processing multiple entities and keeping track of their identifiers in the BulkIdentifierBag
+ * (to prevent the processing of duplicated entities).
+ * This event subscriber resets the list of identifiers treated once a full batch has been processed (the batch size
+ * is configured at the job level).
+ *
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ResetBulkIdentifierBagSubscriber implements EventSubscriberInterface
+{
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            EventInterface::JOB_BATCH_SIZE_REACHED => 'resetJobExecutionBulkIdentifierBar'
+        ];
+    }
+
+    public function resetJobExecutionBulkIdentifierBar(JobExecutionEvent $jobExecutionEvent)
+    {
+        $jobExecution = $jobExecutionEvent->getJobExecution();
+        $executionContext = $jobExecution->getExecutionContext();
+        $bulkIdentifierBag = $executionContext->get('bulk_identifier_bag');
+
+        if (null !== $bulkIdentifierBag) {
+            $bulkIdentifierBag->reset();
+        }
+    }
+}

--- a/src/Akeneo/Bundle/BatchBundle/EventListener/ResetBulkIdentifierBagSubscriber.php
+++ b/src/Akeneo/Bundle/BatchBundle/EventListener/ResetBulkIdentifierBagSubscriber.php
@@ -3,11 +3,11 @@
 namespace Akeneo\Bundle\BatchBundle\EventListener;
 
 use Akeneo\Component\Batch\Event\EventInterface;
-use Akeneo\Component\Batch\Event\JobExecutionEvent;
+use Akeneo\Component\Batch\Event\StepExecutionEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
- * Given a job execution processing multiple entities and keeping track of their identifiers in the BulkIdentifierBag
+ * Given a job processing multiple entities and keeping track of their identifiers in the BulkIdentifierBag
  * (to prevent the processing of duplicated entities).
  * This event subscriber resets the list of identifiers treated once a full batch has been processed (the batch size
  * is configured at the job level).
@@ -18,18 +18,23 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class ResetBulkIdentifierBagSubscriber implements EventSubscriberInterface
 {
-
+    /**
+     * {@inheritdoc}
+     */
     public static function getSubscribedEvents()
     {
         return [
-            EventInterface::JOB_BATCH_SIZE_REACHED => 'resetJobExecutionBulkIdentifierBar'
+            EventInterface::JOB_BATCH_SIZE_REACHED => 'resetJobExecutionBulkIdentifierBar',
         ];
     }
 
-    public function resetJobExecutionBulkIdentifierBar(JobExecutionEvent $jobExecutionEvent)
+    /**
+     * Once a step has reached the job batch size. This event subscriber resets the bulk identifier bag if it exists.
+     */
+    public function resetJobExecutionBulkIdentifierBar(StepExecutionEvent $stepExecutionEvent)
     {
-        $jobExecution = $jobExecutionEvent->getJobExecution();
-        $executionContext = $jobExecution->getExecutionContext();
+        $stepExecution = $stepExecutionEvent->getStepExecution();
+        $executionContext = $stepExecution->getExecutionContext();
         $bulkIdentifierBag = $executionContext->get('bulk_identifier_bag');
 
         if (null !== $bulkIdentifierBag) {

--- a/src/Akeneo/Bundle/BatchBundle/Resources/config/services.yml
+++ b/src/Akeneo/Bundle/BatchBundle/Resources/config/services.yml
@@ -9,6 +9,7 @@ parameters:
     akeneo_batch.launcher.simple_job_launcher.class:          Akeneo\Bundle\BatchBundle\Launcher\SimpleJobLauncher
     akeneo_batch.connectors_config:                           ~
     akeneo_batch.jobs_config:                                 ~
+    akeneo_batch.reset_bulk_identifier_bag.class:             Akeneo\Bundle\BatchBundle\EventListener\ResetBulkIdentifierBagSubscriber
 
 services:
     akeneo_batch.job_instance_factory:
@@ -68,3 +69,8 @@ services:
             - '@akeneo_batch.job.job_registry'
             - '%kernel.root_dir%'
             - '%kernel.environment%'
+
+    akeneo_batch.reset_bulk_identifier_bag:
+        class: '%akeneo_batch.reset_bulk_identifier_bag.class%'
+        tags:
+            - { name: kernel.event_subscriber }

--- a/src/Akeneo/Component/Batch/Event/EventInterface.php
+++ b/src/Akeneo/Component/Batch/Event/EventInterface.php
@@ -18,6 +18,7 @@ interface EventInterface
     const JOB_EXECUTION_FATAL_ERROR = 'akeneo_batch.job_execution_fatal_error';
     const BEFORE_JOB_STATUS_UPGRADE = 'akeneo_batch.before_job_status_upgrade';
     const AFTER_JOB_EXECUTION = 'akeneo_batch.after_job_execution';
+    const JOB_BATCH_SIZE_REACHED = 'akeneo_batch.job_batch_size_reached';
 
     /** Step execution events */
     const BEFORE_STEP_EXECUTION = 'akeneo_batch.before_step_execution';

--- a/src/Akeneo/Component/Batch/Step/ItemStep.php
+++ b/src/Akeneo/Component/Batch/Step/ItemStep.php
@@ -2,6 +2,7 @@
 
 namespace Akeneo\Component\Batch\Step;
 
+use Akeneo\Component\Batch\Event\EventInterface;
 use Akeneo\Component\Batch\Item\FlushableInterface;
 use Akeneo\Component\Batch\Item\InitializableInterface;
 use Akeneo\Component\Batch\Item\InvalidItemException;
@@ -125,6 +126,7 @@ class ItemStep extends AbstractStep
                     $this->write($itemsToWrite);
                     $itemsToWrite = [];
                     $this->getJobRepository()->updateStepExecution($stepExecution);
+                    $this->dispatchStepExecutionEvent(EventInterface::JOB_BATCH_SIZE_REACHED, $stepExecution);
                 }
             }
         }

--- a/src/Akeneo/Component/Batch/spec/Step/ItemStepSpec.php
+++ b/src/Akeneo/Component/Batch/spec/Step/ItemStepSpec.php
@@ -50,6 +50,7 @@ class ItemStepSpec extends ObjectBehavior
         $processor->process('r1')->shouldBeCalled()->willReturn('p1');
         $processor->process('r2')->shouldBeCalled()->willReturn('p2');
         $processor->process('r3')->shouldBeCalled()->willReturn('p3');
+        $dispatcher->dispatch(EventInterface::JOB_BATCH_SIZE_REACHED, Argument::any())->shouldBeCalled();
         $writer->write(['p1', 'p2', 'p3'])->shouldBeCalled();
 
         // second batch
@@ -93,6 +94,7 @@ class ItemStepSpec extends ObjectBehavior
         $processor->process('r1')->shouldBeCalled()->willReturn('p1');
         $processor->process('r2')->shouldBeCalled()->willReturn('p2');
         $processor->process('r3')->shouldBeCalled()->willReturn('p3');
+        $dispatcher->dispatch(EventInterface::JOB_BATCH_SIZE_REACHED, Argument::any())->shouldBeCalled();
         $writer->write(['p1', 'p2', 'p3'])->shouldBeCalled();
 
         // second batch

--- a/src/Pim/Component/Connector/BulkIdentifierBag.php
+++ b/src/Pim/Component/Connector/BulkIdentifierBag.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Pim\Component\Connector;
+
+/**
+ * A bag of identifiers that can be used during bulk operations.
+ *
+ * Typically, during an import, there can be several items with the same identifiers in the same bulk.
+ * Those items are not detected as duplications and lead to errors in database.
+ * This bag aims to store them momentarily during the period of the bulk.
+ *
+ * @author    Julien Janvier <jjanvier@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class BulkIdentifierBag
+{
+    private $identifiers = [];
+
+    /**
+     * @param string $identifier
+     *
+     * @throws \LogicException when the identifier is already in the bag
+     */
+    public function add($identifier)
+    {
+        if ($this->has($identifier)) {
+            throw new \LogicException(sprintf('The identifier "%s" is already contained in the bag.', $identifier));
+        }
+
+        $this->identifiers[] = $identifier;
+    }
+
+    /**
+     * @param string $identifier
+     *
+     * @return bool
+     */
+    public function has($identifier)
+    {
+        return in_array($identifier, $this->identifiers);
+    }
+
+    /**
+     * Empty the bag
+     */
+    public function reset()
+    {
+        $this->identifiers = [];
+    }
+}

--- a/src/Pim/Component/Connector/Item/BulkCompositeIdentifierBag.php
+++ b/src/Pim/Component/Connector/Item/BulkCompositeIdentifierBag.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Pim\Component\Connector\Item;
+
+/**
+ * A bag of composite identifiers (array of identifier values) that can be used during bulk operations.
+ * It supports entities like Attribute Option identifiers which key is attribute code and attribute option code.
+ *
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class BulkCompositeIdentifierBag implements BulkIdentifierBagInterface
+{
+    /** @var array */
+    protected $compositeIdentifiers = [];
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \InvalidArgumentException when the identifier is not an array (composite key)
+     */
+    public function add($compositeIdentifier)
+    {
+        if (!is_array($compositeIdentifier)) {
+            throw new \InvalidArgumentException(sprintf(
+                'The identifier "%s" is not a composite key (an array).',
+                $compositeIdentifier
+            ));
+        }
+
+        if ($this->has($compositeIdentifier)) {
+            throw new \LogicException(sprintf(
+                'The composite identifier "%s" is already contained in the bag.',
+                join(', ', $compositeIdentifier)
+            ));
+        }
+
+        $this->compositeIdentifiers[] = $compositeIdentifier;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function has($compositeIdentifier)
+    {
+        $isPresent = false;
+
+        foreach ($this->compositeIdentifiers as $compositeIdentifierBag) {
+            $isPresent = empty(array_diff($compositeIdentifier, $compositeIdentifierBag)) || $isPresent;
+        }
+
+        return $isPresent;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reset()
+    {
+        $this->compositeIdentifiers = [];
+    }
+}

--- a/src/Pim/Component/Connector/Item/BulkIdentifierBagInterface.php
+++ b/src/Pim/Component/Connector/Item/BulkIdentifierBagInterface.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Pim\Component\Connector\Item;
+
+/**
+ * A bag of identifiers that can be used during bulk operations.
+ *
+ * Typically, during an import, there can be several items with the same identifiers in the same bulk.
+ * Those items are not detected as duplications and lead to errors in database.
+ * This bag aims to store them momentarily during the period of the bulk.
+ *
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface BulkIdentifierBagInterface
+{
+    /**
+     * Method that adds an identifier to the list of identifiers
+     *
+     * @param mixed $identifier
+     *
+     * @throws \LogicException when the identifier is already in the bag
+     */
+    public function add($identifier);
+
+    /**
+     * Checks if the given identifier exists in the bag.
+     * In the case of composite keys it checks if all the values of the composite keys isn't in the list of composite
+     * keys.
+     *
+     * @param $identifier
+     *
+     * @return bool
+     */
+    public function has($identifier);
+
+    /**
+     * Empty the bag
+     */
+    public function reset();
+}

--- a/src/Pim/Component/Connector/Item/BulkSimpleIdentifierBag.php
+++ b/src/Pim/Component/Connector/Item/BulkSimpleIdentifierBag.php
@@ -1,26 +1,23 @@
 <?php
 
-namespace Pim\Component\Connector;
+namespace Pim\Component\Connector\Item;
 
 /**
- * A bag of identifiers that can be used during bulk operations.
+ * A bag of simple identifiers that can be used during bulk operations.
  *
- * Typically, during an import, there can be several items with the same identifiers in the same bulk.
- * Those items are not detected as duplications and lead to errors in database.
- * This bag aims to store them momentarily during the period of the bulk.
+ * This class also supports composite keys (as implemented in the attribute options for instance).
  *
- * @author    Julien Janvier <jjanvier@akeneo.com>
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
  * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class BulkIdentifierBag
+class BulkSimpleIdentifierBag implements BulkIdentifierBagInterface
 {
-    private $identifiers = [];
+    /** @var array */
+    protected $identifiers = [];
 
     /**
-     * @param string $identifier
-     *
-     * @throws \LogicException when the identifier is already in the bag
+     * {@inheritdoc}
      */
     public function add($identifier)
     {
@@ -32,9 +29,7 @@ class BulkIdentifierBag
     }
 
     /**
-     * @param string $identifier
-     *
-     * @return bool
+     * {@inheritdoc}
      */
     public function has($identifier)
     {
@@ -42,7 +37,7 @@ class BulkIdentifierBag
     }
 
     /**
-     * Empty the bag
+     * {@inheritdoc}
      */
     public function reset()
     {

--- a/src/Pim/Component/Connector/Processor/Denormalization/AbstractProcessor.php
+++ b/src/Pim/Component/Connector/Processor/Denormalization/AbstractProcessor.php
@@ -4,7 +4,6 @@ namespace Pim\Component\Connector\Processor\Denormalization;
 
 use Akeneo\Component\Batch\Item\FileInvalidItem;
 use Akeneo\Component\Batch\Item\InvalidItemException;
-use Akeneo\Component\Batch\Item\ItemProcessorInterface;
 use Akeneo\Component\Batch\Model\StepExecution;
 use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
@@ -141,7 +140,10 @@ abstract class AbstractProcessor implements StepExecutionAwareInterface
         }
 
         if ($bag->has($identifier)) {
-            $this->skipItemWithMessage($item, sprintf('An item with the identifier "%s" has already been processed.'));
+            $this->skipItemWithMessage(
+                $item,
+                sprintf('An item with the identifier "%s" has already been processed.', $identifier)
+            );
         }
 
         $bag->add($identifier);

--- a/src/Pim/Component/Connector/Processor/Denormalization/AbstractProcessor.php
+++ b/src/Pim/Component/Connector/Processor/Denormalization/AbstractProcessor.php
@@ -7,9 +7,10 @@ use Akeneo\Component\Batch\Item\InvalidItemException;
 use Akeneo\Component\Batch\Model\StepExecution;
 use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
-use Pim\Component\Connector\BulkIdentifierBag;
 use Pim\Component\Connector\Exception\InvalidItemFromViolationsException;
 use Pim\Component\Connector\Exception\MissingIdentifierException;
+use Pim\Component\Connector\Item\BulkCompositeIdentifierBag;
+use Pim\Component\Connector\Item\BulkSimpleIdentifierBag;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
 
 /**
@@ -129,13 +130,22 @@ abstract class AbstractProcessor implements StepExecutionAwareInterface
      * Stores an identifier in the bag "bulk_identifier_bag",to be able to check duplications.
      * The bag should be reset after each bulk is processed. Typically, in the Writer.
      *
-     * @param array  $item
-     * @param string $identifier
+     * @param array $item
+     * @param mixed $identifier
      */
     protected function checkIdentifierDuplication(array $item, $identifier)
     {
+        if (is_array($identifier) && 1 === count($identifier)) {
+            $identifier = current($identifier);
+        }
+
         if (null === $bag = $this->stepExecution->getExecutionContext()->get('bulk_identifier_bag')) {
-            $bag = new BulkIdentifierBag();
+            $bag = new BulkSimpleIdentifierBag();
+
+            if (is_array($identifier)) {
+                $bag = new BulkCompositeIdentifierBag();
+            }
+
             $this->stepExecution->getExecutionContext()->put('bulk_identifier_bag', $bag);
         }
 

--- a/src/Pim/Component/Connector/Processor/Denormalization/AbstractProcessor.php
+++ b/src/Pim/Component/Connector/Processor/Denormalization/AbstractProcessor.php
@@ -8,6 +8,7 @@ use Akeneo\Component\Batch\Item\ItemProcessorInterface;
 use Akeneo\Component\Batch\Model\StepExecution;
 use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
+use Pim\Component\Connector\BulkIdentifierBag;
 use Pim\Component\Connector\Exception\InvalidItemFromViolationsException;
 use Pim\Component\Connector\Exception\MissingIdentifierException;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
@@ -123,5 +124,26 @@ abstract class AbstractProcessor implements StepExecutionAwareInterface
             0,
             $previousException
         );
+    }
+
+    /**
+     * Stores an identifier in the bag "bulk_identifier_bag",to be able to check duplications.
+     * The bag should be reset after each bulk is processed. Typically, in the Writer.
+     *
+     * @param array  $item
+     * @param string $identifier
+     */
+    protected function checkIdentifierDuplication(array $item, $identifier)
+    {
+        if (null === $bag = $this->stepExecution->getExecutionContext()->get('bulk_identifier_bag')) {
+            $bag = new BulkIdentifierBag();
+            $this->stepExecution->getExecutionContext()->put('bulk_identifier_bag', $bag);
+        }
+
+        if ($bag->has($identifier)) {
+            $this->skipItemWithMessage($item, sprintf('An item with the identifier "%s" has already been processed.'));
+        }
+
+        $bag->add($identifier);
     }
 }

--- a/src/Pim/Component/Connector/Processor/Denormalization/Processor.php
+++ b/src/Pim/Component/Connector/Processor/Denormalization/Processor.php
@@ -60,6 +60,17 @@ class Processor extends AbstractProcessor implements ItemProcessorInterface, Ste
      */
     public function process($item)
     {
+        $identifiers = $this->repository->getIdentifierProperties();
+        if (empty($identifiers)) {
+            $this->skipItemWithMessage($item, 'The identifier must be filled');
+        }
+
+        $identifier = current($identifiers);
+
+        if (array_key_exists($identifier, $item)) {
+            $this->checkIdentifierDuplication($item, $item[$identifier]);
+        }
+
         $entity = $this->findOrCreateObject($item);
 
         try {

--- a/src/Pim/Component/Connector/Processor/Denormalization/Processor.php
+++ b/src/Pim/Component/Connector/Processor/Denormalization/Processor.php
@@ -60,16 +60,21 @@ class Processor extends AbstractProcessor implements ItemProcessorInterface, Ste
      */
     public function process($item)
     {
-        $identifiers = $this->repository->getIdentifierProperties();
-        if (empty($identifiers)) {
+        $identifier = $this->repository->getIdentifierProperties();
+
+        if (empty($identifier) || 0 !== count(array_diff($identifier, array_keys($item)))) {
             $this->skipItemWithMessage($item, 'The identifier must be filled');
         }
 
-        $identifier = current($identifiers);
+        $identifierValues = [];
 
-        if (array_key_exists($identifier, $item)) {
-            $this->checkIdentifierDuplication($item, $item[$identifier]);
+        foreach ($identifier as $identifierCode) {
+            if (isset($item[$identifierCode])) {
+                $identifierValues[] = $item[$identifierCode];
+            }
         }
+
+        $this->checkIdentifierDuplication($item, $identifierValues);
 
         $entity = $this->findOrCreateObject($item);
 

--- a/src/Pim/Component/Connector/Processor/Denormalization/ProductAssociationProcessor.php
+++ b/src/Pim/Component/Connector/Processor/Denormalization/ProductAssociationProcessor.php
@@ -79,6 +79,8 @@ class ProductAssociationProcessor extends AbstractProcessor implements
             $this->skipItemWithMessage($item, 'The identifier must be filled');
         }
 
+        $this->checkIdentifierDuplication($item, $item['identifier']);
+
         $product = $this->findProduct($item['identifier']);
 
         if (!$product) {

--- a/src/Pim/Component/Connector/Processor/Denormalization/ProductProcessor.php
+++ b/src/Pim/Component/Connector/Processor/Denormalization/ProductProcessor.php
@@ -84,6 +84,8 @@ class ProductProcessor extends AbstractProcessor implements ItemProcessorInterfa
             $this->skipItemWithMessage($item, 'The identifier must be filled');
         }
 
+        $this->checkIdentifierDuplication($item, $identifier);
+
         $familyCode = $this->getFamilyCode($item);
         $filteredItem = $this->filterItemData($item);
 

--- a/src/Pim/Component/Connector/spec/BulkIdentifierBagSpec.php
+++ b/src/Pim/Component/Connector/spec/BulkIdentifierBagSpec.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace spec\Pim\Component\Connector;
+
+use PhpSpec\ObjectBehavior;
+
+class BulkIdentifierBagSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Pim\Component\Connector\BulkIdentifierBag');
+    }
+
+    function it_adds_a_new_identifier()
+    {
+        $this->add('sku-1');
+        $this->has('sku-1')->shouldReturn(true);
+    }
+
+    function it_throws_a_logic_exception_when_it_adds_an_identifier_it_already_contains()
+    {
+        $this->add('sku-1');
+        $this->shouldThrow(
+            new \LogicException('The identifier "sku-1" is already contained in the bag.')
+        )->during('add', ['sku-1']);
+    }
+
+    function it_resets_the_idenfitiers()
+    {
+        $this->add('sku-1');
+        $this->add('sku-2');
+
+        $this->has('sku-1')->shouldReturn(true);
+        $this->has('sku-2')->shouldReturn(true);
+
+        $this->reset();
+
+        $this->has('sku-1')->shouldReturn(false);
+        $this->has('sku-2')->shouldReturn(false);
+    }
+}

--- a/src/Pim/Component/Connector/spec/Item/BulkCompositeIdentifierBagSpec.php
+++ b/src/Pim/Component/Connector/spec/Item/BulkCompositeIdentifierBagSpec.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace spec\Pim\Component\Connector\Item;
+
+use PhpSpec\ObjectBehavior;
+
+class BulkCompositeIdentifierBagSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Pim\Component\Connector\Item\BulkCompositeIdentifierBag');
+
+    }
+
+    function it_is_a_bulk_identifier_bag()
+    {
+        $this->shouldImplement('Pim\Component\Connector\Item\BulkIdentifierBagInterface');
+    }
+
+    function is_adds_a_new_composite_identifier()
+    {
+        $this->add(['sku-1', 'other-id-1']);
+        $this->has(['sku-1', 'other-id-1'])->shouldReturn(true);
+    }
+
+    function it_throws_a_logic_exception_when_it_tries_to_add_an_identifier_that_is_not_an_array()
+    {
+        $this->shouldThrow(
+            new \InvalidArgumentException('The identifier "sku-1" is not a composite key (an array).')
+        )->during('add', ['sku-1']);
+    }
+
+    function it_throws_a_logic_exception_when_it_adds_a_composite_identifier_it_already_contains()
+    {
+        $this->add(['sku-1', 'other-id-1']);
+        $this->shouldThrow(
+            new \LogicException('The composite identifier "sku-1, other-id-1" is already contained in the bag.')
+        )->during('add', [['sku-1', 'other-id-1']]);
+    }
+
+    function it_resets_the_composite_idenfitiers_bag()
+    {
+        $this->add(['sku-1', 'id-1']);
+        $this->add(['sku-2', 'id-2']);
+
+        $this->has(['sku-1', 'id-1'])->shouldReturn(true);
+        $this->has(['sku-2', 'id-2'])->shouldReturn(true);
+
+        $this->reset();
+
+        $this->has(['sku-1', 'id-1'])->shouldReturn(false);
+        $this->has(['sku-2', 'id-2'])->shouldReturn(false);
+    }
+}

--- a/src/Pim/Component/Connector/spec/Item/BulkSimpleIdentifierBagSpec.php
+++ b/src/Pim/Component/Connector/spec/Item/BulkSimpleIdentifierBagSpec.php
@@ -1,14 +1,20 @@
 <?php
 
-namespace spec\Pim\Component\Connector;
+namespace spec\Pim\Component\Connector\Item;
 
 use PhpSpec\ObjectBehavior;
 
-class BulkIdentifierBagSpec extends ObjectBehavior
+class BulkSimpleIdentifierBagSpec extends ObjectBehavior
 {
     function it_is_initializable()
     {
-        $this->shouldHaveType('Pim\Component\Connector\BulkIdentifierBag');
+        $this->shouldHaveType('Pim\Component\Connector\Item\BulkSimpleIdentifierBag');
+    }
+
+    function it_is_a_bulk_identifier_bag()
+    {
+
+        $this->shouldImplement('Pim\Component\Connector\Item\BulkIdentifierBagInterface');
     }
 
     function it_adds_a_new_identifier()

--- a/src/Pim/Component/Connector/spec/Processor/Denormalization/ProcessorSpec.php
+++ b/src/Pim/Component/Connector/spec/Processor/Denormalization/ProcessorSpec.php
@@ -10,7 +10,7 @@ use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterfa
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Model\ChannelInterface;
-use Pim\Component\Connector\BulkIdentifierBag;
+use Pim\Component\Connector\Item\BulkSimpleIdentifierBag;
 use Prophecy\Argument;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationList;
@@ -61,7 +61,7 @@ class ProcessorSpec extends ObjectBehavior
         $validator,
         $stepExecution,
         ExecutionContext $executionContext,
-        BulkIdentifierBag $bulkIdentifierBag,
+        BulkSimpleIdentifierBag $bulkIdentifierBag,
         ChannelInterface $channel,
         ConstraintViolationListInterface $violationList
     ) {
@@ -96,7 +96,7 @@ class ProcessorSpec extends ObjectBehavior
         $validator,
         $stepExecution,
         ExecutionContext $executionContext,
-        BulkIdentifierBag $bulkIdentifierBag,
+        BulkSimpleIdentifierBag $bulkIdentifierBag,
         ChannelInterface $channel,
         ConstraintViolationListInterface $violationList
     ) {
@@ -142,7 +142,7 @@ class ProcessorSpec extends ObjectBehavior
         $objectDetacher,
         $stepExecution,
         ExecutionContext $executionContext,
-        BulkIdentifierBag $bulkIdentifierBag,
+        BulkSimpleIdentifierBag $bulkIdentifierBag,
         ChannelInterface $channel
     ) {
         $bulkIdentifierBag->has('mycode')->willReturn(false);
@@ -183,7 +183,7 @@ class ProcessorSpec extends ObjectBehavior
         $repository,
         $stepExecution,
         ExecutionContext $executionContext,
-        BulkIdentifierBag $bulkIdentifierBag,
+        BulkSimpleIdentifierBag $bulkIdentifierBag,
         ChannelInterface $channel
     ) {
         $bulkIdentifierBag->has('mycode')->willReturn(true);

--- a/src/Pim/Component/Connector/spec/Processor/Denormalization/ProductAssociationProcessorSpec.php
+++ b/src/Pim/Component/Connector/spec/Processor/Denormalization/ProductAssociationProcessorSpec.php
@@ -12,7 +12,7 @@ use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Comparator\Filter\ProductFilterInterface;
 use Pim\Component\Catalog\Model\AssociationInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
-use Pim\Component\Connector\BulkIdentifierBag;
+use Pim\Component\Connector\Item\BulkSimpleIdentifierBag;
 use Prophecy\Argument;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationList;
@@ -55,7 +55,7 @@ class ProductAssociationProcessorSpec extends ObjectBehavior
         ProductInterface $product,
         StepExecution $stepExecution,
         ExecutionContext $executionContext,
-        BulkIdentifierBag $bulkIdentifierBag,
+        BulkSimpleIdentifierBag $bulkIdentifierBag,
         AssociationInterface $association,
         ConstraintViolationListInterface $violationList,
         JobParameters $jobParameters
@@ -127,7 +127,7 @@ class ProductAssociationProcessorSpec extends ObjectBehavior
         $productDetacher,
         StepExecution $stepExecution,
         ExecutionContext $executionContext,
-        BulkIdentifierBag $bulkIdentifierBag,
+        BulkSimpleIdentifierBag $bulkIdentifierBag,
         ProductInterface $product,
         JobParameters $jobParameters
     ) {
@@ -202,7 +202,7 @@ class ProductAssociationProcessorSpec extends ObjectBehavior
         $productDetacher,
         StepExecution $stepExecution,
         ExecutionContext $executionContext,
-        BulkIdentifierBag $bulkIdentifierBag,
+        BulkSimpleIdentifierBag $bulkIdentifierBag,
         AssociationInterface $association,
         ProductInterface $product,
         JobParameters $jobParameters
@@ -283,7 +283,7 @@ class ProductAssociationProcessorSpec extends ObjectBehavior
         $productDetacher,
         StepExecution $stepExecution,
         ExecutionContext $executionContext,
-        BulkIdentifierBag $bulkIdentifierBag,
+        BulkSimpleIdentifierBag $bulkIdentifierBag,
         ProductInterface $product,
         JobParameters $jobParameters
     ) {
@@ -352,7 +352,7 @@ class ProductAssociationProcessorSpec extends ObjectBehavior
         $productDetacher,
         StepExecution $stepExecution,
         ExecutionContext $executionContext,
-        BulkIdentifierBag $bulkIdentifierBag,
+        BulkSimpleIdentifierBag $bulkIdentifierBag,
         ProductInterface $product,
         JobParameters $jobParameters
     ) {
@@ -393,7 +393,7 @@ class ProductAssociationProcessorSpec extends ObjectBehavior
     function it_does_not_process_duplicated_associations(
         $stepExecution,
         ExecutionContext $executionContext,
-        BulkIdentifierBag $bulkIdentifierBag,
+        BulkSimpleIdentifierBag $bulkIdentifierBag,
         JobParameters $jobParameters
     ) {
         $bulkIdentifierBag->has('tshirt')->willReturn(true);

--- a/src/Pim/Component/Connector/spec/Processor/Denormalization/ProductAssociationProcessorSpec.php
+++ b/src/Pim/Component/Connector/spec/Processor/Denormalization/ProductAssociationProcessorSpec.php
@@ -2,18 +2,17 @@
 
 namespace spec\Pim\Component\Connector\Processor\Denormalization;
 
+use Akeneo\Component\Batch\Item\ExecutionContext;
 use Akeneo\Component\Batch\Job\JobParameters;
-use Akeneo\Component\Batch\Model\JobExecution;
-use Akeneo\Component\Batch\Model\JobInstance;
 use Akeneo\Component\Batch\Model\StepExecution;
 use Akeneo\Component\StorageUtils\Detacher\ObjectDetacherInterface;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Comparator\Filter\ProductFilterInterface;
 use Pim\Component\Catalog\Model\AssociationInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
-use Pim\Component\Catalog\Comparator\Filter\ProductFilterInterface;
-use Pim\Component\Connector\ArrayConverter\ArrayConverterInterface;
+use Pim\Component\Connector\BulkIdentifierBag;
 use Prophecy\Argument;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationList;
@@ -54,10 +53,18 @@ class ProductAssociationProcessorSpec extends ObjectBehavior
         $productAssocFilter,
         $stepExecution,
         ProductInterface $product,
+        StepExecution $stepExecution,
+        ExecutionContext $executionContext,
+        BulkIdentifierBag $bulkIdentifierBag,
         AssociationInterface $association,
         ConstraintViolationListInterface $violationList,
         JobParameters $jobParameters
     ) {
+        $bulkIdentifierBag->has('tshirt')->willReturn(false);
+        $bulkIdentifierBag->add('tshirt')->shouldBeCalled();
+        $executionContext->get('bulk_identifier_bag')->willReturn($bulkIdentifierBag);
+        $stepExecution->getExecutionContext()->willReturn($executionContext);
+
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $jobParameters->get('enabledComparison')->willReturn(true);
 
@@ -118,9 +125,17 @@ class ProductAssociationProcessorSpec extends ObjectBehavior
         $productAssocFilter,
         $stepExecution,
         $productDetacher,
+        StepExecution $stepExecution,
+        ExecutionContext $executionContext,
+        BulkIdentifierBag $bulkIdentifierBag,
         ProductInterface $product,
         JobParameters $jobParameters
     ) {
+        $bulkIdentifierBag->has('tshirt')->willReturn(false);
+        $bulkIdentifierBag->add('tshirt')->shouldBeCalled();
+        $executionContext->get('bulk_identifier_bag')->willReturn($bulkIdentifierBag);
+        $stepExecution->getExecutionContext()->willReturn($executionContext);
+
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $jobParameters->get('enabledComparison')->willReturn(true);
         $stepExecution->getSummaryInfo('item_position')->shouldBeCalled();
@@ -185,10 +200,18 @@ class ProductAssociationProcessorSpec extends ObjectBehavior
         $productAssocFilter,
         $stepExecution,
         $productDetacher,
+        StepExecution $stepExecution,
+        ExecutionContext $executionContext,
+        BulkIdentifierBag $bulkIdentifierBag,
         AssociationInterface $association,
         ProductInterface $product,
         JobParameters $jobParameters
     ) {
+        $bulkIdentifierBag->has('tshirt')->willReturn(false);
+        $bulkIdentifierBag->add('tshirt')->shouldBeCalled();
+        $executionContext->get('bulk_identifier_bag')->willReturn($bulkIdentifierBag);
+        $stepExecution->getExecutionContext()->willReturn($executionContext);
+
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $stepExecution->getSummaryInfo('item_position')->shouldBeCalled();
         $jobParameters->get('enabledComparison')->willReturn(true);
@@ -258,9 +281,17 @@ class ProductAssociationProcessorSpec extends ObjectBehavior
         $productAssocFilter,
         $stepExecution,
         $productDetacher,
+        StepExecution $stepExecution,
+        ExecutionContext $executionContext,
+        BulkIdentifierBag $bulkIdentifierBag,
         ProductInterface $product,
         JobParameters $jobParameters
     ) {
+        $bulkIdentifierBag->has('tshirt')->willReturn(false);
+        $bulkIdentifierBag->add('tshirt')->shouldBeCalled();
+        $executionContext->get('bulk_identifier_bag')->willReturn($bulkIdentifierBag);
+        $stepExecution->getExecutionContext()->willReturn($executionContext);
+
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $jobParameters->get('enabledComparison')->willReturn(true);
 
@@ -319,9 +350,17 @@ class ProductAssociationProcessorSpec extends ObjectBehavior
         $productAssocFilter,
         $stepExecution,
         $productDetacher,
+        StepExecution $stepExecution,
+        ExecutionContext $executionContext,
+        BulkIdentifierBag $bulkIdentifierBag,
         ProductInterface $product,
         JobParameters $jobParameters
     ) {
+        $bulkIdentifierBag->has('tshirt')->willReturn(false);
+        $bulkIdentifierBag->add('tshirt')->shouldBeCalled();
+        $executionContext->get('bulk_identifier_bag')->willReturn($bulkIdentifierBag);
+        $stepExecution->getExecutionContext()->willReturn($executionContext);
+
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $jobParameters->get('enabledComparison')->willReturn(false);
 
@@ -348,5 +387,51 @@ class ProductAssociationProcessorSpec extends ObjectBehavior
         $this->setStepExecution($stepExecution);
         $productDetacher->detach($product)->shouldBeCalled();
         $this->process($convertedData)->shouldReturn(null);
+    }
+
+
+    function it_does_not_process_duplicated_associations(
+        $stepExecution,
+        ExecutionContext $executionContext,
+        BulkIdentifierBag $bulkIdentifierBag,
+        JobParameters $jobParameters
+    ) {
+        $bulkIdentifierBag->has('tshirt')->willReturn(true);
+        $bulkIdentifierBag->add('tshirt')->shouldNotBeCalled();
+        $executionContext->get('bulk_identifier_bag')->willReturn($bulkIdentifierBag);
+        $stepExecution->getExecutionContext()->willReturn($executionContext);
+        $this->setStepExecution($stepExecution);
+
+        $stepExecution->getJobParameters()->willReturn($jobParameters);
+        $jobParameters->get('enabledComparison')->willReturn(false);
+
+        $convertedData = [
+            'identifier'   => 'tshirt',
+            'values'       => [
+                'sku' => [
+                    [
+                        'locale' => null,
+                        'scope'  => null,
+                        'data'   => 'tshirt'
+                    ],
+                ]
+            ],
+            'associations' => [
+                'XSELL' => [
+                    'groups'  => ['akeneo_tshirt', 'oro_tshirt'],
+                    'product' => ['AKN_TS', 'ORO_TS']
+                ]
+            ]
+        ];
+
+        $stepExecution->incrementSummaryInfo('skip')->shouldBeCalled();
+        $stepExecution->getSummaryInfo('item_position')->shouldBeCalled();
+
+        $this
+            ->shouldThrow('Akeneo\Component\Batch\Item\InvalidItemException')
+            ->during(
+                'process',
+                [$convertedData]
+            );
     }
 }

--- a/src/Pim/Component/Connector/spec/Processor/Denormalization/ProductProcessorSpec.php
+++ b/src/Pim/Component/Connector/spec/Processor/Denormalization/ProductProcessorSpec.php
@@ -12,7 +12,7 @@ use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Builder\ProductBuilderInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Comparator\Filter\ProductFilterInterface;
-use Pim\Component\Connector\BulkIdentifierBag;
+use Pim\Component\Connector\Item\BulkSimpleIdentifierBag;
 use Prophecy\Argument;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationList;
@@ -54,7 +54,7 @@ class ProductProcessorSpec extends ObjectBehavior
         $productFilter,
         $stepExecution,
         ExecutionContext $executionContext,
-        BulkIdentifierBag $bulkIdentifierBag,
+        BulkSimpleIdentifierBag $bulkIdentifierBag,
         ProductInterface $product,
         ConstraintViolationListInterface $violationList,
         JobParameters $jobParameters
@@ -154,7 +154,7 @@ class ProductProcessorSpec extends ObjectBehavior
         $productRepository,
         $stepExecution,
         ExecutionContext $executionContext,
-        BulkIdentifierBag $bulkIdentifierBag,
+        BulkSimpleIdentifierBag $bulkIdentifierBag,
         ProductInterface $product,
         JobParameters $jobParameters
     ) {
@@ -226,7 +226,7 @@ class ProductProcessorSpec extends ObjectBehavior
         $productFilter,
         $stepExecution,
         ExecutionContext $executionContext,
-        BulkIdentifierBag $bulkIdentifierBag,
+        BulkSimpleIdentifierBag $bulkIdentifierBag,
         ProductInterface $product,
         ConstraintViolationListInterface $violationList,
         JobParameters $jobParameters
@@ -330,7 +330,7 @@ class ProductProcessorSpec extends ObjectBehavior
         $productFilter,
         $stepExecution,
         ExecutionContext $executionContext,
-        BulkIdentifierBag $bulkIdentifierBag,
+        BulkSimpleIdentifierBag $bulkIdentifierBag,
         ProductInterface $product,
         ConstraintViolationListInterface $violationList,
         JobParameters $jobParameters
@@ -434,7 +434,7 @@ class ProductProcessorSpec extends ObjectBehavior
         $productFilter,
         $stepExecution,
         ExecutionContext $executionContext,
-        BulkIdentifierBag $bulkIdentifierBag,
+        BulkSimpleIdentifierBag $bulkIdentifierBag,
         ProductInterface $product,
         ConstraintViolationListInterface $violationList,
         JobParameters $jobParameters
@@ -577,7 +577,7 @@ class ProductProcessorSpec extends ObjectBehavior
         $productFilter,
         $stepExecution,
         ExecutionContext $executionContext,
-        BulkIdentifierBag $bulkIdentifierBag,
+        BulkSimpleIdentifierBag $bulkIdentifierBag,
         ProductInterface $product,
         JobParameters $jobParameters
     ) {
@@ -688,7 +688,7 @@ class ProductProcessorSpec extends ObjectBehavior
         $stepExecution,
         ProductInterface $product,
         ExecutionContext $executionContext,
-        BulkIdentifierBag $bulkIdentifierBag,
+        BulkSimpleIdentifierBag $bulkIdentifierBag,
         ConstraintViolationListInterface $violationList,
         JobParameters $jobParameters
     ) {
@@ -801,7 +801,7 @@ class ProductProcessorSpec extends ObjectBehavior
         $productFilter,
         $stepExecution,
         ExecutionContext $executionContext,
-        BulkIdentifierBag $bulkIdentifierBag,
+        BulkSimpleIdentifierBag $bulkIdentifierBag,
         ProductInterface $product,
         JobParameters $jobParameters
     ) {
@@ -901,7 +901,7 @@ class ProductProcessorSpec extends ObjectBehavior
         $productFilter,
         $stepExecution,
         ExecutionContext $executionContext,
-        BulkIdentifierBag $bulkIdentifierBag,
+        BulkSimpleIdentifierBag $bulkIdentifierBag,
         ProductInterface $product,
         ConstraintViolationListInterface $violationList,
         JobParameters $jobParameters
@@ -1007,7 +1007,7 @@ class ProductProcessorSpec extends ObjectBehavior
         $productFilter,
         $stepExecution,
         ExecutionContext $executionContext,
-        BulkIdentifierBag $bulkIdentifierBag,
+        BulkSimpleIdentifierBag $bulkIdentifierBag,
         ProductInterface $product,
         ConstraintViolationListInterface $violationList,
         JobParameters $jobParameters

--- a/src/Pim/Component/Connector/spec/Processor/Denormalization/VariantGroupProcessorSpec.php
+++ b/src/Pim/Component/Connector/spec/Processor/Denormalization/VariantGroupProcessorSpec.php
@@ -13,7 +13,7 @@ use Pim\Bundle\CatalogBundle\Entity\GroupType;
 use Pim\Component\Catalog\Factory\GroupFactory;
 use Pim\Component\Catalog\Model\GroupInterface;
 use Pim\Component\Catalog\Model\ProductTemplateInterface;
-use Pim\Component\Connector\BulkIdentifierBag;
+use Pim\Component\Connector\Item\BulkSimpleIdentifierBag;
 use Prophecy\Argument;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationList;
@@ -46,7 +46,7 @@ class VariantGroupProcessorSpec extends ObjectBehavior
         $validator,
         $stepExecution,
         ExecutionContext $executionContext,
-        BulkIdentifierBag $bulkIdentifierBag,
+        BulkSimpleIdentifierBag $bulkIdentifierBag,
         GroupInterface $variantGroup,
         ProductTemplateInterface $productTemplate,
         ConstraintViolationListInterface $violationList
@@ -88,7 +88,7 @@ class VariantGroupProcessorSpec extends ObjectBehavior
         $validator,
         $stepExecution,
         ExecutionContext $executionContext,
-        BulkIdentifierBag $bulkIdentifierBag,
+        BulkSimpleIdentifierBag $bulkIdentifierBag,
         GroupInterface $variantGroup,
         ProductTemplateInterface $productTemplate,
         ConstraintViolationListInterface $violationList
@@ -144,7 +144,7 @@ class VariantGroupProcessorSpec extends ObjectBehavior
         $validator,
         $stepExecution,
         ExecutionContext $executionContext,
-        BulkIdentifierBag $bulkIdentifierBag,
+        BulkSimpleIdentifierBag $bulkIdentifierBag,
         GroupInterface $variantGroup,
         ProductTemplateInterface $productTemplate,
         ConstraintViolationListInterface $violationList

--- a/src/Pim/Component/Connector/spec/Processor/Denormalization/VariantGroupProcessorSpec.php
+++ b/src/Pim/Component/Connector/spec/Processor/Denormalization/VariantGroupProcessorSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Pim\Component\Connector\Processor\Denormalization;
 
+use Akeneo\Component\Batch\Item\ExecutionContext;
 use Akeneo\Component\Batch\Model\StepExecution;
 use Akeneo\Component\StorageUtils\Detacher\ObjectDetacherInterface;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
@@ -12,6 +13,7 @@ use Pim\Bundle\CatalogBundle\Entity\GroupType;
 use Pim\Component\Catalog\Factory\GroupFactory;
 use Pim\Component\Catalog\Model\GroupInterface;
 use Pim\Component\Catalog\Model\ProductTemplateInterface;
+use Pim\Component\Connector\BulkIdentifierBag;
 use Prophecy\Argument;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationList;
@@ -42,10 +44,18 @@ class VariantGroupProcessorSpec extends ObjectBehavior
         $repository,
         $variantUpdater,
         $validator,
+        $stepExecution,
+        ExecutionContext $executionContext,
+        BulkIdentifierBag $bulkIdentifierBag,
         GroupInterface $variantGroup,
         ProductTemplateInterface $productTemplate,
         ConstraintViolationListInterface $violationList
     ) {
+        $bulkIdentifierBag->has('mycode')->willReturn(false);
+        $bulkIdentifierBag->add('mycode')->shouldBeCalled();
+        $executionContext->get('bulk_identifier_bag')->willReturn($bulkIdentifierBag);
+        $stepExecution->getExecutionContext()->willReturn($executionContext);
+
         $repository->getIdentifierProperties()->willReturn(['code']);
         $repository->findOneByIdentifier(Argument::any())->willReturn($variantGroup);
         $groupType = new GroupType();
@@ -76,10 +86,18 @@ class VariantGroupProcessorSpec extends ObjectBehavior
         $repository,
         $variantUpdater,
         $validator,
+        $stepExecution,
+        ExecutionContext $executionContext,
+        BulkIdentifierBag $bulkIdentifierBag,
         GroupInterface $variantGroup,
         ProductTemplateInterface $productTemplate,
         ConstraintViolationListInterface $violationList
     ) {
+        $bulkIdentifierBag->has('mycode')->willReturn(false);
+        $bulkIdentifierBag->add('mycode')->shouldBeCalled();
+        $executionContext->get('bulk_identifier_bag')->willReturn($bulkIdentifierBag);
+        $stepExecution->getExecutionContext()->willReturn($executionContext);
+
         $repository->getIdentifierProperties()->willReturn(['code']);
         $repository->findOneByIdentifier(Argument::any())->willReturn($variantGroup);
         $groupType = new GroupType();
@@ -109,6 +127,9 @@ class VariantGroupProcessorSpec extends ObjectBehavior
             ->update($variantGroup, $values)
             ->willThrow(new \InvalidArgumentException('Attributes: This property cannot be changed.'));
 
+        $stepExecution->incrementSummaryInfo('skip')->shouldBeCalled();
+        $stepExecution->getSummaryInfo('item_position')->shouldBeCalled();
+
         $this
             ->shouldThrow('Akeneo\Component\Batch\Item\InvalidItemException')
             ->during(
@@ -121,10 +142,18 @@ class VariantGroupProcessorSpec extends ObjectBehavior
         $repository,
         $variantUpdater,
         $validator,
+        $stepExecution,
+        ExecutionContext $executionContext,
+        BulkIdentifierBag $bulkIdentifierBag,
         GroupInterface $variantGroup,
         ProductTemplateInterface $productTemplate,
         ConstraintViolationListInterface $violationList
     ) {
+        $bulkIdentifierBag->has('mycode')->willReturn(false);
+        $bulkIdentifierBag->add('mycode')->shouldBeCalled();
+        $executionContext->get('bulk_identifier_bag')->willReturn($bulkIdentifierBag);
+        $stepExecution->getExecutionContext()->willReturn($executionContext);
+
         $repository->getIdentifierProperties()->willReturn(['code']);
         $repository->findOneByIdentifier(Argument::any())->willReturn($variantGroup);
         $groupType = new GroupType();
@@ -158,6 +187,9 @@ class VariantGroupProcessorSpec extends ObjectBehavior
         $violations = new ConstraintViolationList([$violation]);
         $validator->validate($variantGroup)
             ->willReturn($violations);
+
+        $stepExecution->incrementSummaryInfo('skip')->shouldBeCalled();
+        $stepExecution->getSummaryInfo('item_position')->shouldBeCalled();
 
         $this
             ->shouldThrow('Akeneo\Component\Batch\Item\InvalidItemException')


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Introduces a new BulkIdentifierBagInterface responsible for keeping track of the entities identifiers processed on import (products, product associations and simple entities).

This object is hold by the Step execution context. When a processor wants to check if the entity it is processing has already been processed during the current batch, it just asks the BulkIdentifier if it knows it. 
if not, the entity identifier is added to the BulkIdentifier class and the processing process continues.

Depending on the type of identifier (simple string code, or composite key (array of string like Attribute options), the StepExecution might instanciate a BulkSimpleIdentifierBag class or a BulkCompositeIdentifierBag class.

The bulk is reset every time the step reach the batch size set (default value in the constructor to 100).
We will reset this list of identifiers once a full batch of entities is processed, starting from a clean state to the next batch.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | :white_check_mark:
| Added Behats                      | :white_check_mark:
| Changelog updated                 | :clock1:
| Review and 2 GTM                  | :clock1:
| Micro Demo to the PO (Story only) | :negative_squared_cross_mark:
| Migration script                  | :negative_squared_cross_mark:
| Tech Doc                          | :negative_squared_cross_mark::


:white_check_mark: Done and pass

:red_circle: Done but fail

:clock1: Done but pending

:negative_squared_cross_mark: Not needed
