### PR TITLE
Api 19 : create a category via the API

### DIFF
--- a/src/Akeneo/Component/Classification/Updater/CategoryUpdater.php
+++ b/src/Akeneo/Component/Classification/Updater/CategoryUpdater.php
@@ -71,19 +71,7 @@ class CategoryUpdater implements ObjectUpdaterInterface
                 $category->setLocale($localeCode);
             }
         } elseif ('parent' === $field) {
-            $categoryParent = $this->findParent($data);
-            if (null === $categoryParent) {
-                throw InvalidPropertyException::validEntityCodeExpected(
-                    'parent',
-                    'category code',
-                    'The category does not exist',
-                    'updater',
-                    'category',
-                    $data
-                );
-            }
-
-            $category->setParent($categoryParent);
+            $this->updateParent($category, $data);
         } else {
             try {
                 $this->accessor->setValue($category, $field, $data);
@@ -94,12 +82,30 @@ class CategoryUpdater implements ObjectUpdaterInterface
     }
 
     /**
-     * @param string $code
+     * @param CategoryInterface $category
+     * @param string            $data
      *
-     * @return CategoryInterface|null
+     * @throws InvalidPropertyException
      */
-    protected function findParent($code)
-    {
-        return $this->categoryRepository->findOneByIdentifier($code);
+    protected function updateParent(CategoryInterface $category, $data) {
+        if (null === $data || '' === $data) {
+            $category->setParent(null);
+
+            return;
+        }
+
+        $categoryParent = $this->categoryRepository->findOneByIdentifier($data);
+        if (null === $categoryParent) {
+            throw InvalidPropertyException::validEntityCodeExpected(
+                'parent',
+                'category code',
+                'The category does not exist',
+                'updater',
+                'category',
+                $data
+            );
+        }
+
+        $category->setParent($categoryParent);
     }
 }

--- a/src/Akeneo/Component/Classification/spec/Updater/CategoryUpdaterSpec.php
+++ b/src/Akeneo/Component/Classification/spec/Updater/CategoryUpdaterSpec.php
@@ -4,6 +4,7 @@ namespace spec\Akeneo\Component\Classification\Updater;
 
 use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Akeneo\Component\StorageUtils\Exception\UnknownPropertyException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use PhpSpec\ObjectBehavior;
@@ -104,6 +105,80 @@ class CategoryUpdaterSpec extends ObjectBehavior
                     'category',
                     'unknown'
                 )
+            )
+            ->during('update', [$category, $values, []]);
+    }
+
+    function it_throws_an_exception_when_code_is_not_a_scalar(CategoryInterface $category)
+    {
+        $values = [
+            'code' => [],
+        ];
+
+        $this
+            ->shouldThrow(
+                InvalidPropertyTypeException::scalarExpected('code', 'update', 'category', [])
+            )
+            ->during('update', [$category, $values, []]);
+    }
+
+    function it_throws_an_exception_when_parent_is_not_a_scalar(CategoryInterface $category)
+    {
+        $values = [
+            'parent' => [],
+        ];
+
+        $this
+            ->shouldThrow(
+                InvalidPropertyTypeException::scalarExpected('parent', 'update', 'category', [])
+            )
+            ->during('update', [$category, $values, []]);
+    }
+
+    function it_throws_an_exception_when_labels_is_not_an_array(CategoryInterface $category)
+    {
+        $values = [
+            'labels' => 'foo',
+        ];
+
+        $this
+            ->shouldThrow(
+                InvalidPropertyTypeException::arrayExpected('labels', 'update', 'category', 'foo')
+            )
+            ->during('update', [$category, $values, []]);
+    }
+
+    function it_throws_an_exception_when_one_of_the_labels_in_label_property_is_not_a_scalar(CategoryInterface $category)
+    {
+        $values = [
+            'labels' => [
+                'en_US' => 'foo',
+                'fr_FR' => [],
+            ],
+        ];
+
+        $this
+            ->shouldThrow(
+                InvalidPropertyTypeException::validArrayStructureExpected(
+                    'labels',
+                    'one of the labels is not a scalar',
+                    'update',
+                    'category',
+                    $values['labels']
+                )
+            )
+            ->during('update', [$category, $values, []]);
+    }
+
+    function it_throws_an_exception_when_a_property_is_unknown(CategoryInterface $category)
+    {
+        $values = [
+            'unknown' => 'foo',
+        ];
+
+        $this
+            ->shouldThrow(
+                UnknownPropertyException::unknownProperty('unknown')
             )
             ->during('update', [$category, $values, []]);
     }

--- a/src/Akeneo/Component/StorageUtils/Exception/InvalidObjectException.php
+++ b/src/Akeneo/Component/StorageUtils/Exception/InvalidObjectException.php
@@ -3,7 +3,7 @@
 namespace Akeneo\Component\StorageUtils\Exception;
 
 /**
- * Exception and updater can throw when updating an object unsupported by the updater.
+ * Exception an updater can throw when updating an object unsupported by the updater.
  *
  * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)

--- a/src/Akeneo/Component/StorageUtils/Exception/InvalidPropertyException.php
+++ b/src/Akeneo/Component/StorageUtils/Exception/InvalidPropertyException.php
@@ -3,7 +3,7 @@
 namespace Akeneo\Component\StorageUtils\Exception;
 
 /**
- * Exception and updater can throw when updating a property which is invalid.
+ * Exception an updater can throw when updating a property which is invalid.
  *
  * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)

--- a/src/Akeneo/Component/StorageUtils/Exception/InvalidPropertyTypeException.php
+++ b/src/Akeneo/Component/StorageUtils/Exception/InvalidPropertyTypeException.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Akeneo\Component\StorageUtils\Exception;
+
+/**
+ * Exception an updater can throw when updating a property with an unexpected data type.
+ * For example, when a scalar is provided instead of an array.
+ *
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class InvalidPropertyTypeException extends ObjectUpdaterException
+{
+    const EXPECTED_CODE = 100;
+    const SCALAR_EXPECTED_CODE = 101;
+    const ARRAY_EXPECTED_CODE = 102;
+    const VALID_ARRAY_STRUCTURE_EXPECTED_CODE = 103;
+
+    /** @var string */
+    protected $propertyName;
+
+    /** @var mixed */
+    protected $propertyValue;
+
+    /**
+     * @param string          $propertyName
+     * @param mixed           $propertyValue
+     * @param string          $message
+     * @param int             $code
+     * @param \Exception|null $previous
+     */
+    public function __construct($propertyName, $propertyValue, $message = '', $code = 0, \Exception $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+        $this->propertyName  = $propertyName;
+        $this->propertyValue = $propertyValue;
+    }
+
+    /**
+     * Build an exception when the data is not a scalar value.
+     *
+     * @param string $propertyName
+     * @param string $action
+     * @param string $type
+     * @param mixed  $propertyValue a value that is not a scalar (array, object, null)
+     *
+     * @return InvalidPropertyTypeException
+     */
+    public static function scalarExpected($propertyName, $action, $type, $propertyValue)
+    {
+        $message = 'Property "%s" expects a scalar (for %s %s).';
+
+        return new self(
+            $propertyName,
+            $propertyValue,
+            sprintf($message, $propertyName, $action, $type),
+            self::SCALAR_EXPECTED_CODE
+        );
+    }
+
+    /**
+     * Build an exception when the data is not an array value.
+     *
+     * @param string $propertyName
+     * @param string $action
+     * @param string $type
+     * @param mixed  $propertyValue a value that is not an array (scalar, object, null)
+     *
+     * @return InvalidPropertyTypeException
+     */
+    public static function arrayExpected($propertyName, $action, $type, $propertyValue)
+    {
+        $message = 'Property "%s" expects an array (for %s %s).';
+
+        return new self(
+            $propertyName,
+            $propertyValue,
+            sprintf($message, $propertyName, $action, $type),
+            self::ARRAY_EXPECTED_CODE
+        );
+    }
+
+    /**
+     * Build an exception when the data inside the array does not have the structure expected.
+     * For example, when the array contains scalar values instead of array values.
+     *
+     * @param string $propertyName
+     * @param string $because
+     * @param string $action
+     * @param string $type
+     * @param array  $propertyValue
+     *
+     * @return InvalidPropertyTypeExceptionn
+     */
+    public static function validArrayStructureExpected($propertyName, $because, $action, $type, array $propertyValue)
+    {
+        $message = 'Property "%s" expects a valid array, %s (for %s %s).';
+
+        return new self(
+            $propertyName,
+            $propertyValue,
+            sprintf($message, $propertyName, $because, $action, $type),
+            self::ARRAY_EXPECTED_CODE
+        );
+    }
+
+    /**
+     * @return string
+     */
+    public function getPropertyName()
+    {
+        return $this->propertyName;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPropertyValue()
+    {
+        return $this->propertyValue;
+    }
+}

--- a/src/Pim/Bundle/ApiBundle/Controller/Rest/CategoryController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/Rest/CategoryController.php
@@ -3,11 +3,24 @@
 namespace Pim\Bundle\ApiBundle\Controller\Rest;
 
 use Akeneo\Component\Classification\Repository\CategoryRepositoryInterface;
+use Akeneo\Component\StorageUtils\Exception\ObjectUpdaterException;
+use Akeneo\Component\StorageUtils\Exception\UnknownPropertyException;
+use Akeneo\Component\StorageUtils\Factory\SimpleFactoryInterface;
+use Akeneo\Component\StorageUtils\Saver\SaverInterface;
+use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Pim\Bundle\CatalogBundle\Version;
+use Pim\Component\Api\Exception\DocumentedHttpException;
+use Pim\Component\Api\Exception\ViolationHttpException;
+use Pim\Component\Catalog\Model\CategoryInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 /**
  * @author    Marie Bochu <marie.bochu@akeneo.com>
@@ -22,21 +35,51 @@ class CategoryController
     /** @var NormalizerInterface */
     protected $normalizer;
 
+    /** @var  ValidatorInterface */
+    protected $validator;
+
+    /** @var SimpleFactoryInterface */
+    protected $factory;
+
+    /** @var ObjectUpdaterInterface */
+    protected $updater;
+
+    /** @var SaverInterface */
+    protected $saver;
+
+    /** @var RouterInterface */
+    protected $router;
+
     /** @var string */
     protected $urlDocumentation;
 
     /**
      * @param CategoryRepositoryInterface $repository
      * @param NormalizerInterface         $normalizer
+     * @param SimpleFactoryInterface      $factory
+     * @param ObjectUpdaterInterface      $updater
+     * @param ValidatorInterface          $validator
+     * @param SaverInterface              $saver
+     * @param RouterInterface             $router
      * @param string                      $urlDocumentation
      */
     public function __construct(
         CategoryRepositoryInterface $repository,
         NormalizerInterface $normalizer,
+        SimpleFactoryInterface $factory,
+        ObjectUpdaterInterface $updater,
+        ValidatorInterface $validator,
+        SaverInterface $saver,
+        RouterInterface $router,
         $urlDocumentation
     ) {
         $this->repository = $repository;
         $this->normalizer = $normalizer;
+        $this->factory = $factory;
+        $this->updater = $updater;
+        $this->validator = $validator;
+        $this->saver = $saver;
+        $this->router = $router;
         $this->urlDocumentation = sprintf($urlDocumentation, substr(Version::VERSION, 0, 3));
     }
 
@@ -82,5 +125,88 @@ class CategoryController
         //@TODO use paginate method before return results
 
         return new JsonResponse($categoriesStandard);
+    }
+
+    /**
+     * @param Request $request
+     *
+     * @throws BadRequestHttpException
+     * @throws UnprocessableEntityHttpException
+     *
+     * @return JsonResponse
+     */
+    public function createAction(Request $request)
+    {
+        $data = $this->getDecodedContent($request->getContent());
+
+        if (isset($data['code']) && null !== $this->repository->findOneByIdentifier($data['code'])) {
+            throw new UnprocessableEntityHttpException(sprintf('Category "%s" already exists.', $data['code']));
+        }
+
+        $category = $this->factory->create();
+        $this->updateCategory($category, $data);
+
+        $violations = $this->validator->validate($category);
+        if (0 !== $violations->count()) {
+            throw new ViolationHttpException($violations);
+        }
+
+        $this->saver->save($category);
+
+        $response = new JsonResponse(null, Response::HTTP_CREATED);
+        $route = $this->router->generate('pim_api_rest_category_get', ['code' => $category->getCode()], true);
+        $response->headers->set('Location', $route);
+
+        return $response;
+    }
+
+    /**
+     * Get the JSON decoded content. If the content is not a valid JSON, it throws an error 400.
+     *
+     * @param string $content content of a request to decode
+     *
+     * @throws BadRequestHttpException
+     *
+     * @return array
+     */
+    protected function getDecodedContent($content)
+    {
+        $decodedContent = json_decode($content, true);
+
+        if (null === $decodedContent) {
+            throw new BadRequestHttpException('JSON is not valid.');
+        }
+
+        return $decodedContent;
+    }
+
+    /**
+     * Update a category. It throws an error 422 if a problem occurred during the update.
+     *
+     * @param CategoryInterface $category category to update
+     * @param array             $data     data of the request already decoded
+     *
+     * @throws UnprocessableEntityHttpException
+     */
+    protected function updateCategory(CategoryInterface $category, $data)
+    {
+        try {
+            $this->updater->update($category, $data);
+        } catch (UnknownPropertyException $exception) {
+            throw new DocumentedHttpException(
+                $this->urlDocumentation,
+                sprintf(
+                    'Property "%s" does not exist. Check the standard format documentation.',
+                    $exception->getPropertyName()
+                ),
+                $exception
+            );
+        } catch (ObjectUpdaterException $exception) {
+            throw new DocumentedHttpException(
+                $this->urlDocumentation,
+                sprintf('%s Check the standard format documentation.', $exception->getMessage()),
+                $exception
+            );
+        }
     }
 }

--- a/src/Pim/Bundle/ApiBundle/Resources/config/controllers.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/controllers.yml
@@ -10,6 +10,11 @@ services:
         arguments:
             - '@pim_catalog.repository.category'
             - '@pim_serializer'
+            - '@pim_catalog.factory.category'
+            - '@pim_catalog.updater.category'
+            - '@validator'
+            - '@pim_catalog.saver.category'
+            - '@router'
             - 'https://docs.akeneo.com/%s/reference/standard_format/other_entities.html#category'
 
     pim_api.controller.rest.family:

--- a/src/Pim/Bundle/ApiBundle/Resources/config/routing.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/routing.yml
@@ -1,6 +1,6 @@
 category:
     resource: '@PimApiBundle/Resources/config/routing/category.yml'
-    prefix: /rest/v1
+    prefix: /rest/v1/
 
 family:
     resource: '@PimApiBundle/Resources/config/routing/family.yml'

--- a/src/Pim/Bundle/ApiBundle/Resources/config/routing/category.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/routing/category.yml
@@ -7,3 +7,8 @@ pim_api_rest_category_get:
     path: /categories/{code}
     defaults: { _controller: pim_api.controller.rest.category:getAction, _format: json }
     methods: [GET]
+
+pim_api_rest_controller_create:
+    path: /categories
+    defaults: { _controller: pim_api.controller.rest.category:createAction, _format: json}
+    methods: [POST]

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Category/CreateCategoryIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Category/CreateCategoryIntegration.php
@@ -1,0 +1,7 @@
+<?php
+    /**
+     * Created by PhpStorm.
+     * User: ahocquard
+     * Date: 19/01/17
+     * Time: 17:42
+     */

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Category/CreateCategoryIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Category/CreateCategoryIntegration.php
@@ -1,7 +1,222 @@
 <?php
