### PR TITLE
GITHUB-5450: Make specs independent of developers timezone

### DIFF
--- a/src/Akeneo/Component/Localization/spec/Localizer/DateLocalizerSpec.php
+++ b/src/Akeneo/Component/Localization/spec/Localizer/DateLocalizerSpec.php
@@ -11,9 +11,21 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class DateLocalizerSpec extends ObjectBehavior
 {
+    const TEST_TIMEZONE = 'Europe/Paris';
+
+    protected $userTimezone;
+
     function let(ValidatorInterface $validator, DateFactory $dateFactory)
     {
+        $this->userTimezone = date_default_timezone_get();
+        date_default_timezone_set(self::TEST_TIMEZONE);
+
         $this->beConstructedWith($validator, $dateFactory, ['pim_catalog_date']);
+    }
+
+    function letGo()
+    {
+        date_default_timezone_set($this->userTimezone);
     }
 
     function it_is_a_localizer()

--- a/src/Pim/Component/Catalog/spec/Normalizer/Standard/DateTimeNormalizerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Normalizer/Standard/DateTimeNormalizerSpec.php
@@ -7,9 +7,24 @@ use Prophecy\Argument;
 
 class DateTimeNormalizerSpec extends ObjectBehavior
 {
+    const TEST_TIMEZONE = 'Europe/Paris';
+
+    protected $userTimezone;
+
     function it_is_initializable()
     {
         $this->shouldHaveType('Pim\Component\Catalog\Normalizer\Standard\DateTimeNormalizer');
+    }
+
+    function let()
+    {
+        $this->userTimezone = date_default_timezone_get();
+        date_default_timezone_set(self::TEST_TIMEZONE);
+    }
+
+    function letGo()
+    {
+        date_default_timezone_set($this->userTimezone);
     }
 
     function it_is_a_normalizer()

--- a/src/Pim/Component/Catalog/spec/Normalizer/Standard/DateTimeNormalizerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Normalizer/Standard/DateTimeNormalizerSpec.php
@@ -11,11 +11,6 @@ class DateTimeNormalizerSpec extends ObjectBehavior
 
     protected $userTimezone;
 
-    function it_is_initializable()
-    {
-        $this->shouldHaveType('Pim\Component\Catalog\Normalizer\Standard\DateTimeNormalizer');
-    }
-
     function let()
     {
         $this->userTimezone = date_default_timezone_get();
@@ -25,6 +20,11 @@ class DateTimeNormalizerSpec extends ObjectBehavior
     function letGo()
     {
         date_default_timezone_set($this->userTimezone);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Pim\Component\Catalog\Normalizer\Standard\DateTimeNormalizer');
     }
 
     function it_is_a_normalizer()

--- a/src/Pim/Component/Connector/spec/ArrayConverter/FlatToStandard/AttributeSpec.php
+++ b/src/Pim/Component/Connector/spec/ArrayConverter/FlatToStandard/AttributeSpec.php
@@ -7,8 +7,15 @@ use Pim\Component\Connector\ArrayConverter\FieldsRequirementChecker;
 
 class AttributeSpec extends ObjectBehavior
 {
+    const TEST_TIMEZONE = 'Europe/Paris';
+
+    protected $userTimezone;
+
     function let(FieldsRequirementChecker $fieldChecker)
     {
+        $this->userTimezone = date_default_timezone_get();
+        date_default_timezone_set(self::TEST_TIMEZONE);
+
         $booleanFields = [
             'localizable',
             'useable_as_grid_filter',
@@ -20,6 +27,11 @@ class AttributeSpec extends ObjectBehavior
             'negative_allowed',
         ];
         $this->beConstructedWith($fieldChecker, $booleanFields);
+    }
+
+    function letGo()
+    {
+        date_default_timezone_set($this->userTimezone);
     }
 
     function it_is_a_standard_array_converter()


### PR DESCRIPTION
Some tests fails if `date.timezone` parameter is not `Europe/Paris`. Makes specs related to datetime independent of developers timezone.
See #5450

[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) 

**Description (for Contributor and Core Developer)**

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | :white_check_mark:
| Added Behats                      | :negative_squared_cross_mark:
| Changelog updated                 | :clock1:
| Review and 2 GTM                  | :clock1:
| Micro Demo to the PO (Story only) | :negative_squared_cross_mark:
| Migration script                  | :negative_squared_cross_mark:
| Tech Doc                          | :negative_squared_cross_mark:


:white_check_mark: Done and pass

:red_circle: Done but fail

:clock1: Done but pending

:negative_squared_cross_mark: Not needed
