### PR TITLE
Api 106 : check locales key for the creation/updates of the labels in the API

### DIFF
--- a/src/Pim/Bundle/ApiBundle/Controller/Rest/AttributeController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/Rest/AttributeController.php
@@ -169,7 +169,7 @@ class AttributeController
         $decodedContent = json_decode($content, true);
 
         if (null === $decodedContent) {
-            throw new BadRequestHttpException('Invalid json message received.');
+            throw new BadRequestHttpException('Invalid json message received');
         }
 
         return $decodedContent;

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Attribute/CreateAttributeIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Attribute/CreateAttributeIntegration.php
@@ -32,7 +32,7 @@ JSON;
         $this->assertSame('', $response->getContent());
     }
 
-    public function testFormatStandardWhenAnAttributeIsCreatedButUncompleted()
+    public function testFormatStandardWhenAnAttributeIsCreatedButIncompleted()
     {
         $client = $this->createAuthenticatedClient();
 
@@ -161,7 +161,7 @@ JSON;
         $this->assertSame($attributeStandard, $normalizer->normalize($attribute));
     }
 
-    public function testResponseWhenContentIsNotValid()
+    public function testResponseWhenContentIsEmpty()
     {
         $client = $this->createAuthenticatedClient();
 
@@ -169,7 +169,24 @@ JSON;
 
         $expectedContent = [
             'code'    => 400,
-            'message' => 'Invalid json message received.',
+            'message' => 'Invalid json message received',
+        ];
+
+        $client->request('POST', 'api/rest/v1/attributes', [], [], [], $data);
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+        $this->assertSame($expectedContent, json_decode($response->getContent(), true));
+    }
+
+    public function testResponseWhenContentIsNotValid()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data = '{';
+
+        $expectedContent = [
+            'code'    => 400,
+            'message' => 'Invalid json message received',
         ];
 
         $client->request('POST', 'api/rest/v1/attributes', [], [], [], $data);
@@ -538,6 +555,118 @@ JSON;
             ],
         ];
 
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertSame($expectedContent, json_decode($response->getContent(), true));
+    }
+
+    public function testResponseWhenLocaleCodeInLabelsIsEmpty()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data =
+<<<JSON
+    {
+        "code":"unknown_locale",
+        "type":"pim_catalog_text",
+        "group":"attributeGroupA",
+        "unique":false,
+        "useable_as_grid_filter":false,
+        "allowed_extensions":[],
+        "metric_family":null,
+        "default_metric_unit":null,
+        "reference_data_name":null,
+        "available_locales":[],
+        "max_characters":null,
+        "validation_rule":null,
+        "validation_regexp":null,
+        "wysiwyg_enabled":false,
+        "number_min":null,
+        "number_max":null,
+        "decimals_allowed":false,
+        "negative_allowed":false,
+        "date_min":null,
+        "date_max":null,
+        "max_file_size":null,
+        "minimum_input_length":0,
+        "sort_order":12,
+        "localizable":false,
+        "scopable":false,
+        "labels": {
+            "":"label"
+        }
+    }
+JSON;
+
+        $expectedContent = [
+            'code'    => 422,
+            'message' => 'Validation failed.',
+            'errors'  => [
+                [
+                    'field'   => 'translations[0].locale',
+                    'message' => 'The locale "" does not exist.',
+                ],
+            ],
+        ];
+
+        $client->request('POST', 'api/rest/v1/attributes', [], [], [], $data);
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertSame($expectedContent, json_decode($response->getContent(), true));
+    }
+
+    public function testResponseWhenLocaleCodeDoesNotExist()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data =
+<<<JSON
+    {
+        "code":"unknown_locale",
+        "type":"pim_catalog_text",
+        "group":"attributeGroupA",
+        "unique":false,
+        "useable_as_grid_filter":false,
+        "allowed_extensions":[],
+        "metric_family":null,
+        "default_metric_unit":null,
+        "reference_data_name":null,
+        "available_locales":[],
+        "max_characters":null,
+        "validation_rule":null,
+        "validation_regexp":null,
+        "wysiwyg_enabled":false,
+        "number_min":null,
+        "number_max":null,
+        "decimals_allowed":false,
+        "negative_allowed":false,
+        "date_min":null,
+        "date_max":null,
+        "max_file_size":null,
+        "minimum_input_length":0,
+        "sort_order":12,
+        "localizable":false,
+        "scopable":false,
+        "labels": {
+            "foo": "label"
+        }
+    }
+JSON;
+
+        $expectedContent = [
+            'code'    => 422,
+            'message' => 'Validation failed.',
+            'errors'  => [
+                [
+                    'field'   => 'translations[0].locale',
+                    'message' => 'The locale "foo" does not exist.',
+                ],
+            ],
+        ];
+
+        $client->request('POST', 'api/rest/v1/attributes', [], [], [], $data);
+
+        $response = $client->getResponse();
         $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
         $this->assertSame($expectedContent, json_decode($response->getContent(), true));
     }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Category/PartialUpdateCategoryIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Category/PartialUpdateCategoryIntegration.php
@@ -50,22 +50,22 @@ JSON;
         $this->assertSame(null, json_decode($response->getContent(), true));
     }
 
-    public function testStandardFormatWhenACategoryIsCreatedButUncompleted()
+    public function testStandardFormatWhenACategoryIsCreatedButIncompleted()
     {
         $client = $this->createAuthenticatedClient();
 
         $data =
 <<<JSON
     {
-        "code": "new_category_uncompleted"
+        "code": "new_category_incompleted"
     }
 JSON;
 
-        $client->request('PATCH', 'api/rest/v1/categories/new_category_uncompleted', [], [], [], $data);
+        $client->request('PATCH', 'api/rest/v1/categories/new_category_incompleted', [], [], [], $data);
 
-        $category = $this->get('pim_catalog.repository.category')->findOneByIdentifier('new_category_uncompleted');
+        $category = $this->get('pim_catalog.repository.category')->findOneByIdentifier('new_category_incompleted');
         $categoryStandard = [
-            'code'   => 'new_category_uncompleted',
+            'code'   => 'new_category_incompleted',
             'parent' => null,
             'labels' => [],
         ];

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Family/CreateFamilyIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Family/CreateFamilyIntegration.php
@@ -29,22 +29,22 @@ JSON;
         $this->assertSame('', $response->getContent());
     }
 
-    public function testFormatStandardWhenAFamilyIsCreatedButUncompleted()
+    public function testFormatStandardWhenAFamilyIsCreatedButIncompleted()
     {
         $client = $this->createAuthenticatedClient();
 
         $data =
 <<<JSON
     {
-        "code": "new_family_uncompleted"
+        "code": "new_family_incompleted"
     }
 JSON;
 
         $client->request('POST', 'api/rest/v1/families', [], [], [], $data);
 
-        $family = $this->get('pim_catalog.repository.family')->findOneByIdentifier('new_family_uncompleted');
+        $family = $this->get('pim_catalog.repository.family')->findOneByIdentifier('new_family_incompleted');
         $familyStandard = [
-            'code'                   => 'new_family_uncompleted',
+            'code'                   => 'new_family_incompleted',
             'attributes'             => ['sku'],
             'attribute_as_label'     => 'sku',
             'attribute_requirements' => [
@@ -245,6 +245,70 @@ JSON;
             '_links'  => [
                 'documentation' => [
                     'href' => sprintf('https://docs.akeneo.com/%s/reference/standard_format/other_entities.html#family', $version),
+                ],
+            ],
+        ];
+
+        $client->request('POST', 'api/rest/v1/families', [], [], [], $data);
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertSame($expectedContent, json_decode($response->getContent(), true));
+    }
+
+    public function testResponseWhenLocaleCodeInLabelsIsEmpty()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data =
+<<<JSON
+    {
+        "code": "test_empty_locale",
+        "labels": {
+            "" : "label"
+         }
+    }
+JSON;
+
+        $expectedContent = [
+            'code'    => 422,
+            'message' => 'Validation failed.',
+            'errors'  => [
+                [
+                    'field'   => 'translations[0].locale',
+                    'message' => 'The locale "" does not exist.',
+                ],
+            ],
+        ];
+
+        $client->request('POST', 'api/rest/v1/families', [], [], [], $data);
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertSame($expectedContent, json_decode($response->getContent(), true));
+    }
+
+    public function testResponseWhenLocaleCodeDoesNotExist()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data =
+<<<JSON
+    {
+        "code": "test_unknown_localee",
+        "labels": {
+            "foo" : "label"
+         }
+    }
+JSON;
+
+        $expectedContent = [
+            'code'    => 422,
+            'message' => 'Validation failed.',
+            'errors'  => [
+                [
+                    'field'   => 'translations[0].locale',
+                    'message' => 'The locale "foo" does not exist.',
                 ],
             ],
         ];

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Family/PartialUpdateFamilyIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Family/PartialUpdateFamilyIntegration.php
@@ -49,22 +49,22 @@ JSON;
         $this->assertSame('', $response->getContent());
     }
 
-    public function testFormatStandardWhenAFamilyIsCreatedButUncompleted()
+    public function testFormatStandardWhenAFamilyIsCreatedButIncompleted()
     {
         $client = $this->createAuthenticatedClient();
 
         $data =
 <<<JSON
     {
-        "code": "new_family_uncompleted"
+        "code": "new_family_incompleted"
     }
 JSON;
 
-        $client->request('PATCH', 'api/rest/v1/families/new_family_uncompleted', [], [], [], $data);
+        $client->request('PATCH', 'api/rest/v1/families/new_family_incompleted', [], [], [], $data);
 
-        $family = $this->get('pim_catalog.repository.family')->findOneByIdentifier('new_family_uncompleted');
+        $family = $this->get('pim_catalog.repository.family')->findOneByIdentifier('new_family_incompleted');
         $familyStandard = [
-            'code'                   => 'new_family_uncompleted',
+            'code'                   => 'new_family_incompleted',
             'attributes'             => ['sku'],
             'attribute_as_label'     => 'sku',
             'attribute_requirements' => [

--- a/src/Pim/Bundle/CatalogBundle/Entity/AssociationType.php
+++ b/src/Pim/Bundle/CatalogBundle/Entity/AssociationType.php
@@ -142,7 +142,7 @@ class AssociationType implements AssociationTypeInterface
     public function getTranslation($locale = null)
     {
         $locale = ($locale) ? $locale : $this->locale;
-        if (!$locale) {
+        if (null === $locale) {
             return null;
         }
         foreach ($this->getTranslations() as $translation) {

--- a/src/Pim/Bundle/CatalogBundle/Entity/AttributeGroup.php
+++ b/src/Pim/Bundle/CatalogBundle/Entity/AttributeGroup.php
@@ -245,7 +245,7 @@ class AttributeGroup implements AttributeGroupInterface
     public function getTranslation($locale = null)
     {
         $locale = ($locale) ? $locale : $this->locale;
-        if (!$locale) {
+        if (null === $locale) {
             return null;
         }
         foreach ($this->getTranslations() as $translation) {

--- a/src/Pim/Bundle/CatalogBundle/Entity/Category.php
+++ b/src/Pim/Bundle/CatalogBundle/Entity/Category.php
@@ -97,7 +97,7 @@ class Category extends BaseCategory implements CategoryInterface
     public function getTranslation($locale = null)
     {
         $locale = ($locale) ? $locale : $this->locale;
-        if (!$locale) {
+        if (null === $locale) {
             return null;
         }
         foreach ($this->getTranslations() as $translation) {

--- a/src/Pim/Bundle/CatalogBundle/Entity/Family.php
+++ b/src/Pim/Bundle/CatalogBundle/Entity/Family.php
@@ -293,7 +293,7 @@ class Family implements FamilyInterface
     public function getTranslation($locale = null)
     {
         $locale = ($locale) ? $locale : $this->locale;
-        if (!$locale) {
+        if (null === $locale) {
             return null;
         }
         foreach ($this->getTranslations() as $translation) {

--- a/src/Pim/Bundle/CatalogBundle/Entity/Group.php
+++ b/src/Pim/Bundle/CatalogBundle/Entity/Group.php
@@ -129,7 +129,7 @@ class Group implements GroupInterface
     public function getTranslation($locale = null)
     {
         $locale = ($locale) ? $locale : $this->locale;
-        if (!$locale) {
+        if (null === $locale) {
             return null;
         }
         foreach ($this->getTranslations() as $translation) {

--- a/src/Pim/Bundle/CatalogBundle/Entity/GroupType.php
+++ b/src/Pim/Bundle/CatalogBundle/Entity/GroupType.php
@@ -134,7 +134,7 @@ class GroupType implements GroupTypeInterface
     public function getTranslation($locale = null)
     {
         $locale = ($locale) ? $locale : $this->locale;
-        if (!$locale) {
+        if (null === $locale) {
             return null;
         }
         foreach ($this->getTranslations() as $translation) {

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/validation/attribute.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/validation/attribute.yml
@@ -167,6 +167,8 @@ Pim\Bundle\CatalogBundle\Entity\AttributeTranslation:
         label:
             - Length:
                 max: 100
+        locale:
+            - Pim\Component\Catalog\Validator\Constraints\Locale: ~
 
 Pim\Bundle\CatalogBundle\Entity\AttributeOption:
     constraints:

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/validation/category.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/validation/category.yml
@@ -20,3 +20,5 @@ Pim\Bundle\CatalogBundle\Entity\CategoryTranslation:
         label:
             - Length:
                 max: 100
+        locale:
+            - Pim\Component\Catalog\Validator\Constraints\Locale: ~

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/validation/family.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/validation/family.yml
@@ -21,3 +21,5 @@ Pim\Bundle\CatalogBundle\Entity\FamilyTranslation:
         label:
             - Length:
                 max: 100
+        locale:
+            - Pim\Component\Catalog\Validator\Constraints\Locale: ~

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/validators.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/validators.yml
@@ -18,6 +18,7 @@ parameters:
     pim_catalog.validator.constraint.attribute_type_for_option.class:      Pim\Component\Catalog\Validator\Constraints\AttributeTypeForOptionValidator
     pim_catalog.validator.constraint.is_reference_data_configured.class:   Pim\Component\Catalog\Validator\Constraints\IsReferenceDataConfiguredValidator
     pim_catalog.validator.constraint.unique_variant_group_type.class:      Pim\Component\Catalog\Validator\Constraints\UniqueVariantGroupTypeValidator
+    pim_catalog.validator.constraints.locale_validator.class:              Pim\Component\Catalog\Validator\Constraints\LocaleValidator
     pim_catalog.validator.constraints.channel_validator.class:             Pim\Component\Catalog\Validator\Constraints\ChannelValidator
     pim_catalog.validator.constraint_guesser.chained.class:                Pim\Component\Catalog\Validator\ChainedAttributeConstraintGuesser
     pim_catalog.validator.constraint_guesser.email.class:                  Pim\Component\Catalog\Validator\ConstraintGuesser\EmailGuesser
@@ -96,6 +97,13 @@ services:
             - '@pim_catalog.validator.unique_value_set'
         tags:
             - { name: validator.constraint_validator, alias: pim_unique_value_validator }
+
+    pim_catalog.validator.constraints.locale_validator:
+        class: '%pim_catalog.validator.constraints.locale_validator.class%'
+        arguments:
+            - '@pim_catalog.repository.locale'
+        tags:
+            - { name: validator.constraint_validator, alias: pim_locale_validator }
 
     pim_catalog.validator.constraints.channel_validator:
         class: '%pim_catalog.validator.constraints.channel_validator.class%'

--- a/src/Pim/Component/Catalog/Model/AbstractAttribute.php
+++ b/src/Pim/Component/Catalog/Model/AbstractAttribute.php
@@ -911,7 +911,7 @@ abstract class AbstractAttribute implements AttributeInterface
     public function getTranslation($locale = null)
     {
         $locale = ($locale) ? $locale : $this->locale;
-        if (!$locale) {
+        if (null === $locale) {
             return null;
         }
         foreach ($this->getTranslations() as $translation) {

--- a/src/Pim/Component/Catalog/Validator/Constraints/Locale.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/Locale.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Pim\Component\Catalog\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Constraint to check if a locale exists.
+ *
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class Locale extends Constraint
+{
+    /** @var string */
+    public $message = 'The locale "%locale%" does not exist.';
+}

--- a/src/Pim/Component/Catalog/Validator/Constraints/LocaleValidator.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/LocaleValidator.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Pim\Component\Catalog\Validator\Constraints;
+
+use Pim\Component\Catalog\Repository\LocaleRepositoryInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ * Validate that the locale exists.
+ *
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class LocaleValidator extends ConstraintValidator
+{
+    /** @var LocaleRepositoryInterface */
+    protected $localeRepository;
+
+    /**
+     * @param LocaleRepositoryInterface $localeRepository
+     */
+    public function __construct(LocaleRepositoryInterface $localeRepository)
+    {
+        $this->localeRepository = $localeRepository;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validate($value, Constraint $constraint)
+    {
+        $locale = $this->localeRepository->findOneByIdentifier($value);
+        if (null === $locale) {
+            $this->context->buildViolation(
+                $constraint->message,
+                ['%locale%' => $value]
+            )->addViolation();
+        }
+    }
+}

--- a/src/Pim/Component/Catalog/spec/Validator/Constraints/LocaleSpec.php
+++ b/src/Pim/Component/Catalog/spec/Validator/Constraints/LocaleSpec.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace spec\Pim\Component\Catalog\Validator\Constraints;
+
+use PhpSpec\ObjectBehavior;
+
+class LocaleSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Pim\Component\Catalog\Validator\Constraints\Locale');
+    }
+
+    function it_has_message()
+    {
+        $this->message->shouldBe('The locale "%locale%" does not exist.');
+    }
+
+    function it_is_a_validator_constraint()
+    {
+        $this->shouldBeAnInstanceOf('Symfony\Component\Validator\Constraint');
+    }
+}

--- a/src/Pim/Component/Catalog/spec/Validator/Constraints/LocaleValidatorSpec.php
+++ b/src/Pim/Component/Catalog/spec/Validator/Constraints/LocaleValidatorSpec.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace spec\Pim\Component\Catalog\Validator\Constraints;
+
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Model\LocaleInterface;
+use Pim\Component\Catalog\Repository\LocaleRepositoryInterface;
+use Pim\Component\Catalog\Validator\Constraints\Locale;
+use Prophecy\Argument;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
+
+class LocaleValidatorSpec extends ObjectBehavior
+{
+    function let(LocaleRepositoryInterface $localeRepository, ExecutionContextInterface $context)
+    {
+        $this->beConstructedWith($localeRepository);
+        $this->initialize($context);
+    }
+
+    function it_validates_if_locale_exists(
+        $localeRepository,
+        $context,
+        Locale $constraint,
+        LocaleInterface $locale
+    ) {
+        $localeCode = 'foo';
+
+        $localeRepository->findOneByIdentifier($localeCode)->willReturn($locale);
+        $context->buildViolation(Argument::cetera())->shouldNotBeCalled();
+
+        $this->validate($localeCode, $constraint);
+    }
+
+    function it_adds_violation_if_locale_does_not_exist(
+        $localeRepository,
+        $context,
+        Locale $constraint,
+        ConstraintViolationBuilderInterface $violation
+    ) {
+        $localeCode = 'foo';
+
+        $localeRepository->findOneByIdentifier($localeCode)->willReturn(null);
+        $context->buildViolation($constraint->message, ['%locale%' => $localeCode])->willReturn($violation);
+        $violation->addViolation()->shouldBeCalled();
+
+        $this->validate($localeCode, $constraint);
+    }
+}


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

This PR resolve : 
- a fatal exception when you specified a locale which is empty (dedicated commit).
I've fixed that in every labelizable entities because it's always the same logic to get the translation, and so, always the same error.

For exampbe, before the fix, this request raised an error 500 : 
```
{
	"code": "category",
	"parent": null,
	"labels": {
		"": 12
	}
}
```

-It checks that the locale associated to the label exists when you create an entity
 For the moment, it's checked only in entities handled by the API : family, category and attributes. It does not check if the locale is activated because it implies other stuff out of the scope of the API.

For example, before the fix, this request was well processed : 
```
{
	"code": "category",
	"parent": null,
	"labels": {
		"jean_michel": 12
	}
}
```
[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added Behats                      | -
| Added integration tests           | OK
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
