### PR TITLE
API-63: Manage the access to the web API

### DIFF
--- a/features/Context/Page/Role/Edit.php
+++ b/features/Context/Page/Role/Edit.php
@@ -31,6 +31,12 @@ class Edit extends Form
                         'Pim\Behat\Decorator\Permission\PermissionDecorator'
                     ]
                 ],
+                'API permission' => [
+                    'css'        => '#rights-api',
+                    'decorators' => [
+                        'Pim\Behat\Decorator\Permission\PermissionDecorator'
+                    ]
+                ],
             ],
             $this->elements
         );

--- a/features/Pim/Behat/Context/Domain/System/PermissionsContext.php
+++ b/features/Pim/Behat/Context/Domain/System/PermissionsContext.php
@@ -11,13 +11,15 @@ class PermissionsContext extends PimContext
 {
     /**
      * @param string $action
+     * @param string $api
+     * @param string $type
      * @param string $acls
      *
      * @throws \InvalidArgumentException If $action is not a defined method
      *
-     * @When /^I (grant|revoke) rights to (resources?|groups?) (.*)$/
+     * @When /^I (grant|revoke) rights to( API)? (resources?|groups?) (.*)$/
      */
-    public function iSetRightsToACL($action, $type, $acls)
+    public function iSetRightsToACL($action, $api, $type, $acls)
     {
         if (false !== strpos($type, 'resource')) {
             $type = 'Resource';
@@ -25,7 +27,8 @@ class PermissionsContext extends PimContext
             $type = 'Group';
         }
 
-        $permissionElement = $this->getCurrentPage()->getElement('Permission');
+        $element = $api ? 'API permission' : 'Permission';
+        $permissionElement = $this->getCurrentPage()->getElement($element);
         switch ($action) {
             case 'grant':
                 $method = 'grant' . $type;
@@ -53,5 +56,35 @@ class PermissionsContext extends PimContext
         $this->getSession()->executeScript(
             sprintf('$("%s").each(function () { $(this).click(); });', $iconSelector)
         );
+    }
+
+    /**
+     * @param string $api
+     * @param string $acls
+     * @param string $action
+     *
+     * @throws \InvalidArgumentException If $action is not a defined method
+     *
+     * @When /^I should see( API)? resources? (.*) (granted|revoked)$/
+     */
+    public function iShouldSeeRightsOnACL($api, $acls, $action)
+    {
+        $element = $api ? 'API permission' : 'Permission';
+        $permissionElement = $this->getCurrentPage()->getElement($element);
+        switch ($action) {
+            case 'granted':
+                $method = 'isGrantedResource';
+                break;
+            case 'revoked':
+                $method = 'isRevokedResource';
+                break;
+            default:
+                throw new \InvalidArgumentException(sprintf('Action "%s" does not exist.', $action));
+                break;
+        }
+
+        foreach ($this->listToArray($acls) as $acl) {
+            $permissionElement->$method($acl);
+        }
     }
 }

--- a/features/Pim/Behat/Decorator/Permission/PermissionDecorator.php
+++ b/features/Pim/Behat/Decorator/Permission/PermissionDecorator.php
@@ -109,6 +109,26 @@ class PermissionDecorator extends ElementDecorator
     }
 
     /**
+     * @param string $resource
+     *
+     * @return bool
+     */
+    public function isGrantedResource($resource)
+    {
+        return $this->findResource($resource)->hasClass('granted');
+    }
+
+    /**
+     * @param string $resource
+     *
+     * @return bool
+     */
+    public function isRevokedResource($resource)
+    {
+        return $this->findResource($resource)->hasClass('non-granted');
+    }
+
+    /**
      * @param NodeElement $resource
      */
     public function toggleResource(NodeElement $resource)

--- a/features/api/acl/assert_acl.feature
+++ b/features/api/acl/assert_acl.feature
@@ -1,0 +1,17 @@
+@javascript
+Feature: Define user rights on the web API
+  In order to assign or remove some rights to a group of users
+  As an administrator
+  I need to be able to assign/remove rights
+
+  @info here we check only if ACLs on "Web API permissions" are saved. Check on access resources are done in integration tests
+  Scenario: Successfully edit and apply user rights on web API
+    Given a "default" catalog configuration
+    And I am logged in as "Peter"
+    When I am on the "Administrator" role page
+    And I visit the "Web API permissions" tab
+    Then I revoke rights to API resource Web API permissions
+    And I save the role
+    When I am on the "Administrator" role page
+    And I visit the "Web API permissions" tab
+    Then I should see API resource Web API permissions revoked

--- a/src/Pim/Bundle/ApiBundle/Resources/config/acl.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/acl.yml
@@ -1,0 +1,5 @@
+# API
+pim_api_overall_access:
+    type: action
+    label: pim_api.acl.rights
+    group_name: pim_api.acl_group.overall_access

--- a/src/Pim/Bundle/ApiBundle/Resources/config/acl_groups.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/acl_groups.yml
@@ -1,0 +1,3 @@
+pim_api.acl_group.overall_access:
+    order: 10
+    permission_group: api

--- a/src/Pim/Bundle/ApiBundle/Resources/translations/messages.en.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/translations/messages.en.yml
@@ -1,0 +1,7 @@
+pim_api:
+    acl:
+        rights: Web API permissions
+    acl_group:
+        overall_access: Overall Web API access
+
+rights.api: Web API permissions

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/bundles/oro_user.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/bundles/oro_user.yml
@@ -10,3 +10,10 @@ oro_user:
             field_type: pim_acl_access_level_selector
             default_value: 5
             show_default: true
+        api:
+            label: pim_api.acl.rights
+            view_type: groups
+            types: [action]
+            field_type: pim_acl_access_level_selector
+            default_value: 5
+            show_default: true

--- a/src/Pim/Bundle/UserBundle/Resources/views/Role/update.html.twig
+++ b/src/Pim/Bundle/UserBundle/Resources/views/Role/update.html.twig
@@ -134,22 +134,23 @@
                 {% set groups = acl_groups() %}
 
                 {% for privilegeBlock, privilegeConfig in privilegesConfig %}
-                    <div class="tab-pane" id="rights-{{ privilegeBlock }}">
+                    {% if groups[privilegeBlock] is defined %}
+                        <div class="tab-pane" id="rights-{{ privilegeBlock }}">
                         <div class="tabs-left">
                             {% if 'groups' == privilegeConfig.view_type %}
                                 <ul class="AknVerticalNavtab AknVerticalNavtab--condensed nav nav-list">
                                     <li class="AknVerticalNavtab-item AknVerticalNavtab-header"></li>
-                                    {% for group in groups %}
+                                    {% for group in groups[privilegeBlock] %}
                                         <li class="AknVerticalNavtab-item tab{{ loop.index == 1 ? ' active' : '' }}">
-                                            <a class="AknVerticalNavtab-link" href="#tabs-{{ group|replace({' ': '-', '.': '-'})|lower }}" data-toggle="tab">
+                                            <a class="AknVerticalNavtab-link" href="#tabs-{{ group.name|replace({' ': '-', '.': '-'})|lower }}" data-toggle="tab">
                                                 <span class="AknAcl">
                                                     <i class="AknAcl-icon acl-group-permission-toggle"></i>
-                                                    <span>{{ group|trans }}</span>
+                                                    <span>{{ group.name|trans }}</span>
                                                 </span>
                                             </a>
                                         </li>
                                     {% endfor %}
-                                    {% for child in form[privilegeBlock].children|reverse if child.vars.value.group not in groups and child.vars.value.extensionKey == 'entity' and child.vars.value.identity.name != '(default)' %}
+                                    {% for child in form[privilegeBlock].children|reverse if child.vars.value.group not in groups[privilegeBlock] and child.vars.value.extensionKey == 'entity' and child.vars.value.identity.name != '(default)' %}
                                         {% set groupName = 'oro_security.acl_group.' ~ child.vars.value.identity.name|lower %}
                                         <li class="AknVerticalNavtab-item tab">
                                             <a class="AknVerticalNavtab-link" href="#tabs-{{ groupName|replace({' ': '-', '.': '-'}) }}" data-toggle="tab">
@@ -160,23 +161,25 @@
                                             </a>
                                         </li>
                                     {% endfor %}
-                                    <li class="AknVerticalNavtab-item tab">
-                                        <a class="AknVerticalNavtab-link" href="#tabs-group-system" data-toggle="tab">
-                                            <span class="AknAcl">
-                                                <i class="AknAcl-icon acl-group-permission-toggle"></i>
-                                                <span>{{ 'System'|trans }}</span>
-                                            </span>
-                                        </a>
-                                    </li>
+                                    {% if 'action' == privilegeBlock %}
+                                        <li class="AknVerticalNavtab-item tab">
+                                            <a class="AknVerticalNavtab-link" href="#tabs-group-system" data-toggle="tab">
+                                                <span class="AknAcl">
+                                                    <i class="AknAcl-icon acl-group-permission-toggle"></i>
+                                                    <span>{{ 'System'|trans }}</span>
+                                                </span>
+                                            </a>
+                                        </li>
+                                    {% endif %}
                                 </ul>
                                 <div class="AknTabContainer-content tab-content">
-                                    {% for group in groups %}
-                                        <div id="tabs-{{ group|replace({' ': '-', '.': '-'})|lower }}" class="tab-pane fullheight">
+                                    {% for group in groups[privilegeBlock] %}
+                                        <div id="tabs-{{ group.name|replace({' ': '-', '.': '-'})|lower }}" class="tab-pane fullheight">
                                             <div class="AknTabHeader">
-                                                <h3 class="AknTabHeader-title">{{ group|trans }}</h3>
+                                                <h3 class="AknTabHeader-title">{{ group.name|trans }}</h3>
                                             </div>
                                             <div class="AknFormContainer AknFormContainer--withPadding acl-group">
-                                                {% for child in form[privilegeBlock].children if child.vars.value.group == group %}
+                                                {% for child in form[privilegeBlock].children if child.vars.value.group == group.name %}
                                                     {{ form_widget(child) }}
                                                 {% endfor %}
                                             </div>
@@ -193,22 +196,25 @@
                                             </div>
                                         </div>
                                     {% endfor %}
-                                    <div id="tabs-group-system" class="tab-pane fullheight">
-                                        <div class="AknTabHeader">
-                                            <h3 class="AknTabHeader-title">{{ 'System'|trans }}</h3>
+                                    {% if 'action' == privilegeBlock %}
+                                        <div id="tabs-group-system" class="tab-pane fullheight">
+                                            <div class="AknTabHeader">
+                                                <h3 class="AknTabHeader-title">{{ 'System'|trans }}</h3>
+                                            </div>
+                                            <div class="AknFormContainer AknFormContainer--withPadding acl-group">
+                                                {% for child in form[privilegeBlock].children if child.vars.value.group not in groups and (child.vars.value.extensionKey != 'entity' or child.vars.value.identity.name == '(default)') %}
+                                                    {{ form_widget(child) }}
+                                                {% endfor %}
+                                            </div>
                                         </div>
-                                        <div class="AknFormContainer AknFormContainer--withPadding acl-group">
-                                            {% for child in form[privilegeBlock].children if child.vars.value.group not in groups and (child.vars.value.extensionKey != 'entity' or child.vars.value.identity.name == '(default)') %}
-                                                {{ form_widget(child) }}
-                                            {% endfor %}
-                                        </div>
-                                    </div>
+                                    {% endif %}
                                 </div>
                             </div>
                         {% else %}
                             {{ form_widget(form[privilegeBlock]) }}
                         {% endif %}
                     </div>
+                    {% endif %}
                 {% endfor %}
 
                 <div class="AknTabContainer-content tab-pane" id="users">

--- a/src/Pim/Bundle/UserBundle/Twig/AclGroupsExtension.php
+++ b/src/Pim/Bundle/UserBundle/Twig/AclGroupsExtension.php
@@ -58,28 +58,23 @@ class AclGroupsExtension extends \Twig_Extension
             }
         }
 
-        return $this->getSortedGroupNames($config);
+        return $this->getSortedGroups($config);
     }
 
     /**
-     * Sort the groups by their order and return the names.
+     * Sort the groups by their order.
      * If no order is defined for a group, it will be added after the others
      *
      * @param array $config
      *
-     * @return string[]
+     * @return array
      */
-    protected function getSortedGroupNames($config)
+    protected function getSortedGroups($config)
     {
         $groups = $this->getGroups($config);
-        $groups = $this->sortGroups($groups);
+        $groups= $this->sortGroups($groups);
 
-        $groupNames = [];
-        foreach ($groups as $group) {
-            $groupNames[] = $group['name'];
-        }
-
-        return $groupNames;
+        return $groups;
     }
 
     /**
@@ -91,7 +86,9 @@ class AclGroupsExtension extends \Twig_Extension
     {
         $groups = [];
         foreach ($config as $groupName => $groupConfig) {
-            $groups[] = [
+            $permissionGroup = isset($groupConfig['permission_group']) ? $groupConfig['permission_group'] : 'action';
+
+            $groups[$permissionGroup][] = [
                 'name'  => $groupName,
                 'order' => isset($groupConfig['order']) ? $groupConfig['order'] : -1
             ];
@@ -107,20 +104,22 @@ class AclGroupsExtension extends \Twig_Extension
      */
     protected function sortGroups(array $groups)
     {
-        usort(
-            $groups,
-            function ($first, $second) {
-                if ($first['order'] === $second['order']) {
-                    return 0;
-                }
+        foreach ($groups as $permissionGroup => $group) {
+            usort(
+                $groups[$permissionGroup],
+                function ($first, $second) {
+                    if ($first['order'] === $second['order']) {
+                        return 0;
+                    }
 
-                if ($first['order'] === -1 || $second['order'] === -1) {
-                    return ($first['order'] < $second['order']) ? 1 : -1;
-                }
+                    if ($first['order'] === -1 || $second['order'] === -1) {
+                        return ($first['order'] < $second['order']) ? 1 : -1;
+                    }
 
-                return ($first['order'] < $second['order']) ? -1 : 1;
-            }
-        );
+                    return ($first['order'] < $second['order']) ? -1 : 1;
+                }
+            );
+        }
 
         return $groups;
     }


### PR DESCRIPTION
To manage permissions on API (and correctly separate web API ACL from the UI ACL), we have to create a new tab on role form.

![default_overall_api_access](https://cloud.githubusercontent.com/assets/1131230/21980770/d7fd9d8e-dbe4-11e6-893d-8906bac9e86c.png)

Behat has been added to be sure the behavior works as expected, but ACLs will be really check on integration tests (in an other PR, when authentication will be done), not in behat.


**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | :negative_squared_cross_mark:
| Added Behats                      | :white_check_mark: 
| Added integration tests           | :negative_squared_cross_mark:
| Changelog updated                 | :negative_squared_cross_mark:
| Review and 2 GTM                  | :clock1:
| Migration script                  | :negative_squared_cross_mark:
| Tech Doc                          | :negative_squared_cross_mark:


:white_check_mark: Done and pass

:red_circle: Done but fail

:clock1: Done but pending

:negative_squared_cross_mark: Not needed
