### PR TITLE
AMS-130: Keep working scope in session

### DIFF
--- a/features/Context/AssertionContext.php
+++ b/features/Context/AssertionContext.php
@@ -62,12 +62,13 @@ class AssertionContext extends RawMinkContext
      */
     public function iShouldSeeTheTitle($expectedTitle)
     {
-        $actualTitle = $this->getCurrentPage()->getHeadTitle();
-        if (trim($actualTitle) !== trim($expectedTitle)) {
-            throw $this->createExpectationException(
-                sprintf('Incorrect title. Expected "%s", found "%s"', $expectedTitle, $actualTitle)
-            );
-        }
+        $this->spin(function () use ($expectedTitle) {
+            return trim($this->getCurrentPage()->getHeadTitle()) === trim($expectedTitle);
+        }, sprintf(
+            'Incorrect title. Expected "%s", found "%s"',
+            $expectedTitle,
+            $this->getCurrentPage()->getHeadTitle())
+        );
     }
 
     /**

--- a/features/product/browse_products_by_locale_and_scope.feature
+++ b/features/product/browse_products_by_locale_and_scope.feature
@@ -67,3 +67,11 @@ Feature: Browse products by locale and scope
     And I am on the dashboard page
     When I am on the products page
     Then I should see the text "Products fr"
+
+  Scenario: Keep working scope context through navigation
+    Given I filter by "scope" with operator "equals" and value "Mobile"
+    And I am on the dashboard page
+    When I am on the products page
+    Then I should see the text "Mobile"
+    When I refresh current page
+    Then I should see the text "Mobile"


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This PR changes the behavior of the datagrid scope.
Now, the scope is stored in the session storage, therefore the user keeps its working scope when navigating in the PIM.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | N/A
| Added Behats                      | Y
| Changelog updated                 | N/A
| Review and 2 GTM                  | Y
| Micro Demo to the PO (Story only) | N
| Migration script                  | N/A
| Tech Doc                          | N/A
