### PR TITLE
API-93: Check API overall access

### DIFF
--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -66,4 +66,4 @@ security:
 
     access_control:
         - { path: ^/admin/, role: ROLE_ADMIN }
-        - { path: ^/api/, role: IS_AUTHENTICATED_FULLY }
+        - { path: ^/api/, role: pim_api_overall_access }

--- a/src/Oro/Bundle/NavigationBundle/Resources/config/oro/routing.yml
+++ b/src/Oro/Bundle/NavigationBundle/Resources/config/oro/routing.yml
@@ -1,7 +1,7 @@
 oro_navigation_api_pinbar:
     resource:     "@OroNavigationBundle/Controller/Api/NavigationItemController.php"
     type:         rest
-    prefix:       api/rest/{version}/
+    prefix:       oroapi/rest/{version}/
     requirements:
         version:  latest|v1
     defaults:
@@ -10,7 +10,7 @@ oro_navigation_api_pinbar:
 oro_navigation_api_pagestate:
     resource:     "@OroNavigationBundle/Controller/Api/PagestateController.php"
     type:         rest
-    prefix:       api/rest/{version}/
+    prefix:       oroapi/rest/{version}/
     defaults:
         version:  latest
 

--- a/src/Oro/Bundle/SecurityBundle/Acl/Voter/AclVoter.php
+++ b/src/Oro/Bundle/SecurityBundle/Acl/Voter/AclVoter.php
@@ -5,6 +5,7 @@ namespace Oro\Bundle\SecurityBundle\Acl\Voter;
 use Oro\Bundle\SecurityBundle\Acl\Domain\PermissionGrantingStrategyContextInterface;
 use Oro\Bundle\SecurityBundle\Acl\Extension\AclExtensionInterface;
 use Oro\Bundle\SecurityBundle\Acl\Extension\AclExtensionSelector;
+use Symfony\Component\Security\Acl\Exception\InvalidDomainObjectException;
 use Symfony\Component\Security\Acl\Voter\AclVoter as BaseAclVoter;
 use Symfony\Component\Security\Acl\Voter\FieldVote;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
@@ -59,7 +60,12 @@ class AclVoter extends BaseAclVoter implements PermissionGrantingStrategyContext
         $this->object = $object instanceof FieldVote
             ? $object->getDomainObject()
             : $object;
-        $this->extension = $this->extensionSelector->select($object);
+
+        try {
+            $this->extension = $this->extensionSelector->select($object);
+        } catch (InvalidDomainObjectException $e) {
+            return self::ACCESS_ABSTAIN;
+        }
 
         // replace empty permissions with default ones
         for ($i = 0; $i < count($attributes); $i++) {

--- a/src/Pim/Bundle/ApiBundle/DependencyInjection/PimApiExtension.php
+++ b/src/Pim/Bundle/ApiBundle/DependencyInjection/PimApiExtension.php
@@ -28,6 +28,7 @@ class PimApiExtension extends Extension
         $loader->load('hateoas.yml');
         $loader->load('normalizers.yml');
         $loader->load('repositories.yml');
+        $loader->load('security.yml');
         $loader->load('serializers.yml');
     }
 }

--- a/src/Pim/Bundle/ApiBundle/Resources/config/security.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/security.yml
@@ -1,0 +1,11 @@
+parameters:
+    pim_api.security.voter.action_acl.class: Pim\Bundle\ApiBundle\Security\ActionAclVoter
+
+services:
+    pim_api.security.acl.voter.overall_access:
+        class: '%pim_api.security.voter.action_acl.class%'
+        arguments:
+            - '@security.acl.voter.basic_permissions'
+            - 'pim_api_overall_access'
+        tags:
+            - { name: security.voter, priority: 200 }

--- a/src/Pim/Bundle/ApiBundle/Security/ActionAclVoter.php
+++ b/src/Pim/Bundle/ApiBundle/Security/ActionAclVoter.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Pim\Bundle\ApiBundle\Security;
+
+use Symfony\Component\Security\Acl\Domain\ObjectIdentity;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+
+/**
+ * Wrapper for Oro's ACL voter.
+ * It can vote for any ACL of type "action", even if it doesn't match any existing annotation.
+ *
+ * Oro's SecurityBundle has its own ACL implementation on the top of Symfony's to handle Oro entities
+ * and "@AclAncestor" annotations. It's convenient, but it cannot work in a firewall security context
+ * since the object being voted is the Request (not an annotation or entity).
+ *
+ * We use this voter to build an ObjectIdentity instance and pass it to Oro's voter. It emulates the
+ * fact that an action is being voted instead of a Request instance.
+ *
+ * Of course it is not an ideal solution. Better solutions include:
+ * - Write an extension for the SecurityBundle, but it's hardly extensible without rewriting some parts.
+ * - Use a different system for this case (it means more maintenance).
+ * - Stop using ACLs and rewrite the whole security.
+ *
+ * @see Oro\Bundle\SecurityBundle\Acl\Extension\AclExtensionSelector::select
+ * @see Oro\Bundle\SecurityBundle\Acl\Voter\AclVoter::vote
+ *
+ * @author    Yohan Blain <yohan.blain@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class ActionAclVoter implements VoterInterface
+{
+    const OID_IDENTIFIER = 'action';
+
+    /** @var VoterInterface */
+    protected $baseAclVoter;
+
+    /** @var string */
+    protected $oidType;
+
+    /**
+     * @param VoterInterface $baseAclVoter
+     * @param string         $oidType
+     */
+    public function __construct(VoterInterface $baseAclVoter, $oidType)
+    {
+        $this->baseAclVoter = $baseAclVoter;
+        $this->oidType = $oidType;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsAttribute($attribute)
+    {
+        return $this->oidType === $attribute;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsClass($class)
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function vote(TokenInterface $token, $object, array $attributes)
+    {
+        foreach ($attributes as $attribute) {
+            if (!$this->supportsAttribute($attribute)) {
+                continue;
+            }
+
+            $oid = new ObjectIdentity(static::OID_IDENTIFIER, $attribute);
+
+            return $this->baseAclVoter->vote($token, $oid, ['EXECUTE']);
+        }
+
+        return self::ACCESS_ABSTAIN;
+    }
+}

--- a/src/Pim/Bundle/ApiBundle/tests/integration/ApiTestCase.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/ApiTestCase.php
@@ -34,9 +34,6 @@ abstract class ApiTestCase extends WebTestCase
     /** @var string[] */
     protected static $refreshTokens;
 
-    /** @var ContainerInterface */
-    protected $container;
-
     /**
      * {@inheritdoc}
      */
@@ -59,7 +56,6 @@ abstract class ApiTestCase extends WebTestCase
     {
         static::bootKernel();
 
-        $this->container = static::$kernel->getContainer();
         $configuration = $this->getConfiguration();
 
         self::$count++;
@@ -174,7 +170,7 @@ abstract class ApiTestCase extends WebTestCase
      */
     protected function get($service)
     {
-        return $this->container->get($service);
+        return static::$kernel->getContainer()->get($service);
     }
 
     /**
@@ -184,7 +180,7 @@ abstract class ApiTestCase extends WebTestCase
      */
     protected function getParameter($service)
     {
-        return $this->container->getParameter($service);
+        return static::$kernel->getContainer()->getParameter($service);
     }
 
     /**
@@ -203,7 +199,7 @@ abstract class ApiTestCase extends WebTestCase
      */
     protected function getDatabasePurger()
     {
-        return new DatabasePurger($this->container);
+        return new DatabasePurger(static::$kernel->getContainer());
     }
 
     /**
@@ -213,7 +209,7 @@ abstract class ApiTestCase extends WebTestCase
      */
     protected function getFixturesLoader(Configuration $configuration)
     {
-        return new FixturesLoader($this->container, $configuration);
+        return new FixturesLoader(static::$kernel->getContainer(), $configuration);
     }
 
     /**
@@ -221,7 +217,7 @@ abstract class ApiTestCase extends WebTestCase
      */
     protected function getConnectionCloser()
     {
-        return new ConnectionCloser($this->container);
+        return new ConnectionCloser(static::$kernel->getContainer());
     }
 
     /**

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/AbstractProductTestCase.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/AbstractProductTestCase.php
@@ -12,7 +12,7 @@ use Pim\Bundle\ApiBundle\tests\integration\ApiTestCase;
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class AbstractProductTestCase extends ApiTestCase
+abstract class AbstractProductTestCase extends ApiTestCase
 {
     /**
      * @return Configuration

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Token/GetAccessTokenIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Token/GetAccessTokenIntegration.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace tests\integration\Pim\Bundle\ApiBundle\Controller\Token;
+namespace Pim\Bundle\ApiBundle\tests\integration\Controller\Token;
 
 use Akeneo\Test\Integration\Configuration;
 use Pim\Bundle\ApiBundle\tests\integration\ApiTestCase;

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Token/RefreshTokenIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Token/RefreshTokenIntegration.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace tests\integration\Pim\Bundle\ApiBundle\Controller\Token;
+namespace Pim\Bundle\ApiBundle\tests\integration\Controller\Token;
 
 use Akeneo\Test\Integration\Configuration;
 use Pim\Bundle\ApiBundle\tests\integration\ApiTestCase;
@@ -16,7 +16,7 @@ class RefreshTokenIntegration extends ApiTestCase
         $client->request('POST', 'api/oauth/v1/token',
             [
                 'grant_type'    => 'refresh_token',
-                'refresh_token' => static::$refreshToken,
+                'refresh_token' => static::$refreshTokens[self::USERNAME],
             ],
             [],
             [

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Security/AuthorizationIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Security/AuthorizationIntegration.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Pim\Bundle\ApiBundle\tests\integration\Security;
+
+use Akeneo\Test\Integration\Configuration;
+use Pim\Bundle\ApiBundle\tests\integration\ApiTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @author    Yohan Blain <yohan.blain@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class AuthorizationIntegration extends ApiTestCase
+{
+    public function testAccessGranted()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $client->request('GET', 'api/rest/v1/categories/master');
+
+        $standardCategory = [
+            'code'   => 'master',
+            'parent' => null,
+            'labels' => []
+        ];
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertSame($standardCategory, json_decode($response->getContent(), true));
+    }
+
+    public function testAccessDenied()
+    {
+        $client = $this->createAuthenticatedClient([], [], null, null, 'julia', 'julia');
+
+        $client->request('GET', 'api/rest/v1/categories/master');
+
+        $expectedResponse = [
+            'code'    => 403,
+            'message' => 'Access Denied.',
+        ];
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
+        $this->assertSame($expectedResponse, json_decode($response->getContent(), true));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return new Configuration(
+            [Configuration::getTechnicalCatalogPath()],
+            false
+        );
+    }
+}

--- a/tests/Configuration.php
+++ b/tests/Configuration.php
@@ -49,7 +49,7 @@ class Configuration
 
         $defaultFixturePath = self::getRootDirectory() . DIRECTORY_SEPARATOR . 'tests' .
             DIRECTORY_SEPARATOR . 'fixtures' . DIRECTORY_SEPARATOR;
-        $this->fixtureDirectories [] = $defaultFixturePath;
+        $this->fixtureDirectories[] = $defaultFixturePath;
 
         foreach ($this->fixtureDirectories as $fixtureDirectory) {
             if (!is_dir($fixtureDirectory)) {

--- a/tests/catalog/technical/acl.sql
+++ b/tests/catalog/technical/acl.sql
@@ -1,0 +1,54 @@
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+
+
+--
+-- Dumping data for table `acl_classes`
+--
+
+/*!40000 ALTER TABLE `acl_classes` DISABLE KEYS */;
+INSERT INTO `acl_classes` VALUES (2,'pim_api_overall_access');
+/*!40000 ALTER TABLE `acl_classes` ENABLE KEYS */;
+
+--
+-- Dumping data for table `acl_entries`
+--
+
+/*!40000 ALTER TABLE `acl_entries` DISABLE KEYS */;
+INSERT INTO `acl_entries` VALUES (7,2,NULL,2,NULL,1,0,1,'all',0,0),(8,2,NULL,3,NULL,0,0,1,'all',0,0);
+/*!40000 ALTER TABLE `acl_entries` ENABLE KEYS */;
+
+--
+-- Dumping data for table `acl_object_identities`
+--
+
+/*!40000 ALTER TABLE `acl_object_identities` DISABLE KEYS */;
+INSERT INTO `acl_object_identities` VALUES (3,NULL,2,'action',1);
+/*!40000 ALTER TABLE `acl_object_identities` ENABLE KEYS */;
+
+--
+-- Dumping data for table `acl_object_identity_ancestors`
+--
+
+/*!40000 ALTER TABLE `acl_object_identity_ancestors` DISABLE KEYS */;
+INSERT INTO `acl_object_identity_ancestors` VALUES (3,3);
+/*!40000 ALTER TABLE `acl_object_identity_ancestors` ENABLE KEYS */;
+
+
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
+/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;

--- a/tests/catalog/technical/users.csv
+++ b/tests/catalog/technical/users.csv
@@ -1,2 +1,3 @@
 username;first_name;last_name;email;password;catalog_locale;user_locale;catalog_scope;default_tree;roles;groups;enabled
 admin;John;Doe;admin@example.com;admin;en_US;en_US;ecommerce;master;ROLE_ADMINISTRATOR;IT support;1
+julia;Julia;Stark;julia@example.com;julia;en_US;en_US;ecommerce;master;ROLE_CATALOG_MANAGER;Manager;1


### PR DESCRIPTION
This PR adds an access control on the `/api/` URL pattern. It ensures that users have the "overrall_api_access" ACL granted for their role.

Since it's the first time (I guess) that we need to check ACLs not linked to any Oro annotation so early in the app (we already did but not inside the security itself) some modifications were needed inside Oro ACL implementation.
See the description in the new voter to have more info.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | OK
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
