### PR TITLE
[PIM-6125] Add validator for family attribute_as_label

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -7,7 +7,7 @@
 - GITHUB-5294: Fixed infinite loading if no attribute is configured as a product identifier, cheers @gplanchat!
 - GITHUB-5337: Fixed Widget Registry. Priority is now taken in account.
 - PIM-6127: In the family import, the attributes required should be in the family
-- PIM-6125: In the family import, the attribute_as_label have to be in the family and its type has to be identifier or text
+- PIM-6125: In the family import, the attribute_as_label has to be in the family and its type has to be identifier or text
 
 ## Deprecations
 

--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -7,6 +7,7 @@
 - GITHUB-5294: Fixed infinite loading if no attribute is configured as a product identifier, cheers @gplanchat!
 - GITHUB-5337: Fixed Widget Registry. Priority is now taken in account.
 - PIM-6127: In the family import, the attributes required should be in the family
+- PIM-6125: In the family import, the attribute_as_label have to be in the family and its type has to be identifier or text
 
 ## Deprecations
 

--- a/features/import/import_families.feature
+++ b/features/import/import_families.feature
@@ -97,3 +97,41 @@ Feature: Import families
     Then I should see the text "Skipped 1"
     And I should see the text "The attribute \"description\" cannot be an attribute required for the channel \"tablet\" as it does not belong to this family: Wrong Family"
     And I should see the text "The attribute \"description\" cannot be an attribute required for the channel \"mobile\" as it does not belong to this family: Wrong Family"
+
+  @jira https://akeneo.atlassian.net/browse/PIM-6125
+  Scenario: Successfully raise an error when attribute_as_label is not in the family
+    Given the "footwear" catalog configuration
+    And I am logged in as "Julia"
+    And the following CSV file to import:
+      """
+      code;label-en_US;attributes;attribute_as_label
+      boots;Boots;sku,name,manufacturer,description,weather_conditions,price,rating,side_view,top_view,size,color,lace_color;name
+      wrong_family;Wrong Family;sku;name
+      """
+    And the following job "csv_footwear_family_import" configuration:
+      | filePath | %file to import% |
+    When I am on the "csv_footwear_family_import" import job page
+    And I launch the import job
+    And I wait for the "csv_footwear_family_import" job to finish
+    Then I should see the text "Skipped 1"
+    And I should see the text "The attribute \"name\" does not belong to the family, thus it cannot be used as an \"attribute as label\" for this family: Wrong Family"
+
+  @jira https://akeneo.atlassian.net/browse/PIM-6125
+  Scenario: Successfully raise an error when attribute_as_label is not an identifier nor a text type
+    Given the "footwear" catalog configuration
+    And I am logged in as "Julia"
+    And the following CSV file to import:
+      """
+      code;label-en_US;attributes;attribute_as_label
+      boots;Boots;sku,name,manufacturer,description,weather_conditions,price,rating,side_view,top_view,size,color,lace_color;name
+      wrong_family1;Wrong Family1;sku,description;description
+      wrong_family2;Wrong Family2;sku,heel_color;heel_color
+      """
+    And the following job "csv_footwear_family_import" configuration:
+      | filePath | %file to import% |
+    When I am on the "csv_footwear_family_import" import job page
+    And I launch the import job
+    And I wait for the "csv_footwear_family_import" job to finish
+    Then I should see the text "Skipped 2"
+    And I should see the text "Only text and identifier attribute types can be used as \"attribute as label\" for this family: Wrong Family1"
+    And I should see the text "Only text and identifier attribute types can be used as \"attribute as label\" for this family: Wrong Family2"

--- a/features/import/import_families.feature
+++ b/features/import/import_families.feature
@@ -114,7 +114,7 @@ Feature: Import families
     And I launch the import job
     And I wait for the "csv_footwear_family_import" job to finish
     Then I should see the text "Skipped 1"
-    And I should see the text "The attribute \"name\" does not belong to the family, thus it cannot be used as an \"attribute as label\" for this family: Wrong Family"
+    And I should see the text "Property 'attribute_as_label' must belong to the family: Wrong Family"
 
   @jira https://akeneo.atlassian.net/browse/PIM-6125
   Scenario: Successfully raise an error when attribute_as_label is not an identifier nor a text type
@@ -133,5 +133,5 @@ Feature: Import families
     And I launch the import job
     And I wait for the "csv_footwear_family_import" job to finish
     Then I should see the text "Skipped 2"
-    And I should see the text "Only text and identifier attribute types can be used as \"attribute as label\" for this family: Wrong Family1"
-    And I should see the text "Only text and identifier attribute types can be used as \"attribute as label\" for this family: Wrong Family2"
+    And I should see the text "Property 'attribute_as_label' only supports 'pim_catalog_text' and 'pim_catalog_identifier' attribute types for the family: Wrong Family1"
+    And I should see the text "Property 'attribute_as_label' only supports 'pim_catalog_text' and 'pim_catalog_identifier' attribute types for the family: Wrong Family2"

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/validation/family.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/validation/family.yml
@@ -5,6 +5,7 @@ Pim\Bundle\CatalogBundle\Entity\Family:
             properties:
                 - code
         - Pim\Component\Catalog\Validator\Constraints\FamilyRequirements: ~
+        - Pim\Component\Catalog\Validator\Constraints\FamilyAttributeAsLabel: ~
     properties:
         code:
             - NotBlank: ~

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/validators.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/validators.yml
@@ -13,6 +13,7 @@ parameters:
     pim_catalog.validator.constraint.variant_group_axis.class:             Pim\Component\Catalog\Validator\Constraints\VariantGroupAxisValidator
     pim_catalog.validator.constraint.has_variant_axes.class:               Pim\Component\Catalog\Validator\Constraints\HasVariantAxesValidator
     pim_catalog.validator.constraint.family_requirements.class:            Pim\Component\Catalog\Validator\Constraints\FamilyRequirementsValidator
+    pim_catalog.validator.constraint.family_attribute_as_label.class:      Pim\Component\Catalog\Validator\Constraints\FamilyAttributeAsLabelValidator
     pim_catalog.validator.constraint.scopable_value.class:                 Pim\Component\Catalog\Validator\Constraints\ScopableValueValidator
     pim_catalog.validator.constraint.localizable_value.class:              Pim\Component\Catalog\Validator\Constraints\LocalizableValueValidator
     pim_catalog.validator.constraint.attribute_type_for_option.class:      Pim\Component\Catalog\Validator\Constraints\AttributeTypeForOptionValidator
@@ -135,6 +136,11 @@ services:
             - '@pim_catalog.repository.channel'
         tags:
             - { name: validator.constraint_validator, alias: pim_family_requirements_validator }
+
+    pim_catalog.validator.constraint.family_attribute_as_label:
+        class: '%pim_catalog.validator.constraint.family_attribute_as_label.class%'
+        tags:
+            - { name: validator.constraint_validator, alias: pim_family_attribute_as_label_validator }
 
     pim_catalog.validator.constraint.scopable_value:
         class: '%pim_catalog.validator.constraint.scopable_value.class%'

--- a/src/Pim/Component/Catalog/Validator/Constraints/FamilyAttributeAsLabel.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/FamilyAttributeAsLabel.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Pim\Component\Catalog\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Family attribute_as_label constraint
+ *
+ * @author    Pierre Allard <pierre.allard@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+class FamilyAttributeAsLabel extends Constraint
+{
+    /** @var string */
+    public $messageAttribute = 'The attribute "%attribute%" does not belong to the family, thus it cannot be used as '.
+        'an "attribute as label" for this family';
+
+    /** @var string */
+    public $messageAttributeType = 'Only text and identifier attribute types can be used as "attribute as label" '.
+        'for this family';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validatedBy()
+    {
+        return 'pim_family_attribute_as_label_validator';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTargets()
+    {
+        return self::CLASS_CONSTRAINT;
+    }
+}

--- a/src/Pim/Component/Catalog/Validator/Constraints/FamilyAttributeAsLabel.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/FamilyAttributeAsLabel.php
@@ -11,16 +11,14 @@ use Symfony\Component\Validator\Constraint;
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-
 class FamilyAttributeAsLabel extends Constraint
 {
     /** @var string */
-    public $messageAttribute = 'The attribute "%attribute%" does not belong to the family, thus it cannot be used as '.
-        'an "attribute as label" for this family';
+    public $messageAttribute = "Property 'attribute_as_label' must belong to the family";
 
     /** @var string */
-    public $messageAttributeType = 'Only text and identifier attribute types can be used as "attribute as label" '.
-        'for this family';
+    public $messageAttributeType = "Property 'attribute_as_label' only supports 'pim_catalog_text' and ".
+        "'pim_catalog_identifier' attribute types for the family";
 
     /**
      * {@inheritdoc}

--- a/src/Pim/Component/Catalog/Validator/Constraints/FamilyAttributeAsLabelValidator.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/FamilyAttributeAsLabelValidator.php
@@ -25,15 +25,16 @@ class FamilyAttributeAsLabelValidator extends ConstraintValidator
      */
     public function validate($family, Constraint $constraint)
     {
-        if ($family instanceof FamilyInterface) {
-            if (!$this->isAttributeAsLabelPresent($family)) {
-                $this->context->buildViolation(
-                    $constraint->messageAttribute, ['%attribute%' => $family->getAttributeAsLabel()->getCode()]
-                )->addViolation();
-            }
-            if (!$this->isAttributeAsLabelTypeValid($family)) {
-                $this->context->buildViolation($constraint->messageAttributeType)->addViolation();
-            }
+        if (!($family instanceof FamilyInterface)) {
+            return;
+        }
+
+        if (!$this->doesAttributeAsLabelBelongToFamily($family)) {
+            $this->context->buildViolation($constraint->messageAttribute)->addViolation();
+        }
+
+        if (!$this->isAttributeAsLabelTypeValid($family)) {
+            $this->context->buildViolation($constraint->messageAttributeType)->addViolation();
         }
     }
 
@@ -42,16 +43,9 @@ class FamilyAttributeAsLabelValidator extends ConstraintValidator
      *
      * @return bool
      */
-    protected function isAttributeAsLabelPresent(FamilyInterface $family)
+    protected function doesAttributeAsLabelBelongToFamily(FamilyInterface $family)
     {
-        $attributeAsLabelCode = $family->getAttributeAsLabel()->getCode();
-        foreach ($family->getAttributeCodes() as $attributeCode) {
-            if ($attributeCode === $attributeAsLabelCode) {
-                return true;
-            }
-        }
-
-        return false;
+        return in_array($family->getAttributeAsLabel()->getCode(), $family->getAttributeCodes());
     }
 
     /**

--- a/src/Pim/Component/Catalog/Validator/Constraints/FamilyAttributeAsLabelValidator.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/FamilyAttributeAsLabelValidator.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Pim\Component\Catalog\Validator\Constraints;
+
+use Pim\Component\Catalog\AttributeTypes;
+use Pim\Component\Catalog\Model\FamilyInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ * Family attribute_as_label validator
+ *
+ * This validator will check that:
+ * - the attribute defined as label is an attribute of the family
+ * - the attribute type is "text" or "identifier"
+ *
+ * @author    Pierre Allard <pierre.allard@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class FamilyAttributeAsLabelValidator extends ConstraintValidator
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function validate($family, Constraint $constraint)
+    {
+        if ($family instanceof FamilyInterface) {
+            if (!$this->isAttributeAsLabelPresent($family)) {
+                $this->context->buildViolation(
+                    $constraint->messageAttribute, ['%attribute%' => $family->getAttributeAsLabel()->getCode()]
+                )->addViolation();
+            }
+            if (!$this->isAttributeAsLabelTypeValid($family)) {
+                $this->context->buildViolation($constraint->messageAttributeType)->addViolation();
+            }
+        }
+    }
+
+    /**
+     * @param FamilyInterface $family
+     *
+     * @return bool
+     */
+    protected function isAttributeAsLabelPresent(FamilyInterface $family)
+    {
+        $attributeAsLabelCode = $family->getAttributeAsLabel()->getCode();
+        foreach ($family->getAttributeCodes() as $attributeCode) {
+            if ($attributeCode === $attributeAsLabelCode) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param FamilyInterface $family
+     *
+     * @return bool
+     */
+    protected function isAttributeAsLabelTypeValid(FamilyInterface $family)
+    {
+        return in_array($family->getAttributeAsLabel()->getAttributeType(), [
+                AttributeTypes::IDENTIFIER,
+                AttributeTypes::TEXT
+            ]);
+    }
+}

--- a/src/Pim/Component/Catalog/spec/Validator/Constraints/FamilyAttributeAsLabelValidatorSpec.php
+++ b/src/Pim/Component/Catalog/spec/Validator/Constraints/FamilyAttributeAsLabelValidatorSpec.php
@@ -49,9 +49,7 @@ class FamilyAttributeAsLabelValidatorSpec extends ObjectBehavior
         $family->getAttributeCodes()->willReturn(['anotherAttribute']);
         $attributeAsLabel->getAttributeType()->willReturn('pim_catalog_text');
 
-        $context->buildViolation(
-            Argument::any(), ['%attribute%' => 'attributeAsLabelCode']
-        )->willReturn($violation)->shouldBeCalled();
+        $context->buildViolation(Argument::any())->willReturn($violation)->shouldBeCalled();
 
         $this->validate($family, $minimumRequirements);
     }

--- a/src/Pim/Component/Catalog/spec/Validator/Constraints/FamilyAttributeAsLabelValidatorSpec.php
+++ b/src/Pim/Component/Catalog/spec/Validator/Constraints/FamilyAttributeAsLabelValidatorSpec.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace spec\Pim\Component\Catalog\Validator\Constraints;
+
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\FamilyInterface;
+use Pim\Component\Catalog\Validator\Constraints\FamilyAttributeAsLabel;
+use Prophecy\Argument;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
+
+class FamilyAttributeAsLabelValidatorSpec extends ObjectBehavior
+{
+    function let(FamilyAttributeAsLabel $minimumRequirements, ExecutionContextInterface $context)
+    {
+        $this->initialize($context);
+    }
+
+    function it_is_a_constraint_validator()
+    {
+        $this->shouldImplement('Symfony\Component\Validator\ConstraintValidatorInterface');
+    }
+
+    function it_validates_family(
+        $minimumRequirements,
+        $context,
+        FamilyInterface $family,
+        AttributeInterface $attributeAsLabel
+    ) {
+        $family->getAttributeAsLabel()->willReturn($attributeAsLabel);
+        $attributeAsLabel->getCode()->willReturn('attributeAsLabelCode');
+        $family->getAttributeCodes()->willReturn(['attributeAsLabelCode', 'anotherAttribute']);
+        $attributeAsLabel->getAttributeType()->willReturn('pim_catalog_text');
+
+        $this->validate($family, $minimumRequirements);
+        $context->buildViolation(Argument::cetera())->shouldNotBeCalled();
+    }
+
+    function it_invalidates_family_when_attribute_as_label_is_not_present(
+        $minimumRequirements,
+        $context,
+        FamilyInterface $family,
+        AttributeInterface $attributeAsLabel,
+        ConstraintViolationBuilderInterface $violation
+    ) {
+        $family->getAttributeAsLabel()->willReturn($attributeAsLabel);
+        $attributeAsLabel->getCode()->willReturn('attributeAsLabelCode');
+        $family->getAttributeCodes()->willReturn(['anotherAttribute']);
+        $attributeAsLabel->getAttributeType()->willReturn('pim_catalog_text');
+
+        $context->buildViolation(
+            Argument::any(), ['%attribute%' => 'attributeAsLabelCode']
+        )->willReturn($violation)->shouldBeCalled();
+
+        $this->validate($family, $minimumRequirements);
+    }
+
+    function it_invalidates_family_when_attribute_is_not_text_type(
+        $minimumRequirements,
+        $context,
+        FamilyInterface $family,
+        AttributeInterface $attributeAsLabel,
+        ConstraintViolationBuilderInterface $violation
+    ) {
+        $family->getAttributeAsLabel()->willReturn($attributeAsLabel);
+        $attributeAsLabel->getCode()->willReturn('attributeAsLabelCode');
+        $family->getAttributeCodes()->willReturn(['attributeAsLabelCode', 'anotherAttribute']);
+        $attributeAsLabel->getAttributeType()->willReturn('wrong_type');
+
+        $context->buildViolation(Argument::any())->willReturn($violation)->shouldBeCalled();
+
+        $this->validate($family, $minimumRequirements);
+    }
+}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Prevent:
- import a family with an attribute_as_label not present in the attributes list
- import a family with an attribute_as_label not identifier nor text type

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | y
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Migration script                  | -
| Tech Doc                          | -
