### PR TITLE
[PIM-6113] Wrong context switch on association groups

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -1,3 +1,9 @@
+# 1.6.x
+
+## Bug fixes
+
+- PIM-6113: Fix wrong context switch on association groups
+
 # 1.6.9 (2017-01-17)
 
 ## Bug fixes

--- a/features/Context/DataGridContext.php
+++ b/features/Context/DataGridContext.php
@@ -157,6 +157,8 @@ class DataGridContext extends RawMinkContext implements PageObjectAwareInterface
     /**
      * @param string $title
      *
+     * @throws ExpectationException
+     *
      * @Then /^I could see "([^"]*)" in the manage filters list$/
      */
     public function iCouldSeeInTheManageFiltersList($title)
@@ -631,8 +633,6 @@ class DataGridContext extends RawMinkContext implements PageObjectAwareInterface
      *
      * @throws ExpectationException
      *
-     * @return Step
-     *
      * @Then /^I should see products? (.*)$/
      * @Then /^I should see attributes? (?!(?:.*)in group )(.*)$/
      * @Then /^I should see channels? (.*)$/
@@ -822,18 +822,19 @@ class DataGridContext extends RawMinkContext implements PageObjectAwareInterface
     }
 
     /**
-     * @param string $rows
+     * @param string      $rows
+     * @param string|null $notChecked If not null, it checks checkbox is not checked.
      *
      * @throws ExpectationException
      *
-     * @Then /^the rows? "([^"]*)" should be checked$/
+     * @Then /^the rows? "([^"]*)" should (not )?be checked$/
      */
-    public function theRowShouldBeChecked($rows)
+    public function theRowShouldBeChecked($rows, $notChecked = null)
     {
         $rows = $this->getMainContext()->listToArray($rows);
 
         foreach ($rows as $row) {
-            $this->spin(function () use ($row) {
+            $this->spin(function () use ($row, $notChecked) {
                 $gridRow  = $this->datagrid->getRow($row);
                 $checkbox = $gridRow->find('css', 'td.boolean-cell input[type="checkbox"]:not(:disabled)');
 
@@ -841,33 +842,9 @@ class DataGridContext extends RawMinkContext implements PageObjectAwareInterface
                     return false;
                 }
 
-                return $checkbox->isChecked();
-            }, sprintf('Fail asserting that "%s" row was checked', $row));
-        }
-    }
-
-    /**
-     * @param string $rows
-     *
-     * @throws ExpectationException
-     *
-     * @Then /^the rows? "([^"]*)" should not be checked$/
-     */
-    public function theRowShouldBeUnchecked($rows)
-    {
-        $rows = $this->getMainContext()->listToArray($rows);
-
-        foreach ($rows as $row) {
-            $this->spin(function () use ($row) {
-                $gridRow  = $this->datagrid->getRow($row);
-                $checkbox = $gridRow->find('css', 'td.boolean-cell input[type="checkbox"]:not(:disabled)');
-
-                if (!$checkbox) {
-                    return false;
-                }
-
-                return !$checkbox->isChecked();
-            }, sprintf('Fail asserting that "%s" row was unchecked', $row));
+                return ((null === $notChecked && $checkbox->isChecked()) ||
+                    (null !== $notChecked && !$checkbox->isChecked()));
+            }, sprintf('Fail asserting that "%s" row was %schecked', $row, $notChecked));
         }
     }
 

--- a/features/product/associate_product.feature
+++ b/features/product/associate_product.feature
@@ -207,3 +207,15 @@ Feature: Associate a product
     And I save the product
     And I visit the "Associations" tab
     Then the rows "gray-boots" should be checked
+
+  @jira https://akeneo.atlassian.net/browse/PIM-6113
+  Scenario: Do not keep saved product association groups after switching association type
+    Given I edit the "charcoal-boots" product
+    And I visit the "Associations" tab
+    And I select the "Upsell" association
+    And I press the "Show groups" button
+    And I check the row "caterpillar_boots"
+    And I save the product
+    When I select the "Substitution" association
+    Then I should see the text "0 products and 0 groups"
+    And the row "caterpillar_boots" should not be checked

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/associations.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/associations.js
@@ -310,10 +310,10 @@ define(
                      */
                     var queryParts = metadata.options.url.split('?');
                     var url = queryParts[0];
-                    var queryString = queryParts[1];
-                    var queryStringDecoded = decodeURIComponent(queryString);
-                    var reg = new RegExp('&?association-group-grid\\[associatedIds\\]\\[\\d+\\]=\\d+', 'g');
-                    metadata.options.url = url + '?' + queryStringDecoded.replace(reg, '');
+                    var queryString = decodeURIComponent(queryParts[1])
+                        .replace(/&?association-group-grid\[associatedIds\]\[\d+\]=\d+/g, '')
+                        .replace(/^&/, '');
+                    metadata.options.url = url + '?' + queryString;
 
                     this.$('#grid-' + gridName).data({ metadata: metadata, data: JSON.parse(response.data) });
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/associations.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/associations.js
@@ -301,14 +301,19 @@ define(
                      * The fact is that there is 2 places where these parameters are set: in the URL, and in the
                      * datagrid state (state.parameters.associatedIds).
                      *
-                     * If you do not drop the right part of the URL (containing associatedIds array), you will have
+                     * If you do not drop the params of the URL (containing associatedIds array), you will have
                      * a mix of 2 times the same variable, defined at 2 different places. This leads to a refreshed
                      * datagrid with wrong checkboxes.
                      *
-                     * To prevent this behavior, we removed all the parameters passed in the URL before rendering the
+                     * To prevent this behavior, we removed the parameters passed in the URL before rendering the
                      * grid, to only allow datagrid state parameters.
                      */
-                    metadata.options.url = metadata.options.url.split('?')[0];
+                    var queryParts = metadata.options.url.split('?');
+                    var url = queryParts[0];
+                    var queryString = queryParts[1];
+                    var queryStringDecoded = decodeURIComponent(queryString);
+                    var reg = new RegExp('&?association-group-grid\\[associatedIds\\]\\[\\d+\\]=\\d+', 'g');
+                    metadata.options.url = url + '?' + queryStringDecoded.replace(reg, '');
 
                     this.$('#grid-' + gridName).data({ metadata: metadata, data: JSON.parse(response.data) });
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/associations.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/associations.js
@@ -292,6 +292,22 @@ define(
 
                 $.get(Routing.generate('pim_datagrid_load', urlParams)).then(function (response) {
                     var metadata = response.metadata;
+                    /* Next lines are related to PIM-6113 and need some comments.
+                     *
+                     * When you just saved a datagrid from the Product Edit Form, you will have an URL like
+                     * '/association-group-grid?...&associatedIds[]=1&associatedIds[]=2', in reference of the last
+                     * checked groups in the datagrid.
+                     *
+                     * The fact is that there is 2 places where these parameters are set: in the URL, and in the
+                     * datagrid state (state.parameters.associatedIds).
+                     *
+                     * If you do not drop the right part of the URL (containing associatedIds array), you will have
+                     * a mix of 2 times the same variable, defined at 2 different places. This leads to a refreshed
+                     * datagrid with wrong checkboxes.
+                     *
+                     * To prevent this behavior, we removed all the parameters passed in the URL before rendering the
+                     * grid, to only allow datagrid state parameters.
+                     */
                     metadata.options.url = metadata.options.url.split('?')[0];
 
                     this.$('#grid-' + gridName).data({ metadata: metadata, data: JSON.parse(response.data) });

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/associations.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/associations.js
@@ -290,10 +290,13 @@ define(
                     collection.processFiltersParams(urlParams, filters, gridName + '[_filter]');
                 }
 
-                $.get(Routing.generate('pim_datagrid_load', urlParams)).then(function (resp) {
-                    this.$('#grid-' + gridName).data({ 'metadata': resp.metadata, 'data': JSON.parse(resp.data) });
+                $.get(Routing.generate('pim_datagrid_load', urlParams)).then(function (response) {
+                    var metadata = response.metadata;
+                    metadata.options.url = metadata.options.url.split('?')[0];
 
-                    var gridModules = resp.metadata.requireJSModules;
+                    this.$('#grid-' + gridName).data({ metadata: metadata, data: JSON.parse(response.data) });
+
+                    var gridModules = metadata.requireJSModules;
                     gridModules.push('pim/datagrid/state-listener');
                     require(gridModules, function () {
                         datagridBuilder(_.toArray(arguments));


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

The bug is:
- Go to a PEF
- Go to tab Associations
- Select some groups
- Save
- Go to another group
- It displays the list of previous checked groups in the new grid !

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | :negative_squared_cross_mark:
| Added Behats                      | :white_check_mark:
| Added integration tests           | :negative_squared_cross_mark:
| Changelog updated                 | :white_check_mark:
| Review and 2 GTM                  | :clock1:
| Micro Demo to the PO (Story only) | :clock1:
| Migration script                  | :negative_squared_cross_mark:
| Tech Doc                          | :negative_squared_cross_mark:


:white_check_mark: Done and pass

:red_circle: Done but fail

:clock1: Done but pending

:negative_squared_cross_mark: Not needed
