### PR TITLE
PIM-6150: fix AttributeOptionRepository to correctly handle codes and ids

### DIFF
--- a/features/product/filtering/filter_products_per_option_fields.feature
+++ b/features/product/filtering/filter_products_per_option_fields.feature
@@ -53,3 +53,12 @@ Feature: Filter products per option
     And I filter by "color" with operator "in list" and value "Black, White"
     And I should see entities Shoes
     Then I should see options "[Black], [White]" in filter "color"
+
+  @jira https://akeneo.atlassian.net/browse/PIM-6150
+  Scenario: Successfully keep the option filter on page reload
+    Given I am on the products page
+    And the grid should contain 3 elements
+    When I show the filter "color"
+    And I filter by "color" with operator "in list" and value "Black, White"
+    And I reload the page
+    Then I should see the text "Color: \"[Black], [White]\""

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/AttributeOptionRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/AttributeOptionRepository.php
@@ -39,6 +39,8 @@ class AttributeOptionRepository extends EntityRepository implements
             throw new \InvalidArgumentException('Please supply attribute id as collectionId');
         }
 
+        $identifier = isset($options['type']) && 'code' === $options['type'] ? 'code' : 'id';
+
         $qb = $this->createQueryBuilder('o')
             ->select('o.id, o.code, v.value AS label, a.properties')
             ->leftJoin('o.optionValues', 'v', 'WITH', 'v.locale=:locale')
@@ -55,7 +57,7 @@ class AttributeOptionRepository extends EntityRepository implements
         if (isset($options['ids'])) {
             $qb
                 ->andWhere(
-                    $qb->expr()->in('o.id', ':ids')
+                    $qb->expr()->in(sprintf('o.%s', $identifier), ':ids')
                 )
                 ->setParameter('ids', $options['ids']);
         }
@@ -77,7 +79,7 @@ class AttributeOptionRepository extends EntityRepository implements
 
             $isLabelBlank = (null === $row['label']) || ('' === $row['label']);
             $results[] = [
-                'id'   => (isset($options['type']) && 'code' === $options['type']) ? $row['code'] : $row['id'],
+                'id'   => $row[$identifier],
                 'text' => $isLabelBlank ? sprintf('[%s]', $row['code']) : $row['label'],
             ];
         }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This is a similar fix to #5639.
Caused by #5387 (but case wasn't cover by behats)

When filtering a grid with attribute options, then reloading the grid, the attribute options weren't display anymore because Repository was looking only for ids.
Now it looks for code when asked.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | OK
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
