### PR TITLE
Don't return form extensions by reference

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/registry.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/registry.js
@@ -25,8 +25,9 @@ define(
         var getExtensionMeta = function (formName) {
             return ConfigProvider.getExtensionMap().then(function (extensionMap) {
                 var form = _.findWhere(extensionMap, { code: formName });
+                var extensions = _.where(extensionMap, { parent: form.code });
 
-                return _.where(extensionMap, { parent: form.code });
+                return $.extend(true, {}, extensions);
             });
         };
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

I already had the problem that multiple extensions of the same module were sent by reference, which is a problem.
Maybe we should put some const of something, but this code was fixing my problem.

I make this PR to have the fix somewhere, it can be merged/discussed.
