### PR TITLE
PIM-6110: Saving a product value clear the saved associations

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -1,3 +1,9 @@
+# 1.6.x
+
+## Bug fixes
+
+- PIM-6110: Saving a product value clear the saved associations
+
 # 1.6.8 (2017-01-05)
 
 ## Bug fixes

--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -2,7 +2,7 @@
 
 ## Bug fixes
 
-- PIM-6110: Saving a product value clear the saved associations
+- PIM-6110: Saving a product value clears the saved associations
 
 # 1.6.8 (2017-01-05)
 

--- a/features/product/associate_product.feature
+++ b/features/product/associate_product.feature
@@ -194,3 +194,16 @@ Feature: Associate a product
     And I should see the text "Type: [RELATED]"
     When I press the "Show products" button
     Then I should see the text "SKU: Contains \"gr\""
+
+  @jira https://akeneo.atlassian.net/browse/PIM-6110
+  Scenario: Product associations are not erased when an attribute is saved
+    Given I edit the "charcoal-boots" product
+    When I visit the "Associations" tab
+    And I check the row "gray-boots"
+    And I save the product
+    And I visit the "Attributes" tab
+    And I add available attributes Name
+    When I fill in "Name" with "test"
+    And I save the product
+    And I visit the "Associations" tab
+    Then the rows "gray-boots" should be checked

--- a/features/product/associate_product.feature
+++ b/features/product/associate_product.feature
@@ -203,7 +203,7 @@ Feature: Associate a product
     And I save the product
     And I visit the "Attributes" tab
     And I add available attributes Name
-    When I fill in "Name" with "test"
+    And I fill in "Name" with "test"
     And I save the product
     And I visit the "Associations" tab
     Then the rows "gray-boots" should be checked

--- a/src/Pim/Component/Catalog/Updater/Setter/AssociationFieldSetter.php
+++ b/src/Pim/Component/Catalog/Updater/Setter/AssociationFieldSetter.php
@@ -98,10 +98,14 @@ class AssociationFieldSetter extends AbstractFieldSetter
             ->forAll(function ($key, AssociationInterface $association) use ($data) {
                 $currentData = $data[$association->getAssociationType()->getCode()];
                 if (isset($currentData['products'])) {
-                    $association->getProducts()->clear();
+                    foreach ($association->getProducts() as $productToRemove) {
+                        $association->removeProduct($productToRemove);
+                    }
                 }
                 if (isset($currentData['groups'])) {
-                    $association->getGroups()->clear();
+                    foreach ($association->getGroups() as $groupToRemove) {
+                        $association->removeGroup($groupToRemove);
+                    }
                 }
 
                 return true;


### PR DESCRIPTION
# Note

This fix follow the @anaelChardan Fix on association import that broke the associations when you try to save the product from the UI. cf https://github.com/akeneo/pim-community-dev/pull/5397

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | :white_check_mark: 
| Added Behats                      | :white_check_mark:
| Added integration tests           | :negative_squared_cross_mark:
| Changelog updated                 | :white_check_mark:
| Review and 2 GTM                  | :white_check_mark:
| Micro Demo to the PO (Story only) | :clock1:
| Migration script                  | :negative_squared_cross_mark:
| Tech Doc                          | :negative_squared_cross_mark: