### PR TITLE
API-104: display more informations in response when an exception is thrown

### DIFF
--- a/phpspec.yml.dist
+++ b/phpspec.yml.dist
@@ -70,6 +70,11 @@ suites:
         src_path: src/Akeneo/Bundle/MeasureBundle
 
     ## Pim Components
+    Api:
+        namespace: Pim\Component\Api
+        psr4_prefix: Pim\Component\Api
+        spec_path: src/Pim/Component/Api
+        src_path: src/Pim/Component/Api
     ReferenceData:
         namespace: Pim\Component\ReferenceData
         psr4_prefix: Pim\Component\ReferenceData

--- a/src/Pim/Bundle/ApiBundle/Controller/Rest/CategoryController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/Rest/CategoryController.php
@@ -3,6 +3,7 @@
 namespace Pim\Bundle\ApiBundle\Controller\Rest;
 
 use Akeneo\Component\Classification\Repository\CategoryRepositoryInterface;
+use Pim\Bundle\CatalogBundle\Version;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -21,16 +22,22 @@ class CategoryController
     /** @var NormalizerInterface */
     protected $normalizer;
 
+    /** @var string */
+    protected $urlDocumentation;
+
     /**
      * @param CategoryRepositoryInterface $repository
      * @param NormalizerInterface         $normalizer
+     * @param string                      $urlDocumentation
      */
     public function __construct(
         CategoryRepositoryInterface $repository,
-        NormalizerInterface $normalizer
+        NormalizerInterface $normalizer,
+        $urlDocumentation
     ) {
         $this->repository = $repository;
         $this->normalizer = $normalizer;
+        $this->urlDocumentation = sprintf($urlDocumentation, substr(Version::VERSION, 0, 3));
     }
 
     /**

--- a/src/Pim/Bundle/ApiBundle/DependencyInjection/PimApiExtension.php
+++ b/src/Pim/Bundle/ApiBundle/DependencyInjection/PimApiExtension.php
@@ -25,5 +25,6 @@ class PimApiExtension extends Extension
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('controllers.yml');
         $loader->load('normalizers.yml');
+        $loader->load('serializers.yml');
     }
 }

--- a/src/Pim/Bundle/ApiBundle/DependencyInjection/PimApiExtension.php
+++ b/src/Pim/Bundle/ApiBundle/DependencyInjection/PimApiExtension.php
@@ -24,5 +24,6 @@ class PimApiExtension extends Extension
 
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('controllers.yml');
+        $loader->load('normalizers.yml');
     }
 }

--- a/src/Pim/Bundle/ApiBundle/PimApiBundle.php
+++ b/src/Pim/Bundle/ApiBundle/PimApiBundle.php
@@ -2,8 +2,19 @@
 
 namespace Pim\Bundle\ApiBundle;
 
+use Pim\Bundle\CatalogBundle\DependencyInjection\Compiler\RegisterSerializerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class PimApiBundle extends Bundle
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function build(ContainerBuilder $container)
+    {
+        $container
+            ->addCompilerPass(new RegisterSerializerPass('pim_external_api_exception_serializer'))
+        ;
+    }
 }

--- a/src/Pim/Bundle/ApiBundle/Resources/config/controllers.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/controllers.yml
@@ -9,6 +9,7 @@ services:
         arguments:
             - '@pim_catalog.repository.category'
             - '@pim_serializer'
+            - 'https://docs.akeneo.com/%s/reference/standard_format/other_entities.html#category'
 
     pim_api.controller.rest.family:
         class: '%pim_api.controller.rest.family.class%'

--- a/src/Pim/Bundle/ApiBundle/Resources/config/normalizers.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/normalizers.yml
@@ -1,5 +1,21 @@
+parameters:
+    pim_api.normalizer.exception.documented.class: Pim\Component\Api\Normalizer\Exception\DocumentedNormalizer
+
 services:
     fos_rest.serializer:
         class: FOS\RestBundle\Serializer\SymfonySerializerAdapter
         arguments:
             - '@pim_serializer'
+
+    fos_rest.serializer.exception_normalizer.symfony:
+        class: FOS\RestBundle\Serializer\Normalizer\ExceptionNormalizer
+        arguments:
+            - '@fos_rest.exception.messages_map'
+            - false
+        tags:
+            - { name: pim_serializer.normalizer, priority: 90 }
+
+    pim_api.normalizer.exception.documented:
+        class: '%pim_api.normalizer.exception.documented.class%'
+        tags:
+            - { name: pim_serializer.normalizer, priority: 100 }

--- a/src/Pim/Bundle/ApiBundle/Resources/config/normalizers.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/normalizers.yml
@@ -1,5 +1,6 @@
 parameters:
     pim_api.normalizer.exception.documented.class: Pim\Component\Api\Normalizer\Exception\DocumentedNormalizer
+    pim_api.normalizer.exception.violation.class: Pim\Component\Api\Normalizer\Exception\ViolationNormalizer
 
 services:
     fos_rest.serializer:
@@ -17,5 +18,10 @@ services:
 
     pim_api.normalizer.exception.documented:
         class: '%pim_api.normalizer.exception.documented.class%'
+        tags:
+            - { name: pim_serializer.normalizer, priority: 100 }
+
+    pim_api.normalizer.exception.violation:
+        class: '%pim_api.normalizer.exception.violation.class%'
         tags:
             - { name: pim_serializer.normalizer, priority: 100 }

--- a/src/Pim/Bundle/ApiBundle/Resources/config/normalizers.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/normalizers.yml
@@ -6,7 +6,7 @@ services:
     fos_rest.serializer:
         class: FOS\RestBundle\Serializer\SymfonySerializerAdapter
         arguments:
-            - '@pim_serializer'
+            - '@pim_external_api_exception_serializer'
 
     fos_rest.serializer.exception_normalizer.symfony:
         class: FOS\RestBundle\Serializer\Normalizer\ExceptionNormalizer
@@ -14,14 +14,14 @@ services:
             - '@fos_rest.exception.messages_map'
             - false
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_external_api_exception_serializer.normalizer, priority: 90 }
 
     pim_api.normalizer.exception.documented:
         class: '%pim_api.normalizer.exception.documented.class%'
         tags:
-            - { name: pim_serializer.normalizer, priority: 100 }
+            - { name: pim_external_api_exception_serializer.normalizer, priority: 100 }
 
     pim_api.normalizer.exception.violation:
         class: '%pim_api.normalizer.exception.violation.class%'
         tags:
-            - { name: pim_serializer.normalizer, priority: 100 }
+            - { name: pim_external_api_exception_serializer.normalizer, priority: 100 }

--- a/src/Pim/Bundle/ApiBundle/Resources/config/normalizers.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/normalizers.yml
@@ -1,0 +1,5 @@
+services:
+    fos_rest.serializer:
+        class: FOS\RestBundle\Serializer\SymfonySerializerAdapter
+        arguments:
+            - '@pim_serializer'

--- a/src/Pim/Bundle/ApiBundle/Resources/config/serializers.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/serializers.yml
@@ -1,0 +1,13 @@
+parameters:
+    pim_external_api_exception_serializer.class: Symfony\Component\Serializer\Serializer
+    pim_external_api.encoder.json.class: Symfony\Component\Serializer\Encoder\JsonEncoder
+
+services:
+    pim_external_api_exception_serializer:
+        class: '%pim_external_api_exception_serializer.class%'
+
+    pim_external_api.encoder.json:
+        class: '%pim_external_api.encoder.json.class%'
+        public: false
+        tags:
+            - { name: pim_external_api_exception_serializer.encoder, priority: 90 }

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/bundles/fos_rest.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/bundles/fos_rest.yml
@@ -19,3 +19,4 @@ fos_rest:
         messages:
             Pim\Bundle\EnrichBundle\Exception\DeleteException: true
             Symfony\Component\HttpKernel\Exception\ConflictHttpException: true
+            Symfony\Component\HttpKernel\Exception\HttpException: true

--- a/src/Pim/Component/Api/Exception/DocumentedHttpException.php
+++ b/src/Pim/Component/Api/Exception/DocumentedHttpException.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Pim\Component\Api\Exception;
+
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+
+/**
+ * Add a link to a documentation in the http exception
+ *
+ * @author    Marie Bochu <marie.bochu@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class DocumentedHttpException extends UnprocessableEntityHttpException
+{
+    /** @var string */
+    protected $href;
+
+    /**
+     * @param string          $href
+     * @param null            $message
+     * @param \Exception|null $previous
+     * @param int             $code
+     */
+    public function __construct($href, $message = null, \Exception $previous = null, $code = 0)
+    {
+        parent::__construct($message, $previous, $code);
+
+        $this->href = $href;
+    }
+
+    /**
+     * @return string
+     */
+    public function getHref()
+    {
+        return $this->href;
+    }
+}

