### PR TITLE
Tip 475 : fix an error thrown when saving a product with a media

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/ProductController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/ProductController.php
@@ -363,7 +363,7 @@ class ProductController
 
         $dataFiltered = $this->emptyValuesFilter->filter($product, ['values' => $values]);
 
-        if (null !== $dataFiltered) {
+        if (!empty($dataFiltered)) {
             $data = array_replace($data, $dataFiltered);
         } else {
             $data['values'] = [];

--- a/src/Pim/Component/Catalog/Comparator/Attribute/BooleanComparator.php
+++ b/src/Pim/Component/Catalog/Comparator/Attribute/BooleanComparator.php
@@ -41,7 +41,7 @@ class BooleanComparator implements ComparatorInterface
         $originals = array_merge($default, $originals);
 
         $isNull = null === $originals['data'] && null === $data['data'];
-        $isEquals = (bool) $originals['data'] === (bool) $data['data'];
+        $isEquals = $originals['data'] === (bool) $data['data'];
 
         if ($isNull || $isEquals) {
             return null;

--- a/src/Pim/Component/Catalog/Comparator/Attribute/BooleanComparator.php
+++ b/src/Pim/Component/Catalog/Comparator/Attribute/BooleanComparator.php
@@ -41,7 +41,7 @@ class BooleanComparator implements ComparatorInterface
         $originals = array_merge($default, $originals);
 
         $isNull = null === $originals['data'] && null === $data['data'];
-        $isEquals = $originals['data'] === (bool) $data['data'];
+        $isEquals = $originals['data'] === $data['data'];
 
         if ($isNull || $isEquals) {
             return null;

--- a/src/Pim/Component/Catalog/spec/Comparator/Attribute/BooleanComparatorSpec.php
+++ b/src/Pim/Component/Catalog/spec/Comparator/Attribute/BooleanComparatorSpec.php
@@ -21,7 +21,7 @@ class BooleanComparatorSpec extends ObjectBehavior
         $this->supports('pim_catalog_boolean')->shouldBe(true);
     }
 
-    function it_gets_changes_when_adding_value()
+    function it_gets_changes_when_adding_true_value()
     {
         $changes = ['data' => true, 'locale' => 'en_US', 'scope' => 'ecommerce'];
         $originals = [];
@@ -29,6 +29,19 @@ class BooleanComparatorSpec extends ObjectBehavior
         $this->compare($changes, $originals)->shouldReturn($changes);
 
         $changes = ['data' => 1, 'locale' => 'en_US', 'scope' => 'ecommerce'];
+        $originals = [];
+
+        $this->compare($changes, $originals)->shouldReturn($changes);
+    }
+
+    function it_gets_changes_when_adding_false_value()
+    {
+        $changes = ['data' => false, 'locale' => 'en_US', 'scope' => 'ecommerce'];
+        $originals = [];
+
+        $this->compare($changes, $originals)->shouldReturn($changes);
+
+        $changes = ['data' => 0, 'locale' => 'en_US', 'scope' => 'ecommerce'];
         $originals = [];
 
         $this->compare($changes, $originals)->shouldReturn($changes);

--- a/src/Pim/Component/Catalog/spec/Comparator/Attribute/BooleanComparatorSpec.php
+++ b/src/Pim/Component/Catalog/spec/Comparator/Attribute/BooleanComparatorSpec.php
@@ -27,21 +27,11 @@ class BooleanComparatorSpec extends ObjectBehavior
         $originals = [];
 
         $this->compare($changes, $originals)->shouldReturn($changes);
-
-        $changes = ['data' => 1, 'locale' => 'en_US', 'scope' => 'ecommerce'];
-        $originals = [];
-
-        $this->compare($changes, $originals)->shouldReturn($changes);
     }
 
     function it_gets_changes_when_adding_false_value()
     {
         $changes = ['data' => false, 'locale' => 'en_US', 'scope' => 'ecommerce'];
-        $originals = [];
-
-        $this->compare($changes, $originals)->shouldReturn($changes);
-
-        $changes = ['data' => 0, 'locale' => 'en_US', 'scope' => 'ecommerce'];
         $originals = [];
 
         $this->compare($changes, $originals)->shouldReturn($changes);
@@ -53,20 +43,10 @@ class BooleanComparatorSpec extends ObjectBehavior
         $originals = ['data' => true, 'locale' => 'en_US', 'scope' => 'ecommerce'];
 
         $this->compare($changes, $originals)->shouldReturn($changes);
-
-        $changes = ['data' => 0, 'locale' => 'en_US', 'scope' => 'ecommerce'];
-        $originals = ['data' => true, 'locale' => 'en_US', 'scope' => 'ecommerce'];
-
-        $this->compare($changes, $originals)->shouldReturn($changes);
     }
 
     function it_returns_null_when_values_are_the_same()
     {
-        $changes = ['data' => 1, 'locale' => 'en_US', 'scope' => 'ecommerce'];
-        $originals = ['data' => true, 'locale' => 'en_US', 'scope' => 'ecommerce'];
-
-        $this->compare($changes, $originals)->shouldReturn(null);
-
         $changes = ['data' => true, 'locale' => 'en_US', 'scope' => 'ecommerce'];
         $originals = ['data' => true, 'locale' => 'en_US', 'scope' => 'ecommerce'];
 


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) 

**Description (for Contributor and Core Developer)**


Since the standard format, there is a bug when you try to save a product which has already a media. It's due to a wrong condition check on an empty array.

Unfortunately, it hid a problem with boolean values.

When a product is saved with the UI, boolean product values are set to false, even if they are not modified and null in database (and only for attributes belonging to the family).

This is a well-known behaviour and it has some consequences on the draft.

When you make a proposal on a draft, boolean attributes belonging to the family and no set are in the proposal : the UI set them automatically to false.
Then, the proposal has unmodified boolean values, which is not normal.

In order to avoid that problem, we have two solutions : 
- set automatically the boolean values to "false" when we create a product
- fix the problem in the UI by supporting null values 

The second option will be normally done by @juliensnz . It's could be long and has a lot of impacts. Awaiting that, I did the first option.

I will open a ticket to create a migration script before the 1.7 release, in case of the second option is not done.

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | :white_check_mark: :red_circle: :negative_squared_cross_mark: :clock1:
| Added Behats                      | :white_check_mark: :red_circle: :negative_squared_cross_mark: :clock1:
| Added integration tests           | :white_check_mark: :red_circle: :negative_squared_cross_mark: :clock1:
| Changelog updated                 | :white_check_mark: :red_circle: :negative_squared_cross_mark: :clock1:
| Review and 2 GTM                  | :white_check_mark: :red_circle: :negative_squared_cross_mark: :clock1:
| Micro Demo to the PO (Story only) | :white_check_mark: :red_circle: :negative_squared_cross_mark: :clock1:
| Migration script                  | :white_check_mark: :red_circle: :negative_squared_cross_mark: :clock1:
| Tech Doc                          | :white_check_mark: :red_circle: :negative_squared_cross_mark: :clock1:


:white_check_mark: Done and pass

:red_circle: Done but fail

:clock1: Done but pending

:negative_squared_cross_mark: Not needed
