### PR TITLE
PIM-6093: add warning count on job execution grids

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -23,6 +23,7 @@
 - Complete Duration measure family with week, month, year and related conversions cheers @JulienDotDev!
 - Add CaseBox measure family and conversions, cheers @gplanchat!
 - Add history support for the channel conversion units.
+- Add warning count on export execution grid and dashboard
 
 ## Technical improvements
 
@@ -180,7 +181,7 @@
 - Remove unused `Pim\Bundle\EnrichBundle\Form\Type\ProductCreateType`
 - Remove unused `Pim\Bundle\EnrichBundle\Form\Type\ChannelType`
 - Remove unused `Pim\Bundle\EnrichBundle\Form\Type\ConversionUnitsType`
-- Change the constructor of `Pim\Bundle\EnrichBundle\Controller\ChannelController` to remove all dependencies  
+- Change the constructor of `Pim\Bundle\EnrichBundle\Controller\ChannelController` to remove all dependencies
 - Remove `removeAction` method of `Pim\Bundle\EnrichBundle\Controller\ChannelController`
 - Change the constructor of `Pim\Bundle\EnrichBundle\Controller\Rest\ChannelController` to add `Pim\Component\Catalog\Updater\ChannelUpdater`, `Akeneo\Component\StorageUtils\Saver\SaverInterface`, `Akeneo\Component\StorageUtils\Remover\RemoverInterface`, `Akeneo\Component\StorageUtils\Factory\SimpleFactoryInterface`, `Symfony\Component\Validator\Validator\ValidatorInterface`
 - Change route `pim_enrich_channel_edit` to use `code` identifier instead of `id`

--- a/features/Context/WebUser.php
+++ b/features/Context/WebUser.php
@@ -1689,7 +1689,7 @@ class WebUser extends RawMinkContext
      */
     public function iWaitForTheJobToFinish($code)
     {
-        $condition = '$("#status").length && /(COMPLETED|STOPPED|FAILED|TERMINÉ|ARRÊTÉ|EN ÉCHEC)$/.test($("#status").text().trim())';
+        $condition = '$("#status").length && /(Completed|Stopped|Failed|TERMINÉ|ARRÊTÉ|EN ÉCHEC)$/.test($("#status").text().trim())';
 
         try {
             $this->wait($condition);

--- a/features/dashboard/display_last_operations_widget.feature
+++ b/features/dashboard/display_last_operations_widget.feature
@@ -35,7 +35,7 @@ Feature: Display last operations widget
     When I am on the job tracker page
     Then I should see the "Refresh" button
     And I should see the "Reset" button
-    And I should see the columns Type, Job, User, Status and Started at
+    And I should see the columns Type, Job, User, Started at, Status and Warnings
 
   Scenario: Show job tracker
     Given a "footwear" catalog configuration

--- a/features/datagrid/products_backtothegrid.feature
+++ b/features/datagrid/products_backtothegrid.feature
@@ -44,6 +44,7 @@ Feature: Products back to the grid
       | sneakers_8 |
       | sneakers_9 |
     And I should be able to sort the rows by SKU
+    And I change the page size to 10
     When I change the page number to 2
     And I click on the "boots_1" row
     And I click back to grid

--- a/features/export/browse_export_executions.feature
+++ b/features/export/browse_export_executions.feature
@@ -18,7 +18,7 @@ Feature: Browse export executions
     And I launch the "csv_footwear_product_export" export job
     Then I am on the export executions page
     And the grid should contain 4 elements
-    And I should see the columns Code, Label, Job, Date and Status
+    And I should see the columns Code, Label, Job, Date, Status and Warnings
     And I should see entities csv_footwear_product_export, csv_footwear_attribute_export, csv_footwear_category_export and csv_footwear_product_export
     And the rows should be sorted descending by Date
     And I should be able to sort the rows by Code, Label, Job, Date and Status
@@ -27,6 +27,6 @@ Feature: Browse export executions
       | code      | contains  | product                                     | csv_footwear_product_export, csv_footwear_product_export                                              |
       | label     | contains  | category                                    | csv_footwear_category_export                                                                          |
       | job_name  |           | Attribute export in CSV                     | csv_footwear_attribute_export                                                                         |
-      | status    |           | STOPPING                                    |                                                                                                       |
+      | status    |           | Stopping                                    |                                                                                                       |
       | date      | more than | 09/01/2015 05:00 PM                         | footwear_product_export, footwear_category_export, footwear_attribute_export, footwear_product_export |
       | date      | between   | 09/01/2050 05:00 PM and 09/01/2100 05:00 AM |                                                                                                       |

--- a/features/job-tracker/display_jobs_execution_in_job_tracker.feature
+++ b/features/job-tracker/display_jobs_execution_in_job_tracker.feature
@@ -17,7 +17,7 @@ Feature: Display jobs execution in job tracker
     When I am on the job tracker page
     Then I should see the "Refresh" button
     And I should see the "Reset" button
-    And I should see the columns Type, Job, User, Status and Started at
+    And I should see the columns Type, Job, User, Started at, Status and Warnings
     And the grid should contain 1 element
     And I should see entity CSV footwear category export
 
@@ -39,7 +39,7 @@ Feature: Display jobs execution in job tracker
     When I am on the job tracker page
     Then I should see the "Refresh" button
     And I should see the "Reset" button
-    And I should see the columns Type, Job, User, Status and Started at
+    And I should see the columns Type, Job, User, Started at, Status and Warnings
     And the grid should contain 1 element
     And I should see entity Mass edit common product attributes
 
@@ -61,6 +61,6 @@ Feature: Display jobs execution in job tracker
     And I am on the job tracker page
     And I should see the "Refresh" button
     And I should see the "Reset" button
-    And I should see the columns Type, Job, User, Status and Started at
+    And I should see the columns Type, Job, User, Started at, Status and Warnings
     And the grid should contain 1 element
     And I should see entity CSV footwear category import

--- a/features/mass-action/mass_delete.feature
+++ b/features/mass-action/mass_delete.feature
@@ -52,6 +52,7 @@ Feature: Delete many product at once
 
   Scenario: Successfully mass delete visible products
     Given I sort by "SKU" value ascending
+    Given I change the page size to 10
     And I select all visible entities
     Then I press "Delete" on the "Bulk Actions" dropdown button
     And I should see "Are you sure you want to delete selected products?"

--- a/features/mass-action/select_products_to_mass_edit.feature
+++ b/features/mass-action/select_products_to_mass_edit.feature
@@ -40,7 +40,8 @@ Feature: When I mass edit I should be able to see how many items will be edited
     Then I should see "Mass Edit (19 products)"
 
   Scenario: Successfully count the number of mass-edited items when click on all visible products
-    Given I select all visible entities
+    Given I change the page size to 10
+    And I select all visible entities
     When I press "Change product information" on the "Bulk Actions" dropdown button
     Then I should see "Mass Edit (10 products)"
 

--- a/src/Akeneo/Bundle/BatchBundle/Resources/views/Mails/notification.html.twig
+++ b/src/Akeneo/Bundle/BatchBundle/Resources/views/Mails/notification.html.twig
@@ -10,7 +10,7 @@
     <ul>
         {% for stepExecution in jobExecution.stepExecutions %}
         <li>
-            {{ stepExecution.stepName|trans }} [{{ stepExecution.status }}]
+            {{ stepExecution.stepName|trans }} [{{ stepExecution.status }}] {{ 0 < stepExecution.warnings|length ? 'With ' ~ stepExecution.warnings|length ~ ' warning(s)' : '' }}
         </li>
         {% endfor %}
     </ul>

--- a/src/Oro/Bundle/DataGridBundle/Extension/Toolbar/Configuration.php
+++ b/src/Oro/Bundle/DataGridBundle/Extension/Toolbar/Configuration.php
@@ -20,7 +20,7 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('pageSize')->addDefaultsIfNotSet()
                     ->children()
                         ->booleanNode('hide')->defaultFalse()->end()
-                        ->scalarNode('default_per_page')->defaultValue(10)->end()
+                        ->scalarNode('default_per_page')->defaultValue(25)->end()
                         ->arrayNode('items')
                             ->defaultValue([10, 25, 50, 100])
                             ->prototype('variable')->end()

--- a/src/Pim/Bundle/DashboardBundle/Resources/public/templates/last-operations-widget.html
+++ b/src/Pim/Bundle/DashboardBundle/Resources/public/templates/last-operations-widget.html
@@ -8,23 +8,36 @@
                 <%- __('pim_dashboard.widget.last_operations.type') %>
             </th>
             <th class="AknGrid-headerCell">
-                <%- __('pim_dashboard.widget.last_operations.profile name') %>
+                <%- __('pim_dashboard.widget.last_operations.profile_name') %>
             </th>
             <th class="AknGrid-headerCell">
                 <%- __('pim_dashboard.widget.last_operations.status') %>
+            </th>
+            <th class="AknGrid-headerCell">
+                <%- __('pim_dashboard.widget.last_operations.warning_count') %>
             </th>
             <th class="AknGrid-headerCell"></th>
         </tr>
     </thead>
     <tbody>
     <% _.each(data, function (operation) { %>
+        <% var status = 'success'; %>
+        <% status = (operation.warningCount !== null && parseInt(operation.warningCount) !== 0) ? 'warning' : status %>
+        <% status = (6 === operation.status) ? 'important' : status %>
+        <% var counter = (6 === operation.status) ? 1 : operation.warningCount %>
+
         <tr class="AknGrid-bodyRow">
             <td class="AknGrid-bodyCell"> <%- operation.date %></td>
             <td class="AknGrid-bodyCell"> <%- __('pim_dashboard.widget.last_operations.job_type.'+operation.type) %></td>
             <td class="AknGrid-bodyCell"><%- operation.label %></td>
             <td class="AknGrid-bodyCell">
-                <span class="AknBadge <%- operation.labelClass %>">
+                <span class="AknBadge AknBadge--<%- status %>">
                     <%- operation.statusLabel %>
+                </span>
+            </td>
+            <td class="AknGrid-bodyCell">
+                <span class="AknBadge AknBadge--<%- status %>">
+                    <%- counter %>
                 </span>
             </td>
             <td class="AknGrid-bodyCell AknGrid-bodyCell--right">

--- a/src/Pim/Bundle/DashboardBundle/Resources/translations/jsmessages.en.yml
+++ b/src/Pim/Bundle/DashboardBundle/Resources/translations/jsmessages.en.yml
@@ -5,8 +5,9 @@ pim_dashboard:
             status: Status
             date: Date
             type: Type
-            profile name: Profile name
+            profile_name: Profile name
             details: Details
+            warning_count: Warnings
             job_type:
                 import: Import
                 export: Export

--- a/src/Pim/Bundle/DashboardBundle/Widget/LastOperationsWidget.php
+++ b/src/Pim/Bundle/DashboardBundle/Widget/LastOperationsWidget.php
@@ -92,7 +92,7 @@ class LastOperationsWidget implements WidgetInterface
                 $locale = $this->tokenStorage->getToken()->getUser()->getUiLocale()->getCode();
                 $operation['date'] = $this->presenter->present($operation['date'], ['locale' => $locale]);
             }
-            $operation['canSeeReport'] = in_array($operation['type'], ['import', 'export']) &&
+            $operation['canSeeReport'] = !in_array($operation['type'], ['import', 'export']) ||
                 $this->securityFacade->isGranted(sprintf('pim_importexport_%s_execution_show', $operation['type']));
         }
 

--- a/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/JobExecutionRepository.php
+++ b/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/JobExecutionRepository.php
@@ -40,9 +40,13 @@ class JobExecutionRepository extends EntityRepository implements DatagridReposit
             ->addSelect('j.code AS jobCode')
             ->addSelect('j.label AS jobLabel')
             ->addSelect('j.jobName as jobName')
+            ->addSelect('COUNT(w.id) as warningCount')
         ;
 
         $qb->innerJoin('e.jobInstance', 'j');
+        $qb->leftJoin('e.stepExecutions', 's');
+        $qb->leftJoin('s.warnings', 'w');
+        $qb->groupBy('e.id');
 
         $qb->andWhere('j.type = :jobType');
 
@@ -74,8 +78,11 @@ class JobExecutionRepository extends EntityRepository implements DatagridReposit
     {
         $qb = $this->createQueryBuilder('e');
         $qb
-            ->select('e.id, e.startTime as date, j.type, j.label, e.status')
+            ->select('e.id, e.startTime as date, j.type, j.label, e.status, COUNT(w.id) as warningCount')
             ->innerJoin('e.jobInstance', 'j')
+            ->leftJoin('e.stepExecutions', 's')
+            ->leftJoin('s.warnings', 'w')
+            ->groupBy('e.id')
             ->orderBy('e.startTime', 'DESC')
             ->setMaxResults(10);
 

--- a/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/JobTrackerRepository.php
+++ b/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/JobTrackerRepository.php
@@ -40,7 +40,11 @@ class JobTrackerRepository extends EntityRepository implements DatagridRepositor
             ->addSelect('e.startTime as startTime')
             ->addSelect('j.label AS jobLabel')
             ->addSelect('e.user AS user')
-            ->innerJoin('e.jobInstance', 'j');
+            ->addSelect('COUNT(w.id) as warningCount')
+            ->innerJoin('e.jobInstance', 'j')
+            ->leftJoin('e.stepExecutions', 's')
+            ->leftJoin('s.warnings', 'w')
+            ->groupBy('e.id');
 
         return $qb;
     }

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/job_tracker.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/job_tracker.yml
@@ -11,14 +11,22 @@ datagrid:
                 data_name: jobLabel
             user:
                 label: User
-            status:
-                label: Status
-                type: translateable
             started_at:
                 label: job_tracker.filter.started_at
                 data_name: startTime
                 type: product_value_datetime
                 frontend_type: datetime
+            status:
+                label:         Status
+                type:          twig
+                template:      PimImportExportBundle:Property:status.html.twig
+                frontend_type: html
+            warning:
+                label:         Warnings
+                type:          twig
+                data_name:     warningCount
+                template:      PimImportExportBundle:Property:warning.html.twig
+                frontend_type: html
         actions:
             view:
                 type:      navigate
@@ -34,10 +42,12 @@ datagrid:
                     data_name: jobLabel
                 user:
                     data_name: user
-                status:
-                    data_name: statusLabel
                 started_at:
                     data_name: startTime
+                status:
+                    data_name: statusLabel
+                warning:
+                    data_name: warningCount
             default:
                 started_at: '%oro_datagrid.extension.orm_sorter.class%::DIRECTION_DESC'
         filters:
@@ -54,6 +64,10 @@ datagrid:
                     type:      string
                     label:     User
                     data_name: user
+                started_at:
+                    type:             datetime
+                    data_name:        startTime
+                    filter_by_having: true
                 status:
                     type:             choice
                     data_name:        status
@@ -62,9 +76,9 @@ datagrid:
                         field_options:
                             multiple: true
                             choices: '%akeneo_batch.job.batch_status.class%::getAllLabels()'
-                started_at:
-                    type:             datetime
-                    data_name:        startTime
+                warning:
+                    type:             number
+                    data_name:        warningCount
                     filter_by_having: true
         properties:
             id: ~

--- a/src/Pim/Bundle/ImportExportBundle/Resources/config/datagrid/job_execution.yml
+++ b/src/Pim/Bundle/ImportExportBundle/Resources/config/datagrid/job_execution.yml
@@ -19,9 +19,17 @@ datagrid:
                 type: product_value_datetime
                 frontend_type: datetime
             status:
-                label:     Status
-                type:      translateable
-                data_name: statusLabel
+                label:         Status
+                template:      PimImportExportBundle:Property:status.html.twig
+                type:          twig
+                frontend_type: html
+                data_name:     statusLabel
+            warning:
+                label:         Warnings
+                template:      PimImportExportBundle:Property:warning.html.twig
+                type:          twig
+                frontend_type: html
+                data_name:     warningCount
         properties:
             id: ~
             show_link:
@@ -47,6 +55,8 @@ datagrid:
                     data_name: date
                 status:
                     data_name: statusLabel
+                warning:
+                    data_name: warningCount
             default:
                 date: '%oro_datagrid.extension.orm_sorter.class%::DIRECTION_DESC'
         filters:
@@ -75,3 +85,7 @@ datagrid:
                         field_options:
                             multiple: true
                             choices: '%akeneo_batch.job.batch_status.class%::getAllLabels()'
+                warning:
+                    type:             number
+                    data_name:        warningCount
+                    filter_by_having: true

--- a/src/Pim/Bundle/ImportExportBundle/Resources/translations/messages.en.yml
+++ b/src/Pim/Bundle/ImportExportBundle/Resources/translations/messages.en.yml
@@ -11,14 +11,14 @@ pim_import_export:
         0: Ready
 
     batch_status:
-        1: COMPLETED
-        2: STARTING
-        3: STARTED
-        4: STOPPING
-        5: STOPPED
-        6: FAILED
-        7: ABANDONED
-        8: UNKNOWN
+        1: Completed
+        2: Starting
+        3: Started
+        4: Stopping
+        5: Stopped
+        6: Failed
+        7: Abandoned
+        8: Unknown
 
     download_archive:
         archive: download generated archive|download generated archives
@@ -182,21 +182,22 @@ job_execution.summary:
         title: File encoding:
         skipped: skipped, extension in white list
 
-Step:    Step
-Status:  Status
-Summary: Summary
-Start:   Start
-End:     End
+Step:     Step
+Status:   Status
+Warnings: Warnings
+Summary:  Summary
+Start:    Start
+End:      End
 
 # Process tracker
 set_attribute_requirements: Set attribute requirements
-COMPLETED: COMPLETED
-STARTING: STARTING
-STARTED: STARTED
-STOPPING: STOPPING
-STOPPED: STOPPED
-FAILED:  FAILED
-ABANDONED: ABANDONED
-UNKNOWN: UNKNOWN
+COMPLETED: Completed
+STARTING: Starting
+STARTED: Started
+STOPPING: Stopping
+STOPPED: Stopped
+FAILED:  Failed
+ABANDONED: Abandoned
+UNKNOWN: Unknown
 
 warning.label: Warning

--- a/src/Pim/Bundle/ImportExportBundle/Resources/views/Property/status.html.twig
+++ b/src/Pim/Bundle/ImportExportBundle/Resources/views/Property/status.html.twig
@@ -1,0 +1,5 @@
+{% set status = 'success' %}
+{% set status = record.getValue('warningCount') is not null and record.getValue('warningCount') != 0 ? 'warning' : status  %}
+{% set status = 'FAILED' == record.getValue('exitStatus').exitCode ? 'important' : status %}
+
+<span class="AknBadge AknBadge--{{ status }}">{{ value|trans }}</span>

--- a/src/Pim/Bundle/ImportExportBundle/Resources/views/Property/warning.html.twig
+++ b/src/Pim/Bundle/ImportExportBundle/Resources/views/Property/warning.html.twig
@@ -1,0 +1,6 @@
+{% set status = 'success' %}
+{% set status = value is not null and value != 0 ? 'warning' : status  %}
+{% set status = 'FAILED' == record.getValue('exitStatus').exitCode ? 'important' : status %}
+{% set counter = 'FAILED' == record.getValue('exitStatus').exitCode ? 1 : value %}
+
+<span class="AknBadge AknBadge--{{ status }}">{{ counter }}</span>


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This PR add a warning count column on job tracker and import/export history.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | :negative_squared_cross_mark:
| Added Behats                      | :white_check_mark:
| Added integration tests           |:negative_squared_cross_mark:
| Changelog updated                 | :clock1:
| Review and 2 GTM                  | :white_check_mark:
| Micro Demo to the PO (Story only) | :white_check_mark:
| Migration script                  | :negative_squared_cross_mark:
| Tech Doc                          | :negative_squared_cross_mark:


:white_check_mark: Done and pass

:red_circle: Done but fail

:clock1: Done but pending

:negative_squared_cross_mark: Not needed
