### PR TITLE
Export as Path or URL 

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_export_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_export_edit.yml
@@ -141,6 +141,28 @@ extensions:
             label: pim_enrich.form.job_instance.tab.properties.with_media.title
             tooltip: pim_enrich.form.job_instance.tab.properties.help.with_media.help
 
+    pim-job-instance-csv-product-export-edit-properties-with-media-as-url:
+        module: pim/job/common/edit/field/switch
+        parent: pim-job-instance-csv-product-export-edit-properties
+        position: 161
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.with_media_as_url
+            readOnly: false
+            label: pim_enrich.form.job_instance.tab.properties.with_media_as_url.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.help.with_media_as_url.help
+
+    pim-job-instance-csv-product-export-edit-properties-with-media-base-url:
+        module: pim/job/common/edit/field/text
+        parent: pim-job-instance-csv-product-export-edit-properties
+        position: 162
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.with_media_base_url
+            readOnly: false
+            label: pim_enrich.form.job_instance.tab.properties.with_media_base_url.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.help.with_media_base_url.help
+
     pim-job-instance-csv-product-export-edit-content-structure:
         module: pim/job/product/edit/content/structure
         parent: pim-job-instance-csv-product-export-edit-content

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_export_show.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_export_show.yml
@@ -136,6 +136,28 @@ extensions:
             label: pim_enrich.form.job_instance.tab.properties.with_media.title
             tooltip: pim_enrich.form.job_instance.tab.properties.help.with_media.help
 
+    pim-job-instance-csv-product-export-show-properties-with-media-as-url:
+        module: pim/job/common/edit/field/switch
+        parent: pim-job-instance-csv-product-export-show-properties
+        position: 161
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.with_media_as_url
+            readOnly: true
+            label: pim_enrich.form.job_instance.tab.properties.with_media_as_url.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.help.with_media_as_url.help
+
+    pim-job-instance-csv-product-export-show-properties-with-media-base-url:
+        module: pim/job/common/edit/field/text
+        parent: pim-job-instance-csv-product-export-show-properties
+        position: 162
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.with_media_base_url
+            readOnly: true
+            label: pim_enrich.form.job_instance.tab.properties.with_media_base_url.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.help.with_media_base_url.help
+
     pim-job-instance-csv-product-export-show-content-structure:
         module: pim/job/product/edit/content/structure
         parent: pim-job-instance-csv-product-export-show-content

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_export_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_export_edit.yml
@@ -130,6 +130,28 @@ extensions:
             label: pim_enrich.form.job_instance.tab.properties.with_media.title
             tooltip: pim_enrich.form.job_instance.tab.properties.help.with_media.help
 
+    pim-job-instance-xlsx-product-export-edit-properties-with-media-as-url:
+        module: pim/job/common/edit/field/switch
+        parent: pim-job-instance-xlsx-product-export-edit-properties
+        position: 151
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.with_media_as_url
+            readOnly: false
+            label: pim_enrich.form.job_instance.tab.properties.with_media_as_url.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.help.with_media_as_url.help
+
+    pim-job-instance-xlsx-product-export-edit-properties-with-media-base-url:
+        module: pim/job/common/edit/field/text
+        parent: pim-job-instance-xlsx-product-export-edit-properties
+        position: 152
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.with_media_base_url
+            readOnly: false
+            label: pim_enrich.form.job_instance.tab.properties.with_media_base_url.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.help.with_media_base_url.help
+
     pim-job-instance-xlsx-product-export-edit-content-structure:
         module: pim/job/product/edit/content/structure
         parent: pim-job-instance-xlsx-product-export-edit-content

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_export_show.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_export_show.yml
@@ -125,6 +125,28 @@ extensions:
             label: pim_enrich.form.job_instance.tab.properties.with_media.title
             tooltip: pim_enrich.form.job_instance.tab.properties.help.with_media.help
 
+    pim-job-instance-xlsx-product-export-show-properties-with-media-as-url:
+        module: pim/job/common/edit/field/switch
+        parent: pim-job-instance-xlsx-product-export-show-properties
+        position: 151
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.with_media_as_url
+            readOnly: true
+            label: pim_enrich.form.job_instance.tab.properties.with_media_as_url.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.help.with_media_as_url.help
+
+    pim-job-instance-xlsx-product-export-show-properties-with-media-base-url:
+        module: pim/job/common/edit/field/text
+        parent: pim-job-instance-xlsx-product-export-show-properties
+        position: 152
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.with_media_base_url
+            readOnly: true
+            label: pim_enrich.form.job_instance.tab.properties.with_media_base_url.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.help.with_media_base_url.help
+
     pim-job-instance-xlsx-product-export-show-content-structure:
         module: pim/job/product/edit/content/structure
         parent: pim-job-instance-xlsx-product-export-show-content

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
@@ -478,6 +478,9 @@ pim_enrich:
                     with_media:
                         title: Export files and images
                         help: Whether or not to export product files and images
+                    with_media_as_url:
+                        title: Export files and images as URL
+                        help: Whether or not to export product files and images as URL
                     lines_per_file:
                         title: Number of lines per file
                         help: Define the limit number of lines per file

--- a/src/Pim/Component/Connector/Job/JobParameters/ConstraintCollectionProvider/ProductCsvExport.php
+++ b/src/Pim/Component/Connector/Job/JobParameters/ConstraintCollectionProvider/ProductCsvExport.php
@@ -10,6 +10,7 @@ use Pim\Component\Connector\Validator\Constraints\FilterStructureAttribute;
 use Pim\Component\Connector\Validator\Constraints\FilterStructureLocale;
 use Symfony\Component\Validator\Constraints\Collection;
 use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Url;
 use Symfony\Component\Validator\Constraints\Type;
 
 /**
@@ -52,6 +53,13 @@ class ProductCsvExport implements ConstraintCollectionProviderInterface
                 'groups' => ['Default', 'FileConfiguration'],
             ]
         );
+        $constraintFields['with_media_as_url'] = new Type(
+            [
+                'type'   => 'bool',
+                'groups' => ['Default', 'FileConfiguration'],
+            ]
+        );
+        $constraintFields['with_media_base_url'] = New Url();
         $constraintFields['filters'] = [
             new FilterData(['groups' => ['Default', 'DataFilters']]),
             new Collection(

--- a/src/Pim/Component/Connector/Job/JobParameters/ConstraintCollectionProvider/ProductXlsxExport.php
+++ b/src/Pim/Component/Connector/Job/JobParameters/ConstraintCollectionProvider/ProductXlsxExport.php
@@ -10,6 +10,7 @@ use Pim\Component\Connector\Validator\Constraints\FilterStructureAttribute;
 use Pim\Component\Connector\Validator\Constraints\FilterStructureLocale;
 use Symfony\Component\Validator\Constraints\Collection;
 use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Url;
 use Symfony\Component\Validator\Constraints\Type;
 
 /**
@@ -52,6 +53,13 @@ class ProductXlsxExport implements ConstraintCollectionProviderInterface
                 'groups' => ['Default', 'FileConfiguration'],
             ]
         );
+        $constraintFields['with_media_as_url'] = new Type(
+            [
+                'type'   => 'bool',
+                'groups' => ['Default', 'FileConfiguration'],
+            ]
+        );
+        $constraintFields['with_media_base_url'] = new Url();
         $constraintFields['filters'] = [
             new FilterData(['groups' => ['Default', 'DataFilters']]),
             new Collection(


### PR DESCRIPTION
Intial patch for #5540.

This is not complete, and I'm asking for feedback before I continue.

We're planning on storing our assets in S3, and we'd like to not have Akeneo download the images each time someone does an export, but instead have the URL to cloudfront, with the option to continue exports as they are.

Currently the UI looks like this (I'm not happy with it, but its proof of concept, so whatever):
![screenshot from 2017-01-25 17-19-26](https://cloud.githubusercontent.com/assets/309967/22301354/b54e3e66-e322-11e6-9150-95fed58a2499.png)

- When `with_media = true`, and `with_media_as_url = false` exports continue as they are.
- When `with_media = true`, and `with_media_as_url = true` and `with_media_base_url = blank|null` exports put the path to the file, **exactly** like the REST API does.
- When `with_media = true`, and `with_media_as_url = true` and `with_media_base_url = 'http://someurl.here.com/catalog/'` exports prepend the asset path with the provided URL

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
