### PR TITLE
Improved PHP 7.1 support

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/ChannelRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/ChannelRepository.php
@@ -33,8 +33,12 @@ class ChannelRepository extends EntityRepository implements ChannelRepositoryInt
     /**
      * {@inheritdoc}
      */
-    public function findOneBy(array $criteria, array $orderBy = ['code' => 'ASC'])
+    public function findOneBy(array $criteria, array $orderBy = null)
     {
+        if (null === $orderBy) {
+            $orderBy = ['code' => 'ASC'];
+        }
+
         return parent::findOneBy($criteria, $orderBy);
     }
 

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/LocaleRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/LocaleRepository.php
@@ -32,8 +32,12 @@ class LocaleRepository extends EntityRepository implements LocaleRepositoryInter
     /**
      * {@inheritdoc}
      */
-    public function findOneBy(array $criteria, array $orderBy = ['code' => 'ASC'])
+    public function findOneBy(array $criteria, array $orderBy = null)
     {
+        if (null === $orderBy) {
+            $orderBy = ['code' => 'ASC'];
+        }
+
         return parent::findOneBy($criteria, $orderBy);
     }
 


### PR DESCRIPTION
Hello,

I tried to install Akeneo v1.6 on PHP 7.1, and noticed some issues already fixed on master branch but not yet available on `1.6` branch (see https://github.com/akeneo/pim-community-dev/commit/a53df0fec80ffd4e4f6795caa8bef7af5691ffe6).

Looking at classes, I find another classes that doesn't respect the declaration of EntityRepository parent class functions, so this is my first contribution \o/

> ~~This commit should be also applied on `1.6` branch~~ => nope, cf @damien-carcel comment

Mickaël

