### PR TITLE
AMS-6: Add gherkin to click on icon button

### DIFF
--- a/features/Context/Page/Base/Base.php
+++ b/features/Context/Page/Base/Base.php
@@ -7,6 +7,7 @@ use Behat\Mink\Exception\ElementNotFoundException;
 use Behat\Mink\Exception\UnsupportedDriverActionException;
 use Context\FeatureContext;
 use Context\Spin\SpinCapableTrait;
+use Context\Traits\ClosestTrait;
 use Pim\Behat\Decorator\ElementDecorator;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Element;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Page;
@@ -21,6 +22,7 @@ use SensioLabs\Behat\PageObjectExtension\PageObject\Page;
 class Base extends Page
 {
     use SpinCapableTrait;
+    use ClosestTrait;
 
     protected $elements = [
         'Body'             => ['css' => 'body'],
@@ -233,6 +235,25 @@ class Base extends Page
             // Use Mink search, which use "contains" xpath condition
             $button = $this->findButton($locator);
         }
+        return $button;
+    }
+
+    /**
+     * Get icon button
+     *
+     * @param string  $locator
+     *
+     * @return NodeElement|null
+     */
+    public function getIconButton($locator)
+    {
+        $button = null;
+        $icon = $this->find('css', sprintf('i[data-original-title="%s"]', $locator));
+
+        if (null !== $icon) {
+            $button = $this->getClosest($icon, 'AknIconButton');
+        }
+
         return $button;
     }
 

--- a/features/Context/WebUser.php
+++ b/features/Context/WebUser.php
@@ -1428,6 +1428,18 @@ class WebUser extends RawMinkContext
     }
 
     /**
+     * @param string $button
+     *
+     * @Given /^I should not see the "([^"]*)" icon button$/
+     */
+    public function iShouldNotSeeTheIconButton($button)
+    {
+        $this->spin(function () use ($button) {
+            return null === $this->getCurrentPage()->getIconButton($button);
+        }, sprintf('Icon button "%s" should not be displayed', $button));
+    }
+
+    /**
      * @param string $buttonLabel
      *
      * @Given /^I press the "([^"]*)" button in the popin$/


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

For now we have gherkin to click on buttons, but we have icon button components that can only be identified with their on-hover title.
This method allows to retrieve them.
