### PR TITLE
AMS-175: reset button keeps view filters & doesn't reset scope

### DIFF
--- a/features/Context/AssertionContext.php
+++ b/features/Context/AssertionContext.php
@@ -42,7 +42,7 @@ class AssertionContext extends RawMinkContext
     /**
      * Checks, that page does not contain specified text.
      *
-     * @Then /^I should not see the text "([^"]*)"$/
+     * @Then /^I should not see the text "(?P<text>(?:[^"]|\\")*)"$/
      */
     public function assertPageNotContainsText($text)
     {

--- a/features/datagrid/datagrid_views.feature
+++ b/features/datagrid/datagrid_views.feature
@@ -140,8 +140,6 @@ Feature: Datagrid views
     Then I should see the text "Sneakers only"
     And I should see products purple-sneakers and black-sneakers
     But I should not see product black-boots
-    When I press the "Reset" button
-    Then I should see products black-boots, purple-sneakers and black-sneakers
 
   Scenario: Successfully remove my default view
     Given I am on the products page

--- a/features/product/filtering/reset_product_filters.feature
+++ b/features/product/filtering/reset_product_filters.feature
@@ -1,0 +1,95 @@
+@javascript
+Feature: Reset product grid filters
+  In order to filter products in the catalog
+  As a regular user
+  I need to be able to reset filters on the product grid
+
+  Background:
+    Given the "footwear" catalog configuration
+    And the following products:
+      | sku             | family  | categories        | size | color | groups        |
+      | sandal-white-37 | sandals | summer_collection | 37   | white | similar_boots |
+      | sandal-white-38 | sandals | summer_collection | 38   | white |               |
+      | sandal-white-39 | sandals | summer_collection | 39   | white |               |
+      | sandal-red-37   | sandals | summer_collection | 37   | red   | similar_boots |
+      | sandal-red-38   | sandals | summer_collection | 38   | red   |               |
+      | sandal-red-39   | sandals | summer_collection | 39   | red   |               |
+    And I am logged in as "Mary"
+    And I am on the products page
+
+  Scenario: I successfully reset attribute filters on the defaut view
+    When I show the filter "color"
+    And I filter by "color" with operator "in list" and value "White"
+    Then the grid should contain 3 elements
+    When I show the filter "size"
+    And I filter by "size" with operator "in list" and value "37"
+    Then the grid should contain 1 element
+    When I reset the grid
+    Then the grid should contain 6 elements
+    And I should not see the text "Color: \"White\""
+    And I should not see the text "Size: \"37\""
+
+  Scenario: I successfully reset field filters on the defaut view
+    When I filter by "family" with operator "in list" and value "Sandals"
+    Then the grid should contain 6 elements
+    When I filter by "groups" with operator "in list" and value "Similar boots"
+    Then the grid should contain 2 elements
+    When I reset the grid
+    Then the grid should contain 6 elements
+    And I should see the text "Family: All"
+    And I should see the text "Groups: All"
+
+  Scenario: I successfully keep the scope I work on when I reset the defaut view
+    When I filter by "scope" with operator "equals" and value "Mobile"
+    And I reset the grid
+    Then I should see the text "Mobile"
+    When I reload the page
+    Then the grid should contain 6 elements
+    And I should see the text "Mobile"
+
+  Scenario: I successfully reset attribute filters of an existing view
+    When I show the filter "color"
+    And I filter by "color" with operator "in list" and value "White"
+    Then the grid should contain 3 elements
+    When I show the filter "size"
+    And I filter by "size" with operator "in list" and value "37"
+    And I create the view:
+      | new-view-label | White 37 |
+    Then I should see the text "White 37"
+    And the grid should contain 1 element
+    When I filter by "color" with operator "in list" and value "White, Red"
+    And I filter by "size" with operator "in list" and value "38"
+    Then the grid should contain 2 elements
+    When I reset the grid
+    Then I should see the text "Color: \"White\""
+    And I should see the text "Size: \"37\""
+    And the grid should contain 1 element
+
+  Scenario: I successfully reset field filters of an existing view
+    When I filter by "family" with operator "in list" and value "Sandals"
+    And I filter by "groups" with operator "in list" and value "Similar boots"
+    Then the grid should contain 2 elements
+    When I create the view:
+      | new-view-label | Similar Sandals |
+    Then I should see the text "Similar Sandals"
+    And the grid should contain 2 elements
+    When I filter by "family" with operator "in list" and value "Boots"
+    And I filter by "groups" with operator "in list" and value "Caterpillar boots"
+    And the grid should contain 0 element
+    When I reset the grid
+    Then the grid should contain 2 elements
+    And I should see the text "Family: \"Sandals\""
+    And I should see the text "Groups: \"Similar boots\""
+
+  Scenario: I successfully keep the scope I work on when I reset an existing view
+    When I filter by "scope" with operator "equals" and value "Mobile"
+    And I create the view:
+      | new-view-label | My products |
+    Then I should see the text "My products"
+    And the grid should contain 6 elements
+    When I reset the grid
+    Then I should see the text "Mobile"
+    When I reload the page
+    Then I should see the text "My products"
+    And the grid should contain 6 elements
+    And I should see the text "Mobile"

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/product_scope-filter.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/product_scope-filter.js
@@ -87,6 +87,10 @@ define(
              * @inheritDoc
              */
             _onValueUpdated: function (newValue) {
+                if ('' === newValue.value) {
+                    return;
+                }
+
                 UserContext.set('catalogScope', newValue.value);
 
                 return SelectFilter.prototype._onValueUpdated.apply(this, arguments);

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/action/reset-collection-action.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/action/reset-collection-action.js
@@ -1,6 +1,6 @@
 /* global define */
-define(['oro/datagrid/abstract-action'],
-function(AbstractAction) {
+define(['underscore', 'oro/datagrid/abstract-action'],
+function(_, AbstractAction) {
     'use strict';
 
     /**
@@ -37,7 +37,13 @@ function(AbstractAction) {
          * Execute reset collection
          */
         execute: function() {
-            this.collection.updateState(this.collection.initialState);
+            var initialState = this.collection._initState;
+
+            if (_.has(initialState, 'filters')) {
+                initialState.filters = _.omit(initialState.filters, 'scope');
+            }
+
+            this.collection.updateState(initialState);
             this.collection.fetch();
         }
     });

--- a/src/Pim/Bundle/DataGridBundle/Resources/views/macros.html.twig
+++ b/src/Pim/Bundle/DataGridBundle/Resources/views/macros.html.twig
@@ -26,6 +26,7 @@
     <script type="text/javascript">
         require(
             [
+                'underscore',
                 'jquery',
                 'routing',
                 'oro/datagrid-builder',
@@ -34,6 +35,7 @@
                 'oro/datafilter/product_category-filter'
             ],
             function (
+                _,
                 $,
                 Routing,
                 datagridBuilder,
@@ -77,9 +79,18 @@
                         };
 
                         var applyFilters = function (rawFilters) {
-                            var collection = new PageableCollection();
-                            var filters    = collection.decodeStateData(rawFilters);
+                            var filters = PageableCollection.prototype.decodeStateData(rawFilters);
+                            var options = {};
 
+                            if (!_.isEmpty(filters.filters)) {
+                                options = {
+                                    state: {
+                                        filters: _.omit(filters.filters, 'scope')
+                                    }
+                                };
+                            }
+
+                            var collection = new PageableCollection(null, options);
                             collection.processFiltersParams(urlParams, filters, '{{ name }}[_filter]');
 
                             for (var column in filters.sorters) {


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This PR solves 2 problems about the "Reset" button on the grid:
- It sets the scope to "All", which has no sense
- When you're on a view, it resets filters, but not to the initial state of the view

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | OK
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
