### PR TITLE
AMS-156: force fetching of view on columns update

### DIFF
--- a/features/datagrid/datagrid_views.feature
+++ b/features/datagrid/datagrid_views.feature
@@ -57,6 +57,23 @@ Feature: Datagrid views
     And I should see products purple-sneakers and black-sneakers
     But I should not see product black-boots
 
+  Scenario: Successfully update columns of a view
+    Given I am on the products page
+    When I filter by "family" with operator "in list" and value "Sneakers"
+    And I create the view:
+      | new-view-label | Some shoes |
+    Then I should be on the products page
+    And I should see the flash message "Datagrid view successfully created"
+    And I should see the text "Some shoes"
+    When I display the columns SKU, Name, Family and Manufacturer
+    Then I should see the text "Nike"
+    When I update the view
+    And I apply the "Some shoes" view
+    Then I should be on the products page
+    And I should see the text "Some shoes"
+    And I should see products purple-sneakers and black-sneakers
+    And I should see the text "Nike"
+
   Scenario: Successfully delete a view
     Given I am on the products page
     And I filter by "family" with operator "in list" and value "Boots"

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/grid/view-selector.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/grid/view-selector.js
@@ -236,7 +236,7 @@ define(
                         deferred.resolve(this.getDefaultView());
                     } else {
                         FetcherRegistry.getFetcher('datagrid-view')
-                            .fetch(activeViewId, {alias: this.gridAlias})
+                            .fetch(activeViewId, {alias: this.gridAlias, cached: false})
                             .then(this.postFetchDatagridView.bind(this))
                             .then(function (view) {
                                 deferred.resolve(view);


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

**The bug:**
- Create a custom view
- Click on Columns to customise the grid
- Remove/Add columns, click on Save

**The fix:**
The problem comes from the fetchers, the promises return the View by reference, so when we update the columns, the View from the fetcher has its columns modified too, but it should not. This fix bypass the cache of the fetcher by forcing a re-fetch.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | OK
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

---
_Note:_
- The issue #5600 has been created to answer this problem in the whole PIM.