### PR TITLE
API-17: Get a list of categories

### DIFF
--- a/src/Pim/Bundle/ApiBundle/Controller/Rest/CategoryController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/Rest/CategoryController.php
@@ -59,4 +59,28 @@ class CategoryController
 
         return new JsonResponse($categoryStandard);
     }
+
+    /**
+     * @param Request $request
+     *
+     * @return JsonResponse
+     */
+    public function listAction(Request $request)
+    {
+        //@TODO limit will be set in configuration in an other PR
+        $limit = $request->query->get('limit', 10);
+        $page = $request->query->get('page', 1);
+
+        //@TODO add parameterValidator to validate limit and page
+
+        $offset = $limit * ($page - 1);
+
+        $categories = $this->repository->findBy([], ['root' => 'ASC', 'left' => 'ASC'], $limit, $offset);
+
+        $categoriesStandard = $this->normalizer->normalize($categories, 'external_api');
+
+        //@TODO use paginate method before return results
+
+        return new JsonResponse($categoriesStandard);
+    }
 }

--- a/src/Pim/Bundle/ApiBundle/Resources/config/routing.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/routing.yml
@@ -1,6 +1,6 @@
 category:
     resource: '@PimApiBundle/Resources/config/routing/category.yml'
-    prefix: /rest/v1/categories
+    prefix: /rest/v1
 
 family:
     resource: '@PimApiBundle/Resources/config/routing/family.yml'

--- a/src/Pim/Bundle/ApiBundle/Resources/config/routing/category.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/routing/category.yml
@@ -1,4 +1,9 @@
+pim_api_rest_category_list:
+    path: /categories
+    defaults: { _controller: pim_api.controller.rest.category:listAction, _format: json }
+    methods: [GET]
+
 pim_api_rest_category_get:
-    path: /{code}
+    path: /categories/{code}
     defaults: { _controller: pim_api.controller.rest.category:getAction, _format: json }
     methods: [GET]

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Category/ListCategoryIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Category/ListCategoryIntegration.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace tests\integration\Pim\Bundle\ApiBundle\Controller\Rest\Category;
+
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+class ListCategoryIntegration extends TestCase
+{
+    public function testListCategories()
+    {
+        $client = static::createClient();
+
+        $client->request('GET', 'api/rest/v1/categories');
+
+        $standardCategories = [
+            [
+                'code'   => 'master',
+                'parent' => null,
+                'labels' => []
+            ],
+            [
+                'code'   => 'categoryA',
+                'parent' => 'master',
+                'labels' => [
+                    'en_US' => 'Category A',
+                    'fr_FR' => 'Catégorie A'
+                ]
+            ],
+            [
+                'code'   => 'categoryA1',
+                'parent' => 'categoryA',
+                'labels' => []
+            ],
+            [
+                'code'   => 'categoryA2',
+                'parent' => 'categoryA',
+                'labels' => []
+            ],
+            [
+                'code'   => 'categoryB',
+                'parent' => 'master',
+                'labels' => []
+            ]
+        ];
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertSame($standardCategories, json_decode($response->getContent(), true));
+    }
+
+    public function testOutOfRangeListCategories()
+    {
+        $client = static::createClient();
+
+        $client->request('GET', 'api/rest/v1/categories?limit=10&page=2');
+
+        $standardCategories = [];
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertSame($standardCategories, json_decode($response->getContent(), true));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return new Configuration(
+            [Configuration::getTechnicalCatalogPath()],
+            false
+        );
+    }
+}


### PR DESCRIPTION
Get a list of categories
https://akeneo.atlassian.net/browse/API-17

Call /api/rest/v1/categories
Response 200

```
{"items":[{"code":"master","parent":null,"labels":{"en_US":"Master catalog","de_DE":"Hauptkatalog","fr_FR":"Catalogue principal"}}]}
```

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | :negative_squared_cross_mark:
| Added Behats                      | :negative_squared_cross_mark:
| Added integration tests           | :white_check_mark:
| Changelog updated                 | :negative_squared_cross_mark:
| Review and 2 GTM                  | :white_check_mark:
| Micro Demo to the PO (Story only) | :negative_squared_cross_mark:
| Migration script                  | :negative_squared_cross_mark:
| Tech Doc                          | :negative_squared_cross_mark:


:white_check_mark: Done and pass

:red_circle: Done but fail

:clock1: Done but pending

:negative_squared_cross_mark: Not needed
