### PR TITLE
Fix GroupRepository: use code or id as identifier to fetch Groups

### DIFF
--- a/features/product/filtering/filter_products_per_group.feature
+++ b/features/product/filtering/filter_products_per_group.feature
@@ -45,3 +45,10 @@ Feature: Filter products
     When I filter by "groups" with operator "" and value "Empty"
     Then the grid should contain 0 element
     And I should not see products BOOK, MUG-1, MUG-2 and POSTIT
+
+  Scenario: Successfully keep the group filter on page reload
+    Given I am on the products page
+    When I filter by "groups" with operator "in list" and value "Mug"
+    And I reload the page
+    Then I should see the text "Groups: \"Mug\""
+    And the grid should contain 2 elements

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/GroupRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/GroupRepository.php
@@ -192,9 +192,11 @@ class GroupRepository extends EntityRepository implements GroupRepositoryInterfa
      */
     public function getOptions($dataLocale, $collectionId = null, $search = '', array $options = [])
     {
+        $identifier = isset($options['type']) && 'code' === $options['type'] ? 'code' : 'id';
+
         $selectDQL = sprintf(
             'o.%s as id, COALESCE(NULLIF(t.label, \'\'), CONCAT(\'[\', o.code, \']\')) as text',
-            isset($options['type']) && 'code' === $options['type'] ? 'code' : 'id'
+            $identifier
         );
 
         $qb = $this->createQueryBuilder('o')
@@ -211,7 +213,7 @@ class GroupRepository extends EntityRepository implements GroupRepositoryInterfa
         if (isset($options['ids'])) {
             $qb
                 ->andWhere(
-                    $qb->expr()->in('o.id', ':ids')
+                    $qb->expr()->in(sprintf('o.%s', $identifier), ':ids')
                 )
                 ->setParameter('ids', $options['ids']);
         }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

The grid fetches Groups used as filter, by sending this to the backend:
```
{type: 'code', ids: ['oro_mugs']}
```

The GroupRepository takes the `type` in account for the `SELECT` part of the query, but not in the `WHERE` part. This PR fixes it.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | OK
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -
