### PR TITLE
Split integration TestCase into smaller classes

### DIFF
--- a/tests/ConnectionCloser.php
+++ b/tests/ConnectionCloser.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Akeneo\Test\Integration;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * @author    Yohan Blain <yohan.blain@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class ConnectionCloser
+{
+    /** @var ContainerInterface */
+    protected $container;
+
+    /**
+     * @param ContainerInterface $container
+     */
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * Ensures that all used connections are well closed.
+     *
+     * @see https://github.com/akeneo/pim-community-dev/pull/5484
+     */
+    public function closeConnections()
+    {
+        $doctrine = $this->container->get('doctrine');
+        foreach ($doctrine->getConnections() as $connection) {
+            $connection->close();
+        }
+    }
+}

--- a/tests/DatabasePurger.php
+++ b/tests/DatabasePurger.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Akeneo\Test\Integration;
+
+use Akeneo\Bundle\StorageUtilsBundle\DependencyInjection\AkeneoStorageUtilsExtension;
+use Doctrine\Common\DataFixtures\Purger\MongoDBPurger;
+use Doctrine\Common\DataFixtures\Purger\ORMPurger;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * @author    Yohan Blain <yohan.blain@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class DatabasePurger
+{
+    /** @var ContainerInterface */
+    protected $container;
+
+    /**
+     * @param ContainerInterface $container
+     */
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * Calls the appropriates purgers depending on the storage.
+     */
+    public function purge()
+    {
+        if (AkeneoStorageUtilsExtension::DOCTRINE_MONGODB_ODM === $this->container->getParameter('pim_catalog_product_storage_driver')) {
+            $purgers[] = new MongoDBPurger($this->container->get('doctrine_mongodb')->getManager());
+        }
+
+        $purgers[] = new ORMPurger($this->container->get('doctrine')->getManager());
+
+        foreach ($purgers as $purger) {
+            $purger->purge();
+        }
+    }
+}

--- a/tests/FixturesLoader.php
+++ b/tests/FixturesLoader.php
@@ -1,0 +1,244 @@
+<?php
+
+namespace Akeneo\Test\Integration;
+
+use Akeneo\Bundle\BatchBundle\Command\BatchCommand;
+use Akeneo\Bundle\StorageUtilsBundle\DependencyInjection\AkeneoStorageUtilsExtension;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * @author    Yohan Blain <yohan.blain@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class FixturesLoader
+{
+    /** @var ContainerInterface */
+    protected $container;
+
+    /** @var Configuration */
+    protected $configuration;
+
+    /**
+     * @param ContainerInterface $container
+     * @param Configuration      $configuration
+     */
+    public function __construct(ContainerInterface $container, Configuration $configuration)
+    {
+        $this->container = $container;
+        $this->configuration = $configuration;
+    }
+
+    public function __destruct()
+    {
+        // close the connection created specifically for this repository
+        // TODO: to remove when TIP-385 will be done
+        $doctrineJobRepository = $this->container->get('akeneo_batch.job_repository');
+        $doctrineJobRepository->getJobManager()->getConnection()->close();
+    }
+
+    /**
+     * Loads test catalog.
+     *
+     * @throws \Exception
+     */
+    public function load()
+    {
+        $files = $this->getFilesToLoad($this->configuration->getCatalogDirectories());
+        $filesByType = $this->getFilesToLoadByType($files);
+
+        $this->loadSqlFiles($filesByType['sql']);
+        $this->loadMongoDbFiles($filesByType['mongodb']);
+        $this->loadImportFiles($filesByType['import']);
+    }
+
+    /**
+     * Load SQL file directly by a regular SQL query
+     *
+     * @param array $files
+     */
+    protected function loadSqlFiles(array $files)
+    {
+        $db = $this->container->get('doctrine.orm.entity_manager')->getConnection();
+
+        foreach ($files as $file) {
+            $db->executeQuery(file_get_contents($file));
+        }
+    }
+
+    /**
+     * Load Mongo files directly by a regular MongoDB query
+     *
+     * @param array $files
+     */
+    protected function loadMongoDbFiles(array $files)
+    {
+        $storage = $this->container->getParameter('pim_catalog_product_storage_driver');
+        if (AkeneoStorageUtilsExtension::DOCTRINE_MONGODB_ODM !== $storage) {
+            return;
+        }
+
+        $db = $this->container->get('doctrine.odm.mongodb.document_manager')->getConnection()->akeneo_pim;
+        foreach ($files as $file) {
+            $db->execute(file_get_contents($file));
+        }
+    }
+
+    /**
+     * Load import files via akeneo:batch:job
+     *
+     * @param array $files
+     *
+     * @throws \Exception
+     */
+    protected function loadImportFiles(array $files)
+    {
+        // prepare replace paths to use catalog paths and not the minimal fixtures path, please note that we can
+        // have several files per job in case of Enterprise Catalog, for instance,
+        // [
+        //     'jobs' => [
+        //         "/project/features/Context/catalog/footwear/jobs.yml"
+        //         "/project/features/PimEnterprise/Behat/Context/../../../Context/catalog/footwear/jobs.yml"
+        // ]
+        $replacePaths = [];
+        foreach ($files as $file) {
+            $tokens = explode(DIRECTORY_SEPARATOR, $file);
+            $fileName = array_pop($tokens);
+            if (!isset($replacePaths[$fileName])) {
+                $replacePaths[$fileName] = [];
+            }
+            $replacePaths[$fileName][] = $file;
+        }
+
+        // configure and load job instances in database
+        $jobLoader = $this->container->get('pim_installer.fixture_loader.job_loader');
+        $jobLoader->loadJobInstances($replacePaths);
+
+        // setup application to be able to run akeneo:batch:job command
+        $application = new Application();
+        $application->add(new BatchCommand());
+        $batchJobCommand = $application->find('akeneo:batch:job');
+        $batchJobCommand->setContainer($this->container);
+        $command = new CommandTester($batchJobCommand);
+
+        // install the catalog via the job instances
+        $jobInstances = $jobLoader->getLoadedJobInstances();
+        foreach ($jobInstances as $jobInstance) {
+            $exitCode = $command->execute(
+                [
+                    'command'  => $batchJobCommand->getName(),
+                    'code'     => $jobInstance->getCode(),
+                    '--no-log' => true,
+                    '-v'       => true
+                ]
+            );
+
+            if (0 !== $exitCode) {
+                throw new \Exception(sprintf('Catalog not installable! "%s"', $command->getDisplay()));
+            }
+        }
+
+        $jobLoader->deleteJobInstances();
+    }
+
+    /**
+     * Separate files to load by their type. They can be:
+     *  - regular files to load from an import.
+     *  - SQL files
+     *  - mongo files
+     *
+     * @param array $files
+     *
+     * @return array
+     */
+    protected function getFilesToLoadByType(array $files)
+    {
+        $filesByType = [
+            'sql' => [],
+            'mongodb' => [],
+            'import' => [],
+        ];
+
+        foreach ($files as $filePath) {
+            $realPathParts = pathinfo($filePath);
+
+            // do not try to load files without extension
+            if (!isset($realPathParts['extension'])) {
+                continue;
+            }
+
+            // do not try to load product file that do not match the storage
+            if ('200_products' === $realPathParts['filename']) {
+                $storage = $this->container->getParameter('pim_catalog_product_storage_driver');
+                if ($storage === AkeneoStorageUtilsExtension::DOCTRINE_MONGODB_ODM &&
+                    'sql' === $realPathParts['extension']
+                ) {
+                    continue;
+                }
+                elseif ($storage === AkeneoStorageUtilsExtension::DOCTRINE_ORM &&
+                    'json' === $realPathParts['extension']
+                ) {
+                    continue;
+                }
+            }
+
+            switch ($realPathParts['extension']) {
+                case 'json':
+                    $filesByType['mongodb'][] = $filePath;
+                    break;
+                case 'sql':
+                    $filesByType['sql'][] = $filePath;
+                    break;
+                case 'csv':
+                case 'xls':
+                case 'xlsx':
+                case 'yml':
+                case 'yaml':
+                    $filesByType['import'][] = $filePath;
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        return $filesByType;
+    }
+
+    /**
+     * Get the list of catalog configuration file paths to load
+     *
+     * @param array $directories
+     *
+     * @throws \Exception if no files can be loaded
+     *
+     * @return array
+     */
+    protected function getFilesToLoad(array $directories)
+    {
+        $rawFiles = [];
+        foreach ($directories as $directory) {
+            $rawFiles = array_merge($rawFiles, glob($directory.'/*'));
+        }
+
+        if (empty($rawFiles)) {
+            throw new \Exception(
+                sprintf(
+                    'No catalog file to load found in "%s"',
+                    implode(', ', $directories)
+                )
+            );
+        }
+
+        $files = [];
+        foreach ($rawFiles as $rawFilePath) {
+            if (false === $realFilePath = realpath($rawFilePath)) {
+                continue;
+            }
+            $files[] = $rawFilePath;
+        }
+
+        return $files;
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,13 +2,8 @@
 
 namespace Akeneo\Test\Integration;
 
-use Akeneo\Bundle\BatchBundle\Command\BatchCommand;
-use Akeneo\Bundle\StorageUtilsBundle\DependencyInjection\AkeneoStorageUtilsExtension;
-use Doctrine\Common\DataFixtures\Purger\MongoDBPurger;
-use Doctrine\Common\DataFixtures\Purger\ORMPurger;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Console\Application;
-use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -38,13 +33,6 @@ abstract class TestCase extends KernelTestCase
     abstract protected function getConfiguration();
 
     /**
-     * Method executed after the fixture import
-     */
-    protected function doAfterFixtureImport(Application $application)
-    {
-    }
-
-    /**
      * {@inheritdoc}
      */
     protected function setUp()
@@ -52,18 +40,16 @@ abstract class TestCase extends KernelTestCase
         static::bootKernel();
 
         $this->container = static::$kernel->getContainer();
-
         $configuration = $this->getConfiguration();
+
         self::$count++;
 
         if ($configuration->isDatabasePurgedForEachTest() || 1 === self::$count) {
-            $this->purgeDatabase();
+            $databasePurger = $this->getDatabasePurger();
+            $databasePurger->purge();
 
-            $files = $this->getFilesToLoad($configuration->getCatalogDirectories());
-            $filesByType = $this->getFilesToLoadByType($files);
-            $this->loadSqlFiles($filesByType['sql']);
-            $this->loadMongoDbFiles($filesByType['mongodb']);
-            $this->loadImportFiles($filesByType['import']);
+            $fixturesLoader = $this->getFixturesLoader($configuration);
+            $fixturesLoader->load();
         }
     }
 
@@ -88,237 +74,40 @@ abstract class TestCase extends KernelTestCase
     }
 
     /**
-     * @return string
-     */
-    public function getRootPath()
-    {
-        return realpath($this->getParameter('kernel.root_dir').DIRECTORY_SEPARATOR.'..'.DIRECTORY_SEPARATOR);
-    }
-
-    /**
-     * Load SQL file directly by a regular SQL query
-     *
-     * @param array $files
-     */
-    protected function loadSqlFiles(array $files)
-    {
-        $db = $this->get('doctrine.orm.entity_manager')->getConnection();
-
-        foreach ($files as $file) {
-            $db->executeQuery(file_get_contents($file));
-        }
-    }
-
-    /**
-     * Load Mongo files directly by a regular MongoDB query
-     *
-     * @param array $files
-     */
-    protected function loadMongoDbFiles(array $files)
-    {
-        $storage = $this->container->getParameter('pim_catalog_product_storage_driver');
-        if (AkeneoStorageUtilsExtension::DOCTRINE_MONGODB_ODM !== $storage) {
-            return;
-        }
-
-        $db = $this->get('doctrine.odm.mongodb.document_manager')->getConnection()->akeneo_pim;
-        foreach ($files as $file) {
-            $db->execute(file_get_contents($file));
-        }
-    }
-
-    /**
-     * Load import files via akeneo:batch:job
-     *
-     * @param array $files
-     *
-     * @throws \Exception
-     */
-    protected function loadImportFiles(array $files)
-    {
-        // prepare replace paths to use catalog paths and not the minimal fixtures path, please note that we can
-        // have several files per job in case of Enterprise Catalog, for instance,
-        // [
-        //     'jobs' => [
-        //         "/project/features/Context/catalog/footwear/jobs.yml"
-        //         "/project/features/PimEnterprise/Behat/Context/../../../Context/catalog/footwear/jobs.yml"
-        // ]
-        $replacePaths = [];
-        foreach ($files as $file) {
-            $tokens = explode(DIRECTORY_SEPARATOR, $file);
-            $fileName = array_pop($tokens);
-            if (!isset($replacePaths[$fileName])) {
-                $replacePaths[$fileName] = [];
-            }
-            $replacePaths[$fileName][] = $file;
-        }
-
-        // configure and load job instances in database
-        $jobLoader = $this->get('pim_installer.fixture_loader.job_loader');
-        $jobLoader->loadJobInstances($replacePaths);
-
-        // setup application to be able to run akeneo:batch:job command
-        $application = new Application();
-        $application->add(new BatchCommand());
-        $batchJobCommand = $application->find('akeneo:batch:job');
-        $batchJobCommand->setContainer($this->container);
-        $command = new CommandTester($batchJobCommand);
-
-        // install the catalog via the job instances
-        $jobInstances = $jobLoader->getLoadedJobInstances();
-        foreach ($jobInstances as $jobInstance) {
-            $exitCode = $command->execute(
-                [
-                    'command'  => $batchJobCommand->getName(),
-                    'code'     => $jobInstance->getCode(),
-                    '--no-log' => true,
-                    '-v'       => true
-                ]
-            );
-
-            if (0 !== $exitCode) {
-                throw new \Exception(sprintf('Catalog not installable! "%s"', $command->getDisplay()));
-            }
-        }
-
-        $jobLoader->deleteJobInstances();
-
-        $this->doAfterFixtureImport($application);
-
-        // close the connection created specifically for this repository
-        // TODO: to remove when TIP-385 will be done
-        $doctrineJobRepository = $this->get('akeneo_batch.job_repository');
-        $doctrineJobRepository->getJobManager()->getConnection()->close();
-    }
-
-    /**
-     * Separate files to load by their type. They can be:
-     *  - regular files to load from an import.
-     *  - SQL files
-     *  - mongo files
-     *
-     * @param array $files
-     *
-     * @return array
-     */
-    protected function getFilesToLoadByType(array $files)
-    {
-        $filesByType = [
-            'sql' => [],
-            'mongodb' => [],
-            'import' => [],
-        ];
-
-        foreach ($files as $filePath) {
-            $realPathParts = pathinfo($filePath);
-
-            // do not try to load files without extension
-            if (!isset($realPathParts['extension'])) {
-                continue;
-            }
-
-            // do not try to load product file that do not match the storage
-            if ('200_products' === $realPathParts['filename']) {
-                $storage = $this->container->getParameter('pim_catalog_product_storage_driver');
-                if ($storage === AkeneoStorageUtilsExtension::DOCTRINE_MONGODB_ODM &&
-                    'sql' === $realPathParts['extension']
-                ) {
-                    continue;
-                }
-                elseif ($storage === AkeneoStorageUtilsExtension::DOCTRINE_ORM &&
-                    'json' === $realPathParts['extension']
-                ) {
-                    continue;
-                }
-            }
-
-            switch ($realPathParts['extension']) {
-                case 'json':
-                    $filesByType['mongodb'][] = $filePath;
-                    break;
-                case 'sql':
-                    $filesByType['sql'][] = $filePath;
-                    break;
-                case 'csv':
-                case 'xls':
-                case 'xlsx':
-                case 'yml':
-                case 'yaml':
-                    $filesByType['import'][] = $filePath;
-                    break;
-                default:
-                    break;
-            }
-        }
-
-        return $filesByType;
-    }
-
-    /**
-     * Get the list of catalog configuration file paths to load
-     *
-     * @param array $directories
-     *
-     * @return array
-     * @throws \Exception if no files can be loaded
-     *
-     */
-    protected function getFilesToLoad(array $directories)
-    {
-        $rawFiles = [];
-        foreach ($directories as $directory) {
-            $rawFiles = array_merge($rawFiles, glob($directory.'/*'));
-        }
-
-        if (empty($rawFiles)) {
-            throw new \Exception(
-                sprintf(
-                    'No catalog file to load found in "%s"',
-                    implode(', ', $directories)
-                )
-            );
-        }
-
-        $files = [];
-        foreach ($rawFiles as $rawFilePath) {
-            if (false === $realFilePath = realpath($rawFilePath)) {
-                continue;
-            }
-            $files[] = $rawFilePath;
-        }
-
-        return $files;
-    }
-
-    protected function purgeDatabase()
-    {
-        if (AkeneoStorageUtilsExtension::DOCTRINE_MONGODB_ODM === $this->getParameter('pim_catalog_product_storage_driver')) {
-            $purgers[] = new MongoDBPurger($this->get('doctrine_mongodb')->getManager());
-        }
-
-        $purgers[] = new ORMPurger($this->get('doctrine')->getManager());
-
-        foreach ($purgers as $purger) {
-            $purger->purge();
-        }
-    }
-
-    /**
      * {@inheritdoc}
      */
     protected function tearDown()
     {
-        if (AkeneoStorageUtilsExtension::DOCTRINE_MONGODB_ODM === $this->getParameter('pim_catalog_product_storage_driver')) {
-            $doctrine = $this->get('doctrine_mongodb');
-        } else {
-            $doctrine = $this->get('doctrine');
-        }
-
-        foreach ($doctrine->getConnections() as $connection) {
-            $connection->close();
-        }
+        $connectionCloser = $this->getConnectionCloser();
+        $connectionCloser->closeConnections();
 
         parent::tearDown();
+    }
+
+    /**
+     * @return DatabasePurger
+     */
+    protected function getDatabasePurger()
+    {
+        return new DatabasePurger($this->container);
+    }
+
+    /**
+     * @param Configuration $configuration
+     *
+     * @return FixturesLoader
+     */
+    protected function getFixturesLoader(Configuration $configuration)
+    {
+        return new FixturesLoader($this->container, $configuration);
+    }
+
+    /**
+     * @return ConnectionCloser
+     */
+    protected function getConnectionCloser()
+    {
+        return new ConnectionCloser($this->container);
     }
 
     /**
@@ -327,9 +116,9 @@ abstract class TestCase extends KernelTestCase
      *
      * @param string $name
      *
-     * @return string
-     *
      * @throws \Exception if no fixture $name has been found
+     *
+     * @return string
      */
     protected function getFixturePath($name)
     {


### PR DESCRIPTION
Splitting the TestCase into smaller SRP classes will allow creating other TestCases without falling into inheritance hell.
For example we need a new ApiTestCase that will inherit from WebTestCase (so not from our main TestCase) but we still need the whole fixtures / purge logic.