### PR TITLE
TIP-6038: Fix product created at and updated at on imports in Mongo

### DIFF
--- a/spec/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Saver/ProductSaverSpec.php
+++ b/spec/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Saver/ProductSaverSpec.php
@@ -93,6 +93,11 @@ class ProductSaverSpec extends ObjectBehavior
         $productC->setId(Argument::any())->shouldBeCalled();
         $productD->setId(Argument::any())->shouldBeCalled();
 
+        $productA->setUpdated(Argument::any())->shouldBeCalled();
+        $productB->setUpdated(Argument::any())->shouldBeCalled();
+        $productC->setCreated(Argument::any())->shouldBeCalled();
+        $productD->setCreated(Argument::any())->shouldBeCalled();
+
         $normalizer->normalize($productA, Argument::cetera())->willReturn(['_id' => 'id_a', 'key_a' => 'data_a']);
         $normalizer->normalize($productB, Argument::cetera())->willReturn(['_id' => 'id_b', 'key_b' => 'data_b']);
         $normalizer->normalize($productC, Argument::cetera())->willReturn(['_id' => 'id_c', 'key_c' => 'data_c']);

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Saver/ProductSaver.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Saver/ProductSaver.php
@@ -100,9 +100,14 @@ class ProductSaver extends BaseProductSaver
 
         foreach ($products as $product) {
             if (null === $product->getId()) {
-                $productsToInsert[] = $product;
                 $product->setId($this->mongoFactory->createMongoId());
+                $product->setCreated(new \Datetime('now', new \DateTimeZone('UTC')));
+                $product->setUpdated(new \Datetime('now', new \DateTimeZone('UTC')));
+
+                $productsToInsert[] = $product;
+
             } else {
+                $product->setUpdated(new \Datetime('now', new \DateTimeZone('UTC')));
                 $productsToUpdate[] = $product;
             }
         }

--- a/src/Pim/Bundle/CatalogBundle/MongoDB/Normalizer/Document/ProductNormalizer.php
+++ b/src/Pim/Bundle/CatalogBundle/MongoDB/Normalizer/Document/ProductNormalizer.php
@@ -78,13 +78,8 @@ class ProductNormalizer implements NormalizerInterface, SerializerAwareInterface
 
         $context[self::MONGO_ID] = $data[self::MONGO_ID];
 
-        if (null !== $product->getCreated()) {
-            $data['created'] = $this->normalizer->normalize($product->getCreated(), self::FORMAT, $context);
-        } else {
-            $data['created'] = $this->mongoFactory->createMongoDate();
-        }
-
-        $data['updated'] = $this->mongoFactory->createMongoDate();
+        $data['created'] = $this->normalizer->normalize($product->getCreated(), self::FORMAT, $context);
+        $data['updated'] = $this->normalizer->normalize($product->getUpdated(), self::FORMAT, $context);
 
         if (null !== $product->getFamily()) {
             $data['family'] = $product->getFamily()->getId();


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Simpler way of ensuring that "updatedAt" and "CreatedAt" dates properties of a product are stored properly in mongodb.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | :white_check_mark: :red_circle: :negative_squared_cross_mark: :clock1:
| Added Behats                      | :white_check_mark: :red_circle: :negative_squared_cross_mark: :clock1:
| Changelog updated                 | :white_check_mark: :red_circle: :negative_squared_cross_mark: :clock1:
| Review and 2 GTM                  | :white_check_mark: :red_circle: :negative_squared_cross_mark: :clock1:
| Micro Demo to the PO (Story only) | :white_check_mark: :red_circle: :negative_squared_cross_mark: :clock1:
| Migration script                  | :white_check_mark: :red_circle: :negative_squared_cross_mark: :clock1:
| Tech Doc                          | :white_check_mark: :red_circle: :negative_squared_cross_mark: :clock1:


:white_check_mark: Done and pass

:red_circle: Done but fail

:clock1: Done but pending

:negative_squared_cross_mark: Not needed
