### PR TITLE
TIP-322: fix behat error due to an unknown available locale

### DIFF
--- a/features/export/product-export-builder/export_products_by_locales.feature
+++ b/features/export/product-export-builder/export_products_by_locales.feature
@@ -8,7 +8,7 @@ Feature: Export products according to a locale policy
     Given a "default" catalog configuration
     And the following attributes:
       | code     | type     | localizable | label    | available_locales |
-      | name     | textarea | yes         | Name     | all               |
+      | name     | textarea | yes         | Name     | fr_FR,en_US       |
       | baguette | text     | yes         | Baguette | fr_FR             |
     And the following family:
       | code      | requirements-ecommerce |


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) 

**Description (for Contributor and Core Developer)**

Before the TIP-322 (add business exceptions in updaters), when you update with an unknown available locale, it was silently ignored.

This behaviour has been fixed in this commit, and now, it throws an exception :

https://github.com/akeneo/pim-community-dev/commit/ec5eb1f4890213a6a6f9cf7cb6534ac11cf65109

This PR fixed behats that failed in CE (orm and odm) since the merge.
Scenarios create an attribute with an available locale "all", which is an unknown locale raising an exception now. 
 
[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | :white_check_mark: :red_circle: :negative_squared_cross_mark: :clock1:
| Added Behats                      | :white_check_mark: :red_circle: :negative_squared_cross_mark: :clock1:
| Added integration tests           | :white_check_mark: :red_circle: :negative_squared_cross_mark: :clock1:
| Changelog updated                 | :white_check_mark: :red_circle: :negative_squared_cross_mark: :clock1:
| Review and 2 GTM                  | :white_check_mark: :red_circle: :negative_squared_cross_mark: :clock1:
| Micro Demo to the PO (Story only) | :white_check_mark: :red_circle: :negative_squared_cross_mark: :clock1:
| Migration script                  | :white_check_mark: :red_circle: :negative_squared_cross_mark: :clock1:
| Tech Doc                          | :white_check_mark: :red_circle: :negative_squared_cross_mark: :clock1:


:white_check_mark: Done and pass

:red_circle: Done but fail

:clock1: Done but pending

:negative_squared_cross_mark: Not needed
