### PR TITLE
Api 23 : add creation of a family in the API

### DIFF
--- a/src/Pim/Bundle/ApiBundle/Controller/Rest/FamilyController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/Rest/FamilyController.php
@@ -2,11 +2,25 @@
 
 namespace Pim\Bundle\ApiBundle\Controller\Rest;
 
+use Akeneo\Component\StorageUtils\Exception\ObjectUpdaterException;
+use Akeneo\Component\StorageUtils\Exception\UnknownPropertyException;
+use Akeneo\Component\StorageUtils\Factory\SimpleFactoryInterface;
+use Akeneo\Component\StorageUtils\Saver\SaverInterface;
+use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
+use Pim\Bundle\CatalogBundle\Version;
+use Pim\Component\Api\Exception\DocumentedHttpException;
+use Pim\Component\Api\Exception\ViolationHttpException;
+use Pim\Component\Catalog\Model\FamilyInterface;
 use Pim\Component\Catalog\Repository\FamilyRepositoryInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 /**
  * @author    Philippe Mossière <philippe.mossiere@akeneo.com>
@@ -21,16 +35,52 @@ class FamilyController
     /** @var NormalizerInterface */
     protected $normalizer;
 
+    /** @var  ValidatorInterface */
+    protected $validator;
+
+    /** @var SimpleFactoryInterface */
+    protected $factory;
+
+    /** @var ObjectUpdaterInterface */
+    protected $updater;
+
+    /** @var SaverInterface */
+    protected $saver;
+
+    /** @var RouterInterface */
+    protected $router;
+
+    /** @var string */
+    protected $documentationUrl;
+
     /**
      * @param FamilyRepositoryInterface $repository
      * @param NormalizerInterface       $normalizer
+     * @param SimpleFactoryInterface    $factory
+     * @param ObjectUpdaterInterface    $updater
+     * @param ValidatorInterface        $validator
+     * @param SaverInterface            $saver
+     * @param RouterInterface           $router
+     * @param string                    $documentationUrl
      */
     public function __construct(
         FamilyRepositoryInterface $repository,
-        NormalizerInterface $normalizer
+        NormalizerInterface $normalizer,
+        SimpleFactoryInterface $factory,
+        ObjectUpdaterInterface $updater,
+        ValidatorInterface $validator,
+        SaverInterface $saver,
+        RouterInterface $router,
+        $documentationUrl
     ) {
-        $this->repository = $repository;
-        $this->normalizer = $normalizer;
+        $this->repository       = $repository;
+        $this->normalizer       = $normalizer;
+        $this->factory          = $factory;
+        $this->updater          = $updater;
+        $this->validator        = $validator;
+        $this->saver            = $saver;
+        $this->router           = $router;
+        $this->documentationUrl = sprintf($documentationUrl, substr(Version::VERSION, 0, 3));
     }
 
     /**
@@ -75,5 +125,110 @@ class FamilyController
         //@TODO use paginate method before return results
 
         return new JsonResponse($familiesStandard);
+    }
+
+    /**
+     * @param Request $request
+     *
+     * @throws BadRequestHttpException
+     * @throws UnprocessableEntityHttpException
+     *
+     * @return JsonResponse
+     */
+    public function createAction(Request $request)
+    {
+        $data = $this->getDecodedContent($request->getContent());
+
+        $family = $this->factory->create();
+        $this->updateFamily($family, $data);
+        $this->validateFamily($family);
+
+        $this->saver->save($family);
+
+        $response = $this->getCreateResponse($family);
+
+        return $response;
+    }
+
+    /**
+     * Get the JSON decoded content. If the content is not a valid JSON, it throws an error 400.
+     *
+     * @param string $content content of a request to decode
+     *
+     * @throws BadRequestHttpException
+     *
+     * @return array
+     */
+    protected function getDecodedContent($content)
+    {
+        $decodedContent = json_decode($content, true);
+
+        if (null === $decodedContent) {
+            throw new BadRequestHttpException('Invalid json message received');
+        }
+
+        return $decodedContent;
+    }
+
+    /**
+     * Update a family. It throws an error 422 if a problem occurred during the update.
+     *
+     * @param FamilyInterface $family family to update
+     * @param array           $data   data of the request already decoded, it should be the standard format
+     *
+     * @throws UnprocessableEntityHttpException
+     */
+    protected function updateFamily(FamilyInterface $family, array $data)
+    {
+        try {
+            $this->updater->update($family, $data);
+        } catch (UnknownPropertyException $exception) {
+            throw new DocumentedHttpException(
+                $this->documentationUrl,
+                sprintf(
+                    'Property "%s" does not exist. Check the standard format documentation.',
+                    $exception->getPropertyName()
+                ),
+                $exception
+            );
+        } catch (ObjectUpdaterException $exception) {
+            throw new DocumentedHttpException(
+                $this->documentationUrl,
+                sprintf('%s Check the standard format documentation.', $exception->getMessage()),
+                $exception
+            );
+        }
+    }
+
+    /**
+     * Validate a family. It throws an error 422 with every violated constraints if
+     * the validation failed.
+     *
+     * @param FamilyInterface $family
+     *
+     * @throws ViolationHttpException
+     */
+    protected function validateFamily(FamilyInterface $family)
+    {
+        $violations = $this->validator->validate($family);
+        if (0 !== $violations->count()) {
+            throw new ViolationHttpException($violations);
+        }
+    }
+
+    /**
+     * Get a response with HTTP code 201 when an object is created.
+     *
+     * @param FamilyInterface $family
+     *
+     * @return Response
+     */
+    protected function getCreateResponse(FamilyInterface $family)
+    {
+        $response = new Response(null, Response::HTTP_CREATED);
+        $route = $this->router->generate('pim_api_rest_family_get', ['code' => $family->getCode()], true);
+        $response->headers->set('Location', $route);
+
+        return $response;
     }
 }

--- a/src/Pim/Bundle/ApiBundle/Resources/config/controllers.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/controllers.yml
@@ -23,6 +23,12 @@ services:
         arguments:
             - '@pim_catalog.repository.family'
             - '@pim_serializer'
+            - '@pim_catalog.factory.family'
+            - '@pim_catalog.updater.family'
+            - '@validator'
+            - '@pim_catalog.saver.family'
+            - '@router'
+            - 'https://docs.akeneo.com/%s/reference/standard_format/other_entities.html#family'
 
     pim_api.controller.rest.attribute:
         class: '%pim_api.controller.rest.attribute.class%'

--- a/src/Pim/Bundle/ApiBundle/Resources/config/routing/family.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/routing/family.yml
@@ -7,3 +7,8 @@ pim_api_rest_family_get:
     path: /families/{code}
     defaults: { _controller: pim_api.controller.rest.family:getAction, _format: json }
     methods: [GET]
+
+pim_api_rest_family_create:
+    path: /families
+    defaults: { _controller: pim_api.controller.rest.family:createAction, _format: json }
+    methods: [POST]

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Attribute/GetAttributeIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Attribute/GetAttributeIntegration.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace tests\integration\Pim\Bundle\ApiBundle\Controller\Rest\Attribute;
+namespace Pim\Bundle\ApiBundle\tests\integration\Controller\Rest\Attribute;
 
 use Akeneo\Test\Integration\Configuration;
 use Pim\Bundle\ApiBundle\tests\integration\ApiTestCase;

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Attribute/ListAttributeIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Attribute/ListAttributeIntegration.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace tests\integration\Pim\Bundle\ApiBundle\Controller\Rest\Attribute;
+namespace Pim\Bundle\ApiBundle\tests\integration\Controller\Rest\Attribute;
 
 use Akeneo\Test\Integration\Configuration;
 use Pim\Bundle\ApiBundle\tests\integration\ApiTestCase;

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/AttributeOption/GetAttributeOptionIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/AttributeOption/GetAttributeOptionIntegration.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace tests\integration\Pim\Bundle\ApiBundle\Controller\Rest\AttributeOption;
+namespace Pim\Bundle\ApiBundle\tests\integration\Controller\Rest\AttributeOption;
 
 use Akeneo\Test\Integration\Configuration;
 use Pim\Bundle\ApiBundle\tests\integration\ApiTestCase;

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Category/CreateCategoryIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Category/CreateCategoryIntegration.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace tests\integration\Pim\Bundle\ApiBundle\Controller\Rest\Category;
+namespace Pim\Bundle\ApiBundle\tests\integration\Controller\Rest\Category;
 
 use Akeneo\Test\Integration\Configuration;
 use Pim\Bundle\ApiBundle\tests\integration\ApiTestCase;

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Category/GetCategoryIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Category/GetCategoryIntegration.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace tests\integration\Pim\Bundle\ApiBundle\Controller\Rest\Category;
+namespace Pim\Bundle\ApiBundle\tests\integration\Controller\Rest\Category;
 
 use Akeneo\Test\Integration\Configuration;
 use Pim\Bundle\ApiBundle\tests\integration\ApiTestCase;

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Category/ListCategoryIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Category/ListCategoryIntegration.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace tests\integration\Pim\Bundle\ApiBundle\Controller\Rest\Category;
+namespace Pim\Bundle\ApiBundle\tests\integration\Controller\Rest\Category;
 
 use Akeneo\Test\Integration\Configuration;
 use Pim\Bundle\ApiBundle\tests\integration\ApiTestCase;

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Family/CreateFamilyIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Family/CreateFamilyIntegration.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace tests\integration\Pim\Bundle\ApiBundle\Controller\Rest\Family;
+namespace Pim\Bundle\ApiBundle\tests\integration\Controller\Rest\Family;
 
 use Akeneo\Test\Integration\Configuration;
 use Pim\Bundle\ApiBundle\tests\integration\ApiTestCase;

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Family/CreateFamilyIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Family/CreateFamilyIntegration.php
@@ -1,0 +1,267 @@
+<?php
+
+namespace tests\integration\Pim\Bundle\ApiBundle\Controller\Rest\Family;
+
+use Akeneo\Test\Integration\Configuration;
+use Pim\Bundle\ApiBundle\tests\integration\ApiTestCase;
+use Pim\Bundle\CatalogBundle\Version;
+use Symfony\Component\HttpFoundation\Response;
+
+class CreateFamilyIntegration extends ApiTestCase
+{
+    public function testHttpHeadersInResponseWhenAFamilyIsCreated()
+    {
+        $client = $this->createAuthentifiedClient();
+
+        $data =
+<<<JSON
+    {
+        "code": "new_family_headers"
+    }
+JSON;
+
+        $client->request('POST', 'api/rest/v1/families', [], [], [], $data);
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+        $this->assertArrayHasKey('location', $response->headers->all());
+        $this->assertSame('http://localhost/api/rest/v1/families/new_family_headers', $response->headers->get('location'));
+        $this->assertSame('', $response->getContent());
+    }
+
+    public function testFormatStandardWhenAFamilyIsCreatedButUncompleted()
+    {
+        $client = $this->createAuthentifiedClient();
+
+        $data =
+<<<JSON
+    {
+        "code": "new_family_uncompleted"
+    }
+JSON;
+
+        $client->request('POST', 'api/rest/v1/families', [], [], [], $data);
+
+        $family = $this->get('pim_catalog.repository.family')->findOneByIdentifier('new_family_uncompleted');
+        $familyStandard = [
+            'code'                   => 'new_family_uncompleted',
+            'attributes'             => ['sku'],
+            'attribute_as_label'     => 'sku',
+            'attribute_requirements' => [
+                'ecommerce' => ['sku'],
+                'tablet'    => ['sku'],
+            ],
+            'labels'                 => [],
+        ];
+        $normalizer = $this->get('pim_catalog.normalizer.standard.family');
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+        $this->assertSame($familyStandard, $normalizer->normalize($family));
+    }
+
+    public function testCompleteFamilyCreation()
+    {
+        $client = $this->createAuthentifiedClient();
+
+        $data =
+<<<JSON
+    {
+        "code": "complete_family_creation",
+        "attributes": ["an_image", "a_metric", "a_price"],
+        "attribute_as_label": "sku",
+        "attribute_requirements": {
+            "ecommerce": ["sku", "a_metric"],
+            "tablet": ["sku", "a_price"]
+        },
+        "labels": {
+            "en_US": "Complete Family creation",
+            "fr_FR": "Création complète famille"
+        }
+    }
+JSON;
+        $client->request('POST', 'api/rest/v1/families', [], [], [], $data);
+
+        $family = $this->get('pim_catalog.repository.family')->findOneByIdentifier('complete_family_creation');
+        $familyStandard = [
+            'code'                   => 'complete_family_creation',
+            'attributes'             => ['a_metric', 'a_price', 'an_image', 'sku'],
+            'attribute_as_label'     => 'sku',
+            'attribute_requirements' => [
+                'ecommerce' => ['a_metric', 'sku'],
+                'tablet'    => ['a_price', 'sku'],
+            ],
+            'labels'                 => [
+                'en_US' => 'Complete Family creation',
+                'fr_FR' => 'Création complète famille',
+            ],
+        ];
+        $normalizer = $this->get('pim_catalog.normalizer.standard.family');
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+        $this->assertSame($familyStandard, $normalizer->normalize($family));
+    }
+
+    public function testResponseWhenContentIsEmpty()
+    {
+        $client = $this->createAuthentifiedClient();
+
+        $data = '';
+
+        $expectedContent = [
+            'code'    => 400,
+            'message' => 'Invalid json message received',
+        ];
+
+        $client->request('POST', 'api/rest/v1/families', [], [], [], $data);
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+        $this->assertSame($expectedContent, json_decode($response->getContent(), true));
+    }
+
+    public function testResponseWhenContentIsNotValid()
+    {
+        $client = $this->createAuthentifiedClient();
+
+        $data = '{';
+
+        $expectedContent = [
+            'code'    => 400,
+            'message' => 'Invalid json message received',
+        ];
+
+        $client->request('POST', 'api/rest/v1/families', [], [], [], $data);
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+        $this->assertSame($expectedContent, json_decode($response->getContent(), true));
+    }
+
+    public function testResponseWhenFamilyCodeAlreadyExists()
+    {
+        $client = $this->createAuthentifiedClient();
+
+        $data =
+<<<JSON
+    {
+        "code": "familyA"
+    }
+JSON;
+
+        $expectedContent = [
+            'code'    => 422,
+            'message' => 'Validation failed.',
+            'errors'  => [
+                [
+                    'field'   => 'code',
+                    'message' => 'This value is already used.',
+                ],
+            ],
+        ];
+
+        $client->request('POST', 'api/rest/v1/families', [], [], [], $data);
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertSame($expectedContent, json_decode($response->getContent(), true));
+    }
+
+    public function testResponseWhenValidationFailed()
+    {
+        $client = $this->createAuthentifiedClient();
+
+        $data =
+<<<JSON
+    {
+        "code": ""
+    }
+JSON;
+
+        $expectedContent = [
+            'code'    => 422,
+            'message' => 'Validation failed.',
+            'errors'  => [
+                [
+                    'field'   => 'code',
+                    'message' => 'This value should not be blank.',
+                ],
+            ],
+        ];
+
+        $client->request('POST', 'api/rest/v1/families', [], [], [], $data);
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertSame($expectedContent, json_decode($response->getContent(), true));
+    }
+
+    public function testResponseWhenAPropertyIsNotExpected()
+    {
+        $client = $this->createAuthentifiedClient();
+
+        $data =
+<<<JSON
+    {
+        "code": "new_family",
+        "extra_property": ""
+    }
+JSON;
+
+        $version = substr(Version::VERSION, 0, 3);
+        $expectedContent = [
+            'code'    => 422,
+            'message' => 'Property "extra_property" does not exist. Check the standard format documentation.',
+            '_links'  => [
+                'documentation' => [
+                    'href' => sprintf('https://docs.akeneo.com/%s/reference/standard_format/other_entities.html#family', $version),
+                ],
+            ],
+        ];
+
+        $client->request('POST', 'api/rest/v1/families', [], [], [], $data);
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertSame($expectedContent, json_decode($response->getContent(), true));
+    }
+
+    public function testResponseWhenLabelsIsNull()
+    {
+        $client = $this->createAuthentifiedClient();
+
+        $data =
+<<<JSON
+    {
+        "labels": null
+    }
+JSON;
+
+        $version = substr(Version::VERSION, 0, 3);
+        $expectedContent = [
+            'code'    => 422,
+            'message' => 'Property "labels" expects an array. Check the standard format documentation.',
+            '_links'  => [
+                'documentation' => [
+                    'href' => sprintf('https://docs.akeneo.com/%s/reference/standard_format/other_entities.html#family', $version),
+                ],
+            ],
+        ];
+
+        $client->request('POST', 'api/rest/v1/families', [], [], [], $data);
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertSame($expectedContent, json_decode($response->getContent(), true));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return new Configuration(
+            [Configuration::getTechnicalCatalogPath()],
+            false
+        );
+    }
+}

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Family/GetFamilyIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Family/GetFamilyIntegration.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace tests\integration\Pim\Bundle\ApiBundle\Controller\Rest\Family;
+namespace Pim\Bundle\ApiBundle\tests\integration\Controller\Rest\Family;
 
 use Akeneo\Test\Integration\Configuration;
 use Pim\Bundle\ApiBundle\tests\integration\ApiTestCase;

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Family/ListFamilyIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Family/ListFamilyIntegration.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace tests\integration\Pim\Bundle\ApiBundle\Controller\Rest\Family;
+namespace Pim\Bundle\ApiBundle\tests\integration\Controller\Rest\Family;
 
 use Akeneo\Test\Integration\Configuration;
 use Pim\Bundle\ApiBundle\tests\integration\ApiTestCase;

--- a/src/Pim/Component/Catalog/spec/Updater/FamilyUpdaterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/FamilyUpdaterSpec.php
@@ -4,6 +4,7 @@ namespace spec\Pim\Component\Catalog\Updater;
 
 use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Akeneo\Component\StorageUtils\Exception\UnknownPropertyException;
 use PhpSpec\ObjectBehavior;
 use Pim\Bundle\CatalogBundle\Entity\FamilyTranslation;
@@ -409,11 +410,10 @@ class FamilyUpdaterSpec extends ObjectBehavior
         )->during('update', [$family, $data]);
     }
 
-    function it_throws_an_exception_when_trying_to_update_a_non_existent_field(FamilyInterface $family) {
-        $values = [
+    function it_throws_an_exception_when_trying_to_update_a_non_existent_field(FamilyInterface $family)
+    {
+        $data = [
             'unknown_field' => 'field',
-            'code'          => 'mycode',
-            'parent'        => 'master',
         ];
 
         $this->shouldThrow(
@@ -421,6 +421,168 @@ class FamilyUpdaterSpec extends ObjectBehavior
                     'unknown_field',
                     new NoSuchPropertyException()
                 )
-        )->during('update', [$family, $values, []]);
+        )->during('update', [$family, $data, []]);
+    }
+
+    function it_throws_an_exception_when_code_is_not_a_scalar(FamilyInterface $family)
+    {
+        $data = [
+            'code' => [],
+        ];
+
+        $this
+            ->shouldThrow(
+                InvalidPropertyTypeException::scalarExpected(
+                    'code',
+                    'Pim\Component\Catalog\Updater\FamilyUpdater',
+                    []
+                )
+            )
+            ->during('update', [$family, $data, []]);
+    }
+
+    function it_throws_an_exception_when_attribute_as_label_is_not_a_scalar(FamilyInterface $family)
+    {
+        $data = [
+            'attribute_as_label' => [],
+        ];
+
+        $this
+            ->shouldThrow(
+                InvalidPropertyTypeException::scalarExpected(
+                    'attribute_as_label',
+                    'Pim\Component\Catalog\Updater\FamilyUpdater',
+                    []
+                )
+            )
+            ->during('update', [$family, $data, []]);
+    }
+
+    function it_throws_an_exception_when_attributes_is_not_an_array(FamilyInterface $family)
+    {
+        $data = [
+            'attributes' => 'foo',
+        ];
+
+        $this
+            ->shouldThrow(
+                InvalidPropertyTypeException::arrayExpected(
+                    'attributes',
+                    'Pim\Component\Catalog\Updater\FamilyUpdater',
+                    'foo'
+                )
+            )
+            ->during('update', [$family, $data, []]);
+    }
+
+    function it_throws_an_exception_when_a_value_in_attributes_array_is_not_a_scalar(FamilyInterface $family)
+    {
+        $data = [
+            'attributes' => ['foo', []],
+        ];
+
+        $this
+            ->shouldThrow(
+                InvalidPropertyTypeException::validArrayStructureExpected(
+                    'attributes',
+                    'one of the attributes is not a scalar',
+                    'Pim\Component\Catalog\Updater\FamilyUpdater',
+                    ['foo', []]
+                )
+            )
+            ->during('update', [$family, $data, []]);
+    }
+
+    function it_throws_an_exception_when_labels_is_not_an_array(FamilyInterface $family)
+    {
+        $data = [
+            'labels' => 'foo',
+        ];
+
+        $this
+            ->shouldThrow(
+                InvalidPropertyTypeException::arrayExpected(
+                    'labels',
+                    'Pim\Component\Catalog\Updater\FamilyUpdater',
+                    'foo'
+                )
+            )
+            ->during('update', [$family, $data, []]);
+    }
+
+    function it_throws_an_exception_when_a_value_in_labels_array_is_not_a_scalar(FamilyInterface $family)
+    {
+        $data = [
+            'labels' => [
+                'en_US' => 'us_Label',
+                'fr_FR' => [],
+            ],
+        ];
+
+        $this
+            ->shouldThrow(
+                InvalidPropertyTypeException::validArrayStructureExpected(
+                    'labels',
+                    'one of the labels is not a scalar',
+                    'Pim\Component\Catalog\Updater\FamilyUpdater',
+                    ['en_US' => 'us_Label', 'fr_FR' => []]
+                )
+            )
+            ->during('update', [$family, $data, []]);
+    }
+
+    function it_throws_an_exception_when_attribute_requirements_is_not_an_array(FamilyInterface $family)
+    {
+        $data = [
+            'attribute_requirements' => 'foo',
+        ];
+
+        $this
+            ->shouldThrow(
+                InvalidPropertyTypeException::arrayExpected('attribute_requirements', 'update', 'family', 'foo')
+            )
+            ->during('update', [$family, $data, []]);
+    }
+
+    function it_throws_an_exception_when_a_value_in_attribute_requirements_is_not_an_array(FamilyInterface $family)
+    {
+        $data = [
+            'attribute_requirements' => [
+                'ecommerce' => ['sku'],
+                'tablet'    => 'foo',
+            ],
+        ];
+
+        $this
+            ->shouldThrow(
+                InvalidPropertyTypeException::validArrayStructureExpected(
+                    'attribute_requirements',
+                    'the channel "tablet" is not an array',
+                    'Pim\Component\Catalog\Updater\FamilyUpdater',
+                    ['ecommerce' => ['sku'], 'tablet' => 'foo']
+                )
+            )
+            ->during('update', [$family, $data, []]);
+    }
+
+    function it_throws_an_exception_when_an_attribute_in_attribute_requirements_is_not_a_scalar(FamilyInterface $family)
+    {
+        $data = [
+            'attribute_requirements' => [
+                'ecommerce' => ['sku'],
+                'tablet'    => ['foo', []],
+            ],
+        ];
+
+        $this
+            ->shouldThrow(
+                InvalidPropertyTypeException::validArrayStructureExpected(
+                    'attribute_requirements',
+                    'one of the attributes in the channel "tablet" is not a scalar',
+                    'Pim\Component\Catalog\Updater\FamilyUpdater',
+                    ['ecommerce' => ['sku'], 'tablet' => ['foo', []]]
+                )
+            )
+            ->during('update', [$family, $data, []]);
     }
 }


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

This PR : 
- add the POST operation (=creation) on a family
- add checks on the structure of the standard format to avoid error 500 with invalid data provided

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added Behats                      | -
| Added integration tests           | OK
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
