### PR TITLE
Fix the attribute fixtures and behats due to property validation in attribute updater

### DIFF
--- a/features/enrich/variant-group/edit_variant_group_attribute_value.feature
+++ b/features/enrich/variant-group/edit_variant_group_attribute_value.feature
@@ -37,10 +37,10 @@ Feature: Editing attribute values of a variant group also updates products
       | sku  | groups            | color | size |
       | boot | caterpillar_boots | black | 40   |
     And the following attributes:
-      | code                         | label-en_US           | label-fr_FR           | type         | group     | allowedExtensions    | localizable | available_locales |
-      | technical_description        | Technical description | Description technique | file         | media     | gif,png,jpeg,jpg,txt |             |                   |
-      | simple_select_local_specific | Simple                | Simple                | simpleselect | marketing |                      | yes         | fr_FR,en_US       |
-      | multi_select_local_specific  | Multi                 | Multi                 | multiselect  | marketing |                      | yes         | fr_FR,en_US       |
+      | code                         | label-en_US           | label-fr_FR           | type         | group     | allowed_extensions    | localizable | available_locales |
+      | technical_description        | Technical description | Description technique | file         | media     | gif,png,jpeg,jpg,txt  |             |                   |
+      | simple_select_local_specific | Simple                | Simple                | simpleselect | marketing |                       | yes         | fr_FR,en_US       |
+      | multi_select_local_specific  | Multi                 | Multi                 | multiselect  | marketing |                       | yes         | fr_FR,en_US       |
     And I am logged in as "Julia"
     And I am on the "caterpillar_boots" variant group page
     And I visit the "Attributes" tab

--- a/features/export/export_products_with_media.feature
+++ b/features/export/export_products_with_media.feature
@@ -43,7 +43,7 @@ Feature: Export products with media
       | code      | requirements-tablet | requirements-mobile |
       | flipflop  | sku                 | sku                 |
     And the following attributes:
-      | code    | label   | type  | allowed extensions | families  |
+      | code    | label   | type  | allowed_extensions | families  |
       | picture | Picture | image | jpg                | flipflop  |
     And the following products:
       | sku         | categories        | price          | size | color    | name-en_US | family    |

--- a/features/import/attribute/import_attributes.feature
+++ b/features/import/attribute/import_attributes.feature
@@ -136,7 +136,7 @@ Feature: Import attributes
     And I launch the import job
     And I wait for the "csv_footwear_attribute_import" job to finish
     Then I should see "skipped 1"
-    And I should see "Property \"attribute_type\" does not expect an empty value."
+    And I should see "Property \"type\" does not expect an empty value."
 
   Scenario: Successfully import and update existing attribute
     Given the "footwear" catalog configuration

--- a/features/import/attribute/import_identifier.feature
+++ b/features/import/attribute/import_identifier.feature
@@ -10,8 +10,8 @@ Feature: Import identifier attributes
     And I am logged in as "Julia"
     And the following CSV file to import:
       """
-      type;code;label-en_US;group;unique;useable_as_grid_filter;allowed_extensions;metric_family;default_metric_unit;reference_data_name;localizable;scopable;required;sort_order;label-fr_FR;max_characters;number_min;number_max;decimals_allowed;negative_allowed;max_file_size
-      pim_catalog_identifier;sku;SKU;info;1;0;;;;;0;0;1;1;;;;;;;
+      type;code;label-en_US;group;unique;useable_as_grid_filter;allowed_extensions;metric_family;default_metric_unit;reference_data_name;localizable;scopable;sort_order;label-fr_FR;max_characters;number_min;number_max;decimals_allowed;negative_allowed;max_file_size
+      pim_catalog_identifier;sku;SKU;info;1;0;;;;;0;0;1;;;;;;;
       """
     And the following job "csv_footwear_attribute_import" configuration:
       | filePath | %file to import% |

--- a/features/import/import_invalid_csv_data.feature
+++ b/features/import/import_invalid_csv_data.feature
@@ -32,14 +32,14 @@ Feature: Handle import of invalid CSV data
   Scenario: From an attribute CSV import, create an invalid data file and be able to download it
     Given the following CSV file to import:
       """
-      type;code;label-en_US;group;unique;useable_as_grid_filter;allowed_extensions;metric_family;default_metric_unit;reference_data_name;localizable;scopable;required;sort_order;label-fr_FR;max_characters;number_min;number_max;decimals_allowed;negative_allowed;max_file_size
-      pim_catalog_identifier;sku;SKU;info;1;1;;;;;0;0;1;1;;;;;;;
-      pim_catalog_text;name;Name;info;0;1;;;;;1;0;0;2;;;;;;;
-      pim_catalog_simpleselect;manufacturer;Manufacturer;NICE_GROUP;0;1;;;;;0;0;0;3;;;;;;;
-      pim_catalog_multiselect;weather_conditions;"Weather conditions";info;0;1;;;;;0;0;0;4;;;;;;;
-      pim_catalog_textarea;description;Description;info;0;1;;;;;1;1;0;5;;1000;;;;;
-      pim_catalog_text;comment;Comment;other;0;1;;;;;0;0;0;7;;255;;;;;
-      pim_catalog_price_collection;price;Price;NOPE;0;1;;;;;0;0;0;1;;;1;200;1;;
+      type;code;label-en_US;group;unique;useable_as_grid_filter;allowed_extensions;metric_family;default_metric_unit;reference_data_name;localizable;scopable;sort_order;label-fr_FR;max_characters;number_min;number_max;decimals_allowed;negative_allowed;max_file_size
+      pim_catalog_identifier;sku;SKU;info;1;1;;;;;0;0;1;;;;;;;
+      pim_catalog_text;name;Name;info;0;1;;;;;1;0;2;;;;;;;
+      pim_catalog_simpleselect;manufacturer;Manufacturer;NICE_GROUP;0;1;;;;;0;0;3;;;;;;;
+      pim_catalog_multiselect;weather_conditions;"Weather conditions";info;0;1;;;;;0;0;4;;;;;;;
+      pim_catalog_textarea;description;Description;info;0;1;;;;;1;1;5;;1000;;;;;
+      pim_catalog_text;comment;Comment;other;0;1;;;;;0;0;7;;255;;;;;
+      pim_catalog_price_collection;price;Price;NOPE;0;1;;;;;0;0;1;;;1;200;1;;
       """
     And the following job "csv_footwear_attribute_import" configuration:
       | filePath | %file to import% |
@@ -50,9 +50,9 @@ Feature: Handle import of invalid CSV data
     Then I should see the text "Download invalid data"
     And the invalid data file of "csv_footwear_attribute_import" should contain:
       """
-      type;code;label-en_US;group;unique;useable_as_grid_filter;allowed_extensions;metric_family;default_metric_unit;reference_data_name;localizable;scopable;required;sort_order;label-fr_FR;max_characters;number_min;number_max;decimals_allowed;negative_allowed;max_file_size
-      pim_catalog_simpleselect;manufacturer;Manufacturer;NICE_GROUP;0;1;;;;;0;0;0;3;;;;;;;
-      pim_catalog_price_collection;price;Price;NOPE;0;1;;;;;0;0;0;1;;;1;200;1;;
+      type;code;label-en_US;group;unique;useable_as_grid_filter;allowed_extensions;metric_family;default_metric_unit;reference_data_name;localizable;scopable;sort_order;label-fr_FR;max_characters;number_min;number_max;decimals_allowed;negative_allowed;max_file_size
+      pim_catalog_simpleselect;manufacturer;Manufacturer;NICE_GROUP;0;1;;;;;0;0;3;;;;;;;
+      pim_catalog_price_collection;price;Price;NOPE;0;1;;;;;0;0;1;;;1;200;1;;
       """
 
   Scenario: From an attribute option CSV import, create an invalid data file and be able to download it

--- a/features/import/import_invalid_xlsx_data.feature
+++ b/features/import/import_invalid_xlsx_data.feature
@@ -32,14 +32,14 @@ Feature: Handle import of invalid XLSX data
   Scenario: From an attribute XLSX import, create an invalid data file and be able to download it
     Given the following XLSX file to import:
       """
-      type;code;label-en_US;group;unique;useable_as_grid_filter;allowed_extensions;metric_family;default_metric_unit;reference_data_name;localizable;scopable;required;sort_order;label-fr_FR;max_characters;number_min;number_max;decimals_allowed;negative_allowed;max_file_size
-      pim_catalog_identifier;sku;SKU;info;1;1;;;;;0;0;1;1;;;;;;;
-      pim_catalog_text;name;Name;info;0;1;;;;;1;0;0;2;;;;;;;
-      pim_catalog_simpleselect;manufacturer;Manufacturer;NICE_GROUP;0;1;;;;;0;0;0;3;;;;;;;
-      pim_catalog_multiselect;weather_conditions;"Weather conditions";info;0;1;;;;;0;0;0;4;;;;;;;
-      pim_catalog_textarea;description;Description;info;0;1;;;;;1;1;0;5;;1000;;;;;
-      pim_catalog_text;comment;Comment;other;0;1;;;;;0;0;0;7;;255;;;;;
-      pim_catalog_price_collection;price;Price;NOPE;0;1;;;;;0;0;0;1;;;1;200;1;;
+      type;code;label-en_US;group;unique;useable_as_grid_filter;allowed_extensions;metric_family;default_metric_unit;reference_data_name;localizable;scopable;sort_order;label-fr_FR;max_characters;number_min;number_max;decimals_allowed;negative_allowed;max_file_size
+      pim_catalog_identifier;sku;SKU;info;1;1;;;;;0;0;1;;;;;;;
+      pim_catalog_text;name;Name;info;0;1;;;;;1;0;2;;;;;;;
+      pim_catalog_simpleselect;manufacturer;Manufacturer;NICE_GROUP;0;1;;;;;0;0;3;;;;;;;
+      pim_catalog_multiselect;weather_conditions;"Weather conditions";info;0;1;;;;;0;0;4;;;;;;;
+      pim_catalog_textarea;description;Description;info;0;1;;;;;1;1;5;;1000;;;;;
+      pim_catalog_text;comment;Comment;other;0;1;;;;;0;0;7;;255;;;;;
+      pim_catalog_price_collection;price;Price;NOPE;0;1;;;;;0;0;1;;;1;200;1;;
       """
     And the following job "xlsx_footwear_attribute_import" configuration:
       | filePath | %file to import% |
@@ -50,9 +50,9 @@ Feature: Handle import of invalid XLSX data
     Then I should see the text "Download invalid data"
     And the invalid data file of "xlsx_footwear_attribute_import" should contain:
       """
-      type;code;label-en_US;group;unique;useable_as_grid_filter;allowed_extensions;metric_family;default_metric_unit;reference_data_name;localizable;scopable;required;sort_order;label-fr_FR;max_characters;number_min;number_max;decimals_allowed;negative_allowed;max_file_size
-      pim_catalog_simpleselect;manufacturer;Manufacturer;NICE_GROUP;0;1;;;;;0;0;0;3;;;;;;;
-      pim_catalog_price_collection;price;Price;NOPE;0;1;;;;;0;0;0;1;;;1;200;1;;
+      type;code;label-en_US;group;unique;useable_as_grid_filter;allowed_extensions;metric_family;default_metric_unit;reference_data_name;localizable;scopable;sort_order;label-fr_FR;max_characters;number_min;number_max;decimals_allowed;negative_allowed;max_file_size
+      pim_catalog_simpleselect;manufacturer;Manufacturer;NICE_GROUP;0;1;;;;;0;0;3;;;;;;;;;
+      pim_catalog_price_collection;price;Price;NOPE;0;1;;;;;0;0;1;;;1;200;1;;
       """
 
   Scenario: From an attribute option XLSX import, create an invalid data file and be able to download it

--- a/features/import/product/import_products_with_invalid_data.feature
+++ b/features/import/product/import_products_with_invalid_data.feature
@@ -199,7 +199,7 @@ Feature: Execute a job
   @jira https://akeneo.atlassian.net/browse/PIM-3266
   Scenario: Skip new products with non-existing media attributes during an import
     Given the following attributes:
-      | label       | type  | allowed extensions |
+      | label       | type  | allowed_extensions |
       | Front view  | image | gif, jpg           |
       | User manual | file  | txt, pdf           |
     And the following CSV file to import:
@@ -230,7 +230,7 @@ Feature: Execute a job
       | bic-core-148        | sneakers | Bic Core 148        | 2014_collection |
       | fanatic-freewave-76 | sneakers | Fanatic Freewave 76 | 2014_collection |
     And the following attributes:
-      | label       | type  | allowed extensions |
+      | label       | type  | allowed_extensions |
       | Front view  | image | gif, jpg           |
       | User manual | file  | txt, pdf           |
     And the following CSV file to import:

--- a/features/import/product/import_products_with_media.feature
+++ b/features/import/product/import_products_with_media.feature
@@ -7,7 +7,7 @@ Feature: Import media with products
   Background:
     Given the "footwear" catalog configuration
     And the following attributes:
-      | label       | type  | allowed extensions | max file size |
+      | label       | type  | allowed_extensions | max_file_size |
       | Front view  | image | gif, jpg           | 1             |
       | User manual | file  | txt, pdf           | 1             |
       | Warranty    | file  | txt, pdf           | 1             |

--- a/features/import/product/xlsx/import_products_with_media.feature
+++ b/features/import/product/xlsx/import_products_with_media.feature
@@ -7,7 +7,7 @@ Feature: Import media with products
   Background:
     Given the "footwear" catalog configuration
     And the following attributes:
-      | label       | type  | allowed extensions | max file size |
+      | label       | type  | allowed_extensions | max_file_size |
       | Front view  | image | gif, jpg           | 1             |
       | User manual | file  | txt, pdf           | 1             |
       | Warranty    | file  | txt, pdf           | 1             |

--- a/features/import/product_variant_group/import_variant_group_values_with_valid_data.feature
+++ b/features/import/product_variant_group/import_variant_group_values_with_valid_data.feature
@@ -258,7 +258,7 @@ Feature: Execute an import with valid data
 
   Scenario: Successfully import a csv file of variant group values with medias and files
     Given the following attributes:
-      | label       | type  | allowed extensions |
+      | label       | type  | allowed_extensions |
       | Front view  | image | gif, jpg           |
       | User manual | file  | txt, pdf           |
     And the following CSV file to import:

--- a/features/localization/mass-action/edit_common_attributes.feature
+++ b/features/localization/mass-action/edit_common_attributes.feature
@@ -10,7 +10,7 @@ Feature: Edit common localized attributes of many products at once
       | code       | attributes                                                       |
       | high_heels | sku, name, description, price, rating, size, color, manufacturer |
     And the following attributes:
-      | code    | label  | type   | metric family | default metric unit | families       | decimals_allowed |
+      | code    | label  | type   | metric_family | default_metric_unit | families       | decimals_allowed |
       | weight  | Weight | metric | Weight        | GRAM                | boots, sandals | yes              |
       | time    | Time   | number |               |                     | boots, sandals | yes              |
       | date    | Date   | date   |               |                     | boots, sandals |                  |

--- a/features/mass-action/edit_common_attributes-01.feature
+++ b/features/mass-action/edit_common_attributes-01.feature
@@ -10,7 +10,7 @@ Feature: Edit common attributes of many products at once
       | code       | attributes                                                       |
       | high_heels | sku, name, description, price, rating, size, color, manufacturer |
     And the following attributes:
-      | code        | label       | type   | metric family | default metric unit | families                 |
+      | code        | label       | type   | metric_family | default_metric_unit | families                 |
       | weight      | Weight      | metric | Weight        | GRAM                | boots, sneakers, sandals |
       | heel_height | Heel Height | metric | Length        | CENTIMETER          | high_heels, sandals      |
     And the following product groups:

--- a/features/mass-action/edit_common_attributes_channel.feature
+++ b/features/mass-action/edit_common_attributes_channel.feature
@@ -10,7 +10,7 @@ Feature: Edit common attributes of many products at once
       | code       | attributes                                                       |
       | high_heels | sku, name, description, price, rating, size, color, manufacturer |
     And the following attributes:
-      | code         | label       | type   | metric family | default metric unit | families                 |
+      | code         | label       | type   | metric_family | default_metric_unit | families                 |
       | weight       | Weight      | metric | Weight        | GRAM                | boots, sneakers, sandals |
       | heel_height  | Heel Height | metric | Length        | CENTIMETER          | high_heels, sandals      |
       | buckle_color | Buckle      | text   |               |                     | high_heels               |

--- a/features/mass-action/edit_common_attributes_images.feature
+++ b/features/mass-action/edit_common_attributes_images.feature
@@ -10,7 +10,7 @@ Feature: Edit common attributes of many products at once
       | code       | attributes                                                       |
       | high_heels | sku, name, description, price, rating, size, color, manufacturer |
     And the following attributes:
-      | code         | label       | type   | metric family | default metric unit | families                 |
+      | code         | label       | type   | metric_family | default_metric_unit | families                 |
       | weight       | Weight      | metric | Weight        | GRAM                | boots, sneakers, sandals |
       | heel_height  | Heel Height | metric | Length        | CENTIMETER          | high_heels, sandals      |
       | buckle_color | Buckle      | text   |               |                     | high_heels               |

--- a/features/mass-action/edit_common_attributes_metric.feature
+++ b/features/mass-action/edit_common_attributes_metric.feature
@@ -10,7 +10,7 @@ Feature: Edit common attributes of many products at once
       | code       | attributes                                                       |
       | high_heels | sku, name, description, price, rating, size, color, manufacturer |
     And the following attributes:
-      | code         | label       | type   | metric family | default metric unit | families                 |
+      | code         | label       | type   | metric_family | default_metric_unit | families                 |
       | weight       | Weight      | metric | Weight        | GRAM                | boots, sneakers, sandals |
       | heel_height  | Heel Height | metric | Length        | CENTIMETER          | high_heels, sandals      |
       | buckle_color | Buckle      | text   |               |                     | high_heels               |

--- a/features/mass-action/edit_common_attributes_per_families.feature
+++ b/features/mass-action/edit_common_attributes_per_families.feature
@@ -10,7 +10,7 @@ Feature: Edit common attributes of many products at once
       | code       | attributes                                                       |
       | high_heels | sku, name, description, price, rating, size, color, manufacturer |
     And the following attributes:
-      | code         | label       | type   | metric family | default metric unit | families                 |
+      | code         | label       | type   | metric_family | default_metric_unit | families                 |
       | weight       | Weight      | metric | Weight        | GRAM                | boots, sneakers, sandals |
       | heel_height  | Heel Height | metric | Length        | CENTIMETER          | high_heels, sandals      |
       | buckle_color | Buckle      | text   |               |                     | high_heels               |

--- a/features/mass-action/select_products_to_mass_edit.feature
+++ b/features/mass-action/select_products_to_mass_edit.feature
@@ -7,7 +7,7 @@ Feature: When I mass edit I should be able to see how many items will be edited
       | code       | attributes                                                       |
       | high_heels | sku, name, description, price, rating, size, color, manufacturer |
     And the following attributes:
-      | code        | label       | type   | metric family | default metric unit | families                 |
+      | code        | label       | type   | metric_family | default_metric_unit | families                 |
       | weight      | Weight      | metric | Weight        | GRAM                | boots, sneakers, sandals |
       | heel_height | Heel Height | metric | Length        | CENTIMETER          | high_heels               |
     And the following products:

--- a/features/product/edit_product.feature
+++ b/features/product/edit_product.feature
@@ -13,7 +13,7 @@ Feature: Edit a product
       | name        | text     | no          |                 | Name        | no       |
       | other_name  | text     | yes         |                 | Other Name  | yes      |
     And the following attributes:
-      | code        | label      | type   | metric family | default metric unit |
+      | code        | label      | type   | metric_family | default_metric_unit |
       | length      | Shoes size | metric | Length        | CENTIMETER          |
     And the following products:
       | sku    |

--- a/features/product/join_a_document_to_a_product.feature
+++ b/features/product/join_a_document_to_a_product.feature
@@ -7,7 +7,7 @@ Feature: Join a document to a product
   Background:
     Given the "default" catalog configuration
     And the following attribute:
-      | label       | type | allowed extensions |
+      | label       | type | allowed_extensions |
       | Description | file | txt                |
     And a "Car" product
     And the "Car" product has the "Description" attribute

--- a/features/product/join_an_image_to_a_product.feature
+++ b/features/product/join_an_image_to_a_product.feature
@@ -8,7 +8,7 @@ Feature: Join an image to a product
     Given the "default" catalog configuration
     And a "Car" product
     And the following attribute:
-      | label  | type  | allowed extensions |
+      | label  | type  | allowed_extensions |
       | Visual | image | jpg,gif            |
     And the "Car" product has the "visual" attribute
     And I am logged in as "Mary"

--- a/features/product/remove_product.feature
+++ b/features/product/remove_product.feature
@@ -10,7 +10,7 @@ Feature: Remove a product
       | code       | attributes                                                       |
       | high_heels | sku, name, description, price, rating, size, color, manufacturer |
     And the following attributes:
-      | code        | label       | type   | metric family | default metric unit | families                 |
+      | code        | label       | type   | metric_family | default_metric_unit | families                 |
       | weight      | Weight      | metric | Weight        | GRAM                | boots, sneakers, sandals |
       | heel_height | Heel Height | metric | Length        | CENTIMETER          | high_heels               |
     And the following products:

--- a/features/reference-data/mass-action/edit_common_attributes.feature
+++ b/features/reference-data/mass-action/edit_common_attributes.feature
@@ -10,7 +10,7 @@ Feature: Mass edit common attributes for reference data
       | code           | attributes                                             |
       | platform_shoes | sku, name, description, color, heel_color, sole_fabric |
     And the following attributes:
-      | code        | label       | type   | metric family | default metric unit | families       |
+      | code        | label       | type   | metric_family | default_metric_unit | families       |
       | heel_height | Heel height | metric | Length        | CENTIMETER          | platform_shoes |
     And the following "heel_color" attribute reference data: Red, Green, Light green, Blue, Yellow, Cyan, Magenta, Black, White
     And the following "sole_fabric" attribute reference data: PVC, Nylon, Neoprene, Spandex, Wool, Kevlar, Jute

--- a/features/reference-data/variant-group/edit_variant_group_attribute_value.feature
+++ b/features/reference-data/variant-group/edit_variant_group_attribute_value.feature
@@ -27,7 +27,7 @@ Feature: Editing attribute values of a variant group also updates products with 
       | sku  | groups            | color | size |
       | boot | caterpillar_boots | black | 40   |
     And the following attributes:
-      | code                  | label-en_US           | type | group | allowedExtensions    |
+      | code                  | label-en_US           | type | group | allowed_extensions    |
       | technical_description | Technical description | file | media | gif,png,jpeg,jpg,txt |
     And I am logged in as "Julia"
     And I am on the "caterpillar_boots" variant group page

--- a/features/update/copy_metric.feature
+++ b/features/update/copy_metric.feature
@@ -6,9 +6,9 @@ Feature: Update metric fields
   Scenario: Successfully update a metric field
     Given a "default" catalog configuration
     And the following attributes:
-      | code   | type   | metricFamily | defaultMetricUnit |
-      | width  | metric | Length       | METER             |
-      | height | metric | Length       | METER             |
+      | code   | type   | metric_family | default_metric_unit |
+      | width  | metric | Length       | METER               |
+      | height | metric | Length       | METER               |
     And the following products:
       | sku  | width         |
       | BOX1 | 30 CENTIMETER |

--- a/features/update/set_metric.feature
+++ b/features/update/set_metric.feature
@@ -6,11 +6,11 @@ Feature: Update metric fields
   Scenario: Successfully update a metric field
     Given a "default" catalog configuration
     And the following attributes:
-      | code   | type   | localizable | scopable | metricFamily | defaultMetricUnit |
-      | weight | metric | yes         | no       | Weight       | KILOGRAM          |
-      | width  | metric | no          | yes      | Length       | METER             |
-      | height | metric | yes         | yes      | Length       | METER             |
-      | depth  | metric | no          | no       | Length       | METER             |
+      | code   | type   | localizable | scopable | metric_family | default_metric_unit |
+      | weight | metric | yes         | no       | Weight       | KILOGRAM             |
+      | width  | metric | no          | yes      | Length       | METER                |
+      | height | metric | yes         | yes      | Length       | METER                |
+      | depth  | metric | no          | no       | Length       | METER                |
     And the following products:
       | sku  |
       | BOX1 |

--- a/src/Pim/Component/Catalog/Updater/AttributeUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/AttributeUpdater.php
@@ -126,6 +126,7 @@ class AttributeUpdater implements ObjectUpdaterInterface
                 'sort_order',
                 'localizable',
                 'scopable',
+                'required',
             ]
         )) {
             if (null !== $data && !is_scalar($data)) {


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

Since the API, we can't pass unknown properties in the updaters. In this case, it throws an exception.

A lot of behats use legacy properties or a a syntax that is not accepted anymore.
For example "metric family" instead of "metric_family".

This PR fix them.

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | OK
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
