### PR TITLE
Tip 322: add business exception in updaters

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -156,3 +156,4 @@
 - Remove useless class `Pim\Bundle\ImportExportBundle\JobTemplate\JobTemplateProviderInterface`
 - Remove useless class `Pim\Bundle\ImportExportBundle\Twig\NormalizeConfigurationExtension`
 - Remove useless class `Pim\Bundle\ImportExportBundle\ViewElement\Checker\JobNameVisibilityChecker`
+- Change exception `\InvalidArgumentException` by `Akeneo\Component\StorageUtils\Exception\ObjectUpdaterException` thrown by `Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface:update()`

--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -157,3 +157,4 @@
 - Remove useless class `Pim\Bundle\ImportExportBundle\Twig\NormalizeConfigurationExtension`
 - Remove useless class `Pim\Bundle\ImportExportBundle\ViewElement\Checker\JobNameVisibilityChecker`
 - Change exception `\InvalidArgumentException` by `Akeneo\Component\StorageUtils\Exception\ObjectUpdaterException` thrown by `Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface:update()`
+- Change the constructor of `Pim\Component\Catalog\Updater\AssociationTypeUpdater` to remove `Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface`

--- a/features/import/attribute/import_attributes.feature
+++ b/features/import/attribute/import_attributes.feature
@@ -136,7 +136,7 @@ Feature: Import attributes
     And I launch the import job
     And I wait for the "csv_footwear_attribute_import" job to finish
     Then I should see "skipped 1"
-    And I should see "attributeType must be filled."
+    And I should see "Property \"attribute_type\" does not expect an empty value (for updater attribute)."
 
   Scenario: Successfully import and update existing attribute
     Given the "footwear" catalog configuration
@@ -172,7 +172,7 @@ Feature: Import attributes
     And I wait for the "csv_footwear_attribute_import" job to finish
     Then I should see "read lines 1"
     Then I should see "skipped 1"
-    Then I should see "Attribute expects a string with the format \"yyyy-mm-dd\" as data, \"2000/12/12\" given"
+    Then I should see "Property \"date_min\" expects a string with the format \"yyyy-mm-dd\" as data, \"2000/12/12\" given (for updater attribute)."
 
   Scenario: Fail to import attribute with invalid date
     Given the "footwear" catalog configuration
@@ -189,7 +189,7 @@ Feature: Import attributes
     And I wait for the "csv_footwear_attribute_import" job to finish
     Then I should see "read lines 1"
     Then I should see "skipped 1"
-    Then I should see "Invalid date, \"2000-99-12\" given"
+    Then I should see "Property \"date_min\" expects a string with the format \"yyyy-mm-dd\" as data, \"2000-99-12\" given (for updater attribute)."
 
   Scenario: Fail to import attribute with invalid data
     Given the "footwear" catalog configuration
@@ -208,7 +208,7 @@ Feature: Import attributes
     Then I should see "read lines 2"
     Then I should see "skipped 2"
     Then I should see "maxFileSize: This value should be a valid number.: not an int"
-    Then I should see "AttributeGroup \"not a group\" does not exist"
+    Then I should see "Property \"group\" expects a valid code. The attribute group does not exist, \"not a group\" given (for updater attribute)."
 
   Scenario: Successfully import new attribute
     Given the "footwear" catalog configuration

--- a/features/import/import_categories.feature
+++ b/features/import/import_categories.feature
@@ -47,8 +47,8 @@ Feature: Import categories
     When I am on the "csv_footwear_category_import" import job page
     And I launch the import job
     And I wait for the "csv_footwear_category_import" job to finish
-    Then I should see "The parent category \"clothes\" does not exist"
-    And I should see "The parent category \"clothes\" does not exist"
+    Then I should see "Property \"parent\" expects a valid category code. The category does not exist, \"clothes\" given (for updater category)."
+    And I should see "Property \"parent\" expects a valid category code. The category does not exist, \"tshirts\" given (for updater category)."
     And there should be the following categories:
       | code        | label       | parent    |
       | computers   | Computers   |           |

--- a/features/import/import_options.feature
+++ b/features/import/import_options.feature
@@ -67,7 +67,7 @@ Feature: Import options
     And I launch the import job
     And I wait for the "csv_footwear_option_import" job to finish
     Then I should see "skipped 1"
-    And I should see "Attribute \"unknown\" does not exist"
+    And I should see "Property \"attribute\" expects a valid attribute code. The attribute does not exist, \"unknown\" given (for updater attribute option)."
 
   @jira https://akeneo.atlassian.net/browse/PIM-3820
   Scenario: Import options with localizable label

--- a/features/import/product_group/import_groups.feature
+++ b/features/import/product_group/import_groups.feature
@@ -90,7 +90,7 @@ Feature: Import groups
     And I wait for the "csv_footwear_group_import" job to finish
     Then I should see "read lines 1"
     And I should see "skipped 1"
-    And I should see "Cannot process variant group \"New_VG\", only groups are accepted"
+    And I should see "Property \"type\" expects a valid group type. Cannot process variant group, only groups are supported, \"New_VG\" given (for updater group)"
 
   Scenario: Skip the line if we encounter an existing variant group
     Given the following CSV file to import:
@@ -105,7 +105,7 @@ Feature: Import groups
     And I wait for the "csv_footwear_group_import" job to finish
     Then I should see "read lines 1"
     And I should see "skipped 1"
-    And I should see "Cannot process variant group \"AKENEO_TSHIRT\", only groups are accepted"
+    And I should see "Property \"type\" expects a valid group type. Cannot process variant group, only groups are supported, \"AKENEO_TSHIRT\" given (for updater group)"
 
   Scenario: Skip the line if we try to set axis on a standard group
     Given the following CSV file to import:

--- a/features/import/product_group/xlsx/import_groups.feature
+++ b/features/import/product_group/xlsx/import_groups.feature
@@ -89,7 +89,7 @@ Feature: Import Xlsx groups
     And I wait for the "xlsx_footwear_group_import" job to finish
     Then I should see "read lines 1"
     And I should see "skipped 1"
-    And I should see "Cannot process variant group \"New_VG\", only groups are accepted"
+    And I should see "Property \"type\" expects a valid group type. Cannot process variant group, only groups are supported, \"New_VG\" given (for updater group)"
 
   Scenario: Skip the line if we encounter an existing variant group
     Given the following XLSX file to import:
@@ -104,7 +104,7 @@ Feature: Import Xlsx groups
     And I wait for the "xlsx_footwear_group_import" job to finish
     Then I should see "read lines 1"
     And I should see "skipped 1"
-    And I should see "Cannot process variant group \"AKENEO_TSHIRT\", only groups are accepted"
+    And I should see "Property \"type\" expects a valid group type. Cannot process variant group, only groups are supported, \"AKENEO_TSHIRT\" given (for updater group)."
 
   Scenario: Skip the line if we try to set axis on a standard group
     Given the following XLSX file to import:

--- a/features/import/product_variant_group/import_variant_group_with_invalid_properties.feature
+++ b/features/import/product_variant_group/import_variant_group_with_invalid_properties.feature
@@ -40,7 +40,7 @@ Feature: Execute an import with invalid properties
     When I am on the "csv_footwear_variant_group_import" import job page
     And I launch the import job
     And I wait for the "csv_footwear_variant_group_import" job to finish
-    Then I should see "Attributes: This property cannot be changed."
+    Then I should see "Property \"axes\" cannot be modified, \"manufacturer,size\" given (for updater variant group)."
     And I should see "read lines 1"
     And I should see "Skipped 1"
     And there should be the following groups:
@@ -59,7 +59,7 @@ Feature: Execute an import with invalid properties
     When I am on the "csv_footwear_variant_group_import" import job page
     And I launch the import job
     And I wait for the "csv_footwear_variant_group_import" job to finish
-    Then I should see "Attributes: This property cannot be changed."
+    Then I should see "Property \"axes\" cannot be modified, \"color\" given (for updater variant group)."
     And I should see "read lines 1"
     And I should see "Skipped 1"
     And there should be the following groups:

--- a/src/Akeneo/Component/Batch/Updater/JobInstanceUpdater.php
+++ b/src/Akeneo/Component/Batch/Updater/JobInstanceUpdater.php
@@ -6,6 +6,7 @@ use Akeneo\Component\Batch\Job\JobParameters;
 use Akeneo\Component\Batch\Job\JobParametersFactory;
 use Akeneo\Component\Batch\Job\JobRegistry;
 use Akeneo\Component\Batch\Model\JobInstance;
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Doctrine\Common\Util\ClassUtils;
 
@@ -42,11 +43,9 @@ class JobInstanceUpdater implements ObjectUpdaterInterface
     public function update($jobInstance, array $data, array $options = [])
     {
         if (!$jobInstance instanceof JobInstance) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    'Expects a "Akeneo\Component\Batch\Model\JobInstance", "%s" provided.',
-                    ClassUtils::getClass($jobInstance)
-                )
+            throw InvalidObjectException::objectExpected(
+                ClassUtils::getClass($jobInstance),
+                JobInstance::class
             );
         }
 

--- a/src/Akeneo/Component/Batch/spec/Updater/JobInstanceUpdaterSpec.php
+++ b/src/Akeneo/Component/Batch/spec/Updater/JobInstanceUpdaterSpec.php
@@ -7,6 +7,7 @@ use Akeneo\Component\Batch\Job\JobParameters;
 use Akeneo\Component\Batch\Job\JobParametersFactory;
 use Akeneo\Component\Batch\Job\JobRegistry;
 use Akeneo\Component\Batch\Model\JobInstance;
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
@@ -62,6 +63,11 @@ class JobInstanceUpdaterSpec extends ObjectBehavior
 
     function it_throw_an_exception_id_it_is_not_a_job_instance()
     {
-        $this->shouldThrow('\InvalidArgumentException')->during('update', [new \stdClass(), []]);
+        $this->shouldThrow(
+            InvalidObjectException::objectExpected(
+                'stdClass',
+                'Akeneo\Component\Batch\Model\JobInstance'
+            )
+        )->during('update', [new \stdClass(), []]);
     }
 }

--- a/src/Akeneo/Component/Classification/Updater/CategoryUpdater.php
+++ b/src/Akeneo/Component/Classification/Updater/CategoryUpdater.php
@@ -3,9 +3,13 @@
 namespace Akeneo\Component\Classification\Updater;
 
 use Akeneo\Component\Classification\Model\CategoryInterface;
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\UnknownPropertyException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Doctrine\Common\Util\ClassUtils;
+use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 
@@ -39,11 +43,9 @@ class CategoryUpdater implements ObjectUpdaterInterface
     public function update($category, array $data, array $options = [])
     {
         if (!$category instanceof CategoryInterface) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    'Expects a "Akeneo\Component\Classification\Model\CategoryInterface", "%s" provided.',
-                    ClassUtils::getClass($category)
-                )
+            throw InvalidObjectException::objectExpected(
+                ClassUtils::getClass($category),
+                'Akeneo\Component\Classification\Model\CategoryInterface'
             );
         }
 
@@ -58,6 +60,9 @@ class CategoryUpdater implements ObjectUpdaterInterface
      * @param CategoryInterface $category
      * @param string            $field
      * @param mixed             $data
+     *
+     * @throws InvalidPropertyException
+     * @throws UnknownPropertyException
      */
     protected function setData(CategoryInterface $category, $field, $data)
     {
@@ -67,13 +72,24 @@ class CategoryUpdater implements ObjectUpdaterInterface
             }
         } elseif ('parent' === $field) {
             $categoryParent = $this->findParent($data);
-            if (null !== $categoryParent) {
-                $category->setParent($categoryParent);
-            } else {
-                throw new \InvalidArgumentException(sprintf('The parent category "%s" does not exist', $data));
+            if (null === $categoryParent) {
+                throw InvalidPropertyException::validEntityCodeExpected(
+                    'parent',
+                    'category code',
+                    'The category does not exist',
+                    'updater',
+                    'category',
+                    $data
+                );
             }
+
+            $category->setParent($categoryParent);
         } else {
-            $this->accessor->setValue($category, $field, $data);
+            try {
+                $this->accessor->setValue($category, $field, $data);
+            } catch (NoSuchPropertyException $e) {
+                throw UnknownPropertyException::unknownProperty($field, $e);
+            }
         }
     }
 

--- a/src/Akeneo/Component/Classification/spec/Updater/CategoryUpdaterSpec.php
+++ b/src/Akeneo/Component/Classification/spec/Updater/CategoryUpdaterSpec.php
@@ -2,11 +2,13 @@
 
 namespace spec\Akeneo\Component\Classification\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
+use Akeneo\Component\StorageUtils\Exception\UnknownPropertyException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use PhpSpec\ObjectBehavior;
 use Pim\Bundle\CatalogBundle\Entity\CategoryTranslation;
 use Akeneo\Component\Classification\Model\CategoryInterface;
-use Prophecy\Argument;
+use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
 
 class CategoryUpdaterSpec extends ObjectBehavior
 {
@@ -28,8 +30,9 @@ class CategoryUpdaterSpec extends ObjectBehavior
     function it_throws_an_exception_when_trying_to_update_anything_else_than_a_category()
     {
         $this->shouldThrow(
-            new \InvalidArgumentException(
-                'Expects a "Akeneo\Component\Classification\Model\CategoryInterface", "stdClass" provided.'
+            InvalidObjectException::objectExpected(
+                'stdClass',
+                'Akeneo\Component\Classification\Model\CategoryInterface'
             )
         )->during(
             'update',
@@ -54,5 +57,17 @@ class CategoryUpdaterSpec extends ObjectBehavior
         ];
 
         $this->update($category, $values, []);
+    }
+
+    function it_throws_an_exception_when_trying_to_update_a_non_existent_field(CategoryInterface $category) {
+        $values = [
+            'non_existent_field' => 'field',
+            'code'               => 'mycode',
+            'parent'             => 'master',
+        ];
+
+        $this
+            ->shouldThrow(UnknownPropertyException::unknownProperty('non_existent_field', new NoSuchPropertyException()))
+            ->during('update', [$category, $values, []]);
     }
 }

--- a/src/Akeneo/Component/StorageUtils/Exception/ImmutablePropertyException.php
+++ b/src/Akeneo/Component/StorageUtils/Exception/ImmutablePropertyException.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Akeneo\Component\StorageUtils\Exception;
+
+/**
+ *  Exception an updater can throw when updating a property that can't be modified.
+ *
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ImmutablePropertyException extends ObjectUpdaterException
+{
+    /** @var string */
+    protected $propertyName;
+
+    /** @var string */
+    protected $propertyValue;
+
+    /**
+     * @param string          $propertyName
+     * @param string          $propertyValue
+     * @param string          $message
+     * @param int             $code
+     * @param \Exception|null $previous
+     */
+    public function __construct($propertyName, $propertyValue, $message = '', $code = 0, \Exception $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+        $this->propertyName  = $propertyName;
+        $this->propertyValue = $propertyValue;
+    }
+
+    /**
+     * @param string $propertyName
+     * @param string $propertyValue
+     * @param string $action
+     * @param string $type
+     *
+     * @return ImmutablePropertyException
+     */
+    public static function immutableProperty($propertyName, $propertyValue, $action, $type)
+    {
+        return new self(
+            $propertyName,
+            $propertyValue,
+            sprintf(
+                'Property "%s" cannot be modified, "%s" given (for %s %s).',
+                $propertyName,
+                $propertyValue,
+                $action,
+                $type
+            )
+        );
+    }
+
+    /**
+     * @return string
+     */
+    public function getPropertyName()
+    {
+        return $this->propertyName;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPropertyValue()
+    {
+        return $this->propertyValue;
+    }
+}

--- a/src/Akeneo/Component/StorageUtils/Exception/InvalidObjectException.php
+++ b/src/Akeneo/Component/StorageUtils/Exception/InvalidObjectException.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Akeneo\Component\StorageUtils\Exception;
+
+/**
+ * Exception and updater can throw when updating an object unsupported by the updater.
+ *
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class InvalidObjectException extends ObjectUpdaterException
+{
+    /* @var string */
+    protected $objectClassName;
+
+    /* @var string */
+    protected $expectedClassName;
+
+    /**
+     * @param string     $objectClassName
+     * @param string     $expectedClassName
+     * @param string     $message
+     * @param int        $code
+     * @param \Exception $previous
+     */
+    public function __construct($objectClassName, $expectedClassName, $message = '', $code = 0, \Exception $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+        $this->objectClassName   = $objectClassName;
+        $this->expectedClassName = $expectedClassName;
+    }
+
+    /**
+     * @param string $objectClassName
+     * @param string $expectedClassName
+     *
+     * @return InvalidObjectException
+     */
+    public static function objectExpected($objectClassName, $expectedClassName)
+    {
+        return new self(
+            $objectClassName,
+            $expectedClassName,
+            sprintf(
+                'Expects a "%s", "%s" given.',
+                $expectedClassName,
+                $objectClassName
+            )
+        );
+    }
+
+    /**
+     * @return string
+     */
+    public function getObjectClassName()
+    {
+        return $this->objectClassName;
+    }
+
+    /**
+     * @return string
+     */
+    public function getExpectedClassName()
+    {
+        return $this->expectedClassName;
+    }
+}

--- a/src/Akeneo/Component/StorageUtils/Exception/InvalidPropertyException.php
+++ b/src/Akeneo/Component/StorageUtils/Exception/InvalidPropertyException.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace Akeneo\Component\StorageUtils\Exception;
+
+/**
+ * Exception and updater can throw when updating a property which is invalid.
+ *
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class InvalidPropertyException extends ObjectUpdaterException
+{
+    const EXPECTED_CODE = 100;
+    const DATE_EXPECTED_CODE = 101;
+    const BOOLEAN_EXPECTED_CODE = 102;
+    const FLOAT_EXPECTED_CODE = 103;
+    const INTEGER_EXPECTED_CODE = 104;
+    const NUMERIC_EXPECTED_CODE = 105;
+    const STRING_EXPECTED_CODE = 106;
+    const ARRAY_EXPECTED_CODE = 108;
+    const ARRAY_OF_ARRAYS_EXPECTED_CODE = 109;
+
+    const NOT_EMPTY_VALUE_EXPECTED_CODE = 200;
+
+    const VALID_ENTITY_CODE_EXPECTED_CODE = 300;
+    const VALID_GROUP_TYPE_EXPECTED_CODE = 301;
+
+    /** @var string */
+    protected $propertyName;
+
+    /** @var string */
+    protected $propertyValue;
+
+    /**
+     * @param string          $propertyName
+     * @param string          $propertyValue
+     * @param string          $message
+     * @param int             $code
+     * @param \Exception|null $previous
+     */
+    public function __construct($propertyName, $propertyValue, $message = '', $code = 0, \Exception $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+        $this->propertyName  = $propertyName;
+        $this->propertyValue = $propertyValue;
+    }
+
+    /**
+     * Build an exception when the data is empty and should not.
+     *
+     * @param string $propertyName
+     * @param string $action
+     * @param string $type
+     *
+     * @return InvalidPropertyException
+     */
+    public static function valueNotEmptyExpected($propertyName, $action, $type)
+    {
+        $message = 'Property "%s" does not expect an empty value (for %s %s).';
+
+        return new self(
+            $propertyName,
+            null,
+            sprintf($message, $propertyName, $action, $type),
+            self::NOT_EMPTY_VALUE_EXPECTED_CODE
+        );
+    }
+
+    /**
+     * Build an exception when the data is an invalid entity code.
+     *
+     * @param string $propertyName
+     * @param string $key
+     * @param string $because
+     * @param string $action
+     * @param string $type
+     * @param string $propertyValue
+     *
+     * @return InvalidPropertyException
+     */
+    public static function validEntityCodeExpected($propertyName, $key, $because, $action, $type, $propertyValue)
+    {
+        $message = 'Property "%s" expects a valid %s. %s, "%s" given (for %s %s).';
+
+        return new self(
+            $propertyName,
+            $propertyValue,
+            sprintf($message, $propertyName, $key, $because, $propertyValue, $action, $type),
+            self::VALID_ENTITY_CODE_EXPECTED_CODE
+        );
+    }
+
+    /**
+     * Build an exception when the date is invalid.
+     *
+     * @param string $propertyName
+     * @param string $format
+     * @param string $action
+     * @param string $type
+     * @param string $propertyValue
+     *
+     * @return InvalidPropertyException
+     */
+    public static function dateExpected($propertyName, $format, $action, $type, $propertyValue)
+    {
+        $message = 'Property "%s" expects a string with the format "%s" as data, "%s" given (for %s %s).';
+
+        return new self(
+            $propertyName,
+            $propertyValue,
+            sprintf($message, $propertyName, $format, $propertyValue, $action, $type),
+            self::DATE_EXPECTED_CODE
+        );
+    }
+
+    /**
+     * Build an exception when the group type is invalid or is not allowed.
+     *
+     * @param string $propertyName
+     * @param string $because
+     * @param string $action
+     * @param string $type
+     * @param string $propertyValue
+     *
+     * @return InvalidPropertyException
+     */
+    public static function validGroupTypeExpected($propertyName, $because, $action, $type, $propertyValue)
+    {
+        $message = 'Property "%s" expects a valid group type. %s, "%s" given (for %s %s).';
+
+        return new self(
+            $propertyName,
+            $propertyValue,
+            sprintf($message, $propertyName, $because, $propertyValue, $action, $type),
+            self::VALID_GROUP_TYPE_EXPECTED_CODE
+        );
+    }
+
+    /**
+     * @return string
+     */
+    public function getPropertyName()
+    {
+        return $this->propertyName;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPropertyValue()
+    {
+        return $this->propertyValue;
+    }
+}

--- a/src/Akeneo/Component/StorageUtils/Exception/ObjectUpdaterException.php
+++ b/src/Akeneo/Component/StorageUtils/Exception/ObjectUpdaterException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Akeneo\Component\StorageUtils\Exception;
+
+/**
+ * This exception is the root exception for updaters.
+ * It can be thrown by an updater when performing an action on an object.
+ * Updaters should not throw any other exception.
+ *
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+abstract class ObjectUpdaterException extends \LogicException
+{
+}

--- a/src/Akeneo/Component/StorageUtils/Exception/UnknownPropertyException.php
+++ b/src/Akeneo/Component/StorageUtils/Exception/UnknownPropertyException.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Akeneo\Component\StorageUtils\Exception;
+
+/**
+ * Exception an updater can throw when updating value on an unknown property.
+ *
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class UnknownPropertyException extends ObjectUpdaterException
+{
+    /** @var string */
+    protected $propertyName;
+
+    /**
+     * @param string          $propertyName
+     * @param string          $message
+     * @param int             $code
+     * @param \Exception|null $previous
+     */
+    public function __construct($propertyName, $message = '', $code = 0, \Exception $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+        $this->propertyName = $propertyName;
+    }
+
+    /**
+     * @param string          $propertyName
+     * @param \Exception|null $previous
+     *
+     * @return UnknownPropertyException
+     */
+    public static function unknownProperty($propertyName, \Exception $previous = null)
+    {
+        return new self(
+            $propertyName,
+            sprintf(
+                'Property "%s" does not exist.',
+                $propertyName
+            ),
+            0,
+            $previous
+        );
+    }
+
+    /**
+     * @return string
+     */
+    public function getPropertyName()
+    {
+        return $this->propertyName;
+    }
+}

--- a/src/Akeneo/Component/StorageUtils/Updater/ObjectUpdaterInterface.php
+++ b/src/Akeneo/Component/StorageUtils/Updater/ObjectUpdaterInterface.php
@@ -2,6 +2,8 @@
 
 namespace Akeneo\Component\StorageUtils\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\ObjectUpdaterException;
+
 /**
  * Updates an object with a set of data
  *
@@ -18,7 +20,7 @@ interface ObjectUpdaterInterface
      * @param array  $data    The data to update
      * @param array  $options The options to use
      *
-     * @throws \InvalidArgumentException
+     * @throws ObjectUpdaterException
      *
      * @return ObjectUpdaterInterface
      */

--- a/src/Akeneo/Component/StorageUtils/spec/Exception/ImmutablePropertyExceptionSpec.php
+++ b/src/Akeneo/Component/StorageUtils/spec/Exception/ImmutablePropertyExceptionSpec.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace spec\Akeneo\Component\StorageUtils\Exception;
+
+use Akeneo\Component\StorageUtils\Exception\ImmutablePropertyException;
+use PhpSpec\ObjectBehavior;
+
+class ImmutablePropertyExceptionSpec extends ObjectBehavior
+{
+    function it_creates_an_immutable_property_exception()
+    {
+        $exception = ImmutablePropertyException::immutableProperty('property', 'property_value', 'action', 'type');
+
+        $this->beConstructedWith(
+            'property',
+            'property_value',
+            'Property "property" cannot be modified, "property_value" given (for action type).',
+            0
+        );
+
+        $this->shouldBeAnInstanceOf(get_class($exception));
+        $this->getPropertyName()->shouldReturn('property');
+        $this->getPropertyValue()->shouldReturn($exception->getPropertyValue());
+        $this->getMessage()->shouldReturn($exception->getMessage());
+        $this->getCode()->shouldReturn($exception->getCode());
+    }
+}

--- a/src/Akeneo/Component/StorageUtils/spec/Exception/InvalidObjectExceptionSpec.php
+++ b/src/Akeneo/Component/StorageUtils/spec/Exception/InvalidObjectExceptionSpec.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace spec\Akeneo\Component\StorageUtils\Exception;
+
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
+use PhpSpec\ObjectBehavior;
+
+class InvalidObjectExceptionSpec extends ObjectBehavior
+{
+    function it_creates_an_immutable_property_exception()
+    {
+        $exception = InvalidObjectException::objectExpected('stdClass', 'ProductInterface');
+
+        $this->beConstructedWith(
+            'stdClass',
+            'ProductInterface',
+            'Expects a "ProductInterface", "stdClass" given.',
+            0
+        );
+
+        $this->shouldBeAnInstanceOf(get_class($exception));
+        $this->getObjectClassName()->shouldReturn($exception->getObjectClassName());
+        $this->getExpectedClassName()->shouldReturn($exception->getExpectedClassName());
+        $this->getMessage()->shouldReturn($exception->getMessage());
+        $this->getCode()->shouldReturn($exception->getCode());
+    }
+}

--- a/src/Akeneo/Component/StorageUtils/spec/Exception/InvalidPropertyExceptionSpec.php
+++ b/src/Akeneo/Component/StorageUtils/spec/Exception/InvalidPropertyExceptionSpec.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace spec\Akeneo\Component\StorageUtils\Exception;
+
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use PhpSpec\ObjectBehavior;
+
+class InvalidPropertyExceptionSpec extends ObjectBehavior
+{
+    function it_creates_an_empty_value_exception()
+    {
+        $exception = InvalidPropertyException::valueNotEmptyExpected('attribute', 'action', 'type');
+
+        $this->beConstructedWith(
+            'attribute',
+            null,
+            'Property "attribute" does not expect an empty value (for action type).',
+            InvalidPropertyException::NOT_EMPTY_VALUE_EXPECTED_CODE
+        );
+
+        $this->shouldBeAnInstanceOf(get_class($exception));
+        $this->getPropertyName()->shouldReturn($exception->getPropertyName());
+        $this->getPropertyValue()->shouldReturn($exception->getPropertyValue());
+        $this->getMessage()->shouldReturn($exception->getMessage());
+        $this->getCode()->shouldReturn($exception->getCode());
+    }
+
+    function it_creates_an_invalid_entity_code_exception()
+    {
+        $exception = InvalidPropertyException::validEntityCodeExpected('attribute', 'code', 'The attribute does not exist', 'action', 'type', 'unknown_code');
+
+        $this->beConstructedWith(
+            'attribute',
+            'unknown_code',
+            'Property "attribute" expects a valid code. The attribute does not exist, "unknown_code" given (for action type).',
+            InvalidPropertyException::VALID_ENTITY_CODE_EXPECTED_CODE
+        );
+
+        $this->shouldBeAnInstanceOf(get_class($exception));
+        $this->getPropertyName()->shouldReturn($exception->getPropertyName());
+        $this->getPropertyValue()->shouldReturn($exception->getPropertyValue());
+        $this->getMessage()->shouldReturn($exception->getMessage());
+        $this->getCode()->shouldReturn($exception->getCode());
+    }
+
+    function it_creates_an_invalid_date_exception()
+    {
+        $exception = InvalidPropertyException::dateExpected('created_date', 'yyyy-mm-dd', 'action', 'type', '2017/12/12');
+
+        $this->beConstructedWith(
+            'created_date',
+            '2017/12/12',
+            'Property "created_date" expects a string with the format "yyyy-mm-dd" as data, "2017/12/12" given (for action type).',
+            InvalidPropertyException::DATE_EXPECTED_CODE
+        );
+
+        $this->shouldBeAnInstanceOf(get_class($exception));
+        $this->getPropertyName()->shouldReturn($exception->getPropertyName());
+        $this->getPropertyValue()->shouldReturn($exception->getPropertyValue());
+        $this->getMessage()->shouldReturn($exception->getMessage());
+        $this->getCode()->shouldReturn($exception->getCode());
+    }
+
+    function it_creates_an_invalid_group_type_exception()
+    {
+        $exception = InvalidPropertyException::validGroupTypeExpected('group', 'Group is not valid', 'action', 'type', 'variant');
+
+        $this->beConstructedWith(
+            'group',
+            'variant',
+            'Property "group" expects a valid group type. Group is not valid, "variant" given (for action type).',
+            InvalidPropertyException::VALID_GROUP_TYPE_EXPECTED_CODE
+        );
+
+        $this->shouldBeAnInstanceOf(get_class($exception));
+        $this->getPropertyName()->shouldReturn($exception->getPropertyName());
+        $this->getPropertyValue()->shouldReturn($exception->getPropertyValue());
+        $this->getMessage()->shouldReturn($exception->getMessage());
+        $this->getCode()->shouldReturn($exception->getCode());
+    }
+}

--- a/src/Akeneo/Component/StorageUtils/spec/Exception/UnknownPropertyExceptionSpec.php
+++ b/src/Akeneo/Component/StorageUtils/spec/Exception/UnknownPropertyExceptionSpec.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace spec\Akeneo\Component\StorageUtils\Exception;
+
+use Akeneo\Component\StorageUtils\Exception\UnknownPropertyException;
+use PhpSpec\ObjectBehavior;
+
+class UnknownPropertyExceptionSpec extends ObjectBehavior
+{
+    function it_creates_an_unknown_property_exception()
+    {
+        $previous = new \Exception();
+        $exception = UnknownPropertyException::unknownProperty('property', $previous);
+
+        $this->beConstructedWith(
+            'property',
+            'Property "property" does not exist.',
+            0,
+            $previous
+        );
+
+        $this->shouldBeAnInstanceOf(get_class($exception));
+        $this->getPropertyName()->shouldReturn('property');
+        $this->getMessage()->shouldReturn($exception->getMessage());
+        $this->getCode()->shouldReturn($exception->getCode());
+        $this->getPrevious()->shouldReturn($exception->getPrevious());
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/updaters.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/updaters.yml
@@ -161,8 +161,6 @@ services:
 
     pim_catalog.updater.association_type:
         class: '%pim_catalog.updater.association_type.class%'
-        arguments:
-            - '@pim_catalog.repository.association_type'
 
     pim_catalog.updater.variant_group:
         class: '%pim_catalog.updater.variant_group.class%'

--- a/src/Pim/Bundle/DataGridBundle/Updater/DatagridViewUpdater.php
+++ b/src/Pim/Bundle/DataGridBundle/Updater/DatagridViewUpdater.php
@@ -2,11 +2,11 @@
 
 namespace Pim\Bundle\DataGridBundle\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Doctrine\Common\Util\ClassUtils;
 use Pim\Bundle\DataGridBundle\Entity\DatagridView;
-use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
  * Update the datagrid view properties
@@ -34,12 +34,9 @@ class DatagridViewUpdater implements ObjectUpdaterInterface
     public function update($datagridView, array $data, array $options = [])
     {
         if (!$datagridView instanceof DatagridView) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    'Expects a "%s", "%s" provided.',
-                    DatagridView::class,
-                    ClassUtils::getClass($datagridView)
-                )
+            throw InvalidObjectException::objectExpected(
+                ClassUtils::getClass($datagridView),
+                DatagridView::class
             );
         }
 

--- a/src/Pim/Bundle/DataGridBundle/spec/Updater/DatagridViewUpdaterSpec.php
+++ b/src/Pim/Bundle/DataGridBundle/spec/Updater/DatagridViewUpdaterSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Pim\Bundle\DataGridBundle\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Pim\Bundle\DataGridBundle\Entity\DatagridView;
@@ -26,9 +27,14 @@ class DatagridViewUpdaterSpec extends ObjectBehavior
         $this->shouldImplement(ObjectUpdaterInterface::class);
     }
 
-    function it_throws_an_exception_if_the_given_object_is_not_a_datagrid(UserInterface $user)
+    function it_throws_an_exception_if_the_given_object_is_not_a_datagrid()
     {
-        $this->shouldThrow('\InvalidArgumentException')->during('update', [$user, []]);
+        $this->shouldThrow(
+            InvalidObjectException::objectExpected(
+                'stdClass',
+                DatagridView::class
+            )
+        )->during('update', [new \stdClass(), []]);
     }
 
     function it_updates_the_data_grid_property($userRepository, DatagridView $datagridView, UserInterface $user)

--- a/src/Pim/Component/Catalog/Updater/AssociationTypeUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/AssociationTypeUpdater.php
@@ -24,16 +24,9 @@ class AssociationTypeUpdater implements ObjectUpdaterInterface
     /** @var PropertyAccessor */
     protected $accessor;
 
-    /** @var IdentifiableObjectRepositoryInterface */
-    protected $assocTypeRepository;
-
-    /**
-     * @param IdentifiableObjectRepositoryInterface $assocTypeRepository
-     */
-    public function __construct(IdentifiableObjectRepositoryInterface $assocTypeRepository)
+    public function __construct()
     {
         $this->accessor = PropertyAccess::createPropertyAccessor();
-        $this->assocTypeRepository = $assocTypeRepository;
     }
 
     /**

--- a/src/Pim/Component/Catalog/Updater/AssociationTypeUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/AssociationTypeUpdater.php
@@ -2,10 +2,13 @@
 
 namespace Pim\Component\Catalog\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
+use Akeneo\Component\StorageUtils\Exception\UnknownPropertyException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Doctrine\Common\Util\ClassUtils;
 use Pim\Component\Catalog\Model\AssociationTypeInterface;
+use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 
@@ -30,7 +33,7 @@ class AssociationTypeUpdater implements ObjectUpdaterInterface
     public function __construct(IdentifiableObjectRepositoryInterface $assocTypeRepository)
     {
         $this->accessor = PropertyAccess::createPropertyAccessor();
-        $this->associationTypeRepository = $assocTypeRepository;
+        $this->assocTypeRepository = $assocTypeRepository;
     }
 
     /**
@@ -39,11 +42,9 @@ class AssociationTypeUpdater implements ObjectUpdaterInterface
     public function update($associationType, array $data, array $options = [])
     {
         if (!$associationType instanceof AssociationTypeInterface) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    'Expects a "Pim\Component\Catalog\Model\AssociationTypeInterface", "%s" provided.',
-                    ClassUtils::getClass($associationType)
-                )
+            throw InvalidObjectException::objectExpected(
+                ClassUtils::getClass($associationType),
+                AssociationTypeInterface::class
             );
         }
 
@@ -58,6 +59,8 @@ class AssociationTypeUpdater implements ObjectUpdaterInterface
      * @param AssociationTypeInterface $associationType
      * @param string                   $field
      * @param mixed                    $data
+     *
+     * @throws UnknownPropertyException
      */
     protected function setData(AssociationTypeInterface $associationType, $field, $data)
     {
@@ -68,7 +71,11 @@ class AssociationTypeUpdater implements ObjectUpdaterInterface
                 $translation->setLabel($label);
             }
         } else {
-            $this->accessor->setValue($associationType, $field, $data);
+            try {
+                $this->accessor->setValue($associationType, $field, $data);
+            } catch (NoSuchPropertyException $e) {
+                throw UnknownPropertyException::unknownProperty($field, $e);
+            }
         }
     }
 }

--- a/src/Pim/Component/Catalog/Updater/AttributeGroupUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/AttributeGroupUpdater.php
@@ -2,6 +2,8 @@
 
 namespace Pim\Component\Catalog\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Doctrine\Common\Util\ClassUtils;
@@ -54,11 +56,9 @@ class AttributeGroupUpdater implements ObjectUpdaterInterface
     public function update($attributeGroup, array $data, array $options = [])
     {
         if (!$attributeGroup instanceof AttributeGroupInterface) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    'Expects a "Pim\Component\Catalog\Model\AttributeGroupInterface", "%s" provided.',
-                    ClassUtils::getClass($attributeGroup)
-                )
+            throw InvalidObjectException::objectExpected(
+                ClassUtils::getClass($attributeGroup),
+                AttributeGroupInterface::class
             );
         }
 
@@ -74,7 +74,7 @@ class AttributeGroupUpdater implements ObjectUpdaterInterface
      * @param string                  $field
      * @param mixed                   $data
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidPropertyException
      */
     protected function setData($attributeGroup, $field, $data)
     {
@@ -105,6 +105,8 @@ class AttributeGroupUpdater implements ObjectUpdaterInterface
     /**
      * @param AttributeGroupInterface $attributeGroup
      * @param string[]                $data
+     *
+     * @throws InvalidPropertyException
      */
     protected function setAttributes(AttributeGroupInterface $attributeGroup, array $data)
     {
@@ -123,10 +125,14 @@ class AttributeGroupUpdater implements ObjectUpdaterInterface
         foreach ($data as $attributeCode) {
             $attribute = $this->findAttribute($attributeCode);
             if (null === $attribute) {
-                throw new \InvalidArgumentException(sprintf(
-                    'Attribute with "%s" code does not exist',
+                throw InvalidPropertyException::validEntityCodeExpected(
+                    'attributes',
+                    'attribute code',
+                    'The attribute does not exist',
+                    'updater',
+                    'attribute group',
                     $attributeCode
-                ));
+                );
             }
             $attributeGroup->addAttribute($attribute);
         }

--- a/src/Pim/Component/Catalog/Updater/AttributeOptionUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/AttributeOptionUpdater.php
@@ -2,7 +2,10 @@
 
 namespace Pim\Component\Catalog\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
+use Doctrine\Common\Util\ClassUtils;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\AttributeOptionInterface;
 use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
@@ -45,11 +48,9 @@ class AttributeOptionUpdater implements ObjectUpdaterInterface
     public function update($attributeOption, array $data, array $options = [])
     {
         if (!$attributeOption instanceof AttributeOptionInterface) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    'Expects a "Pim\Component\Catalog\Model\AttributeOptionInterface", "%s" provided.',
-                    ClassUtils::getClass($attributeOption)
-                )
+            throw InvalidObjectException::objectExpected(
+                ClassUtils::getClass($attributeOption),
+                AttributeOptionInterface::class
             );
         }
 
@@ -70,7 +71,7 @@ class AttributeOptionUpdater implements ObjectUpdaterInterface
      * @param string                   $field
      * @param mixed                    $data
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidPropertyException
      */
     protected function setData(AttributeOptionInterface $attributeOption, $field, $data)
     {
@@ -83,7 +84,14 @@ class AttributeOptionUpdater implements ObjectUpdaterInterface
             if (null !== $attribute) {
                 $attributeOption->setAttribute($attribute);
             } else {
-                throw new \InvalidArgumentException(sprintf('Attribute "%s" does not exist', $data));
+                throw InvalidPropertyException::validEntityCodeExpected(
+                    'attribute',
+                    'attribute code',
+                    'The attribute does not exist',
+                    'updater',
+                    'attribute option',
+                    $data
+                );
             }
         }
 

--- a/src/Pim/Component/Catalog/Updater/AttributeUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/AttributeUpdater.php
@@ -162,15 +162,25 @@ class AttributeUpdater implements ObjectUpdaterInterface
      * @param array              $availableLocaleCodes
      *
      * @throws UnknownPropertyException
+     * @throws InvalidPropertyException
      */
     protected function setAvailableLocales(AttributeInterface $attribute, $field, array $availableLocaleCodes)
     {
         $locales = [];
         foreach ($availableLocaleCodes as $localeCode) {
             $locale = $this->localeRepository->findOneByIdentifier($localeCode);
-            if (null !== $locale) {
-                $locales[] = $locale;
+            if (null === $locale) {
+                throw InvalidPropertyException::validEntityCodeExpected(
+                    'available_locales',
+                    'locale code',
+                    'The locale does not exist',
+                    'updater',
+                    'attribute',
+                    $localeCode
+                );
             }
+
+            $locales[] = $locale;
         }
 
         $this->setValue($attribute, $field, $locales);

--- a/src/Pim/Component/Catalog/Updater/AttributeUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/AttributeUpdater.php
@@ -2,6 +2,9 @@
 
 namespace Pim\Component\Catalog\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\UnknownPropertyException;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Doctrine\Common\Util\ClassUtils;
 use Pim\Component\Catalog\AttributeTypeRegistry;
@@ -9,6 +12,7 @@ use Pim\Component\Catalog\Model\AttributeGroupInterface;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Repository\AttributeGroupRepositoryInterface;
 use Pim\Component\Catalog\Repository\LocaleRepositoryInterface;
+use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 
@@ -55,11 +59,9 @@ class AttributeUpdater implements ObjectUpdaterInterface
     public function update($attribute, array $data, array $options = [])
     {
         if (!$attribute instanceof AttributeInterface) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    'Expects a "Pim\Component\Catalog\Model\AttributeInterface", "%s" provided.',
-                    ClassUtils::getClass($attribute)
-                )
+            throw InvalidObjectException::objectExpected(
+                ClassUtils::getClass($attribute),
+                AttributeInterface::class
             );
         }
 
@@ -75,7 +77,8 @@ class AttributeUpdater implements ObjectUpdaterInterface
      * @param string             $field
      * @param mixed              $data
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidPropertyException
+     * @throws UnknownPropertyException
      */
     protected function setData(AttributeInterface $attribute, $field, $data)
     {
@@ -93,12 +96,12 @@ class AttributeUpdater implements ObjectUpdaterInterface
                 $this->setAvailableLocales($attribute, $field, $data);
                 break;
             case 'date_min':
-                $this->validateDateFormat($data);
+                $this->validateDateFormat('date_min', $data);
                 $date = $this->getDate($data);
                 $attribute->setDateMin($date);
                 break;
             case 'date_max':
-                $this->validateDateFormat($data);
+                $this->validateDateFormat('date_max', $data);
                 $date = $this->getDate($data);
                 $attribute->setDateMax($date);
                 break;
@@ -106,7 +109,7 @@ class AttributeUpdater implements ObjectUpdaterInterface
                 $attribute->setAllowedExtensions(implode(',', $data));
                 break;
             default:
-                $this->accessor->setValue($attribute, $field, $data);
+                $this->setValue($attribute, $field, $data);
         }
     }
 
@@ -120,6 +123,22 @@ class AttributeUpdater implements ObjectUpdaterInterface
         $attributeGroup = $this->attrGroupRepo->findOneByIdentifier($code);
 
         return $attributeGroup;
+    }
+
+    /**
+     * @param $attribute
+     * @param $field
+     * @param $data
+     *
+     * @throws UnknownPropertyException
+     */
+    protected function setValue($attribute, $field, $data)
+    {
+        try {
+            $this->accessor->setValue($attribute, $field, $data);
+        } catch (NoSuchPropertyException $e) {
+            throw UnknownPropertyException::unknownProperty($field, $e);
+        }
     }
 
     /**
@@ -141,6 +160,8 @@ class AttributeUpdater implements ObjectUpdaterInterface
      * @param AttributeInterface $attribute
      * @param string             $field
      * @param array              $availableLocaleCodes
+     *
+     * @throws UnknownPropertyException
      */
     protected function setAvailableLocales(AttributeInterface $attribute, $field, array $availableLocaleCodes)
     {
@@ -152,33 +173,46 @@ class AttributeUpdater implements ObjectUpdaterInterface
             }
         }
 
