### PR TITLE
Take locale and scope into mind when replacing local paths with stored

### DIFF
--- a/features/Context/catalog/apparel/attributes.csv
+++ b/features/Context/catalog/apparel/attributes.csv
@@ -28,3 +28,4 @@ customs_tax;Customs tax;Customs tax;Taxe de douanes;Zollsteuer;pim_catalog_price
 under_european_law;Under European law;Under European law;Sous la loi Européenne;Nach europäischem Recht;pim_catalog_boolean;general;1;;;4;0;;;;;;;;;;;de_DE,fr_FR
 datasheet;Datasheet;Datasheet;Fiche technique;Datenblatt;pim_catalog_file;internal;;;;4;;;;10;txt,pdf,doc,docx,csv,rtf;;;;;;;
 attachment;Attachment;Attachment;Attachements;Befestigung;pim_catalog_file;internal;;;;5;;;;10;zip,rar,7z,txt,pdf,doc,docx,csv,rtf;;;;;;;
+localizable_image;Localizable image;Localizable image;Image localisée;Lokalisiertes Bild;pim_catalog_image;media;;;;3;1;;;1;gif,png,jpeg,jpg;;;;;;;

--- a/features/enrich/variant-group/edit_attributes_of_a_variant_group.feature
+++ b/features/enrich/variant-group/edit_attributes_of_a_variant_group.feature
@@ -22,8 +22,6 @@ Feature: Edit attributes of a variant group
       | tshirts | description  | k                | en_US  | print     |
       | tshirts | description  | l                | de_DE  | print     |
       | jackets | description  | m                | en_US  | ecommerce |
-      | sweaters | localizable_image | %fixtures%/akeneo.jpg    | en_US  |           |
-      | sweaters | localizable_image | %fixtures%/akeneo2.jpg   | en_GB  |           |
     And I am logged in as "Julia"
 
   Scenario: Successfully display attributes of a variant group
@@ -88,7 +86,11 @@ Feature: Edit attributes of a variant group
     Then I should see the text "This variant group has no attributes yet"
 
   Scenario: Successfully save localized image attributes on variant group
-    Given I am on the "sweaters" variant group page
+    Given the following variant group values:
+      | group    | attribute         | value                  | locale | scope |
+      | sweaters | localizable_image | %fixtures%/akeneo.jpg  | en_US  |       |
+      | sweaters | localizable_image | %fixtures%/akeneo2.jpg | en_GB  |       |
+    And I am on the "sweaters" variant group page
     And I visit the "Attributes" tab
     When I switch the locale to "en_US"
     Then I should see the text "akeneo.jpg"

--- a/features/enrich/variant-group/edit_attributes_of_a_variant_group.feature
+++ b/features/enrich/variant-group/edit_attributes_of_a_variant_group.feature
@@ -22,6 +22,8 @@ Feature: Edit attributes of a variant group
       | tshirts | description  | k                | en_US  | print     |
       | tshirts | description  | l                | de_DE  | print     |
       | jackets | description  | m                | en_US  | ecommerce |
+      | sweaters | localizable_image | %fixtures%/akeneo.jpg    | en_US  |           |
+      | sweaters | localizable_image | %fixtures%/akeneo2.jpg   | en_GB  |           |
     And I am logged in as "Julia"
 
   Scenario: Successfully display attributes of a variant group
@@ -84,3 +86,18 @@ Feature: Edit attributes of a variant group
     When I am on the "sweaters" variant group page
     And I visit the "Attributes" tab
     Then I should see the text "This variant group has no attributes yet"
+
+  Scenario: Successfully save localized image attributes on variant group
+    Given I am on the "sweaters" variant group page
+    And I visit the "Attributes" tab
+    When I switch the locale to "en_US"
+    Then I should see the text "akeneo.jpg"
+    When I switch the locale to "en_GB"
+    Then I should see the text "akeneo2.jpg"
+    And I save the variant group
+    And I reload the page
+    And I visit the "Attributes" tab
+    When I switch the locale to "en_US"
+    Then I should see the text "akeneo.jpg"
+    When I switch the locale to "en_GB"
+    Then I should see the text "akeneo2.jpg"

--- a/src/Pim/Component/Catalog/Updater/VariantGroupUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/VariantGroupUpdater.php
@@ -382,8 +382,12 @@ class VariantGroupUpdater implements ObjectUpdaterInterface
         foreach ($mergedValues as $value) {
             if (null !== $value->getMedia()) {
                 $attributeCode = $value->getAttribute()->getCode();
-                foreach (array_keys($mergedValuesData[$attributeCode]) as $index) {
-                    $mergedValuesData[$attributeCode][$index]['data']['filePath'] = $value->getMedia()->getKey();
+                foreach ($mergedValuesData[$attributeCode] as $index => $mergedValuesDataValues) {
+                    if ($value->getLocale() === $mergedValuesDataValues['locale'] &&
+                        $value->getScope() === $mergedValuesDataValues['scope']
+                    ) {
+                        $mergedValuesData[$attributeCode][$index]['data']['filePath'] = $value->getMedia()->getKey();
+                    }
                 }
             }
         }

--- a/src/Pim/Component/Catalog/spec/Updater/VariantGroupUpdaterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/VariantGroupUpdaterSpec.php
@@ -237,6 +237,17 @@ class VariantGroupUpdaterSpec extends ObjectBehavior
                     'scope'  => 'ecommerce',
                     'data'   => 'original description de_DE'
                 ]
+            ],
+            'image' => [
+                [
+                    'locale' => 'en_US',
+                    'scope'  => null,
+                    'data'   => [
+                        'originalFilename' => 'originalFilename',
+                        'filePath' => 'originalFilepath',
+                        'hash' => 'originalhash',
+                    ]
+                ]
             ]
         ];
 
@@ -253,6 +264,26 @@ class VariantGroupUpdaterSpec extends ObjectBehavior
                     'data'   => 'new description fr_FR'
                 ]
 
+            ],
+            'image' => [
+                [
+                    'locale' => 'en_US',
+                    'scope'  => null,
+                    'data'   => [
+                        'originalFilename' => 'originalFilename',
+                        'filePath' => 'originalFilepath',
+                        'hash' => 'originalhash',
+                    ]
+                ],
+                [
+                    'locale' => 'de_DE',
+                    'scope'  => null,
+                    'data'   => [
+                        'originalFilename' => 'newFilename',
+                        'filePath' => 'newFilepath',
+                        'hash' => 'newhash',
+                    ]
+                ]
             ]
         ];
 
@@ -272,6 +303,26 @@ class VariantGroupUpdaterSpec extends ObjectBehavior
                     'locale' => 'fr_FR',
                     'scope'  => 'ecommerce',
                     'data'   => 'new description fr_FR'
+                ]
+            ],
+            'image' => [
+                [
+                    'locale' => 'en_US',
+                    'scope'  => null,
+                    'data'   => [
+                        'originalFilename' => 'originalFilename',
+                        'filePath' => 'originalFilepath',
+                        'hash' => 'originalhash',
+                    ]
+                ],
+                [
+                    'locale' => 'de_DE',
+                    'scope'  => null,
+                    'data'   => [
+                        'originalFilename' => 'newFilename',
+                        'filePath' => 'newFilepath',
+                        'hash' => 'newhash',
+                    ]
                 ]
             ]
         ];


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no 
| BC breaks? | hopefully not
| Deprecations? | no
| Fixed tickets | fixes #5491 
| Related issues/PRs | -
| License | OSL 3.0

#### What's in this PR?

With this PR the `VariantGroupUpdate::replaceMediaLocalePathsByStoredPaths()` is fixed to take the locale and scope of the attribute into mind. So only the correct `filePath` of the current attributes locale/scope gets updated and not all with the `filePath` of the last value iteration of the given `$attributeCode`

#### Missing behat features

The behat feature [`Edit attributes of a variant group`](https://github.com/akeneo/pim-community-dev/blob/1.6/features/enrich/variant-group/edit_attributes_of_a_variant_group.feature) has two scenarios which covers the save of edited localized/scoped attributes (`Successfully edit a localizable attribute of a variant group` and `Successfully edit a localizable and scopable attribute of a variant group`).

But a file/image attribute is not specially covered. Since the code path in `VariantGroupUpdater::replaceMediaLocalPathsByStoredPaths()` is only executed if the attribute has a media, it isn't covered by the behat scenarios.