### PR TITLE
TIP-322: Remove technical informations in error messages

### DIFF
--- a/features/import/attribute/import_attributes.feature
+++ b/features/import/attribute/import_attributes.feature
@@ -136,7 +136,7 @@ Feature: Import attributes
     And I launch the import job
     And I wait for the "csv_footwear_attribute_import" job to finish
     Then I should see "skipped 1"
-    And I should see "Property \"attribute_type\" does not expect an empty value (for updater attribute)."
+    And I should see "Property \"attribute_type\" does not expect an empty value."
 
   Scenario: Successfully import and update existing attribute
     Given the "footwear" catalog configuration
@@ -172,7 +172,7 @@ Feature: Import attributes
     And I wait for the "csv_footwear_attribute_import" job to finish
     Then I should see "read lines 1"
     Then I should see "skipped 1"
-    Then I should see "Property \"date_min\" expects a string with the format \"yyyy-mm-dd\" as data, \"2000/12/12\" given (for updater attribute)."
+    Then I should see "Property \"date_min\" expects a string with the format \"yyyy-mm-dd\" as data, \"2000/12/12\" given."
 
   Scenario: Fail to import attribute with invalid date
     Given the "footwear" catalog configuration
@@ -189,7 +189,7 @@ Feature: Import attributes
     And I wait for the "csv_footwear_attribute_import" job to finish
     Then I should see "read lines 1"
     Then I should see "skipped 1"
-    Then I should see "Property \"date_min\" expects a string with the format \"yyyy-mm-dd\" as data, \"2000-99-12\" given (for updater attribute)."
+    Then I should see "Property \"date_min\" expects a string with the format \"yyyy-mm-dd\" as data, \"2000-99-12\" given."
 
   Scenario: Fail to import attribute with invalid data
     Given the "footwear" catalog configuration
@@ -208,7 +208,7 @@ Feature: Import attributes
     Then I should see "read lines 2"
     Then I should see "skipped 2"
     Then I should see "maxFileSize: This value should be a valid number.: not an int"
-    Then I should see "Property \"group\" expects a valid code. The attribute group does not exist, \"not a group\" given (for updater attribute)."
+    Then I should see "Property \"group\" expects a valid code. The attribute group does not exist, \"not a group\" given."
 
   Scenario: Successfully import new attribute
     Given the "footwear" catalog configuration

--- a/features/import/import_categories.feature
+++ b/features/import/import_categories.feature
@@ -47,8 +47,8 @@ Feature: Import categories
     When I am on the "csv_footwear_category_import" import job page
     And I launch the import job
     And I wait for the "csv_footwear_category_import" job to finish
-    Then I should see "Property \"parent\" expects a valid category code. The category does not exist, \"clothes\" given (for updater category)."
-    And I should see "Property \"parent\" expects a valid category code. The category does not exist, \"tshirts\" given (for updater category)."
+    Then I should see "Property \"parent\" expects a valid category code. The category does not exist, \"clothes\" given."
+    And I should see "Property \"parent\" expects a valid category code. The category does not exist, \"tshirts\" given."
     And there should be the following categories:
       | code        | label       | parent    |
       | computers   | Computers   |           |

--- a/features/import/import_options.feature
+++ b/features/import/import_options.feature
@@ -67,7 +67,7 @@ Feature: Import options
     And I launch the import job
     And I wait for the "csv_footwear_option_import" job to finish
     Then I should see "skipped 1"
-    And I should see "Property \"attribute\" expects a valid attribute code. The attribute does not exist, \"unknown\" given (for updater attribute option)."
+    And I should see "Property \"attribute\" expects a valid attribute code. The attribute does not exist, \"unknown\" given."
 
   @jira https://akeneo.atlassian.net/browse/PIM-3820
   Scenario: Import options with localizable label

--- a/features/import/product_group/import_groups.feature
+++ b/features/import/product_group/import_groups.feature
@@ -90,7 +90,7 @@ Feature: Import groups
     And I wait for the "csv_footwear_group_import" job to finish
     Then I should see "read lines 1"
     And I should see "skipped 1"
-    And I should see "Property \"type\" expects a valid group type. Cannot process variant group, only groups are supported, \"New_VG\" given (for updater group)"
+    And I should see "Property \"type\" expects a valid group type. Cannot process variant group, only groups are supported, \"New_VG\" given"
 
   Scenario: Skip the line if we encounter an existing variant group
     Given the following CSV file to import:
@@ -105,7 +105,7 @@ Feature: Import groups
     And I wait for the "csv_footwear_group_import" job to finish
     Then I should see "read lines 1"
     And I should see "skipped 1"
-    And I should see "Property \"type\" expects a valid group type. Cannot process variant group, only groups are supported, \"AKENEO_TSHIRT\" given (for updater group)"
+    And I should see "Property \"type\" expects a valid group type. Cannot process variant group, only groups are supported, \"AKENEO_TSHIRT\" given"
 
   Scenario: Skip the line if we try to set axis on a standard group
     Given the following CSV file to import:

--- a/features/import/product_group/xlsx/import_groups.feature
+++ b/features/import/product_group/xlsx/import_groups.feature
@@ -89,7 +89,7 @@ Feature: Import Xlsx groups
     And I wait for the "xlsx_footwear_group_import" job to finish
     Then I should see "read lines 1"
     And I should see "skipped 1"
-    And I should see "Property \"type\" expects a valid group type. Cannot process variant group, only groups are supported, \"New_VG\" given (for updater group)"
+    And I should see "Property \"type\" expects a valid group type. Cannot process variant group, only groups are supported, \"New_VG\" given"
 
   Scenario: Skip the line if we encounter an existing variant group
     Given the following XLSX file to import:
@@ -104,7 +104,7 @@ Feature: Import Xlsx groups
     And I wait for the "xlsx_footwear_group_import" job to finish
     Then I should see "read lines 1"
     And I should see "skipped 1"
-    And I should see "Property \"type\" expects a valid group type. Cannot process variant group, only groups are supported, \"AKENEO_TSHIRT\" given (for updater group)."
+    And I should see "Property \"type\" expects a valid group type. Cannot process variant group, only groups are supported, \"AKENEO_TSHIRT\" given."
 
   Scenario: Skip the line if we try to set axis on a standard group
     Given the following XLSX file to import:

--- a/features/import/product_variant_group/import_variant_group_with_invalid_properties.feature
+++ b/features/import/product_variant_group/import_variant_group_with_invalid_properties.feature
@@ -40,7 +40,7 @@ Feature: Execute an import with invalid properties
     When I am on the "csv_footwear_variant_group_import" import job page
     And I launch the import job
     And I wait for the "csv_footwear_variant_group_import" job to finish
-    Then I should see "Property \"axes\" cannot be modified, \"manufacturer,size\" given (for updater variant group)."
+    Then I should see "Property \"axes\" cannot be modified, \"manufacturer,size\" given."
     And I should see "read lines 1"
     And I should see "Skipped 1"
     And there should be the following groups:
@@ -59,7 +59,7 @@ Feature: Execute an import with invalid properties
     When I am on the "csv_footwear_variant_group_import" import job page
     And I launch the import job
     And I wait for the "csv_footwear_variant_group_import" job to finish
-    Then I should see "Property \"axes\" cannot be modified, \"color\" given (for updater variant group)."
+    Then I should see "Property \"axes\" cannot be modified, \"color\" given."
     And I should see "read lines 1"
     And I should see "Skipped 1"
     And there should be the following groups:

--- a/src/Akeneo/Component/Classification/Updater/CategoryUpdater.php
+++ b/src/Akeneo/Component/Classification/Updater/CategoryUpdater.php
@@ -77,8 +77,7 @@ class CategoryUpdater implements ObjectUpdaterInterface
                     'parent',
                     'category code',
                     'The category does not exist',
-                    'updater',
-                    'category',
+                    static::class,
                     $data
                 );
             }

--- a/src/Akeneo/Component/StorageUtils/Exception/ImmutablePropertyException.php
+++ b/src/Akeneo/Component/StorageUtils/Exception/ImmutablePropertyException.php
@@ -17,39 +17,49 @@ class ImmutablePropertyException extends ObjectUpdaterException
     /** @var string */
     protected $propertyValue;
 
+    /** @var string */
+    protected $className;
+
     /**
      * @param string          $propertyName
      * @param string          $propertyValue
+     * @param string          $className
      * @param string          $message
      * @param int             $code
      * @param \Exception|null $previous
      */
-    public function __construct($propertyName, $propertyValue, $message = '', $code = 0, \Exception $previous = null)
-    {
+    public function __construct(
+        $propertyName,
+        $propertyValue,
+        $className,
+        $message = '',
+        $code = 0,
+        \Exception $previous = null
+    ) {
         parent::__construct($message, $code, $previous);
+
         $this->propertyName  = $propertyName;
         $this->propertyValue = $propertyValue;
+        $this->className = $className;
     }
 
     /**
      * @param string $propertyName
      * @param string $propertyValue
-     * @param string $action
-     * @param string $type
+     * @param string $className
      *
      * @return ImmutablePropertyException
      */
-    public static function immutableProperty($propertyName, $propertyValue, $action, $type)
+    public static function immutableProperty($propertyName, $propertyValue, $className)
     {
         return new self(
             $propertyName,
             $propertyValue,
+            $className,
             sprintf(
-                'Property "%s" cannot be modified, "%s" given (for %s %s).',
+                'Property "%s" cannot be modified, "%s" given.',
                 $propertyName,
-                $propertyValue,
-                $action,
-                $type
+                $propertyValue
             )
         );
     }
@@ -68,5 +78,13 @@ class ImmutablePropertyException extends ObjectUpdaterException
     public function getPropertyValue()
     {
         return $this->propertyValue;
+    }
+
+    /**
+     * @return string
+     */
+    public function getClassName()
+    {
+        return $this->className;
     }
 }

--- a/src/Akeneo/Component/StorageUtils/Exception/InvalidPropertyException.php
+++ b/src/Akeneo/Component/StorageUtils/Exception/InvalidPropertyException.php
@@ -32,37 +32,49 @@ class InvalidPropertyException extends ObjectUpdaterException
     /** @var string */
     protected $propertyValue;
 
+    /** @var string */
+    protected $className;
+
     /**
      * @param string          $propertyName
      * @param string          $propertyValue
+     * @param string          $className
      * @param string          $message
      * @param int             $code
      * @param \Exception|null $previous
      */
-    public function __construct($propertyName, $propertyValue, $message = '', $code = 0, \Exception $previous = null)
-    {
+    public function __construct(
+        $propertyName,
+        $propertyValue,
+        $className,
+        $message = '',
+        $code = 0,
+        \Exception $previous = null
+    ) {
         parent::__construct($message, $code, $previous);
+
         $this->propertyName  = $propertyName;
         $this->propertyValue = $propertyValue;
+        $this->className = $className;
     }
 
     /**
      * Build an exception when the data is empty and should not.
      *
      * @param string $propertyName
-     * @param string $action
-     * @param string $type
+     * @param string $className
      *
      * @return InvalidPropertyException
      */
-    public static function valueNotEmptyExpected($propertyName, $action, $type)
+    public static function valueNotEmptyExpected($propertyName, $className)
     {
-        $message = 'Property "%s" does not expect an empty value (for %s %s).';
+        $message = 'Property "%s" does not expect an empty value.';
 
         return new self(
             $propertyName,
             null,
-            sprintf($message, $propertyName, $action, $type),
+            $className,
+            sprintf($message, $propertyName),
             self::NOT_EMPTY_VALUE_EXPECTED_CODE
         );
     }
@@ -73,20 +85,20 @@ class InvalidPropertyException extends ObjectUpdaterException
      * @param string $propertyName
      * @param string $key
      * @param string $because
-     * @param string $action
-     * @param string $type
+     * @param string $className
      * @param string $propertyValue
      *
      * @return InvalidPropertyException
      */
-    public static function validEntityCodeExpected($propertyName, $key, $because, $action, $type, $propertyValue)
+    public static function validEntityCodeExpected($propertyName, $key, $because, $className, $propertyValue)
     {
-        $message = 'Property "%s" expects a valid %s. %s, "%s" given (for %s %s).';
+        $message = 'Property "%s" expects a valid %s. %s, "%s" given.';
 
         return new self(
             $propertyName,
             $propertyValue,
-            sprintf($message, $propertyName, $key, $because, $propertyValue, $action, $type),
+            $className,
+            sprintf($message, $propertyName, $key, $because, $propertyValue),
             self::VALID_ENTITY_CODE_EXPECTED_CODE
         );
     }
@@ -96,20 +108,20 @@ class InvalidPropertyException extends ObjectUpdaterException
      *
      * @param string $propertyName
      * @param string $format
-     * @param string $action
-     * @param string $type
+     * @param string $className
      * @param string $propertyValue
      *
      * @return InvalidPropertyException
      */
-    public static function dateExpected($propertyName, $format, $action, $type, $propertyValue)
+    public static function dateExpected($propertyName, $format, $className, $propertyValue)
     {
-        $message = 'Property "%s" expects a string with the format "%s" as data, "%s" given (for %s %s).';
+        $message = 'Property "%s" expects a string with the format "%s" as data, "%s" given.';
 
         return new self(
             $propertyName,
             $propertyValue,
-            sprintf($message, $propertyName, $format, $propertyValue, $action, $type),
+            $className,
+            sprintf($message, $propertyName, $format, $propertyValue),
             self::DATE_EXPECTED_CODE
         );
     }
@@ -119,20 +131,20 @@ class InvalidPropertyException extends ObjectUpdaterException
      *
      * @param string $propertyName
      * @param string $because
-     * @param string $action
-     * @param string $type
+     * @param string $className
      * @param string $propertyValue
      *
      * @return InvalidPropertyException
      */
-    public static function validGroupTypeExpected($propertyName, $because, $action, $type, $propertyValue)
+    public static function validGroupTypeExpected($propertyName, $because, $className, $propertyValue)
     {
-        $message = 'Property "%s" expects a valid group type. %s, "%s" given (for %s %s).';
+        $message = 'Property "%s" expects a valid group type. %s, "%s" given.';
 
         return new self(
             $propertyName,
             $propertyValue,
-            sprintf($message, $propertyName, $because, $propertyValue, $action, $type),
+            $className,
+            sprintf($message, $propertyName, $because, $propertyValue),
             self::VALID_GROUP_TYPE_EXPECTED_CODE
         );
     }
@@ -151,5 +163,13 @@ class InvalidPropertyException extends ObjectUpdaterException
     public function getPropertyValue()
     {
         return $this->propertyValue;
+    }
+
+    /**
+     * @return string
+     */
+    public function getClassName()
+    {
+        return $this->className;
     }
 }

--- a/src/Akeneo/Component/StorageUtils/spec/Exception/ImmutablePropertyExceptionSpec.php
+++ b/src/Akeneo/Component/StorageUtils/spec/Exception/ImmutablePropertyExceptionSpec.php
@@ -9,18 +9,24 @@ class ImmutablePropertyExceptionSpec extends ObjectBehavior
 {
     function it_creates_an_immutable_property_exception()
     {
-        $exception = ImmutablePropertyException::immutableProperty('property', 'property_value', 'action', 'type');
+        $exception = ImmutablePropertyException::immutableProperty(
+            'property',
+            'property_value',
+            'Pim\Component\Catalog\Updater\Attribute'
+        );
 
         $this->beConstructedWith(
             'property',
             'property_value',
-            'Property "property" cannot be modified, "property_value" given (for action type).',
+            'Pim\Component\Catalog\Updater\Attribute',
+            'Property "property" cannot be modified, "property_value" given.',
             0
         );
 
         $this->shouldBeAnInstanceOf(get_class($exception));
         $this->getPropertyName()->shouldReturn('property');
         $this->getPropertyValue()->shouldReturn($exception->getPropertyValue());
+        $this->getClassName()->shouldReturn($exception->getClassName());
         $this->getMessage()->shouldReturn($exception->getMessage());
         $this->getCode()->shouldReturn($exception->getCode());
     }

--- a/src/Akeneo/Component/StorageUtils/spec/Exception/InvalidPropertyExceptionSpec.php
+++ b/src/Akeneo/Component/StorageUtils/spec/Exception/InvalidPropertyExceptionSpec.php
@@ -9,72 +9,99 @@ class InvalidPropertyExceptionSpec extends ObjectBehavior
 {
     function it_creates_an_empty_value_exception()
     {
-        $exception = InvalidPropertyException::valueNotEmptyExpected('attribute', 'action', 'type');
+        $exception = InvalidPropertyException::valueNotEmptyExpected(
+            'attribute',
+            'Pim\Component\Catalog\Updater\Attribute'
+        );
 
         $this->beConstructedWith(
             'attribute',
             null,
-            'Property "attribute" does not expect an empty value (for action type).',
+            'Pim\Component\Catalog\Updater\Attribute',
+            'Property "attribute" does not expect an empty value.',
             InvalidPropertyException::NOT_EMPTY_VALUE_EXPECTED_CODE
         );
 
         $this->shouldBeAnInstanceOf(get_class($exception));
         $this->getPropertyName()->shouldReturn($exception->getPropertyName());
         $this->getPropertyValue()->shouldReturn($exception->getPropertyValue());
+        $this->getClassName()->shouldReturn($exception->getClassName());
         $this->getMessage()->shouldReturn($exception->getMessage());
         $this->getCode()->shouldReturn($exception->getCode());
     }
 
     function it_creates_an_invalid_entity_code_exception()
     {
-        $exception = InvalidPropertyException::validEntityCodeExpected('attribute', 'code', 'The attribute does not exist', 'action', 'type', 'unknown_code');
+        $exception = InvalidPropertyException::validEntityCodeExpected(
+            'attribute',
+            'code',
+            'The attribute does not exist',
+            'Pim\Component\Catalog\Updater\Attribute',
+            'unknown_code'
+        );
 
         $this->beConstructedWith(
             'attribute',
             'unknown_code',
-            'Property "attribute" expects a valid code. The attribute does not exist, "unknown_code" given (for action type).',
+            'Pim\Component\Catalog\Updater\Attribute',
+            'Property "attribute" expects a valid code. The attribute does not exist, "unknown_code" given.',
             InvalidPropertyException::VALID_ENTITY_CODE_EXPECTED_CODE
         );
 
         $this->shouldBeAnInstanceOf(get_class($exception));
         $this->getPropertyName()->shouldReturn($exception->getPropertyName());
         $this->getPropertyValue()->shouldReturn($exception->getPropertyValue());
+        $this->getClassName()->shouldReturn($exception->getClassName());
         $this->getMessage()->shouldReturn($exception->getMessage());
         $this->getCode()->shouldReturn($exception->getCode());
     }
 
     function it_creates_an_invalid_date_exception()
     {
-        $exception = InvalidPropertyException::dateExpected('created_date', 'yyyy-mm-dd', 'action', 'type', '2017/12/12');
+        $exception = InvalidPropertyException::dateExpected(
+            'created_date',
+            'yyyy-mm-dd',
+            'Pim\Component\Catalog\Updater\Setter\DateAttributeSetter',
+            '2017/12/12'
+        );
 
         $this->beConstructedWith(
             'created_date',
             '2017/12/12',
-            'Property "created_date" expects a string with the format "yyyy-mm-dd" as data, "2017/12/12" given (for action type).',
+            'Pim\Component\Catalog\Updater\Setter\DateAttributeSetter',
+            'Property "created_date" expects a string with the format "yyyy-mm-dd" as data, "2017/12/12" given.',
             InvalidPropertyException::DATE_EXPECTED_CODE
         );
 
         $this->shouldBeAnInstanceOf(get_class($exception));
         $this->getPropertyName()->shouldReturn($exception->getPropertyName());
         $this->getPropertyValue()->shouldReturn($exception->getPropertyValue());
+        $this->getClassName()->shouldReturn($exception->getClassName());
         $this->getMessage()->shouldReturn($exception->getMessage());
         $this->getCode()->shouldReturn($exception->getCode());
     }
 
     function it_creates_an_invalid_group_type_exception()
     {
-        $exception = InvalidPropertyException::validGroupTypeExpected('group', 'Group is not valid', 'action', 'type', 'variant');
+        $exception = InvalidPropertyException::validGroupTypeExpected(
+            'group',
+            'Group is not valid',
+            'Pim\Component\Catalog\Updater\Attribute',
+            'variant'
+        );
 
         $this->beConstructedWith(
             'group',
             'variant',
-            'Property "group" expects a valid group type. Group is not valid, "variant" given (for action type).',
+            'Pim\Component\Catalog\Updater\Attribute',
+            'Property "group" expects a valid group type. Group is not valid, "variant" given.',
             InvalidPropertyException::VALID_GROUP_TYPE_EXPECTED_CODE
         );
 
         $this->shouldBeAnInstanceOf(get_class($exception));
         $this->getPropertyName()->shouldReturn($exception->getPropertyName());
         $this->getPropertyValue()->shouldReturn($exception->getPropertyValue());
+        $this->getClassName()->shouldReturn($exception->getClassName());
         $this->getMessage()->shouldReturn($exception->getMessage());
         $this->getCode()->shouldReturn($exception->getCode());
     }

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Filter/CategoryFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Filter/CategoryFilter.php
@@ -147,10 +147,10 @@ class CategoryFilter implements FieldFilterInterface
      */
     protected function checkValue($field, $values)
     {
-        FieldFilterHelper::checkArray($field, $values, 'category');
+        FieldFilterHelper::checkArray($field, $values, static::class);
 
         foreach ($values as $value) {
-            FieldFilterHelper::checkIdentifier($field, $value, 'category');
+            FieldFilterHelper::checkIdentifier($field, $value, static::class);
         }
     }
 

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/AbstractAttributeFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/AbstractAttributeFilter.php
@@ -44,11 +44,10 @@ abstract class AbstractAttributeFilter extends AbstractFilter implements Attribu
      * @param AttributeInterface $attribute
      * @param string             $locale
      * @param string             $scope
-     * @param string             $type
      *
      * @throws InvalidArgumentException
      */
-    protected function checkLocaleAndScope(AttributeInterface $attribute, $locale, $scope, $type)
+    protected function checkLocaleAndScope(AttributeInterface $attribute, $locale, $scope)
     {
         try {
             $this->attrValidatorHelper->validateLocale($attribute, $locale);
@@ -57,8 +56,7 @@ abstract class AbstractAttributeFilter extends AbstractFilter implements Attribu
             throw InvalidArgumentException::expectedFromPreviousException(
                 $e,
                 $attribute->getCode(),
-                'filter',
-                $type
+                static::class
             );
         }
     }

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/BooleanFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/BooleanFilter.php
@@ -72,8 +72,7 @@ class BooleanFilter extends AbstractAttributeFilter implements FieldFilterInterf
         if (!is_bool($value)) {
             throw InvalidArgumentException::booleanExpected(
                 $attribute->getCode(),
-                'filter',
-                'boolean',
+                static::class,
                 gettype($value)
             );
         }
@@ -91,7 +90,7 @@ class BooleanFilter extends AbstractAttributeFilter implements FieldFilterInterf
     public function addFieldFilter($field, $operator, $value, $locale = null, $scope = null, $options = [])
     {
         if (!is_bool($value)) {
-            throw InvalidArgumentException::booleanExpected($field, 'filter', 'boolean', gettype($value));
+            throw InvalidArgumentException::booleanExpected($field, static::class, gettype($value));
         }
 
         $field = sprintf('%s.%s', ProductQueryUtility::NORMALIZED_FIELD, $field);

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/CompletenessFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/CompletenessFilter.php
@@ -166,11 +166,11 @@ class CompletenessFilter extends AbstractFieldFilter implements FieldFilterInter
     protected function checkScopeAndValue($field, $scope, $value)
     {
         if (!is_numeric($value)) {
-            throw InvalidArgumentException::numericExpected($field, 'filter', 'completeness', gettype($value));
+            throw InvalidArgumentException::numericExpected($field, static::class, gettype($value));
         }
 
         if (null === $scope) {
-            throw InvalidArgumentException::scopeExpected($field, 'filter', 'completeness');
+            throw InvalidArgumentException::scopeExpected($field, static::class);
         }
     }
 
@@ -191,8 +191,7 @@ class CompletenessFilter extends AbstractFieldFilter implements FieldFilterInter
             throw InvalidArgumentException::arrayKeyExpected(
                 $field,
                 'locales',
-                'filter',
-                'completeness',
+                static::class,
                 print_r(array_keys($options), true)
             );
         }
@@ -200,8 +199,7 @@ class CompletenessFilter extends AbstractFieldFilter implements FieldFilterInter
         if (!isset($options['locales']) || !is_array($options['locales'])) {
             throw InvalidArgumentException::arrayOfArraysExpected(
                 $field,
-                'filter',
-                'completeness',
+                static::class,
                 print_r($options, true)
             );
         }

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/DateFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/DateFilter.php
@@ -119,8 +119,7 @@ class DateFilter extends AbstractAttributeFilter implements AttributeFilterInter
             throw InvalidArgumentException::expected(
                 $type,
                 'array with 2 elements, string or \DateTime',
-                'filter',
-                'date',
+                static::class,
                 print_r($value, true)
             );
         }
@@ -163,8 +162,7 @@ class DateFilter extends AbstractAttributeFilter implements AttributeFilterInter
                 throw InvalidArgumentException::expected(
                     $type,
                     'a string with the format yyyy-mm-dd',
-                    'filter',
-                    'date',
+                    static::class,
                     $value
                 );
             }
@@ -177,8 +175,7 @@ class DateFilter extends AbstractAttributeFilter implements AttributeFilterInter
         throw InvalidArgumentException::expected(
             $type,
             'array with 2 elements, string or \DateTime',
-            'filter',
-            'date',
+            static::class,
             print_r($value, true)
         );
     }

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/DateTimeFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/DateTimeFilter.php
@@ -60,7 +60,7 @@ class DateTimeFilter extends AbstractFieldFilter implements FieldFilterInterface
 
         if (Operators::SINCE_LAST_JOB === $operator) {
             if (!is_string($value)) {
-                throw InvalidArgumentException::stringExpected($field, 'filter', 'updated', gettype($value));
+                throw InvalidArgumentException::stringExpected($field, static::class, gettype($value));
             }
 
             $jobInstance = $this->jobInstanceRepository->findOneByIdentifier($value);
@@ -75,7 +75,7 @@ class DateTimeFilter extends AbstractFieldFilter implements FieldFilterInterface
 
         if (Operators::SINCE_LAST_N_DAYS === $operator) {
             if (!is_numeric($value)) {
-                throw InvalidArgumentException::numericExpected($field, 'filter', 'updated', gettype($value));
+                throw InvalidArgumentException::numericExpected($field, static::class, gettype($value));
             }
 
             $fromDate = new \DateTime(sprintf('%s days ago', $value), new \DateTimeZone('UTC'));
@@ -149,8 +149,7 @@ class DateTimeFilter extends AbstractFieldFilter implements FieldFilterInterface
             throw InvalidArgumentException::expected(
                 $type,
                 'array with 2 elements, string or \DateTime',
-                'filter',
-                'date',
+                static::class,
                 print_r($value, true)
             );
         }
@@ -194,8 +193,7 @@ class DateTimeFilter extends AbstractFieldFilter implements FieldFilterInterface
                 throw InvalidArgumentException::expected(
                     $type,
                     'a string with the format yyyy-mm-dd H:i:s',
-                    'filter',
-                    'date',
+                    static::class,
                     $value
                 );
             }