-        $this->accessor->setValue($attribute, $field, $locales);
+        $this->setValue($attribute, $field, $locales);
     }
 
     /**
      * @param AttributeInterface $attribute
      * @param string             $data
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidPropertyException
      */
     protected function setGroup(AttributeInterface $attribute, $data)
     {
         $attributeGroup = $this->findAttributeGroup($data);
-        if (null !== $attributeGroup) {
-            $attribute->setGroup($attributeGroup);
-        } else {
-            throw new \InvalidArgumentException(sprintf('AttributeGroup "%s" does not exist', $data));
+        if (null === $attributeGroup) {
+            throw InvalidPropertyException::validEntityCodeExpected(
+                'group',
+                'code',
+                'The attribute group does not exist',
+                'updater',
+                'attribute',
+                $data
+            );
         }
+
+        $attribute->setGroup($attributeGroup);
     }
 
     /**
-     * @param AttributeInterface $attribute
-     * @param string|null        $data
+     * @param $attribute
+     * @param $data
+     *
+     * @throws InvalidPropertyException
      */
     protected function setType($attribute, $data)
     {
         if (('' === $data) || (null === $data)) {
-            throw new \InvalidArgumentException('attributeType must be filled.');
+            throw InvalidPropertyException::valueNotEmptyExpected(
+                'attribute_type',
+                'updater',
+                'attribute'
+            );
         }
 
         try {
@@ -187,7 +221,14 @@ class AttributeUpdater implements ObjectUpdaterInterface
             $attribute->setBackendType($attributeType->getBackendType());
             $attribute->setUnique($attributeType->isUnique());
         } catch (\LogicException $exception) {
-            throw new \InvalidArgumentException(sprintf('AttributeType "%s" does not exist.', $data));
+            throw InvalidPropertyException::validEntityCodeExpected(
+                'attribute_type',
+                'attribute type',
+                'The attribute type does not exist',
+                'updater',
+                'attribute',
+                $data
+            );
         }
     }
 
@@ -201,11 +242,12 @@ class AttributeUpdater implements ObjectUpdaterInterface
      * - "2015-45-31"
      * - "not a date"
      *
+     * @param string $field
      * @param string $data
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidPropertyException
      */
-    protected function validateDateFormat($data)
+    protected function validateDateFormat($field, $data)
     {
         if (null === $data) {
             return;
@@ -214,12 +256,22 @@ class AttributeUpdater implements ObjectUpdaterInterface
         try {
             new \DateTime($data);
         } catch (\Exception $e) {
-            throw new \InvalidArgumentException(sprintf('Invalid date, "%s" given', $data), 0, $e);
+            throw InvalidPropertyException::dateExpected(
+                $field,
+                'yyyy-mm-dd',
+                'updater',
+                'attribute',
+                $data
+            );
         }
 
         if (!preg_match('/^\d{4}-\d{2}-\d{2}/', $data)) {
-            throw new \InvalidArgumentException(
-                sprintf('Attribute expects a string with the format "yyyy-mm-dd" as data, "%s" given', $data)
+            throw InvalidPropertyException::dateExpected(
+                $field,
+                'yyyy-mm-dd',
+                'updater',
+                'attribute',
+                $data
             );
         }
     }

--- a/src/Pim/Component/Catalog/Updater/ChannelUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/ChannelUpdater.php
@@ -2,6 +2,8 @@
 
 namespace Pim\Component\Catalog\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Doctrine\Common\Util\ClassUtils;
@@ -58,11 +60,9 @@ class ChannelUpdater implements ObjectUpdaterInterface
     public function update($channel, array $data, array $options = [])
     {
         if (!$channel instanceof ChannelInterface) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    'Expects a "Pim\Component\Catalog\Model\ChannelInterface", "%s" provided.',
-                    ClassUtils::getClass($channel)
-                )
+            throw InvalidObjectException::objectExpected(
+                ClassUtils::getClass($channel),
+                ChannelInterface::class
             );
         }
 
@@ -78,7 +78,7 @@ class ChannelUpdater implements ObjectUpdaterInterface
      * @param string           $field
      * @param mixed            $data
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidPropertyException
      */
     protected function setData(ChannelInterface $channel, $field, $data)
     {
@@ -107,12 +107,21 @@ class ChannelUpdater implements ObjectUpdaterInterface
     /**
      * @param ChannelInterface $channel
      * @param string           $treeCode
+     *
+     * @throws InvalidPropertyException
      */
     protected function setCategoryTree(ChannelInterface $channel, $treeCode)
     {
         $category = $this->categoryRepository->findOneByIdentifier($treeCode);
         if (null === $category) {
-            throw new \InvalidArgumentException(sprintf('Category with "%s" code does not exist', $treeCode));
+            throw InvalidPropertyException::validEntityCodeExpected(
+                'category_tree',
+                'code',
+                'The category does not exist',
+                'updater',
+                'channel',
+                $treeCode
+            );
         }
         $channel->setCategory($category);
     }
@@ -120,6 +129,8 @@ class ChannelUpdater implements ObjectUpdaterInterface
     /**
      * @param ChannelInterface $channel
      * @param array            $currencyCodes
+     *
+     * @throws InvalidPropertyException
      */
     protected function setCurrencies(ChannelInterface $channel, array $currencyCodes)
     {
@@ -127,7 +138,14 @@ class ChannelUpdater implements ObjectUpdaterInterface
         foreach ($currencyCodes as $currencyCode) {
             $currency = $this->currencyRepository->findOneByIdentifier($currencyCode);
             if (null === $currency) {
-                throw new \InvalidArgumentException(sprintf('Currency with "%s" code does not exist', $currencyCode));
+                throw InvalidPropertyException::validEntityCodeExpected(
+                    'currencies',
+                    'code',
+                    'The currency does not exist',
+                    'updater',
+                    'channel',
+                    $currencyCode
+                );
             }
 
             $currencies[] = $currency;
@@ -139,6 +157,8 @@ class ChannelUpdater implements ObjectUpdaterInterface
     /**
      * @param ChannelInterface $channel
      * @param array            $localeCodes
+     *
+     * @throws InvalidPropertyException
      */
     protected function setLocales(ChannelInterface $channel, array $localeCodes)
     {
@@ -146,7 +166,14 @@ class ChannelUpdater implements ObjectUpdaterInterface
         foreach ($localeCodes as $localeCode) {
             $locale = $this->localeRepository->findOneByIdentifier($localeCode);
             if (null === $locale) {
-                throw new \InvalidArgumentException(sprintf('Locale with "%s" code does not exist', $localeCode));
+                throw InvalidPropertyException::validEntityCodeExpected(
+                    'locales',
+                    'code',
+                    'The locale does not exist',
+                    'updater',
+                    'channel',
+                    $localeCode
+                );
             }
 
             $locales[] = $locale;

--- a/src/Pim/Component/Catalog/Updater/CurrencyUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/CurrencyUpdater.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Component\Catalog\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Doctrine\Common\Util\ClassUtils;
 use Pim\Component\Catalog\Model\CurrencyInterface;
@@ -27,11 +28,9 @@ class CurrencyUpdater implements ObjectUpdaterInterface
     public function update($currency, array $data, array $options = [])
     {
         if (!$currency instanceof CurrencyInterface) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    'Expects a "Pim\Component\Catalog\Model\CurrencyInterface", "%s" provided.',
-                    ClassUtils::getClass($currency)
-                )
+            throw InvalidObjectException::objectExpected(
+                ClassUtils::getClass($currency),
+                CurrencyInterface::class
             );
         }
 

--- a/src/Pim/Component/Catalog/Updater/FamilyUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/FamilyUpdater.php
@@ -2,6 +2,9 @@
 
 namespace Pim\Component\Catalog\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\UnknownPropertyException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Doctrine\Common\Collections\ArrayCollection;
@@ -14,6 +17,7 @@ use Pim\Component\Catalog\Model\FamilyInterface;
 use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
 use Pim\Component\Catalog\Repository\AttributeRequirementRepositoryInterface;
 use Pim\Component\Catalog\Repository\ChannelRepositoryInterface;
+use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 
@@ -72,11 +76,9 @@ class FamilyUpdater implements ObjectUpdaterInterface
     public function update($family, array $data, array $options = [])
     {
         if (!$family instanceof FamilyInterface) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    'Expects a "Pim\Component\Catalog\Model\FamilyInterface", "%s" provided.',
-                    ClassUtils::getClass($family)
-                )
+            throw InvalidObjectException::objectExpected(
+                ClassUtils::getClass($family),
+                FamilyInterface::class
             );
         }
 
@@ -91,6 +93,9 @@ class FamilyUpdater implements ObjectUpdaterInterface
      * @param FamilyInterface $family
      * @param string          $field
      * @param mixed           $data
+     *
+     * @throws UnknownPropertyException
+     * @throws InvalidPropertyException
      */
     protected function setData(FamilyInterface $family, $field, $data)
     {
@@ -108,7 +113,23 @@ class FamilyUpdater implements ObjectUpdaterInterface
                 $this->setAttributeAsLabel($family, $data);
                 break;
             default:
-                $this->accessor->setValue($family, $field, $data);
+                $this->setValue($family, $field, $data);
+        }
+    }
+
+    /**
+     * @param $attribute
+     * @param $field
+     * @param $data
+     *
+     * @throws UnknownPropertyException
+     */
+    protected function setValue($attribute, $field, $data)
+    {
+        try {
+            $this->accessor->setValue($attribute, $field, $data);
+        } catch (NoSuchPropertyException $e) {
+            throw UnknownPropertyException::unknownProperty($field, $e);
         }
     }
 
@@ -128,6 +149,8 @@ class FamilyUpdater implements ObjectUpdaterInterface
     /**
      * @param FamilyInterface $family
      * @param array           $data
+     *
+     * @throws InvalidPropertyException
      */
     protected function setAttributeRequirements(FamilyInterface $family, array $data)
     {
@@ -173,6 +196,8 @@ class FamilyUpdater implements ObjectUpdaterInterface
      * @param array           $attributeCodes
      * @param string          $channelCode
      *
+     * @throws InvalidPropertyException
+     *
      * @return array
      */
     protected function createAttributeRequirementsByChannel(
@@ -184,8 +209,13 @@ class FamilyUpdater implements ObjectUpdaterInterface
         foreach ($attributeCodes as $attributeCode) {
             $attribute = $this->attributeRepository->findOneByIdentifier($attributeCode);
             if (null === $attribute) {
-                throw new \InvalidArgumentException(
-                    sprintf('Attribute with "%s" code does not exist', $attributeCode)
+                throw InvalidPropertyException::validEntityCodeExpected(
+                    'attribute_requirements',
+                    'code',
+                    'The attribute does not exist',
+                    'updater',
+                    'family',
+                    $attributeCode
                 );
             }
             if (AttributeTypes::IDENTIFIER !== $attribute->getAttributeType()) {
@@ -199,6 +229,8 @@ class FamilyUpdater implements ObjectUpdaterInterface
     /**
      * @param FamilyInterface                 $family
      * @param AttributeRequirementInterface[] $requirements
+     *
+     * @throws InvalidPropertyException
      *
      * @return AttributeRequirementInterface[]
      */
@@ -225,14 +257,21 @@ class FamilyUpdater implements ObjectUpdaterInterface
      * @param AttributeInterface $attribute
      * @param string             $channelCode
      *
+     * @throws InvalidPropertyException
+     *
      * @return AttributeRequirementInterface
      */
     protected function createAttributeRequirement(FamilyInterface $family, AttributeInterface $attribute, $channelCode)
     {
         $channel = $this->channelRepository->findOneByIdentifier($channelCode);
         if (null === $channel) {
-            throw new \InvalidArgumentException(
-                sprintf('Channel with "%s" code does not exist', $channelCode)
+            throw InvalidPropertyException::validEntityCodeExpected(
+                'attribute_requirements',
+                'code',
+                'The channel does not exist',
+                'updater',
+                'family',
+                $channelCode
             );
         }
 
@@ -253,7 +292,7 @@ class FamilyUpdater implements ObjectUpdaterInterface
      * @param FamilyInterface $family
      * @param array           $data
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidPropertyException
      */
     protected function addAttributes(FamilyInterface $family, array $data)
     {
@@ -266,8 +305,13 @@ class FamilyUpdater implements ObjectUpdaterInterface
             if (null !== $attribute = $this->attributeRepository->findOneByIdentifier($attributeCode)) {
                 $family->addAttribute($attribute);
             } else {
-                throw new \InvalidArgumentException(
-                    sprintf('Attribute with "%s" code does not exist', $attributeCode)
+                throw InvalidPropertyException::validEntityCodeExpected(
+                    'attributes',
+                    'code',
+                    'The attribute does not exist',
+                    'updater',
+                    'family',
+                    $attributeCode
                 );
             }
         }
@@ -277,15 +321,20 @@ class FamilyUpdater implements ObjectUpdaterInterface
      * @param FamilyInterface $family
      * @param string          $data
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidPropertyException
      */
     protected function setAttributeAsLabel(FamilyInterface $family, $data)
     {
         if (null !== $attribute = $this->attributeRepository->findOneByIdentifier($data)) {
             $family->setAttributeAsLabel($attribute);
         } else {
-            throw new \InvalidArgumentException(
-                sprintf('Attribute with "%s" code does not exist', $data)
+            throw InvalidPropertyException::validEntityCodeExpected(
+                'attributes',
+                'code',
+                'The attribute does not exist',
+                'updater',
+                'family',
+                $data
             );
         }
     }

--- a/src/Pim/Component/Catalog/Updater/GroupTypeUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/GroupTypeUpdater.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Component\Catalog\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Doctrine\Common\Util\ClassUtils;
 use Pim\Component\Catalog\Model\GroupTypeInterface;
@@ -31,11 +32,9 @@ class GroupTypeUpdater implements ObjectUpdaterInterface
     public function update($groupType, array $data, array $options = [])
     {
         if (!$groupType instanceof GroupTypeInterface) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    'Expects a "Pim\Component\Catalog\Model\GroupTypeInterface", "%s" provided.',
-                    ClassUtils::getClass($groupType)
-                )
+            throw InvalidObjectException::objectExpected(
+                ClassUtils::getClass($groupType),
+                GroupTypeInterface::class
             );
         }
 

--- a/src/Pim/Component/Catalog/Updater/GroupUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/GroupUpdater.php
@@ -2,6 +2,8 @@
 
 namespace Pim\Component\Catalog\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Doctrine\Common\Util\ClassUtils;
 use Pim\Component\Catalog\Model\GroupInterface;
@@ -58,11 +60,9 @@ class GroupUpdater implements ObjectUpdaterInterface
     public function update($group, array $data, array $options = [])
     {
         if (!$group instanceof GroupInterface) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    'Expects a "Pim\Component\Catalog\Model\GroupInterface", "%s" provided.',
-                    ClassUtils::getClass($group)
-                )
+            throw InvalidObjectException::objectExpected(
+                ClassUtils::getClass($group),
+                'Pim\Component\Catalog\Model\GroupInterface'
             );
         }
 
@@ -77,6 +77,8 @@ class GroupUpdater implements ObjectUpdaterInterface
      * @param GroupInterface $group
      * @param string         $field
      * @param mixed          $data
+     *
+     * @throws InvalidPropertyException
      */
     protected function setData(GroupInterface $group, $field, $data)
     {
@@ -112,21 +114,31 @@ class GroupUpdater implements ObjectUpdaterInterface
      * @param GroupInterface $group
      * @param string         $type
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidPropertyException
      */
     protected function setType(GroupInterface $group, $type)
     {
         $groupType = $this->groupTypeRepository->findOneByIdentifier($type);
 
         if (null === $groupType) {
-            throw new \InvalidArgumentException(sprintf('Type "%s" does not exist', $type));
+            throw InvalidPropertyException::validEntityCodeExpected(
+                'type',
+                'group type',
+                'The group type does not exist',
+                'updater',
+                'group',
+                $type
+            );
         }
 
         if ($groupType->isVariant()) {
-            throw new \InvalidArgumentException(sprintf(
-                'Cannot process variant group "%s", only groups are accepted',
+            throw InvalidPropertyException::validGroupTypeExpected(
+                'type',
+                'Cannot process variant group, only groups are supported',
+                'updater',
+                'group',
                 $group->getCode()
-            ));
+            );
         }
 
         $group->setType($groupType);
@@ -149,7 +161,7 @@ class GroupUpdater implements ObjectUpdaterInterface
      * @param GroupInterface $group
      * @param string[]       $attributeCodes
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidPropertyException
      */
     protected function setAxis(GroupInterface $group, array $attributeCodes)
     {
@@ -157,7 +169,14 @@ class GroupUpdater implements ObjectUpdaterInterface
         foreach ($attributeCodes as $attributeCode) {
             $attribute = $this->attributeRepository->findOneByIdentifier($attributeCode);
             if (null === $attribute) {
-                throw new \InvalidArgumentException(sprintf('Attribute "%s" does not exist', $attributeCode));
+                throw InvalidPropertyException::validEntityCodeExpected(
+                    'axis',
+                    'attribute code',
+                    'The attribute does not exist',
+                    'updater',
+                    'group',
+                    $attributeCode
+                );
             }
             $attributes[] = $attribute;
         }
@@ -166,7 +185,7 @@ class GroupUpdater implements ObjectUpdaterInterface
 
     /**
      * @param GroupInterface $group
-     * @param array          $labels
+     * @param array          $productIds
      */
     protected function setProducts(GroupInterface $group, array $productIds)
     {

--- a/src/Pim/Component/Catalog/Updater/LocaleUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/LocaleUpdater.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Component\Catalog\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Doctrine\Common\Util\ClassUtils;
 use Pim\Component\Catalog\Model\LocaleInterface;
@@ -26,11 +27,9 @@ class LocaleUpdater implements ObjectUpdaterInterface
     public function update($locale, array $data, array $options = [])
     {
         if (!$locale instanceof LocaleInterface) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    'Expects a "Pim\Component\Catalog\Model\LocaleInterface", "%s" provided.',
-                    ClassUtils::getClass($locale)
-                )
+            throw InvalidObjectException::objectExpected(
+                ClassUtils::getClass($locale),
+                LocaleInterface::class
             );
         }
 
@@ -45,8 +44,6 @@ class LocaleUpdater implements ObjectUpdaterInterface
      * @param LocaleInterface $locale
      * @param string          $field
      * @param mixed           $data
-     *
-     * @throws \InvalidArgumentException
      */
     protected function setData(LocaleInterface $locale, $field, $data)
     {

--- a/src/Pim/Component/Catalog/Updater/ProductUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/ProductUpdater.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Component\Catalog\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Akeneo\Component\StorageUtils\Updater\PropertySetterInterface;
 use Doctrine\Common\Util\ClassUtils;
@@ -112,11 +113,9 @@ class ProductUpdater implements ObjectUpdaterInterface
     public function update($product, array $data, array $options = [])
     {
         if (!$product instanceof ProductInterface) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    'Expects a "Pim\Component\Catalog\Model\ProductInterface", "%s" provided.',
-                    ClassUtils::getClass($product)
-                )
+            throw InvalidObjectException::objectExpected(
+                ClassUtils::getClass($product),
+                ProductInterface::class
             );
         }
 

--- a/src/Pim/Component/Catalog/Updater/VariantGroupUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/VariantGroupUpdater.php
@@ -2,6 +2,8 @@
 
 namespace Pim\Component\Catalog\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\ImmutablePropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
@@ -97,11 +99,9 @@ class VariantGroupUpdater implements ObjectUpdaterInterface
     public function update($variantGroup, array $data, array $options = [])
     {
         if (!$variantGroup instanceof GroupInterface) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    'Expects a "Pim\Component\Catalog\Model\GroupInterface", "%s" provided.',
-                    ClassUtils::getClass($variantGroup)
-                )
+            throw InvalidPropertyException::objectExpected(
+                ClassUtils::getClass($variantGroup),
+                GroupInterface::class
             );
         }
 
@@ -117,7 +117,8 @@ class VariantGroupUpdater implements ObjectUpdaterInterface
      * @param string         $field
      * @param mixed          $data
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidPropertyException
+     * @throws ImmutablePropertyException
      */
     protected function setData(GroupInterface $variantGroup, $field, $data)
     {
@@ -161,7 +162,7 @@ class VariantGroupUpdater implements ObjectUpdaterInterface
      * @param GroupInterface $variantGroup
      * @param string         $type
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidPropertyException
      */
     protected function setType(GroupInterface $variantGroup, $type)
     {
@@ -169,15 +170,20 @@ class VariantGroupUpdater implements ObjectUpdaterInterface
         if (null !== $groupType) {
             $variantGroup->setType($groupType);
         } else {
-            throw new \InvalidArgumentException(sprintf('Type "%s" does not exist', $type));
+            throw InvalidPropertyException::validEntityCodeExpected(
+                'type',
+                'group type',
+                'The group type does not exist',
+                'updater',
+                'variant group',
+                $type
+            );
         }
     }
 
     /**
      * @param GroupInterface $variantGroup
      * @param array          $labels
-     *
-     * @throws \InvalidArgumentException
      */
     protected function setLabels(GroupInterface $variantGroup, array $labels)
     {
@@ -192,13 +198,19 @@ class VariantGroupUpdater implements ObjectUpdaterInterface
      * @param GroupInterface $variantGroup
      * @param array          $axes
      *
-     * @throws \InvalidArgumentException
+     * @throws ImmutablePropertyException
+     * @throws InvalidPropertyException
      */
     protected function setAxes(GroupInterface $variantGroup, array $axes)
     {
         if (null !== $variantGroup->getId()) {
             if (array_diff($this->getOriginalAxes($variantGroup->getAxisAttributes()), array_values($axes))) {
-                throw new \InvalidArgumentException('Attributes: This property cannot be changed.');
+                throw ImmutablePropertyException::immutableProperty(
+                    'axes',
+                    implode(',', $axes),
+                    'updater',
+                    'variant group'
+                );
             }
         }
 
@@ -207,7 +219,14 @@ class VariantGroupUpdater implements ObjectUpdaterInterface
             if (null !== $attribute) {
                 $variantGroup->addAxisAttribute($attribute);
             } else {
-                throw new \InvalidArgumentException(sprintf('Attribute "%s" does not exist', $axis));
+                throw InvalidPropertyException::validEntityCodeExpected(
+                    'axes',
+                    'attribute code',
+                    'The attribute does not exist',
+                    'updater',
+                    'variant group',
+                    $axis
+                );
             }
         }
     }

--- a/src/Pim/Component/Catalog/spec/Updater/AssociationTypeUpdaterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/AssociationTypeUpdaterSpec.php
@@ -11,11 +11,6 @@ use Pim\Component\Catalog\Model\AssociationTypeInterface;
 
 class AssociationTypeUpdaterSpec extends ObjectBehavior
 {
-    function let(IdentifiableObjectRepositoryInterface $associationTypeRepository)
-    {
-        $this->beConstructedWith($associationTypeRepository);
-    }
-
     function it_is_initializable()
     {
         $this->shouldHaveType('Pim\Component\Catalog\Updater\AssociationTypeUpdater');

--- a/src/Pim/Component/Catalog/spec/Updater/AssociationTypeUpdaterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/AssociationTypeUpdaterSpec.php
@@ -2,6 +2,8 @@
 
 namespace spec\Pim\Component\Catalog\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
+use Akeneo\Component\StorageUtils\Exception\UnknownPropertyException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use PhpSpec\ObjectBehavior;
 use Pim\Bundle\CatalogBundle\Entity\AssociationTypeTranslation;
@@ -27,8 +29,9 @@ class AssociationTypeUpdaterSpec extends ObjectBehavior
     function it_throws_an_exception_when_trying_to_update_anything_else_than_an_association_type()
     {
         $this->shouldThrow(
-            new \InvalidArgumentException(
-                'Expects a "Pim\Component\Catalog\Model\AssociationTypeInterface", "stdClass" provided.'
+            InvalidObjectException::objectExpected(
+                'stdClass',
+                'Pim\Component\Catalog\Model\AssociationTypeInterface'
             )
         )->during(
             'update',
@@ -54,5 +57,16 @@ class AssociationTypeUpdaterSpec extends ObjectBehavior
         ];
 
         $this->update($associationType, $values, []);
+    }
+
+    function it_throws_an_exception_when_trying_to_update_a_non_existent_field(AssociationTypeInterface $associationType) {
+        $values = [
+            'non_existent_field' => 'field',
+            'code'               => 'mycode',
+        ];
+
+        $this
+            ->shouldThrow(new UnknownPropertyException('non_existent_field', 'Property "non_existent_field" does not exist.'))
+            ->during('update', [$associationType, $values, []]);
     }
 }

--- a/src/Pim/Component/Catalog/spec/Updater/AttributeGroupUpdaterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/AttributeGroupUpdaterSpec.php
@@ -2,6 +2,8 @@
 
 namespace spec\Pim\Component\Catalog\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Model\AttributeGroupInterface;
@@ -33,8 +35,9 @@ class AttributeGroupUpdaterSpec extends ObjectBehavior
     function it_throw_an_exception_when_trying_to_update_anything_else_than_an_attribute_group()
     {
         $this->shouldThrow(
-            new \InvalidArgumentException(
-                'Expects a "Pim\Component\Catalog\Model\AttributeGroupInterface", "stdClass" provided.'
+            InvalidObjectException::objectExpected(
+                'stdClass',
+                'Pim\Component\Catalog\Model\AttributeGroupInterface'
             )
         )->during(
             'update',
@@ -99,7 +102,16 @@ class AttributeGroupUpdaterSpec extends ObjectBehavior
         $attributeGroup->getAttributes()->willReturn([]);
 
         $attributeRepository->findOneByIdentifier('foo')->willReturn(null);
-        $this->shouldThrow(new \InvalidArgumentException('Attribute with "foo" code does not exist'))
+
+        $this->shouldThrow(
+            InvalidPropertyException::validEntityCodeExpected(
+               'attributes',
+               'attribute code',
+               'The attribute does not exist',
+               'updater',
+               'attribute group',
+               'foo'
+            ))
             ->during('update', [$attributeGroup, $values]);
     }
 

--- a/src/Pim/Component/Catalog/spec/Updater/AttributeOptionUpdaterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/AttributeOptionUpdaterSpec.php
@@ -2,6 +2,8 @@
 
 namespace spec\Pim\Component\Catalog\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\AttributeOptionInterface;
@@ -24,6 +26,19 @@ class AttributeOptionUpdaterSpec extends ObjectBehavior
     function it_is_a_updater()
     {
         $this->shouldImplement('Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface');
+    }
+
+    function it_throw_an_exception_when_trying_to_update_anything_else_than_an_attribute_option()
+    {
+        $this->shouldThrow(
+            InvalidObjectException::objectExpected(
+                'stdClass',
+                'Pim\Component\Catalog\Model\AttributeOptionInterface'
+            )
+        )->during(
+            'update',
+            [new \stdClass(), []]
+        );
     }
 
     function it_updates_all_fields_on_a_new_attribute_option(
@@ -66,7 +81,16 @@ class AttributeOptionUpdaterSpec extends ObjectBehavior
         $attributeOption->setCode('mycode')->shouldBeCalled();
         $attributeRepository->findOneByIdentifier('myattribute')->willReturn(null);
 
-        $this->shouldThrow('\InvalidArgumentException')->during(
+        $this->shouldThrow(
+            InvalidPropertyException::validEntityCodeExpected(
+                'attribute',
+                'attribute code',
+                'The attribute does not exist',
+                'updater',
+                'attribute option',
+                'myattribute'
+            )
+        )->during(
             'update',
             [
                 $attributeOption,

--- a/src/Pim/Component/Catalog/spec/Updater/AttributeUpdaterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/AttributeUpdaterSpec.php
@@ -226,4 +226,23 @@ class AttributeUpdaterSpec extends ObjectBehavior
             ->shouldThrow(UnknownPropertyException::unknownProperty('non_existent_field', new NoSuchPropertyException()))
             ->during('update', [$attribute, $values, []]);
     }
+
+    function it_throws_an_exception_if_locale_does_not_exist($localeRepository, AttributeInterface $attribute) {
+        $localeRepository->findOneByIdentifier('foo')->willReturn(null);
+
+        $values = [
+            'available_locales' => ['foo']
+        ];
+
+        $this->shouldThrow(
+            InvalidPropertyException::validEntityCodeExpected(
+                'available_locales',
+                'locale code',
+                'The locale does not exist',
+                'updater',
+                'attribute',
+                'foo'
+            )
+        )->during('update', [$attribute, $values, []]);
+    }
 }

--- a/src/Pim/Component/Catalog/spec/Updater/ChannelUpdaterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/ChannelUpdaterSpec.php
@@ -2,6 +2,8 @@
 
 namespace spec\Pim\Component\Catalog\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use PhpSpec\ObjectBehavior;
 use Pim\Bundle\CatalogBundle\Entity\ChannelTranslation;
@@ -35,8 +37,9 @@ class ChannelUpdaterSpec extends ObjectBehavior
     function it_throws_an_exception_when_trying_to_update_anything_else_than_a_channel()
     {
         $this->shouldThrow(
-            new \InvalidArgumentException(
-                'Expects a "Pim\Component\Catalog\Model\ChannelInterface", "stdClass" provided.'
+            InvalidObjectException::objectExpected(
+                'stdClass',
+                'Pim\Component\Catalog\Model\ChannelInterface'
             )
         )->during(
             'update',
@@ -120,8 +123,19 @@ class ChannelUpdaterSpec extends ObjectBehavior
 
         $channel->setCode('ecommerce')->shouldBeCalled();
 
-        $this->shouldThrow(new \InvalidArgumentException(sprintf('Category with "%s" code does not exist', 'unknown')))
-            ->during('update', [$channel, $values]);
+        $this->shouldThrow(
+            InvalidPropertyException::validEntityCodeExpected(
+                'category_tree',
+                'code',
+                'The category does not exist',
+                'updater',
+                'channel',
+                'unknown'
+            )
+        )->during(
+            'update',
+            [$channel, $values]
+        );
     }
 
     function it_throws_an_exception_if_locale_not_found(
@@ -142,8 +156,19 @@ class ChannelUpdaterSpec extends ObjectBehavior
         $localeRepository->findOneByIdentifier('unknown')->willReturn(null);
         $currencyRepository->findOneByIdentifier('EUR')->willReturn($eur);
 
-        $this->shouldThrow(new \InvalidArgumentException(sprintf('Locale with "%s" code does not exist', 'unknown')))
-            ->during('update', [$channel, $values]);
+        $this->shouldThrow(
+            InvalidPropertyException::validEntityCodeExpected(
+                'locales',
+                'code',
+                'The locale does not exist',
+                'updater',
+                'channel',
+                'unknown'
+            )
+        )->during(
+            'update',
+            [$channel, $values]
+        );
     }
 
     function it_throws_an_exception_if_currency_not_found(
@@ -167,7 +192,15 @@ class ChannelUpdaterSpec extends ObjectBehavior
         $localeRepository->findOneByIdentifier('fr_FR')->willReturn($frFR);
         $currencyRepository->findOneByIdentifier('unknown')->willReturn(null);
 
-        $this->shouldThrow(new \InvalidArgumentException(sprintf('Currency with "%s" code does not exist', 'unknown')))
-            ->during('update', [$channel, $values]);
+        $this->shouldThrow(
+            InvalidPropertyException::validEntityCodeExpected(
+                'currencies',
+                'code',
+                'The currency does not exist',
+                'updater',
+                'channel',
+                'unknown'
+            )
+        )->during('update', [$channel, $values]);
     }
 }

--- a/src/Pim/Component/Catalog/spec/Updater/CurrencyUpdaterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/CurrencyUpdaterSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Pim\Component\Catalog\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Model\CurrencyInterface;
 
@@ -20,8 +21,9 @@ class CurrencyUpdaterSpec extends ObjectBehavior
     function it_throw_an_exception_when_trying_to_update_anything_else_than_an_attribute_group()
     {
         $this->shouldThrow(
-            new \InvalidArgumentException(
-                'Expects a "Pim\Component\Catalog\Model\CurrencyInterface", "stdClass" provided.'
+            InvalidObjectException::objectExpected(
+                'stdClass',
+                'Pim\Component\Catalog\Model\CurrencyInterface'
             )
         )->during(
             'update',

--- a/src/Pim/Component/Catalog/spec/Updater/GroupTypeUpdaterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/GroupTypeUpdaterSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Pim\Component\Catalog\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Model\GroupTypeInterface;
 
@@ -20,8 +21,9 @@ class GroupTypeUpdaterSpec extends ObjectBehavior
     function it_throw_an_exception_when_trying_to_update_anything_else_than_a_group_type()
     {
         $this->shouldThrow(
-            new \InvalidArgumentException(
-                'Expects a "Pim\Component\Catalog\Model\GroupTypeInterface", "stdClass" provided.'
+            InvalidObjectException::objectExpected(
+                'stdClass',
+                'Pim\Component\Catalog\Model\GroupTypeInterface'
             )
         )->during(
             'update',

--- a/src/Pim/Component/Catalog/spec/Updater/GroupUpdaterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/GroupUpdaterSpec.php
@@ -2,6 +2,8 @@
 
 namespace spec\Pim\Component\Catalog\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use PhpSpec\ObjectBehavior;
 use Pim\Bundle\CatalogBundle\Entity\GroupTranslation;
 use Pim\Component\Catalog\Model\AttributeInterface;
@@ -37,8 +39,9 @@ class GroupUpdaterSpec extends ObjectBehavior
     function it_throws_an_exception_when_trying_to_update_anything_else_than_a_variant_group()
     {
         $this->shouldThrow(
-            new \InvalidArgumentException(
-                'Expects a "Pim\Component\Catalog\Model\GroupInterface", "stdClass" provided.'
+            InvalidObjectException::objectExpected(
+                'stdClass',
+                'Pim\Component\Catalog\Model\GroupInterface'
             )
         )->during(
             'update',
@@ -92,18 +95,49 @@ class GroupUpdaterSpec extends ObjectBehavior
         $this->update($group, $values, []);
     }
 
-    function it_throws_an_error_if_type_is_unknown(GroupInterface $group)
+    function it_throws_an_error_if_type_is_unknown($groupTypeRepository, GroupInterface $group)
     {
         $group->setCode('mycode')->shouldBeCalled();
-        $group->getId()->willReturn(null);
+        $groupTypeRepository->findOneByIdentifier('UNKNOWN')->willReturn(null);
 
         $values = [
             'code' => 'mycode',
             'type' => 'UNKNOWN',
         ];
 
-        $this->shouldThrow(new \InvalidArgumentException('Type "UNKNOWN" does not exist'))
-            ->during('update', [$group, $values, []]);
+        $this->shouldThrow(
+            InvalidPropertyException::validEntityCodeExpected(
+                'type',
+                'group type',
+                'The group type does not exist',
+                'updater',
+                'group',
+                'UNKNOWN'
+            )
+        )->during('update', [$group, $values, []]);
+    }
+
+    function it_throws_an_error_if_it_is_a_variant_group_type($groupTypeRepository, GroupInterface $group, GroupTypeInterface $groupType)
+    {
+        $group->setCode('mycode')->shouldBeCalled();
+        $groupTypeRepository->findOneByIdentifier('variant')->willReturn($groupType);
+        $groupType->isVariant()->willReturn(true);
+        $group->getCode()->willReturn('mycode');
+
+        $values = [
+            'code' => 'mycode',
+            'type' => 'variant',
+        ];
+
+        $this->shouldThrow(
+            InvalidPropertyException::validGroupTypeExpected(
+                'type',
+                'Cannot process variant group, only groups are supported',
+                'updater',
+                'group',
+                'mycode'
+            )
+        )->during('update', [$group, $values, []]);
     }
 
     function it_throws_an_exception_if_attribute_is_unknown($attributeRepository, GroupInterface $group)
@@ -117,7 +151,15 @@ class GroupUpdaterSpec extends ObjectBehavior
             'axis' => ['foo']
         ];
 
-        $this->shouldThrow(new \InvalidArgumentException('Attribute "foo" does not exist'))
-            ->during('update', [$group, $values, []]);
+        $this->shouldThrow(
+            InvalidPropertyException::validEntityCodeExpected(
+                'axis',
+                'attribute code',
+                'The attribute does not exist',
+                'updater',
+                'group',
+                'foo'
+            )
+        )->during('update', [$group, $values, []]);
     }
 }

--- a/src/Pim/Component/Catalog/spec/Updater/LocaleUpdaterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/LocaleUpdaterSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Pim\Component\Catalog\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Model\LocaleInterface;
 use Prophecy\Argument;
@@ -21,8 +22,9 @@ class LocaleUpdaterSpec extends ObjectBehavior
     function it_throws_an_exception_when_trying_to_update_anything_else_than_a_locale()
     {
         $this->shouldThrow(
-            new \InvalidArgumentException(
-                'Expects a "Pim\Component\Catalog\Model\LocaleInterface", "stdClass" provided.'
+            InvalidObjectException::objectExpected(
+                'stdClass',
+                'Pim\Component\Catalog\Model\LocaleInterface'
             )
         )->during(
             'update',

--- a/src/Pim/Component/Catalog/spec/Updater/ProductUpdaterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/ProductUpdaterSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Pim\Component\Catalog\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
 use Akeneo\Component\StorageUtils\Updater\PropertySetterInterface;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Model\ProductInterface;
@@ -32,8 +33,11 @@ class ProductUpdaterSpec extends ObjectBehavior
 
     function it_throws_an_exception_when_trying_to_update_anything_else_than_a_product()
     {
-        $this->shouldThrow(new \InvalidArgumentException('Expects a "Pim\Component\Catalog\Model\ProductInterface", "stdClass" provided.'))->during(
-            'update', [new \stdClass(), []]
+        $this->shouldThrow(
+            InvalidObjectException::objectExpected(
+                'stdClass',
+                'Pim\Component\Catalog\Model\ProductInterface'
+            )
         );
     }
 

--- a/src/Pim/Component/Catalog/spec/Updater/VariantGroupUpdaterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/VariantGroupUpdaterSpec.php
@@ -2,6 +2,9 @@
 
 namespace spec\Pim\Component\Catalog\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\ImmutablePropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Doctrine\Common\Collections\ArrayCollection;
 use PhpSpec\ObjectBehavior;
@@ -53,8 +56,11 @@ class VariantGroupUpdaterSpec extends ObjectBehavior
 
     function it_throws_an_exception_when_trying_to_update_anything_else_than_a_variant_group()
     {
-        $this->shouldThrow(new \InvalidArgumentException('Expects a "Pim\Component\Catalog\Model\GroupInterface", "stdClass" provided.'))->during(
-            'update', [new \stdClass(), []]
+        $this->shouldThrow(
+            InvalidObjectException::objectExpected(
+                'stdClass',
+                'Pim\Component\Catalog\Model\GroupInterface'
+            )
         );
     }
 
@@ -181,8 +187,16 @@ class VariantGroupUpdaterSpec extends ObjectBehavior
             'type' => 'UNKNOWN',
         ];
 
-        $this->shouldThrow(new \InvalidArgumentException('Type "UNKNOWN" does not exist'))
-            ->during('update', [$variantGroup, $values, []]);
+        $this->shouldThrow(
+            InvalidPropertyException::validEntityCodeExpected(
+                'type',
+                'group type',
+                'The group type does not exist',
+                'updater',
+                'variant group',
+                'UNKNOWN'
+            )
+        )->during('update', [$variantGroup, $values, []]);
     }
 
     function it_throws_an_error_if_axis_is_unknown(GroupInterface $variantGroup)
@@ -195,8 +209,16 @@ class VariantGroupUpdaterSpec extends ObjectBehavior
             'axes' => ['unknown', 'secondary_color'],
         ];
 
-        $this->shouldThrow(new \InvalidArgumentException('Attribute "unknown" does not exist'))
-            ->during('update', [$variantGroup, $values, []]);
+        $this->shouldThrow(
+            InvalidPropertyException::validEntityCodeExpected(
+                'axes',
+                'attribute code',
+                'The attribute does not exist',
+                'updater',
+                'variant group',
+                'unknown'
+            )
+        )->during('update', [$variantGroup, $values, []]);
     }
 
     function it_throws_an_error_if_axis_is_updated(GroupInterface $variantGroup)
@@ -212,8 +234,14 @@ class VariantGroupUpdaterSpec extends ObjectBehavior
             'axes' => ['main_color'],
         ];
 
-        $this->shouldThrow(new \InvalidArgumentException('Attributes: This property cannot be changed.'))
-            ->during('update', [$variantGroup, $values, []]);
+        $this->shouldThrow(
+            ImmutablePropertyException::immutableProperty(
+                'axes',
+                'main_color',
+                'updater',
+                'variant group'
+            )
+        )->during('update', [$variantGroup, $values, []]);
     }
 
     function it_merges_original_and_new_values(

--- a/src/Pim/Component/Connector/Processor/Denormalization/JobInstanceProcessor.php
+++ b/src/Pim/Component/Connector/Processor/Denormalization/JobInstanceProcessor.php
@@ -10,6 +10,7 @@ use Akeneo\Component\Batch\Job\JobRegistry;
 use Akeneo\Component\Batch\Model\JobInstance;
 use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
 use Akeneo\Component\StorageUtils\Detacher\ObjectDetacherInterface;
+use Akeneo\Component\StorageUtils\Exception\ObjectUpdaterException;
 use Akeneo\Component\StorageUtils\Factory\SimpleFactoryInterface;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
@@ -85,6 +86,8 @@ class JobInstanceProcessor extends AbstractProcessor implements ItemProcessorInt
 
         try {
             $this->updater->update($entity, $item);
+        } catch (ObjectUpdaterException $exception) {
+            $this->skipItemWithMessage($item, $exception->getMessage(), $exception);
         } catch (\InvalidArgumentException $exception) {
             $this->skipItemWithMessage($item, $exception->getMessage(), $exception);
         }

--- a/src/Pim/Component/Connector/Processor/Denormalization/Processor.php
+++ b/src/Pim/Component/Connector/Processor/Denormalization/Processor.php
@@ -5,6 +5,7 @@ namespace Pim\Component\Connector\Processor\Denormalization;
 use Akeneo\Component\Batch\Item\ItemProcessorInterface;
 use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
 use Akeneo\Component\StorageUtils\Detacher\ObjectDetacherInterface;
+use Akeneo\Component\StorageUtils\Exception\ObjectUpdaterException;
 use Akeneo\Component\StorageUtils\Factory\SimpleFactoryInterface;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
@@ -63,6 +64,8 @@ class Processor extends AbstractProcessor implements ItemProcessorInterface, Ste
 
         try {
             $this->updater->update($entity, $item);
+        } catch (ObjectUpdaterException $exception) {
+            $this->skipItemWithMessage($item, $exception->getMessage(), $exception);
         } catch (\InvalidArgumentException $exception) {
             $this->skipItemWithMessage($item, $exception->getMessage(), $exception);
         }

--- a/src/Pim/Component/Connector/Processor/Denormalization/ProductAssociationProcessor.php
+++ b/src/Pim/Component/Connector/Processor/Denormalization/ProductAssociationProcessor.php
@@ -5,6 +5,7 @@ namespace Pim\Component\Connector\Processor\Denormalization;
 use Akeneo\Component\Batch\Item\ItemProcessorInterface;
 use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
 use Akeneo\Component\StorageUtils\Detacher\ObjectDetacherInterface;
+use Akeneo\Component\StorageUtils\Exception\ObjectUpdaterException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Pim\Component\Catalog\Comparator\Filter\ProductFilterInterface;
@@ -104,6 +105,9 @@ class ProductAssociationProcessor extends AbstractProcessor implements
 
         try {
             $this->updateProduct($product, $item);
+        } catch (ObjectUpdaterException $exception) {
+            $this->detachProduct($product);
+            $this->skipItemWithMessage($item, $exception->getMessage(), $exception);
         } catch (\InvalidArgumentException $exception) {
             $this->detachProduct($product);
             $this->skipItemWithMessage($item, $exception->getMessage(), $exception);
@@ -133,7 +137,7 @@ class ProductAssociationProcessor extends AbstractProcessor implements
      * @param ProductInterface $product
      * @param array            $item
      *
-     * @throws \InvalidArgumentException
+     * @throws ObjectUpdaterException
      */
     protected function updateProduct(ProductInterface $product, array $item)
     {

--- a/src/Pim/Component/Connector/Processor/Denormalization/ProductProcessor.php
+++ b/src/Pim/Component/Connector/Processor/Denormalization/ProductProcessor.php
@@ -5,6 +5,7 @@ namespace Pim\Component\Connector\Processor\Denormalization;
 use Akeneo\Component\Batch\Item\ItemProcessorInterface;
 use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
 use Akeneo\Component\StorageUtils\Detacher\ObjectDetacherInterface;
+use Akeneo\Component\StorageUtils\Exception\ObjectUpdaterException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Pim\Component\Catalog\Builder\ProductBuilderInterface;
@@ -107,6 +108,9 @@ class ProductProcessor extends AbstractProcessor implements ItemProcessorInterfa
 
         try {
             $this->updateProduct($product, $filteredItem);
+        } catch (ObjectUpdaterException $exception) {
+            $this->detachProduct($product);
+            $this->skipItemWithMessage($item, $exception->getMessage(), $exception);
         } catch (\InvalidArgumentException $exception) {
             $this->detachProduct($product);
             $this->skipItemWithMessage($item, $exception->getMessage(), $exception);
@@ -192,7 +196,7 @@ class ProductProcessor extends AbstractProcessor implements ItemProcessorInterfa
      * @param ProductInterface $product
      * @param array            $filteredItem
      *
-     * @throws \InvalidArgumentException
+     * @throws ObjectUpdaterException
      */
     protected function updateProduct(ProductInterface $product, array $filteredItem)
     {

--- a/src/Pim/Component/User/Updater/GroupUpdater.php
+++ b/src/Pim/Component/User/Updater/GroupUpdater.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Component\User\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Doctrine\Common\Util\ClassUtils;
 use Pim\Component\User\Model\GroupInterface;
@@ -26,11 +27,9 @@ class GroupUpdater implements ObjectUpdaterInterface
     public function update($group, array $data, array $options = [])
     {
         if (!$group instanceof GroupInterface) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    'Expects a "Pim\Component\User\Model\GroupInterface", "%s" provided.',
-                    ClassUtils::getClass($group)
-                )
+            throw InvalidObjectException::objectExpected(
+                ClassUtils::getClass($group),
+                GroupInterface::class
             );
         }
 

--- a/src/Pim/Component/User/Updater/RoleUpdater.php
+++ b/src/Pim/Component/User/Updater/RoleUpdater.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Component\User\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Doctrine\Common\Util\ClassUtils;
 use Oro\Bundle\SecurityBundle\Acl\Persistence\AclManager;
@@ -40,11 +41,9 @@ class RoleUpdater implements ObjectUpdaterInterface
     public function update($role, array $data, array $options = [])
     {
         if (!$role instanceof Role) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    'Expects a "Oro\Bundle\UserBundle\Entity\Role", "%s" provided.',
-                    ClassUtils::getClass($role)
-                )
+            throw InvalidObjectException::objectExpected(
+                ClassUtils::getClass($role),
+                Role::class
             );
         }
 

--- a/src/Pim/Component/User/Updater/UserUpdater.php
+++ b/src/Pim/Component/User/Updater/UserUpdater.php
@@ -3,6 +3,8 @@
 namespace Pim\Component\User\Updater;
 
 use Akeneo\Component\Classification\Model\CategoryInterface;
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Doctrine\Common\Util\ClassUtils;
@@ -81,11 +83,9 @@ class UserUpdater implements ObjectUpdaterInterface
     public function update($user, array $data, array $options = [])
     {
         if (!$user instanceof UserInterface) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    'Expects a "Pim\Bundle\UserBundle\Entity\UserInterface", "%s" provided.',
-                    ClassUtils::getClass($user)
-                )
+            throw InvalidObjectException::objectExpected(
+                ClassUtils::getClass($user),
+                UserInterface::class
             );
         }
 
@@ -105,7 +105,7 @@ class UserUpdater implements ObjectUpdaterInterface
      * @param string        $field
      * @param mixed         $data
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidPropertyException
      */
     protected function setData(UserInterface $user, $field, $data)
     {
@@ -143,10 +143,10 @@ class UserUpdater implements ObjectUpdaterInterface
                 $user->setEmailNotifications($data);
                 break;
             case 'catalog_locale':
-                $user->setCatalogLocale($this->findLocale($data));
+                $user->setCatalogLocale($this->findLocale('catalog_locale', $data));
                 break;
             case 'user_locale':
-                $user->setUiLocale($this->findLocale($data));
+                $user->setUiLocale($this->findLocale('user_locale', $data));
                 break;
             case 'catalog_scope':
                 $user->setCatalogScope($this->findChannel($data));
@@ -179,30 +179,49 @@ class UserUpdater implements ObjectUpdaterInterface
     /**
      * @param string $code
      *
-     * @return CategoryInterface|null
+     * @throws InvalidPropertyException
+     *
+     * @return CategoryInterface
      */
     protected function findCategory($code)
     {
         $category = $this->categoryRepository->findOneByIdentifier($code);
 
         if (null === $category) {
-            throw new \InvalidArgumentException(sprintf('Category %s was not found', $code));
+            throw InvalidPropertyException::validEntityCodeExpected(
+                'default_tree',
+                'category code',
+                'The category does not exist',
+                'updater',
+                'user',
+                $code
+            );
         }
 
         return $category;
     }
 
     /**
+     * @param string $field
      * @param string $code
      *
-     * @return LocaleInterface|null
+     * @throws InvalidPropertyException
+     *
+     * @return LocaleInterface
      */
-    protected function findLocale($code)
+    protected function findLocale($field, $code)
     {
         $locale = $this->localeRepository->findOneByIdentifier($code);
 
         if (null === $locale) {
-            throw new \InvalidArgumentException(sprintf('Locale %s was not found', $code));
+            throw InvalidPropertyException::validEntityCodeExpected(
+                $field,
+                'locale code',
+                'The locale does not exist',
+                'updater',
+                'user',
+                $code
+            );
         }
 
         return $locale;
@@ -211,6 +230,8 @@ class UserUpdater implements ObjectUpdaterInterface
     /**
      * @param string $code
      *
+     * @throws InvalidPropertyException
+     *
      * @return ChannelInterface|null
      */
     protected function findChannel($code)
@@ -218,7 +239,14 @@ class UserUpdater implements ObjectUpdaterInterface
         $channel = $this->channelRepository->findOneByIdentifier($code);
 
         if (null === $channel) {
-            throw new \InvalidArgumentException(sprintf('Channel %s was not found', $code));
+            throw InvalidPropertyException::validEntityCodeExpected(
+                'catalog_scope',
+                'channel code',
+                'The channel does not exist',
+                'updater',
+                'user',
+                $code
+            );
         }
 
         return $channel;
@@ -227,14 +255,23 @@ class UserUpdater implements ObjectUpdaterInterface
     /**
      * @param string $code
      *
-     * @return Role|null
+     * @throws InvalidPropertyException
+     *
+     * @return Role
      */
     protected function findRole($code)
     {
         $role = $this->roleRepository->findOneByIdentifier($code);
 
         if (null === $role) {
-            throw new \InvalidArgumentException(sprintf('Role %s was not found', $code));
+            throw InvalidPropertyException::validEntityCodeExpected(
+                'roles',
+                'role',
+                'The role does not exist',
+                'updater',
+                'user',
+                $code
+            );
         }
 
         return $role;
@@ -243,14 +280,23 @@ class UserUpdater implements ObjectUpdaterInterface
     /**
      * @param string $code
      *
-     * @return GroupInterface|null
+     * @throws InvalidPropertyException
+     *
+     * @return GroupInterface
      */
     protected function findGroup($code)
     {
         $group = $this->groupRepository->findOneByIdentifier($code);
 
         if (null === $group) {
-            throw new \InvalidArgumentException(sprintf('Group %s was not found', $code));
+            throw InvalidPropertyException::validEntityCodeExpected(
+                'groups',
+                'group',
+                'The group does not exist',
+                'updater',
+                'user',
+                $code
+            );
         }
 
         return $group;


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) 

**Description (for Contributor and Core Developer)**

Currently, updaters don't throw any Business exception in updaters  (just native php exception \InvalidArgumentException). 

The only way to differentiate an exception from another one is the message. Moreover, messages are not always consistent (different for the same error type, depending of the updater).

In API, we should be able to differentiate structure problems (a boolean instead of string for example) and functional problems (an entity code does not exist for example).

The scope of this PR is just Updaters, not Adders and Setters for the moment.

Note : Inspired from src/Pim/Component/Catalog/Exception/InvalidArgumentException.php

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | :white_check_mark:
| Added Behats                      | :white_check_mark:
| Changelog updated                 | :red_circle:
| Review and 2 GTM                  | :clock1:
| Micro Demo to the PO (Story only) | 
| Migration script                  | 
| Tech Doc                          | 


:white_check_mark: Done and pass

:red_circle: Done but fail

:clock1: Done but pending

:negative_squared_cross_mark: Not needed
