### PR TITLE
Docs: Change rm command line arguments order

### DIFF
--- a/UPGRADE-1.6.md
+++ b/UPGRADE-1.6.md
@@ -131,7 +131,7 @@ This modification introduces a new constraint, the minimum version of PHP for Ak
 
 6. Then remove your old upgrades folder:
     ```
-     rm $PIM_DIR/upgrades/schema -rf
+     rm -rf $PIM_DIR/upgrades/schema
     ```
 
 7. Now you're ready to update your dependencies:
@@ -215,7 +215,7 @@ This modification introduces a new constraint, the minimum version of PHP for Ak
 9. Then, generate JS translations and re-generate the PIM assets:
 
     ```
-     rm $PIM_DIR/web/js/translation/ -rf
+     rm -rf $PIM_DIR/web/js/translation/
      php app/console pim:installer:assets
     ```
 


### PR DESCRIPTION
MacOS supports the "rm -rf file"-syntax but not "rm file -rf".

[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
