### PR TITLE
TIP-475: Fix an error thrown when saving a product which has already a media

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/ProductController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/ProductController.php
@@ -363,7 +363,7 @@ class ProductController
 
         $dataFiltered = $this->emptyValuesFilter->filter($product, ['values' => $values]);
 
-        if (null !== $dataFiltered) {
+        if (!empty($dataFiltered)) {
             $data = array_replace($data, $dataFiltered);
         } else {
             $data['values'] = [];

--- a/src/Pim/Component/Catalog/Builder/ProductBuilder.php
+++ b/src/Pim/Component/Catalog/Builder/ProductBuilder.php
@@ -6,6 +6,7 @@ use Pim\Component\Catalog\AttributeTypes;
 use Pim\Component\Catalog\Factory\ProductValueFactory;
 use Pim\Component\Catalog\Manager\AttributeValuesResolver;
 use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\FamilyInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Model\ProductPriceInterface;
 use Pim\Component\Catalog\Model\ProductValueInterface;
@@ -107,6 +108,7 @@ class ProductBuilder implements ProductBuilderInterface
         if (null !== $familyCode) {
             $family = $this->familyRepository->findOneByIdentifier($familyCode);
             $product->setFamily($family);
+            $this->addBooleanToProduct($product);
         }
 
         $event = new GenericEvent($product);
@@ -363,6 +365,36 @@ class ProductBuilder implements ProductBuilderInterface
     {
         foreach ($product->getValues() as $value) {
             $this->addMissingPrices($value);
+        }
+    }
+
+    /**
+     * Set product values to "false" by default for every boolean attributes in the product's family.
+     *
+     * This workaround is due to the UI that does not manage null values for boolean attributes, only false or true.
+     * It avoids to automatically submit boolean attributes belonging to the product's family in a proposal,
+     * even if those boolean attributes were not modified by the user.
+     *
+     * To remove when the UI will manage null values in boolean attributes.
+     *
+     * @param ProductInterface $product
+     */
+    protected function addBooleanToProduct(ProductInterface $product)
+    {
+        $family = $product->getFamily();
+
+        if (null !== $family) {
+            foreach ($family->getAttributes() as $attribute) {
+                if (AttributeTypes::BOOLEAN === $attribute->getAttributeType()) {
+                    $requiredValues = $this->valuesResolver->resolveEligibleValues([$attribute]);
+
+                    foreach ($requiredValues as $value) {
+                        $productValue = $this->productValueFactory->create($attribute, $value['scope'], $value['locale']);
+                        $productValue->setBoolean(false);
+                        $product->addValue($productValue);
+                    }
+                }
+            }
         }
     }
 }

--- a/src/Pim/Component/Catalog/Comparator/Attribute/BooleanComparator.php
+++ b/src/Pim/Component/Catalog/Comparator/Attribute/BooleanComparator.php
@@ -41,7 +41,7 @@ class BooleanComparator implements ComparatorInterface
         $originals = array_merge($default, $originals);
 
         $isNull = null === $originals['data'] && null === $data['data'];
-        $isEquals = (bool) $originals['data'] === (bool) $data['data'];
+        $isEquals = $originals['data'] === (bool) $data['data'];
 
         if ($isNull || $isEquals) {
             return null;

--- a/src/Pim/Component/Catalog/Comparator/Attribute/BooleanComparator.php
+++ b/src/Pim/Component/Catalog/Comparator/Attribute/BooleanComparator.php
@@ -41,7 +41,7 @@ class BooleanComparator implements ComparatorInterface
         $originals = array_merge($default, $originals);
 
         $isNull = null === $originals['data'] && null === $data['data'];
-        $isEquals = $originals['data'] === (bool) $data['data'];
+        $isEquals = $originals['data'] === $data['data'];
 
         if ($isNull || $isEquals) {
             return null;

--- a/src/Pim/Component/Catalog/spec/Comparator/Attribute/BooleanComparatorSpec.php
+++ b/src/Pim/Component/Catalog/spec/Comparator/Attribute/BooleanComparatorSpec.php
@@ -21,7 +21,7 @@ class BooleanComparatorSpec extends ObjectBehavior
         $this->supports('pim_catalog_boolean')->shouldBe(true);
     }
 
-    function it_gets_changes_when_adding_value()
+    function it_gets_changes_when_adding_true_value()
     {
         $changes = ['data' => true, 'locale' => 'en_US', 'scope' => 'ecommerce'];
         $originals = [];
@@ -29,6 +29,19 @@ class BooleanComparatorSpec extends ObjectBehavior
         $this->compare($changes, $originals)->shouldReturn($changes);
 
         $changes = ['data' => 1, 'locale' => 'en_US', 'scope' => 'ecommerce'];
+        $originals = [];
+
+        $this->compare($changes, $originals)->shouldReturn($changes);
+    }
+
+    function it_gets_changes_when_adding_false_value()
+    {
+        $changes = ['data' => false, 'locale' => 'en_US', 'scope' => 'ecommerce'];
+        $originals = [];
+
+        $this->compare($changes, $originals)->shouldReturn($changes);
+
+        $changes = ['data' => 0, 'locale' => 'en_US', 'scope' => 'ecommerce'];
         $originals = [];
 
         $this->compare($changes, $originals)->shouldReturn($changes);

--- a/src/Pim/Component/Catalog/spec/Comparator/Attribute/BooleanComparatorSpec.php
+++ b/src/Pim/Component/Catalog/spec/Comparator/Attribute/BooleanComparatorSpec.php
@@ -27,21 +27,11 @@ class BooleanComparatorSpec extends ObjectBehavior
         $originals = [];
 
         $this->compare($changes, $originals)->shouldReturn($changes);
-
-        $changes = ['data' => 1, 'locale' => 'en_US', 'scope' => 'ecommerce'];
-        $originals = [];
-
-        $this->compare($changes, $originals)->shouldReturn($changes);
     }
 
     function it_gets_changes_when_adding_false_value()
     {
         $changes = ['data' => false, 'locale' => 'en_US', 'scope' => 'ecommerce'];
-        $originals = [];
-
-        $this->compare($changes, $originals)->shouldReturn($changes);
-
-        $changes = ['data' => 0, 'locale' => 'en_US', 'scope' => 'ecommerce'];
         $originals = [];
 
         $this->compare($changes, $originals)->shouldReturn($changes);
@@ -53,20 +43,10 @@ class BooleanComparatorSpec extends ObjectBehavior
         $originals = ['data' => true, 'locale' => 'en_US', 'scope' => 'ecommerce'];
 
         $this->compare($changes, $originals)->shouldReturn($changes);
-
-        $changes = ['data' => 0, 'locale' => 'en_US', 'scope' => 'ecommerce'];
-        $originals = ['data' => true, 'locale' => 'en_US', 'scope' => 'ecommerce'];
-
-        $this->compare($changes, $originals)->shouldReturn($changes);
     }
 
     function it_returns_null_when_values_are_the_same()
     {
-        $changes = ['data' => 1, 'locale' => 'en_US', 'scope' => 'ecommerce'];
-        $originals = ['data' => true, 'locale' => 'en_US', 'scope' => 'ecommerce'];
-
-        $this->compare($changes, $originals)->shouldReturn(null);
-
         $changes = ['data' => true, 'locale' => 'en_US', 'scope' => 'ecommerce'];
         $originals = ['data' => true, 'locale' => 'en_US', 'scope' => 'ecommerce'];
 


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) 

**Description (for Contributor and Core Developer)**

Since the standard format, there is a bug when you try to save a product which has already a media. It's due to a wrong condition check on an empty array.

Note : the boolean comparator had a bad behavior due to a "test commit" merged into master. 
It was a false positive. I've reverted the behavior (+ add a spec).

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | :white_check_mark: :red_circle: :negative_squared_cross_mark: :clock1:
| Added Behats                      | :white_check_mark: :red_circle: :negative_squared_cross_mark: :clock1:
| Changelog updated                 | :white_check_mark: :red_circle: :negative_squared_cross_mark: :clock1:
| Review and 2 GTM                  | :white_check_mark: :red_circle: :negative_squared_cross_mark: :clock1:
| Micro Demo to the PO (Story only) | :white_check_mark: :red_circle: :negative_squared_cross_mark: :clock1:
| Migration script                  | :white_check_mark: :red_circle: :negative_squared_cross_mark: :clock1:
| Tech Doc                          | :white_check_mark: :red_circle: :negative_squared_cross_mark: :clock1:


:white_check_mark: Done and pass

:red_circle: Done but fail

:clock1: Done but pending

:negative_squared_cross_mark: Not needed
