### PR TITLE
TIP-682: Update to Symfony 2.7.23

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -32,6 +32,7 @@
 - TIP-667: Introduce a product value factory service to instanciate product values.
 - GITHUB-5391: Redo association type edit form using backbonejs architecture and internal REST API
 - TIP-652: Redo the import/export screens in new PEF architecture
+- TIP-682: Update to Symfony 2.7.23
 
 ## BC breaks
 - Change the constructor of `Pim\Component\Catalog\Denormalizer\Standard\ProductValueDenormalizer` to add `Pim\Component\Catalog\Factory\ProductValueFactory`

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -7,7 +7,7 @@ imports:
 framework:
     #esi:             ~
     translator:      { fallback: en }
-    secret:          %secret%
+    secret:          "%secret%"
     router:
         resource: "%kernel.root_dir%/config/routing.yml"
         strict_requirements: "%kernel.debug%"
@@ -18,8 +18,8 @@ framework:
         enabled: true
         api: 2.5
     templating:      { engines: ['twig', 'php'] } #assets_version: SomeVersionScheme
-    default_locale:           "%locale%"
-    trusted_proxies:          ~
+    default_locale:  "%locale%"
+    trusted_proxies: ~
     session:
         name:                 BAPID
         handler_id:           session.handler.pdo

--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -12,12 +12,16 @@ web_profiler:
 monolog:
     handlers:
         main:
-            type:  stream
-            path:  "%kernel.logs_dir%/%kernel.environment%.log"
-            level: debug
+            type:     stream
+            path:     "%kernel.logs_dir%/%kernel.environment%.log"
+            level:    debug
+            channels: [!event]
         firephp:
-            type:  firephp
-            level: info
+            type:     firephp
+            level:    info
+        console:
+            type:     console
+            channels: [!event, !doctrine]
 
 oro_assetic:
     css_debug:      ~

--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -41,7 +41,7 @@ pim_api:
 # Oro platform
 
 oro_default:
-    pattern:  /
+    path:  /
     defaults:
         template:    PimDashboardBundle:Dashboard:index.html.twig
         _controller: FrameworkBundle:Template:template

--- a/composer.json
+++ b/composer.json
@@ -42,21 +42,21 @@
         "jms/serializer-bundle": "1.0.0",
         "knplabs/knp-menu": "2.0.1",
         "knplabs/knp-menu-bundle": "2.0.0",
-        "kriswallsmith/assetic": "1.1.3",
+        "kriswallsmith/assetic": "1.4.0",
         "leafo/lessphp": "0.5.0",
         "league/flysystem": "1.0.11",
         "league/flysystem-ziparchive": "1.0.2",
         "liip/imagine-bundle": "1.3.0",
         "imagine/imagine": "0.6.2",
-        "monolog/monolog": "1.18.2",
+        "monolog/monolog": "1.22.0",
         "oneup/flysystem-bundle": "1.1.0",
-        "sensio/distribution-bundle": "~4.0",
-        "sensio/framework-extra-bundle": "~3.0,>=3.0.2",
-        "sensio/generator-bundle": "2.3.5",
-        "symfony/assetic-bundle": "2.3.1",
-        "symfony/monolog-bundle": "2.10.0",
-        "symfony/swiftmailer-bundle": "2.3.8",
-        "symfony/symfony": "2.7.2",
+        "sensio/distribution-bundle": "4.0.38",
+        "sensio/framework-extra-bundle": "3.0.19",
+        "sensio/generator-bundle": "2.5.3",
+        "symfony/assetic-bundle": "2.8.1",
+        "symfony/monolog-bundle": "2.12.1",
+        "symfony/swiftmailer-bundle": "2.4.2",
+        "symfony/symfony": "2.7.23",
         "twig/extensions": "1.2.0",
         "box/spout": "2.5.0"
     },
@@ -76,8 +76,8 @@
         "behat/transliterator":"1.0.1",
         "doctrine/mongodb-odm-bundle": "3.2.0",
         "sensiolabs/behat-page-object-extension": "1.0.1",
-        "phpspec/phpspec": "3.0.0",
-        "akeneo/phpspec-skip-example-extension": "2.0.0",
+        "phpspec/phpspec": "3.0.*",
+        "akeneo/phpspec-skip-example-extension": "2.0.*",
         "akeneo/php-coupling-detector": "dev-master"
     },
     "suggest": {
@@ -85,7 +85,7 @@
         "akeneo/catalogs": "In order to install one of the Akeneo catalogs"
     },
     "scripts": {
-        "post-install-cmd": [
+        "symfony-scripts": [
             "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::buildBootstrap",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::clearCache",
@@ -95,15 +95,11 @@
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::prepareDeploymentTarget",
             "php app/console fos:js-routing:dump --target=web/js/routes.js"
         ],
+        "post-install-cmd": [
+            "@symfony-scripts"
+        ],
         "post-update-cmd": [
-            "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters",
-            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::buildBootstrap",
-            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::clearCache",
-            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installAssets",
-            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installRequirementsFile",
-            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::removeSymfonyStandardFiles",
-            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::prepareDeploymentTarget",
-            "php app/console fos:js-routing:dump --target=web/js/routes.js"
+            "@symfony-scripts"
         ]
     },
     "config": {

--- a/src/Oro/Bundle/FilterBundle/Filter/AbstractFilter.php
+++ b/src/Oro/Bundle/FilterBundle/Filter/AbstractFilter.php
@@ -82,7 +82,7 @@ abstract class AbstractFilter implements FilterInterface
         $operatorChoices = $formBuilderType->getOption('choices');
 
         $choices = [];
-        foreach ($operatorChoices as $key => $choice) {
+        foreach ($operatorChoices as $choice => $key) {
             $choices[] = new ChoiceView($key, (string) $key, $choice);
         }
 

--- a/src/Oro/Bundle/FilterBundle/Form/Type/Filter/FilterType.php
+++ b/src/Oro/Bundle/FilterBundle/Form/Type/Filter/FilterType.php
@@ -72,7 +72,8 @@ class FilterType extends AbstractType
     {
         $result = ['required' => false];
         if ($options['operator_choices']) {
-            $result['choices'] = $options['operator_choices'];
+            $result['choices'] = array_flip($options['operator_choices']);
+            $result['choices_as_values'] = true;
         }
         $result = array_merge($result, $options['operator_options']);
 

--- a/src/Pim/Bundle/FilterBundle/spec/Filter/ProductValue/BooleanFilterSpec.php
+++ b/src/Pim/Bundle/FilterBundle/spec/Filter/ProductValue/BooleanFilterSpec.php
@@ -91,7 +91,7 @@ class BooleanFilterSpec extends ObjectBehavior
         $form->createView()->willReturn($formView);
 
         $formBuilder->get('type')->willReturn($typeFormBuilder);
-        $typeFormBuilder->getOption('choices')->willReturn([$noChoice, $yesChoice]);
+        $typeFormBuilder->getOption('choices')->willReturn(['overriden_choice_1' => 0, 'overriden_choice_2' => 1]);
         $formView->children = ['value' => $fieldView, 'type' => $typeView];
         $formView->vars = ['populate_default' => true];
         $fieldView->vars = ['multiple' => true, 'choices' => [$yesChoice, $noChoice]];


### PR DESCRIPTION
## Description

This PR updates the PIM to the last version of Symfony 2.7.

This version come with a new behavior on the ChoiceType field from the Form component (https://symfony.com/doc/2.7/reference/forms/types/choice.html#choices-as-values), causing the labels of the datagrid filters operators to be replaced by their codes (simple numbers, see screenshot below).

![image](https://cloud.githubusercontent.com/assets/5039018/21982272/d9d094c0-dbeb-11e6-9557-2d1d585bd6f0.png)

This problem is fixed by the second commit.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | :negative_squared_cross_mark:
| Added Behats                      | :negative_squared_cross_mark:
| Added integration tests           | :negative_squared_cross_mark:
| Changelog updated                 | :white_check_mark:
| Review and 2 GTM                  | :white_check_mark:
| Micro Demo to the PO (Story only) | :negative_squared_cross_mark:
| Migration script                  | :negative_squared_cross_mark:
| Tech Doc                          | :negative_squared_cross_mark: