### PR TITLE
API-22: Create a new attribute

### DIFF
--- a/src/Pim/Bundle/ApiBundle/Controller/Rest/AttributeController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/Rest/AttributeController.php
@@ -2,11 +2,25 @@
 
 namespace Pim\Bundle\ApiBundle\Controller\Rest;
 
+use Akeneo\Component\StorageUtils\Exception\ObjectUpdaterException;
+use Akeneo\Component\StorageUtils\Exception\UnknownPropertyException;
+use Akeneo\Component\StorageUtils\Factory\SimpleFactoryInterface;
+use Akeneo\Component\StorageUtils\Saver\SaverInterface;
+use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
+use Pim\Bundle\CatalogBundle\Version;
+use Pim\Component\Api\Exception\DocumentedHttpException;
+use Pim\Component\Api\Exception\ViolationHttpException;
+use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 /**
  * @author    Philippe Mossière <philippe.mossiere@akeneo.com>
@@ -21,16 +35,52 @@ class AttributeController
     /** @var NormalizerInterface */
     protected $normalizer;
 
+    /** @var SimpleFactoryInterface */
+    protected $factory;
+
+    /** @var ObjectUpdaterInterface */
+    protected $updater;
+
+    /** @var  ValidatorInterface */
+    protected $validator;
+
+    /** @var SaverInterface */
+    protected $saver;
+
+    /** @var RouterInterface */
+    protected $router;
+
+    /** @var string */
+    protected $urlDocumentation;
+
     /**
      * @param AttributeRepositoryInterface $repository
      * @param NormalizerInterface          $normalizer
+     * @param SimpleFactoryInterface       $factory
+     * @param ObjectUpdaterInterface       $updater
+     * @param ValidatorInterface           $validator
+     * @param SaverInterface               $saver
+     * @param RouterInterface              $router
+     * @param string                       $urlDocumentation
      */
     public function __construct(
         AttributeRepositoryInterface $repository,
-        NormalizerInterface $normalizer
+        NormalizerInterface $normalizer,
+        SimpleFactoryInterface $factory,
+        ObjectUpdaterInterface $updater,
+        ValidatorInterface $validator,
+        SaverInterface $saver,
+        RouterInterface $router,
+        $urlDocumentation
     ) {
         $this->repository = $repository;
         $this->normalizer = $normalizer;
+        $this->factory = $factory;
+        $this->updater = $updater;
+        $this->validator = $validator;
+        $this->saver = $saver;
+        $this->router = $router;
+        $this->urlDocumentation = sprintf($urlDocumentation, substr(Version::VERSION, 0, 3));
     }
 
     /**
@@ -75,5 +125,95 @@ class AttributeController
         //@TODO use paginate method before return results
 
         return new JsonResponse($attributesStandard);
+    }
+
+    /**
+     * @param Request $request
+     *
+     * @throws BadRequestHttpException
+     * @throws UnprocessableEntityHttpException
+     *
+     * @return Response
+     */
+    public function createAction(Request $request)
+    {
+        $data = $this->getDecodedContent($request->getContent());
+
+        $attribute = $this->factory->create();
+        $this->updateAttribute($attribute, $data);
+
+        $violations = $this->validator->validate($attribute);
+
+        if (0 !== $violations->count()) {
+            throw new ViolationHttpException($violations);
+        }
+
+        $this->saver->save($attribute);
+
+        $response = $this->getCreateResponse($attribute);
+
+        return $response;
+    }
+
+    /**
+     * Get the JSON decoded content. If the content is not a valid JSON, it throws an error 400.
+     *
+     * @param string $content content of a request to decode
+     *
+     * @throws BadRequestHttpException
+     *
+     * @return array
+     */
+    protected function getDecodedContent($content)
+    {
+        $decodedContent = json_decode($content, true);
+
+        if (null === $decodedContent) {
+            throw new BadRequestHttpException('Invalid json message received.');
+        }
+
+        return $decodedContent;
+    }
+
+    /**
+     * @param AttributeInterface $attribute
+     * @param                    $data
+     */
+    protected function updateAttribute(AttributeInterface $attribute, $data)
+    {
+        try {
+            $this->updater->update($attribute, $data);
+        } catch (UnknownPropertyException $exception) {
+            throw new DocumentedHttpException(
+                $this->urlDocumentation,
+                sprintf(
+                    'Property "%s" does not exist. Check the standard format documentation.',
+                    $exception->getPropertyName()
+                ),
+                $exception
+            );
+        } catch (ObjectUpdaterException $exception) {
+            throw new DocumentedHttpException(
+                $this->urlDocumentation,
+                sprintf('%s Check the standard format documentation.', $exception->getMessage()),
+                $exception
+            );
+        }
+    }
+
+    /**
+     * Get a response with HTTP code 201 when an object is created.
+     *
+     * @param AttributeInterface $attribute
+     *
+     * @return Response
+     */
+    protected function getCreateResponse(AttributeInterface $attribute)
+    {
+        $response = new Response(null, Response::HTTP_CREATED);
+        $route = $this->router->generate('pim_api_rest_attribute_get', ['code' => $attribute->getCode()], true);
+        $response->headers->set('Location', $route);
+
+        return $response;
     }
 }

--- a/src/Pim/Bundle/ApiBundle/Resources/config/controllers.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/controllers.yml
@@ -29,6 +29,12 @@ services:
         arguments:
             - '@pim_catalog.repository.attribute'
             - '@pim_serializer'
+            - '@pim_catalog.factory.attribute'
+            - '@pim_catalog.updater.attribute'
+            - '@validator'
+            - '@pim_catalog.saver.attribute'
+            - '@router'
+            - 'https://docs.akeneo.com/%s/reference/standard_format/other_entities.html#attribute'
 
     pim_api.controller.rest.attribute_option:
         class: '%pim_api.controller.rest.attribute_option.class%'

--- a/src/Pim/Bundle/ApiBundle/Resources/config/routing.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/routing.yml
@@ -1,6 +1,6 @@
 category:
     resource: '@PimApiBundle/Resources/config/routing/category.yml'
-    prefix: /rest/v1/
+    prefix: /rest/v1
 
 family:
     resource: '@PimApiBundle/Resources/config/routing/family.yml'

--- a/src/Pim/Bundle/ApiBundle/Resources/config/routing/attribute.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/routing/attribute.yml
@@ -3,6 +3,11 @@ pim_api_rest_attribute_list:
     defaults: { _controller: pim_api.controller.rest.attribute:listAction, _format: json }
     methods: [GET]
 
+pim_api_rest_attribute_create:
+    path: /attributes
+    defaults: { _controller: pim_api.controller.rest.attribute:createAction, _format: json }
+    methods: [POST]
+
 pim_api_rest_attribute_get:
     path: /attributes/{code}
     defaults: { _controller: pim_api.controller.rest.attribute:getAction, _format: json }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Attribute/CreateAttributeIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Attribute/CreateAttributeIntegration.php
@@ -1,0 +1,555 @@
+<?php
+
+namespace Pim\Bundle\ApiBundle\tests\integration\Controller\Rest\Attribute;
+
+use Akeneo\Test\Integration\Configuration;
+use Pim\Bundle\ApiBundle\tests\integration\ApiTestCase;
+use Pim\Bundle\CatalogBundle\Version;
+use Symfony\Component\HttpFoundation\Response;
+
+class CreateAttributeIntegration extends ApiTestCase
+{
+    public function testHttpHeadersInResponseWhenACategoryIsCreated()
+    {
+        $client = $this->createAuthentifiedClient();
+
+        $data =
+<<<JSON
+    {
+        "code":"an_attr_text",
+        "type":"pim_catalog_text",
+        "group":"attributeGroupA"
+    }
+JSON;
+
+        $client->request('POST', 'api/rest/v1/attributes', [], [], [], $data);
+
+        $response = $client->getResponse();
+
+        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+        $this->assertArrayHasKey('location', $response->headers->all());
+        $this->assertSame('http://localhost/api/rest/v1/attributes/an_attr_text', $response->headers->get('location'));
+        $this->assertSame('', $response->getContent());
+    }
+
+    public function testFormatStandardWhenAnAttributeIsCreatedButUncompleted()
+    {
+        $client = $this->createAuthentifiedClient();
+
+        $data =
+<<<JSON
+    {
+        "code":"an_incomplete_text",
+        "type":"pim_catalog_text",
+        "group":"attributeGroupA"
+    }
+JSON;
+
+        $client->request('POST', 'api/rest/v1/attributes', [], [], [], $data);
+
+        $attribute = $this->get('pim_catalog.repository.attribute')->findOneByIdentifier('an_incomplete_text');
+
+        $attributeStandard = [
+            'code'                   => 'an_incomplete_text',
+            'type'                   => 'pim_catalog_text',
+            'group'                  => 'attributeGroupA',
+            'unique'                 => false,
+            'useable_as_grid_filter' => false,
+            'allowed_extensions'     => [],
+            'metric_family'          => null,
+            'default_metric_unit'    => null,
+            'reference_data_name'    => null,
+            'available_locales'      => [],
+            'max_characters'         => null,
+            'validation_rule'        => null,
+            'validation_regexp'      => null,
+            'wysiwyg_enabled'        => false,
+            'number_min'             => null,
+            'number_max'             => null,
+            'decimals_allowed'       => false,
+            'negative_allowed'       => false,
+            'date_min'               => null,
+            'date_max'               => null,
+            'max_file_size'          => null,
+            'minimum_input_length'   => 0,
+            'sort_order'             => 0,
+            'localizable'            => false,
+            'scopable'               => false,
+            'labels'                 => [],
+        ];
+        $normalizer = $this->get('pim_catalog.normalizer.standard.attribute');
+
+        $response = $client->getResponse();
+
+        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+        $this->assertSame($attributeStandard, $normalizer->normalize($attribute));
+    }
+
+    public function testCompleteAttributeCreation()
+    {
+        $client = $this->createAuthentifiedClient();
+
+        $data =
+<<<JSON
+    {
+        "code":"a_new_text",
+        "type":"pim_catalog_text",
+        "group":"attributeGroupA",
+        "unique":false,
+        "useable_as_grid_filter":false,
+        "allowed_extensions":[],
+        "metric_family":null,
+        "default_metric_unit":null,
+        "reference_data_name":null,
+        "available_locales":[],
+        "max_characters":null,
+        "validation_rule":null,
+        "validation_regexp":null,
+        "wysiwyg_enabled":false,
+        "number_min":null,
+        "number_max":null,
+        "decimals_allowed":false,
+        "negative_allowed":false,
+        "date_min":null,
+        "date_max":null,
+        "max_file_size":null,
+        "minimum_input_length":0,
+        "sort_order":12,
+        "localizable":false,
+        "scopable":false,
+        "labels":[]
+    }
+JSON;
+
+        $client->request('POST', 'api/rest/v1/attributes', [], [], [], $data);
+
+        $attribute = $this->get('pim_catalog.repository.attribute')->findOneByIdentifier('a_new_text');
+
+        $attributeStandard = [
+            'code'                   => 'a_new_text',
+            'type'                   => 'pim_catalog_text',
+            'group'                  => 'attributeGroupA',
+            'unique'                 => false,
+            'useable_as_grid_filter' => false,
+            'allowed_extensions'     => [],
+            'metric_family'          => null,
+            'default_metric_unit'    => null,
+            'reference_data_name'    => null,
+            'available_locales'      => [],
+            'max_characters'         => null,
+            'validation_rule'        => null,
+            'validation_regexp'      => null,
+            'wysiwyg_enabled'        => false,
+            'number_min'             => null,
+            'number_max'             => null,
+            'decimals_allowed'       => false,
+            'negative_allowed'       => false,
+            'date_min'               => null,
+            'date_max'               => null,
+            'max_file_size'          => null,
+            'minimum_input_length'   => 0,
+            'sort_order'             => 12,
+            'localizable'            => false,
+            'scopable'               => false,
+            'labels'                 => [],
+        ];
+        $normalizer = $this->get('pim_catalog.normalizer.standard.attribute');
+
+        $response = $client->getResponse();
+
+        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+        $this->assertSame($attributeStandard, $normalizer->normalize($attribute));
+    }
+
+    public function testResponseWhenContentIsNotValid()
+    {
+        $client = $this->createAuthentifiedClient();
+
+        $data = '';
+
+        $expectedContent = [
+            'code'    => 400,
+            'message' => 'Invalid json message received.',
+        ];
+
+        $client->request('POST', 'api/rest/v1/attributes', [], [], [], $data);
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+        $this->assertSame($expectedContent, json_decode($response->getContent(), true));
+    }
+
+    public function testResponseWhenAttributeCodeAlreadyExists()
+    {
+        $client = $this->createAuthentifiedClient();
+
+        $data =
+<<<JSON
+    {
+        "code": "a_text",
+        "type":"pim_catalog_text",
+        "group":"attributeGroupA"
+    }
+JSON;
+
+        $expectedContent = [
+            'code'    => 422,
+            'message' => 'Validation failed.',
+            'errors'  => [
+                [
+                    'field'   => 'code',
+                    'message' => 'This value is already used.',
+                ]
+            ],
+        ];
+
+        $client->request('POST', 'api/rest/v1/attributes', [], [], [], $data);
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertSame($expectedContent, json_decode($response->getContent(), true));
+    }
+
+    public function testResponseWhenAttributeCodeIsNotScalar()
+    {
+        $client = $this->createAuthentifiedClient();
+
+        $data =
+<<<JSON
+    {
+        "code":[]
+    }
+JSON;
+
+        $version = substr(Version::VERSION, 0, 3);
+        $expectedContent = [
+            'code'    => 422,
+            'message' => 'Property "code" expects a scalar. Check the standard format documentation.',
+            '_links'  => [
+                'documentation' => [
+                    'href' => sprintf('https://docs.akeneo.com/%s/reference/standard_format/other_entities.html#attribute', $version),
+                ]
+            ]
+        ];
+
+        $client->request('POST', 'api/rest/v1/attributes', [], [], [], $data);
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertSame($expectedContent, json_decode($response->getContent(), true));
+    }
+
+    public function testResponseWhenAttributeGroupIsNotValid()
+    {
+        $client = $this->createAuthentifiedClient();
+
+        $data =
+<<<JSON
+    {
+        "code":"an_incomplete_text",
+        "type":"pim_catalog_text",
+        "group":"attributeGroupC"
+    }
+JSON;
+
+        $version = substr(Version::VERSION, 0, 3);
+        $expectedContent = [
+            'code'    => 422,
+            'message' => 'Property "group" expects a valid code. The attribute group does not exist, "attributeGroupC" given. Check the standard format documentation.',
+            '_links'  => [
+                'documentation' => [
+                    'href' => sprintf('https://docs.akeneo.com/%s/reference/standard_format/other_entities.html#attribute', $version),
+                ]
+            ]
+        ];
+
+        $client->request('POST', 'api/rest/v1/attributes', [], [], [], $data);
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertSame($expectedContent, json_decode($response->getContent(), true));
+    }
+
+    public function testResponseWhenAttributeTypeIsEmpty()
+    {
+        $client = $this->createAuthentifiedClient();
+
+        $data =
+<<<JSON
+    {
+        "type":null
+    }
+JSON;
+
+        $version = substr(Version::VERSION, 0, 3);
+        $expectedContent = [
+            'code'    => 422,
+            'message' => 'Property "type" does not expect an empty value. Check the standard format documentation.',
+            '_links'  => [
+                'documentation' => [
+                    'href' => sprintf('https://docs.akeneo.com/%s/reference/standard_format/other_entities.html#attribute', $version),
+                ]
+            ]
+        ];
+
+        $client->request('POST', 'api/rest/v1/attributes', [], [], [], $data);
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertSame($expectedContent, json_decode($response->getContent(), true));
+    }
+
+    public function testResponseWhenAttributeTypeIsNotValid()
+    {
+        $client = $this->createAuthentifiedClient();
+
+        $data =
+<<<JSON
+    {
+        "code":"an_incomplete_text",
+        "type":"pim_catalog_matrix",
+        "group":"attributeGroupC"
+    }
+JSON;
+
+        $version = substr(Version::VERSION, 0, 3);
+        $expectedContent = [
+            'code'    => 422,
+            'message' => 'Property "type" expects a valid attribute type. The attribute type does not exist, "pim_catalog_matrix" given. Check the standard format documentation.',
+            '_links'  => [
+                'documentation' => [
+                    'href' => sprintf('https://docs.akeneo.com/%s/reference/standard_format/other_entities.html#attribute', $version),
+                ]
+            ]
+        ];
+
+        $client->request('POST', 'api/rest/v1/attributes', [], [], [], $data);
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertSame($expectedContent, json_decode($response->getContent(), true));
+    }
+
+    public function testResponseWhenAPropertyIsNotExpected()
+    {
+        $client = $this->createAuthentifiedClient();
+
+        $data =
+<<<JSON
+    {
+        "code": "a_",
+        "type":"pim_catalog_text",
+        "group":"attributeGroupA",
+        "extra_property": ""
+    }
+JSON;
+
+        $version = substr(Version::VERSION, 0, 3);
+        $expectedContent = [
+            'code'    => 422,
+            'message' => 'Property "extra_property" does not exist. Check the standard format documentation.',
+            '_links'  => [
+                'documentation' => [
+                    'href' => sprintf('https://docs.akeneo.com/%s/reference/standard_format/other_entities.html#attribute', $version),
+                ],
+            ],
+        ];
+
+        $client->request('POST', 'api/rest/v1/attributes', [], [], [], $data);
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertSame($expectedContent, json_decode($response->getContent(), true));
+    }
+
+    public function testResponseWhenADateIsNotValid()
+    {
+        $client = $this->createAuthentifiedClient();
+
+        $data =
+<<<JSON
+    {
+        "code":"an_invalid_date",
+        "type":"pim_catalog_date",
+        "date_min":"a date"
+    }
+JSON;
+
+        $version = substr(Version::VERSION, 0, 3);
+        $expectedContent = [
+            'code'    => 422,
+            'message' => 'Property "date_min" expects a string with the format "yyyy-mm-dd" as data, "a date" given. Check the standard format documentation.',
+            '_links'  => [
+                'documentation' => [
+                    'href' => sprintf('https://docs.akeneo.com/%s/reference/standard_format/other_entities.html#attribute', $version),
+                ]
+            ]
+        ];
+
+        $client->request('POST', 'api/rest/v1/attributes', [], [], [], $data);
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertSame($expectedContent, json_decode($response->getContent(), true));
+    }
+
+    public function testResponseWhenAvailableLocalesIsNotValid()
+    {
+        $client = $this->createAuthentifiedClient();
+
+        $data =
+<<<JSON
+    {
+        "available_locales":["akeneo_PIM"]
+    }
+JSON;
+
+        $version = substr(Version::VERSION, 0, 3);
+        $expectedContent = [
+            'code'    => 422,
+            'message' => 'Property "available_locales" expects a valid locale code. The locale does not exist, "akeneo_PIM" given. Check the standard format documentation.',
+            '_links'  => [
+                'documentation' => [
+                    'href' => sprintf('https://docs.akeneo.com/%s/reference/standard_format/other_entities.html#attribute', $version),
+                ]
+            ]
+        ];
+
+        $client->request('POST', 'api/rest/v1/attributes', [], [], [], $data);
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertSame($expectedContent, json_decode($response->getContent(), true));
+    }
+
+    public function testResponseWhenArrayExpectedValueHasAnInvalidStructure()
+    {
+        $client = $this->createAuthentifiedClient();
+
+        $data =
+<<<JSON
+    {
+        "available_locales":{
+            "en_US": []
+        }
+    }
+JSON;
+
+        $version = substr(Version::VERSION, 0, 3);
+        $expectedContent = [
+            'code'    => 422,
+            'message' => 'Property "available_locales" expects a valid array, one of the "available_locales" values is not a scalar. Check the standard format documentation.',
+            '_links'  => [
+                'documentation' => [
+                    'href' => sprintf('https://docs.akeneo.com/%s/reference/standard_format/other_entities.html#attribute', $version),
+                ]
+            ]
+        ];
+
+        $client->request('POST', 'api/rest/v1/attributes', [], [], [], $data);
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertSame($expectedContent, json_decode($response->getContent(), true));
+    }
+
+    public function testResponseWhenAllowedExtensionsIsNullCreation()
+    {
+        $client = $this->createAuthentifiedClient();
+
+        $data =
+<<<JSON
+    {
+        "allowed_extensions":null
+    }
+JSON;
+
+        $client->request('POST', 'api/rest/v1/attributes', [], [], [], $data);
+
+        $response = $client->getResponse();
+
+        $version = substr(Version::VERSION, 0, 3);
+        $expectedContent = [
+            'code'    => 422,
+            'message' => 'Property "allowed_extensions" expects an array. Check the standard format documentation.',
+            '_links'  => [
+                'documentation' => [
+                    'href' => sprintf('https://docs.akeneo.com/%s/reference/standard_format/other_entities.html#attribute', $version),
+                ],
+            ],
+        ];
+
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertSame($expectedContent, json_decode($response->getContent(), true));
+    }
+
+    public function testResponseWhenLabelsIsNull()
+    {
+        $client = $this->createAuthentifiedClient();
+
+        $data =
+<<<JSON
+    {
+        "labels":null
+    }
+JSON;
+
+        $client->request('POST', 'api/rest/v1/attributes', [], [], [], $data);
+
+        $response = $client->getResponse();
+
+        $version = substr(Version::VERSION, 0, 3);
+        $expectedContent = [
+            'code'    => 422,
+            'message' => 'Property "labels" expects an array. Check the standard format documentation.',
+            '_links'  => [
+                'documentation' => [
+                    'href' => sprintf('https://docs.akeneo.com/%s/reference/standard_format/other_entities.html#attribute', $version),
+                ],
+            ],
+        ];
+
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertSame($expectedContent, json_decode($response->getContent(), true));
+    }
+
+    public function testResponseWhenAvailableLocalesIsNull()
+    {
+        $client = $this->createAuthentifiedClient();
+
+        $data =
+<<<JSON
+    {
+        "available_locales":null
+    }
+JSON;
+
+        $client->request('POST', 'api/rest/v1/attributes', [], [], [], $data);
+
+        $response = $client->getResponse();
+
+        $version = substr(Version::VERSION, 0, 3);
+        $expectedContent = [
+            'code'    => 422,
+            'message' => 'Property "available_locales" expects an array. Check the standard format documentation.',
+            '_links'  => [
+                'documentation' => [
+                    'href' => sprintf('https://docs.akeneo.com/%s/reference/standard_format/other_entities.html#attribute', $version),
+                ],
+            ],
+        ];
+
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertSame($expectedContent, json_decode($response->getContent(), true));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return new Configuration(
+            [Configuration::getTechnicalCatalogPath()],
+            false
+        );
+    }
+}

--- a/src/Pim/Component/Catalog/Updater/AttributeUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/AttributeUpdater.php
@@ -83,7 +83,7 @@ class AttributeUpdater implements ObjectUpdaterInterface
     protected function setData(AttributeInterface $attribute, $field, $data)
     {
         switch ($field) {
-            case 'attribute_type':
+            case 'type':
                 $this->setType($attribute, $data);
                 break;
             case 'labels':
@@ -216,7 +216,7 @@ class AttributeUpdater implements ObjectUpdaterInterface
     protected function setType($attribute, $data)
     {
         if (('' === $data) || (null === $data)) {
-            throw InvalidPropertyException::valueNotEmptyExpected('attribute_type', static::class);
+            throw InvalidPropertyException::valueNotEmptyExpected('type', static::class);
         }
 
         try {
@@ -226,7 +226,7 @@ class AttributeUpdater implements ObjectUpdaterInterface
             $attribute->setUnique($attributeType->isUnique());
         } catch (\LogicException $exception) {
             throw InvalidPropertyException::validEntityCodeExpected(
-                'attribute_type',
+                'type',
                 'attribute type',
                 'The attribute type does not exist',
                 static::class,

--- a/src/Pim/Component/Catalog/Updater/AttributeUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/AttributeUpdater.php
@@ -67,7 +67,7 @@ class AttributeUpdater implements ObjectUpdaterInterface
         }
 
         foreach ($data as $field => $value) {
-            $this->validateDatatype($field, $value);
+            $this->validateDataType($field, $value);
             $this->setData($attribute, $field, $value);
         }
 
@@ -83,11 +83,11 @@ class AttributeUpdater implements ObjectUpdaterInterface
      * @throws InvalidPropertyTypeException
      * @throws UnknownPropertyException
      */
-    protected function validateDatatype($field, $data)
+    protected function validateDataType($field, $data)
     {
         if (in_array($field, ['labels', 'available_locales', 'allowed_extensions'])) {
             if (!is_array($data)) {
-                throw InvalidPropertyTypeException::arrayExpected($field, 'update', 'attribute', $data);
+                throw InvalidPropertyTypeException::arrayExpected($field, static::class, $data);
             }
 
             foreach ($data as $key => $value) {
@@ -95,8 +95,7 @@ class AttributeUpdater implements ObjectUpdaterInterface
                     throw InvalidPropertyTypeException::validArrayStructureExpected(
                         $field,
                         sprintf('one of the "%s" values is not a scalar', $field),
-                        'update',
-                        'attribute',
+                        static::class,
                         $data
                     );
                 }
@@ -130,7 +129,7 @@ class AttributeUpdater implements ObjectUpdaterInterface
             ]
         )) {
             if (null !== $data && !is_scalar($data)) {
-                throw InvalidPropertyTypeException::scalarExpected($field, 'update', 'attribute', $data);
+                throw InvalidPropertyTypeException::scalarExpected($field, static::class, $data);
             }
         } else {
             throw UnknownPropertyException::unknownProperty($field);

--- a/src/Pim/Component/Catalog/spec/Updater/AttributeUpdaterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/AttributeUpdaterSpec.php
@@ -245,7 +245,7 @@ class AttributeUpdaterSpec extends ObjectBehavior
 
         $this
             ->shouldThrow(
-                InvalidPropertyTypeException::scalarExpected('code', 'update', 'attribute', [])
+                InvalidPropertyTypeException::scalarExpected('code', 'Pim\Component\Catalog\Updater\AttributeUpdater', [])
             )
             ->during('update', [$attribute, $values, []]);
     }
@@ -258,7 +258,7 @@ class AttributeUpdaterSpec extends ObjectBehavior
 
         $this
             ->shouldThrow(
-                InvalidPropertyTypeException::arrayExpected('labels', 'update', 'attribute', 'not_an_array')
+                InvalidPropertyTypeException::arrayExpected('labels', 'Pim\Component\Catalog\Updater\AttributeUpdater', 'not_an_array')
             )
             ->during('update', [$attribute, $values, []]);
     }
@@ -271,7 +271,7 @@ class AttributeUpdaterSpec extends ObjectBehavior
 
         $this
             ->shouldThrow(
-                InvalidPropertyTypeException::arrayExpected('available_locales', 'update', 'attribute', 'not_an_array')
+                InvalidPropertyTypeException::arrayExpected('available_locales', 'Pim\Component\Catalog\Updater\AttributeUpdater', 'not_an_array')
             )
             ->during('update', [$attribute, $values, []]);
     }
@@ -284,7 +284,7 @@ class AttributeUpdaterSpec extends ObjectBehavior
 
         $this
             ->shouldThrow(
-                InvalidPropertyTypeException::arrayExpected('allowed_extensions', 'update', 'attribute', 'not_an_array')
+                InvalidPropertyTypeException::arrayExpected('allowed_extensions', 'Pim\Component\Catalog\Updater\AttributeUpdater', 'not_an_array')
             )
             ->during('update', [$attribute, $values, []]);
     }

--- a/src/Pim/Component/Catalog/spec/Updater/AttributeUpdaterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/AttributeUpdaterSpec.php
@@ -64,7 +64,7 @@ class AttributeUpdaterSpec extends ObjectBehavior
         $data = [
             'labels' => ['en_US' => 'Test1', 'fr_FR' => 'Test2'],
             'group' => 'marketing',
-            'attribute_type' => 'pim_catalog_text',
+            'type' => 'pim_catalog_text',
             'date_min' => '2016-12-12T00:00:00+01:00'
         ];
 
@@ -87,7 +87,7 @@ class AttributeUpdaterSpec extends ObjectBehavior
         $attributeType->getBackendType()->willReturn('backend');
         $attributeType->isUnique()->willReturn(true);
 
-        $accessor->setValue($attribute, 'attribute_type', 'pim_catalog_text');
+        $accessor->setValue($attribute, 'type', 'pim_catalog_text');
 
         $this->update($attribute, $data);
     }
@@ -105,7 +105,7 @@ class AttributeUpdaterSpec extends ObjectBehavior
         $data = [
             'labels' => ['en_US' => 'Test1', 'fr_FR' => 'Test2'],
             'group' => 'marketing',
-            'attribute_type' => 'pim_catalog_text'
+            'type' => 'pim_catalog_text'
         ];
 
         $attribute->setLocale('en_US')->shouldBeCalled();
@@ -138,10 +138,10 @@ class AttributeUpdaterSpec extends ObjectBehavior
     function it_throws_an_exception_if_it_attribute_type_is_empty(AttributeInterface $attribute)
     {
         $this->shouldThrow(
-            InvalidPropertyException::valueNotEmptyExpected('attribute_type', 'Pim\Component\Catalog\Updater\AttributeUpdater')
+            InvalidPropertyException::valueNotEmptyExpected('type', 'Pim\Component\Catalog\Updater\AttributeUpdater')
         )->during(
             'update',
-            [$attribute, ['attribute_type' => '']]
+            [$attribute, ['type' => '']]
         );
     }
 
@@ -151,13 +151,13 @@ class AttributeUpdaterSpec extends ObjectBehavior
 
         $this->shouldThrow(
             InvalidPropertyException::validEntityCodeExpected(
-                'attribute_type',
+                'type',
                 'attribute type',
                 'The attribute type does not exist',
                 'Pim\Component\Catalog\Updater\AttributeUpdater',
                 'unknown_type'
             )
-        )->during('update', [$attribute, ['attribute_type' => 'unknown_type']]);
+        )->during('update', [$attribute, ['type' => 'unknown_type']]);
     }
 
     function it_throws_an_exception_if_data_is_not_a_date(AttributeInterface $attribute)
@@ -210,7 +210,7 @@ class AttributeUpdaterSpec extends ObjectBehavior
             'non_existent_field' => 'field',
             'labels' => ['en_US' => 'Test1', 'fr_FR' => 'Test2'],
             'group' => 'marketing',
-            'attribute_type' => 'pim_catalog_text'
+            'type' => 'pim_catalog_text'
         ];
 
         $this

--- a/src/Pim/Component/Catalog/spec/Updater/AttributeUpdaterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/AttributeUpdaterSpec.php
@@ -4,6 +4,7 @@ namespace spec\Pim\Component\Catalog\Updater;
 
 use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Akeneo\Component\StorageUtils\Exception\UnknownPropertyException;
 use PhpSpec\ObjectBehavior;
 use Pim\Bundle\CatalogBundle\AttributeType\AttributeTypeInterface;
@@ -234,5 +235,57 @@ class AttributeUpdaterSpec extends ObjectBehavior
                 'foo'
             )
         )->during('update', [$attribute, $values, []]);
+    }
+
+    function it_throws_an_exception_when_code_is_not_scalar(AttributeInterface $attribute)
+    {
+        $values = [
+            'code' => [],
+        ];
+
+        $this
+            ->shouldThrow(
+                InvalidPropertyTypeException::scalarExpected('code', 'update', 'attribute', [])
+            )
+            ->during('update', [$attribute, $values, []]);
+    }
+
+    function it_throws_an_exception_when_labels_is_not_an_array(AttributeInterface $attribute)
+    {
+        $values = [
+            'labels' => 'not_an_array',
+        ];
+
+        $this
+            ->shouldThrow(
+                InvalidPropertyTypeException::arrayExpected('labels', 'update', 'attribute', 'not_an_array')
+            )
+            ->during('update', [$attribute, $values, []]);
+    }
+
+    function it_throws_an_exception_when_available_locales_is_not_an_array(AttributeInterface $attribute)
+    {
+        $values = [
+            'available_locales' => 'not_an_array',
+        ];
+
+        $this
+            ->shouldThrow(
+                InvalidPropertyTypeException::arrayExpected('available_locales', 'update', 'attribute', 'not_an_array')
+            )
+            ->during('update', [$attribute, $values, []]);
+    }
+
+    function it_throws_an_exception_when_allowed_extensions_is_not_an_array(AttributeInterface $attribute)
+    {
+        $values = [
+            'allowed_extensions' => 'not_an_array',
+        ];
+
+        $this
+            ->shouldThrow(
+                InvalidPropertyTypeException::arrayExpected('allowed_extensions', 'update', 'attribute', 'not_an_array')
+            )
+            ->during('update', [$attribute, $values, []]);
     }
 }

