### PR TITLE
TIP-671: Deprecate ProductBuilder method "addPriceForCurrencyWithData"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,19 +38,16 @@ install:
     - if [ "$TRAVIS_PHP_VERSION" = "7.0" ] || [ "$TRAVIS_PHP_VERSION" = "7.1" ]; then
         composer require alcaeus/mongo-php-adapter --ignore-platform-reqs;
       fi;
-    - ./app/console pim:install
-    - ./app/console oro:requirejs:generate-config
+    - cp ./app/config/parameters_test.yml.dist ./app/config/parameters_test.yml
+    - ./app/console --env=test pim:install
+    - ./app/console --env=test oro:requirejs:generate-config
     - npm install
-    - curl http://get.sensiolabs.org/php-cs-fixer-v1.11.phar -o php-cs-fixer
-
-before_script:
-    - cp ./app/config/parameters.yml ./app/config/parameters_test.yml
 
 script:
     - ./bin/phpunit -c app/phpunit.travis.xml --testsuite PIM_Unit_Test
     - ./bin/phpunit -c app/phpunit.travis.xml --testsuite PIM_Integration_Test
     - ./bin/phpspec run
-    - php php-cs-fixer fix --dry-run -v --diff --config-file=.php_cs.php
+    - ./bin/php-cs-fixer fix --dry-run -v --diff --config-file=.php_cs.php
     - grunt travis
 
 notifications:

--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -13,7 +13,8 @@
   Filters `categories`, `family` and `groups` have been introduced and the _PQB_ now uses them by default. The filters `categories.code`, `family.code` and `groups.code` are deprecated.
   In the next version, the deprecated filters will be removed.
 - As it's not needed anymore to convert `codes` to `ids` in order to filter products, `Pim\Bundle\CatalogBundle\Doctrine\Common\Filter\ObjectIdResolver` and `Pim\Bundle\CatalogBundle\Doctrine\Common\Filter\ObjectIdResolverInterface` are now deprecated.
-- Creating a product value with the ProductBuilder (`Pim\Component\Catalog\Denormalizer\Standard\ProductValueDenormalizer`) using the `createProductValue` function is now deprecated. It is advised to use the ProductValueFactory (`Pim\Component\Catalog\Factory\ProductValueFactory`) instead.
+- Creating a product value with the ProductBuilder (`Pim\Component\Catalog\Denormalizer\Standard\ProductValueDenormalizer`) using the `createProductValue` method is now deprecated. It is advised to use the ProductValueFactory (`Pim\Component\Catalog\Factory\ProductValueFactory`) instead.
+- Adding a price to a product value with the ProductBuilder (`Pim\Component\Catalog\Denormalizer\Standard\ProductValueDenormalizer`) using the `addPriceForCurrencyWithData` method is now deprecated. It is advised to use `addPriceForCurrency` instead.
 
 ## Functional improvements
 

--- a/app/config/parameters_test.yml.dist
+++ b/app/config/parameters_test.yml.dist
@@ -1,0 +1,10 @@
+parameters:
+    database_driver:   pdo_mysql
+    database_host:     localhost
+    database_port:     ~
+    database_name:     akeneo_pim
+    database_user:     akeneo_pim
+    database_password: akeneo_pim
+    locale:            en
+    secret:            ThisTokenIsNotSoSecretChangeIt
+    installer_data:    PimInstallerBundle:minimal

--- a/src/Pim/Bundle/VersioningBundle/Denormalizer/Flat/ProductValue/PricesDenormalizer.php
+++ b/src/Pim/Bundle/VersioningBundle/Denormalizer/Flat/ProductValue/PricesDenormalizer.php
@@ -82,7 +82,7 @@ class PricesDenormalizer extends AbstractValueDenormalizer
      */
     protected function addPriceForCurrency(ProductValueInterface $value, $data, $currency)
     {
-        $priceValue = $this->productBuilder->addPriceForCurrencyWithData($value, $currency, $data);
+        $priceValue = $this->productBuilder->addPriceForCurrency($value, $currency, $data);
         $value->addPrice($priceValue);
     }
 

--- a/src/Pim/Bundle/VersioningBundle/spec/Denormalizer/Flat/ProductValue/PricesDenormalizerSpec.php
+++ b/src/Pim/Bundle/VersioningBundle/spec/Denormalizer/Flat/ProductValue/PricesDenormalizerSpec.php
@@ -30,13 +30,13 @@ class PricesDenormalizerSpec extends ObjectBehavior
         ProductPriceInterface $productPriceEur,
         ProductPriceInterface $productPriceUsd
     ) {
-        $productBuilder->addPriceForCurrencyWithData($priceValue, 'EUR', '100')
+        $productBuilder->addPriceForCurrency($priceValue, 'EUR', '100')
             ->willReturn($productPriceEur)
             ->shouldBeCalled();
         $priceValue->addPrice($productPriceEur)
             ->shouldBeCalled();
 
-        $productBuilder->addPriceForCurrencyWithData($priceValue, 'USD', '25')
+        $productBuilder->addPriceForCurrency($priceValue, 'USD', '25')
             ->willReturn($productPriceUsd)
             ->shouldBeCalled();
         $priceValue->addPrice($productPriceUsd)
@@ -57,19 +57,19 @@ class PricesDenormalizerSpec extends ObjectBehavior
         ProductPriceInterface $productPriceEur,
         ProductPriceInterface $productPriceUsd
     ) {
-        $productBuilder->addPriceForCurrencyWithData($priceValue, 'EUR', '120.00')
+        $productBuilder->addPriceForCurrency($priceValue, 'EUR', '120.00')
             ->willReturn($productPriceEur)
             ->shouldBeCalled();
         $priceValue->addPrice($productPriceEur)
             ->shouldBeCalled();
 
-        $productBuilder->addPriceForCurrencyWithData($priceValue, 'USD', '145.40')
+        $productBuilder->addPriceForCurrency($priceValue, 'USD', '145.40')
             ->willReturn($productPriceUsd)
             ->shouldBeCalled();
         $priceValue->addPrice($productPriceUsd)
             ->shouldBeCalled();
 
-        $productBuilder->addPriceForCurrencyWithData($priceValue, 'CHF', '100')
+        $productBuilder->addPriceForCurrency($priceValue, 'CHF', '100')
             ->willReturn($productPriceUsd)
             ->shouldBeCalled();
         $priceValue->addPrice($productPriceUsd)
@@ -87,7 +87,7 @@ class PricesDenormalizerSpec extends ObjectBehavior
         ProductPriceInterface $price,
         ArrayCollection $priceCollection
     ) {
-        $productBuilder->addPriceForCurrencyWithData(Argument::cetera())->willReturn($price);
+        $productBuilder->addPriceForCurrency(Argument::cetera())->willReturn($price);
         $priceValue->addPrice($price)->shouldBeCalled();
         $priceValue->getPrices()->willReturn($priceCollection);
 

--- a/src/Pim/Component/Catalog/Builder/ProductBuilder.php
+++ b/src/Pim/Component/Catalog/Builder/ProductBuilder.php
@@ -37,7 +37,7 @@ class ProductBuilder implements ProductBuilderInterface
 
     /** @var AssociationTypeRepositoryInterface */
     protected $assocTypeRepository;
-    
+
     /** @var EventDispatcherInterface */
     protected $eventDispatcher;
 
@@ -184,13 +184,16 @@ class ProductBuilder implements ProductBuilderInterface
     /**
      * {@inheritdoc}
      */
-    public function addPriceForCurrency(ProductValueInterface $value, $currency)
+    public function addPriceForCurrency(ProductValueInterface $value, $currency, $amount = null)
     {
         if (!$this->hasPriceForCurrency($value, $currency)) {
             $value->addPrice(new $this->productPriceClass(null, $currency));
         }
 
-        return $this->getPriceForCurrency($value, $currency);
+        $price = $this->getPriceForCurrency($value, $currency);
+        $price->setData($amount);
+
+        return $price;
     }
 
     /**
@@ -198,10 +201,7 @@ class ProductBuilder implements ProductBuilderInterface
      */
     public function addPriceForCurrencyWithData(ProductValueInterface $value, $currency, $amount)
     {
-        $price = $this->addPriceForCurrency($value, $currency);
-        $price->setData($amount);
-
-        return $price;
+        return $this->addPriceForCurrency($value, $currency, $amount);
     }
 
     /**

--- a/src/Pim/Component/Catalog/Builder/ProductBuilderInterface.php
+++ b/src/Pim/Component/Catalog/Builder/ProductBuilderInterface.php
@@ -74,14 +74,16 @@ interface ProductBuilderInterface
     public function removeAttributeFromProduct(ProductInterface $product, AttributeInterface $attribute);
 
     /**
-     * Add a product price with currency to the value. If the price already exists, it is returned.
+     * Add a product price with currency and data to the value. If the price
+     * already exists, its data is updated and it is returned.
      *
      * @param ProductValueInterface $value
      * @param string                $currency
+     * @param float|int|null        $amount
      *
      * @return null|ProductPriceInterface
      */
-    public function addPriceForCurrency(ProductValueInterface $value, $currency);
+    public function addPriceForCurrency(ProductValueInterface $value, $currency, $amount = null);
 
     /**
      * Add a product price with currency and data to the value. If the price already exists, its data is
@@ -92,6 +94,9 @@ interface ProductBuilderInterface
      * @param float|int             $amount
      *
      * @return null|ProductPriceInterface
+     *
+     * @deprecated Will be removed in 1.8.
+     *             Please use "Pim\Component\Catalog\Builder\ProductBuilderInterface::addPriceForCurrency" instead.
      */
     public function addPriceForCurrencyWithData(ProductValueInterface $value, $currency, $amount);
 

--- a/src/Pim/Component/Catalog/Updater/Adder/PriceCollectionAttributeAdder.php
+++ b/src/Pim/Component/Catalog/Updater/Adder/PriceCollectionAttributeAdder.php
@@ -157,7 +157,7 @@ class PriceCollectionAttributeAdder extends AbstractAttributeAdder
         }
 
         foreach ($data as $price) {
-            $this->productBuilder->addPriceForCurrencyWithData($value, $price['currency'], $price['amount']);
+            $this->productBuilder->addPriceForCurrency($value, $price['currency'], $price['amount']);
         }
     }
 }

--- a/src/Pim/Component/Catalog/Updater/Copier/PriceCollectionAttributeCopier.php
+++ b/src/Pim/Component/Catalog/Updater/Copier/PriceCollectionAttributeCopier.php
@@ -107,7 +107,7 @@ class PriceCollectionAttributeCopier extends AbstractAttributeCopier
     {
         foreach ($fromValue->getData() as $price) {
             $this->productBuilder
-                ->addPriceForCurrencyWithData($toValue, $price->getCurrency(), $price->getData());
+                ->addPriceForCurrency($toValue, $price->getCurrency(), $price->getData());
         }
     }
 }

--- a/src/Pim/Component/Catalog/Updater/Setter/PriceCollectionAttributeSetter.php
+++ b/src/Pim/Component/Catalog/Updater/Setter/PriceCollectionAttributeSetter.php
@@ -133,7 +133,7 @@ class PriceCollectionAttributeSetter extends AbstractAttributeSetter
         }
 
         foreach ($data as $price) {
-            $this->productBuilder->addPriceForCurrencyWithData($value, $price['currency'], $price['amount']);
+            $this->productBuilder->addPriceForCurrency($value, $price['currency'], $price['amount']);
         }
     }
 }

--- a/src/Pim/Component/Catalog/spec/Updater/Adder/PriceCollectionAttributeAdderSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Adder/PriceCollectionAttributeAdderSpec.php
@@ -201,7 +201,7 @@ class PriceCollectionAttributeAdderSpec extends ObjectBehavior
         $product2->getValue('attributeCode', $locale, $scope)->willReturn(null);
         $productValue->getPrices()->willReturn([$price]);
 
-        $builder->addPriceForCurrencyWithData($productValue, 'EUR', 123.2)->shouldBeCalledTimes(2);
+        $builder->addPriceForCurrency($productValue, 'EUR', 123.2)->shouldBeCalledTimes(2);
         $this->addattributeData($product1, $attribute, $data, ['locale' => $locale, 'scope' => $scope]);
         $this->addattributeData($product2, $attribute, $data, ['locale' => $locale, 'scope' => $scope]);
     }

--- a/src/Pim/Component/Catalog/spec/Updater/Copier/PriceCollectionAttributeCopierSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Copier/PriceCollectionAttributeCopierSpec.php
@@ -90,7 +90,7 @@ class PriceCollectionAttributeCopierSpec extends ObjectBehavior
 
         $builder->addProductValue($product3, $toAttribute, $toLocale, $toScope)->shouldBeCalledTimes(1)->willReturn($toProductValue);
 
-        $builder->addPriceForCurrencyWithData($toProductValue, 'USD', 123)->shouldBeCalled();
+        $builder->addPriceForCurrency($toProductValue, 'USD', 123)->shouldBeCalled();
 
         $products = [$product1, $product2, $product3, $product4];
         foreach ($products as $product) {

--- a/src/Pim/Component/Catalog/spec/Updater/Setter/PriceCollectionAttributeSetterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Setter/PriceCollectionAttributeSetterSpec.php
@@ -157,13 +157,13 @@ class PriceCollectionAttributeSetterSpec extends ObjectBehavior
         $productValue->getPrices()->willReturn([$price]);
         $price->setData(null)->shouldBeCalled();
 
-        $builder->addPriceForCurrencyWithData($productValue, 'EUR', 123.2)->shouldBeCalled();
+        $builder->addPriceForCurrency($productValue, 'EUR', 123.2)->shouldBeCalled();
         $this->setattributeData($product1, $attribute, $data, ['locale' => $locale, 'scope' => $scope]);
         $this->setattributeData($product2, $attribute, $data, ['locale' => $locale, 'scope' => $scope]);
         $this->setattributeData($product3, $attribute, $data, ['locale' => $locale, 'scope' => $scope]);
 
         $data = [['amount' => 'foo', 'currency' => 'EUR']];
-        $builder->addPriceForCurrencyWithData($productValue, 'EUR', 'foo')->shouldBeCalled();
+        $builder->addPriceForCurrency($productValue, 'EUR', 'foo')->shouldBeCalled();
         $this->setattributeData($product4, $attribute, $data, ['locale' => $locale, 'scope' => $scope]);
     }
 }


### PR DESCRIPTION
## Description
Right now, the ProductBuilder can add prices to the product value with two different method:
- `addPriceForCurrency` which will only add a currency, with no amount,
- `addPriceForCurrencyWithData` which add both amount and currency.

This could be done by only one method, for which the amount can be null. So `addPriceForCurrencyWithData` becomes deprecated, and only `addPriceForCurrency` is used everywhere in the PIM.

### Bonus

Since our integration tests are ran on Travis, it is mandatory to install the PIM. However, the minimal catalog is enough, and way faster to install than icecat_demo_dev, so a new `app/config/parameters_test.yml.dist` model is added and used by Travis.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | :white_check_mark:
| Added Behats                      | :negative_squared_cross_mark:
| Added integration tests           | :negative_squared_cross_mark:
| Changelog updated                 | :negative_squared_cross_mark:
| Review and 2 GTM                  | :clock1:
| Micro Demo to the PO (Story only) | :negative_squared_cross_mark:
| Migration script                  | :negative_squared_cross_mark:
| Tech Doc                          | :negative_squared_cross_mark: