### PR TITLE
[PIM-6127] In the family import, the attributes required should be in the family

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -6,6 +6,7 @@
 - GITHUB-5062: Fixed unit conversion for ElectricCharge, cheers @gplanchat!
 - GITHUB-5294: Fixed infinite loading if no attribute is configured as a product identifier, cheers @gplanchat!
 - GITHUB-5337: Fixed Widget Registry. Priority is now taken in account.
+- PIM-6127: In the family import, the attributes required should be in the family
 
 ## Deprecations
 

--- a/features/Context/WebUser.php
+++ b/features/Context/WebUser.php
@@ -1686,10 +1686,13 @@ class WebUser extends RawMinkContext
      * @param string $code
      *
      * @When /^I wait for the "([^"]*)" job to finish$/
+     *
+     * @throws \Exception
      */
     public function iWaitForTheJobToFinish($code)
     {
-        $condition = '$("#status").length && /(Completed|Stopped|Failed|TERMINÉ|ARRÊTÉ|EN ÉCHEC)$/.test($("#status").text().trim())';
+        $condition = '$("#status").length && '.
+            '/(completed|stopped|failed|terminé|arrêté|en échec)$/.test($("#status").text().trim().toLowerCase())';
 
         try {
             $this->wait($condition);

--- a/features/enrich/variant-group/add_attributes_to_a_variant_group.feature
+++ b/features/enrich/variant-group/add_attributes_to_a_variant_group.feature
@@ -94,8 +94,8 @@ Feature: Add attributes to a variant group
     And the following "high_heel_main_color" attribute options: Red, Blue
     And the following "high_heel_main_fabric" attribute options: Leather, Silk
     And the following family:
-      | code       | requirements-mobile                              | requirements-tablet |
-      | high_heels | sku, high_heel_main_color, high_heel_main_fabric | sku                 |
+      | code       | requirements-mobile                              | requirements-tablet | attributes                                       |
+      | high_heels | sku, high_heel_main_color, high_heel_main_fabric | sku                 | sku, high_heel_main_color, high_heel_main_fabric |
     And the following product groups:
       | code       | label      | axis                                        | type    |
       | high_heels | High heels | high_heel_main_color, high_heel_main_fabric | VARIANT |

--- a/features/export/product-export-builder/export_products_by_boolean.feature
+++ b/features/export/product-export-builder/export_products_by_boolean.feature
@@ -7,8 +7,8 @@ Feature: Export products according to boolean attribute filter
   Background:
     Given a "footwear" catalog configuration
     And the following family:
-      | code    | requirements-mobile |
-      | rangers | sku, name           |
+      | code    | requirements-mobile | attributes |
+      | rangers | sku, name           | sku, name  |
     And the following products:
       | sku      | enabled | family  | categories        | handmade |
       | SNKRS-1B | 1       | rangers | summer_collection | 0        |
@@ -17,15 +17,15 @@ Feature: Export products according to boolean attribute filter
 
   Scenario: Export products by boolean values without using the UI
     Given the following job "csv_footwear_product_export" configuration:
-      | filePath | %tmp%/product_export/product_export.csv                                                                              |
+      | filePath | %tmp%/product_export/product_export.csv                                                                             |
       | filters  | {"structure":{"locales":["en_US"],"scope":"mobile"},"data":[{"field": "handmade", "operator": "=", "value": true}]} |
     When I am on the "csv_footwear_product_export" export job page
     And I launch the export job
     And I wait for the "csv_footwear_product_export" job to finish
     Then exported file of "csv_footwear_product_export" should contain:
     """
-    sku;categories;enabled;family;groups;handmade
-    SNKRS-1R;summer_collection;1;rangers;;1
+    sku;categories;enabled;family;groups;handmade;name-en_US
+    SNKRS-1R;summer_collection;1;rangers;;1;
     """
 
   Scenario: Export products by boolean values using the UI
@@ -43,6 +43,6 @@ Feature: Export products according to boolean attribute filter
     And I wait for the "csv_footwear_product_export" job to finish
     Then exported file of "csv_footwear_product_export" should contain:
     """
-    sku;categories;enabled;family;groups;handmade
-    SNKRS-1B;summer_collection;1;rangers;;0
+    sku;categories;enabled;family;groups;handmade;name-en_US
+    SNKRS-1B;summer_collection;1;rangers;;0;
     """

--- a/features/export/product-export-builder/export_products_by_completeness.feature
+++ b/features/export/product-export-builder/export_products_by_completeness.feature
@@ -10,8 +10,8 @@ Feature: Export products according to a completeness policy
       | code | type     | localizable | label |
       | name | textarea | yes         | Name  |
     And the following family:
-      | code      | requirements-ecommerce |
-      | localized | sku, name              |
+      | code      | requirements-ecommerce | attributes |
+      | localized | sku, name              | sku, name  |
     And the following products:
       | sku        | categories | family    | name-fr_FR | name-en_US |
       | french     | default    | localized | French     |            |
@@ -63,8 +63,8 @@ Feature: Export products according to a completeness policy
     And I wait for the "csv_product_export" job to finish
     Then exported file of "csv_product_export" should contain:
       """
-      sku;categories;enabled;family;groups
-      empty;default;1;localized;
+      sku;categories;enabled;family;groups;name-en_US;name-fr_FR
+      empty;default;1;localized;;;
       """
 
   @ce

--- a/features/export/product-export-builder/export_products_by_families.feature
+++ b/features/export/product-export-builder/export_products_by_families.feature
@@ -7,10 +7,10 @@ Feature: Export products according to their families
   Background:
     Given an "footwear" catalog configuration
     And the following family:
-      | code       | requirements-mobile |
-      | rangers    | sku, name           |
-      | boots      | sku, name           |
-      | heels      | sku, name           |
+      | code       | requirements-mobile | attributes |
+      | rangers    | sku, name           | sku, name  |
+      | boots      | sku, name           |            |
+      | heels      | sku, name           |            |
     And the following products:
       | sku     | family  | categories        | name-en_US       |
       | SNKRS-1 | rangers | summer_collection | Black rangers    |

--- a/features/export/product-export-builder/export_products_by_identifier.feature
+++ b/features/export/product-export-builder/export_products_by_identifier.feature
@@ -7,8 +7,8 @@ Feature: Export products according to their skus
   Background:
     Given an "footwear" catalog configuration
     And the following family:
-      | code    | requirements-mobile |
-      | rangers | sku, name           |
+      | code    | requirements-mobile | attributes |
+      | rangers | sku, name           | sku, name  |
     And the following products:
       | sku      | enabled | family  | categories        | name-en_US    |
       | SNKRS-1B | 1       | rangers | summer_collection | Black rangers |

--- a/features/export/product-export-builder/export_products_by_locales.feature
+++ b/features/export/product-export-builder/export_products_by_locales.feature
@@ -11,8 +11,8 @@ Feature: Export products according to a locale policy
       | name     | textarea | yes         | Name     | fr_FR,en_US       |
       | baguette | text     | yes         | Baguette | fr_FR             |
     And the following family:
-      | code      | requirements-ecommerce |
-      | localized | sku, name              |
+      | code      | requirements-ecommerce | attributes |
+      | localized | sku, name              | sku, name  |
     And the following products:
       | sku        | categories | family    | name-fr_FR | name-en_US | baguette-fr_FR |
       | french     | default    | localized | French     |            | Yes            |

--- a/features/export/product-export-builder/export_products_by_status.feature
+++ b/features/export/product-export-builder/export_products_by_status.feature
@@ -7,8 +7,8 @@ Feature: Export products according to their statuses
   Background:
     Given an "footwear" catalog configuration
     And the following family:
-      | code    | requirements-mobile |
-      | rangers | sku, name           |
+      | code    | requirements-mobile | attributes |
+      | rangers | sku, name           | sku, name  |
     And the following products:
       | sku      | enabled | family  | categories        | name-en_US    |
       | SNKRS-1B | 1       | rangers | summer_collection | Black rangers |

--- a/features/export/product-export-builder/export_products_by_textarea.feature
+++ b/features/export/product-export-builder/export_products_by_textarea.feature
@@ -7,8 +7,8 @@ Feature: Export products according to textarea attribute filter
   Background:
     Given a "footwear" catalog configuration
     And the following family:
-      | code    | requirements-mobile |
-      | rangers | sku, name           |
+      | code    | requirements-mobile | attributes |
+      | rangers | sku, name           | sku, name  |
     And the following products:
       | sku      | enabled | family  | categories        | description-en_US-mobile |
       | SNKRS-1B | 1       | rangers | summer_collection | Awesome                  |
@@ -65,8 +65,8 @@ Feature: Export products according to textarea attribute filter
     And I wait for the "csv_footwear_product_export" job to finish
     Then exported file of "csv_footwear_product_export" should contain:
     """
-    sku;categories;enabled;family;groups;description-en_US-mobile
-    SNKRS-1R;summer_collection;1;rangers;;Awesome description
+    sku;categories;enabled;family;groups;description-en_US-mobile;name-en_US
+    SNKRS-1R;summer_collection;1;rangers;;Awesome description;
     """
 
   Scenario: Export products by textarea values using the UI
@@ -84,9 +84,9 @@ Feature: Export products according to textarea attribute filter
     And I wait for the "csv_footwear_product_export" job to finish
     Then exported file of "csv_footwear_product_export" should contain:
     """
-    sku;categories;enabled;family;groups;description-en_US-mobile
-    SNKRS-1B;summer_collection;1;rangers;;Awesome
-    SNKRS-1R;summer_collection;1;rangers;;Awesome description
+    sku;categories;enabled;family;groups;description-en_US-mobile;name-en_US
+    SNKRS-1B;summer_collection;1;rangers;;Awesome;
+    SNKRS-1R;summer_collection;1;rangers;;Awesome description;
     """
 
   Scenario: Export products by textarea values using the UI
@@ -104,9 +104,9 @@ Feature: Export products according to textarea attribute filter
     And I wait for the "csv_footwear_product_export" job to finish
     Then exported file of "csv_footwear_product_export" should contain:
     """
-    sku;categories;enabled;family;groups;description-en_US-mobile
-    SNKRS-1B;summer_collection;1;rangers;;Awesome
-    SNKRS-1R;summer_collection;1;rangers;;Awesome description
+    sku;categories;enabled;family;groups;description-en_US-mobile;name-en_US
+    SNKRS-1B;summer_collection;1;rangers;;Awesome;
+    SNKRS-1R;summer_collection;1;rangers;;Awesome description;
     """
 
   @skip

--- a/features/import/import_families.feature
+++ b/features/import/import_families.feature
@@ -78,3 +78,21 @@ Feature: Import families
     Then the row "pretty-shoe" should contain:
       | column | value   |
       | Family | [heels] |
+
+  @jira https://akeneo.atlassian.net/browse/PIM-6127
+  Scenario: Successfully raise an error when required attribute is not in the family
+    Given the "footwear" catalog configuration
+    And I am logged in as "Julia"
+    And the following CSV file to import:
+      """
+      code;label-en_US;attributes;attribute_as_label;requirements-tablet;requirements-mobile
+      boots;Boots;sku,name,manufacturer,description,weather_conditions,price,rating,side_view,top_view,size,color,lace_color;name;sku,name,description,weather_conditions,price,rating,side_view,size,color;sku,name,price,size,color
+      wrong_family;Wrong Family;sku,name;name;description;description
+      """
+    And the following job "csv_footwear_family_import" configuration:
+      | filePath | %file to import% |
+    When I am on the "csv_footwear_family_import" import job page
+    And I launch the import job
+    And I wait for the "csv_footwear_family_import" job to finish
+    Then I should see the text "Skipped 1"
+    And I should see the text "The attribute \"wrong_family\" cannot be an attribute required for the family as it does not belong to the family."

--- a/features/import/import_families.feature
+++ b/features/import/import_families.feature
@@ -95,4 +95,5 @@ Feature: Import families
     And I launch the import job
     And I wait for the "csv_footwear_family_import" job to finish
     Then I should see the text "Skipped 1"
-    And I should see the text "The attribute \"wrong_family\" cannot be an attribute required for the family as it does not belong to the family."
+    And I should see the text "The attribute \"description\" cannot be an attribute required for the channel \"tablet\" as it does not belong to this family: Wrong Family"
+    And I should see the text "The attribute \"description\" cannot be an attribute required for the channel \"mobile\" as it does not belong to this family: Wrong Family"

--- a/src/Pim/Component/Catalog/Validator/Constraints/FamilyRequirements.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/FamilyRequirements.php
@@ -18,7 +18,14 @@ class FamilyRequirements extends Constraint
      *
      * @var string
      */
-    public $message = 'Family "%family%" should have requirements for identifier "%id%" and channel(s) "%channels%"';
+    public $messageChannel = 'Family "%family%" should have requirements for identifier "%id%" and channel(s) '.
+        '"%channels%"';
+
+    /**
+     * @var string
+     */
+    public $messageAttribute = 'The attribute "%attribute%" cannot be an attribute required for the channel '.
+        '"%channel%" as it does not belong to this family';
 
     /**
      * {@inheritdoc}

--- a/src/Pim/Component/Catalog/Validator/Constraints/FamilyRequirementsValidator.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/FamilyRequirementsValidator.php
@@ -2,7 +2,6 @@
 
 namespace Pim\Component\Catalog\Validator\Constraints;
 
-use Pim\Component\Catalog\Model\AttributeRequirementInterface;
 use Pim\Component\Catalog\Model\FamilyInterface;
 use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
 use Pim\Component\Catalog\Repository\ChannelRepositoryInterface;
@@ -89,7 +88,7 @@ class FamilyRequirementsValidator extends ConstraintValidator
                 $this->context
                     ->buildViolation($constraint->messageAttribute, [
                         '%attribute%' => $attributeRequirement->getAttributeCode(),
-                        '%channel%' => $attributeRequirement->getChannelCode(),
+                        '%channel%'   => $attributeRequirement->getChannelCode(),
                     ])
                     ->addViolation();
             }

--- a/src/Pim/Component/Catalog/Validator/Constraints/FamilyRequirementsValidator.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/FamilyRequirementsValidator.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Component\Catalog\Validator\Constraints;
 
+use Pim\Component\Catalog\Model\AttributeRequirementInterface;
 use Pim\Component\Catalog\Model\FamilyInterface;
 use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
 use Pim\Component\Catalog\Repository\ChannelRepositoryInterface;
@@ -10,6 +11,10 @@ use Symfony\Component\Validator\ConstraintValidator;
 
 /**
  * Family requirements validator
+ *
+ * This validator will check that:
+ * - every requirement must have a list of requirement for every channel,
+ * - a required attribute must be an attribute of a family.
  *
  * @author    Nicolas Dupont <nicolas@akeneo.com>
  * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
@@ -41,18 +46,52 @@ class FamilyRequirementsValidator extends ConstraintValidator
     public function validate($family, Constraint $constraint)
     {
         if ($family instanceof FamilyInterface) {
-            $missingChannelCodes = $this->getMissingChannelCodes($family);
-            if (0 < count($missingChannelCodes)) {
-                $identifierCode = $this->attributeRepository->getIdentifierCode();
-                $this->context->buildViolation(
-                    $constraint->message,
-                    [
-                        '%family%'    => $family->getCode(),
-                        '%id%'        => $identifierCode,
-                        '%channels%'  => implode(', ', $missingChannelCodes)
+            $this->validateMissingChannels($family, $constraint);
+            $this->validateRequiredAttributes($family, $constraint);
+        }
+    }
 
-                    ]
-                )->addViolation();
+    /**
+     * Validates that there is no missing channel for the family.
+     *
+     * @param FamilyInterface $family
+     * @param Constraint      $constraint
+     */
+    protected function validateMissingChannels(FamilyInterface $family, Constraint $constraint)
+    {
+        $missingChannelCodes = $this->getMissingChannelCodes($family);
+        if (0 < count($missingChannelCodes)) {
+            $identifierCode = $this->attributeRepository->getIdentifierCode();
+            $this->context->buildViolation(
+                $constraint->messageChannel,
+                [
+                    '%family%'    => $family->getCode(),
+                    '%id%'        => $identifierCode,
+                    '%channels%'  => implode(', ', $missingChannelCodes)
+
+                ]
+            )->addViolation();
+        }
+    }
+
+    /**
+     * Validates that every required attribute is a family attribute.
+     *
+     * @param FamilyInterface $family
+     * @param Constraint      $constraint
+     */
+    protected function validateRequiredAttributes(FamilyInterface $family, Constraint $constraint)
+    {
+        $familyAttributeCodes = $family->getAttributeCodes();
+
+        foreach ($family->getAttributeRequirements() as $code => $attributeRequirement) {
+            if (!in_array($attributeRequirement->getAttributeCode(), $familyAttributeCodes)) {
+                $this->context
+                    ->buildViolation($constraint->messageAttribute, [
+                        '%attribute%' => $attributeRequirement->getAttributeCode(),
+                        '%channel%' => $attributeRequirement->getChannelCode(),
+                    ])
+                    ->addViolation();
             }
         }
     }

--- a/src/Pim/Component/Catalog/spec/Validator/Constraints/FamilyRequirementsValidatorSpec.php
+++ b/src/Pim/Component/Catalog/spec/Validator/Constraints/FamilyRequirementsValidatorSpec.php
@@ -39,6 +39,7 @@ class FamilyRequirementsValidatorSpec extends ObjectBehavior
         AttributeRequirementInterface $requirementMobile
     ) {
         $family->getAttributeRequirements()->willReturn([$requirementEcommerce, $requirementMobile]);
+        $family->getAttributeCodes()->willReturn(['sku','ecommerce']);
         $attributeRepository->getIdentifierCode()->willReturn('sku');
         $requirementEcommerce->getAttributeCode()->willReturn('sku');
         $requirementEcommerce->getChannelCode()->willReturn('ecommerce');
@@ -63,6 +64,7 @@ class FamilyRequirementsValidatorSpec extends ObjectBehavior
         ConstraintViolationBuilderInterface $violation
     ) {
         $family->getAttributeRequirements()->willReturn([$requirementEcommerce, $requirementMobile]);
+        $family->getAttributeCodes()->willReturn(['sku','ecommerce']);
         $attributeRepository->getIdentifierCode()->willReturn('sku');
         $requirementEcommerce->getAttributeCode()->willReturn('sku');
         $requirementEcommerce->getChannelCode()->willReturn('ecommerce');
@@ -72,6 +74,25 @@ class FamilyRequirementsValidatorSpec extends ObjectBehavior
         $channelRepository->getChannelCodes()->willReturn(['ecommerce', 'mobile', 'print']);
 
         $family->getCode()->willReturn('familyCode');
+        $context->buildViolation(Argument::any(), Argument::any())
+            ->willReturn($violation)
+            ->shouldBeCalled();
+
+        $this->validate($family, $minimumRequirements);
+    }
+
+    function it_does_not_validate_family_with_required_attribute_not_present(
+        $channelRepository,
+        $context,
+        $minimumRequirements,
+        FamilyInterface $family,
+        AttributeRequirementInterface $attributeRequirement,
+        ConstraintViolationBuilderInterface $violation
+    ) {
+        $family->getCode()->willReturn('familyCode');
+        $family->getAttributeRequirements()->willReturn([$attributeRequirement]);
+        $family->getAttributeCodes()->willReturn([]);
+        $channelRepository->getChannelCodes()->willReturn(['ecommerce']);
         $context->buildViolation(Argument::any(), Argument::any())
             ->willReturn($violation)
             ->shouldBeCalled();


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

Actually, you can import a family with a required attribute it is NOT in the attributes list of the family.
This PR fixes this wrong behavior and skip this item with a warning.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | y
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Migration script                  | -
| Tech Doc                          | -
