### PR TITLE
PIM-6086: cleaning+migration command for MongoDB documents

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-6110: Saving a product value clears the saved associations
+- PIM-6086: Command that removes obsolete relations and migrates normalizedData for MongoDB documents.
 
 # 1.6.8 (2017-01-05)
 

--- a/src/Pim/Bundle/CatalogBundle/Command/CleanMongoDBCommand.php
+++ b/src/Pim/Bundle/CatalogBundle/Command/CleanMongoDBCommand.php
@@ -1,0 +1,555 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\Command;
+
+use Akeneo\Bundle\StorageUtilsBundle\DependencyInjection\AkeneoStorageUtilsExtension;
+use Pim\Component\ReferenceData\Model\ConfigurationInterface;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Command that removes obsolete relations and migrates normalizedData for MongoDB documents.
+ *
+ * @author    Remy Betus <remy.betus@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 30)
+ */
+class CleanMongoDBCommand extends ContainerAwareCommand
+{
+    const MONGODB_PRODUCT_COLLECTION = 'pim_catalog_product';
+
+    /** @var array $familyIds */
+    protected $familyIds;
+
+    /** @var array $categoryIds */
+    protected $categoryIds;
+
+    /** @var array $attributes */
+    protected $attributes;
+
+    /** @var array $optionIds */
+    protected $optionIds;
+
+    /** @var array $missingEntities */
+    protected $missingEntities;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('pim:mongodb:clean')
+            ->setDescription(
+                'Cleans MongoDB documents: removes missing related entities and then fix normalizedData'
+            )
+            ->addOption(
+                'dry-run',
+                null,
+                InputOption::VALUE_NONE,
+                "Do the checks, display errors but do not update any products."
+            );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->missingEntities = [];
+        $storageDriver = $this->getContainer()->getParameter('pim_catalog_product_storage_driver');
+
+        if (AkeneoStorageUtilsExtension::DOCTRINE_MONGODB_ODM !== $storageDriver) {
+            $output->writeln('<error>This command could be only launched on MongoDB storage</error>');
+
+            return -1;
+        }
+
+        $this->findMissingEntities($output, $input->getOption('dry-run'));
+
+        $this->printReport($output);
+
+        return 0;
+    }
+
+    /**
+     * Displays report
+     *
+     * @param OutputInterface $output
+     */
+    protected function printReport(OutputInterface $output)
+    {
+        $table = $this->getHelper('table');
+        $table->setHeaders(['Entity class', 'ID', '# missing']);
+
+        $table->setRows([]);
+
+        foreach ($this->missingEntities as $missingEntityName => $missingEntity) {
+            foreach ($missingEntity as $id => $count) {
+                $table->addRow([$missingEntityName, $id, $count]);
+            }
+        }
+
+        $table->render($output);
+    }
+
+    /**
+     * Finds missing entities (family, channel, attribute, option(s), reference data). A dry run option is available
+     * so it won't update anything.
+     *
+     * @param OutputInterface $output
+     * @param bool            $dryRun
+     */
+    protected function findMissingEntities(OutputInterface $output, $dryRun = false)
+    {
+        $db = $this->getMongoConnection();
+        $productCollection = new \MongoCollection($db, self::MONGODB_PRODUCT_COLLECTION);
+
+        $products = $productCollection->find([]);
+        $numberOfProducts = $products->count();
+        $output->writeln(
+            sprintf(
+                '%sCleaning MongoDB documents for <comment>%s</comment> (<comment>%s</comment> entries).',
+                ($dryRun) ? 'DRY RUN (check only) - ' : '',
+                self::MONGODB_PRODUCT_COLLECTION,
+                number_format($numberOfProducts, 0, '.', ',')
+            )
+        );
+
+        $processedProducts = 0;
+        $startTime = new \DateTime('now');
+        foreach ($products as $product) {
+            $product = $this->checkFamily($product);
+            $product = $this->checkCategories($product);
+            $product = $this->checkValues($product);
+
+            if (!$dryRun) {
+                $productCollection->update(
+                    ['_id' => new \MongoId($product['_id'])],
+                    $product
+                );
+            }
+
+            if (0 === $processedProducts % 1500) {
+                $this->displayProgress($output, $startTime, $numberOfProducts, $processedProducts);
+            }
+            $processedProducts++;
+        }
+        $output->writeln('<comment>finished!</comment>');
+    }
+
+    /**
+     * Custom progress display. Progress component from Console was slowing down the
+     * process too much.
+     *
+     * @param OutputInterface $output
+     * @param \DateTime       $startTime
+     * @param integer         $numberOfProducts
+     * @param integer         $processedProducts
+     */
+    protected function displayProgress(
+        OutputInterface $output,
+        \DateTime $startTime,
+        $numberOfProducts,
+        $processedProducts
+    ) {
+        $now = new \DateTime('now');
+        $elapsedTime = $startTime->diff($now);
+        $output->writeln(
+            sprintf(
+                "Progress: %d%% - %d / %d - Elapsed time %s",
+                ceil(($processedProducts * 100) / $numberOfProducts),
+                $processedProducts,
+                $numberOfProducts,
+                $elapsedTime->format('%H:%I:%S')
+            )
+        );
+    }
+
+    /**
+     * Checks entities related to product values and removes them if they no longer exist.
+     *
+     * Checked entities are:
+     * - attributes
+     * - attribute options
+     * - reference data (assets included)
+     *
+     * @param array $product
+     *
+     * @return array the changes to perform on current MongoBD document to fix missing related entities.
+     */
+    protected function checkValues(array $product)
+    {
+        if (!isset($product['values'])) {
+            return $product;
+        }
+
+        foreach ($product['values'] as $valueIndex => $value) {
+            $product = $this->checkAttribute($product, $valueIndex);
+
+            if (!isset($product['values'][$valueIndex])) {
+                continue;
+            }
+
+            if (isset($value['option'])) {
+                $product = $this->checkAttributeOption($product, $valueIndex);
+            }
+
+            if (!isset($product['values'][$valueIndex])) {
+                continue;
+            }
+
+            if (isset($value['optionIds'])) {
+                $product = $this->checkAttributeOptions($product, $valueIndex);
+            }
+
+            if (!isset($product['values'][$valueIndex])) {
+                continue;
+            }
+
+            $product = $this->checkReferenceDataFields($product, $valueIndex);
+        }
+
+        return $product;
+    }
+
+    /**
+     * Checks if the reference data ID of a product values exists and removes it otherwise.
+     *
+     * @param array $product
+     * @param int   $valueIndex
+     *
+     * @return bool
+     */
+    protected function checkReferenceDataFields(array $product, $valueIndex)
+    {
+        $referenceDataFields = $this->getReferenceDataFields();
+        foreach ($referenceDataFields as $name => $referenceData) {
+            if (isset($product[$valueIndex][$referenceData])) {
+                $product = $this->checkReferenceDataField($referenceData, $product, $valueIndex);
+            }
+        }
+
+        return $product;
+    }
+
+    /**
+     * Checks if a reference data exists.
+     *
+     * @param array   $referenceData configuration (name, class) of the reference data
+     * @param array   $product
+     * @param integer $valueIndex    index of the prodcut value
+     *
+     * @return bool whether the reference data exists or not.
+     */
+    protected function checkReferenceDataField(array $referenceData, array $product, $valueIndex)
+    {
+        $referenceDataField = $product['values'][$valueIndex][$referenceData['field']];
+
+        if (!is_array($referenceDataField)) {
+            if (null !== $this->findEntity($referenceData['class'], $referenceDataField)) {
+                $this->addMissingEntity($referenceData['class'], $referenceDataField);
+            }
+
+            unset($product['values'][$valueIndex][$referenceData['field']]);
+        } else {
+            foreach ($referenceDataField as $key => $referenceDataId) {
+                if (null !== $this->findEntity($referenceData['class'], $referenceDataId)) {
+                    $this->addMissingEntity($referenceData['class'], $referenceDataId);
+                }
+
+                unset($product['values'][$valueIndex][$referenceData['field']][$key]);
+            }
+        }
+    }
+
+    /**
+     * Adds a missing entity in the list
+     *
+     * @param string $entityName
+     * @param int    $id
+     */
+    protected function addMissingEntity($entityName, $id)
+    {
+        if (!isset($this->missingEntities[$entityName])) {
+            $this->missingEntities[$entityName] = [];
+        }
+
+        if (!isset($this->missingEntities[$entityName][$id])) {
+            $this->missingEntities[$entityName][$id] = 0;
+        }
+
+        $this->missingEntities[$entityName][$id]++;
+    }
+
+    /**
+     * Finds an entity given its class and its ID
+     *
+     * @param string $entityClass
+     * @param int    $id
+     *
+     * @return null|object
+     */
+    protected function findEntity($entityClass, $id)
+    {
+        return $this->getContainer()->get('doctrine.orm.entity_manager')->find($entityClass, $id);
+    }
+
+    /**
+     * Checks if the attribute options ID of a product values exists and removes it otherwise.
+     *
+     * @param array $product
+     * @param int   $valueIndex
+     *
+     * @return bool
+     */
+    protected function checkAttributeOptions(array $product, $valueIndex)
+    {
+        if (null === $this->optionIds) {
+            $qb = $this->getContainer()->get('pim_catalog.repository.attribute_option')->createQueryBuilder('ao')
+                ->select('ao.id');
+            $results = $qb->getQuery()->getArrayResult();
+
+            $this->optionIds = array_column($results, 'id');
+        }
+
+        $attributeId = $product['values'][$valueIndex]['attribute'];
+
+        foreach ($product['values'][$valueIndex]['optionIds'] as $key => $optionId) {
+            if (!in_array($optionId, $this->optionIds)) {
+                $this->addMissingEntity(
+                    $this->getContainer()->getParameter('pim_catalog.entity.attribute_option.class'),
+                    sprintf(
+                        'attribute %s > option %s',
+                        isset($this->attributes[$attributeId]) ? $this->attributes[$attributeId]['code'] : 'unknown',
+                        $optionId
+                    )
+                );
+
+                unset($product['values'][$valueIndex]['optionIds'][$key]);
+            }
+        }
+
+        return $product;
+    }
+
+    /**
+     * Checks if the attribute option ID of a product value exists and removes it otherwise.
+     *
+     * @param array $product
+     * @param int   $valueIndex
+     *
+     * @return bool
+     */
+    protected function checkAttributeOption(array $product, $valueIndex)
+    {
+        if (null === $this->optionIds) {
+            $qb = $this->getContainer()->get('pim_catalog.repository.attribute_option')->createQueryBuilder('ao')
+                ->select('ao.id');
+            $results = $qb->getQuery()->getArrayResult();
+
+            $this->optionIds = array_column($results, 'id');
+        }
+
+        $optionId = $product['values'][$valueIndex]['option'];
+        $attributeId = $product['values'][$valueIndex]['attribute'];
+
+        if (!in_array($optionId, $this->optionIds)) {
+            $this->addMissingEntity(
+                $this->getContainer()->getParameter('pim_catalog.entity.attribute_option.class'),
+                sprintf(
+                    'attribute %s > option %s',
+                    isset($this->attributes[$attributeId]) ? $this->attributes[$attributeId]['code'] : 'unknown',
+                    $optionId
+                )
+            );
+
+            unset($product['values'][$valueIndex]);
+        }
+
+        return $product;
+    }
+
+    /**
+     * Checks if the attribute ID of a product value exists and removes it otherwise.
+     *
+     * @param array $product
+     * @param int   $valueIndex
+     *
+     * @return array
+     */
+    protected function checkAttribute(array $product, $valueIndex)
+    {
+        if (null === $this->attributes) {
+            $qb = $this->getContainer()->get('doctrine.orm.entity_manager')->createQueryBuilder()
+                ->select(['a.id', 'a.code'])
+                ->from($this->getContainer()->getParameter('pim_catalog.entity.attribute.class'), 'a', 'a.id');
+
+            $this->attributes = $qb->getQuery()->getArrayResult();
+        }
+
+        $attributeId = $product['values'][$valueIndex]['attribute'];
+
+        if (!isset($this->attributes[$attributeId])) {
+            $this->addMissingEntity(
+                $this->getContainer()->getParameter('pim_catalog.entity.attribute.class'),
+                $attributeId
+            );
+
+            unset($product['values'][$valueIndex]);
+        }
+
+        return $product;
+    }
+
+    /**
+     * Checks if the category IDs exit and removes it from the product otherwise.
+     *
+     * @param array $product
+     *
+     * @return array
+     */
+    protected function checkCategories(array $product)
+    {
+        if (!isset($product['categoryIds'])) {
+            return $product;
+        }
+
+        if (null === $this->categoryIds) {
+            $qb = $this->getContainer()->get('pim_catalog.repository.category')->createQueryBuilder('c')
+                ->select('c.id');
+            $results = $qb->getQuery()->getArrayResult();
+
+            $this->categoryIds = array_column($results, 'id');
+        }
+
+        foreach ($product['categoryIds'] as $key => $categoryId) {
+            if (!in_array($categoryId, $this->categoryIds)) {
+                $this->addMissingEntity(
+                    $this->getContainer()->getParameter('pim_catalog.entity.category.class'),
+                    $categoryId
+                );
+
+                unset($product['categoryIds'][$key]);
+            }
+        }
+
+        return $product;
+    }
+
+    /**
+     * Checks if the family ID exists and removes it from the product otherwise. It also migrate "label" field that
+     * was renamed between 1.5 and 1.6.
+     *
+     * @param array $product
+     *
+     * @return array
+     */
+    protected function checkFamily(array $product)
+    {
+        if (!isset($product['family'])) {
+            return $product;
+        }
+
+        if (isset($product['normalizedData']['family']['label'])) {
+            $product['normalizedData']['family']['labels'] = $product['normalizedData']['family']['label'];
+            $this->addMissingEntity(
+                'Obsolete normalizedData.family.label field name',
+                'N/A'
+            );
+
+            unset($product['normalizedData']['family']['label']);
+        }
+
+        if (null === $this->familyIds) {
+            $qb = $this->getContainer()->get('pim_catalog.repository.family')->createQueryBuilder('f')
+                ->select('f.id');
+            $results = $qb->getQuery()->getArrayResult();
+
+            $this->familyIds = array_column($results, 'id');
+        }
+
+        if (in_array($product['family'], $this->familyIds)) {
+            return $product;
+        }
+
+        $this->addMissingEntity(
+            $this->getContainer()->getParameter('pim_catalog.entity.family.class'),
+            $product['family']
+        );
+
+        unset($product['family']);
+        unset($product['normalizedData']['family']);
+        unset($product['normalizedData']['completenesses']);
+        unset($product['completenesses']);
+
+        return $product;
+    }
+
+    /**
+     * Search in Doctrine mapping what is the field name defined for all the reference data.
+     *
+     * @throws \LogicException if any error of mapping for the reference data.
+     *
+     * @return array
+     */
+    protected function getReferenceDataFields()
+    {
+        $valueClass = $this->getContainer()->getParameter('pim_catalog.entity.product_value.class');
+        $manager = $this->getContainer()->get('doctrine_mongodb.odm.document_manager');
+
+        $metadata = $manager->getClassMetadata($valueClass);
+        $fields = [];
+        foreach ($this->getReferenceDataConfiguration() as $referenceData) {
+            $referenceDataName = $referenceData->getName();
+            if (ConfigurationInterface::TYPE_MULTI === $referenceData->getType()) {
+                $fieldName = $metadata->getFieldMapping($referenceDataName);
+
+                if (!isset($fieldName['idsField'])) {
+                    throw new \LogicException(
+                        sprintf(
+                            'No field name defined for reference data "%s"',
+                            $referenceDataName
+                        )
+                    );
+                }
+
+                $idField = $fieldName['idsField'];
+            } else {
+                $idField = $referenceDataName;
+            }
+
+            $fields[$referenceDataName] = ['field' => $idField, 'class' => $referenceData->getClass()];
+        }
+
+        return $fields;
+    }
+
+    /**
+     * Get configuration for reference data.
+     *
+     * @return \Pim\Component\ReferenceData\Model\ConfigurationInterface[]
+     */
+    protected function getReferenceDataConfiguration()
+    {
+        $referenceDataRegistry = $this->getContainer()->get('pim_reference_data.registry');
+
+        return $referenceDataRegistry->all();
+    }
+
+    /**
+     * Get MongoDB Connection
+     *
+     * @return \MongoDB the database
+     */
+    protected function getMongoConnection()
+    {
+        $mongoConnection = $this->getContainer()->get('doctrine_mongodb.odm.default_connection');
+
+        $dbName = $this->getContainer()->getParameter('mongodb_database');
+
+        return $mongoConnection->getMongoClient()->$dbName;
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/MongoDB/Normalizer/Document/ProductNormalizer.php
+++ b/src/Pim/Bundle/CatalogBundle/MongoDB/Normalizer/Document/ProductNormalizer.php
@@ -9,7 +9,7 @@ use Symfony\Component\Serializer\SerializerAwareInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 
 /**
- * A transfomer to normalize a product object into a MongoDB object
+ * A transformer to normalize a product object into a MongoDB object
  *
  * @author    Benoit Jacquemont <benoit@akeneo.com>
  * @copyright 2014 Akeneo SAS (http://www.akeneo.com)


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

```
app/console pim:product:pim:mongodb:clean
```

This brings a new command to clean MongoDB documents and remove osolete relations with MySQL stored entities:
- attribute
- attribute options
- families
- categories
- reference data (assets included)

An out of sync state can occur when performing deletion operations on MySQL entities that cascades towers a MongoDB cleaning. If an error occurs and prevent the MongoDB query from being completely executed, it results to this out of sync situation.

This also fixes a BC in MongoDB:
BC in MongoDB JSON :
- [v1.6.7 TranslationNormalizer.php#L47](https://github.com/akeneo/pim-community-dev/blob/v1.6.7/src/Pim/Component/Catalog/Normalizer/Structured/TranslationNormalizer.php#L47)
- [v1.5.16 TranslationNormalizer#L47](https://github.com/akeneo/pim-community-dev/blob/v1.5.16/src/Pim/Bundle/TransformBundle/Normalizer/Structured/TranslationNormalizer.php#L47)

Which leads to 2 different MongoDB JSON for families, for instance:
```
> db.pim_catalog_product.find({'_id': ObjectId('55d72ffe51dd2a0b2ee709df')}, {'normalizedData.family': 1}).pretty();
{
    "_id" : ObjectId("55d72ffe51dd2a0b2ee709df"),
    "normalizedData" : {
        "family" : {
            "code" : "RCXXX",
            "labels" : {
                "fr_FR" : "RCXXX-Foo"
            },
            "attributeAsLabel" : "Bar"
        }
    }
}
> db.pim_catalog_product.find({'_id': ObjectId('55d733dc51dd2a0b2e0dd2bd')}, {'normalizedData.family': 1}).pretty();
{
    "_id" : ObjectId("55d733dc51dd2a0b2e0dd2bd"),
    "normalizedData" : {
        "family" : {
            "code" : "RCXXX",
            "label" : {
                "fr_FR" : "RCXXX-Foo"
            },
            "attributeAsLabel" : "Bar"
        }
    }
}
```

Progess is shown as below:

```
app/console pim:mongodb:clean --env=prod  --dry-run
DRY RUN (check only) - Cleaning MongoDB documents for pim_catalog_product (1,214,545 entries).
Progress: 1% - 1000 / 1214545 - Elapsed time 00:00:05
Progress: 1% - 2000 / 1214545 - Elapsed time 00:00:11
...
Progress: 100% - 1212000 / 1214545 - Elapsed time 01:06:36
Progress: 100% - 1213000 / 1214545 - Elapsed time 01:06:37
Progress: 100% - 1214000 / 1214545 - Elapsed time 01:06:39
finished!
+----------------------------------------------------+-----+-----------+
| Entity class                                       | ID  | # missing |
+----------------------------------------------------+-----+-----------+
| Pim\Bundle\CatalogBundle\Entity\Attribute          | 11  | 839394    |
| Pim\Bundle\CatalogBundle\Entity\Attribute          | 15  | 1214543   |
| Foo\Bundle\CustomEntityBundle\Entity\Family        | 173 | 260       |
| Obsolete normalizedData.family.label field name    | N/A | 1         |
+----------------------------------------------------+-----+-----------+

```

**Note to ElasticSearch users:** due to the changes operated on normalizedData, you will have to re-index the content.

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | :negative_squared_cross_mark: 
| Added Behats                      | :negative_squared_cross_mark: 
| Changelog updated                 | :white_check_mark:
| Review and 2 GTM                  | n°1 :white_check_mark: n°2 :clock1:
| Micro Demo to the PO (Story only) | :negative_squared_cross_mark:
| Migration script                  | it is a migration script
| Tech Doc                          | :negative_squared_cross_mark:


:white_check_mark: Done and pass

:red_circle: Done but fail

:clock1: Done but pending

:negative_squared_cross_mark: Not needed
