### PR TITLE
TIP-681: Deprecate ProductBuilderInterface::removePricesNotInCurrency

### DIFF
--- a/src/Pim/Component/Catalog/Builder/ProductBuilderInterface.php
+++ b/src/Pim/Component/Catalog/Builder/ProductBuilderInterface.php
@@ -105,6 +105,8 @@ interface ProductBuilderInterface
      *
      * @param ProductValueInterface $value
      * @param array                 $currencies
+     *
+     * @deprecated Will be removed in 1.8.
      */
     public function removePricesNotInCurrency(ProductValueInterface $value, array $currencies);
 


### PR DESCRIPTION
**Description**

This method will not be needed in 1.8, thanks to the new ProductValueFactory.

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | :negative_squared_cross_mark:
| Added Behats                      | :negative_squared_cross_mark:
| Added integration tests           | :negative_squared_cross_mark:
| Changelog updated                 | :negative_squared_cross_mark:
| Review and 2 GTM                  | :clock1:
| Micro Demo to the PO (Story only) | :negative_squared_cross_mark:
| Migration script                  | :negative_squared_cross_mark:
| Tech Doc                          | :negative_squared_cross_mark: