### PR TITLE
Fix versionning issue with data migration

### DIFF
--- a/spec/Pim/Bundle/EnrichBundle/Provider/StructureVersion/ProductStructureVersionProviderSpec.php
+++ b/spec/Pim/Bundle/EnrichBundle/Provider/StructureVersion/ProductStructureVersionProviderSpec.php
@@ -35,4 +35,14 @@ class ProductStructureVersionProviderSpec extends ObjectBehavior
 
         $this->getStructureVersion()->shouldReturn(12);
     }
+
+    function it_provides_null_when_no_history_is_available($versionRepository)
+    {
+        $this->addResource('Locale');
+
+        $versionRepository->getNewestLogEntryForRessources(['Locale'])
+            ->willReturn(null);
+
+        $this->getStructureVersion()->shouldReturn(null);
+    }
 }

--- a/src/Pim/Bundle/EnrichBundle/Provider/StructureVersion/ProductStructureVersionProvider.php
+++ b/src/Pim/Bundle/EnrichBundle/Provider/StructureVersion/ProductStructureVersionProvider.php
@@ -32,10 +32,13 @@ class ProductStructureVersionProvider implements StructureVersionProviderInterfa
      */
     public function getStructureVersion()
     {
-        return $this->versionRepository
-            ->getNewestLogEntryForRessources($this->resourceNames)
-            ->getLoggedAt()
-            ->getTimestamp();
+        $latest = $this->versionRepository->getNewestLogEntryForRessources($this->resourceNames);
+
+        if (null === $latest) {
+            return null;
+        }
+
+        return $latest->getLoggedAt()->getTimestamp();
     }
 
     /**

--- a/src/Pim/Bundle/EnrichBundle/Provider/StructureVersion/StructureVersionProviderInterface.php
+++ b/src/Pim/Bundle/EnrichBundle/Provider/StructureVersion/StructureVersionProviderInterface.php
@@ -14,7 +14,7 @@ interface StructureVersionProviderInterface
     /**
      * Returns the last version of the structure which the provider is responsible
      *
-     * @return int The current structure version number
+     * @return null|int The current structure version number
      */
     public function getStructureVersion();
 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This PR fixes the issue with data migration (MySQL to Mongo, or pim version upgrade) when the verionning is lost:
 PHP Fatal error: Call to a member function getLoggedAt() on null in vendor/akeneo/pim-community-dev/src/Pim/Bundle/EnrichBundle/Provider/StructureVersion/ProductStructureVersionProvider.php on line 37

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | :negative_squared_cross_mark:
| Added Behats                      | :negative_squared_cross_mark:
| Added integration tests           | :negative_squared_cross_mark:
| Changelog updated                 | :negative_squared_cross_mark:
| Review and 2 GTM                  | :white_check_mark:
| Micro Demo to the PO (Story only) | :negative_squared_cross_mark:
| Migration script                  | :negative_squared_cross_mark:
| Tech Doc                          | :negative_squared_cross_mark:
