### PR TITLE
PIM-6152: Fix fatal error on import in case of wrong column count

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -4,6 +4,10 @@
 
 - PIM-6149: Remove version number displayed on login page
 
+## Bug fixes
+
+- PIM-6152: Fix fatal error on import in case of wrong column count
+
 # 1.6.10 (2017-02-02)
 
 ## Bug fixes

--- a/features/import/product/import_products_with_invalid_data.feature
+++ b/features/import/product/import_products_with_invalid_data.feature
@@ -434,3 +434,22 @@ Feature: Execute a job
     And I wait for the "csv_footwear_product_import" job to finish
     Then I should see "skipped 1"
     And I should see "Attribute or field \"associations\" expects existing product identifier as data, \"unknown\" given"
+
+  @jira https://akeneo.atlassian.net/browse/PIM-6152
+  Scenario: Display the lines with wrong number of columns
+    Given the following CSV file to import:
+      """
+      sku;description-en_US-tablet
+      product_ok
+      product_notok1;Description;foo
+      product_notok2;Description;;foo
+      """
+    And the following job "csv_footwear_product_import" configuration:
+      | filePath | %file to import% |
+    When I am on the "csv_footwear_product_import" import job page
+    And I launch the import job
+    And I wait for the "csv_footwear_product_import" job to finish
+    Then I should see the text "Status: COMPLETED"
+    And I should see the text "created 1"
+    And I should see the text "Expecting to have 2 columns, actually have 3"
+    And I should see the text "Expecting to have 2 columns, actually have 4"

--- a/src/Pim/Bundle/ConnectorBundle/Resources/translations/messages.en.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/translations/messages.en.yml
@@ -5,7 +5,8 @@ pim_connector:
         entity_reader.title:                 Entity extraction
         csv_reader:
             title: CSV reader
-            invalid_item_columns_count: 'Expecting to have %totalColumnsCount% columns, actually have %itemColumnsCount% in %csvPath%:%lineno%'
+        file_reader:
+            invalid_item_columns_count: 'Expecting to have %totalColumnsCount% columns, actually have %itemColumnsCount% in %filePath%:%lineno%'
         csv_product_reader.title:            CSV product reader
         csv_category_reader.title:           CSV category reader
         csv_variant_group .title:            CSV variant group reader

--- a/src/Pim/Component/Connector/Archiver/AbstractInvalidItemWriter.php
+++ b/src/Pim/Component/Connector/Archiver/AbstractInvalidItemWriter.php
@@ -98,7 +98,7 @@ abstract class AbstractInvalidItemWriter extends AbstractFilesystemArchiver
             $currentLineNumber++;
 
             if ($invalidLineNumbers->contains($currentLineNumber)) {
-                $itemsToWrite[] = array_combine($headers, $readItem);
+                $itemsToWrite[] = array_combine($headers, array_slice($readItem, 0, count($headers)));
                 $invalidLineNumbers->removeElement($currentLineNumber);
             }
 

--- a/src/Pim/Component/Connector/Reader/File/Csv/Reader.php
+++ b/src/Pim/Component/Connector/Reader/File/Csv/Reader.php
@@ -59,10 +59,9 @@ class Reader implements ItemReaderInterface, StepExecutionAwareInterface, Flusha
      */
     public function read()
     {
-        $filePath = null;
+        $jobParameters = $this->stepExecution->getJobParameters();
+        $filePath = $jobParameters->get('filePath');
         if (null === $this->fileIterator) {
-            $jobParameters = $this->stepExecution->getJobParameters();
-            $filePath = $jobParameters->get('filePath');
             $delimiter = $jobParameters->get('delimiter');
             $enclosure = $jobParameters->get('enclosure');
             $defaultOptions = [

--- a/src/Pim/Component/Connector/Reader/File/Xlsx/Reader.php
+++ b/src/Pim/Component/Connector/Reader/File/Xlsx/Reader.php
@@ -59,10 +59,9 @@ class Reader implements ItemReaderInterface, StepExecutionAwareInterface, Flusha
      */
     public function read()
     {
-        $filePath = null;
+        $jobParameters = $this->stepExecution->getJobParameters();
+        $filePath = $jobParameters->get('filePath');
         if (null === $this->fileIterator) {
-            $jobParameters = $this->stepExecution->getJobParameters();
-            $filePath = $jobParameters->get('filePath');
             $this->fileIterator = $this->fileIteratorFactory->create($filePath, $this->options);
             $this->fileIterator->rewind();
         }


### PR DESCRIPTION
When you import a file with the wrong column count:
- the error was not translated
- path in the error was missing
- it raises a fatal error when invalid item file was written

This PR fix all of this.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | n
| Added Behats                      | y
| Changelog updated                 | y
| Review and 2 GTM                  | Todo
| Migration script                  | -
| Tech Doc                          | -
