### PR TITLE
GITHUB-5391: Fix update association type grid subtitle

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/associations.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/associations.js
@@ -267,6 +267,7 @@ define(
                     .siblings('.target-button')
                     .removeClass('AknButton--hidden');
 
+                this.renderPanes();
                 this.updateListenerSelectors();
 
                 var currentGrid = this.datagrids[this.getCurrentAssociationTarget()];


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

In the product association view, 
when I switch association type
Then I should see that the association grid title has been updated.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | :negative_squared_cross_mark:
| Added Behats                      | :negative_squared_cross_mark: (unskipped scenarios will be merged from 1.6 into master right after this one is merged
| Added integration tests           | :negative_squared_cross_mark:
| Changelog updated                 | :negative_squared_cross_mark:
| Review and 2 GTM                  | :clock1:
| Micro Demo to the PO (Story only) | :clock1:
| Migration script                  | :negative_squared_cross_mark:
| Tech Doc                          | :negative_squared_cross_mark:


:white_check_mark: Done and pass

:red_circle: Done but fail

:clock1: Done but pending

:negative_squared_cross_mark: Not needed
