### PR TITLE
PIM-6038: Product updated at date updated in product saver instead of…

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -6,6 +6,7 @@
 - PIM-6042: Successfully import product associations without removing already existing associations when option "compare values" is set to true
 - PIM-6041: Fix wrong conversion units output for channel export profiles csv and xlsx
 - PIM-6047: Do not export conversion units of channels if no conversion is set
+- PIM-6038: Fix product imports that do not change the product update date correctly (mongodb)
 
 # 1.6.7 (2016-12-20)
 

--- a/features/export/product-export-builder/export_products_by_specific_date.feature
+++ b/features/export/product-export-builder/export_products_by_specific_date.feature
@@ -1,10 +1,10 @@
+@javascript
 Feature: Export products according to a date
   In order to use the enriched product data
   As a product manager
   I need to be able to export the products according to a date
 
-  @javascript
-  Scenario: Export only the products updated since the last export
+  Scenario: Export only the products updated by the UI since the last export
     Given a "footwear" catalog configuration
     And the following job "csv_footwear_product_export" configuration:
       | filePath | %tmp%/product_export/product_export.csv                                                                                                                  |
@@ -36,7 +36,6 @@ Feature: Export products according to a date
       SNKRS-1B;summer_collection;black;;1;sneakers;;;;"Model 1";;;50.00;70.00;;;45;;;;;;hot;;
       """
 
-  @javascript
   Scenario: Update the updated time condition field
     Given a "footwear" catalog configuration
     And I am logged in as "Julia"
@@ -49,7 +48,7 @@ Feature: Export products according to a date
     And I press "Save"
     And I should not see the text "There are unsaved changes"
 
-  @javascript @skip
+  @skip
   Scenario: Error management when the updated time condition field is updated
     Given a "footwear" catalog configuration
     And I am logged in as "Julia"
@@ -72,7 +71,6 @@ Feature: Export products according to a date
     Then I should be on the "csv_footwear_product_export" export job edit page
     And I should see a validation error "This value should be 0 or more."
 
-  @javascript
   Scenario: Export only the products updated since a defined date
     Given a "footwear" catalog configuration
     And the following products:
@@ -98,3 +96,43 @@ Feature: Export products according to a date
     And I launch the export job
     And I wait for the "csv_footwear_product_export" job to finish
     Then exported file of "csv_footwear_product_export" should be empty
+
+  @jira https://akeneo.atlassian.net/browse/PIM-6038
+  Scenario: Export only the products updated by an import since the last export
+    Given a "footwear" catalog configuration
+    And the following job "csv_footwear_product_export" configuration:
+      | filePath | %tmp%/product_export/product_export.csv                                                                                                                  |
+      | filters  | {"structure":{"locales":["en_US"],"scope":"mobile"},"data":[{"field": "updated", "operator": "SINCE LAST JOB", "value": "csv_footwear_product_export"}]} |
+    And the following products:
+      | sku      | family   | categories        | price          | size | color | name-en_US |
+      | SNKRS-1B | sneakers | summer_collection | 50 EUR, 70 USD | 45   | black | Model 1    |
+      | SNKRS-1R | sneakers | summer_collection | 50 EUR, 70 USD | 45   | red   | Model 1    |
+    And the following CSV file to import:
+      """
+      sku;categories;color;description-en_US-mobile;enabled;family;groups;lace_color;manufacturer;name-en_US;price-EUR;price-USD;rating;side_view;size;top_view;weather_conditions
+      SNKRS-1B;summer_collection;black;;1;sneakers;;;;"Model 1";50.00;70.00;;;45;;hot
+      SNKRS-1R;summer_collection;red;;1;sneakers;;;;"Model 1";50.00;70.00;;;45;;
+      """
+    And the following job "csv_footwear_product_import" configuration:
+      | filePath | %file to import% |
+    And I am logged in as "Julia"
+    When I am on the "csv_footwear_product_export" export job page
+    And I launch the export job
+    And I wait for the "csv_footwear_product_export" job to finish
+    Then exported file of "csv_footwear_product_export" should contain:
+      """
+      sku;categories;color;description-en_US-mobile;enabled;family;groups;lace_color;manufacturer;name-en_US;price-EUR;price-USD;rating;side_view;size;top_view;weather_conditions
+      SNKRS-1B;summer_collection;black;;1;sneakers;;;;"Model 1";50.00;70.00;;;45;;
+      SNKRS-1R;summer_collection;red;;1;sneakers;;;;"Model 1";50.00;70.00;;;45;;
+      """
+    When I am on the "csv_footwear_product_import" import job page
+    And I launch the import job
+    And I wait for the "csv_footwear_product_import" job to finish
+    And I am on the "csv_footwear_product_export" export job page
+    And I launch the export job
+    And I wait for the "csv_footwear_product_export" job to finish
+    Then exported file of "csv_footwear_product_export" should contain:
+      """
+      sku;categories;color;description-en_US-mobile;enabled;family;groups;lace_color;manufacturer;name-en_US;price-EUR;price-USD;rating;side_view;size;top_view;weather_conditions
+      SNKRS-1B;summer_collection;black;;1;sneakers;;;;"Model 1";50.00;70.00;;;45;;hot
+      """

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Saver/ProductSaver.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Saver/ProductSaver.php
@@ -98,9 +98,13 @@ class ProductSaver extends BaseProductSaver
 
         foreach ($products as $product) {
             if (null === $product->getId()) {
-                $productsToInsert[] = $product;
                 $product->setId($this->mongoFactory->createMongoId());
+                $product->setCreated(new \Datetime('now', new \DateTimeZone('UTC')));
+                $product->setUpdated(new \Datetime('now', new \DateTimeZone('UTC')));
+
+                $productsToInsert[] = $product;
             } else {
+                $product->setUpdated(new \Datetime('now', new \DateTimeZone('UTC')));
                 $productsToUpdate[] = $product;
             }
 

--- a/src/Pim/Bundle/CatalogBundle/MongoDB/Normalizer/Document/ProductNormalizer.php
+++ b/src/Pim/Bundle/CatalogBundle/MongoDB/Normalizer/Document/ProductNormalizer.php
@@ -78,13 +78,8 @@ class ProductNormalizer implements NormalizerInterface, SerializerAwareInterface
 
         $context[self::MONGO_ID] = $data[self::MONGO_ID];
 
-        if (null !== $product->getCreated()) {
-            $data['created'] = $this->normalizer->normalize($product->getCreated(), self::FORMAT, $context);
-        } else {
-            $data['created'] = $this->mongoFactory->createMongoDate();
-        }
-
-        $data['updated'] = $this->mongoFactory->createMongoDate();
+        $data['created'] = $this->normalizer->normalize($product->getCreated(), self::FORMAT, $context);
+        $data['updated'] = $this->normalizer->normalize($product->getUpdated(), self::FORMAT, $context);
 
         if (null !== $product->getFamily()) {
             $data['family'] = $product->getFamily()->getId();

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Saver/ProductSaverSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Saver/ProductSaverSpec.php
@@ -81,6 +81,13 @@ class ProductSaverSpec extends ObjectBehavior
         $productC->setId(Argument::any())->shouldBeCalled();
         $productD->setId(Argument::any())->shouldBeCalled();
 
+        $productA->setUpdated(Argument::any())->shouldBeCalled();
+        $productB->setUpdated(Argument::any())->shouldBeCalled();
+        $productC->setCreated(Argument::any())->shouldBeCalled();
+        $productC->setUpdated(Argument::any())->shouldBeCalled();
+        $productD->setCreated(Argument::any())->shouldBeCalled();
+        $productD->setUpdated(Argument::any())->shouldBeCalled();
+
         $normalizer->normalize($productA, Argument::cetera())->willReturn(['_id' => 'id_a', 'key_a' => 'data_a']);
         $normalizer->normalize($productB, Argument::cetera())->willReturn(['_id' => 'id_b', 'key_b' => 'data_b']);
         $normalizer->normalize($productC, Argument::cetera())->willReturn(['_id' => 'id_c', 'key_c' => 'data_c']);

--- a/src/Pim/Bundle/CatalogBundle/spec/MongoDB/Normalizer/Document/ProductNormalizerSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/MongoDB/Normalizer/Document/ProductNormalizerSpec.php
@@ -44,12 +44,12 @@ class ProductNormalizerSpec extends ObjectBehavior
         $this->supportsNormalization($product, 'json')->shouldReturn(false);
     }
 
-    function it_normalizes_a_new_product_into_mongodb_document(
+    function it_normalizes_a_product_into_mongodb_document(
         $mongoFactory,
         $serializer,
         ProductInterface $product,
         \MongoId $mongoId,
-        \MongoDate $mongoDate,
+        \DateTime $date,
         Association $assoc1,
         Association $assoc2,
         CategoryInterface $category1,
@@ -60,8 +60,7 @@ class ProductNormalizerSpec extends ObjectBehavior
         ProductValueInterface $value2,
         FamilyInterface $family
     ) {
-        $mongoFactory->createMongoId()->willReturn($mongoId);
-        $mongoFactory->createMongoDate()->willReturn($mongoDate);
+        $mongoFactory->createMongoId('product1')->willReturn($mongoId);
 
         $family->getId()->willReturn(36);
 
@@ -71,8 +70,9 @@ class ProductNormalizerSpec extends ObjectBehavior
         $group1->getId()->willReturn(56);
         $group2->getId()->willReturn(78);
 
-        $product->getId()->willReturn(null);
-        $product->getCreated()->willReturn(null);
+        $product->getId()->willReturn('product1');
+        $product->getCreated()->willReturn($date);
+        $product->getUpdated()->willReturn($date);
         $product->getFamily()->willReturn($family);
         $product->isEnabled()->willReturn(true);
         $product->getGroups()->willReturn([$group1, $group2]);
@@ -89,11 +89,12 @@ class ProductNormalizerSpec extends ObjectBehavior
         $serializer->normalize($value2, 'mongodb_document', $context)->willReturn('my_value_2');
         $serializer->normalize($assoc1, 'mongodb_document', $context)->willReturn('my_assoc_1');
         $serializer->normalize($assoc2, 'mongodb_document', $context)->willReturn('my_assoc_2');
+        $serializer->normalize($date, 'mongodb_document', $context)->willReturn($date);
 
         $this->normalize($product, 'mongodb_document')->shouldReturn([
             '_id'            => $mongoId,
-            'created'        => $mongoDate,
-            'updated'        => $mongoDate,
+            'created'        => $date,
+            'updated'        => $date,
             'family'         => 36,
             'enabled'        => true,
             'groupIds'       => [56, 78],
@@ -101,16 +102,16 @@ class ProductNormalizerSpec extends ObjectBehavior
             'associations'   => ['my_assoc_1', 'my_assoc_2'],
             'values'         => ['my_value_1', 'my_value_2'],
             'normalizedData' => ['data' => 'data'],
-            'completenesses' => []
+            'completenesses' => [],
         ]);
     }
 
-    function it_normalizes_a_new_product_without_family_into_mongodb_document(
-        $mongoFactory,
+    function it_normalizes_a_product_without_family_into_mongodb_document(
         $serializer,
+        $mongoFactory,
         ProductInterface $product,
         \MongoId $mongoId,
-        \MongoDate $mongoDate,
+        \DateTime $date,
         Association $assoc1,
         Association $assoc2,
         CategoryInterface $category1,
@@ -120,8 +121,7 @@ class ProductNormalizerSpec extends ObjectBehavior
         ProductValueInterface $value1,
         ProductValueInterface $value2
     ) {
-        $mongoFactory->createMongoId()->willReturn($mongoId);
-        $mongoFactory->createMongoDate()->willReturn($mongoDate);
+        $mongoFactory->createMongoId('product1')->willReturn($mongoId);
 
         $category1->getId()->willReturn(12);
         $category2->getId()->willReturn(34);
@@ -129,8 +129,9 @@ class ProductNormalizerSpec extends ObjectBehavior
         $group1->getId()->willReturn(56);
         $group2->getId()->willReturn(78);
 
-        $product->getId()->willReturn(null);
-        $product->getCreated()->willReturn(null);
+        $product->getId()->willReturn('product1');
+        $product->getCreated()->willReturn($date);
+        $product->getUpdated()->willReturn($date);
         $product->getFamily()->willReturn(null);
         $product->isEnabled()->willReturn(true);
         $product->getGroups()->willReturn([$group1, $group2]);
@@ -147,136 +148,19 @@ class ProductNormalizerSpec extends ObjectBehavior
         $serializer->normalize($value2, 'mongodb_document', $context)->willReturn('my_value_2');
         $serializer->normalize($assoc1, 'mongodb_document', $context)->willReturn('my_assoc_1');
         $serializer->normalize($assoc2, 'mongodb_document', $context)->willReturn('my_assoc_2');
+        $serializer->normalize($date, 'mongodb_document', $context)->willReturn($date);
 
         $this->normalize($product, 'mongodb_document')->shouldReturn([
             '_id'            => $mongoId,
-            'created'        => $mongoDate,
-            'updated'        => $mongoDate,
+            'created'        => $date,
+            'updated'        => $date,
             'enabled'        => true,
             'groupIds'       => [56, 78],
             'categoryIds'    => [12, 34],
             'associations'   => ['my_assoc_1', 'my_assoc_2'],
             'values'         => ['my_value_1', 'my_value_2'],
             'normalizedData' => ['data' => 'data'],
-            'completenesses' => []
-        ]);
-    }
-
-    function it_normalizes_an_existing_product_into_mongodb_document(
-        $mongoFactory,
-        $serializer,
-        ProductInterface $product,
-        \MongoId $mongoId,
-        \MongoDate $mongoDate,
-        Association $assoc1,
-        Association $assoc2,
-        CategoryInterface $category1,
-        CategoryInterface $category2,
-        GroupInterface $group1,
-        GroupInterface $group2,
-        ProductValueInterface $value1,
-        ProductValueInterface $value2,
-        FamilyInterface $family
-    ) {
-        $mongoFactory->createMongoId('product1')->willReturn($mongoId);
-        $mongoFactory->createMongoDate()->willReturn($mongoDate);
-
-        $family->getId()->willReturn(36);
-
-        $category1->getId()->willReturn(12);
-        $category2->getId()->willReturn(34);
-
-        $group1->getId()->willReturn(56);
-        $group2->getId()->willReturn(78);
-
-        $product->getId()->willReturn('product1');
-        $product->getCreated()->willReturn(null);
-        $product->getFamily()->willReturn($family);
-        $product->isEnabled()->willReturn(true);
-        $product->getGroups()->willReturn([$group1, $group2]);
-        $product->getCategories()->willReturn([$category1, $category2]);
-        $product->getAssociations()->willReturn([$assoc1, $assoc2]);
-        $product->getValues()->willReturn([$value1, $value2]);
-
-        $context = ['_id' => $mongoId];
-
-        $serializer
-            ->normalize($product, 'mongodb_json')
-            ->willReturn(['data' => 'data', 'completenesses' => 'completenesses']);
-        $serializer->normalize($value1, 'mongodb_document', $context)->willReturn('my_value_1');
-        $serializer->normalize($value2, 'mongodb_document', $context)->willReturn('my_value_2');
-        $serializer->normalize($assoc1, 'mongodb_document', $context)->willReturn('my_assoc_1');
-        $serializer->normalize($assoc2, 'mongodb_document', $context)->willReturn('my_assoc_2');
-
-        $this->normalize($product, 'mongodb_document')->shouldReturn([
-            '_id'            => $mongoId,
-            'created'        => $mongoDate,
-            'updated'        => $mongoDate,
-            'family'         => 36,
-            'enabled'        => true,
-            'groupIds'       => [56, 78],
-            'categoryIds'    => [12, 34],
-            'associations'   => ['my_assoc_1', 'my_assoc_2'],
-            'values'         => ['my_value_1', 'my_value_2'],
-            'normalizedData' => ['data' => 'data'],
-            'completenesses' => []
-        ]);
-    }
-
-    function it_normalizes_an_existing_product_without_family_into_mongodb_document(
-        $mongoFactory,
-        $serializer,
-        ProductInterface $product,
-        \MongoId $mongoId,
-        \MongoDate $mongoDate,
-        Association $assoc1,
-        Association $assoc2,
-        CategoryInterface $category1,
-        CategoryInterface $category2,
-        GroupInterface $group1,
-        GroupInterface $group2,
-        ProductValueInterface $value1,
-        ProductValueInterface $value2
-    ) {
-        $mongoFactory->createMongoId('product1')->willReturn($mongoId);
-        $mongoFactory->createMongoDate()->willReturn($mongoDate);
-
-        $category1->getId()->willReturn(12);
-        $category2->getId()->willReturn(34);
-
-        $group1->getId()->willReturn(56);
-        $group2->getId()->willReturn(78);
-
-        $product->getId()->willReturn('product1');
-        $product->getCreated()->willReturn(null);
-        $product->getFamily()->willReturn(null);
-        $product->isEnabled()->willReturn(true);
-        $product->getGroups()->willReturn([$group1, $group2]);
-        $product->getCategories()->willReturn([$category1, $category2]);
-        $product->getAssociations()->willReturn([$assoc1, $assoc2]);
-        $product->getValues()->willReturn([$value1, $value2]);
-
-        $context = ['_id' => $mongoId];
-
-        $serializer
-            ->normalize($product, 'mongodb_json')
-            ->willReturn(['data' => 'data', 'completenesses' => 'completenesses']);
-        $serializer->normalize($value1, 'mongodb_document', $context)->willReturn('my_value_1');
-        $serializer->normalize($value2, 'mongodb_document', $context)->willReturn('my_value_2');
-        $serializer->normalize($assoc1, 'mongodb_document', $context)->willReturn('my_assoc_1');
-        $serializer->normalize($assoc2, 'mongodb_document', $context)->willReturn('my_assoc_2');
-
-        $this->normalize($product, 'mongodb_document')->shouldReturn([
-            '_id'            => $mongoId,
-            'created'        => $mongoDate,
-            'updated'        => $mongoDate,
-            'enabled'        => true,
-            'groupIds'       => [56, 78],
-            'categoryIds'    => [12, 34],
-            'associations'   => ['my_assoc_1', 'my_assoc_2'],
-            'values'         => ['my_value_1', 'my_value_2'],
-            'normalizedData' => ['data' => 'data'],
-            'completenesses' => []
+            'completenesses' => [],
         ]);
     }
 }


### PR DESCRIPTION
… normalizer

**Description (for Contributor and Core Developer)**

Updates the createdAt and updatedAt dates of the product directly in the saver. In ORM those value are set using the TimestampableSubscriber. But in Mongo this subscriber is not called.

Prior to this PR those values were created while normalizing the product into a Mongo document. but updatedAt date was not correctly set in the normalizedData.

normalizedData.updated is used by the pqb mongo filters to filter on the datetime updated.

On Master we may rework this part a bit because anytime the product saver is called the updatedAt gets updated disregarding that there is an actual change (mongodb only).

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | :white_check_mark:
| Added Behats                      | :white_check_mark:
| Changelog updated                 | :white_check_mark:
| Review and 2 GTM                  | :white_check_mark:
| Micro Demo to the PO (Story only) | :negative_squared_cross_mark: 
| Migration script                  | :negative_squared_cross_mark:
| Tech Doc                          | :negative_squared_cross_mark:


:white_check_mark: Done and pass

:red_circle: Done but fail

:clock1: Done but pending

:negative_squared_cross_mark: Not needed
