### PR TITLE
[PIM-6140] Fix job execution 'equals to' filter

### DIFF
--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-6146: Fix product import after associated product deletion (MongoDB)
+- PIM-6140: Fix 'equals to' filters on job tracker page
 
 # 1.5.18 (2017-02-01)
 

--- a/features/job-tracker/display_jobs_execution_in_job_tracker.feature
+++ b/features/job-tracker/display_jobs_execution_in_job_tracker.feature
@@ -68,3 +68,19 @@ Feature: Display jobs execution in job tracker
     And I should see the columns Type, Job, User, Status and Started at
     And the grid should contain 1 element
     And I should see entity Footwear category import
+
+  @jira https://akeneo.atlassian.net/browse/PIM-6140
+  Scenario: Successfully filter job executions with "equals to" filter
+    Given I am on the exports page
+    And I launch the "footwear_product_export" export job
+    And I logout
+    And I am logged in as "admin"
+    And I am on the exports page
+    And I launch the "footwear_category_export" export job
+    When I am on the job tracker page
+    Then I should be able to use the following filters:
+      | filter   | operator    | value                   | result                                            |
+      | Job      | is equal to | Footwear product export | Footwear product export                           |
+      | User     | is equal to | Julia                   | Footwear product export                           |
+      | Type     | is equal to | import                  |                                                   |
+      | Type     | is equal to | export                  | Footwear product export, Footwear category export |

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/job_tracker.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/job_tracker.yml
@@ -47,15 +47,15 @@ datagrid:
                 type:
                     type:      string
                     label:     Type
-                    data_name: type
+                    data_name: j.type
                 job:
                     type: string
                     label: Job
-                    data_name: jobLabel
+                    data_name: j.label
                 user:
                     type:      string
                     label:     User
-                    data_name: user
+                    data_name: e.user
                 status:
                     type:             choice
                     data_name:        status


### PR DESCRIPTION
Backport of https://github.com/akeneo/pim-community-dev/pull/5605 from 1.6 to 1.5