### PR TITLE
API-29: Create a new attribute option

### DIFF
--- a/src/Pim/Bundle/ApiBundle/Controller/Rest/AttributeController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/Rest/AttributeController.php
@@ -176,6 +176,8 @@ class AttributeController
     }
 
     /**
+     * Update an attribute. It throws an error 422 if a problem occurred during the update.
+     *
      * @param AttributeInterface $attribute
      * @param array              $data
      *

--- a/src/Pim/Bundle/ApiBundle/Controller/Rest/AttributeOptionController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/Rest/AttributeOptionController.php
@@ -2,12 +2,27 @@
 
 namespace Pim\Bundle\ApiBundle\Controller\Rest;
 
+use Akeneo\Component\StorageUtils\Exception\ObjectUpdaterException;
+use Akeneo\Component\StorageUtils\Exception\UnknownPropertyException;
+use Akeneo\Component\StorageUtils\Factory\SimpleFactoryInterface;
+use Akeneo\Component\StorageUtils\Saver\SaverInterface;
+use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
+use Pim\Bundle\CatalogBundle\Version;
+use Pim\Component\Api\Exception\DocumentedHttpException;
+use Pim\Component\Api\Exception\ViolationHttpException;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\AttributeOptionInterface;
 use Pim\Component\Catalog\Repository\AttributeOptionRepositoryInterface;
 use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 /**
  * @author    Philippe Mossière <philippe.mossiere@akeneo.com>
@@ -25,25 +40,61 @@ class AttributeOptionController
     /** @var NormalizerInterface */
     protected $normalizer;
 
+    /** @var SimpleFactoryInterface */
+    protected $factory;
+
+    /** @var ObjectUpdaterInterface */
+    protected $updater;
+
+    /** @var  ValidatorInterface */
+    protected $validator;
+
+    /** @var SaverInterface */
+    protected $saver;
+
+    /** @var RouterInterface */
+    protected $router;
+
     /** @var array */
     protected $supportedAttributeTypes;
+
+    /** @var string */
+    protected $urlDocumentation;
 
     /**
      * @param AttributeRepositoryInterface       $attributeRepository
      * @param AttributeOptionRepositoryInterface $attributeOptionsRepository
      * @param NormalizerInterface                $normalizer
+     * @param SimpleFactoryInterface             $factory
+     * @param ObjectUpdaterInterface             $updater
+     * @param ValidatorInterface                 $validator
+     * @param SaverInterface                     $saver
+     * @param RouterInterface                    $router
      * @param array                              $supportedAttributeTypes
+     * @param string                             $urlDocumentation
      */
     public function __construct(
         AttributeRepositoryInterface $attributeRepository,
         AttributeOptionRepositoryInterface $attributeOptionsRepository,
         NormalizerInterface $normalizer,
-        $supportedAttributeTypes
+        SimpleFactoryInterface $factory,
+        ObjectUpdaterInterface $updater,
+        ValidatorInterface $validator,
+        SaverInterface $saver,
+        RouterInterface $router,
+        $supportedAttributeTypes,
+        $urlDocumentation
     ) {
         $this->attributeRepository = $attributeRepository;
         $this->attributeOptionsRepository = $attributeOptionsRepository;
         $this->normalizer = $normalizer;
+        $this->factory = $factory;
+        $this->updater = $updater;
+        $this->validator = $validator;
+        $this->saver = $saver;
+        $this->router = $router;
         $this->supportedAttributeTypes = $supportedAttributeTypes;
+        $this->urlDocumentation = sprintf($urlDocumentation, substr(Version::VERSION, 0, 3));
     }
 
     /**
@@ -57,21 +108,8 @@ class AttributeOptionController
      */
     public function getAction(Request $request, $attributeCode, $optionCode)
     {
-        $attribute = $this->attributeRepository->findOneByIdentifier($attributeCode);
-        if (null === $attribute) {
-            throw new NotFoundHttpException(sprintf('Attribute "%s" does not exist.', $attributeCode));
-        }
-
-        $attributeType = $attribute->getAttributeType();
-        if (!in_array($attributeType, $this->supportedAttributeTypes)) {
-            throw new NotFoundHttpException(
-                sprintf(
-                    'Attribute "%s" does not support options. Only attributes of type "%s" support options.',
-                    $attributeCode,
-                    implode('", "', $this->supportedAttributeTypes)
-                )
-            );
-        }
+        $attribute = $this->getAttribute($attributeCode);
+        $this->isAttributeSupportingOptions($attribute);
 
         $attributeOption = $this->attributeOptionsRepository->findOneByIdentifier($attributeCode . '.' . $optionCode);
         if (null === $attributeOption) {
@@ -87,5 +125,156 @@ class AttributeOptionController
         $attributeOptionStandard = $this->normalizer->normalize($attributeOption, 'standard');
 
         return new JsonResponse($attributeOptionStandard);
+    }
+
+    /**
+     * @param Request $request
+     * @param string  $attributeCode
+     *
+     * @return Response
+     */
+    public function createAction(Request $request, $attributeCode)
+    {
+        $data = $this->getDecodedContent($request->getContent());
+
+        $attribute = $this->getAttribute($attributeCode);
+
+        $this->isAttributeSupportingOptions($attribute);
+
+        if (isset($data['attribute']) && $data['attribute'] !== $attributeCode) {
+            throw new UnprocessableEntityHttpException(
+                sprintf(
+                    'Attribute code "%s" in the request body must match "%s" in the URI.',
+                    $data['attribute'],
+                    $attributeCode
+                )
+            );
+        }
+
+        $attributeOption = $this->factory->create();
+        $this->updateAttributeOption($attributeOption, $data);
+
+        $violations = $this->validator->validate($attributeOption);
+        if (0 !== $violations->count()) {
+            throw new ViolationHttpException($violations);
+        }
+
+        $this->saver->save($attributeOption);
+
+        $response = $this->getCreateResponse($attribute, $attributeOption);
+
+        return $response;
+    }
+
+    /**
+     * Return an attribute. Throw an exception if attribute doesn't exist.
+     *
+     * @param string $attributeCode
+     *
+     * @throws NotFoundHttpException
+     *
+     * @return mixed
+     */
+    protected function getAttribute($attributeCode)
+    {
+        $attribute = $this->attributeRepository->findOneByIdentifier($attributeCode);
+        if (null === $attribute) {
+            throw new NotFoundHttpException(sprintf('Attribute "%s" does not exist.', $attributeCode));
+        }
+
+        return $attribute;
+    }
+
+    /**
+     * Verify if an attribute supports options.
+     *
+     * @param AttributeInterface $attribute
+     *
+     * @throws NotFoundHttpException
+     */
+    protected function isAttributeSupportingOptions($attribute)
+    {
+        $attributeType = $attribute->getAttributeType();
+        if (!in_array($attributeType, $this->supportedAttributeTypes)) {
+            throw new NotFoundHttpException(
+                sprintf(
+                    'Attribute "%s" does not support options. Only attributes of type "%s" support options.',
+                    $attribute->getCode(),
+                    implode('", "', $this->supportedAttributeTypes)
+                )
+            );
+        }
+    }
+
+    /**
+     * Get the JSON decoded content. If the content is not a valid JSON, it throws an error 400.
+     *
+     * @param string $content content of a request to decode
+     *
+     * @throws BadRequestHttpException
+     *
+     * @return array
+     */
+    protected function getDecodedContent($content)
+    {
+        $decodedContent = json_decode($content, true);
+
+        if (null === $decodedContent) {
+            throw new BadRequestHttpException('Invalid json message received');
+        }
+
+        return $decodedContent;
+    }
+
+    /**
+     * Update an attribute option. It throws an error 422 if a problem occurred during the update.
+     *
+     * @param AttributeOptionInterface $attributeOption
+     * @param array                    $data
+     */
+    protected function updateAttributeOption(AttributeOptionInterface $attributeOption, $data)
+    {
+        try {
+            $this->updater->update($attributeOption, $data);
+        } catch (UnknownPropertyException $exception) {
+            throw new DocumentedHttpException(
+                $this->urlDocumentation,
+                sprintf(
+                    'Property "%s" does not exist. Check the standard format documentation.',
+                    $exception->getPropertyName()
+                ),
+                $exception
+            );
+        } catch (ObjectUpdaterException $exception) {
+            throw new DocumentedHttpException(
+                $this->urlDocumentation,
+                sprintf('%s Check the standard format documentation.', $exception->getMessage()),
+                $exception
+            );
+        }
+    }
+
+    /**
+     * Get a response with HTTP code 201 when an object is created.
+     *
+     * @param AttributeInterface       $attribute
+     * @param AttributeOptionInterface $attributeOption
+     *
+     * @return Response
+     */
+    protected function getCreateResponse(AttributeInterface $attribute, AttributeOptionInterface $attributeOption)
+    {
+        $response = new Response(null, Response::HTTP_CREATED);
+        $route = $this->router->generate(
+            'pim_api_rest_attribute_option_get',
+            [
+                'attributeCode' => $attribute->getCode(),
+                'optionCode'    => $attributeOption->getCode(),
+            ],
+            true
+        );
+        $response->headers->set('Location', $route);
+
+        return $response;
     }
 }

--- a/src/Pim/Bundle/ApiBundle/Resources/config/controllers.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/controllers.yml
@@ -49,7 +49,13 @@ services:
             - '@pim_catalog.repository.attribute'
             - '@pim_catalog.repository.attribute_option'
             - '@pim_serializer'
+            - '@pim_catalog.factory.attribute_option'
+            - '@pim_catalog.updater.attribute_option'
+            - '@validator'
+            - '@pim_catalog.saver.attribute_option'
+            - '@router'
             - ['pim_catalog_simpleselect', 'pim_catalog_multiselect']
+            - 'https://docs.akeneo.com/%s/reference/standard_format/other_entities.html#attribute-option'
 
     pim_api.controller.token:
         scope: request

--- a/src/Pim/Bundle/ApiBundle/Resources/config/routing/attribute.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/routing/attribute.yml
@@ -13,6 +13,11 @@ pim_api_rest_attribute_get:
     defaults: { _controller: pim_api.controller.rest.attribute:getAction, _format: json }
     methods: [GET]
 
+pim_api_rest_attribute_option_create:
+    path: /attributes/{attributeCode}/options
+    defaults: { _controller: pim_api.controller.rest.attribute_option:createAction, _format: json }
+    methods: [POST]
+
 pim_api_rest_attribute_option_get:
     path: /attributes/{attributeCode}/options/{optionCode}
     defaults: { _controller: pim_api.controller.rest.attribute_option:getAction, _format: json }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/AttributeOption/CreateAttributeOptionIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/AttributeOption/CreateAttributeOptionIntegration.php
@@ -1,0 +1,334 @@
+<?php
+
+namespace Pim\Bundle\ApiBundle\tests\integration\Controller\Rest\AttributeOption;
+
+use Akeneo\Test\Integration\Configuration;
+use Pim\Bundle\ApiBundle\tests\integration\ApiTestCase;
+use Pim\Bundle\CatalogBundle\Version;
+use Symfony\Component\HttpFoundation\Response;
+
+class CreateAttributeOptionIntegration extends ApiTestCase
+{
+    public function testHttpHeadersInResponseWhenAnAttributeOptionIsCreated()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data =
+<<<JSON
+    {
+        "code":"optionC",
+        "attribute":"a_multi_select",
+        "sort_order":30,
+        "labels":{"en_US":"Option C"}
+    }
+JSON;
+
+        $client->request('POST', 'api/rest/v1/attributes/a_multi_select/options', [], [], [], $data);
+
+        $response = $client->getResponse();
+
+        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+        $this->assertArrayHasKey('location', $response->headers->all());
+        $this->assertSame(
+            'http://localhost/api/rest/v1/attributes/a_multi_select/options/optionC',
+            $response->headers->get('location')
+        );
+        $this->assertSame('', $response->getContent());
+    }
+
+    public function testFormatStandardWhenAnAttributeOptionIsCreatedButUncompleted()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data =
+<<<JSON
+    {
+        "code":"optionD",
+        "attribute":"a_multi_select",
+        "labels":[]
+    }
+JSON;
+        $client->request('POST', 'api/rest/v1/attributes/a_multi_select/options', [], [], [], $data);
+
+        $attributeOption = $this->get('pim_catalog.repository.attribute_option')
+            ->findOneByIdentifier('a_multi_select' . '.' . 'optionD');
+
+        $attributeOptionStandard = [
+            'code'       => 'optionD',
+            'attribute'  => 'a_multi_select',
+            'sort_order' => 1,
+            'labels'     => [],
+        ];
+        $normalizer = $this->get('pim_catalog.normalizer.standard.attribute_option');
+
+        $response = $client->getResponse();
+
+        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+        $this->assertSame($attributeOptionStandard, $normalizer->normalize($attributeOption));
+    }
+
+    public function testCompleteAttributeOptionCreation()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data =
+<<<JSON
+    {
+        "code":"optionE",
+        "attribute":"a_multi_select",
+        "sort_order":30,
+        "labels":{"en_US":"Option E"}
+    }
+JSON;
+
+        $client->request('POST', 'api/rest/v1/attributes/a_multi_select/options', [], [], [], $data);
+
+        $attributeOption = $this->get('pim_catalog.repository.attribute_option')
+            ->findOneByIdentifier('a_multi_select' . '.' . 'optionE');
+
+        $attributeOptionStandard = [
+            'code'       => 'optionE',
+            'attribute'  => 'a_multi_select',
+            'sort_order' => 30,
+            'labels'     => [
+                'en_US' => 'Option E',
+            ],
+        ];
+        $normalizer = $this->get('pim_catalog.normalizer.standard.attribute_option');
+
+        $response = $client->getResponse();
+
+        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+        $this->assertSame($attributeOptionStandard, $normalizer->normalize($attributeOption));
+    }
+
+    public function testResponseWhenContentIsInvalid()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data = '{';
+
+        $expectedContent = [
+            'code'    => 400,
+            'message' => 'Invalid json message received',
+        ];
+
+        $client->request('POST', 'api/rest/v1/attributes/a_multi_select/options', [], [], [], $data);
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+        $this->assertSame($expectedContent, json_decode($response->getContent(), true));
+    }
+
+    public function testResponseWhenContentIsEmpty()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data = '';
+
+        $expectedContent = [
+            'code'    => 400,
+            'message' => 'Invalid json message received',
+        ];
+
+        $client->request('POST', 'api/rest/v1/attributes/a_multi_select/options', [], [], [], $data);
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+        $this->assertSame($expectedContent, json_decode($response->getContent(), true));
+    }
+
+    public function testResponseWhenJsonIsEmpty()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data = '{}';
+
+        $expectedContent = [
+            'code'    => 422,
+            'message' => 'Validation failed.',
+            'errors'  => [
+                [
+                    'field'   => 'code',
+                    'message' => 'This value should not be blank.',
+                ],
+                [
+                    'field'   => 'attribute',
+                    'message' => 'This value should not be blank.',
+                ],
+            ],
+        ];
+
+        $client->request('POST', 'api/rest/v1/attributes/a_multi_select/options', [], [], [], $data);
+        $response = $client->getResponse();
+
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertSame($expectedContent, json_decode($response->getContent(), true));
+    }
+
+    public function testResponseWhenAttributeDoesNotExist()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data =
+<<<JSON
+    {
+        "attribute":"an_unknown_multi_select"
+    }
+JSON;
+
+        $expectedContent = [
+            'code'    => 404,
+            'message' => 'Attribute "an_unknown_multi_select" does not exist.',
+        ];
+
+        $client->request('POST', 'api/rest/v1/attributes/an_unknown_multi_select/options', [], [], [], $data);
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
+        $this->assertSame($expectedContent, json_decode($response->getContent(), true));
+    }
+
+    public function testResponseWhenAttributeDoesNotSupportOptions()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data =
+<<<JSON
+    {
+        "attribute":"sku"
+    }
+JSON;
+        $expectedContent = [
+            'code'    => 404,
+            'message' => 'Attribute "sku" does not support options. Only attributes of type "pim_catalog_simpleselect", "pim_catalog_multiselect" support options.',
+        ];
+
+        $client->request('POST', 'api/rest/v1/attributes/sku/options', [], [], [], $data);
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
+        $this->assertSame($expectedContent, json_decode($response->getContent(), true));
+    }
+
+    public function testResponseWhenAttributeInUriIsNotIdenticalAsInRequestBody()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data =
+<<<JSON
+    {
+        "code":"optionE",
+        "attribute":"a_multi_sel"
+    }
+JSON;
+
+        $expectedContent = [
+            'code'    => 422,
+            'message' => 'Attribute code "a_multi_sel" in the request body must match "a_multi_select" in the URI.',
+        ];
+
+        $client->request('POST', 'api/rest/v1/attributes/a_multi_select/options', [], [], [], $data);
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertSame($expectedContent, json_decode($response->getContent(), true));
+    }
+
+    public function testResponseWhenAPropertyIsNotExpected()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data =
+<<<JSON
+    {
+        "attribute":"a_multi_select",
+        "extra_property": null
+    }
+JSON;
+
+        $version = substr(Version::VERSION, 0, 3);
+        $expectedContent = [
+            'code'    => 422,
+            'message' => 'Property "extra_property" does not exist. Check the standard format documentation.',
+            '_links'  => [
+                'documentation' => [
+                    'href' => sprintf('https://docs.akeneo.com/%s/reference/standard_format/other_entities.html#attribute-option', $version),
+                ],
+            ],
+        ];
+
+        $client->request('POST', 'api/rest/v1/attributes/a_multi_select/options', [], [], [], $data);
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertSame($expectedContent, json_decode($response->getContent(), true));
+    }
+
+    public function testResponseWhenLabelsIsNull()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data =
+<<<JSON
+    {
+        "attribute":"a_multi_select",
+        "labels": null
+    }
+JSON;
+
+        $version = substr(Version::VERSION, 0, 3);
+        $expectedContent = [
+            'code'    => 422,
+            'message' => 'Property "labels" expects an array. Check the standard format documentation.',
+            '_links'  => [
+                'documentation' => [
+                    'href' => sprintf('https://docs.akeneo.com/%s/reference/standard_format/other_entities.html#attribute-option', $version),
+                ],
+            ],
+        ];
+
+        $client->request('POST', 'api/rest/v1/attributes/a_multi_select/options', [], [], [], $data);
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertSame($expectedContent, json_decode($response->getContent(), true));
+    }
+
+    public function testResponseWhenAttributeIsNotInRequestBody()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data =
+<<<JSON
+    {
+        "code":"optionD",
+        "labels":[],
+        "sort_order": 1
+    }
+JSON;
+
+        $expectedContent = [
+            'code'    => 422,
+            'message' => 'Validation failed.',
+            'errors'  => [
+                [
+                    'field'   => 'attribute',
+                    'message' => 'This value should not be blank.',
+                ],
+            ],
+        ];
+
+        $client->request('POST', 'api/rest/v1/attributes/a_multi_select/options', [], [], [], $data);
+        $response = $client->getResponse();
+
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertSame($expectedContent, json_decode($response->getContent(), true));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return new Configuration(
+            [Configuration::getTechnicalCatalogPath()],
+            false
+        );
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/validation/attribute.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/validation/attribute.yml
@@ -185,4 +185,5 @@ Pim\Bundle\CatalogBundle\Entity\AttributeOption:
             - Length:
                 max: 255
         attribute:
+            - NotBlank: ~
             - Valid: ~

--- a/src/Pim/Component/Catalog/Validator/Constraints/AttributeTypeForOptionValidator.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/AttributeTypeForOptionValidator.php
@@ -26,7 +26,7 @@ class AttributeTypeForOptionValidator extends ConstraintValidator
         if ($attributeOption instanceof AttributeOptionInterface) {
             $attribute = $attributeOption->getAttribute();
             $authorizedTypes = [AttributeTypes::OPTION_SIMPLE_SELECT, AttributeTypes::OPTION_MULTI_SELECT];
-            if (!in_array($attribute->getAttributeType(), $authorizedTypes)) {
+            if (null !== $attribute && !in_array($attribute->getAttributeType(), $authorizedTypes)) {
                 $this->addInvalidAttributeViolation($constraint, $attributeOption);
             }
         }

--- a/src/Pim/Component/Catalog/spec/Updater/AttributeOptionUpdaterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/AttributeOptionUpdaterSpec.php
@@ -4,6 +4,7 @@ namespace spec\Pim\Component\Catalog\Updater;
 
 use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\AttributeOptionInterface;
@@ -132,5 +133,39 @@ class AttributeOptionUpdaterSpec extends ObjectBehavior
                 ]
             ]
         );
+    }
+
+    function it_throws_an_exception_when_code_is_not_scalar(AttributeOptionInterface $attributeOption)
+    {
+        $values = [
+            'code' => [],
+        ];
+
+        $this
+            ->shouldThrow(
+                InvalidPropertyTypeException::scalarExpected(
+                    'code',
+                    'Pim\Component\Catalog\Updater\AttributeOptionUpdater',
+                    []
+                )
+            )
+            ->during('update', [$attributeOption, $values, []]);
+    }
+
+    function it_throws_an_exception_when_labels_is_not_an_array(AttributeOptionInterface $attributeOption)
+    {
+        $values = [
+            'labels' => 'not_an_array',
+        ];
+
+        $this
+            ->shouldThrow(
+                InvalidPropertyTypeException::arrayExpected(
+                    'labels',
+                    'Pim\Component\Catalog\Updater\AttributeOptionUpdater',
+                    'not_an_array'
+                )
+            )
+            ->during('update', [$attributeOption, $values, []]);
     }
 }

--- a/src/Pim/Component/Catalog/spec/Validator/Constraints/AttributeTypeForOptionValidatorSpec.php
+++ b/src/Pim/Component/Catalog/spec/Validator/Constraints/AttributeTypeForOptionValidatorSpec.php
@@ -61,4 +61,15 @@ class AttributeTypeForOptionValidatorSpec extends ObjectBehavior
 
         $this->validate($attributeOption, $constraint);
     }
+
+    function it_does_not_add_violations_if_attribute_is_null(
+        $context,
+        AttributeOptionInterface $attributeOption,
+        AttributeTypeForOption $constraint
+    ) {
+        $attributeOption->getAttribute()->willReturn(null);
+        $context->buildViolation(Argument::cetera())->shouldNotBeCalled();
+
+        $this->validate($attributeOption, $constraint);
+    }
 }


### PR DESCRIPTION
Create a new attribute option

https://akeneo.atlassian.net/browse/API-29

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | OK
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
