### PR TITLE
API-58: Manage permissions to view or modify the catalog structure

### DIFF
--- a/src/Pim/Bundle/ApiBundle/Resources/config/acl.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/acl.yml
@@ -3,3 +3,39 @@ pim_api_overall_access:
     type: action
     label: pim_api.acl.rights
     group_name: pim_api.acl_group.overall_access
+
+pim_api_attribute_list:
+    type: action
+    label: pim_api.acl.attribute.list
+    group_name: pim_api.acl_group.attribute
+pim_api_attribute_edit:
+    type: action
+    label: pim_api.acl.attribute.edit
+    group_name: pim_api.acl_group.attribute
+
+pim_api_attribute_option_list:
+    type: action
+    label: pim_api.acl.attribute_option.list
+    group_name: pim_api.acl_group.attribute_option
+pim_api_attribute_option_edit:
+    type: action
+    label: pim_api.acl.attribute_option.edit
+    group_name: pim_api.acl_group.attribute_option
+
+pim_api_category_list:
+    type: action
+    label: pim_api.acl.category.list
+    group_name: pim_api.acl_group.category
+pim_api_category_edit:
+    type: action
+    label: pim_api.acl.category.edit
+    group_name: pim_api.acl_group.category
+
+pim_api_family_list:
+    type: action
+    label: pim_api.acl.family.list
+    group_name: pim_api.acl_group.family
+pim_api_family_edit:
+    type: action
+    label: pim_api.acl.family.edit
+    group_name: pim_api.acl_group.family

--- a/src/Pim/Bundle/ApiBundle/Resources/config/acl_groups.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/acl_groups.yml
@@ -1,3 +1,15 @@
 pim_api.acl_group.overall_access:
     order: 10
     permission_group: api
+pim_api.acl_group.attribute:
+    order: 20
+    permission_group: api
+pim_api.acl_group.attribute_option:
+    order: 20
+    permission_group: api
+pim_api.acl_group.category:
+    order: 20
+    permission_group: api
+pim_api.acl_group.family:
+    order: 20
+    permission_group: api

--- a/upgrades/schema/Version_1_7_20170116172612_acl.php
+++ b/upgrades/schema/Version_1_7_20170116172612_acl.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Pim\Upgrade\Schema;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+use Oro\Bundle\SecurityBundle\Model\AclPermission;
+use Oro\Bundle\SecurityBundle\Model\AclPrivilege;
+use Oro\Bundle\SecurityBundle\Model\AclPrivilegeIdentity;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Security\Acl\Domain\RoleSecurityIdentity;
+
+/**
+ * Set to false all ACLs on the API for all roles
+ */
+class Version_1_7_20170116172612_acl extends AbstractMigration implements ContainerAwareInterface
+{
+    /** @var ContainerInterface */
+    protected $container;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setContainer(ContainerInterface $container = null)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $acls = [
+            'pim_api_attribute_edit',
+            'pim_api_attribute_list',
+            'pim_api_attribute_option_edit',
+            'pim_api_attribute_option_list',
+            'pim_api_category_edit',
+            'pim_api_category_list',
+            'pim_api_family_edit',
+            'pim_api_family_list',
+            'pim_api_overall_access'
+        ];
+
+        $aclManager = $this->container->get('oro_security.acl.manager');
+        $roles = $this->container->get('pim_user.repository.role')->findAll();
+
+        foreach ($acls as $acl) {
+            foreach ($roles as $role) {
+                $privilege = new AclPrivilege();
+                $identity = new AclPrivilegeIdentity(sprintf('action:%s', $acl));
+                $privilege
+                    ->setIdentity($identity)
+                    ->addPermission(new AclPermission('EXECUTE', 0));
+
+                $aclManager->getPrivilegeRepository()
+                    ->savePrivileges(new RoleSecurityIdentity($role), new ArrayCollection([$privilege]));
+            }
+        }
+
+        $aclManager->clearCache();
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        $this->throwIrreversibleMigrationException();
+    }
+}


### PR DESCRIPTION
- [x] add ACLs for attributes, families & categories
- [x] add a migration script to set to false all ACLs on the API

As authentication is not already done, there is no tests on this part (will be done in an other PR)


**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | :negative_squared_cross_mark: 
| Added Behats                      | :negative_squared_cross_mark: 
| Added integration tests           | :negative_squared_cross_mark: 
| Changelog updated                 | :negative_squared_cross_mark:
| Review and 2 GTM                  | :clock1:
| Migration script                  | :white_check_mark:
| Tech Doc                          | :negative_squared_cross_mark: 


:white_check_mark: Done and pass

:red_circle: Done but fail

:clock1: Done but pending

:negative_squared_cross_mark: Not needed
