### PR TITLE
Tip 322 : add business exceptions in adders, setters, removers and copiers

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -163,6 +163,14 @@
 - Remove useless class `Pim\Bundle\ImportExportBundle\Twig\NormalizeConfigurationExtension`
 - Remove useless class `Pim\Bundle\ImportExportBundle\ViewElement\Checker\JobNameVisibilityChecker`
 - Change exception `\InvalidArgumentException` by `Akeneo\Component\StorageUtils\Exception\ObjectUpdaterException` thrown by `Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface:update()`
+- Change exception `Pim\Component\Catalog\Exception\InvalidArgumentException` and `\RuntimeException` by `Akeneo\Component\StorageUtils\Exception\ObjectUpdaterException` thrown by `Pim\Component\Catalog\Updater\Copier\AttributeCopierInterface:copyAttributeData()`
+- Change exception `Pim\Component\Catalog\Exception\InvalidArgumentException` and `\RuntimeException` by `Akeneo\Component\StorageUtils\Exception\ObjectUpdaterException` thrown by `Pim\Component\Catalog\Updater\Copier\FieldCopierInterface:copyFieldData()`
+- Add exception `Akeneo\Component\StorageUtils\Exception\ObjectUpdaterException` thrown by `Pim\Component\Catalog\Updater\Adder\AttributeAdderInterface:addAttributeData()`
+- Add exception `Akeneo\Component\StorageUtils\Exception\ObjectUpdaterException` thrown by `Pim\Component\Catalog\Updater\Adder\FieldAdderInterface:addFieldData()`
+- Add exception `Akeneo\Component\StorageUtils\Exception\ObjectUpdaterException` thrown by `Pim\Component\Catalog\Updater\Remover\AttributeRemoverInterface:removeAttributeData()`
+- Add exception `Akeneo\Component\StorageUtils\Exception\ObjectUpdaterException` thrown by `Pim\Component\Catalog\Updater\Remover\FieldRemoverInterface:removeFieldData()`
+- Add exception `Akeneo\Component\StorageUtils\Exception\ObjectUpdaterException` thrown by `Pim\Component\Catalog\Updater\Setter\AttributeSetterInterface:setAttributeData()`
+- Add exception `Akeneo\Component\StorageUtils\Exception\ObjectUpdaterException` thrown by `Pim\Component\Catalog\Updater\Setter\FieldSetterInterface:setFieldData()`
 - Change the constructor of `Pim\Component\Catalog\Updater\AssociationTypeUpdater` to remove `Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface`
 - Remove `createDatagridQueryBuilder` method from `Pim\Component\Catalog\Repository\CurrencyRepositoryInterface`
 - Remove `createDatagridQueryBuilder` method from `Pim\Component\Catalog\Repository\LocaleInterface`

--- a/features/import/product/import_products_with_associations.feature
+++ b/features/import/product/import_products_with_associations.feature
@@ -57,7 +57,7 @@ Feature: Execute a job
     And I launch the import job
     And I wait for the "csv_footwear_product_import" job to finish
     Then there should be 1 product
-    And I should see "Attribute or field \"associations\" expects existing product identifier as data, \"SKU-002\" given"
+    And I should see "Property \"associations\" expects a valid product identifier. The product does not exist, \"SKU-002\" given."
 
   Scenario: Successfully import a csv file with associations between invalid but existing products
     Given the following products:

--- a/features/import/product/import_products_with_invalid_data.feature
+++ b/features/import/product/import_products_with_invalid_data.feature
@@ -217,7 +217,7 @@ Feature: Execute a job
     And I launch the import job
     And I wait for the "csv_footwear_product_import" job to finish
     And there should be 1 product
-    And I should see "Attribute or field \"frontView\" expects a valid pathname as data"
+    And I should see "Property \"frontView\" expects a valid pathname as data"
     And the product "fanatic-freewave-76" should have the following values:
       | name-en_US | Fanatic Freewave 76     |
       | frontView  | fanatic-freewave-76.gif |
@@ -249,7 +249,7 @@ Feature: Execute a job
     And I wait for the "csv_footwear_product_import" job to finish
     Then I should see "skipped 1"
     And there should be 2 products
-    And I should see "Attribute or field \"frontView\" expects a valid pathname as data"
+    And I should see "Property \"frontView\" expects a valid pathname as data"
     And the product "fanatic-freewave-76" should have the following values:
       | frontView  | fanatic-freewave-76.gif |
       | userManual | fanatic-freewave-76.txt |
@@ -433,4 +433,4 @@ Feature: Execute a job
     And I launch the import job
     And I wait for the "csv_footwear_product_import" job to finish
     Then I should see "skipped 1"
-    And I should see "Attribute or field \"associations\" expects existing product identifier as data, \"unknown\" given"
+    And I should see "Property \"associations\" expects a valid product identifier. The product does not exist, \"unknown\" given."

--- a/features/import/product/xlsx/import_products_with_associations.feature
+++ b/features/import/product/xlsx/import_products_with_associations.feature
@@ -56,7 +56,7 @@ Feature: Execute a job
     And I launch the import job
     And I wait for the "xlsx_footwear_product_import" job to finish
     Then there should be 1 product
-    And I should see "Attribute or field \"associations\" expects existing product identifier as data, \"SKU-002\" given"
+    And I should see "Property \"associations\" expects a valid product identifier. The product does not exist, \"SKU-002\" given."
 
   Scenario: Successfully import a xlsx file with associations between invalid but existing products
     Given the following products:

--- a/src/Akeneo/Component/StorageUtils/Exception/InvalidPropertyException.php
+++ b/src/Akeneo/Component/StorageUtils/Exception/InvalidPropertyException.php
@@ -13,18 +13,13 @@ class InvalidPropertyException extends ObjectUpdaterException
 {
     const EXPECTED_CODE = 100;
     const DATE_EXPECTED_CODE = 101;
-    const BOOLEAN_EXPECTED_CODE = 102;
-    const FLOAT_EXPECTED_CODE = 103;
-    const INTEGER_EXPECTED_CODE = 104;
-    const NUMERIC_EXPECTED_CODE = 105;
-    const STRING_EXPECTED_CODE = 106;
-    const ARRAY_EXPECTED_CODE = 108;
-    const ARRAY_OF_ARRAYS_EXPECTED_CODE = 109;
 
     const NOT_EMPTY_VALUE_EXPECTED_CODE = 200;
 
     const VALID_ENTITY_CODE_EXPECTED_CODE = 300;
     const VALID_GROUP_TYPE_EXPECTED_CODE = 301;
+    const VALID_GROUP_EXPECTED_CODE = 302;
+    const VALID_PATH_EXPECTED_CODE = 304;
 
     /** @var string */
     protected $propertyName;
@@ -53,7 +48,7 @@ class InvalidPropertyException extends ObjectUpdaterException
     ) {
         parent::__construct($message, $code, $previous);
 
-        $this->propertyName  = $propertyName;
+        $this->propertyName = $propertyName;
         $this->propertyValue = $propertyValue;
         $this->className = $className;
     }
@@ -146,6 +141,74 @@ class InvalidPropertyException extends ObjectUpdaterException
             $className,
             sprintf($message, $propertyName, $because, $propertyValue),
             self::VALID_GROUP_TYPE_EXPECTED_CODE
+        );
+    }
+
+    /**
+     * Build an exception when the group is invalid or is not allowed.
+     *
+     * @param string $propertyName
+     * @param string $because
+     * @param string $className
+     * @param string $propertyValue
+     *
+     * @return InvalidPropertyException
+     */
+    public static function validGroupExpected($propertyName, $because, $className, $propertyValue)
+    {
+        $message = 'Property "%s" expects a valid group. %s, "%s" given.';
+
+        return new self(
+            $propertyName,
+            $propertyValue,
+            $className,
+            sprintf($message, $propertyName, $because, $propertyValue),
+            self::VALID_GROUP_EXPECTED_CODE
+        );
+    }
+
+    /**
+     * Build an exception when the pathname is invalid.
+     *
+     * @param string $propertyName
+     * @param string $className
+     * @param string $propertyValue
+     *
+     * @return InvalidPropertyException
+     */
+    public static function validPathExpected($propertyName, $className, $propertyValue)
+    {
+        $message = 'Property "%s" expects a valid pathname as data, "%s" given.';
+
+        return new self(
+            $propertyName,
+            $propertyValue,
+            $className,
+            sprintf($message, $propertyName, $propertyValue),
+            self::VALID_PATH_EXPECTED_CODE
+        );
+    }
+
+    /**
+     * Build an exception from a previous one.
+     *
+     * @param string     $propertyName
+     * @param string     $className
+     * @param \Exception $exception
+     *
+     * @return InvalidPropertyException
+     */
+    public static function expectedFromPreviousException($propertyName, $className, \Exception $exception)
+    {
+        $message = 'Property "%s" expects valid data, scope and locale. %s';
+
+        return new self(
+            $propertyName,
+            null,
+            $className,
+            sprintf($message, $propertyName, $exception->getMessage()),
+            $exception->getCode(),
+            $exception
         );
     }
 

--- a/src/Akeneo/Component/StorageUtils/Exception/InvalidPropertyTypeException.php
+++ b/src/Akeneo/Component/StorageUtils/Exception/InvalidPropertyTypeException.php
@@ -13,9 +13,18 @@ namespace Akeneo\Component\StorageUtils\Exception;
 class InvalidPropertyTypeException extends ObjectUpdaterException
 {
     const EXPECTED_CODE = 100;
+
     const SCALAR_EXPECTED_CODE = 101;
-    const ARRAY_EXPECTED_CODE = 102;
-    const VALID_ARRAY_STRUCTURE_EXPECTED_CODE = 103;
+    const BOOLEAN_EXPECTED_CODE = 102;
+    const FLOAT_EXPECTED_CODE = 103;
+    const INTEGER_EXPECTED_CODE = 104;
+    const NUMERIC_EXPECTED_CODE = 105;
+    const STRING_EXPECTED_CODE = 106;
+
+    const ARRAY_EXPECTED_CODE = 200;
+    const VALID_ARRAY_STRUCTURE_EXPECTED_CODE = 201;
+    const ARRAY_OF_ARRAYS_EXPECTED_CODE = 202;
+    const ARRAY_KEY_EXPECTED_CODE = 203;
 
     /** @var string */
     protected $propertyName;
@@ -34,10 +43,16 @@ class InvalidPropertyTypeException extends ObjectUpdaterException
      * @param int             $code
      * @param \Exception|null $previous
      */
-    public function __construct($propertyName, $propertyValue, $className, $message = '', $code = 0, \Exception $previous = null)
-    {
+    public function __construct(
+        $propertyName,
+        $propertyValue,
+        $className,
+        $message = '',
+        $code = 0,
+        \Exception $previous = null
+    ) {
         parent::__construct($message, $code, $previous);
-        $this->propertyName  = $propertyName;
+        $this->propertyName = $propertyName;
         $this->propertyValue = $propertyValue;
         $this->className = $className;
     }
@@ -53,14 +68,124 @@ class InvalidPropertyTypeException extends ObjectUpdaterException
      */
     public static function scalarExpected($propertyName, $className, $propertyValue)
     {
-        $message = 'Property "%s" expects a scalar.';
+        $message = 'Property "%s" expects a scalar as data, "%s" given.';
 
         return new self(
             $propertyName,
-            $className,
             $propertyValue,
-            sprintf($message, $propertyName),
+            $className,
+            sprintf($message, $propertyName, gettype($propertyValue)),
             self::SCALAR_EXPECTED_CODE
+        );
+    }
+
+    /**
+     * Build an exception when the data is not a boolean value.
+     *
+     * @param string $propertyName
+     * @param string $className
+     * @param mixed  $propertyValue a value that not a boolean
+     *
+     * @return InvalidPropertyTypeException
+     */
+    public static function booleanExpected($propertyName, $className, $propertyValue)
+    {
+        $message = 'Property "%s" expects a boolean as data, "%s" given.';
+
+        return new self(
+            $propertyName,
+            $propertyValue,
+            $className,
+            sprintf($message, $propertyName, gettype($propertyValue)),
+            self::BOOLEAN_EXPECTED_CODE
+        );
+    }
+
+    /**
+     * Build an exception when the data is not a float value.
+     *
+     * @param string $propertyName
+     * @param string $className
+     * @param mixed  $propertyValue a value that not a float
+     *
+     * @return InvalidPropertyTypeException
+     */
+    public static function floatExpected($propertyName, $className, $propertyValue)
+    {
+        $message = 'Property "%s" expects a float as data, "%s" given.';
+
+        return new self(
+            $propertyName,
+            $propertyValue,
+            $className,
+            sprintf($message, $propertyName, gettype($propertyValue)),
+            self::FLOAT_EXPECTED_CODE
+        );
+    }
+
+    /**
+     * Build an exception when the data is not a integer value.
+     *
+     * @param string $propertyName
+     * @param string $className
+     * @param mixed  $propertyValue a value that not an integer
+     *
+     * @return InvalidPropertyTypeException
+     */
+    public static function integerExpected($propertyName, $className, $propertyValue)
+    {
+        $message = 'Property "%s" expects an integer as data, "%s" given.';
+
+        return new self(
+            $propertyName,
+            $propertyValue,
+            $className,
+            sprintf($message, $propertyName, gettype($propertyValue)),
+            self::INTEGER_EXPECTED_CODE
+        );
+    }
+
+    /**
+     * Build an exception when the data is not a numeric value.
+     *
+     * @param string $propertyName
+     * @param string $className
+     * @param mixed  $propertyValue a value that is not a numeric
+     *
+     * @return InvalidPropertyTypeException
+     */
+    public static function numericExpected($propertyName, $className, $propertyValue)
+    {
+        $message = 'Property "%s" expects a numeric as data, "%s" given.';
+
+        return new self(
+            $propertyName,
+            $propertyValue,
+            $className,
+            sprintf($message, $propertyName, gettype($propertyValue)),
+            self::NUMERIC_EXPECTED_CODE
+        );
+    }
+
+    /**
+     * Build an exception when the data is not a string value.
+     *
+     * @param string $propertyName
+     * @param string $className
+     * @param string $propertyValue a value that is not a string
+     *
+     * @return InvalidPropertyTypeException
+     */
+    public static function stringExpected($propertyName, $className, $propertyValue)
+    {
+        $message = 'Property "%s" expects a string as data, "%s" given.';
+
+        return new self(
+            $propertyName,
+            $propertyValue,
+            $className,
+            sprintf($message, $propertyName, gettype($propertyValue)),
+            self::STRING_EXPECTED_CODE
         );
     }
 
@@ -75,38 +200,83 @@ class InvalidPropertyTypeException extends ObjectUpdaterException
      */
     public static function arrayExpected($propertyName, $className, $propertyValue)
     {
-        $message = 'Property "%s" expects an array.';
+        $message = 'Property "%s" expects an array as data, "%s" given.';
 
         return new self(
             $propertyName,
-            $className,
             $propertyValue,
-            sprintf($message, $propertyName),
+            $className,
+            sprintf($message, $propertyName, gettype($propertyValue)),
             self::ARRAY_EXPECTED_CODE
         );
     }
 
     /**
      * Build an exception when the data inside the array does not have the structure expected.
-     * For example, when the array contains scalar values instead of array values.
+     * It's a generic exception to use if a most specific exception about array does not exist.
      *
      * @param string $propertyName
      * @param string $because
      * @param string $className
-     * @param array  $propertyValue
+     * @param array  $propertyValue an array with an invalid structure
      *
-     * @return InvalidPropertyTypeExceptionn
+     * @return InvalidPropertyTypeException
      */
     public static function validArrayStructureExpected($propertyName, $because, $className, array $propertyValue)
     {
-        $message = 'Property "%s" expects a valid array, %s.';
+        $message = 'Property "%s" expects an array with valid data, %s.';
 
         return new self(
             $propertyName,
-            $className,
             $propertyValue,
+            $className,
             sprintf($message, $propertyName, $because),
-            self::ARRAY_EXPECTED_CODE
+            self::VALID_ARRAY_STRUCTURE_EXPECTED_CODE
+        );
+    }
+
+    /**
+     * Build an exception when the data are not an array of arrays.
+     *
+     * @param string $propertyName
+     * @param string $className
+     * @param array  $propertyValue an array that does not contain arrays
+     *
+     * @return InvalidPropertyTypeException
+     */
+    public static function arrayOfArraysExpected($propertyName, $className, array $propertyValue)
+    {
+        $message = 'Property "%s" expects an array of arrays as data.';
+
+        return new self(
+            $propertyName,
+            $propertyValue,
+            $className,
+            sprintf($message, $propertyName),
+            self::ARRAY_OF_ARRAYS_EXPECTED_CODE
+        );
+    }
+
+    /**
+     * Build an exception when the data is an array that does not contain an expected key.
+     *
+     * @param string $propertyName
+     * @param string $key
+     * @param string $className
+     * @param array  $propertyValue an array that does not contain a specific key
+     *
+     * @return InvalidPropertyTypeException
+     */
+    public static function arrayKeyExpected($propertyName, $key, $className, array $propertyValue)
+    {
+        $message = 'Property "%s" expects an array with the key "%s" as data.';
+
+        return new self(
+            $propertyName,
+            $propertyValue,
+            $className,
+            sprintf($message, $propertyName, $key),
+            self::ARRAY_KEY_EXPECTED_CODE
         );
     }
 
@@ -124,5 +294,13 @@ class InvalidPropertyTypeException extends ObjectUpdaterException
     public function getPropertyValue()
     {
         return $this->propertyValue;
+    }
+
+    /**
+     * @return string
+     */
+    public function getClassName()
+    {
+        return $this->className;
     }
 }

--- a/src/Akeneo/Component/StorageUtils/spec/Exception/InvalidPropertyExceptionSpec.php
+++ b/src/Akeneo/Component/StorageUtils/spec/Exception/InvalidPropertyExceptionSpec.php
@@ -105,4 +105,77 @@ class InvalidPropertyExceptionSpec extends ObjectBehavior
         $this->getMessage()->shouldReturn($exception->getMessage());
         $this->getCode()->shouldReturn($exception->getCode());
     }
+
+    function it_creates_an_invalid_group_exception()
+    {
+        $exception = InvalidPropertyException::validGroupExpected(
+            'group',
+            'Group is not supported',
+            'Pim\Component\Catalog\Updater\Attribute',
+            'foo'
+        );
+
+        $this->beConstructedWith(
+            'group',
+            'foo',
+            'Pim\Component\Catalog\Updater\Attribute',
+            'Property "group" expects a valid group. Group is not supported, "foo" given.',
+            InvalidPropertyException::VALID_GROUP_EXPECTED_CODE
+        );
+
+        $this->shouldBeAnInstanceOf(get_class($exception));
+        $this->getPropertyName()->shouldReturn($exception->getPropertyName());
+        $this->getPropertyValue()->shouldReturn($exception->getPropertyValue());
+        $this->getClassName()->shouldReturn($exception->getClassName());
+        $this->getMessage()->shouldReturn($exception->getMessage());
+        $this->getCode()->shouldReturn($exception->getCode());
+    }
+
+    function it_creates_an_invalid_path_exception()
+    {
+        $exception = InvalidPropertyException::validPathExpected(
+            'path',
+            'Pim\Component\Catalog\Updater\Attribute',
+            '/tmp/foo'
+        );
+
+        $this->beConstructedWith(
+            'path',
+            '/tmp/foo',
+            'Pim\Component\Catalog\Updater\Attribute',
+            'Property "path" expects a valid pathname as data, "/tmp/foo" given.',
+            InvalidPropertyException::VALID_PATH_EXPECTED_CODE
+        );
+
+        $this->shouldBeAnInstanceOf(get_class($exception));
+        $this->getPropertyName()->shouldReturn($exception->getPropertyName());
+        $this->getPropertyValue()->shouldReturn($exception->getPropertyValue());
+        $this->getClassName()->shouldReturn($exception->getClassName());
+        $this->getMessage()->shouldReturn($exception->getMessage());
+        $this->getCode()->shouldReturn($exception->getCode());
+    }
+
+    function it_creates_an_exception_from_a_previous_exception()
+    {
+        $exception = InvalidPropertyException::expectedFromPreviousException(
+            'attribute',
+            'Pim\Component\Catalog\Updater\Attribute',
+            new \Exception('This is an exception message.', 42)
+        );
+
+        $this->beConstructedWith(
+            'attribute',
+            null,
+            'Pim\Component\Catalog\Updater\Attribute',
+            'Property "attribute" expects valid data, scope and locale. This is an exception message.',
+            42
+        );
+
+        $this->shouldBeAnInstanceOf(get_class($exception));
+        $this->getPropertyName()->shouldReturn($exception->getPropertyName());
+        $this->getPropertyValue()->shouldReturn($exception->getPropertyValue());
+        $this->getClassName()->shouldReturn($exception->getClassName());
+        $this->getMessage()->shouldReturn($exception->getMessage());
+        $this->getCode()->shouldReturn($exception->getCode());
+    }
 }

--- a/src/Akeneo/Component/StorageUtils/spec/Exception/InvalidPropertyTypeExceptionSpec.php
+++ b/src/Akeneo/Component/StorageUtils/spec/Exception/InvalidPropertyTypeExceptionSpec.php
@@ -1,0 +1,251 @@
+<?php
+
+namespace spec\Akeneo\Component\StorageUtils\Exception;
+
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
+use PhpSpec\ObjectBehavior;
+
+class InvalidPropertyTypeExceptionSpec extends ObjectBehavior
+{
+    function it_creates_a_not_scalar_exception()
+    {
+        $exception = InvalidPropertyTypeException::scalarExpected(
+            'attribute',
+            'Pim\Component\Catalog\Updater\Attribute',
+            []
+        );
+
+        $this->beConstructedWith(
+            'attribute',
+            [],
+            'Pim\Component\Catalog\Updater\Attribute',
+            'Property "attribute" expects a scalar as data, "array" given.',
+            InvalidPropertyTypeException::SCALAR_EXPECTED_CODE
+        );
+
+        $this->shouldBeAnInstanceOf(get_class($exception));
+        $this->getPropertyName()->shouldReturn($exception->getPropertyName());
+        $this->getPropertyValue()->shouldReturn($exception->getPropertyValue());
+        $this->getClassName()->shouldReturn($exception->getClassName());
+        $this->getMessage()->shouldReturn($exception->getMessage());
+        $this->getCode()->shouldReturn($exception->getCode());
+    }
+
+    function it_creates_a_not_boolean_exception()
+    {
+        $exception = InvalidPropertyTypeException::booleanExpected(
+            'attribute',
+            'Pim\Component\Catalog\Updater\Attribute',
+            []
+        );
+
+        $this->beConstructedWith(
+            'attribute',
+            [],
+            'Pim\Component\Catalog\Updater\Attribute',
+            'Property "attribute" expects a boolean as data, "array" given.',
+            InvalidPropertyTypeException::BOOLEAN_EXPECTED_CODE
+        );
+
+        $this->shouldBeAnInstanceOf(get_class($exception));
+        $this->getPropertyName()->shouldReturn($exception->getPropertyName());
+        $this->getPropertyValue()->shouldReturn($exception->getPropertyValue());
+        $this->getClassName()->shouldReturn($exception->getClassName());
+        $this->getMessage()->shouldReturn($exception->getMessage());
+        $this->getCode()->shouldReturn($exception->getCode());
+    }
+
+    function it_creates_a_not_float_exception()
+    {
+        $exception = InvalidPropertyTypeException::floatExpected(
+            'attribute',
+            'Pim\Component\Catalog\Updater\Attribute',
+            []
+        );
+
+        $this->beConstructedWith(
+            'attribute',
+            [],
+            'Pim\Component\Catalog\Updater\Attribute',
+            'Property "attribute" expects a float as data, "array" given.',
+            InvalidPropertyTypeException::FLOAT_EXPECTED_CODE
+        );
+
+        $this->shouldBeAnInstanceOf(get_class($exception));
+        $this->getPropertyName()->shouldReturn($exception->getPropertyName());
+        $this->getPropertyValue()->shouldReturn($exception->getPropertyValue());
+        $this->getClassName()->shouldReturn($exception->getClassName());
+        $this->getMessage()->shouldReturn($exception->getMessage());
+        $this->getCode()->shouldReturn($exception->getCode());
+    }
+
+    function it_creates_a_not_integer_exception()
+    {
+        $exception = InvalidPropertyTypeException::integerExpected(
+            'attribute',
+            'Pim\Component\Catalog\Updater\Attribute',
+            []
+        );
+
+        $this->beConstructedWith(
+            'attribute',
+            [],
+            'Pim\Component\Catalog\Updater\Attribute',
+            'Property "attribute" expects an integer as data, "array" given.',
+            InvalidPropertyTypeException::INTEGER_EXPECTED_CODE
+        );
+
+        $this->shouldBeAnInstanceOf(get_class($exception));
+        $this->getPropertyName()->shouldReturn($exception->getPropertyName());
+        $this->getPropertyValue()->shouldReturn($exception->getPropertyValue());
+        $this->getClassName()->shouldReturn($exception->getClassName());
+        $this->getMessage()->shouldReturn($exception->getMessage());
+        $this->getCode()->shouldReturn($exception->getCode());
+    }
+
+    function it_creates_a_not_numeric_exception()
+    {
+        $exception = InvalidPropertyTypeException::numericExpected(
+            'attribute',
+            'Pim\Component\Catalog\Updater\Attribute',
+            []
+        );
+
+        $this->beConstructedWith(
+            'attribute',
+            [],
+            'Pim\Component\Catalog\Updater\Attribute',
+            'Property "attribute" expects a numeric as data, "array" given.',
+            InvalidPropertyTypeException::NUMERIC_EXPECTED_CODE
+        );
+
+        $this->shouldBeAnInstanceOf(get_class($exception));
+        $this->getPropertyName()->shouldReturn($exception->getPropertyName());
+        $this->getPropertyValue()->shouldReturn($exception->getPropertyValue());
+        $this->getClassName()->shouldReturn($exception->getClassName());
+        $this->getMessage()->shouldReturn($exception->getMessage());
+        $this->getCode()->shouldReturn($exception->getCode());
+    }
+
+    function it_creates_a_not_string_exception()
+    {
+        $exception = InvalidPropertyTypeException::stringExpected(
+            'attribute',
+            'Pim\Component\Catalog\Updater\Attribute',
+            []
+        );
+
+        $this->beConstructedWith(
+            'attribute',
+            [],
+            'Pim\Component\Catalog\Updater\Attribute',
+            'Property "attribute" expects a string as data, "array" given.',
+            InvalidPropertyTypeException::STRING_EXPECTED_CODE
+        );
+
+        $this->shouldBeAnInstanceOf(get_class($exception));
+        $this->getPropertyName()->shouldReturn($exception->getPropertyName());
+        $this->getPropertyValue()->shouldReturn($exception->getPropertyValue());
+        $this->getClassName()->shouldReturn($exception->getClassName());
+        $this->getMessage()->shouldReturn($exception->getMessage());
+        $this->getCode()->shouldReturn($exception->getCode());
+    }
+
+    function it_creates_a_not_array_exception()
+    {
+        $exception = InvalidPropertyTypeException::arrayExpected(
+            'attribute',
+            'Pim\Component\Catalog\Updater\Attribute',
+            true
+        );
+
+        $this->beConstructedWith(
+            'attribute',
+            true,
+            'Pim\Component\Catalog\Updater\Attribute',
+            'Property "attribute" expects an array as data, "boolean" given.',
+            InvalidPropertyTypeException::ARRAY_EXPECTED_CODE
+        );
+
+        $this->shouldBeAnInstanceOf(get_class($exception));
+        $this->getPropertyName()->shouldReturn($exception->getPropertyName());
+        $this->getPropertyValue()->shouldReturn($exception->getPropertyValue());
+        $this->getClassName()->shouldReturn($exception->getClassName());
+        $this->getMessage()->shouldReturn($exception->getMessage());
+        $this->getCode()->shouldReturn($exception->getCode());
+    }
+
+    function it_creates_a_not_bad_array_structure_exception()
+    {
+        $exception = InvalidPropertyTypeException::validArrayStructureExpected(
+            'attribute',
+            'one of the attribute code is no a scalar, "array" given',
+            'Pim\Component\Catalog\Updater\Attribute',
+            [[]]
+        );
+
+        $this->beConstructedWith(
+            'attribute',
+            [[]],
+            'Pim\Component\Catalog\Updater\Attribute',
+            'Property "attribute" expects an array with valid data, one of the attribute code is no a scalar, "array" given.',
+            InvalidPropertyTypeException::VALID_ARRAY_STRUCTURE_EXPECTED_CODE
+        );
+
+        $this->shouldBeAnInstanceOf(get_class($exception));
+        $this->getPropertyName()->shouldReturn($exception->getPropertyName());
+        $this->getPropertyValue()->shouldReturn($exception->getPropertyValue());
+        $this->getClassName()->shouldReturn($exception->getClassName());
+        $this->getMessage()->shouldReturn($exception->getMessage());
+        $this->getCode()->shouldReturn($exception->getCode());
+    }
+
+    function it_creates_a_not_array_of_arrays_structure_exception()
+    {
+        $exception = InvalidPropertyTypeException::arrayOfArraysExpected(
+            'attribute',
+            'Pim\Component\Catalog\Updater\Attribute',
+            ['string']
+        );
+
+        $this->beConstructedWith(
+            'attribute',
+            ['string'],
+            'Pim\Component\Catalog\Updater\Attribute',
+            'Property "attribute" expects an array of arrays as data.',
+            InvalidPropertyTypeException::ARRAY_OF_ARRAYS_EXPECTED_CODE
+        );
+
+        $this->shouldBeAnInstanceOf(get_class($exception));
+        $this->getPropertyName()->shouldReturn($exception->getPropertyName());
+        $this->getPropertyValue()->shouldReturn($exception->getPropertyValue());
+        $this->getClassName()->shouldReturn($exception->getClassName());
+        $this->getMessage()->shouldReturn($exception->getMessage());
+        $this->getCode()->shouldReturn($exception->getCode());
+    }
+
+    function it_creates_a_not_key_not_found_exception()
+    {
+        $exception = InvalidPropertyTypeException::arrayKeyExpected(
+            'attribute',
+            'currency',
+            'Pim\Component\Catalog\Updater\Attribute',
+            []
+        );
+
+        $this->beConstructedWith(
+            'attribute',
+            [],
+            'Pim\Component\Catalog\Updater\Attribute',
+            'Property "attribute" expects an array with the key "currency" as data.',
+            InvalidPropertyTypeException::ARRAY_KEY_EXPECTED_CODE
+        );
+
+        $this->shouldBeAnInstanceOf(get_class($exception));
+        $this->getPropertyName()->shouldReturn($exception->getPropertyName());
+        $this->getPropertyValue()->shouldReturn($exception->getPropertyValue());
+        $this->getClassName()->shouldReturn($exception->getClassName());
+        $this->getMessage()->shouldReturn($exception->getMessage());
+        $this->getCode()->shouldReturn($exception->getCode());
+    }
+}

--- a/src/Pim/Component/Catalog/Updater/Adder/AbstractAttributeAdder.php
+++ b/src/Pim/Component/Catalog/Updater/Adder/AbstractAttributeAdder.php
@@ -2,8 +2,8 @@
 
 namespace Pim\Component\Catalog\Updater\Adder;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Pim\Component\Catalog\Builder\ProductBuilderInterface;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Validator\AttributeValidatorHelper;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -66,6 +66,8 @@ abstract class AbstractAttributeAdder implements AttributeAdderInterface
      * @param AttributeInterface $attribute
      * @param string             $locale
      * @param string             $scope
+     *
+     * @throws InvalidPropertyException
      */
     protected function checkLocaleAndScope(AttributeInterface $attribute, $locale, $scope)
     {
@@ -73,10 +75,10 @@ abstract class AbstractAttributeAdder implements AttributeAdderInterface
             $this->attrValidatorHelper->validateLocale($attribute, $locale);
             $this->attrValidatorHelper->validateScope($attribute, $scope);
         } catch (\LogicException $e) {
-            throw InvalidArgumentException::expectedFromPreviousException(
-                $e,
+            throw InvalidPropertyException::expectedFromPreviousException(
                 $attribute->getCode(),
-                static::class
+                static::class,
+                $e
             );
         }
     }

--- a/src/Pim/Component/Catalog/Updater/Adder/AttributeAdderInterface.php
+++ b/src/Pim/Component/Catalog/Updater/Adder/AttributeAdderInterface.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Component\Catalog\Updater\Adder;
 
+use Akeneo\Component\StorageUtils\Exception\ObjectUpdaterException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 
@@ -21,6 +22,8 @@ interface AttributeAdderInterface extends AdderInterface
      * @param AttributeInterface $attribute The attribute of the product to update
      * @param mixed              $data      The data to add
      * @param array              $options   Options passed to the adder
+     *
+     * @throws ObjectUpdaterException
      */
     public function addAttributeData(
         ProductInterface $product,

--- a/src/Pim/Component/Catalog/Updater/Adder/CategoryFieldAdder.php
+++ b/src/Pim/Component/Catalog/Updater/Adder/CategoryFieldAdder.php
@@ -2,8 +2,9 @@
 
 namespace Pim\Component\Catalog\Updater\Adder;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\ProductInterface;
 
 /**
@@ -46,9 +47,10 @@ class CategoryFieldAdder extends AbstractFieldAdder
             if (null !== $category) {
                 $categories[] = $category;
             } else {
-                throw InvalidArgumentException::expected(
+                throw InvalidPropertyException::validEntityCodeExpected(
                     $field,
-                    'existing category code',
+                    'category code',
+                    'The category does not exist',
                     static::class,
                     $categoryCode
                 );
@@ -65,24 +67,26 @@ class CategoryFieldAdder extends AbstractFieldAdder
      *
      * @param string $field
      * @param mixed  $data
+     *
+     * @throws InvalidPropertyTypeException
      */
     protected function checkData($field, $data)
     {
         if (!is_array($data)) {
-            throw InvalidArgumentException::arrayExpected(
+            throw InvalidPropertyTypeException::arrayExpected(
                 $field,
                 static::class,
-                gettype($data)
+                $data
             );
         }
 
         foreach ($data as $key => $value) {
             if (!is_string($value)) {
-                throw InvalidArgumentException::arrayStringValueExpected(
+                throw InvalidPropertyTypeException::validArrayStructureExpected(
                     $field,
-                    $key,
+                    sprintf('one of the category codes is not a string, "%s" given', gettype($value)),
                     static::class,
-                    gettype($value)
+                    $data
                 );
             }
         }

--- a/src/Pim/Component/Catalog/Updater/Adder/FieldAdderInterface.php
+++ b/src/Pim/Component/Catalog/Updater/Adder/FieldAdderInterface.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Component\Catalog\Updater\Adder;
 
+use Akeneo\Component\StorageUtils\Exception\ObjectUpdaterException;
 use Pim\Component\Catalog\Model\ProductInterface;
 
 /**
@@ -20,6 +21,8 @@ interface FieldAdderInterface extends AdderInterface
      * @param string           $field   The field of the product to modify
      * @param mixed            $data    The data to add
      * @param array            $options Options passed to the adder
+     *
+     * @throws ObjectUpdaterException
      */
     public function addFieldData(ProductInterface $product, $field, $data, array $options = []);
 

--- a/src/Pim/Component/Catalog/Updater/Adder/MultiSelectAttributeAdder.php
+++ b/src/Pim/Component/Catalog/Updater/Adder/MultiSelectAttributeAdder.php
@@ -2,9 +2,10 @@
 
 namespace Pim\Component\Catalog\Updater\Adder;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Pim\Component\Catalog\Builder\ProductBuilderInterface;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\AttributeOptionInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
@@ -58,9 +59,9 @@ class MultiSelectAttributeAdder extends AbstractAttributeAdder
         foreach ($data as $optionCode) {
             $option = $this->getOption($attribute, $optionCode);
             if (null === $option) {
-                throw InvalidArgumentException::arrayInvalidKey(
+                throw InvalidPropertyException::validEntityCodeExpected(
                     $attribute->getCode(),
-                    'code',
+                    'option code',
                     'The option does not exist',
                     static::class,
                     $optionCode
@@ -78,24 +79,26 @@ class MultiSelectAttributeAdder extends AbstractAttributeAdder
      *
      * @param AttributeInterface $attribute
      * @param mixed              $data
+     *
+     * @throws InvalidPropertyTypeException
      */
     protected function checkData(AttributeInterface $attribute, $data)
     {
         if (!is_array($data)) {
-            throw InvalidArgumentException::arrayExpected(
+            throw InvalidPropertyTypeException::arrayExpected(
                 $attribute->getCode(),
                 static::class,
-                gettype($data)
+                $data
             );
         }
 
         foreach ($data as $key => $value) {
             if (!is_string($value)) {
-                throw InvalidArgumentException::arrayStringValueExpected(
+                throw InvalidPropertyTypeException::validArrayStructureExpected(
                     $attribute->getCode(),
-                    $key,
+                    sprintf('one of the option codes is not a string, "%s" given', gettype($value)),
                     static::class,
-                    gettype($value)
+                    $data
                 );
             }
         }

--- a/src/Pim/Component/Catalog/Updater/Adder/PriceCollectionAttributeAdder.php
+++ b/src/Pim/Component/Catalog/Updater/Adder/PriceCollectionAttributeAdder.php
@@ -2,8 +2,9 @@
 
 namespace Pim\Component\Catalog\Updater\Adder;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Pim\Component\Catalog\Builder\ProductBuilderInterface;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Repository\CurrencyRepositoryInterface;
@@ -73,58 +74,64 @@ class PriceCollectionAttributeAdder extends AbstractAttributeAdder
      * @param AttributeInterface $attribute
      * @param mixed              $data
      *
-     * @return mixed
+     * @throws InvalidPropertyTypeException
+     * @throws InvalidPropertyException
      */
     protected function checkData(AttributeInterface $attribute, $data)
     {
         if (!is_array($data)) {
-            throw InvalidArgumentException::arrayExpected(
+            throw InvalidPropertyTypeException::arrayExpected(
                 $attribute->getCode(),
                 static::class,
-                gettype($data)
+                $data
             );
         }
 
         foreach ($data as $price) {
             if (!is_array($price)) {
-                throw InvalidArgumentException::arrayOfArraysExpected(
+                throw InvalidPropertyTypeException::arrayOfArraysExpected(
                     $attribute->getCode(),
                     static::class,
-                    gettype($data)
+                    $data
                 );
             }
 
             if (!array_key_exists('amount', $price)) {
-                throw InvalidArgumentException::arrayKeyExpected(
+                throw InvalidPropertyTypeException::arrayKeyExpected(
                     $attribute->getCode(),
                     'amount',
                     static::class,
-                    print_r($data, true)
+                    $data
                 );
             }
 
             if (!array_key_exists('currency', $price)) {
-                throw InvalidArgumentException::arrayKeyExpected(
+                throw InvalidPropertyTypeException::arrayKeyExpected(
                     $attribute->getCode(),
                     'currency',
                     static::class,
-                    print_r($data, true)
+                    $data
                 );
             }
 
             if (!is_numeric($price['amount']) && null !== $price['amount']) {
-                throw InvalidArgumentException::arrayNumericKeyExpected(
+                throw new InvalidPropertyTypeException(
                     $attribute->getCode(),
-                    'amount',
+                    $price['amount'],
                     static::class,
-                    gettype($price['amount'])
+                    sprintf(
+                        'Property "%s" expects a numeric as data for the currency, "%s" given.',
+                        $attribute->getCode(),
+                        $price['amount']
+                    ),
+                    InvalidPropertyTypeException::NUMERIC_EXPECTED_CODE
                 );
             }
 
             if (!in_array($price['currency'], $this->currencyRepository->getActivatedCurrencyCodes())) {
-                throw InvalidArgumentException::arrayInvalidKey(
+                throw InvalidPropertyException::validEntityCodeExpected(
                     $attribute->getCode(),
-                    'currency',
+                    'currency code',
                     'The currency does not exist',
                     static::class,
                     $price['currency']

--- a/src/Pim/Component/Catalog/Updater/Copier/AbstractAttributeCopier.php
+++ b/src/Pim/Component/Catalog/Updater/Copier/AbstractAttributeCopier.php
@@ -2,8 +2,8 @@
 
 namespace Pim\Component\Catalog\Updater\Copier;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Pim\Component\Catalog\Builder\ProductBuilderInterface;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Validator\AttributeValidatorHelper;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -64,6 +64,8 @@ abstract class AbstractAttributeCopier implements AttributeCopierInterface
      * @param AttributeInterface $attribute
      * @param string             $locale
      * @param string             $scope
+     *
+     * @throws InvalidPropertyException
      */
     protected function checkLocaleAndScope(AttributeInterface $attribute, $locale, $scope)
     {
@@ -71,10 +73,10 @@ abstract class AbstractAttributeCopier implements AttributeCopierInterface
             $this->attrValidatorHelper->validateLocale($attribute, $locale);
             $this->attrValidatorHelper->validateScope($attribute, $scope);
         } catch (\LogicException $e) {
-            throw InvalidArgumentException::expectedFromPreviousException(
-                $e,
+            throw InvalidPropertyException::expectedFromPreviousException(
                 $attribute->getCode(),
-                static::class
+                static::class,
+                $e
             );
         }
     }

--- a/src/Pim/Component/Catalog/Updater/Copier/AttributeCopierInterface.php
+++ b/src/Pim/Component/Catalog/Updater/Copier/AttributeCopierInterface.php
@@ -2,7 +2,7 @@
 
 namespace Pim\Component\Catalog\Updater\Copier;
 
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
+use Akeneo\Component\StorageUtils\Exception\ObjectUpdaterException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 
@@ -24,8 +24,7 @@ interface AttributeCopierInterface extends CopierInterface
      * @param AttributeInterface $toAttribute
      * @param array              $options
      *
-     * @throws InvalidArgumentException
-     * @throws \RuntimeException
+     * @throws ObjectUpdaterException
      */
     public function copyAttributeData(
         ProductInterface $fromProduct,

--- a/src/Pim/Component/Catalog/Updater/Copier/FieldCopierInterface.php
+++ b/src/Pim/Component/Catalog/Updater/Copier/FieldCopierInterface.php
@@ -2,7 +2,7 @@
 
 namespace Pim\Component\Catalog\Updater\Copier;
 
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
+use Akeneo\Component\StorageUtils\Exception\ObjectUpdaterException;
 use Pim\Component\Catalog\Model\ProductInterface;
 
 /**
@@ -23,8 +23,7 @@ interface FieldCopierInterface extends CopierInterface
      * @param string           $toField
      * @param array            $options
      *
-     * @throws InvalidArgumentException
-     * @throws \RuntimeException
+     * @throws ObjectUpdaterException
      */
     public function copyFieldData(
         ProductInterface $fromProduct,

--- a/src/Pim/Component/Catalog/Updater/ProductPropertyAdder.php
+++ b/src/Pim/Component/Catalog/Updater/ProductPropertyAdder.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Component\Catalog\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Component\StorageUtils\Updater\PropertyAdderInterface;
 use Doctrine\Common\Util\ClassUtils;
@@ -43,11 +44,9 @@ class ProductPropertyAdder implements PropertyAdderInterface
     public function addData($product, $field, $data, array $options = [])
     {
         if (!$product instanceof ProductInterface) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    'Expects a "Pim\Component\Catalog\Model\ProductInterface", "%s" provided.',
-                    ClassUtils::getClass($product)
-                )
+            throw InvalidObjectException::objectExpected(
+                ClassUtils::getClass($product),
+                ProductInterface::class
             );
         }
 

--- a/src/Pim/Component/Catalog/Updater/ProductPropertyCopier.php
+++ b/src/Pim/Component/Catalog/Updater/ProductPropertyCopier.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Component\Catalog\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Component\StorageUtils\Updater\PropertyCopierInterface;
 use Doctrine\Common\Util\ClassUtils;
@@ -48,9 +49,12 @@ class ProductPropertyCopier implements PropertyCopierInterface
         array $options = []
     ) {
         if (!$fromProduct instanceof ProductInterface || !$toProduct instanceof ProductInterface) {
-            throw new \InvalidArgumentException(
+            throw new InvalidObjectException(
+                ClassUtils::getClass($fromProduct),
+                ProductInterface::class,
                 sprintf(
-                    'Expects a "Pim\Component\Catalog\Model\ProductInterface", "%s" and "%s" provided.',
+                    'Expects a "%s", "%s" and "%s" provided.',
+                    ProductInterface::class,
                     ClassUtils::getClass($fromProduct),
                     ClassUtils::getClass($toProduct)
                 )

--- a/src/Pim/Component/Catalog/Updater/ProductPropertyRemover.php
+++ b/src/Pim/Component/Catalog/Updater/ProductPropertyRemover.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Component\Catalog\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Component\StorageUtils\Updater\PropertyRemoverInterface;
 use Doctrine\Common\Util\ClassUtils;
@@ -43,11 +44,9 @@ class ProductPropertyRemover implements PropertyRemoverInterface
     public function removeData($product, $field, $data, array $options = [])
     {
         if (!$product instanceof ProductInterface) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    'Expects a "Pim\Component\Catalog\Model\ProductInterface", "%s" provided.',
-                    ClassUtils::getClass($product)
-                )
+            throw InvalidObjectException::objectExpected(
+                ClassUtils::getClass($product),
+                ProductInterface::class
             );
         }
 

--- a/src/Pim/Component/Catalog/Updater/ProductPropertySetter.php
+++ b/src/Pim/Component/Catalog/Updater/ProductPropertySetter.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Component\Catalog\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Component\StorageUtils\Updater\PropertySetterInterface;
 use Doctrine\Common\Util\ClassUtils;
@@ -43,11 +44,9 @@ class ProductPropertySetter implements PropertySetterInterface
     public function setData($product, $field, $data, array $options = [])
     {
         if (!$product instanceof ProductInterface) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    'Expects a "Pim\Component\Catalog\Model\ProductInterface", "%s" provided.',
-                    ClassUtils::getClass($product)
-                )
+            throw InvalidObjectException::objectExpected(
+                ClassUtils::getClass($product),
+                ProductInterface::class
             );
         }
 

--- a/src/Pim/Component/Catalog/Updater/Remover/AbstractAttributeRemover.php
+++ b/src/Pim/Component/Catalog/Updater/Remover/AbstractAttributeRemover.php
@@ -2,7 +2,7 @@
 
 namespace Pim\Component\Catalog\Updater\Remover;
 
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Validator\AttributeValidatorHelper;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -50,7 +50,7 @@ abstract class AbstractAttributeRemover implements AttributeRemoverInterface
      * @param string             $locale
      * @param string             $scope
      *
-     * @throws InvalidArgumentException
+     * @throws InvalidPropertyException
      */
     protected function checkLocaleAndScope(AttributeInterface $attribute, $locale, $scope)
     {
@@ -58,10 +58,10 @@ abstract class AbstractAttributeRemover implements AttributeRemoverInterface
             $this->attrValidatorHelper->validateLocale($attribute, $locale);
             $this->attrValidatorHelper->validateScope($attribute, $scope);
         } catch (\LogicException $e) {
-            throw InvalidArgumentException::expectedFromPreviousException(
-                $e,
+            throw InvalidPropertyException::expectedFromPreviousException(
                 $attribute->getCode(),
-                static::class
+                static::class,
+                $e
             );
         }
     }

--- a/src/Pim/Component/Catalog/Updater/Remover/AttributeRemoverInterface.php
+++ b/src/Pim/Component/Catalog/Updater/Remover/AttributeRemoverInterface.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Component\Catalog\Updater\Remover;
 
+use Akeneo\Component\StorageUtils\Exception\ObjectUpdaterException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 
@@ -21,6 +22,8 @@ interface AttributeRemoverInterface extends RemoverInterface
      * @param AttributeInterface $attribute The attribute of the product to modify
      * @param mixed              $data      The data to remove
      * @param array              $options   Options passed to the remover
+     *
+     * @throws ObjectUpdaterException
      */
     public function removeAttributeData(
         ProductInterface $product,

--- a/src/Pim/Component/Catalog/Updater/Remover/CategoryFieldRemover.php
+++ b/src/Pim/Component/Catalog/Updater/Remover/CategoryFieldRemover.php
@@ -2,8 +2,9 @@
 
 namespace Pim\Component\Catalog\Updater\Remover;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\ProductInterface;
 
 /**
@@ -44,9 +45,10 @@ class CategoryFieldRemover extends AbstractFieldRemover
             $category = $this->categoryRepository->findOneByIdentifier($categoryCode);
 
             if (null === $category) {
-                throw InvalidArgumentException::expected(
+                throw InvalidPropertyException::validEntityCodeExpected(
                     $field,
-                    'existing category code',
+                    'category code',
+                    'The category does not exist',
                     static::class,
                     $categoryCode
                 );
@@ -64,24 +66,26 @@ class CategoryFieldRemover extends AbstractFieldRemover
      *
      * @param string $field
      * @param mixed  $data
+     *
+     * @throws InvalidPropertyTypeException
      */
     protected function checkData($field, $data)
     {
         if (!is_array($data)) {
-            throw InvalidArgumentException::arrayExpected(
+            throw InvalidPropertyTypeException::arrayExpected(
                 $field,
                 static::class,
-                gettype($data)
+                $data
             );
         }
 
         foreach ($data as $key => $value) {
             if (!is_string($value)) {
-                throw InvalidArgumentException::arrayStringValueExpected(
+                throw InvalidPropertyTypeException::validArrayStructureExpected(
                     $field,
-                    $key,
+                    sprintf('one of the category codes is not a string, "%s" given', gettype($value)),
                     static::class,
-                    gettype($value)
+                    $data
                 );
             }
         }

--- a/src/Pim/Component/Catalog/Updater/Remover/FieldRemoverInterface.php
+++ b/src/Pim/Component/Catalog/Updater/Remover/FieldRemoverInterface.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Component\Catalog\Updater\Remover;
 
+use Akeneo\Component\StorageUtils\Exception\ObjectUpdaterException;
 use Pim\Component\Catalog\Model\ProductInterface;
 
 /**
@@ -20,6 +21,8 @@ interface FieldRemoverInterface extends RemoverInterface
      * @param string           $field   The field of the product to modify
      * @param mixed            $data    The data to remove
      * @param array            $options Options passed to the remover
+     *
+     * @throws ObjectUpdaterException
      */
     public function removeFieldData(ProductInterface $product, $field, $data, array $options = []);
 

--- a/src/Pim/Component/Catalog/Updater/Remover/GroupFieldRemover.php
+++ b/src/Pim/Component/Catalog/Updater/Remover/GroupFieldRemover.php
@@ -2,8 +2,9 @@
 
 namespace Pim\Component\Catalog\Updater\Remover;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\ProductInterface;
 
 /**
@@ -44,17 +45,18 @@ class GroupFieldRemover extends AbstractFieldRemover
             $group = $this->groupRepository->findOneByIdentifier($groupCode);
 
             if (null === $group) {
-                throw InvalidArgumentException::expected(
+                throw InvalidPropertyException::validEntityCodeExpected(
                     $field,
-                    'existing group code',
+                    'group code',
+                    'The group does not exist',
                     static::class,
                     $groupCode
                 );
             }
             if ($group->getType()->isVariant()) {
-                throw InvalidArgumentException::expected(
+                throw InvalidPropertyException::validGroupExpected(
                     $field,
-                    'non variant group code',
+                    'Cannot process variant group, only groups are supported',
                     static::class,
                     $groupCode
                 );
@@ -72,24 +74,26 @@ class GroupFieldRemover extends AbstractFieldRemover
      *
      * @param string $field
      * @param mixed  $data
+     *
+     * @throws InvalidPropertyTypeException
      */
     protected function checkData($field, $data)
     {
         if (!is_array($data)) {
-            throw InvalidArgumentException::arrayExpected(
+            throw InvalidPropertyTypeException::arrayExpected(
                 $field,
                 static::class,
-                gettype($data)
+                $data
             );
         }
 
         foreach ($data as $key => $value) {
             if (!is_string($value)) {
-                throw InvalidArgumentException::arrayStringValueExpected(
+                throw InvalidPropertyTypeException::validArrayStructureExpected(
                     $field,
-                    $key,
+                    sprintf('one of the group codes is not a string, "%s" given', gettype($value)),
                     static::class,
-                    gettype($value)
+                    $data
                 );
             }
         }

--- a/src/Pim/Component/Catalog/Updater/Remover/MultiSelectAttributeRemover.php
+++ b/src/Pim/Component/Catalog/Updater/Remover/MultiSelectAttributeRemover.php
@@ -2,8 +2,9 @@
 
 namespace Pim\Component\Catalog\Updater\Remover;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\AttributeOptionInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
@@ -38,10 +39,7 @@ class MultiSelectAttributeRemover extends AbstractAttributeRemover
     }
 
     /**
-     * @param ProductInterface   $product
-     * @param AttributeInterface $attribute
-     * @param array              $data
-     * @param array              $options
+     * {@inheritdoc}
      */
     public function removeAttributeData(
         ProductInterface $product,
@@ -57,9 +55,9 @@ class MultiSelectAttributeRemover extends AbstractAttributeRemover
         foreach ($data as $optionCode) {
             $option = $this->getOption($attribute, $optionCode);
             if (null === $option) {
-                throw InvalidArgumentException::arrayInvalidKey(
+                throw InvalidPropertyException::validEntityCodeExpected(
                     $attribute->getCode(),
-                    'code',
+                    'option code',
                     'The option does not exist',
                     static::class,
                     $optionCode
@@ -100,24 +98,26 @@ class MultiSelectAttributeRemover extends AbstractAttributeRemover
      *
      * @param AttributeInterface $attribute
      * @param mixed              $data
+     *
+     * @throws InvalidPropertyTypeException
      */
     protected function checkData(AttributeInterface $attribute, $data)
     {
         if (!is_array($data)) {
-            throw InvalidArgumentException::arrayExpected(
+            throw InvalidPropertyTypeException::arrayExpected(
                 $attribute->getCode(),
                 static::class,
-                gettype($data)
+                $data
             );
         }
 
         foreach ($data as $key => $value) {
             if (!is_string($value)) {
-                throw InvalidArgumentException::arrayStringValueExpected(
+                throw InvalidPropertyTypeException::validArrayStructureExpected(
                     $attribute->getCode(),
-                    $key,
+                    sprintf('one of the option codes is not a string, "%s" given', gettype($value)),
                     static::class,
-                    gettype($value)
+                    $data
                 );
             }
         }

--- a/src/Pim/Component/Catalog/Updater/Remover/PriceCollectionAttributeRemover.php
+++ b/src/Pim/Component/Catalog/Updater/Remover/PriceCollectionAttributeRemover.php
@@ -2,7 +2,8 @@
 
 namespace Pim\Component\Catalog\Updater\Remover;
 
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Repository\CurrencyRepositoryInterface;
@@ -93,49 +94,50 @@ class PriceCollectionAttributeRemover extends AbstractAttributeRemover
      * @param AttributeInterface $attribute
      * @param mixed              $data
      *
-     * @return mixed
+     * @throws InvalidPropertyTypeException
+     * @throws InvalidPropertyException
      */
     protected function checkData(AttributeInterface $attribute, $data)
     {
         if (!is_array($data)) {
-            throw InvalidArgumentException::arrayExpected(
+            throw InvalidPropertyTypeException::arrayExpected(
                 $attribute->getCode(),
                 static::class,
-                gettype($data)
+                $data
             );
         }
 
         foreach ($data as $price) {
             if (!is_array($price)) {
-                throw InvalidArgumentException::arrayOfArraysExpected(
+                throw InvalidPropertyTypeException::arrayOfArraysExpected(
                     $attribute->getCode(),
                     static::class,
-                    gettype($data)
+                    $data
                 );
             }
 
             if (!array_key_exists('amount', $price)) {
-                throw InvalidArgumentException::arrayKeyExpected(
+                throw InvalidPropertyTypeException::arrayKeyExpected(
                     $attribute->getCode(),
                     'amount',
                     static::class,
-                    print_r($data, true)
+                    $data
                 );
             }
 
             if (!array_key_exists('currency', $price)) {
-                throw InvalidArgumentException::arrayKeyExpected(
+                throw InvalidPropertyTypeException::arrayKeyExpected(
                     $attribute->getCode(),
                     'currency',
                     static::class,
-                    print_r($data, true)
+                    $data
                 );
             }
 
             if (!in_array($price['currency'], $this->currencyRepository->getActivatedCurrencyCodes())) {
-                throw InvalidArgumentException::arrayInvalidKey(
+                throw InvalidPropertyException::validEntityCodeExpected(
                     $attribute->getCode(),
-                    'currency',
+                    'currency code',
                     'The currency does not exist',
                     static::class,
                     $price['currency']

--- a/src/Pim/Component/Catalog/Updater/Setter/AbstractAttributeSetter.php
+++ b/src/Pim/Component/Catalog/Updater/Setter/AbstractAttributeSetter.php
@@ -2,8 +2,8 @@
 
 namespace Pim\Component\Catalog\Updater\Setter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Pim\Component\Catalog\Builder\ProductBuilderInterface;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Validator\AttributeValidatorHelper;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -58,6 +58,8 @@ abstract class AbstractAttributeSetter implements AttributeSetterInterface
      * @param AttributeInterface $attribute
      * @param string             $locale
      * @param string             $scope
+     *
+     * @throws InvalidPropertyException
      */
     protected function checkLocaleAndScope(AttributeInterface $attribute, $locale, $scope)
     {
@@ -65,10 +67,10 @@ abstract class AbstractAttributeSetter implements AttributeSetterInterface
             $this->attrValidatorHelper->validateLocale($attribute, $locale);
             $this->attrValidatorHelper->validateScope($attribute, $scope);
         } catch (\LogicException $e) {
-            throw InvalidArgumentException::expectedFromPreviousException(
-                $e,
+            throw InvalidPropertyException::expectedFromPreviousException(
                 $attribute->getCode(),
-                static::class
+                static::class,
+                $e
             );
         }
     }

--- a/src/Pim/Component/Catalog/Updater/Setter/AssociationFieldSetter.php
+++ b/src/Pim/Component/Catalog/Updater/Setter/AssociationFieldSetter.php
@@ -2,9 +2,10 @@
 
 namespace Pim\Component\Catalog\Updater\Setter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Pim\Component\Catalog\Builder\ProductBuilderInterface;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AssociationInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 
@@ -126,15 +127,18 @@ class AssociationFieldSetter extends AbstractFieldSetter
      * Set products and groups to associations
      *
      * @param ProductInterface $product
+     *
+     * @throws InvalidPropertyException
      */
     protected function setProductsAndGroupsToAssociations(ProductInterface $product, $data)
     {
         foreach ($data as $typeCode => $items) {
             $association = $product->getAssociationForTypeCode($typeCode);
             if (null === $association) {
-                throw InvalidArgumentException::expected(
+                throw InvalidPropertyException::validEntityCodeExpected(
                     'associations',
-                    'existing association type code',
+                    'association type code',
+                    'The association type does not exist',
                     static::class,
                     $typeCode
                 );
@@ -151,15 +155,18 @@ class AssociationFieldSetter extends AbstractFieldSetter
     /**
      * @param AssociationInterface $association
      * @param array                $productsIdentifiers
+     *
+     * @throws InvalidPropertyException
      */
     protected function setAssociatedProducts(AssociationInterface $association, $productsIdentifiers)
     {
         foreach ($productsIdentifiers as $productIdentifier) {
             $associatedProduct = $this->productRepository->findOneByIdentifier($productIdentifier);
-            if (!$associatedProduct) {
-                throw InvalidArgumentException::expected(
+            if (null === $associatedProduct) {
+                throw InvalidPropertyException::validEntityCodeExpected(
                     'associations',
-                    'existing product identifier',
+                    'product identifier',
+                    'The product does not exist',
                     static::class,
                     $productIdentifier
                 );
@@ -171,15 +178,18 @@ class AssociationFieldSetter extends AbstractFieldSetter
     /**
      * @param AssociationInterface $association
      * @param array                $groupsCodes
+     *
+     * @throws InvalidPropertyException
      */
     protected function setAssociatedGroups(AssociationInterface $association, $groupsCodes)
     {
         foreach ($groupsCodes as $groupCode) {
             $associatedGroup = $this->groupRepository->findOneByIdentifier($groupCode);
-            if (!$associatedGroup) {
-                throw InvalidArgumentException::expected(
+            if (null === $associatedGroup) {
+                throw InvalidPropertyException::validEntityCodeExpected(
                     'associations',
-                    'existing group code',
+                    'group code',
+                    'The group does not exist',
                     static::class,
                     $groupCode
                 );
@@ -194,15 +204,15 @@ class AssociationFieldSetter extends AbstractFieldSetter
      * @param string $field
      * @param mixed  $data
      *
-     * @throws InvalidArgumentException
+     * @throws InvalidPropertyTypeException
      */
     protected function checkData($field, $data)
     {
         if (!is_array($data)) {
-            throw InvalidArgumentException::arrayExpected(
+            throw InvalidPropertyTypeException::arrayExpected(
                 $field,
                 static::class,
-                gettype($data)
+                $data
             );
         }
 
@@ -217,33 +227,44 @@ class AssociationFieldSetter extends AbstractFieldSetter
      * @param string $assocTypeCode
      * @param mixed  $items
      *
-     * @throws InvalidArgumentException
+     * @throws InvalidPropertyTypeException
      */
     protected function checkAssociationData($field, array $data, $assocTypeCode, $items)
     {
         if (!is_array($items) || !is_string($assocTypeCode) ||
             (!isset($items['products']) && !isset($items['groups']))
         ) {
-            throw InvalidArgumentException::associationFormatExpected($field, $data);
+            throw InvalidPropertyTypeException::validArrayStructureExpected(
+                $field,
+                sprintf('association format is not valid for the association type "%s".', $assocTypeCode),
+                static::class,
+                $data
+            );
         }
 
         foreach ($items as $itemData) {
-            $this->checkAssociationItems($field, $data, $itemData);
+            $this->checkAssociationItems($field, $assocTypeCode, $data, $itemData);
         }
     }
 
     /**
      * @param string $field
+     * @param string $assocTypeCode
      * @param array  $data
      * @param array  $items
      *
-     * @throws InvalidArgumentException
+     * @throws InvalidPropertyTypeException
      */
-    protected function checkAssociationItems($field, array $data, array $items)
+    protected function checkAssociationItems($field, $assocTypeCode, array $data, array $items)
     {
         foreach ($items as $code) {
             if (!is_string($code)) {
-                throw InvalidArgumentException::associationFormatExpected($field, $data);
+                throw InvalidPropertyTypeException::validArrayStructureExpected(
+                    $field,
+                    sprintf('association format is not valid for the association type "%s".', $assocTypeCode),
+                    static::class,
+                    $data
+                );
             }
         }
     }

--- a/src/Pim/Component/Catalog/Updater/Setter/AttributeSetterInterface.php
+++ b/src/Pim/Component/Catalog/Updater/Setter/AttributeSetterInterface.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Component\Catalog\Updater\Setter;
 
+use Akeneo\Component\StorageUtils\Exception\ObjectUpdaterException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 
@@ -21,6 +22,8 @@ interface AttributeSetterInterface extends SetterInterface
      * @param AttributeInterface $attribute The attribute of the product to modify
      * @param mixed              $data      The data to set
      * @param array              $options   Options passed to the setter
+     *
+     * @throws ObjectUpdaterException
      */
     public function setAttributeData(
         ProductInterface $product,

--- a/src/Pim/Component/Catalog/Updater/Setter/CategoryFieldSetter.php
+++ b/src/Pim/Component/Catalog/Updater/Setter/CategoryFieldSetter.php
@@ -2,8 +2,9 @@
 
 namespace Pim\Component\Catalog\Updater\Setter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\CategoryInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 
@@ -45,15 +46,15 @@ class CategoryFieldSetter extends AbstractFieldSetter
             $category = $this->getCategory($categoryCode);
 
             if (null === $category) {
-                throw InvalidArgumentException::expected(
+                throw InvalidPropertyException::validEntityCodeExpected(
                     $field,
-                    'existing category code',
+                    'category code',
+                    'The category does not exist',
                     static::class,
                     $categoryCode
                 );
-            } else {
-                $categories[] = $category;
             }
+            $categories[] = $category;
         }
 
         $oldCategories = $product->getCategories();
@@ -71,24 +72,26 @@ class CategoryFieldSetter extends AbstractFieldSetter
      *
      * @param string $field
      * @param mixed  $data
+     *
+     * @throws InvalidPropertyTypeException
      */
     protected function checkData($field, $data)
     {
         if (!is_array($data)) {
-            throw InvalidArgumentException::arrayExpected(
+            throw InvalidPropertyTypeException::arrayExpected(
                 $field,
                 static::class,
-                gettype($data)
+                $data
             );
         }
 
         foreach ($data as $key => $value) {
             if (!is_string($value)) {
-                throw InvalidArgumentException::arrayStringValueExpected(
+                throw InvalidPropertyTypeException::validArrayStructureExpected(
                     $field,
-                    $key,
+                    sprintf('one of the category codes is not a string, "%s" given', gettype($value)),
                     static::class,
-                    gettype($value)
+                    $data
                 );
             }
         }

--- a/src/Pim/Component/Catalog/Updater/Setter/DateAttributeSetter.php
+++ b/src/Pim/Component/Catalog/Updater/Setter/DateAttributeSetter.php
@@ -2,8 +2,8 @@
 
 namespace Pim\Component\Catalog\Updater\Setter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Pim\Component\Catalog\Builder\ProductBuilderInterface;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Validator\AttributeValidatorHelper;
@@ -55,7 +55,7 @@ class DateAttributeSetter extends AbstractAttributeSetter
      * @param AttributeInterface $attribute
      * @param mixed              $data
      *
-     * @throws InvalidArgumentException
+     * @throws InvalidPropertyException
      *
      * @return string
      */
@@ -66,9 +66,9 @@ class DateAttributeSetter extends AbstractAttributeSetter
         } elseif (is_string($data)) {
             $this->validateDateFormat($attribute, $data);
         } elseif (null !== $data && !is_string($data)) {
-            throw InvalidArgumentException::expected(
+            throw InvalidPropertyException::dateExpected(
                 $attribute->getCode(),
-                'datetime or string',
+                'yyyy-mm-dd',
                 static::class,
                 gettype($data)
             );
@@ -81,7 +81,7 @@ class DateAttributeSetter extends AbstractAttributeSetter
      * @param AttributeInterface $attribute
      * @param string             $data
      *
-     * @throws InvalidArgumentException
+     * @throws InvalidPropertyException
      */
     protected function validateDateFormat(AttributeInterface $attribute, $data)
     {
@@ -89,14 +89,19 @@ class DateAttributeSetter extends AbstractAttributeSetter
             new \DateTime($data);
 
             if (!preg_match('/^\d{4}-\d{2}-\d{2}/', $data)) {
-                throw new \Exception('Invalid date');
+                throw InvalidPropertyException::dateExpected(
+                    $attribute->getCode(),
+                    'yyyy-mm-dd',
+                    static::class,
+                    $data
+                );
             }
         } catch (\Exception $e) {
-            throw InvalidArgumentException::expected(
+            throw InvalidPropertyException::dateExpected(
                 $attribute->getCode(),
-                'a string with the format yyyy-mm-dd',
+                'yyyy-mm-dd',
                 static::class,
-                gettype($data)
+                $data
             );
         }
     }

--- a/src/Pim/Component/Catalog/Updater/Setter/FamilyFieldSetter.php
+++ b/src/Pim/Component/Catalog/Updater/Setter/FamilyFieldSetter.php
@@ -2,8 +2,9 @@
 
 namespace Pim\Component\Catalog\Updater\Setter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\FamilyInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 
@@ -43,9 +44,10 @@ class FamilyFieldSetter extends AbstractFieldSetter
         if (null !== $data && '' !== $data) {
             $family = $this->getFamily($data);
             if (null === $family) {
-                throw InvalidArgumentException::expected(
+                throw InvalidPropertyException::validEntityCodeExpected(
                     $field,
-                    'existing family code',
+                    'family code',
+                    'The family does not exist',
                     static::class,
                     $data
                 );
@@ -61,14 +63,16 @@ class FamilyFieldSetter extends AbstractFieldSetter
      *
      * @param string $field
      * @param mixed  $data
+     *
+     * @throws InvalidPropertyTypeException
      */
     protected function checkData($field, $data)
     {
-        if (!is_string($data) && null !== $data && '' !== $data) {
-            throw InvalidArgumentException::stringExpected(
+        if (!is_string($data) && null !== $data) {
+            throw InvalidPropertyTypeException::stringExpected(
                 $field,
                 static::class,
-                gettype($data)
+                $data
             );
         }
     }

--- a/src/Pim/Component/Catalog/Updater/Setter/FieldSetterInterface.php
+++ b/src/Pim/Component/Catalog/Updater/Setter/FieldSetterInterface.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Component\Catalog\Updater\Setter;
 
+use Akeneo\Component\StorageUtils\Exception\ObjectUpdaterException;
 use Pim\Component\Catalog\Model\ProductInterface;
 
 /**
@@ -20,6 +21,8 @@ interface FieldSetterInterface extends SetterInterface
      * @param string           $field   The field of the product to modify
      * @param mixed            $data    The data to set
      * @param array            $options Options passed to the setter
+     *
+     * @throws ObjectUpdaterException
      */
     public function setFieldData(ProductInterface $product, $field, $data, array $options = []);
 

--- a/src/Pim/Component/Catalog/Updater/Setter/GroupFieldSetter.php
+++ b/src/Pim/Component/Catalog/Updater/Setter/GroupFieldSetter.php
@@ -2,8 +2,9 @@
 
 namespace Pim\Component\Catalog\Updater\Setter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\ProductInterface;
 
 /**
@@ -45,9 +46,10 @@ class GroupFieldSetter extends AbstractFieldSetter
             $group = $this->groupRepository->findOneByIdentifier($groupCode);
 
             if (null === $group) {
-                throw InvalidArgumentException::expected(
+                throw InvalidPropertyException::validEntityCodeExpected(
                     $field,
-                    'existing group code',
+                    'group code',
+                    'The group does not exist',
                     static::class,
                     $groupCode
                 );
@@ -71,24 +73,26 @@ class GroupFieldSetter extends AbstractFieldSetter
      *
      * @param string $field
      * @param mixed  $data
+     *
+     * @throws InvalidPropertyTypeException
      */
     protected function checkData($field, $data)
     {
         if (!is_array($data)) {
-            throw InvalidArgumentException::arrayExpected(
+            throw InvalidPropertyTypeException::arrayExpected(
                 $field,
                 static::class,
-                gettype($data)
+                $data
             );
         }
 
         foreach ($data as $key => $value) {
             if (!is_string($value)) {
-                throw InvalidArgumentException::arrayStringValueExpected(
+                throw InvalidPropertyTypeException::validArrayStructureExpected(
                     $field,
-                    $key,
+                    sprintf('one of the group codes is not a string, "%s" given', gettype($value)),
                     static::class,
-                    gettype($value)
+                    $data
                 );
             }
         }

--- a/src/Pim/Component/Catalog/Updater/Setter/MediaAttributeSetter.php
+++ b/src/Pim/Component/Catalog/Updater/Setter/MediaAttributeSetter.php
@@ -5,8 +5,9 @@ namespace Pim\Component\Catalog\Updater\Setter;
 use Akeneo\Component\FileStorage\File\FileStorerInterface;
 use Akeneo\Component\FileStorage\Model\FileInfoInterface;
 use Akeneo\Component\FileStorage\Repository\FileInfoRepositoryInterface;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Pim\Component\Catalog\Builder\ProductBuilderInterface;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\FileStorage;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
@@ -99,15 +100,13 @@ class MediaAttributeSetter extends AbstractAttributeSetter
     /**
      * @param AttributeInterface $attribute
      * @param mixed              $data
+     *
+     * @throws InvalidPropertyTypeException
      */
     protected function checkData(AttributeInterface $attribute, $data)
     {
-        if (null === $data) {
-            return;
-        }
-
-        if (!is_string($data)) {
-            throw InvalidArgumentException::stringExpected($attribute->getCode(), static::class, gettype($data));
+        if (null !== $data && !is_string($data)) {
+            throw InvalidPropertyTypeException::stringExpected($attribute->getCode(), static::class, $data);
         }
     }
 
@@ -117,7 +116,7 @@ class MediaAttributeSetter extends AbstractAttributeSetter
      * @param AttributeInterface $attribute
      * @param mixed              $data
      *
-     * @throws InvalidArgumentException If an invalid filePath is provided
+     * @throws InvalidPropertyException If an invalid filePath is provided
      *
      * @return FileInfoInterface|null
      */
@@ -130,9 +129,8 @@ class MediaAttributeSetter extends AbstractAttributeSetter
         $rawFile = new \SplFileInfo($data);
 
         if (!$rawFile->isFile()) {
-            throw InvalidArgumentException::expected(
+            throw InvalidPropertyException::validPathExpected(
                 $attribute->getCode(),
-                'a valid pathname',
                 static::class,
                 $data
             );

--- a/src/Pim/Component/Catalog/Updater/Setter/MetricAttributeSetter.php
+++ b/src/Pim/Component/Catalog/Updater/Setter/MetricAttributeSetter.php
@@ -2,8 +2,8 @@
 
 namespace Pim\Component\Catalog\Updater\Setter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Pim\Component\Catalog\Builder\ProductBuilderInterface;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Factory\MetricFactory;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
@@ -73,28 +73,30 @@ class MetricAttributeSetter extends AbstractAttributeSetter
      *
      * @param AttributeInterface $attribute
      * @param mixed              $data
+     *
+     * @throws InvalidPropertyTypeException
      */
     protected function checkData(AttributeInterface $attribute, $data)
     {
         if (!is_array($data)) {
-            throw InvalidArgumentException::arrayExpected($attribute->getCode(), static::class, gettype($data));
+            throw InvalidPropertyTypeException::arrayExpected($attribute->getCode(), static::class, $data);
         }
 
         if (!array_key_exists('amount', $data)) {
-            throw InvalidArgumentException::arrayKeyExpected(
+            throw InvalidPropertyTypeException::arrayKeyExpected(
                 $attribute->getCode(),
                 'amount',
                 static::class,
-                print_r($data, true)
+                $data
             );
         }
 
         if (!array_key_exists('unit', $data)) {
-            throw InvalidArgumentException::arrayKeyExpected(
+            throw InvalidPropertyTypeException::arrayKeyExpected(
                 $attribute->getCode(),
                 'unit',
                 static::class,
-                print_r($data, true)
+                $data
             );
         }
     }

--- a/src/Pim/Component/Catalog/Updater/Setter/MultiSelectAttributeSetter.php
+++ b/src/Pim/Component/Catalog/Updater/Setter/MultiSelectAttributeSetter.php
@@ -2,9 +2,10 @@
 
 namespace Pim\Component\Catalog\Updater\Setter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Pim\Component\Catalog\Builder\ProductBuilderInterface;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Validator\AttributeValidatorHelper;
@@ -56,7 +57,7 @@ class MultiSelectAttributeSetter extends AbstractAttributeSetter
         foreach ($data as $optionCode) {
             $option = $this->getOption($attribute, $optionCode);
             if (null === $option) {
-                throw InvalidArgumentException::arrayInvalidKey(
+                throw InvalidPropertyException::validEntityCodeExpected(
                     $attribute->getCode(),
                     'code',
                     'The option does not exist',
@@ -76,24 +77,26 @@ class MultiSelectAttributeSetter extends AbstractAttributeSetter
      *
      * @param AttributeInterface $attribute
      * @param mixed              $data
+     *
+     * @throws InvalidPropertyTypeException
      */
     protected function checkData(AttributeInterface $attribute, $data)
     {
         if (!is_array($data)) {
-            throw InvalidArgumentException::arrayExpected(
+            throw InvalidPropertyTypeException::arrayExpected(
                 $attribute->getCode(),
                 static::class,
-                gettype($data)
+                $data
             );
         }
 
         foreach ($data as $key => $value) {
             if (!is_string($value)) {
-                throw InvalidArgumentException::arrayStringValueExpected(
+                throw InvalidPropertyTypeException::validArrayStructureExpected(
                     $attribute->getCode(),
-                    $key,
+                    sprintf('one of the options is not a string, "%s" given', gettype($value)),
                     static::class,
-                    gettype($value)
+                    $data
                 );
             }
         }

--- a/src/Pim/Component/Catalog/Updater/Setter/PriceCollectionAttributeSetter.php
+++ b/src/Pim/Component/Catalog/Updater/Setter/PriceCollectionAttributeSetter.php
@@ -2,8 +2,8 @@
 
 namespace Pim\Component\Catalog\Updater\Setter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Pim\Component\Catalog\Builder\ProductBuilderInterface;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Validator\AttributeValidatorHelper;
@@ -65,42 +65,42 @@ class PriceCollectionAttributeSetter extends AbstractAttributeSetter
      * @param AttributeInterface $attribute
      * @param mixed              $data
      *
-     * @return mixed
+     * @throws InvalidPropertyTypeException
      */
     protected function checkData(AttributeInterface $attribute, $data)
     {
         if (!is_array($data)) {
-            throw InvalidArgumentException::arrayExpected(
+            throw InvalidPropertyTypeException::arrayExpected(
                 $attribute->getCode(),
                 static::class,
-                gettype($data)
+                $data
             );
         }
 
         foreach ($data as $price) {
             if (!is_array($price)) {
-                throw InvalidArgumentException::arrayOfArraysExpected(
+                throw InvalidPropertyTypeException::arrayOfArraysExpected(
                     $attribute->getCode(),
                     static::class,
-                    gettype($data)
+                    $data
                 );
             }
 
             if (!array_key_exists('amount', $price)) {
-                throw InvalidArgumentException::arrayKeyExpected(
+                throw InvalidPropertyTypeException::arrayKeyExpected(
                     $attribute->getCode(),
                     'amount',
                     static::class,
-                    print_r($data, true)
+                    $data
                 );
             }
 
             if (!array_key_exists('currency', $price)) {
-                throw InvalidArgumentException::arrayKeyExpected(
+                throw InvalidPropertyTypeException::arrayKeyExpected(
                     $attribute->getCode(),
                     'currency',
                     static::class,
-                    print_r($data, true)
+                    $data
                 );
             }
         }

--- a/src/Pim/Component/Catalog/Updater/Setter/SimpleSelectAttributeSetter.php
+++ b/src/Pim/Component/Catalog/Updater/Setter/SimpleSelectAttributeSetter.php
@@ -2,6 +2,8 @@
 
 namespace Pim\Component\Catalog\Updater\Setter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Pim\Component\Catalog\Builder\ProductBuilderInterface;
 use Pim\Component\Catalog\Exception\InvalidArgumentException;
@@ -59,7 +61,7 @@ class SimpleSelectAttributeSetter extends AbstractAttributeSetter
         } else {
             $option = $this->getOption($attribute, $data);
             if (null === $option) {
-                throw InvalidArgumentException::validEntityCodeExpected(
+                throw InvalidPropertyException::validEntityCodeExpected(
                     $attribute->getCode(),
                     'code',
                     'The option does not exist',
@@ -77,6 +79,8 @@ class SimpleSelectAttributeSetter extends AbstractAttributeSetter
      *
      * @param AttributeInterface $attribute
      * @param mixed              $data
+     *
+     * @throws InvalidPropertyTypeException
      */
     protected function checkData(AttributeInterface $attribute, $data)
     {
@@ -85,10 +89,10 @@ class SimpleSelectAttributeSetter extends AbstractAttributeSetter
         }
 
         if (!is_string($data) && !is_numeric($data)) {
-            throw InvalidArgumentException::stringExpected(
+            throw InvalidPropertyTypeException::stringExpected(
                 $attribute->getCode(),
                 static::class,
-                gettype($data)
+                $data
             );
         }
     }

--- a/src/Pim/Component/Catalog/Updater/Setter/VariantGroupFieldSetter.php
+++ b/src/Pim/Component/Catalog/Updater/Setter/VariantGroupFieldSetter.php
@@ -2,8 +2,9 @@
 
 namespace Pim\Component\Catalog\Updater\Setter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\ProductInterface;
 
 /**
@@ -42,18 +43,19 @@ class VariantGroupFieldSetter extends AbstractFieldSetter
         if (null !== $data) {
             $variantGroup = $this->groupRepository->findOneByIdentifier($data);
             if (null === $variantGroup) {
-                throw InvalidArgumentException::expected(
+                throw InvalidPropertyException::validEntityCodeExpected(
                     $field,
-                    'existing variant group code',
+                    'variant group code',
+                    'The variant group does not exist',
                     static::class,
                     $data
                 );
             }
 
             if (!$variantGroup->getType()->isVariant()) {
-                throw InvalidArgumentException::expected(
+                throw InvalidPropertyException::validGroupExpected(
                     $field,
-                    'variant group code',
+                    'Cannot process group, only variant groups are supported',
                     static::class,
                     $data
                 );
@@ -77,14 +79,16 @@ class VariantGroupFieldSetter extends AbstractFieldSetter
      *
      * @param string $field
      * @param mixed  $data
+     *
+     * @throws InvalidPropertyTypeException
      */
     protected function checkData($field, $data)
     {
         if (!is_string($data) && null !== $data) {
-            throw InvalidArgumentException::stringExpected(
+            throw InvalidPropertyTypeException::stringExpected(
                 $field,
                 static::class,
-                gettype($data)
+                $data
             );
         }
     }

--- a/src/Pim/Component/Catalog/Updater/VariantGroupUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/VariantGroupUpdater.php
@@ -3,6 +3,7 @@
 namespace Pim\Component\Catalog\Updater;
 
 use Akeneo\Component\StorageUtils\Exception\ImmutablePropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Doctrine\Common\Collections\ArrayCollection;
@@ -99,7 +100,7 @@ class VariantGroupUpdater implements ObjectUpdaterInterface
     public function update($variantGroup, array $data, array $options = [])
     {
         if (!$variantGroup instanceof GroupInterface) {
-            throw InvalidPropertyException::objectExpected(
+            throw InvalidObjectException::objectExpected(
                 ClassUtils::getClass($variantGroup),
                 GroupInterface::class
             );

--- a/src/Pim/Component/Catalog/spec/Updater/Adder/AssociationFieldAdderSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Adder/AssociationFieldAdderSpec.php
@@ -2,6 +2,8 @@
 
 namespace spec\Pim\Component\Catalog\Updater\Adder;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Builder\ProductBuilderInterface;
@@ -35,44 +37,54 @@ class AssociationFieldAdderSpec extends ObjectBehavior
     function it_checks_valid_association_data_format(ProductInterface $product)
     {
         $this->shouldThrow(
-            InvalidArgumentException::arrayExpected(
+            InvalidPropertyTypeException::arrayExpected(
                 'associations',
                 'Pim\Component\Catalog\Updater\Adder\AssociationFieldAdder',
-                'string'
+                'not an array'
             )
         )->during('addFieldData', [$product, 'associations', 'not an array']);
 
         $this->shouldThrow(
-            InvalidArgumentException::associationFormatExpected(
+            InvalidPropertyTypeException::validArrayStructureExpected(
                 'associations',
+                'association format is not valid for the association type "0".',
+                'Pim\Component\Catalog\Updater\Adder\AssociationFieldAdder',
                 [0 => []]
             )
         )->during('addFieldData', [$product, 'associations', [0 => []]]);
 
         $this->shouldThrow(
-            InvalidArgumentException::associationFormatExpected(
+            InvalidPropertyTypeException::validArrayStructureExpected(
                 'associations',
+                'association format is not valid for the association type "assoc_type_code".',
+                'Pim\Component\Catalog\Updater\Adder\AssociationFieldAdder',
                 ['assoc_type_code' => []]
             )
         )->during('addFieldData', [$product, 'associations', ['assoc_type_code' => []]]);
 
         $this->shouldThrow(
-            InvalidArgumentException::associationFormatExpected(
+            InvalidPropertyTypeException::validArrayStructureExpected(
                 'associations',
+                'association format is not valid for the association type "assoc_type_code".',
+                'Pim\Component\Catalog\Updater\Adder\AssociationFieldAdder',
                 ['assoc_type_code' => ['products' => []]]
             )
         )->during('addFieldData', [$product, 'associations', ['assoc_type_code' => ['products' => []]]]);
 
         $this->shouldThrow(
-            InvalidArgumentException::associationFormatExpected(
+            InvalidPropertyTypeException::validArrayStructureExpected(
                 'associations',
+                'association format is not valid for the association type "assoc_type_code".',
+                'Pim\Component\Catalog\Updater\Adder\AssociationFieldAdder',
                 ['assoc_type_code' => ['groups' => []]]
             )
         )->during('addFieldData', [$product, 'associations', ['assoc_type_code' => ['groups' => []]]]);
 
         $this->shouldThrow(
-            InvalidArgumentException::associationFormatExpected(
+            InvalidPropertyTypeException::validArrayStructureExpected(
                 'associations',
+                'association format is not valid for the association type "assoc_type_code".',
+                'Pim\Component\Catalog\Updater\Adder\AssociationFieldAdder',
                 ['assoc_type_code' => ['products' => [1], 'groups' => []]]
             )
         )->during(
@@ -81,8 +93,10 @@ class AssociationFieldAdderSpec extends ObjectBehavior
         );
 
         $this->shouldThrow(
-            InvalidArgumentException::associationFormatExpected(
+            InvalidPropertyTypeException::validArrayStructureExpected(
                 'associations',
+                'association format is not valid for the association type "assoc_type_code".',
+                'Pim\Component\Catalog\Updater\Adder\AssociationFieldAdder',
                 ['assoc_type_code' => ['products' => [], 'groups' => [2]]]
             )
         )->during(
@@ -148,9 +162,10 @@ class AssociationFieldAdderSpec extends ObjectBehavior
         $product->getAssociationForTypeCode('non valid association type code')->willReturn(null);
 
         $this->shouldThrow(
-            InvalidArgumentException::expected(
+            InvalidPropertyException::validEntityCodeExpected(
                 'associations',
-                'existing association type code',
+                'association type code',
+                'The association type does not exist',
                 'Pim\Component\Catalog\Updater\Adder\AssociationFieldAdder',
                 'non valid association type code'
             )
@@ -177,9 +192,10 @@ class AssociationFieldAdderSpec extends ObjectBehavior
         $productRepository->findOneByIdentifier('not existing product')->willReturn(null);
 
         $this->shouldThrow(
-            InvalidArgumentException::expected(
+            InvalidPropertyException::validEntityCodeExpected(
                 'associations',
-                'existing product identifier',
+                'product identifier',
+                'The product does not exist',
                 'Pim\Component\Catalog\Updater\Adder\AssociationFieldAdder',
                 'not existing product'
             )
@@ -206,9 +222,10 @@ class AssociationFieldAdderSpec extends ObjectBehavior
         $groupRepository->findOneByIdentifier('not existing group')->willReturn(null);
 
         $this->shouldThrow(
-            InvalidArgumentException::expected(
+            InvalidPropertyException::validEntityCodeExpected(
                 'associations',
-                'existing group code',
+                'group code',
+                'The group does not exist',
                 'Pim\Component\Catalog\Updater\Adder\AssociationFieldAdder',
                 'not existing group'
             )

--- a/src/Pim/Component/Catalog/spec/Updater/Adder/CategoryFieldAdderSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Adder/CategoryFieldAdderSpec.php
@@ -2,6 +2,8 @@
 
 namespace spec\Pim\Component\Catalog\Updater\Adder;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\CategoryInterface;
@@ -34,19 +36,19 @@ class CategoryFieldAdderSpec extends ObjectBehavior
     function it_checks_valid_data_format(ProductInterface $product)
     {
         $this->shouldThrow(
-            InvalidArgumentException::arrayExpected(
+            InvalidPropertyTypeException::arrayExpected(
                 'categories',
                 'Pim\Component\Catalog\Updater\Adder\CategoryFieldAdder',
-                'string'
+                'not an array'
             )
         )->during('addFieldData', [$product, 'categories', 'not an array']);
 
         $this->shouldThrow(
-            InvalidArgumentException::arrayStringValueExpected(
+            InvalidPropertyTypeException::validArrayStructureExpected(
                 'categories',
-                0,
+                'one of the category codes is not a string, "array" given',
                 'Pim\Component\Catalog\Updater\Adder\CategoryFieldAdder',
-                'array'
+                [['array of array']]
             )
         )->during('addFieldData', [$product, 'categories', [['array of array']]]);
     }
@@ -79,9 +81,10 @@ class CategoryFieldAdderSpec extends ObjectBehavior
         $categoryRepository->findOneByIdentifier('non valid category code')->willReturn(null);
 
         $this->shouldThrow(
-            InvalidArgumentException::expected(
+            InvalidPropertyException::validEntityCodeExpected(
                 'categories',
-                'existing category code',
+                'category code',
+                'The category does not exist',
                 'Pim\Component\Catalog\Updater\Adder\CategoryFieldAdder',
                 'non valid category code'
             )

--- a/src/Pim/Component/Catalog/spec/Updater/Adder/GroupFieldAdderSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Adder/GroupFieldAdderSpec.php
@@ -2,6 +2,8 @@
 
 namespace spec\Pim\Component\Catalog\Updater\Adder;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\GroupInterface;
@@ -35,19 +37,19 @@ class GroupFieldAdderSpec extends ObjectBehavior
     function it_checks_valid_data_format(ProductInterface $product)
     {
         $this->shouldThrow(
-            InvalidArgumentException::arrayExpected(
+            InvalidPropertyTypeException::arrayExpected(
                 'groups',
                 'Pim\Component\Catalog\Updater\Adder\GroupFieldAdder',
-                'string'
+                'not an array'
             )
         )->during('addFieldData', [$product, 'groups', 'not an array']);
 
         $this->shouldThrow(
-            InvalidArgumentException::arrayStringValueExpected(
+            InvalidPropertyTypeException::validArrayStructureExpected(
                 'groups',
-                0,
+                'one of the group codes is not a string, "array" given',
                 'Pim\Component\Catalog\Updater\Adder\GroupFieldAdder',
-                'array'
+                [['array of array']]
             )
         )->during('addFieldData', [$product, 'groups', [['array of array']]]);
     }
@@ -87,9 +89,10 @@ class GroupFieldAdderSpec extends ObjectBehavior
         $groupRepository->findOneByIdentifier('not valid code')->willReturn(null);
 
         $this->shouldThrow(
-            InvalidArgumentException::expected(
+            InvalidPropertyException::validEntityCodeExpected(
                 'groups',
-                'existing group code',
+                'group code',
+                'The group does not exist',
                 'Pim\Component\Catalog\Updater\Adder\GroupFieldAdder',
                 'not valid code'
             )
@@ -112,9 +115,9 @@ class GroupFieldAdderSpec extends ObjectBehavior
         $variantType->isVariant()->willReturn(true);
 
         $this->shouldThrow(
-            InvalidArgumentException::expected(
+            InvalidPropertyException::validGroupExpected(
                 'groups',
-                'non variant group code',
+                'Cannot process variant group, only groups are supported',
                 'Pim\Component\Catalog\Updater\Adder\GroupFieldAdder',
                 'variant'
             )

--- a/src/Pim/Component/Catalog/spec/Updater/Adder/MultiSelectAttributeAdderSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Adder/MultiSelectAttributeAdderSpec.php
@@ -2,6 +2,8 @@
 
 namespace spec\Pim\Component\Catalog\Updater\Adder;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Builder\ProductBuilderInterface;
@@ -78,11 +80,11 @@ class MultiSelectAttributeAdderSpec extends ObjectBehavior
         $data = ['foo' => ['bar' => 'baz']];
 
         $this->shouldThrow(
-            InvalidArgumentException::arrayStringValueExpected(
+            InvalidPropertyTypeException::validArrayStructureExpected(
                 'attributeCode',
-                'foo',
+                'one of the option codes is not a string, "array" given',
                 'Pim\Component\Catalog\Updater\Adder\MultiSelectAttributeAdder',
-                'array'
+                $data
             )
         )->during('addAttributeData', [$product, $attribute, $data, ['locale' => 'fr_FR', 'scope' => 'mobile']]);
     }
@@ -102,9 +104,9 @@ class MultiSelectAttributeAdderSpec extends ObjectBehavior
             ->willReturn(null);
 
         $this->shouldThrow(
-            InvalidArgumentException::arrayInvalidKey(
+            InvalidPropertyException::validEntityCodeExpected(
                 'attributeCode',
-                'code',
+                'option code',
                 'The option does not exist',
                 'Pim\Component\Catalog\Updater\Adder\MultiSelectAttributeAdder',
                 'unknown code'

--- a/src/Pim/Component/Catalog/spec/Updater/Adder/PriceCollectionAttributeAdderSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Adder/PriceCollectionAttributeAdderSpec.php
@@ -2,6 +2,8 @@
 
 namespace spec\Pim\Component\Catalog\Updater\Adder;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Builder\ProductBuilderInterface;
 use Pim\Component\Catalog\Exception\InvalidArgumentException;
@@ -74,10 +76,10 @@ class PriceCollectionAttributeAdderSpec extends ObjectBehavior
         $data = 'not an array';
 
         $this->shouldThrow(
-            InvalidArgumentException::arrayExpected(
+            InvalidPropertyTypeException::arrayExpected(
                 'attributeCode',
                 'Pim\Component\Catalog\Updater\Adder\PriceCollectionAttributeAdder',
-                gettype($data)
+                $data
             )
         )->during('addAttributeData', [$product, $attribute, $data, ['locale' => 'fr_FR', 'scope' => 'mobile']]);
     }
@@ -91,10 +93,10 @@ class PriceCollectionAttributeAdderSpec extends ObjectBehavior
         $data = ['not an array'];
 
         $this->shouldThrow(
-            InvalidArgumentException::arrayOfArraysExpected(
+            InvalidPropertyTypeException::arrayOfArraysExpected(
                 'attributeCode',
                 'Pim\Component\Catalog\Updater\Adder\PriceCollectionAttributeAdder',
-                gettype($data)
+                $data
             )
         )->during('addAttributeData', [$product, $attribute, $data, ['locale' => 'fr_FR', 'scope' => 'mobile']]);
     }
@@ -108,11 +110,11 @@ class PriceCollectionAttributeAdderSpec extends ObjectBehavior
         $data = [['not the data key' => 123]];
 
         $this->shouldThrow(
-            InvalidArgumentException::arrayKeyExpected(
+            InvalidPropertyTypeException::arrayKeyExpected(
                 'attributeCode',
                 'amount',
                 'Pim\Component\Catalog\Updater\Adder\PriceCollectionAttributeAdder',
-                print_r($data, true)
+                $data
             )
         )->during('addAttributeData', [$product, $attribute, $data, ['locale' => 'fr_FR', 'scope' => 'mobile']]);
     }
@@ -126,11 +128,12 @@ class PriceCollectionAttributeAdderSpec extends ObjectBehavior
         $data = [['amount' => 'non numeric value', 'currency' => 'EUR']];
 
         $this->shouldThrow(
-            InvalidArgumentException::arrayNumericKeyExpected(
+            new InvalidPropertyTypeException(
                 'attributeCode',
-                'amount',
+                'non numeric value',
                 'Pim\Component\Catalog\Updater\Adder\PriceCollectionAttributeAdder',
-                gettype('text')
+                'Property "attributeCode" expects a numeric as data for the currency, "non numeric value" given.',
+                InvalidPropertyTypeException::NUMERIC_EXPECTED_CODE
             )
         )->during('addAttributeData', [$product, $attribute, $data, ['locale' => 'fr_FR', 'scope' => 'mobile']]);
     }
@@ -144,11 +147,11 @@ class PriceCollectionAttributeAdderSpec extends ObjectBehavior
         $data = [['amount' => 123, 'not the currency key' => 'euro']];
 
         $this->shouldThrow(
-            InvalidArgumentException::arrayKeyExpected(
+            InvalidPropertyTypeException::arrayKeyExpected(
                 'attributeCode',
                 'currency',
                 'Pim\Component\Catalog\Updater\Adder\PriceCollectionAttributeAdder',
-                print_r($data, true)
+                $data
             )
         )->during('addAttributeData', [$product, $attribute, $data, ['locale' => 'fr_FR', 'scope' => 'mobile']]);
     }
@@ -165,9 +168,9 @@ class PriceCollectionAttributeAdderSpec extends ObjectBehavior
         $data = [['amount' => 123, 'currency' => 'invalid currency']];
 
         $this->shouldThrow(
-            InvalidArgumentException::arrayInvalidKey(
+            InvalidPropertyException::validEntityCodeExpected(
                 'attributeCode',
-                'currency',
+                'currency code',
                 'The currency does not exist',
                 'Pim\Component\Catalog\Updater\Adder\PriceCollectionAttributeAdder',
                 'invalid currency'

--- a/src/Pim/Component/Catalog/spec/Updater/Copier/BaseAttributeCopierSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Copier/BaseAttributeCopierSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Pim\Component\Catalog\Updater\Copier;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Builder\ProductBuilderInterface;
 use Pim\Component\Catalog\Exception\InvalidArgumentException;
@@ -115,7 +116,7 @@ class BaseAttributeCopierSpec extends ObjectBehavior
         }
     }
 
-    function it_copies__a_date_value_to_a_product_value(
+    function it_copies_a_date_value_to_a_product_value(
         $builder,
         $attrValidatorHelper,
         AttributeInterface $fromAttribute,
@@ -358,7 +359,11 @@ class BaseAttributeCopierSpec extends ObjectBehavior
         $fromAttribute->isLocalizable()->willReturn(true);
         $attrValidatorHelper->validateLocale($fromAttribute, null)->willThrow($e);
         $this->shouldThrow(
-            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'Pim\Component\Catalog\Updater\Copier\BaseAttributeCopier')
+            InvalidPropertyException::expectedFromPreviousException(
+                'attributeCode',
+                'Pim\Component\Catalog\Updater\Copier\BaseAttributeCopier',
+                $e
+            )
         )->during('copyAttributeData', [$product, $product, $fromAttribute, $toAttribute, []]);
     }
 
@@ -373,7 +378,11 @@ class BaseAttributeCopierSpec extends ObjectBehavior
         $fromAttribute->isLocalizable()->willReturn(false);
         $attrValidatorHelper->validateLocale($fromAttribute, 'en_US')->willThrow($e);
         $this->shouldThrow(
-            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'Pim\Component\Catalog\Updater\Copier\BaseAttributeCopier')
+            InvalidPropertyException::expectedFromPreviousException(
+                'attributeCode',
+                'Pim\Component\Catalog\Updater\Copier\BaseAttributeCopier',
+                $e
+            )
         )->during(
             'copyAttributeData',
             [$product, $product, $fromAttribute, $toAttribute, ['from_locale' => 'en_US', 'from_scope' => 'ecommerce']]
@@ -391,7 +400,11 @@ class BaseAttributeCopierSpec extends ObjectBehavior
         $fromAttribute->isLocalizable()->willReturn(true);
         $attrValidatorHelper->validateLocale($fromAttribute, 'uz-UZ')->willThrow($e);
         $this->shouldThrow(
-            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'Pim\Component\Catalog\Updater\Copier\BaseAttributeCopier')
+            InvalidPropertyException::expectedFromPreviousException(
+                'attributeCode',
+                'Pim\Component\Catalog\Updater\Copier\BaseAttributeCopier',
+                $e
+            )
         )->during(
             'copyAttributeData',
             [$product, $product, $fromAttribute, $toAttribute, ['from_locale' => 'uz-UZ', 'from_scope' => 'ecommerce']]
@@ -411,7 +424,11 @@ class BaseAttributeCopierSpec extends ObjectBehavior
         $attrValidatorHelper->validateLocale($fromAttribute, null)->shouldBeCalled();
         $attrValidatorHelper->validateScope($fromAttribute, null)->willThrow($e);
         $this->shouldThrow(
-            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'Pim\Component\Catalog\Updater\Copier\BaseAttributeCopier')
+            InvalidPropertyException::expectedFromPreviousException(
+                'attributeCode',
+                'Pim\Component\Catalog\Updater\Copier\BaseAttributeCopier',
+                $e
+            )
         )->during(
             'copyAttributeData',
             [$product, $product, $fromAttribute, $toAttribute, ['from_locale' => null, 'from_scope' => null]]
@@ -431,7 +448,11 @@ class BaseAttributeCopierSpec extends ObjectBehavior
         $attrValidatorHelper->validateLocale($fromAttribute, null)->shouldBeCalled();
         $attrValidatorHelper->validateScope($fromAttribute, 'ecommerce')->willThrow($e);
         $this->shouldThrow(
-            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'Pim\Component\Catalog\Updater\Copier\BaseAttributeCopier')
+            InvalidPropertyException::expectedFromPreviousException(
+                'attributeCode',
+                'Pim\Component\Catalog\Updater\Copier\BaseAttributeCopier',
+                $e
+            )
         )->during(
             'copyAttributeData',
             [$product, $product, $fromAttribute, $toAttribute, ['from_locale' => null, 'from_scope' => 'ecommerce']]
@@ -451,7 +472,11 @@ class BaseAttributeCopierSpec extends ObjectBehavior
         $attrValidatorHelper->validateLocale($fromAttribute, null)->shouldBeCalled();
         $attrValidatorHelper->validateScope($fromAttribute, 'ecommerce')->willThrow($e);
         $this->shouldThrow(
-            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'Pim\Component\Catalog\Updater\Copier\BaseAttributeCopier')
+            InvalidPropertyException::expectedFromPreviousException(
+                'attributeCode',
+                'Pim\Component\Catalog\Updater\Copier\BaseAttributeCopier',
+                $e
+            )
         )->during(
             'copyAttributeData',
             [$product, $product, $fromAttribute, $toAttribute, ['from_locale' => null, 'from_scope' => 'ecommerce']]

--- a/src/Pim/Component/Catalog/spec/Updater/ProductPropertyAdderSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/ProductPropertyAdderSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Pim\Component\Catalog\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Model\AttributeInterface;
@@ -56,5 +57,18 @@ class ProductPropertyAdderSpec extends ObjectBehavior
             ->shouldBeCalled();
 
         $this->addData($product, 'category', 'tshirt', []);
+    }
+
+    function it_throws_an_exception_when_trying_to_add_anything_else_than_a_product()
+    {
+        $this->shouldThrow(
+            InvalidObjectException::objectExpected(
+                'stdClass',
+                'Pim\Component\Catalog\Model\ProductInterface'
+            )
+        )->during(
+            'addData',
+            [new \stdClass(), 'category', []]
+        );
     }
 }

--- a/src/Pim/Component/Catalog/spec/Updater/ProductPropertyCopierSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/ProductPropertyCopierSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Pim\Component\Catalog\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Model\AttributeInterface;
@@ -67,6 +68,20 @@ class ProductPropertyCopierSpec extends ObjectBehavior
         $attributeRepository->findOneByIdentifier(Argument::any())->willReturn(null);
         $this->shouldThrow(new \LogicException('No copier found for fields "unknown_field" and "to_field"'))->during(
             'copyData', [$product, $product, 'unknown_field', 'to_field', []]
+        );
+    }
+
+    function it_throws_an_exception_when_trying_to_copy_anything_else_than_a_product()
+    {
+        $this->shouldThrow(
+            new InvalidObjectException(
+                'stdClass',
+                ProductInterface::class,
+                'Expects a "Pim\Component\Catalog\Model\ProductInterface", "stdClass" and "stdClass" provided.'
+            )
+        )->during(
+            'copyData',
+            [new \stdClass(), new \stdClass(), 'from_category', 'from_category', []]
         );
     }
 }

--- a/src/Pim/Component/Catalog/spec/Updater/ProductPropertyRemoverSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/ProductPropertyRemoverSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Pim\Component\Catalog\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Model\AttributeInterface;
@@ -70,6 +71,19 @@ class ProductPropertyRemoverSpec extends ObjectBehavior
 
         $this->shouldThrow(new \LogicException('No remover found for field "unknown_field"'))->during(
             'removeData', [$product, 'unknown_field', 'code']
+        );
+    }
+
+    function it_throws_an_exception_when_trying_to_remove_anything_else_than_a_product()
+    {
+        $this->shouldThrow(
+            InvalidObjectException::objectExpected(
+                'stdClass',
+                'Pim\Component\Catalog\Model\ProductInterface'
+            )
+        )->during(
+            'removeData',
+            [new \stdClass(), 'category', []]
         );
     }
 }

--- a/src/Pim/Component/Catalog/spec/Updater/ProductPropertySetterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/ProductPropertySetterSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Pim\Component\Catalog\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Model\AttributeInterface;
@@ -64,6 +65,19 @@ class ProductPropertySetterSpec extends ObjectBehavior
         $attributeRepository->findOneByIdentifier(Argument::any())->willReturn(null);
         $this->shouldThrow(new \LogicException('No setter found for field "unknown_field"'))->during(
             'setData', [$product, 'unknown_field', 'data', ['locale' => 'fr_FR', 'scope' => 'ecommerce']]
+        );
+    }
+
+    function it_throws_an_exception_when_trying_to_set_anything_else_than_a_product()
+    {
+        $this->shouldThrow(
+            InvalidObjectException::objectExpected(
+                'stdClass',
+                'Pim\Component\Catalog\Model\ProductInterface'
+            )
+        )->during(
+            'setData',
+            [new \stdClass(), 'category', []]
         );
     }
 }

--- a/src/Pim/Component/Catalog/spec/Updater/ProductUpdaterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/ProductUpdaterSpec.php
@@ -38,6 +38,9 @@ class ProductUpdaterSpec extends ObjectBehavior
                 'stdClass',
                 'Pim\Component\Catalog\Model\ProductInterface'
             )
+        )->during(
+            'update',
+            [new \stdClass(), []]
         );
     }
 

--- a/src/Pim/Component/Catalog/spec/Updater/Remover/CategoryFieldRemoverSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Remover/CategoryFieldRemoverSpec.php
@@ -2,6 +2,8 @@
 
 namespace spec\Pim\Component\Catalog\Updater\Remover;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Exception\InvalidArgumentException;
@@ -48,9 +50,10 @@ class CategoryFieldRemoverSpec extends ObjectBehavior
         $categoryRepository->findOneByIdentifier('unknown_category')->willReturn(null);
 
         $this->shouldThrow(
-            InvalidArgumentException::expected(
+            InvalidPropertyException::validEntityCodeExpected(
                 'categories',
-                'existing category code',
+                'category code',
+                'The category does not exist',
                 'Pim\Component\Catalog\Updater\Remover\CategoryFieldRemover',
                 'unknown_category'
             )
@@ -60,19 +63,19 @@ class CategoryFieldRemoverSpec extends ObjectBehavior
     function it_throws_an_exception_if_data_are_invalid(ProductInterface $bookProduct)
     {
         $this->shouldThrow(
-            InvalidArgumentException::arrayExpected(
+            InvalidPropertyTypeException::arrayExpected(
                 'categories',
                 'Pim\Component\Catalog\Updater\Remover\CategoryFieldRemover',
-                'string'
+                'category_code'
             )
         )->duringRemoveFieldData($bookProduct, 'categories', 'category_code');
 
         $this->shouldThrow(
-            InvalidArgumentException::arrayStringValueExpected(
+            InvalidPropertyTypeException::validArrayStructureExpected(
                 'categories',
-                0,
+                'one of the category codes is not a string, "integer" given',
                 'Pim\Component\Catalog\Updater\Remover\CategoryFieldRemover',
-                'integer'
+                [42]
             )
         )->duringRemoveFieldData($bookProduct, 'categories', [42]);
     }

--- a/src/Pim/Component/Catalog/spec/Updater/Remover/GroupFieldRemoverSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Remover/GroupFieldRemoverSpec.php
@@ -2,6 +2,8 @@
 
 namespace spec\Pim\Component\Catalog\Updater\Remover;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\GroupInterface;
@@ -63,9 +65,10 @@ class GroupFieldRemoverSpec extends ObjectBehavior
         $groupRepository->findOneByIdentifier('not valid code')->willReturn(null);
 
         $this->shouldThrow(
-            InvalidArgumentException::expected(
+            InvalidPropertyException::validEntityCodeExpected(
                 'groups',
-                'existing group code',
+                'group code',
+                'The group does not exist',
                 'Pim\Component\Catalog\Updater\Remover\GroupFieldRemover',
                 'not valid code'
             )
@@ -75,19 +78,19 @@ class GroupFieldRemoverSpec extends ObjectBehavior
     function it_checks_valid_data_format(ProductInterface $product)
     {
         $this->shouldThrow(
-            InvalidArgumentException::arrayExpected(
+            InvalidPropertyTypeException::arrayExpected(
                 'groups',
                 'Pim\Component\Catalog\Updater\Remover\GroupFieldRemover',
-                'string'
+                'not an array'
             )
         )->during('removeFieldData', [$product, 'groups', 'not an array']);
 
         $this->shouldThrow(
-            InvalidArgumentException::arrayStringValueExpected(
+            InvalidPropertyTypeException::validArrayStructureExpected(
                 'groups',
-                0,
+                'one of the group codes is not a string, "array" given',
                 'Pim\Component\Catalog\Updater\Remover\GroupFieldRemover',
-                'array'
+                [['array of array']]
             )
         )->during('removeFieldData', [$product, 'groups', [['array of array']]]);
     }
@@ -108,9 +111,9 @@ class GroupFieldRemoverSpec extends ObjectBehavior
         $variantType->isVariant()->willReturn(true);
 
         $this->shouldThrow(
-            InvalidArgumentException::expected(
+            InvalidPropertyException::validGroupExpected(
                 'groups',
-                'non variant group code',
+                'Cannot process variant group, only groups are supported',
                 'Pim\Component\Catalog\Updater\Remover\GroupFieldRemover',
                 'variant'
             )

--- a/src/Pim/Component/Catalog/spec/Updater/Remover/MultiSelectAttributeRemoverSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Remover/MultiSelectAttributeRemoverSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Pim\Component\Catalog\Updater\Remover;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Exception\InvalidArgumentException;
@@ -77,10 +78,10 @@ class MultiSelectAttributeRemoverSpec extends ObjectBehavior
 
         $data = 'not an array!';
         $this->shouldThrow(
-            InvalidArgumentException::arrayExpected(
+            InvalidPropertyTypeException::arrayExpected(
                 'attributeCode',
                 'Pim\Component\Catalog\Updater\Remover\MultiSelectAttributeRemover',
-                gettype($data)
+                $data
             )
         )->during('removeAttributeData', [$product, $attribute, $data, ['locale' => 'fr_FR', 'scope' => 'mobile']]);
     }
@@ -93,11 +94,11 @@ class MultiSelectAttributeRemoverSpec extends ObjectBehavior
 
         $data = [0];
         $this->shouldThrow(
-            InvalidArgumentException::arrayStringValueExpected(
+            InvalidPropertyTypeException::validArrayStructureExpected(
                 'attributeCode',
-                0,
+                'one of the option codes is not a string, "integer" given',
                 'Pim\Component\Catalog\Updater\Remover\MultiSelectAttributeRemover',
-                gettype($data[0])
+                $data
             )
         )->during('removeAttributeData', [$product, $attribute, $data, ['locale' => 'fr_FR', 'scope' => 'mobile']]);
     }

--- a/src/Pim/Component/Catalog/spec/Updater/Remover/PriceCollectionAttributeRemoverSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Remover/PriceCollectionAttributeRemoverSpec.php
@@ -2,6 +2,8 @@
 
 namespace spec\Pim\Component\Catalog\Updater\Remover;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
@@ -97,10 +99,10 @@ class PriceCollectionAttributeRemoverSpec extends ObjectBehavior
         $data = 'not an array';
 
         $this->shouldThrow(
-            InvalidArgumentException::arrayExpected(
+            InvalidPropertyTypeException::arrayExpected(
                 'attributeCode',
                 'Pim\Component\Catalog\Updater\Remover\PriceCollectionAttributeRemover',
-                gettype($data)
+                $data
             )
         )->during('removeAttributeData', [$product, $attribute, $data, ['locale' => 'fr_FR', 'scope' => 'mobile']]);
     }
@@ -114,10 +116,10 @@ class PriceCollectionAttributeRemoverSpec extends ObjectBehavior
         $data = ['not an array'];
 
         $this->shouldThrow(
-            InvalidArgumentException::arrayOfArraysExpected(
+            InvalidPropertyTypeException::arrayOfArraysExpected(
                 'attributeCode',
                 'Pim\Component\Catalog\Updater\Remover\PriceCollectionAttributeRemover',
-                gettype($data)
+                $data
             )
         )->during('removeAttributeData', [$product, $attribute, $data, ['locale' => 'fr_FR', 'scope' => 'mobile']]);
     }
@@ -131,11 +133,11 @@ class PriceCollectionAttributeRemoverSpec extends ObjectBehavior
         $data = [['not the data key' => 123]];
 
         $this->shouldThrow(
-            InvalidArgumentException::arrayKeyExpected(
+            InvalidPropertyTypeException::arrayKeyExpected(
                 'attributeCode',
                 'amount',
                 'Pim\Component\Catalog\Updater\Remover\PriceCollectionAttributeRemover',
-                print_r($data, true)
+                $data
             )
         )->during('removeAttributeData', [$product, $attribute, $data, ['locale' => 'fr_FR', 'scope' => 'mobile']]);
     }
@@ -149,11 +151,11 @@ class PriceCollectionAttributeRemoverSpec extends ObjectBehavior
         $data = [['amount' => 123, 'not the currency key' => 'euro']];
 
         $this->shouldThrow(
-            InvalidArgumentException::arrayKeyExpected(
+            InvalidPropertyTypeException::arrayKeyExpected(
                 'attributeCode',
                 'currency',
                 'Pim\Component\Catalog\Updater\Remover\PriceCollectionAttributeRemover',
-                print_r($data, true)
+                $data
             )
         )->during('removeAttributeData', [$product, $attribute, $data, ['locale' => 'fr_FR', 'scope' => 'mobile']]);
     }
@@ -170,9 +172,9 @@ class PriceCollectionAttributeRemoverSpec extends ObjectBehavior
         $data = [['amount' => 123, 'currency' => 'invalid currency']];
 
         $this->shouldThrow(
-            InvalidArgumentException::arrayInvalidKey(
+            InvalidPropertyException::validEntityCodeExpected(
                 'attributeCode',
-                'currency',
+                'currency code',
                 'The currency does not exist',
                 'Pim\Component\Catalog\Updater\Remover\PriceCollectionAttributeRemover',
                 'invalid currency'

--- a/src/Pim/Component/Catalog/spec/Updater/Setter/AssociationFieldSetterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Setter/AssociationFieldSetterSpec.php
@@ -2,6 +2,8 @@
 
 namespace spec\Pim\Component\Catalog\Updater\Setter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Doctrine\Common\Collections\ArrayCollection;
 use PhpSpec\ObjectBehavior;
@@ -38,30 +40,36 @@ class AssociationFieldSetterSpec extends ObjectBehavior
     function it_checks_valid_association_data_format(ProductInterface $product)
     {
         $this->shouldThrow(
-            InvalidArgumentException::arrayExpected(
+            InvalidPropertyTypeException::arrayExpected(
                 'associations',
                 'Pim\Component\Catalog\Updater\Setter\AssociationFieldSetter',
-                'string'
+                'not an array'
             )
         )->during('setFieldData', [$product, 'associations', 'not an array']);
 
         $this->shouldThrow(
-            InvalidArgumentException::associationFormatExpected(
+            InvalidPropertyTypeException::validArrayStructureExpected(
                 'associations',
+                'association format is not valid for the association type "0".',
+                'Pim\Component\Catalog\Updater\Setter\AssociationFieldSetter',
                 [0 => []]
             )
         )->during('setFieldData', [$product, 'associations', [0 => []]]);
 
         $this->shouldThrow(
-            InvalidArgumentException::associationFormatExpected(
+            InvalidPropertyTypeException::validArrayStructureExpected(
                 'associations',
+                'association format is not valid for the association type "assoc_type_code".',
+                'Pim\Component\Catalog\Updater\Setter\AssociationFieldSetter',
                 ['assoc_type_code' => []]
             )
         )->during('setFieldData', [$product, 'associations', ['assoc_type_code' => []]]);
 
         $this->shouldThrow(
-            InvalidArgumentException::associationFormatExpected(
+            InvalidPropertyTypeException::validArrayStructureExpected(
                 'associations',
+                'association format is not valid for the association type "assoc_type_code".',
+                'Pim\Component\Catalog\Updater\Setter\AssociationFieldSetter',
                 ['assoc_type_code' => ['products' => [1], 'groups' => []]]
             )
         )->during(
@@ -70,8 +78,10 @@ class AssociationFieldSetterSpec extends ObjectBehavior
         );
 
         $this->shouldThrow(
-            InvalidArgumentException::associationFormatExpected(
+            InvalidPropertyTypeException::validArrayStructureExpected(
                 'associations',
+                'association format is not valid for the association type "assoc_type_code".',
+                'Pim\Component\Catalog\Updater\Setter\AssociationFieldSetter',
                 ['assoc_type_code' => ['products' => [], 'groups' => [2]]]
             )
         )->during(
@@ -149,9 +159,10 @@ class AssociationFieldSetterSpec extends ObjectBehavior
         $product->getAssociationForTypeCode('non valid association type code')->willReturn(null);
 
         $this->shouldThrow(
-            InvalidArgumentException::expected(
+            InvalidPropertyException::validEntityCodeExpected(
                 'associations',
-                'existing association type code',
+                'association type code',
+                'The association type does not exist',
                 'Pim\Component\Catalog\Updater\Setter\AssociationFieldSetter',
                 'non valid association type code'
             )
@@ -184,9 +195,10 @@ class AssociationFieldSetterSpec extends ObjectBehavior
         $productRepository->findOneByIdentifier('not existing product')->willReturn(null);
 
         $this->shouldThrow(
-            InvalidArgumentException::expected(
+            InvalidPropertyException::validEntityCodeExpected(
                 'associations',
-                'existing product identifier',
+                'product identifier',
+                'The product does not exist',
                 'Pim\Component\Catalog\Updater\Setter\AssociationFieldSetter',
                 'not existing product'
             )
@@ -217,9 +229,10 @@ class AssociationFieldSetterSpec extends ObjectBehavior
         $groupRepository->findOneByIdentifier('not existing group')->willReturn(null);
 
         $this->shouldThrow(
-            InvalidArgumentException::expected(
+            InvalidPropertyException::validEntityCodeExpected(
                 'associations',
-                'existing group code',
+                'group code',
+                'The group does not exist',
                 'Pim\Component\Catalog\Updater\Setter\AssociationFieldSetter',
                 'not existing group'
             )

--- a/src/Pim/Component/Catalog/spec/Updater/Setter/CategoryFieldSetterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Setter/CategoryFieldSetterSpec.php
@@ -2,6 +2,8 @@
 
 namespace spec\Pim\Component\Catalog\Updater\Setter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\CategoryInterface;
@@ -34,19 +36,19 @@ class CategoryFieldSetterSpec extends ObjectBehavior
     function it_checks_valid_data_format(ProductInterface $product)
     {
         $this->shouldThrow(
-            InvalidArgumentException::arrayExpected(
+            InvalidPropertyTypeException::arrayExpected(
                 'categories',
                 'Pim\Component\Catalog\Updater\Setter\CategoryFieldSetter',
-                'string'
+                'not an array'
             )
         )->during('setFieldData', [$product, 'categories', 'not an array']);
 
         $this->shouldThrow(
-            InvalidArgumentException::arrayStringValueExpected(
+            InvalidPropertyTypeException::validArrayStructureExpected(
                 'categories',
-                0,
+                'one of the category codes is not a string, "array" given',
                 'Pim\Component\Catalog\Updater\Setter\CategoryFieldSetter',
-                'array'
+                [['array of array']]
             )
         )->during('setFieldData', [$product, 'categories', [['array of array']]]);
     }
@@ -81,9 +83,10 @@ class CategoryFieldSetterSpec extends ObjectBehavior
         $categoryRepository->findOneByIdentifier('non valid category code')->willReturn(null);
 
         $this->shouldThrow(
-            InvalidArgumentException::expected(
+            InvalidPropertyException::validEntityCodeExpected(
                 'categories',
-                'existing category code',
+                'category code',
+                'The category does not exist',
                 'Pim\Component\Catalog\Updater\Setter\CategoryFieldSetter',
                 'non valid category code'
             )

--- a/src/Pim/Component/Catalog/spec/Updater/Setter/DateAttributeSetterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Setter/DateAttributeSetterSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Pim\Component\Catalog\Updater\Setter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Builder\ProductBuilderInterface;
 use Pim\Component\Catalog\Exception\InvalidArgumentException;
@@ -76,11 +77,11 @@ class DateAttributeSetterSpec extends ObjectBehavior
         $data = 'not a date';
 
         $this->shouldThrow(
-            InvalidArgumentException::expected(
+            InvalidPropertyException::dateExpected(
                 'attributeCode',
-                'a string with the format yyyy-mm-dd',
+                'yyyy-mm-dd',
                 'Pim\Component\Catalog\Updater\Setter\DateAttributeSetter',
-                gettype($data)
+                'not a date'
             )
         )->during('setAttributeData', [$product, $attribute, $data, ['locale' => 'fr_FR', 'scope' => 'mobile']]);
     }
@@ -94,11 +95,11 @@ class DateAttributeSetterSpec extends ObjectBehavior
         $data = '1970-mm-01';
 
         $this->shouldThrow(
-            InvalidArgumentException::expected(
+            InvalidPropertyException::dateExpected(
                 'attributeCode',
-                'a string with the format yyyy-mm-dd',
+                'yyyy-mm-dd',
                 'Pim\Component\Catalog\Updater\Setter\DateAttributeSetter',
-                gettype($data)
+                '1970-mm-01'
             )
         )->during('setAttributeData', [$product, $attribute, $data, ['locale' => 'fr_FR', 'scope' => 'mobile']]);
     }
@@ -126,11 +127,11 @@ class DateAttributeSetterSpec extends ObjectBehavior
         $data = 132654;
 
         $this->shouldThrow(
-            InvalidArgumentException::expected(
+            InvalidPropertyException::dateExpected(
                 'attributeCode',
-                'datetime or string',
+                'yyyy-mm-dd',
                 'Pim\Component\Catalog\Updater\Setter\DateAttributeSetter',
-                gettype($data)
+                'integer'
             )
         )->during('setAttributeData', [$product, $attribute, $data, ['locale' => 'fr_FR', 'scope' => 'mobile']]);
     }

--- a/src/Pim/Component/Catalog/spec/Updater/Setter/FamilyFieldSetterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Setter/FamilyFieldSetterSpec.php
@@ -2,6 +2,8 @@
 
 namespace spec\Pim\Component\Catalog\Updater\Setter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\FamilyInterface;
@@ -34,10 +36,10 @@ class FamilyFieldSetterSpec extends ObjectBehavior
     function it_checks_valid_data_format(ProductInterface $product)
     {
         $this->shouldThrow(
-            InvalidArgumentException::stringExpected(
+            InvalidPropertyTypeException::stringExpected(
                 'family',
                 'Pim\Component\Catalog\Updater\Setter\FamilyFieldSetter',
-                'array'
+                ['not a string']
             )
         )->during('setFieldData', [$product, 'family', ['not a string']]);
     }
@@ -65,9 +67,10 @@ class FamilyFieldSetterSpec extends ObjectBehavior
         $familyRepository->findOneByIdentifier('shirt')->willReturn(null);
 
         $this->shouldThrow(
-            InvalidArgumentException::expected(
+            InvalidPropertyException::validEntityCodeExpected(
                 'family',
-                'existing family code',
+                'family code',
+                'The family does not exist',
                 'Pim\Component\Catalog\Updater\Setter\FamilyFieldSetter',
                 'shirt'
             )

--- a/src/Pim/Component/Catalog/spec/Updater/Setter/GroupFieldSetterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Setter/GroupFieldSetterSpec.php
@@ -2,6 +2,8 @@
 
 namespace spec\Pim\Component\Catalog\Updater\Setter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\GroupInterface;
@@ -35,19 +37,19 @@ class GroupFieldSetterSpec extends ObjectBehavior
     function it_checks_valid_data_format(ProductInterface $product)
     {
         $this->shouldThrow(
-            InvalidArgumentException::arrayExpected(
+            InvalidPropertyTypeException::arrayExpected(
                 'groups',
                 'Pim\Component\Catalog\Updater\Setter\GroupFieldSetter',
-                'string'
+                'not an array'
             )
         )->during('setFieldData', [$product, 'groups', 'not an array']);
 
         $this->shouldThrow(
-            InvalidArgumentException::arrayStringValueExpected(
+            InvalidPropertyTypeException::validArrayStructureExpected(
                 'groups',
-                0,
+                'one of the group codes is not a string, "array" given',
                 'Pim\Component\Catalog\Updater\Setter\GroupFieldSetter',
-                'array'
+                [['array of array']]
             )
         )->during('setFieldData', [$product, 'groups', [['array of array']]]);
     }
@@ -93,9 +95,10 @@ class GroupFieldSetterSpec extends ObjectBehavior
         $groupRepository->findOneByIdentifier('not valid code')->willReturn(null);
 
         $this->shouldThrow(
-            InvalidArgumentException::expected(
+            InvalidPropertyException::validEntityCodeExpected(
                 'groups',
-                'existing group code',
+                'group code',
+                'The group does not exist',
                 'Pim\Component\Catalog\Updater\Setter\GroupFieldSetter',
                 'not valid code'
             )

--- a/src/Pim/Component/Catalog/spec/Updater/Setter/MediaAttributeSetterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Setter/MediaAttributeSetterSpec.php
@@ -5,6 +5,8 @@ namespace spec\Pim\Component\Catalog\Updater\Setter;
 use Akeneo\Component\FileStorage\File\FileStorerInterface;
 use Akeneo\Component\FileStorage\Model\FileInfoInterface;
 use Akeneo\Component\FileStorage\Repository\FileInfoRepositoryInterface;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Builder\ProductBuilderInterface;
 use Pim\Component\Catalog\Exception\InvalidArgumentException;
@@ -90,7 +92,7 @@ class MediaAttributeSetterSpec extends ObjectBehavior
         $data = new \stdClass();
 
         $this->shouldThrow(
-            InvalidArgumentException::stringExpected('attributeCode', 'Pim\Component\Catalog\Updater\Setter\MediaAttributeSetter', gettype($data))
+            InvalidPropertyTypeException::stringExpected('attributeCode', 'Pim\Component\Catalog\Updater\Setter\MediaAttributeSetter', $data)
         )->during('setAttributeData', [$product, $attribute, $data, ['locale' => 'fr_FR', 'scope' => 'mobile']]);
     }
 
@@ -103,9 +105,8 @@ class MediaAttributeSetterSpec extends ObjectBehavior
         $data = 'path/to/unknown/file';
 
         $this->shouldThrow(
-            InvalidArgumentException::expected(
+            InvalidPropertyException::validPathExpected(
                 'attributeCode',
-                'a valid pathname',
                 'Pim\Component\Catalog\Updater\Setter\MediaAttributeSetter',
                 'path/to/unknown/file'
             )

--- a/src/Pim/Component/Catalog/spec/Updater/Setter/MetricAttributeSetterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Setter/MetricAttributeSetterSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Pim\Component\Catalog\Updater\Setter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Factory\MetricFactory;
 use Pim\Component\Catalog\Builder\ProductBuilderInterface;
@@ -77,7 +78,7 @@ class MetricAttributeSetterSpec extends ObjectBehavior
         $data = 'Not an array';
 
         $this->shouldThrow(
-            InvalidArgumentException::arrayExpected('attributeCode', 'Pim\Component\Catalog\Updater\Setter\MetricAttributeSetter', gettype($data))
+            InvalidPropertyTypeException::arrayExpected('attributeCode', 'Pim\Component\Catalog\Updater\Setter\MetricAttributeSetter', $data)
         )->during('setAttributeData', [$product, $attribute, $data, ['locale' => 'fr_FR', 'scope' => 'mobile']]);
     }
 
@@ -90,11 +91,11 @@ class MetricAttributeSetterSpec extends ObjectBehavior
         $data = ['unit' => 'KILOGRAM'];
 
         $this->shouldThrow(
-            InvalidArgumentException::arrayKeyExpected(
+            InvalidPropertyTypeException::arrayKeyExpected(
                 'attributeCode',
                 'amount',
                 'Pim\Component\Catalog\Updater\Setter\MetricAttributeSetter',
-                print_r($data, true)
+                $data
             )
         )->during('setAttributeData', [$product, $attribute, $data, ['locale' => 'fr_FR', 'scope' => 'mobile']]);
     }
@@ -108,11 +109,11 @@ class MetricAttributeSetterSpec extends ObjectBehavior
         $data = ['amount' => 'data value'];
 
         $this->shouldThrow(
-            InvalidArgumentException::arrayKeyExpected(
+            InvalidPropertyTypeException::arrayKeyExpected(
                 'attributeCode',
                 'unit',
                 'Pim\Component\Catalog\Updater\Setter\MetricAttributeSetter',
-                print_r($data, true)
+                $data
             )
         )->during('setAttributeData', [$product, $attribute, $data, ['locale' => 'fr_FR', 'scope' => 'mobile']]);
     }

--- a/src/Pim/Component/Catalog/spec/Updater/Setter/MultiSelectAttributeSetterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Setter/MultiSelectAttributeSetterSpec.php
@@ -2,6 +2,8 @@
 
 namespace spec\Pim\Component\Catalog\Updater\Setter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Builder\ProductBuilderInterface;
@@ -78,12 +80,12 @@ class MultiSelectAttributeSetterSpec extends ObjectBehavior
         $data = ['foo' => ['bar' => 'baz']];
 
         $this->shouldThrow(
-            InvalidArgumentException::arrayStringValueExpected(
-                'attributeCode',
-                'foo',
-                'Pim\Component\Catalog\Updater\Setter\MultiSelectAttributeSetter',
-                'array'
-            )
+           InvalidPropertyTypeException::validArrayStructureExpected(
+               'attributeCode',
+               'one of the options is not a string, "array" given',
+               'Pim\Component\Catalog\Updater\Setter\MultiSelectAttributeSetter',
+               $data
+           )
         )->during('setAttributeData', [$product, $attribute, $data, ['locale' => 'fr_FR', 'scope' => 'mobile']]);
     }
 
@@ -102,7 +104,7 @@ class MultiSelectAttributeSetterSpec extends ObjectBehavior
             ->willReturn(null);
 
         $this->shouldThrow(
-            InvalidArgumentException::arrayInvalidKey(
+            InvalidPropertyException::validEntityCodeExpected(
                 'attributeCode',
                 'code',
                 'The option does not exist',

--- a/src/Pim/Component/Catalog/spec/Updater/Setter/PriceCollectionAttributeSetterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Setter/PriceCollectionAttributeSetterSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Pim\Component\Catalog\Updater\Setter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Builder\ProductBuilderInterface;
 use Pim\Component\Catalog\Exception\InvalidArgumentException;
@@ -70,10 +71,10 @@ class PriceCollectionAttributeSetterSpec extends ObjectBehavior
         $data = 'not an array';
 
         $this->shouldThrow(
-            InvalidArgumentException::arrayExpected(
+            InvalidPropertyTypeException::arrayExpected(
                 'attributeCode',
                 'Pim\Component\Catalog\Updater\Setter\PriceCollectionAttributeSetter',
-                gettype($data)
+                $data
             )
         )->during('setAttributeData', [$product, $attribute, $data, ['locale' => 'fr_FR', 'scope' => 'mobile']]);
     }
@@ -87,10 +88,10 @@ class PriceCollectionAttributeSetterSpec extends ObjectBehavior
         $data = ['not an array'];
 
         $this->shouldThrow(
-            InvalidArgumentException::arrayOfArraysExpected(
+            InvalidPropertyTypeException::arrayOfArraysExpected(
                 'attributeCode',
                 'Pim\Component\Catalog\Updater\Setter\PriceCollectionAttributeSetter',
-                gettype($data)
+                $data
             )
         )->during('setAttributeData', [$product, $attribute, $data, ['locale' => 'fr_FR', 'scope' => 'mobile']]);
     }
@@ -104,11 +105,11 @@ class PriceCollectionAttributeSetterSpec extends ObjectBehavior
         $data = [['not the data key' => 123]];
 
         $this->shouldThrow(
-            InvalidArgumentException::arrayKeyExpected(
+            InvalidPropertyTypeException::arrayKeyExpected(
                 'attributeCode',
                 'amount',
                 'Pim\Component\Catalog\Updater\Setter\PriceCollectionAttributeSetter',
-                print_r($data, true)
+                $data
             )
         )->during('setAttributeData', [$product, $attribute, $data, ['locale' => 'fr_FR', 'scope' => 'mobile']]);
     }
@@ -122,11 +123,11 @@ class PriceCollectionAttributeSetterSpec extends ObjectBehavior
         $data = [['amount' => 123, 'not the currency key' => 'euro']];
 
         $this->shouldThrow(
-            InvalidArgumentException::arrayKeyExpected(
+            InvalidPropertyTypeException::arrayKeyExpected(
                 'attributeCode',
                 'currency',
                 'Pim\Component\Catalog\Updater\Setter\PriceCollectionAttributeSetter',
-                print_r($data, true)
+                $data
             )
         )->during('setAttributeData', [$product, $attribute, $data, ['locale' => 'fr_FR', 'scope' => 'mobile']]);
     }

--- a/src/Pim/Component/Catalog/spec/Updater/Setter/SimpleSelectAttributeSetterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Setter/SimpleSelectAttributeSetterSpec.php
@@ -2,6 +2,8 @@
 
 namespace spec\Pim\Component\Catalog\Updater\Setter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Builder\ProductBuilderInterface;
@@ -79,10 +81,10 @@ class SimpleSelectAttributeSetterSpec extends ObjectBehavior
 
         $this
             ->shouldThrow(
-                InvalidArgumentException::stringExpected(
+                InvalidPropertyTypeException::stringExpected(
                     'attributeCode',
                     'Pim\Component\Catalog\Updater\Setter\SimpleSelectAttributeSetter',
-                    gettype($data)
+                    $data
                 )
             )
             ->duringSetAttributeData($product, $attribute, $data, ['locale' => 'fr_FR', 'scope' => 'mobile']);
@@ -102,10 +104,10 @@ class SimpleSelectAttributeSetterSpec extends ObjectBehavior
 
         $this
             ->shouldNotThrow(
-                InvalidArgumentException::stringExpected(
+                InvalidPropertyTypeException::stringExpected(
                     'attributeCode',
                     'Pim\Component\Catalog\Updater\Setter\SimpleSelectAttributeSetter',
-                    gettype($data)
+                    $data
                 )
             )
             ->duringSetAttributeData($product, $attribute, $data, ['locale' => 'fr_FR', 'scope' => 'mobile']);
@@ -121,12 +123,12 @@ class SimpleSelectAttributeSetterSpec extends ObjectBehavior
 
         $this
             ->shouldThrow(
-                InvalidArgumentException::validEntityCodeExpected(
+                InvalidPropertyException::validEntityCodeExpected(
                     'attributeCode',
                     'code',
                     'The option does not exist',
                     'Pim\Component\Catalog\Updater\Setter\SimpleSelectAttributeSetter',
-                    $data
+                    'unknown code'
                 )
             )
             ->duringSetAttributeData($product, $attribute, $data, ['locale' => 'fr_FR', 'scope' => 'mobile']);

--- a/src/Pim/Component/Catalog/spec/Updater/Setter/TextAttributeSetterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Setter/TextAttributeSetterSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Pim\Component\Catalog\Updater\Setter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Builder\ProductBuilderInterface;
 use Pim\Component\Catalog\Exception\InvalidArgumentException;
@@ -117,7 +118,11 @@ class TextAttributeSetterSpec extends ObjectBehavior
         $attribute->isLocalizable()->willReturn(true);
         $attrValidatorHelper->validateLocale($attribute, null)->willThrow($e);
         $this->shouldThrow(
-            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'Pim\Component\Catalog\Updater\Setter\TextAttributeSetter')
+           InvalidPropertyException::expectedFromPreviousException(
+               'attributeCode',
+               'Pim\Component\Catalog\Updater\Setter\TextAttributeSetter',
+               $e
+           )
         )->during('setAttributeData', [$product, $attribute, '', ['locale' => null, 'scope' => 'ecommerce']]);
     }
 
@@ -131,7 +136,11 @@ class TextAttributeSetterSpec extends ObjectBehavior
         $attribute->isLocalizable()->willReturn(false);
         $attrValidatorHelper->validateLocale($attribute, 'en_US')->willThrow($e);
         $this->shouldThrow(
-            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'Pim\Component\Catalog\Updater\Setter\TextAttributeSetter')
+            InvalidPropertyException::expectedFromPreviousException(
+                'attributeCode',
+                'Pim\Component\Catalog\Updater\Setter\TextAttributeSetter',
+                $e
+            )
         )->during('setAttributeData', [$product, $attribute, '', ['locale' => 'en_US', 'scope' => 'ecommerce']]);
     }
 
@@ -145,7 +154,11 @@ class TextAttributeSetterSpec extends ObjectBehavior
         $attribute->isLocalizable()->willReturn(true);
         $attrValidatorHelper->validateLocale($attribute, 'uz-UZ')->willThrow($e);
         $this->shouldThrow(
-            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'Pim\Component\Catalog\Updater\Setter\TextAttributeSetter')
+            InvalidPropertyException::expectedFromPreviousException(
+                'attributeCode',
+                'Pim\Component\Catalog\Updater\Setter\TextAttributeSetter',
+                $e
+            )
         )->during('setAttributeData', [$product, $attribute, '', ['locale' => 'uz-UZ', 'scope' => 'ecommerce']]);
     }
 
@@ -161,7 +174,11 @@ class TextAttributeSetterSpec extends ObjectBehavior
         $attrValidatorHelper->validateLocale($attribute, null)->shouldBeCalled();
         $attrValidatorHelper->validateScope($attribute, null)->willThrow($e);
         $this->shouldThrow(
-            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'Pim\Component\Catalog\Updater\Setter\TextAttributeSetter')
+            InvalidPropertyException::expectedFromPreviousException(
+                'attributeCode',
+                'Pim\Component\Catalog\Updater\Setter\TextAttributeSetter',
+                $e
+            )
         )->during('setAttributeData', [$product, $attribute, '', ['locale' => null, 'scope' => null]]);
     }
 
@@ -177,7 +194,11 @@ class TextAttributeSetterSpec extends ObjectBehavior
         $attrValidatorHelper->validateLocale($attribute, null)->shouldBeCalled();
         $attrValidatorHelper->validateScope($attribute, 'ecommerce')->willThrow($e);
         $this->shouldThrow(
-            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'Pim\Component\Catalog\Updater\Setter\TextAttributeSetter')
+            InvalidPropertyException::expectedFromPreviousException(
+                'attributeCode',
+                'Pim\Component\Catalog\Updater\Setter\TextAttributeSetter',
+                $e
+            )
         )->during('setAttributeData', [$product, $attribute, '', ['locale' => null, 'scope' => 'ecommerce']]);
     }
 
@@ -193,7 +214,11 @@ class TextAttributeSetterSpec extends ObjectBehavior
         $attrValidatorHelper->validateLocale($attribute, null)->shouldBeCalled();
         $attrValidatorHelper->validateScope($attribute, 'ecommerce')->willThrow($e);
         $this->shouldThrow(
-            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'Pim\Component\Catalog\Updater\Setter\TextAttributeSetter')
+            InvalidPropertyException::expectedFromPreviousException(
+                'attributeCode',
+                'Pim\Component\Catalog\Updater\Setter\TextAttributeSetter',
+                $e
+            )
         )->during('setAttributeData', [$product, $attribute, '', ['locale' => null, 'scope' => 'ecommerce']]);
     }
 }

--- a/src/Pim/Component/Catalog/spec/Updater/Setter/VariantGroupFieldSetterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Setter/VariantGroupFieldSetterSpec.php
@@ -2,6 +2,9 @@
 
 namespace spec\Pim\Component\Catalog\Updater\Setter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\GroupInterface;
@@ -35,10 +38,10 @@ class VariantGroupFieldSetterSpec extends ObjectBehavior
     function it_checks_valid_data_format(ProductInterface $product)
     {
         $this->shouldThrow(
-            InvalidArgumentException::stringExpected(
+            InvalidPropertyTypeException::stringExpected(
                 'variant_group',
                 'Pim\Component\Catalog\Updater\Setter\VariantGroupFieldSetter',
-                'array'
+                ['not a string']
             )
         )->during('setFieldData', [$product, 'variant_group', ['not a string']]);
     }
@@ -81,9 +84,9 @@ class VariantGroupFieldSetterSpec extends ObjectBehavior
         $nonVariantType->isVariant()->willReturn(false);
 
         $this->shouldThrow(
-            InvalidArgumentException::expected(
+            InvalidPropertyException::validGroupExpected(
                 'variant_group',
-                'variant group code',
+                'Cannot process group, only variant groups are supported',
                 'Pim\Component\Catalog\Updater\Setter\VariantGroupFieldSetter',
                 'pack'
             )
@@ -101,9 +104,10 @@ class VariantGroupFieldSetterSpec extends ObjectBehavior
         $nonVariantType->isVariant()->willReturn(false);
 
         $this->shouldThrow(
-            InvalidArgumentException::expected(
+            InvalidPropertyException::validEntityCodeExpected(
                 'variant_group',
-                'existing variant group code',
+                'variant group code',
+                'The variant group does not exist',
                 'Pim\Component\Catalog\Updater\Setter\VariantGroupFieldSetter',
                 'not valid code'
             )

--- a/src/Pim/Component/Catalog/spec/Updater/VariantGroupUpdaterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/VariantGroupUpdaterSpec.php
@@ -61,6 +61,9 @@ class VariantGroupUpdaterSpec extends ObjectBehavior
                 'stdClass',
                 'Pim\Component\Catalog\Model\GroupInterface'
             )
+        )->during(
+            'update',
+            [new \stdClass(), []]
         );
     }
 

--- a/src/Pim/Component/Connector/Processor/Denormalization/JobInstanceProcessor.php
+++ b/src/Pim/Component/Connector/Processor/Denormalization/JobInstanceProcessor.php
@@ -88,8 +88,6 @@ class JobInstanceProcessor extends AbstractProcessor implements ItemProcessorInt
             $this->updater->update($entity, $item);
         } catch (ObjectUpdaterException $exception) {
             $this->skipItemWithMessage($item, $exception->getMessage(), $exception);
-        } catch (\InvalidArgumentException $exception) {
-            $this->skipItemWithMessage($item, $exception->getMessage(), $exception);
         }
 
         $violations = $this->validator->validate($entity);

--- a/src/Pim/Component/Connector/Processor/Denormalization/Processor.php
+++ b/src/Pim/Component/Connector/Processor/Denormalization/Processor.php
@@ -66,8 +66,6 @@ class Processor extends AbstractProcessor implements ItemProcessorInterface, Ste
             $this->updater->update($entity, $item);
         } catch (ObjectUpdaterException $exception) {
             $this->skipItemWithMessage($item, $exception->getMessage(), $exception);
-        } catch (\InvalidArgumentException $exception) {
-            $this->skipItemWithMessage($item, $exception->getMessage(), $exception);
         }
 
         $violations = $this->validate($entity);

--- a/src/Pim/Component/Connector/Processor/Denormalization/ProductAssociationProcessor.php
+++ b/src/Pim/Component/Connector/Processor/Denormalization/ProductAssociationProcessor.php
@@ -20,9 +20,7 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
  * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class ProductAssociationProcessor extends AbstractProcessor implements
-    ItemProcessorInterface,
-    StepExecutionAwareInterface
+class ProductAssociationProcessor extends AbstractProcessor implements ItemProcessorInterface, StepExecutionAwareInterface
 {
     /** @var IdentifiableObjectRepositoryInterface */
     protected $repository;
@@ -106,9 +104,6 @@ class ProductAssociationProcessor extends AbstractProcessor implements
         try {
             $this->updateProduct($product, $item);
         } catch (ObjectUpdaterException $exception) {
-            $this->detachProduct($product);
-            $this->skipItemWithMessage($item, $exception->getMessage(), $exception);
-        } catch (\InvalidArgumentException $exception) {
             $this->detachProduct($product);
             $this->skipItemWithMessage($item, $exception->getMessage(), $exception);
         }

--- a/src/Pim/Component/Connector/Processor/Denormalization/ProductProcessor.php
+++ b/src/Pim/Component/Connector/Processor/Denormalization/ProductProcessor.php
@@ -111,9 +111,6 @@ class ProductProcessor extends AbstractProcessor implements ItemProcessorInterfa
         } catch (ObjectUpdaterException $exception) {
             $this->detachProduct($product);
             $this->skipItemWithMessage($item, $exception->getMessage(), $exception);
-        } catch (\InvalidArgumentException $exception) {
-            $this->detachProduct($product);
-            $this->skipItemWithMessage($item, $exception->getMessage(), $exception);
         }
 
         $violations = $this->validateProduct($product);

--- a/src/Pim/Component/Connector/spec/Processor/Denormalization/ProcessorSpec.php
+++ b/src/Pim/Component/Connector/spec/Processor/Denormalization/ProcessorSpec.php
@@ -4,6 +4,7 @@ namespace spec\Pim\Component\Connector\Processor\Denormalization;
 
 use Akeneo\Component\Batch\Model\StepExecution;
 use Akeneo\Component\StorageUtils\Detacher\ObjectDetacherInterface;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Factory\SimpleFactory;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
@@ -93,7 +94,7 @@ class ProcessorSpec extends ObjectBehavior
 
         $updater
             ->update($channel, $values)
-            ->willThrow(new \InvalidArgumentException());
+            ->willThrow(new InvalidPropertyException('code', 'value', 'className', 'The code could not be blank.'));
 
         $this
             ->shouldThrow('Akeneo\Component\Batch\Item\InvalidItemException')

--- a/src/Pim/Component/Connector/spec/Processor/Denormalization/ProductAssociationProcessorSpec.php
+++ b/src/Pim/Component/Connector/spec/Processor/Denormalization/ProductAssociationProcessorSpec.php
@@ -7,6 +7,7 @@ use Akeneo\Component\Batch\Model\JobExecution;
 use Akeneo\Component\Batch\Model\JobInstance;
 use Akeneo\Component\Batch\Model\StepExecution;
 use Akeneo\Component\StorageUtils\Detacher\ObjectDetacherInterface;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use PhpSpec\ObjectBehavior;
@@ -163,7 +164,7 @@ class ProductAssociationProcessorSpec extends ObjectBehavior
 
         $productUpdater
             ->update($product, $filteredData)
-            ->willThrow(new \InvalidArgumentException('association does not exists'));
+            ->willThrow(new InvalidPropertyException('associations', 'value', 'className', 'association does not exists'));
 
         $stepExecution->incrementSummaryInfo('skip')->shouldBeCalled();
         $this->setStepExecution($stepExecution);

--- a/src/Pim/Component/Connector/spec/Processor/Denormalization/ProductProcessorSpec.php
+++ b/src/Pim/Component/Connector/spec/Processor/Denormalization/ProductProcessorSpec.php
@@ -5,6 +5,7 @@ namespace spec\Pim\Component\Connector\Processor\Denormalization;
 use Akeneo\Component\Batch\Job\JobParameters;
 use Akeneo\Component\Batch\Model\StepExecution;
 use Akeneo\Component\StorageUtils\Detacher\ObjectDetacherInterface;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use PhpSpec\ObjectBehavior;
@@ -559,7 +560,7 @@ class ProductProcessorSpec extends ObjectBehavior
 
         $productUpdater
             ->update($product, $filteredData)
-            ->willThrow(new \InvalidArgumentException('family does not exists'));
+            ->willThrow(new InvalidPropertyException('family', 'value', 'className', 'family does not exists'));
 
         $productDetacher->detach($product)->shouldBeCalled();
         $stepExecution->incrementSummaryInfo('skip')->shouldBeCalled();

--- a/src/Pim/Component/Connector/spec/Processor/Denormalization/VariantGroupProcessorSpec.php
+++ b/src/Pim/Component/Connector/spec/Processor/Denormalization/VariantGroupProcessorSpec.php
@@ -4,6 +4,7 @@ namespace spec\Pim\Component\Connector\Processor\Denormalization;
 
 use Akeneo\Component\Batch\Model\StepExecution;
 use Akeneo\Component\StorageUtils\Detacher\ObjectDetacherInterface;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Doctrine\Common\Collections\ArrayCollection;
@@ -107,7 +108,7 @@ class VariantGroupProcessorSpec extends ObjectBehavior
 
         $variantUpdater
             ->update($variantGroup, $values)
-            ->willThrow(new \InvalidArgumentException('Attributes: This property cannot be changed.'));
+            ->willThrow(new InvalidPropertyException('attributes', 'value', 'className', 'This property cannot be changed.'));
 
         $this
             ->shouldThrow('Akeneo\Component\Batch\Item\InvalidItemException')
@@ -149,10 +150,6 @@ class VariantGroupProcessorSpec extends ObjectBehavior
         $this
             ->process($values)
             ->shouldReturn($variantGroup);
-
-        $variantUpdater
-            ->update($variantGroup, $values)
-            ->willThrow(new \InvalidArgumentException('Attributes: This property cannot be changed.'));
 
         $violation = new ConstraintViolation('Error', 'foo', [], 'bar', 'code', 'mycode');
         $violations = new ConstraintViolationList([$violation]);

--- a/src/Pim/Component/ReferenceData/Updater/Setter/ReferenceDataCollectionSetter.php
+++ b/src/Pim/Component/ReferenceData/Updater/Setter/ReferenceDataCollectionSetter.php
@@ -2,9 +2,10 @@
 
 namespace Pim\Component\ReferenceData\Updater\Setter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Doctrine\Common\Util\ClassUtils;
 use Pim\Component\Catalog\Builder\ProductBuilderInterface;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Updater\Setter\AbstractAttributeSetter;
@@ -59,14 +60,10 @@ class ReferenceDataCollectionSetter extends AbstractAttributeSetter
             $referenceData = $repository->findOneBy(['code' => $referenceDataCode]);
 
             if (null === $referenceData) {
-                throw InvalidArgumentException::arrayInvalidKey(
+                throw InvalidPropertyException::validEntityCodeExpected(
                     $attribute->getCode(),
-                    'code',
-                    sprintf(
-                        'No reference data "%s" with code "%s" has been found',
-                        $attribute->getReferenceDataName(),
-                        $referenceDataCode
-                    ),
+                    'reference data code',
+                    sprintf('The code of the reference data "%s" does not exist', $attribute->getReferenceDataName()),
                     static::class,
                     $referenceDataCode
                 );
@@ -93,20 +90,20 @@ class ReferenceDataCollectionSetter extends AbstractAttributeSetter
     protected function checkData(AttributeInterface $attribute, $data)
     {
         if (!is_array($data)) {
-            throw InvalidArgumentException::arrayExpected(
+            throw InvalidPropertyTypeException::arrayExpected(
                 $attribute->getCode(),
                 static::class,
-                gettype($data)
+                $data
             );
         }
 
         foreach ($data as $key => $value) {
             if (!is_string($value)) {
-                throw InvalidArgumentException::arrayStringKeyExpected(
+                throw InvalidPropertyTypeException::arrayStringKeyExpected(
                     $attribute->getCode(),
                     $key,
                     static::class,
-                    gettype($value)
+                    $data
                 );
             }
         }

--- a/src/Pim/Component/ReferenceData/Updater/Setter/ReferenceDataSetter.php
+++ b/src/Pim/Component/ReferenceData/Updater/Setter/ReferenceDataSetter.php
@@ -2,6 +2,8 @@
 
 namespace Pim\Component\ReferenceData\Updater\Setter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Pim\Component\Catalog\Builder\ProductBuilderInterface;
 use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
@@ -59,14 +61,10 @@ class ReferenceDataSetter extends AbstractAttributeSetter
             $referenceData = $repository->findOneBy(['code' => $data]);
 
             if (null === $referenceData) {
-                throw InvalidArgumentException::validEntityCodeExpected(
+                throw InvalidPropertyException::validEntityCodeExpected(
                     $attribute->getCode(),
-                    'code',
-                    sprintf(
-                        'No reference data "%s" with code "%s" has been found',
-                        $attribute->getReferenceDataName(),
-                        $data
-                    ),
+                    'reference data code',
+                    sprintf('The code of the reference data "%s" does not exist', $attribute->getReferenceDataName()),
                     static::class,
                     $data
                 );
@@ -81,6 +79,8 @@ class ReferenceDataSetter extends AbstractAttributeSetter
      *
      * @param AttributeInterface $attribute
      * @param mixed              $data
+     *
+     * @throws InvalidPropertyTypeException
      */
     protected function checkData(AttributeInterface $attribute, $data)
     {
@@ -89,10 +89,10 @@ class ReferenceDataSetter extends AbstractAttributeSetter
         }
 
         if (!is_string($data)) {
-            throw InvalidArgumentException::stringExpected(
+            throw InvalidPropertyTypeException::stringExpected(
                 $attribute->getCode(),
                 static::class,
-                gettype($data)
+                $data
             );
         }
     }

--- a/src/Pim/Component/ReferenceData/spec/Updater/Setter/ReferenceDataCollectionSetterSpec.php
+++ b/src/Pim/Component/ReferenceData/spec/Updater/Setter/ReferenceDataCollectionSetterSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Pim\Component\ReferenceData\Updater\Setter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Persistence\ObjectRepository;
 use PhpSpec\ObjectBehavior;
@@ -95,7 +96,15 @@ class ReferenceDataCollectionSetterSpec extends ObjectBehavior
         ProductInterface $product,
         AttributeInterface $attribute
     ) {
-        $this->shouldThrow('InvalidArgumentException')->during('setAttributeData', [
+        $attribute->getCode()->willReturn('attribute_code');
+
+        $this->shouldThrow(
+            InvalidPropertyTypeException::arrayExpected(
+                'attribute_code',
+                'Pim\Component\ReferenceData\Updater\Setter\ReferenceDataCollectionSetter',
+                'shiny_metal'
+            )
+        )->during('setAttributeData', [
             $product, $attribute, 'shiny_metal', ['locale' => 'fr_FR', 'scope' => 'mobile']
         ]);
     }

--- a/src/Pim/Component/ReferenceData/spec/Updater/Setter/ReferenceDataSetterSpec.php
+++ b/src/Pim/Component/ReferenceData/spec/Updater/Setter/ReferenceDataSetterSpec.php
@@ -2,6 +2,8 @@
 
 namespace spec\Pim\Component\ReferenceData\Updater\Setter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Doctrine\Common\Persistence\ObjectRepository;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Builder\ProductBuilderInterface;
@@ -81,7 +83,15 @@ class ReferenceDataSetterSpec extends ObjectBehavior
         ProductInterface $product,
         AttributeInterface $attribute
     ) {
-        $this->shouldThrow('InvalidArgumentException')->during('setAttributeData', [
+        $attribute->getCode()->willReturn('attribute_code');
+
+        $this->shouldThrow(
+            InvalidPropertyTypeException::stringExpected(
+                'attribute_code',
+                'Pim\Component\ReferenceData\Updater\Setter\ReferenceDataSetter',
+                ['shiny_metal']
+            )
+        )->during('setAttributeData', [
             $product, $attribute, ['shiny_metal'], ['locale' => 'fr_FR', 'scope' => 'mobile']
         ]);
     }
@@ -101,10 +111,10 @@ class ReferenceDataSetterSpec extends ObjectBehavior
         $repositoryResolver->resolve('customMaterials')->willReturn($repository);
         $repository->findOneBy(['code' => 'hulk_retriever'])->willReturn(null);
 
-        $exception = InvalidArgumentException::validEntityCodeExpected(
+        $exception = InvalidPropertyException::validEntityCodeExpected(
             'lace_fabric',
-            'code',
-            'No reference data "customMaterials" with code "hulk_retriever" has been found',
+            'reference data code',
+            'The code of the reference data "customMaterials" does not exist',
             'Pim\Component\ReferenceData\Updater\Setter\ReferenceDataSetter',
             'hulk_retriever'
         );


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

In the API, we need the property name of the exception to be able to create specific API exceptions.

In order to do that, a reworking of the exception has been done for the updaters to throw business exception.
This is the same PR  for the adders, setters, removers, an copiers.



[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added Behats                      | OK
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
