### PR TITLE
PIM-6107: Fix an issue where family code is not displayed

### DIFF
--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -2,6 +2,8 @@
 
 ## Bug fixes
 
+- PIM-5854: On MySQL, the family code is not displayed if the family label is empty
+- PIM-6107: On MongoDb, the family code is not displayed if the family label is empty
 - PIM-6064: Fix a grid issue with attribute named ID 
 - PIM-6092: Always allow to create new option on select2
 

--- a/features/import/import_families.feature
+++ b/features/import/import_families.feature
@@ -39,3 +39,25 @@ Feature: Import categories
       | code     | attributes                       | attribute_as_label | requirements-mobile | requirements-tablet         | label-en_US |
       | heels    | sku,name,manufacturer,heel_color | name               | sku,manufacturer    | sku,heel_color,manufacturer | Heels       |
       | tractors | sku,name,manufacturer            | name               | sku                 | sku                         | Tractor     |
+
+  @jira https://akeneo.atlassian.net/browse/PIM-6107
+  Scenario: Import an empty label should display the family code on the product datagrid
+    Given the "footwear" catalog configuration
+    And the following products:
+      | sku         | family |
+      | pretty-shoe | heels  |
+    And I am logged in as "Julia"
+    And the following CSV file to import:
+      """
+      code;attributes;attribute_as_label;requirements-mobile;requirements-tablet;label-en_US
+      heels;sku,name,manufacturer,heel_color;name;manufacturer;manufacturer,heel_color;
+      """
+    And the following job "footwear_family_import" configuration:
+      | filePath | %file to import% |
+    When I am on the "footwear_family_import" import job page
+    And I launch the import job
+    And I wait for the "footwear_family_import" job to finish
+    And I am on the products page
+    Then the row "pretty-shoe" should contain:
+      | column | value   |
+      | Family | [heels] |

--- a/spec/Pim/Bundle/CatalogBundle/Doctrine/ORM/Sorter/FamilySorterSpec.php
+++ b/spec/Pim/Bundle/CatalogBundle/Doctrine/ORM/Sorter/FamilySorterSpec.php
@@ -46,7 +46,7 @@ class FamilySorterSpec extends ObjectBehavior
         ;
         $qb
             ->addSelect(
-                'COALESCE(sorterfamilyTranslations.label, CONCAT(\'[\', sorterfamily.code, \']\')) as sorterfamilyLabel'
+                'COALESCE(NULLIF(sorterfamilyTranslations.label, \'\'), CONCAT(\'[\', sorterfamily.code, \']\')) as sorterfamilyLabel'
             )
             ->shouldBeCalled()
             ->willReturn($qb)

--- a/spec/Pim/Bundle/DataGridBundle/Datasource/ResultRecord/MongoDbOdm/Product/FamilyTransformerSpec.php
+++ b/spec/Pim/Bundle/DataGridBundle/Datasource/ResultRecord/MongoDbOdm/Product/FamilyTransformerSpec.php
@@ -38,4 +38,20 @@ class FamilyTransformerSpec extends ObjectBehavior
 
         $this->transform($result, $locale)->shouldReturn($expected);
     }
+
+    function it_transforms_product_family_label_if_empty(\MongoId $id)
+    {
+        $result = [
+            'normalizedData' => [
+                'family' => [
+                    'code' => 'expected-code',
+                    'label' => ['fr_FR' => ''],
+                ]
+            ]
+        ];
+
+        $expected = $result + ['familyLabel'  => '[expected-code]'];
+
+        $this->transform($result, 'fr_FR')->shouldReturn($expected);
+    }
 }

--- a/spec/Pim/Bundle/DataGridBundle/Extension/Selector/Orm/Product/FamilySelectorSpec.php
+++ b/spec/Pim/Bundle/DataGridBundle/Extension/Selector/Orm/Product/FamilySelectorSpec.php
@@ -10,17 +10,17 @@ use Prophecy\Argument;
 
 class FamilySelectorSpec extends ObjectBehavior
 {
-    function it_is_initializable()
+    public function it_is_initializable()
     {
         $this->shouldHaveType('Pim\Bundle\DataGridBundle\Extension\Selector\Orm\Product\FamilySelector');
     }
 
-    function it_is_a_selector()
+    public function it_is_a_selector()
     {
         $this->shouldImplement('Pim\Bundle\DataGridBundle\Extension\Selector\SelectorInterface');
     }
 
-    function it_applies_a_selector(
+    public function it_applies_a_selector(
         DatasourceInterface $datasource, 
         DatagridConfiguration $configuration,
         QueryBuilder $queryBuilder

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/AttributeRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/AttributeRepository.php
@@ -121,8 +121,8 @@ class AttributeRepository extends EntityRepository implements
         $qb = $this->createQueryBuilder('a');
         $qb
             ->select('a.id')
-            ->addSelect('COALESCE(at.label, CONCAT(\'[\', a.code, \']\')) as attribute_label')
-            ->addSelect('COALESCE(gt.label, CONCAT(\'[\', g.code, \']\')) as group_label')
+            ->addSelect('COALESCE(NULLIF(at.label, \'\'), CONCAT(\'[\', a.code, \']\')) as attribute_label')
+            ->addSelect('COALESCE(NULLIF(gt.label, \'\'), CONCAT(\'[\', g.code, \']\')) as group_label')
             ->leftJoin('a.translations', 'at', 'WITH', 'at.locale = :localeCode')
             ->leftJoin('a.group', 'g')
             ->leftJoin('g.translations', 'gt', 'WITH', 'gt.locale = :localeCode')
@@ -275,8 +275,8 @@ class AttributeRepository extends EntityRepository implements
         $results = $qb->getQuery()->execute([], AbstractQuery::HYDRATE_ARRAY);
 
         if ($withLabel) {
-            $labelExpr = 'COALESCE(trans.label, CONCAT(CONCAT(\'[\', att.code), \']\'))';
-            $groupLabelExpr = 'COALESCE(gtrans.label, CONCAT(CONCAT(\'[\', g.code), \']\'))';
+            $labelExpr = 'COALESCE(NULLIF(trans.label, \'\'), CONCAT(CONCAT(\'[\', att.code), \']\'))';
+            $groupLabelExpr = 'COALESCE(NULLIF(gtrans.label, \'\'), CONCAT(CONCAT(\'[\', g.code), \']\'))';
 
             $qb = $this->_em->createQueryBuilder()
                 ->select('att.code', sprintf('%s as label', $labelExpr))

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/FamilyRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/FamilyRepository.php
@@ -64,7 +64,7 @@ class FamilyRepository extends EntityRepository implements FamilyRepositoryInter
 
         $qb = $this->_em->createQueryBuilder()
             ->select('f.id')
-            ->addSelect('COALESCE(ft.label, CONCAT(\'[\', f.code, \']\')) as label')
+            ->addSelect('COALESCE(NULLIF(ft.label, \'\'), CONCAT(\'[\', f.code, \']\')) as label')
             ->from('Pim\Bundle\CatalogBundle\Entity\Family', 'f')
             ->leftJoin('f.translations', 'ft', 'WITH', 'ft.locale = :localeCode')
             ->orderBy('label')

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/GroupRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/GroupRepository.php
@@ -240,7 +240,7 @@ class GroupRepository extends EntityRepository implements GroupRepositoryInterfa
     public function getOptions($dataLocale, $collectionId = null, $search = '', array $options = [])
     {
         $qb = $this->createQueryBuilder('o')
-            ->select('o.id as id, COALESCE(t.label, CONCAT(\'[\', o.code, \']\')) as text')
+            ->select('o.id as id, COALESCE(NULLIF(t.label, \'\'), CONCAT(\'[\', o.code, \']\')) as text')
             ->leftJoin('o.translations', 't', 'WITH', 't.locale=:locale')
             ->addOrderBy('text', 'ASC')
             ->setParameter('locale', $dataLocale);

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Sorter/FamilySorter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Sorter/FamilySorter.php
@@ -49,7 +49,7 @@ class FamilySorter implements FieldSorterInterface
             ->leftJoin($rootAlias.'.family', $family)
             ->leftJoin($family.'.translations', $trans, 'WITH', $trans.'.locale = :dataLocale');
         $this->qb
-            ->addSelect('COALESCE('.$trans.'.label, CONCAT(\'[\', '.$family.'.code, \']\')) as '.$field);
+            ->addSelect('COALESCE(NULLIF('.$trans.'.label, \'\'), CONCAT(\'[\', '.$family.'.code, \']\')) as '.$field);
 
         $this->qb->addOrderBy($field, $direction);
 

--- a/src/Pim/Bundle/DataGridBundle/Datasource/ResultRecord/MongoDbOdm/Product/FamilyTransformer.php
+++ b/src/Pim/Bundle/DataGridBundle/Datasource/ResultRecord/MongoDbOdm/Product/FamilyTransformer.php
@@ -25,8 +25,12 @@ class FamilyTransformer
 
         if (isset($normalizedData['family'])) {
             $family = $normalizedData['family'];
-            $result['familyLabel'] = isset($family['label'][$locale]) ?
-                $family['label'][$locale] : '['.$family['code'].']';
+            $result['familyLabel'] = '['.$family['code'].']';
+
+            if (isset($family['label'][$locale]) && '' !== $family['label'][$locale]) {
+                $result['familyLabel'] = $family['label'][$locale];
+            }
+
             if (isset($family['attributeAsLabel']) && $family['attributeAsLabel'] !== null) {
                 $attributeCode = $family['attributeAsLabel'];
                 if (isset($result[$attributeCode])) {

--- a/src/Pim/Bundle/DataGridBundle/Extension/Selector/Orm/Product/FamilySelector.php
+++ b/src/Pim/Bundle/DataGridBundle/Extension/Selector/Orm/Product/FamilySelector.php
@@ -24,9 +24,7 @@ class FamilySelector implements SelectorInterface
 
         $datasource->getQueryBuilder()
             ->leftJoin($rootAlias.'.family', 'family')
-            ->leftJoin('family.translations', 'ft', 'WITH', 'ft.locale = :dataLocale');
-
-        $datasource->getQueryBuilder()
-            ->addSelect('COALESCE(ft.label, CONCAT(\'[\', family.code, \']\')) as familyLabel');
+            ->leftJoin('family.translations', 'ft', 'WITH', 'ft.locale = :dataLocale')
+            ->addSelect('COALESCE(NULLIF(ft.label, \'\'), CONCAT(\'[\', family.code, \']\')) as familyLabel');
     }
 }

--- a/src/Pim/Bundle/DataGridBundle/spec/Extension/Selector/Orm/Product/FamilySelectorSpec.php
+++ b/src/Pim/Bundle/DataGridBundle/spec/Extension/Selector/Orm/Product/FamilySelectorSpec.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace spec\Pim\Bundle\DataGridBundle\Extension\Selector\Orm\Product;
+
+use Doctrine\ORM\QueryBuilder;
+use Oro\Bundle\DataGridBundle\Datagrid\Common\DatagridConfiguration;
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\DataGridBundle\Datasource\DatasourceInterface;
+use Prophecy\Argument;
+
+class FamilySelectorSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Pim\Bundle\DataGridBundle\Extension\Selector\Orm\Product\FamilySelector');
+    }
+
+    function it_is_a_selector()
+    {
+        $this->shouldImplement('Pim\Bundle\DataGridBundle\Extension\Selector\SelectorInterface');
+    }
+
+    function it_applies_a_selector(
+        DatasourceInterface $datasource, 
+        DatagridConfiguration $configuration,
+        QueryBuilder $queryBuilder
+    ) {
+        $datasource->getQueryBuilder()->willReturn($queryBuilder);
+        $queryBuilder->getRootAlias()->willReturn('p');
+
+        $queryBuilder->leftJoin('p.family', 'family')->willReturn($queryBuilder);
+        $queryBuilder->leftJoin('family.translations', 'ft', 'WITH', 'ft.locale = :dataLocale')->willReturn($queryBuilder);
+        $queryBuilder->addSelect('COALESCE(NULLIF(ft.label, \'\'), CONCAT(\'[\', family.code, \']\')) as familyLabel')->shouldBeCalled();
+    
+        $this->apply($datasource, $configuration);
+    }
+}


### PR DESCRIPTION
# For reviewers

This is a backport of a 1.6 fix + an adaptation for mongo. What is to be reviewed is:
*  ̀CHANGELOG-1.5.md ̀
*  ̀features/import/import_families.feature ̀
*  ̀.../FamilyTransformer.php ̀
*  ̀.../FamilyTransformerSpec.php ̀

The issue is that, in some cases we store empty labels during import and only took care of the `null` case. Now we also check that the label is not empty when we replace it by the code.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | :negative_squared_cross_mark:
| Added Behats                      | :white_check_mark:
| Added integration tests           | :negative_squared_cross_mark:
| Changelog updated                 | :white_check_mark:
| Review and 2 GTM                  | :clock1:
| Micro Demo to the PO (Story only) | :clock1:
| Migration script                  | :negative_squared_cross_mark:
| Tech Doc                          | :negative_squared_cross_mark:
