### PR TITLE
API-35: valid headers on the API

### DIFF
--- a/phpspec.yml.dist
+++ b/phpspec.yml.dist
@@ -102,6 +102,11 @@ suites:
         psr4_prefix: Pim\Bundle\AnalyticsBundle
         spec_path: src/Pim/Bundle/AnalyticsBundle
         src_path: src/Pim/Bundle/AnalyticsBundle
+    ApiBundle:
+        namespace: Pim\Bundle\ApiBundle
+        psr4_prefix: Pim\Bundle\ApiBundle
+        spec_path: src/Pim/Bundle/ApiBundle
+        src_path: src/Pim/Bundle/ApiBundle
     CatalogBundle:
         namespace: Pim\Bundle\CatalogBundle
         psr4_prefix: Pim\Bundle\CatalogBundle

--- a/src/Pim/Bundle/ApiBundle/DependencyInjection/PimApiExtension.php
+++ b/src/Pim/Bundle/ApiBundle/DependencyInjection/PimApiExtension.php
@@ -24,6 +24,7 @@ class PimApiExtension extends Extension
 
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('controllers.yml');
+        $loader->load('event_subscribers.yml');
         $loader->load('hateoas.yml');
         $loader->load('normalizers.yml');
         $loader->load('repositories.yml');

--- a/src/Pim/Bundle/ApiBundle/EventSubscriber/CheckHeadersRequestSubscriber.php
+++ b/src/Pim/Bundle/ApiBundle/EventSubscriber/CheckHeadersRequestSubscriber.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Pim\Bundle\ApiBundle\EventSubscriber;
+
+use FOS\RestBundle\FOSRestBundle;
+use FOS\RestBundle\Negotiation\FormatNegotiator;
+use FOS\RestBundle\Util\StopFormatListenerException;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Exception\NotAcceptableHttpException;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Check headers for the API:
+ *    - for GET, only application/json in Accept header is allowed
+ *    - for PUT, POST & PATCH, only application/json in Content-Type header is allowed
+ *
+ * @author    Marie Bochu <marie.bochu@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class CheckHeadersRequestSubscriber implements EventSubscriberInterface
+{
+    /** @var FormatNegotiator */
+    protected $formatNegotiator;
+
+    /**
+     * @param FormatNegotiator $formatNegotiator
+     */
+    public function __construct(FormatNegotiator $formatNegotiator)
+    {
+        $this->formatNegotiator = $formatNegotiator;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            KernelEvents::REQUEST => 'onKernelRequest'
+        ];
+    }
+
+    /**
+     * Check the headers in Request
+     *
+     * @param GetResponseEvent $event The event
+     */
+    public function onKernelRequest(GetResponseEvent $event)
+    {
+        $request = $event->getRequest();
+
+        if (!$request->attributes->has(FOSRestBundle::ZONE_ATTRIBUTE) ||
+            $event->getRequestType() !== HttpKernelInterface::MASTER_REQUEST
+        ) {
+            return;
+        }
+
+        try {
+            $best = $this->formatNegotiator->getBest($request->headers->get('accept'));
+
+            if (null === $best) {
+                return;
+            }
+
+            if ('GET' === $request->getMethod()) {
+                $accept = $request->headers->get('accept', null);
+                if (null !== $accept && $accept !== $best->getValue() && !preg_match('|\*\/\*|', $accept)) {
+                    throw new NotAcceptableHttpException(
+                        sprintf('"%s" in "Accept" header is not valid. Only "%s" is allowed.', $accept, $best->getValue())
+                    );
+                }
+
+                return;
+            }
+
+            if (in_array($request->getMethod(), ['PUT', 'PATCH', 'POST'])) {
+                $contentType = $request->headers->get('content-type');
+                if (null !== $contentType &&
+                    !in_array($contentType, ['application/x-www-form-urlencoded', $best->getValue()])
+                ) {
+                    throw new NotAcceptableHttpException(
+                        sprintf(
+                            '"%s" in "Content-Type" header is not valid. Only "%s" is allowed.',
+                            $contentType,
+                            $best->getValue()
+                        )
+                    );
+                }
+            }
+        } catch (StopFormatListenerException $e) {
+            // do nothing.
+            // StopFormatListenerException is thrown when the URI is outside the API
+        }
+    }
+}

--- a/src/Pim/Bundle/ApiBundle/Resources/config/event_subscribers.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/event_subscribers.yml
@@ -1,0 +1,10 @@
+parameters:
+    pim_api.event_subscriber.check_headers_request.class: Pim\Bundle\ApiBundle\EventSubscriber\CheckHeadersRequestSubscriber
+
+services:
+    pim_api.event_subscriber.check_headers_request:
+        class: '%pim_api.event_subscriber.check_headers_request.class%'
+        arguments:
+            - '@fos_rest.format_negotiator'
+        tags:
+            - { name: kernel.event_subscriber, event: kernel.request, method: onKernelRequest }

--- a/src/Pim/Bundle/ApiBundle/spec/EventSubscriber/CheckHeadersRequestSubscriberSpec.php
+++ b/src/Pim/Bundle/ApiBundle/spec/EventSubscriber/CheckHeadersRequestSubscriberSpec.php
@@ -1,0 +1,227 @@
+<?php
+
+namespace spec\Pim\Bundle\ApiBundle\EventSubscriber;
+
+use FOS\RestBundle\FOSRestBundle;
+use FOS\RestBundle\Negotiation\FormatNegotiator;
+use Negotiation\AcceptHeader;
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Exception\NotAcceptableHttpException;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class CheckHeadersRequestSubscriberSpec extends ObjectBehavior
+{
+    public function let(FormatNegotiator $formatNegotiator, GetResponseEvent $event)
+    {
+        $this->beConstructedWith($formatNegotiator);
+    }
+
+    public function it_subscribes_to_prePersist()
+    {
+        $this->getSubscribedEvents()
+            ->shouldReturn([KernelEvents::REQUEST => 'onKernelRequest']);
+    }
+
+    public function it_successfully_valid_default_accept_header(
+        $event,
+        $formatNegotiator,
+        Request $request,
+        ParameterBag $headers,
+        ParameterBag $attributes,
+        CustomAcceptHeader $best
+    ) {
+        $formatNegotiator->getBest('*/*')->willReturn($best);
+        $best->getValue()->willReturn('application/json');
+
+        $event->getRequest()->willReturn($request);
+        $request->getMethod()->willReturn('GET');
+        $event->getRequestType()->willReturn(HttpKernelInterface::MASTER_REQUEST);
+
+        $request->attributes = $attributes;
+        $attributes->has(FOSRestBundle::ZONE_ATTRIBUTE)->willReturn(true);
+
+        $request->headers = $headers;
+        $headers->get('accept', null)->willReturn('*/*');
+
+        $this->onKernelRequest($event)->shouldReturn(null);
+    }
+
+    public function it_successfully_valid_json_accept_header(
+        $event,
+        $formatNegotiator,
+        Request $request,
+        ParameterBag $headers,
+        ParameterBag $attributes,
+        CustomAcceptHeader $best
+    ) {
+        $formatNegotiator->getBest('application/json')->willReturn($best);
+        $best->getValue()->willReturn('application/json');
+
+        $event->getRequest()->willReturn($request);
+        $request->getMethod()->willReturn('GET');
+        $event->getRequestType()->willReturn(HttpKernelInterface::MASTER_REQUEST);
+
+        $request->attributes = $attributes;
+        $attributes->has(FOSRestBundle::ZONE_ATTRIBUTE)->willReturn(true);
+
+        $request->headers = $headers;
+        $headers->get('accept', null)->willReturn('application/json');
+
+        $this->onKernelRequest($event)->shouldReturn(null);
+    }
+
+    public function it_throws_an_exception_when_accept_header_is_xml(
+        $event,
+        $formatNegotiator,
+        Request $request,
+        ParameterBag $headers,
+        ParameterBag $attributes,
+        CustomAcceptHeader $best
+    ) {
+        $formatNegotiator->getBest('application/xml')->willReturn($best);
+        $best->getValue()->willReturn('application/json');
+
+        $event->getRequest()->willReturn($request);
+        $request->getMethod()->willReturn('GET');
+        $event->getRequestType()->willReturn(HttpKernelInterface::MASTER_REQUEST);
+
+        $request->attributes = $attributes;
+        $attributes->has(FOSRestBundle::ZONE_ATTRIBUTE)->willReturn(true);
+
+        $request->headers = $headers;
+        $headers->get('accept', null)->willReturn('application/xml');
+
+        $this->shouldThrow(new NotAcceptableHttpException('"application/xml" in "Accept" header is not valid. Only "application/json" is allowed.'))
+            ->during('onKernelRequest', [$event]);
+    }
+
+    public function it_successfully_valid_default_content_type_header(
+        $event,
+        $formatNegotiator,
+        Request $request,
+        ParameterBag $headers,
+        ParameterBag $attributes,
+        CustomAcceptHeader $best
+    ) {
+        $formatNegotiator->getBest(null)->willReturn($best);
+        $headers->get('accept')->willReturn(null);
+        $best->getValue()->willReturn('application/json');
+
+        $event->getRequest()->willReturn($request);
+        $request->getMethod()->willReturn('POST');
+        $event->getRequestType()->willReturn(HttpKernelInterface::MASTER_REQUEST);
+
+        $request->attributes = $attributes;
+        $attributes->has(FOSRestBundle::ZONE_ATTRIBUTE)->willReturn(true);
+
+        $request->headers = $headers;
+        $headers->get('content-type', null)->willReturn('application/x-www-form-urlencoded');
+
+        $this->onKernelRequest($event)->shouldReturn(null);
+    }
+
+    public function it_successfully_valid_json_content_type_header(
+        $event,
+        $formatNegotiator,
+        Request $request,
+        ParameterBag $headers,
+        ParameterBag $attributes,
+        CustomAcceptHeader $best
+    ) {
+        $formatNegotiator->getBest(null)->willReturn($best);
+        $headers->get('accept')->willReturn(null);
+        $best->getValue()->willReturn('application/json');
+
+        $event->getRequest()->willReturn($request);
+        $request->getMethod()->willReturn('POST');
+        $event->getRequestType()->willReturn(HttpKernelInterface::MASTER_REQUEST);
+
+        $request->attributes = $attributes;
+        $attributes->has(FOSRestBundle::ZONE_ATTRIBUTE)->willReturn(true);
+
+        $request->headers = $headers;
+        $headers->get('content-type', null)->willReturn('application/json');
+
+        $this->onKernelRequest($event)->shouldReturn(null);
+    }
+
+    public function it_throws_an_exception_when_content_type_header_is_xml(
+        $event,
+        $formatNegotiator,
+        Request $request,
+        ParameterBag $headers,
+        ParameterBag $attributes,
+        CustomAcceptHeader $best
+    ) {
+        $formatNegotiator->getBest(null)->willReturn($best);
+        $headers->get('accept')->willReturn(null);
+        $best->getValue()->willReturn('application/json');
+
+        $event->getRequest()->willReturn($request);
+        $request->getMethod()->willReturn('POST');
+        $event->getRequestType()->willReturn(HttpKernelInterface::MASTER_REQUEST);
+
+        $request->attributes = $attributes;
+        $attributes->has(FOSRestBundle::ZONE_ATTRIBUTE)->willReturn(true);
+
+        $request->headers = $headers;
+        $headers->get('content-type', null)->willReturn('application/xml');
+
+        $this->shouldThrow(new NotAcceptableHttpException('"application/xml" in "Content-Type" header is not valid. Only "application/json" is allowed.'))
+            ->during('onKernelRequest', [$event]);
+    }
+
+    public function it_stops_if_uri_is_not_in_api(
+        $event,
+        $formatNegotiator,
+        ParameterBag $headers,
+        Request $request,
+        ParameterBag $attributes,
+        CustomAcceptHeader $best
+    ) {
+        $formatNegotiator->getBest('')->willThrow('FOS\RestBundle\Util\StopFormatListenerException');
+        $request->headers = $headers;
+        $headers->get('accept')->willReturn('');
+        $event->getRequest()->willReturn($request);
+        $event->getRequestType()->willReturn(HttpKernelInterface::MASTER_REQUEST);
+
+        $request->attributes = $attributes;
+        $attributes->has(FOSRestBundle::ZONE_ATTRIBUTE)->willReturn(true);
+
+        $best->getValue()->shouldNotBeCalled();
+        $request->getMethod()->shouldNotBeCalled();
+
+        $this->onKernelRequest($event)->shouldReturn(null);
+    }
+
+    public function it_returns_null_if_request_is_not_a_master_request(
+        $event,
+        $formatNegotiator,
+        ParameterBag $headers,
+        Request $request,
+        ParameterBag $attributes,
+        CustomAcceptHeader $best
+    ) {
+        $formatNegotiator->getBest('*/*')->willThrow('FOS\RestBundle\Util\StopFormatListenerException');
+        $headers->get('accept')->willReturn('*/*');
+        $event->getRequest()->willReturn($request);
+        $event->getRequestType()->willReturn(HttpKernelInterface::SUB_REQUEST);
+
+        $request->attributes = $attributes;
+        $attributes->has(FOSRestBundle::ZONE_ATTRIBUTE)->willReturn(true);
+
+        $best->getValue()->shouldNotBeCalled();
+        $request->getMethod()->shouldNotBeCalled();
+
+        $this->onKernelRequest($event)->shouldReturn(null);
+    }
+}
+
+interface CustomAcceptHeader extends AcceptHeader
+{
+    public function getValue();
+}

--- a/src/Pim/Bundle/ApiBundle/tests/integration/EventSubscriber/CheckHeadersRequestSubscriberIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/EventSubscriber/CheckHeadersRequestSubscriberIntegration.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Pim\Bundle\ApiBundle\tests\integration\EventSubscriber;
+
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+class CheckHeadersRequestSubscriberIntegration extends TestCase
+{
+    protected $purgeDatabaseForEachTest = false;
+
+    public function testErrorIfAcceptHeaderIsXml()
+    {
+        $client = static::createClient();
+
+        $client->request('GET', 'api/rest/v1/categories/master', [], [], ['HTTP_ACCEPT' => 'application/xml']);
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_NOT_ACCEPTABLE, $response->getStatusCode(), 'Header is not acceptable');
+        $content = json_decode($response->getContent(), true);
+        $this->assertCount(2, $content, 'Error response contains 2 items');
+        $this->assertSame(Response::HTTP_NOT_ACCEPTABLE, $content['code']);
+        $this->assertSame('"application/xml" in "Accept" header is not valid. Only "application/json" is allowed.', $content['message']);
+    }
+
+    public function testSuccessIfAcceptHeaderIsJson()
+    {
+        $client = static::createClient();
+
+        $client->request('GET', 'api/rest/v1/categories/master', [], [], ['HTTP_ACCEPT' => 'application/json']);
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode(), 'Header is acceptable');
+    }
+
+    public function testSuccessIfAcceptHeaderIsEmpty()
+    {
+        $client = static::createClient();
+
+        $client->request('GET', 'api/rest/v1/categories/master');
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode(), 'Header is acceptable');
+    }
+
+    public function testErrorIfContentTypeHeaderIsXml()
+    {
+        $client = static::createClient();
+
+        $client->request('POST', 'api/rest/v1/categories', [], [], [
+            'CONTENT_TYPE' => 'application/xml',
+        ], '{"code": "my_category"}');
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_NOT_ACCEPTABLE, $response->getStatusCode(), 'Header is not acceptable');
+        $content = json_decode($response->getContent(), true);
+        $this->assertCount(2, $content, 'Error response contains 2 items');
+        $this->assertSame(Response::HTTP_NOT_ACCEPTABLE, $content['code']);
+        $this->assertSame('"application/xml" in "Content-Type" header is not valid. Only "application/json" is allowed.', $content['message']);
+    }
+
+    public function testSuccessIfContentTypeHeaderIsJson()
+    {
+        $client = static::createClient();
+
+        $client->request('POST', 'api/rest/v1/categories', [], [], [
+            'CONTENT_TYPE' => 'application/json',
+        ], '{"code": "my_category"}');
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode(), 'Header is acceptable');
+    }
+
+    public function testSuccessIfContentTypeHeaderIsEmpty()
+    {
+        $client = static::createClient();
+
+        $client->request('POST', 'api/rest/v1/categories', [], [], [
+            'CONTENT_TYPE' => 'application/json'
+        ], '{"code": "my_category_1"}');
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode(), 'Header is acceptable');
+    }
+
+    public function testSuccessWhenRouteIsOutsideTheAPI()
+    {
+        $client = static::createClient();
+
+        $client->request('GET', '/');
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode(), 'Page is accessible without error');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return new Configuration(
+            [Configuration::getTechnicalCatalogPath()],
+            false
+        );
+    }
+}

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/bundles/fos_rest.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/bundles/fos_rest.yml
@@ -1,4 +1,7 @@
 fos_rest:
+    zone:
+        - { path: ^/api }
+        - { path: ^/(?!_profiler|_wdt) }
     view:
         failed_validation: HTTP_BAD_REQUEST
         default_engine: php
@@ -6,8 +9,8 @@ fos_rest:
             json: true
     format_listener:
         rules:
-            - { path: '', priorities: ['html', 'json'], fallback_format: html, prefer_extension: true }
             - { path: '^/api', priorities: ['json'], fallback_format: json, prefer_extension: true }
+            - { path: '', stop: true }
     body_listener:
         decoders:
             json: fos_rest.decoder.json


### PR DESCRIPTION
Valid headers in the API.
`Accept` (when you GET a resource) and `Content-Type` (when you POST/PATCH a resource) headers are not required in the API, but if one of them are in headers and are different than `application/json`, we throw a `NotAcceptableHttpException` (error 406).

Why do we accept `*/*` for a GET and `application/x-www-form-urlencoded` for POST & PATCH ?
These headers are added by Symfony, we cannot change that :)

--
Cannot merge this PR as long as there is not PATCH/POST action in the API, tests added in this PR are wrong
 

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | :white_check_mark: 
| Added Behats                      | :negative_squared_cross_mark:
| Added integration tests           | :white_check_mark:
| Changelog updated                 | :negative_squared_cross_mark:
| Review and 2 GTM                  | :clock1:
| Migration script                  | :negative_squared_cross_mark:
| Tech Doc                          | :negative_squared_cross_mark:


:white_check_mark: Done and pass

:red_circle: Done but fail

:clock1: Done but pending

:negative_squared_cross_mark: Not needed
