### PR TITLE
Remove unused redirectAfterEdit()

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Controller/ProductController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/ProductController.php
@@ -182,25 +182,6 @@ class ProductController
     }
 
     /**
-     * Switch case to redirect after saving a product from the edit form
-     *
-     * @param array $params
-     *
-     * @return Response
-     */
-    protected function redirectAfterEdit($params)
-    {
-        switch ($request->get('action')) {
-            case self::CREATE:
-                $route = 'pim_enrich_product_edit';
-                $params['create_popin'] = true;
-                break;
-        }
-
-        return $this->redirectToRoute($route, $params);
-    }
-
-    /**
      * List categories associated with the provided product and descending from the category
      * defined by the parent parameter.
      *


### PR DESCRIPTION
While migrating to V. 1.6 I've noticed an error with the undefined `$result` in the `ProductController`: `switch ($request->get('action')) {` 

It seems, that this method isn't used anymore, so it can be removed.