### PR TITLE
Reduce memory leak with integration tests

### DIFF
--- a/tests/ConnectionCloser.php
+++ b/tests/ConnectionCloser.php
@@ -33,5 +33,7 @@ class ConnectionCloser
         foreach ($doctrine->getConnections() as $connection) {
             $connection->close();
         }
+
+        gc_collect_cycles();
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,8 +3,6 @@
 namespace Akeneo\Test\Integration;
 
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
-use Symfony\Component\Console\Application;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * @author    Marie Bochu <marie.bochu@akeneo.com>
@@ -15,9 +13,6 @@ abstract class TestCase extends KernelTestCase
 {
     /** @var int Count of test inside the same test class */
     protected static $count = 0;
-
-    /** @var ContainerInterface */
-    protected $container;
 
     /**
      * {@inheritdoc}
@@ -37,9 +32,8 @@ abstract class TestCase extends KernelTestCase
      */
     protected function setUp()
     {
-        static::bootKernel();
+        static::bootKernel(['debug' => false]);
 
-        $this->container = static::$kernel->getContainer();
         $configuration = $this->getConfiguration();
 
         self::$count++;
@@ -60,7 +54,7 @@ abstract class TestCase extends KernelTestCase
      */
     protected function get($service)
     {
-        return $this->container->get($service);
+        return static::$kernel->getContainer()->get($service);
     }
 
     /**
@@ -70,7 +64,7 @@ abstract class TestCase extends KernelTestCase
      */
     protected function getParameter($service)
     {
-        return $this->container->getParameter($service);
+        return static::$kernel->getContainer()->getParameter($service);
     }
 
     /**
@@ -89,7 +83,7 @@ abstract class TestCase extends KernelTestCase
      */
     protected function getDatabasePurger()
     {
-        return new DatabasePurger($this->container);
+        return new DatabasePurger(static::$kernel->getContainer());
     }
 
     /**
@@ -99,7 +93,7 @@ abstract class TestCase extends KernelTestCase
      */
     protected function getFixturesLoader(Configuration $configuration)
     {
-        return new FixturesLoader($this->container, $configuration);
+        return new FixturesLoader(static::$kernel->getContainer(), $configuration);
     }
 
     /**
@@ -107,7 +101,7 @@ abstract class TestCase extends KernelTestCase
      */
     protected function getConnectionCloser()
     {
-        return new ConnectionCloser($this->container);
+        return new ConnectionCloser(static::$kernel->getContainer());
     }
 
     /**


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

Currently there is a memory leak with our integration tests. 
When we launch a test with phpunit, Symfony boot a kernel and keep the container in property `$container`.
When a test is finished, the kernel is shutdown and `$container` set to null. This operation is repeated on each test.
Problem with our current implementation is we created our own `$container` where we kept all containers in memory (we saw it with [php-meminfo](https://github.com/BitOne/php-meminfo)). So for 444 tests, we had 444 containers, 444 unit of work, etc \o/

Other baby fix: we launch now integration tests with `debug = false` (we save ~500Mo of memory)

About `gc_collect_cycles`, I don't know why we have to call it explicitly to save so much memory, if someone has an idea :) cc @BitOne ?

So, it's better but there is still a small leak :(
Jobs are never deleted from memory, I suppose it's because we create a specific entity manager (so a specific unit of work) for jobs, but I cannot clear them.
IMHO, we can investigate later, we have time before reach the memory limit.

Before fix:
![phpunit-before](https://cloud.githubusercontent.com/assets/1131230/22855996/9b01a376-f089-11e6-91d0-19c62dadb1fc.png)

Fix without `gc_collect_cycles`:
![phpunit-without-gccollect](https://cloud.githubusercontent.com/assets/1131230/22855998/9ef5ef82-f089-11e6-9e0c-9e4e64329418.png)

Fix with `gc_collect_cycles`:
![phpunit-with-gccollect](https://cloud.githubusercontent.com/assets/1131230/22856121/9ad28af8-f08b-11e6-9166-c851cb0752ca.png)


[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