+
+namespace tests\integration\Pim\Bundle\ApiBundle\Controller\Rest\Category;
+
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Pim\Bundle\CatalogBundle\Version;
+use Symfony\Component\HttpFoundation\Response;
+
+class CreateCategoryIntegration extends TestCase
+{
+    public function testHttpHeadersInResponseWhenACategoryIsCreated()
+    {
+        $client = static::createClient();
+        $data =
+<<<JSON
+    {
+        "code": "new_category_headers"
+    }
+JSON;
+
+        $client->request('POST', 'api/rest/v1/categories', [], [], [], $data);
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+        $this->assertArrayHasKey('location', $response->headers->all());
+        $this->assertSame('http://localhost/api/rest/v1/categories/new_category_headers', $response->headers->get('location'));
+        $this->assertSame([], json_decode($response->getContent(), true));
+    }
+
+    public function testFormatStandardWhenACategoryIsCreatedButUncompleted()
+    {
+        $client = static::createClient();
+        $data =
+<<<JSON
+    {
+        "code": "new_category_uncompleted"
+    }
+JSON;
+
+        $client->request('POST', 'api/rest/v1/categories', [], [], [], $data);
+
+        $category = $this->get('pim_catalog.repository.category')->findOneByIdentifier('new_category_uncompleted');
+        $categoryStandard = [
+            'code'   => 'new_category_uncompleted',
+            'parent' => null,
+            'labels' => [],
+        ];
+        $normalizer = $this->get('pim_catalog.normalizer.standard.category');
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+        $this->assertSame($categoryStandard, $normalizer->normalize($category));
+    }
+
+    public function testCompleteCategoryCreation()
+    {
+        $client = static::createClient();
+        $data =
+<<<JSON
+    {
+        "code": "categoryC",
+        "parent": "master",
+        "labels": {
+            "en_US": "Category C",
+            "fr_FR": "Catégorie C"
+        }
+    }
+JSON;
+        $client->request('POST', 'api/rest/v1/categories', [], [], [], $data);
+
+        $category = $this->get('pim_catalog.repository.category')->findOneByIdentifier('categoryC');
+        $categoryStandard = [
+            'code'   => 'categoryC',
+            'parent' => 'master',
+            'labels' => [
+                'en_US' => 'Category C',
+                'fr_FR' => 'Catégorie C',
+            ],
+        ];
+        $normalizer = $this->get('pim_catalog.normalizer.standard.category');
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+        $this->assertSame($categoryStandard, $normalizer->normalize($category));
+    }
+
+    public function testResponseWhenContentIsNotValid()
+    {
+        $client = static::createClient();
+        $data = '';
+
+        $expectedContent = [
+            'code'    => 400,
+            'message' => 'JSON is not valid.',
+        ];
+
+        $client->request('POST', 'api/rest/v1/categories', [], [], [], $data);
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+        $this->assertSame($expectedContent, json_decode($response->getContent(), true));
+    }
+
+    public function testResponseWhenCategoryCodeAlreadyExists()
+    {
+        $client = static::createClient();
+        $data =
+<<<JSON
+    {
+        "code": "categoryA"
+    }
+JSON;
+
+        $expectedContent = [
+            'code'    => 422,
+            'message' => 'Category "categoryA" already exists.',
+        ];
+
+        $client->request('POST', 'api/rest/v1/categories', [], [], [], $data);
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertSame($expectedContent, json_decode($response->getContent(), true));
+    }
+
+
+    public function testResponseWhenValidationFailed()
+    {
+        $client = static::createClient();
+        $data =
+<<<JSON
+    {
+        "code": ""
+    }
+JSON;
+
+        $expectedContent = [
+            'code'    => 422,
+            'message' => 'Validation failed.',
+            'errors'  => [
+                [
+                    'field'   => 'code',
+                    'message' => 'This value should not be blank.',
+                ],
+            ],
+        ];
+
+        $client->request('POST', 'api/rest/v1/categories', [], [], [], $data);
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertSame($expectedContent, json_decode($response->getContent(), true));
+    }
+
+    public function testResponseWhenAPropertyIsNotExpected()
+    {
+        $client = static::createClient();
+        $data =
+<<<JSON
+    {
+        "code": "sales",
+        "extra_property": ""
+    }
+JSON;
+
+        $version = substr(Version::VERSION, 0, 3);
+        $expectedContent = [
+            'code'    => 422,
+            'message' => 'Property "extra_property" does not exist. Check the standard format documentation.',
+            '_links'  => [
+                'documentation' => [
+                    'href' => sprintf('https://docs.akeneo.com/%s/reference/standard_format/other_entities.html#category', $version),
+                ],
+            ],
+        ];
+
+        $client->request('POST', 'api/rest/v1/categories', [], [], [], $data);
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertSame($expectedContent, json_decode($response->getContent(), true));
+    }
+
+    public function testResponseWhenLabelsIsNull()
+    {
+        $client = static::createClient();
+        $data =
+<<<JSON
+    {
+        "labels": null
+    }
+JSON;
+
+        $version = substr(Version::VERSION, 0, 3);
+        $expectedContent = [
+            'code'    => 422,
+            'message' => 'Property "labels" expects an array (for update category). Check the standard format documentation.',
+            '_links'  => [
+                'documentation' => [
+                    'href' => sprintf('https://docs.akeneo.com/%s/reference/standard_format/other_entities.html#category', $version),
+                ],
+            ],
+        ];
+
+        $client->request('POST', 'api/rest/v1/categories', [], [], [], $data);
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertSame($expectedContent, json_decode($response->getContent(), true));
+    }
+
     /**
-     * Created by PhpStorm.
-     * User: ahocquard
-     * Date: 19/01/17
-     * Time: 17:42
+     * {@inheritdoc}
      */
+    protected function getConfiguration()
+    {
+        return new Configuration(
+            [Configuration::getTechnicalCatalogPath()],
+            false
+        );
+    }
+}

--- a/src/Pim/Component/Api/Exception/ViolationHttpException.php
+++ b/src/Pim/Component/Api/Exception/ViolationHttpException.php
@@ -25,7 +25,7 @@ class ViolationHttpException extends UnprocessableEntityHttpException
      */
     public function __construct(
         ConstraintViolationListInterface $violations,
-        $message = 'Validation failed',
+        $message = 'Validation failed.',
         \Exception $previous = null,
         $code = 0
     ) {

--- a/src/Pim/Component/Api/spec/Normalizer/Exception/ViolationNormalizerSpec.php
+++ b/src/Pim/Component/Api/spec/Normalizer/Exception/ViolationNormalizerSpec.php
@@ -19,7 +19,7 @@ class ViolationNormalizerSpec extends ObjectBehavior
 
         $this->normalize($exception)->shouldReturn([
             'code'    => Response::HTTP_UNPROCESSABLE_ENTITY,
-            'message' => 'Validation failed',
+            'message' => 'Validation failed.',
             'errors'  => [
                 ['field' => 'code', 'message' => 'Not Blank'],
                 ['field' => 'name', 'message' => 'Too long']


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) 

**Description (for Contributor and Core Developer)**

Implementation of the POST (=create) on the category entity.

- I've had a new business exception when the standard format has a wrong input type
- Check the standard format in the updater
- A parent category can be set to null now (impossible before)




[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | :white_check_mark:
| Added Behats                      | :negative_squared_cross_mark:
| Added integration tests           | :white_check_mark: 
| Changelog updated                 | :negative_squared_cross_mark: 
| Review and 2 GTM                  | :clock1:
| Micro Demo to the PO (Story only) | :negative_squared_cross_mark: 
| Migration script                  |:negative_squared_cross_mark:
| Tech Doc                          | :negative_squared_cross_mark: 


:white_check_mark: Done and pass

:red_circle: Done but fail

:clock1: Done but pending

:negative_squared_cross_mark: Not needed
