### PR TITLE
Remove PHP 7.1 failure allowed from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,3 @@ script:
 
 notifications:
   slack: akeneo:fDZaQeRRj1gVtXCW3f2kQAxo
-
-matrix:
-  allow_failures:
-    - php: "7.1"

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/ChannelRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/ChannelRepository.php
@@ -21,8 +21,12 @@ class ChannelRepository extends EntityRepository implements ChannelRepositoryInt
     /**
      * {@inheritdoc}
      */
-    public function findBy(array $criteria, array $orderBy = ['code' => 'ASC'], $limit = null, $offset = null)
+    public function findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
     {
+        if (null === $orderBy) {
+            $orderBy = ['code' => 'ASC'];
+        }
+
         return parent::findBy($criteria, $orderBy, $limit, $offset);
     }
 

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/LocaleRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/LocaleRepository.php
@@ -20,8 +20,12 @@ class LocaleRepository extends EntityRepository implements LocaleRepositoryInter
     /**
      * {@inheritdoc}
      */
-    public function findBy(array $criteria, array $orderBy = ['code' => 'ASC'], $limit = null, $offset = null)
+    public function findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
     {
+        if (null === $orderBy) {
+            $orderBy = ['code' => 'ASC'];
+        }
+
         return parent::findBy($criteria, $orderBy, $limit, $offset);
     }
 


### PR DESCRIPTION
**Description**

We do ugly stuff in the `ChannelRepository` and the `LocaleRepository`: overriding the `findBy` method from Doctrine EntityRepository and changing its signature. This is not allowed in PHP 7.1 anymore, so PIM installation fails.

This PR fixes this ugliness, and as we recently bump to Symfony 2.7.23, all static tests are now OK with PHP 7.1. So we can remove it from "allow_failures" in Travis!

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | :negative_squared_cross_mark:
| Added Behats                      | :negative_squared_cross_mark:
| Added integration tests           | :negative_squared_cross_mark:
| Changelog updated                 | :negative_squared_cross_mark:
| Review and 2 GTM                  | :clock1:
| Micro Demo to the PO (Story only) | :negative_squared_cross_mark:
| Migration script                  | :negative_squared_cross_mark:
| Tech Doc                          | :negative_squared_cross_mark: