### PR TITLE
Fixed a fatal error when using denormalization of ref data on fixture jobs

### DIFF
--- a/src/Pim/Component/Connector/Processor/Denormalization/AbstractProcessor.php
+++ b/src/Pim/Component/Connector/Processor/Denormalization/AbstractProcessor.php
@@ -112,13 +112,16 @@ abstract class AbstractProcessor implements StepExecutionAwareInterface
         ConstraintViolationListInterface $violations,
         \Exception $previousException = null
     ) {
+        $lineNumber = null;
         if ($this->stepExecution) {
             $this->stepExecution->incrementSummaryInfo('skip');
+
+            $lineNumber = ($this->stepExecution->getSummaryInfo('read_lines') + 1);
         }
 
         throw new InvalidItemFromViolationsException(
             $violations,
-            new FileInvalidItem($item, ($this->stepExecution->getSummaryInfo('read_lines') + 1)),
+            new FileInvalidItem($item, $lineNumber),
             [],
             0,
             $previousException

--- a/src/Pim/Component/Connector/Processor/Denormalization/AbstractProcessor.php
+++ b/src/Pim/Component/Connector/Processor/Denormalization/AbstractProcessor.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Component\Connector\Processor\Denormalization;
 
+use Akeneo\Component\Batch\Item\DataInvalidItem;
 use Akeneo\Component\Batch\Item\FileInvalidItem;
 use Akeneo\Component\Batch\Item\InvalidItemException;
 use Akeneo\Component\Batch\Item\ItemProcessorInterface;
@@ -112,16 +113,17 @@ abstract class AbstractProcessor implements StepExecutionAwareInterface
         ConstraintViolationListInterface $violations,
         \Exception $previousException = null
     ) {
-        $lineNumber = null;
         if ($this->stepExecution) {
             $this->stepExecution->incrementSummaryInfo('skip');
 
-            $lineNumber = ($this->stepExecution->getSummaryInfo('read_lines') + 1);
+            $invalidItem = new FileInvalidItem($item, $this->stepExecution->getSummaryInfo('read_lines') + 1);
+        } else {
+            $invalidItem = new DataInvalidItem($item);
         }
 
         throw new InvalidItemFromViolationsException(
             $violations,
-            new FileInvalidItem($item, $lineNumber),
+            $invalidItem,
             [],
             0,
             $previousException


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

```
                                                                  
  [Symfony\Component\Debug\Exception\FatalThrowableError]          
  Fatal error: Call to a member function getSummaryInfo() on null  
                                                                   


Exception trace:
 () at /.../vendor/akeneo/pim-community-dev/src/Pim/Component/Connector/Processor/Denormalization/AbstractProcessor.php:121
 Pim\Component\Connector\Processor\Denormalization\AbstractProcessor->skipItemWithConstraintViolations() at /../vendor/akeneo/pim-community-dev/src/Pim/Component/Connector/Processor/Denormalization/JobInstanceProcessor.php:105
 Pim\Component\Connector\Processor\Denormalization\JobInstanceProcessor->process() at /.../vendor/akeneo/pim-community-dev/src/Pim/Bundle/InstallerBundle/FixtureLoader/JobInstancesBuilder.php:111
 Pim\Bundle\InstallerBundle\FixtureLoader\JobInstancesBuilder->buildJobInstances() at /.../vendor/akeneo/pim-community-dev/src/Pim/Bundle/InstallerBundle/FixtureLoader/JobInstancesBuilder.php:60
 Pim\Bundle\InstallerBundle\FixtureLoader\JobInstancesBuilder->build() at /.../vendor/akeneo/pim-community-dev/src/Pim/Bundle/InstallerBundle/FixtureLoader/FixtureJobLoader.php:60
 Pim\Bundle\InstallerBundle\FixtureLoader\FixtureJobLoader->loadJobInstances() at /.../vendor/akeneo/pim-community-dev/src/Pim/Bundle/InstallerBundle/Command/DatabaseCommand.php:154
 Pim\Bundle\InstallerBundle\Command\DatabaseCommand->loadFixturesStep() at /.../vendor/akeneo/pim-community-dev/src/Pim/Bundle/InstallerBundle/Command/DatabaseCommand.php:108
 Pim\Bundle\InstallerBundle\Command\DatabaseCommand->execute() at /.../vendor/symfony/symfony/src/Symfony/Component/Console/Command/Command.php:259
 Symfony\Component\Console\Command\Command->run() at /.../vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:886
 Symfony\Component\Console\Application->doRunCommand() at /.../vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:195
 Symfony\Component\Console\Application->doRun() at /.../vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Console/Application.php:96
 Symfony\Bundle\FrameworkBundle\Console\Application->doRun() at /.../vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:126
 Symfony\Component\Console\Application->run() at /.../vendor/akeneo/pim-community-dev/src/Pim/Bundle/InstallerBundle/CommandExecutor.php:60
 Pim\Bundle\InstallerBundle\CommandExecutor->runCommand() at /.../vendor/akeneo/pim-community-dev/src/Pim/Bundle/InstallerBundle/Command/InstallCommand.php:121
 Pim\Bundle\InstallerBundle\Command\InstallCommand->databaseStep() at /.../vendor/akeneo/pim-community-dev/src/Pim/Bundle/InstallerBundle/Command/InstallCommand.php:77
 Pim\Bundle\InstallerBundle\Command\InstallCommand->execute() at /.../vendor/symfony/symfony/src/Symfony/Component/Console/Command/Command.php:259
 Symfony\Component\Console\Command\Command->run() at /.../vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:886
 Symfony\Component\Console\Application->doRunCommand() at /.../vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:195
 Symfony\Component\Console\Application->doRun() at /.../vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Console/Application.php:96
 Symfony\Bundle\FrameworkBundle\Console\Application->doRun() at /.../vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:126
 Symfony\Component\Console\Application->run() at /.../app/console:29
```

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | :white_check_mark: :red_circle: :negative_squared_cross_mark: :clock1:
| Added Behats                      | :white_check_mark: :red_circle: :negative_squared_cross_mark: :clock1:
| Added integration tests           | :white_check_mark: :red_circle: :negative_squared_cross_mark: :clock1:
| Changelog updated                 | :white_check_mark: :red_circle: :negative_squared_cross_mark: :clock1:
| Review and 2 GTM                  | :white_check_mark: :red_circle: :negative_squared_cross_mark: :clock1:
| Micro Demo to the PO (Story only) | :white_check_mark: :red_circle: :negative_squared_cross_mark: :clock1:
| Migration script                  | :white_check_mark: :red_circle: :negative_squared_cross_mark: :clock1:
| Tech Doc                          | :white_check_mark: :red_circle: :negative_squared_cross_mark: :clock1:


:white_check_mark: Done and pass

:red_circle: Done but fail

:clock1: Done but pending

:negative_squared_cross_mark: Not needed