@@ -206,8 +204,7 @@ class DateTimeFilter extends AbstractFieldFilter implements FieldFilterInterface
         throw InvalidArgumentException::expected(
             $type,
             'array with 2 elements, string or \DateTime',
-            'filter',
-            'date',
+            static::class,
             print_r($value, true)
         );
     }

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/FamilyFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/FamilyFilter.php
@@ -64,10 +64,10 @@ class FamilyFilter extends AbstractFieldFilter implements FieldFilterInterface
      */
     protected function checkValue($field, $values)
     {
-        FieldFilterHelper::checkArray($field, $values, 'family');
+        FieldFilterHelper::checkArray($field, $values, static::class);
 
         foreach ($values as $value) {
-            FieldFilterHelper::checkIdentifier($field, $value, 'family');
+            FieldFilterHelper::checkIdentifier($field, $value, static::class);
         }
     }
 

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/GroupsFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/GroupsFilter.php
@@ -62,10 +62,10 @@ class GroupsFilter extends AbstractFieldFilter implements FieldFilterInterface
      */
     protected function checkValue($field, $values)
     {
-        FieldFilterHelper::checkArray($field, $values, 'groups');
+        FieldFilterHelper::checkArray($field, $values, static::class);
 
         foreach ($values as $value) {
-            FieldFilterHelper::checkIdentifier($field, $value, 'groups');
+            FieldFilterHelper::checkIdentifier($field, $value, static::class);
         }
     }
 

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/MediaFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/MediaFilter.php
@@ -111,8 +111,7 @@ class MediaFilter extends AbstractAttributeFilter implements AttributeFilterInte
         if (!is_string($value)) {
             throw InvalidArgumentException::stringExpected(
                 $attribute->getCode(),
-                'filter',
-                'media',
+                static::class,
                 gettype($value)
             );
         }

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/MetricFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/MetricFilter.php
@@ -120,15 +120,14 @@ class MetricFilter extends AbstractAttributeFilter implements AttributeFilterInt
     protected function checkValue(AttributeInterface $attribute, $data)
     {
         if (!is_array($data)) {
-            throw InvalidArgumentException::arrayExpected($attribute->getCode(), 'filter', 'metric', gettype($data));
+            throw InvalidArgumentException::arrayExpected($attribute->getCode(), static::class, gettype($data));
         }
 
         if (!array_key_exists('amount', $data)) {
             throw InvalidArgumentException::arrayKeyExpected(
                 $attribute->getCode(),
                 'amount',
-                'filter',
-                'metric',
+                static::class,
                 print_r($data, true)
             );
         }
@@ -137,8 +136,7 @@ class MetricFilter extends AbstractAttributeFilter implements AttributeFilterInt
             throw InvalidArgumentException::arrayKeyExpected(
                 $attribute->getCode(),
                 'unit',
-                'filter',
-                'metric',
+                static::class,
                 print_r($data, true)
             );
         }
@@ -147,8 +145,7 @@ class MetricFilter extends AbstractAttributeFilter implements AttributeFilterInt
             throw InvalidArgumentException::arrayNumericKeyExpected(
                 $attribute->getCode(),
                 'amount',
-                'filter',
-                'metric',
+                static::class,
                 gettype($data['amount'])
             );
         }
@@ -157,8 +154,7 @@ class MetricFilter extends AbstractAttributeFilter implements AttributeFilterInt
             throw InvalidArgumentException::arrayStringKeyExpected(
                 $attribute->getCode(),
                 'unit',
-                'filter',
-                'metric',
+                static::class,
                 gettype($data['unit'])
             );
         }
@@ -174,8 +170,7 @@ class MetricFilter extends AbstractAttributeFilter implements AttributeFilterInt
                     'The unit does not exist in the attribute\'s family "%s"',
                     $attribute->getMetricFamily()
                 ),
-                'filter',
-                'metric',
+                static::class,
                 $data['unit']
             );
         }

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/NumberFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/NumberFilter.php
@@ -47,7 +47,7 @@ class NumberFilter extends AbstractAttributeFilter implements AttributeFilterInt
         $this->checkLocaleAndScope($attribute, $locale, $scope, 'number');
 
         if (null !== $value && !is_numeric($value)) {
-            throw InvalidArgumentException::numericExpected($attribute->getCode(), 'filter', 'number', gettype($value));
+            throw InvalidArgumentException::numericExpected($attribute->getCode(), static::class, gettype($value));
         }
 
         $field = ProductQueryUtility::getNormalizedValueFieldFromAttribute($attribute, $locale, $scope);

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/OptionFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/OptionFilter.php
@@ -65,12 +65,11 @@ class OptionFilter extends AbstractAttributeFilter implements AttributeFilterInt
             throw InvalidArgumentException::expectedFromPreviousException(
                 $e,
                 $attribute->getCode(),
-                'filter',
-                'option'
+                static::class
             );
         }
 
-        $this->checkLocaleAndScope($attribute, $locale, $scope, 'option');
+        $this->checkLocaleAndScope($attribute, $locale, $scope);
 
         if (Operators::IS_EMPTY !== $operator && Operators::IS_NOT_EMPTY !== $operator) {
             $this->checkValue($options['field'], $value);
@@ -101,10 +100,10 @@ class OptionFilter extends AbstractAttributeFilter implements AttributeFilterInt
      */
     protected function checkValue($field, $values)
     {
-        FieldFilterHelper::checkArray($field, $values, 'option');
+        FieldFilterHelper::checkArray($field, $values, static::class);
 
         foreach ($values as $value) {
-            FieldFilterHelper::checkIdentifier($field, $value, 'option');
+            FieldFilterHelper::checkIdentifier($field, $value, static::class);
         }
     }
 

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/OptionsFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/OptionsFilter.php
@@ -65,8 +65,7 @@ class OptionsFilter extends AbstractAttributeFilter implements AttributeFilterIn
             throw InvalidArgumentException::expectedFromPreviousException(
                 $e,
                 $attribute->getCode(),
-                'filter',
-                'options'
+                static::class
             );
         }
 
@@ -101,10 +100,10 @@ class OptionsFilter extends AbstractAttributeFilter implements AttributeFilterIn
      */
     protected function checkValue($field, $values)
     {
-        FieldFilterHelper::checkArray($field, $values, 'options');
+        FieldFilterHelper::checkArray($field, $values, static::class);
 
         foreach ($values as $value) {
-            FieldFilterHelper::checkIdentifier($field, $value, 'options');
+            FieldFilterHelper::checkIdentifier($field, $value, static::class);
         }
     }
 

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/PriceFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/PriceFilter.php
@@ -116,15 +116,14 @@ class PriceFilter extends AbstractAttributeFilter implements AttributeFilterInte
     protected function checkValue(AttributeInterface $attribute, $data)
     {
         if (!is_array($data)) {
-            throw InvalidArgumentException::arrayExpected($attribute->getCode(), 'filter', 'price', gettype($data));
+            throw InvalidArgumentException::arrayExpected($attribute->getCode(), static::class, gettype($data));
         }
 
         if (!array_key_exists('amount', $data)) {
             throw InvalidArgumentException::arrayKeyExpected(
                 $attribute->getCode(),
                 'amount',
-                'filter',
-                'price',
+                static::class,
                 print_r($data, true)
             );
         }
@@ -133,8 +132,7 @@ class PriceFilter extends AbstractAttributeFilter implements AttributeFilterInte
             throw InvalidArgumentException::arrayKeyExpected(
                 $attribute->getCode(),
                 'currency',
-                'filter',
-                'price',
+                static::class,
                 print_r($data, true)
             );
         }
@@ -143,8 +141,7 @@ class PriceFilter extends AbstractAttributeFilter implements AttributeFilterInte
             throw InvalidArgumentException::arrayNumericKeyExpected(
                 $attribute->getCode(),
                 'amount',
-                'filter',
-                'price',
+                static::class,
                 gettype($data['amount'])
             );
         }
@@ -153,8 +150,7 @@ class PriceFilter extends AbstractAttributeFilter implements AttributeFilterInte
             throw InvalidArgumentException::arrayStringKeyExpected(
                 $attribute->getCode(),
                 'currency',
-                'filter',
-                'price',
+                static::class,
                 gettype($data['currency'])
             );
         }
@@ -164,8 +160,7 @@ class PriceFilter extends AbstractAttributeFilter implements AttributeFilterInte
                 $attribute->getCode(),
                 'currency',
                 'The currency does not exist',
-                'filter',
-                'price',
+                static::class,
                 $data['currency']
             );
         }

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/ProductIdFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/ProductIdFilter.php
@@ -33,7 +33,7 @@ class ProductIdFilter extends AbstractFieldFilter implements FieldFilterInterfac
     public function addFieldFilter($field, $operator, $value, $locale = null, $scope = null, $options = [])
     {
         if (!is_string($value) && !is_array($value)) {
-            throw InvalidArgumentException::expected($field, 'array or string value', 'filter', 'productId', $value);
+            throw InvalidArgumentException::expected($field, 'array or string value', static::class, $value);
         }
 
         $this->applyFilter('_id', $operator, $value);

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/StringFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/StringFilter.php
@@ -57,8 +57,7 @@ class StringFilter extends AbstractAttributeFilter implements AttributeFilterInt
             throw InvalidArgumentException::expectedFromPreviousException(
                 $e,
                 $attribute->getCode(),
-                'filter',
-                'string'
+                static::class
             );
         }
 
@@ -165,7 +164,7 @@ class StringFilter extends AbstractAttributeFilter implements AttributeFilterInt
     protected function checkScalarValue($field, $value)
     {
         if (!is_string($value) && null !== $value) {
-            throw InvalidArgumentException::stringExpected($field, 'filter', 'string', gettype($value));
+            throw InvalidArgumentException::stringExpected($field, static::class, gettype($value));
         }
     }
 

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/AbstractAttributeFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/AbstractAttributeFilter.php
@@ -44,11 +44,10 @@ abstract class AbstractAttributeFilter extends AbstractFilter implements Attribu
      * @param AttributeInterface $attribute
      * @param string             $locale
      * @param string             $scope
-     * @param string             $type
      *
      * @throws InvalidArgumentException
      */
-    protected function checkLocaleAndScope(AttributeInterface $attribute, $locale, $scope, $type)
+    protected function checkLocaleAndScope(AttributeInterface $attribute, $locale, $scope)
     {
         try {
             $this->attrValidatorHelper->validateLocale($attribute, $locale);
@@ -57,8 +56,7 @@ abstract class AbstractAttributeFilter extends AbstractFilter implements Attribu
             throw InvalidArgumentException::expectedFromPreviousException(
                 $e,
                 $attribute->getCode(),
-                'filter',
-                $type
+                static::class
             );
         }
     }

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/BooleanFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/BooleanFilter.php
@@ -50,13 +50,12 @@ class BooleanFilter extends AbstractAttributeFilter implements AttributeFilterIn
         $scope = null,
         $options = []
     ) {
-        $this->checkLocaleAndScope($attribute, $locale, $scope, 'boolean');
+        $this->checkLocaleAndScope($attribute, $locale, $scope);
 
         if (!is_bool($value)) {
             throw InvalidArgumentException::booleanExpected(
                 $attribute->getCode(),
-                'filter',
-                'boolean',
+                static::class,
                 gettype($value)
             );
         }
@@ -82,7 +81,7 @@ class BooleanFilter extends AbstractAttributeFilter implements AttributeFilterIn
     public function addFieldFilter($field, $operator, $value, $locale = null, $scope = null, $options = [])
     {
         if (!is_bool($value)) {
-            throw InvalidArgumentException::booleanExpected($field, 'filter', 'boolean', gettype($value));
+            throw InvalidArgumentException::booleanExpected($field, static::class, gettype($value));
         }
 
         $field = current($this->qb->getRootAliases()) . '.' . FieldFilterHelper::getCode($field);

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/CompletenessFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/CompletenessFilter.php
@@ -85,11 +85,11 @@ class CompletenessFilter extends AbstractFieldFilter implements FieldFilterInter
     protected function checkScopeAndValue($field, $scope, $value)
     {
         if (!is_numeric($value)) {
-            throw InvalidArgumentException::numericExpected($field, 'filter', 'completeness', gettype($value));
+            throw InvalidArgumentException::numericExpected($field, static::class, gettype($value));
         }
 
         if (null === $scope) {
-            throw InvalidArgumentException::scopeExpected($field, 'filter', 'completeness');
+            throw InvalidArgumentException::scopeExpected($field, static::class);
         }
     }
 
@@ -109,8 +109,7 @@ class CompletenessFilter extends AbstractFieldFilter implements FieldFilterInter
             throw InvalidArgumentException::arrayKeyExpected(
                 $field,
                 'locales',
-                'filter',
-                'completeness',
+                static::class,
                 print_r($options, true)
             );
         }
@@ -118,8 +117,7 @@ class CompletenessFilter extends AbstractFieldFilter implements FieldFilterInter
         if (!isset($options['locales']) || !is_array($options['locales'])) {
             throw InvalidArgumentException::arrayOfArraysExpected(
                 $field,
-                'filter',
-                'completeness',
+                static::class,
                 print_r($options, true)
             );
         }

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/DateFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/DateFilter.php
@@ -45,7 +45,7 @@ class DateFilter extends AbstractAttributeFilter implements AttributeFilterInter
         $scope = null,
         $options = []
     ) {
-        $this->checkLocaleAndScope($attribute, $locale, $scope, 'date');
+        $this->checkLocaleAndScope($attribute, $locale, $scope);
 
         if (Operators::IS_EMPTY !== $operator && Operators::IS_NOT_EMPTY !== $operator) {
             $value = $this->formatValues($attribute->getCode(), $value);
@@ -100,8 +100,7 @@ class DateFilter extends AbstractAttributeFilter implements AttributeFilterInter
             throw InvalidArgumentException::expected(
                 $type,
                 'array with 2 elements, string or \DateTime',
-                'filter',
-                'date',
+                static::class,
                 print_r($value, true)
             );
         }
@@ -144,8 +143,7 @@ class DateFilter extends AbstractAttributeFilter implements AttributeFilterInter
                 throw InvalidArgumentException::expected(
                     $type,
                     'a string with the format yyyy-mm-dd',
-                    'filter',
-                    'date',
+                    static::class,
                     $value
                 );
             }
@@ -156,8 +154,7 @@ class DateFilter extends AbstractAttributeFilter implements AttributeFilterInter
         throw InvalidArgumentException::expected(
             $type,
             'array with 2 elements, string or \DateTime',
-            'filter',
-            'date',
+            static::class,
             print_r($value, true)
         );
     }

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/DateTimeFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/DateTimeFilter.php
@@ -52,7 +52,7 @@ class DateTimeFilter extends AbstractFieldFilter implements FieldFilterInterface
         switch ($operator) {
             case Operators::SINCE_LAST_JOB:
                 if (!is_string($value)) {
-                    throw InvalidArgumentException::stringExpected($field, 'filter', 'updated', gettype($value));
+                    throw InvalidArgumentException::stringExpected($field, static::class, gettype($value));
                 }
 
                 $this->addUpdatedSinceLastJob($field, $value);
@@ -60,7 +60,7 @@ class DateTimeFilter extends AbstractFieldFilter implements FieldFilterInterface
 
             case Operators::SINCE_LAST_N_DAYS:
                 if (!is_numeric($value)) {
-                    throw InvalidArgumentException::numericExpected($field, 'filter', 'updated', gettype($value));
+                    throw InvalidArgumentException::numericExpected($field, static::class, gettype($value));
                 }
 
                 $this->addSinceLastNDays($field, $value);
@@ -162,8 +162,7 @@ class DateTimeFilter extends AbstractFieldFilter implements FieldFilterInterface
             throw InvalidArgumentException::expected(
                 $type,
                 'array with 2 elements, string or \DateTime',
-                'filter',
-                'date',
+                static::class,
                 print_r($value, true)
             );
         }
@@ -207,8 +206,7 @@ class DateTimeFilter extends AbstractFieldFilter implements FieldFilterInterface
                 throw InvalidArgumentException::expected(
                     $type,
                     'a string with the format yyyy-mm-dd H:i:s',
-                    'filter',
-                    'date',
+                    static::class,
                     $value
                 );
             }
@@ -219,8 +217,7 @@ class DateTimeFilter extends AbstractFieldFilter implements FieldFilterInterface
         throw InvalidArgumentException::expected(
             $type,
             'array with 2 elements, string or \DateTime',
-            'filter',
-            'date',
+            static::class,
             print_r($value, true)
         );
     }

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/FamilyFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/FamilyFilter.php
@@ -86,10 +86,10 @@ class FamilyFilter extends AbstractFieldFilter implements FieldFilterInterface
      */
     protected function checkValue($field, $values)
     {
-        FieldFilterHelper::checkArray($field, $values, 'family');
+        FieldFilterHelper::checkArray($field, $values, static::class);
 
         foreach ($values as $value) {
-            FieldFilterHelper::checkIdentifier($field, $value, 'family');
+            FieldFilterHelper::checkIdentifier($field, $value, static::class);
         }
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/GroupsFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/GroupsFilter.php
@@ -108,10 +108,10 @@ class GroupsFilter extends AbstractFieldFilter implements FieldFilterInterface
      */
     protected function checkValue($field, $values)
     {
-        FieldFilterHelper::checkArray($field, $values, FieldFilterHelper::getCode($field));
+        FieldFilterHelper::checkArray($field, $values, static::class);
 
         foreach ($values as $value) {
-            FieldFilterHelper::checkIdentifier($field, $value, FieldFilterHelper::getCode($field));
+            FieldFilterHelper::checkIdentifier($field, $value, static::class);
         }
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/MediaFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/MediaFilter.php
@@ -43,7 +43,7 @@ class MediaFilter extends AbstractAttributeFilter implements AttributeFilterInte
         $scope = null,
         $options = []
     ) {
-        $this->checkLocaleAndScope($attribute, $locale, $scope, 'media');
+        $this->checkLocaleAndScope($attribute, $locale, $scope);
 
         if ($operator === Operators::IS_EMPTY || $operator === Operators::IS_NOT_EMPTY) {
             $this->addEmptyTypeFilter($attribute, $operator, $locale, $scope);
@@ -188,7 +188,7 @@ class MediaFilter extends AbstractAttributeFilter implements AttributeFilterInte
     protected function checkValue(AttributeInterface $attribute, $value)
     {
         if (!is_string($value)) {
-            throw InvalidArgumentException::stringExpected($attribute->getCode(), 'filter', 'media', gettype($value));
+            throw InvalidArgumentException::stringExpected($attribute->getCode(), static::class, gettype($value));
         }
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/MetricFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/MetricFilter.php
@@ -57,7 +57,7 @@ class MetricFilter extends AbstractAttributeFilter implements AttributeFilterInt
         $scope = null,
         $options = []
     ) {
-        $this->checkLocaleAndScope($attribute, $locale, $scope, 'metric');
+        $this->checkLocaleAndScope($attribute, $locale, $scope);
 
         if (Operators::IS_EMPTY === $operator || Operators::IS_NOT_EMPTY === $operator) {
             $this->addEmptyTypeFilter($attribute, $operator, $locale, $scope);
@@ -147,15 +147,14 @@ class MetricFilter extends AbstractAttributeFilter implements AttributeFilterInt
     protected function checkValue(AttributeInterface $attribute, $data)
     {
         if (!is_array($data)) {
-            throw InvalidArgumentException::arrayExpected($attribute->getCode(), 'filter', 'metric', gettype($data));
+            throw InvalidArgumentException::arrayExpected($attribute->getCode(), static::class, gettype($data));
         }
 
         if (!array_key_exists('amount', $data)) {
             throw InvalidArgumentException::arrayKeyExpected(
                 $attribute->getCode(),
                 'amount',
-                'filter',
-                'metric',
+                static::class,
                 print_r($data, true)
             );
         }
@@ -164,8 +163,7 @@ class MetricFilter extends AbstractAttributeFilter implements AttributeFilterInt
             throw InvalidArgumentException::arrayKeyExpected(
                 $attribute->getCode(),
                 'unit',
-                'filter',
-                'metric',
+                static::class,
                 print_r($data, true)
             );
         }
@@ -174,8 +172,7 @@ class MetricFilter extends AbstractAttributeFilter implements AttributeFilterInt
             throw InvalidArgumentException::arrayNumericKeyExpected(
                 $attribute->getCode(),
                 'amount',
-                'filter',
-                'metric',
+                static::class,
                 gettype($data['amount'])
             );
         }
@@ -184,8 +181,7 @@ class MetricFilter extends AbstractAttributeFilter implements AttributeFilterInt
             throw InvalidArgumentException::arrayStringKeyExpected(
                 $attribute->getCode(),
                 'unit',
-                'filter',
-                'metric',
+                static::class,
                 gettype($data['unit'])
             );
         }
@@ -201,8 +197,7 @@ class MetricFilter extends AbstractAttributeFilter implements AttributeFilterInt
                     'The unit does not exist in the attribute\'s family "%s"',
                     $attribute->getMetricFamily()
                 ),
-                'filter',
-                'metric',
+                static::class,
                 $data['unit']
             );
         }

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/NumberFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/NumberFilter.php
@@ -43,10 +43,10 @@ class NumberFilter extends AbstractAttributeFilter implements AttributeFilterInt
         $scope = null,
         $options = []
     ) {
-        $this->checkLocaleAndScope($attribute, $locale, $scope, 'number');
+        $this->checkLocaleAndScope($attribute, $locale, $scope);
 
         if (null !== $value && !is_numeric($value)) {
-            throw InvalidArgumentException::numericExpected($attribute->getCode(), 'filter', 'number', gettype($value));
+            throw InvalidArgumentException::numericExpected($attribute->getCode(), static::class, gettype($value));
         }
 
         $joinAlias = $this->getUniqueAlias('filter' . $attribute->getCode());

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/OptionFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/OptionFilter.php
@@ -64,12 +64,11 @@ class OptionFilter extends AbstractAttributeFilter implements AttributeFilterInt
             throw InvalidArgumentException::expectedFromPreviousException(
                 $e,
                 $attribute->getCode(),
-                'filter',
-                'option'
+                static::class
             );
         }
 
-        $this->checkLocaleAndScope($attribute, $locale, $scope, 'option');
+        $this->checkLocaleAndScope($attribute, $locale, $scope);
         $field = $options['field'];
 
         if (Operators::IS_EMPTY !== $operator && Operators::IS_NOT_EMPTY !== $operator) {
@@ -119,10 +118,10 @@ class OptionFilter extends AbstractAttributeFilter implements AttributeFilterInt
      */
     protected function checkValue($field, $values)
     {
-        FieldFilterHelper::checkArray($field, $values, 'option');
+        FieldFilterHelper::checkArray($field, $values, static::class);
 
         foreach ($values as $value) {
-            FieldFilterHelper::checkIdentifier($field, $value, 'option');
+            FieldFilterHelper::checkIdentifier($field, $value, static::class);
         }
     }
 

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/OptionsFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/OptionsFilter.php
@@ -64,12 +64,11 @@ class OptionsFilter extends AbstractAttributeFilter implements AttributeFilterIn
             throw InvalidArgumentException::expectedFromPreviousException(
                 $e,
                 $attribute->getCode(),
-                'filter',
-                'options'
+                static::class
             );
         }
 
-        $this->checkLocaleAndScope($attribute, $locale, $scope, 'options');
+        $this->checkLocaleAndScope($attribute, $locale, $scope);
 
         if (Operators::IS_EMPTY !== $operator && Operators::IS_NOT_EMPTY !== $operator) {
             $this->checkValue($options['field'], $value);
@@ -162,10 +161,10 @@ class OptionsFilter extends AbstractAttributeFilter implements AttributeFilterIn
      */
     protected function checkValue($field, $values)
     {
-        FieldFilterHelper::checkArray($field, $values, 'options');
+        FieldFilterHelper::checkArray($field, $values, static::class);
 
         foreach ($values as $value) {
-            FieldFilterHelper::checkIdentifier($field, $value, 'options');
+            FieldFilterHelper::checkIdentifier($field, $value, static::class);
         }
     }
 

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/PriceFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/PriceFilter.php
@@ -164,15 +164,14 @@ class PriceFilter extends AbstractAttributeFilter implements AttributeFilterInte
     protected function checkValue(AttributeInterface $attribute, $data)
     {
         if (!is_array($data)) {
-            throw InvalidArgumentException::arrayExpected($attribute->getCode(), 'filter', 'price', gettype($data));
+            throw InvalidArgumentException::arrayExpected($attribute->getCode(), static::class, gettype($data));
         }
 
         if (!array_key_exists('amount', $data)) {
             throw InvalidArgumentException::arrayKeyExpected(
                 $attribute->getCode(),
                 'amount',
-                'filter',
-                'price',
+                static::class,
                 print_r($data, true)
             );
         }
@@ -181,8 +180,7 @@ class PriceFilter extends AbstractAttributeFilter implements AttributeFilterInte
             throw InvalidArgumentException::arrayKeyExpected(
                 $attribute->getCode(),
                 'currency',
-                'filter',
-                'price',
+                static::class,
                 print_r($data, true)
             );
         }
@@ -191,8 +189,7 @@ class PriceFilter extends AbstractAttributeFilter implements AttributeFilterInte
             throw InvalidArgumentException::arrayNumericKeyExpected(
                 $attribute->getCode(),
                 'amount',
-                'filter',
-                'price',
+                static::class,
                 gettype($data['amount'])
             );
         }
@@ -201,8 +198,7 @@ class PriceFilter extends AbstractAttributeFilter implements AttributeFilterInte
             throw InvalidArgumentException::arrayStringKeyExpected(
                 $attribute->getCode(),
                 'currency',
-                'filter',
-                'price',
+                static::class,
                 gettype($data['currency'])
             );
         }
@@ -212,8 +208,7 @@ class PriceFilter extends AbstractAttributeFilter implements AttributeFilterInte
                 $attribute->getCode(),
                 'currency',
                 'The currency does not exist',
-                'filter',
-                'price',
+                static::class,
                 $data['currency']
             );
         }

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/ProductIdFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/ProductIdFilter.php
@@ -32,7 +32,7 @@ class ProductIdFilter extends AbstractFieldFilter implements FieldFilterInterfac
     public function addFieldFilter($field, $operator, $value, $locale = null, $scope = null, $options = [])
     {
         if (!is_numeric($value) && !is_array($value)) {
-            throw InvalidArgumentException::expected($field, 'array or numeric value', 'filter', 'productId', $value);
+            throw InvalidArgumentException::expected($field, 'array or numeric value', static::class, $value);
         }
 
         $field = current($this->qb->getRootAliases()) . '.' . $field;

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/StringFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/StringFilter.php
@@ -56,12 +56,11 @@ class StringFilter extends AbstractAttributeFilter implements AttributeFilterInt
             throw InvalidArgumentException::expectedFromPreviousException(
                 $e,
                 $attribute->getCode(),
-                'filter',
-                'string'
+                static::class
             );
         }
 
-        $this->checkLocaleAndScope($attribute, $locale, $scope, 'string');
+        $this->checkLocaleAndScope($attribute, $locale, $scope);
 
         if (Operators::IS_EMPTY !== $operator && Operators::IS_NOT_EMPTY !== $operator) {
             $this->checkValue($options['field'], $value);
@@ -184,7 +183,7 @@ class StringFilter extends AbstractAttributeFilter implements AttributeFilterInt
     protected function checkScalarValue($field, $value)
     {
         if (!is_string($value) && null !== $value) {
-            throw InvalidArgumentException::stringExpected($field, 'filter', 'string', gettype($value));
+            throw InvalidArgumentException::stringExpected($field, static::class, gettype($value));
         }
     }
 

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/BooleanFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/BooleanFilterSpec.php
@@ -103,8 +103,11 @@ class BooleanFilterSpec extends ObjectBehavior
 
     function it_throws_an_exception_if_value_is_not_a_boolean()
     {
-        $this->shouldThrow(InvalidArgumentException::booleanExpected('enabled', 'filter', 'boolean', gettype('not a boolean')))
-            ->during('addFieldFilter', ['enabled', '=', 'not a boolean']);
+        $this->shouldThrow(InvalidArgumentException::booleanExpected(
+            'enabled',
+            'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\BooleanFilter',
+            gettype('not a boolean')
+        ))->during('addFieldFilter', ['enabled', '=', 'not a boolean']);
     }
 
     function it_returns_supported_fields()

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/CompletenessFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/CompletenessFilterSpec.php
@@ -259,8 +259,11 @@ class CompletenessFilterSpec extends ObjectBehavior
     function it_throws_an_exception_if_value_is_not_an_integer()
     {
         $this->shouldThrow(
-            InvalidArgumentException::numericExpected('completeness', 'filter', 'completeness', gettype('123'))
-        )->during('addFieldFilter', ['completeness', '=', '12a3', 'fr_FR', 'mobile']);
+            InvalidArgumentException::numericExpected(
+                'completeness',
+                'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\CompletenessFilter',
+                gettype('123')
+            ))->during('addFieldFilter', ['completeness', '=', '12a3', 'fr_FR', 'mobile']);
     }
 
     function it_throws_an_exception_if_options_are_not_set_correctly()
@@ -270,8 +273,7 @@ class CompletenessFilterSpec extends ObjectBehavior
                 InvalidArgumentException::arrayKeyExpected(
                     'completeness',
                     'locales',
-                    'filter',
-                    'completeness',
+                    'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\CompletenessFilter',
                     print_r(['wrong_key'], true)
                 )
             )->during(
@@ -290,8 +292,7 @@ class CompletenessFilterSpec extends ObjectBehavior
             ->shouldThrow(
                 InvalidArgumentException::arrayOfArraysExpected(
                     'completeness',
-                    'filter',
-                    'completeness',
+                    'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\CompletenessFilter',
                     print_r(['locales' => 'en_US'], true)
                 )
             )->during(

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/DateFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/DateFilterSpec.php
@@ -195,8 +195,7 @@ class DateFilterSpec extends ObjectBehavior
             InvalidArgumentException::expected(
                 'release_date',
                 'array with 2 elements, string or \DateTime',
-                'filter',
-                'date',
+                'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\DateFilter',
                 print_r(123, true)
             )
         )->during('addAttributeFilter', [$date, '>', 123]);
@@ -210,8 +209,7 @@ class DateFilterSpec extends ObjectBehavior
             InvalidArgumentException::expected(
                 'release_date',
                 'a string with the format yyyy-mm-dd',
-                'filter',
-                'date',
+                'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\DateFilter',
                 'not a valid date format'
             )
         )->during('addAttributeFilter', [$date, '>', ['not a valid date format', 'WRONG']]);
@@ -225,8 +223,7 @@ class DateFilterSpec extends ObjectBehavior
             InvalidArgumentException::expected(
                 'release_date',
                 'array with 2 elements, string or \DateTime',
-                'filter',
-                'date',
+                'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\DateFilter',
                 123
             )
         )->during('addAttributeFilter', [$date, '>', [123, 123]]);
@@ -240,8 +237,7 @@ class DateFilterSpec extends ObjectBehavior
             InvalidArgumentException::expected(
                 'release_date',
                 'array with 2 elements, string or \DateTime',
-                'filter',
-                'date',
+                'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\DateFilter',
                 print_r([123, 123, 'three'], true)
             )
         )->during('addAttributeFilter', [$date, '>', [123, 123, 'three']]);

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/DateTimeFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/DateTimeFilterSpec.php
@@ -194,8 +194,7 @@ class DateTimeFilterSpec extends ObjectBehavior
             InvalidArgumentException::expected(
                 'updated',
                 'array with 2 elements, string or \DateTime',
-                'filter',
-                'date',
+                'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\DateTimeFilter',
                 print_r(123, true)
             )
         )->during('addFieldFilter', ['updated', '>', 123]);
@@ -205,7 +204,11 @@ class DateTimeFilterSpec extends ObjectBehavior
     {
         $this
             ->shouldThrow(
-                InvalidArgumentException::stringExpected('updated', 'filter', 'updated', 'integer')
+                InvalidArgumentException::stringExpected(
+                    'updated',
+                    'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\DateTimeFilter',
+                    'integer'
+                )
             )->during(
                 'addFieldFilter',
                 [
@@ -222,7 +225,7 @@ class DateTimeFilterSpec extends ObjectBehavior
     {
         $this
             ->shouldThrow(
-                InvalidArgumentException::numericExpected('updated', 'filter', 'updated', 'string')
+                InvalidArgumentException::numericExpected('updated', 'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\DateTimeFilter', 'string')
             )->during(
                 'addFieldFilter',
                 [
@@ -241,8 +244,7 @@ class DateTimeFilterSpec extends ObjectBehavior
             InvalidArgumentException::expected(
                 'updated',
                 'a string with the format yyyy-mm-dd H:i:s',
-                'filter',
-                'date',
+                'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\DateTimeFilter',
                 'not a valid date format'
             )
         )->during('addFieldFilter', ['updated', '>', ['not a valid date format', 'WRONG']]);
@@ -254,8 +256,7 @@ class DateTimeFilterSpec extends ObjectBehavior
             InvalidArgumentException::expected(
                 'updated',
                 'array with 2 elements, string or \DateTime',
-                'filter',
-                'date',
+                'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\DateTimeFilter',
                 123
             )
         )->during('addFieldFilter', ['updated', '>', [123, 123]]);
@@ -267,8 +268,7 @@ class DateTimeFilterSpec extends ObjectBehavior
             InvalidArgumentException::expected(
                 'updated',
                 'array with 2 elements, string or \DateTime',
-                'filter',
-                'date',
+                'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\DateTimeFilter',
                 print_r([123, 123, 'three'], true)
             )
         )->during('addFieldFilter', ['updated', '>', [123, 123, 'three']]);

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/FamilyFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/FamilyFilterSpec.php
@@ -152,13 +152,20 @@ class FamilyFilterSpec extends ObjectBehavior
 
     function it_throws_an_exception_if_value_is_not_an_array()
     {
-        $this->shouldThrow(InvalidArgumentException::arrayExpected('family', 'filter', 'family', gettype('not an array')))
-            ->during('addFieldFilter', ['family', 'IN', 'not an array']);
+        $this->shouldThrow(InvalidArgumentException::arrayExpected(
+            'family',
+            'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\FamilyFilter',
+            gettype('not an array')
+        ))->during('addFieldFilter', ['family', 'IN', 'not an array']);
     }
 
     function it_throws_an_exception_if_content_of_array_is_not_string_or_numeric_or_empty()
     {
-        $this->shouldThrow(InvalidArgumentException::stringExpected('family', 'filter', 'family', gettype(false)))
+        $this->shouldThrow(InvalidArgumentException::stringExpected(
+            'family',
+            'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\FamilyFilter',
+            gettype(false)
+        ))
             ->during('addFieldFilter', ['family', 'IN', ['a_code', false]]);
     }
 

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/GroupsFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/GroupsFilterSpec.php
@@ -145,16 +145,16 @@ class GroupsFilterSpec extends ObjectBehavior
 
     function it_throws_an_exception_if_value_is_not_an_array()
     {
-        $this->shouldThrow(InvalidArgumentException::arrayExpected('groups', 'filter', 'groups', gettype('not an array')))
+        $this->shouldThrow(InvalidArgumentException::arrayExpected('groups', 'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\GroupsFilter', gettype('not an array')))
             ->during('addFieldFilter', ['groups.id', 'IN', 'not an array']);
     }
 
     function it_throws_an_exception_if_content_of_array_is_not_string_or_numeric_or_empty()
     {
-        $this->shouldThrow(InvalidArgumentException::numericExpected('groups', 'filter', 'groups', gettype('WRONG')))
+        $this->shouldThrow(InvalidArgumentException::numericExpected('groups', 'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\GroupsFilter', gettype('WRONG')))
             ->during('addFieldFilter', ['groups.id', 'IN', [1, 2, 'WRONG']]);
 
-        $this->shouldThrow(InvalidArgumentException::stringExpected('groups', 'filter', 'groups', gettype(false)))
+        $this->shouldThrow(InvalidArgumentException::stringExpected('groups', 'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\GroupsFilter', gettype(false)))
             ->during('addFieldFilter', ['groups', 'IN', ['a_code', false]]);
     }
 

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/MediaFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/MediaFilterSpec.php
@@ -156,7 +156,11 @@ class MediaFilterSpec extends ObjectBehavior
         $image->getCode()->willReturn('media_code');
         $value = ['amount' => 132, 'unit' => 'foo'];
         $this->shouldThrow(
-            InvalidArgumentException::stringExpected('media_code', 'filter', 'media', gettype($value))
+            InvalidArgumentException::stringExpected(
+                'media_code',
+                'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\MediaFilter',
+                gettype($value)
+            )
         )->during('addAttributeFilter', [$image, '=', $value]);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/MetricFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/MetricFilterSpec.php
@@ -250,25 +250,45 @@ class MetricFilterSpec extends ObjectBehavior
 
         $value = ['unit' => 'foo'];
         $this->shouldThrow(
-            InvalidArgumentException::arrayKeyExpected('metric_code', 'amount', 'filter', 'metric', print_r($value, true))
+            InvalidArgumentException::arrayKeyExpected(
+                'metric_code',
+                'amount',
+                'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\MetricFilter',
+                print_r($value, true)
+            )
         )
             ->during('addAttributeFilter', [$attribute, '=', $value]);
 
         $value = ['amount' => 459];
         $this->shouldThrow(
-            InvalidArgumentException::arrayKeyExpected('metric_code', 'unit', 'filter', 'metric', print_r($value, true))
+            InvalidArgumentException::arrayKeyExpected(
+                'metric_code',
+                'unit',
+                'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\MetricFilter',
+                print_r($value, true)
+            )
         )
             ->during('addAttributeFilter', [$attribute, '=', $value]);
 
         $value = ['amount' => 'foo', 'unit' => 'foo'];
         $this->shouldThrow(
-            InvalidArgumentException::arrayNumericKeyExpected('metric_code', 'amount', 'filter', 'metric', 'string')
+            InvalidArgumentException::arrayNumericKeyExpected(
+                'metric_code',
+                'amount',
+                'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\MetricFilter',
+                'string'
+            )
         )
             ->during('addAttributeFilter', [$attribute, '=', $value]);
 
         $value = ['amount' => 132, 'unit' => 42];
         $this->shouldThrow(
-            InvalidArgumentException::arrayStringKeyExpected('metric_code', 'unit', 'filter', 'metric', 'integer')
+            InvalidArgumentException::arrayStringKeyExpected(
+                'metric_code',
+                'unit',
+                'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\MetricFilter',
+                'integer'
+            )
         )
             ->during('addAttributeFilter', [$attribute, '=', $value]);
     }
@@ -287,8 +307,7 @@ class MetricFilterSpec extends ObjectBehavior
                 'metric_code',
                 'unit',
                 'The unit does not exist in the attribute\'s family "length"',
-                'filter',
-                'metric',
+                'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\MetricFilter',
                 'foo'
             )
         )->during('addAttributeFilter', [$attribute, '=', $value]);

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/NumberFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/NumberFilterSpec.php
@@ -153,7 +153,7 @@ class NumberFilterSpec extends ObjectBehavior
     {
         $attribute->getCode()->willReturn('number_code');
 
-        $this->shouldThrow(InvalidArgumentException::numericExpected('number_code', 'filter', 'number', gettype('WRONG')))
+        $this->shouldThrow(InvalidArgumentException::numericExpected('number_code', 'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\NumberFilter', gettype('WRONG')))
             ->during('addAttributeFilter', [$attribute, '=', 'WRONG']);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/OptionFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/OptionFilterSpec.php
@@ -31,7 +31,10 @@ class OptionFilterSpec extends ObjectBehavior
 
     function it_is_initializable()
     {
-        $this->shouldHaveType('Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\OptionFilter');
+
+        $this->shouldHaveType(
+            'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\OptionFilter')
+        ;
     }
 
     function it_is_a_filter()
@@ -204,14 +207,22 @@ class OptionFilterSpec extends ObjectBehavior
     function it_throws_an_exception_if_value_is_not_an_array(AttributeInterface $attribute)
     {
         $attribute->getCode()->willReturn('option_code');
-        $this->shouldThrow(InvalidArgumentException::arrayExpected('option_code', 'filter', 'option', gettype('WRONG')))
+        $this->shouldThrow(InvalidArgumentException::arrayExpected(
+            'option_code',
+            'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\OptionFilter',
+            gettype('WRONG')
+        ))
             ->during('addAttributeFilter', [$attribute, 'IN', 'WRONG', null, null, ['field' => 'option_code.id']]);
     }
 
     function it_throws_an_exception_if_the_content_of_value_are_not_numeric(AttributeInterface $attribute)
     {
         $attribute->getCode()->willReturn('option_code');
-        $this->shouldThrow(InvalidArgumentException::numericExpected('option_code', 'filter', 'option', gettype('not numeric')))
+        $this->shouldThrow(InvalidArgumentException::numericExpected(
+            'option_code',
+            'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\OptionFilter',
+            gettype('not numeric')
+        ))
             ->during('addAttributeFilter', [$attribute, 'IN', [123, 'not numeric'], null, null, ['field' => 'option_code.id']]);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/OptionsFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/OptionsFilterSpec.php
@@ -199,7 +199,7 @@ class OptionsFilterSpec extends ObjectBehavior
     function it_throws_an_exception_if_the_content_of_value_are_not_numeric(AttributeInterface $attribute)
     {
         $attribute->getCode()->willReturn('options_code');
-        $this->shouldThrow(InvalidArgumentException::numericExpected('options_code', 'filter', 'options', gettype('not numeric')))
+        $this->shouldThrow(InvalidArgumentException::numericExpected('options_code', 'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\OptionsFilter', gettype('not numeric')))
             ->during('addAttributeFilter', [$attribute, 'IN', [123, 'not numeric'], null, null, ['field' => 'options_code.id']]);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/PriceFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/PriceFilterSpec.php
@@ -221,7 +221,12 @@ class PriceFilterSpec extends ObjectBehavior
 
         $value = ['currency' => 'foo'];
         $this->shouldThrow(
-            InvalidArgumentException::arrayKeyExpected('price_code', 'amount', 'filter', 'price', print_r($value, true))
+            InvalidArgumentException::arrayKeyExpected(
+                'price_code',
+                'amount',
+                'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\PriceFilter',
+                print_r($value, true)
+            )
         )
             ->during('addAttributeFilter', [$attribute, '=', $value]);
 
@@ -230,21 +235,30 @@ class PriceFilterSpec extends ObjectBehavior
             InvalidArgumentException::arrayKeyExpected(
                 'price_code',
                 'currency',
-                'filter',
-                'price',
+                'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\PriceFilter',
                 print_r($value, true)
             )
         )->during('addAttributeFilter', [$attribute, '=', $value]);
 
         $value = ['amount' => 'foo', 'currency' => 'foo'];
         $this->shouldThrow(
-            InvalidArgumentException::arrayNumericKeyExpected('price_code', 'amount', 'filter', 'price', 'string')
+            InvalidArgumentException::arrayNumericKeyExpected(
+                'price_code',
+                'amount',
+                'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\PriceFilter',
+                'string'
+            )
         )
             ->during('addAttributeFilter', [$attribute, '=', $value]);
 
         $value = ['amount' => 132, 'currency' => 42];
         $this->shouldThrow(
-            InvalidArgumentException::arrayStringKeyExpected('price_code', 'currency', 'filter', 'price', 'integer')
+            InvalidArgumentException::arrayStringKeyExpected(
+                'price_code',
+                'currency',
+                'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\PriceFilter',
+                'integer'
+            )
         )->during('addAttributeFilter', [$attribute, '=', $value]);
     }
 
@@ -259,8 +273,7 @@ class PriceFilterSpec extends ObjectBehavior
                 'price_code',
                 'currency',
                 'The currency does not exist',
-                'filter',
-                'price',
+                'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\PriceFilter',
                 'FOO'
             )
         )->during('addAttributeFilter', [$attribute, '=', $value]);

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/ProductIdFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/ProductIdFilterSpec.php
@@ -32,7 +32,11 @@ class ProductIdFilterSpec extends ObjectBehavior
 
     function it_throws_an_exception_if_value_is_not_a_numeric_or_an_array()
     {
-        $this->shouldThrow(InvalidArgumentException::expected('id', 'array or string value', 'filter', 'productId', 1234))
+        $this->shouldThrow(InvalidArgumentException::expected(
+            'id',
+            'array or string value',
+            'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\ProductIdFilter',
+            1234))
             ->during('addFieldFilter', ['id', '=', 1234]);
     }
 

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/StringFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/StringFilterSpec.php
@@ -183,8 +183,11 @@ class StringFilterSpec extends ObjectBehavior
     {
         $attribute->getCode()->willReturn('attributeCode');
 
-        $this->shouldThrow(InvalidArgumentException::stringExpected('attributeCode', 'filter', 'string', gettype(123)))
-            ->during('addAttributeFilter', [$attribute, '=', 123, null, null, ['field' => 'attributeCode']]);
+        $this->shouldThrow(InvalidArgumentException::stringExpected(
+            'attributeCode',
+            'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\StringFilter',
+            gettype(123)
+        ))->during('addAttributeFilter', [$attribute, '=', 123, null, null, ['field' => 'attributeCode']]);
     }
 
     function it_throws_an_exception_when_locale_is_expected(
@@ -196,7 +199,11 @@ class StringFilterSpec extends ObjectBehavior
         $attribute->isLocalizable()->willReturn(true);
         $attrValidatorHelper->validateLocale($attribute, null)->willThrow($e);
         $this->shouldThrow(
-            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'filter', 'string')
+            InvalidArgumentException::expectedFromPreviousException(
+                $e,
+                'attributeCode',
+                'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\StringFilter'
+            )
         )->during('addAttributeFilter', [$attribute, '=', 123, null, null, ['field' => 'attributeCode']]);
     }
 
@@ -209,7 +216,7 @@ class StringFilterSpec extends ObjectBehavior
         $attribute->isLocalizable()->willReturn(false);
         $attrValidatorHelper->validateLocale($attribute, 'en_US')->willThrow($e);
         $this->shouldThrow(
-            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'filter', 'string')
+            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\StringFilter')
         )->during('addAttributeFilter', [$attribute, '=', 123, 'en_US', 'ecommerce', ['field' => 'attributeCode']]);
     }
 
@@ -222,7 +229,7 @@ class StringFilterSpec extends ObjectBehavior
         $attribute->isLocalizable()->willReturn(true);
         $attrValidatorHelper->validateLocale($attribute, 'uz-UZ')->willThrow($e);
         $this->shouldThrow(
-            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'filter', 'string')
+            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\StringFilter')
         )->during('addAttributeFilter', [$attribute, '=', 123, 'uz-UZ', 'ecommerce', ['field' => 'attributeCode']]);
     }
 
@@ -237,7 +244,7 @@ class StringFilterSpec extends ObjectBehavior
         $attrValidatorHelper->validateLocale($attribute, null)->shouldBeCalled();
         $attrValidatorHelper->validateScope($attribute, null)->willThrow($e);
         $this->shouldThrow(
-            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'filter', 'string')
+            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\StringFilter')
         )->during('addAttributeFilter', [$attribute, '=', 123, null, null, ['field' => 'attributeCode']]);
     }
 
@@ -252,7 +259,7 @@ class StringFilterSpec extends ObjectBehavior
         $attrValidatorHelper->validateLocale($attribute, null)->shouldBeCalled();
         $attrValidatorHelper->validateScope($attribute, 'ecommerce')->willThrow($e);
         $this->shouldThrow(
-            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'filter', 'string')
+            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\StringFilter')
         )->during('addAttributeFilter', [$attribute, '=', 123, null, 'ecommerce', ['field' => 'attributeCode']]);
     }
 
@@ -267,7 +274,7 @@ class StringFilterSpec extends ObjectBehavior
         $attrValidatorHelper->validateLocale($attribute, null)->shouldBeCalled();
         $attrValidatorHelper->validateScope($attribute, 'ecommerce')->willThrow($e);
         $this->shouldThrow(
-            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'filter', 'string')
+            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\StringFilter')
         )->during('addAttributeFilter', [$attribute, '=', 123, null, 'ecommerce', ['field' => 'attributeCode']]);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/BooleanFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/BooleanFilterSpec.php
@@ -50,8 +50,11 @@ class BooleanFilterSpec extends ObjectBehavior
 
     function it_throws_an_exception_if_value_is_not_a_boolean()
     {
-        $this->shouldThrow(InvalidArgumentException::booleanExpected('enabled', 'filter', 'boolean', gettype('fuu')))
-            ->during('addFieldFilter', ['enabled', '=', 'fuu']);
+        $this->shouldThrow(InvalidArgumentException::booleanExpected(
+            'enabled',
+            'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\BooleanFilter',
+            gettype('fuu')
+        ))->during('addFieldFilter', ['enabled', '=', 'fuu']);
     }
 
     function it_adds_an_equal_filter_on_a_field_in_the_query(

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/CompletenessFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/CompletenessFilterSpec.php
@@ -329,7 +329,7 @@ class CompletenessFilterSpec extends ObjectBehavior
 
     function it_throws_an_exception_if_value_is_not_a_integer()
     {
-        $this->shouldThrow(InvalidArgumentException::numericExpected('completeness', 'filter', 'completeness', gettype('123')))
+        $this->shouldThrow(InvalidArgumentException::numericExpected('completeness', 'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\CompletenessFilter', gettype('123')))
             ->during('addFieldFilter', ['completeness', '=', '12z3', 'en_US', 'mobile']);
     }
 
@@ -340,8 +340,7 @@ class CompletenessFilterSpec extends ObjectBehavior
                 InvalidArgumentException::arrayKeyExpected(
                     'completeness',
                     'locales',
-                    'filter',
-                    'completeness',
+                    'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\CompletenessFilter',
                     print_r([], true)
                 )
             )
@@ -361,8 +360,7 @@ class CompletenessFilterSpec extends ObjectBehavior
             ->shouldThrow(
                 InvalidArgumentException::arrayOfArraysExpected(
                     'completeness',
-                    'filter',
-                    'completeness',
+                    'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\CompletenessFilter',
                     print_r(['locales' => 'fr_FR'], true)
                 )
             )

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/DateFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/DateFilterSpec.php
@@ -334,7 +334,12 @@ class DateFilterSpec extends ObjectBehavior
         $attribute->getCode()->willReturn('release_date');
 
         $this->shouldThrow(
-            InvalidArgumentException::expected('release_date', 'array with 2 elements, string or \DateTime', 'filter', 'date', print_r(123, true))
+            InvalidArgumentException::expected(
+                'release_date',
+                'array with 2 elements, string or \DateTime',
+                'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\DateFilter',
+                print_r(123, true)
+            )
         )->during('addAttributeFilter', [$attribute, '>', 123]);
     }
 
@@ -343,7 +348,12 @@ class DateFilterSpec extends ObjectBehavior
         $attribute->getCode()->willReturn('release_date');
 
         $this->shouldThrow(
-            InvalidArgumentException::expected('release_date', 'a string with the format yyyy-mm-dd', 'filter', 'date', 'not a valid date format')
+            InvalidArgumentException::expected(
+                'release_date',
+                'a string with the format yyyy-mm-dd',
+                'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\DateFilter',
+                'not a valid date format'
+            )
         )->during('addAttributeFilter', [$attribute, '>', ['not a valid date format', 'WRONG']]);
     }
 
@@ -355,8 +365,7 @@ class DateFilterSpec extends ObjectBehavior
             InvalidArgumentException::expected(
                 'release_date',
                 'array with 2 elements, string or \DateTime',
-                'filter',
-                'date',
+                'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\DateFilter',
                 123
             )
         )->during('addAttributeFilter', [$attribute, '>', [123, 123]]);
@@ -370,8 +379,7 @@ class DateFilterSpec extends ObjectBehavior
             InvalidArgumentException::expected(
                 'release_date',
                 'array with 2 elements, string or \DateTime',
-                'filter',
-                'date',
+                'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\DateFilter',
                 print_r([123, 123, 'three'], true)
             )
         )->during('addAttributeFilter', [$attribute, '>', [123, 123, 'three']]);

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/DateTimeFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/DateTimeFilterSpec.php
@@ -275,7 +275,11 @@ class DateTimeFilterSpec extends ObjectBehavior
     {
         $this
             ->shouldThrow(
-                InvalidArgumentException::stringExpected('updated', 'filter', 'updated', 'integer')
+                InvalidArgumentException::stringExpected(
+                    'updated',
+                    'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\DateTimeFilter',
+                    'integer'
+                )
             )->during(
                 'addFieldFilter',
                 [
@@ -292,7 +296,11 @@ class DateTimeFilterSpec extends ObjectBehavior
     {
         $this
             ->shouldThrow(
-                InvalidArgumentException::numericExpected('updated', 'filter', 'updated', 'string')
+                InvalidArgumentException::numericExpected(
+                    'updated',
+                    'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\DateTimeFilter',
+                    'string'
+                )
             )->during(
                 'addFieldFilter',
                 [
@@ -308,14 +316,24 @@ class DateTimeFilterSpec extends ObjectBehavior
     function it_throws_an_exception_if_value_is_not_a_string_an_array_or_a_datetime()
     {
         $this->shouldThrow(
-            InvalidArgumentException::expected('updated_at', 'array with 2 elements, string or \DateTime', 'filter', 'date', print_r(123, true))
+            InvalidArgumentException::expected(
+                'updated_at',
+                'array with 2 elements, string or \DateTime',
+                'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\DateTimeFilter',
+                print_r(123, true)
+            )
         )->during('addFieldFilter', ['updated_at', '>', 123]);
     }
 
     function it_throws_an_error_if_data_is_not_a_valid_date_format()
     {
         $this->shouldThrow(
-            InvalidArgumentException::expected('updated_at', 'a string with the format yyyy-mm-dd H:i:s', 'filter', 'date', 'not a valid date format')
+            InvalidArgumentException::expected(
+                'updated_at',
+                'a string with the format yyyy-mm-dd H:i:s',
+                'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\DateTimeFilter',
+                'not a valid date format'
+            )
         )->during('addFieldFilter', ['updated_at', '>', ['not a valid date format', 'WRONG']]);
     }
 
@@ -325,8 +343,7 @@ class DateTimeFilterSpec extends ObjectBehavior
             InvalidArgumentException::expected(
                 'updated_at',
                 'array with 2 elements, string or \DateTime',
-                'filter',
-                'date',
+                'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\DateTimeFilter',
                 123
             )
         )->during('addFieldFilter', ['updated_at', '>', [123, 123]]);
@@ -338,8 +355,7 @@ class DateTimeFilterSpec extends ObjectBehavior
             InvalidArgumentException::expected(
                 'updated_at',
                 'array with 2 elements, string or \DateTime',
-                'filter',
-                'date',
+                'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\DateTimeFilter',
                 print_r([123, 123, 'three'], true)
             )
         )->during('addFieldFilter', ['updated_at', '>', [123, 123, 'three']]);

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/FamilyFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/FamilyFilterSpec.php
@@ -142,11 +142,19 @@ class FamilyFilterSpec extends ObjectBehavior
 
     function it_throws_an_exception_if_value_is_not_an_array()
     {
-        $this->shouldThrow(InvalidArgumentException::arrayExpected('family', 'filter', 'family', gettype('WRONG')))->during('addFieldFilter', ['family', 'IN', 'WRONG']);
+        $this->shouldThrow(InvalidArgumentException::arrayExpected(
+            'family',
+            'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\FamilyFilter',
+            gettype('WRONG')
+        ))->during('addFieldFilter', ['family', 'IN', 'WRONG']);
     }
 
     function it_throws_an_exception_if_values_in_array_are_not_strings_or_numerics()
     {
-        $this->shouldThrow(InvalidArgumentException::stringExpected('family', 'filter', 'family', gettype(false)))->during('addFieldFilter', ['family', 'IN', [false]]);
+        $this->shouldThrow(InvalidArgumentException::stringExpected(
+            'family',
+            'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\FamilyFilter',
+            gettype(false)
+        ))->during('addFieldFilter', ['family', 'IN', [false]]);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/GroupsFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/GroupsFilterSpec.php
@@ -149,11 +149,19 @@ class GroupsFilterSpec extends ObjectBehavior
 
     function it_throws_an_exception_if_value_is_not_an_array()
     {
-        $this->shouldThrow(InvalidArgumentException::arrayExpected('groups', 'filter', 'groups', gettype('WRONG')))->during('addFieldFilter', ['groups', 'IN', 'WRONG']);
+        $this->shouldThrow(InvalidArgumentException::arrayExpected(
+            'groups',
+            'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\GroupsFilter',
+            gettype('WRONG')
+        ))->during('addFieldFilter', ['groups', 'IN', 'WRONG']);
     }
 
     function it_throws_an_exception_if_values_in_array_are_not_strings_or_numerics()
     {
-        $this->shouldThrow(InvalidArgumentException::stringExpected('groups', 'filter', 'groups', gettype(false)))->during('addFieldFilter', ['groups', 'IN', [false]]);
+        $this->shouldThrow(InvalidArgumentException::stringExpected(
+            'groups',
+            'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\GroupsFilter',
+            gettype(false)
+        ))->during('addFieldFilter', ['groups', 'IN', [false]]);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/MediaFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/MediaFilterSpec.php
@@ -239,7 +239,11 @@ class MediaFilterSpec extends ObjectBehavior
         $attribute->getCode()->willReturn('media_code');
         $value = ['amount' => 132, 'unit' => 'foo'];
         $this->shouldThrow(
-            InvalidArgumentException::stringExpected('media_code', 'filter', 'media', gettype($value))
+            InvalidArgumentException::stringExpected(
+                'media_code',
+                'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\MediaFilter',
+                gettype($value)
+            )
         )->during('addAttributeFilter', [$attribute, '=', $value]);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/MetricFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/MetricFilterSpec.php
@@ -139,25 +139,45 @@ class MetricFilterSpec extends ObjectBehavior
 
         $value = ['unit' => 'foo'];
         $this->shouldThrow(
-            InvalidArgumentException::arrayKeyExpected('metric_code', 'amount', 'filter', 'metric', print_r($value, true))
+            InvalidArgumentException::arrayKeyExpected(
+                'metric_code',
+                'amount',
+                'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\MetricFilter',
+                print_r($value, true)
+            )
         )
             ->during('addAttributeFilter', [$attribute, '=', $value]);
 
         $value = ['amount' => 459];
         $this->shouldThrow(
-            InvalidArgumentException::arrayKeyExpected('metric_code', 'unit', 'filter', 'metric', print_r($value, true))
+            InvalidArgumentException::arrayKeyExpected(
+                'metric_code',
+                'unit',
+                'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\MetricFilter',
+                print_r($value, true)
+            )
         )
             ->during('addAttributeFilter', [$attribute, '=', $value]);
 
         $value = ['amount' => 'foo', 'unit' => 'foo'];
         $this->shouldThrow(
-            InvalidArgumentException::arrayNumericKeyExpected('metric_code', 'amount', 'filter', 'metric', 'string')
+            InvalidArgumentException::arrayNumericKeyExpected(
+                'metric_code',
+                'amount',
+                'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\MetricFilter',
+                'string'
+            )
         )
             ->during('addAttributeFilter', [$attribute, '=', $value]);
 
         $value = ['amount' => 132, 'unit' => 42];
         $this->shouldThrow(
-            InvalidArgumentException::arrayStringKeyExpected('metric_code', 'unit', 'filter', 'metric', 'integer')
+            InvalidArgumentException::arrayStringKeyExpected(
+                'metric_code',
+                'unit',
+                'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\MetricFilter',
+                'integer'
+            )
         )
             ->during('addAttributeFilter', [$attribute, '=', $value]);
     }
@@ -174,8 +194,7 @@ class MetricFilterSpec extends ObjectBehavior
                 'metric_code',
                 'unit',
                 'The unit does not exist in the attribute\'s family "length"',
-                'filter',
-                'metric',
+                'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\MetricFilter',
                 'foo'
             )
         )->during('addAttributeFilter', [$attribute, '=', $value]);

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/NumberFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/NumberFilterSpec.php
@@ -136,7 +136,9 @@ class NumberFilterSpec extends ObjectBehavior
     function it_throws_an_exception_if_value_is_not_a_numeric(AttributeInterface $attribute)
     {
         $attribute->getCode()->willReturn('number_code');
-        $this->shouldThrow(InvalidArgumentException::numericExpected('number_code', 'filter', 'number', gettype('WRONG')))
-            ->during('addAttributeFilter', [$attribute, '=', 'WRONG']);
+        $this->shouldThrow(InvalidArgumentException::numericExpected(
+            'number_code', 'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\NumberFilter',
+            gettype('WRONG')
+        ))->during('addAttributeFilter', [$attribute, '=', 'WRONG']);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/OptionFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/OptionFilterSpec.php
@@ -166,13 +166,15 @@ class OptionFilterSpec extends ObjectBehavior
     function it_throws_an_exception_if_value_is_not_an_array(AttributeInterface $attribute)
     {
         $attribute->getCode()->willReturn('option_code');
-        $this->shouldThrow(InvalidArgumentException::arrayExpected('option_code', 'filter', 'option', gettype('WRONG')))->during('addAttributeFilter', [$attribute, 'IN', 'WRONG', null, null, ['field' => 'option_code.id']]);
+        $this->shouldThrow(InvalidArgumentException::arrayExpected('option_code', 'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\OptionFilter', gettype('WRONG')))->during('addAttributeFilter', [$attribute, 'IN', 'WRONG', null, null, ['field' => 'option_code.id']]);
     }
 
     function it_throws_an_exception_if_the_content_of_value_are_not_numeric(AttributeInterface $attribute)
     {
         $attribute->getCode()->willReturn('option_code');
-        $this->shouldThrow(InvalidArgumentException::numericExpected('option_code', 'filter', 'option', gettype('not numeric')))
-            ->during('addAttributeFilter', [$attribute, 'IN', [123, 'not numeric'], null, null, ['field' => 'option_code.id']]);
+        $this->shouldThrow(InvalidArgumentException::numericExpected(
+            'option_code', 'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\OptionFilter',
+            gettype('not numeric')
+        ))->during('addAttributeFilter', [$attribute, 'IN', [123, 'not numeric'], null, null, ['field' => 'option_code.id']]);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/OptionsFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/OptionsFilterSpec.php
@@ -206,14 +206,20 @@ class OptionsFilterSpec extends ObjectBehavior
     function it_throws_an_exception_if_value_is_not_an_array(AttributeInterface $attribute)
     {
         $attribute->getCode()->willReturn('options_code');
-        $this->shouldThrow(InvalidArgumentException::arrayExpected('options_code', 'filter', 'options', gettype('WRONG')))
-            ->during('addAttributeFilter', [$attribute, 'IN', 'WRONG', null, null, ['field' => 'options_code.id']]);
+        $this->shouldThrow(InvalidArgumentException::arrayExpected(
+            'options_code',
+            'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\OptionsFilter',
+            gettype('WRONG')
+        ))->during('addAttributeFilter', [$attribute, 'IN', 'WRONG', null, null, ['field' => 'options_code.id']]);
     }
 
     function it_throws_an_exception_if_the_content_of_value_are_not_numeric(AttributeInterface $attribute)
     {
         $attribute->getCode()->willReturn('options_code');
-        $this->shouldThrow(InvalidArgumentException::numericExpected('options_code', 'filter', 'options', gettype('WRONG')))
-            ->during('addAttributeFilter', [$attribute, 'IN', [123, 'not numeric'], null, null, ['field' => 'options_code.id']]);
+        $this->shouldThrow(InvalidArgumentException::numericExpected(
+            'options_code',
+            'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\OptionsFilter',
+            gettype('WRONG')
+        ))->during('addAttributeFilter', [$attribute, 'IN', [123, 'not numeric'], null, null, ['field' => 'options_code.id']]);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/PriceFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/PriceFilterSpec.php
@@ -303,7 +303,12 @@ class PriceFilterSpec extends ObjectBehavior
 
         $value = ['currency' => 'foo'];
         $this->shouldThrow(
-            InvalidArgumentException::arrayKeyExpected('price_code', 'amount', 'filter', 'price', print_r($value, true))
+            InvalidArgumentException::arrayKeyExpected(
+                'price_code',
+                'amount',
+                'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\PriceFilter',
+                print_r($value, true)
+            )
         )
             ->during('addAttributeFilter', [$attribute, '=', $value]);
 
@@ -312,8 +317,7 @@ class PriceFilterSpec extends ObjectBehavior
             InvalidArgumentException::arrayKeyExpected(
                 'price_code',
                 'currency',
-                'filter',
-                'price',
+                'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\PriceFilter',
                 print_r($value, true)
             )
         )
@@ -321,13 +325,23 @@ class PriceFilterSpec extends ObjectBehavior
 
         $value = ['amount' => 'foo', 'currency' => 'foo'];
         $this->shouldThrow(
-            InvalidArgumentException::arrayNumericKeyExpected('price_code', 'amount', 'filter', 'price', 'string')
+            InvalidArgumentException::arrayNumericKeyExpected(
+                'price_code',
+                'amount',
+                'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\PriceFilter',
+                'string'
+            )
         )
             ->during('addAttributeFilter', [$attribute, '=', $value]);
 
         $value = ['amount' => 132, 'currency' => 42];
         $this->shouldThrow(
-            InvalidArgumentException::arrayStringKeyExpected('price_code', 'currency', 'filter', 'price', 'integer')
+            InvalidArgumentException::arrayStringKeyExpected(
+                'price_code',
+                'currency',
+                'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\PriceFilter',
+                'integer'
+            )
         )
             ->during('addAttributeFilter', [$attribute, '=', $value]);
     }
@@ -343,8 +357,7 @@ class PriceFilterSpec extends ObjectBehavior
                 'price_code',
                 'currency',
                 'The currency does not exist',
-                'filter',
-                'price',
+                'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\PriceFilter',
                 'FOO'
             )
         )->during('addAttributeFilter', [$attribute, '=', $value]);

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/ProductIdFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/ProductIdFilterSpec.php
@@ -43,6 +43,11 @@ class ProductIdFilterSpec extends ObjectBehavior
 
     function it_throws_an_exception_if_value_is_not_a_numeric_or_an_array()
     {
-        $this->shouldThrow(InvalidArgumentException::expected('id', 'array or numeric value', 'filter', 'productId', 'WRONG'))->during('addFieldFilter', ['id', '=', 'WRONG']);
+        $this->shouldThrow(InvalidArgumentException::expected(
+            'id',
+            'array or numeric value',
+            'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\ProductIdFilter',
+            'WRONG'
+        ))->during('addFieldFilter', ['id', '=', 'WRONG']);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/StringFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/StringFilterSpec.php
@@ -229,8 +229,11 @@ class StringFilterSpec extends ObjectBehavior
     function it_throws_an_exception_if_value_is_not_a_string(AttributeInterface $attribute)
     {
         $attribute->getCode()->willReturn('attributeCode');
-        $this->shouldThrow(InvalidArgumentException::stringExpected('attributeCode', 'filter', 'string', gettype(123)))
-            ->during('addAttributeFilter', [$attribute, '=', 123, null, null, ['field' => 'attributeCode']]);
+        $this->shouldThrow(InvalidArgumentException::stringExpected(
+            'attributeCode',
+            'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\StringFilter',
+            gettype(123)
+        ))->during('addAttributeFilter', [$attribute, '=', 123, null, null, ['field' => 'attributeCode']]);
     }
 
     function it_throws_an_exception_when_locale_is_expected(
@@ -242,7 +245,7 @@ class StringFilterSpec extends ObjectBehavior
         $attribute->isLocalizable()->willReturn(true);
         $attrValidatorHelper->validateLocale($attribute, null)->willThrow($e);
         $this->shouldThrow(
-            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'filter', 'string')
+            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\StringFilter')
         )->during('addAttributeFilter', [$attribute, '=', 123, null, null, ['field' => 'attributeCode']]);
     }
 
@@ -255,7 +258,7 @@ class StringFilterSpec extends ObjectBehavior
         $attribute->isLocalizable()->willReturn(false);
         $attrValidatorHelper->validateLocale($attribute, 'en_US')->willThrow($e);
         $this->shouldThrow(
-            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'filter', 'string')
+            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\StringFilter')
         )->during('addAttributeFilter', [$attribute, '=', 123, 'en_US', 'ecommerce', ['field' => 'attributeCode']]);
     }
 
@@ -268,7 +271,7 @@ class StringFilterSpec extends ObjectBehavior
         $attribute->isLocalizable()->willReturn(true);
         $attrValidatorHelper->validateLocale($attribute, 'uz-UZ')->willThrow($e);
         $this->shouldThrow(
-            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'filter', 'string')
+            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\StringFilter')
         )->during('addAttributeFilter', [$attribute, '=', 123, 'uz-UZ', 'ecommerce', ['field' => 'attributeCode']]);
     }
 
@@ -283,7 +286,7 @@ class StringFilterSpec extends ObjectBehavior
         $attrValidatorHelper->validateLocale($attribute, null)->shouldBeCalled();
         $attrValidatorHelper->validateScope($attribute, null)->willThrow($e);
         $this->shouldThrow(
-            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'filter', 'string')
+            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\StringFilter')
         )->during('addAttributeFilter', [$attribute, '=', 123, null, null, ['field' => 'attributeCode']]);
     }
 
@@ -298,7 +301,7 @@ class StringFilterSpec extends ObjectBehavior
         $attrValidatorHelper->validateLocale($attribute, null)->shouldBeCalled();
         $attrValidatorHelper->validateScope($attribute, 'ecommerce')->willThrow($e);
         $this->shouldThrow(
-            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'filter', 'string')
+            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\StringFilter')
         )->during('addAttributeFilter', [$attribute, '=', 123, null, 'ecommerce', ['field' => 'attributeCode']]);
     }
 
@@ -313,7 +316,7 @@ class StringFilterSpec extends ObjectBehavior
         $attrValidatorHelper->validateLocale($attribute, null)->shouldBeCalled();
         $attrValidatorHelper->validateScope($attribute, 'ecommerce')->willThrow($e);
         $this->shouldThrow(
-            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'filter', 'string')
+            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\StringFilter')
         )->during('addAttributeFilter', [$attribute, '=', 123, null, 'ecommerce', ['field' => 'attributeCode']]);
     }
 }

--- a/src/Pim/Bundle/ReferenceDataBundle/Doctrine/MongoDB/Filter/ReferenceDataFilter.php
+++ b/src/Pim/Bundle/ReferenceDataBundle/Doctrine/MongoDB/Filter/ReferenceDataFilter.php
@@ -119,10 +119,10 @@ class ReferenceDataFilter extends AbstractAttributeFilter implements AttributeFi
      */
     protected function checkValue($field, $values)
     {
-        FieldFilterHelper::checkArray($field, $values, 'reference_data');
+        FieldFilterHelper::checkArray($field, $values, static::class);
 
         foreach ($values as $value) {
-            FieldFilterHelper::checkIdentifier($field, $value, 'reference_data');
+            FieldFilterHelper::checkIdentifier($field, $value, static::class);
         }
     }
 
@@ -141,8 +141,7 @@ class ReferenceDataFilter extends AbstractAttributeFilter implements AttributeFi
                 $attribute->getCode(),
                 'code',
                 $e->getMessage(),
-                'setter',
-                'reference data',
+                static::class,
                 implode(',', $value)
             );
         }

--- a/src/Pim/Bundle/ReferenceDataBundle/Doctrine/ORM/Filter/ReferenceDataFilter.php
+++ b/src/Pim/Bundle/ReferenceDataBundle/Doctrine/ORM/Filter/ReferenceDataFilter.php
@@ -73,12 +73,11 @@ class ReferenceDataFilter extends AbstractAttributeFilter implements AttributeFi
             throw InvalidArgumentException::expectedFromPreviousException(
                 $e,
                 $attribute->getCode(),
-                'filter',
-                'reference data simple select'
+                static::class
             );
         }
 
-        $this->checkLocaleAndScope($attribute, $locale, $scope, 'reference_data');
+        $this->checkLocaleAndScope($attribute, $locale, $scope);
 
         if (Operators::IS_EMPTY !== $operator) {
             $field = $options['field'];
@@ -181,10 +180,10 @@ class ReferenceDataFilter extends AbstractAttributeFilter implements AttributeFi
      */
     protected function checkValue($field, $values)
     {
-        FieldFilterHelper::checkArray($field, $values, 'reference_data');
+        FieldFilterHelper::checkArray($field, $values, static::class);
 
         foreach ($values as $value) {
-            FieldFilterHelper::checkIdentifier($field, $value, 'reference_data');
+            FieldFilterHelper::checkIdentifier($field, $value, static::class);
         }
     }
 
@@ -203,8 +202,7 @@ class ReferenceDataFilter extends AbstractAttributeFilter implements AttributeFi
                 $attribute->getCode(),
                 'code',
                 $e->getMessage(),
-                'setter',
-                'reference data',
+                static::class,
                 implode(',', $value)
             );
         }

--- a/src/Pim/Bundle/ReferenceDataBundle/spec/Doctrine/MongoDB/Filter/ReferenceDataFilterSpec.php
+++ b/src/Pim/Bundle/ReferenceDataBundle/spec/Doctrine/MongoDB/Filter/ReferenceDataFilterSpec.php
@@ -145,13 +145,21 @@ class ReferenceDataFilterSpec extends ObjectBehavior
 
         $value = 'string';
         $this->shouldThrow(
-            InvalidArgumentException::arrayExpected('color', 'filter', 'reference_data', $value)
+            InvalidArgumentException::arrayExpected(
+                'color',
+                'Pim\Bundle\ReferenceDataBundle\Doctrine\MongoDB\Filter\ReferenceDataFilter',
+                $value
+            )
         )
             ->during('addAttributeFilter', [$attribute, '=', $value, null, null, ['field' => 'color']]);
 
         $value = [false];
         $this->shouldThrow(
-            InvalidArgumentException::stringExpected('color', 'filter', 'reference_data', 'boolean')
+            InvalidArgumentException::stringExpected(
+                'color',
+                'Pim\Bundle\ReferenceDataBundle\Doctrine\MongoDB\Filter\ReferenceDataFilter',
+                'boolean'
+            )
         )
             ->during('addAttributeFilter', [$attribute, '=', $value, null, null, ['field' => 'color']]);
     }

--- a/src/Pim/Bundle/ReferenceDataBundle/spec/Doctrine/ORM/Filter/ReferenceDataFilterSpec.php
+++ b/src/Pim/Bundle/ReferenceDataBundle/spec/Doctrine/ORM/Filter/ReferenceDataFilterSpec.php
@@ -172,13 +172,21 @@ class ReferenceDataFilterSpec extends ObjectBehavior
 
         $value = 'string';
         $this->shouldThrow(
-            InvalidArgumentException::arrayExpected('color', 'filter', 'reference_data', $value)
+            InvalidArgumentException::arrayExpected(
+                'color',
+                'Pim\Bundle\ReferenceDataBundle\Doctrine\ORM\Filter\ReferenceDataFilter',
+                $value
+            )
         )
             ->during('addAttributeFilter', [$attribute, '=', $value, null, null, ['field' => 'color']]);
 
         $value = [false];
         $this->shouldThrow(
-            InvalidArgumentException::stringExpected('color', 'filter', 'reference_data', 'boolean')
+            InvalidArgumentException::stringExpected(
+                'color',
+                'Pim\Bundle\ReferenceDataBundle\Doctrine\ORM\Filter\ReferenceDataFilter',
+                'boolean'
+            )
         )
             ->during('addAttributeFilter', [$attribute, '=', $value, null, null, ['field' => 'color']]);
     }

--- a/src/Pim/Component/Catalog/Exception/InvalidArgumentException.php
+++ b/src/Pim/Component/Catalog/Exception/InvalidArgumentException.php
@@ -32,18 +32,34 @@ class InvalidArgumentException extends \InvalidArgumentException
     const SCOPE_EXPECTED_CODE = 302;
     const ASSOCIATION_FORMAT_EXPECTED_CODE = 303;
 
+    /** @var string */
+    protected $className;
+
+    /**
+     * @param string          $className
+     * @param string          $message
+     * @param int             $code
+     * @param \Exception|null $previous
+     */
+    public function __construct($className, $message = '', $code = 0, \Exception $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+
+        $this->className = $className;
+    }
+
     /**
      * @param string $name
      * @param string $expected
-     * @param string $action
-     * @param string $type
+     * @param string $className
      * @param string $data
      *
      * @return InvalidArgumentException
      */
-    public static function expected($name, $expected, $action, $type, $data)
+    public static function expected($name, $expected, $className, $data)
     {
         return new self(
+            $className,
             sprintf(
                 'Attribute or field "%s" expects %s as data, "%s" given (for %s %s).',
                 $name,
@@ -58,15 +74,15 @@ class InvalidArgumentException extends \InvalidArgumentException
 
     /**
      * @param string $name
-     * @param string $action
-     * @param string $type
+     * @param string $className
      * @param string $data
      *
      * @return InvalidArgumentException
      */
-    public static function booleanExpected($name, $action, $type, $data)
+    public static function booleanExpected($name, $className, $data)
     {
         return new self(
+            $className,
             sprintf(
                 'Attribute or field "%s" expects a boolean as data, "%s" given (for %s %s).',
                 $name,
@@ -80,15 +96,15 @@ class InvalidArgumentException extends \InvalidArgumentException
 
     /**
      * @param string $name
-     * @param string $action
-     * @param string $type
+     * @param string $className
      * @param string $data
      *
      * @return InvalidArgumentException
      */
-    public static function floatExpected($name, $action, $type, $data)
+    public static function floatExpected($name, $className, $data)
     {
         return new self(
+            $className,
             sprintf(
                 'Attribute or field "%s" expects a float as data, "%s" given (for %s %s).',
                 $name,
@@ -102,15 +118,15 @@ class InvalidArgumentException extends \InvalidArgumentException
 
     /**
      * @param string $name
-     * @param string $action
-     * @param string $type
+     * @param string $className
      * @param string $data
      *
      * @return InvalidArgumentException
      */
-    public static function integerExpected($name, $action, $type, $data)
+    public static function integerExpected($name, $className, $data)
     {
         return new self(
+            $className,
             sprintf(
                 'Attribute or field "%s" expects an integer as data, "%s" given (for %s %s).',
                 $name,
@@ -124,15 +140,15 @@ class InvalidArgumentException extends \InvalidArgumentException
 
     /**
      * @param string $name
-     * @param string $action
-     * @param string $type
+     * @param string $className
      * @param string $data
      *
      * @return InvalidArgumentException
      */
-    public static function numericExpected($name, $action, $type, $data)
+    public static function numericExpected($name, $className, $data)
     {
         return new self(
+            $className,
             sprintf(
                 'Attribute or field "%s" expects a numeric as data, "%s" given (for %s %s).',
                 $name,
@@ -146,15 +162,15 @@ class InvalidArgumentException extends \InvalidArgumentException
 
     /**
      * @param string $name
-     * @param string $action
-     * @param string $type
+     * @param string $className
      * @param string $data
      *
      * @return InvalidArgumentException
      */
-    public static function stringExpected($name, $action, $type, $data)
+    public static function stringExpected($name, $className, $data)
     {
         return new self(
+            $className,
             sprintf(
                 'Attribute or field "%s" expects a string as data, "%s" given (for %s %s).',
                 $name,
@@ -168,15 +184,15 @@ class InvalidArgumentException extends \InvalidArgumentException
 
     /**
      * @param string $name
-     * @param string $action
-     * @param string $type
+     * @param string $className
      * @param string $data
      *
      * @return InvalidArgumentException
      */
-    public static function arrayExpected($name, $action, $type, $data)
+    public static function arrayExpected($name, $className, $data)
     {
         return new self(
+            $className,
             sprintf(
                 'Attribute or field "%s" expects an array as data, "%s" given (for %s %s).',
                 $name,
@@ -190,15 +206,15 @@ class InvalidArgumentException extends \InvalidArgumentException
 
     /**
      * @param string $name
-     * @param string $action
-     * @param string $type
+     * @param string $className
      * @param string $data
      *
      * @return InvalidArgumentException
      */
-    public static function arrayOfArraysExpected($name, $action, $type, $data)
+    public static function arrayOfArraysExpected($name, $className, $data)
     {
         return new self(
+            $className,
             sprintf(
                 'Attribute or field "%s" expects an array of arrays as data, "%s" given (for %s %s).',
                 $name,
@@ -213,15 +229,15 @@ class InvalidArgumentException extends \InvalidArgumentException
     /**
      * @param string $name
      * @param string $key
-     * @param string $action
-     * @param string $type
+     * @param string $className
      * @param string $data
      *
      * @return InvalidArgumentException
      */
-    public static function arrayKeyExpected($name, $key, $action, $type, $data)
+    public static function arrayKeyExpected($name, $key, $className, $data)
     {
         return new self(
+            $className,
             sprintf(
                 'Attribute or field "%s" expects an array with the key "%s" as data, "%s" given (for %s %s).',
                 $name,
@@ -238,18 +254,18 @@ class InvalidArgumentException extends \InvalidArgumentException
      * @param string $name
      * @param string $key
      * @param string $because
-     * @param string $action
-     * @param string $type
+     * @param string $className
      * @param string $data
      *
      * @return InvalidArgumentException
      */
-    public static function arrayInvalidKey($name, $key, $because, $action, $type, $data)
+    public static function arrayInvalidKey($name, $key, $because, $className, $data)
     {
         $err = 'Attribute or field "%s" expects an array with valid data for the key "%s". %s, "%s" given (for %s %s).';
 
         return new self(
-            sprintf($err, $name, $key, $because, $data, $action, $type),
+            $className,
+            sprintf($err, $name, $key, $because, $data),
             self::ARRAY_INVALID_KEY_CODE
         );
     }
@@ -258,18 +274,18 @@ class InvalidArgumentException extends \InvalidArgumentException
      * @param string $name
      * @param string $key
      * @param string $because
-     * @param string $action
-     * @param string $type
+     * @param string $className
      * @param string $data
      *
      * @return InvalidArgumentException
      */
-    public static function validEntityCodeExpected($name, $key, $because, $action, $type, $data)
+    public static function validEntityCodeExpected($name, $key, $because, $className, $data)
     {
         $err = 'Attribute or field "%s" expects a valid %s. %s, "%s" given (for %s %s).';
 
         return new self(
-            sprintf($err, $name, $key, $because, $data, $action, $type),
+            $className,
+            sprintf($err, $name, $key, $because, $data),
             self::VALID_ENTITY_CODE_EXPECTED_CODE
         );
     }
@@ -277,15 +293,15 @@ class InvalidArgumentException extends \InvalidArgumentException
     /**
      * @param string $name
      * @param string $key
-     * @param string $action
-     * @param string $type
+     * @param string $className
      * @param string $data
      *
      * @return InvalidArgumentException
      */
-    public static function arrayNumericKeyExpected($name, $key, $action, $type, $data)
+    public static function arrayNumericKeyExpected($name, $key, $className, $data)
     {
         return new self(
+            $className,
             sprintf(
                 'Attribute or field "%s" expects an array with numeric data for the key "%s", "%s" given (for %s %s).',
                 $name,
@@ -301,15 +317,15 @@ class InvalidArgumentException extends \InvalidArgumentException
     /**
      * @param string $name
      * @param string $key
-     * @param string $action
-     * @param string $type
+     * @param string $className
      * @param string $data
      *
      * @return InvalidArgumentException
      */
-    public static function arrayStringKeyExpected($name, $key, $action, $type, $data)
+    public static function arrayStringKeyExpected($name, $key, $className, $data)
     {
         return new self(
+            $className,
             sprintf(
                 'Attribute or field "%s" expects an array with string data for the key "%s", "%s" given (for %s %s).',
                 $name,
@@ -325,15 +341,15 @@ class InvalidArgumentException extends \InvalidArgumentException
     /**
      * @param string $name
      * @param string $key
-     * @param string $action
-     * @param string $type
+     * @param string $className
      * @param string $data
      *
      * @return InvalidArgumentException
      */
-    public static function arrayStringValueExpected($name, $key, $action, $type, $data)
+    public static function arrayStringValueExpected($name, $key, $className, $data)
     {
         return new self(
+            $className,
             sprintf(
                 'Attribute or field "%s" expects an array with a string value for the key "%s", '.
                 '"%s" given (for %s %s).',
@@ -355,6 +371,7 @@ class InvalidArgumentException extends \InvalidArgumentException
     public static function emptyArray($name)
     {
         return new self(
+            null,
             sprintf('Attribute or field "%s" expects a non empty array.', $name),
             self::EMPTY_ARRAY_CODE
         );
@@ -362,14 +379,14 @@ class InvalidArgumentException extends \InvalidArgumentException
 
     /**
      * @param string $name
-     * @param string $action
-     * @param string $type
+     * @param string $className
      *
      * @return InvalidArgumentException
      */
-    public static function localeAndScopeExpected($name, $action, $type)
+    public static function localeAndScopeExpected($name, $className)
     {
         return new self(
+            $className,
             sprintf(
                 'Attribute or field "%s" expects a valid scope and locale (for %s %s).',
                 $name,
@@ -382,14 +399,14 @@ class InvalidArgumentException extends \InvalidArgumentException
 
     /**
      * @param string $name
-     * @param string $action
-     * @param string $type
+     * @param string $className
      *
      * @return InvalidArgumentException
      */
-    public static function scopeExpected($name, $action, $type)
+    public static function scopeExpected($name, $className)
     {
         return new self(
+            $className,
             sprintf(
                 'Attribute or field "%s" expects a valid scope (for %s %s).',
                 $name,
@@ -409,6 +426,7 @@ class InvalidArgumentException extends \InvalidArgumentException
     public static function associationFormatExpected($name, $data)
     {
         return new self(
+            null,
             sprintf(
                 'Attribute or field "%s" expects a valid association format as ["associationTypeCode1" => '.
                 '["products" => ["sku1, "sku2"], "groups" => ["group1"]]]", "%s" given.',
@@ -422,14 +440,14 @@ class InvalidArgumentException extends \InvalidArgumentException
     /**
      * @param \Exception $exception
      * @param string     $name
-     * @param string     $action
-     * @param string     $type
+     * @param string     $className
      *
      * @return InvalidArgumentException
      */
-    public static function expectedFromPreviousException(\Exception $exception, $name, $action, $type)
+    public static function expectedFromPreviousException(\Exception $exception, $name, $className)
     {
         return new self(
+            $className,
             sprintf(
                 'Attribute or field "%s" expects valid data, scope and locale (for %s %s). %s',
                 $name,

--- a/src/Pim/Component/Catalog/Exception/InvalidArgumentException.php
+++ b/src/Pim/Component/Catalog/Exception/InvalidArgumentException.php
@@ -61,12 +61,10 @@ class InvalidArgumentException extends \InvalidArgumentException
         return new self(
             $className,
             sprintf(
-                'Attribute or field "%s" expects %s as data, "%s" given (for %s %s).',
+                'Attribute or field "%s" expects %s as data, "%s" given.',
                 $name,
                 $expected,
-                $data,
-                $action,
-                $type
+                $data
             ),
             self::EXPECTED_CODE
         );
@@ -84,11 +82,9 @@ class InvalidArgumentException extends \InvalidArgumentException
         return new self(
             $className,
             sprintf(
-                'Attribute or field "%s" expects a boolean as data, "%s" given (for %s %s).',
+                'Attribute or field "%s" expects a boolean as data, "%s" given.',
                 $name,
-                $data,
-                $action,
-                $type
+                $data
             ),
             self::BOOLEAN_EXPECTED_CODE
         );
@@ -106,11 +102,9 @@ class InvalidArgumentException extends \InvalidArgumentException
         return new self(
             $className,
             sprintf(
-                'Attribute or field "%s" expects a float as data, "%s" given (for %s %s).',
+                'Attribute or field "%s" expects a float as data, "%s" given.',
                 $name,
-                $data,
-                $action,
-                $type
+                $data
             ),
             self::FLOAT_EXPECTED_CODE
         );
@@ -128,11 +122,9 @@ class InvalidArgumentException extends \InvalidArgumentException
         return new self(
             $className,
             sprintf(
-                'Attribute or field "%s" expects an integer as data, "%s" given (for %s %s).',
+                'Attribute or field "%s" expects an integer as data, "%s" given.',
                 $name,
-                $data,
-                $action,
-                $type
+                $data
             ),
             self::INTEGER_EXPECTED_CODE
         );
@@ -150,11 +142,9 @@ class InvalidArgumentException extends \InvalidArgumentException
         return new self(
             $className,
             sprintf(
-                'Attribute or field "%s" expects a numeric as data, "%s" given (for %s %s).',
+                'Attribute or field "%s" expects a numeric as data, "%s" given.',
                 $name,
-                $data,
-                $action,
-                $type
+                $data
             ),
             self::NUMERIC_EXPECTED_CODE
         );
@@ -172,11 +162,9 @@ class InvalidArgumentException extends \InvalidArgumentException
         return new self(
             $className,
             sprintf(
-                'Attribute or field "%s" expects a string as data, "%s" given (for %s %s).',
+                'Attribute or field "%s" expects a string as data, "%s" given.',
                 $name,
-                $data,
-                $action,
-                $type
+                $data
             ),
             self::STRING_EXPECTED_CODE
         );
@@ -194,11 +182,9 @@ class InvalidArgumentException extends \InvalidArgumentException
         return new self(
             $className,
             sprintf(
-                'Attribute or field "%s" expects an array as data, "%s" given (for %s %s).',
+                'Attribute or field "%s" expects an array as data, "%s" given.',
                 $name,
-                $data,
-                $action,
-                $type
+                $data
             ),
             self::ARRAY_EXPECTED_CODE
         );
@@ -216,11 +202,9 @@ class InvalidArgumentException extends \InvalidArgumentException
         return new self(
             $className,
             sprintf(
-                'Attribute or field "%s" expects an array of arrays as data, "%s" given (for %s %s).',
+                'Attribute or field "%s" expects an array of arrays as data, "%s" given.',
                 $name,
-                $data,
-                $action,
-                $type
+                $data
             ),
             self::ARRAY_OF_ARRAYS_EXPECTED_CODE
         );
@@ -239,12 +223,10 @@ class InvalidArgumentException extends \InvalidArgumentException
         return new self(
             $className,
             sprintf(
-                'Attribute or field "%s" expects an array with the key "%s" as data, "%s" given (for %s %s).',
+                'Attribute or field "%s" expects an array with the key "%s" as data, "%s" given.',
                 $name,
                 $key,
-                $data,
-                $action,
-                $type
+                $data
             ),
             self::ARRAY_KEY_EXPECTED_CODE
         );
@@ -261,7 +243,7 @@ class InvalidArgumentException extends \InvalidArgumentException
      */
     public static function arrayInvalidKey($name, $key, $because, $className, $data)
     {
-        $err = 'Attribute or field "%s" expects an array with valid data for the key "%s". %s, "%s" given (for %s %s).';
+        $err = 'Attribute or field "%s" expects an array with valid data for the key "%s". %s, "%s" given.';
 
         return new self(
             $className,
@@ -281,7 +263,7 @@ class InvalidArgumentException extends \InvalidArgumentException
      */
     public static function validEntityCodeExpected($name, $key, $because, $className, $data)
     {
-        $err = 'Attribute or field "%s" expects a valid %s. %s, "%s" given (for %s %s).';
+        $err = 'Attribute or field "%s" expects a valid %s. %s, "%s" given.';
 
         return new self(
             $className,
@@ -303,12 +285,10 @@ class InvalidArgumentException extends \InvalidArgumentException
         return new self(
             $className,
             sprintf(
-                'Attribute or field "%s" expects an array with numeric data for the key "%s", "%s" given (for %s %s).',
+                'Attribute or field "%s" expects an array with numeric data for the key "%s", "%s" given.',
                 $name,
                 $key,
-                $data,
-                $action,
-                $type
+                $data
             ),
             self::ARRAY_NUMERIC_KEY_EXPECTED_CODE
         );
@@ -327,12 +307,10 @@ class InvalidArgumentException extends \InvalidArgumentException
         return new self(
             $className,
             sprintf(
-                'Attribute or field "%s" expects an array with string data for the key "%s", "%s" given (for %s %s).',
+                'Attribute or field "%s" expects an array with string data for the key "%s", "%s" given.',
                 $name,
                 $key,
-                $data,
-                $action,
-                $type
+                $data
             ),
             self::ARRAY_STRING_KEY_EXPECTED_CODE
         );
@@ -352,12 +330,10 @@ class InvalidArgumentException extends \InvalidArgumentException
             $className,
             sprintf(
                 'Attribute or field "%s" expects an array with a string value for the key "%s", '.
-                '"%s" given (for %s %s).',
+                '"%s" given.',
                 $name,
                 $key,
-                $data,
-                $action,
-                $type
+                $data
             ),
             self::ARRAY_STRING_VALUE_EXPECTED_CODE
         );
@@ -388,10 +364,8 @@ class InvalidArgumentException extends \InvalidArgumentException
         return new self(
             $className,
             sprintf(
-                'Attribute or field "%s" expects a valid scope and locale (for %s %s).',
-                $name,
-                $action,
-                $type
+                'Attribute or field "%s" expects a valid scope and locale.',
+                $name
             ),
             self::LOCALE_AND_SCOPE_EXPECTED_CODE
         );
@@ -408,10 +382,8 @@ class InvalidArgumentException extends \InvalidArgumentException
         return new self(
             $className,
             sprintf(
-                'Attribute or field "%s" expects a valid scope (for %s %s).',
-                $name,
-                $action,
-                $type
+                'Attribute or field "%s" expects a valid scope.',
+                $name
             ),
             self::SCOPE_EXPECTED_CODE
         );
@@ -449,10 +421,8 @@ class InvalidArgumentException extends \InvalidArgumentException
         return new self(
             $className,
             sprintf(
-                'Attribute or field "%s" expects valid data, scope and locale (for %s %s). %s',
+                'Attribute or field "%s" expects valid data, scope and locale. %s',
                 $name,
-                $action,
-                $type,
                 $exception->getMessage()
             ),
             $exception->getCode(),

--- a/src/Pim/Component/Catalog/Query/Filter/FieldFilterHelper.php
+++ b/src/Pim/Component/Catalog/Query/Filter/FieldFilterHelper.php
@@ -65,12 +65,12 @@ class FieldFilterHelper
      *
      * @param string $field
      * @param mixed  $value
-     * @param string $filter
+     * @param string $className
      */
-    public static function checkArray($field, $value, $filter)
+    public static function checkArray($field, $value, $className)
     {
         if (!is_array($value)) {
-            throw InvalidArgumentException::arrayExpected(static::getCode($field), 'filter', $filter, gettype($value));
+            throw InvalidArgumentException::arrayExpected(static::getCode($field), $className, gettype($value));
         }
     }
 
@@ -79,16 +79,15 @@ class FieldFilterHelper
      *
      * @param string $field
      * @param mixed  $value
-     * @param string $filter
+     * @param string $className
      */
-    public static function checkIdentifier($field, $value, $filter)
+    public static function checkIdentifier($field, $value, $className)
     {
         $invalidIdField = static::hasProperty($field) && static::getProperty($field) === 'id' && !is_numeric($value);
         if ($invalidIdField) {
             throw InvalidArgumentException::numericExpected(
                 static::getCode($field),
-                'filter',
-                $filter,
+                $className,
                 gettype($value)
             );
         }
@@ -98,7 +97,7 @@ class FieldFilterHelper
             !is_string($value) && !is_numeric($value);
 
         if ($invalidDefaultField || $invalidStringField) {
-            throw InvalidArgumentException::stringExpected(static::getCode($field), 'filter', $filter, gettype($value));
+            throw InvalidArgumentException::stringExpected(static::getCode($field), $className, gettype($value));
         }
     }
 }

--- a/src/Pim/Component/Catalog/Updater/Adder/AbstractAttributeAdder.php
+++ b/src/Pim/Component/Catalog/Updater/Adder/AbstractAttributeAdder.php
@@ -66,11 +66,8 @@ abstract class AbstractAttributeAdder implements AttributeAdderInterface
      * @param AttributeInterface $attribute
      * @param string             $locale
      * @param string             $scope
-     * @param string             $type
-     *
-     * @throws InvalidArgumentException
      */
-    protected function checkLocaleAndScope(AttributeInterface $attribute, $locale, $scope, $type)
+    protected function checkLocaleAndScope(AttributeInterface $attribute, $locale, $scope)
     {
         try {
             $this->attrValidatorHelper->validateLocale($attribute, $locale);
@@ -79,8 +76,7 @@ abstract class AbstractAttributeAdder implements AttributeAdderInterface
             throw InvalidArgumentException::expectedFromPreviousException(
                 $e,
                 $attribute->getCode(),
-                'setter',
-                $type
+                static::class
             );
         }
     }

--- a/src/Pim/Component/Catalog/Updater/Adder/AssociationFieldAdder.php
+++ b/src/Pim/Component/Catalog/Updater/Adder/AssociationFieldAdder.php
@@ -90,8 +90,7 @@ class AssociationFieldAdder extends AbstractFieldAdder
                 throw InvalidArgumentException::expected(
                     'associations',
                     'existing association type code',
-                    'adder',
-                    'association',
+                    static::class,
                     $typeCode
                 );
             }
@@ -112,8 +111,7 @@ class AssociationFieldAdder extends AbstractFieldAdder
                 throw InvalidArgumentException::expected(
                     'associations',
                     'existing product identifier',
-                    'adder',
-                    'association',
+                    static::class,
                     $productIdentifier
                 );
             }
@@ -133,8 +131,7 @@ class AssociationFieldAdder extends AbstractFieldAdder
                 throw InvalidArgumentException::expected(
                     'associations',
                     'existing group code',
-                    'adder',
-                    'association',
+                    static::class,
                     $groupCode
                 );
             }
@@ -155,8 +152,7 @@ class AssociationFieldAdder extends AbstractFieldAdder
         if (!is_array($data)) {
             throw InvalidArgumentException::arrayExpected(
                 $field,
-                'adder',
-                'association',
+                static::class,
                 gettype($data)
             );
         }

--- a/src/Pim/Component/Catalog/Updater/Adder/CategoryFieldAdder.php
+++ b/src/Pim/Component/Catalog/Updater/Adder/CategoryFieldAdder.php
@@ -49,8 +49,7 @@ class CategoryFieldAdder extends AbstractFieldAdder
                 throw InvalidArgumentException::expected(
                     $field,
                     'existing category code',
-                    'adder',
-                    'category',
+                    static::class,
                     $categoryCode
                 );
             }
@@ -72,8 +71,7 @@ class CategoryFieldAdder extends AbstractFieldAdder
         if (!is_array($data)) {
             throw InvalidArgumentException::arrayExpected(
                 $field,
-                'adder',
-                'category',
+                static::class,
                 gettype($data)
             );
         }
@@ -83,8 +81,7 @@ class CategoryFieldAdder extends AbstractFieldAdder
                 throw InvalidArgumentException::arrayStringValueExpected(
                     $field,
                     $key,
-                    'adder',
-                    'category',
+                    static::class,
                     gettype($value)
                 );
             }

--- a/src/Pim/Component/Catalog/Updater/Adder/GroupFieldAdder.php
+++ b/src/Pim/Component/Catalog/Updater/Adder/GroupFieldAdder.php
@@ -47,16 +47,14 @@ class GroupFieldAdder extends AbstractFieldAdder
                 throw InvalidArgumentException::expected(
                     $field,
                     'existing group code',
-                    'adder',
-                    'groups',
+                    static::class,
                     $groupCode
                 );
             } elseif ($group->getType()->isVariant()) {
                 throw InvalidArgumentException::expected(
                     $field,
                     'non variant group code',
-                    'adder',
-                    'groups',
+                    static::class,
                     $groupCode
                 );
             } else {
@@ -80,8 +78,7 @@ class GroupFieldAdder extends AbstractFieldAdder
         if (!is_array($data)) {
             throw InvalidArgumentException::arrayExpected(
                 $field,
-                'adder',
-                'groups',
+                static::class,
                 gettype($data)
             );
         }
@@ -91,8 +88,7 @@ class GroupFieldAdder extends AbstractFieldAdder
                 throw InvalidArgumentException::arrayStringValueExpected(
                     $field,
                     $key,
-                    'adder',
-                    'groups',
+                    static::class,
                     gettype($value)
                 );
             }

--- a/src/Pim/Component/Catalog/Updater/Adder/MultiSelectAttributeAdder.php
+++ b/src/Pim/Component/Catalog/Updater/Adder/MultiSelectAttributeAdder.php
@@ -51,7 +51,7 @@ class MultiSelectAttributeAdder extends AbstractAttributeAdder
         array $options = []
     ) {
         $options = $this->resolver->resolve($options);
-        $this->checkLocaleAndScope($attribute, $options['locale'], $options['scope'], 'multi select');
+        $this->checkLocaleAndScope($attribute, $options['locale'], $options['scope']);
         $this->checkData($attribute, $data);
 
         $attributeOptions = [];
@@ -62,8 +62,7 @@ class MultiSelectAttributeAdder extends AbstractAttributeAdder
                     $attribute->getCode(),
                     'code',
                     'The option does not exist',
-                    'adder',
-                    'multi select',
+                    static::class,
                     $optionCode
                 );
             }
@@ -85,8 +84,7 @@ class MultiSelectAttributeAdder extends AbstractAttributeAdder
         if (!is_array($data)) {
             throw InvalidArgumentException::arrayExpected(
                 $attribute->getCode(),
-                'adder',
-                'multi select',
+                static::class,
                 gettype($data)
             );
         }
@@ -96,8 +94,7 @@ class MultiSelectAttributeAdder extends AbstractAttributeAdder
                 throw InvalidArgumentException::arrayStringValueExpected(
                     $attribute->getCode(),
                     $key,
-                    'adder',
-                    'multi select',
+                    static::class,
                     gettype($value)
                 );
             }

--- a/src/Pim/Component/Catalog/Updater/Adder/PriceCollectionAttributeAdder.php
+++ b/src/Pim/Component/Catalog/Updater/Adder/PriceCollectionAttributeAdder.php
@@ -61,7 +61,7 @@ class PriceCollectionAttributeAdder extends AbstractAttributeAdder
         array $options = []
     ) {
         $options = $this->resolver->resolve($options);
-        $this->checkLocaleAndScope($attribute, $options['locale'], $options['scope'], 'prices collection');
+        $this->checkLocaleAndScope($attribute, $options['locale'], $options['scope']);
         $this->checkData($attribute, $data);
 
         $this->addPrices($product, $attribute, $data, $options['locale'], $options['scope']);
@@ -80,8 +80,7 @@ class PriceCollectionAttributeAdder extends AbstractAttributeAdder
         if (!is_array($data)) {
             throw InvalidArgumentException::arrayExpected(
                 $attribute->getCode(),
-                'adder',
-                'prices collection',
+                static::class,
                 gettype($data)
             );
         }
@@ -90,8 +89,7 @@ class PriceCollectionAttributeAdder extends AbstractAttributeAdder
             if (!is_array($price)) {
                 throw InvalidArgumentException::arrayOfArraysExpected(
                     $attribute->getCode(),
-                    'adder',
-                    'prices collection',
+                    static::class,
                     gettype($data)
                 );
             }
@@ -100,8 +98,7 @@ class PriceCollectionAttributeAdder extends AbstractAttributeAdder
                 throw InvalidArgumentException::arrayKeyExpected(
                     $attribute->getCode(),
                     'amount',
-                    'adder',
-                    'prices collection',
+                    static::class,
                     print_r($data, true)
                 );
             }
@@ -110,8 +107,7 @@ class PriceCollectionAttributeAdder extends AbstractAttributeAdder
                 throw InvalidArgumentException::arrayKeyExpected(
                     $attribute->getCode(),
                     'currency',
-                    'adder',
-                    'prices collection',
+                    static::class,
                     print_r($data, true)
                 );
             }
@@ -120,8 +116,7 @@ class PriceCollectionAttributeAdder extends AbstractAttributeAdder
                 throw InvalidArgumentException::arrayNumericKeyExpected(
                     $attribute->getCode(),
                     'amount',
-                    'adder',
-                    'prices collection',
+                    static::class,
                     gettype($price['amount'])
                 );
             }
@@ -131,8 +126,7 @@ class PriceCollectionAttributeAdder extends AbstractAttributeAdder
                     $attribute->getCode(),
                     'currency',
                     'The currency does not exist',
-                    'adder',
-                    'prices collection',
+                    static::class,
                     $price['currency']
                 );
             }

--- a/src/Pim/Component/Catalog/Updater/AttributeGroupUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/AttributeGroupUpdater.php
@@ -129,8 +129,7 @@ class AttributeGroupUpdater implements ObjectUpdaterInterface
                     'attributes',
                     'attribute code',
                     'The attribute does not exist',
-                    'updater',
-                    'attribute group',
+                    static::class,
                     $attributeCode
                 );
             }

--- a/src/Pim/Component/Catalog/Updater/AttributeOptionUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/AttributeOptionUpdater.php
@@ -88,8 +88,7 @@ class AttributeOptionUpdater implements ObjectUpdaterInterface
                     'attribute',
                     'attribute code',
                     'The attribute does not exist',
-                    'updater',
-                    'attribute option',
+                    static::class,
                     $data
                 );
             }

--- a/src/Pim/Component/Catalog/Updater/AttributeUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/AttributeUpdater.php
@@ -174,8 +174,7 @@ class AttributeUpdater implements ObjectUpdaterInterface
                     'available_locales',
                     'locale code',
                     'The locale does not exist',
-                    'updater',
-                    'attribute',
+                    static::class,
                     $localeCode
                 );
             }
@@ -200,8 +199,7 @@ class AttributeUpdater implements ObjectUpdaterInterface
                 'group',
                 'code',
                 'The attribute group does not exist',
-                'updater',
-                'attribute',
+                static::class,
                 $data
             );
         }
@@ -218,11 +216,7 @@ class AttributeUpdater implements ObjectUpdaterInterface
     protected function setType($attribute, $data)
     {
         if (('' === $data) || (null === $data)) {
-            throw InvalidPropertyException::valueNotEmptyExpected(
-                'attribute_type',
-                'updater',
-                'attribute'
-            );
+            throw InvalidPropertyException::valueNotEmptyExpected('attribute_type', static::class);
         }
 
         try {
@@ -235,8 +229,7 @@ class AttributeUpdater implements ObjectUpdaterInterface
                 'attribute_type',
                 'attribute type',
                 'The attribute type does not exist',
-                'updater',
-                'attribute',
+                static::class,
                 $data
             );
         }
@@ -266,23 +259,11 @@ class AttributeUpdater implements ObjectUpdaterInterface
         try {
             new \DateTime($data);
         } catch (\Exception $e) {
-            throw InvalidPropertyException::dateExpected(
-                $field,
-                'yyyy-mm-dd',
-                'updater',
-                'attribute',
-                $data
-            );
+            throw InvalidPropertyException::dateExpected($field, 'yyyy-mm-dd', static::class, $data);
         }
 
         if (!preg_match('/^\d{4}-\d{2}-\d{2}/', $data)) {
-            throw InvalidPropertyException::dateExpected(
-                $field,
-                'yyyy-mm-dd',
-                'updater',
-                'attribute',
-                $data
-            );
+            throw InvalidPropertyException::dateExpected($field, 'yyyy-mm-dd', static::class, $data);
         }
     }
 

--- a/src/Pim/Component/Catalog/Updater/ChannelUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/ChannelUpdater.php
@@ -132,8 +132,7 @@ class ChannelUpdater implements ObjectUpdaterInterface
                 'category_tree',
                 'code',
                 'The category does not exist',
-                'updater',
-                'channel',
+                static::class,
                 $treeCode
             );
         }
@@ -156,8 +155,7 @@ class ChannelUpdater implements ObjectUpdaterInterface
                     'currencies',
                     'code',
                     'The currency does not exist',
-                    'updater',
-                    'channel',
+                    static::class,
                     $currencyCode
                 );
             }
@@ -184,8 +182,7 @@ class ChannelUpdater implements ObjectUpdaterInterface
                     'locales',
                     'code',
                     'The locale does not exist',
-                    'updater',
-                    'channel',
+                    static::class,
                     $localeCode
                 );
             }
@@ -226,8 +223,7 @@ class ChannelUpdater implements ObjectUpdaterInterface
                     'conversionUnits',
                     'attributeCode',
                     'the attribute code for the conversion unit does not exist',
-                    'updater',
-                    'channel',
+                    static::class,
                     $attributeCode
                 );
             }
@@ -237,8 +233,7 @@ class ChannelUpdater implements ObjectUpdaterInterface
                     'conversionUnits',
                     'unitCode',
                     'the metric unit code for the conversion unit does not exist',
-                    'updater',
-                    'channel',
+                    static::class,
                     $conversionUnit
                 );
             }

--- a/src/Pim/Component/Catalog/Updater/Copier/AbstractAttributeCopier.php
+++ b/src/Pim/Component/Catalog/Updater/Copier/AbstractAttributeCopier.php
@@ -64,11 +64,8 @@ abstract class AbstractAttributeCopier implements AttributeCopierInterface
      * @param AttributeInterface $attribute
      * @param string             $locale
      * @param string             $scope
-     * @param string             $type
-     *
-     * @throws InvalidArgumentException
      */
-    protected function checkLocaleAndScope(AttributeInterface $attribute, $locale, $scope, $type)
+    protected function checkLocaleAndScope(AttributeInterface $attribute, $locale, $scope)
     {
         try {
             $this->attrValidatorHelper->validateLocale($attribute, $locale);
@@ -77,8 +74,7 @@ abstract class AbstractAttributeCopier implements AttributeCopierInterface
             throw InvalidArgumentException::expectedFromPreviousException(
                 $e,
                 $attribute->getCode(),
-                'copier',
-                $type
+                static::class
             );
         }
     }

--- a/src/Pim/Component/Catalog/Updater/Copier/BaseAttributeCopier.php
+++ b/src/Pim/Component/Catalog/Updater/Copier/BaseAttributeCopier.php
@@ -49,8 +49,8 @@ class BaseAttributeCopier extends AbstractAttributeCopier
         $fromScope = $options['from_scope'];
         $toScope = $options['to_scope'];
 
-        $this->checkLocaleAndScope($fromAttribute, $fromLocale, $fromScope, 'base');
-        $this->checkLocaleAndScope($toAttribute, $toLocale, $toScope, 'base');
+        $this->checkLocaleAndScope($fromAttribute, $fromLocale, $fromScope);
+        $this->checkLocaleAndScope($toAttribute, $toLocale, $toScope);
 
         $this->copySingleValue(
             $fromProduct,

--- a/src/Pim/Component/Catalog/Updater/Copier/MediaAttributeCopier.php
+++ b/src/Pim/Component/Catalog/Updater/Copier/MediaAttributeCopier.php
@@ -72,8 +72,8 @@ class MediaAttributeCopier extends AbstractAttributeCopier
         $fromScope = $options['from_scope'];
         $toScope = $options['to_scope'];
 
-        $this->checkLocaleAndScope($fromAttribute, $fromLocale, $fromScope, 'media');
-        $this->checkLocaleAndScope($toAttribute, $toLocale, $toScope, 'media');
+        $this->checkLocaleAndScope($fromAttribute, $fromLocale, $fromScope);
+        $this->checkLocaleAndScope($toAttribute, $toLocale, $toScope);
 
         $this->copySingleValue(
             $fromProduct,

--- a/src/Pim/Component/Catalog/Updater/Copier/MetricAttributeCopier.php
+++ b/src/Pim/Component/Catalog/Updater/Copier/MetricAttributeCopier.php
@@ -56,8 +56,8 @@ class MetricAttributeCopier extends AbstractAttributeCopier
         $fromScope = $options['from_scope'];
         $toScope = $options['to_scope'];
 
-        $this->checkLocaleAndScope($fromAttribute, $fromLocale, $fromScope, 'metric');
-        $this->checkLocaleAndScope($toAttribute, $toLocale, $toScope, 'metric');
+        $this->checkLocaleAndScope($fromAttribute, $fromLocale, $fromScope);
+        $this->checkLocaleAndScope($toAttribute, $toLocale, $toScope);
         $this->attrValidatorHelper->validateUnitFamilies($fromAttribute, $toAttribute);
 
         $this->copySingleValue(

--- a/src/Pim/Component/Catalog/Updater/Copier/MultiSelectAttributeCopier.php
+++ b/src/Pim/Component/Catalog/Updater/Copier/MultiSelectAttributeCopier.php
@@ -50,8 +50,8 @@ class MultiSelectAttributeCopier extends AbstractAttributeCopier
         $fromScope = $options['from_scope'];
         $toScope = $options['to_scope'];
 
-        $this->checkLocaleAndScope($fromAttribute, $fromLocale, $fromScope, 'multi select');
-        $this->checkLocaleAndScope($toAttribute, $toLocale, $toScope, 'multi select');
+        $this->checkLocaleAndScope($fromAttribute, $fromLocale, $fromScope);
+        $this->checkLocaleAndScope($toAttribute, $toLocale, $toScope);
 
         $this->copySingleValue(
             $fromProduct,

--- a/src/Pim/Component/Catalog/Updater/Copier/PriceCollectionAttributeCopier.php
+++ b/src/Pim/Component/Catalog/Updater/Copier/PriceCollectionAttributeCopier.php
@@ -50,8 +50,8 @@ class PriceCollectionAttributeCopier extends AbstractAttributeCopier
         $fromScope = $options['from_scope'];
         $toScope = $options['to_scope'];
 
-        $this->checkLocaleAndScope($fromAttribute, $fromLocale, $fromScope, 'price collection');
-        $this->checkLocaleAndScope($toAttribute, $toLocale, $toScope, 'price collection');
+        $this->checkLocaleAndScope($fromAttribute, $fromLocale, $fromScope);
+        $this->checkLocaleAndScope($toAttribute, $toLocale, $toScope);
 
         $this->copySingleValue(
             $fromProduct,

--- a/src/Pim/Component/Catalog/Updater/Copier/SimpleSelectAttributeCopier.php
+++ b/src/Pim/Component/Catalog/Updater/Copier/SimpleSelectAttributeCopier.php
@@ -49,8 +49,8 @@ class SimpleSelectAttributeCopier extends AbstractAttributeCopier
         $fromScope = $options['from_scope'];
         $toScope = $options['to_scope'];
 
-        $this->checkLocaleAndScope($fromAttribute, $fromLocale, $fromScope, 'simple select');
-        $this->checkLocaleAndScope($toAttribute, $toLocale, $toScope, 'simple select');
+        $this->checkLocaleAndScope($fromAttribute, $fromLocale, $fromScope);
+        $this->checkLocaleAndScope($toAttribute, $toLocale, $toScope);
 
         $this->copySingleValue(
             $fromProduct,

--- a/src/Pim/Component/Catalog/Updater/FamilyUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/FamilyUpdater.php
@@ -213,8 +213,7 @@ class FamilyUpdater implements ObjectUpdaterInterface
                     'attribute_requirements',
                     'code',
                     'The attribute does not exist',
-                    'updater',
-                    'family',
+                    static::class,
                     $attributeCode
                 );
             }
@@ -269,8 +268,7 @@ class FamilyUpdater implements ObjectUpdaterInterface
                 'attribute_requirements',
                 'code',
                 'The channel does not exist',
-                'updater',
-                'family',
+                static::class,
                 $channelCode
             );
         }
@@ -309,8 +307,7 @@ class FamilyUpdater implements ObjectUpdaterInterface
                     'attributes',
                     'code',
                     'The attribute does not exist',
-                    'updater',
-                    'family',
+                    static::class,
                     $attributeCode
                 );
             }
@@ -332,8 +329,7 @@ class FamilyUpdater implements ObjectUpdaterInterface
                 'attributes',
                 'code',
                 'The attribute does not exist',
-                'updater',
-                'family',
+                static::class,
                 $data
             );
         }

--- a/src/Pim/Component/Catalog/Updater/GroupUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/GroupUpdater.php
@@ -125,8 +125,7 @@ class GroupUpdater implements ObjectUpdaterInterface
                 'type',
                 'group type',
                 'The group type does not exist',
-                'updater',
-                'group',
+                static::class,
                 $type
             );
         }
@@ -135,8 +134,7 @@ class GroupUpdater implements ObjectUpdaterInterface
             throw InvalidPropertyException::validGroupTypeExpected(
                 'type',
                 'Cannot process variant group, only groups are supported',
-                'updater',
-                'group',
+                static::class,
                 $group->getCode()
             );
         }
@@ -173,8 +171,7 @@ class GroupUpdater implements ObjectUpdaterInterface
                     'axis',
                     'attribute code',
                     'The attribute does not exist',
-                    'updater',
-                    'group',
+                    static::class,
                     $attributeCode
                 );
             }

--- a/src/Pim/Component/Catalog/Updater/Remover/AbstractAttributeRemover.php
+++ b/src/Pim/Component/Catalog/Updater/Remover/AbstractAttributeRemover.php
@@ -49,11 +49,10 @@ abstract class AbstractAttributeRemover implements AttributeRemoverInterface
      * @param AttributeInterface $attribute
      * @param string             $locale
      * @param string             $scope
-     * @param string             $type
      *
      * @throws InvalidArgumentException
      */
-    protected function checkLocaleAndScope(AttributeInterface $attribute, $locale, $scope, $type)
+    protected function checkLocaleAndScope(AttributeInterface $attribute, $locale, $scope)
     {
         try {
             $this->attrValidatorHelper->validateLocale($attribute, $locale);
@@ -62,8 +61,7 @@ abstract class AbstractAttributeRemover implements AttributeRemoverInterface
             throw InvalidArgumentException::expectedFromPreviousException(
                 $e,
                 $attribute->getCode(),
-                'remover',
-                $type
+                static::class
             );
         }
     }

--- a/src/Pim/Component/Catalog/Updater/Remover/CategoryFieldRemover.php
+++ b/src/Pim/Component/Catalog/Updater/Remover/CategoryFieldRemover.php
@@ -47,8 +47,7 @@ class CategoryFieldRemover extends AbstractFieldRemover
                 throw InvalidArgumentException::expected(
                     $field,
                     'existing category code',
-                    'remover',
-                    'category',
+                    static::class,
                     $categoryCode
                 );
             }
@@ -71,8 +70,7 @@ class CategoryFieldRemover extends AbstractFieldRemover
         if (!is_array($data)) {
             throw InvalidArgumentException::arrayExpected(
                 $field,
-                'remover',
-                'category',
+                static::class,
                 gettype($data)
             );
         }
@@ -82,8 +80,7 @@ class CategoryFieldRemover extends AbstractFieldRemover
                 throw InvalidArgumentException::arrayStringValueExpected(
                     $field,
                     $key,
-                    'remover',
-                    'category',
+                    static::class,
                     gettype($value)
                 );
             }

--- a/src/Pim/Component/Catalog/Updater/Remover/GroupFieldRemover.php
+++ b/src/Pim/Component/Catalog/Updater/Remover/GroupFieldRemover.php
@@ -47,8 +47,7 @@ class GroupFieldRemover extends AbstractFieldRemover
                 throw InvalidArgumentException::expected(
                     $field,
                     'existing group code',
-                    'remover',
-                    'groups',
+                    static::class,
                     $groupCode
                 );
             }
@@ -56,8 +55,7 @@ class GroupFieldRemover extends AbstractFieldRemover
                 throw InvalidArgumentException::expected(
                     $field,
                     'non variant group code',
-                    'remover',
-                    'groups',
+                    static::class,
                     $groupCode
                 );
             }
@@ -80,8 +78,7 @@ class GroupFieldRemover extends AbstractFieldRemover
         if (!is_array($data)) {
             throw InvalidArgumentException::arrayExpected(
                 $field,
-                'remover',
-                'groups',
+                static::class,
                 gettype($data)
             );
         }
@@ -91,8 +88,7 @@ class GroupFieldRemover extends AbstractFieldRemover
                 throw InvalidArgumentException::arrayStringValueExpected(
                     $field,
                     $key,
-                    'remover',
-                    'groups',
+                    static::class,
                     gettype($value)
                 );
             }

--- a/src/Pim/Component/Catalog/Updater/Remover/MultiSelectAttributeRemover.php
+++ b/src/Pim/Component/Catalog/Updater/Remover/MultiSelectAttributeRemover.php
@@ -50,7 +50,7 @@ class MultiSelectAttributeRemover extends AbstractAttributeRemover
         array $options = []
     ) {
         $options = $this->resolver->resolve($options);
-        $this->checkLocaleAndScope($attribute, $options['locale'], $options['scope'], 'multi-select');
+        $this->checkLocaleAndScope($attribute, $options['locale'], $options['scope']);
         $this->checkData($attribute, $data);
 
         $attributeOptions = [];
@@ -61,8 +61,7 @@ class MultiSelectAttributeRemover extends AbstractAttributeRemover
                     $attribute->getCode(),
                     'code',
                     'The option does not exist',
-                    'remover',
-                    'multi select',
+                    static::class,
                     $optionCode
                 );
             }
@@ -107,8 +106,7 @@ class MultiSelectAttributeRemover extends AbstractAttributeRemover
         if (!is_array($data)) {
             throw InvalidArgumentException::arrayExpected(
                 $attribute->getCode(),
-                'remover',
-                'multi select',
+                static::class,
                 gettype($data)
             );
         }
@@ -118,8 +116,7 @@ class MultiSelectAttributeRemover extends AbstractAttributeRemover
                 throw InvalidArgumentException::arrayStringValueExpected(
                     $attribute->getCode(),
                     $key,
-                    'remover',
-                    'multi select',
+                    static::class,
                     gettype($value)
                 );
             }

--- a/src/Pim/Component/Catalog/Updater/Remover/PriceCollectionAttributeRemover.php
+++ b/src/Pim/Component/Catalog/Updater/Remover/PriceCollectionAttributeRemover.php
@@ -59,7 +59,7 @@ class PriceCollectionAttributeRemover extends AbstractAttributeRemover
         array $options = []
     ) {
         $options = $this->resolver->resolve($options);
-        $this->checkLocaleAndScope($attribute, $options['locale'], $options['scope'], 'prices collection');
+        $this->checkLocaleAndScope($attribute, $options['locale'], $options['scope']);
         $this->checkData($attribute, $data);
 
         $this->removePrices($product, $attribute, $data, $options['locale'], $options['scope']);
@@ -100,8 +100,7 @@ class PriceCollectionAttributeRemover extends AbstractAttributeRemover
         if (!is_array($data)) {
             throw InvalidArgumentException::arrayExpected(
                 $attribute->getCode(),
-                'remover',
-                'prices collection',
+                static::class,
                 gettype($data)
             );
         }
@@ -110,8 +109,7 @@ class PriceCollectionAttributeRemover extends AbstractAttributeRemover
             if (!is_array($price)) {
                 throw InvalidArgumentException::arrayOfArraysExpected(
                     $attribute->getCode(),
-                    'remover',
-                    'prices collection',
+                    static::class,
                     gettype($data)
                 );
             }
@@ -120,8 +118,7 @@ class PriceCollectionAttributeRemover extends AbstractAttributeRemover
                 throw InvalidArgumentException::arrayKeyExpected(
                     $attribute->getCode(),
                     'amount',
-                    'remover',
-                    'prices collection',
+                    static::class,
                     print_r($data, true)
                 );
             }
@@ -130,8 +127,7 @@ class PriceCollectionAttributeRemover extends AbstractAttributeRemover
                 throw InvalidArgumentException::arrayKeyExpected(
                     $attribute->getCode(),
                     'currency',
-                    'remover',
-                    'prices collection',
+                    static::class,
                     print_r($data, true)
                 );
             }
@@ -141,8 +137,7 @@ class PriceCollectionAttributeRemover extends AbstractAttributeRemover
                     $attribute->getCode(),
                     'currency',
                     'The currency does not exist',
-                    'remover',
-                    'prices collection',
+                    static::class,
                     $price['currency']
                 );
             }

--- a/src/Pim/Component/Catalog/Updater/Setter/AbstractAttributeSetter.php
+++ b/src/Pim/Component/Catalog/Updater/Setter/AbstractAttributeSetter.php
@@ -58,11 +58,8 @@ abstract class AbstractAttributeSetter implements AttributeSetterInterface
      * @param AttributeInterface $attribute
      * @param string             $locale
      * @param string             $scope
-     * @param string             $type
-     *
-     * @throws InvalidArgumentException
      */
-    protected function checkLocaleAndScope(AttributeInterface $attribute, $locale, $scope, $type)
+    protected function checkLocaleAndScope(AttributeInterface $attribute, $locale, $scope)
     {
         try {
             $this->attrValidatorHelper->validateLocale($attribute, $locale);
@@ -71,8 +68,7 @@ abstract class AbstractAttributeSetter implements AttributeSetterInterface
             throw InvalidArgumentException::expectedFromPreviousException(
                 $e,
                 $attribute->getCode(),
-                'setter',
-                $type
+                static::class
             );
         }
     }

--- a/src/Pim/Component/Catalog/Updater/Setter/AssociationFieldSetter.php
+++ b/src/Pim/Component/Catalog/Updater/Setter/AssociationFieldSetter.php
@@ -135,8 +135,7 @@ class AssociationFieldSetter extends AbstractFieldSetter
                 throw InvalidArgumentException::expected(
                     'associations',
                     'existing association type code',
-                    'setter',
-                    'association',
+                    static::class,
                     $typeCode
                 );
             }
@@ -161,8 +160,7 @@ class AssociationFieldSetter extends AbstractFieldSetter
                 throw InvalidArgumentException::expected(
                     'associations',
                     'existing product identifier',
-                    'setter',
-                    'association',
+                    static::class,
                     $productIdentifier
                 );
             }
@@ -182,8 +180,7 @@ class AssociationFieldSetter extends AbstractFieldSetter
                 throw InvalidArgumentException::expected(
                     'associations',
                     'existing group code',
-                    'setter',
-                    'association',
+                    static::class,
                     $groupCode
                 );
             }
@@ -204,8 +201,7 @@ class AssociationFieldSetter extends AbstractFieldSetter
         if (!is_array($data)) {
             throw InvalidArgumentException::arrayExpected(
                 $field,
-                'setter',
-                'association',
+                static::class,
                 gettype($data)
             );
         }

--- a/src/Pim/Component/Catalog/Updater/Setter/BooleanAttributeSetter.php
+++ b/src/Pim/Component/Catalog/Updater/Setter/BooleanAttributeSetter.php
@@ -40,7 +40,7 @@ class BooleanAttributeSetter extends AbstractAttributeSetter
         array $options = []
     ) {
         $options = $this->resolver->resolve($options);
-        $this->checkLocaleAndScope($attribute, $options['locale'], $options['scope'], 'boolean');
+        $this->checkLocaleAndScope($attribute, $options['locale'], $options['scope']);
 
         $this->setData($product, $attribute, $data, $options['locale'], $options['scope']);
     }

--- a/src/Pim/Component/Catalog/Updater/Setter/CategoryFieldSetter.php
+++ b/src/Pim/Component/Catalog/Updater/Setter/CategoryFieldSetter.php
@@ -48,8 +48,7 @@ class CategoryFieldSetter extends AbstractFieldSetter
                 throw InvalidArgumentException::expected(
                     $field,
                     'existing category code',
-                    'setter',
-                    'category',
+                    static::class,
                     $categoryCode
                 );
             } else {
@@ -78,8 +77,7 @@ class CategoryFieldSetter extends AbstractFieldSetter
         if (!is_array($data)) {
             throw InvalidArgumentException::arrayExpected(
                 $field,
-                'setter',
-                'category',
+                static::class,
                 gettype($data)
             );
         }
@@ -89,8 +87,7 @@ class CategoryFieldSetter extends AbstractFieldSetter
                 throw InvalidArgumentException::arrayStringValueExpected(
                     $field,
                     $key,
-                    'setter',
-                    'category',
+                    static::class,
                     gettype($value)
                 );
             }

--- a/src/Pim/Component/Catalog/Updater/Setter/DateAttributeSetter.php
+++ b/src/Pim/Component/Catalog/Updater/Setter/DateAttributeSetter.php
@@ -43,7 +43,7 @@ class DateAttributeSetter extends AbstractAttributeSetter
         array $options = []
     ) {
         $options = $this->resolver->resolve($options);
-        $this->checkLocaleAndScope($attribute, $options['locale'], $options['scope'], 'date');
+        $this->checkLocaleAndScope($attribute, $options['locale'], $options['scope']);
         $data = $this->formatData($attribute, $data);
 
         $this->setData($product, $attribute, $data, $options['locale'], $options['scope']);
@@ -69,10 +69,8 @@ class DateAttributeSetter extends AbstractAttributeSetter
             throw InvalidArgumentException::expected(
                 $attribute->getCode(),
                 'datetime or string',
-                gettype($data),
-                'setter',
-                'date',
-                $data
+                static::class,
+                gettype($data)
             );
         }
 
@@ -97,10 +95,8 @@ class DateAttributeSetter extends AbstractAttributeSetter
             throw InvalidArgumentException::expected(
                 $attribute->getCode(),
                 'a string with the format yyyy-mm-dd',
-                'setter',
-                'date',
-                gettype($data),
-                $data
+                static::class,
+                gettype($data)
             );
         }
     }

--- a/src/Pim/Component/Catalog/Updater/Setter/FamilyFieldSetter.php
+++ b/src/Pim/Component/Catalog/Updater/Setter/FamilyFieldSetter.php
@@ -46,8 +46,7 @@ class FamilyFieldSetter extends AbstractFieldSetter
                 throw InvalidArgumentException::expected(
                     $field,
                     'existing family code',
-                    'setter',
-                    'family',
+                    static::class,
                     $data
                 );
             }
@@ -68,8 +67,7 @@ class FamilyFieldSetter extends AbstractFieldSetter
         if (!is_string($data) && null !== $data && '' !== $data) {
             throw InvalidArgumentException::stringExpected(
                 $field,
-                'setter',
-                'family',
+                static::class,
                 gettype($data)
             );
         }

--- a/src/Pim/Component/Catalog/Updater/Setter/GroupFieldSetter.php
+++ b/src/Pim/Component/Catalog/Updater/Setter/GroupFieldSetter.php
@@ -48,8 +48,7 @@ class GroupFieldSetter extends AbstractFieldSetter
                 throw InvalidArgumentException::expected(
                     $field,
                     'existing group code',
-                    'setter',
-                    'groups',
+                    static::class,
                     $groupCode
                 );
             } else {
@@ -78,8 +77,7 @@ class GroupFieldSetter extends AbstractFieldSetter
         if (!is_array($data)) {
             throw InvalidArgumentException::arrayExpected(
                 $field,
-                'setter',
-                'groups',
+                static::class,
                 gettype($data)
             );
         }
@@ -89,8 +87,7 @@ class GroupFieldSetter extends AbstractFieldSetter
                 throw InvalidArgumentException::arrayStringValueExpected(
                     $field,
                     $key,
-                    'setter',
-                    'groups',
+                    static::class,
                     gettype($value)
                 );
             }

--- a/src/Pim/Component/Catalog/Updater/Setter/MediaAttributeSetter.php
+++ b/src/Pim/Component/Catalog/Updater/Setter/MediaAttributeSetter.php
@@ -60,7 +60,7 @@ class MediaAttributeSetter extends AbstractAttributeSetter
         array $options = []
     ) {
         $options = $this->resolver->resolve($options);
-        $this->checkLocaleAndScope($attribute, $options['locale'], $options['scope'], 'media');
+        $this->checkLocaleAndScope($attribute, $options['locale'], $options['scope']);
         $this->checkData($attribute, $data);
 
         if (null === $data) {
@@ -107,7 +107,7 @@ class MediaAttributeSetter extends AbstractAttributeSetter
         }
 
         if (!is_string($data)) {
-            throw InvalidArgumentException::stringExpected($attribute->getCode(), 'setter', 'media', gettype($data));
+            throw InvalidArgumentException::stringExpected($attribute->getCode(), static::class, gettype($data));
         }
     }
 
@@ -133,8 +133,7 @@ class MediaAttributeSetter extends AbstractAttributeSetter
             throw InvalidArgumentException::expected(
                 $attribute->getCode(),
                 'a valid pathname',
-                'setter',
-                'media',
+                static::class,
                 $data
             );
         }

--- a/src/Pim/Component/Catalog/Updater/Setter/MetricAttributeSetter.php
+++ b/src/Pim/Component/Catalog/Updater/Setter/MetricAttributeSetter.php
@@ -54,7 +54,7 @@ class MetricAttributeSetter extends AbstractAttributeSetter
         array $options = []
     ) {
         $options = $this->resolver->resolve($options);
-        $this->checkLocaleAndScope($attribute, $options['locale'], $options['scope'], 'metric');
+        $this->checkLocaleAndScope($attribute, $options['locale'], $options['scope']);
 
         if (null === $data) {
             $data = ['amount' => null, 'unit' => null];
@@ -77,15 +77,14 @@ class MetricAttributeSetter extends AbstractAttributeSetter
     protected function checkData(AttributeInterface $attribute, $data)
     {
         if (!is_array($data)) {
-            throw InvalidArgumentException::arrayExpected($attribute->getCode(), 'setter', 'metric', gettype($data));
+            throw InvalidArgumentException::arrayExpected($attribute->getCode(), static::class, gettype($data));
         }
 
         if (!array_key_exists('amount', $data)) {
             throw InvalidArgumentException::arrayKeyExpected(
                 $attribute->getCode(),
                 'amount',
-                'setter',
-                'metric',
+                static::class,
                 print_r($data, true)
             );
         }
@@ -94,8 +93,7 @@ class MetricAttributeSetter extends AbstractAttributeSetter
             throw InvalidArgumentException::arrayKeyExpected(
                 $attribute->getCode(),
                 'unit',
-                'setter',
-                'metric',
+                static::class,
                 print_r($data, true)
             );
         }

--- a/src/Pim/Component/Catalog/Updater/Setter/MultiSelectAttributeSetter.php
+++ b/src/Pim/Component/Catalog/Updater/Setter/MultiSelectAttributeSetter.php
@@ -49,7 +49,7 @@ class MultiSelectAttributeSetter extends AbstractAttributeSetter
         $data,
         array $options = []
     ) {
-        $this->checkLocaleAndScope($attribute, $options['locale'], $options['scope'], 'multi select');
+        $this->checkLocaleAndScope($attribute, $options['locale'], $options['scope']);
         $this->checkData($attribute, $data);
 
         $attributeOptions = [];
@@ -60,8 +60,7 @@ class MultiSelectAttributeSetter extends AbstractAttributeSetter
                     $attribute->getCode(),
                     'code',
                     'The option does not exist',
-                    'setter',
-                    'multi select',
+                    static::class,
                     $optionCode
                 );
             }
@@ -83,8 +82,7 @@ class MultiSelectAttributeSetter extends AbstractAttributeSetter
         if (!is_array($data)) {
             throw InvalidArgumentException::arrayExpected(
                 $attribute->getCode(),
-                'setter',
-                'multi select',
+                static::class,
                 gettype($data)
             );
         }
@@ -94,8 +92,7 @@ class MultiSelectAttributeSetter extends AbstractAttributeSetter
                 throw InvalidArgumentException::arrayStringValueExpected(
                     $attribute->getCode(),
                     $key,
-                    'setter',
-                    'multi select',
+                    static::class,
                     gettype($value)
                 );
             }

--- a/src/Pim/Component/Catalog/Updater/Setter/NumberAttributeSetter.php
+++ b/src/Pim/Component/Catalog/Updater/Setter/NumberAttributeSetter.php
@@ -42,7 +42,7 @@ class NumberAttributeSetter extends AbstractAttributeSetter
         array $options = []
     ) {
         $options = $this->resolver->resolve($options);
-        $this->checkLocaleAndScope($attribute, $options['locale'], $options['scope'], 'number');
+        $this->checkLocaleAndScope($attribute, $options['locale'], $options['scope']);
 
         $this->setData($product, $attribute, $data, $options['locale'], $options['scope']);
     }

--- a/src/Pim/Component/Catalog/Updater/Setter/PriceCollectionAttributeSetter.php
+++ b/src/Pim/Component/Catalog/Updater/Setter/PriceCollectionAttributeSetter.php
@@ -53,7 +53,7 @@ class PriceCollectionAttributeSetter extends AbstractAttributeSetter
         array $options = []
     ) {
         $options = $this->resolver->resolve($options);
-        $this->checkLocaleAndScope($attribute, $options['locale'], $options['scope'], 'prices collection');
+        $this->checkLocaleAndScope($attribute, $options['locale'], $options['scope']);
         $this->checkData($attribute, $data);
 
         $this->setPrices($product, $attribute, $data, $options['locale'], $options['scope']);
@@ -72,8 +72,7 @@ class PriceCollectionAttributeSetter extends AbstractAttributeSetter
         if (!is_array($data)) {
             throw InvalidArgumentException::arrayExpected(
                 $attribute->getCode(),
-                'setter',
-                'prices collection',
+                static::class,
                 gettype($data)
             );
         }
@@ -82,8 +81,7 @@ class PriceCollectionAttributeSetter extends AbstractAttributeSetter
             if (!is_array($price)) {
                 throw InvalidArgumentException::arrayOfArraysExpected(
                     $attribute->getCode(),
-                    'setter',
-                    'prices collection',
+                    static::class,
                     gettype($data)
                 );
             }
@@ -92,8 +90,7 @@ class PriceCollectionAttributeSetter extends AbstractAttributeSetter
                 throw InvalidArgumentException::arrayKeyExpected(
                     $attribute->getCode(),
                     'amount',
-                    'setter',
-                    'prices collection',
+                    static::class,
                     print_r($data, true)
                 );
             }
@@ -102,8 +99,7 @@ class PriceCollectionAttributeSetter extends AbstractAttributeSetter
                 throw InvalidArgumentException::arrayKeyExpected(
                     $attribute->getCode(),
                     'currency',
-                    'setter',
-                    'prices collection',
+                    static::class,
                     print_r($data, true)
                 );
             }

--- a/src/Pim/Component/Catalog/Updater/Setter/SimpleSelectAttributeSetter.php
+++ b/src/Pim/Component/Catalog/Updater/Setter/SimpleSelectAttributeSetter.php
@@ -51,7 +51,7 @@ class SimpleSelectAttributeSetter extends AbstractAttributeSetter
         array $options = []
     ) {
         $options = $this->resolver->resolve($options);
-        $this->checkLocaleAndScope($attribute, $options['locale'], $options['scope'], 'text');
+        $this->checkLocaleAndScope($attribute, $options['locale'], $options['scope']);
         $this->checkData($attribute, $data);
 
         if (null === $data) {
@@ -63,8 +63,7 @@ class SimpleSelectAttributeSetter extends AbstractAttributeSetter
                     $attribute->getCode(),
                     'code',
                     'The option does not exist',
-                    'setter',
-                    'simple select',
+                    static::class,
                     $data
                 );
             }
@@ -88,8 +87,7 @@ class SimpleSelectAttributeSetter extends AbstractAttributeSetter
         if (!is_string($data) && !is_numeric($data)) {
             throw InvalidArgumentException::stringExpected(
                 $attribute->getCode(),
-                'setter',
-                'simple select',
+                static::class,
                 gettype($data)
             );
         }

--- a/src/Pim/Component/Catalog/Updater/Setter/TextAttributeSetter.php
+++ b/src/Pim/Component/Catalog/Updater/Setter/TextAttributeSetter.php
@@ -42,7 +42,7 @@ class TextAttributeSetter extends AbstractAttributeSetter
         array $options = []
     ) {
         $options = $this->resolver->resolve($options);
-        $this->checkLocaleAndScope($attribute, $options['locale'], $options['scope'], 'text');
+        $this->checkLocaleAndScope($attribute, $options['locale'], $options['scope']);
 
         $this->setData($product, $attribute, $data, $options['locale'], $options['scope']);
     }

--- a/src/Pim/Component/Catalog/Updater/Setter/VariantGroupFieldSetter.php
+++ b/src/Pim/Component/Catalog/Updater/Setter/VariantGroupFieldSetter.php
@@ -45,8 +45,7 @@ class VariantGroupFieldSetter extends AbstractFieldSetter
                 throw InvalidArgumentException::expected(
                     $field,
                     'existing variant group code',
-                    'setter',
-                    'variant_group',
+                    static::class,
                     $data
                 );
             }
@@ -55,8 +54,7 @@ class VariantGroupFieldSetter extends AbstractFieldSetter
                 throw InvalidArgumentException::expected(
                     $field,
                     'variant group code',
-                    'setter',
-                    'variant_group',
+                    static::class,
                     $data
                 );
             }
@@ -85,8 +83,7 @@ class VariantGroupFieldSetter extends AbstractFieldSetter
         if (!is_string($data) && null !== $data) {
             throw InvalidArgumentException::stringExpected(
                 $field,
-                'setter',
-                'variant_group',
+                static::class,
                 gettype($data)
             );
         }

--- a/src/Pim/Component/Catalog/Updater/VariantGroupUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/VariantGroupUpdater.php
@@ -174,8 +174,7 @@ class VariantGroupUpdater implements ObjectUpdaterInterface
                 'type',
                 'group type',
                 'The group type does not exist',
-                'updater',
-                'variant group',
+                static::class,
                 $type
             );
         }
@@ -208,7 +207,7 @@ class VariantGroupUpdater implements ObjectUpdaterInterface
                 throw ImmutablePropertyException::immutableProperty(
                     'axes',
                     implode(',', $axes),
-                    'updater',
+                    static::class,
                     'variant group'
                 );
             }
@@ -223,8 +222,7 @@ class VariantGroupUpdater implements ObjectUpdaterInterface
                     'axes',
                     'attribute code',
                     'The attribute does not exist',
-                    'updater',
-                    'variant group',
+                    static::class,
                     $axis
                 );
             }

--- a/src/Pim/Component/Catalog/spec/Updater/Adder/AssociationFieldAdderSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Adder/AssociationFieldAdderSpec.php
@@ -37,8 +37,7 @@ class AssociationFieldAdderSpec extends ObjectBehavior
         $this->shouldThrow(
             InvalidArgumentException::arrayExpected(
                 'associations',
-                'adder',
-                'association',
+                'Pim\Component\Catalog\Updater\Adder\AssociationFieldAdder',
                 'string'
             )
         )->during('addFieldData', [$product, 'associations', 'not an array']);
@@ -152,8 +151,7 @@ class AssociationFieldAdderSpec extends ObjectBehavior
             InvalidArgumentException::expected(
                 'associations',
                 'existing association type code',
-                'adder',
-                'association',
+                'Pim\Component\Catalog\Updater\Adder\AssociationFieldAdder',
                 'non valid association type code'
             )
         )->during(
@@ -182,8 +180,7 @@ class AssociationFieldAdderSpec extends ObjectBehavior
             InvalidArgumentException::expected(
                 'associations',
                 'existing product identifier',
-                'adder',
-                'association',
+                'Pim\Component\Catalog\Updater\Adder\AssociationFieldAdder',
                 'not existing product'
             )
         )->during(
@@ -212,8 +209,7 @@ class AssociationFieldAdderSpec extends ObjectBehavior
             InvalidArgumentException::expected(
                 'associations',
                 'existing group code',
-                'adder',
-                'association',
+                'Pim\Component\Catalog\Updater\Adder\AssociationFieldAdder',
                 'not existing group'
             )
         )->during(

--- a/src/Pim/Component/Catalog/spec/Updater/Adder/CategoryFieldAdderSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Adder/CategoryFieldAdderSpec.php
@@ -36,8 +36,7 @@ class CategoryFieldAdderSpec extends ObjectBehavior
         $this->shouldThrow(
             InvalidArgumentException::arrayExpected(
                 'categories',
-                'adder',
-                'category',
+                'Pim\Component\Catalog\Updater\Adder\CategoryFieldAdder',
                 'string'
             )
         )->during('addFieldData', [$product, 'categories', 'not an array']);
@@ -46,8 +45,7 @@ class CategoryFieldAdderSpec extends ObjectBehavior
             InvalidArgumentException::arrayStringValueExpected(
                 'categories',
                 0,
-                'adder',
-                'category',
+                'Pim\Component\Catalog\Updater\Adder\CategoryFieldAdder',
                 'array'
             )
         )->during('addFieldData', [$product, 'categories', [['array of array']]]);
@@ -84,8 +82,7 @@ class CategoryFieldAdderSpec extends ObjectBehavior
             InvalidArgumentException::expected(
                 'categories',
                 'existing category code',
-                'adder',
-                'category',
+                'Pim\Component\Catalog\Updater\Adder\CategoryFieldAdder',
                 'non valid category code'
             )
         )->during('addFieldData', [$product, 'categories', ['mug', 'non valid category code']]);

--- a/src/Pim/Component/Catalog/spec/Updater/Adder/GroupFieldAdderSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Adder/GroupFieldAdderSpec.php
@@ -37,8 +37,7 @@ class GroupFieldAdderSpec extends ObjectBehavior
         $this->shouldThrow(
             InvalidArgumentException::arrayExpected(
                 'groups',
-                'adder',
-                'groups',
+                'Pim\Component\Catalog\Updater\Adder\GroupFieldAdder',
                 'string'
             )
         )->during('addFieldData', [$product, 'groups', 'not an array']);
@@ -47,8 +46,7 @@ class GroupFieldAdderSpec extends ObjectBehavior
             InvalidArgumentException::arrayStringValueExpected(
                 'groups',
                 0,
-                'adder',
-                'groups',
+                'Pim\Component\Catalog\Updater\Adder\GroupFieldAdder',
                 'array'
             )
         )->during('addFieldData', [$product, 'groups', [['array of array']]]);
@@ -92,8 +90,7 @@ class GroupFieldAdderSpec extends ObjectBehavior
             InvalidArgumentException::expected(
                 'groups',
                 'existing group code',
-                'adder',
-                'groups',
+                'Pim\Component\Catalog\Updater\Adder\GroupFieldAdder',
                 'not valid code'
             )
         )->during('addFieldData', [$product, 'groups', ['pack', 'not valid code']]);
@@ -118,8 +115,7 @@ class GroupFieldAdderSpec extends ObjectBehavior
             InvalidArgumentException::expected(
                 'groups',
                 'non variant group code',
-                'adder',
-                'groups',
+                'Pim\Component\Catalog\Updater\Adder\GroupFieldAdder',
                 'variant'
             )
         )->during('addFieldData', [$product, 'groups', ['pack', 'variant']]);

--- a/src/Pim/Component/Catalog/spec/Updater/Adder/MultiSelectAttributeAdderSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Adder/MultiSelectAttributeAdderSpec.php
@@ -81,8 +81,7 @@ class MultiSelectAttributeAdderSpec extends ObjectBehavior
             InvalidArgumentException::arrayStringValueExpected(
                 'attributeCode',
                 'foo',
-                'adder',
-                'multi select',
+                'Pim\Component\Catalog\Updater\Adder\MultiSelectAttributeAdder',
                 'array'
             )
         )->during('addAttributeData', [$product, $attribute, $data, ['locale' => 'fr_FR', 'scope' => 'mobile']]);
@@ -107,8 +106,7 @@ class MultiSelectAttributeAdderSpec extends ObjectBehavior
                 'attributeCode',
                 'code',
                 'The option does not exist',
-                'adder',
-                'multi select',
+                'Pim\Component\Catalog\Updater\Adder\MultiSelectAttributeAdder',
                 'unknown code'
             )
         )->during('addAttributeData', [$product, $attribute, $data, ['locale' => 'fr_FR', 'scope' => 'mobile']]);

--- a/src/Pim/Component/Catalog/spec/Updater/Adder/PriceCollectionAttributeAdderSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Adder/PriceCollectionAttributeAdderSpec.php
@@ -74,7 +74,11 @@ class PriceCollectionAttributeAdderSpec extends ObjectBehavior
         $data = 'not an array';
 
         $this->shouldThrow(
-            InvalidArgumentException::arrayExpected('attributeCode', 'adder', 'prices collection', gettype($data))
+            InvalidArgumentException::arrayExpected(
+                'attributeCode',
+                'Pim\Component\Catalog\Updater\Adder\PriceCollectionAttributeAdder',
+                gettype($data)
+            )
         )->during('addAttributeData', [$product, $attribute, $data, ['locale' => 'fr_FR', 'scope' => 'mobile']]);
     }
 
@@ -89,8 +93,7 @@ class PriceCollectionAttributeAdderSpec extends ObjectBehavior
         $this->shouldThrow(
             InvalidArgumentException::arrayOfArraysExpected(
                 'attributeCode',
-                'adder',
-                'prices collection',
+                'Pim\Component\Catalog\Updater\Adder\PriceCollectionAttributeAdder',
                 gettype($data)
             )
         )->during('addAttributeData', [$product, $attribute, $data, ['locale' => 'fr_FR', 'scope' => 'mobile']]);
@@ -108,8 +111,7 @@ class PriceCollectionAttributeAdderSpec extends ObjectBehavior
             InvalidArgumentException::arrayKeyExpected(
                 'attributeCode',
                 'amount',
-                'adder',
-                'prices collection',
+                'Pim\Component\Catalog\Updater\Adder\PriceCollectionAttributeAdder',
                 print_r($data, true)
             )
         )->during('addAttributeData', [$product, $attribute, $data, ['locale' => 'fr_FR', 'scope' => 'mobile']]);
@@ -127,8 +129,7 @@ class PriceCollectionAttributeAdderSpec extends ObjectBehavior
             InvalidArgumentException::arrayNumericKeyExpected(
                 'attributeCode',
                 'amount',
-                'adder',
-                'prices collection',
+                'Pim\Component\Catalog\Updater\Adder\PriceCollectionAttributeAdder',
                 gettype('text')
             )
         )->during('addAttributeData', [$product, $attribute, $data, ['locale' => 'fr_FR', 'scope' => 'mobile']]);
@@ -146,8 +147,7 @@ class PriceCollectionAttributeAdderSpec extends ObjectBehavior
             InvalidArgumentException::arrayKeyExpected(
                 'attributeCode',
                 'currency',
-                'adder',
-                'prices collection',
+                'Pim\Component\Catalog\Updater\Adder\PriceCollectionAttributeAdder',
                 print_r($data, true)
             )
         )->during('addAttributeData', [$product, $attribute, $data, ['locale' => 'fr_FR', 'scope' => 'mobile']]);
@@ -169,8 +169,7 @@ class PriceCollectionAttributeAdderSpec extends ObjectBehavior
                 'attributeCode',
                 'currency',
                 'The currency does not exist',
-                'adder',
-                'prices collection',
+                'Pim\Component\Catalog\Updater\Adder\PriceCollectionAttributeAdder',
                 'invalid currency'
             )
         )->during('addAttributeData', [$product, $attribute, $data, ['locale' => 'fr_FR', 'scope' => 'mobile']]);

--- a/src/Pim/Component/Catalog/spec/Updater/AttributeGroupUpdaterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/AttributeGroupUpdaterSpec.php
@@ -105,12 +105,11 @@ class AttributeGroupUpdaterSpec extends ObjectBehavior
 
         $this->shouldThrow(
             InvalidPropertyException::validEntityCodeExpected(
-               'attributes',
-               'attribute code',
-               'The attribute does not exist',
-               'updater',
-               'attribute group',
-               'foo'
+                'attributes',
+                'attribute code',
+                'The attribute does not exist',
+                'Pim\Component\Catalog\Updater\AttributeGroupUpdater',
+                'foo'
             ))
             ->during('update', [$attributeGroup, $values]);
     }

--- a/src/Pim/Component/Catalog/spec/Updater/AttributeOptionUpdaterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/AttributeOptionUpdaterSpec.php
@@ -86,8 +86,7 @@ class AttributeOptionUpdaterSpec extends ObjectBehavior
                 'attribute',
                 'attribute code',
                 'The attribute does not exist',
-                'updater',
-                'attribute option',
+                'Pim\Component\Catalog\Updater\AttributeOptionUpdater',
                 'myattribute'
             )
         )->during(

--- a/src/Pim/Component/Catalog/spec/Updater/AttributeUpdaterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/AttributeUpdaterSpec.php
@@ -126,8 +126,7 @@ class AttributeUpdaterSpec extends ObjectBehavior
                 'group',
                 'code',
                 'The attribute group does not exist',
-                'updater',
-                'attribute',
+                'Pim\Component\Catalog\Updater\AttributeUpdater',
                 'marketing'
             )
         )->during(
@@ -139,11 +138,7 @@ class AttributeUpdaterSpec extends ObjectBehavior
     function it_throws_an_exception_if_it_attribute_type_is_empty(AttributeInterface $attribute)
     {
         $this->shouldThrow(
-            InvalidPropertyException::valueNotEmptyExpected(
-                'attribute_type',
-                'updater',
-                'attribute'
-            )
+            InvalidPropertyException::valueNotEmptyExpected('attribute_type', 'Pim\Component\Catalog\Updater\AttributeUpdater')
         )->during(
             'update',
             [$attribute, ['attribute_type' => '']]
@@ -159,8 +154,7 @@ class AttributeUpdaterSpec extends ObjectBehavior
                 'attribute_type',
                 'attribute type',
                 'The attribute type does not exist',
-                'updater',
-                'attribute',
+                'Pim\Component\Catalog\Updater\AttributeUpdater',
                 'unknown_type'
             )
         )->during('update', [$attribute, ['attribute_type' => 'unknown_type']]);
@@ -172,8 +166,7 @@ class AttributeUpdaterSpec extends ObjectBehavior
             InvalidPropertyException::dateExpected(
                 'date_min',
                 'yyyy-mm-dd',
-                'updater',
-                'attribute',
+                'Pim\Component\Catalog\Updater\AttributeUpdater',
                 'not a date'
             )
         )->during(
@@ -188,8 +181,7 @@ class AttributeUpdaterSpec extends ObjectBehavior
             InvalidPropertyException::dateExpected(
                 'date_min',
                 'yyyy-mm-dd',
-                'updater',
-                'attribute',
+                'Pim\Component\Catalog\Updater\AttributeUpdater',
                 '45/45/2016'
             )
         )->during(
@@ -204,8 +196,7 @@ class AttributeUpdaterSpec extends ObjectBehavior
             InvalidPropertyException::dateExpected(
                 'date_min',
                 'yyyy-mm-dd',
-                'updater',
-                'attribute',
+                'Pim\Component\Catalog\Updater\AttributeUpdater',
                 '2016/12/12'
             )
         )->during(
@@ -239,8 +230,7 @@ class AttributeUpdaterSpec extends ObjectBehavior
                 'available_locales',
                 'locale code',
                 'The locale does not exist',
-                'updater',
-                'attribute',
+                'Pim\Component\Catalog\Updater\AttributeUpdater',
                 'foo'
             )
         )->during('update', [$attribute, $values, []]);

--- a/src/Pim/Component/Catalog/spec/Updater/ChannelUpdaterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/ChannelUpdaterSpec.php
@@ -150,8 +150,7 @@ class ChannelUpdaterSpec extends ObjectBehavior
                 'category_tree',
                 'code',
                 'The category does not exist',
-                'updater',
-                'channel',
+                'Pim\Component\Catalog\Updater\ChannelUpdater',
                 'unknown'
             )
         )->during(
@@ -183,8 +182,7 @@ class ChannelUpdaterSpec extends ObjectBehavior
                 'locales',
                 'code',
                 'The locale does not exist',
-                'updater',
-                'channel',
+                'Pim\Component\Catalog\Updater\ChannelUpdater',
                 'unknown'
             )
         )->during(
@@ -219,8 +217,7 @@ class ChannelUpdaterSpec extends ObjectBehavior
                 'currencies',
                 'code',
                 'The currency does not exist',
-                'updater',
-                'channel',
+                'Pim\Component\Catalog\Updater\ChannelUpdater',
                 'unknown'
             )
         )->during('update', [$channel, $values]);
@@ -256,8 +253,7 @@ class ChannelUpdaterSpec extends ObjectBehavior
                 'conversionUnits',
                 'attributeCode',
                 'the attribute code for the conversion unit does not exist',
-                'updater',
-                'channel',
+                'Pim\Component\Catalog\Updater\ChannelUpdater',
                 'unknown_attribute'
             )
         )->during('update', [$channel, $values]);
@@ -298,8 +294,7 @@ class ChannelUpdaterSpec extends ObjectBehavior
                 'conversionUnits',
                 'unitCode',
                 'the metric unit code for the conversion unit does not exist',
-                'updater',
-                'channel',
+                'Pim\Component\Catalog\Updater\ChannelUpdater',
                 'unknown_unit_code'
             )
         )->during('update', [$channel, $values]);

--- a/src/Pim/Component/Catalog/spec/Updater/Copier/BaseAttributeCopierSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Copier/BaseAttributeCopierSpec.php
@@ -358,7 +358,7 @@ class BaseAttributeCopierSpec extends ObjectBehavior
         $fromAttribute->isLocalizable()->willReturn(true);
         $attrValidatorHelper->validateLocale($fromAttribute, null)->willThrow($e);
         $this->shouldThrow(
-            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'copier', 'base')
+            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'Pim\Component\Catalog\Updater\Copier\BaseAttributeCopier')
         )->during('copyAttributeData', [$product, $product, $fromAttribute, $toAttribute, []]);
     }
 
@@ -373,7 +373,7 @@ class BaseAttributeCopierSpec extends ObjectBehavior
         $fromAttribute->isLocalizable()->willReturn(false);
         $attrValidatorHelper->validateLocale($fromAttribute, 'en_US')->willThrow($e);
         $this->shouldThrow(
-            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'copier', 'base')
+            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'Pim\Component\Catalog\Updater\Copier\BaseAttributeCopier')
         )->during(
             'copyAttributeData',
             [$product, $product, $fromAttribute, $toAttribute, ['from_locale' => 'en_US', 'from_scope' => 'ecommerce']]
@@ -391,7 +391,7 @@ class BaseAttributeCopierSpec extends ObjectBehavior
         $fromAttribute->isLocalizable()->willReturn(true);
         $attrValidatorHelper->validateLocale($fromAttribute, 'uz-UZ')->willThrow($e);
         $this->shouldThrow(
-            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'copier', 'base')
+            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'Pim\Component\Catalog\Updater\Copier\BaseAttributeCopier')
         )->during(
             'copyAttributeData',
             [$product, $product, $fromAttribute, $toAttribute, ['from_locale' => 'uz-UZ', 'from_scope' => 'ecommerce']]
@@ -411,7 +411,7 @@ class BaseAttributeCopierSpec extends ObjectBehavior
         $attrValidatorHelper->validateLocale($fromAttribute, null)->shouldBeCalled();
         $attrValidatorHelper->validateScope($fromAttribute, null)->willThrow($e);
         $this->shouldThrow(
-            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'copier', 'base')
+            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'Pim\Component\Catalog\Updater\Copier\BaseAttributeCopier')
         )->during(
             'copyAttributeData',
             [$product, $product, $fromAttribute, $toAttribute, ['from_locale' => null, 'from_scope' => null]]
@@ -431,7 +431,7 @@ class BaseAttributeCopierSpec extends ObjectBehavior
         $attrValidatorHelper->validateLocale($fromAttribute, null)->shouldBeCalled();
         $attrValidatorHelper->validateScope($fromAttribute, 'ecommerce')->willThrow($e);
         $this->shouldThrow(
-            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'copier', 'base')
+            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'Pim\Component\Catalog\Updater\Copier\BaseAttributeCopier')
         )->during(
             'copyAttributeData',
             [$product, $product, $fromAttribute, $toAttribute, ['from_locale' => null, 'from_scope' => 'ecommerce']]
@@ -451,7 +451,7 @@ class BaseAttributeCopierSpec extends ObjectBehavior
         $attrValidatorHelper->validateLocale($fromAttribute, null)->shouldBeCalled();
         $attrValidatorHelper->validateScope($fromAttribute, 'ecommerce')->willThrow($e);
         $this->shouldThrow(
-            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'copier', 'base')
+            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'Pim\Component\Catalog\Updater\Copier\BaseAttributeCopier')
         )->during(
             'copyAttributeData',
             [$product, $product, $fromAttribute, $toAttribute, ['from_locale' => null, 'from_scope' => 'ecommerce']]

--- a/src/Pim/Component/Catalog/spec/Updater/FamilyUpdaterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/FamilyUpdaterSpec.php
@@ -303,8 +303,7 @@ class FamilyUpdaterSpec extends ObjectBehavior
                 'attributes',
                 'code',
                 'The attribute does not exist',
-                'updater',
-                'family',
+                'Pim\Component\Catalog\Updater\FamilyUpdater',
                 'sku'
             )
         )->during('update', [$family, $data]);
@@ -338,8 +337,7 @@ class FamilyUpdaterSpec extends ObjectBehavior
                 'attribute_requirements',
                 'code',
                 'The attribute does not exist',
-                'updater',
-                'family',
+                'Pim\Component\Catalog\Updater\FamilyUpdater',
                 'sku'
             )
         )->during('update', [$family, $data]);
@@ -371,8 +369,7 @@ class FamilyUpdaterSpec extends ObjectBehavior
                 'attributes',
                 'code',
                 'The attribute does not exist',
-                'updater',
-                'family',
+                'Pim\Component\Catalog\Updater\FamilyUpdater',
                 'unknown'
             )
         )->during('update', [$family, $data]);
@@ -406,8 +403,7 @@ class FamilyUpdaterSpec extends ObjectBehavior
                 'attribute_requirements',
                 'code',
                 'The channel does not exist',
-                'updater',
-                'family',
+                'Pim\Component\Catalog\Updater\FamilyUpdater',
                 'mobile'
             )
         )->during('update', [$family, $data]);

--- a/src/Pim/Component/Catalog/spec/Updater/GroupUpdaterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/GroupUpdaterSpec.php
@@ -110,8 +110,7 @@ class GroupUpdaterSpec extends ObjectBehavior
                 'type',
                 'group type',
                 'The group type does not exist',
-                'updater',
-                'group',
+                'Pim\Component\Catalog\Updater\GroupUpdater',
                 'UNKNOWN'
             )
         )->during('update', [$group, $values, []]);
@@ -133,8 +132,7 @@ class GroupUpdaterSpec extends ObjectBehavior
             InvalidPropertyException::validGroupTypeExpected(
                 'type',
                 'Cannot process variant group, only groups are supported',
-                'updater',
-                'group',
+                'Pim\Component\Catalog\Updater\GroupUpdater',
                 'mycode'
             )
         )->during('update', [$group, $values, []]);
@@ -156,8 +154,7 @@ class GroupUpdaterSpec extends ObjectBehavior
                 'axis',
                 'attribute code',
                 'The attribute does not exist',
-                'updater',
-                'group',
+                'Pim\Component\Catalog\Updater\GroupUpdater',
                 'foo'
             )
         )->during('update', [$group, $values, []]);

--- a/src/Pim/Component/Catalog/spec/Updater/Remover/CategoryFieldRemoverSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Remover/CategoryFieldRemoverSpec.php
@@ -48,9 +48,11 @@ class CategoryFieldRemoverSpec extends ObjectBehavior
         $categoryRepository->findOneByIdentifier('unknown_category')->willReturn(null);
 
         $this->shouldThrow(
-            new InvalidArgumentException(
-                'Attribute or field "categories" expects existing category code as data, "unknown_category" given (for remover category).',
-                InvalidArgumentException::EXPECTED_CODE
+            InvalidArgumentException::expected(
+                'categories',
+                'existing category code',
+                'Pim\Component\Catalog\Updater\Remover\CategoryFieldRemover',
+                'unknown_category'
             )
         )->duringRemoveFieldData($bookProduct, 'categories', ['unknown_category']);
     }
@@ -58,16 +60,19 @@ class CategoryFieldRemoverSpec extends ObjectBehavior
     function it_throws_an_exception_if_data_are_invalid(ProductInterface $bookProduct)
     {
         $this->shouldThrow(
-            new InvalidArgumentException(
-                'Attribute or field "categories" expects an array as data, "string" given (for remover category).',
-                InvalidArgumentException::ARRAY_EXPECTED_CODE
+            InvalidArgumentException::arrayExpected(
+                'categories',
+                'Pim\Component\Catalog\Updater\Remover\CategoryFieldRemover',
+                'string'
             )
         )->duringRemoveFieldData($bookProduct, 'categories', 'category_code');
 
         $this->shouldThrow(
-            new InvalidArgumentException(
-                'Attribute or field "categories" expects an array with a string value for the key "0", "integer" given (for remover category).',
-                InvalidArgumentException::ARRAY_STRING_VALUE_EXPECTED_CODE
+            InvalidArgumentException::arrayStringValueExpected(
+                'categories',
+                0,
+                'Pim\Component\Catalog\Updater\Remover\CategoryFieldRemover',
+                'integer'
             )
         )->duringRemoveFieldData($bookProduct, 'categories', [42]);
     }

--- a/src/Pim/Component/Catalog/spec/Updater/Remover/GroupFieldRemoverSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Remover/GroupFieldRemoverSpec.php
@@ -66,8 +66,7 @@ class GroupFieldRemoverSpec extends ObjectBehavior
             InvalidArgumentException::expected(
                 'groups',
                 'existing group code',
-                'remover',
-                'groups',
+                'Pim\Component\Catalog\Updater\Remover\GroupFieldRemover',
                 'not valid code'
             )
         )->during('removeFieldData', [$product, 'groups', ['pack', 'not valid code']]);
@@ -78,8 +77,7 @@ class GroupFieldRemoverSpec extends ObjectBehavior
         $this->shouldThrow(
             InvalidArgumentException::arrayExpected(
                 'groups',
-                'remover',
-                'groups',
+                'Pim\Component\Catalog\Updater\Remover\GroupFieldRemover',
                 'string'
             )
         )->during('removeFieldData', [$product, 'groups', 'not an array']);
@@ -88,8 +86,7 @@ class GroupFieldRemoverSpec extends ObjectBehavior
             InvalidArgumentException::arrayStringValueExpected(
                 'groups',
                 0,
-                'remover',
-                'groups',
+                'Pim\Component\Catalog\Updater\Remover\GroupFieldRemover',
                 'array'
             )
         )->during('removeFieldData', [$product, 'groups', [['array of array']]]);
@@ -114,8 +111,7 @@ class GroupFieldRemoverSpec extends ObjectBehavior
             InvalidArgumentException::expected(
                 'groups',
                 'non variant group code',
-                'remover',
-                'groups',
+                'Pim\Component\Catalog\Updater\Remover\GroupFieldRemover',
                 'variant'
             )
         )->during('removeFieldData', [$product, 'groups', ['pack', 'variant']]);

--- a/src/Pim/Component/Catalog/spec/Updater/Remover/MultiSelectAttributeRemoverSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Remover/MultiSelectAttributeRemoverSpec.php
@@ -79,8 +79,7 @@ class MultiSelectAttributeRemoverSpec extends ObjectBehavior
         $this->shouldThrow(
             InvalidArgumentException::arrayExpected(
                 'attributeCode',
-                'remover',
-                'multi select',
+                'Pim\Component\Catalog\Updater\Remover\MultiSelectAttributeRemover',
                 gettype($data)
             )
         )->during('removeAttributeData', [$product, $attribute, $data, ['locale' => 'fr_FR', 'scope' => 'mobile']]);
@@ -97,8 +96,7 @@ class MultiSelectAttributeRemoverSpec extends ObjectBehavior
             InvalidArgumentException::arrayStringValueExpected(
                 'attributeCode',
                 0,
-                'remover',
-                'multi select',
+                'Pim\Component\Catalog\Updater\Remover\MultiSelectAttributeRemover',
                 gettype($data[0])
             )
         )->during('removeAttributeData', [$product, $attribute, $data, ['locale' => 'fr_FR', 'scope' => 'mobile']]);

--- a/src/Pim/Component/Catalog/spec/Updater/Remover/PriceCollectionAttributeRemoverSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Remover/PriceCollectionAttributeRemoverSpec.php
@@ -45,9 +45,7 @@ class PriceCollectionAttributeRemoverSpec extends ObjectBehavior
         $attrValidatorHelper,
         $currencyRepository,
         AttributeInterface $attribute,
-        ProductInterface $product,
-        ProductValueInterface $priceValue,
-        ProductPriceInterface $price
+        ProductInterface $product
     ) {
         $attrValidatorHelper->validateLocale(Argument::cetera())->shouldBeCalled();
         $attrValidatorHelper->validateScope(Argument::cetera())->shouldBeCalled();
@@ -99,7 +97,11 @@ class PriceCollectionAttributeRemoverSpec extends ObjectBehavior
         $data = 'not an array';
 
         $this->shouldThrow(
-            InvalidArgumentException::arrayExpected('attributeCode', 'remover', 'prices collection', gettype($data))
+            InvalidArgumentException::arrayExpected(
+                'attributeCode',
+                'Pim\Component\Catalog\Updater\Remover\PriceCollectionAttributeRemover',
+                gettype($data)
+            )
         )->during('removeAttributeData', [$product, $attribute, $data, ['locale' => 'fr_FR', 'scope' => 'mobile']]);
     }
 
@@ -114,8 +116,7 @@ class PriceCollectionAttributeRemoverSpec extends ObjectBehavior
         $this->shouldThrow(
             InvalidArgumentException::arrayOfArraysExpected(
                 'attributeCode',
-                'remover',
-                'prices collection',
+                'Pim\Component\Catalog\Updater\Remover\PriceCollectionAttributeRemover',
                 gettype($data)
             )
         )->during('removeAttributeData', [$product, $attribute, $data, ['locale' => 'fr_FR', 'scope' => 'mobile']]);
@@ -133,8 +134,7 @@ class PriceCollectionAttributeRemoverSpec extends ObjectBehavior
             InvalidArgumentException::arrayKeyExpected(
                 'attributeCode',
                 'amount',
-                'remover',
-                'prices collection',
+                'Pim\Component\Catalog\Updater\Remover\PriceCollectionAttributeRemover',
                 print_r($data, true)
             )
         )->during('removeAttributeData', [$product, $attribute, $data, ['locale' => 'fr_FR', 'scope' => 'mobile']]);
@@ -152,8 +152,7 @@ class PriceCollectionAttributeRemoverSpec extends ObjectBehavior
             InvalidArgumentException::arrayKeyExpected(
                 'attributeCode',
                 'currency',
-                'remover',
-                'prices collection',
+                'Pim\Component\Catalog\Updater\Remover\PriceCollectionAttributeRemover',
                 print_r($data, true)
             )
         )->during('removeAttributeData', [$product, $attribute, $data, ['locale' => 'fr_FR', 'scope' => 'mobile']]);
@@ -175,8 +174,7 @@ class PriceCollectionAttributeRemoverSpec extends ObjectBehavior
                 'attributeCode',
                 'currency',
                 'The currency does not exist',
-                'remover',
-                'prices collection',
+                'Pim\Component\Catalog\Updater\Remover\PriceCollectionAttributeRemover',
                 'invalid currency'
             )
         )->during('removeAttributeData', [$product, $attribute, $data, ['locale' => 'fr_FR', 'scope' => 'mobile']]);

--- a/src/Pim/Component/Catalog/spec/Updater/Setter/AssociationFieldSetterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Setter/AssociationFieldSetterSpec.php
@@ -40,8 +40,7 @@ class AssociationFieldSetterSpec extends ObjectBehavior
         $this->shouldThrow(
             InvalidArgumentException::arrayExpected(
                 'associations',
-                'setter',
-                'association',
+                'Pim\Component\Catalog\Updater\Setter\AssociationFieldSetter',
                 'string'
             )
         )->during('setFieldData', [$product, 'associations', 'not an array']);
@@ -153,8 +152,7 @@ class AssociationFieldSetterSpec extends ObjectBehavior
             InvalidArgumentException::expected(
                 'associations',
                 'existing association type code',
-                'setter',
-                'association',
+                'Pim\Component\Catalog\Updater\Setter\AssociationFieldSetter',
                 'non valid association type code'
             )
         )->during(
@@ -189,8 +187,7 @@ class AssociationFieldSetterSpec extends ObjectBehavior
             InvalidArgumentException::expected(
                 'associations',
                 'existing product identifier',
-                'setter',
-                'association',
+                'Pim\Component\Catalog\Updater\Setter\AssociationFieldSetter',
                 'not existing product'
             )
         )->during(
@@ -223,8 +220,7 @@ class AssociationFieldSetterSpec extends ObjectBehavior
             InvalidArgumentException::expected(
                 'associations',
                 'existing group code',
-                'setter',
-                'association',
+                'Pim\Component\Catalog\Updater\Setter\AssociationFieldSetter',
                 'not existing group'
             )
         )->during(

--- a/src/Pim/Component/Catalog/spec/Updater/Setter/CategoryFieldSetterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Setter/CategoryFieldSetterSpec.php
@@ -36,8 +36,7 @@ class CategoryFieldSetterSpec extends ObjectBehavior
         $this->shouldThrow(
             InvalidArgumentException::arrayExpected(
                 'categories',
-                'setter',
-                'category',
+                'Pim\Component\Catalog\Updater\Setter\CategoryFieldSetter',
                 'string'
             )
         )->during('setFieldData', [$product, 'categories', 'not an array']);
@@ -46,8 +45,7 @@ class CategoryFieldSetterSpec extends ObjectBehavior
             InvalidArgumentException::arrayStringValueExpected(
                 'categories',
                 0,
-                'setter',
-                'category',
+                'Pim\Component\Catalog\Updater\Setter\CategoryFieldSetter',
                 'array'
             )
         )->during('setFieldData', [$product, 'categories', [['array of array']]]);
@@ -86,8 +84,7 @@ class CategoryFieldSetterSpec extends ObjectBehavior
             InvalidArgumentException::expected(
                 'categories',
                 'existing category code',
-                'setter',
-                'category',
+                'Pim\Component\Catalog\Updater\Setter\CategoryFieldSetter',
                 'non valid category code'
             )
         )->during('setFieldData', [$product, 'categories', ['mug', 'non valid category code']]);

--- a/src/Pim/Component/Catalog/spec/Updater/Setter/DateAttributeSetterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Setter/DateAttributeSetterSpec.php
@@ -79,8 +79,7 @@ class DateAttributeSetterSpec extends ObjectBehavior
             InvalidArgumentException::expected(
                 'attributeCode',
                 'a string with the format yyyy-mm-dd',
-                'setter',
-                'date',
+                'Pim\Component\Catalog\Updater\Setter\DateAttributeSetter',
                 gettype($data)
             )
         )->during('setAttributeData', [$product, $attribute, $data, ['locale' => 'fr_FR', 'scope' => 'mobile']]);
@@ -98,8 +97,7 @@ class DateAttributeSetterSpec extends ObjectBehavior
             InvalidArgumentException::expected(
                 'attributeCode',
                 'a string with the format yyyy-mm-dd',
-                'setter',
-                'date',
+                'Pim\Component\Catalog\Updater\Setter\DateAttributeSetter',
                 gettype($data)
             )
         )->during('setAttributeData', [$product, $attribute, $data, ['locale' => 'fr_FR', 'scope' => 'mobile']]);
@@ -131,9 +129,8 @@ class DateAttributeSetterSpec extends ObjectBehavior
             InvalidArgumentException::expected(
                 'attributeCode',
                 'datetime or string',
-                gettype($data),
-                'setter',
-                'date'
+                'Pim\Component\Catalog\Updater\Setter\DateAttributeSetter',
+                gettype($data)
             )
         )->during('setAttributeData', [$product, $attribute, $data, ['locale' => 'fr_FR', 'scope' => 'mobile']]);
     }

--- a/src/Pim/Component/Catalog/spec/Updater/Setter/FamilyFieldSetterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Setter/FamilyFieldSetterSpec.php
@@ -36,8 +36,7 @@ class FamilyFieldSetterSpec extends ObjectBehavior
         $this->shouldThrow(
             InvalidArgumentException::stringExpected(
                 'family',
-                'setter',
-                'family',
+                'Pim\Component\Catalog\Updater\Setter\FamilyFieldSetter',
                 'array'
             )
         )->during('setFieldData', [$product, 'family', ['not a string']]);
@@ -54,11 +53,7 @@ class FamilyFieldSetterSpec extends ObjectBehavior
         $this->setFieldData($product, 'family', 'shirt');
     }
 
-    function it_empty_family_field(
-        $familyRepository,
-        ProductInterface $product,
-        FamilyInterface $shirt
-    ) {
+    function it_empty_family_field(ProductInterface $product) {
         $product->setFamily(null)->shouldBeCalled();
         $this->setFieldData($product, 'family', null);
     }
@@ -73,8 +68,7 @@ class FamilyFieldSetterSpec extends ObjectBehavior
             InvalidArgumentException::expected(
                 'family',
                 'existing family code',
-                'setter',
-                'family',
+                'Pim\Component\Catalog\Updater\Setter\FamilyFieldSetter',
                 'shirt'
             )
         )->during('setFieldData', [$product, 'family', 'shirt']);

--- a/src/Pim/Component/Catalog/spec/Updater/Setter/GroupFieldSetterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Setter/GroupFieldSetterSpec.php
@@ -37,8 +37,7 @@ class GroupFieldSetterSpec extends ObjectBehavior
         $this->shouldThrow(
             InvalidArgumentException::arrayExpected(
                 'groups',
-                'setter',
-                'groups',
+                'Pim\Component\Catalog\Updater\Setter\GroupFieldSetter',
                 'string'
             )
         )->during('setFieldData', [$product, 'groups', 'not an array']);
@@ -47,8 +46,7 @@ class GroupFieldSetterSpec extends ObjectBehavior
             InvalidArgumentException::arrayStringValueExpected(
                 'groups',
                 0,
-                'setter',
-                'groups',
+                'Pim\Component\Catalog\Updater\Setter\GroupFieldSetter',
                 'array'
             )
         )->during('setFieldData', [$product, 'groups', [['array of array']]]);
@@ -98,8 +96,7 @@ class GroupFieldSetterSpec extends ObjectBehavior
             InvalidArgumentException::expected(
                 'groups',
                 'existing group code',
-                'setter',
-                'groups',
+                'Pim\Component\Catalog\Updater\Setter\GroupFieldSetter',
                 'not valid code'
             )
         )->during('setFieldData', [$product, 'groups', ['pack', 'not valid code']]);

--- a/src/Pim/Component/Catalog/spec/Updater/Setter/MediaAttributeSetterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Setter/MediaAttributeSetterSpec.php
@@ -90,7 +90,7 @@ class MediaAttributeSetterSpec extends ObjectBehavior
         $data = new \stdClass();
 
         $this->shouldThrow(
-            InvalidArgumentException::stringExpected('attributeCode', 'setter', 'media', gettype($data))
+            InvalidArgumentException::stringExpected('attributeCode', 'Pim\Component\Catalog\Updater\Setter\MediaAttributeSetter', gettype($data))
         )->during('setAttributeData', [$product, $attribute, $data, ['locale' => 'fr_FR', 'scope' => 'mobile']]);
     }
 
@@ -106,8 +106,7 @@ class MediaAttributeSetterSpec extends ObjectBehavior
             InvalidArgumentException::expected(
                 'attributeCode',
                 'a valid pathname',
-                'setter',
-                'media',
+                'Pim\Component\Catalog\Updater\Setter\MediaAttributeSetter',
                 'path/to/unknown/file'
             )
         )->during('setAttributeData', [$product, $attribute, $data, ['locale' => 'fr_FR', 'scope' => 'mobile']]);

--- a/src/Pim/Component/Catalog/spec/Updater/Setter/MetricAttributeSetterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Setter/MetricAttributeSetterSpec.php
@@ -77,7 +77,7 @@ class MetricAttributeSetterSpec extends ObjectBehavior
         $data = 'Not an array';
 
         $this->shouldThrow(
-            InvalidArgumentException::arrayExpected('attributeCode', 'setter', 'metric', gettype($data))
+            InvalidArgumentException::arrayExpected('attributeCode', 'Pim\Component\Catalog\Updater\Setter\MetricAttributeSetter', gettype($data))
         )->during('setAttributeData', [$product, $attribute, $data, ['locale' => 'fr_FR', 'scope' => 'mobile']]);
     }
 
@@ -93,8 +93,7 @@ class MetricAttributeSetterSpec extends ObjectBehavior
             InvalidArgumentException::arrayKeyExpected(
                 'attributeCode',
                 'amount',
-                'setter',
-                'metric',
+                'Pim\Component\Catalog\Updater\Setter\MetricAttributeSetter',
                 print_r($data, true)
             )
         )->during('setAttributeData', [$product, $attribute, $data, ['locale' => 'fr_FR', 'scope' => 'mobile']]);
@@ -109,8 +108,12 @@ class MetricAttributeSetterSpec extends ObjectBehavior
         $data = ['amount' => 'data value'];
 
         $this->shouldThrow(
-            InvalidArgumentException::arrayKeyExpected('attributeCode', 'unit', 'setter', 'metric',
-                print_r($data, true))
+            InvalidArgumentException::arrayKeyExpected(
+                'attributeCode',
+                'unit',
+                'Pim\Component\Catalog\Updater\Setter\MetricAttributeSetter',
+                print_r($data, true)
+            )
         )->during('setAttributeData', [$product, $attribute, $data, ['locale' => 'fr_FR', 'scope' => 'mobile']]);
     }
 

--- a/src/Pim/Component/Catalog/spec/Updater/Setter/MultiSelectAttributeSetterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Setter/MultiSelectAttributeSetterSpec.php
@@ -81,8 +81,7 @@ class MultiSelectAttributeSetterSpec extends ObjectBehavior
             InvalidArgumentException::arrayStringValueExpected(
                 'attributeCode',
                 'foo',
-                'setter',
-                'multi select',
+                'Pim\Component\Catalog\Updater\Setter\MultiSelectAttributeSetter',
                 'array'
             )
         )->during('setAttributeData', [$product, $attribute, $data, ['locale' => 'fr_FR', 'scope' => 'mobile']]);
@@ -107,8 +106,7 @@ class MultiSelectAttributeSetterSpec extends ObjectBehavior
                 'attributeCode',
                 'code',
                 'The option does not exist',
-                'setter',
-                'multi select',
+                'Pim\Component\Catalog\Updater\Setter\MultiSelectAttributeSetter',
                 'unknown code'
             )
         )->during('setAttributeData', [$product, $attribute, $data, ['locale' => 'fr_FR', 'scope' => 'mobile']]);

--- a/src/Pim/Component/Catalog/spec/Updater/Setter/PriceCollectionAttributeSetterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Setter/PriceCollectionAttributeSetterSpec.php
@@ -70,7 +70,11 @@ class PriceCollectionAttributeSetterSpec extends ObjectBehavior
         $data = 'not an array';
 
         $this->shouldThrow(
-            InvalidArgumentException::arrayExpected('attributeCode', 'setter', 'prices collection', gettype($data))
+            InvalidArgumentException::arrayExpected(
+                'attributeCode',
+                'Pim\Component\Catalog\Updater\Setter\PriceCollectionAttributeSetter',
+                gettype($data)
+            )
         )->during('setAttributeData', [$product, $attribute, $data, ['locale' => 'fr_FR', 'scope' => 'mobile']]);
     }
 
@@ -85,8 +89,7 @@ class PriceCollectionAttributeSetterSpec extends ObjectBehavior
         $this->shouldThrow(
             InvalidArgumentException::arrayOfArraysExpected(
                 'attributeCode',
-                'setter',
-                'prices collection',
+                'Pim\Component\Catalog\Updater\Setter\PriceCollectionAttributeSetter',
                 gettype($data)
             )
         )->during('setAttributeData', [$product, $attribute, $data, ['locale' => 'fr_FR', 'scope' => 'mobile']]);
@@ -104,8 +107,7 @@ class PriceCollectionAttributeSetterSpec extends ObjectBehavior
             InvalidArgumentException::arrayKeyExpected(
                 'attributeCode',
                 'amount',
-                'setter',
-                'prices collection',
+                'Pim\Component\Catalog\Updater\Setter\PriceCollectionAttributeSetter',
                 print_r($data, true)
             )
         )->during('setAttributeData', [$product, $attribute, $data, ['locale' => 'fr_FR', 'scope' => 'mobile']]);
@@ -123,8 +125,7 @@ class PriceCollectionAttributeSetterSpec extends ObjectBehavior
             InvalidArgumentException::arrayKeyExpected(
                 'attributeCode',
                 'currency',
-                'setter',
-                'prices collection',
+                'Pim\Component\Catalog\Updater\Setter\PriceCollectionAttributeSetter',
                 print_r($data, true)
             )
         )->during('setAttributeData', [$product, $attribute, $data, ['locale' => 'fr_FR', 'scope' => 'mobile']]);

--- a/src/Pim/Component/Catalog/spec/Updater/Setter/SimpleSelectAttributeSetterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Setter/SimpleSelectAttributeSetterSpec.php
@@ -79,7 +79,11 @@ class SimpleSelectAttributeSetterSpec extends ObjectBehavior
 
         $this
             ->shouldThrow(
-                InvalidArgumentException::stringExpected('attributeCode', 'setter', 'simple select', gettype($data))
+                InvalidArgumentException::stringExpected(
+                    'attributeCode',
+                    'Pim\Component\Catalog\Updater\Setter\SimpleSelectAttributeSetter',
+                    gettype($data)
+                )
             )
             ->duringSetAttributeData($product, $attribute, $data, ['locale' => 'fr_FR', 'scope' => 'mobile']);
     }
@@ -98,7 +102,11 @@ class SimpleSelectAttributeSetterSpec extends ObjectBehavior
 
         $this
             ->shouldNotThrow(
-                InvalidArgumentException::stringExpected('attributeCode', 'setter', 'simple select', gettype($data))
+                InvalidArgumentException::stringExpected(
+                    'attributeCode',
+                    'Pim\Component\Catalog\Updater\Setter\SimpleSelectAttributeSetter',
+                    gettype($data)
+                )
             )
             ->duringSetAttributeData($product, $attribute, $data, ['locale' => 'fr_FR', 'scope' => 'mobile']);
     }
@@ -117,8 +125,7 @@ class SimpleSelectAttributeSetterSpec extends ObjectBehavior
                     'attributeCode',
                     'code',
                     'The option does not exist',
-                    'setter',
-                    'simple select',
+                    'Pim\Component\Catalog\Updater\Setter\SimpleSelectAttributeSetter',
                     $data
                 )
             )

--- a/src/Pim/Component/Catalog/spec/Updater/Setter/TextAttributeSetterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Setter/TextAttributeSetterSpec.php
@@ -117,7 +117,7 @@ class TextAttributeSetterSpec extends ObjectBehavior
         $attribute->isLocalizable()->willReturn(true);
         $attrValidatorHelper->validateLocale($attribute, null)->willThrow($e);
         $this->shouldThrow(
-            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'setter', 'text')
+            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'Pim\Component\Catalog\Updater\Setter\TextAttributeSetter')
         )->during('setAttributeData', [$product, $attribute, '', ['locale' => null, 'scope' => 'ecommerce']]);
     }
 
@@ -131,7 +131,7 @@ class TextAttributeSetterSpec extends ObjectBehavior
         $attribute->isLocalizable()->willReturn(false);
         $attrValidatorHelper->validateLocale($attribute, 'en_US')->willThrow($e);
         $this->shouldThrow(
-            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'setter', 'text')
+            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'Pim\Component\Catalog\Updater\Setter\TextAttributeSetter')
         )->during('setAttributeData', [$product, $attribute, '', ['locale' => 'en_US', 'scope' => 'ecommerce']]);
     }
 
@@ -145,7 +145,7 @@ class TextAttributeSetterSpec extends ObjectBehavior
         $attribute->isLocalizable()->willReturn(true);
         $attrValidatorHelper->validateLocale($attribute, 'uz-UZ')->willThrow($e);
         $this->shouldThrow(
-            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'setter', 'text')
+            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'Pim\Component\Catalog\Updater\Setter\TextAttributeSetter')
         )->during('setAttributeData', [$product, $attribute, '', ['locale' => 'uz-UZ', 'scope' => 'ecommerce']]);
     }
 
@@ -161,7 +161,7 @@ class TextAttributeSetterSpec extends ObjectBehavior
         $attrValidatorHelper->validateLocale($attribute, null)->shouldBeCalled();
         $attrValidatorHelper->validateScope($attribute, null)->willThrow($e);
         $this->shouldThrow(
-            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'setter', 'text')
+            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'Pim\Component\Catalog\Updater\Setter\TextAttributeSetter')
         )->during('setAttributeData', [$product, $attribute, '', ['locale' => null, 'scope' => null]]);
     }
 
@@ -177,7 +177,7 @@ class TextAttributeSetterSpec extends ObjectBehavior
         $attrValidatorHelper->validateLocale($attribute, null)->shouldBeCalled();
         $attrValidatorHelper->validateScope($attribute, 'ecommerce')->willThrow($e);
         $this->shouldThrow(
-            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'setter', 'text')
+            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'Pim\Component\Catalog\Updater\Setter\TextAttributeSetter')
         )->during('setAttributeData', [$product, $attribute, '', ['locale' => null, 'scope' => 'ecommerce']]);
     }
 
@@ -193,7 +193,7 @@ class TextAttributeSetterSpec extends ObjectBehavior
         $attrValidatorHelper->validateLocale($attribute, null)->shouldBeCalled();
         $attrValidatorHelper->validateScope($attribute, 'ecommerce')->willThrow($e);
         $this->shouldThrow(
-            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'setter', 'text')
+            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'Pim\Component\Catalog\Updater\Setter\TextAttributeSetter')
         )->during('setAttributeData', [$product, $attribute, '', ['locale' => null, 'scope' => 'ecommerce']]);
     }
 }

--- a/src/Pim/Component/Catalog/spec/Updater/Setter/VariantGroupFieldSetterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Setter/VariantGroupFieldSetterSpec.php
@@ -37,8 +37,7 @@ class VariantGroupFieldSetterSpec extends ObjectBehavior
         $this->shouldThrow(
             InvalidArgumentException::stringExpected(
                 'variant_group',
-                'setter',
-                'variant_group',
+                'Pim\Component\Catalog\Updater\Setter\VariantGroupFieldSetter',
                 'array'
             )
         )->during('setFieldData', [$product, 'variant_group', ['not a string']]);
@@ -85,8 +84,7 @@ class VariantGroupFieldSetterSpec extends ObjectBehavior
             InvalidArgumentException::expected(
                 'variant_group',
                 'variant group code',
-                'setter',
-                'variant_group',
+                'Pim\Component\Catalog\Updater\Setter\VariantGroupFieldSetter',
                 'pack'
             )
         )->during('setFieldData', [$product, 'variant_group', 'pack']);
@@ -106,8 +104,7 @@ class VariantGroupFieldSetterSpec extends ObjectBehavior
             InvalidArgumentException::expected(
                 'variant_group',
                 'existing variant group code',
-                'setter',
-                'variant_group',
+                'Pim\Component\Catalog\Updater\Setter\VariantGroupFieldSetter',
                 'not valid code'
             )
         )->during('setFieldData', [$product, 'variant_group', 'not valid code']);

--- a/src/Pim/Component/Catalog/spec/Updater/VariantGroupUpdaterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/VariantGroupUpdaterSpec.php
@@ -192,8 +192,7 @@ class VariantGroupUpdaterSpec extends ObjectBehavior
                 'type',
                 'group type',
                 'The group type does not exist',
-                'updater',
-                'variant group',
+                'Pim\Component\Catalog\Updater\VariantGroupUpdater',
                 'UNKNOWN'
             )
         )->during('update', [$variantGroup, $values, []]);
@@ -214,8 +213,7 @@ class VariantGroupUpdaterSpec extends ObjectBehavior
                 'axes',
                 'attribute code',
                 'The attribute does not exist',
-                'updater',
-                'variant group',
+                'Pim\Component\Catalog\Updater\VariantGroupUpdater',
                 'unknown'
             )
         )->during('update', [$variantGroup, $values, []]);
@@ -238,7 +236,7 @@ class VariantGroupUpdaterSpec extends ObjectBehavior
             ImmutablePropertyException::immutableProperty(
                 'axes',
                 'main_color',
-                'updater',
+                'Pim\Component\Catalog\Updater\VariantGroupUpdater',
                 'variant group'
             )
         )->during('update', [$variantGroup, $values, []]);

--- a/src/Pim/Component/ReferenceData/Updater/Copier/ReferenceDataAttributeCopier.php
+++ b/src/Pim/Component/ReferenceData/Updater/Copier/ReferenceDataAttributeCopier.php
@@ -52,8 +52,8 @@ class ReferenceDataAttributeCopier extends AbstractAttributeCopier
         $fromScope = $options['from_scope'];
         $toScope = $options['to_scope'];
 
-        $this->checkLocaleAndScope($fromAttribute, $fromLocale, $fromScope, 'reference data');
-        $this->checkLocaleAndScope($toAttribute, $toLocale, $toScope, 'reference data');
+        $this->checkLocaleAndScope($fromAttribute, $fromLocale, $fromScope);
+        $this->checkLocaleAndScope($toAttribute, $toLocale, $toScope);
 
         $this->copySingleValue(
             $fromProduct,

--- a/src/Pim/Component/ReferenceData/Updater/Copier/ReferenceDataCollectionAttributeCopier.php
+++ b/src/Pim/Component/ReferenceData/Updater/Copier/ReferenceDataCollectionAttributeCopier.php
@@ -53,8 +53,8 @@ class ReferenceDataCollectionAttributeCopier extends AbstractAttributeCopier
         $fromScope = $options['from_scope'];
         $toScope = $options['to_scope'];
 
-        $this->checkLocaleAndScope($fromAttribute, $fromLocale, $fromScope, 'reference data collection');
-        $this->checkLocaleAndScope($toAttribute, $toLocale, $toScope, 'reference data collection');
+        $this->checkLocaleAndScope($fromAttribute, $fromLocale, $fromScope);
+        $this->checkLocaleAndScope($toAttribute, $toLocale, $toScope);
 
         $this->copySingleValue(
             $fromProduct,

--- a/src/Pim/Component/ReferenceData/Updater/Setter/ReferenceDataCollectionSetter.php
+++ b/src/Pim/Component/ReferenceData/Updater/Setter/ReferenceDataCollectionSetter.php
@@ -49,7 +49,7 @@ class ReferenceDataCollectionSetter extends AbstractAttributeSetter
         $data,
         array $options = []
     ) {
-        $this->checkLocaleAndScope($attribute, $options['locale'], $options['scope'], 'reference data collection');
+        $this->checkLocaleAndScope($attribute, $options['locale'], $options['scope']);
         $this->checkData($attribute, $data);
 
         $refDataCollection = [];
@@ -67,8 +67,7 @@ class ReferenceDataCollectionSetter extends AbstractAttributeSetter
                         $attribute->getReferenceDataName(),
                         $referenceDataCode
                     ),
-                    'setter',
-                    'reference data collection',
+                    static::class,
                     $referenceDataCode
                 );
             }
@@ -96,8 +95,7 @@ class ReferenceDataCollectionSetter extends AbstractAttributeSetter
         if (!is_array($data)) {
             throw InvalidArgumentException::arrayExpected(
                 $attribute->getCode(),
-                'setter',
-                'reference data collection',
+                static::class,
                 gettype($data)
             );
         }
@@ -107,8 +105,7 @@ class ReferenceDataCollectionSetter extends AbstractAttributeSetter
                 throw InvalidArgumentException::arrayStringKeyExpected(
                     $attribute->getCode(),
                     $key,
-                    'setter',
-                    'reference data collection',
+                    static::class,
                     gettype($value)
                 );
             }

--- a/src/Pim/Component/ReferenceData/Updater/Setter/ReferenceDataSetter.php
+++ b/src/Pim/Component/ReferenceData/Updater/Setter/ReferenceDataSetter.php
@@ -49,7 +49,7 @@ class ReferenceDataSetter extends AbstractAttributeSetter
         $data,
         array $options = []
     ) {
-        $this->checkLocaleAndScope($attribute, $options['locale'], $options['scope'], 'reference data');
+        $this->checkLocaleAndScope($attribute, $options['locale'], $options['scope']);
         $this->checkData($attribute, $data);
 
         if (empty($data)) {
@@ -67,8 +67,7 @@ class ReferenceDataSetter extends AbstractAttributeSetter
                         $attribute->getReferenceDataName(),
                         $data
                     ),
-                    'setter',
-                    'reference data',
+                    static::class,
                     $data
                 );
             }
@@ -92,8 +91,7 @@ class ReferenceDataSetter extends AbstractAttributeSetter
         if (!is_string($data)) {
             throw InvalidArgumentException::stringExpected(
                 $attribute->getCode(),
-                'setter',
-                'reference data',
+                static::class,
                 gettype($data)
             );
         }

--- a/src/Pim/Component/ReferenceData/spec/Updater/Setter/ReferenceDataSetterSpec.php
+++ b/src/Pim/Component/ReferenceData/spec/Updater/Setter/ReferenceDataSetterSpec.php
@@ -105,8 +105,7 @@ class ReferenceDataSetterSpec extends ObjectBehavior
             'lace_fabric',
             'code',
             'No reference data "customMaterials" with code "hulk_retriever" has been found',
-            'setter',
-            'reference data',
+            'Pim\Component\ReferenceData\Updater\Setter\ReferenceDataSetter',
             'hulk_retriever'
         );
 

--- a/src/Pim/Component/User/Updater/UserUpdater.php
+++ b/src/Pim/Component/User/Updater/UserUpdater.php
@@ -192,8 +192,7 @@ class UserUpdater implements ObjectUpdaterInterface
                 'default_tree',
                 'category code',
                 'The category does not exist',
-                'updater',
-                'user',
+                static::class,
                 $code
             );
         }
@@ -218,8 +217,7 @@ class UserUpdater implements ObjectUpdaterInterface
                 $field,
                 'locale code',
                 'The locale does not exist',
-                'updater',
-                'user',
+                static::class,
                 $code
             );
         }
@@ -243,8 +241,7 @@ class UserUpdater implements ObjectUpdaterInterface
                 'catalog_scope',
                 'channel code',
                 'The channel does not exist',
-                'updater',
-                'user',
+                static::class,
                 $code
             );
         }
@@ -268,8 +265,7 @@ class UserUpdater implements ObjectUpdaterInterface
                 'roles',
                 'role',
                 'The role does not exist',
-                'updater',
-                'user',
+                static::class,
                 $code
             );
         }
@@ -293,8 +289,7 @@ class UserUpdater implements ObjectUpdaterInterface
                 'groups',
                 'group',
                 'The group does not exist',
-                'updater',
-                'user',
+                static::class,
                 $code
             );
         }


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

In some errors messages, we add some informations such like that:
`Property "attribute_type" does not expect an empty value (for updater attribute).`

`for updater attribute` is a technical information and should not be shown to user.
This PR : 
- removes this informations in messages.
- add the class name where the error comes from. It's not used for the moment, but if, _one day_, we'll want to have more informations in our logs, we'll able to have this information.


[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | done
| Added Behats                      | done
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
