### PR TITLE
TIP-697: Fix variant group values copy to product

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/GroupSaver.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/GroupSaver.php
@@ -104,13 +104,9 @@ class GroupSaver implements SaverInterface, BulkSaverInterface
 
         $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE, new GenericEvent($group, $options));
 
-        $this->persistGroup($group, $options);
+        $this->persistGroupAndSaveAssociatedProducts($group, $options);
 
         $this->objectManager->flush();
-
-        if ($group->getType()->isVariant() && true === $options['copy_values_to_products']) {
-            $this->copyVariantGroupValues($group);
-        }
 
         $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE, new GenericEvent($group));
     }
@@ -133,7 +129,7 @@ class GroupSaver implements SaverInterface, BulkSaverInterface
 
             $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE, new GenericEvent($group, $options));
 
-            $this->persistGroup($group, $options);
+            $this->persistGroupAndSaveAssociatedProducts($group, $options);
         }
 
         $this->objectManager->flush();
@@ -207,7 +203,7 @@ class GroupSaver implements SaverInterface, BulkSaverInterface
      * @param       $group
      * @param array $options
      */
-    protected function persistGroup($group, array $options)
+    protected function persistGroupAndSaveAssociatedProducts($group, array $options)
     {
         $context = $this->productClassName;
         $this->versionContext->addContextInfo(


### PR DESCRIPTION
## Description

During variant group saving, the protected method `copyVariantGroupValues` is called twice by the `save` method of the GroupSaver:
- once in the method `persistGroup` (renamed at the occasion in `persistGroupAndSaveAssociatedProducts` to be more explicit)
- then a second time in the `save`, just after `persistGroupAndSaveAssociatedProducts`.

This PR removes the second call to the method, which is completely useless, and further more could be source of possible bugs as product are detached at the end of the first call.

## Definition Of Done
| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
