### PR TITLE
PIM-5987: Fix import duplicated products from the same batch 

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -6,6 +6,7 @@
 - GITHUB-5062: Fixed unit conversion for ElectricCharge, cheers @gplanchat!
 - GITHUB-5294: Fixed infinite loading if no attribute is configured as a product identifier, cheers @gplanchat!
 - GITHUB-5337: Fixed Widget Registry. Priority is now taken in account.
+- PIM-5897: Introducing a BulkIdentifierBag class used to keep track of the entities identifiers imported (avoiding to import duplicated entities).
 
 ## Deprecations
 

--- a/features/Context/FixturesContext.php
+++ b/features/Context/FixturesContext.php
@@ -102,6 +102,7 @@ class FixturesContext extends BaseFixturesContext
         }
 
         $converter = $this->getContainer()->get('pim_connector.array_converter.flat_to_standard.product');
+
         $processor = $this->getContainer()->get('pim_connector.processor.denormalization.product');
 
         $jobExecution = new JobExecution();
@@ -388,6 +389,11 @@ class FixturesContext extends BaseFixturesContext
         $attributeBulks = [];
         $attributeConverter = $this->getContainer()->get('pim_connector.array_converter.flat_to_standard.attribute');
         $attributeProcessor = $this->getContainer()->get('pim_connector.processor.denormalization.attribute');
+
+        $dummyJobExecution = new JobExecution();
+        $dummyStepExecution = new StepExecution('', $dummyJobExecution);
+        $attributeProcessor->setStepExecution($dummyStepExecution);
+
         foreach ($attributeData as $index => $data) {
             $convertedData = $attributeConverter->convert($data);
             $attribute = $attributeProcessor->process($convertedData);
@@ -401,6 +407,11 @@ class FixturesContext extends BaseFixturesContext
         $optionsBulks = [];
         $optionConverter = $this->getContainer()->get('pim_connector.array_converter.flat_to_standard.attribute_option');
         $optionProcessor = $this->getContainer()->get('pim_connector.processor.denormalization.attribute_option');
+
+        $dummyJobExecution = new JobExecution();
+        $dummyStepExecution = new StepExecution('', $dummyJobExecution);
+        $optionProcessor->setStepExecution($dummyStepExecution);
+
         foreach ($optionData as $index => $data) {
             $convertedData = $optionConverter->convert($data);
             $option = $optionProcessor->process($convertedData);
@@ -1711,6 +1722,11 @@ class FixturesContext extends BaseFixturesContext
         $convertedData = $converter->convert($data);
 
         $processor = $this->getContainer()->get('pim_connector.processor.denormalization.attribute');
+
+        $dummyJobExecution = new JobExecution();
+        $dummyStepExecution = new StepExecution('', $dummyJobExecution);
+        $processor->setStepExecution($dummyStepExecution);
+
         $attribute = $processor->process($convertedData);
 
         $familiesToPersist = [];
@@ -1783,6 +1799,11 @@ class FixturesContext extends BaseFixturesContext
 
         $converter = $this->getContainer()->get('pim_connector.array_converter.flat_to_standard.category');
         $processor = $this->getContainer()->get('pim_connector.processor.denormalization.category');
+
+        $dummyJobExecution = new JobExecution();
+        $dummyStepExecution = new StepExecution('', $dummyJobExecution);
+        $processor->setStepExecution($dummyStepExecution);
+
         $convertedData = $converter->convert($data);
         $category = $processor->process($convertedData);
 
@@ -2030,6 +2051,10 @@ class FixturesContext extends BaseFixturesContext
         $converter = $this->getContainer()->get('pim_connector.array_converter.flat_to_standard.family');
         $processor = $this->getContainer()->get('pim_connector.processor.denormalization.family');
 
+        $dummyJobExecution = new JobExecution();
+        $dummyStepExecution = new StepExecution('', $dummyJobExecution);
+        $processor->setStepExecution($dummyStepExecution);
+
         $convertedData = $converter->convert($data);
         $family = $processor->process($convertedData);
         $this->getFamilySaver()->save($family);
@@ -2050,8 +2075,15 @@ class FixturesContext extends BaseFixturesContext
             $data = ['code' => $data];
         }
 
+
+
         $converter = $this->getContainer()->get('pim_connector.array_converter.flat_to_standard.attribute_group');
         $processor = $this->getContainer()->get('pim_connector.processor.denormalization.attribute_group');
+
+        $dummyJobExecution = new JobExecution();
+        $dummyStepExecution = new StepExecution('', $dummyJobExecution);
+        $processor->setStepExecution($dummyStepExecution);
+
         $convertedData = $converter->convert($data);
         $attributeGroup = $processor->process($convertedData);
         $this->getContainer()->get('pim_catalog.saver.attribute_group')->save($attributeGroup);

--- a/features/import/attribute/import_attributes.feature
+++ b/features/import/attribute/import_attributes.feature
@@ -199,15 +199,17 @@ Feature: Import attributes
       type;code;label-de_DE;label-en_US;label-fr_FR;group;unique;useable_as_grid_filter;allowed_extensions;metric_family;default_metric_unit;reference_data_name;localizable;scopable;available_locales;sort_order;max_characters;validation_rule;validation_regexp;wysiwyg_enabled;number_min;number_max;decimals_allowed;negative_allowed;date_min;date_max;metric_family;default_metric_unit;max_file_size;allowed_extensions
       pim_catalog_image;media_code;Meine große Code;My awesome code;Mon super code;marketing;0;1;;family;;;0;0;en_US,fr_FR;3;300;validation_rule;;1;3;5;true;true;2000-08-08;2015-08-08;;EUR;not an int;jpg
       pim_catalog_image;media_code;Meine große Code;My awesome code;Mon super code;not a group;0;1;;family;;;0;0;en_US,fr_FR;3;300;validation_rule;;1;3;5;true;true;2000-08-08;2015-08-08;;EUR;not an int;jpg
+      pim_catalog_image;media_code_2;Meine große Code;My awesome code;Mon super code;not a group;0;1;;family;;;0;0;en_US,fr_FR;3;300;validation_rule;;1;3;5;true;true;2000-08-08;2015-08-08;;EUR;not an int;jpg
       """
     And the following job "csv_footwear_attribute_import" configuration:
       | filePath | %file to import% |
     When I am on the "csv_footwear_attribute_import" import job page
     And I launch the import job
     And I wait for the "csv_footwear_attribute_import" job to finish
-    Then I should see "read lines 2"
-    Then I should see "skipped 2"
+    Then I should see "read lines 3"
+    Then I should see "skipped 3"
     Then I should see "maxFileSize: This value should be a valid number.: not an int"
+    Then I should see "An item with the identifier \"media_code\" has already been processed."
     Then I should see "Property \"group\" expects a valid code. The attribute group does not exist, \"not a group\" given (for updater attribute)."
 
   Scenario: Successfully import new attribute

--- a/features/import/import_invalid_csv_data.feature
+++ b/features/import/import_invalid_csv_data.feature
@@ -198,3 +198,47 @@ Feature: Handle import of invalid CSV data
       code;type;label-en_US;axis
       caterpil ar;VARIANT;Caterpillar;color,size
       """
+
+  Scenario: From a product CSV import, the job does not import duplicated products
+    Given the following CSV file to import:
+      """
+      sku;family
+      SKU-002;sneakers
+      SKU-003;sneakers
+      SKU-003;sneakers
+      SKU-005;boots
+      """
+    And the following job "csv_footwear_product_import" configuration:
+      | filePath | %file to import% |
+    And I am logged in as "Julia"
+    And I am on the "csv_footwear_product_import" export job page
+    And I launch the "csv_footwear_product_import" import job
+    And I wait for the "csv_footwear_product_import" job to finish
+    Then I should see the text "Download invalid data"
+    And the invalid data file of "csv_footwear_product_import" should contain:
+      """
+      sku;family
+      SKU-003;sneakers
+      """
+
+  Scenario: From an attribute CSV import, the job does not import duplicated attributes
+    Given the following CSV file to import:
+      """
+      type;code;label-en_US;group;unique;useable_as_grid_filter;allowed_extensions;metric_family;default_metric_unit;reference_data_name;localizable;scopable;required;sort_order;label-fr_FR;max_characters;number_min;number_max;decimals_allowed;negative_allowed;max_file_size
+      pim_catalog_text;name;Name;info;0;1;;;;;1;0;0;2;;;;;;;
+      pim_catalog_text;comment;Comment;other;0;1;;;;;0;0;0;7;;255;;;;;
+      pim_catalog_text;comment;Comment;other;0;1;;;;;0;0;0;7;;255;;;;;
+      pim_catalog_multiselect;weather_conditions;"Weather conditions";info;0;1;;;;;0;0;0;4;;;;;;;
+      """
+    And the following job "csv_footwear_attribute_import" configuration:
+      | filePath | %file to import% |
+    And I am logged in as "Julia"
+    And I am on the "csv_footwear_attribute_import" export job page
+    And I launch the "csv_footwear_attribute_import" import job
+    And I wait for the "csv_footwear_attribute_import" job to finish
+    Then I should see the text "Download invalid data"
+    And the invalid data file of "csv_footwear_attribute_import" should contain:
+      """
+      type;code;label-en_US;group;unique;useable_as_grid_filter;allowed_extensions;metric_family;default_metric_unit;reference_data_name;localizable;scopable;required;sort_order;label-fr_FR;max_characters;number_min;number_max;decimals_allowed;negative_allowed;max_file_size
+      pim_catalog_text;comment;Comment;other;0;1;;;;;0;0;0;7;;255;;;;;
+      """

--- a/features/import/product/import_products_with_invalid_data.feature
+++ b/features/import/product/import_products_with_invalid_data.feature
@@ -292,7 +292,7 @@ Feature: Execute a job
     And I launch the import job
     And I wait for the "csv_footwear_product_import" job to finish
     Then there should be 1 product
-    And I should see "The value SKU-001 is already set on another product for the unique attribute sku"
+    And I should see "An item with the identifier \"SKU-001\" has already been processed."
     And the product "SKU-001" should have the following value:
       | name-en_US | high heels |
 

--- a/src/Pim/Component/Connector/BulkIdentifierBag.php
+++ b/src/Pim/Component/Connector/BulkIdentifierBag.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Pim\Component\Connector;
+
+/**
+ * A bag of identifiers that can be used during bulk operations.
+ *
+ * Typically, during an import, there can be several items with the same identifiers in the same bulk.
+ * Those items are not detected as duplications and lead to errors in database.
+ * This bag aims to store them momentarily during the period of the bulk.
+ *
+ * @author    Julien Janvier <jjanvier@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class BulkIdentifierBag
+{
+    private $identifiers = [];
+
+    /**
+     * @param string $identifier
+     *
+     * @throws \LogicException when the identifier is already in the bag
+     */
+    public function add($identifier)
+    {
+        if ($this->has($identifier)) {
+            throw new \LogicException(sprintf('The identifier "%s" is already contained in the bag.', $identifier));
+        }
+
+        $this->identifiers[] = $identifier;
+    }
+
+    /**
+     * @param string $identifier
+     *
+     * @return bool
+     */
+    public function has($identifier)
+    {
+        return in_array($identifier, $this->identifiers);
+    }
+
+    /**
+     * Empty the bag
+     */
+    public function reset()
+    {
+        $this->identifiers = [];
+    }
+}

--- a/src/Pim/Component/Connector/Processor/Denormalization/AbstractProcessor.php
+++ b/src/Pim/Component/Connector/Processor/Denormalization/AbstractProcessor.php
@@ -127,8 +127,8 @@ abstract class AbstractProcessor implements StepExecutionAwareInterface
     }
 
     /**
-     * Stores an identifier in the bag "bulk_identifier_bag",to be able to check duplications.
-     * The bag should be reset after each bulk is processed. Typically, in the Writer.
+     * Stores an identifier in the bag "bulk_identifier_bag" in order to check duplications.
+     * The bag should be reset after each bulk is processed.
      *
      * @param array  $item
      * @param string $identifier

--- a/src/Pim/Component/Connector/Processor/Denormalization/AbstractProcessor.php
+++ b/src/Pim/Component/Connector/Processor/Denormalization/AbstractProcessor.php
@@ -8,6 +8,7 @@ use Akeneo\Component\Batch\Item\ItemProcessorInterface;
 use Akeneo\Component\Batch\Model\StepExecution;
 use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
+use Pim\Component\Connector\BulkIdentifierBag;
 use Pim\Component\Connector\Exception\InvalidItemFromViolationsException;
 use Pim\Component\Connector\Exception\MissingIdentifierException;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
@@ -123,5 +124,26 @@ abstract class AbstractProcessor implements StepExecutionAwareInterface
             0,
             $previousException
         );
+    }
+
+    /**
+     * Stores an identifier in the bag "bulk_identifier_bag",to be able to check duplications.
+     * The bag should be reset after each bulk is processed. Typically, in the Writer.
+     *
+     * @param array  $item
+     * @param string $identifier
+     */
+    protected function checkIdentifierDuplication(array $item, $identifier)
+    {
+        if (null === $bag = $this->stepExecution->getExecutionContext()->get('bulk_identifier_bag')) {
+            $bag = new BulkIdentifierBag();
+            $this->stepExecution->getExecutionContext()->put('bulk_identifier_bag', $bag);
+        }
+
+        if ($bag->has($identifier)) {
+            $this->skipItemWithMessage($item, sprintf('An item with the identifier "%s" has already been processed.'));
+        }
+
+        $bag->add($identifier);
     }
 }

--- a/src/Pim/Component/Connector/Processor/Denormalization/ProductAssociationProcessor.php
+++ b/src/Pim/Component/Connector/Processor/Denormalization/ProductAssociationProcessor.php
@@ -79,6 +79,8 @@ class ProductAssociationProcessor extends AbstractProcessor implements
             $this->skipItemWithMessage($item, 'The identifier must be filled');
         }
 
+        $this->checkIdentifierDuplication($item, $item['identifier']);
+
         $product = $this->findProduct($item['identifier']);
 
         if (!$product) {

--- a/src/Pim/Component/Connector/Processor/Denormalization/ProductProcessor.php
+++ b/src/Pim/Component/Connector/Processor/Denormalization/ProductProcessor.php
@@ -84,6 +84,8 @@ class ProductProcessor extends AbstractProcessor implements ItemProcessorInterfa
             $this->skipItemWithMessage($item, 'The identifier must be filled');
         }
 
+        $this->checkIdentifierDuplication($item, $identifier);
+
         $familyCode = $this->getFamilyCode($item);
         $filteredItem = $this->filterItemData($item);
 

--- a/src/Pim/Component/Connector/spec/BulkIdentifierBagSpec.php
+++ b/src/Pim/Component/Connector/spec/BulkIdentifierBagSpec.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace spec\Pim\Component\Connector;
+
+use PhpSpec\ObjectBehavior;
+
+class BulkIdentifierBagSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Pim\Component\Connector\BulkIdentifierBag');
+    }
+
+    function it_adds_a_new_identifier()
+    {
+        $this->add('sku-1');
+        $this->has('sku-1')->shouldReturn(true);
+    }
+
+    function it_throws_a_logic_exception_when_it_adds_an_identifier_it_already_contains()
+    {
+        $this->add('sku-1');
+        $this->shouldThrow(
+            new \LogicException('The identifier "sku-1" is already contained in the bag.')
+        )->during('add', ['sku-1']);
+    }
+
+    function it_resets_the_idenfitiers()
+    {
+        $this->add('sku-1');
+        $this->add('sku-2');
+
+        $this->has('sku-1')->shouldReturn(true);
+        $this->has('sku-2')->shouldReturn(true);
+
+        $this->reset();
+
+        $this->has('sku-1')->shouldReturn(false);
+        $this->has('sku-2')->shouldReturn(false);
+    }
+}

--- a/src/Pim/Component/Connector/spec/Processor/Denormalization/ProductAssociationProcessorSpec.php
+++ b/src/Pim/Component/Connector/spec/Processor/Denormalization/ProductAssociationProcessorSpec.php
@@ -2,18 +2,17 @@
 
 namespace spec\Pim\Component\Connector\Processor\Denormalization;
 
+use Akeneo\Component\Batch\Item\ExecutionContext;
 use Akeneo\Component\Batch\Job\JobParameters;
-use Akeneo\Component\Batch\Model\JobExecution;
-use Akeneo\Component\Batch\Model\JobInstance;
 use Akeneo\Component\Batch\Model\StepExecution;
 use Akeneo\Component\StorageUtils\Detacher\ObjectDetacherInterface;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Comparator\Filter\ProductFilterInterface;
 use Pim\Component\Catalog\Model\AssociationInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
-use Pim\Component\Catalog\Comparator\Filter\ProductFilterInterface;
-use Pim\Component\Connector\ArrayConverter\ArrayConverterInterface;
+use Pim\Component\Connector\BulkIdentifierBag;
 use Prophecy\Argument;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationList;
@@ -54,10 +53,18 @@ class ProductAssociationProcessorSpec extends ObjectBehavior
         $productAssocFilter,
         $stepExecution,
         ProductInterface $product,
+        StepExecution $stepExecution,
+        ExecutionContext $executionContext,
+        BulkIdentifierBag $bulkIdentifierBag,
         AssociationInterface $association,
         ConstraintViolationListInterface $violationList,
         JobParameters $jobParameters
     ) {
+        $bulkIdentifierBag->has('tshirt')->willReturn(false);
+        $bulkIdentifierBag->add('tshirt')->shouldBeCalled();
+        $executionContext->get('bulk_identifier_bag')->willReturn($bulkIdentifierBag);
+        $stepExecution->getExecutionContext()->willReturn($executionContext);
+
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $jobParameters->get('enabledComparison')->willReturn(true);
 
@@ -118,9 +125,17 @@ class ProductAssociationProcessorSpec extends ObjectBehavior
         $productAssocFilter,
         $stepExecution,
         $productDetacher,
+        StepExecution $stepExecution,
+        ExecutionContext $executionContext,
+        BulkIdentifierBag $bulkIdentifierBag,
         ProductInterface $product,
         JobParameters $jobParameters
     ) {
+        $bulkIdentifierBag->has('tshirt')->willReturn(false);
+        $bulkIdentifierBag->add('tshirt')->shouldBeCalled();
+        $executionContext->get('bulk_identifier_bag')->willReturn($bulkIdentifierBag);
+        $stepExecution->getExecutionContext()->willReturn($executionContext);
+
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $jobParameters->get('enabledComparison')->willReturn(true);
         $stepExecution->getSummaryInfo('item_position')->shouldBeCalled();
@@ -185,10 +200,18 @@ class ProductAssociationProcessorSpec extends ObjectBehavior
         $productAssocFilter,
         $stepExecution,
         $productDetacher,
+        StepExecution $stepExecution,
+        ExecutionContext $executionContext,
+        BulkIdentifierBag $bulkIdentifierBag,
         AssociationInterface $association,
         ProductInterface $product,
         JobParameters $jobParameters
     ) {
+        $bulkIdentifierBag->has('tshirt')->willReturn(false);
+        $bulkIdentifierBag->add('tshirt')->shouldBeCalled();
+        $executionContext->get('bulk_identifier_bag')->willReturn($bulkIdentifierBag);
+        $stepExecution->getExecutionContext()->willReturn($executionContext);
+
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $stepExecution->getSummaryInfo('item_position')->shouldBeCalled();
         $jobParameters->get('enabledComparison')->willReturn(true);
@@ -258,9 +281,17 @@ class ProductAssociationProcessorSpec extends ObjectBehavior
         $productAssocFilter,
         $stepExecution,
         $productDetacher,
+        StepExecution $stepExecution,
+        ExecutionContext $executionContext,
+        BulkIdentifierBag $bulkIdentifierBag,
         ProductInterface $product,
         JobParameters $jobParameters
     ) {
+        $bulkIdentifierBag->has('tshirt')->willReturn(false);
+        $bulkIdentifierBag->add('tshirt')->shouldBeCalled();
+        $executionContext->get('bulk_identifier_bag')->willReturn($bulkIdentifierBag);
+        $stepExecution->getExecutionContext()->willReturn($executionContext);
+
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $jobParameters->get('enabledComparison')->willReturn(true);
 
@@ -319,9 +350,17 @@ class ProductAssociationProcessorSpec extends ObjectBehavior
         $productAssocFilter,
         $stepExecution,
         $productDetacher,
+        StepExecution $stepExecution,
+        ExecutionContext $executionContext,
+        BulkIdentifierBag $bulkIdentifierBag,
         ProductInterface $product,
         JobParameters $jobParameters
     ) {
+        $bulkIdentifierBag->has('tshirt')->willReturn(false);
+        $bulkIdentifierBag->add('tshirt')->shouldBeCalled();
+        $executionContext->get('bulk_identifier_bag')->willReturn($bulkIdentifierBag);
+        $stepExecution->getExecutionContext()->willReturn($executionContext);
+
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $jobParameters->get('enabledComparison')->willReturn(false);
 
@@ -348,5 +387,51 @@ class ProductAssociationProcessorSpec extends ObjectBehavior
         $this->setStepExecution($stepExecution);
         $productDetacher->detach($product)->shouldBeCalled();
         $this->process($convertedData)->shouldReturn(null);
+    }
+
+
+    function it_does_not_process_duplicated_associations(
+        $stepExecution,
+        ExecutionContext $executionContext,
+        BulkIdentifierBag $bulkIdentifierBag,
+        JobParameters $jobParameters
+    ) {
+        $bulkIdentifierBag->has('tshirt')->willReturn(true);
+        $bulkIdentifierBag->add('tshirt')->shouldNotBeCalled();
+        $executionContext->get('bulk_identifier_bag')->willReturn($bulkIdentifierBag);
+        $stepExecution->getExecutionContext()->willReturn($executionContext);
+        $this->setStepExecution($stepExecution);
+
+        $stepExecution->getJobParameters()->willReturn($jobParameters);
+        $jobParameters->get('enabledComparison')->willReturn(false);
+
+        $convertedData = [
+            'identifier'   => 'tshirt',
+            'values'       => [
+                'sku' => [
+                    [
+                        'locale' => null,
+                        'scope'  => null,
+                        'data'   => 'tshirt'
+                    ],
+                ]
+            ],
+            'associations' => [
+                'XSELL' => [
+                    'groups'  => ['akeneo_tshirt', 'oro_tshirt'],
+                    'product' => ['AKN_TS', 'ORO_TS']
+                ]
+            ]
+        ];
+
+        $stepExecution->incrementSummaryInfo('skip')->shouldBeCalled();
+        $stepExecution->getSummaryInfo('item_position')->shouldBeCalled();
+
+        $this
+            ->shouldThrow('Akeneo\Component\Batch\Item\InvalidItemException')
+            ->during(
+                'process',
+                [$convertedData]
+            );
     }
 }

--- a/src/Pim/Component/Connector/spec/Processor/Denormalization/VariantGroupProcessorSpec.php
+++ b/src/Pim/Component/Connector/spec/Processor/Denormalization/VariantGroupProcessorSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Pim\Component\Connector\Processor\Denormalization;
 
+use Akeneo\Component\Batch\Item\ExecutionContext;
 use Akeneo\Component\Batch\Model\StepExecution;
 use Akeneo\Component\StorageUtils\Detacher\ObjectDetacherInterface;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
@@ -12,6 +13,7 @@ use Pim\Bundle\CatalogBundle\Entity\GroupType;
 use Pim\Component\Catalog\Factory\GroupFactory;
 use Pim\Component\Catalog\Model\GroupInterface;
 use Pim\Component\Catalog\Model\ProductTemplateInterface;
+use Pim\Component\Connector\BulkIdentifierBag;
 use Prophecy\Argument;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationList;
@@ -42,10 +44,18 @@ class VariantGroupProcessorSpec extends ObjectBehavior
         $repository,
         $variantUpdater,
         $validator,
+        $stepExecution,
+        ExecutionContext $executionContext,
+        BulkIdentifierBag $bulkIdentifierBag,
         GroupInterface $variantGroup,
         ProductTemplateInterface $productTemplate,
         ConstraintViolationListInterface $violationList
     ) {
+        $bulkIdentifierBag->has('mycode')->willReturn(false);
+        $bulkIdentifierBag->add('mycode')->shouldBeCalled();
+        $executionContext->get('bulk_identifier_bag')->willReturn($bulkIdentifierBag);
+        $stepExecution->getExecutionContext()->willReturn($executionContext);
+
         $repository->getIdentifierProperties()->willReturn(['code']);
         $repository->findOneByIdentifier(Argument::any())->willReturn($variantGroup);
         $groupType = new GroupType();
@@ -76,10 +86,18 @@ class VariantGroupProcessorSpec extends ObjectBehavior
         $repository,
         $variantUpdater,
         $validator,
+        $stepExecution,
+        ExecutionContext $executionContext,
+        BulkIdentifierBag $bulkIdentifierBag,
         GroupInterface $variantGroup,
         ProductTemplateInterface $productTemplate,
         ConstraintViolationListInterface $violationList
     ) {
+        $bulkIdentifierBag->has('mycode')->willReturn(false);
+        $bulkIdentifierBag->add('mycode')->shouldBeCalled();
+        $executionContext->get('bulk_identifier_bag')->willReturn($bulkIdentifierBag);
+        $stepExecution->getExecutionContext()->willReturn($executionContext);
+
         $repository->getIdentifierProperties()->willReturn(['code']);
         $repository->findOneByIdentifier(Argument::any())->willReturn($variantGroup);
         $groupType = new GroupType();
@@ -109,6 +127,9 @@ class VariantGroupProcessorSpec extends ObjectBehavior
             ->update($variantGroup, $values)
             ->willThrow(new \InvalidArgumentException('Attributes: This property cannot be changed.'));
 
+        $stepExecution->incrementSummaryInfo('skip')->shouldBeCalled();
+        $stepExecution->getSummaryInfo('item_position')->shouldBeCalled();
+
         $this
             ->shouldThrow('Akeneo\Component\Batch\Item\InvalidItemException')
             ->during(
@@ -121,10 +142,18 @@ class VariantGroupProcessorSpec extends ObjectBehavior
         $repository,
         $variantUpdater,
         $validator,
+        $stepExecution,
+        ExecutionContext $executionContext,
+        BulkIdentifierBag $bulkIdentifierBag,
         GroupInterface $variantGroup,
         ProductTemplateInterface $productTemplate,
         ConstraintViolationListInterface $violationList
     ) {
+        $bulkIdentifierBag->has('mycode')->willReturn(false);
+        $bulkIdentifierBag->add('mycode')->shouldBeCalled();
+        $executionContext->get('bulk_identifier_bag')->willReturn($bulkIdentifierBag);
+        $stepExecution->getExecutionContext()->willReturn($executionContext);
+
         $repository->getIdentifierProperties()->willReturn(['code']);
         $repository->findOneByIdentifier(Argument::any())->willReturn($variantGroup);
         $groupType = new GroupType();
@@ -158,6 +187,9 @@ class VariantGroupProcessorSpec extends ObjectBehavior
         $violations = new ConstraintViolationList([$violation]);
         $validator->validate($variantGroup)
             ->willReturn($violations);
+
+        $stepExecution->incrementSummaryInfo('skip')->shouldBeCalled();
+        $stepExecution->getSummaryInfo('item_position')->shouldBeCalled();
 
         $this
             ->shouldThrow('Akeneo\Component\Batch\Item\InvalidItemException')


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When importing duplicated lines on a product import that live within the same batch size, the PIM creates a duplicated products for the duplicated row.

This fix keeps tracks of the processed product skus living in the same batch size and prevent duplicated rows from being imported twice.

A message is sent to the user that a duplicated line has been found and that it won't be imported.

In the next version (maybe 1.8) a new strategy will be implemented in order to have a consistent mecanism regarding those duplicated See ticket.
The POs are aware this solution is not optimum but they'd rather prevent the duplication creation and having different behaviors on import than create duplicated products.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
