### PR TITLE
PIM-6124: Import family with missing requirement column does not remove associated requirements

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -6,6 +6,7 @@
 - PIM-6062: Fix potential Unix commands injection
 - PIM-5085: Fix update of the normalized data on family update (mongodb)
 - PIM-6080: Fix simple and multi select removal on product export builder
+- PIM-6124: Importing family with missing requirement column does not remove associated requirements anymore
 - PIM-6140: Fix 'equals to' filters on job tracker page
 
 # 1.6.9 (2017-01-17)

--- a/features/import/import_families.feature
+++ b/features/import/import_families.feature
@@ -78,3 +78,21 @@ Feature: Import families
     Then the row "pretty-shoe" should contain:
       | column | value   |
       | Family | [heels] |
+
+  @jira https://akeneo.atlassian.net/browse/PIM-6124
+  Scenario: Import a family with missing requirements does not remove associated family requirements
+    Given the "footwear" catalog configuration
+    And I am logged in as "Julia"
+    And the following CSV file to import:
+      """
+      code;attributes;attribute_as_label;requirements-mobile;label-en_US
+      heels;sku,name,manufacturer,heel_color;name;manufacturer;Heels
+      """
+    And the following job "csv_footwear_family_import" configuration:
+      | filePath | %file to import% |
+    When I am on the "csv_footwear_family_import" import job page
+    And I launch the import job
+    And I wait for the "csv_footwear_family_import" job to finish
+    Then there should be the following families:
+      | code     | attributes                       | attribute_as_label | requirements-mobile | requirements-tablet                                                   | label-en_US |
+      | heels    | sku,name,manufacturer,heel_color | name               | sku,manufacturer    | sku,name,description,price,side_view,size,color,heel_color,sole_color | Heels       |

--- a/src/Pim/Component/Catalog/spec/Updater/FamilyUpdaterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/FamilyUpdaterSpec.php
@@ -23,14 +23,14 @@ class FamilyUpdaterSpec extends ObjectBehavior
         AttributeRepositoryInterface $attributeRepository,
         ChannelRepositoryInterface $channelRepository,
         AttributeRequirementFactory $attrRequiFactory,
-        AttributeRequirementRepositoryInterface $attrRequiRepo
+        AttributeRequirementRepositoryInterface $attributeRequirementRepo
     ) {
         $this->beConstructedWith(
             $familyRepository,
             $attributeRepository,
             $channelRepository,
             $attrRequiFactory,
-            $attrRequiRepo
+            $attributeRequirementRepo
         );
     }
 
@@ -59,6 +59,7 @@ class FamilyUpdaterSpec extends ObjectBehavior
     function it_updates_a_family(
         $attrRequiFactory,
         $channelRepository,
+        $attributeRequirementRepo,
         FamilyTranslation $translation,
         FamilyInterface $family,
         AttributeRepositoryInterface $attributeRepository,
@@ -102,49 +103,55 @@ class FamilyUpdaterSpec extends ObjectBehavior
 
         $skuMobileRqrmt->getAttribute()->willReturn($skuAttribute);
         $skuMobileRqrmt->getChannelCode()->willReturn('mobile');
+
+        $skuAttribute->getCode()->willReturn('sku');
+        $skuAttribute->getAttributeType()->willReturn(AttributeTypes::IDENTIFIER);
+
         $skuPrintRqrmt->getAttribute()->willReturn($skuAttribute);
         $skuPrintRqrmt->getChannelCode()->willReturn('print');
 
-        $attributeRepository->findOneByIdentifier('sku')->willReturn($skuAttribute);
+        $family->removeAttributeRequirement($skuMobileRqrmt)->shouldNotBeCalled();
+        $family->removeAttributeRequirement($skuPrintRqrmt)->shouldNotBeCalled();
+
         $attributeRepository->findOneByIdentifier('name')->willReturn($nameAttribute);
         $attributeRepository->findOneByIdentifier('description')->willReturn($descAttribute);
-        $attributeRepository->findOneByIdentifier('price')->willReturn($priceAttribute);
-        $attributeRepository->getIdentifier()->willReturn($skuAttribute);
 
-        $skuAttribute->getAttributeType()->willReturn('pim_catalog_identifier');
-        $nameAttribute->getAttributeType()->willReturn('pim_catalog_text');
-        $descAttribute->getAttributeType()->willReturn('pim_catalog_textarea');
-        $priceAttribute->getAttributeType()->willReturn('pim_catalog_price_collection');
-
-        $channelRepository->getChannelCodes()->willReturn(['mobile', 'print']);
         $channelRepository->findOneByIdentifier('mobile')->willReturn($mobileChannel);
         $channelRepository->findOneByIdentifier('print')->willReturn($printChannel);
 
-        $attrRequiFactory->createAttributeRequirement($nameAttribute, $mobileChannel, true)
-            ->willReturn($nameMobileRqrmt);
+        $mobileChannel->getId()->willReturn(1);
+        $printChannel->getId()->willReturn(2);
+
+        $attributeRequirementRepo->findOneBy([
+            'attribute' => 2,
+            'channel' => 1,
+            'family' => 42
+        ])->willReturn($nameMobileRqrmt);
+        $attributeRequirementRepo->findOneBy([
+            'attribute' => 2,
+            'channel' => 2,
+            'family' => 42
+        ])->willReturn(null);
+        $attributeRequirementRepo->findOneBy([
+            'attribute' => 3,
+            'channel' => 2,
+            'family' => 42
+        ])->willReturn($descPrintRqrmt);
+
         $attrRequiFactory->createAttributeRequirement($nameAttribute, $printChannel, true)->willReturn($namePrintRqrmt);
-        $attrRequiFactory->createAttributeRequirement($descAttribute, $printChannel, true)->willReturn($descPrintRqrmt);
 
-        $nameMobileRqrmt->getAttribute()->willReturn($nameAttribute);
-        $namePrintRqrmt->getAttribute()->willReturn($nameAttribute);
-        $descPrintRqrmt->getAttribute()->willReturn($descAttribute);
+        $family->addAttributeRequirement($nameMobileRqrmt)->shouldBeCalled();
+        $family->addAttributeRequirement($descPrintRqrmt)->shouldBeCalled();
+        $family->addAttributeRequirement($namePrintRqrmt)->shouldBeCalled();
 
-        $family
-            ->setAttributeRequirements(
-                [
-                    $skuMobileRqrmt,
-                    $skuPrintRqrmt,
-                    $nameMobileRqrmt,
-                    $namePrintRqrmt,
-                    $descPrintRqrmt,
-                ]
-            )
-            ->shouldBeCalled();
+        $attributeRepository->findOneByIdentifier('sku')->willReturn($skuAttribute);
+        $attributeRepository->findOneByIdentifier('price')->willReturn($priceAttribute);
+
+        $nameAttribute->getAttributeType()->willReturn(AttributeTypes::TEXT);
+        $descAttribute->getAttributeType()->willReturn(AttributeTypes::TEXTAREA);
+        $priceAttribute->getAttributeType()->willReturn(AttributeTypes::PRICE_COLLECTION);
 
         $family->setCode('mycode')->shouldBeCalled();
-        $nameMobileRqrmt->setRequired(true)->shouldBeCalled();
-        $namePrintRqrmt->setRequired(true)->shouldBeCalled();
-        $descPrintRqrmt->setRequired(true)->shouldBeCalled();
 
         $family->addAttribute($skuAttribute)->shouldBeCalled();
         $family->addAttribute($nameAttribute)->shouldBeCalled();
@@ -168,7 +175,7 @@ class FamilyUpdaterSpec extends ObjectBehavior
         $this->update($family, $values, []);
     }
 
-    public function it_should_not_remove_identifier_requirements_when_no_requirements_are_provided(
+    function it_does_not_remove_identifier_requirements_when_no_requirements_are_provided(
         FamilyInterface $family
     ) {
         $values = [
@@ -181,94 +188,133 @@ class FamilyUpdaterSpec extends ObjectBehavior
         $this->update($family, $values, []);
     }
 
-    public function it_should_not_remove_identifier_requirements_when_empty_requirements_are_provided(
-        $channelRepository,
+    function it_does_not_remove_requirements_when_channel_column_is_missing(
         FamilyInterface $family,
-        AttributeRepositoryInterface $attributeRepository,
         AttributeInterface $skuAttribute,
         AttributeRequirementInterface $skuMobileRqrmt,
-        AttributeRequirementInterface $skuPrintRqrmt,
-        ChannelInterface $mobileChannel,
-        ChannelInterface $printChannel
+        AttributeRequirementInterface $skuEcommerceRqrmt,
+        AttributeRequirementInterface $nameEcommerceRqrmt
     ) {
         $values = [
-            'code' => 'mycode',
-            'requirements' => []
+            'requirements' => [
+                'mobile' => ['sku']
+            ]
         ];
-        $family->getAttributeRequirements()->willReturn([$skuMobileRqrmt, $skuPrintRqrmt]);
-        $skuMobileRqrmt->getAttribute()->willReturn($skuAttribute);
-        $skuPrintRqrmt->getAttribute()->willReturn($skuAttribute);
+        $family->getAttributeRequirements()->willReturn([
+            'sku_ecommerce' => $skuEcommerceRqrmt,
+            'name_ecommerce' => $nameEcommerceRqrmt,
+            'sku_mobile' => $skuMobileRqrmt
+        ]);
+
+        $skuEcommerceRqrmt->getChannelCode()->willReturn('ecommerce');
         $skuMobileRqrmt->getChannelCode()->willReturn('mobile');
-        $skuPrintRqrmt->getChannelCode()->willReturn('print');
-        $skuAttribute->getAttributeType()->willReturn(AttributeTypes::IDENTIFIER);
+        $nameEcommerceRqrmt->getChannelCode()->willReturn('ecommerce');
 
-        $channelRepository->getChannelCodes()->willReturn(['mobile', 'print']);
-        $channelRepository->findOneByIdentifier('mobile')->willReturn($mobileChannel);
-        $channelRepository->findOneByIdentifier('print')->willReturn($printChannel);
-        $attributeRepository->getIdentifier()->willReturn($skuAttribute);
+        $skuMobileRqrmt->getAttribute()->willReturn($skuAttribute);
 
-        $family->setCode('mycode')->shouldBeCalled();
-        $family->setAttributeRequirements([$skuMobileRqrmt, $skuPrintRqrmt])->shouldBeCalled();
+        $skuAttribute->getCode()->willReturn('sku');
+
+        $family->removeAttributeRequirement($nameEcommerceRqrmt)->shouldNotBeCalled();
+        $family->removeAttributeRequirement($skuEcommerceRqrmt)->shouldNotBeCalled();
+        $family->removeAttributeRequirement($skuMobileRqrmt)->shouldNotBeCalled();
+
+        $family->addAttributeRequirement($nameEcommerceRqrmt)->shouldNotBeCalled();
+        $family->addAttributeRequirement($skuEcommerceRqrmt)->shouldNotBeCalled();
+        $family->addAttributeRequirement($skuMobileRqrmt)->shouldNotBeCalled();
 
         $this->update($family, $values, []);
     }
 
-    public function it_should_not_remove_identifier_requirements_when_other_requirements_are_provided(
+    function it_does_not_remove_identifier_requirements_when_empty_requirements_are_provided(
+        FamilyInterface $family,
+        AttributeRequirementInterface $skuMobileRqrmt,
+        AttributeRequirementInterface $skuPrintRqrmt
+    ) {
+        $values = [
+            'requirements' => []
+        ];
+        $family->getAttributeRequirements()->willReturn([$skuMobileRqrmt, $skuPrintRqrmt]);
+
+        $skuMobileRqrmt->getChannelCode()->willReturn('mobile');
+        $skuPrintRqrmt->getChannelCode()->willReturn('print');
+
+        $family->removeAttributeRequirement($skuMobileRqrmt)->shouldNotBeCalled();
+        $family->removeAttributeRequirement($skuPrintRqrmt)->shouldNotBeCalled();
+        $family->addAttributeRequirement($skuMobileRqrmt)->shouldNotBeCalled();
+        $family->addAttributeRequirement($skuPrintRqrmt)->shouldNotBeCalled();
+
+        $this->update($family, $values, []);
+    }
+
+    function it_does_not_remove_identifier_requirements_when_other_requirements_are_provided(
         $attrRequiFactory,
         $channelRepository,
+        $attributeRepository,
+        $attributeRequirementRepo,
         FamilyInterface $family,
-        AttributeRepositoryInterface $attributeRepository,
         AttributeInterface $skuAttribute,
         AttributeInterface $nameAttribute,
-        AttributeInterface $descAttribute,
+        AttributeInterface $descriptionAttribute,
         AttributeRequirementInterface $skuMobileRqrmt,
         AttributeRequirementInterface $skuPrintRqrmt,
         AttributeRequirementInterface $namePrintRqrmt,
         AttributeRequirementInterface $descPrintRqrmt,
-        ChannelInterface $mobileChannel,
         ChannelInterface $printChannel
     ) {
         $values = [
-            'code' => 'mycode',
             'requirements' => [
                 'print' => ['name', 'description']
             ]
         ];
+
         $family->getAttributeRequirements()->willReturn([$skuMobileRqrmt, $skuPrintRqrmt]);
-        $family->getId()->willReturn(42);
-        $skuMobileRqrmt->getAttribute()->willReturn($skuAttribute);
-        $skuPrintRqrmt->getAttribute()->willReturn($skuAttribute);
+
         $skuMobileRqrmt->getChannelCode()->willReturn('mobile');
+
         $skuPrintRqrmt->getChannelCode()->willReturn('print');
+        $skuPrintRqrmt->getAttribute()->willReturn($skuAttribute);
+
+        $skuAttribute->getCode()->willReturn('sku');
         $skuAttribute->getAttributeType()->willReturn(AttributeTypes::IDENTIFIER);
 
-        $channelRepository->findOneByIdentifier('print')->willReturn($printChannel);
+        $family->removeAttributeRequirement($skuMobileRqrmt)->shouldNotBeCalled();
+        $family->removeAttributeRequirement($skuPrintRqrmt)->shouldNotBeCalled();
+
         $attributeRepository->findOneByIdentifier('name')->willReturn($nameAttribute);
-        $attributeRepository->findOneByIdentifier('description')->willReturn($descAttribute);
-        $attrRequiFactory->createAttributeRequirement($nameAttribute, $printChannel, true)
-            ->willReturn($namePrintRqrmt);
-        $attrRequiFactory->createAttributeRequirement($descAttribute, $printChannel, true)
-            ->willReturn($descPrintRqrmt);
-        $namePrintRqrmt->getAttribute()->willReturn($nameAttribute);
-        $descPrintRqrmt->getAttribute()->willReturn($descAttribute);
+        $attributeRepository->findOneByIdentifier('description')->willReturn($descriptionAttribute);
 
-        $channelRepository->getChannelCodes()->willReturn(['mobile', 'print']);
-        $channelRepository->findOneByIdentifier('mobile')->willReturn($mobileChannel);
         $channelRepository->findOneByIdentifier('print')->willReturn($printChannel);
-        $attributeRepository->getIdentifier()->willReturn($skuAttribute);
 
-        $family->setCode('mycode')->shouldBeCalled();
-        $family->setAttributeRequirements(
-            [$skuMobileRqrmt, $skuPrintRqrmt, $namePrintRqrmt, $descPrintRqrmt]
-        )
-        ->shouldBeCalled();
-        $namePrintRqrmt->setRequired(true)->shouldBeCalled();
-        $descPrintRqrmt->setRequired(true)->shouldBeCalled();
+        $printChannel->getId()->willReturn('1');
+        $nameAttribute->getId()->willReturn('1');
+        $descriptionAttribute->getId()->willReturn('2');
+        $family->getId()->willReturn('1');
+
+        $attributeRequirementRepo->findOneBy([
+            'attribute' => '1',
+            'channel' => '1',
+            'family' => '1'
+        ])->willReturn(null);
+        $attributeRequirementRepo->findOneBy([
+            'attribute' => '2',
+            'channel' => '1',
+            'family' => '1'
+        ])->willReturn(null);
+
+        $attrRequiFactory->createAttributeRequirement($nameAttribute, $printChannel, true)->willReturn($namePrintRqrmt);
+        $attrRequiFactory->createAttributeRequirement(
+            $descriptionAttribute,
+            $printChannel,
+            true
+        )->willReturn($descPrintRqrmt);
+
+        $family->addAttributeRequirement($namePrintRqrmt)->shouldBeCalled();
+        $family->addAttributeRequirement($descPrintRqrmt)->shouldBeCalled();
 
         $this->update($family, $values, []);
     }
 
-    public function it_throws_an_exception_if_attribute_does_not_exist(
+    function it_throws_an_exception_if_attribute_does_not_exist(
         $attributeRepository,
         FamilyInterface $family,
         AttributeInterface $priceAttribute


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
When a family is imported with a missing column in the file, requirements were removed.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added Behats                      | OK
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
