### PR TITLE
[PIM-702] Remove hardcoded channels and locales

### DIFF
--- a/features/Context/FixturesContext.php
+++ b/features/Context/FixturesContext.php
@@ -18,11 +18,9 @@ use Oro\Bundle\UserBundle\Entity\Role;
 use Pim\Behat\Context\FixturesContext as BaseFixturesContext;
 use Pim\Bundle\CatalogBundle\Doctrine\Common\Saver\ProductSaver;
 use Pim\Bundle\CatalogBundle\Entity\AssociationType;
-use Pim\Bundle\CatalogBundle\Entity\AttributeGroup;
 use Pim\Bundle\CatalogBundle\Entity\AttributeOption;
 use Pim\Bundle\CatalogBundle\Entity\AttributeRequirement;
 use Pim\Bundle\CatalogBundle\Entity\Channel;
-use Pim\Bundle\CatalogBundle\Entity\Group;
 use Pim\Bundle\CatalogBundle\Entity\GroupType;
 use Pim\Bundle\CommentBundle\Entity\Comment;
 use Pim\Bundle\CommentBundle\Model\CommentInterface;
@@ -33,13 +31,11 @@ use Pim\Component\Catalog\Builder\ProductBuilderInterface;
 use Pim\Component\Catalog\Factory\GroupFactory;
 use Pim\Component\Catalog\Model\Association;
 use Pim\Component\Catalog\Model\AttributeOptionInterface;
-use Pim\Component\Catalog\Model\FamilyInterface;
 use Pim\Component\Catalog\Model\LocaleInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
 use Pim\Component\Connector\Job\JobParameters\DefaultValuesProvider\ProductCsvImport;
 use Pim\Component\Connector\Job\JobParameters\DefaultValuesProvider\SimpleCsvExport;
-use Pim\Component\Connector\Processor\Denormalization\ProductProcessor;
 use Pim\Component\ReferenceData\Model\ReferenceDataInterface;
 
 /**
@@ -421,13 +417,28 @@ class FixturesContext extends BaseFixturesContext
     {
         foreach ($table->getHash() as $data) {
             $family = $this->getFamily($data['code']);
-            $requirement = $this->normalizeRequirements($family);
+            unset($data['code']);
 
-            assertEquals($data['attributes'], implode(',', $family->getAttributeCodes()));
-            assertEquals($data['attribute_as_label'], $family->getAttributeAsLabel()->getCode());
-            assertEquals($data['requirements-mobile'], $requirement['requirements-mobile']);
-            assertEquals($data['requirements-tablet'], $requirement['requirements-tablet']);
-            assertEquals($data['label-en_US'], $family->getTranslation('en_US')->getLabel());
+            foreach ($data as $key => $expectedValue) {
+                $matches = null;
+                if ('attributes' === $key) {
+                    assertEquals($expectedValue, implode(',', $family->getAttributeCodes()));
+                } elseif ('attribute_as_label' === $key) {
+                    assertEquals($expectedValue, $family->getAttributeAsLabel()->getCode());
+                } elseif (preg_match('/^requirements-(?P<channel>.+)$/', $key, $matches)) {
+                    $requiredAttributes = [];
+                    foreach ($family->getAttributeRequirements() as $attributeRequirement) {
+                        if ($matches['channel'] === $attributeRequirement->getChannelCode()) {
+                            $requiredAttributes[] = $attributeRequirement->getAttributeCode();
+                        }
+                    }
+                    assertEquals(join(',',$requiredAttributes), $expectedValue);
+                } elseif (preg_match('/^label-(?P<locale>.+)$/', $key, $matches)) {
+                    assertEquals($expectedValue, $family->getTranslation($matches['locale'])->getLabel());
+                } else {
+                    throw new \InvalidArgumentException(sprintf('Unknown column name "%s" on family check', $key));
+                }
+            }
         }
     }
 
@@ -468,42 +479,37 @@ class FixturesContext extends BaseFixturesContext
     {
         foreach ($table->getHash() as $data) {
             $channel = $this->getChannel($data['code']);
+            unset($data['code']);
 
-            if (isset($data['label-en_US'])) {
-                assertEquals($data['label-en_US'], $channel->getTranslation('en_US')->getLabel());
-            }
-
-            if (isset($data['label-de_DE'])) {
-                assertEquals($data['label-de_DE'], $channel->getTranslation('de_DE')->getLabel());
-            }
-
-            if (isset($data['label-fr_FR'])) {
-                assertEquals($data['label-fr_FR'], $channel->getTranslation('fr_FR')->getLabel());
-            }
-
-            assertEquals($data['tree'], $channel->getCategory()->getCode());
-
-            $locales = $channel->getLocaleCodes();
-            asort($locales);
-            assertEquals($data['locales'], implode(',', $locales));
-
-            $currencies = $channel->getCurrencies();
-            $currencyCodes = [];
-            foreach ($currencies as $currency) {
-                $currencyCodes[] = $currency->getCode();
-            }
-            asort($currencyCodes);
-            assertEquals($data['currencies'], implode(',', $currencyCodes));
-
-            if ('' !== $data['conversion_units']) {
-                $units = explode(',', $data['conversion_units']);
-                $formattedUnits = [];
-                foreach ($units as $unit) {
-                    list($key, $value) = explode(':', trim($unit));
-                    $formattedUnits[trim($key)] = trim($value);
+            foreach ($data as $key => $expectedValue) {
+                if ('tree' === $key) {
+                    assertEquals($expectedValue, $channel->getCategory()->getCode());
+                } elseif ('locales' === $key) {
+                    $locales = $channel->getLocaleCodes();
+                    asort($locales);
+                    assertEquals($expectedValue, implode(',', $locales));
+                } elseif ('currencies' === $key) {
+                    $currencyCodes = [];
+                    foreach ($channel->getCurrencies() as $currency) {
+                        $currencyCodes[] = $currency->getCode();
+                    }
+                    asort($currencyCodes);
+                    assertEquals($expectedValue, implode(',', $currencyCodes));
+                } elseif ('conversion_units' === $key) {
+                    if ('' !== $expectedValue) {
+                        $units = explode(',', $expectedValue);
+                        $formattedUnits = [];
+                        foreach ($units as $unit) {
+                            list($key, $value) = explode(':', trim($unit));
+                            $formattedUnits[trim($key)] = trim($value);
+                        }
+                        assertEquals($formattedUnits, $channel->getConversionUnits());
+                    }
+                } elseif (preg_match('/^label-(?P<locale>.+)$/', $key, $matches)) {
+                    assertEquals($expectedValue, $channel->getTranslation($matches['locale'])->getLabel());
+                } else {
+                    throw new \InvalidArgumentException(sprintf('Unknown column name "%s" on channel check', $key));
                 }
-
-                assertEquals($formattedUnits, $channel->getConversionUnits());
             }
         }
     }
@@ -517,9 +523,17 @@ class FixturesContext extends BaseFixturesContext
     {
         foreach ($table->getHash() as $data) {
             $groupType = $this->getGroupType($data['code']);
+            unset($data['code']);
 
-            assertEquals($data['label-en_US'], $groupType->getTranslation('en_US')->getLabel());
-            assertEquals($data['is_variant'], (int)$groupType->isVariant());
+            foreach ($data as $key => $expectedValue) {
+                if ('is_variant' === $key) {
+                    assertEquals($expectedValue, (int)$groupType->isVariant());
+                } elseif (preg_match('/^label-(?P<locale>.+)$/', $key, $matches)) {
+                    assertEquals($expectedValue, $groupType->getTranslation($matches['locale'])->getLabel());
+                } else {
+                    throw new \InvalidArgumentException(sprintf('Unknown column name "%s" on group type check', $key));
+                }
+            }
         }
     }
 
@@ -531,48 +545,28 @@ class FixturesContext extends BaseFixturesContext
     public function thereShouldBeTheFollowingAttributeGroups(TableNode $table)
     {
         foreach ($table->getHash() as $data) {
-            /** @var AttributeGroup $group */
             $group = $this->getAttributeGroup($data['code']);
+            unset($data['code']);
 
-            assertEquals($data['label-en_US'], $group->getTranslation('en_US')->getLabel());
-            assertEquals($data['sort_order'], $group->getSortOrder());
-
-            $attributes = $group->getAttributes();
-            $codes = [];
-            foreach ($attributes as $attribute) {
-                $codes[] = $attribute->getCode();
-            }
-            asort($codes);
-            assertEquals($data['attributes'], implode(',', $codes));
-        }
-    }
-
-    /**
-     * Normalize the requirements
-     *
-     * @param FamilyInterface $family
-     *
-     * @return array
-     */
-    protected function normalizeRequirements(FamilyInterface $family)
-    {
-        $required = [];
-        $flat     = [];
-        foreach ($family->getAttributeRequirements() as $requirement) {
-            $channelCode = $requirement->getChannel()->getCode();
-            if (!isset($required['requirements-' . $channelCode])) {
-                $required['requirements-' . $channelCode] = [];
-            }
-            if ($requirement->isRequired()) {
-                $required['requirements-' . $channelCode][] = $requirement->getAttribute()->getCode();
+            foreach ($data as $key => $expectedValue) {
+                if ('sort_order' === $key) {
+                    assertEquals($expectedValue, $group->getSortOrder());
+                } elseif ('attributes' === $key) {
+                    $codes = [];
+                    foreach ($group->getAttributes() as $attribute) {
+                        $codes[] = $attribute->getCode();
+                    }
+                    asort($codes);
+                    assertEquals($expectedValue, implode(',', $codes));
+                } elseif (preg_match('/^label-(?P<locale>.+)$/', $key, $matches)) {
+                    assertEquals($expectedValue, $group->getTranslation($matches['locale'])->getLabel());
+                } else {
+                    throw new \InvalidArgumentException(
+                        sprintf('Unknown column name "%s" on attribute type check', $key)
+                    );
+                }
             }
         }
-
-        foreach ($required as $key => $attributes) {
-            $flat[$key] = implode(',', $attributes);
-        }
-
-        return $flat;
     }
 
     /**
@@ -588,11 +582,18 @@ class FixturesContext extends BaseFixturesContext
                 'AttributeOption',
                 ['code' => $data['code'], 'attribute' => $attribute]
             );
-            $option->setLocale('en_US');
-            assertEquals($data['label-en_US'], (string) $option);
+            unset($data['attribute']);
+            unset($data['code']);
 
-            if (isset($data['sort_order'])) {
-                assertEquals($data['sort_order'], (string) $option->getSortOrder());
+            foreach ($data as $key => $expectedValue) {
+                if ('sort_order' === $key) {
+                    assertEquals($expectedValue, (string) $option->getSortOrder());
+                } elseif (preg_match('/^label-(?P<locale>.+)$/', $key, $matches)) {
+                    $option->setLocale($matches['locale']);
+                    assertEquals($expectedValue, (string) $option);
+                } else {
+                    throw new \InvalidArgumentException(sprintf('Unknown column name "%s" on option check', $key));
+                }
             }
         }
     }
@@ -606,11 +607,21 @@ class FixturesContext extends BaseFixturesContext
     {
         foreach ($table->getHash() as $data) {
             $category = $this->getCategory($data['code']);
-            assertEquals($data['label'], $category->getTranslation('en_US')->getLabel());
-            if (empty($data['parent'])) {
-                assertNull($category->getParent());
-            } else {
-                assertEquals($data['parent'], $category->getParent()->getCode());
+            unset ($data['code']);
+
+            foreach ($data as $key => $expectedValue) {
+                if ('parent' === $key) {
+                    if (empty($expectedValue)) {
+                        assertNull($category->getParent());
+                    } else {
+                        assertEquals($expectedValue, $category->getParent()->getCode());
+                    }
+                    assertEquals($expectedValue, (string) $option->getSortOrder());
+                } elseif (preg_match('/^label-(?P<locale>.+)$/', $key, $matches)) {
+                    assertEquals($expectedValue, $category->getTranslation($matches['locale'])->getLabel());
+                } else {
+                    throw new \InvalidArgumentException(sprintf('Unknown column name "%s" on category check', $key));
+                }
             }
         }
     }
@@ -624,8 +635,17 @@ class FixturesContext extends BaseFixturesContext
     {
         foreach ($table->getHash() as $data) {
             $associationType = $this->getAssociationType($data['code']);
-            assertEquals($data['label-en_US'], $associationType->getTranslation('en_US')->getLabel());
-            assertEquals($data['label-fr_FR'], $associationType->getTranslation('fr_FR')->getLabel());
+            unset ($data['code']);
+
+            foreach ($data as $key => $expectedValue) {
+                if (preg_match('/^label-(?P<locale>.+)$/', $key, $matches)) {
+                    assertEquals($expectedValue, $associationType->getTranslation($matches['locale'])->getLabel());
+                } else {
+                    throw new \InvalidArgumentException(
+                        sprintf('Unknown column name "%s" on association type check', $key)
+                    );
+                }
+            }
         }
     }
 
@@ -639,20 +659,25 @@ class FixturesContext extends BaseFixturesContext
         $this->getEntityManager()->clear();
         foreach ($table->getHash() as $data) {
             $group = $this->getProductGroup($data['code']);
+            unset($data['code']);
             $this->refresh($group);
 
-            assertEquals($data['label-en_US'], $group->getTranslation('en_US')->getLabel());
-            assertEquals($data['label-fr_FR'], $group->getTranslation('fr_FR')->getLabel());
-            assertEquals($data['type'], $group->getType()->getCode());
-
-            if ($group->getType()->isVariant()) {
-                $attributes = [];
-                foreach ($group->getAxisAttributes() as $attribute) {
-                    $attributes[] = $attribute->getCode();
+            foreach ($data as $key => $expectedValue) {
+                if ('type' === $key) {
+                    assertEquals($expectedValue, $group->getType()->getCode());
+                } elseif (($group->getType()->isVariant()) && ('axis' === $key)) {
+                    $attributes = [];
+                    foreach ($group->getAxisAttributes() as $attribute) {
+                        $attributes[] = $attribute->getCode();
+                    }
+                    asort($attributes);
+                    $attributes = implode(',', $attributes);
+                        assertEquals($data['axis'], $attributes);
+                } elseif (preg_match('/^label-(?P<locale>.+)$/', $key, $matches)) {
+                    assertEquals($expectedValue, $group->getTranslation($matches['locale'])->getLabel());
+                } else {
+                    throw new \InvalidArgumentException(sprintf('Unknown column name "%s" on group check', $key));
                 }
-                asort($attributes);
-                $attributes = implode(',', $attributes);
-                assertEquals($data['axis'], $attributes);
             }
         }
     }

--- a/features/Context/NavigationContext.php
+++ b/features/Context/NavigationContext.php
@@ -39,19 +39,6 @@ class NavigationContext extends BaseNavigationContext
     }
 
     /**
-     * @param string $identifier
-     *
-     * @Given /^I edit the "([^"]*)" user group$/
-     */
-    public function iEditTheUserGroup($identifier)
-    {
-        $page   = 'UserGroup';
-        $getter = sprintf('get%s', $page);
-        $entity = $this->getFixturesContext()->$getter($identifier);
-        $this->openPage(sprintf('UserGroup edit', $page), ['id' => $entity->getId()]);
-    }
-
-    /**
      * @param string $label
      *
      * @Given /^I edit the "([^"]+)" user role$/

--- a/features/Pim/Behat/Context/FixturesContext.php
+++ b/features/Pim/Behat/Context/FixturesContext.php
@@ -8,6 +8,7 @@ use Context\Spin\SpinCapableTrait;
 use Context\Spin\TimeoutException;
 use Doctrine\Common\Util\ClassUtils;
 use Doctrine\Common\Util\Inflector;
+use Pim\Component\Catalog\Model\CategoryInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 
 /**
@@ -28,7 +29,7 @@ class FixturesContext extends PimContext
         'Channel'          => 'PimCatalogBundle:Channel',
         'Currency'         => 'PimCatalogBundle:Currency',
         'Family'           => 'PimCatalogBundle:Family',
-        'ProductCategory'  => 'PimCatalogBundle:Category',
+        'Category'         => 'PimCatalogBundle:Category',
         'AssociationType'  => 'PimCatalogBundle:AssociationType',
         'JobInstance'      => 'Akeneo\Component\Batch\Model\JobInstance',
         'JobConfiguration' => 'Pim\Component\Connector\Model\JobConfiguration',

--- a/features/Pim/Behat/Context/FixturesContext.php
+++ b/features/Pim/Behat/Context/FixturesContext.php
@@ -28,7 +28,6 @@ class FixturesContext extends PimContext
         'Channel'          => 'PimCatalogBundle:Channel',
         'Currency'         => 'PimCatalogBundle:Currency',
         'Family'           => 'PimCatalogBundle:Family',
-        'Category'         => 'PimCatalogBundle:Category', // TODO: To remove
         'ProductCategory'  => 'PimCatalogBundle:Category',
         'AssociationType'  => 'PimCatalogBundle:AssociationType',
         'JobInstance'      => 'Akeneo\Component\Batch\Model\JobInstance',

--- a/features/Pim/Behat/Context/NavigationContext.php
+++ b/features/Pim/Behat/Context/NavigationContext.php
@@ -220,12 +220,12 @@ class NavigationContext extends PimContext implements PageObjectAwareInterface
      * @param string $identifier
      * @param string $page
      *
-     * @Given /^I edit the "([^"]*)" (\w+)$/
+     * @Given /^I edit the "([^"]*)" ([\w ]+)$/
      * @Given /^I am on the "([^"]*)" ((?!channel)\w+) page$/
      */
     public function iAmOnTheEntityEditPage($identifier, $page)
     {
-        $page   = ucfirst($page);
+        $page   = preg_replace('/ /', '', ucwords($page));
         $getter = sprintf('get%s', $page);
         $entity = $this->getFixturesContext()->$getter($identifier);
         $this->openPage(sprintf('%s edit', $page), ['id' => $entity->getId()]);

--- a/features/enrich/variant-group/add_attributes_to_a_variant_group.feature
+++ b/features/enrich/variant-group/add_attributes_to_a_variant_group.feature
@@ -97,8 +97,8 @@ Feature: Add attributes to a variant group
       | code       | requirements-mobile                              | requirements-tablet | attributes                                       |
       | high_heels | sku, high_heel_main_color, high_heel_main_fabric | sku                 | sku, high_heel_main_color, high_heel_main_fabric |
     And the following product groups:
-      | code       | label      | axis                                        | type    |
-      | high_heels | High heels | high_heel_main_color, high_heel_main_fabric | VARIANT |
+      | code       | label-en_US | axis                                        | type    |
+      | high_heels | High heels  | high_heel_main_color, high_heel_main_fabric | VARIANT |
     And the following product:
       | sku     | family     | high_heel_main_color | high_heel_main_fabric |
       | heel001 | high_heels | Red                  | Silk                  |

--- a/features/enrich/variant-group/add_products/add_products_history_updated_with_context.feature
+++ b/features/enrich/variant-group/add_products/add_products_history_updated_with_context.feature
@@ -7,8 +7,8 @@ Feature: Add products to a variant group
   Background:
     Given the "footwear" catalog configuration
     And the following product groups:
-      | code   | label  | axis  | type    |
-      | SANDAL | Sandal | color | VARIANT |
+      | code   | label-en_US | axis  | type    |
+      | SANDAL | Sandal      | color | VARIANT |
     And the following variant group values:
       | group  | attribute    | value       | locale | scope |
       | SANDAL | manufacturer | Converse    |        |       |

--- a/features/enrich/variant-group/add_products/add_products_history_updated_without_context.feature
+++ b/features/enrich/variant-group/add_products/add_products_history_updated_without_context.feature
@@ -7,8 +7,8 @@ Feature: Add products to a variant group
   Background:
     Given the "footwear" catalog configuration
     And the following product groups:
-      | code   | label  | axis  | type    |
-      | SANDAL | Sandal | color | VARIANT |
+      | code   | label-en_US | axis  | type    |
+      | SANDAL | Sandal      | color | VARIANT |
     And the following variant group values:
       | group  | attribute    | value       | locale | scope |
       | SANDAL | manufacturer | Converse    |        |       |

--- a/features/enrich/variant-group/add_products/add_products_reject_addition.feature
+++ b/features/enrich/variant-group/add_products/add_products_reject_addition.feature
@@ -12,8 +12,8 @@ Feature: Add products to a variant group
       | sandal-white-38 | sandals | winter_collection | 38   | white | old name   |
       | sandal-white-39 | sandals | winter_collection | 39   | white | old name   |
     And the following product groups:
-      | code   | label  | axis        | type    |
-      | SANDAL | Sandal | size, color | VARIANT |
+      | code   | label-en_US | axis        | type    |
+      | SANDAL | Sandal      | size, color | VARIANT |
     And the following variant group values:
       | group  | attribute    | value       | locale | scope |
       | SANDAL | manufacturer | Converse    |        |       |

--- a/features/enrich/variant-group/add_products/add_products_updated_with_values.feature
+++ b/features/enrich/variant-group/add_products/add_products_updated_with_values.feature
@@ -12,8 +12,8 @@ Feature: Add products to a variant group
       | sandal-white-38 | sandals | winter_collection | 38   | white | old name   |
       | sandal-white-39 | sandals | winter_collection | 39   | white | old name   |
     And the following product groups:
-      | code   | label  | axis        | type    |
-      | SANDAL | Sandal | size, color | VARIANT |
+      | code   | label-en_US | axis        | type    |
+      | SANDAL | Sandal      | size, color | VARIANT |
     And the following variant group values:
       | group  | attribute    | value       | locale | scope |
       | SANDAL | manufacturer | Converse    |        |       |

--- a/features/enrich/variant-group/browse_variant_groups.feature
+++ b/features/enrich/variant-group/browse_variant_groups.feature
@@ -13,7 +13,7 @@ Feature: Browse variant groups
       | size      | Size       | simpleselect |
       | dimension | Dimensions | simpleselect |
     And the following product groups:
-      | code              | label             | axis        | type    |
+      | code              | label-en_US       | axis        | type    |
       | tshirt_akeneo     | Akeneo T-Shirt    | size, color | VARIANT |
       | mug               | Mug               | color       | VARIANT |
       | sticker_akeneo    | Akeneo Sticker    | dimension   | VARIANT |

--- a/features/enrich/variant-group/edit_variant_browse_products.feature
+++ b/features/enrich/variant-group/edit_variant_browse_products.feature
@@ -17,10 +17,10 @@ Feature: Edit a variant group adding/removing products
     And the following "color" attribute options: Yellow, Blue, Green, Pink and Red
     And the following "size" attribute options: XS, S, M, L and XL
     And the following product groups:
-      | code       | label      | axis        | type    |
-      | MUG        | MUG Akeneo | color       | VARIANT |
-      | POSTIT     | Postit     | color, size | VARIANT |
-      | CROSS_SELL | Cross sell |             | X_SELL |
+      | code       | label-en_US | axis        | type    |
+      | MUG        | MUG Akeneo  | color       | VARIANT |
+      | POSTIT     | Postit      | color, size | VARIANT |
+      | CROSS_SELL | Cross sell  |             | X_SELL |
     And the following products:
       | sku    | groups          | family    | color  | size |
       | MUG_A1 |                 | mug       |        |      |

--- a/features/enrich/variant-group/edit_variant_sort_products.feature
+++ b/features/enrich/variant-group/edit_variant_sort_products.feature
@@ -16,13 +16,13 @@ Feature: Sort available products for a variant group
       | size  | Size  | simpleselect | yes                    |
     And the following "color" attribute options: Yellow, Blue, Green and Red
     And the following "size" attribute options: XS, S, M, L and XL
-    And the following products:
-      | sku    | family    | color | size |
-      | MUG_1  | mug       | Red   | M    |
-      | POSTIT | furniture | Blue  | XL   |
     And the following product groups:
-      | code   | label  | axis        | products | type    |
-      | POSTIT | Postit | color, size | POSTIT   | VARIANT |
+      | code   | label-en_US | axis        | type    |
+      | POSTIT | Postit      | color, size | VARIANT |
+    And the following products:
+      | sku    | family    | color | size | groups |
+      | MUG_1  | mug       | Red   | M    |        |
+      | POSTIT | furniture | Blue  | XL   | POSTIT |
     And I am logged in as "Julia"
 
   Scenario: Successfully sort products

--- a/features/enrich/variant-group/remove_products.feature
+++ b/features/enrich/variant-group/remove_products.feature
@@ -7,8 +7,8 @@ Feature: Remove products from a variant group
   Background:
     Given the "footwear" catalog configuration
     And the following product groups:
-      | code   | label  | axis        | type    |
-      | SANDAL | Sandal | size, color | VARIANT |
+      | code   | label-en_US | axis        | type    |
+      | SANDAL | Sandal      | size, color | VARIANT |
     And the following products:
       | sku             | groups | family  | categories        | size | color |
       | sandal-white-37 | SANDAL | sandals | winter_collection | 37   | white |

--- a/features/export/export_products_with_media.feature
+++ b/features/export/export_products_with_media.feature
@@ -39,12 +39,12 @@ Feature: Export products with media
 
   @jira https://akeneo.atlassian.net/browse/PIM-3785
   Scenario: Successfully export products with nullable media
-    Given the following family:
-      | code      | requirements-tablet | requirements-mobile |
-      | flipflop  | sku                 | sku                 |
-    And the following attributes:
-      | code    | label   | type  | allowed extensions | families  |
-      | picture | Picture | image | jpg                | flipflop  |
+    Given the following attributes:
+      | code    | label   | type  | allowed extensions |
+      | picture | Picture | image | jpg                |
+    And the following family:
+      | code      | attributes  | requirements-tablet | requirements-mobile |
+      | flipflop  | sku,picture | sku                 | sku                 |
     And the following products:
       | sku         | categories        | price          | size | color    | name-en_US | family    |
       | FLIPFLOP-1R | summer_collection | 50 EUR, 70 USD | 45   | red      | Model 1    | flipflop  |

--- a/features/import/import_categories.feature
+++ b/features/import/import_categories.feature
@@ -22,7 +22,7 @@ Feature: Import categories
     And I launch the import job
     And I wait for the "csv_footwear_category_import" job to finish
     Then there should be the following categories:
-      | code        | label       | parent    |
+      | code        | label-en_US | parent    |
       | computers   | Computers   |           |
       | laptops     | Laptops     | computers |
       | hard_drives | Hard drives | laptops   |
@@ -50,7 +50,7 @@ Feature: Import categories
     Then I should see "Property \"parent\" expects a valid category code. The category does not exist, \"clothes\" given."
     And I should see "Property \"parent\" expects a valid category code. The category does not exist, \"tshirts\" given."
     And there should be the following categories:
-      | code        | label       | parent    |
+      | code        | label-en_US | parent    |
       | computers   | Computers   |           |
       | laptops     | Laptops     | computers |
       | hard_drives | Hard drives | laptops   |
@@ -92,7 +92,7 @@ Feature: Import categories
     And I launch the import job
     And I wait for the "xlsx_footwear_category_import" job to finish
     Then there should be the following categories:
-      | code        | label       | parent    |
+      | code        | labelen_US  | parent    |
       | computers   | Computers   |           |
       | laptops     | Laptops     | computers |
       | hard_drives | Hard drives | laptops   |

--- a/features/import/product/import_products.feature
+++ b/features/import/product/import_products.feature
@@ -7,8 +7,8 @@ Feature: Execute a job
   Background:
     Given the "footwear" catalog configuration
     And the following product groups:
-      | code  | label     | type    |
-      | CROSS | Bag Cross | RELATED |
+      | code  | label-en_US | type    |
+      | CROSS | Bag Cross   | RELATED |
     And I am logged in as "Julia"
 
   Scenario: Successfully import a csv file of products

--- a/features/import/product/import_products_and_download_imported_file.feature
+++ b/features/import/product/import_products_and_download_imported_file.feature
@@ -7,8 +7,8 @@ Feature: Execute a job
   Background:
     Given the "footwear" catalog configuration
     And the following product groups:
-      | code  | label     | type    |
-      | CROSS | Bag Cross | RELATED |
+      | code  | label-en_US | type    |
+      | CROSS | Bag Cross   | RELATED |
     And I am logged in as "Julia"
 
   Scenario: Successfully import a csv file of products and be able to download the imported file

--- a/features/import/product/import_products_with_associations.feature
+++ b/features/import/product/import_products_with_associations.feature
@@ -7,8 +7,8 @@ Feature: Execute a job
   Background:
     Given the "footwear" catalog configuration
     And the following product groups:
-      | code  | label     | type    |
-      | CROSS | Bag Cross | RELATED |
+      | code  | label-en_US | type    |
+      | CROSS | Bag Cross   | RELATED |
     And I am logged in as "Julia"
 
   Scenario: Successfully import a csv file of products with associations

--- a/features/import/product/import_products_with_invalid_data.feature
+++ b/features/import/product/import_products_with_invalid_data.feature
@@ -7,8 +7,8 @@ Feature: Execute a job
   Background:
     Given the "footwear" catalog configuration
     And the following product groups:
-      | code  | label     | type    |
-      | CROSS | Bag Cross | RELATED |
+      | code  | label-en_US | type    |
+      | CROSS | Bag Cross   | RELATED |
     And I am logged in as "Julia"
 
   @jira https://akeneo.atlassian.net/browse/PIM-3266

--- a/features/import/product/import_products_with_variant_group_values.feature
+++ b/features/import/product/import_products_with_variant_group_values.feature
@@ -16,8 +16,8 @@ Feature: Execute a product import
       | sandal-red-38   | sandals | winter_collection | 38   | red   |
       | sandal-red-39   | sandals | winter_collection | 39   | red   |
     And the following product groups:
-      | code   | label  | axis        | type    | products                                                                                       |
-      | SANDAL | Sandal | size, color | VARIANT | sandal-white-37, sandal-white-38, sandal-white-39, sandal-red-37, sandal-red-38, sandal-red-39 |
+      | code   | label-en_US | axis        | type    | products                                                                                       |
+      | SANDAL | Sandal      | size, color | VARIANT | sandal-white-37, sandal-white-38, sandal-white-39, sandal-red-37, sandal-red-38, sandal-red-39 |
     And the following variant group values:
       | group  | attribute   | value                | locale | scope  |
       | SANDAL | name        | My VG US name        | en_US  |        |

--- a/features/import/product/xlsx/import_products.feature
+++ b/features/import/product/xlsx/import_products.feature
@@ -7,8 +7,8 @@ Feature: Import XLSX products
   Background:
     Given the "footwear" catalog configuration
     And the following product groups:
-      | code  | label     | type    |
-      | CROSS | Bag Cross | RELATED |
+      | code  | label-en_US | type    |
+      | CROSS | Bag Cross   | RELATED |
     And I am logged in as "Julia"
 
   Scenario: Successfully import an XLSX file of products

--- a/features/import/product/xlsx/import_products_with_associations.feature
+++ b/features/import/product/xlsx/import_products_with_associations.feature
@@ -7,8 +7,8 @@ Feature: Execute a job
   Background:
     Given the "footwear" catalog configuration
     And the following product groups:
-      | code  | label     | type    |
-      | CROSS | Bag Cross | RELATED |
+      | code  | label-en_US | type    |
+      | CROSS | Bag Cross   | RELATED |
     And I am logged in as "Julia"
 
   Scenario: Successfully import a xlsx file of products with associations

--- a/features/import/product_group/import_groups.feature
+++ b/features/import/product_group/import_groups.feature
@@ -7,11 +7,11 @@ Feature: Import groups
   Background:
     Given the "footwear" catalog configuration
     And the following product groups:
-      | code          | label          | type    | axis        |
-      | ORO_TSHIRT    | Oro T-shirt    | VARIANT | size, color |
-      | AKENEO_TSHIRT | Akeneo T-shirt | VARIANT | size        |
-      | ORO_XSELL     | Oro X          | XSELL   |             |
-      | AKENEO_XSELL  | Akeneo X       | XSELL   |             |
+      | code          | label-en_US    | type    | axis       |
+      | ORO_TSHIRT    | Oro T-shirt    | VARIANT | size,color |
+      | AKENEO_TSHIRT | Akeneo T-shirt | VARIANT | size       |
+      | ORO_XSELL     | Oro X          | XSELL   |            |
+      | AKENEO_XSELL  | Akeneo X       | XSELL   |            |
     And I am logged in as "Julia"
 
   Scenario: Successfully import standard groups to create and update products (no variant groups)

--- a/features/import/product_group/xlsx/import_groups.feature
+++ b/features/import/product_group/xlsx/import_groups.feature
@@ -7,7 +7,7 @@ Feature: Import Xlsx groups
   Background:
     Given the "footwear" catalog configuration
     And the following product groups:
-      | code          | label          | type    | axis        |
+      | code          | label-en_US    | type    | axis        |
       | ORO_TSHIRT    | Oro T-shirt    | VARIANT | size, color |
       | AKENEO_TSHIRT | Akeneo T-shirt | VARIANT | size        |
       | ORO_XSELL     | Oro X          | XSELL   |             |

--- a/features/import/product_variant_group/import_variant_group_having_products.feature
+++ b/features/import/product_variant_group/import_variant_group_having_products.feature
@@ -15,9 +15,9 @@ Feature: Execute an import of variant group having matching products
       | sandal-red-38   | sandals | winter_collection | 38   | red   |
       | sandal-red-39   | sandals | winter_collection | 39   | red   |
     And the following product groups:
-      | code    | label   | axis        | type    | products                                          |
-      | SANDAL  | Sandal  | size, color | VARIANT | sandal-white-37, sandal-white-38, sandal-white-39 |
-      | SANDAL2 | Sandal2 | size, color | VARIANT | sandal-red-37, sandal-red-38, sandal-red-39       |
+      | code    | label-en_US | axis        | type    | products                                          |
+      | SANDAL  | Sandal      | size, color | VARIANT | sandal-white-37, sandal-white-38, sandal-white-39 |
+      | SANDAL2 | Sandal2     | size, color | VARIANT | sandal-red-37, sandal-red-38, sandal-red-39       |
     And I am logged in as "Julia"
 
   @jira https://akeneo.atlassian.net/browse/PIM-5990

--- a/features/import/product_variant_group/import_variant_group_values_with_axis_as_data.feature
+++ b/features/import/product_variant_group/import_variant_group_values_with_axis_as_data.feature
@@ -15,8 +15,8 @@ Feature: Execute an import with axis as data
       | sandal-red-38   | sandals | winter_collection | 38   | red   |
       | sandal-red-39   | sandals | winter_collection | 39   | red   |
     And the following product groups:
-      | code   | label  | axis        | type    | products                                                                                       |
-      | SANDAL | Sandal | size, color | VARIANT | sandal-white-37, sandal-white-38, sandal-white-39, sandal-red-37, sandal-red-38, sandal-red-39 |
+      | code   | label-en_US | axis        | type    | products                                                                                       |
+      | SANDAL | Sandal      | size, color | VARIANT | sandal-white-37, sandal-white-38, sandal-white-39, sandal-red-37, sandal-red-38, sandal-red-39 |
     And I am logged in as "Julia"
 
   Scenario: Skip variant group if one axis is used as values

--- a/features/import/product_variant_group/import_variant_group_values_with_empty_data.feature
+++ b/features/import/product_variant_group/import_variant_group_values_with_empty_data.feature
@@ -15,9 +15,9 @@ Feature: Execute an import with empty data
       | sandal-red-38   | sandals | winter_collection | 38   | red   | old name   |
       | sandal-red-39   | sandals | winter_collection | 39   | red   | old name   |
     And the following product groups:
-      | code    | label   | axis        | type    | products                                          |
-      | SANDAL  | Sandal  | size, color | VARIANT | sandal-white-37, sandal-white-38, sandal-white-39 |
-      | SANDAL2 | Sandal2 | size, color | VARIANT | sandal-red-37, sandal-red-38, sandal-red-39       |
+      | code    | label-en_US | axis        | type    | products                                          |
+      | SANDAL  | Sandal      | size, color | VARIANT | sandal-white-37, sandal-white-38, sandal-white-39 |
+      | SANDAL2 | Sandal2     | size, color | VARIANT | sandal-red-37, sandal-red-38, sandal-red-39       |
     And I am logged in as "Julia"
 
   Scenario: Successfully import a csv file with values for one variant group and empty values for the other

--- a/features/import/product_variant_group/import_variant_group_values_with_file_upload.feature
+++ b/features/import/product_variant_group/import_variant_group_values_with_file_upload.feature
@@ -15,8 +15,8 @@ Feature: Execute an import with file upload
       | sandal-red-38   | sandals | winter_collection | 38   | red   |
       | sandal-red-39   | sandals | winter_collection | 39   | red   |
     And the following product groups:
-      | code   | label  | axis        | type    | products                                                                                       |
-      | SANDAL | Sandal | size, color | VARIANT | sandal-white-37, sandal-white-38, sandal-white-39, sandal-red-37, sandal-red-38, sandal-red-39 |
+      | code   | label-en_US | axis        | type    | products                                                                                       |
+      | SANDAL | Sandal      | size, color | VARIANT | sandal-white-37, sandal-white-38, sandal-white-39, sandal-red-37, sandal-red-38, sandal-red-39 |
     And I am logged in as "Julia"
 
   Scenario: Successfully import a csv file of variant group values through file upload

--- a/features/import/product_variant_group/import_variant_group_values_with_invalid_data.feature
+++ b/features/import/product_variant_group/import_variant_group_values_with_invalid_data.feature
@@ -36,9 +36,9 @@ Feature: Execute an import with invalid data
       | sandal2-red-37   | sandals | winter_collection | 37   | red   |
       | sandal2-red-38   | sandals | winter_collection | 38   | red   |
     And the following product groups:
-      | code    | label     | axis        | type    | products                                                                                       |
-      | SANDAL  | Sandal    | size, color | VARIANT | sandal-white-37, sandal-white-38, sandal-white-39, sandal-red-37, sandal-red-38, sandal-red-39 |
-      | SANDAL2 | SandalTwo | size, color | VARIANT | sandal2-white-37, sandal2-white-38, sandal2-red-37, sandal2-red-38                             |
+      | code    | label-en_US | axis        | type    | products                                                                                       |
+      | SANDAL  | Sandal      | size, color | VARIANT | sandal-white-37, sandal-white-38, sandal-white-39, sandal-red-37, sandal-red-38, sandal-red-39 |
+      | SANDAL2 | SandalTwo   | size, color | VARIANT | sandal2-white-37, sandal2-white-38, sandal2-red-37, sandal2-red-38                             |
     And the following attributes:
       | code        | label-en_US | type | scopable | max_characters | validation_rule | validation_regexp |
       | custom_desc | Desc        | text | no       |                |                 |                   |

--- a/features/import/product_variant_group/import_variant_group_values_with_valid_data.feature
+++ b/features/import/product_variant_group/import_variant_group_values_with_valid_data.feature
@@ -32,8 +32,8 @@ Feature: Execute an import with valid data
       | sandal-red-38   | sandals | winter_collection | 38   | red   |
       | sandal-red-39   | sandals | winter_collection | 39   | red   |
     And the following product groups:
-      | code   | label  | axis        | type    | products                                                                                       |
-      | SANDAL | Sandal | size, color | VARIANT | sandal-white-37, sandal-white-38, sandal-white-39, sandal-red-37, sandal-red-38, sandal-red-39 |
+      | code   | label-en_US | axis        | type    | products                                                                                       |
+      | SANDAL | Sandal      | size, color | VARIANT | sandal-white-37, sandal-white-38, sandal-white-39, sandal-red-37, sandal-red-38, sandal-red-39 |
     And I am logged in as "Julia"
 
   Scenario: Successfully import a csv file of variant group values with localizable, scopable textarea

--- a/features/import/product_variant_group/import_variant_group_with_invalid_properties.feature
+++ b/features/import/product_variant_group/import_variant_group_with_invalid_properties.feature
@@ -7,9 +7,9 @@ Feature: Execute an import with invalid properties
   Background:
     Given the "footwear" catalog configuration
     And the following product groups:
-      | code   | label  | axis        | type    |
-      | SANDAL | Sandal | size, color | VARIANT |
-      | NOT_VG | Not VG |             | RELATED |
+      | code   | label-en_US | axis        | type    |
+      | SANDAL | Sandal      | size, color | VARIANT |
+      | NOT_VG | Not VG      |             | RELATED |
     And I am logged in as "Julia"
 
   Scenario: Stop the import if variant group code column is not provided

--- a/features/import/product_variant_group/import_variant_group_with_scopable_or_localizable_data.feature
+++ b/features/import/product_variant_group/import_variant_group_with_scopable_or_localizable_data.feature
@@ -7,8 +7,8 @@ Feature: Execute an import with scopable or localizable data
   Background:
     Given the "apparel" catalog configuration
     And the following product groups:
-      | code   | label  | axis        | type    |
-      | SANDAL | Sandal | size, color | VARIANT |
+      | code   | label-en_US | axis        | type    |
+      | SANDAL | Sandal      | size, color | VARIANT |
     And I am logged in as "Julia"
 
   Scenario: Avoid data loss when importing variant group localizable/scopable values

--- a/features/import/product_variant_group/import_variant_group_with_valid_properties.feature
+++ b/features/import/product_variant_group/import_variant_group_with_valid_properties.feature
@@ -7,9 +7,9 @@ Feature: Execute an import with valid properties
   Background:
     Given the "footwear" catalog configuration
     And the following product groups:
-      | code   | label  | axis        | type    |
-      | SANDAL | Sandal | color, size | VARIANT |
-      | NOT_VG | Not VG |             | RELATED |
+      | code   | label-en_US | axis        | type    |
+      | SANDAL | Sandal      | color, size | VARIANT |
+      | NOT_VG | Not VG      |             | RELATED |
     And I am logged in as "Julia"
 
   Scenario: Successfully import a csv file of variant group to create a new one

--- a/features/import/product_variant_group/xlsx/import_variant_group_with_valid_properties.feature
+++ b/features/import/product_variant_group/xlsx/import_variant_group_with_valid_properties.feature
@@ -7,9 +7,9 @@ Feature: Execute an Xlsx import with valid properties
   Background:
     Given the "footwear" catalog configuration
     And the following product groups:
-      | code   | label  | axis        | type    |
-      | SANDAL | Sandal | color, size | VARIANT |
-      | NOT_VG | Not VG |             | RELATED |
+      | code   | label-en_US | axis        | type    |
+      | SANDAL | Sandal      | color, size | VARIANT |
+      | NOT_VG | Not VG      |             | RELATED |
     And I am logged in as "Julia"
 
   Scenario: Successfully import a XLSX file of variant group to create a new one

--- a/features/import/xlsx/import_channels.feature
+++ b/features/import/xlsx/import_channels.feature
@@ -9,7 +9,7 @@ Feature: Import channels
     And I am logged in as "Julia"
     And the following XLSX file to import:
       """
-      code;label;color;currencies;locales;tree
+      code;label-en_US;color;currencies;locales;tree
       site;Site;blue;USD,EUR;de_DE,en_US,hy_AM;2014_collection
       """
     And the following job "xlsx_footwear_channel_import" configuration:
@@ -18,8 +18,8 @@ Feature: Import channels
     And I launch the import job
     And I wait for the "xlsx_footwear_channel_import" job to finish
     Then there should be the following channels:
-      | code | label | color | currencies | locales           | tree            | conversion_units |
-      | site | Site  | blue  | EUR,USD    | de_DE,en_US,hy_AM | 2014_collection |                  |
+      | code | label-en_US | currencies | locales           | tree            | conversion_units |
+      | site | Site        | EUR,USD    | de_DE,en_US,hy_AM | 2014_collection |                  |
 
   Scenario: Successfully remove locales and currencies
     Given the "apparel" catalog configuration
@@ -29,7 +29,7 @@ Feature: Import channels
     And I am logged in as "Julia"
     And the following XLSX file to import:
       """
-      code;label;currencies;locales;tree
+      code;label-en_US;currencies;locales;tree
       print;Print;USD;en_US;2015_collection
       """
     And the following job "xlsx_channel_import" configuration:
@@ -38,5 +38,5 @@ Feature: Import channels
     And I launch the import job
     And I wait for the "xlsx_channel_import" job to finish
     Then there should be the following channels:
-      | code  | label | currencies | locales | tree            | conversion_units |
-      | print | Print | USD        | en_US   | 2015_collection |                  |
+      | code  | label-en_US | currencies | locales | tree            | conversion_units |
+      | print | Print       | USD        | en_US   | 2015_collection |                  |

--- a/features/mass-action/edit_common_attributes-01.feature
+++ b/features/mass-action/edit_common_attributes-01.feature
@@ -6,15 +6,17 @@ Feature: Edit common attributes of many products at once
 
   Background:
     Given a "footwear" catalog configuration
-    And the following family:
-      | code       | attributes                                                       |
-      | high_heels | sku, name, description, price, rating, size, color, manufacturer |
     And the following attributes:
-      | code        | label       | type   | metric family | default metric unit | families                 |
-      | weight      | Weight      | metric | Weight        | GRAM                | boots, sneakers, sandals |
-      | heel_height | Heel Height | metric | Length        | CENTIMETER          | high_heels, sandals      |
+      | code        | label       | type   | metric family | default metric unit |
+      | weight      | Weight      | metric | Weight        | GRAM                |
+      | heel_height | Heel Height | metric | Length        | CENTIMETER          |
+    And the following family:
+      | code       | attributes                                                                                                        |
+      | high_heels | sku,name,description,price,rating,size,color,manufacturer,heel_height                                             |
+      | sneakers   | sku,name,manufacturer,description,weather_conditions,price,rating,side_view,top_view,size,color,lace_color,weight |
+      | sandals    | sku,name,manufacturer,description,price,rating,side_view,size,color,weight,heel_height                            |
     And the following product groups:
-      | code          | label         | axis  | type    |
+      | code          | label-en_US   | axis  | type    |
       | variant_heels | Variant Heels | color | VARIANT |
     And the following variant group values:
       | group         | attribute   | value         |

--- a/features/mass-action/edit_common_attributes_channel.feature
+++ b/features/mass-action/edit_common_attributes_channel.feature
@@ -15,7 +15,7 @@ Feature: Edit common attributes of many products at once
       | heel_height  | Heel Height | metric | Length        | CENTIMETER          | high_heels, sandals      |
       | buckle_color | Buckle      | text   |               |                     | high_heels               |
     And the following product groups:
-      | code          | label         | axis  | type    |
+      | code          | label-en_US   | axis  | type    |
       | variant_heels | Variant Heels | color | VARIANT |
     And the following variant group values:
       | group         | attribute   | value         |

--- a/features/mass-action/edit_common_attributes_images.feature
+++ b/features/mass-action/edit_common_attributes_images.feature
@@ -15,7 +15,7 @@ Feature: Edit common attributes of many products at once
       | heel_height  | Heel Height | metric | Length        | CENTIMETER          | high_heels, sandals      |
       | buckle_color | Buckle      | text   |               |                     | high_heels               |
     And the following product groups:
-      | code          | label         | axis  | type    |
+      | code          | label-en_US   | axis  | type    |
       | variant_heels | Variant Heels | color | VARIANT |
     And the following variant group values:
       | group         | attribute   | value         |

--- a/features/mass-action/edit_common_attributes_metric.feature
+++ b/features/mass-action/edit_common_attributes_metric.feature
@@ -15,7 +15,7 @@ Feature: Edit common attributes of many products at once
       | heel_height  | Heel Height | metric | Length        | CENTIMETER          | high_heels, sandals      |
       | buckle_color | Buckle      | text   |               |                     | high_heels               |
     And the following product groups:
-      | code          | label         | axis  | type    |
+      | code          | label-en_US   | axis  | type    |
       | variant_heels | Variant Heels | color | VARIANT |
     And the following variant group values:
       | group         | attribute   | value         |

--- a/features/mass-action/edit_common_attributes_per_families.feature
+++ b/features/mass-action/edit_common_attributes_per_families.feature
@@ -6,16 +6,19 @@ Feature: Edit common attributes of many products at once
 
   Background:
     Given a "footwear" catalog configuration
-    And the following family:
-      | code       | attributes                                                       |
-      | high_heels | sku, name, description, price, rating, size, color, manufacturer |
     And the following attributes:
-      | code         | label       | type   | metric family | default metric unit | families                 |
-      | weight       | Weight      | metric | Weight        | GRAM                | boots, sneakers, sandals |
-      | heel_height  | Heel Height | metric | Length        | CENTIMETER          | high_heels, sandals      |
-      | buckle_color | Buckle      | text   |               |                     | high_heels               |
+      | code         | label       | type   | metric family | default metric unit |
+      | weight       | Weight      | metric | Weight        | GRAM                |
+      | heel_height  | Heel Height | metric | Length        | CENTIMETER          |
+      | buckle_color | Buckle      | text   |               |                     |
+    And the following family:
+      | code       | attributes                                                                                                        |
+      | high_heels | sku,name,description,price,rating,size,color,manufacturer,heel_height,buckle_color                                |
+      | boots      | sku,name,manufacturer,description,weather_conditions,price,rating,side_view,top_view,size,color,lace_color,weight |
+      | sneakers   | sku,name,manufacturer,description,weather_conditions,price,rating,side_view,top_view,size,color,lace_color,weight |
+      | sandals    | sku,name,manufacturer,description,price,rating,side_view,size,color,weight                                        |
     And the following product groups:
-      | code          | label         | axis  | type    |
+      | code          | label-en_US   | axis  | type    |
       | variant_heels | Variant Heels | color | VARIANT |
     And the following variant group values:
       | group         | attribute   | value         |

--- a/features/product-group/add_products.feature
+++ b/features/product-group/add_products.feature
@@ -7,8 +7,8 @@ Feature: Add products to a group
   Background:
     Given the "footwear" catalog configuration
     And the following product groups:
-      | code       | label      | type  |
-      | CROSS_SELL | Cross Sell | XSELL |
+      | code       | label-en_US | type  |
+      | CROSS_SELL | Cross Sell  | XSELL |
     And the following products:
       | sku             | family  | categories        | size | color |
       | sandal-white-37 | sandals | winter_collection | 37   | white |

--- a/features/product-group/browse_product_groups.feature
+++ b/features/product-group/browse_product_groups.feature
@@ -12,7 +12,7 @@ Feature: Browse product groups
       | color | Color | simpleselect |
       | size  | Size  | simpleselect |
     And the following product groups:
-      | code          | label          | axis        | type    |
+      | code          | label-en_US    | axis        | type    |
       | tshirt_akeneo | Akeneo T-Shirt | size, color | VARIANT |
       | mug_akeneo    | Akeneo Mug     | color       | VARIANT |
       | CROSS_SELL_1  | Cross Sell     |             | X_SELL  |

--- a/features/product-group/delete_product_group.feature
+++ b/features/product-group/delete_product_group.feature
@@ -7,8 +7,8 @@ Feature: Delete a product group
   Background:
     Given the "default" catalog configuration
     And the following product groups:
-      | code | label      | type   |
-      | MUG  | MUG Akeneo | X_SELL |
+      | code | label-en_US | type   |
+      | MUG  | MUG Akeneo  | X_SELL |
     And I am logged in as "Julia"
 
   Scenario: Successfully delete a product group from the grid

--- a/features/product-group/remove_products.feature
+++ b/features/product-group/remove_products.feature
@@ -7,8 +7,8 @@ Feature: Remove products from a group
   Background:
     Given the "footwear" catalog configuration
     And the following product groups:
-      | code       | label      | type  |
-      | CROSS_SELL | Cross Sell | XSELL |
+      | code       | label-en_US | type  |
+      | CROSS_SELL | Cross Sell  | XSELL |
     And the following products:
       | sku             | groups     | family  | categories        | size | color |
       | sandal-white-37 | CROSS_SELL | sandals | winter_collection | 37   | white |

--- a/features/product/display_groups_in_the_grid.feature
+++ b/features/product/display_groups_in_the_grid.feature
@@ -12,7 +12,7 @@ Feature: Display product attributes in the grid
       | gray-boots   |
       | white-boots  |
     And the following product groups:
-      | code         | label          | type     | products                 |
+      | code         | label-en_US    | type     | products                 |
       | boots_akeneo | Akeneo Boots   | RELATED  | black-boots, white-boots |
       | no_label     |                | RELATED  | gray-boots, white-boots  |
     When I am logged in as "Julia"

--- a/features/product/ensure_variant_read_only.feature
+++ b/features/product/ensure_variant_read_only.feature
@@ -19,7 +19,7 @@ Feature: Disable attribute fields updated by a variant group
     And the following "options" attribute options: Blue
     And the following "color" attribute options: Red, black and Green
     And the following product groups:
-      | code          | label          | axis  | type    |
+      | code          | label-en_US    | axis  | type    |
       | tshirt_akeneo | Akeneo T-Shirt | color | VARIANT |
     And the following variant group values:
       | group         | attribute   | value            | locale | scope     |

--- a/features/product/filtering/filter_products_per_group.feature
+++ b/features/product/filtering/filter_products_per_group.feature
@@ -21,10 +21,10 @@ Feature: Filter products
       | MUG-2  | furniture | black |
       | POSTIT | furniture |       |
     And the following product groups:
-      | code   | label  | axis  | type    | products     |
-      | MUG    | Mug    | color | VARIANT | MUG-1, MUG-2 |
-      | POSTIT | Postit |       | X_SELL  | POSTIT       |
-      | EMPTY  | Empty  |       | X_SELL  |              |
+      | code   | label-en_US | axis  | type    | products     |
+      | MUG    | Mug         | color | VARIANT | MUG-1, MUG-2 |
+      | POSTIT | Postit      |       | X_SELL  | POSTIT       |
+      | EMPTY  | Empty       |       | X_SELL  |              |
     And I am logged in as "Mary"
 
   Scenario: Successfully display datagrid with group

--- a/features/reference-data/variant-group/add_products.feature
+++ b/features/reference-data/variant-group/add_products.feature
@@ -14,8 +14,8 @@ Feature: Add products with reference data to a variant group
       | sandal-red-38   | sandals | winter_collection | 38   | Red        |
       | sandal-red-39   | sandals | winter_collection | 39   | Red        |
     And the following product groups:
-      | code   | label  | axis             | type    |
-      | SANDAL | Sandal | size, sole_color | VARIANT |
+      | code   | label-en_US | axis             | type    |
+      | SANDAL | Sandal      | size, sole_color | VARIANT |
     And I am logged in as "Julia"
 
   Scenario: Successfully add products in variant groups, products are updated with variant group values
@@ -32,8 +32,8 @@ Feature: Add products with reference data to a variant group
       | code       | attributes                  |
       | high_heels | sku, sole_color, heel_color |
     And the following product groups:
-      | code       | label      | axis                         | type    |
-      | HIGH_HEELS | High heels | size, sole_color, heel_color | VARIANT |
+      | code       | label-en_US | axis                         | type    |
+      | HIGH_HEELS | High heels  | size, sole_color, heel_color | VARIANT |
     And the following products:
       | sku            | family     | categories        | size | sole_color | heel_color |
       | heel-yellow-37 | high_heels | winter_collection | 37   | Yellow     | Black      |

--- a/features/reference-data/variant-group/import_with_reference_data_axis.feature
+++ b/features/reference-data/variant-group/import_with_reference_data_axis.feature
@@ -11,8 +11,8 @@ Feature: Import variant group involving reference data
       | color  | red  | Red   |
       | color  | blue | Blue  |
     And the following product groups:
-      | code   | label  | axis       | type    |
-      | jacket | Jacket | sole_color | VARIANT |
+      | code   | label-en_US | axis       | type    |
+      | jacket | Jacket      | sole_color | VARIANT |
     And the following products:
       | sku       | sole_color | groups |
       | my-jacket | red        | jacket |

--- a/features/update/add_association.feature
+++ b/features/update/add_association.feature
@@ -12,10 +12,10 @@ Feature: Update association fields
       | associatedTwo   |
       | associatedThree |
     And the following product groups:
-      | code       | label | type   |
-      | groupOne   | One   | upsell |
-      | groupTwo   | Two   | upsell |
-      | groupThree | Three | upsell |
+      | code       | label-en_US | type   |
+      | groupOne   | One         | upsell |
+      | groupTwo   | Two         | upsell |
+      | groupThree | Three       | upsell |
     Then I should get the following products after apply the following updater to it:
       | product | actions                                                                                                                                                    | result                                                                                                                                      |
       | owner   | [{"type": "add_data", "field": "associations", "data": {"similar":{"products":["associatedOne"], "groups":[]}}}]                                           | {"associations":{"similar":{"products":["associatedOne"]}}}                                                                                 |

--- a/features/update/remove_group.feature
+++ b/features/update/remove_group.feature
@@ -9,7 +9,7 @@ Feature: Remove groups fields
       | code |
       | PACK |
     And the following product groups:
-      | code  | label       | type |
+      | code  | label-en_US | type |
       | PACK1 | First pack  | PACK |
       | PACK2 | Second pack | PACK |
       | PACK3 | Third pack  | PACK |

--- a/features/update/set_association.feature
+++ b/features/update/set_association.feature
@@ -14,11 +14,11 @@ Feature: Update association fields
       | associatedOne |
       | associatedTwo |
     And the following product groups:
-      | code     | label | type   |
-      | groupOne | One   | upsell |
-      | groupTwo | Two   | upsell |
+      | code     | label-en_US | type   |
+      | groupOne | One         | upsell |
+      | groupTwo | Two         | upsell |
     Then I should get the following products after apply the following updater to it:
-      | product    | actions                                                                                                                                                                                         | result                                                                                                                                              |
+      | product    | actions                                                                                                                                                                                       | result                                                                                                                                              |
       | ownerOne   | [{"type": "set_data", "field": "associations", "data": {"similar":{"products":["associatedOne"], "groups":[]}}}]                                                                              | {"associations":{"similar":{"products":["associatedOne"]}}}                                                                                         |
       | ownerTwo   | [{"type": "set_data", "field": "associations", "data": {"similar":{"products":["associatedOne"], "groups":["groupOne"]}}}]                                                                    | {"associations":{"similar":{"products":["associatedOne"],"groups":["groupOne"]}}}                                                                   |
       | ownerThree | [{"type": "set_data", "field": "associations", "data": {"similar":{"products":["associatedOne","associatedTwo"], "groups":["groupOne","groupTwo"]}}}]                                         | {"associations":{"similar":{"products":["associatedOne","associatedTwo"],"groups":["groupOne","groupTwo"]}}}                                        |

--- a/features/update/set_group.feature
+++ b/features/update/set_group.feature
@@ -6,15 +6,15 @@ Feature: Update groups fields
   Scenario: Successfully update the groups field
     Given a "default" catalog configuration
     And the following products:
-      | sku                              |
-      | pack1                            |
-      | pack2                            |
-      | pack1_and_pack2                  |
+      | sku             |
+      | pack1           |
+      | pack2           |
+      | pack1_and_pack2 |
     Given the following group type:
-      | code    |
+      | code |
       | PACK |
     And the following product groups:
-      | code  | label       | type |
+      | code  | label-en_US | type |
       | PACK1 | First pack  | PACK |
       | PACK2 | Second pack | PACK |
       | PACK3 | Third pack  | PACK |

--- a/features/update/set_variant_group.feature
+++ b/features/update/set_variant_group.feature
@@ -6,34 +6,34 @@ Feature: Update variant group fields
   Scenario: Successfully update the variant group field
     Given a "footwear" catalog configuration
     And the following products:
-      | sku                              |
-      | tshirt1                          |
-      | tshirt2                          |
+      | sku     |
+      | tshirt1 |
+      | tshirt2 |
     And the following product groups:
-      | code    | label         | type    | axis |
+      | code    | label-en_US   | type    | axis |
       | TSHIRT1 | First tshirt  | VARIANT | size |
       | TSHIRT2 | Second tshirt | VARIANT | size |
       | TSHIRT3 | Third tshirt  | VARIANT | size |
     Then I should get the following products after apply the following updater to it:
-      | product             | actions                                                                                                                                | result                       |
-      | tshirt1             | [{"type": "set_data", "field": "variant_group", "data": "TSHIRT1"}]                                                                    | {"variant_group": "TSHIRT1"} |
-      | tshirt1             | [{"type": "set_data", "field": "variant_group", "data": null}]                                                                         | {"variant_group": ""}        |
-      | tshirt2             | [{"type": "set_data", "field": "variant_group", "data": "TSHIRT2"}]                                                                    | {"variant_group": "TSHIRT2"} |
-      | tshirt2             | [{"type": "set_data", "field": "variant_group", "data": "TSHIRT1"}, {"type": "set_data", "field": "variant_group", "data": "TSHIRT3"}] | {"variant_group": "TSHIRT3"} |
+      | product | actions                                                                                                                                | result                       |
+      | tshirt1 | [{"type": "set_data", "field": "variant_group", "data": "TSHIRT1"}]                                                                    | {"variant_group": "TSHIRT1"} |
+      | tshirt1 | [{"type": "set_data", "field": "variant_group", "data": null}]                                                                         | {"variant_group": ""}        |
+      | tshirt2 | [{"type": "set_data", "field": "variant_group", "data": "TSHIRT2"}]                                                                    | {"variant_group": "TSHIRT2"} |
+      | tshirt2 | [{"type": "set_data", "field": "variant_group", "data": "TSHIRT1"}, {"type": "set_data", "field": "variant_group", "data": "TSHIRT3"}] | {"variant_group": "TSHIRT3"} |
 
   Scenario: Successfully update the variant group field and the group field
     Given a "footwear" catalog configuration
     And the following products:
-      | sku                              |
-      | tshirt1                          |
-      | tshirt2                          |
-      | tshirt3                          |
-      | tshirt4                          |
+      | sku     |
+      | tshirt1 |
+      | tshirt2 |
+      | tshirt3 |
+      | tshirt4 |
     Given the following group type:
       | code |
       | PACK |
     And the following product groups:
-      | code    | label         | type    | axis |
+      | code    | label-en_US   | type    | axis |
       | TSHIRT1 | First tshirt  | VARIANT | size |
       | TSHIRT2 | Second tshirt | VARIANT | size |
       | TSHIRT3 | Third tshirt  | VARIANT | size |

--- a/src/Pim/Component/Catalog/Validator/Constraints/FamilyAttributeAsLabel.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/FamilyAttributeAsLabel.php
@@ -17,8 +17,7 @@ class FamilyAttributeAsLabel extends Constraint
     public $messageAttribute = "Property 'attribute_as_label' must belong to the family";
 
     /** @var string */
-    public $messageAttributeType = "Property 'attribute_as_label' only supports 'pim_catalog_text' and ".
-        "'pim_catalog_identifier' attribute types for the family";
+    public $messageAttributeType = "Property 'attribute_as_label' only supports 'pim_catalog_text' and 'pim_catalog_identifier' attribute types for the family";
 
     /**
      * {@inheritdoc}

--- a/src/Pim/Component/Catalog/Validator/Constraints/FamilyRequirements.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/FamilyRequirements.php
@@ -18,14 +18,12 @@ class FamilyRequirements extends Constraint
      *
      * @var string
      */
-    public $messageChannel = 'Family "%family%" should have requirements for identifier "%id%" and channel(s) '.
-        '"%channels%"';
+    public $messageChannel = 'Family "%family%" should have requirements for identifier "%id%" and channel(s) "%channels%"';
 
     /**
      * @var string
      */
-    public $messageAttribute = 'The attribute "%attribute%" cannot be an attribute required for the channel '.
-        '"%channel%" as it does not belong to this family';
+    public $messageAttribute = 'The attribute "%attribute%" cannot be an attribute required for the channel "%channel%" as it does not belong to this family';
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
### First

First, in the behat contexts, there is some hardcoded locales and channels.
- For example, when you declare an attribute option, you can not specify the locale, it's "en_US".
- Another example is the test (the entity should be like ...), you can not specify what locale do you want to check neither channel, or the list of available locales and channels is hardcoded.
This is only usable by footwear catalog.


### Second

We don't test in the "and the following ..." and "the entity should be ..." if the columns
- are "valid", i.e. they still exists (ex I found a "color" column :+1: )
- are all checked, because the list of column is hardcoded.
- are "localized", because by default we only check "en_US" for some entities.

### This is a taco :taco: 

This PR fixes all this.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Migration script                  | -
| Tech Doc                          | -
