### PR TITLE
AMS-70: remove unused overly in view selector

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/grid/view-selector-line.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/grid/view-selector-line.html
@@ -1,6 +1,3 @@
 <div class="select2-result-label-view">
     <span class="view-label <%- isCurrent ? 'view-label-current' : '' %>"><%- view.text %></span>
-
-    <div class="grid-view-selector-line-overlay" data-drop-zone="overlay">
-    </div>
 </div>

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/lib/select2.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/lib/select2.less
@@ -293,33 +293,14 @@
               font-style: italic;
               font-weight: bold;
             }
-
-            .grid-view-selector-line-overlay {
-              background-color: fade(@AknDarkBlue, 85%);
-              display: none;
-              position: absolute;
-              top: 0;
-              left: 0;
-              width: 100%;
-              height: 100%;
-              padding: 10px;
-              flex-direction: row-reverse;
-              align-items: center;
-              align-content: center;
-            }
           }
         }
 
         &.select2-highlighted {
           background: none;
-          color: #000;
 
           .select2-result-label {
-            .select2-result-label-view {
-              .grid-view-selector-line-overlay {
-                display: flex;
-              }
-            }
+            background-color: @AknDefaultHoverBackground;
           }
         }
       }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This PR removes the overlay in the view selector and update the style to use the default hover color:

![screenshot from 2017-01-25 11 24 34](https://cloud.githubusercontent.com/assets/301169/22286874/e15df1e0-e2f0-11e6-9872-34b7138681c0.png)


**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -
