### PR TITLE
API-50: Don't bypass the firewall in integration tests

### DIFF
--- a/app/config/security_test.yml
+++ b/app/config/security_test.yml
@@ -1,9 +1,5 @@
 security:
     firewalls:
-        api:
-            pattern:        ^/api
-            security:       false
-
         main:
             http_basic:
                 realm:      "Secured REST Area"

--- a/src/Pim/Bundle/ApiBundle/tests/integration/ApiTestCase.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/ApiTestCase.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace Pim\Bundle\ApiBundle\tests\integration;
+
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\ConnectionCloser;
+use Akeneo\Test\Integration\DatabasePurger;
+use Akeneo\Test\Integration\FixturesLoader;
+use Symfony\Bundle\FrameworkBundle\Client;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Test case dedicated to PIM API interaction including authentication handling.
+ *
+ * @author    Yohan Blain <yohan.blain@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+abstract class ApiTestCase extends WebTestCase
+{
+    /** @var int Count of executed tests inside the same test class */
+    protected static $count = 0;
+
+    /** @var ContainerInterface */
+    protected $container;
+
+    /** @var string */
+    protected $accessToken;
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function setUpBeforeClass()
+    {
+        self::$count = 0;
+    }
+
+    /**
+     * @return Configuration
+     */
+    abstract protected function getConfiguration();
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        static::bootKernel();
+
+        $this->container = static::$kernel->getContainer();
+        $configuration = $this->getConfiguration();
+
+        self::$count++;
+
+        if ($configuration->isDatabasePurgedForEachTest() || 1 === self::$count) {
+            $databasePurger = $this->getDatabasePurger();
+            $databasePurger->purge();
+
+            $fixturesLoader = $this->getFixturesLoader($configuration);
+            $fixturesLoader->load();
+        }
+    }
+
+    /**
+     * Adds a valid access token to the client, so it is included in all its requests.
+     *
+     * @param array $options
+     * @param array $server
+     *
+     * @throws \Exception
+     *
+     * @return Client
+     */
+    protected function createAuthentifiedClient(array $options = [], array $server = [])
+    {
+        if (null === $this->accessToken) {
+            $consoleApp = new Application(self::$kernel);
+            $consoleApp->setAutoExit(false);
+
+            $input  = new ArrayInput(['command' => 'pim:oauth-server:create-client']);
+            $output = new BufferedOutput();
+
+            $consoleApp->run($input, $output);
+
+            $content = $output->fetch();
+            preg_match('/client_id: (.+)\nsecret: (.+)$/', $content, $matches);
+            $clientId = $matches[1];
+            $secret   = $matches[2];
+
+            $oauthClient = self::createClient();
+            $oauthClient->request('POST', 'api/oauth/v1/token',
+                [
+                    'username'   => 'admin',
+                    'password'   => 'admin',
+                    'grant_type' => 'password',
+                ],
+                [],
+                [
+                    'PHP_AUTH_USER' => $clientId,
+                    'PHP_AUTH_PW'   => $secret,
+                ]
+            );
+
+            $response = $oauthClient->getResponse();
+            $responseBody = json_decode($response->getContent(), true);
+            $this->accessToken = $responseBody['access_token'];
+        }
+
+        $client = self::createClient($options, $server);
+        $client->setServerParameter('HTTP_AUTHORIZATION', 'Bearer '.$this->accessToken);
+
+        return $client;
+    }
+
+    /**
+     * @param string $service
+     *
+     * @return mixed
+     */
+    protected function get($service)
+    {
+        return $this->container->get($service);
+    }
+
+    /**
+     * @param string $service
+     *
+     * @return mixed
+     */
+    protected function getParameter($service)
+    {
+        return $this->container->getParameter($service);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function tearDown()
+    {
+        $connectionCloser = $this->getConnectionCloser();
+        $connectionCloser->closeConnections();
+
+        parent::tearDown();
+    }
+
+    /**
+     * @return DatabasePurger
+     */
+    protected function getDatabasePurger()
+    {
+        return new DatabasePurger($this->container);
+    }
+
+    /**
+     * @param Configuration $configuration
+     *
+     * @return FixturesLoader
+     */
+    protected function getFixturesLoader(Configuration $configuration)
+    {
+        return new FixturesLoader($this->container, $configuration);
+    }
+
+    /**
+     * @return ConnectionCloser
+     */
+    protected function getConnectionCloser()
+    {
+        return new ConnectionCloser($this->container);
+    }
+}

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Attribute/GetAttributeIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Attribute/GetAttributeIntegration.php
@@ -3,14 +3,14 @@
 namespace tests\integration\Pim\Bundle\ApiBundle\Controller\Rest\Attribute;
 
 use Akeneo\Test\Integration\Configuration;
-use Akeneo\Test\Integration\TestCase;
+use Pim\Bundle\ApiBundle\tests\integration\ApiTestCase;
 use Symfony\Component\HttpFoundation\Response;
 
-class GetAttributeIntegration extends TestCase
+class GetAttributeIntegration extends ApiTestCase
 {
     public function testGetAnAttribute()
     {
-        $client = static::createClient();
+        $client = $this->createAuthentifiedClient();
 
         $client->request('GET', 'api/rest/v1/attributes/sku');
 
@@ -50,7 +50,7 @@ class GetAttributeIntegration extends TestCase
 
     public function testNotFoundAnAttribute()
     {
-        $client = static::createClient();
+        $client = $this->createAuthentifiedClient();
 
         $client->request('GET', 'api/rest/v1/attributes/not_found');
 

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Attribute/ListAttributeIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Attribute/ListAttributeIntegration.php
@@ -3,14 +3,14 @@
 namespace tests\integration\Pim\Bundle\ApiBundle\Controller\Rest\Attribute;
 
 use Akeneo\Test\Integration\Configuration;
-use Akeneo\Test\Integration\TestCase;
+use Pim\Bundle\ApiBundle\tests\integration\ApiTestCase;
 use Symfony\Component\HttpFoundation\Response;
 
-class ListAttributeIntegration extends TestCase
+class ListAttributeIntegration extends ApiTestCase
 {
     public function testListAttributes()
     {
-        $client = static::createClient();
+        $client = $this->createAuthentifiedClient();
 
         $client->request('GET', 'api/rest/v1/attributes');
 
@@ -312,7 +312,7 @@ class ListAttributeIntegration extends TestCase
 
     public function testListAttributesWithLimitAndPage()
     {
-        $client = static::createClient();
+        $client = $this->createAuthentifiedClient();
 
         $client->request('GET', 'api/rest/v1/attributes?limit=5&page=2');
         $standardAttributes = [
@@ -464,7 +464,7 @@ class ListAttributeIntegration extends TestCase
 
     public function testOutOfRangeListAttributes()
     {
-        $client = static::createClient();
+        $client = $this->createAuthentifiedClient();
 
         $client->request('GET', 'api/rest/v1/attributes?limit=100&page=2');
 

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/AttributeOption/GetAttributeOptionIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/AttributeOption/GetAttributeOptionIntegration.php
@@ -3,14 +3,14 @@
 namespace tests\integration\Pim\Bundle\ApiBundle\Controller\Rest\AttributeOption;
 
 use Akeneo\Test\Integration\Configuration;
-use Akeneo\Test\Integration\TestCase;
+use Pim\Bundle\ApiBundle\tests\integration\ApiTestCase;
 use Symfony\Component\HttpFoundation\Response;
 
-class GetAttributeOptionIntegration extends TestCase
+class GetAttributeOptionIntegration extends ApiTestCase
 {
     public function testGetAnAttributeOption()
     {
-        $client = static::createClient();
+        $client = $this->createAuthentifiedClient();
 
         $client->request('GET', 'api/rest/v1/attributes/a_multi_select/options/optionA');
 
@@ -30,7 +30,7 @@ class GetAttributeOptionIntegration extends TestCase
 
     public function testNotFoundAnAttribute()
     {
-        $client = static::createClient();
+        $client = $this->createAuthentifiedClient();
 
         $client->request('GET', 'api/rest/v1/attributes/not_found/options/not_found');
 
@@ -44,7 +44,7 @@ class GetAttributeOptionIntegration extends TestCase
 
     public function testNotSupportedOptionsAttribute()
     {
-        $client = static::createClient();
+        $client = $this->createAuthentifiedClient();
 
         $client->request('GET', 'api/rest/v1/attributes/sku/options/sku');
 
@@ -61,7 +61,7 @@ class GetAttributeOptionIntegration extends TestCase
 
     public function testNotExistingOptionsAttribute()
     {
-        $client = static::createClient();
+        $client = $this->createAuthentifiedClient();
 
         $client->request('GET', 'api/rest/v1/attributes/a_multi_select/options/not_existing_option');
         $response = $client->getResponse();

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Category/CreateCategoryIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Category/CreateCategoryIntegration.php
@@ -3,15 +3,16 @@
 namespace tests\integration\Pim\Bundle\ApiBundle\Controller\Rest\Category;
 
 use Akeneo\Test\Integration\Configuration;
-use Akeneo\Test\Integration\TestCase;
+use Pim\Bundle\ApiBundle\tests\integration\ApiTestCase;
 use Pim\Bundle\CatalogBundle\Version;
 use Symfony\Component\HttpFoundation\Response;
 
-class CreateCategoryIntegration extends TestCase
+class CreateCategoryIntegration extends ApiTestCase
 {
     public function testHttpHeadersInResponseWhenACategoryIsCreated()
     {
-        $client = static::createClient();
+        $client = $this->createAuthentifiedClient();
+
         $data =
 <<<JSON
     {
@@ -30,7 +31,8 @@ JSON;
 
     public function testFormatStandardWhenACategoryIsCreatedButUncompleted()
     {
-        $client = static::createClient();
+        $client = $this->createAuthentifiedClient();
+
         $data =
 <<<JSON
     {
@@ -55,7 +57,8 @@ JSON;
 
     public function testCompleteCategoryCreation()
     {
-        $client = static::createClient();
+        $client = $this->createAuthentifiedClient();
+
         $data =
 <<<JSON
     {
@@ -87,7 +90,8 @@ JSON;
 
     public function testResponseWhenContentIsNotValid()
     {
-        $client = static::createClient();
+        $client = $this->createAuthentifiedClient();
+
         $data = '';
 
         $expectedContent = [
@@ -103,7 +107,8 @@ JSON;
 
     public function testResponseWhenCategoryCodeAlreadyExists()
     {
-        $client = static::createClient();
+        $client = $this->createAuthentifiedClient();
+
         $data =
 <<<JSON
     {
@@ -126,7 +131,8 @@ JSON;
 
     public function testResponseWhenValidationFailed()
     {
-        $client = static::createClient();
+        $client = $this->createAuthentifiedClient();
+
         $data =
 <<<JSON
     {
@@ -154,7 +160,8 @@ JSON;
 
     public function testResponseWhenAPropertyIsNotExpected()
     {
-        $client = static::createClient();
+        $client = $this->createAuthentifiedClient();
+
         $data =
 <<<JSON
     {
@@ -183,7 +190,8 @@ JSON;
 
     public function testResponseWhenLabelsIsNull()
     {
-        $client = static::createClient();
+        $client = $this->createAuthentifiedClient();
+
         $data =
 <<<JSON
     {

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Category/GetCategoryIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Category/GetCategoryIntegration.php
@@ -3,14 +3,14 @@
 namespace tests\integration\Pim\Bundle\ApiBundle\Controller\Rest\Category;
 
 use Akeneo\Test\Integration\Configuration;
-use Akeneo\Test\Integration\TestCase;
+use Pim\Bundle\ApiBundle\tests\integration\ApiTestCase;
 use Symfony\Component\HttpFoundation\Response;
 
-class GetCategoryIntegration extends TestCase
+class GetCategoryIntegration extends ApiTestCase
 {
     public function testGetACategory()
     {
-        $client = static::createClient();
+        $client = $this->createAuthentifiedClient();
 
         $client->request('GET', 'api/rest/v1/categories/master');
 
@@ -27,7 +27,7 @@ class GetCategoryIntegration extends TestCase
 
     public function testGetACompleteCategory()
     {
-        $client = static::createClient();
+        $client = $this->createAuthentifiedClient();
 
         $client->request('GET', 'api/rest/v1/categories/categoryA');
 
@@ -47,7 +47,7 @@ class GetCategoryIntegration extends TestCase
 
     public function testNotFoundACategory()
     {
-        $client = static::createClient();
+        $client = $this->createAuthentifiedClient();
 
         $client->request('GET', 'api/rest/v1/categories/not_found');
 

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Category/ListCategoryIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Category/ListCategoryIntegration.php
@@ -3,14 +3,14 @@
 namespace tests\integration\Pim\Bundle\ApiBundle\Controller\Rest\Category;
 
 use Akeneo\Test\Integration\Configuration;
-use Akeneo\Test\Integration\TestCase;
+use Pim\Bundle\ApiBundle\tests\integration\ApiTestCase;
 use Symfony\Component\HttpFoundation\Response;
 
-class ListCategoryIntegration extends TestCase
+class ListCategoryIntegration extends ApiTestCase
 {
     public function testListCategories()
     {
-        $client = static::createClient();
+        $client = $this->createAuthentifiedClient();
 
         $client->request('GET', 'api/rest/v1/categories');
 
@@ -52,7 +52,7 @@ class ListCategoryIntegration extends TestCase
 
     public function testOutOfRangeListCategories()
     {
-        $client = static::createClient();
+        $client = $this->createAuthentifiedClient();
 
         $client->request('GET', 'api/rest/v1/categories?limit=10&page=2');
 

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Family/GetFamilyIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Family/GetFamilyIntegration.php
@@ -3,14 +3,14 @@
 namespace tests\integration\Pim\Bundle\ApiBundle\Controller\Rest\Family;
 
 use Akeneo\Test\Integration\Configuration;
-use Akeneo\Test\Integration\TestCase;
+use Pim\Bundle\ApiBundle\tests\integration\ApiTestCase;
 use Symfony\Component\HttpFoundation\Response;
 
-class GetFamilyIntegration extends TestCase
+class GetFamilyIntegration extends ApiTestCase
 {
     public function testGetAFamily()
     {
-        $client = static::createClient();
+        $client = $this->createAuthentifiedClient();
 
         $client->request('GET', 'api/rest/v1/families/familyA');
         $standardFamily = [
@@ -91,7 +91,7 @@ class GetFamilyIntegration extends TestCase
 
     public function testNotFoundFamily()
     {
-        $client = static::createClient();
+        $client = $this->createAuthentifiedClient();
 
         $client->request('GET', 'api/rest/v1/families/not_found');
 

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Family/ListFamilyIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Family/ListFamilyIntegration.php
@@ -3,14 +3,14 @@
 namespace tests\integration\Pim\Bundle\ApiBundle\Controller\Rest\Family;
 
 use Akeneo\Test\Integration\Configuration;
-use Akeneo\Test\Integration\TestCase;
+use Pim\Bundle\ApiBundle\tests\integration\ApiTestCase;
 use Symfony\Component\HttpFoundation\Response;
 
-class ListFamilyIntegration extends TestCase
+class ListFamilyIntegration extends ApiTestCase
 {
     public function testListFamilies()
     {
-        $client = static::createClient();
+        $client = $this->createAuthentifiedClient();
 
         $client->request('GET', 'api/rest/v1/families');
 
@@ -94,7 +94,7 @@ class ListFamilyIntegration extends TestCase
 
     public function testOutOfRangeListFamilies()
     {
-        $client = static::createClient();
+        $client = $this->createAuthentifiedClient();
 
         $client->request('GET', 'api/rest/v1/families?limit=10&page=2');
 

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Token/GetAccessTokenIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Token/GetAccessTokenIntegration.php
@@ -3,13 +3,13 @@
 namespace tests\integration\Pim\Bundle\ApiBundle\Controller\Token;
 
 use Akeneo\Test\Integration\Configuration;
-use Akeneo\Test\Integration\TestCase;
+use Pim\Bundle\ApiBundle\tests\integration\ApiTestCase;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\HttpFoundation\Response;
 
-class GetAccessTokenIntegration extends TestCase
+class GetAccessTokenIntegration extends ApiTestCase
 {
     /** @var string */
     protected $clientId;

--- a/src/Pim/Bundle/ApiBundle/tests/integration/EventSubscriber/CheckHeadersRequestSubscriberIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/EventSubscriber/CheckHeadersRequestSubscriberIntegration.php
@@ -3,16 +3,16 @@
 namespace Pim\Bundle\ApiBundle\tests\integration\EventSubscriber;
 
 use Akeneo\Test\Integration\Configuration;
-use Akeneo\Test\Integration\TestCase;
+use Pim\Bundle\ApiBundle\tests\integration\ApiTestCase;
 use Symfony\Component\HttpFoundation\Response;
 
-class CheckHeadersRequestSubscriberIntegration extends TestCase
+class CheckHeadersRequestSubscriberIntegration extends ApiTestCase
 {
     protected $purgeDatabaseForEachTest = false;
 
     public function testErrorIfAcceptHeaderIsXml()
     {
-        $client = static::createClient();
+        $client = $this->createAuthentifiedClient();
 
         $client->request('GET', 'api/rest/v1/categories/master', [], [], ['HTTP_ACCEPT' => 'application/xml']);
 
@@ -26,7 +26,7 @@ class CheckHeadersRequestSubscriberIntegration extends TestCase
 
     public function testSuccessIfAcceptHeaderIsJson()
     {
-        $client = static::createClient();
+        $client = $this->createAuthentifiedClient();
 
         $client->request('GET', 'api/rest/v1/categories/master', [], [], ['HTTP_ACCEPT' => 'application/json']);
 
@@ -36,7 +36,7 @@ class CheckHeadersRequestSubscriberIntegration extends TestCase
 
     public function testSuccessIfAcceptHeaderIsEmpty()
     {
-        $client = static::createClient();
+        $client = $this->createAuthentifiedClient();
 
         $client->request('GET', 'api/rest/v1/categories/master');
 
@@ -46,7 +46,7 @@ class CheckHeadersRequestSubscriberIntegration extends TestCase
 
     public function testErrorIfContentTypeHeaderIsXml()
     {
-        $client = static::createClient();
+        $client = $this->createAuthentifiedClient();
 
         $client->request('POST', 'api/rest/v1/categories', [], [], [
             'CONTENT_TYPE' => 'application/xml',
@@ -62,7 +62,7 @@ class CheckHeadersRequestSubscriberIntegration extends TestCase
 
     public function testSuccessIfContentTypeHeaderIsJson()
     {
-        $client = static::createClient();
+        $client = $this->createAuthentifiedClient();
 
         $client->request('POST', 'api/rest/v1/categories', [], [], [
             'CONTENT_TYPE' => 'application/json',
@@ -74,7 +74,7 @@ class CheckHeadersRequestSubscriberIntegration extends TestCase
 
     public function testSuccessIfContentTypeHeaderIsEmpty()
     {
-        $client = static::createClient();
+        $client = $this->createAuthentifiedClient();
 
         $client->request('POST', 'api/rest/v1/categories', [], [], [
             'CONTENT_TYPE' => 'application/json'
@@ -86,7 +86,7 @@ class CheckHeadersRequestSubscriberIntegration extends TestCase
 
     public function testSuccessWhenRouteIsOutsideTheAPI()
     {
-        $client = static::createClient();
+        $client = $this->createAuthentifiedClient();
 
         $client->request('GET', '/');
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,7 +2,7 @@
 
 namespace Akeneo\Test\Integration;
 
-use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -11,9 +11,9 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-abstract class TestCase extends WebTestCase
+abstract class TestCase extends KernelTestCase
 {
-    /** @var int Count of test inside the same test class */
+    /** @var int Count of executed tests inside the same test class */
     protected static $count = 0;
 
     /** @var ContainerInterface */


### PR DESCRIPTION
Until now the security firewall was disabled in test environment. This PR re-enables it to allow the tests to use the real OAuth workflow.

These steps are now executed for each test case:
1. create a client via the dedicated command
2. call `/api/oauth/v1/token` to get an access token

Then the token is included in every requests.
To do that we introduce a new TestCase for the API.

The good news: the integration tests are closer to the real application behavior.
The bad news: it is approximately 15% slower.