### PR TITLE
TIP-686: Deprecate some methods in ProductBuilder

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -14,7 +14,6 @@
   In the next version, the deprecated filters will be removed.
 - As it's not needed anymore to convert `codes` to `ids` in order to filter products, `Pim\Bundle\CatalogBundle\Doctrine\Common\Filter\ObjectIdResolver` and `Pim\Bundle\CatalogBundle\Doctrine\Common\Filter\ObjectIdResolverInterface` are now deprecated.
 - Creating a product value with the ProductBuilder (`Pim\Component\Catalog\Denormalizer\Standard\ProductValueDenormalizer`) using the `createProductValue` method is now deprecated. It is advised to use the ProductValueFactory (`Pim\Component\Catalog\Factory\ProductValueFactory`) instead.
-- Adding a price to a product value with the ProductBuilder (`Pim\Component\Catalog\Denormalizer\Standard\ProductValueDenormalizer`) using the `addPriceForCurrencyWithData` method is now deprecated. It is advised to use `addPriceForCurrency` instead.
 
 ## Functional improvements
 

--- a/src/Pim/Component/Catalog/Builder/ProductBuilder.php
+++ b/src/Pim/Component/Catalog/Builder/ProductBuilder.php
@@ -99,7 +99,7 @@ class ProductBuilder implements ProductBuilderInterface
         $product = new $this->productClass();
 
         $identifierAttribute = $this->attributeRepository->getIdentifier();
-        $productValue = $this->addProductValue($product, $identifierAttribute, null, null);
+        $productValue = $this->addOrReplaceProductValue($product, $identifierAttribute, null, null);
 
         if (null !== $identifier) {
             $productValue->setData($identifier);
@@ -134,7 +134,7 @@ class ProductBuilder implements ProductBuilderInterface
         );
 
         foreach ($missingValues as $value) {
-            $this->addProductValue($product, $attributes[$value['attribute']], $value['locale'], $value['scope']);
+            $this->addOrReplaceProductValue($product, $attributes[$value['attribute']], $value['locale'], $value['scope']);
         }
 
         $this->addMissingPricesToProduct($product);
@@ -167,7 +167,7 @@ class ProductBuilder implements ProductBuilderInterface
         $requiredValues = $this->valuesResolver->resolveEligibleValues([$attribute]);
 
         foreach ($requiredValues as $value) {
-            $this->addProductValue($product, $attribute, $value['locale'], $value['scope']);
+            $this->addOrReplaceProductValue($product, $attribute, $value['locale'], $value['scope']);
         }
     }
 
@@ -227,11 +227,24 @@ class ProductBuilder implements ProductBuilderInterface
         $locale = null,
         $scope = null
     ) {
+        return $this->addOrReplaceProductValue($product, $attribute, $locale, $scope);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addOrReplaceProductValue(
+        ProductInterface $product,
+        AttributeInterface $attribute,
+        $locale = null,
+        $scope = null
+    ) {
         $productValue = $this->productValueFactory->create($attribute, $scope, $locale);
         $product->addValue($productValue);
 
         return $productValue;
     }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Pim/Component/Catalog/Builder/ProductBuilderInterface.php
+++ b/src/Pim/Component/Catalog/Builder/ProductBuilderInterface.php
@@ -82,6 +82,8 @@ interface ProductBuilderInterface
      * @param float|int|null        $amount
      *
      * @return null|ProductPriceInterface
+     *
+     * @deprecated will be removed in 1.8
      */
     public function addPriceForCurrency(ProductValueInterface $value, $currency, $amount = null);
 
@@ -96,7 +98,6 @@ interface ProductBuilderInterface
      * @return null|ProductPriceInterface
      *
      * @deprecated Will be removed in 1.8.
-     *             Please use "Pim\Component\Catalog\Builder\ProductBuilderInterface::addPriceForCurrency" instead.
      */
     public function addPriceForCurrencyWithData(ProductValueInterface $value, $currency, $amount);
 
@@ -106,7 +107,7 @@ interface ProductBuilderInterface
      * @param ProductValueInterface $value
      * @param array                 $currencies
      *
-     * @deprecated Will be removed in 1.8.
+     * @deprecated will be removed in 1.8.
      */
     public function removePricesNotInCurrency(ProductValueInterface $value, array $currencies);
 
@@ -116,6 +117,8 @@ interface ProductBuilderInterface
      * @param ProductValueInterface $value
      *
      * @return ProductValueInterface
+     *
+     * @deprecated will be removed in 1.8.
      */
     public function addMissingPrices(ProductValueInterface $value);
 
@@ -128,8 +131,27 @@ interface ProductBuilderInterface
      * @param string             $scope
      *
      * @return ProductValueInterface
+     *
+     * @deprecated will be removed in 1.8. Please use "addOrReplaceProductValue" instead.
      */
     public function addProductValue(
+        ProductInterface $product,
+        AttributeInterface $attribute,
+        $locale = null,
+        $scope = null
+    );
+
+    /**
+     * Add or replace a product value.
+     *
+     * @param ProductInterface   $product
+     * @param AttributeInterface $attribute
+     * @param string             $locale
+     * @param string             $scope
+     *
+     * @return ProductValueInterface
+     */
+    public function addOrReplaceProductValue(
         ProductInterface $product,
         AttributeInterface $attribute,
         $locale = null,

--- a/src/Pim/Component/Catalog/Updater/Adder/MultiSelectAttributeAdder.php
+++ b/src/Pim/Component/Catalog/Updater/Adder/MultiSelectAttributeAdder.php
@@ -119,7 +119,7 @@ class MultiSelectAttributeAdder extends AbstractAttributeAdder
     ) {
         $value = $product->getValue($attribute->getCode(), $locale, $scope);
         if (null === $value) {
-            $value = $this->productBuilder->addProductValue($product, $attribute, $locale, $scope);
+            $value = $this->productBuilder->addOrReplaceProductValue($product, $attribute, $locale, $scope);
         }
 
         foreach ($attributeOptions as $attributeOption) {

--- a/src/Pim/Component/Catalog/Updater/Adder/PriceCollectionAttributeAdder.php
+++ b/src/Pim/Component/Catalog/Updater/Adder/PriceCollectionAttributeAdder.php
@@ -147,7 +147,7 @@ class PriceCollectionAttributeAdder extends AbstractAttributeAdder
         $value = $product->getValue($attribute->getCode(), $locale, $scope);
 
         if (null === $value) {
-            $value = $this->productBuilder->addProductValue($product, $attribute, $locale, $scope);
+            $value = $this->productBuilder->addOrReplaceProductValue($product, $attribute, $locale, $scope);
         }
 
         foreach ($data as $price) {

--- a/src/Pim/Component/Catalog/Updater/Copier/BaseAttributeCopier.php
+++ b/src/Pim/Component/Catalog/Updater/Copier/BaseAttributeCopier.php
@@ -103,7 +103,7 @@ class BaseAttributeCopier extends AbstractAttributeCopier
         if (null !== $fromValue) {
             $toValue = $toProduct->getValue($toAttribute->getCode(), $toLocale, $toScope);
             if (null === $toValue) {
-                $toValue = $this->productBuilder->addProductValue($toProduct, $toAttribute, $toLocale, $toScope);
+                $toValue = $this->productBuilder->addOrReplaceProductValue($toProduct, $toAttribute, $toLocale, $toScope);
             }
 
             $toValue->setData($fromValue->getData());

--- a/src/Pim/Component/Catalog/Updater/Copier/MediaAttributeCopier.php
+++ b/src/Pim/Component/Catalog/Updater/Copier/MediaAttributeCopier.php
@@ -111,7 +111,7 @@ class MediaAttributeCopier extends AbstractAttributeCopier
         if (null !== $fromValue) {
             $toValue = $toProduct->getValue($toAttribute->getCode(), $toLocale, $toScope);
             if (null === $toValue) {
-                $toValue = $this->productBuilder->addProductValue($toProduct, $toAttribute, $toLocale, $toScope);
+                $toValue = $this->productBuilder->addOrReplaceProductValue($toProduct, $toAttribute, $toLocale, $toScope);
             }
 
             $file = null;

--- a/src/Pim/Component/Catalog/Updater/Copier/MetricAttributeCopier.php
+++ b/src/Pim/Component/Catalog/Updater/Copier/MetricAttributeCopier.php
@@ -97,7 +97,7 @@ class MetricAttributeCopier extends AbstractAttributeCopier
             $fromData = $fromValue->getData();
             $toValue = $toProduct->getValue($toAttribute->getCode(), $toLocale, $toScope);
             if (null === $toValue) {
-                $toValue = $this->productBuilder->addProductValue($toProduct, $toAttribute, $toLocale, $toScope);
+                $toValue = $this->productBuilder->addOrReplaceProductValue($toProduct, $toAttribute, $toLocale, $toScope);
             }
 
             if (null === $metric = $toValue->getMetric()) {

--- a/src/Pim/Component/Catalog/Updater/Copier/MultiSelectAttributeCopier.php
+++ b/src/Pim/Component/Catalog/Updater/Copier/MultiSelectAttributeCopier.php
@@ -91,7 +91,7 @@ class MultiSelectAttributeCopier extends AbstractAttributeCopier
         if (null !== $fromValue) {
             $toValue = $toProduct->getValue($toAttribute->getCode(), $toLocale, $toScope);
             if (null === $toValue) {
-                $toValue = $this->productBuilder->addProductValue($toProduct, $toAttribute, $toLocale, $toScope);
+                $toValue = $this->productBuilder->addOrReplaceProductValue($toProduct, $toAttribute, $toLocale, $toScope);
             }
 
             $this->removeOptions($toValue);

--- a/src/Pim/Component/Catalog/Updater/Copier/PriceCollectionAttributeCopier.php
+++ b/src/Pim/Component/Catalog/Updater/Copier/PriceCollectionAttributeCopier.php
@@ -91,7 +91,7 @@ class PriceCollectionAttributeCopier extends AbstractAttributeCopier
         if (null !== $fromValue) {
             $toValue = $toProduct->getValue($toAttribute->getCode(), $toLocale, $toScope);
             if (null === $toValue) {
-                $toValue = $this->productBuilder->addProductValue($toProduct, $toAttribute, $toLocale, $toScope);
+                $toValue = $this->productBuilder->addOrReplaceProductValue($toProduct, $toAttribute, $toLocale, $toScope);
             }
             $this->copyPrices($fromValue, $toValue);
         }

--- a/src/Pim/Component/Catalog/Updater/Copier/SimpleSelectAttributeCopier.php
+++ b/src/Pim/Component/Catalog/Updater/Copier/SimpleSelectAttributeCopier.php
@@ -88,7 +88,7 @@ class SimpleSelectAttributeCopier extends AbstractAttributeCopier
         if (null !== $fromValue) {
             $toValue = $toProduct->getValue($toAttribute->getCode(), $toLocale, $toScope);
             if (null === $toValue) {
-                $toValue = $this->productBuilder->addProductValue($toProduct, $toAttribute, $toLocale, $toScope);
+                $toValue = $this->productBuilder->addOrReplaceProductValue($toProduct, $toAttribute, $toLocale, $toScope);
             }
 
             $toValue->setOption($fromValue->getData());

--- a/src/Pim/Component/Catalog/Updater/Setter/BooleanAttributeSetter.php
+++ b/src/Pim/Component/Catalog/Updater/Setter/BooleanAttributeSetter.php
@@ -59,7 +59,7 @@ class BooleanAttributeSetter extends AbstractAttributeSetter
         $value = $product->getValue($attribute->getCode(), $locale, $scope);
 
         if (null === $value) {
-            $value = $this->productBuilder->addProductValue($product, $attribute, $locale, $scope);
+            $value = $this->productBuilder->addOrReplaceProductValue($product, $attribute, $locale, $scope);
         }
 
         if (1 === $data || '1' === $data || 0 === $data || '0' === $data) {

--- a/src/Pim/Component/Catalog/Updater/Setter/DateAttributeSetter.php
+++ b/src/Pim/Component/Catalog/Updater/Setter/DateAttributeSetter.php
@@ -114,7 +114,7 @@ class DateAttributeSetter extends AbstractAttributeSetter
     {
         $value = $product->getValue($attribute->getCode(), $locale, $scope);
         if (null === $value) {
-            $value = $this->productBuilder->addProductValue($product, $attribute, $locale, $scope);
+            $value = $this->productBuilder->addOrReplaceProductValue($product, $attribute, $locale, $scope);
         }
 
         if (null !== $data) {

--- a/src/Pim/Component/Catalog/Updater/Setter/MediaAttributeSetter.php
+++ b/src/Pim/Component/Catalog/Updater/Setter/MediaAttributeSetter.php
@@ -90,7 +90,7 @@ class MediaAttributeSetter extends AbstractAttributeSetter
     ) {
         $value = $product->getValue($attribute->getCode(), $locale, $scope);
         if (null === $value) {
-            $value = $this->productBuilder->addProductValue($product, $attribute, $locale, $scope);
+            $value = $this->productBuilder->addOrReplaceProductValue($product, $attribute, $locale, $scope);
         }
 
         $value->setMedia($fileInfo);

--- a/src/Pim/Component/Catalog/Updater/Setter/MetricAttributeSetter.php
+++ b/src/Pim/Component/Catalog/Updater/Setter/MetricAttributeSetter.php
@@ -119,7 +119,7 @@ class MetricAttributeSetter extends AbstractAttributeSetter
     ) {
         $value = $product->getValue($attribute->getCode(), $locale, $scope);
         if (null === $value) {
-            $value = $this->productBuilder->addProductValue($product, $attribute, $locale, $scope);
+            $value = $this->productBuilder->addOrReplaceProductValue($product, $attribute, $locale, $scope);
         }
 
         if (null === $metric = $value->getMetric()) {

--- a/src/Pim/Component/Catalog/Updater/Setter/MultiSelectAttributeSetter.php
+++ b/src/Pim/Component/Catalog/Updater/Setter/MultiSelectAttributeSetter.php
@@ -117,7 +117,7 @@ class MultiSelectAttributeSetter extends AbstractAttributeSetter
     ) {
         $value = $product->getValue($attribute->getCode(), $locale, $scope);
         if (null === $value) {
-            $value = $this->productBuilder->addProductValue($product, $attribute, $locale, $scope);
+            $value = $this->productBuilder->addOrReplaceProductValue($product, $attribute, $locale, $scope);
         }
 
         foreach ($value->getOptions() as $option) {

--- a/src/Pim/Component/Catalog/Updater/Setter/NumberAttributeSetter.php
+++ b/src/Pim/Component/Catalog/Updater/Setter/NumberAttributeSetter.php
@@ -60,7 +60,7 @@ class NumberAttributeSetter extends AbstractAttributeSetter
     {
         $value = $product->getValue($attribute->getCode(), $locale, $scope);
         if (null === $value) {
-            $value = $this->productBuilder->addProductValue($product, $attribute, $locale, $scope);
+            $value = $this->productBuilder->addOrReplaceProductValue($product, $attribute, $locale, $scope);
         }
         $value->setData($data);
     }

--- a/src/Pim/Component/Catalog/Updater/Setter/PriceCollectionAttributeSetter.php
+++ b/src/Pim/Component/Catalog/Updater/Setter/PriceCollectionAttributeSetter.php
@@ -120,7 +120,7 @@ class PriceCollectionAttributeSetter extends AbstractAttributeSetter
         $value = $product->getValue($attribute->getCode(), $locale, $scope);
 
         if (null === $value) {
-            $value = $this->productBuilder->addProductValue($product, $attribute, $locale, $scope);
+            $value = $this->productBuilder->addOrReplaceProductValue($product, $attribute, $locale, $scope);
         } else {
             $prices = $value->getPrices();
             foreach ($prices as $price) {

--- a/src/Pim/Component/Catalog/Updater/Setter/SimpleSelectAttributeSetter.php
+++ b/src/Pim/Component/Catalog/Updater/Setter/SimpleSelectAttributeSetter.php
@@ -111,7 +111,7 @@ class SimpleSelectAttributeSetter extends AbstractAttributeSetter
     ) {
         $value = $product->getValue($attribute->getCode(), $locale, $scope);
         if (null === $value) {
-            $value = $this->productBuilder->addProductValue($product, $attribute, $locale, $scope);
+            $value = $this->productBuilder->addOrReplaceProductValue($product, $attribute, $locale, $scope);
         }
         $value->setOption($option);
     }

--- a/src/Pim/Component/Catalog/Updater/Setter/TextAttributeSetter.php
+++ b/src/Pim/Component/Catalog/Updater/Setter/TextAttributeSetter.php
@@ -60,7 +60,7 @@ class TextAttributeSetter extends AbstractAttributeSetter
     {
         $value = $product->getValue($attribute->getCode(), $locale, $scope);
         if (null === $value) {
-            $value = $this->productBuilder->addProductValue($product, $attribute, $locale, $scope);
+            $value = $this->productBuilder->addOrReplaceProductValue($product, $attribute, $locale, $scope);
         }
         if (is_string($data) && '' === trim($data)) {
             $data = null;

--- a/src/Pim/Component/Catalog/spec/Builder/ProductBuilderSpec.php
+++ b/src/Pim/Component/Catalog/spec/Builder/ProductBuilderSpec.php
@@ -227,6 +227,6 @@ class ProductBuilderSpec extends ObjectBehavior
 
         $product->addValue(Argument::any())->shouldBeCalled();
 
-        $this->addProductValue($product, $size);
+        $this->addOrReplaceProductValue($product, $size);
     }
 }

--- a/src/Pim/Component/Catalog/spec/Updater/Adder/MultiSelectAttributeAdderSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Adder/MultiSelectAttributeAdderSpec.php
@@ -137,7 +137,7 @@ class MultiSelectAttributeAdderSpec extends ObjectBehavior
         $productValue->addOption($attributeOption)->shouldBeCalled();
 
         $builder
-            ->addProductValue($product2, $attribute, $locale, $scope)
+            ->addOrReplaceProductValue($product2, $attribute, $locale, $scope)
             ->willReturn($productValue);
 
         $product1->getValue('attributeCode', $locale, $scope)->shouldBeCalled()->willReturn($productValue);

--- a/src/Pim/Component/Catalog/spec/Updater/Adder/PriceCollectionAttributeAdderSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Adder/PriceCollectionAttributeAdderSpec.php
@@ -193,7 +193,7 @@ class PriceCollectionAttributeAdderSpec extends ObjectBehavior
         $attribute->getCode()->willReturn('attributeCode');
 
         $builder
-            ->addProductValue($product2, $attribute, $locale, $scope)
+            ->addOrReplaceProductValue($product2, $attribute, $locale, $scope)
             ->willReturn($productValue);
 
         $product1->getValue('attributeCode', $locale, $scope)->willReturn($productValue);

--- a/src/Pim/Component/Catalog/spec/Updater/Copier/BaseAttributeCopierSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Copier/BaseAttributeCopierSpec.php
@@ -96,7 +96,7 @@ class BaseAttributeCopierSpec extends ObjectBehavior
         $product4->getValue('fromAttributeCode', $fromLocale, $fromScope)->willReturn($fromProductValue);
         $product4->getValue('toAttributeCode', $toLocale, $toScope)->willReturn($toProductValue);
 
-        $builder->addProductValue($product3, $toAttribute, $toLocale, $toScope)->shouldBeCalledTimes(1)->willReturn($toProductValue);
+        $builder->addOrReplaceProductValue($product3, $toAttribute, $toLocale, $toScope)->shouldBeCalledTimes(1)->willReturn($toProductValue);
 
         $products = [$product1, $product2, $product3, $product4];
         foreach ($products as $product) {
@@ -153,7 +153,7 @@ class BaseAttributeCopierSpec extends ObjectBehavior
         $product4->getValue('fromAttributeCode', $fromLocale, $fromScope)->willReturn($fromProductValue);
         $product4->getValue('toAttributeCode', $toLocale, $toScope)->willReturn($toProductValue);
 
-        $builder->addProductValue($product3, $toAttribute, $toLocale, $toScope)->shouldBeCalledTimes(1)->willReturn($toProductValue);
+        $builder->addOrReplaceProductValue($product3, $toAttribute, $toLocale, $toScope)->shouldBeCalledTimes(1)->willReturn($toProductValue);
 
         $products = [$product1, $product2, $product3, $product4];
         foreach ($products as $product) {
@@ -210,7 +210,7 @@ class BaseAttributeCopierSpec extends ObjectBehavior
         $product4->getValue('fromAttributeCode', $fromLocale, $fromScope)->willReturn($fromProductValue);
         $product4->getValue('toAttributeCode', $toLocale, $toScope)->willReturn($toProductValue);
 
-        $builder->addProductValue($product3, $toAttribute, $toLocale, $toScope)->shouldBeCalledTimes(1)->willReturn($toProductValue);
+        $builder->addOrReplaceProductValue($product3, $toAttribute, $toLocale, $toScope)->shouldBeCalledTimes(1)->willReturn($toProductValue);
 
         $products = [$product1, $product2, $product3, $product4];
         foreach ($products as $product) {
@@ -267,7 +267,7 @@ class BaseAttributeCopierSpec extends ObjectBehavior
         $product4->getValue('fromAttributeCode', $fromLocale, $fromScope)->willReturn($fromProductValue);
         $product4->getValue('toAttributeCode', $toLocale, $toScope)->willReturn($toProductValue);
 
-        $builder->addProductValue($product3, $toAttribute, $toLocale, $toScope)
+        $builder->addOrReplaceProductValue($product3, $toAttribute, $toLocale, $toScope)
             ->shouldBeCalledTimes(1)
             ->willReturn($toProductValue);
 
@@ -326,7 +326,7 @@ class BaseAttributeCopierSpec extends ObjectBehavior
         $product4->getValue('fromAttributeCode', $fromLocale, $fromScope)->willReturn($fromProductValue);
         $product4->getValue('toAttributeCode', $toLocale, $toScope)->willReturn($toProductValue);
 
-        $builder->addProductValue($product3, $toAttribute, $toLocale, $toScope)
+        $builder->addOrReplaceProductValue($product3, $toAttribute, $toLocale, $toScope)
             ->shouldBeCalledTimes(1)
             ->willReturn($toProductValue);
 

--- a/src/Pim/Component/Catalog/spec/Updater/Copier/MediaAttributeCopierSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Copier/MediaAttributeCopierSpec.php
@@ -193,7 +193,7 @@ class MediaAttributeCopierSpec extends ObjectBehavior
         $product->getValue('fromAttributeCode', $fromLocale, $fromScope)->willReturn($fromProductValue);
         $product->getValue('toAttributeCode', $toLocale, $toScope)->willReturn(null);
 
-        $builder->addProductValue($product, $toAttribute, $toLocale, $toScope)->willReturn($toProductValue);
+        $builder->addOrReplaceProductValue($product, $toAttribute, $toLocale, $toScope)->willReturn($toProductValue);
         $toProductValue->getMedia()->willReturn($toMedia);
 
         $toProductValue->setMedia($fileInfo)->shouldBeCalled();

--- a/src/Pim/Component/Catalog/spec/Updater/Copier/MetricAttributeCopierSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Copier/MetricAttributeCopierSpec.php
@@ -109,7 +109,7 @@ class MetricAttributeCopierSpec extends ObjectBehavior
 
         $metricFactory->createMetric('Weight')->shouldBeCalledTimes(1)->willReturn($metric);
 
-        $builder->addProductValue($product3, $toAttribute, $toLocale, $toScope)->shouldBeCalledTimes(1)->willReturn($toProductValue);
+        $builder->addOrReplaceProductValue($product3, $toAttribute, $toLocale, $toScope)->shouldBeCalledTimes(1)->willReturn($toProductValue);
 
         $products = [$product1, $product2, $product3, $product4];
         foreach ($products as $product) {

--- a/src/Pim/Component/Catalog/spec/Updater/Copier/MultiSelectAttributeCopierSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Copier/MultiSelectAttributeCopierSpec.php
@@ -99,7 +99,7 @@ class MultiSelectAttributeCopierSpec extends ObjectBehavior
         $product4->getValue('fromAttributeCode', $fromLocale, $fromScope)->willReturn($fromProductValue);
         $product4->getValue('toAttributeCode', $toLocale, $toScope)->willReturn($toProductValue);
 
-        $builder->addProductValue($product3, $toAttribute, $toLocale, $toScope)->shouldBeCalledTimes(1)->willReturn($toProductValue);
+        $builder->addOrReplaceProductValue($product3, $toAttribute, $toLocale, $toScope)->shouldBeCalledTimes(1)->willReturn($toProductValue);
 
         $products = [$product1, $product2, $product3, $product4];
         foreach ($products as $product) {

--- a/src/Pim/Component/Catalog/spec/Updater/Copier/PriceCollectionAttributeCopierSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Copier/PriceCollectionAttributeCopierSpec.php
@@ -88,7 +88,7 @@ class PriceCollectionAttributeCopierSpec extends ObjectBehavior
         $product4->getValue('fromAttributeCode', $fromLocale, $fromScope)->willReturn($fromProductValue);
         $product4->getValue('toAttributeCode', $toLocale, $toScope)->willReturn($toProductValue);
 
-        $builder->addProductValue($product3, $toAttribute, $toLocale, $toScope)->shouldBeCalledTimes(1)->willReturn($toProductValue);
+        $builder->addOrReplaceProductValue($product3, $toAttribute, $toLocale, $toScope)->shouldBeCalledTimes(1)->willReturn($toProductValue);
 
         $builder->addPriceForCurrency($toProductValue, 'USD', 123)->shouldBeCalled();
 

--- a/src/Pim/Component/Catalog/spec/Updater/Copier/SimpleSelectAttributeCopierSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Copier/SimpleSelectAttributeCopierSpec.php
@@ -95,7 +95,7 @@ class SimpleSelectAttributeCopierSpec extends ObjectBehavior
         $product4->getValue('fromAttributeCode', $fromLocale, $fromScope)->willReturn($fromProductValue);
         $product4->getValue('toAttributeCode', $toLocale, $toScope)->willReturn($toProductValue);
 
-        $builder->addProductValue($product3, $toAttribute, $toLocale, $toScope)->shouldBeCalledTimes(1)->willReturn($toProductValue);
+        $builder->addOrReplaceProductValue($product3, $toAttribute, $toLocale, $toScope)->shouldBeCalledTimes(1)->willReturn($toProductValue);
 
         $products = [$product1, $product2, $product3, $product4];
         foreach ($products as $product) {

--- a/src/Pim/Component/Catalog/spec/Updater/Setter/BooleanAttributeSetterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Setter/BooleanAttributeSetterSpec.php
@@ -73,7 +73,7 @@ class BooleanAttributeSetterSpec extends ObjectBehavior
         $productValue->setData($data)->shouldBeCalled();
 
         $builder
-            ->addProductValue($product2, $attribute, $locale, $scope)
+            ->addOrReplaceProductValue($product2, $attribute, $locale, $scope)
             ->willReturn($productValue);
 
         $product1->getValue('attributeCode', $locale, $scope)->willReturn($productValue);

--- a/src/Pim/Component/Catalog/spec/Updater/Setter/DateAttributeSetterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Setter/DateAttributeSetterSpec.php
@@ -151,7 +151,7 @@ class DateAttributeSetterSpec extends ObjectBehavior
         $productValue->setData(Argument::type('\Datetime'))->shouldBeCalled();
 
         $builder
-            ->addProductValue($product2, $attribute, $locale, $scope)
+            ->addOrReplaceProductValue($product2, $attribute, $locale, $scope)
             ->willReturn($productValue);
 
         $product1->getValue('attributeCode', $locale, $scope)->shouldBeCalled()->willReturn($productValue);
@@ -177,7 +177,7 @@ class DateAttributeSetterSpec extends ObjectBehavior
         $attribute->getCode()->willReturn('attributeCode');
         $productValue->setData(Argument::type('\Datetime'))->shouldBeCalled();
         $builder
-            ->addProductValue($product2, $attribute, $locale, $scope)
+            ->addOrReplaceProductValue($product2, $attribute, $locale, $scope)
             ->willReturn($productValue);
         $product1->getValue('attributeCode', $locale, $scope)->shouldBeCalled()->willReturn($productValue);
         $product2->getValue('attributeCode', $locale, $scope)->willReturn(null);

--- a/src/Pim/Component/Catalog/spec/Updater/Setter/MediaAttributeSetterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Setter/MediaAttributeSetterSpec.php
@@ -166,7 +166,7 @@ class MediaAttributeSetterSpec extends ObjectBehavior
 
         $data = realpath(__DIR__.'/../../../../../../../features/Context/fixtures/akeneo.jpg');
 
-        $builder->addProductValue($product, $attribute, Argument::cetera())->shouldBeCalled()->willReturn($value);
+        $builder->addOrReplaceProductValue($product, $attribute, Argument::cetera())->shouldBeCalled()->willReturn($value);
         $repository->findOneByIdentifier(Argument::any())->willReturn(null);
         $storer->store(Argument::cetera())->willReturn($fileInfo);
 

--- a/src/Pim/Component/Catalog/spec/Updater/Setter/MetricAttributeSetterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Setter/MetricAttributeSetterSpec.php
@@ -141,7 +141,7 @@ class MetricAttributeSetterSpec extends ObjectBehavior
         $metric->setData($data['amount'])->shouldBeCalled();
 
         $builder
-            ->addProductValue($product2, $attribute, $locale, $scope)
+            ->addOrReplaceProductValue($product2, $attribute, $locale, $scope)
             ->willReturn($productValue);
 
         $factory->createMetric('Weight')->shouldBeCalledTimes(3)->willReturn($metric);
@@ -178,7 +178,7 @@ class MetricAttributeSetterSpec extends ObjectBehavior
         $metric->setUnit('KILOGRAM')->shouldBeCalled();
         $metric->setData($data['amount'])->shouldBeCalled();
 
-        $builder->addProductValue($product2, $attribute, $locale, $scope)
+        $builder->addOrReplaceProductValue($product2, $attribute, $locale, $scope)
             ->willReturn($productValue);
 
         $factory->createMetric('Weight')->shouldBeCalledTimes(3)->willReturn($metric);

--- a/src/Pim/Component/Catalog/spec/Updater/Setter/MultiSelectAttributeSetterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Setter/MultiSelectAttributeSetterSpec.php
@@ -140,7 +140,7 @@ class MultiSelectAttributeSetterSpec extends ObjectBehavior
         $productValue->addOption($attributeOption)->shouldBeCalled();
 
         $builder
-            ->addProductValue($product2, $attribute, $locale, $scope)
+            ->addOrReplaceProductValue($product2, $attribute, $locale, $scope)
             ->willReturn($productValue);
 
         $product1->getValue('attributeCode', $locale, $scope)->shouldBeCalled()->willReturn($productValue);

--- a/src/Pim/Component/Catalog/spec/Updater/Setter/NumberAttributeSetterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Setter/NumberAttributeSetterSpec.php
@@ -66,7 +66,7 @@ class NumberAttributeSetterSpec extends ObjectBehavior
         $productValue->setData($data)->shouldBeCalled();
 
         $builder
-            ->addProductValue($product2, $attribute, $locale, $scope)
+            ->addOrReplaceProductValue($product2, $attribute, $locale, $scope)
             ->willReturn($productValue);
 
         $product1->getValue('attributeCode', $locale, $scope)->shouldBeCalled()->willReturn($productValue);
@@ -94,7 +94,7 @@ class NumberAttributeSetterSpec extends ObjectBehavior
         $productValue->setData($data)->shouldBeCalled();
 
         $builder
-            ->addProductValue($product2, $attribute, $locale, $scope)
+            ->addOrReplaceProductValue($product2, $attribute, $locale, $scope)
             ->willReturn($productValue);
 
         $product1->getValue('attributeCode', $locale, $scope)->shouldBeCalled()->willReturn($productValue);

--- a/src/Pim/Component/Catalog/spec/Updater/Setter/PriceCollectionAttributeSetterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Setter/PriceCollectionAttributeSetterSpec.php
@@ -148,7 +148,7 @@ class PriceCollectionAttributeSetterSpec extends ObjectBehavior
         $attribute->getCode()->willReturn('attributeCode');
 
         $builder
-            ->addProductValue($product2, $attribute, $locale, $scope)
+            ->addOrReplaceProductValue($product2, $attribute, $locale, $scope)
             ->willReturn($productValue);
 
         $product1->getValue('attributeCode', $locale, $scope)->shouldBeCalled()->willReturn($productValue);

--- a/src/Pim/Component/Catalog/spec/Updater/Setter/SimpleSelectAttributeSetterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Setter/SimpleSelectAttributeSetterSpec.php
@@ -157,7 +157,7 @@ class SimpleSelectAttributeSetterSpec extends ObjectBehavior
         $productValue->setOption($attributeOption)->shouldBeCalled();
 
         $builder
-            ->addProductValue($product2, $attribute, $locale, $scope)
+            ->addOrReplaceProductValue($product2, $attribute, $locale, $scope)
             ->willReturn($productValue);
 
         $product1->getValue('attributeCode', $locale, $scope)->shouldBeCalled()->willReturn($productValue);

--- a/src/Pim/Component/Catalog/spec/Updater/Setter/TextAttributeSetterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Setter/TextAttributeSetterSpec.php
@@ -71,7 +71,7 @@ class TextAttributeSetterSpec extends ObjectBehavior
         $productValue->setData($data)->shouldBeCalled();
 
         $builder
-            ->addProductValue($product2, $attribute, $locale, $scope)
+            ->addOrReplaceProductValue($product2, $attribute, $locale, $scope)
             ->willReturn($productValue);
 
         $product1->getValue('attributeCode', $locale, $scope)->shouldBeCalled()->willReturn($productValue);
@@ -99,7 +99,7 @@ class TextAttributeSetterSpec extends ObjectBehavior
         $productValue->setData(null)->shouldBeCalled();
 
         $builder
-            ->addProductValue($product2, $attribute, $locale, $scope)
+            ->addOrReplaceProductValue($product2, $attribute, $locale, $scope)
             ->willReturn($productValue);
 
         $product1->getValue('attributeCode', $locale, $scope)->shouldBeCalled()->willReturn($productValue);

--- a/src/Pim/Component/ReferenceData/Updater/Copier/ReferenceDataAttributeCopier.php
+++ b/src/Pim/Component/ReferenceData/Updater/Copier/ReferenceDataAttributeCopier.php
@@ -103,7 +103,7 @@ class ReferenceDataAttributeCopier extends AbstractAttributeCopier
         if (null !== $fromValue) {
             $toValue = $toProduct->getValue($toAttribute->getCode(), $toLocale, $toScope);
             if (null === $toValue) {
-                $toValue = $this->productBuilder->addProductValue($toProduct, $toAttribute, $toLocale, $toScope);
+                $toValue = $this->productBuilder->addOrReplaceProductValue($toProduct, $toAttribute, $toLocale, $toScope);
             }
 
             $fromDataGetter = $this->getValueMethodName($fromValue, $fromAttribute, 'get');

--- a/src/Pim/Component/ReferenceData/Updater/Copier/ReferenceDataCollectionAttributeCopier.php
+++ b/src/Pim/Component/ReferenceData/Updater/Copier/ReferenceDataCollectionAttributeCopier.php
@@ -106,7 +106,7 @@ class ReferenceDataCollectionAttributeCopier extends AbstractAttributeCopier
         if (null !== $fromValue) {
             $toValue = $toProduct->getValue($toAttribute->getCode(), $toLocale, $toScope);
             if (null === $toValue) {
-                $toValue = $this->productBuilder->addProductValue($toProduct, $toAttribute, $toLocale, $toScope);
+                $toValue = $this->productBuilder->addOrReplaceProductValue($toProduct, $toAttribute, $toLocale, $toScope);
             }
 
             $this->removeReferenceDataCollection($toValue, $toAttribute);

--- a/src/Pim/Component/ReferenceData/Updater/Setter/ReferenceDataCollectionSetter.php
+++ b/src/Pim/Component/ReferenceData/Updater/Setter/ReferenceDataCollectionSetter.php
@@ -133,7 +133,7 @@ class ReferenceDataCollectionSetter extends AbstractAttributeSetter
         $value = $product->getValue($attribute->getCode(), $locale, $scope);
 
         if (null === $value) {
-            $value = $this->productBuilder->addProductValue($product, $attribute, $locale, $scope);
+            $value = $this->productBuilder->addOrReplaceProductValue($product, $attribute, $locale, $scope);
         }
 
         $referenceDataName = $attribute->getReferenceDataName();

--- a/src/Pim/Component/ReferenceData/Updater/Setter/ReferenceDataSetter.php
+++ b/src/Pim/Component/ReferenceData/Updater/Setter/ReferenceDataSetter.php
@@ -118,7 +118,7 @@ class ReferenceDataSetter extends AbstractAttributeSetter
         $value = $product->getValue($attribute->getCode(), $locale, $scope);
 
         if (null === $value) {
-            $value = $this->productBuilder->addProductValue($product, $attribute, $locale, $scope);
+            $value = $this->productBuilder->addOrReplaceProductValue($product, $attribute, $locale, $scope);
         }
 
         $setMethod = MethodNameGuesser::guess('set', $attribute->getReferenceDataName(), true);

--- a/src/Pim/Component/ReferenceData/spec/Updater/Copier/ReferenceDataAttributeCopierSpec.php
+++ b/src/Pim/Component/ReferenceData/spec/Updater/Copier/ReferenceDataAttributeCopierSpec.php
@@ -87,7 +87,7 @@ class ReferenceDataAttributeCopierSpec extends ObjectBehavior
         $product4->getValue('fromAttributeCode', $fromLocale, $fromScope)->willReturn($fromProductValue);
         $product4->getValue('toAttributeCode', $toLocale, $toScope)->willReturn($toProductValue);
 
-        $builder->addProductValue($product3, $toAttribute, $toLocale, $toScope)->shouldBeCalledTimes(1)->willReturn($toProductValue);
+        $builder->addOrReplaceProductValue($product3, $toAttribute, $toLocale, $toScope)->shouldBeCalledTimes(1)->willReturn($toProductValue);
 
         $products = [$product1, $product2, $product3, $product4];
         foreach ($products as $product) {

--- a/src/Pim/Component/ReferenceData/spec/Updater/Copier/ReferenceDataCollectionAttributeCopierSpec.php
+++ b/src/Pim/Component/ReferenceData/spec/Updater/Copier/ReferenceDataCollectionAttributeCopierSpec.php
@@ -93,7 +93,7 @@ class ReferenceDataCollectionAttributeCopierSpec extends ObjectBehavior
         $product4->getValue('fromAttributeCode', $fromLocale, $fromScope)->willReturn($fromProductValue);
         $product4->getValue('toAttributeCode', $toLocale, $toScope)->willReturn($toProductValue);
 
-        $builder->addProductValue($product3, $toAttribute, $toLocale, $toScope)->shouldBeCalledTimes(1)->willReturn($toProductValue);
+        $builder->addOrReplaceProductValue($product3, $toAttribute, $toLocale, $toScope)->shouldBeCalledTimes(1)->willReturn($toProductValue);
 
         $products = [$product1, $product2, $product3, $product4];
         foreach ($products as $product) {

--- a/src/Pim/Component/ReferenceData/spec/Updater/Setter/ReferenceDataCollectionSetterSpec.php
+++ b/src/Pim/Component/ReferenceData/spec/Updater/Setter/ReferenceDataCollectionSetterSpec.php
@@ -167,7 +167,7 @@ class ReferenceDataCollectionSetterSpec extends ObjectBehavior
         $product2->getValue('custom_material', $locale, $scope)->willReturn($productValue2);
         $product3->getValue('custom_material', $locale, $scope)->willReturn($productValue3);
 
-        $builder->addProductValue($product1, $attribute, $locale, $scope)
+        $builder->addOrReplaceProductValue($product1, $attribute, $locale, $scope)
             ->shouldBeCalled()
             ->willReturn($productValue1);
 

--- a/src/Pim/Component/ReferenceData/spec/Updater/Setter/ReferenceDataSetterSpec.php
+++ b/src/Pim/Component/ReferenceData/spec/Updater/Setter/ReferenceDataSetterSpec.php
@@ -178,7 +178,7 @@ class ReferenceDataSetterSpec extends ObjectBehavior
         $product2->getValue('custom_material', $locale, $scope)->willReturn($productValue2);
         $product3->getValue('custom_material', $locale, $scope)->willReturn($productValue3);
 
-        $builder->addProductValue($product1, $attribute, $locale, $scope)
+        $builder->addOrReplaceProductValue($product1, $attribute, $locale, $scope)
             ->shouldBeCalled()
             ->willReturn($productValue1);
 
@@ -214,7 +214,7 @@ class ReferenceDataSetterSpec extends ObjectBehavior
         $product1->getValue('custom_material', $locale, $scope)->willReturn(null);
         $product2->getValue('custom_material', $locale, $scope)->willReturn($productValue2);
 
-        $builder->addProductValue($product1, $attribute, $locale, $scope)
+        $builder->addOrReplaceProductValue($product1, $attribute, $locale, $scope)
             ->shouldBeCalled()
             ->willReturn($productValue1);
 


### PR DESCRIPTION
## Description

In the future, product values will be handled differently, directly through the ProductValueFactory, which will be called by `ProductBuilder::addOrReplaceProductValue`.

So a lot of methods used to manipulate prices in the ProductBuilder are now deprecated, even if there is no replacement yet.

## Definition Of Done
| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | ✅
| Added Behats                      | ❎
| Added integration tests           | ❎
| Changelog updated                 | ✅
| Review and 2 GTM                  | 🕐
| Micro Demo to the PO (Story only) | ❎
| Migration script                  | ❎
| Tech Doc                          | ❎

🕐 Pending / Work in progress
✅ Done / Validated
❎ Not needed
