### PR TITLE
PIM-6062: Fix potential unix commands injection

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-6113: Fix wrong context switch on association groups
+- PIM-6062: Fix potential Unix commands injection
 
 # 1.6.9 (2017-01-17)
 

--- a/features/Context/CommandContext.php
+++ b/features/Context/CommandContext.php
@@ -220,14 +220,15 @@ class CommandContext extends PimContext
     }
 
     /**
+     * Runs app/console $command in the test environment
+     *
      * @When /^I run '([^\']*)'$/
+     *
+     * @param string $command
      */
     public function iRun($command)
     {
-        $pathFinder   = new PhpExecutableFinder();
-        $php          = $pathFinder->find();
-        $rootDir      = $this->getRootDir();
-        $command      = $this->replacePlaceholders($command);
-        $this->output = shell_exec(sprintf('%s %s/console %s', $php, $rootDir, $command));
+        $commandLauncher = $this->getService('pim_catalog.command_launcher');
+        $commandLauncher->executeForeground($this->replacePlaceholders($command));
     }
 }

--- a/features/technical/security.feature
+++ b/features/technical/security.feature
@@ -1,0 +1,10 @@
+Feature: Security
+  In order to check security of the external command
+  As a developer
+  I need to be able to execute shell commands without security issues
+
+  @jira https://akeneo.atlassian.net/browse/PIM-6062
+  Scenario: Fail when trying to inject command
+    Given file "%tmp%/this_will_raise_an_error.txt" should not exist
+    When I run '$(touch %tmp%/this_will_raise_an_error.txt)'
+    Then file "%tmp%/this_will_raise_an_error.txt" should not exist

--- a/src/Akeneo/Component/Console/CommandLauncher.php
+++ b/src/Akeneo/Component/Console/CommandLauncher.php
@@ -72,6 +72,7 @@ class CommandLauncher
             $logfile = sprintf('%s/logs/command_execute.log', $this->rootDir);
         }
         $cmd .= sprintf(' >> %s 2>&1 &', $logfile);
+        $cmd = escapeshellcmd($cmd);
         exec($cmd);
 
         return null;
@@ -87,6 +88,8 @@ class CommandLauncher
     public function executeForeground($command)
     {
         $cmd = $this->buildCommandString($command);
+        $cmd = escapeshellcmd($cmd);
+
         $output = [];
         $status = null;
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Avoid UNIX command injection through curl

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | :white_check_mark: :red_circle: :negative_squared_cross_mark: :clock1:
| Added Behats                      | :white_check_mark: :red_circle: :negative_squared_cross_mark: :clock1:
| Added integration tests           | :white_check_mark: :red_circle: :negative_squared_cross_mark: :clock1:
| Changelog updated                 | :white_check_mark: :red_circle: :negative_squared_cross_mark: :clock1:
| Review and 2 GTM                  | :white_check_mark: :red_circle: :negative_squared_cross_mark: :clock1:
| Micro Demo to the PO (Story only) | :white_check_mark: :red_circle: :negative_squared_cross_mark: :clock1:
| Migration script                  | :white_check_mark: :red_circle: :negative_squared_cross_mark: :clock1:
| Tech Doc                          | :white_check_mark: :red_circle: :negative_squared_cross_mark: :clock1:

