### PR TITLE
AMS-128: Keep working locale in session

### DIFF
--- a/features/product/browse_products_by_locale_and_scope.feature
+++ b/features/product/browse_products_by_locale_and_scope.feature
@@ -19,7 +19,6 @@ Feature: Browse products by locale and scope
       | postit | furniture | Post it    | Etiquette  | My ecommerce description    | Ma description ecommerce    | Ma description mobile    | large.jpeg      | small.jpeg   |
     And I am logged in as "Mary"
     And I am on the products page
-    And I display the columns SKU, Name, Image, Description and Family
 
   @skip
   Scenario: Successfully display english data on products page
@@ -62,3 +61,9 @@ Feature: Browse products by locale and scope
       | [image]       | small.jpeg            |
       | [description] | Ma description mobile |
       | family        | [furniture]           |
+
+  Scenario: Keep working local context through navigation
+    Given I switch the locale to "fr_FR"
+    And I am on the dashboard page
+    When I am on the products page
+    Then I should see the text "Products fr"

--- a/src/Oro/Bundle/UserBundle/Controller/UserController.php
+++ b/src/Oro/Bundle/UserBundle/Controller/UserController.php
@@ -161,6 +161,8 @@ class UserController extends Controller
                 $this->get('translator')->trans('oro.user.controller.user.message.saved')
             );
 
+            $this->get('session')->remove('dataLocale');
+
             return new RedirectResponse(
                 $this->get('router')->generate('oro_user_update', ['id' => $user->getId()])
             );

--- a/src/Pim/Bundle/CatalogBundle/Helper/LocaleHelper.php
+++ b/src/Pim/Bundle/CatalogBundle/Helper/LocaleHelper.php
@@ -44,7 +44,7 @@ class LocaleHelper
      */
     public function getCurrentLocaleCode()
     {
-        return $this->userContext->getCurrentLocale()->getCode();
+        return $this->userContext->getUiLocale()->getCode();
     }
 
     /**

--- a/src/Pim/Bundle/CatalogBundle/spec/Helper/LocaleHelperSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Helper/LocaleHelperSpec.php
@@ -13,7 +13,7 @@ class LocaleHelperSpec extends ObjectBehavior
     function let(UserContext $userContext, LocaleRepositoryInterface $localeRepository, LocaleInterface $en)
     {
         $en->getCode()->willReturn('en_US');
-        $userContext->getCurrentLocale()->willReturn($en);
+        $userContext->getUiLocale()->willReturn($en);
 
         $this->beConstructedWith($userContext, $localeRepository);
     }

--- a/src/Pim/Bundle/EnrichBundle/Resources/views/MassEditAction/product/configure/edit-common-attributes.html.twig
+++ b/src/Pim/Bundle/EnrichBundle/Resources/views/MassEditAction/product/configure/edit-common-attributes.html.twig
@@ -57,7 +57,7 @@
 
                                 $('#mass-edit-common-attribute-description').html(_.__(
                                     'pim_enrich.mass_edit_action.edit_common_attributes.description',
-                                    {'locale': locale.label, 'channel': channel.labels[UserContext.get('catalogLocale')]}
+                                    {'locale': locale.label, 'channel': channel.labels[UserContext.get('uiLocale')]}
                                 ));
                             });
                         });

--- a/src/Pim/Bundle/UserBundle/EventListener/LocaleListener.php
+++ b/src/Pim/Bundle/UserBundle/EventListener/LocaleListener.php
@@ -20,6 +20,7 @@ class LocaleListener
     {
         $user = $event->getAuthenticationToken()->getUser();
 
+        $event->getRequest()->getSession()->remove('dataLocale');
         $event->getRequest()->getSession()->set('_locale', $user->getUiLocale()->getCode());
     }
 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This PR changes the behavior of the datagrid locale.
Now, the dataLocale is stored in the session, therefore the user keeps its working locale when navigating in the PIM.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Y
| Added Behats                      | Y
| Changelog updated                 | N
| Review and 2 GTM                  | Y
| Micro Demo to the PO (Story only) | N
| Migration script                  | N/A
| Tech Doc                          | N/A
