### PR TITLE
Api 35 : content type header is mandatory in the API, allowing automatic JSON validation in FOS listener 

### DIFF
--- a/src/Pim/Bundle/ApiBundle/EventSubscriber/CheckHeadersRequestSubscriber.php
+++ b/src/Pim/Bundle/ApiBundle/EventSubscriber/CheckHeadersRequestSubscriber.php
@@ -8,6 +8,7 @@ use FOS\RestBundle\Util\StopFormatListenerException;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\Exception\NotAcceptableHttpException;
+use Symfony\Component\HttpKernel\Exception\UnsupportedMediaTypeHttpException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 
@@ -78,10 +79,17 @@ class CheckHeadersRequestSubscriber implements EventSubscriberInterface
 
             if (in_array($request->getMethod(), ['PUT', 'PATCH', 'POST'])) {
                 $contentType = $request->headers->get('content-type');
-                if (null !== $contentType &&
-                    !in_array($contentType, ['application/x-www-form-urlencoded', $best->getValue()])
-                ) {
-                    throw new NotAcceptableHttpException(
+                if (null === $contentType) {
+                    throw new UnsupportedMediaTypeHttpException(
+                        sprintf(
+                            'The "Content-Type" header is missing. "%s" has to be specified as value.',
+                            $best->getValue()
+                        )
+                    );
+                }
+
+                if ($contentType !== $best->getValue()) {
+                    throw new UnsupportedMediaTypeHttpException(
                         sprintf(
                             '"%s" in "Content-Type" header is not valid. Only "%s" is allowed.',
                             $contentType,

--- a/src/Pim/Bundle/ApiBundle/tests/integration/ApiTestCase.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/ApiTestCase.php
@@ -112,6 +112,7 @@ abstract class ApiTestCase extends WebTestCase
 
         $client = self::createClient($options, $server);
         $client->setServerParameter('HTTP_AUTHORIZATION', 'Bearer '.$this->accessToken);
+        $client->setServerParameter('CONTENT_TYPE', 'application/json');
 
         return $client;
     }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/ApiTestCase.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/ApiTestCase.php
@@ -102,6 +102,7 @@ abstract class ApiTestCase extends WebTestCase
                 [
                     'PHP_AUTH_USER' => $clientId,
                     'PHP_AUTH_PW'   => $secret,
+                    'CONTENT_TYPE'  => 'application/json',
                 ]
             );
 

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Token/GetAccessTokenIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Token/GetAccessTokenIntegration.php
@@ -49,6 +49,7 @@ class GetAccessTokenIntegration extends ApiTestCase
             [
                 'PHP_AUTH_USER' => $this->clientId,
                 'PHP_AUTH_PW'   => $this->secret,
+                'CONTENT_TYPE'  => 'application/json',
             ]
         );
 
@@ -76,6 +77,7 @@ class GetAccessTokenIntegration extends ApiTestCase
             [
                 'PHP_AUTH_USER' => $this->clientId,
                 'PHP_AUTH_PW'   => $this->secret,
+                'CONTENT_TYPE'  => 'application/json',
             ]
         );
 
@@ -102,6 +104,7 @@ class GetAccessTokenIntegration extends ApiTestCase
             [
                 'PHP_AUTH_USER' => $this->clientId,
                 'PHP_AUTH_PW'   => $this->secret,
+                'CONTENT_TYPE'  => 'application/json',
             ]
         );
 
@@ -128,6 +131,7 @@ class GetAccessTokenIntegration extends ApiTestCase
             [
                 'PHP_AUTH_USER' => $this->clientId,
                 'PHP_AUTH_PW'   => $this->secret,
+                'CONTENT_TYPE'  => 'application/json',
             ]
         );
 
@@ -154,6 +158,7 @@ class GetAccessTokenIntegration extends ApiTestCase
             [
                 'PHP_AUTH_USER' => 'michel_id',
                 'PHP_AUTH_PW'   => $this->secret,
+                'CONTENT_TYPE'  => 'application/json',
             ]
         );
 
@@ -180,6 +185,7 @@ class GetAccessTokenIntegration extends ApiTestCase
             [
                 'PHP_AUTH_USER' => $this->clientId,
                 'PHP_AUTH_PW'   => 'michel_secret',
+                'CONTENT_TYPE'  => 'application/json',
             ]
         );
 
@@ -205,6 +211,7 @@ class GetAccessTokenIntegration extends ApiTestCase
             [
                 'PHP_AUTH_USER' => $this->clientId,
                 'PHP_AUTH_PW'   => $this->secret,
+                'CONTENT_TYPE'  => 'application/json',
             ]
         );
 
@@ -230,6 +237,7 @@ class GetAccessTokenIntegration extends ApiTestCase
             [
                 'PHP_AUTH_USER' => $this->clientId,
                 'PHP_AUTH_PW'   => $this->secret,
+                'CONTENT_TYPE'  => 'application/json',
             ]
         );
 
@@ -256,6 +264,7 @@ class GetAccessTokenIntegration extends ApiTestCase
             [
                 'PHP_AUTH_USER' => $this->clientId,
                 'PHP_AUTH_PW'   => $this->secret,
+                'CONTENT_TYPE'  => 'application/json',
             ]
         );
 

--- a/src/Pim/Bundle/ApiBundle/tests/integration/EventSubscriber/CheckHeadersRequestSubscriberIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/EventSubscriber/CheckHeadersRequestSubscriberIntegration.php
@@ -53,10 +53,10 @@ class CheckHeadersRequestSubscriberIntegration extends ApiTestCase
         ], '{"code": "my_category"}');
 
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_NOT_ACCEPTABLE, $response->getStatusCode(), 'Header is not acceptable');
+        $this->assertSame(Response::HTTP_UNSUPPORTED_MEDIA_TYPE, $response->getStatusCode(), 'Header is not acceptable');
         $content = json_decode($response->getContent(), true);
         $this->assertCount(2, $content, 'Error response contains 2 items');
-        $this->assertSame(Response::HTTP_NOT_ACCEPTABLE, $content['code']);
+        $this->assertSame(Response::HTTP_UNSUPPORTED_MEDIA_TYPE, $content['code']);
         $this->assertSame('"application/xml" in "Content-Type" header is not valid. Only "application/json" is allowed.', $content['message']);
     }
 
@@ -67,18 +67,6 @@ class CheckHeadersRequestSubscriberIntegration extends ApiTestCase
         $client->request('POST', 'api/rest/v1/categories', [], [], [
             'CONTENT_TYPE' => 'application/json',
         ], '{"code": "my_category"}');
-
-        $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode(), 'Header is acceptable');
-    }
-
-    public function testSuccessIfContentTypeHeaderIsEmpty()
-    {
-        $client = $this->createAuthentifiedClient();
-
-        $client->request('POST', 'api/rest/v1/categories', [], [], [
-            'CONTENT_TYPE' => 'application/json'
-        ], '{"code": "my_category_1"}');
 
         $response = $client->getResponse();
         $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode(), 'Header is acceptable');


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**
Originally, the Content-type header was not mandatory in the POST/PUT/PATCH request. And if it was specified, it should be "application/json".

A lot of clients use a Content-Type by default. For example, curl use "application/x-www-form-urlencoded" if you don't specify any Content-Type header.

Therefore, it's pretty useless to allow users to not specify anything, because the client do (or rather force) that for them...
We've chosen to force the user to specify the Content-Type header.

Moreover, a FOSRest listener checks that the format is JSON when the Content-Type is "application/JSON" with a specific error message in case it's not.

https://github.com/FriendsOfSymfony/FOSRestBundle/blob/master/EventListener/BodyListener.php#L115

We've chosen to keep the message thrown by this validation (and it's better to check the format in a listener).

Unfortunately, we will keep the method getDecodedContent in the controllers, because this listener does not throw any exception if the content is empty (which is not our case : it should throw an exception).

https://github.com/FriendsOfSymfony/FOSRestBundle/blob/master/EventListener/BodyListener.php#L108

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
