### PR TITLE
PIM-6092: Always allow to create new option on select2

### DIFF
--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-6064: Fix a grid issue with attribute named ID 
+- PIM-6092: Always allow to create new option on select2
 
 ## Technical improvements
 

--- a/src/Pim/Bundle/UIBundle/Controller/AjaxOptionController.php
+++ b/src/Pim/Bundle/UIBundle/Controller/AjaxOptionController.php
@@ -77,7 +77,11 @@ class AjaxOptionController
             );
         }
 
-        if ($query->get('isCreatable') && 0 === count($choices['results'])) {
+        if (
+            $query->get('isCreatable') &&
+            !empty($search) &&
+            !in_array($choices['results'], ['id' => $search, 'text' => $search])
+        ) {
             $choices['results'] = [
                 ['id' => $search, 'text' => $search]
             ];


### PR DESCRIPTION
| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | :negative_squared_cross_mark:
| Added Behats                      | :negative_squared_cross_mark:
| Changelog updated                 | :white_check_mark: 
| Review and 2 GTM                  | :red_circle:
| Micro Demo to the PO (Story only) | :white_check_mark: 
| Migration script                  | :negative_squared_cross_mark:
| Tech Doc                          | :negative_squared_cross_mark:

# Note

Assuming you have a "animal" tag, if you try to add "anima" you will not be able to do it as it will select animal by default. Adding the search term to the search results fix it.