--- a/src/Pim/Component/Api/Exception/ViolationHttpException.php
+++ b/src/Pim/Component/Api/Exception/ViolationHttpException.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Pim\Component\Api\Exception;
+
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+
+/**
+ * Http exception when validation failed on an entity
+ *
+ * @author    Marie Bochu <marie.bochu@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ViolationHttpException extends UnprocessableEntityHttpException
+{
+    /** @var string */
+    protected $violations;
+
+    /**
+     * @param ConstraintViolationListInterface $violations
+     * @param string                           $message
+     * @param \Exception|null                  $previous
+     * @param int                              $code
+     */
+    public function __construct(
+        ConstraintViolationListInterface $violations,
+        $message = 'Validation failed',
+        \Exception $previous = null,
+        $code = 0
+    ) {
+        parent::__construct($message, $previous, $code);
+
+        $this->violations = $violations;
+    }
+
+    /**
+     * @return ConstraintViolationListInterface
+     */
+    public function getViolations()
+    {
+        return $this->violations;
+    }
+}

--- a/src/Pim/Component/Api/Normalizer/Exception/DocumentedNormalizer.php
+++ b/src/Pim/Component/Api/Normalizer/Exception/DocumentedNormalizer.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Pim\Component\Api\Normalizer\Exception;
+
+use Pim\Component\Api\Exception\DocumentedHttpException;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * Normalize a DocumentedHttpException with a link to the documentation
+ *
+ * @author    Marie Bochu <marie.bochu@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/MIT MIT
+ */
+class DocumentedNormalizer implements NormalizerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function normalize($exception, $format = null, array $context = [])
+    {
+        // TODO: call new Link() when pagination will be done
+        $data = [
+            'code'    => $exception->getStatusCode(),
+            'message' => $exception->getMessage(),
+            '_links'  => [
+                'documentation' => [
+                    'href' => $exception->getHref()
+                ]
+            ]
+        ];
+
+        return $data;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsNormalization($exception, $format = null)
+    {
+        return $exception instanceof DocumentedHttpException;
+    }
+}

--- a/src/Pim/Component/Api/Normalizer/Exception/ViolationNormalizer.php
+++ b/src/Pim/Component/Api/Normalizer/Exception/ViolationNormalizer.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Pim\Component\Api\Normalizer\Exception;
+
+use Pim\Component\Api\Exception\ViolationHttpException;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+
+/**
+ * Normalize a ViolationHttpException with all errors
+ *
+ * @author    Marie Bochu <marie.bochu@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/MIT MIT
+ */
+class ViolationNormalizer implements NormalizerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function normalize($exception, $format = null, array $context = [])
+    {
+        $errors = $this->normalizeViolations($exception->getViolations());
+
+        $data = [
+            'code'    => $exception->getStatusCode(),
+            'message' => $exception->getMessage(),
+            'errors'  => $errors
+        ];
+
+        return $data;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsNormalization($exception, $format = null)
+    {
+        return $exception instanceof ViolationHttpException;
+    }
+
+    /**
+     * @param ConstraintViolationListInterface $violations
+     *
+     * @return array
+     */
+    protected function normalizeViolations(ConstraintViolationListInterface $violations)
+    {
+        $errors = [];
+        foreach ($violations as $violation) {
+            $errors[] = ['field' => $violation->getPropertyPath(), 'message' => $violation->getMessage()];
+        }
+
+        return $errors;
+    }
+}

--- a/src/Pim/Component/Api/spec/Exception/DocumentedHttpExceptionSpec.php
+++ b/src/Pim/Component/Api/spec/Exception/DocumentedHttpExceptionSpec.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace spec\Pim\Component\Api\Exception;
+
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Api\Exception\DocumentedHttpException;
+use Symfony\Component\HttpFoundation\Response;
+
+class DocumentedHttpExceptionSpec extends ObjectBehavior
+{
+    function it_creates_an_object_updater_http_exception()
+    {
+        $previous = new \Exception();
+
+        $this->beConstructedWith('http://example.com', 'Property "xx" does not exist', $previous, 0);
+
+        $this->shouldBeAnInstanceOf(DocumentedHttpException::class);
+        $this->getHref()->shouldReturn('http://example.com');
+        $this->getMessage()->shouldReturn('Property "xx" does not exist');
+        $this->getCode()->shouldReturn(0);
+        $this->getPrevious()->shouldReturn($previous);
+        $this->getStatusCode()->shouldReturn(Response::HTTP_UNPROCESSABLE_ENTITY);
+    }
+}

--- a/src/Pim/Component/Api/spec/Exception/ViolationHttpExceptionSpec.php
+++ b/src/Pim/Component/Api/spec/Exception/ViolationHttpExceptionSpec.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace spec\Pim\Component\Api\Exception;
+
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Api\Exception\ViolationHttpException;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+
+class ViolationHttpExceptionSpec extends ObjectBehavior
+{
+    function it_creates_an_object_updater_http_exception(ConstraintViolationListInterface $constraintViolation)
+    {
+        $previous = new \Exception();
+
+        $this->beConstructedWith($constraintViolation, 'Property "xx" does not exist', $previous, 0);
+
+        $this->shouldBeAnInstanceOf(ViolationHttpException::class);
+        $this->getViolations()->shouldReturn($constraintViolation);
+        $this->getMessage()->shouldReturn('Property "xx" does not exist');
+        $this->getCode()->shouldReturn(0);
+        $this->getPrevious()->shouldReturn($previous);
+        $this->getStatusCode()->shouldReturn(Response::HTTP_UNPROCESSABLE_ENTITY);
+    }
+}

--- a/src/Pim/Component/Api/spec/Normalizer/Exception/DocumentedNormalizerSpec.php
+++ b/src/Pim/Component/Api/spec/Normalizer/Exception/DocumentedNormalizerSpec.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace spec\Pim\Component\Api\Normalizer\Exception;
+
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Api\Exception\DocumentedHttpException;
+use Symfony\Component\HttpFoundation\Response;
+
+class DocumentedNormalizerSpec extends ObjectBehavior
+{
+    function it_normalizes_an_exception()
+    {
+        $exception = new DocumentedHttpException(
+            'http://example.net',
+            'Property "xx" does not exist'
+        );
+
+        $this->normalize($exception)->shouldReturn([
+            'code' => Response::HTTP_UNPROCESSABLE_ENTITY,
+            'message' => 'Property "xx" does not exist',
+            '_links' => [
+                'documentation' => [
+                    'href' => 'http://example.net'
+                ]
+            ]
+        ]);
+    }
+}

--- a/src/Pim/Component/Api/spec/Normalizer/Exception/ViolationNormalizerSpec.php
+++ b/src/Pim/Component/Api/spec/Normalizer/Exception/ViolationNormalizerSpec.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace spec\Pim\Component\Api\Normalizer\Exception;
+
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Api\Exception\ViolationHttpException;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\ConstraintViolationList;
+
+class ViolationNormalizerSpec extends ObjectBehavior
+{
+    function it_normalizes_an_exception()
+    {
+        $violationCode = new ConstraintViolation('Not Blank', '', [], '', 'code', '');
+        $violationName = new ConstraintViolation('Too long', '', [], '', 'name', '');
+        $constraintViolation = new ConstraintViolationList([$violationCode, $violationName]);
+        $exception = new ViolationHttpException($constraintViolation);
+
+        $this->normalize($exception)->shouldReturn([
+            'code'    => Response::HTTP_UNPROCESSABLE_ENTITY,
+            'message' => 'Validation failed',
+            'errors'  => [
+                ['field' => 'code', 'message' => 'Not Blank'],
+                ['field' => 'name', 'message' => 'Too long']
+            ]
+        ]);
+    }
+}


### PR DESCRIPTION
FosRestBundle catch exception thrown by the API and normalize them in [ExceptionNormalizer](https://github.com/FriendsOfSymfony/FOSRestBundle/blob/master/Serializer/Normalizer/ExceptionNormalizer.php), which returns errors like that:
```
{
   "code": 404,
   "message": "Not Found"
}
```

In the API, we need for some errors to add informations in the response.
When errors come from the updater (with an unknown field for instance), response has to return a link to the documentation of the standard format:

 ```
{
   "code": 404,
   "message": "Not Found",
   "links": {
      "documentation": {
         "href": "https://docs.akeneo.com/..."
      }
   }
}
```

When errors come from the validators, response has to return all errors:
 ```
{
  "code":422,
  "message": "Validation failed"
  "errors":[
     {
      "field": "xxx", "message": "yyy"
     }
   ] 
}
```

- [x] use the symfony serializer instead of JMS
- [x] create normalizer for updaters errors
- [x] create normalizer for validators errors
- [x] add specs

EDIT: we created a new serializer for API exceptions to be sure these exceptions will be processed only on the API.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | :white_check_mark:
| Added Behats                      | :negative_squared_cross_mark:
| Added integration tests           | :negative_squared_cross_mark:
| Changelog updated                 | :negative_squared_cross_mark:
| Review and 2 GTM                  |  :clock1:
| Migration script                  |  :negative_squared_cross_mark:
| Tech Doc                          | :negative_squared_cross_mark: 


:white_check_mark: Done and pass

:red_circle: Done but fail

:clock1: Done but pending

:negative_squared_cross_mark: Not needed
