### PR TITLE
API-87: Launch integration tests in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,33 +11,44 @@ cache:
   directories:
     - $HOME/.composer/cache/files
 
-before_script:
-    - echo 'date.timezone = "Europe/Paris"' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
-
 before_install:
     - phpenv config-add travis.php.ini
     - phpenv config-rm xdebug.ini || echo "xdebug not available for PHP $TRAVIS_PHP_VERSION"
+    - echo 'date.timezone = "Europe/Paris"' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
     - echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
-    - composer self-update --no-interaction
     - if [ "$TRAVIS_PHP_VERSION" = "5.6" ]; then
         echo "extension = mongo.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini;
       fi;
-    - if [ "$TRAVIS_PHP_VERSION" == "7.0" ] || [ "$TRAVIS_PHP_VERSION" == "7.1" ]; then
+    - if [ "$TRAVIS_PHP_VERSION" = "7.0" ] || [ "$TRAVIS_PHP_VERSION" = "7.1" ]; then
         pecl install mongodb;
       fi;
+    - if [ "$TRAVIS_PHP_VERSION" = "5.6" ]; then
+        yes '' | pecl install apcu-4.0.11;
+      fi;
+    - if [ "$TRAVIS_PHP_VERSION" = "7.0" ] || [ "$TRAVIS_PHP_VERSION" = "7.1" ]; then
+        yes '' | pecl install apcu;
+      fi;
+    - npm install -g grunt-cli
+
 install:
+    - mysql -u root -e 'CREATE DATABASE akeneo_pim;'
+    - mysql -u root -e 'CREATE USER "akeneo_pim"@"localhost" IDENTIFIED BY "akeneo_pim";'
+    - mysql -u root -e 'GRANT ALL ON akeneo_pim.* TO "akeneo_pim"@"localhost";'
     - composer update --prefer-dist --no-interaction --ignore-platform-reqs
-    - if [ "$TRAVIS_PHP_VERSION" == "7.0" ] || [ "$TRAVIS_PHP_VERSION" == "7.1" ]; then
+    - if [ "$TRAVIS_PHP_VERSION" = "7.0" ] || [ "$TRAVIS_PHP_VERSION" = "7.1" ]; then
         composer require alcaeus/mongo-php-adapter --ignore-platform-reqs;
       fi;
+    - ./app/console pim:install
     - ./app/console oro:requirejs:generate-config
-    - ./app/console assets:install
-    - npm install -g grunt-cli
     - npm install
     - curl http://get.sensiolabs.org/php-cs-fixer-v1.11.phar -o php-cs-fixer
 
+before_script:
+    - cp ./app/config/parameters.yml ./app/config/parameters_test.yml
+
 script:
     - ./bin/phpunit -c app/phpunit.travis.xml --testsuite PIM_Unit_Test
+    - ./bin/phpunit -c app/phpunit.travis.xml --testsuite PIM_Integration_Test
     - ./bin/phpspec run
     - php php-cs-fixer fix --dry-run -v --diff --config-file=.php_cs.php
     - grunt travis
@@ -48,4 +59,3 @@ notifications:
 matrix:
   allow_failures:
     - php: "7.1"
-

--- a/app/phpunit.travis.xml
+++ b/app/phpunit.travis.xml
@@ -9,8 +9,8 @@
     processIsolation="false"
     stopOnFailure="false"
     syntaxCheck="false"
-    bootstrap="../vendor/autoload.php" >
-
+    bootstrap="./autoload.php"
+>
     <php>
         <ini name="intl.default_locale" value="en"/>
         <ini name="intl.error_level" value="0"/>
@@ -23,6 +23,11 @@
         <!-- PIM test suites -->
         <testsuite name="PIM_Unit_Test">
             <directory suffix="Test.php">../src/Pim/Bundle/*Bundle/Tests/Unit</directory>
+        </testsuite>
+
+        <testsuite name="PIM_Integration_Test">
+            <directory suffix="Integration.php">../src/Pim/Component/*/tests/integration</directory>
+            <directory suffix="Integration.php">../src/Pim/Bundle/*Bundle/tests/integration</directory>
         </testsuite>
 
     </testsuites>

--- a/src/Pim/Bundle/VersioningBundle/Normalizer/Flat/ProductValueNormalizer.php
+++ b/src/Pim/Bundle/VersioningBundle/Normalizer/Flat/ProductValueNormalizer.php
@@ -176,7 +176,7 @@ class ProductValueNormalizer implements NormalizerInterface, SerializerAwareInte
         usort(
             $options,
             function ($first, $second) {
-                return $first->getSortOrder() > $second->getSortOrder();
+                return $first->getSortOrder() - $second->getSortOrder();
             }
         );
         $sortedCollection = new ArrayCollection($options);

--- a/src/Pim/Bundle/VersioningBundle/tests/integration/Normalizer/Flat/ProductIntegration.php
+++ b/src/Pim/Bundle/VersioningBundle/tests/integration/Normalizer/Flat/ProductIntegration.php
@@ -223,7 +223,7 @@ class ProductIntegration extends TestCase
             'a_metric_without_decimal-unit'                      => 'CENTIMETER',
             'a_metric_without_decimal_negative'                  => '-20',
             'a_metric_without_decimal_negative-unit'             => 'CELSIUS',
-            'a_multi_select'                                     => 'optionB,optionA',
+            'a_multi_select'                                     => 'optionA,optionB',
             'a_number_float'                                     => '12.5678',
             'a_number_float_negative'                            => '-99.8732',
             'a_number_integer'                                   => '42',

--- a/src/Pim/Component/Catalog/tests/integration/Normalizer/Standard/AttributeOptionIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Normalizer/Standard/AttributeOptionIntegration.php
@@ -16,7 +16,7 @@ class AttributeOptionIntegration extends TestCase
         $expected = [
             'code'       => 'optionA',
             'attribute'  => 'a_multi_select',
-            'sort_order' => 1,
+            'sort_order' => 10,
             'labels'     => [
                 'en_US' => 'Option A'
             ]

--- a/tests/catalog/technical/attribute_options.csv
+++ b/tests/catalog/technical/attribute_options.csv
@@ -1,5 +1,5 @@
 code;attribute;sort_order;label-en_US
-optionA;a_multi_select;1;Option A
-optionB;a_multi_select;1;Option B
-optionA;a_simple_select;1;Option A
-optionB;a_simple_select;1;Option B
+optionA;a_multi_select;10;Option A
+optionB;a_multi_select;20;Option B
+optionA;a_simple_select;10;Option A
+optionB;a_simple_select;20;Option B


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) 

**Description (for Contributor and Core Developer)**

This PR allows to run the integration tests into Travis:

![job 41574 1 akeneo pim community dev travis ci](https://cloud.githubusercontent.com/assets/659491/21752972/8cf1e5aa-d5e2-11e6-8f7c-a5c18b895c3c.png)

The PIM is now fully installed in Travis. That means:
- install APCu (because it's required by Symfony and it's not installed by default)
- create MySQL user and database before the install
- launch the install command

There is almost no impact on builds execution time.