### PR TITLE
Api 30 : add partial update of a category in the API

### DIFF
--- a/src/Akeneo/Component/Classification/Updater/CategoryUpdater.php
+++ b/src/Akeneo/Component/Classification/Updater/CategoryUpdater.php
@@ -51,7 +51,7 @@ class CategoryUpdater implements ObjectUpdaterInterface
         }
 
         foreach ($data as $field => $value) {
-            $this->validateDatatype($field, $value);
+            $this->validateDataType($field, $value);
             $this->setData($category, $field, $value);
         }
 
@@ -67,7 +67,7 @@ class CategoryUpdater implements ObjectUpdaterInterface
      * @throws InvalidPropertyTypeException
      * @throws UnknownPropertyException
      */
-    protected function validateDatatype($field, $data)
+    protected function validateDataType($field, $data)
     {
         if ('labels' === $field) {
             if (!is_array($data)) {

--- a/src/Pim/Bundle/ApiBundle/Resources/config/routing/category.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/routing/category.yml
@@ -12,3 +12,8 @@ pim_api_rest_controller_create:
     path: /categories
     defaults: { _controller: pim_api.controller.rest.category:createAction, _format: json}
     methods: [POST]
+
+pim_api_rest_controller_partial_update:
+    path: /categories/{code}
+    defaults: { _controller: pim_api.controller.rest.category:partialUpdateAction, _format: json}
+    methods: [PATCH]

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Category/PartialUpdateCategoryIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Category/PartialUpdateCategoryIntegration.php
@@ -1,0 +1,406 @@
+<?php
+
+namespace tests\integration\Pim\Bundle\ApiBundle\Controller\Rest\Category;
+
+use Akeneo\Test\Integration\Configuration;
+use Pim\Bundle\ApiBundle\tests\integration\ApiTestCase;
+use Pim\Bundle\CatalogBundle\Version;
+use Symfony\Component\HttpFoundation\Response;
+
+class PartialUpdateCategoryIntegration extends ApiTestCase
+{
+    public function testHttpHeadersInResponseWhenACategoryIsUpdated()
+    {
+        $client = $this->createAuthentifiedClient();
+
+        $data =
+<<<JSON
+    {
+        "parent": null
+    }
+JSON;
+
+        $client->request('PATCH', 'api/rest/v1/categories/categoryA1', [], [], [], $data);
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        $this->assertArrayHasKey('location', $response->headers->all());
+        $this->assertSame('http://localhost/api/rest/v1/categories/categoryA1', $response->headers->get('location'));
+        $this->assertSame(null, json_decode($response->getContent(), true));
+    }
+
+    public function testHttpHeadersInResponseWhenACategoryIsCreated()
+    {
+        $client = $this->createAuthentifiedClient();
+
+        $data =
+<<<JSON
+    {
+        "code": "new_category_headers",
+        "parent": null
+    }
+JSON;
+
+        $client->request('PATCH', 'api/rest/v1/categories/new_category_headers', [], [], [], $data);
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+        $this->assertArrayHasKey('location', $response->headers->all());
+        $this->assertSame('http://localhost/api/rest/v1/categories/new_category_headers', $response->headers->get('location'));
+        $this->assertSame(null, json_decode($response->getContent(), true));
+    }
+
+    public function testStandardFormatWhenACategoryIsCreatedButUncompleted()
+    {
+        $client = $this->createAuthentifiedClient();
+
+        $data =
+<<<JSON
+    {
+        "code": "new_category_uncompleted"
+    }
+JSON;
+
+        $client->request('PATCH', 'api/rest/v1/categories/new_category_uncompleted', [], [], [], $data);
+
+        $category = $this->get('pim_catalog.repository.category')->findOneByIdentifier('new_category_uncompleted');
+        $categoryStandard = [
+            'code'   => 'new_category_uncompleted',
+            'parent' => null,
+            'labels' => [],
+        ];
+        $normalizer = $this->get('pim_catalog.normalizer.standard.category');
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+        $this->assertSame($categoryStandard, $normalizer->normalize($category));
+    }
+
+    public function testStandardFormatWhenACategoryIsCreatedWithAnEmptyContent()
+    {
+        $client = $this->createAuthentifiedClient();
+
+        $data = '{}';
+
+        $client->request('PATCH', 'api/rest/v1/categories/new_category_empty_content', [], [], [], $data);
+
+        $category = $this->get('pim_catalog.repository.category')->findOneByIdentifier('new_category_empty_content');
+        $categoryStandard = [
+            'code'   => 'new_category_empty_content',
+            'parent' => null,
+            'labels' => [],
+        ];
+        $normalizer = $this->get('pim_catalog.normalizer.standard.category');
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+        $this->assertSame($categoryStandard, $normalizer->normalize($category));
+    }
+
+    public function testCompleteCategoryCreationWithCodeProvided()
+    {
+        $client = $this->createAuthentifiedClient();
+
+        $data =
+<<<JSON
+    {
+        "code": "categoryC",
+        "parent": "master",
+        "labels": {
+            "en_US": "Category C",
+            "fr_FR": "Catégorie C"
+        }
+    }
+JSON;
+        $client->request('PATCH', 'api/rest/v1/categories/categoryC', [], [], [], $data);
+
+        $category = $this->get('pim_catalog.repository.category')->findOneByIdentifier('categoryC');
+        $categoryStandard = [
+            'code'   => 'categoryC',
+            'parent' => 'master',
+            'labels' => [
+                'en_US' => 'Category C',
+                'fr_FR' => 'Catégorie C',
+            ],
+        ];
+        $normalizer = $this->get('pim_catalog.normalizer.standard.category');
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+        $this->assertSame($categoryStandard, $normalizer->normalize($category));
+    }
+
+    public function testCompleteCategoryCreationWithoutCodeProvided()
+    {
+        $client = $this->createAuthentifiedClient();
+
+        $data =
+<<<JSON
+    {
+        "parent": "master",
+        "labels": {
+            "en_US": "Category D",
+            "fr_FR": "Catégorie D"
+        }
+    }
+JSON;
+        $client->request('PATCH', 'api/rest/v1/categories/categoryD', [], [], [], $data);
+
+        $category = $this->get('pim_catalog.repository.category')->findOneByIdentifier('categoryD');
+        $categoryStandard = [
+            'code'   => 'categoryD',
+            'parent' => 'master',
+            'labels' => [
+                'en_US' => 'Category D',
+                'fr_FR' => 'Catégorie D',
+            ],
+        ];
+        $normalizer = $this->get('pim_catalog.normalizer.standard.category');
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+        $this->assertSame($categoryStandard, $normalizer->normalize($category));
+    }
+
+    public function testPartialUpdateWithAnEmptyContent()
+    {
+        $client = $this->createAuthentifiedClient();
+
+        $data = '{}';
+
+        $client->request('PATCH', 'api/rest/v1/categories/categoryA', [], [], [], $data);
+
+        $category = $this->get('pim_catalog.repository.category')->findOneByIdentifier('categoryA');
+        $categoryStandard = [
+            'code'   => 'categoryA',
+            'parent' => 'master',
+            'labels' => [
+                'en_US' => 'Category A',
+                'fr_FR' => 'Catégorie A',
+            ],
+        ];
+        $normalizer = $this->get('pim_catalog.normalizer.standard.category');
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        $this->assertSame($categoryStandard, $normalizer->normalize($category));
+    }
+
+    public function testPartialUpdateWithCodeProvided()
+    {
+        $client = $this->createAuthentifiedClient();
+
+        $data =
+<<<JSON
+    {
+        "code": "categoryA",
+        "labels": {
+            "en_US": "Category A updated"
+        }
+    }
+JSON;
+
+        $client->request('PATCH', 'api/rest/v1/categories/categoryA', [], [], [], $data);
+
+        $category = $this->get('pim_catalog.repository.category')->findOneByIdentifier('categoryA');
+        $categoryStandard = [
+            'code'   => 'categoryA',
+            'parent' => 'master',
+            'labels' => [
+                'en_US' => 'Category A updated',
+                'fr_FR' => 'Catégorie A',
+            ],
+        ];
+        $normalizer = $this->get('pim_catalog.normalizer.standard.category');
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        $this->assertSame($categoryStandard, $normalizer->normalize($category));
+    }
+
+    public function testPartialUpdateWithoutCodeProvided()
+    {
+        $client = $this->createAuthentifiedClient();
+
+        $data =
+<<<JSON
+    {
+        "parent": "categoryA1",
+        "labels": {
+            "en_US": "Category A2 updated"
+        }
+    }
+JSON;
+
+        $client->request('PATCH', 'api/rest/v1/categories/categoryA2', [], [], [], $data);
+
+        $category = $this->get('pim_catalog.repository.category')->findOneByIdentifier('categoryA2');
+        $categoryStandard = [
+            'code'   => 'categoryA2',
+            'parent' => 'categoryA1',
+            'labels' => [
+                'en_US' => 'Category A2 updated',
+            ],
+        ];
+        $normalizer = $this->get('pim_catalog.normalizer.standard.category');
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        $this->assertSame($categoryStandard, $normalizer->normalize($category));
+    }
+
+    public function testResponseWhenContentIsEmpty()
+    {
+        $client = $this->createAuthentifiedClient();
+
+        $data = '';
+
+        $expectedContent = [
+            'code'    => 400,
+            'message' => 'Invalid json message received',
+        ];
+
+        $client->request('PATCH', 'api/rest/v1/categories/categoryA', [], [], [], $data);
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+        $this->assertSame($expectedContent, json_decode($response->getContent(), true));
+    }
+
+    public function testResponseWhenContentIsNotValid()
+    {
+        $client = $this->createAuthentifiedClient();
+
+        $data = '{';
+
+        $expectedContent = [
+            'code'    => 400,
+            'message' => 'Invalid json message received',
+        ];
+
+        $client->request('PATCH', 'api/rest/v1/categories/categoryA', [], [], [], $data);
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+        $this->assertSame($expectedContent, json_decode($response->getContent(), true));
+    }
+
+    public function testResponseWhenValidationFailed()
+    {
+        $client = $this->createAuthentifiedClient();
+
+        $data =
+<<<JSON
+    {
+        "code": "new_code"
+    }
+JSON;
+
+        $expectedContent = [
+            'code'    => 422,
+            'message' => 'Validation failed.',
+            'errors'  => [
+                [
+                    'field'   => 'code',
+                    'message' => 'This property cannot be changed.',
+                ],
+            ],
+        ];
+
+        $client->request('PATCH', 'api/rest/v1/categories/categoryA', [], [], [], $data);
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertSame($expectedContent, json_decode($response->getContent(), true));
+    }
+
+    public function testResponseWhenAPropertyIsNotExpected()
+    {
+        $client = $this->createAuthentifiedClient();
+
+        $data =
+<<<JSON
+    {
+        "extra_property": ""
+    }
+JSON;
+
+        $version = substr(Version::VERSION, 0, 3);
+        $expectedContent = [
+            'code'    => 422,
+            'message' => 'Property "extra_property" does not exist. Check the standard format documentation.',
+            '_links'  => [
+                'documentation' => [
+                    'href' => sprintf('https://docs.akeneo.com/%s/reference/standard_format/other_entities.html#category', $version),
+                ],
+            ],
+        ];
+
+        $client->request('PATCH', 'api/rest/v1/categories/categoryA', [], [], [], $data);
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertSame($expectedContent, json_decode($response->getContent(), true));
+    }
+
+    public function testResponseWhenLabelsIsNull()
+    {
+        $client = $this->createAuthentifiedClient();
+
+        $data =
+<<<JSON
+    {
+        "labels": null
+    }
+JSON;
+
+        $version = substr(Version::VERSION, 0, 3);
+        $expectedContent = [
+            'code'    => 422,
+            'message' => 'Property "labels" expects an array. Check the standard format documentation.',
+            '_links'  => [
+                'documentation' => [
+                    'href' => sprintf('https://docs.akeneo.com/%s/reference/standard_format/other_entities.html#category', $version),
+                ],
+            ],
+        ];
+
+        $client->request('PATCH', 'api/rest/v1/categories/categoryA', [], [], [], $data);
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertSame($expectedContent, json_decode($response->getContent(), true));
+    }
+
+    public function testResponseWhenACategoryIsCreatedWithInconsistentCodes()
+    {
+        $client = $this->createAuthentifiedClient();
+
+        $data =
+<<<JSON
+    {
+        "code": "inconsistent_code2"
+    }
+JSON;
+
+        $expectedContent = [
+            'code'    => 422,
+            'message' => 'The code "inconsistent_code2" provided in the request body must match the code "inconsistent_code1" provided in the url.',
+        ];
+
+        $client->request('PATCH', 'api/rest/v1/categories/inconsistent_code1', [], [], [], $data);
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertSame($expectedContent, json_decode($response->getContent(), true));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return new Configuration(
+            [Configuration::getTechnicalCatalogPath()],
+            false
+        );
+    }
+}


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

Method PATCH to update partially a category. 
It's an upsert operation : if the category does not exist, it creates it.
The code is optional in the body (already provided in the url).

In case of a creation, the code should be the same between the url query parameter and the body (if it's provided in the body).


[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | OK
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
