### PR TITLE
API-40: Get a single attribute option

### DIFF
--- a/src/Pim/Bundle/ApiBundle/Controller/Rest/AttributeOptionController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/Rest/AttributeOptionController.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Pim\Bundle\ApiBundle\Controller\Rest;
+
+use Pim\Component\Catalog\Repository\AttributeOptionRepositoryInterface;
+use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * @author    Philippe Mossière <philippe.mossiere@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class AttributeOptionController
+{
+    /** @var AttributeRepositoryInterface */
+    protected $attributeRepository;
+
+    /** @var AttributeOptionRepositoryInterface */
+    protected $attributeOptionsRepository;
+
+    /** @var NormalizerInterface */
+    protected $normalizer;
+
+    /** @var array */
+    protected $supportedAttributeTypes;
+
+    /**
+     * @param AttributeRepositoryInterface       $attributeRepository
+     * @param AttributeOptionRepositoryInterface $attributeOptionsRepository
+     * @param NormalizerInterface                $normalizer
+     * @param array                              $supportedAttributeTypes
+     */
+    public function __construct(
+        AttributeRepositoryInterface $attributeRepository,
+        AttributeOptionRepositoryInterface $attributeOptionsRepository,
+        NormalizerInterface $normalizer,
+        $supportedAttributeTypes
+    ) {
+        $this->attributeRepository = $attributeRepository;
+        $this->attributeOptionsRepository = $attributeOptionsRepository;
+        $this->normalizer = $normalizer;
+        $this->supportedAttributeTypes = $supportedAttributeTypes;
+    }
+
+    /**
+     * @param Request $request
+     * @param string  $attributeCode
+     * @param string  $optionCode
+     *
+     * @throws NotFoundHttpException
+     *
+     * @return JsonResponse
+     */
+    public function getAction(Request $request, $attributeCode, $optionCode)
+    {
+        $attribute = $this->attributeRepository->findOneByIdentifier($attributeCode);
+        if (null === $attribute) {
+            throw new NotFoundHttpException(sprintf('Attribute "%s" does not exist.', $attributeCode));
+        }
+
+        $attributeType = $attribute->getAttributeType();
+        if (!in_array($attributeType, $this->supportedAttributeTypes)) {
+            throw new NotFoundHttpException(
+                sprintf(
+                    'Attribute "%s" does not support options. Only attributes of type "%s" support options.',
+                    $attributeCode,
+                    implode('", "', $this->supportedAttributeTypes)
+                )
+            );
+        }
+
+        $attributeOption = $this->attributeOptionsRepository->findOneByIdentifier($attributeCode . '.' . $optionCode);
+        if (null === $attributeOption) {
+            throw new NotFoundHttpException(
+                sprintf(
+                    'Attribute option "%s" does not exist or is not an option of the attribute "%s".',
+                    $optionCode,
+                    $attributeCode
+                )
+            );
+        }
+
+        $attributeOptionStandard = $this->normalizer->normalize($attributeOption, 'standard');
+
+        return new JsonResponse($attributeOptionStandard);
+    }
+}

--- a/src/Pim/Bundle/ApiBundle/Resources/config/controllers.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/controllers.yml
@@ -2,6 +2,7 @@ parameters:
     pim_api.controller.rest.category.class: Pim\Bundle\ApiBundle\Controller\Rest\CategoryController
     pim_api.controller.rest.family.class: Pim\Bundle\ApiBundle\Controller\Rest\FamilyController
     pim_api.controller.rest.attribute.class: Pim\Bundle\ApiBundle\Controller\Rest\AttributeController
+    pim_api.controller.rest.attribute_option.class: Pim\Bundle\ApiBundle\Controller\Rest\AttributeOptionController
 
 services:
     pim_api.controller.rest.category:
@@ -21,3 +22,11 @@ services:
         arguments:
             - '@pim_catalog.repository.attribute'
             - '@pim_serializer'
+
+    pim_api.controller.rest.attribute_option:
+        class: '%pim_api.controller.rest.attribute_option.class%'
+        arguments:
+            - '@pim_catalog.repository.attribute'
+            - '@pim_catalog.repository.attribute_option'
+            - '@pim_serializer'
+            - ['pim_catalog_simpleselect', 'pim_catalog_multiselect']

--- a/src/Pim/Bundle/ApiBundle/Resources/config/routing/attribute.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/routing/attribute.yml
@@ -2,3 +2,8 @@ pim_api_rest_attribute_get:
     path: /{code}
     defaults: { _controller: pim_api.controller.rest.attribute:getAction, _format: json }
     methods: [GET]
+
+pim_api_rest_attribute_option_get:
+    path: /{attributeCode}/options/{optionCode}
+    defaults: { _controller: pim_api.controller.rest.attribute_option:getAction, _format: json }
+    methods: [GET]

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/AttributeOption/GetAttributeOptionIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/AttributeOption/GetAttributeOptionIntegration.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace tests\integration\Pim\Bundle\ApiBundle\Controller\Rest\AttributeOption;
+
+use Symfony\Component\HttpFoundation\Response;
+use Test\Integration\TestCase;
+
+class GetAttributeOptionIntegration extends TestCase
+{
+    public function testGetAnAttributeOption()
+    {
+        $client = static::createClient();
+
+        $client->request('GET', 'api/rest/v1/attributes/a_multi_select/options/optionA');
+
+        $standardAttributeOption = [
+            'code'       => 'optionA',
+            'attribute'  => 'a_multi_select',
+            'sort_order' => 10,
+            'labels'     => [
+                'en_US' => 'Option A',
+            ],
+        ];
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertSame($standardAttributeOption, json_decode($response->getContent(), true));
+    }
+
+    public function testNotFoundAnAttribute()
+    {
+        $client = static::createClient();
+
+        $client->request('GET', 'api/rest/v1/attributes/not_found/options/not_found');
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
+        $content = json_decode($response->getContent(), true);
+        $this->assertCount(2, $content, 'response contains 2 items');
+        $this->assertSame(Response::HTTP_NOT_FOUND, $content['code']);
+        $this->assertSame('Attribute "not_found" does not exist.', $content['message']);
+    }
+
+    public function testNotSupportedOptionsAttribute()
+    {
+        $client = static::createClient();
+
+        $client->request('GET', 'api/rest/v1/attributes/sku/options/sku');
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
+        $content = json_decode($response->getContent(), true);
+        $this->assertCount(2, $content, 'response contains 2 items');
+        $this->assertSame(Response::HTTP_NOT_FOUND, $content['code']);
+        $this->assertSame(
+            'Attribute "sku" does not support options. Only attributes of type "pim_catalog_simpleselect", "pim_catalog_multiselect" support options.',
+            $content['message']
+        );
+    }
+
+    public function testNotExistingOptionsAttribute()
+    {
+        $client = static::createClient();
+
+        $client->request('GET', 'api/rest/v1/attributes/a_multi_select/options/not_existing_option');
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
+        $content = json_decode($response->getContent(), true);
+        $this->assertCount(2, $content, 'response contains 2 items');
+        $this->assertSame(Response::HTTP_NOT_FOUND, $content['code']);
+        $this->assertSame(
+            'Attribute option "not_existing_option" does not exist or is not an option of the attribute "a_multi_select".',
+            $content['message']
+        );
+    }
+}


### PR DESCRIPTION
Get a single attribute option 
https://akeneo.atlassian.net/browse/API-40

Call GET 'api/rest/v1/attributes/tshirt_style/options/turtleneck'

Return 200:
 
```
{"code":"turtleneck","attribute":"tshirt_style","sort_order":1,"labels":{"de_DE":"Rollkragen","en_US":"Turtleneck","fr_FR":"Col roul\u00e9"}}
```

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | :negative_squared_cross_mark:
| Added Behats                      | :negative_squared_cross_mark:
| Added integration tests           | :white_check_mark:
| Changelog updated                 | :negative_squared_cross_mark:
| Review and 2 GTM                  | :white_check_mark:
| Micro Demo to the PO (Story only) | :negative_squared_cross_mark:
| Migration script                  | :negative_squared_cross_mark:
| Tech Doc                          | :negative_squared_cross_mark: