### PR TITLE
[PIM-6140] Fix job execution 'equals to' filter

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -6,6 +6,7 @@
 - PIM-6062: Fix potential Unix commands injection
 - PIM-5085: Fix update of the normalized data on family update (mongodb)
 - PIM-6080: Fix simple and multi select removal on product export builder
+- PIM-6140: Fix 'equals to' filters on job tracker page
 
 # 1.6.9 (2017-01-17)
 

--- a/features/job-tracker/display_jobs_execution_in_job_tracker.feature
+++ b/features/job-tracker/display_jobs_execution_in_job_tracker.feature
@@ -64,3 +64,19 @@ Feature: Display jobs execution in job tracker
     And I should see the columns Type, Job, User, Status and Started at
     And the grid should contain 1 element
     And I should see entity CSV footwear category import
+
+  @jira https://akeneo.atlassian.net/browse/PIM-6140
+  Scenario: Successfully filter job executions with "equals to" filter
+    Given I am on the exports page
+    And I launch the "csv_footwear_product_export" export job
+    And I logout
+    And I am logged in as "admin"
+    And I am on the exports page
+    And I launch the "csv_footwear_category_export" export job
+    When I am on the job tracker page
+    Then I should be able to use the following filters:
+      | filter   | operator    | value                       | result                                                    |
+      | job      | is equal to | CSV footwear product export | CSV footwear product export                               |
+      | user     | is equal to | Julia                       | CSV footwear product export                               |
+      | type     | is equal to | import                      |                                                           |
+      | type     | is equal to | export                      | CSV footwear product export, CSV footwear category export |

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/job_tracker.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/job_tracker.yml
@@ -47,15 +47,15 @@ datagrid:
                 type:
                     type:      string
                     label:     Type
-                    data_name: type
+                    data_name: j.type
                 job:
                     type: string
                     label: Job
-                    data_name: jobLabel
+                    data_name: j.label
                 user:
                     type:      string
                     label:     User
-                    data_name: user
+                    data_name: e.user
                 status:
                     type:             choice
                     data_name:        status


### PR DESCRIPTION
This PR fix the string filter 'equals to', it does not work in the "job tracker" page.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | y
| Added integration tests           | -
| Changelog updated                 | y
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

Before :
![screen shot 2017-01-30 at 18 09 06](https://cloud.githubusercontent.com/assets/1590933/22460962/a96e26d6-e7a7-11e6-87c8-f95085b2f553.png)
