### PR TITLE
AMS-164: detach old view selectors in order to avoid multiple subscribers

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/grid/view-selector.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/grid/view-selector.js
@@ -80,6 +80,8 @@ define(
                 this.listenTo(this.getRoot(), 'grid:view-selector:close-selector', this.closeSelect2.bind(this));
                 this.listenTo(this.getRoot(), 'grid:product-grid:state_changed', this.onGridStateChange.bind(this));
 
+                Backbone.Router.prototype.on('route', this.unbindEvents.bind(this));
+
                 return FetcherRegistry.getFetcher('datagrid-view')
                     .defaultColumns(this.gridAlias)
                     .then(function (columns) {
@@ -87,6 +89,13 @@ define(
 
                         return BaseForm.prototype.configure.apply(this, arguments);
                     }.bind(this));
+            },
+
+            /**
+             * Detach event listeners
+             */
+            unbindEvents: function () {
+                this.off();
             },
 
             /**


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

- The problem: When switching from grid to other page multiple times, then going on a project and selecting another category, there is multiple times the message "You're leaving project scope."
- Why: We instanciate the View Selector in [_views.html.twig](https://github.com/akeneo/pim-community-dev/blob/master/src/Pim/Bundle/DataGridBundle/Resources/views/Datagrid/_views.html.twig), so, each time we go on the grid, we instanciate a new View Selector, and each instance listens to some events.
- Solution: Unbind view selector subscribers on route change

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | Not possible
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -