### PR TITLE
AMS-176: fallback on default view if working view has been deleted

### DIFF
--- a/features/datagrid/datagrid_views.feature
+++ b/features/datagrid/datagrid_views.feature
@@ -210,6 +210,39 @@ Feature: Datagrid views
     And I should see the text "Mobile only"
     And I should see the text "Mobile"
 
+  Scenario: Successfully display the default view if my custom default view has been deleted
+    Given I am on the products page
+    And I filter by "family" with operator "in list" and value "Boots"
+    And I create the view:
+      | new-view-label | Boots only |
+    Then I should be on the products page
+    And I should see the flash message "Datagrid view successfully created"
+    When I logout
+    And I am logged in as "Julia"
+    And I am on the my account page
+    And I press the "Edit" button
+    And I visit the "Additional" tab
+    Then I should see the text "Default product grid view"
+    When I fill in the following information:
+      | Default product grid view | Boots only |
+    And I press the "Save" button
+    And I am on the products page
+    Then I should see the text "Boots only"
+    When I logout
+    And I am logged in as "Mary"
+    When I am on the products page
+    And I apply the "Boots only" view
+    And I delete the view
+    And I confirm the deletion
+    Then I should be on the products page
+    And I should see the flash message "Datagrid view successfully removed"
+    And I should see the text "Default view"
+    When I logout
+    And I am logged in as "Julia"
+    And I am on the products page
+    And I should see the text "Default view"
+    But I should not see the text "Boots only"
+
   @ce
   Scenario: Don't display view type switcher if there is only one view type
     Given I am on the products page

--- a/src/Pim/Bundle/DataGridBundle/Controller/Rest/DatagridViewController.php
+++ b/src/Pim/Bundle/DataGridBundle/Controller/Rest/DatagridViewController.php
@@ -137,10 +137,13 @@ class DatagridViewController
     public function getAction($identifier)
     {
         $view = $this->datagridViewRepo->find($identifier);
-        $view = current($this->datagridViewFilter->filterCollection([$view], 'pim.internal_api.datagrid_view.view'));
-
         if (null === $view) {
-            return new NotFoundHttpException();
+            return new JsonResponse(null, 404);
+        }
+
+        $view = current($this->datagridViewFilter->filterCollection([$view], 'pim.internal_api.datagrid_view.view'));
+        if (null === $view) {
+            return new JsonResponse(null, 404);
         }
 
         $normalizedView = $this->normalizer->normalize($view, 'internal_api');

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/grid/view-selector.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/grid/view-selector.js
@@ -244,7 +244,10 @@ define(
                             .then(this.postFetchDatagridView.bind(this))
                             .then(function (view) {
                                 deferred.resolve(view);
-                            });
+                            })
+                            .fail(function () {
+                                this.selectView(userDefaultView ? userDefaultView : this.getDefaultView());
+                            }.bind(this));
                     } else {
                         // Other, set the default view
                         deferred.resolve(this.getDefaultView());


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Since PIM-6058, a user can use a view created by another user to set as his default view.
If the custom view is deleted, it was just broken.
Now we fallback on the grid default view.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | OK
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
