### PR TITLE
API-50: Access token route

### DIFF
--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -30,11 +30,6 @@ security:
             pattern:                        ^/media
             security:                       false
 
-        # TODO: enabled oAuth autorization with API-47
-        rest:
-            pattern:                        ^/api
-            anonymous:                      true
-
         login:
             pattern:                        ^/user/(login|reset-request|send-email|check-email)$
             provider:                       chain_provider
@@ -44,6 +39,15 @@ security:
             pattern:                        ^/user/reset/*
             provider:                       chain_provider
             anonymous:                      true
+
+        oauth_token:
+            pattern:                        ^/api/oauth/v1/token
+            security:                       false
+
+        api:
+            pattern:                        ^/api
+            fos_oauth:                      true
+            stateless:                      true
 
         main:
             pattern:                        ^/
@@ -62,3 +66,4 @@ security:
 
     access_control:
         - { path: ^/admin/, role: ROLE_ADMIN }
+        - { path: ^/api/, role: IS_AUTHENTICATED_FULLY }

--- a/app/config/security_test.yml
+++ b/app/config/security_test.yml
@@ -1,10 +1,14 @@
 security:
     firewalls:
+        api:
+            pattern:        ^/api
+            security:       false
+
         main:
             http_basic:
-                realm: "Secured REST Area"
-            provider: oro_user
-            form_login: false
-            logout: false
-            remember_me: false
-            anonymous: true
+                realm:      "Secured REST Area"
+            provider:       oro_user
+            form_login:     false
+            logout:         false
+            remember_me:    false
+            anonymous:      true

--- a/src/Pim/Bundle/ApiBundle/Controller/TokenController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/TokenController.php
@@ -54,7 +54,7 @@ class TokenController
     protected function getErrorMessage($errorCode)
     {
         $messages = [
-            OAuth2::ERROR_INVALID_REQUEST     => 'Parameter "grant_type", "username" or "password" is missing or empty',
+            OAuth2::ERROR_INVALID_REQUEST     => 'Parameter "grant_type", "username" or "password" is missing, empty or invalid',
             OAuth2::ERROR_INVALID_CLIENT      => 'Parameter "client_id" is missing or does not match any client, or secret is invalid',
             OAuth2::ERROR_UNAUTHORIZED_CLIENT => 'This grant type is not authorized for this client',
             OAuth2::ERROR_INVALID_GRANT       => 'No user found for the given username and password',

--- a/src/Pim/Bundle/ApiBundle/Controller/TokenController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/TokenController.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Pim\Bundle\ApiBundle\Controller;
+
+use OAuth2\OAuth2;
+use OAuth2\OAuth2ServerException;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @author    Yohan Blain <yohan.blain@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class TokenController
+{
+    /** @var OAuth2 */
+    protected $oauthServer;
+
+    /**
+     * @param OAuth2 $oauthServer
+     */
+    public function __construct(OAuth2 $oauthServer)
+    {
+        $this->oauthServer = $oauthServer;
+    }
+
+    /**
+     * @param Request $request
+     *
+     * @return Response
+     */
+    public function tokenAction(Request $request)
+    {
+        try {
+            return $this->oauthServer->grantAccessToken($request);
+        } catch (OAuth2ServerException $e) {
+            $message = $this->getErrorMessage($e->getMessage());
+
+            return new JsonResponse(
+                [
+                    'code'    => Response::HTTP_UNPROCESSABLE_ENTITY,
+                    'message' => null !== $message ? $message : $e->getDescription(),
+                ],
+                Response::HTTP_UNPROCESSABLE_ENTITY
+            );
+        }
+    }
+
+    /**
+     * Wraps the mapping between FOS OAuth server error messages (which are actually kind of codes) and our messages.
+     *
+     * @param string $errorCode
+     *
+     * @return string|null
+     */
+    protected function getErrorMessage($errorCode)
+    {
+        $messages = [
+            OAuth2::ERROR_INVALID_REQUEST     => 'Parameter "grant_type", "username" or "password" is missing or empty',
+            OAuth2::ERROR_INVALID_CLIENT      => 'Parameter "client_id" is missing or does not match any client, or secret is invalid',
+            OAuth2::ERROR_UNAUTHORIZED_CLIENT => 'This grant type is not authorized for this client',
+            OAuth2::ERROR_INVALID_GRANT       => 'No user found for the given username and password',
+        ];
+
+        return isset($messages[$errorCode]) ? $messages[$errorCode] : null;
+    }
+}

--- a/src/Pim/Bundle/ApiBundle/Controller/TokenController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/TokenController.php
@@ -4,9 +4,9 @@ namespace Pim\Bundle\ApiBundle\Controller;
 
 use OAuth2\OAuth2;
 use OAuth2\OAuth2ServerException;
-use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 
 /**
  * @author    Yohan Blain <yohan.blain@akeneo.com>
@@ -29,6 +29,8 @@ class TokenController
     /**
      * @param Request $request
      *
+     * @throws UnprocessableEntityHttpException
+     *
      * @return Response
      */
     public function tokenAction(Request $request)
@@ -38,13 +40,7 @@ class TokenController
         } catch (OAuth2ServerException $e) {
             $message = $this->getErrorMessage($e->getMessage());
 
-            return new JsonResponse(
-                [
-                    'code'    => Response::HTTP_UNPROCESSABLE_ENTITY,
-                    'message' => null !== $message ? $message : $e->getDescription(),
-                ],
-                Response::HTTP_UNPROCESSABLE_ENTITY
-            );
+            throw new UnprocessableEntityHttpException(null !== $message ? $message : $e->getDescription());
         }
     }
 

--- a/src/Pim/Bundle/ApiBundle/Resources/config/controllers.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/controllers.yml
@@ -3,6 +3,7 @@ parameters:
     pim_api.controller.rest.family.class: Pim\Bundle\ApiBundle\Controller\Rest\FamilyController
     pim_api.controller.rest.attribute.class: Pim\Bundle\ApiBundle\Controller\Rest\AttributeController
     pim_api.controller.rest.attribute_option.class: Pim\Bundle\ApiBundle\Controller\Rest\AttributeOptionController
+    pim_api.controller.token.class: Pim\Bundle\ApiBundle\Controller\TokenController
 
 services:
     pim_api.controller.rest.category:
@@ -36,3 +37,9 @@ services:
             - '@pim_catalog.repository.attribute_option'
             - '@pim_serializer'
             - ['pim_catalog_simpleselect', 'pim_catalog_multiselect']
+
+    pim_api.controller.token:
+        scope: request
+        class: '%pim_api.controller.token.class%'
+        arguments:
+            - '@fos_oauth_server.server'

--- a/src/Pim/Bundle/ApiBundle/Resources/config/routing.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/routing.yml
@@ -13,4 +13,4 @@ attribute:
 fos_oauth_server_token:
     path: /oauth/v1/token
     defaults: { _controller: pim_api.controller.token:tokenAction }
-    methods: [GET]
+    methods: [POST]

--- a/src/Pim/Bundle/ApiBundle/Resources/config/routing.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/routing.yml
@@ -9,3 +9,8 @@ family:
 attribute:
     resource: '@PimApiBundle/Resources/config/routing/attribute.yml'
     prefix: /rest/v1
+
+fos_oauth_server_token:
+    path: /oauth/v1/token
+    defaults: { _controller: pim_api.controller.token:tokenAction }
+    methods: [GET]

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Token/GetAccessTokenIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Token/GetAccessTokenIntegration.php
@@ -4,7 +4,6 @@ namespace tests\integration\Pim\Bundle\ApiBundle\Controller\Token;
 
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;
-use OAuth2\OAuth2;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
@@ -40,13 +39,18 @@ class GetAccessTokenIntegration extends TestCase
     {
         $client = static::createClient();
 
-        $client->request('GET', 'api/oauth/v1/token', [
-            'client_id'     => $this->clientId,
-            'client_secret' => $this->secret,
-            'username'      => 'admin',
-            'password'      => 'admin',
-            'grant_type'    => 'password',
-        ]);
+        $client->request('POST', 'api/oauth/v1/token',
+            [
+               'username'   => 'admin',
+               'password'   => 'admin',
+               'grant_type' => 'password',
+            ],
+            [],
+            [
+                'PHP_AUTH_USER' => $this->clientId,
+                'PHP_AUTH_PW'   => $this->secret,
+            ]
+        );
 
         $response = $client->getResponse();
         $responseBody = json_decode($response->getContent(), true);
@@ -63,12 +67,17 @@ class GetAccessTokenIntegration extends TestCase
     {
         $client = static::createClient();
 
-        $client->request('GET', 'api/oauth/v1/token', [
-            'client_id'     => $this->clientId,
-            'client_secret' => $this->secret,
-            'username'      => 'admin',
-            'password'      => 'admin',
-        ]);
+        $client->request('POST', 'api/oauth/v1/token',
+            [
+                'username'   => 'admin',
+                'password'   => 'admin',
+            ],
+            [],
+            [
+                'PHP_AUTH_USER' => $this->clientId,
+                'PHP_AUTH_PW'   => $this->secret,
+            ]
+        );
 
         $response = $client->getResponse();
         $responseBody = json_decode($response->getContent(), true);
@@ -83,13 +92,18 @@ class GetAccessTokenIntegration extends TestCase
     {
         $client = static::createClient();
 
-        $client->request('GET', 'api/oauth/v1/token', [
-            'client_id'     => $this->clientId,
-            'client_secret' => $this->secret,
-            'username'      => 'admin',
-            'password'      => 'admin',
-            'grant_type'    => 'token',
-        ]);
+        $client->request('POST', 'api/oauth/v1/token',
+            [
+                'username'   => 'admin',
+                'password'   => 'admin',
+                'grant_type' => 'token',
+            ],
+            [],
+            [
+                'PHP_AUTH_USER' => $this->clientId,
+                'PHP_AUTH_PW'   => $this->secret,
+            ]
+        );
 
         $response = $client->getResponse();
         $responseBody = json_decode($response->getContent(), true);
@@ -104,13 +118,18 @@ class GetAccessTokenIntegration extends TestCase
     {
         $client = static::createClient();
 
-        $client->request('GET', 'api/oauth/v1/token', [
-            'client_id'     => 'michel_id',
-            'client_secret' => $this->secret,
-            'username'      => 'admin',
-            'password'      => 'admin',
-            'grant_type'    => 'password',
-        ]);
+        $client->request('POST', 'api/oauth/v1/token',
+            [
+                'username'   => 'admin',
+                'password'   => 'admin',
+                'grant_type' => 'password',
+            ],
+            [],
+            [
+                'PHP_AUTH_USER' => 'michel_id',
+                'PHP_AUTH_PW'   => $this->secret,
+            ]
+        );
 
         $response = $client->getResponse();
         $responseBody = json_decode($response->getContent(), true);
@@ -125,13 +144,18 @@ class GetAccessTokenIntegration extends TestCase
     {
         $client = static::createClient();
 
-        $client->request('GET', 'api/oauth/v1/token', [
-            'client_id'     => $this->clientId,
-            'client_secret' => 'michel_secret',
-            'username'      => 'admin',
-            'password'      => 'admin',
-            'grant_type'    => 'password',
-        ]);
+        $client->request('POST', 'api/oauth/v1/token',
+            [
+                'username'   => 'admin',
+                'password'   => 'admin',
+                'grant_type' => 'password',
+            ],
+            [],
+            [
+                'PHP_AUTH_USER' => $this->clientId,
+                'PHP_AUTH_PW'   => 'michel_secret',
+            ]
+        );
 
         $response = $client->getResponse();
         $responseBody = json_decode($response->getContent(), true);
@@ -146,12 +170,17 @@ class GetAccessTokenIntegration extends TestCase
     {
         $client = static::createClient();
 
-        $client->request('GET', 'api/oauth/v1/token', [
-            'client_id'     => $this->clientId,
-            'client_secret' => $this->secret,
-            'password'      => 'admin',
-            'grant_type'    => 'password',
-        ]);
+        $client->request('POST', 'api/oauth/v1/token',
+            [
+                'password'   => 'admin',
+                'grant_type' => 'password',
+            ],
+            [],
+            [
+                'PHP_AUTH_USER' => $this->clientId,
+                'PHP_AUTH_PW'   => $this->secret,
+            ]
+        );
 
         $response = $client->getResponse();
         $responseBody = json_decode($response->getContent(), true);
@@ -166,12 +195,17 @@ class GetAccessTokenIntegration extends TestCase
     {
         $client = static::createClient();
 
-        $client->request('GET', 'api/oauth/v1/token', [
-            'client_id'     => $this->clientId,
-            'client_secret' => $this->secret,
-            'username'      => 'admin',
-            'grant_type'    => 'password',
-        ]);
+        $client->request('POST', 'api/oauth/v1/token',
+            [
+                'username'   => 'admin',
+                'grant_type' => 'password',
+            ],
+            [],
+            [
+                'PHP_AUTH_USER' => $this->clientId,
+                'PHP_AUTH_PW'   => $this->secret,
+            ]
+        );
 
         $response = $client->getResponse();
         $responseBody = json_decode($response->getContent(), true);
@@ -186,13 +220,18 @@ class GetAccessTokenIntegration extends TestCase
     {
         $client = static::createClient();
 
-        $client->request('GET', 'api/oauth/v1/token', [
-            'client_id'     => $this->clientId,
-            'client_secret' => $this->secret,
-            'username'      => 'michel',
-            'password'      => 'michelpwd',
-            'grant_type'    => 'password',
-        ]);
+        $client->request('POST', 'api/oauth/v1/token',
+            [
+                'username'   => 'michel',
+                'password'   => 'michelpwd',
+                'grant_type' => 'password',
+            ],
+            [],
+            [
+                'PHP_AUTH_USER' => $this->clientId,
+                'PHP_AUTH_PW'   => $this->secret,
+            ]
+        );
 
         $response = $client->getResponse();
         $responseBody = json_decode($response->getContent(), true);

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Token/GetAccessTokenIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Token/GetAccessTokenIntegration.php
@@ -83,12 +83,38 @@ class GetAccessTokenIntegration extends TestCase
         $responseBody = json_decode($response->getContent(), true);
 
         $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
-        $this->assertSame('Parameter "grant_type", "username" or "password" is missing or empty', $responseBody['message']);
+        $this->assertSame('Parameter "grant_type", "username" or "password" is missing, empty or invalid', $responseBody['message']);
         $this->assertArrayNotHasKey('access_token', $responseBody);
         $this->assertArrayNotHasKey('refresh_token', $responseBody);
     }
 
     public function testInvalidGrantType()
+    {
+        $client = static::createClient();
+
+        $client->request('POST', 'api/oauth/v1/token',
+            [
+                'username'   => 'admin',
+                'password'   => 'admin',
+                'grant_type' => 'passwordd',
+            ],
+            [],
+            [
+                'PHP_AUTH_USER' => $this->clientId,
+                'PHP_AUTH_PW'   => $this->secret,
+            ]
+        );
+
+        $response = $client->getResponse();
+        $responseBody = json_decode($response->getContent(), true);
+
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertSame('Parameter "grant_type", "username" or "password" is missing, empty or invalid', $responseBody['message']);
+        $this->assertArrayNotHasKey('access_token', $responseBody);
+        $this->assertArrayNotHasKey('refresh_token', $responseBody);
+    }
+
+    public function testUnauthorizedGrantType()
     {
         $client = static::createClient();
 
@@ -186,7 +212,7 @@ class GetAccessTokenIntegration extends TestCase
         $responseBody = json_decode($response->getContent(), true);
 
         $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
-        $this->assertSame('Parameter "grant_type", "username" or "password" is missing or empty', $responseBody['message']);
+        $this->assertSame('Parameter "grant_type", "username" or "password" is missing, empty or invalid', $responseBody['message']);
         $this->assertArrayNotHasKey('access_token', $responseBody);
         $this->assertArrayNotHasKey('refresh_token', $responseBody);
     }
@@ -211,7 +237,7 @@ class GetAccessTokenIntegration extends TestCase
         $responseBody = json_decode($response->getContent(), true);
 
         $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
-        $this->assertSame('Parameter "grant_type", "username" or "password" is missing or empty', $responseBody['message']);
+        $this->assertSame('Parameter "grant_type", "username" or "password" is missing, empty or invalid', $responseBody['message']);
         $this->assertArrayNotHasKey('access_token', $responseBody);
         $this->assertArrayNotHasKey('refresh_token', $responseBody);
     }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Token/GetAccessTokenIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Token/GetAccessTokenIntegration.php
@@ -1,0 +1,216 @@
+<?php
+
+namespace tests\integration\Pim\Bundle\ApiBundle\Controller\Token;
+
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use OAuth2\OAuth2;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\HttpFoundation\Response;
+
+class GetAccessTokenIntegration extends TestCase
+{
+    /** @var string */
+    protected $clientId;
+
+    /** @var string */
+    protected $secret;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $consoleApp = new Application(self::$kernel);
+        $consoleApp->setAutoExit(false);
+
+        $input = new ArrayInput(['command' => 'pim:oauth-server:create-client']);
+        $output = new BufferedOutput();
+
+        $consoleApp->run($input, $output);
+
+        $content = $output->fetch();
+        preg_match('/client_id: (.+)\nsecret: (.+)$/', $content, $matches);
+        $this->clientId = $matches[1];
+        $this->secret = $matches[2];
+    }
+
+    public function testGetAccessToken()
+    {
+        $client = static::createClient();
+
+        $client->request('GET', 'api/oauth/v1/token', [
+            'client_id'     => $this->clientId,
+            'client_secret' => $this->secret,
+            'username'      => 'admin',
+            'password'      => 'admin',
+            'grant_type'    => 'password',
+        ]);
+
+        $response = $client->getResponse();
+        $responseBody = json_decode($response->getContent(), true);
+
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertArrayHasKey('access_token', $responseBody);
+        $this->assertArrayHasKey('expires_in', $responseBody);
+        $this->assertArrayHasKey('token_type', $responseBody);
+        $this->assertArrayHasKey('scope', $responseBody);
+        $this->assertArrayHasKey('refresh_token', $responseBody);
+    }
+
+    public function testMissingGrantType()
+    {
+        $client = static::createClient();
+
+        $client->request('GET', 'api/oauth/v1/token', [
+            'client_id'     => $this->clientId,
+            'client_secret' => $this->secret,
+            'username'      => 'admin',
+            'password'      => 'admin',
+        ]);
+
+        $response = $client->getResponse();
+        $responseBody = json_decode($response->getContent(), true);
+
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertSame('Parameter "grant_type", "username" or "password" is missing or empty', $responseBody['message']);
+        $this->assertArrayNotHasKey('access_token', $responseBody);
+        $this->assertArrayNotHasKey('refresh_token', $responseBody);
+    }
+
+    public function testInvalidGrantType()
+    {
+        $client = static::createClient();
+
+        $client->request('GET', 'api/oauth/v1/token', [
+            'client_id'     => $this->clientId,
+            'client_secret' => $this->secret,
+            'username'      => 'admin',
+            'password'      => 'admin',
+            'grant_type'    => 'token',
+        ]);
+
+        $response = $client->getResponse();
+        $responseBody = json_decode($response->getContent(), true);
+
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertSame('This grant type is not authorized for this client', $responseBody['message']);
+        $this->assertArrayNotHasKey('access_token', $responseBody);
+        $this->assertArrayNotHasKey('refresh_token', $responseBody);
+    }
+
+    public function testInvalidClientId()
+    {
+        $client = static::createClient();
+
+        $client->request('GET', 'api/oauth/v1/token', [
+            'client_id'     => 'michel_id',
+            'client_secret' => $this->secret,
+            'username'      => 'admin',
+            'password'      => 'admin',
+            'grant_type'    => 'password',
+        ]);
+
+        $response = $client->getResponse();
+        $responseBody = json_decode($response->getContent(), true);
+
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertSame('Parameter "client_id" is missing or does not match any client, or secret is invalid', $responseBody['message']);
+        $this->assertArrayNotHasKey('access_token', $responseBody);
+        $this->assertArrayNotHasKey('refresh_token', $responseBody);
+    }
+
+    public function testInvalidSecret()
+    {
+        $client = static::createClient();
+
+        $client->request('GET', 'api/oauth/v1/token', [
+            'client_id'     => $this->clientId,
+            'client_secret' => 'michel_secret',
+            'username'      => 'admin',
+            'password'      => 'admin',
+            'grant_type'    => 'password',
+        ]);
+
+        $response = $client->getResponse();
+        $responseBody = json_decode($response->getContent(), true);
+
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertSame('Parameter "client_id" is missing or does not match any client, or secret is invalid', $responseBody['message']);
+        $this->assertArrayNotHasKey('access_token', $responseBody);
+        $this->assertArrayNotHasKey('refresh_token', $responseBody);
+    }
+
+    public function testMissingUsername()
+    {
+        $client = static::createClient();
+
+        $client->request('GET', 'api/oauth/v1/token', [
+            'client_id'     => $this->clientId,
+            'client_secret' => $this->secret,
+            'password'      => 'admin',
+            'grant_type'    => 'password',
+        ]);
+
+        $response = $client->getResponse();
+        $responseBody = json_decode($response->getContent(), true);
+
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertSame('Parameter "grant_type", "username" or "password" is missing or empty', $responseBody['message']);
+        $this->assertArrayNotHasKey('access_token', $responseBody);
+        $this->assertArrayNotHasKey('refresh_token', $responseBody);
+    }
+
+    public function testMissingPassword()
+    {
+        $client = static::createClient();
+
+        $client->request('GET', 'api/oauth/v1/token', [
+            'client_id'     => $this->clientId,
+            'client_secret' => $this->secret,
+            'username'      => 'admin',
+            'grant_type'    => 'password',
+        ]);
+
+        $response = $client->getResponse();
+        $responseBody = json_decode($response->getContent(), true);
+
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertSame('Parameter "grant_type", "username" or "password" is missing or empty', $responseBody['message']);
+        $this->assertArrayNotHasKey('access_token', $responseBody);
+        $this->assertArrayNotHasKey('refresh_token', $responseBody);
+    }
+
+    public function testUserNotFound()
+    {
+        $client = static::createClient();
+
+        $client->request('GET', 'api/oauth/v1/token', [
+            'client_id'     => $this->clientId,
+            'client_secret' => $this->secret,
+            'username'      => 'michel',
+            'password'      => 'michelpwd',
+            'grant_type'    => 'password',
+        ]);
+
+        $response = $client->getResponse();
+        $responseBody = json_decode($response->getContent(), true);
+
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertSame('No user found for the given username and password', $responseBody['message']);
+        $this->assertArrayNotHasKey('access_token', $responseBody);
+        $this->assertArrayNotHasKey('refresh_token', $responseBody);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return new Configuration(
+            [Configuration::getTechnicalCatalogPath()],
+            false
+        );
+    }
+}


### PR DESCRIPTION
In this PR:
- New route that wraps FOS OAuth2 server and transform the response for error cases.
- New security firewall for the API.
- This firewall has been disabled to allow integration tests to pass. As we still want to test the firewall, it will be reactivated and integration tests will be reworked in another PR.


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | :negative_squared_cross_mark:
| Added Behats                      | :negative_squared_cross_mark:
| Added integration tests           | :white_check_mark:
| Changelog updated                 | :negative_squared_cross_mark:
| Review and 2 GTM                  | :clock1:
| Micro Demo to the PO (Story only) | :white_check_mark:
| Migration script                  | :negative_squared_cross_mark:
| Tech Doc                          | :negative_squared_cross_mark:


:white_check_mark: Done and pass

:red_circle: Done but fail

:clock1: Done but pending

:negative_squared_cross_mark: Not needed
