### PR TITLE
Fixing channel conversion units versionning

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -22,6 +22,7 @@
 - Add Energy measure family and conversions cheers @JulienDotDev!
 - Complete Duration measure family with week, month, year and related conversions cheers @JulienDotDev!
 - Add CaseBox measure family and conversions, cheers @gplanchat!
+- Add history support for the channel conversion units.
 
 ## Technical improvements
 

--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -37,6 +37,7 @@
 - GITHUB-5455: Redo channel edit form using backbonejs architecture and internal REST API, implement `Pim\Bundle\CatalogBundle\Doctrine\Common\Remover\ChannelRemover` and move validation logic from controller to newly created remover
 
 ## BC breaks
+- Change the constructor of `Pim\Component\Catalog\Updater\ChannelUpdater` to add `Pim\Component\Catalog\Repositor\AttributeRepositoryInterface` and add `Akeneo\Bundle\MeasureBundle\Manager\MeasureManager`
 - Change the constructor of `Pim\Component\Catalog\Denormalizer\Standard\ProductValueDenormalizer` to add `Pim\Component\Catalog\Factory\ProductValueFactory`
 - Change the constructor of `Pim\Component\Catalog\Builder\ProductBuilder` to add `Pim\Component\Catalog\Factory\ProductValueFactory`
 - Add `getAllChildrenCodes` to `Akeneo\Component\Classification\Repository\CategoryRepositoryInterface`

--- a/features/Context/WebUser.php
+++ b/features/Context/WebUser.php
@@ -651,22 +651,21 @@ class WebUser extends RawMinkContext
         $this->spin(function () use ($field, $label, $expected) {
             if ($field->hasClass('select2-focusser')) {
                 for ($i = 0; $i < 2; ++$i) {
-                    if (!$field->getParent()) {
+                    $parent = $field->getParent();
+                    if (!$parent) {
                         break;
                     }
-                    $field = $field->getParent();
+                    $field = $parent;
                 }
-                if ($select = $field->find('css', 'select')) {
-                    $actual = $select->find('css', 'option[selected]')->getHtml();
-                } else {
-                    $actual = trim($field->find('css', '.select2-chosen')->getHtml());
-                }
+
+                $actual = trim($field->find('css', '.select2-chosen')->getHtml());
             } elseif ($field->hasClass('select2-input')) {
                 for ($i = 0; $i < 4; ++$i) {
-                    if (!$field->getParent()) {
+                    $parent = $field->getParent();
+                    if (!$parent) {
                         break;
                     }
-                    $field = $field->getParent();
+                    $field = $parent;
                 }
                 if ($select = $field->find('css', 'select')) {
                     $options = $field->findAll('css', 'option[selected]');

--- a/features/channel/edit_channel.feature
+++ b/features/channel/edit_channel.feature
@@ -87,7 +87,6 @@ Feature: Edit a channel
     And I should not see the text "There are unsaved changes."
     Then I should not see the text "This collection should contain 1 element or more."
 
-
   Scenario: Successfully display validation message when the required locales field is empty
     Given I am logged in as "Peter"
     And I am on the "tablet" channel page
@@ -95,3 +94,35 @@ Feature: Edit a channel
       | Locales | |
     And I press the "Save" button
     Then I should see the text "This collection should contain 1 element or more."
+
+  Scenario: Successfully updates a channel conversion units
+    Given I am logged in as "Peter"
+    And I am on the "tablet" channel page
+    And I fill in the following information:
+      | Volume | Liter      |
+      | Length | Millimeter |
+    When I press the "Save" button
+    Then I should not see the text "There are unsaved changes."
+    And the field Volume should contain "Liter"
+    And the field Length should contain "Millimeter"
+    And the field Weight should contain "Do not convert"
+    When I fill in the following information:
+      | Volume | Do not convert |
+      | Length | Millimeter     |
+      | Weight | Gram           |
+    And I press the "Save" button
+    Then I should not see the text "There are unsaved changes."
+    And the field Weight should contain "Gram"
+    And the field Length should contain "Millimeter"
+    And the field Volume should contain "Do not convert"
+
+  Scenario: Successfully updates a channel and its history
+    Given I am logged in as "Peter"
+    And I am on the "tablet" channel page
+    And I fill in the following information:
+      | Volume | Liter      |
+      | Length | Millimeter |
+    And I press the "Save" button
+    And I should not see the text "There are unsaved changes."
+    When I visit the "History" tab
+    Then there should be 2 updates

--- a/features/import/import_channels.feature
+++ b/features/import/import_channels.feature
@@ -10,7 +10,7 @@ Feature: Import channels
     And the following CSV file to import:
       """
       code;label;currencies;locales;tree;conversion_units
-      site;Site;USD,EUR;de_DE,en_US,hy_AM;2014_collection;"weight: GRAM, maximum_scan_size: KILOMETER, display_diagonal: DEKAMETER, viewing_area: DEKAMETER"
+      site;Site;USD,EUR;de_DE,en_US,hy_AM;2014_collection;"weight: GRAM, length: MILLIMETER, volume: LITER"
       """
     And the following job "csv_footwear_channel_import" configuration:
       | filePath | %file to import% |
@@ -18,8 +18,8 @@ Feature: Import channels
     And I launch the import job
     And I wait for the "csv_footwear_channel_import" job to finish
     Then there should be the following channels:
-      | code | label | currencies | locales           | tree            | conversion_units                                                                                 |
-      | site | Site  | EUR,USD    | de_DE,en_US,hy_AM | 2014_collection | weight: GRAM, maximum_scan_size: KILOMETER, display_diagonal: DEKAMETER, viewing_area: DEKAMETER |
+      | code | label | currencies | locales           | tree            | conversion_units                                |
+      | site | Site  | EUR,USD    | de_DE,en_US,hy_AM | 2014_collection | weight: GRAM, length: MILLIMETER, volume: LITER |
 
   @jira https://akeneo.atlassian.net/browse/PIM-6041
   Scenario: Successfully import channel do not create empty conversion unit

--- a/src/Akeneo/Bundle/MeasureBundle/CHANGELOG.md
+++ b/src/Akeneo/Bundle/MeasureBundle/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.5.1 (2017-01-21)
+ - rename unitExistsInFamily to unitSymbolExistsInFamily
+ - Add unitCodeExistsInFamily in the MeasureManager
+
 # 0.5.0 (2016-04-30)
  - Use phpspec and not phpunit anymore, thanks to @fitn
  - Fix missing family constants, thanks to @danielsan80

--- a/src/Akeneo/Bundle/MeasureBundle/CHANGELOG.md
+++ b/src/Akeneo/Bundle/MeasureBundle/CHANGELOG.md
@@ -1,6 +1,14 @@
-# 0.5.1 (2017-01-21)
- - rename unitExistsInFamily to unitSymbolExistsInFamily
- - Add unitCodeExistsInFamily in the MeasureManager
+# 0.6.0 (2017-01-21)
+
+## Functional improvements
+ - The measure manager is now able to return the list the unit codes for a given family
+ - The measure manager is now able to tell if a unit code exists in a given family
+
+## BC breaks
+ - remove `unitExistsInFamily` from `Akeneo\Bundle\MeasureBundle\Manager\MeasureManager`
+ - Add `unitSymbolExistsInFamily` `Akeneo\Bundle\MeasureBundle\Manager\MeasureManager`
+ - Add `unitCodeExistsInFamily` in `Akeneo\Bundle\MeasureBundle\Manager\MeasureManager`
+ - Add `getUnitCodesForFamily` in `Akeneo\Bundle\MeasureBundle\Manager\MeasureManager`
 
 # 0.5.0 (2016-04-30)
  - Use phpspec and not phpunit anymore, thanks to @fitn

--- a/src/Akeneo/Bundle/MeasureBundle/CHANGELOG.md
+++ b/src/Akeneo/Bundle/MeasureBundle/CHANGELOG.md
@@ -1,8 +1,8 @@
 # 0.6.0 (2017-01-21)
 
 ## Functional improvements
- - The measure manager is now able to return the list the unit codes for a given family
- - The measure manager is now able to tell if a unit code exists in a given family
+ - The measure manager is now able to return the list of unit codes for a given family
+ - The measure manager is now able to tell if a unit code exists for a given family
 
 ## BC breaks
  - remove `unitExistsInFamily` from `Akeneo\Bundle\MeasureBundle\Manager\MeasureManager`

--- a/src/Akeneo/Bundle/MeasureBundle/Manager/MeasureManager.php
+++ b/src/Akeneo/Bundle/MeasureBundle/Manager/MeasureManager.php
@@ -47,16 +47,29 @@ class MeasureManager
     }
 
     /**
-     * Check if unit exists in the given family
+     * Check if the unit symbol (like 'g' for GRAM) exists for the given family
      *
-     * @param string $unit   the unit to check
-     * @param string $family the measure family
+     * @param string $unitSymbol the unit symbol to check
+     * @param string $family     the measure family
      *
      * @return bool
      */
-    public function unitExistsInFamily($unit, $family)
+    public function unitSymbolExistsInFamily($unitSymbol, $family)
     {
-        return in_array($unit, $this->getUnitSymbolsForFamily($family));
+        return in_array($unitSymbol, $this->getUnitSymbolsForFamily($family));
+    }
+
+    /**
+     * Check if the unit code (like 'GRAM' or 'KILOMETER') exists for the given family
+     *
+     * @param string $unitCode the unit code to check
+     * @param string $family   the measure family
+     *
+     * @return bool
+     */
+    public function unitCodeExistsInFamily($unitCode, $family)
+    {
+        return in_array($unitCode, $this->getUnitsForFamily($family));
     }
 
     /**
@@ -90,5 +103,24 @@ class MeasureManager
         }
 
         return $this->config[$family];
+    }
+
+    /**
+     * Get unit codes for a measure family
+     *
+     * @param string $family the measure family
+     *
+     * @return array the measure units code
+     */
+    protected function getUnitsForFamily($family)
+    {
+        $familyConfig = $this->getFamilyConfig($family);
+        $units = [];
+
+        foreach ($familyConfig['units'] as $unit => $unitData) {
+            $units[] = $unit;
+        }
+
+        return $units;
     }
 }

--- a/src/Akeneo/Bundle/MeasureBundle/Manager/MeasureManager.php
+++ b/src/Akeneo/Bundle/MeasureBundle/Manager/MeasureManager.php
@@ -69,7 +69,7 @@ class MeasureManager
      */
     public function unitCodeExistsInFamily($unitCode, $family)
     {
-        return in_array($unitCode, $this->getUnitsForFamily($family));
+        return in_array($unitCode, $this->getUnitCodesForFamily($family));
     }
 
     /**
@@ -84,6 +84,20 @@ class MeasureManager
         $familyConfig = $this->getFamilyConfig($family);
 
         return $familyConfig['standard'];
+    }
+
+    /**
+     * Get unit codes for a measure family
+     *
+     * @param string $family the measure family
+     *
+     * @return array the measure units code
+     */
+    public function getUnitCodesForFamily($family)
+    {
+        $familyConfig = $this->getFamilyConfig($family);
+
+        return array_keys($familyConfig['units']);
     }
 
     /**
@@ -103,24 +117,5 @@ class MeasureManager
         }
 
         return $this->config[$family];
-    }
-
-    /**
-     * Get unit codes for a measure family
-     *
-     * @param string $family the measure family
-     *
-     * @return array the measure units code
-     */
-    protected function getUnitsForFamily($family)
-    {
-        $familyConfig = $this->getFamilyConfig($family);
-        $units = [];
-
-        foreach ($familyConfig['units'] as $unit => $unitData) {
-            $units[] = $unit;
-        }
-
-        return $units;
     }
 }

--- a/src/Akeneo/Bundle/MeasureBundle/spec/Manager/MeasureManagerSpec.php
+++ b/src/Akeneo/Bundle/MeasureBundle/spec/Manager/MeasureManagerSpec.php
@@ -33,6 +33,12 @@ class MeasureManagerSpec extends ObjectBehavior
                 new \InvalidArgumentException('Undefined measure family "foo"')
             )
             ->during('getUnitSymbolsForFamily', ['foo']);
+
+        $this
+            ->shouldThrow(
+                new \InvalidArgumentException('Undefined measure family "foo"')
+            )
+            ->during('getUnitCodesForFamily', ['foo']);
     }
 
     public function it_returns_unit_symbols_list_from_a_family()
@@ -48,10 +54,39 @@ class MeasureManagerSpec extends ObjectBehavior
             );
     }
 
+    public function it_indicates_wether_a_unit_symbol_exists_for_a_family()
+    {
+        $this
+            ->unitSymbolExistsInFamily('mg', WeightFamilyInterface::FAMILY)
+            ->shouldReturn(true);
+
+        $this
+            ->unitSymbolExistsInFamily('foo', WeightFamilyInterface::FAMILY)
+            ->shouldReturn(false);
+    }
+
     public function it_returns_standard_unit_for_a_family()
     {
         $this
             ->getStandardUnitForFamily(WeightFamilyInterface::FAMILY)
             ->shouldReturn(WeightFamilyInterface::GRAM);
+    }
+
+    public function it_returns_unit_codes_for_a_family()
+    {
+        $this
+            ->getUnitCodesForFamily(WeightFamilyInterface::FAMILY)
+            ->shouldReturn(['MILLIGRAM', 'GRAM', 'KILOGRAM']);
+    }
+
+    public function it_indicates_wether_a_unit_code_exists_for_a_family()
+    {
+        $this
+            ->unitCodeExistsInFamily(WeightFamilyInterface::GRAM, WeightFamilyInterface::FAMILY)
+            ->shouldReturn(true);
+
+        $this
+            ->unitCodeExistsInFamily('FOO', WeightFamilyInterface::FAMILY)
+            ->shouldReturn(false);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/updaters.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/updaters.yml
@@ -143,6 +143,7 @@ services:
             - '@pim_catalog.repository.category'
             - '@pim_catalog.repository.locale'
             - '@pim_catalog.repository.currency'
+            - '@pim_catalog.repository.attribute'
 
     pim_catalog.updater.locale:
         class: '%pim_catalog.updater.locale.class%'

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/updaters.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/updaters.yml
@@ -144,6 +144,7 @@ services:
             - '@pim_catalog.repository.locale'
             - '@pim_catalog.repository.currency'
             - '@pim_catalog.repository.attribute'
+            - '@akeneo_measure.manager'
 
     pim_catalog.updater.locale:
         class: '%pim_catalog.updater.locale.class%'

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/channel/form/properties/conversion-unit.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/channel/form/properties/conversion-unit.js
@@ -100,7 +100,7 @@ define([
                     data.conversion_units = {};
                 }
 
-                if (value !== "no_conversion") {
+                if (value !== 'no_conversion') {
                     data.conversion_units[attribute] = value;
                 } else {
                     delete data.conversion_units[attribute];

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/channel/form/properties/conversion-unit.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/channel/form/properties/conversion-unit.js
@@ -96,17 +96,16 @@ define([
             setAttributeConversionUnit: function (attribute, value) {
                 var data = this.getFormData();
 
-                var key = _.findIndex(data.conversion_units, function (unit) {
-                    return _.has(unit, attribute);
-                });
-
-                if (0 > key) {
-                    var conversionUnit = {};
-                    conversionUnit[attribute] = value;
-                    data.conversion_units.push(conversionUnit);
-                } else {
-                    data.conversion_units[key][attribute] = value;
+                if (_.isEmpty(data.conversion_units)) {
+                    data.conversion_units = {};
                 }
+
+                if (value !== "no_conversion") {
+                    data.conversion_units[attribute] = value;
+                } else {
+                    delete data.conversion_units[attribute];
+                }
+
                 this.setData(data);
             }
         });

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/channel/tab/properties/conversion-unit.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/channel/tab/properties/conversion-unit.html
@@ -1,7 +1,7 @@
 <div class="tabsection-title"><%- label %></div>
 <div class="tabsection-content">
     <div class="AknFormContainer AknFormContainer--withPadding">
-    <% _.each(metrics, function (attribute, key) { %>
+        <% _.each(metrics, function (attribute, key) { %>
         <div class="AknFieldContainer">
             <div class="AknFieldContainer-header">
                 <label class="AknFieldContainer-label control-label" for="<%- fieldBaseId + attribute.code %>">
@@ -10,12 +10,12 @@
             </div>
             <div class="AknFieldContainer-inputContainer">
                 <select class="select2" id="<%- fieldBaseId + attribute.code %>">
-                    <% key = _.findIndex(conversionUnits, function (unit) { return _.has(unit, attribute.code) }) %>
-                    <option <%- (0 > key) ? 'selected' : '' %>>
+                    <% isMetricConfigured = !_.isUndefined(conversionUnits[attribute.code]) %>
+                    <option value="no_conversion" <%- (!isMetricConfigured) ? 'selected' : '' %>>
                         <%- doNotConvertLabel %>
                     </option>
                     <% _.each(_.keys(measures[attribute.metric_family].units), function (unit) { %>
-                    <option value="<%- unit %>" <%- (0 <= key && unit == conversionUnits[key][attribute.code]) ? 'selected' : '' %>>
+                    <option value="<%- unit %>" <%- (isMetricConfigured && unit == conversionUnits[attribute.code]) ? 'selected' : '' %>>
                         <%- _.__(unit) %>
                     </option>
                     <% }) %>

--- a/src/Pim/Component/Catalog/Updater/ChannelUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/ChannelUpdater.php
@@ -9,7 +9,6 @@ use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterfa
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Doctrine\Common\Util\ClassUtils;
 use Pim\Component\Catalog\Model\ChannelInterface;
-use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
 
 /**
  * Updates a channel
@@ -29,7 +28,7 @@ class ChannelUpdater implements ObjectUpdaterInterface
     /** @var IdentifiableObjectRepositoryInterface */
     protected $currencyRepository;
 
-    /** @var AttributeRepositoryInterface */
+    /** @var IdentifiableObjectRepositoryInterface */
     protected $attributeRepository;
 
     /** @var MeasureManager */
@@ -68,7 +67,7 @@ class ChannelUpdater implements ObjectUpdaterInterface
      *     },
      *     'locales': ['en_US'],
      *     'currencies': ['EUR', 'USD'],
-     *     'conversion_units': ["weight" => "GRAM", "display_diagnoal" => "METER"],
+     *     'conversion_units': ["weight" => "GRAM", "display_diagonal" => "METER"],
      *     'category_tree': 'master'
      * }
      */
@@ -215,10 +214,9 @@ class ChannelUpdater implements ObjectUpdaterInterface
      * @param ChannelInterface $channel
      * @param array            $conversionUnits
      *
-     * @internal param $convertionUnits
-     *
+     * @throws InvalidPropertyException
      */
-    protected function setConversionUnits($channel, $conversionUnits)
+    protected function setConversionUnits(ChannelInterface $channel, $conversionUnits)
     {
         foreach ($conversionUnits as $attributeCode => $conversionUnit) {
             $attribute = $this->attributeRepository->findOneByIdentifier($attributeCode);

--- a/src/Pim/Component/Catalog/Updater/ChannelUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/ChannelUpdater.php
@@ -221,28 +221,31 @@ class ChannelUpdater implements ObjectUpdaterInterface
     protected function setConversionUnits($channel, $conversionUnits)
     {
         foreach ($conversionUnits as $attributeCode => $conversionUnit) {
-            $isConversionMetricValid = false;
-
             $attribute = $this->attributeRepository->findOneByIdentifier($attributeCode);
 
-            if ($attribute !== null &&
-                $this->measureManager->unitCodeExistsInFamily($conversionUnit, $attribute->getMetricFamily())
-            ) {
-                $isConversionMetricValid = true;
-            }
-
-            if (!$isConversionMetricValid) {
+            if ($attribute === null) {
                 throw InvalidPropertyException::validEntityCodeExpected(
                     'conversionUnits',
-                    'attributeCode and metric code',
+                    'attributeCode',
                     'the attribute code does not exists',
                     'updater',
                     'channel',
-                    sprintf('(%s, %s)', $attributeCode, $conversionUnit)
+                    $attributeCode
                 );
             }
-        }
 
-        $channel->setConversionUnits($conversionUnits);
+            if (!$this->measureManager->unitCodeExistsInFamily($conversionUnit, $attribute->getMetricFamily())) {
+                throw InvalidPropertyException::validEntityCodeExpected(
+                    'conversionUnits',
+                    'conversionUnit',
+                    'the metric unit does not exists',
+                    'updater',
+                    'channel',
+                    $conversionUnit
+                );
+            }
+
+            $channel->setConversionUnits($conversionUnits);
+        }
     }
 }

--- a/src/Pim/Component/Catalog/Updater/ChannelUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/ChannelUpdater.php
@@ -227,7 +227,7 @@ class ChannelUpdater implements ObjectUpdaterInterface
                 throw InvalidPropertyException::validEntityCodeExpected(
                     'conversionUnits',
                     'attributeCode',
-                    'the attribute code does not exists',
+                    'the attribute code for the conversion unit does not exist',
                     'updater',
                     'channel',
                     $attributeCode
@@ -237,8 +237,8 @@ class ChannelUpdater implements ObjectUpdaterInterface
             if (!$this->measureManager->unitCodeExistsInFamily($conversionUnit, $attribute->getMetricFamily())) {
                 throw InvalidPropertyException::validEntityCodeExpected(
                     'conversionUnits',
-                    'conversionUnit',
-                    'the metric unit does not exists',
+                    'unitCode',
+                    'the metric unit code for the conversion unit does not exist',
                     'updater',
                     'channel',
                     $conversionUnit


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This adds the versioning support for the conversion units of channels. (not supported 1.6).

**Solution:**
This PR fixes the way the conversionUnits are sent and saved into the channel:
```
[
   "attribute_code_1" => "metric",
   "attribute_code2" => "metric",
]
```
instead of:
```
[
   [ "attribute_code1" =>"metric"],
   [ "attribute_code2" =>"metric"]
]
```

**What does that do ?:**

This PR Adapts the channelUpdater to do some validation on the conversionUnits before setting the data from the form into the channel property.

It also adapts the way the conversionUnits are sent from the UI on save.
It also adapts the way the conversionUnits property is shown from the template.

No migration needed as the channel edit form has been pefized in 1.7 and the backend format of the conversion units for the channel remains the same.

**Questions:**
One function has been renamed in the MeasureManager and another one added.

*Where do we describe those changes:*
1. PIM changelog
2. MeasureBundle changelog (+ add a release version ?)
3. Both of them

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added Behats                      | OK
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
