### PR TITLE
[PIM-6080] Fix simple-multi select removal on product export builder

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -5,6 +5,7 @@
 - PIM-6113: Fix wrong context switch on association groups
 - PIM-6062: Fix potential Unix commands injection
 - PIM-5085: Fix update of the normalized data on family update (mongodb)
+- PIM-6080: Fix simple and multi select removal on product export builder
 
 # 1.6.9 (2017-01-17)
 

--- a/features/Pim/Behat/Decorator/Export/Filter/BaseDecorator.php
+++ b/features/Pim/Behat/Decorator/Export/Filter/BaseDecorator.php
@@ -24,6 +24,9 @@ class BaseDecorator extends ElementDecorator
      */
     public function remove()
     {
+        $this->spin(function () {
+            return $this->find('css', '.remove');
+        }, 'Can not find the remove button.')->click();
     }
 
     /**

--- a/features/export/product-export-builder/export_products_by_multiselect.feature
+++ b/features/export/product-export-builder/export_products_by_multiselect.feature
@@ -95,3 +95,16 @@ Feature: Export products according to multi select values
       BOOT-6;;;;1;boots;;;;"The boot 6";;;;;;;cold
       BOOT-7;;;;1;boots;;;;"The boot 7";;;;;;;
       """
+
+  Scenario: Successfully remove multi select filter
+    Given I am logged in as "Julia"
+    And I am on the "csv_footwear_product_export" export job edit page
+    And I visit the "Content" tab
+    And I add available attributes Weather conditions
+    And I filter by "weather_conditions.code" with operator "Is empty" and value ""
+    And I press the "Save" button
+    And I should not see the text "There are unsaved changes"
+    And I am on the "csv_footwear_product_export" export job edit page
+    And I visit the "Content" tab
+    When I hide the filter "weather_conditions.code"
+    Then I should not see the filter "weather_conditions.code"

--- a/features/export/product-export-builder/export_products_by_simpleselect.feature
+++ b/features/export/product-export-builder/export_products_by_simpleselect.feature
@@ -109,3 +109,16 @@ Feature: Export products according to simple select values
       sku;categories;color;description-en_US-mobile;enabled;family;groups;lace_color;manufacturer;name-en_US;price-EUR;price-USD;rating;side_view;size;top_view;weather_conditions
       BOOT-2;;;;1;boots;;;Converse;"The boot 2";;;;;;;
       """
+
+  Scenario: Successfully remove simple select filter
+    Given I am logged in as "Julia"
+    And I am on the "csv_footwear_product_export" export job edit page
+    And I visit the "Content" tab
+    And I add available attributes Manufacturer
+    And I filter by "manufacturer.code" with operator "Is empty" and value ""
+    And I press the "Save" button
+    And I should not see the text "There are unsaved changes"
+    And I am on the "csv_footwear_product_export" export job edit page
+    And I visit the "Content" tab
+    When I hide the filter "manufacturer.code"
+    Then I should not see the filter "manufacturer.code"

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/export/product/edit/content/data.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/export/product/edit/content/data.js
@@ -298,8 +298,9 @@ define(
              * @param {string} fieldCode
              */
             removeFilter: function (fieldCode) {
+                var cleanedFieldCode = fieldCode.replace(/\.code$/, '');
                 this.filterViews = _.filter(this.filterViews, function (filterView) {
-                    return filterView.getCode() !== fieldCode;
+                    return filterView.getCode() !== cleanedFieldCode;
                 });
 
                 this.updateModel();


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

This PR fixes the fact than when you try to remove an attribute of type "simple select" or "multi select" on the product export builder, it does nothing.

The issue was resolved by using the standard filter name (without '.code' at the end of the filter).

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | OK
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
