### PR TITLE
Enable array ProductValue to string

### DIFF
--- a/src/Pim/Component/Catalog/Model/AbstractProductValue.php
+++ b/src/Pim/Component/Catalog/Model/AbstractProductValue.php
@@ -517,7 +517,7 @@ abstract class AbstractProductValue implements ProductValueInterface
             $data = $data->format(\DateTime::ISO8601);
         }
 
-        if ($data instanceof Collection) {
+        if ($data instanceof Collection || is_array($data)) {
             $items = [];
             foreach ($data as $item) {
                 $value = (string) $item;


### PR DESCRIPTION
In the case of a product value holding array values, like one linked to a `json_array` doctrine type, the actual `__toString` method will crash before of array to string conversion.