### PR TITLE
Do extra thing after the fixture import

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -38,6 +38,13 @@ abstract class TestCase extends KernelTestCase
     abstract protected function getConfiguration();
 
     /**
+     * Method executed after the fixture import
+     */
+    protected function doAfterFixtureImport(Application $application)
+    {
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function setUp()
@@ -175,6 +182,8 @@ abstract class TestCase extends KernelTestCase
         }
 
         $jobLoader->deleteJobInstances();
+
+        $this->doAfterFixtureImport($application);
 
         // close the connection created specifically for this repository
         // TODO: to remove when TIP-385 will be done


### PR DESCRIPTION
`doAfterFixtureImport` allows to do extra things after a database initialization.
Use case: In the EE, we need to clean the rights after a data fixture import.  

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | no
| Added Behats                      | no
| Added integration tests           | no
| Changelog updated                 | no
| Review and 2 GTM                  | no
| Micro Demo to the PO (Story only) | no
| Migration script                  | no
| Tech Doc                          | no