### PR TITLE
CsvEncoder: close resource after reading content

### DIFF
--- a/src/Pim/Component/Connector/Encoder/CsvEncoder.php
+++ b/src/Pim/Component/Connector/Encoder/CsvEncoder.php
@@ -52,7 +52,7 @@ class CsvEncoder implements EncoderInterface
 
         $this->initializeContext($context);
 
-        $output = fopen('php://temp', 'r+');
+        $output = fopen('php://temp', 'r+b');
 
         $first = reset($data);
         if (isset($first) && is_array($first)) {
@@ -71,7 +71,10 @@ class CsvEncoder implements EncoderInterface
             $this->write($output, $data, $this->delimiter, $this->enclosure);
         }
 
-        return $this->readCsv($output);
+        $content = $this->readCsv($output);
+        fclose($output);
+
+        return $content;
     }
 
     /**


### PR DESCRIPTION
If we don't close the file handler, we could have unexpected behavior on multiple use of this encoder.
