### PR TITLE
Tip 322 : Remove technical informations in error messages

### DIFF
--- a/src/Akeneo/Component/Classification/Updater/CategoryUpdater.php
+++ b/src/Akeneo/Component/Classification/Updater/CategoryUpdater.php
@@ -71,7 +71,7 @@ class CategoryUpdater implements ObjectUpdaterInterface
     {
         if ('labels' === $field) {
             if (!is_array($data)) {
-                throw InvalidPropertyTypeException::arrayExpected('labels', 'update', 'category', $data);
+                throw InvalidPropertyTypeException::arrayExpected('labels', static::class, $data);
             }
 
             foreach ($data as $localeCode => $label) {
@@ -79,15 +79,14 @@ class CategoryUpdater implements ObjectUpdaterInterface
                     throw InvalidPropertyTypeException::validArrayStructureExpected(
                         'labels',
                         'one of the labels is not a scalar',
-                        'update',
-                        'category',
+                        static::class,
                         $data
                     );
                 }
             }
         } elseif (in_array($field, ['code', 'parent'])) {
             if (null !== $data && !is_scalar($data)) {
-                throw InvalidPropertyTypeException::scalarExpected($field, 'update', 'category', $data);
+                throw InvalidPropertyTypeException::scalarExpected($field, static::class, $data);
             }
         } else {
             throw UnknownPropertyException::unknownProperty($field);

--- a/src/Akeneo/Component/Classification/spec/Updater/CategoryUpdaterSpec.php
+++ b/src/Akeneo/Component/Classification/spec/Updater/CategoryUpdaterSpec.php
@@ -116,7 +116,7 @@ class CategoryUpdaterSpec extends ObjectBehavior
 
         $this
             ->shouldThrow(
-                InvalidPropertyTypeException::scalarExpected('code', 'update', 'category', [])
+                InvalidPropertyTypeException::scalarExpected('code', 'Akeneo\Component\Classification\Updater\CategoryUpdater', [])
             )
             ->during('update', [$category, $values, []]);
     }
@@ -129,7 +129,7 @@ class CategoryUpdaterSpec extends ObjectBehavior
 
         $this
             ->shouldThrow(
-                InvalidPropertyTypeException::scalarExpected('parent', 'update', 'category', [])
+                InvalidPropertyTypeException::scalarExpected('parent', 'Akeneo\Component\Classification\Updater\CategoryUpdater', [])
             )
             ->during('update', [$category, $values, []]);
     }
@@ -142,7 +142,7 @@ class CategoryUpdaterSpec extends ObjectBehavior
 
         $this
             ->shouldThrow(
-                InvalidPropertyTypeException::arrayExpected('labels', 'update', 'category', 'foo')
+                InvalidPropertyTypeException::arrayExpected('labels', 'Akeneo\Component\Classification\Updater\CategoryUpdater', 'foo')
             )
             ->during('update', [$category, $values, []]);
     }
@@ -161,8 +161,7 @@ class CategoryUpdaterSpec extends ObjectBehavior
                 InvalidPropertyTypeException::validArrayStructureExpected(
                     'labels',
                     'one of the labels is not a scalar',
-                    'update',
-                    'category',
+                    'Akeneo\Component\Classification\Updater\CategoryUpdater',
                     $values['labels']
                 )
             )

--- a/src/Akeneo/Component/StorageUtils/Exception/InvalidPropertyTypeException.php
+++ b/src/Akeneo/Component/StorageUtils/Exception/InvalidPropertyTypeException.php
@@ -23,38 +23,43 @@ class InvalidPropertyTypeException extends ObjectUpdaterException
     /** @var mixed */
     protected $propertyValue;
 
+    /** @var string */
+    protected $className;
+
     /**
      * @param string          $propertyName
      * @param mixed           $propertyValue
+     * @param string          $className
      * @param string          $message
      * @param int             $code
      * @param \Exception|null $previous
      */
-    public function __construct($propertyName, $propertyValue, $message = '', $code = 0, \Exception $previous = null)
+    public function __construct($propertyName, $propertyValue, $className, $message = '', $code = 0, \Exception $previous = null)
     {
         parent::__construct($message, $code, $previous);
         $this->propertyName  = $propertyName;
         $this->propertyValue = $propertyValue;
+        $this->className = $className;
     }
 
     /**
      * Build an exception when the data is not a scalar value.
      *
      * @param string $propertyName
-     * @param string $action
-     * @param string $type
+     * @param string $className
      * @param mixed  $propertyValue a value that is not a scalar (array, object, null)
      *
      * @return InvalidPropertyTypeException
      */
-    public static function scalarExpected($propertyName, $action, $type, $propertyValue)
+    public static function scalarExpected($propertyName, $className, $propertyValue)
     {
-        $message = 'Property "%s" expects a scalar (for %s %s).';
+        $message = 'Property "%s" expects a scalar.';
 
         return new self(
             $propertyName,
+            $className,
             $propertyValue,
-            sprintf($message, $propertyName, $action, $type),
+            sprintf($message, $propertyName),
             self::SCALAR_EXPECTED_CODE
         );
     }
@@ -63,20 +68,20 @@ class InvalidPropertyTypeException extends ObjectUpdaterException
      * Build an exception when the data is not an array value.
      *
      * @param string $propertyName
-     * @param string $action
-     * @param string $type
+     * @param string $className
      * @param mixed  $propertyValue a value that is not an array (scalar, object, null)
      *
      * @return InvalidPropertyTypeException
      */
-    public static function arrayExpected($propertyName, $action, $type, $propertyValue)
+    public static function arrayExpected($propertyName, $className, $propertyValue)
     {
-        $message = 'Property "%s" expects an array (for %s %s).';
+        $message = 'Property "%s" expects an array.';
 
         return new self(
             $propertyName,
+            $className,
             $propertyValue,
-            sprintf($message, $propertyName, $action, $type),
+            sprintf($message, $propertyName),
             self::ARRAY_EXPECTED_CODE
         );
     }
@@ -87,20 +92,20 @@ class InvalidPropertyTypeException extends ObjectUpdaterException
      *
      * @param string $propertyName
      * @param string $because
-     * @param string $action
-     * @param string $type
+     * @param string $className
      * @param array  $propertyValue
      *
      * @return InvalidPropertyTypeExceptionn
      */
-    public static function validArrayStructureExpected($propertyName, $because, $action, $type, array $propertyValue)
+    public static function validArrayStructureExpected($propertyName, $because, $className, array $propertyValue)
     {
-        $message = 'Property "%s" expects a valid array, %s (for %s %s).';
+        $message = 'Property "%s" expects a valid array, %s.';
 
         return new self(
             $propertyName,
+            $className,
             $propertyValue,
-            sprintf($message, $propertyName, $because, $action, $type),
+            sprintf($message, $propertyName, $because),
             self::ARRAY_EXPECTED_CODE
         );
     }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Category/CreateCategoryIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Category/CreateCategoryIntegration.php
@@ -202,7 +202,7 @@ JSON;
         $version = substr(Version::VERSION, 0, 3);
         $expectedContent = [
             'code'    => 422,
-            'message' => 'Property "labels" expects an array (for update category). Check the standard format documentation.',
+            'message' => 'Property "labels" expects an array. Check the standard format documentation.',
             '_links'  => [
                 'documentation' => [
                     'href' => sprintf('https://docs.akeneo.com/%s/reference/standard_format/other_entities.html#category', $version),


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**
It's exactly the same as https://github.com/akeneo/pim-community-dev/pull/5602.

In some errors messages, we add some informations such like that:
`Property "attribute_type" does not expect an empty value (for updater attribute).`

`for updater` attribute is a technical information and should not be shown to user.

This PR deletes messages of this type in the api-web branch, because we have added a new exception "InvalidPropertyTypeException".



[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added Behats                      | -
| Added integration tests           | OK
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