--- a/src/Pim/Component/Catalog/tests/integration/Normalizer/Standard/AttributeIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Normalizer/Standard/AttributeIntegration.php
@@ -11,8 +11,6 @@ use Pim\Component\Catalog\tests\integration\Normalizer\Standard\AbstractStandard
  */
 class AttributeIntegration extends AbstractStandardNormalizerTestCase
 {
-    protected $purgeDatabaseForEachTest = false;
-
     public function testAttributeIdentifier()
     {
         $expected = [

--- a/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Attribute.php
+++ b/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Attribute.php
@@ -62,8 +62,6 @@ class Attribute implements ArrayConverterInterface
             $labelTokens = explode('-', $field);
             $labelLocale = $labelTokens[1];
             $convertedItem['labels'][$labelLocale] = $data;
-        } elseif ('type' === $field) {
-            $convertedItem['attribute_type'] = $data;
         } elseif ('number_min' === $field ||
             'number_max' === $field ||
             'max_file_size'=== $field

--- a/src/Pim/Component/Connector/ArrayConverter/StandardToFlat/Attribute.php
+++ b/src/Pim/Component/Connector/ArrayConverter/StandardToFlat/Attribute.php
@@ -36,9 +36,6 @@ class Attribute extends AbstractSimpleArrayConverter implements ArrayConverterIn
                     $convertedItem[$labelKey] = $label;
                 }
                 break;
-            case 'attribute_type':
-                $convertedItem['type'] = $data;
-                break;
             case 'options':
             case 'available_locales':
             case 'allowed_extensions':

--- a/src/Pim/Component/Connector/spec/ArrayConverter/FlatToStandard/AttributeSpec.php
+++ b/src/Pim/Component/Connector/spec/ArrayConverter/FlatToStandard/AttributeSpec.php
@@ -66,7 +66,7 @@ class AttributeSpec extends ObjectBehavior
                 'en_US' => 'SKU',
                 'fr_FR' => 'SKU',
             ],
-            'attribute_type'         => 'pim_catalog_identifier',
+            'type'                   => 'pim_catalog_identifier',
             'code'                   => 'sku',
             'group'                  => 'marketing',
             'unique'                 => true,
@@ -107,7 +107,7 @@ class AttributeSpec extends ObjectBehavior
                 'en_US' => 'SKU',
                 'fr_FR' => 'SKU',
             ],
-            'attribute_type'         => 'pim_catalog_identifier',
+            'type'                   => 'pim_catalog_identifier',
             'code'                   => 'sku',
             'group'                  => 'marketing',
             'unique'                 => true,
@@ -126,27 +126,27 @@ class AttributeSpec extends ObjectBehavior
     function it_fills_options_only_when_not_blank()
     {
         $itemBlank = [
-            'attribute_type' => 'pim_catalog_integer',
+            'type'           => 'pim_catalog_integer',
             'code'           => 'num',
             'number_min'     => '',
             'number_max'     => '',
         ];
         $itemFilled = [
-            'attribute_type' => 'pim_catalog_integer',
+            'type'           => 'pim_catalog_integer',
             'code'           => 'num',
             'number_min'     => '12',
             'number_max'     => '15',
         ];
         $this->convert($itemBlank)->shouldReturn([
             'labels'         => [],
-            'attribute_type' => 'pim_catalog_integer',
+            'type'           => 'pim_catalog_integer',
             'code'           => 'num',
             'number_min'     => null,
             'number_max'     => null,
         ]);
         $this->convert($itemFilled)->shouldReturn([
             'labels'         => [],
-            'attribute_type' => 'pim_catalog_integer',
+            'type'           => 'pim_catalog_integer',
             'code'           => 'num',
             'number_min'     => '12.0000',
             'number_max'     => '15.0000',

--- a/src/Pim/Component/Connector/spec/ArrayConverter/StandardToFlat/AttributeSpec.php
+++ b/src/Pim/Component/Connector/spec/ArrayConverter/StandardToFlat/AttributeSpec.php
@@ -54,7 +54,7 @@ class AttributeSpec extends ObjectBehavior
                 'fr_FR' => 'La description',
                 'en_US' => 'The description',
             ],
-            'attribute_type'         => 'pim_catalog_text',
+            'type'                   => 'pim_catalog_text',
             'number_min'             => 23.5,
             'number_max'             => 29.9,
             'max_file_size'          => 3500,


### PR DESCRIPTION
Create a new attribute
https://akeneo.atlassian.net/browse/API-22

```
POST /api/rest/v1/attributes
```
with
```
{"code":"a_new_text","type":"pim_catalog_text","group":"attributeGroupA","unique":false,"useable_as_grid_filter":false,"allowed_extensions":[],"metric_family":null,"default_metric_unit":null,"reference_data_name":null,"available_locales":[],"max_characters":null,"validation_rule":null,"validation_regexp":null,"wysiwyg_enabled":false,"number_min":null,"number_max":null,"decimals_allowed":false,"negative_allowed":false,"date_min":null,"date_max":null,"max_file_size":null,"minimum_input_length":0,"sort_order":12,"localizable":false,"scopable":false,"labels":[]}
```
RESPONSE 200

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | OK
| Changelog updated                 | -
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
