### PR TITLE
API-88: Fix "Too many connections" error on integration tests

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -144,6 +144,11 @@ class TestCase extends KernelTestCase
         }
 
         $jobLoader->deleteJobInstances();
+
+        // close the connection created specifically for this repository
+        // TODO: to remove when TIP-385 will be done
+        $doctrineJobRepository = $this->get('akeneo_batch.job_repository');
+        $doctrineJobRepository->getJobManager()->getConnection()->close();
     }
 
     /**
@@ -187,5 +192,23 @@ class TestCase extends KernelTestCase
         foreach ($purgers as $purger) {
             $purger->purge();
         }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function tearDown()
+    {
+        if (AkeneoStorageUtilsExtension::DOCTRINE_MONGODB_ODM === $this->getParameter('pim_catalog_product_storage_driver')) {
+            $doctrine = $this->get('doctrine_mongodb');
+        } else {
+            $doctrine = $this->get('doctrine');
+        }
+
+        foreach ($doctrine->getConnections() as $connection) {
+            $connection->close();
+        }
+
+        parent::tearDown();
     }
 }


### PR DESCRIPTION
Currently, there is a "Too many connections" error when too many tests are launched with phpunit.
Error comes from two things:
- doctrine which does not close properly connections.
- DoctrineJobRepository creates is own connection but never close it

:warning: **Warning** :warning: :
Even if we close properly connections in our tests, there is still connections unclosed in our current version of doctrine-bundle (Stof fixed this bug in this [PR](https://github.com/doctrine/DoctrineBundle/commit/2f8d7263c4c44445b51fc2d9bf71d21f7016347d)).
We can try to upgrade this bundle, launch CI and perfbench to check the impact. If there is no impact, we can merge. If not, take a look at this PR and fix directly the problem inside the PIM.

EDIT:
Upgrade to the last version of DoctrineBundle increase by 4 the time of import on ORM (not on mongo). So we keep the tearDown method in our code.