### PR TITLE
API-65: rename ObjectUpdateException to PropertyException and use them in PQB

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -163,15 +163,15 @@
 - Remove useless class `Pim\Bundle\ImportExportBundle\JobTemplate\JobTemplateProviderInterface`
 - Remove useless class `Pim\Bundle\ImportExportBundle\Twig\NormalizeConfigurationExtension`
 - Remove useless class `Pim\Bundle\ImportExportBundle\ViewElement\Checker\JobNameVisibilityChecker`
-- Change exception `\InvalidArgumentException` by `Akeneo\Component\StorageUtils\Exception\ObjectUpdaterException` thrown by `Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface:update()`
-- Change exception `Pim\Component\Catalog\Exception\InvalidArgumentException` and `\RuntimeException` by `Akeneo\Component\StorageUtils\Exception\ObjectUpdaterException` thrown by `Pim\Component\Catalog\Updater\Copier\AttributeCopierInterface:copyAttributeData()`
-- Change exception `Pim\Component\Catalog\Exception\InvalidArgumentException` and `\RuntimeException` by `Akeneo\Component\StorageUtils\Exception\ObjectUpdaterException` thrown by `Pim\Component\Catalog\Updater\Copier\FieldCopierInterface:copyFieldData()`
-- Add exception `Akeneo\Component\StorageUtils\Exception\ObjectUpdaterException` thrown by `Pim\Component\Catalog\Updater\Adder\AttributeAdderInterface:addAttributeData()`
-- Add exception `Akeneo\Component\StorageUtils\Exception\ObjectUpdaterException` thrown by `Pim\Component\Catalog\Updater\Adder\FieldAdderInterface:addFieldData()`
-- Add exception `Akeneo\Component\StorageUtils\Exception\ObjectUpdaterException` thrown by `Pim\Component\Catalog\Updater\Remover\AttributeRemoverInterface:removeAttributeData()`
-- Add exception `Akeneo\Component\StorageUtils\Exception\ObjectUpdaterException` thrown by `Pim\Component\Catalog\Updater\Remover\FieldRemoverInterface:removeFieldData()`
-- Add exception `Akeneo\Component\StorageUtils\Exception\ObjectUpdaterException` thrown by `Pim\Component\Catalog\Updater\Setter\AttributeSetterInterface:setAttributeData()`
-- Add exception `Akeneo\Component\StorageUtils\Exception\ObjectUpdaterException` thrown by `Pim\Component\Catalog\Updater\Setter\FieldSetterInterface:setFieldData()`
+- Change exception `\InvalidArgumentException` by `Akeneo\Component\StorageUtils\Exception\PropertyException` thrown by `Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface:update()`
+- Change exception `Pim\Component\Catalog\Exception\InvalidArgumentException` and `\RuntimeException` by `Akeneo\Component\StorageUtils\Exception\PropertyException` thrown by `Pim\Component\Catalog\Updater\Copier\AttributeCopierInterface:copyAttributeData()`
+- Change exception `Pim\Component\Catalog\Exception\InvalidArgumentException` and `\RuntimeException` by `Akeneo\Component\StorageUtils\Exception\PropertyException` thrown by `Pim\Component\Catalog\Updater\Copier\FieldCopierInterface:copyFieldData()`
+- Add exception `Akeneo\Component\StorageUtils\Exception\PropertyException` thrown by `Pim\Component\Catalog\Updater\Adder\AttributeAdderInterface:addAttributeData()`
+- Add exception `Akeneo\Component\StorageUtils\Exception\PropertyException` thrown by `Pim\Component\Catalog\Updater\Adder\FieldAdderInterface:addFieldData()`
+- Add exception `Akeneo\Component\StorageUtils\Exception\PropertyException` thrown by `Pim\Component\Catalog\Updater\Remover\AttributeRemoverInterface:removeAttributeData()`
+- Add exception `Akeneo\Component\StorageUtils\Exception\PropertyException` thrown by `Pim\Component\Catalog\Updater\Remover\FieldRemoverInterface:removeFieldData()`
+- Add exception `Akeneo\Component\StorageUtils\Exception\PropertyException` thrown by `Pim\Component\Catalog\Updater\Setter\AttributeSetterInterface:setAttributeData()`
+- Add exception `Akeneo\Component\StorageUtils\Exception\PropertyException` thrown by `Pim\Component\Catalog\Updater\Setter\FieldSetterInterface:setFieldData()`
 - Change the constructor of `Pim\Component\Catalog\Updater\AssociationTypeUpdater` to remove `Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface`
 - Remove `createDatagridQueryBuilder` method from `Pim\Component\Catalog\Repository\CurrencyRepositoryInterface`
 - Remove `createDatagridQueryBuilder` method from `Pim\Component\Catalog\Repository\LocaleInterface`

--- a/src/Akeneo/Component/StorageUtils/Exception/ImmutablePropertyException.php
+++ b/src/Akeneo/Component/StorageUtils/Exception/ImmutablePropertyException.php
@@ -9,7 +9,7 @@ namespace Akeneo\Component\StorageUtils\Exception;
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class ImmutablePropertyException extends ObjectUpdaterException
+class ImmutablePropertyException extends PropertyException
 {
     /** @var string */
     protected $propertyName;

--- a/src/Akeneo/Component/StorageUtils/Exception/InvalidObjectException.php
+++ b/src/Akeneo/Component/StorageUtils/Exception/InvalidObjectException.php
@@ -9,7 +9,7 @@ namespace Akeneo\Component\StorageUtils\Exception;
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class InvalidObjectException extends ObjectUpdaterException
+class InvalidObjectException extends \LogicException
 {
     /* @var string */
     protected $objectClassName;

--- a/src/Akeneo/Component/StorageUtils/Exception/InvalidPropertyException.php
+++ b/src/Akeneo/Component/StorageUtils/Exception/InvalidPropertyException.php
@@ -9,7 +9,7 @@ namespace Akeneo\Component\StorageUtils\Exception;
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class InvalidPropertyException extends ObjectUpdaterException
+class InvalidPropertyException extends PropertyException
 {
     const EXPECTED_CODE = 100;
     const DATE_EXPECTED_CODE = 101;

--- a/src/Akeneo/Component/StorageUtils/Exception/InvalidPropertyException.php
+++ b/src/Akeneo/Component/StorageUtils/Exception/InvalidPropertyException.php
@@ -20,6 +20,7 @@ class InvalidPropertyException extends PropertyException
     const VALID_GROUP_TYPE_EXPECTED_CODE = 301;
     const VALID_GROUP_EXPECTED_CODE = 302;
     const VALID_PATH_EXPECTED_CODE = 304;
+    const VALID_DATA_EXPECTED_CODE = 305;
 
     /** @var string */
     protected $propertyName;
@@ -168,6 +169,28 @@ class InvalidPropertyException extends PropertyException
     }
 
     /**
+     * Build an exception when a data is excepted.
+     *
+     * @param string $propertyName
+     * @param string $data
+     * @param string $className
+     *
+     * @return InvalidPropertyException
+     */
+    public static function dataExpected($propertyName, $data, $className)
+    {
+        $message = 'Property "%s" expects %s.';
+
+        return new self(
+            $propertyName,
+            null,
+            $className,
+            sprintf($message, $propertyName, $data),
+            self::VALID_DATA_EXPECTED_CODE
+        );
+    }
+
+    /**
      * Build an exception when the pathname is invalid.
      *
      * @param string $propertyName
@@ -200,13 +223,11 @@ class InvalidPropertyException extends PropertyException
      */
     public static function expectedFromPreviousException($propertyName, $className, \Exception $exception)
     {
-        $message = 'Property "%s" expects valid data, scope and locale. %s';
-
         return new self(
             $propertyName,
             null,
             $className,
-            sprintf($message, $propertyName, $exception->getMessage()),
+            $exception->getMessage(),
             $exception->getCode(),
             $exception
         );

--- a/src/Akeneo/Component/StorageUtils/Exception/InvalidPropertyTypeException.php
+++ b/src/Akeneo/Component/StorageUtils/Exception/InvalidPropertyTypeException.php
@@ -10,7 +10,7 @@ namespace Akeneo\Component\StorageUtils\Exception;
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class InvalidPropertyTypeException extends ObjectUpdaterException
+class InvalidPropertyTypeException extends PropertyException
 {
     const EXPECTED_CODE = 100;
 

--- a/src/Akeneo/Component/StorageUtils/Exception/PropertyException.php
+++ b/src/Akeneo/Component/StorageUtils/Exception/PropertyException.php
@@ -11,6 +11,6 @@ namespace Akeneo\Component\StorageUtils\Exception;
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-abstract class ObjectUpdaterException extends \LogicException
+abstract class PropertyException extends \LogicException
 {
 }

--- a/src/Akeneo/Component/StorageUtils/Exception/UnknownPropertyException.php
+++ b/src/Akeneo/Component/StorageUtils/Exception/UnknownPropertyException.php
@@ -9,7 +9,7 @@ namespace Akeneo\Component\StorageUtils\Exception;
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class UnknownPropertyException extends ObjectUpdaterException
+class UnknownPropertyException extends PropertyException
 {
     /** @var string */
     protected $propertyName;

--- a/src/Akeneo/Component/StorageUtils/Updater/ObjectUpdaterInterface.php
+++ b/src/Akeneo/Component/StorageUtils/Updater/ObjectUpdaterInterface.php
@@ -2,7 +2,7 @@
 
 namespace Akeneo\Component\StorageUtils\Updater;
 
-use Akeneo\Component\StorageUtils\Exception\ObjectUpdaterException;
+use Akeneo\Component\StorageUtils\Exception\PropertyException;
 
 /**
  * Updates an object with a set of data
@@ -20,7 +20,7 @@ interface ObjectUpdaterInterface
      * @param array  $data    The data to update
      * @param array  $options The options to use
      *
-     * @throws ObjectUpdaterException
+     * @throws PropertyException
      *
      * @return ObjectUpdaterInterface
      */

--- a/src/Akeneo/Component/StorageUtils/spec/Exception/InvalidPropertyExceptionSpec.php
+++ b/src/Akeneo/Component/StorageUtils/spec/Exception/InvalidPropertyExceptionSpec.php
@@ -167,8 +167,32 @@ class InvalidPropertyExceptionSpec extends ObjectBehavior
             'attribute',
             null,
             'Pim\Component\Catalog\Updater\Attribute',
-            'Property "attribute" expects valid data, scope and locale. This is an exception message.',
+            'This is an exception message.',
             42
+        );
+
+        $this->shouldBeAnInstanceOf(get_class($exception));
+        $this->getPropertyName()->shouldReturn($exception->getPropertyName());
+        $this->getPropertyValue()->shouldReturn($exception->getPropertyValue());
+        $this->getClassName()->shouldReturn($exception->getClassName());
+        $this->getMessage()->shouldReturn($exception->getMessage());
+        $this->getCode()->shouldReturn($exception->getCode());
+    }
+
+    function it_creates_a_data_expected_exception()
+    {
+        $exception = InvalidPropertyException::dataExpected(
+            'name',
+            'a valid scope',
+            'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\CompletenessFilter'
+        );
+
+        $this->beConstructedWith(
+            'name',
+            null,
+            'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\CompletenessFilter',
+            'Property "name" expects a valid scope.',
+            InvalidPropertyException::VALID_DATA_EXPECTED_CODE
         );
 
         $this->shouldBeAnInstanceOf(get_class($exception));

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Remover/ChannelRemover.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Remover/ChannelRemover.php
@@ -7,7 +7,6 @@ use Akeneo\Component\StorageUtils\Remover\RemoverInterface;
 use Akeneo\Component\StorageUtils\StorageEvents;
 use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\Common\Util\ClassUtils;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Repository\ChannelRepositoryInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Translation\TranslatorInterface;
@@ -79,7 +78,6 @@ class ChannelRemover implements RemoverInterface
     /**
      * @param $object
      *
-     * @throws InvalidArgumentException
      * @throws \LogicException
      */
     private function validateObject($object)

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/AbstractAttributeFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/AbstractAttributeFilter.php
@@ -2,7 +2,7 @@
 
 namespace Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter;
 
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Query\Filter\AttributeFilterInterface;
 use Pim\Component\Catalog\Validator\AttributeValidatorHelper;
@@ -45,7 +45,7 @@ abstract class AbstractAttributeFilter extends AbstractFilter implements Attribu
      * @param string             $locale
      * @param string             $scope
      *
-     * @throws InvalidArgumentException
+     * @throws InvalidPropertyException
      */
     protected function checkLocaleAndScope(AttributeInterface $attribute, $locale, $scope)
     {
@@ -53,10 +53,10 @@ abstract class AbstractAttributeFilter extends AbstractFilter implements Attribu
             $this->attrValidatorHelper->validateLocale($attribute, $locale);
             $this->attrValidatorHelper->validateScope($attribute, $scope);
         } catch (\LogicException $e) {
-            throw InvalidArgumentException::expectedFromPreviousException(
-                $e,
+            throw InvalidPropertyException::expectedFromPreviousException(
                 $attribute->getCode(),
-                static::class
+                static::class,
+                $e
             );
         }
     }

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/BooleanFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/BooleanFilter.php
@@ -2,8 +2,8 @@
 
 namespace Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Pim\Bundle\CatalogBundle\ProductQueryUtility;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Query\Filter\AttributeFilterInterface;
 use Pim\Component\Catalog\Query\Filter\FieldFilterInterface;
@@ -67,13 +67,13 @@ class BooleanFilter extends AbstractAttributeFilter implements FieldFilterInterf
         $scope = null,
         $options = []
     ) {
-        $this->checkLocaleAndScope($attribute, $locale, $scope, 'boolean');
+        $this->checkLocaleAndScope($attribute, $locale, $scope);
 
         if (!is_bool($value)) {
-            throw InvalidArgumentException::booleanExpected(
+            throw InvalidPropertyTypeException::booleanExpected(
                 $attribute->getCode(),
                 static::class,
-                gettype($value)
+                $value
             );
         }
 
@@ -90,7 +90,7 @@ class BooleanFilter extends AbstractAttributeFilter implements FieldFilterInterf
     public function addFieldFilter($field, $operator, $value, $locale = null, $scope = null, $options = [])
     {
         if (!is_bool($value)) {
-            throw InvalidArgumentException::booleanExpected($field, static::class, gettype($value));
+            throw InvalidPropertyTypeException::booleanExpected($field, static::class, $value);
         }
 
         $field = sprintf('%s.%s', ProductQueryUtility::NORMALIZED_FIELD, $field);

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/CompletenessFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/CompletenessFilter.php
@@ -2,9 +2,10 @@
 
 namespace Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Doctrine\ODM\MongoDB\Query\Expr;
 use Pim\Bundle\CatalogBundle\ProductQueryUtility;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Exception\ObjectNotFoundException;
 use Pim\Component\Catalog\Model\ChannelInterface;
 use Pim\Component\Catalog\Query\Filter\FieldFilterInterface;
@@ -161,16 +162,18 @@ class CompletenessFilter extends AbstractFieldFilter implements FieldFilterInter
      * @param string $field
      * @param mixed  $scope
      * @param mixed  $value
-     * @throws InvalidArgumentException
+     *
+     * @throws InvalidPropertyTypeException
+     * @throws InvalidPropertyException
      */
     protected function checkScopeAndValue($field, $scope, $value)
     {
         if (!is_numeric($value)) {
-            throw InvalidArgumentException::numericExpected($field, static::class, gettype($value));
+            throw InvalidPropertyTypeException::numericExpected($field, static::class, $value);
         }
 
         if (null === $scope) {
-            throw InvalidArgumentException::scopeExpected($field, static::class);
+            throw InvalidPropertyException::dataExpected($field, 'a valid scope', static::class);
         }
     }
 
@@ -183,24 +186,25 @@ class CompletenessFilter extends AbstractFieldFilter implements FieldFilterInter
      *
      * @param string $field
      * @param array  $options
-     * @throws InvalidArgumentException
+     *
+     * @throws InvalidPropertyTypeException
      */
     protected function checkOptions($field, array $options)
     {
         if (!array_key_exists('locales', $options)) {
-            throw InvalidArgumentException::arrayKeyExpected(
+            throw InvalidPropertyTypeException::arrayKeyExpected(
                 $field,
                 'locales',
                 static::class,
-                print_r(array_keys($options), true)
+                $options
             );
         }
 
         if (!isset($options['locales']) || !is_array($options['locales'])) {
-            throw InvalidArgumentException::arrayOfArraysExpected(
+            throw InvalidPropertyTypeException::arrayOfArraysExpected(
                 $field,
                 static::class,
-                print_r($options, true)
+                $options
             );
         }
     }

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/DateFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/DateFilter.php
@@ -2,8 +2,9 @@
 
 namespace Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Pim\Bundle\CatalogBundle\ProductQueryUtility;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Query\Filter\AttributeFilterInterface;
 use Pim\Component\Catalog\Query\Filter\Operators;
@@ -46,7 +47,7 @@ class DateFilter extends AbstractAttributeFilter implements AttributeFilterInter
         $scope = null,
         $options = []
     ) {
-        $this->checkLocaleAndScope($attribute, $locale, $scope, 'date');
+        $this->checkLocaleAndScope($attribute, $locale, $scope);
 
         if (Operators::IS_EMPTY === $operator || Operators::IS_NOT_EMPTY === $operator) {
             $value = null;
@@ -111,16 +112,18 @@ class DateFilter extends AbstractAttributeFilter implements AttributeFilterInter
      * @param string $type
      * @param mixed  $value
      *
+     * @throws InvalidPropertyException
+     *
      * @return mixed $value
      */
     protected function formatValues($type, $value)
     {
         if (is_array($value) && 2 !== count($value)) {
-            throw InvalidArgumentException::expected(
+            throw InvalidPropertyTypeException::validArrayStructureExpected(
                 $type,
-                'array with 2 elements, string or \DateTime',
+                'should contain 2 strings with the format "yyyy-mm-dd"',
                 static::class,
-                print_r($value, true)
+                $value
             );
         }
 
@@ -141,7 +144,7 @@ class DateFilter extends AbstractAttributeFilter implements AttributeFilterInter
      * @param string $type
      * @param mixed  $value
      *
-     * @throws InvalidArgumentException
+     * @throws InvalidPropertyException
      *
      * @return int|null
      */
@@ -159,9 +162,9 @@ class DateFilter extends AbstractAttributeFilter implements AttributeFilterInter
             $dateTime = \DateTime::createFromFormat(static::DATETIME_FORMAT, $value);
 
             if (!$dateTime || 0 < $dateTime->getLastErrors()['warning_count']) {
-                throw InvalidArgumentException::expected(
+                throw InvalidPropertyException::dateExpected(
                     $type,
-                    'a string with the format yyyy-mm-dd',
+                    'yyyy-mm-dd',
                     static::class,
                     $value
                 );
@@ -172,11 +175,6 @@ class DateFilter extends AbstractAttributeFilter implements AttributeFilterInter
             return $dateTime->getTimestamp();
         }
 
-        throw InvalidArgumentException::expected(
-            $type,
-            'array with 2 elements, string or \DateTime',
-            static::class,
-            print_r($value, true)
-        );
+        throw InvalidPropertyException::dateExpected($type, 'yyyy-mm-dd', static::class, $value);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/DateTimeFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/DateTimeFilter.php
@@ -4,9 +4,10 @@ namespace Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter;
 
 use Akeneo\Component\Batch\Job\BatchStatus;
 use Akeneo\Component\Batch\Job\JobRepositoryInterface;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Pim\Bundle\CatalogBundle\ProductQueryUtility;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Query\Filter\FieldFilterInterface;
 use Pim\Component\Catalog\Query\Filter\Operators;
 
@@ -60,7 +61,7 @@ class DateTimeFilter extends AbstractFieldFilter implements FieldFilterInterface
 
         if (Operators::SINCE_LAST_JOB === $operator) {
             if (!is_string($value)) {
-                throw InvalidArgumentException::stringExpected($field, static::class, gettype($value));
+                throw InvalidPropertyTypeException::stringExpected($field, static::class, $value);
             }
 
             $jobInstance = $this->jobInstanceRepository->findOneByIdentifier($value);
@@ -75,7 +76,7 @@ class DateTimeFilter extends AbstractFieldFilter implements FieldFilterInterface
 
         if (Operators::SINCE_LAST_N_DAYS === $operator) {
             if (!is_numeric($value)) {
-                throw InvalidArgumentException::numericExpected($field, static::class, gettype($value));
+                throw InvalidPropertyTypeException::numericExpected($field, static::class, $value);
             }
 
             $fromDate = new \DateTime(sprintf('%s days ago', $value), new \DateTimeZone('UTC'));
@@ -139,18 +140,18 @@ class DateTimeFilter extends AbstractFieldFilter implements FieldFilterInterface
      * @param string $type
      * @param mixed  $value
      *
-     * @throws InvalidArgumentException
+     * @throws InvalidPropertyTypeException
      *
      * @return mixed $value
      */
     protected function formatValues($type, $value)
     {
         if (is_array($value) && 2 !== count($value)) {
-            throw InvalidArgumentException::expected(
+            throw InvalidPropertyTypeException::validArrayStructureExpected(
                 $type,
-                'array with 2 elements, string or \DateTime',
+                'should contain 2 strings with the format "yyyy-mm-dd H:i:s"',
                 static::class,
-                print_r($value, true)
+                $value
             );
         }
 
@@ -171,7 +172,8 @@ class DateTimeFilter extends AbstractFieldFilter implements FieldFilterInterface
      * @param string $type
      * @param mixed  $value
      *
-     * @throws InvalidArgumentException
+     * @throws InvalidPropertyException
+     * @throws InvalidPropertyTypeException
      *
      * @return integer
      */
@@ -183,6 +185,7 @@ class DateTimeFilter extends AbstractFieldFilter implements FieldFilterInterface
 
         if ($value instanceof \DateTime) {
             $value->setTimezone(new \DateTimeZone('UTC'));
+
             return $value->getTimestamp();
         }
 
@@ -190,9 +193,9 @@ class DateTimeFilter extends AbstractFieldFilter implements FieldFilterInterface
             $dateTime = \DateTime::createFromFormat(static::DATETIME_FORMAT, $value);
 
             if (!$dateTime || 0 < $dateTime->getLastErrors()['warning_count']) {
-                throw InvalidArgumentException::expected(
+                throw InvalidPropertyException::dateExpected(
                     $type,
-                    'a string with the format yyyy-mm-dd H:i:s',
+                    'yyyy-mm-dd H:i:s',
                     static::class,
                     $value
                 );
@@ -201,11 +204,6 @@ class DateTimeFilter extends AbstractFieldFilter implements FieldFilterInterface
             return $dateTime->getTimestamp();
         }
 
-        throw InvalidArgumentException::expected(
-            $type,
-            'array with 2 elements, string or \DateTime',
-            static::class,
-            print_r($value, true)
-        );
+        throw InvalidPropertyException::dateExpected($type, 'yyyy-mm-dd H:i:s', static::class, $value);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/MediaFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/MediaFilter.php
@@ -2,8 +2,8 @@
 
 namespace Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Pim\Bundle\CatalogBundle\ProductQueryUtility;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Query\Filter\AttributeFilterInterface;
 use Pim\Component\Catalog\Query\Filter\Operators;
@@ -44,7 +44,7 @@ class MediaFilter extends AbstractAttributeFilter implements AttributeFilterInte
         $scope = null,
         $options = []
     ) {
-        $this->checkLocaleAndScope($attribute, $locale, $scope, 'media');
+        $this->checkLocaleAndScope($attribute, $locale, $scope);
         if (Operators::IS_EMPTY !== $operator && Operators::IS_NOT_EMPTY !== $operator) {
             $this->checkValue($attribute, $value);
         }
@@ -105,14 +105,16 @@ class MediaFilter extends AbstractAttributeFilter implements AttributeFilterInte
     /**
      * @param AttributeInterface $attribute
      * @param mixed              $value
+     *
+     * @throws InvalidPropertyTypeException
      */
     protected function checkValue(AttributeInterface $attribute, $value)
     {
         if (!is_string($value)) {
-            throw InvalidArgumentException::stringExpected(
+            throw InvalidPropertyTypeException::stringExpected(
                 $attribute->getCode(),
                 static::class,
-                gettype($value)
+                $value
             );
         }
     }

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/NumberFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/NumberFilter.php
@@ -4,7 +4,6 @@ namespace Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter;
 
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Pim\Bundle\CatalogBundle\ProductQueryUtility;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Query\Filter\AttributeFilterInterface;
 use Pim\Component\Catalog\Query\Filter\Operators;

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/NumberFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/NumberFilter.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Pim\Bundle\CatalogBundle\ProductQueryUtility;
 use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
@@ -44,10 +45,10 @@ class NumberFilter extends AbstractAttributeFilter implements AttributeFilterInt
         $scope = null,
         $options = []
     ) {
-        $this->checkLocaleAndScope($attribute, $locale, $scope, 'number');
+        $this->checkLocaleAndScope($attribute, $locale, $scope);
 
         if (null !== $value && !is_numeric($value)) {
-            throw InvalidArgumentException::numericExpected($attribute->getCode(), static::class, gettype($value));
+            throw InvalidPropertyTypeException::numericExpected($attribute->getCode(), static::class, $value);
         }
 
         $field = ProductQueryUtility::getNormalizedValueFieldFromAttribute($attribute, $locale, $scope);

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/OptionFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/OptionFilter.php
@@ -2,9 +2,9 @@
 
 namespace Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Pim\Bundle\CatalogBundle\Doctrine\Common\Filter\ObjectIdResolverInterface;
 use Pim\Bundle\CatalogBundle\ProductQueryUtility;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Query\Filter\AttributeFilterInterface;
 use Pim\Component\Catalog\Query\Filter\FieldFilterHelper;
@@ -62,7 +62,7 @@ class OptionFilter extends AbstractAttributeFilter implements AttributeFilterInt
         try {
             $options = $this->resolver->resolve($options);
         } catch (\Exception $e) {
-            throw InvalidArgumentException::expectedFromPreviousException(
+            throw InvalidPropertyException::expectedFromPreviousException(
                 $e,
                 $attribute->getCode(),
                 static::class

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/OptionsFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/OptionsFilter.php
@@ -5,7 +5,6 @@ namespace Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Pim\Bundle\CatalogBundle\Doctrine\Common\Filter\ObjectIdResolverInterface;
 use Pim\Bundle\CatalogBundle\ProductQueryUtility;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Query\Filter\AttributeFilterInterface;
 use Pim\Component\Catalog\Query\Filter\FieldFilterHelper;

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/OptionsFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/OptionsFilter.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Pim\Bundle\CatalogBundle\Doctrine\Common\Filter\ObjectIdResolverInterface;
 use Pim\Bundle\CatalogBundle\ProductQueryUtility;
 use Pim\Component\Catalog\Exception\InvalidArgumentException;
@@ -62,14 +63,14 @@ class OptionsFilter extends AbstractAttributeFilter implements AttributeFilterIn
         try {
             $options = $this->resolver->resolve($options);
         } catch (\Exception $e) {
-            throw InvalidArgumentException::expectedFromPreviousException(
-                $e,
+            throw InvalidPropertyException::expectedFromPreviousException(
                 $attribute->getCode(),
-                static::class
+                static::class,
+                $e
             );
         }
 
-        $this->checkLocaleAndScope($attribute, $locale, $scope, 'options');
+        $this->checkLocaleAndScope($attribute, $locale, $scope);
 
         if (Operators::IS_EMPTY !== $operator && Operators::IS_NOT_EMPTY !== $operator) {
             $this->checkValue($options['field'], $value);

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/PriceFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/PriceFilter.php
@@ -2,8 +2,9 @@
 
 namespace Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Pim\Bundle\CatalogBundle\ProductQueryUtility;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Query\Filter\AttributeFilterInterface;
 use Pim\Component\Catalog\Query\Filter\Operators;
@@ -51,7 +52,7 @@ class PriceFilter extends AbstractAttributeFilter implements AttributeFilterInte
         $scope = null,
         $options = []
     ) {
-        $this->checkLocaleAndScope($attribute, $locale, $scope, 'price');
+        $this->checkLocaleAndScope($attribute, $locale, $scope);
 
         if (Operators::IS_EMPTY !== $operator && Operators::IS_NOT_EMPTY !== $operator) {
             $this->checkValue($attribute, $value);
@@ -116,47 +117,47 @@ class PriceFilter extends AbstractAttributeFilter implements AttributeFilterInte
     protected function checkValue(AttributeInterface $attribute, $data)
     {
         if (!is_array($data)) {
-            throw InvalidArgumentException::arrayExpected($attribute->getCode(), static::class, gettype($data));
+            throw InvalidPropertyTypeException::arrayExpected($attribute->getCode(), static::class, $data);
         }
 
         if (!array_key_exists('amount', $data)) {
-            throw InvalidArgumentException::arrayKeyExpected(
+            throw InvalidPropertyTypeException::arrayKeyExpected(
                 $attribute->getCode(),
                 'amount',
                 static::class,
-                print_r($data, true)
+                $data
             );
         }
 
         if (!array_key_exists('currency', $data)) {
-            throw InvalidArgumentException::arrayKeyExpected(
+            throw InvalidPropertyTypeException::arrayKeyExpected(
                 $attribute->getCode(),
                 'currency',
                 static::class,
-                print_r($data, true)
+                $data
             );
         }
 
         if (null !== $data['amount'] && !is_numeric($data['amount'])) {
-            throw InvalidArgumentException::arrayNumericKeyExpected(
+            throw InvalidPropertyTypeException::validArrayStructureExpected(
                 $attribute->getCode(),
-                'amount',
+                sprintf('key "amount" has to be a numeric, "%s" given', gettype($data['amount'])),
                 static::class,
-                gettype($data['amount'])
+                $data
             );
         }
 
         if (!is_string($data['currency'])) {
-            throw InvalidArgumentException::arrayStringKeyExpected(
+            throw InvalidPropertyTypeException::validArrayStructureExpected(
                 $attribute->getCode(),
-                'currency',
+                sprintf('key "currency" has to be a string, "%s" given', gettype($data['currency'])),
                 static::class,
-                gettype($data['currency'])
+                $data
             );
         }
 
         if (!in_array($data['currency'], $this->currencyRepository->getActivatedCurrencyCodes())) {
-            throw InvalidArgumentException::arrayInvalidKey(
+            throw InvalidPropertyException::validEntityCodeExpected(
                 $attribute->getCode(),
                 'currency',
                 'The currency does not exist',

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/ProductIdFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/ProductIdFilter.php
@@ -2,7 +2,7 @@
 
 namespace Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter;
 
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Pim\Component\Catalog\Query\Filter\FieldFilterInterface;
 use Pim\Component\Catalog\Query\Filter\Operators;
 
@@ -33,7 +33,17 @@ class ProductIdFilter extends AbstractFieldFilter implements FieldFilterInterfac
     public function addFieldFilter($field, $operator, $value, $locale = null, $scope = null, $options = [])
     {
         if (!is_string($value) && !is_array($value)) {
-            throw InvalidArgumentException::expected($field, 'array or string value', static::class, $value);
+            throw new InvalidPropertyTypeException(
+                $field,
+                $value,
+                static::class,
+                sprintf(
+                    'Property "%s" expects array or string value, "%s" given.',
+                    $field,
+                    gettype($value)
+                ),
+                InvalidPropertyTypeException::EXPECTED_CODE
+            );
         }
 
         $this->applyFilter('_id', $operator, $value);

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/StringFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/StringFilter.php
@@ -2,8 +2,9 @@
 
 namespace Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Pim\Bundle\CatalogBundle\ProductQueryUtility;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Query\Filter\AttributeFilterInterface;
 use Pim\Component\Catalog\Query\Filter\Operators;
@@ -54,14 +55,14 @@ class StringFilter extends AbstractAttributeFilter implements AttributeFilterInt
         try {
             $options = $this->resolver->resolve($options);
         } catch (\Exception $e) {
-            throw InvalidArgumentException::expectedFromPreviousException(
-                $e,
+            throw InvalidPropertyException::expectedFromPreviousException(
                 $attribute->getCode(),
-                static::class
+                static::class,
+                $e
             );
         }
 
-        $this->checkLocaleAndScope($attribute, $locale, $scope, 'string');
+        $this->checkLocaleAndScope($attribute, $locale, $scope);
 
         if (Operators::IS_EMPTY !== $operator && Operators::IS_NOT_EMPTY !== $operator) {
             $this->checkValue($options['field'], $value);
@@ -164,7 +165,7 @@ class StringFilter extends AbstractAttributeFilter implements AttributeFilterInt
     protected function checkScalarValue($field, $value)
     {
         if (!is_string($value) && null !== $value) {
-            throw InvalidArgumentException::stringExpected($field, static::class, gettype($value));
+            throw InvalidPropertyTypeException::stringExpected($field, static::class, $value);
         }
     }
 

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Condition/CriteriaCondition.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Condition/CriteriaCondition.php
@@ -2,8 +2,8 @@
 
 namespace Pim\Bundle\CatalogBundle\Doctrine\ORM\Condition;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Doctrine\ORM\QueryBuilder;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Exception\ProductQueryException;
 use Pim\Component\Catalog\Query\Filter\Operators;
 
@@ -97,6 +97,7 @@ class CriteriaCondition
      *
      * @throws ProductQueryException
      * @throws \InvalidArgumentException
+     * @throws InvalidPropertyException
      *
      * @return string
      */
@@ -145,7 +146,7 @@ class CriteriaCondition
             }
 
             if (0 === count($value)) {
-                throw InvalidArgumentException::emptyArray($field);
+                throw InvalidPropertyException::valueNotEmptyExpected($field, static::class);
             }
 
             $method = $operators[$operator];

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/AbstractAttributeFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/AbstractAttributeFilter.php
@@ -2,7 +2,7 @@
 
 namespace Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter;
 
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Query\Filter\AttributeFilterInterface;
 use Pim\Component\Catalog\Validator\AttributeValidatorHelper;
@@ -45,7 +45,7 @@ abstract class AbstractAttributeFilter extends AbstractFilter implements Attribu
      * @param string             $locale
      * @param string             $scope
      *
-     * @throws InvalidArgumentException
+     * @throws InvalidPropertyException
      */
     protected function checkLocaleAndScope(AttributeInterface $attribute, $locale, $scope)
     {
@@ -53,10 +53,10 @@ abstract class AbstractAttributeFilter extends AbstractFilter implements Attribu
             $this->attrValidatorHelper->validateLocale($attribute, $locale);
             $this->attrValidatorHelper->validateScope($attribute, $scope);
         } catch (\LogicException $e) {
-            throw InvalidArgumentException::expectedFromPreviousException(
-                $e,
+            throw InvalidPropertyException::expectedFromPreviousException(
                 $attribute->getCode(),
-                static::class
+                static::class,
+                $e
             );
         }
     }

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/BooleanFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/BooleanFilter.php
@@ -2,7 +2,7 @@
 
 namespace Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter;
 
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Query\Filter\AttributeFilterInterface;
 use Pim\Component\Catalog\Query\Filter\FieldFilterHelper;
@@ -53,10 +53,10 @@ class BooleanFilter extends AbstractAttributeFilter implements AttributeFilterIn
         $this->checkLocaleAndScope($attribute, $locale, $scope);
 
         if (!is_bool($value)) {
-            throw InvalidArgumentException::booleanExpected(
+            throw InvalidPropertyTypeException::booleanExpected(
                 $attribute->getCode(),
                 static::class,
-                gettype($value)
+                $value
             );
         }
 
@@ -81,7 +81,7 @@ class BooleanFilter extends AbstractAttributeFilter implements AttributeFilterIn
     public function addFieldFilter($field, $operator, $value, $locale = null, $scope = null, $options = [])
     {
         if (!is_bool($value)) {
-            throw InvalidArgumentException::booleanExpected($field, static::class, gettype($value));
+            throw InvalidPropertyTypeException::booleanExpected($field, static::class, $value);
         }
 
         $field = current($this->qb->getRootAliases()) . '.' . FieldFilterHelper::getCode($field);

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/CompletenessFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/CompletenessFilter.php
@@ -2,8 +2,9 @@
 
 namespace Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Pim\Bundle\CatalogBundle\Doctrine\ORM\Join\CompletenessJoin;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Query\Filter\FieldFilterInterface;
 use Pim\Component\Catalog\Query\Filter\Operators;
 
@@ -81,15 +82,18 @@ class CompletenessFilter extends AbstractFieldFilter implements FieldFilterInter
      * @param string $field
      * @param mixed  $scope
      * @param mixed  $value
+     *
+     * @throws InvalidPropertyTypeException
+     * @throws InvalidPropertyException
      */
     protected function checkScopeAndValue($field, $scope, $value)
     {
         if (!is_numeric($value)) {
-            throw InvalidArgumentException::numericExpected($field, static::class, gettype($value));
+            throw InvalidPropertyTypeException::numericExpected($field, static::class, $value);
         }
 
         if (null === $scope) {
-            throw InvalidArgumentException::scopeExpected($field, static::class);
+            throw InvalidPropertyException::dataExpected($field, 'a valid scope', static::class);
         }
     }
 
@@ -102,23 +106,25 @@ class CompletenessFilter extends AbstractFieldFilter implements FieldFilterInter
      *
      * @param string $field
      * @param array  $options
+     *
+     * @throws InvalidPropertyTypeException
      */
     protected function checkOptions($field, array $options)
     {
         if (!array_key_exists('locales', $options)) {
-            throw InvalidArgumentException::arrayKeyExpected(
+            throw InvalidPropertyTypeException::arrayKeyExpected(
                 $field,
                 'locales',
                 static::class,
-                print_r($options, true)
+                $options
             );
         }
 
         if (!isset($options['locales']) || !is_array($options['locales'])) {
-            throw InvalidArgumentException::arrayOfArraysExpected(
+            throw InvalidPropertyTypeException::arrayOfArraysExpected(
                 $field,
                 static::class,
-                print_r($options, true)
+                $options
             );
         }
     }

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/DateFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/DateFilter.php
@@ -2,7 +2,8 @@
 
 namespace Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter;
 
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Query\Filter\AttributeFilterInterface;
 use Pim\Component\Catalog\Query\Filter\Operators;
@@ -92,16 +93,18 @@ class DateFilter extends AbstractAttributeFilter implements AttributeFilterInter
      * @param string $type
      * @param mixed  $value
      *
+     * @throws InvalidPropertyException
+     *
      * @return mixed $value
      */
     protected function formatValues($type, $value)
     {
         if (is_array($value) && 2 !== count($value)) {
-            throw InvalidArgumentException::expected(
+            throw InvalidPropertyTypeException::validArrayStructureExpected(
                 $type,
-                'array with 2 elements, string or \DateTime',
+                'should contain 2 strings with the format "yyyy-mm-dd"',
                 static::class,
-                print_r($value, true)
+                $value
             );
         }
 
@@ -122,7 +125,7 @@ class DateFilter extends AbstractAttributeFilter implements AttributeFilterInter
      * @param string $type
      * @param mixed  $value
      *
-     * @throws InvalidArgumentException
+     * @throws InvalidPropertyException
      *
      * @return string
      */
@@ -140,9 +143,9 @@ class DateFilter extends AbstractAttributeFilter implements AttributeFilterInter
             $dateTime = \DateTime::createFromFormat(static::DATETIME_FORMAT, $value);
 
             if (!$dateTime || 0 < $dateTime->getLastErrors()['warning_count']) {
-                throw InvalidArgumentException::expected(
+                throw InvalidPropertyException::dateExpected(
                     $type,
-                    'a string with the format yyyy-mm-dd',
+                    'yyyy-mm-dd',
                     static::class,
                     $value
                 );
@@ -151,11 +154,6 @@ class DateFilter extends AbstractAttributeFilter implements AttributeFilterInter
             return $dateTime->format(static::DATETIME_FORMAT);
         }
 
-        throw InvalidArgumentException::expected(
-            $type,
-            'array with 2 elements, string or \DateTime',
-            static::class,
-            print_r($value, true)
-        );
+        throw InvalidPropertyException::dateExpected($type, 'yyyy-mm-dd', static::class, $value);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/DateTimeFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/DateTimeFilter.php
@@ -4,8 +4,9 @@ namespace Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter;
 
 use Akeneo\Component\Batch\Job\BatchStatus;
 use Akeneo\Component\Batch\Job\JobRepositoryInterface;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Query\Filter\FieldFilterInterface;
 use Pim\Component\Catalog\Query\Filter\Operators;
 
@@ -52,7 +53,7 @@ class DateTimeFilter extends AbstractFieldFilter implements FieldFilterInterface
         switch ($operator) {
             case Operators::SINCE_LAST_JOB:
                 if (!is_string($value)) {
-                    throw InvalidArgumentException::stringExpected($field, static::class, gettype($value));
+                    throw InvalidPropertyTypeException::stringExpected($field, static::class, $value);
                 }
 
                 $this->addUpdatedSinceLastJob($field, $value);
@@ -60,7 +61,7 @@ class DateTimeFilter extends AbstractFieldFilter implements FieldFilterInterface
 
             case Operators::SINCE_LAST_N_DAYS:
                 if (!is_numeric($value)) {
-                    throw InvalidArgumentException::numericExpected($field, static::class, gettype($value));
+                    throw InvalidPropertyTypeException::numericExpected($field, static::class, $value);
                 }
 
                 $this->addSinceLastNDays($field, $value);
@@ -152,18 +153,18 @@ class DateTimeFilter extends AbstractFieldFilter implements FieldFilterInterface
      * @param string $type
      * @param mixed  $value
      *
-     * @throws InvalidArgumentException
+     * @throws InvalidPropertyTypeException
      *
      * @return mixed $value
      */
     protected function formatValues($type, $value)
     {
         if (is_array($value) && 2 !== count($value)) {
-            throw InvalidArgumentException::expected(
+            throw InvalidPropertyTypeException::validArrayStructureExpected(
                 $type,
-                'array with 2 elements, string or \DateTime',
+                'should contain 2 strings with the format "yyyy-mm-dd H:i:s"',
                 static::class,
-                print_r($value, true)
+                $value
             );
         }
 
@@ -184,7 +185,8 @@ class DateTimeFilter extends AbstractFieldFilter implements FieldFilterInterface
      * @param string $type
      * @param mixed  $value
      *
-     * @throws InvalidArgumentException
+     * @throws InvalidPropertyException
+     * @throws InvalidPropertyTypeException
      *
      * @return string
      */
@@ -196,6 +198,7 @@ class DateTimeFilter extends AbstractFieldFilter implements FieldFilterInterface
 
         if ($value instanceof \DateTime) {
             $value->setTimezone(new \DateTimeZone('UTC'));
+
             return $value->format(static::DATETIME_FORMAT);
         }
 
@@ -203,9 +206,9 @@ class DateTimeFilter extends AbstractFieldFilter implements FieldFilterInterface
             $dateTime = \DateTime::createFromFormat(static::DATETIME_FORMAT, $value);
 
             if (!$dateTime || 0 < $dateTime->getLastErrors()['warning_count']) {
-                throw InvalidArgumentException::expected(
+                throw InvalidPropertyException::dateExpected(
                     $type,
-                    'a string with the format yyyy-mm-dd H:i:s',
+                    'yyyy-mm-dd H:i:s',
                     static::class,
                     $value
                 );
@@ -214,11 +217,6 @@ class DateTimeFilter extends AbstractFieldFilter implements FieldFilterInterface
             return $dateTime->format(static::DATETIME_FORMAT);
         }
 
-        throw InvalidArgumentException::expected(
-            $type,
-            'array with 2 elements, string or \DateTime',
-            static::class,
-            print_r($value, true)
-        );
+        throw InvalidPropertyException::dateExpected($type, 'yyyy-mm-dd H:i:s', static::class, $value);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/MediaFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/MediaFilter.php
@@ -2,7 +2,7 @@
 
 namespace Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter;
 
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Query\Filter\AttributeFilterInterface;
 use Pim\Component\Catalog\Query\Filter\Operators;
@@ -188,7 +188,7 @@ class MediaFilter extends AbstractAttributeFilter implements AttributeFilterInte
     protected function checkValue(AttributeInterface $attribute, $value)
     {
         if (!is_string($value)) {
-            throw InvalidArgumentException::stringExpected($attribute->getCode(), static::class, gettype($value));
+            throw InvalidPropertyTypeException::stringExpected($attribute->getCode(), static::class, $value);
         }
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/MetricFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/MetricFilter.php
@@ -4,7 +4,8 @@ namespace Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter;
 
 use Akeneo\Bundle\MeasureBundle\Convert\MeasureConverter;
 use Akeneo\Bundle\MeasureBundle\Manager\MeasureManager;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Query\Filter\AttributeFilterInterface;
 use Pim\Component\Catalog\Query\Filter\Operators;
@@ -143,46 +144,49 @@ class MetricFilter extends AbstractAttributeFilter implements AttributeFilterInt
      *
      * @param AttributeInterface $attribute
      * @param mixed              $data
+     *
+     * @throws InvalidPropertyTypeException
+     * @throws InvalidPropertyException
      */
     protected function checkValue(AttributeInterface $attribute, $data)
     {
         if (!is_array($data)) {
-            throw InvalidArgumentException::arrayExpected($attribute->getCode(), static::class, gettype($data));
+            throw InvalidPropertyTypeException::arrayExpected($attribute->getCode(), static::class, $data);
         }
 
         if (!array_key_exists('amount', $data)) {
-            throw InvalidArgumentException::arrayKeyExpected(
+            throw InvalidPropertyTypeException::arrayKeyExpected(
                 $attribute->getCode(),
                 'amount',
                 static::class,
-                print_r($data, true)
+                $data
             );
         }
 
         if (!array_key_exists('unit', $data)) {
-            throw InvalidArgumentException::arrayKeyExpected(
+            throw InvalidPropertyTypeException::arrayKeyExpected(
                 $attribute->getCode(),
                 'unit',
                 static::class,
-                print_r($data, true)
+                $data
             );
         }
 
         if (null !== $data['amount'] && !is_numeric($data['amount'])) {
-            throw InvalidArgumentException::arrayNumericKeyExpected(
+            throw InvalidPropertyTypeException::validArrayStructureExpected(
                 $attribute->getCode(),
-                'amount',
+                sprintf('key "amount" has to be a numeric, "%s" given', gettype($data['amount'])),
                 static::class,
-                gettype($data['amount'])
+                $data
             );
         }
 
         if (!is_string($data['unit'])) {
-            throw InvalidArgumentException::arrayStringKeyExpected(
+            throw InvalidPropertyTypeException::validArrayStructureExpected(
                 $attribute->getCode(),
-                'unit',
+                sprintf('key "unit" has to be a string, "%s" given', gettype($data['unit'])),
                 static::class,
-                gettype($data['unit'])
+                $data
             );
         }
 
@@ -190,7 +194,7 @@ class MetricFilter extends AbstractAttributeFilter implements AttributeFilterInt
             $data['unit'],
             $this->measureManager->getUnitSymbolsForFamily($attribute->getMetricFamily())
         )) {
-            throw InvalidArgumentException::arrayInvalidKey(
+            throw InvalidPropertyException::validEntityCodeExpected(
                 $attribute->getCode(),
                 'unit',
                 sprintf(

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/NumberFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/NumberFilter.php
@@ -2,7 +2,7 @@
 
 namespace Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter;
 
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Query\Filter\AttributeFilterInterface;
 use Pim\Component\Catalog\Query\Filter\Operators;
@@ -46,7 +46,7 @@ class NumberFilter extends AbstractAttributeFilter implements AttributeFilterInt
         $this->checkLocaleAndScope($attribute, $locale, $scope);
 
         if (null !== $value && !is_numeric($value)) {
-            throw InvalidArgumentException::numericExpected($attribute->getCode(), static::class, gettype($value));
+            throw InvalidPropertyTypeException::numericExpected($attribute->getCode(), static::class, $value);
         }
 
         $joinAlias = $this->getUniqueAlias('filter' . $attribute->getCode());

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/OptionFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/OptionFilter.php
@@ -2,8 +2,8 @@
 
 namespace Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Pim\Bundle\CatalogBundle\Doctrine\Common\Filter\ObjectIdResolverInterface;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Query\Filter\AttributeFilterInterface;
 use Pim\Component\Catalog\Query\Filter\FieldFilterHelper;
@@ -61,7 +61,7 @@ class OptionFilter extends AbstractAttributeFilter implements AttributeFilterInt
         try {
             $options = $this->resolver->resolve($options);
         } catch (\Exception $e) {
-            throw InvalidArgumentException::expectedFromPreviousException(
+            throw InvalidPropertyException::expectedFromPreviousException(
                 $e,
                 $attribute->getCode(),
                 static::class

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/OptionsFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/OptionsFilter.php
@@ -2,8 +2,8 @@
 
 namespace Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Pim\Bundle\CatalogBundle\Doctrine\Common\Filter\ObjectIdResolverInterface;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Query\Filter\AttributeFilterInterface;
 use Pim\Component\Catalog\Query\Filter\FieldFilterHelper;
@@ -61,7 +61,7 @@ class OptionsFilter extends AbstractAttributeFilter implements AttributeFilterIn
         try {
             $options = $this->resolver->resolve($options);
         } catch (\Exception $e) {
-            throw InvalidArgumentException::expectedFromPreviousException(
+            throw InvalidPropertyException::expectedFromPreviousException(
                 $e,
                 $attribute->getCode(),
                 static::class

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/PriceFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/PriceFilter.php
@@ -2,7 +2,8 @@
 
 namespace Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter;
 
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Query\Filter\AttributeFilterInterface;
 use Pim\Component\Catalog\Query\Filter\Operators;
@@ -50,7 +51,7 @@ class PriceFilter extends AbstractAttributeFilter implements AttributeFilterInte
         $scope = null,
         $options = []
     ) {
-        $this->checkLocaleAndScope($attribute, $locale, $scope, 'price');
+        $this->checkLocaleAndScope($attribute, $locale, $scope);
 
         if (Operators::IS_EMPTY === $operator || Operators::IS_NOT_EMPTY === $operator) {
             $this->addEmptyTypeFilter($attribute, $value, $operator, $locale, $scope);
@@ -160,51 +161,54 @@ class PriceFilter extends AbstractAttributeFilter implements AttributeFilterInte
     /**
      * @param AttributeInterface $attribute
      * @param mixed              $data
+     *
+     * @throws InvalidPropertyTypeException
+     * @throws InvalidPropertyException
      */
     protected function checkValue(AttributeInterface $attribute, $data)
     {
         if (!is_array($data)) {
-            throw InvalidArgumentException::arrayExpected($attribute->getCode(), static::class, gettype($data));
+            throw InvalidPropertyTypeException::arrayExpected($attribute->getCode(), static::class, $data);
         }
 
         if (!array_key_exists('amount', $data)) {
-            throw InvalidArgumentException::arrayKeyExpected(
+            throw InvalidPropertyTypeException::arrayKeyExpected(
                 $attribute->getCode(),
                 'amount',
                 static::class,
-                print_r($data, true)
+                $data
             );
         }
 
         if (!array_key_exists('currency', $data)) {
-            throw InvalidArgumentException::arrayKeyExpected(
+            throw InvalidPropertyTypeException::arrayKeyExpected(
                 $attribute->getCode(),
                 'currency',
                 static::class,
-                print_r($data, true)
+                $data
             );
         }
 
         if (null !== $data['amount'] && !is_numeric($data['amount'])) {
-            throw InvalidArgumentException::arrayNumericKeyExpected(
+            throw InvalidPropertyTypeException::validArrayStructureExpected(
                 $attribute->getCode(),
-                'amount',
+                sprintf('key "amount" has to be a numeric, "%s" given', gettype($data['amount'])),
                 static::class,
-                gettype($data['amount'])
+                $data
             );
         }
 
         if (!is_string($data['currency'])) {
-            throw InvalidArgumentException::arrayStringKeyExpected(
+            throw InvalidPropertyTypeException::validArrayStructureExpected(
                 $attribute->getCode(),
-                'currency',
+                sprintf('key "currency" has to be a string, "%s" given', gettype($data['currency'])),
                 static::class,
-                gettype($data['currency'])
+                $data
             );
         }
 
         if (!in_array($data['currency'], $this->currencyRepository->getActivatedCurrencyCodes())) {
-            throw InvalidArgumentException::arrayInvalidKey(
+            throw InvalidPropertyException::validEntityCodeExpected(
                 $attribute->getCode(),
                 'currency',
                 'The currency does not exist',

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/ProductIdFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/ProductIdFilter.php
@@ -2,7 +2,7 @@
 
 namespace Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter;
 
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Pim\Component\Catalog\Query\Filter\FieldFilterInterface;
 
 /**
@@ -32,7 +32,17 @@ class ProductIdFilter extends AbstractFieldFilter implements FieldFilterInterfac
     public function addFieldFilter($field, $operator, $value, $locale = null, $scope = null, $options = [])
     {
         if (!is_numeric($value) && !is_array($value)) {
-            throw InvalidArgumentException::expected($field, 'array or numeric value', static::class, $value);
+            throw new InvalidPropertyTypeException(
+                $field,
+                $value,
+                static::class,
+                sprintf(
+                    'Property "%s" expects array or numeric value, "%s" given.',
+                    $field,
+                    gettype($value)
+                ),
+                InvalidPropertyTypeException::EXPECTED_CODE
+            );
         }
 
         $field = current($this->qb->getRootAliases()) . '.' . $field;

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/StringFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/StringFilter.php
@@ -2,7 +2,8 @@
 
 namespace Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter;
 
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Query\Filter\AttributeFilterInterface;
 use Pim\Component\Catalog\Query\Filter\Operators;
@@ -53,7 +54,7 @@ class StringFilter extends AbstractAttributeFilter implements AttributeFilterInt
         try {
             $options = $this->resolver->resolve($options);
         } catch (\Exception $e) {
-            throw InvalidArgumentException::expectedFromPreviousException(
+            throw InvalidPropertyException::expectedFromPreviousException(
                 $e,
                 $attribute->getCode(),
                 static::class
@@ -179,11 +180,13 @@ class StringFilter extends AbstractAttributeFilter implements AttributeFilterInt
     /**
      * @param string $field
      * @param mixed  $value
+     *
+     * @throws InvalidPropertyTypeException
      */
     protected function checkScalarValue($field, $value)
     {
         if (!is_string($value) && null !== $value) {
-            throw InvalidArgumentException::stringExpected($field, static::class, gettype($value));
+            throw InvalidPropertyTypeException::stringExpected($field, static::class, $value);
         }
     }
 

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/BooleanFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/BooleanFilterSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Doctrine\ODM\MongoDB\Query\Builder;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Exception\InvalidArgumentException;
@@ -103,10 +104,10 @@ class BooleanFilterSpec extends ObjectBehavior
 
     function it_throws_an_exception_if_value_is_not_a_boolean()
     {
-        $this->shouldThrow(InvalidArgumentException::booleanExpected(
+        $this->shouldThrow(InvalidPropertyTypeException::booleanExpected(
             'enabled',
             'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\BooleanFilter',
-            gettype('not a boolean')
+            'not a boolean'
         ))->during('addFieldFilter', ['enabled', '=', 'not a boolean']);
     }
 

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/BooleanFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/BooleanFilterSpec.php
@@ -5,7 +5,6 @@ namespace spec\Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Doctrine\ODM\MongoDB\Query\Builder;
 use PhpSpec\ObjectBehavior;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Validator\AttributeValidatorHelper;
 use Prophecy\Argument;

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/CompletenessFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/CompletenessFilterSpec.php
@@ -2,10 +2,10 @@
 
 namespace spec\Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Doctrine\ODM\MongoDB\Query\Builder;
 use Doctrine\ODM\MongoDB\Query\Expr;
 use PhpSpec\ObjectBehavior;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\ChannelInterface;
 use Pim\Component\Catalog\Repository\ChannelRepositoryInterface;
 use Prophecy\Argument;
@@ -249,20 +249,20 @@ class CompletenessFilterSpec extends ObjectBehavior
     function it_throws_an_exception_when_scope_is_not_provided()
     {
         $this
-            ->shouldThrow('Pim\Component\Catalog\Exception\InvalidArgumentException')
+            ->shouldThrow('Akeneo\Component\StorageUtils\Exception\InvalidPropertyException')
             ->duringAddFieldFilter('completeness', '=', 100);
         $this
-            ->shouldThrow('Pim\Component\Catalog\Exception\InvalidArgumentException')
+            ->shouldThrow('Akeneo\Component\StorageUtils\Exception\InvalidPropertyException')
             ->duringAddFieldFilter('completeness', '=', 100, 'fr_FR', null);
     }
 
     function it_throws_an_exception_if_value_is_not_an_integer()
     {
         $this->shouldThrow(
-            InvalidArgumentException::numericExpected(
+            InvalidPropertyTypeException::numericExpected(
                 'completeness',
                 'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\CompletenessFilter',
-                gettype('123')
+                '12a3'
             ))->during('addFieldFilter', ['completeness', '=', '12a3', 'fr_FR', 'mobile']);
     }
 
@@ -270,11 +270,11 @@ class CompletenessFilterSpec extends ObjectBehavior
     {
         $this
             ->shouldThrow(
-                InvalidArgumentException::arrayKeyExpected(
+                InvalidPropertyTypeException::arrayKeyExpected(
                     'completeness',
                     'locales',
                     'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\CompletenessFilter',
-                    print_r(['wrong_key'], true)
+                    ['wrong_key' => ['en_US', 'fr_FR']]
                 )
             )->during(
                 'addFieldFilter',
@@ -290,10 +290,10 @@ class CompletenessFilterSpec extends ObjectBehavior
 
         $this
             ->shouldThrow(
-                InvalidArgumentException::arrayOfArraysExpected(
+                InvalidPropertyTypeException::arrayOfArraysExpected(
                     'completeness',
                     'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\CompletenessFilter',
-                    print_r(['locales' => 'en_US'], true)
+                    ['locales' => 'en_US']
                 )
             )->during(
                 'addFieldFilter',

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/DateFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/DateFilterSpec.php
@@ -2,9 +2,10 @@
 
 namespace spec\Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Doctrine\ODM\MongoDB\Query\Builder;
 use PhpSpec\ObjectBehavior;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Validator\AttributeValidatorHelper;
 use Prophecy\Argument;
@@ -192,11 +193,11 @@ class DateFilterSpec extends ObjectBehavior
         $date->getCode()->willReturn('release_date');
 
         $this->shouldThrow(
-            InvalidArgumentException::expected(
+            InvalidPropertyException::dateExpected(
                 'release_date',
-                'array with 2 elements, string or \DateTime',
+                'yyyy-mm-dd',
                 'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\DateFilter',
-                print_r(123, true)
+                123
             )
         )->during('addAttributeFilter', [$date, '>', 123]);
     }
@@ -206,9 +207,9 @@ class DateFilterSpec extends ObjectBehavior
         $date->getCode()->willReturn('release_date');
 
         $this->shouldThrow(
-            InvalidArgumentException::expected(
+            InvalidPropertyException::dateExpected(
                 'release_date',
-                'a string with the format yyyy-mm-dd',
+                'yyyy-mm-dd',
                 'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\DateFilter',
                 'not a valid date format'
             )
@@ -220,9 +221,9 @@ class DateFilterSpec extends ObjectBehavior
         $date->getCode()->willReturn('release_date');
 
         $this->shouldThrow(
-            InvalidArgumentException::expected(
+            InvalidPropertyException::dateExpected(
                 'release_date',
-                'array with 2 elements, string or \DateTime',
+                'yyyy-mm-dd',
                 'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\DateFilter',
                 123
             )
@@ -234,11 +235,11 @@ class DateFilterSpec extends ObjectBehavior
         $date->getCode()->willReturn('release_date');
 
         $this->shouldThrow(
-            InvalidArgumentException::expected(
+            InvalidPropertyTypeException::validArrayStructureExpected(
                 'release_date',
-                'array with 2 elements, string or \DateTime',
+                'should contain 2 strings with the format "yyyy-mm-dd"',
                 'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\DateFilter',
-                print_r([123, 123, 'three'], true)
+                [123, 123, 'three']
             )
         )->during('addAttributeFilter', [$date, '>', [123, 123, 'three']]);
     }

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/DateTimeFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/DateTimeFilterSpec.php
@@ -5,10 +5,11 @@ namespace spec\Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter;
 use Akeneo\Component\Batch\Job\JobRepositoryInterface;
 use Akeneo\Component\Batch\Model\JobExecution;
 use Akeneo\Component\Batch\Model\JobInstance;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Doctrine\ODM\MongoDB\Query\Builder;
 use PhpSpec\ObjectBehavior;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Prophecy\Argument;
 
 /**
@@ -191,11 +192,11 @@ class DateTimeFilterSpec extends ObjectBehavior
     function it_throws_an_exception_if_value_is_not_a_string_an_array_or_datetime()
     {
         $this->shouldThrow(
-            InvalidArgumentException::expected(
+            InvalidPropertyException::dateExpected(
                 'updated',
-                'array with 2 elements, string or \DateTime',
+                'yyyy-mm-dd H:i:s',
                 'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\DateTimeFilter',
-                print_r(123, true)
+                123
             )
         )->during('addFieldFilter', ['updated', '>', 123]);
     }
@@ -204,10 +205,10 @@ class DateTimeFilterSpec extends ObjectBehavior
     {
         $this
             ->shouldThrow(
-                InvalidArgumentException::stringExpected(
+                InvalidPropertyTypeException::stringExpected(
                     'updated',
                     'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\DateTimeFilter',
-                    'integer'
+                    42
                 )
             )->during(
                 'addFieldFilter',
@@ -225,7 +226,7 @@ class DateTimeFilterSpec extends ObjectBehavior
     {
         $this
             ->shouldThrow(
-                InvalidArgumentException::numericExpected('updated', 'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\DateTimeFilter', 'string')
+                InvalidPropertyTypeException::numericExpected('updated', 'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\DateTimeFilter', 'csv_product_export')
             )->during(
                 'addFieldFilter',
                 [
@@ -241,9 +242,9 @@ class DateTimeFilterSpec extends ObjectBehavior
     function it_throws_an_error_if_data_is_not_a_valid_date_format()
     {
         $this->shouldThrow(
-            InvalidArgumentException::expected(
+            InvalidPropertyException::dateExpected(
                 'updated',
-                'a string with the format yyyy-mm-dd H:i:s',
+                'yyyy-mm-dd H:i:s',
                 'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\DateTimeFilter',
                 'not a valid date format'
             )
@@ -253,9 +254,9 @@ class DateTimeFilterSpec extends ObjectBehavior
     function it_throws_an_exception_if_value_is_an_array_but_does_not_contain_strings_or_dates()
     {
         $this->shouldThrow(
-            InvalidArgumentException::expected(
+            InvalidPropertyException::dateExpected(
                 'updated',
-                'array with 2 elements, string or \DateTime',
+                'yyyy-mm-dd H:i:s',
                 'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\DateTimeFilter',
                 123
             )
@@ -265,11 +266,11 @@ class DateTimeFilterSpec extends ObjectBehavior
     function it_throws_an_exception_if_value_is_an_array_but_does_not_contain_two_values()
     {
         $this->shouldThrow(
-            InvalidArgumentException::expected(
+            InvalidPropertyTypeException::validArrayStructureExpected(
                 'updated',
-                'array with 2 elements, string or \DateTime',
+                'should contain 2 strings with the format "yyyy-mm-dd H:i:s"',
                 'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\DateTimeFilter',
-                print_r([123, 123, 'three'], true)
+                [123, 123, 'three']
             )
         )->during('addFieldFilter', ['updated', '>', [123, 123, 'three']]);
     }

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/FamilyFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/FamilyFilterSpec.php
@@ -2,10 +2,10 @@
 
 namespace spec\Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Doctrine\ODM\MongoDB\Query\Builder;
 use PhpSpec\ObjectBehavior;
 use Pim\Bundle\CatalogBundle\Doctrine\Common\Filter\ObjectIdResolverInterface;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Prophecy\Argument;
 
 /**
@@ -152,19 +152,19 @@ class FamilyFilterSpec extends ObjectBehavior
 
     function it_throws_an_exception_if_value_is_not_an_array()
     {
-        $this->shouldThrow(InvalidArgumentException::arrayExpected(
+        $this->shouldThrow(InvalidPropertyTypeException::arrayExpected(
             'family',
             'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\FamilyFilter',
-            gettype('not an array')
+            'not an array'
         ))->during('addFieldFilter', ['family', 'IN', 'not an array']);
     }
 
     function it_throws_an_exception_if_content_of_array_is_not_string_or_numeric_or_empty()
     {
-        $this->shouldThrow(InvalidArgumentException::stringExpected(
+        $this->shouldThrow(InvalidPropertyTypeException::stringExpected(
             'family',
             'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\FamilyFilter',
-            gettype(false)
+            false
         ))
             ->during('addFieldFilter', ['family', 'IN', ['a_code', false]]);
     }

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/GroupsFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/GroupsFilterSpec.php
@@ -2,10 +2,10 @@
 
 namespace spec\Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Doctrine\ODM\MongoDB\Query\Builder;
 use PhpSpec\ObjectBehavior;
 use Pim\Bundle\CatalogBundle\Doctrine\Common\Filter\ObjectIdResolverInterface;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Prophecy\Argument;
 
 /**
@@ -145,16 +145,16 @@ class GroupsFilterSpec extends ObjectBehavior
 
     function it_throws_an_exception_if_value_is_not_an_array()
     {
-        $this->shouldThrow(InvalidArgumentException::arrayExpected('groups', 'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\GroupsFilter', gettype('not an array')))
+        $this->shouldThrow(InvalidPropertyTypeException::arrayExpected('groups', 'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\GroupsFilter', 'not an array'))
             ->during('addFieldFilter', ['groups.id', 'IN', 'not an array']);
     }
 
     function it_throws_an_exception_if_content_of_array_is_not_string_or_numeric_or_empty()
     {
-        $this->shouldThrow(InvalidArgumentException::numericExpected('groups', 'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\GroupsFilter', gettype('WRONG')))
+        $this->shouldThrow(InvalidPropertyTypeException::numericExpected('groups', 'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\GroupsFilter', 'WRONG'))
             ->during('addFieldFilter', ['groups.id', 'IN', [1, 2, 'WRONG']]);
 
-        $this->shouldThrow(InvalidArgumentException::stringExpected('groups', 'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\GroupsFilter', gettype(false)))
+        $this->shouldThrow(InvalidPropertyTypeException::stringExpected('groups', 'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\GroupsFilter', false))
             ->during('addFieldFilter', ['groups', 'IN', ['a_code', false]]);
     }
 

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/MediaFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/MediaFilterSpec.php
@@ -2,9 +2,9 @@
 
 namespace spec\Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Doctrine\ODM\MongoDB\Query\Builder;
 use PhpSpec\ObjectBehavior;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Validator\AttributeValidatorHelper;
 use Prophecy\Argument;
@@ -156,10 +156,10 @@ class MediaFilterSpec extends ObjectBehavior
         $image->getCode()->willReturn('media_code');
         $value = ['amount' => 132, 'unit' => 'foo'];
         $this->shouldThrow(
-            InvalidArgumentException::stringExpected(
+            InvalidPropertyTypeException::stringExpected(
                 'media_code',
                 'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\MediaFilter',
-                gettype($value)
+                $value
             )
         )->during('addAttributeFilter', [$image, '=', $value]);
     }

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/MetricFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/MetricFilterSpec.php
@@ -4,9 +4,10 @@ namespace spec\Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter;
 
 use Akeneo\Bundle\MeasureBundle\Convert\MeasureConverter;
 use Akeneo\Bundle\MeasureBundle\Manager\MeasureManager;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Doctrine\ODM\MongoDB\Query\Builder;
 use PhpSpec\ObjectBehavior;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Validator\AttributeValidatorHelper;
 use Prophecy\Argument;
@@ -250,44 +251,44 @@ class MetricFilterSpec extends ObjectBehavior
 
         $value = ['unit' => 'foo'];
         $this->shouldThrow(
-            InvalidArgumentException::arrayKeyExpected(
+            InvalidPropertyTypeException::arrayKeyExpected(
                 'metric_code',
                 'amount',
                 'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\MetricFilter',
-                print_r($value, true)
+                $value
             )
         )
             ->during('addAttributeFilter', [$attribute, '=', $value]);
 
         $value = ['amount' => 459];
         $this->shouldThrow(
-            InvalidArgumentException::arrayKeyExpected(
+            InvalidPropertyTypeException::arrayKeyExpected(
                 'metric_code',
                 'unit',
                 'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\MetricFilter',
-                print_r($value, true)
+                $value
             )
         )
             ->during('addAttributeFilter', [$attribute, '=', $value]);
 
         $value = ['amount' => 'foo', 'unit' => 'foo'];
         $this->shouldThrow(
-            InvalidArgumentException::arrayNumericKeyExpected(
+            InvalidPropertyTypeException::validArrayStructureExpected(
                 'metric_code',
-                'amount',
+                'key "amount" has to be a numeric, "string" given',
                 'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\MetricFilter',
-                'string'
+                $value
             )
         )
             ->during('addAttributeFilter', [$attribute, '=', $value]);
 
         $value = ['amount' => 132, 'unit' => 42];
         $this->shouldThrow(
-            InvalidArgumentException::arrayStringKeyExpected(
+            InvalidPropertyTypeException::validArrayStructureExpected(
                 'metric_code',
-                'unit',
+                'key "unit" has to be a string, "integer" given',
                 'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\MetricFilter',
-                'integer'
+                $value
             )
         )
             ->during('addAttributeFilter', [$attribute, '=', $value]);
@@ -303,7 +304,7 @@ class MetricFilterSpec extends ObjectBehavior
         $attribute->getCode()->willReturn('metric_code');
         $value = ['amount' => 132, 'unit' => 'foo'];
         $this->shouldThrow(
-            InvalidArgumentException::arrayInvalidKey(
+            InvalidPropertyException::validEntityCodeExpected(
                 'metric_code',
                 'unit',
                 'The unit does not exist in the attribute\'s family "length"',

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/NumberFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/NumberFilterSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Doctrine\ODM\MongoDB\Query\Builder;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Exception\InvalidArgumentException;
@@ -153,7 +154,7 @@ class NumberFilterSpec extends ObjectBehavior
     {
         $attribute->getCode()->willReturn('number_code');
 
-        $this->shouldThrow(InvalidArgumentException::numericExpected('number_code', 'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\NumberFilter', gettype('WRONG')))
+        $this->shouldThrow(InvalidPropertyTypeException::numericExpected('number_code', 'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\NumberFilter', 'WRONG'))
             ->during('addAttributeFilter', [$attribute, '=', 'WRONG']);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/NumberFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/NumberFilterSpec.php
@@ -5,7 +5,6 @@ namespace spec\Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Doctrine\ODM\MongoDB\Query\Builder;
 use PhpSpec\ObjectBehavior;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Validator\AttributeValidatorHelper;
 use Prophecy\Argument;

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/OptionFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/OptionFilterSpec.php
@@ -2,10 +2,10 @@
 
 namespace spec\Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Doctrine\ODM\MongoDB\Query\Builder;
 use PhpSpec\ObjectBehavior;
 use Pim\Bundle\CatalogBundle\Doctrine\Common\Filter\ObjectIdResolverInterface;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Validator\AttributeValidatorHelper;
 use Prophecy\Argument;
@@ -207,10 +207,10 @@ class OptionFilterSpec extends ObjectBehavior
     function it_throws_an_exception_if_value_is_not_an_array(AttributeInterface $attribute)
     {
         $attribute->getCode()->willReturn('option_code');
-        $this->shouldThrow(InvalidArgumentException::arrayExpected(
+        $this->shouldThrow(InvalidPropertyTypeException::arrayExpected(
             'option_code',
             'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\OptionFilter',
-            gettype('WRONG')
+            'WRONG'
         ))
             ->during('addAttributeFilter', [$attribute, 'IN', 'WRONG', null, null, ['field' => 'option_code.id']]);
     }
@@ -218,10 +218,10 @@ class OptionFilterSpec extends ObjectBehavior
     function it_throws_an_exception_if_the_content_of_value_are_not_numeric(AttributeInterface $attribute)
     {
         $attribute->getCode()->willReturn('option_code');
-        $this->shouldThrow(InvalidArgumentException::numericExpected(
+        $this->shouldThrow(InvalidPropertyTypeException::numericExpected(
             'option_code',
             'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\OptionFilter',
-            gettype('not numeric')
+            'not numeric'
         ))
             ->during('addAttributeFilter', [$attribute, 'IN', [123, 'not numeric'], null, null, ['field' => 'option_code.id']]);
     }

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/OptionsFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/OptionsFilterSpec.php
@@ -2,10 +2,10 @@
 
 namespace spec\Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Doctrine\ODM\MongoDB\Query\Builder;
 use PhpSpec\ObjectBehavior;
 use Pim\Bundle\CatalogBundle\Doctrine\Common\Filter\ObjectIdResolverInterface;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Validator\AttributeValidatorHelper;
 use Prophecy\Argument;
@@ -199,7 +199,7 @@ class OptionsFilterSpec extends ObjectBehavior
     function it_throws_an_exception_if_the_content_of_value_are_not_numeric(AttributeInterface $attribute)
     {
         $attribute->getCode()->willReturn('options_code');
-        $this->shouldThrow(InvalidArgumentException::numericExpected('options_code', 'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\OptionsFilter', gettype('not numeric')))
+        $this->shouldThrow(InvalidPropertyTypeException::numericExpected('options_code', 'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\OptionsFilter', 'not numeric'))
             ->during('addAttributeFilter', [$attribute, 'IN', [123, 'not numeric'], null, null, ['field' => 'options_code.id']]);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/PriceFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/PriceFilterSpec.php
@@ -2,9 +2,10 @@
 
 namespace spec\Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Doctrine\ODM\MongoDB\Query\Builder;
 use PhpSpec\ObjectBehavior;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Repository\CurrencyRepositoryInterface;
 use Pim\Component\Catalog\Validator\AttributeValidatorHelper;
@@ -221,43 +222,43 @@ class PriceFilterSpec extends ObjectBehavior
 
         $value = ['currency' => 'foo'];
         $this->shouldThrow(
-            InvalidArgumentException::arrayKeyExpected(
+            InvalidPropertyTypeException::arrayKeyExpected(
                 'price_code',
                 'amount',
                 'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\PriceFilter',
-                print_r($value, true)
+                $value
             )
         )
             ->during('addAttributeFilter', [$attribute, '=', $value]);
 
         $value = ['amount' => 459];
         $this->shouldThrow(
-            InvalidArgumentException::arrayKeyExpected(
+            InvalidPropertyTypeException::arrayKeyExpected(
                 'price_code',
                 'currency',
                 'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\PriceFilter',
-                print_r($value, true)
+                $value
             )
         )->during('addAttributeFilter', [$attribute, '=', $value]);
 
         $value = ['amount' => 'foo', 'currency' => 'foo'];
         $this->shouldThrow(
-            InvalidArgumentException::arrayNumericKeyExpected(
+            InvalidPropertyTypeException::validArrayStructureExpected(
                 'price_code',
-                'amount',
+                'key "amount" has to be a numeric, "string" given',
                 'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\PriceFilter',
-                'string'
+                $value
             )
         )
             ->during('addAttributeFilter', [$attribute, '=', $value]);
 
         $value = ['amount' => 132, 'currency' => 42];
         $this->shouldThrow(
-            InvalidArgumentException::arrayStringKeyExpected(
+            InvalidPropertyTypeException::validArrayStructureExpected(
                 'price_code',
-                'currency',
+                'key "currency" has to be a string, "integer" given',
                 'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\PriceFilter',
-                'integer'
+                $value
             )
         )->during('addAttributeFilter', [$attribute, '=', $value]);
     }
@@ -269,7 +270,7 @@ class PriceFilterSpec extends ObjectBehavior
         $attribute->getCode()->willReturn('price_code');
         $value = ['amount' => 132, 'currency' => 'FOO'];
         $this->shouldThrow(
-            InvalidArgumentException::arrayInvalidKey(
+            InvalidPropertyException::validEntityCodeExpected(
                 'price_code',
                 'currency',
                 'The currency does not exist',

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/ProductIdFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/ProductIdFilterSpec.php
@@ -2,9 +2,10 @@
 
 namespace spec\Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Doctrine\ODM\MongoDB\Query\Builder;
 use PhpSpec\ObjectBehavior;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 
 /**
  * @require Doctrine\ODM\MongoDB\Query\Builder
@@ -32,11 +33,15 @@ class ProductIdFilterSpec extends ObjectBehavior
 
     function it_throws_an_exception_if_value_is_not_a_numeric_or_an_array()
     {
-        $this->shouldThrow(InvalidArgumentException::expected(
-            'id',
-            'array or string value',
-            'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\ProductIdFilter',
-            1234))
+        $this->shouldThrow(
+            new InvalidPropertyTypeException(
+                'id',
+                1234,
+                'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\ProductIdFilter',
+                'Property "id" expects array or string value, "integer" given.',
+                100
+            )
+        )
             ->during('addFieldFilter', ['id', '=', 1234]);
     }
 

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/StringFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Filter/StringFilterSpec.php
@@ -2,10 +2,11 @@
 
 namespace spec\Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Doctrine\MongoDB\Query\Expr;
 use Doctrine\ODM\MongoDB\Query\Builder;
 use PhpSpec\ObjectBehavior;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Validator\AttributeValidatorHelper;
 use Prophecy\Argument;
@@ -183,10 +184,10 @@ class StringFilterSpec extends ObjectBehavior
     {
         $attribute->getCode()->willReturn('attributeCode');
 
-        $this->shouldThrow(InvalidArgumentException::stringExpected(
+        $this->shouldThrow(InvalidPropertyTypeException::stringExpected(
             'attributeCode',
             'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\StringFilter',
-            gettype(123)
+            123
         ))->during('addAttributeFilter', [$attribute, '=', 123, null, null, ['field' => 'attributeCode']]);
     }
 
@@ -199,10 +200,10 @@ class StringFilterSpec extends ObjectBehavior
         $attribute->isLocalizable()->willReturn(true);
         $attrValidatorHelper->validateLocale($attribute, null)->willThrow($e);
         $this->shouldThrow(
-            InvalidArgumentException::expectedFromPreviousException(
-                $e,
+            InvalidPropertyException::expectedFromPreviousException(
                 'attributeCode',
-                'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\StringFilter'
+                'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\StringFilter',
+                $e
             )
         )->during('addAttributeFilter', [$attribute, '=', 123, null, null, ['field' => 'attributeCode']]);
     }
@@ -216,7 +217,7 @@ class StringFilterSpec extends ObjectBehavior
         $attribute->isLocalizable()->willReturn(false);
         $attrValidatorHelper->validateLocale($attribute, 'en_US')->willThrow($e);
         $this->shouldThrow(
-            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\StringFilter')
+            InvalidPropertyException::expectedFromPreviousException('attributeCode', 'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\StringFilter', $e)
         )->during('addAttributeFilter', [$attribute, '=', 123, 'en_US', 'ecommerce', ['field' => 'attributeCode']]);
     }
 
@@ -229,7 +230,7 @@ class StringFilterSpec extends ObjectBehavior
         $attribute->isLocalizable()->willReturn(true);
         $attrValidatorHelper->validateLocale($attribute, 'uz-UZ')->willThrow($e);
         $this->shouldThrow(
-            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\StringFilter')
+            InvalidPropertyException::expectedFromPreviousException('attributeCode', 'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\StringFilter', $e)
         )->during('addAttributeFilter', [$attribute, '=', 123, 'uz-UZ', 'ecommerce', ['field' => 'attributeCode']]);
     }
 
@@ -244,7 +245,7 @@ class StringFilterSpec extends ObjectBehavior
         $attrValidatorHelper->validateLocale($attribute, null)->shouldBeCalled();
         $attrValidatorHelper->validateScope($attribute, null)->willThrow($e);
         $this->shouldThrow(
-            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\StringFilter')
+            InvalidPropertyException::expectedFromPreviousException('attributeCode', 'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\StringFilter', $e)
         )->during('addAttributeFilter', [$attribute, '=', 123, null, null, ['field' => 'attributeCode']]);
     }
 
@@ -259,7 +260,7 @@ class StringFilterSpec extends ObjectBehavior
         $attrValidatorHelper->validateLocale($attribute, null)->shouldBeCalled();
         $attrValidatorHelper->validateScope($attribute, 'ecommerce')->willThrow($e);
         $this->shouldThrow(
-            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\StringFilter')
+            InvalidPropertyException::expectedFromPreviousException('attributeCode', 'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\StringFilter', $e)
         )->during('addAttributeFilter', [$attribute, '=', 123, null, 'ecommerce', ['field' => 'attributeCode']]);
     }
 
@@ -274,7 +275,7 @@ class StringFilterSpec extends ObjectBehavior
         $attrValidatorHelper->validateLocale($attribute, null)->shouldBeCalled();
         $attrValidatorHelper->validateScope($attribute, 'ecommerce')->willThrow($e);
         $this->shouldThrow(
-            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\StringFilter')
+            InvalidPropertyException::expectedFromPreviousException('attributeCode', 'Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\StringFilter', $e)
         )->during('addAttributeFilter', [$attribute, '=', 123, null, 'ecommerce', ['field' => 'attributeCode']]);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/BooleanFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/BooleanFilterSpec.php
@@ -2,10 +2,10 @@
 
 namespace spec\Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Doctrine\ORM\Query\Expr;
 use Doctrine\ORM\QueryBuilder;
 use PhpSpec\ObjectBehavior;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Validator\AttributeValidatorHelper;
 use Prophecy\Argument;
@@ -50,10 +50,10 @@ class BooleanFilterSpec extends ObjectBehavior
 
     function it_throws_an_exception_if_value_is_not_a_boolean()
     {
-        $this->shouldThrow(InvalidArgumentException::booleanExpected(
+        $this->shouldThrow(InvalidPropertyTypeException::booleanExpected(
             'enabled',
             'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\BooleanFilter',
-            gettype('fuu')
+            'fuu'
         ))->during('addFieldFilter', ['enabled', '=', 'fuu']);
     }
 

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/CompletenessFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/CompletenessFilterSpec.php
@@ -2,13 +2,12 @@
 
 namespace spec\Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Query\Expr;
 use Doctrine\ORM\QueryBuilder;
 use PhpSpec\ObjectBehavior;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
-use Pim\Component\Catalog\Query\Filter\Operators;
 use Prophecy\Argument;
 
 class CompletenessFilterSpec extends ObjectBehavior
@@ -329,7 +328,7 @@ class CompletenessFilterSpec extends ObjectBehavior
 
     function it_throws_an_exception_if_value_is_not_a_integer()
     {
-        $this->shouldThrow(InvalidArgumentException::numericExpected('completeness', 'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\CompletenessFilter', gettype('123')))
+        $this->shouldThrow(InvalidPropertyTypeException::numericExpected('completeness', 'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\CompletenessFilter', '12z3'))
             ->during('addFieldFilter', ['completeness', '=', '12z3', 'en_US', 'mobile']);
     }
 
@@ -337,11 +336,11 @@ class CompletenessFilterSpec extends ObjectBehavior
     {
         $this
             ->shouldThrow(
-                InvalidArgumentException::arrayKeyExpected(
+                InvalidPropertyTypeException::arrayKeyExpected(
                     'completeness',
                     'locales',
                     'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\CompletenessFilter',
-                    print_r([], true)
+                    []
                 )
             )
             ->during(
@@ -358,10 +357,10 @@ class CompletenessFilterSpec extends ObjectBehavior
 
         $this
             ->shouldThrow(
-                InvalidArgumentException::arrayOfArraysExpected(
+                InvalidPropertyTypeException::arrayOfArraysExpected(
                     'completeness',
                     'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\CompletenessFilter',
-                    print_r(['locales' => 'fr_FR'], true)
+                    ['locales' => 'fr_FR']
                 )
             )
             ->during(

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/DateFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/DateFilterSpec.php
@@ -2,10 +2,11 @@
 
 namespace spec\Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Doctrine\ORM\Query\Expr;
 use Doctrine\ORM\QueryBuilder;
 use PhpSpec\ObjectBehavior;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Validator\AttributeValidatorHelper;
 use Prophecy\Argument;
@@ -334,11 +335,11 @@ class DateFilterSpec extends ObjectBehavior
         $attribute->getCode()->willReturn('release_date');
 
         $this->shouldThrow(
-            InvalidArgumentException::expected(
+            InvalidPropertyException::dateExpected(
                 'release_date',
-                'array with 2 elements, string or \DateTime',
+                'yyyy-mm-dd',
                 'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\DateFilter',
-                print_r(123, true)
+                123
             )
         )->during('addAttributeFilter', [$attribute, '>', 123]);
     }
@@ -348,9 +349,9 @@ class DateFilterSpec extends ObjectBehavior
         $attribute->getCode()->willReturn('release_date');
 
         $this->shouldThrow(
-            InvalidArgumentException::expected(
+            InvalidPropertyException::dateExpected(
                 'release_date',
-                'a string with the format yyyy-mm-dd',
+                'yyyy-mm-dd',
                 'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\DateFilter',
                 'not a valid date format'
             )
@@ -362,9 +363,9 @@ class DateFilterSpec extends ObjectBehavior
         $attribute->getCode()->willReturn('release_date');
 
         $this->shouldThrow(
-            InvalidArgumentException::expected(
+            InvalidPropertyException::dateExpected(
                 'release_date',
-                'array with 2 elements, string or \DateTime',
+                'yyyy-mm-dd',
                 'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\DateFilter',
                 123
             )
@@ -376,11 +377,11 @@ class DateFilterSpec extends ObjectBehavior
         $attribute->getCode()->willReturn('release_date');
 
         $this->shouldThrow(
-            InvalidArgumentException::expected(
+            InvalidPropertyTypeException::validArrayStructureExpected(
                 'release_date',
-                'array with 2 elements, string or \DateTime',
+                'should contain 2 strings with the format "yyyy-mm-dd"',
                 'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\DateFilter',
-                print_r([123, 123, 'three'], true)
+                [123, 123, 'three']
             )
         )->during('addAttributeFilter', [$attribute, '>', [123, 123, 'three']]);
     }

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/DateTimeFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/DateTimeFilterSpec.php
@@ -5,12 +5,13 @@ namespace spec\Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter;
 use Akeneo\Component\Batch\Job\JobRepositoryInterface;
 use Akeneo\Component\Batch\Model\JobExecution;
 use Akeneo\Component\Batch\Model\JobInstance;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Doctrine\ORM\Query\Expr;
 use Doctrine\ORM\Query\Expr\Comparison;
 use Doctrine\ORM\QueryBuilder;
 use PhpSpec\ObjectBehavior;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Prophecy\Argument;
 
 class DateTimeFilterSpec extends ObjectBehavior
@@ -275,10 +276,10 @@ class DateTimeFilterSpec extends ObjectBehavior
     {
         $this
             ->shouldThrow(
-                InvalidArgumentException::stringExpected(
+                InvalidPropertyTypeException::stringExpected(
                     'updated',
                     'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\DateTimeFilter',
-                    'integer'
+                    42
                 )
             )->during(
                 'addFieldFilter',
@@ -296,10 +297,10 @@ class DateTimeFilterSpec extends ObjectBehavior
     {
         $this
             ->shouldThrow(
-                InvalidArgumentException::numericExpected(
+                InvalidPropertyTypeException::numericExpected(
                     'updated',
                     'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\DateTimeFilter',
-                    'string'
+                    'csv_product_export'
                 )
             )->during(
                 'addFieldFilter',
@@ -316,11 +317,11 @@ class DateTimeFilterSpec extends ObjectBehavior
     function it_throws_an_exception_if_value_is_not_a_string_an_array_or_a_datetime()
     {
         $this->shouldThrow(
-            InvalidArgumentException::expected(
+            InvalidPropertyException::dateExpected(
                 'updated_at',
-                'array with 2 elements, string or \DateTime',
+                'yyyy-mm-dd H:i:s',
                 'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\DateTimeFilter',
-                print_r(123, true)
+                123
             )
         )->during('addFieldFilter', ['updated_at', '>', 123]);
     }
@@ -328,9 +329,9 @@ class DateTimeFilterSpec extends ObjectBehavior
     function it_throws_an_error_if_data_is_not_a_valid_date_format()
     {
         $this->shouldThrow(
-            InvalidArgumentException::expected(
+            InvalidPropertyException::dateExpected(
                 'updated_at',
-                'a string with the format yyyy-mm-dd H:i:s',
+                'yyyy-mm-dd H:i:s',
                 'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\DateTimeFilter',
                 'not a valid date format'
             )
@@ -340,9 +341,9 @@ class DateTimeFilterSpec extends ObjectBehavior
     function it_throws_an_exception_if_value_is_an_array_but_does_not_contain_strings_or_dates()
     {
         $this->shouldThrow(
-            InvalidArgumentException::expected(
+            InvalidPropertyException::dateExpected(
                 'updated_at',
-                'array with 2 elements, string or \DateTime',
+                'yyyy-mm-dd H:i:s',
                 'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\DateTimeFilter',
                 123
             )
@@ -352,11 +353,11 @@ class DateTimeFilterSpec extends ObjectBehavior
     function it_throws_an_exception_if_value_is_an_array_but_does_not_contain_two_values()
     {
         $this->shouldThrow(
-            InvalidArgumentException::expected(
+            InvalidPropertyTypeException::validArrayStructureExpected(
                 'updated_at',
-                'array with 2 elements, string or \DateTime',
+                'should contain 2 strings with the format "yyyy-mm-dd H:i:s"',
                 'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\DateTimeFilter',
-                print_r([123, 123, 'three'], true)
+                [123, 123, 'three']
             )
         )->during('addFieldFilter', ['updated_at', '>', [123, 123, 'three']]);
     }

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/FamilyFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/FamilyFilterSpec.php
@@ -2,11 +2,11 @@
 
 namespace spec\Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Doctrine\ORM\Query\Expr;
 use Doctrine\ORM\QueryBuilder;
 use PhpSpec\ObjectBehavior;
 use Pim\Bundle\CatalogBundle\Doctrine\Common\Filter\ObjectIdResolverInterface;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Prophecy\Argument;
 
 class FamilyFilterSpec extends ObjectBehavior
@@ -142,19 +142,19 @@ class FamilyFilterSpec extends ObjectBehavior
 
     function it_throws_an_exception_if_value_is_not_an_array()
     {
-        $this->shouldThrow(InvalidArgumentException::arrayExpected(
+        $this->shouldThrow(InvalidPropertyTypeException::arrayExpected(
             'family',
             'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\FamilyFilter',
-            gettype('WRONG')
+            'WRONG'
         ))->during('addFieldFilter', ['family', 'IN', 'WRONG']);
     }
 
     function it_throws_an_exception_if_values_in_array_are_not_strings_or_numerics()
     {
-        $this->shouldThrow(InvalidArgumentException::stringExpected(
+        $this->shouldThrow(InvalidPropertyTypeException::stringExpected(
             'family',
             'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\FamilyFilter',
-            gettype(false)
+            false
         ))->during('addFieldFilter', ['family', 'IN', [false]]);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/GroupsFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/GroupsFilterSpec.php
@@ -8,7 +8,6 @@ use Doctrine\ORM\Query\Expr;
 use Doctrine\ORM\QueryBuilder;
 use PhpSpec\ObjectBehavior;
 use Pim\Bundle\CatalogBundle\Doctrine\Common\Filter\ObjectIdResolverInterface;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Prophecy\Argument;
 
 class GroupsFilterSpec extends ObjectBehavior

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/GroupsFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/GroupsFilterSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Query\Expr;
 use Doctrine\ORM\QueryBuilder;
@@ -149,19 +150,19 @@ class GroupsFilterSpec extends ObjectBehavior
 
     function it_throws_an_exception_if_value_is_not_an_array()
     {
-        $this->shouldThrow(InvalidArgumentException::arrayExpected(
+        $this->shouldThrow(InvalidPropertyTypeException::arrayExpected(
             'groups',
             'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\GroupsFilter',
-            gettype('WRONG')
+            'WRONG'
         ))->during('addFieldFilter', ['groups', 'IN', 'WRONG']);
     }
 
     function it_throws_an_exception_if_values_in_array_are_not_strings_or_numerics()
     {
-        $this->shouldThrow(InvalidArgumentException::stringExpected(
+        $this->shouldThrow(InvalidPropertyTypeException::stringExpected(
             'groups',
             'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\GroupsFilter',
-            gettype(false)
+            false
         ))->during('addFieldFilter', ['groups', 'IN', [false]]);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/MediaFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/MediaFilterSpec.php
@@ -2,10 +2,10 @@
 
 namespace spec\Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Doctrine\ORM\Query\Expr;
 use Doctrine\ORM\QueryBuilder;
 use PhpSpec\ObjectBehavior;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Validator\AttributeValidatorHelper;
 use Prophecy\Argument;
@@ -239,10 +239,10 @@ class MediaFilterSpec extends ObjectBehavior
         $attribute->getCode()->willReturn('media_code');
         $value = ['amount' => 132, 'unit' => 'foo'];
         $this->shouldThrow(
-            InvalidArgumentException::stringExpected(
+            InvalidPropertyTypeException::stringExpected(
                 'media_code',
                 'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\MediaFilter',
-                gettype($value)
+                $value
             )
         )->during('addAttributeFilter', [$attribute, '=', $value]);
     }

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/MetricFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/MetricFilterSpec.php
@@ -9,7 +9,6 @@ use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Doctrine\ORM\Query\Expr;
 use Doctrine\ORM\QueryBuilder;
 use PhpSpec\ObjectBehavior;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Validator\AttributeValidatorHelper;
 use Prophecy\Argument;

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/MetricFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/MetricFilterSpec.php
@@ -4,6 +4,8 @@ namespace spec\Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter;
 
 use Akeneo\Bundle\MeasureBundle\Convert\MeasureConverter;
 use Akeneo\Bundle\MeasureBundle\Manager\MeasureManager;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Doctrine\ORM\Query\Expr;
 use Doctrine\ORM\QueryBuilder;
 use PhpSpec\ObjectBehavior;
@@ -139,44 +141,44 @@ class MetricFilterSpec extends ObjectBehavior
 
         $value = ['unit' => 'foo'];
         $this->shouldThrow(
-            InvalidArgumentException::arrayKeyExpected(
+            InvalidPropertyTypeException::arrayKeyExpected(
                 'metric_code',
                 'amount',
                 'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\MetricFilter',
-                print_r($value, true)
+                $value
             )
         )
             ->during('addAttributeFilter', [$attribute, '=', $value]);
 
         $value = ['amount' => 459];
         $this->shouldThrow(
-            InvalidArgumentException::arrayKeyExpected(
+            InvalidPropertyTypeException::arrayKeyExpected(
                 'metric_code',
                 'unit',
                 'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\MetricFilter',
-                print_r($value, true)
+                $value
             )
         )
             ->during('addAttributeFilter', [$attribute, '=', $value]);
 
         $value = ['amount' => 'foo', 'unit' => 'foo'];
         $this->shouldThrow(
-            InvalidArgumentException::arrayNumericKeyExpected(
+            InvalidPropertyTypeException::validArrayStructureExpected(
                 'metric_code',
-                'amount',
+                'key "amount" has to be a numeric, "string" given',
                 'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\MetricFilter',
-                'string'
+                $value
             )
         )
             ->during('addAttributeFilter', [$attribute, '=', $value]);
 
         $value = ['amount' => 132, 'unit' => 42];
         $this->shouldThrow(
-            InvalidArgumentException::arrayStringKeyExpected(
+            InvalidPropertyTypeException::validArrayStructureExpected(
                 'metric_code',
-                'unit',
+                'key "unit" has to be a string, "integer" given',
                 'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\MetricFilter',
-                'integer'
+                $value
             )
         )
             ->during('addAttributeFilter', [$attribute, '=', $value]);
@@ -190,7 +192,7 @@ class MetricFilterSpec extends ObjectBehavior
         $attribute->getCode()->willReturn('metric_code');
         $value = ['amount' => 132, 'unit' => 'foo'];
         $this->shouldThrow(
-            InvalidArgumentException::arrayInvalidKey(
+            InvalidPropertyException::validEntityCodeExpected(
                 'metric_code',
                 'unit',
                 'The unit does not exist in the attribute\'s family "length"',

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/NumberFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/NumberFilterSpec.php
@@ -2,10 +2,10 @@
 
 namespace spec\Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Doctrine\ORM\Query\Expr;
 use Doctrine\ORM\QueryBuilder;
 use PhpSpec\ObjectBehavior;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Validator\AttributeValidatorHelper;
 use Prophecy\Argument;
@@ -136,9 +136,9 @@ class NumberFilterSpec extends ObjectBehavior
     function it_throws_an_exception_if_value_is_not_a_numeric(AttributeInterface $attribute)
     {
         $attribute->getCode()->willReturn('number_code');
-        $this->shouldThrow(InvalidArgumentException::numericExpected(
+        $this->shouldThrow(InvalidPropertyTypeException::numericExpected(
             'number_code', 'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\NumberFilter',
-            gettype('WRONG')
+            'WRONG'
         ))->during('addAttributeFilter', [$attribute, '=', 'WRONG']);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/OptionFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/OptionFilterSpec.php
@@ -2,11 +2,11 @@
 
 namespace spec\Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Doctrine\ORM\Query\Expr;
 use Doctrine\ORM\QueryBuilder;
 use PhpSpec\ObjectBehavior;
 use Pim\Bundle\CatalogBundle\Doctrine\Common\Filter\ObjectIdResolverInterface;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Validator\AttributeValidatorHelper;
 use Prophecy\Argument;
@@ -166,15 +166,15 @@ class OptionFilterSpec extends ObjectBehavior
     function it_throws_an_exception_if_value_is_not_an_array(AttributeInterface $attribute)
     {
         $attribute->getCode()->willReturn('option_code');
-        $this->shouldThrow(InvalidArgumentException::arrayExpected('option_code', 'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\OptionFilter', gettype('WRONG')))->during('addAttributeFilter', [$attribute, 'IN', 'WRONG', null, null, ['field' => 'option_code.id']]);
+        $this->shouldThrow(InvalidPropertyTypeException::arrayExpected('option_code', 'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\OptionFilter', 'WRONG'))->during('addAttributeFilter', [$attribute, 'IN', 'WRONG', null, null, ['field' => 'option_code.id']]);
     }
 
     function it_throws_an_exception_if_the_content_of_value_are_not_numeric(AttributeInterface $attribute)
     {
         $attribute->getCode()->willReturn('option_code');
-        $this->shouldThrow(InvalidArgumentException::numericExpected(
+        $this->shouldThrow(InvalidPropertyTypeException::numericExpected(
             'option_code', 'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\OptionFilter',
-            gettype('not numeric')
+            'not numeric'
         ))->during('addAttributeFilter', [$attribute, 'IN', [123, 'not numeric'], null, null, ['field' => 'option_code.id']]);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/OptionsFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/OptionsFilterSpec.php
@@ -2,12 +2,12 @@
 
 namespace spec\Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Query\Expr;
 use Doctrine\ORM\QueryBuilder;
 use PhpSpec\ObjectBehavior;
 use Pim\Bundle\CatalogBundle\Doctrine\Common\Filter\ObjectIdResolverInterface;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Validator\AttributeValidatorHelper;
 use Prophecy\Argument;
@@ -206,20 +206,20 @@ class OptionsFilterSpec extends ObjectBehavior
     function it_throws_an_exception_if_value_is_not_an_array(AttributeInterface $attribute)
     {
         $attribute->getCode()->willReturn('options_code');
-        $this->shouldThrow(InvalidArgumentException::arrayExpected(
+        $this->shouldThrow(InvalidPropertyTypeException::arrayExpected(
             'options_code',
             'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\OptionsFilter',
-            gettype('WRONG')
+            'WRONG'
         ))->during('addAttributeFilter', [$attribute, 'IN', 'WRONG', null, null, ['field' => 'options_code.id']]);
     }
 
     function it_throws_an_exception_if_the_content_of_value_are_not_numeric(AttributeInterface $attribute)
     {
         $attribute->getCode()->willReturn('options_code');
-        $this->shouldThrow(InvalidArgumentException::numericExpected(
+        $this->shouldThrow(InvalidPropertyTypeException::numericExpected(
             'options_code',
             'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\OptionsFilter',
-            gettype('WRONG')
+            'not numeric'
         ))->during('addAttributeFilter', [$attribute, 'IN', [123, 'not numeric'], null, null, ['field' => 'options_code.id']]);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/PriceFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/PriceFilterSpec.php
@@ -8,7 +8,6 @@ use Doctrine\ORM\Query\Expr;
 use Doctrine\ORM\Query\Expr\Comparison;
 use Doctrine\ORM\QueryBuilder;
 use PhpSpec\ObjectBehavior;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Repository\CurrencyRepositoryInterface;
 use Pim\Component\Catalog\Validator\AttributeValidatorHelper;

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/PriceFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/PriceFilterSpec.php
@@ -2,6 +2,8 @@
 
 namespace spec\Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Doctrine\ORM\Query\Expr;
 use Doctrine\ORM\Query\Expr\Comparison;
 use Doctrine\ORM\QueryBuilder;
@@ -303,44 +305,44 @@ class PriceFilterSpec extends ObjectBehavior
 
         $value = ['currency' => 'foo'];
         $this->shouldThrow(
-            InvalidArgumentException::arrayKeyExpected(
+            InvalidPropertyTypeException::arrayKeyExpected(
                 'price_code',
                 'amount',
                 'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\PriceFilter',
-                print_r($value, true)
+                $value
             )
         )
             ->during('addAttributeFilter', [$attribute, '=', $value]);
 
         $value = ['amount' => 459];
         $this->shouldThrow(
-            InvalidArgumentException::arrayKeyExpected(
+            InvalidPropertyTypeException::arrayKeyExpected(
                 'price_code',
                 'currency',
                 'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\PriceFilter',
-                print_r($value, true)
+                $value
             )
         )
             ->during('addAttributeFilter', [$attribute, '=', $value]);
 
         $value = ['amount' => 'foo', 'currency' => 'foo'];
         $this->shouldThrow(
-            InvalidArgumentException::arrayNumericKeyExpected(
+            InvalidPropertyTypeException::validArrayStructureExpected(
                 'price_code',
-                'amount',
+                'key "amount" has to be a numeric, "string" given',
                 'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\PriceFilter',
-                'string'
+                $value
             )
         )
             ->during('addAttributeFilter', [$attribute, '=', $value]);
 
         $value = ['amount' => 132, 'currency' => 42];
         $this->shouldThrow(
-            InvalidArgumentException::arrayStringKeyExpected(
+            InvalidPropertyTypeException::validArrayStructureExpected(
                 'price_code',
-                'currency',
+                'key "currency" has to be a string, "integer" given',
                 'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\PriceFilter',
-                'integer'
+                $value
             )
         )
             ->during('addAttributeFilter', [$attribute, '=', $value]);
@@ -353,7 +355,7 @@ class PriceFilterSpec extends ObjectBehavior
         $attribute->getCode()->willReturn('price_code');
         $value = ['amount' => 132, 'currency' => 'FOO'];
         $this->shouldThrow(
-            InvalidArgumentException::arrayInvalidKey(
+            InvalidPropertyException::validEntityCodeExpected(
                 'price_code',
                 'currency',
                 'The currency does not exist',

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/ProductIdFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/ProductIdFilterSpec.php
@@ -2,10 +2,11 @@
 
 namespace spec\Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Doctrine\ORM\Query\Expr;
 use Doctrine\ORM\QueryBuilder;
 use PhpSpec\ObjectBehavior;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 
 class ProductIdFilterSpec extends ObjectBehavior
 {
@@ -43,11 +44,14 @@ class ProductIdFilterSpec extends ObjectBehavior
 
     function it_throws_an_exception_if_value_is_not_a_numeric_or_an_array()
     {
-        $this->shouldThrow(InvalidArgumentException::expected(
-            'id',
-            'array or numeric value',
-            'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\ProductIdFilter',
-            'WRONG'
-        ))->during('addFieldFilter', ['id', '=', 'WRONG']);
+        $this->shouldThrow(
+            new InvalidPropertyTypeException(
+                'id',
+                'WRONG',
+                'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\ProductIdFilter',
+                'Property "id" expects array or numeric value, "string" given.',
+                100
+            )
+        )->during('addFieldFilter', ['id', '=', 'WRONG']);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/StringFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/StringFilterSpec.php
@@ -2,10 +2,11 @@
 
 namespace spec\Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Doctrine\ORM\Query\Expr;
 use Doctrine\ORM\QueryBuilder;
 use PhpSpec\ObjectBehavior;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Validator\AttributeValidatorHelper;
 use Prophecy\Argument;
@@ -229,10 +230,10 @@ class StringFilterSpec extends ObjectBehavior
     function it_throws_an_exception_if_value_is_not_a_string(AttributeInterface $attribute)
     {
         $attribute->getCode()->willReturn('attributeCode');
-        $this->shouldThrow(InvalidArgumentException::stringExpected(
+        $this->shouldThrow(InvalidPropertyTypeException::stringExpected(
             'attributeCode',
             'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\StringFilter',
-            gettype(123)
+            123
         ))->during('addAttributeFilter', [$attribute, '=', 123, null, null, ['field' => 'attributeCode']]);
     }
 
@@ -245,7 +246,7 @@ class StringFilterSpec extends ObjectBehavior
         $attribute->isLocalizable()->willReturn(true);
         $attrValidatorHelper->validateLocale($attribute, null)->willThrow($e);
         $this->shouldThrow(
-            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\StringFilter')
+            InvalidPropertyException::expectedFromPreviousException('attributeCode', 'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\StringFilter', $e)
         )->during('addAttributeFilter', [$attribute, '=', 123, null, null, ['field' => 'attributeCode']]);
     }
 
@@ -258,7 +259,7 @@ class StringFilterSpec extends ObjectBehavior
         $attribute->isLocalizable()->willReturn(false);
         $attrValidatorHelper->validateLocale($attribute, 'en_US')->willThrow($e);
         $this->shouldThrow(
-            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\StringFilter')
+            InvalidPropertyException::expectedFromPreviousException('attributeCode', 'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\StringFilter', $e)
         )->during('addAttributeFilter', [$attribute, '=', 123, 'en_US', 'ecommerce', ['field' => 'attributeCode']]);
     }
 
@@ -271,7 +272,7 @@ class StringFilterSpec extends ObjectBehavior
         $attribute->isLocalizable()->willReturn(true);
         $attrValidatorHelper->validateLocale($attribute, 'uz-UZ')->willThrow($e);
         $this->shouldThrow(
-            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\StringFilter')
+            InvalidPropertyException::expectedFromPreviousException('attributeCode', 'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\StringFilter', $e)
         )->during('addAttributeFilter', [$attribute, '=', 123, 'uz-UZ', 'ecommerce', ['field' => 'attributeCode']]);
     }
 
@@ -286,7 +287,7 @@ class StringFilterSpec extends ObjectBehavior
         $attrValidatorHelper->validateLocale($attribute, null)->shouldBeCalled();
         $attrValidatorHelper->validateScope($attribute, null)->willThrow($e);
         $this->shouldThrow(
-            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\StringFilter')
+            InvalidPropertyException::expectedFromPreviousException('attributeCode', 'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\StringFilter', $e)
         )->during('addAttributeFilter', [$attribute, '=', 123, null, null, ['field' => 'attributeCode']]);
     }
 
@@ -301,7 +302,7 @@ class StringFilterSpec extends ObjectBehavior
         $attrValidatorHelper->validateLocale($attribute, null)->shouldBeCalled();
         $attrValidatorHelper->validateScope($attribute, 'ecommerce')->willThrow($e);
         $this->shouldThrow(
-            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\StringFilter')
+            InvalidPropertyException::expectedFromPreviousException('attributeCode', 'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\StringFilter', $e)
         )->during('addAttributeFilter', [$attribute, '=', 123, null, 'ecommerce', ['field' => 'attributeCode']]);
     }
 
@@ -316,7 +317,7 @@ class StringFilterSpec extends ObjectBehavior
         $attrValidatorHelper->validateLocale($attribute, null)->shouldBeCalled();
         $attrValidatorHelper->validateScope($attribute, 'ecommerce')->willThrow($e);
         $this->shouldThrow(
-            InvalidArgumentException::expectedFromPreviousException($e, 'attributeCode', 'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\StringFilter')
+            InvalidPropertyException::expectedFromPreviousException('attributeCode', 'Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\StringFilter', $e)
         )->during('addAttributeFilter', [$attribute, '=', 123, null, 'ecommerce', ['field' => 'attributeCode']]);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Boolean/BooleanFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Boolean/BooleanFilterIntegration.php
@@ -50,8 +50,8 @@ class BooleanFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_yes_no" expects a boolean as data, "string" given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException
+     * @expectedExceptionMessage Property "a_yes_no" expects a boolean as data, "string" given.
      */
     public function testErrorDataIsMalformed()
     {
@@ -59,8 +59,8 @@ class BooleanFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_yes_no" expects a boolean as data, "NULL" given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException
+     * @expectedExceptionMessage Property "a_yes_no" expects a boolean as data, "NULL" given.
      */
     public function testErrorDataIsNull()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Boolean/LocalizableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Boolean/LocalizableFilterIntegration.php
@@ -67,8 +67,8 @@ class LocalizableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_localizable_yes_no" expects valid data, scope and locale. Attribute "a_localizable_yes_no" expects a locale, none given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_localizable_yes_no" expects a locale, none given.
      */
     public function testErrorLocalizable()
     {
@@ -76,8 +76,8 @@ class LocalizableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_localizable_yes_no" expects valid data, scope and locale. Attribute "a_localizable_yes_no" expects an existing and activated locale, "NOT_FOUND" given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_localizable_yes_no" expects an existing and activated locale, "NOT_FOUND" given.
      */
     public function testLocaleNotFound()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Boolean/LocalizableScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Boolean/LocalizableScopableFilterIntegration.php
@@ -73,8 +73,8 @@ class LocalizableScopableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_localizable_scopable_yes_no" expects valid data, scope and locale. Attribute "a_localizable_scopable_yes_no" expects a locale, none given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_localizable_scopable_yes_no" expects a locale, none given.
      */
     public function testErrorLocalizable()
     {
@@ -82,8 +82,8 @@ class LocalizableScopableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_localizable_scopable_yes_no" expects valid data, scope and locale. Attribute "a_localizable_scopable_yes_no" expects a scope, none given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_localizable_scopable_yes_no" expects a scope, none given.
      */
     public function testErrorScopable()
     {
@@ -91,8 +91,8 @@ class LocalizableScopableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_localizable_scopable_yes_no" expects valid data, scope and locale. Attribute "a_localizable_scopable_yes_no" expects an existing and activated locale, "NOT_FOUND" given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_localizable_scopable_yes_no" expects an existing and activated locale, "NOT_FOUND" given.
      */
     public function testLocaleNotFound()
     {
@@ -100,8 +100,8 @@ class LocalizableScopableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_localizable_scopable_yes_no" expects valid data, scope and locale. Attribute "a_localizable_scopable_yes_no" expects an existing scope, "NOT_FOUND" given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_localizable_scopable_yes_no" expects an existing scope, "NOT_FOUND" given.
      */
     public function testScopeNotFound()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Boolean/ScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Boolean/ScopableFilterIntegration.php
@@ -67,8 +67,8 @@ class ScopableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_scopable_yes_no" expects valid data, scope and locale. Attribute "a_scopable_yes_no" expects a scope, none given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_scopable_yes_no" expects a scope, none given.
      */
     public function testErrorScopable()
     {
@@ -76,8 +76,8 @@ class ScopableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_scopable_yes_no" expects valid data, scope and locale. Attribute "a_scopable_yes_no" expects an existing scope, "NOT_FOUND" given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_scopable_yes_no" expects an existing scope, "NOT_FOUND" given.
      */
     public function testScopeNotFound()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Boolean/ScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Boolean/ScopableFilterIntegration.php
@@ -4,7 +4,6 @@ namespace Pim\Bundle\CatalogBundle\tests\integration\PQB\Filter\Boolean;
 
 use Pim\Bundle\CatalogBundle\tests\integration\PQB\Filter\AbstractFilterTestCase;
 use Pim\Component\Catalog\AttributeTypes;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Query\Filter\Operators;
 
 /**

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/CompletenessFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/CompletenessFilterIntegration.php
@@ -309,12 +309,8 @@ class CompletenessFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "completeness" expects an array with the key "locales" as data, "Array
-     * (
-     *     [locale] =>
-     *     [scope] => ecommerce
-     * )" given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException
+     * @expectedExceptionMessage Property "completeness" expects an array with the key "locales" as data.
      */
     public function testErrorLocalesIsMissing()
     {
@@ -322,12 +318,8 @@ class CompletenessFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "completeness" expects an array of arrays as data, "Array
-     * (
-     *     [locale] =>
-     *     [scope] => string
-     * )" given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException
+     * @expectedExceptionMessage Property "completeness" expects an array of arrays as data.
      */
     public function testErrorLocalesIsMalformed()
     {
@@ -335,8 +327,8 @@ class CompletenessFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "completeness" expects a valid scope.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Property "completeness" expects a valid scope.
      */
     public function testErrorScopeIsMissing()
     {
@@ -344,8 +336,8 @@ class CompletenessFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "completeness" expects a numeric as data, "string" given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException
+     * @expectedExceptionMessage Property "completeness" expects a numeric as data, "string" given.
      */
     public function testErrorDataIsNotAnNumeric()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Date/DateFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Date/DateFilterIntegration.php
@@ -119,10 +119,8 @@ class DateFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_date" expects array with 2 elements, string or \DateTime as data, "Array
-     * (
-     * )" given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException
+     * @expectedExceptionMessage Property "a_date" expects an array with valid data, should contain 2 strings with the format "yyyy-mm-dd".
      */
     public function testErrorDataIsMalformedWithEmptyArray()
     {
@@ -130,8 +128,8 @@ class DateFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_date" expects a string with the format yyyy-mm-dd as data, "2016-12-12T00:00:00" given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Property "a_date" expects a string with the format "yyyy-mm-dd" as data, "2016-12-12T00:00:00" given.
      */
     public function testErrorDataIsMalformedWithISODate()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Date/LocalizableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Date/LocalizableFilterIntegration.php
@@ -117,8 +117,8 @@ class LocalizableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_localizable_date" expects valid data, scope and locale. Attribute "a_localizable_date" expects a locale, none given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_localizable_date" expects a locale, none given.
      */
     public function testErrorMetricLocalizable()
     {
@@ -126,8 +126,8 @@ class LocalizableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_localizable_date" expects valid data, scope and locale. Attribute "a_localizable_date" expects an existing and activated locale, "NOT_FOUND" given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_localizable_date" expects an existing and activated locale, "NOT_FOUND" given.
      */
     public function testLocaleNotFound()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Date/LocalizableScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Date/LocalizableScopableFilterIntegration.php
@@ -128,8 +128,8 @@ class LocalizableScopableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_localizable_scopable_date" expects valid data, scope and locale. Attribute "a_localizable_scopable_date" expects a locale, none given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_localizable_scopable_date" expects a locale, none given.
      */
     public function testErrorMetricLocalizable()
     {
@@ -137,8 +137,8 @@ class LocalizableScopableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_localizable_scopable_date" expects valid data, scope and locale. Attribute "a_localizable_scopable_date" expects a scope, none given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_localizable_scopable_date" expects a scope, none given.
      */
     public function testErrorMetricScopable()
     {
@@ -146,8 +146,8 @@ class LocalizableScopableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_localizable_scopable_date" expects valid data, scope and locale. Attribute "a_localizable_scopable_date" expects an existing and activated locale, "NOT_FOUND" given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_localizable_scopable_date" expects an existing and activated locale, "NOT_FOUND" given.
      */
     public function testLocaleNotFound()
     {
@@ -155,8 +155,8 @@ class LocalizableScopableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_localizable_scopable_date" expects valid data, scope and locale. Attribute "a_localizable_scopable_date" expects an existing scope, "NOT_FOUND" given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_localizable_scopable_date" expects an existing scope, "NOT_FOUND" given.
      */
     public function testNotFoundScope()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Date/ScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Date/ScopableFilterIntegration.php
@@ -118,8 +118,8 @@ class ScopableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_scopable_date" expects valid data, scope and locale. Attribute "a_scopable_date" expects a scope, none given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_scopable_date" expects a scope, none given.
      */
     public function testErrorMetricScopable()
     {
@@ -127,8 +127,8 @@ class ScopableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_scopable_date" expects valid data, scope and locale. Attribute "a_scopable_date" expects an existing scope, "NOT_FOUND" given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_scopable_date" expects an existing scope, "NOT_FOUND" given.
      */
     public function testScopeNotFound()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/DateTimeFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/DateTimeFilterIntegration.php
@@ -94,10 +94,8 @@ class DateTimeFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "updated" expects array with 2 elements, string or \DateTime as data, "Array
-     * (
-     * )" given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException
+     * @expectedExceptionMessage Property "updated" expects an array with valid data, should contain 2 strings with the format "yyyy-mm-dd H:i:s".
      */
     public function testErrorDataIsMalformedWithEmptyArray()
     {
@@ -105,8 +103,8 @@ class DateTimeFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "updated" expects a string with the format yyyy-mm-dd H:i:s as data, "2016-12-12T00:00:00" given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Property "updated" expects a string with the format "yyyy-mm-dd H:i:s" as data, "2016-12-12T00:00:00" given.
      */
     public function testErrorDataIsMalformedWithISODate()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/FamilyFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/FamilyFilterIntegration.php
@@ -57,8 +57,8 @@ class FamilyFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "family" expects an array as data, "string" given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException
+     * @expectedExceptionMessage Property "family" expects an array as data, "string" given.
      */
     public function testErrorDataIsMalformed()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/GroupsFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/GroupsFilterIntegration.php
@@ -63,8 +63,8 @@ class GroupsFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "groups" expects an array as data, "string" given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException
+     * @expectedExceptionMessage Property "groups" expects an array as data, "string" given.
      */
     public function testErrorDataIsMalformed()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Media/LocalizableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Media/LocalizableFilterIntegration.php
@@ -120,8 +120,8 @@ class LocalizableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_localizable_image" expects valid data, scope and locale. Attribute "a_localizable_image" expects a locale, none given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_localizable_image" expects a locale, none given.
      */
     public function testErrorLocale()
     {
@@ -129,8 +129,8 @@ class LocalizableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_localizable_image" expects valid data, scope and locale. Attribute "a_localizable_image" expects an existing and activated locale, "NOT_FOUND" given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_localizable_image" expects an existing and activated locale, "NOT_FOUND" given.
      */
     public function testLocaleNotFound()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Media/LocalizableScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Media/LocalizableScopableFilterIntegration.php
@@ -115,8 +115,8 @@ class LocalizableScopableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_localizable_scopable_image" expects valid data, scope and locale. Attribute "a_localizable_scopable_image" expects a locale, none given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_localizable_scopable_image" expects a locale, none given.
      */
     public function testErrorLocale()
     {
@@ -124,8 +124,8 @@ class LocalizableScopableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_localizable_scopable_image" expects valid data, scope and locale. Attribute "a_localizable_scopable_image" expects a scope, none given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_localizable_scopable_image" expects a scope, none given.
      */
     public function testErrorScope()
     {
@@ -133,8 +133,8 @@ class LocalizableScopableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_localizable_scopable_image" expects valid data, scope and locale. Attribute "a_localizable_scopable_image" expects an existing and activated locale, "NOT_FOUND" given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_localizable_scopable_image" expects an existing and activated locale, "NOT_FOUND" given.
      */
     public function testLocaleNotFound()
     {
@@ -142,8 +142,8 @@ class LocalizableScopableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_localizable_scopable_image" expects valid data, scope and locale. Attribute "a_localizable_scopable_image" expects an existing scope, "NOT_FOUND" given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_localizable_scopable_image" expects an existing scope, "NOT_FOUND" given.
      */
     public function testScopeNotFound()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Media/MediaFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Media/MediaFilterIntegration.php
@@ -101,8 +101,8 @@ class MediaFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "an_image" expects a string as data, "array" given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException
+     * @expectedExceptionMessage Property "an_image" expects a string as data, "array" given.
      */
     public function testErrorDataIsMalformed()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Media/ScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Media/ScopableFilterIntegration.php
@@ -123,8 +123,8 @@ class ScopableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_scopable_image" expects valid data, scope and locale. Attribute "a_scopable_image" expects an existing scope, "NOT_FOUND" given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_scopable_image" expects an existing scope, "NOT_FOUND" given.
      */
     public function testScopeNotFound()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Metric/LocalizableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Metric/LocalizableFilterIntegration.php
@@ -125,8 +125,8 @@ class LocalizableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_localizable_metric" expects valid data, scope and locale. Attribute "a_localizable_metric" expects a locale, none given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_localizable_metric" expects a locale, none given.
      */
     public function testErrorMetricLocalizable()
     {
@@ -134,8 +134,8 @@ class LocalizableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_localizable_metric" expects valid data, scope and locale. Attribute "a_localizable_metric" expects an existing and activated locale, "NOT_FOUND" given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_localizable_metric" expects an existing and activated locale, "NOT_FOUND" given.
      */
     public function testLocaleNotFound()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Metric/LocalizableScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Metric/LocalizableScopableFilterIntegration.php
@@ -188,8 +188,8 @@ class LocalizableScopableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_scopable_localizable_metric" expects valid data, scope and locale. Attribute "a_scopable_localizable_metric" expects a locale, none given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_scopable_localizable_metric" expects a locale, none given.
      */
     public function testErrorMetricLocalizable()
     {
@@ -197,8 +197,8 @@ class LocalizableScopableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_scopable_localizable_metric" expects valid data, scope and locale. Attribute "a_scopable_localizable_metric" expects a scope, none given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_scopable_localizable_metric" expects a scope, none given.
      */
     public function testErrorMetricScopable()
     {
@@ -206,8 +206,8 @@ class LocalizableScopableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_scopable_localizable_metric" expects valid data, scope and locale. Attribute "a_scopable_localizable_metric" expects an existing and activated locale, "NOT_FOUND" given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_scopable_localizable_metric" expects an existing and activated locale, "NOT_FOUND" given.
      */
     public function testLocaleNotFound()
     {
@@ -215,8 +215,8 @@ class LocalizableScopableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_scopable_localizable_metric" expects valid data, scope and locale. Attribute "a_scopable_localizable_metric" expects an existing scope, "NOT_FOUND" given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_scopable_localizable_metric" expects an existing scope, "NOT_FOUND" given.
      */
     public function testScopeNotFound()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Metric/MetricFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Metric/MetricFilterIntegration.php
@@ -110,8 +110,8 @@ class MetricFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_metric" expects an array as data, "string" given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException
+     * @expectedExceptionMessage Property "a_metric" expects an array as data, "string" given.
      */
     public function testErrorDataIsMalformed()
     {
@@ -119,11 +119,8 @@ class MetricFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_metric" expects an array with the key "amount" as data, "Array
-     * (
-     * [unit] => WATT
-     * )" given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException
+     * @expectedExceptionMessage Property "a_metric" expects an array with the key "amount" as data.
      */
     public function testErrorAmountIsMissing()
     {
@@ -131,11 +128,8 @@ class MetricFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_metric" expects an array with the key "unit" as data, "Array
-     * (
-     * [amount] =>
-     * )" given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException
+     * @expectedExceptionMessage Property "a_metric" expects an array with the key "unit" as data.
      */
     public function testErrorCurrencyIsMissing()
     {
@@ -143,7 +137,7 @@ class MetricFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
      * @expectedExceptionMessage The unit does not exist in the attribute's family "Power"
      */
     public function testErrorUnitNotFound()

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Metric/ScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Metric/ScopableFilterIntegration.php
@@ -123,8 +123,8 @@ class ScopableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_scopable_metric" expects valid data, scope and locale. Attribute "a_scopable_metric" expects a scope, none given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_scopable_metric" expects a scope, none given.
      */
     public function testErrorMetricScopable()
     {
@@ -132,8 +132,8 @@ class ScopableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_scopable_metric" expects valid data, scope and locale. Attribute "a_scopable_metric" expects an existing scope, "NOT_FOUND" given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_scopable_metric" expects an existing scope, "NOT_FOUND" given.
      */
     public function testScopeNotFound()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Number/LocalizableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Number/LocalizableFilterIntegration.php
@@ -123,8 +123,8 @@ class LocalizableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_localizable_number" expects valid data, scope and locale. Attribute "a_localizable_number" expects a locale, none given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_localizable_number" expects a locale, none given.
      */
     public function testErrorLocalizable()
     {
@@ -132,8 +132,8 @@ class LocalizableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_localizable_number" expects valid data, scope and locale. Attribute "a_localizable_number" expects an existing and activated locale, "NOT_FOUND" given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_localizable_number" expects an existing and activated locale, "NOT_FOUND" given.
      */
     public function testLocaleNotFound()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Number/LocalizableScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Number/LocalizableScopableFilterIntegration.php
@@ -121,8 +121,8 @@ class LocalizableScopableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_localizable_scopable_number" expects valid data, scope and locale. Attribute "a_localizable_scopable_number" expects a locale, none given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_localizable_scopable_number" expects a locale, none given.
      */
     public function testErrorLocalizable()
     {
@@ -130,8 +130,8 @@ class LocalizableScopableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_localizable_scopable_number" expects valid data, scope and locale. Attribute "a_localizable_scopable_number" expects a scope, none given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_localizable_scopable_number" expects a scope, none given.
      */
     public function testErrorScopable()
     {
@@ -139,8 +139,8 @@ class LocalizableScopableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_localizable_scopable_number" expects valid data, scope and locale. Attribute "a_localizable_scopable_number" expects an existing and activated locale, "NOT_FOUND" given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_localizable_scopable_number" expects an existing and activated locale, "NOT_FOUND" given.
      */
     public function testLocaleNotFound()
     {
@@ -148,8 +148,8 @@ class LocalizableScopableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_localizable_scopable_number" expects valid data, scope and locale. Attribute "a_localizable_scopable_number" expects an existing scope, "NOT_FOUND" given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_localizable_scopable_number" expects an existing scope, "NOT_FOUND" given.
      */
     public function testScopeNotFound()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Number/NumberFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Number/NumberFilterIntegration.php
@@ -110,8 +110,8 @@ class NumberFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_number_float_negative" expects a numeric as data, "string" given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException
+     * @expectedExceptionMessage Property "a_number_float_negative" expects a numeric as data, "string" given.
      */
     public function testErrorDataIsMalformed()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Number/ScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Number/ScopableFilterIntegration.php
@@ -111,8 +111,8 @@ class ScopableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_scopable_number" expects valid data, scope and locale. Attribute "a_scopable_number" expects a scope, none given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_scopable_number" expects a scope, none given.
      */
     public function testErrorScopable()
     {
@@ -120,8 +120,8 @@ class ScopableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_scopable_number" expects valid data, scope and locale. Attribute "a_scopable_number" expects an existing scope, "NOT_FOUND" given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_scopable_number" expects an existing scope, "NOT_FOUND" given.
      */
     public function testScopeNotFound()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Option/LocalizableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Option/LocalizableFilterIntegration.php
@@ -88,8 +88,8 @@ class LocalizableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_localizable_simple_select" expects valid data, scope and locale. Attribute "a_localizable_simple_select" expects a locale, none given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_localizable_simple_select" expects a locale, none given.
      */
     public function testErrorOptionLocalizable()
     {
@@ -97,8 +97,8 @@ class LocalizableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_localizable_simple_select" expects valid data, scope and locale. Attribute "a_localizable_simple_select" expects an existing and activated locale, "NOT_FOUND" given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_localizable_simple_select" expects an existing and activated locale, "NOT_FOUND" given.
      */
     public function testLocaleNotFound()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Option/LocalizableScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Option/LocalizableScopableFilterIntegration.php
@@ -92,8 +92,8 @@ class LocalizableScopableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_localizable_scopable_simple_select" expects valid data, scope and locale. Attribute "a_localizable_scopable_simple_select" expects a locale, none given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_localizable_scopable_simple_select" expects a locale, none given.
      */
     public function testErrorOptionLocalizable()
     {
@@ -101,8 +101,8 @@ class LocalizableScopableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_localizable_scopable_simple_select" expects valid data, scope and locale. Attribute "a_localizable_scopable_simple_select" expects a scope, none given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_localizable_scopable_simple_select" expects a scope, none given.
      */
     public function testErrorOptionScopable()
     {
@@ -110,8 +110,8 @@ class LocalizableScopableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_localizable_scopable_simple_select" expects valid data, scope and locale. Attribute "a_localizable_scopable_simple_select" expects an existing and activated locale, "NOT_FOUND" given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_localizable_scopable_simple_select" expects an existing and activated locale, "NOT_FOUND" given.
      */
     public function testLocaleNotFound()
     {
@@ -119,8 +119,8 @@ class LocalizableScopableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_localizable_scopable_simple_select" expects valid data, scope and locale. Attribute "a_localizable_scopable_simple_select" expects an existing scope, "NOT_FOUND" given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_localizable_scopable_simple_select" expects an existing scope, "NOT_FOUND" given.
      */
     public function testScopeNotFound()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Option/OptionFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Option/OptionFilterIntegration.php
@@ -78,8 +78,8 @@ class OptionFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_simple_select" expects an array as data, "string" given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException
+     * @expectedExceptionMessage Property "a_simple_select" expects an array as data, "string" given.
      */
     public function testErrorDataIsMalformed()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Option/ScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Option/ScopableFilterIntegration.php
@@ -87,8 +87,8 @@ class ScopableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_select_scopable_simple_select" expects valid data, scope and locale. Attribute "a_select_scopable_simple_select" expects a scope, none given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_select_scopable_simple_select" expects a scope, none given.
      */
     public function testErrorOptionScopable()
     {
@@ -96,8 +96,8 @@ class ScopableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_select_scopable_simple_select" expects valid data, scope and locale. Attribute "a_select_scopable_simple_select" expects an existing scope, "NOT_FOUND" given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_select_scopable_simple_select" expects an existing scope, "NOT_FOUND" given.
      */
     public function testScopeNotFound()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Options/LocalizableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Options/LocalizableFilterIntegration.php
@@ -93,8 +93,8 @@ class LocalizableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_localizable_multi_select" expects valid data, scope and locale. Attribute "a_localizable_multi_select" expects a locale, none given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_localizable_multi_select" expects a locale, none given.
      */
     public function testErrorOptionLocalizable()
     {
@@ -102,8 +102,8 @@ class LocalizableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_localizable_multi_select" expects valid data, scope and locale. Attribute "a_localizable_multi_select" expects an existing and activated locale, "NOT_FOUND" given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_localizable_multi_select" expects an existing and activated locale, "NOT_FOUND" given.
      */
     public function testLocaleNotFound()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Options/LocalizableScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Options/LocalizableScopableFilterIntegration.php
@@ -97,8 +97,8 @@ class LocalizableScopableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_localizable_scopable_multi_select" expects valid data, scope and locale. Attribute "a_localizable_scopable_multi_select" expects a locale, none given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_localizable_scopable_multi_select" expects a locale, none given.
      */
     public function testErrorOptionLocalizable()
     {
@@ -106,8 +106,8 @@ class LocalizableScopableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_localizable_scopable_multi_select" expects valid data, scope and locale. Attribute "a_localizable_scopable_multi_select" expects a scope, none given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_localizable_scopable_multi_select" expects a scope, none given.
      */
     public function testErrorOptionScopable()
     {
@@ -115,8 +115,8 @@ class LocalizableScopableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_localizable_scopable_multi_select" expects valid data, scope and locale. Attribute "a_localizable_scopable_multi_select" expects an existing and activated locale, "NOT_FOUND" given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_localizable_scopable_multi_select" expects an existing and activated locale, "NOT_FOUND" given.
      */
     public function testLocaleNotFound()
     {
@@ -124,8 +124,8 @@ class LocalizableScopableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_localizable_scopable_multi_select" expects valid data, scope and locale. Attribute "a_localizable_scopable_multi_select" expects an existing scope, "NOT_FOUND" given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_localizable_scopable_multi_select" expects an existing scope, "NOT_FOUND" given.
      */
     public function testScopeNotFound()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Options/OptionsFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Options/OptionsFilterIntegration.php
@@ -86,8 +86,8 @@ class OptionsFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_multi_select" expects an array as data, "string" given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException
+     * @expectedExceptionMessage Property "a_multi_select" expects an array as data, "string" given.
      */
     public function testErrorDataIsMalformed()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Options/ScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Options/ScopableFilterIntegration.php
@@ -95,8 +95,8 @@ class ScopableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_scopable_multi_select" expects valid data, scope and locale. Attribute "a_scopable_multi_select" expects a scope, none given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_scopable_multi_select" expects a scope, none given.
      */
     public function testErrorOptionScopable()
     {
@@ -104,8 +104,8 @@ class ScopableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_scopable_multi_select" expects valid data, scope and locale. Attribute "a_scopable_multi_select" expects an existing scope, "NOT_FOUND" given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_scopable_multi_select" expects an existing scope, "NOT_FOUND" given.
      */
     public function testScopeNotFound()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Price/LocalizableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Price/LocalizableFilterIntegration.php
@@ -129,8 +129,8 @@ class LocalizableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_localizable_price" expects valid data, scope and locale. Attribute "a_localizable_price" expects a locale, none given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_localizable_price" expects a locale, none given.
      */
     public function testErrorPriceLocalizable()
     {
@@ -138,8 +138,8 @@ class LocalizableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_localizable_price" expects valid data, scope and locale. Attribute "a_localizable_price" expects an existing and activated locale, "NOT_FOUND" given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_localizable_price" expects an existing and activated locale, "NOT_FOUND" given.
      */
     public function testLocaleNotFound()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Price/LocalizableScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Price/LocalizableScopableFilterIntegration.php
@@ -212,8 +212,8 @@ class LocalizableScopableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_scopable_localizable_price" expects valid data, scope and locale. Attribute "a_scopable_localizable_price" expects a locale, none given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_scopable_localizable_price" expects a locale, none given.
      */
     public function testErrorPriceLocalizableAndScopable()
     {
@@ -221,8 +221,8 @@ class LocalizableScopableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_scopable_localizable_price" expects valid data, scope and locale. Attribute "a_scopable_localizable_price" expects a scope, none given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_scopable_localizable_price" expects a scope, none given.
      */
     public function testErrorPriceLocalizable()
     {
@@ -230,8 +230,8 @@ class LocalizableScopableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_scopable_localizable_price" expects valid data, scope and locale. Attribute "a_scopable_localizable_price" expects an existing and activated locale, "NOT_FOUND" given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_scopable_localizable_price" expects an existing and activated locale, "NOT_FOUND" given.
      */
     public function testLocaleNotFound()
     {
@@ -239,8 +239,8 @@ class LocalizableScopableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_scopable_localizable_price" expects valid data, scope and locale. Attribute "a_scopable_localizable_price" expects an existing scope, "NOT_FOUND" given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_scopable_localizable_price" expects an existing scope, "NOT_FOUND" given.
      */
     public function testScopeNotFound()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Price/PriceFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Price/PriceFilterIntegration.php
@@ -137,8 +137,8 @@ class PriceFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_price" expects an array as data, "string" given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException
+     * @expectedExceptionMessage Property "a_price" expects an array as data, "string" given.
      */
     public function testErrorDataIsMalformed()
     {
@@ -146,11 +146,8 @@ class PriceFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_price" expects an array with the key "amount" as data, "Array
-     * (
-     * [currency] => USD
-     * )" given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException
+     * @expectedExceptionMessage Property "a_price" expects an array with the key "amount" as data.
      */
     public function testErrorAmountIsMissing()
     {
@@ -158,11 +155,8 @@ class PriceFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_price" expects an array with the key "currency" as data, "Array
-     * (
-     * [amount] =>
-     * )" given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException
+     * @expectedExceptionMessage Property "a_price" expects an array with the key "currency" as data.
      */
     public function testErrorCurrencyIsMissing()
     {
@@ -170,8 +164,8 @@ class PriceFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_price" expects an array with valid data for the key "currency". The currency does not exist, "NOT_FOUND" given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Property "a_price" expects a valid currency. The currency does not exist, "NOT_FOUND" given.
      */
     public function testErrorCurrencyNotFound()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Price/ScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Price/ScopableFilterIntegration.php
@@ -127,8 +127,8 @@ class ScopableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_scopable_price" expects valid data, scope and locale. Attribute "a_scopable_price" expects a scope, none given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_scopable_price" expects a scope, none given.
      */
     public function testErrorPriceScopable()
     {
@@ -136,8 +136,8 @@ class ScopableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_scopable_price" expects valid data, scope and locale. Attribute "a_scopable_price" expects an existing scope, "NOT_FOUND" given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_scopable_price" expects an existing scope, "NOT_FOUND" given.
      */
     public function testScopeNotFound()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/String/LocalizableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/String/LocalizableFilterIntegration.php
@@ -129,8 +129,8 @@ class LocalizableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_localizable_text" expects valid data, scope and locale. Attribute "a_localizable_text" expects a locale, none given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_localizable_text" expects a locale, none given.
      */
     public function testErrorLocalizable()
     {
@@ -138,8 +138,8 @@ class LocalizableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_localizable_text" expects valid data, scope and locale. Attribute "a_localizable_text" expects an existing and activated locale, "NOT_FOUND" given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_localizable_text" expects an existing and activated locale, "NOT_FOUND" given.
      */
     public function testLocaleNotFound()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/String/LocalizableScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/String/LocalizableScopableFilterIntegration.php
@@ -147,8 +147,8 @@ class LocalizableScopableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_localizable_scopable_text" expects valid data, scope and locale. Attribute "a_localizable_scopable_text" expects a locale, none given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_localizable_scopable_text" expects a locale, none given.
      */
     public function testErrorLocalizable()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/String/ScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/String/ScopableFilterIntegration.php
@@ -129,8 +129,8 @@ class ScopableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_scopable_text" expects valid data, scope and locale. Attribute "a_scopable_text" expects a scope, none given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_scopable_text" expects a scope, none given.
      */
     public function testErrorScopable()
     {
@@ -138,8 +138,8 @@ class ScopableFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_scopable_text" expects valid data, scope and locale. Attribute "a_scopable_text" expects an existing scope, "NOT_FOUND" given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Attribute "a_scopable_text" expects an existing scope, "NOT_FOUND" given.
      */
     public function testScopeNotFound()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/String/StringFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/String/StringFilterIntegration.php
@@ -109,8 +109,8 @@ class StringFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute or field "a_text" expects a string as data, "array" given.
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException
+     * @expectedExceptionMessage Property "a_text" expects a string as data, "array" given.
      */
     public function testErrorDataIsMalformed()
     {

--- a/src/Pim/Bundle/EnrichBundle/Connector/Processor/MassEdit/Product/AddProductToVariantGroupProcessor.php
+++ b/src/Pim/Bundle/EnrichBundle/Connector/Processor/MassEdit/Product/AddProductToVariantGroupProcessor.php
@@ -3,7 +3,6 @@
 namespace Pim\Bundle\EnrichBundle\Connector\Processor\MassEdit\Product;
 
 use Pim\Bundle\EnrichBundle\Connector\Processor\AbstractProcessor;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Repository\GroupRepositoryInterface;
 use Pim\Component\Catalog\Updater\ProductTemplateUpdaterInterface;

--- a/src/Pim/Bundle/EnrichBundle/Connector/Processor/MassEdit/Product/AddProductValueProcessor.php
+++ b/src/Pim/Bundle/EnrichBundle/Connector/Processor/MassEdit/Product/AddProductValueProcessor.php
@@ -4,7 +4,6 @@ namespace Pim\Bundle\EnrichBundle\Connector\Processor\MassEdit\Product;
 
 use Akeneo\Component\StorageUtils\Updater\PropertyAdderInterface;
 use Pim\Bundle\EnrichBundle\Connector\Processor\AbstractProcessor;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/ChannelController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/ChannelController.php
@@ -2,7 +2,7 @@
 
 namespace Pim\Bundle\EnrichBundle\Controller\Rest;
 
-use Akeneo\Component\StorageUtils\Exception\ObjectUpdaterException;
+use Akeneo\Component\StorageUtils\Exception\PropertyException;
 use Akeneo\Component\StorageUtils\Factory\SimpleFactoryInterface;
 use Akeneo\Component\StorageUtils\Remover\RemoverInterface;
 use Akeneo\Component\StorageUtils\Saver\SaverInterface;
@@ -119,7 +119,7 @@ class ChannelController
      *
      * @param Request $request
      *
-     * @throws ObjectUpdaterException
+     * @throws PropertyException
      * @throws \LogicException
      * @throws \InvalidArgumentException
      *
@@ -141,7 +141,7 @@ class ChannelController
      * @param string  $code
      *
      * @throws HttpExceptionInterface
-     * @throws ObjectUpdaterException
+     * @throws PropertyException
      * @throws \LogicException
      * @throws \InvalidArgumentException
      *
@@ -203,7 +203,7 @@ class ChannelController
      * @param Request          $request
      *
      * @throws \LogicException
-     * @throws ObjectUpdaterException
+     * @throws PropertyException
      * @throws \InvalidArgumentException
      *
      * @return JsonResponse

--- a/src/Pim/Bundle/EnrichBundle/Form/DataTransformer/IdentifiableModelTransformer.php
+++ b/src/Pim/Bundle/EnrichBundle/Form/DataTransformer/IdentifiableModelTransformer.php
@@ -4,7 +4,6 @@ namespace Pim\Bundle\EnrichBundle\Form\DataTransformer;
 
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Doctrine\Common\Util\ClassUtils;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
 use Symfony\Component\OptionsResolver\OptionsResolver;

--- a/src/Pim/Bundle/ReferenceDataBundle/Doctrine/MongoDB/Filter/ReferenceDataFilter.php
+++ b/src/Pim/Bundle/ReferenceDataBundle/Doctrine/MongoDB/Filter/ReferenceDataFilter.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Bundle\ReferenceDataBundle\Doctrine\MongoDB\Filter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\AbstractAttributeFilter;
 use Pim\Bundle\CatalogBundle\ProductQueryUtility;
 use Pim\Bundle\ReferenceDataBundle\Doctrine\ReferenceDataIdResolver;
@@ -60,7 +61,7 @@ class ReferenceDataFilter extends AbstractAttributeFilter implements AttributeFi
         $scope = null,
         $options = []
     ) {
-        $this->checkLocaleAndScope($attribute, $locale, $scope, 'number');
+        $this->checkLocaleAndScope($attribute, $locale, $scope);
 
         if (!in_array($operator, [Operators::IS_EMPTY, Operators::IS_NOT_EMPTY])) {
             $field = $options['field'];
@@ -140,7 +141,7 @@ class ReferenceDataFilter extends AbstractAttributeFilter implements AttributeFi
         try {
             $value = $this->idsResolver->resolve($attribute->getReferenceDataName(), $value);
         } catch (\LogicException $e) {
-            throw InvalidArgumentException::validEntityCodeExpected(
+            throw InvalidPropertyException::validEntityCodeExpected(
                 $attribute->getCode(),
                 'code',
                 $e->getMessage(),

--- a/src/Pim/Bundle/ReferenceDataBundle/Doctrine/MongoDB/Filter/ReferenceDataFilter.php
+++ b/src/Pim/Bundle/ReferenceDataBundle/Doctrine/MongoDB/Filter/ReferenceDataFilter.php
@@ -6,7 +6,6 @@ use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Filter\AbstractAttributeFilter;
 use Pim\Bundle\CatalogBundle\ProductQueryUtility;
 use Pim\Bundle\ReferenceDataBundle\Doctrine\ReferenceDataIdResolver;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Query\Filter\AttributeFilterInterface;
 use Pim\Component\Catalog\Query\Filter\FieldFilterHelper;

--- a/src/Pim/Bundle/ReferenceDataBundle/Doctrine/ORM/Filter/ReferenceDataFilter.php
+++ b/src/Pim/Bundle/ReferenceDataBundle/Doctrine/ORM/Filter/ReferenceDataFilter.php
@@ -2,9 +2,9 @@
 
 namespace Pim\Bundle\ReferenceDataBundle\Doctrine\ORM\Filter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Pim\Bundle\CatalogBundle\Doctrine\ORM\Filter\AbstractAttributeFilter;
 use Pim\Bundle\ReferenceDataBundle\Doctrine\ReferenceDataIdResolver;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Query\Filter\AttributeFilterInterface;
 use Pim\Component\Catalog\Query\Filter\FieldFilterHelper;
@@ -70,7 +70,7 @@ class ReferenceDataFilter extends AbstractAttributeFilter implements AttributeFi
         try {
             $options = $this->optionsResolver->resolve($options);
         } catch (\Exception $e) {
-            throw InvalidArgumentException::expectedFromPreviousException(
+            throw InvalidPropertyException::expectedFromPreviousException(
                 $e,
                 $attribute->getCode(),
                 static::class
@@ -154,7 +154,7 @@ class ReferenceDataFilter extends AbstractAttributeFilter implements AttributeFi
         try {
             $value = $this->idsResolver->resolve($attribute->getReferenceDataName(), $value);
         } catch (\LogicException $e) {
-            throw InvalidArgumentException::validEntityCodeExpected(
+            throw InvalidPropertyException::validEntityCodeExpected(
                 $attribute->getCode(),
                 'code',
                 $e->getMessage(),

--- a/src/Pim/Bundle/ReferenceDataBundle/spec/Doctrine/MongoDB/Filter/ReferenceDataFilterSpec.php
+++ b/src/Pim/Bundle/ReferenceDataBundle/spec/Doctrine/MongoDB/Filter/ReferenceDataFilterSpec.php
@@ -2,11 +2,11 @@
 
 namespace spec\Pim\Bundle\ReferenceDataBundle\Doctrine\MongoDB\Filter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Doctrine\MongoDB\Query\Expr;
 use Doctrine\ODM\MongoDB\Query\Builder;
 use PhpSpec\ObjectBehavior;
 use Pim\Bundle\ReferenceDataBundle\Doctrine\ReferenceDataIdResolver;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Validator\AttributeValidatorHelper;
 use Pim\Component\ReferenceData\ConfigurationRegistryInterface;
@@ -145,20 +145,20 @@ class ReferenceDataFilterSpec extends ObjectBehavior
 
         $value = 'string';
         $this->shouldThrow(
-            InvalidArgumentException::arrayExpected(
+            InvalidPropertyTypeException::arrayExpected(
                 'color',
                 'Pim\Bundle\ReferenceDataBundle\Doctrine\MongoDB\Filter\ReferenceDataFilter',
-                $value
+                'string'
             )
         )
             ->during('addAttributeFilter', [$attribute, '=', $value, null, null, ['field' => 'color']]);
 
         $value = [false];
         $this->shouldThrow(
-            InvalidArgumentException::stringExpected(
+            InvalidPropertyTypeException::stringExpected(
                 'color',
                 'Pim\Bundle\ReferenceDataBundle\Doctrine\MongoDB\Filter\ReferenceDataFilter',
-                'boolean'
+                false
             )
         )
             ->during('addAttributeFilter', [$attribute, '=', $value, null, null, ['field' => 'color']]);

--- a/src/Pim/Bundle/ReferenceDataBundle/spec/Doctrine/ORM/Filter/ReferenceDataFilterSpec.php
+++ b/src/Pim/Bundle/ReferenceDataBundle/spec/Doctrine/ORM/Filter/ReferenceDataFilterSpec.php
@@ -2,11 +2,12 @@
 
 namespace spec\Pim\Bundle\ReferenceDataBundle\Doctrine\ORM\Filter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Doctrine\ORM\Query\Expr;
 use Doctrine\ORM\QueryBuilder;
 use PhpSpec\ObjectBehavior;
 use Pim\Bundle\ReferenceDataBundle\Doctrine\ReferenceDataIdResolver;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Validator\AttributeValidatorHelper;
 use Pim\Component\ReferenceData\ConfigurationRegistryInterface;
@@ -174,20 +175,20 @@ class ReferenceDataFilterSpec extends ObjectBehavior
 
         $value = 'string';
         $this->shouldThrow(
-            InvalidArgumentException::arrayExpected(
+            InvalidPropertyTypeException::arrayExpected(
                 'color',
                 'Pim\Bundle\ReferenceDataBundle\Doctrine\ORM\Filter\ReferenceDataFilter',
-                $value
+                'string'
             )
         )
             ->during('addAttributeFilter', [$attribute, '=', $value, null, null, ['field' => 'color']]);
 
         $value = [false];
         $this->shouldThrow(
-            InvalidArgumentException::stringExpected(
+            InvalidPropertyTypeException::stringExpected(
                 'color',
                 'Pim\Bundle\ReferenceDataBundle\Doctrine\ORM\Filter\ReferenceDataFilter',
-                'boolean'
+                false
             )
         )
             ->during('addAttributeFilter', [$attribute, '=', $value, null, null, ['field' => 'color']]);

--- a/src/Pim/Component/Catalog/Query/Filter/FieldFilterHelper.php
+++ b/src/Pim/Component/Catalog/Query/Filter/FieldFilterHelper.php
@@ -2,7 +2,7 @@
 
 namespace Pim\Component\Catalog\Query\Filter;
 
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 
 /**
  * Field filter helper
@@ -66,11 +66,13 @@ class FieldFilterHelper
      * @param string $field
      * @param mixed  $value
      * @param string $className
+     *
+     * @throws InvalidPropertyTypeException
      */
     public static function checkArray($field, $value, $className)
     {
         if (!is_array($value)) {
-            throw InvalidArgumentException::arrayExpected(static::getCode($field), $className, gettype($value));
+            throw InvalidPropertyTypeException::arrayExpected(static::getCode($field), $className, $value);
         }
     }
 
@@ -80,15 +82,17 @@ class FieldFilterHelper
      * @param string $field
      * @param mixed  $value
      * @param string $className
+     *
+     * @throws InvalidPropertyTypeException
      */
     public static function checkIdentifier($field, $value, $className)
     {
         $invalidIdField = static::hasProperty($field) && static::getProperty($field) === 'id' && !is_numeric($value);
         if ($invalidIdField) {
-            throw InvalidArgumentException::numericExpected(
+            throw InvalidPropertyTypeException::numericExpected(
                 static::getCode($field),
                 $className,
-                gettype($value)
+                $value
             );
         }
 
@@ -97,7 +101,7 @@ class FieldFilterHelper
             !is_string($value) && !is_numeric($value);
 
         if ($invalidDefaultField || $invalidStringField) {
-            throw InvalidArgumentException::stringExpected(static::getCode($field), $className, gettype($value));
+            throw InvalidPropertyTypeException::stringExpected(static::getCode($field), $className, $value);
         }
     }
 }

--- a/src/Pim/Component/Catalog/Query/Filter/FieldFilterInterface.php
+++ b/src/Pim/Component/Catalog/Query/Filter/FieldFilterInterface.php
@@ -2,6 +2,8 @@
 
 namespace Pim\Component\Catalog\Query\Filter;
 
+use Akeneo\Component\StorageUtils\Exception\PropertyException;
+
 /**
  * Filter interface
  *
@@ -20,6 +22,8 @@ interface FieldFilterInterface extends FilterInterface
      * @param string       $locale   the locale
      * @param string       $scope    the scope
      * @param array        $options  the filter options
+     *
+     * @throws PropertyException
      *
      * @return FieldFilterInterface
      */

--- a/src/Pim/Component/Catalog/Updater/Adder/AttributeAdderInterface.php
+++ b/src/Pim/Component/Catalog/Updater/Adder/AttributeAdderInterface.php
@@ -2,7 +2,7 @@
 
 namespace Pim\Component\Catalog\Updater\Adder;
 
-use Akeneo\Component\StorageUtils\Exception\ObjectUpdaterException;
+use Akeneo\Component\StorageUtils\Exception\PropertyException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 
@@ -23,7 +23,7 @@ interface AttributeAdderInterface extends AdderInterface
      * @param mixed              $data      The data to add
      * @param array              $options   Options passed to the adder
      *
-     * @throws ObjectUpdaterException
+     * @throws PropertyException
      */
     public function addAttributeData(
         ProductInterface $product,

--- a/src/Pim/Component/Catalog/Updater/Adder/FieldAdderInterface.php
+++ b/src/Pim/Component/Catalog/Updater/Adder/FieldAdderInterface.php
@@ -2,7 +2,7 @@
 
 namespace Pim\Component\Catalog\Updater\Adder;
 
-use Akeneo\Component\StorageUtils\Exception\ObjectUpdaterException;
+use Akeneo\Component\StorageUtils\Exception\PropertyException;
 use Pim\Component\Catalog\Model\ProductInterface;
 
 /**
@@ -22,7 +22,7 @@ interface FieldAdderInterface extends AdderInterface
      * @param mixed            $data    The data to add
      * @param array            $options Options passed to the adder
      *
-     * @throws ObjectUpdaterException
+     * @throws PropertyException
      */
     public function addFieldData(ProductInterface $product, $field, $data, array $options = []);
 

--- a/src/Pim/Component/Catalog/Updater/Copier/AttributeCopierInterface.php
+++ b/src/Pim/Component/Catalog/Updater/Copier/AttributeCopierInterface.php
@@ -2,7 +2,7 @@
 
 namespace Pim\Component\Catalog\Updater\Copier;
 
-use Akeneo\Component\StorageUtils\Exception\ObjectUpdaterException;
+use Akeneo\Component\StorageUtils\Exception\PropertyException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 
@@ -24,7 +24,7 @@ interface AttributeCopierInterface extends CopierInterface
      * @param AttributeInterface $toAttribute
      * @param array              $options
      *
-     * @throws ObjectUpdaterException
+     * @throws PropertyException
      */
     public function copyAttributeData(
         ProductInterface $fromProduct,

--- a/src/Pim/Component/Catalog/Updater/Copier/FieldCopierInterface.php
+++ b/src/Pim/Component/Catalog/Updater/Copier/FieldCopierInterface.php
@@ -2,7 +2,7 @@
 
 namespace Pim\Component\Catalog\Updater\Copier;
 
-use Akeneo\Component\StorageUtils\Exception\ObjectUpdaterException;
+use Akeneo\Component\StorageUtils\Exception\PropertyException;
 use Pim\Component\Catalog\Model\ProductInterface;
 
 /**
@@ -23,7 +23,7 @@ interface FieldCopierInterface extends CopierInterface
      * @param string           $toField
      * @param array            $options
      *
-     * @throws ObjectUpdaterException
+     * @throws PropertyException
      */
     public function copyFieldData(
         ProductInterface $fromProduct,

--- a/src/Pim/Component/Catalog/Updater/Remover/AttributeRemoverInterface.php
+++ b/src/Pim/Component/Catalog/Updater/Remover/AttributeRemoverInterface.php
@@ -2,7 +2,7 @@
 
 namespace Pim\Component\Catalog\Updater\Remover;
 
-use Akeneo\Component\StorageUtils\Exception\ObjectUpdaterException;
+use Akeneo\Component\StorageUtils\Exception\PropertyException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 
@@ -23,7 +23,7 @@ interface AttributeRemoverInterface extends RemoverInterface
      * @param mixed              $data      The data to remove
      * @param array              $options   Options passed to the remover
      *
-     * @throws ObjectUpdaterException
+     * @throws PropertyException
      */
     public function removeAttributeData(
         ProductInterface $product,

--- a/src/Pim/Component/Catalog/Updater/Remover/FieldRemoverInterface.php
+++ b/src/Pim/Component/Catalog/Updater/Remover/FieldRemoverInterface.php
@@ -2,7 +2,7 @@
 
 namespace Pim\Component\Catalog\Updater\Remover;
 
-use Akeneo\Component\StorageUtils\Exception\ObjectUpdaterException;
+use Akeneo\Component\StorageUtils\Exception\PropertyException;
 use Pim\Component\Catalog\Model\ProductInterface;
 
 /**
@@ -22,7 +22,7 @@ interface FieldRemoverInterface extends RemoverInterface
      * @param mixed            $data    The data to remove
      * @param array            $options Options passed to the remover
      *
-     * @throws ObjectUpdaterException
+     * @throws PropertyException
      */
     public function removeFieldData(ProductInterface $product, $field, $data, array $options = []);
 

--- a/src/Pim/Component/Catalog/Updater/Setter/AttributeSetterInterface.php
+++ b/src/Pim/Component/Catalog/Updater/Setter/AttributeSetterInterface.php
@@ -2,7 +2,7 @@
 
 namespace Pim\Component\Catalog\Updater\Setter;
 
-use Akeneo\Component\StorageUtils\Exception\ObjectUpdaterException;
+use Akeneo\Component\StorageUtils\Exception\PropertyException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 
@@ -23,7 +23,7 @@ interface AttributeSetterInterface extends SetterInterface
      * @param mixed              $data      The data to set
      * @param array              $options   Options passed to the setter
      *
-     * @throws ObjectUpdaterException
+     * @throws PropertyException
      */
     public function setAttributeData(
         ProductInterface $product,

--- a/src/Pim/Component/Catalog/Updater/Setter/FieldSetterInterface.php
+++ b/src/Pim/Component/Catalog/Updater/Setter/FieldSetterInterface.php
@@ -2,7 +2,7 @@
 
 namespace Pim\Component\Catalog\Updater\Setter;
 
-use Akeneo\Component\StorageUtils\Exception\ObjectUpdaterException;
+use Akeneo\Component\StorageUtils\Exception\PropertyException;
 use Pim\Component\Catalog\Model\ProductInterface;
 
 /**
@@ -22,7 +22,7 @@ interface FieldSetterInterface extends SetterInterface
      * @param mixed            $data    The data to set
      * @param array            $options Options passed to the setter
      *
-     * @throws ObjectUpdaterException
+     * @throws PropertyException
      */
     public function setFieldData(ProductInterface $product, $field, $data, array $options = []);
 

--- a/src/Pim/Component/Catalog/Updater/Setter/SimpleSelectAttributeSetter.php
+++ b/src/Pim/Component/Catalog/Updater/Setter/SimpleSelectAttributeSetter.php
@@ -6,7 +6,6 @@ use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Pim\Component\Catalog\Builder\ProductBuilderInterface;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\AttributeOptionInterface;
 use Pim\Component\Catalog\Model\ProductInterface;

--- a/src/Pim/Component/Catalog/Validator/Constraints/Boolean.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/Boolean.php
@@ -14,7 +14,7 @@ use Symfony\Component\Validator\Constraint;
 class Boolean extends Constraint
 {
     /** @var string */
-    public $message = 'Attribute or field "%attribute%" expects a boolean as data, "%givenType%" given.';
+    public $message = 'Property "%attribute%" expects a boolean as data, "%givenType%" given.';
 
     /**
      * {@inheritdoc}

--- a/src/Pim/Component/Catalog/Validator/Constraints/IsString.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/IsString.php
@@ -14,7 +14,7 @@ use Symfony\Component\Validator\Constraint;
 class IsString extends Constraint
 {
     /** @var string */
-    public $message = 'Attribute or field "%attribute%" expects a string as data, "%givenType%" given.';
+    public $message = 'Property "%attribute%" expects a string as data, "%givenType%" given.';
 
     /**
      * {@inheritdoc}

--- a/src/Pim/Component/Catalog/spec/Updater/Adder/AssociationFieldAdderSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Adder/AssociationFieldAdderSpec.php
@@ -7,7 +7,6 @@ use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Builder\ProductBuilderInterface;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AssociationInterface;
 use Pim\Component\Catalog\Model\GroupInterface;
 use Pim\Component\Catalog\Model\ProductInterface;

--- a/src/Pim/Component/Catalog/spec/Updater/Adder/CategoryFieldAdderSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Adder/CategoryFieldAdderSpec.php
@@ -5,7 +5,6 @@ namespace spec\Pim\Component\Catalog\Updater\Adder;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use PhpSpec\ObjectBehavior;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\CategoryInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Akeneo\Component\Classification\Repository\CategoryRepositoryInterface;

--- a/src/Pim/Component/Catalog/spec/Updater/Adder/GroupFieldAdderSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Adder/GroupFieldAdderSpec.php
@@ -5,7 +5,6 @@ namespace spec\Pim\Component\Catalog\Updater\Adder;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use PhpSpec\ObjectBehavior;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\GroupInterface;
 use Pim\Component\Catalog\Model\GroupTypeInterface;
 use Pim\Component\Catalog\Model\ProductInterface;

--- a/src/Pim/Component/Catalog/spec/Updater/Adder/MultiSelectAttributeAdderSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Adder/MultiSelectAttributeAdderSpec.php
@@ -7,7 +7,6 @@ use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Builder\ProductBuilderInterface;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\AttributeOptionInterface;
 use Pim\Component\Catalog\Model\ProductInterface;

--- a/src/Pim/Component/Catalog/spec/Updater/Adder/PriceCollectionAttributeAdderSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Adder/PriceCollectionAttributeAdderSpec.php
@@ -6,7 +6,6 @@ use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Builder\ProductBuilderInterface;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Model\ProductPriceInterface;

--- a/src/Pim/Component/Catalog/spec/Updater/Copier/BaseAttributeCopierSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Copier/BaseAttributeCopierSpec.php
@@ -5,7 +5,6 @@ namespace spec\Pim\Component\Catalog\Updater\Copier;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Builder\ProductBuilderInterface;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Model\ProductValue;

--- a/src/Pim/Component/Catalog/spec/Updater/Remover/CategoryFieldRemoverSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Remover/CategoryFieldRemoverSpec.php
@@ -6,7 +6,6 @@ use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use PhpSpec\ObjectBehavior;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\CategoryInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 

--- a/src/Pim/Component/Catalog/spec/Updater/Remover/GroupFieldRemoverSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Remover/GroupFieldRemoverSpec.php
@@ -5,7 +5,6 @@ namespace spec\Pim\Component\Catalog\Updater\Remover;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use PhpSpec\ObjectBehavior;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\GroupInterface;
 use Pim\Component\Catalog\Model\GroupTypeInterface;
 use Pim\Component\Catalog\Model\ProductInterface;

--- a/src/Pim/Component/Catalog/spec/Updater/Remover/MultiSelectAttributeRemoverSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Remover/MultiSelectAttributeRemoverSpec.php
@@ -5,7 +5,6 @@ namespace spec\Pim\Component\Catalog\Updater\Remover;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use PhpSpec\ObjectBehavior;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\AttributeOptionInterface;
 use Pim\Component\Catalog\Model\ProductInterface;

--- a/src/Pim/Component/Catalog/spec/Updater/Remover/PriceCollectionAttributeRemoverSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Remover/PriceCollectionAttributeRemoverSpec.php
@@ -5,7 +5,6 @@ namespace spec\Pim\Component\Catalog\Updater\Remover;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use PhpSpec\ObjectBehavior;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Model\ProductPriceInterface;

--- a/src/Pim/Component/Catalog/spec/Updater/Setter/AssociationFieldSetterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Setter/AssociationFieldSetterSpec.php
@@ -8,7 +8,6 @@ use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterfa
 use Doctrine\Common\Collections\ArrayCollection;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Builder\ProductBuilderInterface;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AssociationInterface;
 use Pim\Component\Catalog\Model\AssociationTypeInterface;
 use Pim\Component\Catalog\Model\GroupInterface;

--- a/src/Pim/Component/Catalog/spec/Updater/Setter/CategoryFieldSetterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Setter/CategoryFieldSetterSpec.php
@@ -5,7 +5,6 @@ namespace spec\Pim\Component\Catalog\Updater\Setter;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use PhpSpec\ObjectBehavior;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\CategoryInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Akeneo\Component\Classification\Repository\CategoryRepositoryInterface;

--- a/src/Pim/Component/Catalog/spec/Updater/Setter/DateAttributeSetterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Setter/DateAttributeSetterSpec.php
@@ -5,7 +5,6 @@ namespace spec\Pim\Component\Catalog\Updater\Setter;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Builder\ProductBuilderInterface;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Model\ProductValueInterface;

--- a/src/Pim/Component/Catalog/spec/Updater/Setter/FamilyFieldSetterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Setter/FamilyFieldSetterSpec.php
@@ -5,7 +5,6 @@ namespace spec\Pim\Component\Catalog\Updater\Setter;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use PhpSpec\ObjectBehavior;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\FamilyInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Repository\FamilyRepositoryInterface;

--- a/src/Pim/Component/Catalog/spec/Updater/Setter/GroupFieldSetterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Setter/GroupFieldSetterSpec.php
@@ -5,7 +5,6 @@ namespace spec\Pim\Component\Catalog\Updater\Setter;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use PhpSpec\ObjectBehavior;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\GroupInterface;
 use Pim\Component\Catalog\Model\GroupTypeInterface;
 use Pim\Component\Catalog\Model\ProductInterface;

--- a/src/Pim/Component/Catalog/spec/Updater/Setter/MediaAttributeSetterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Setter/MediaAttributeSetterSpec.php
@@ -9,7 +9,6 @@ use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Builder\ProductBuilderInterface;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Model\ProductValueInterface;

--- a/src/Pim/Component/Catalog/spec/Updater/Setter/MetricAttributeSetterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Setter/MetricAttributeSetterSpec.php
@@ -6,7 +6,6 @@ use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Factory\MetricFactory;
 use Pim\Component\Catalog\Builder\ProductBuilderInterface;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\MetricInterface;
 use Pim\Component\Catalog\Model\ProductInterface;

--- a/src/Pim/Component/Catalog/spec/Updater/Setter/MultiSelectAttributeSetterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Setter/MultiSelectAttributeSetterSpec.php
@@ -7,7 +7,6 @@ use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Builder\ProductBuilderInterface;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\AttributeOptionInterface;
 use Pim\Component\Catalog\Model\ProductInterface;

--- a/src/Pim/Component/Catalog/spec/Updater/Setter/PriceCollectionAttributeSetterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Setter/PriceCollectionAttributeSetterSpec.php
@@ -5,7 +5,6 @@ namespace spec\Pim\Component\Catalog\Updater\Setter;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Builder\ProductBuilderInterface;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Model\ProductPriceInterface;

--- a/src/Pim/Component/Catalog/spec/Updater/Setter/SimpleSelectAttributeSetterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Setter/SimpleSelectAttributeSetterSpec.php
@@ -7,7 +7,6 @@ use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Builder\ProductBuilderInterface;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\AttributeOptionInterface;
 use Pim\Component\Catalog\Model\ProductInterface;

--- a/src/Pim/Component/Catalog/spec/Updater/Setter/TextAttributeSetterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Setter/TextAttributeSetterSpec.php
@@ -5,7 +5,6 @@ namespace spec\Pim\Component\Catalog\Updater\Setter;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Builder\ProductBuilderInterface;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Model\ProductValue;

--- a/src/Pim/Component/Catalog/spec/Updater/Setter/VariantGroupFieldSetterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Setter/VariantGroupFieldSetterSpec.php
@@ -2,11 +2,9 @@
 
 namespace spec\Pim\Component\Catalog\Updater\Setter;
 
-use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use PhpSpec\ObjectBehavior;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\GroupInterface;
 use Pim\Component\Catalog\Model\GroupTypeInterface;
 use Pim\Component\Catalog\Model\ProductInterface;

--- a/src/Pim/Component/Catalog/spec/Validator/Constraints/BooleanSpec.php
+++ b/src/Pim/Component/Catalog/spec/Validator/Constraints/BooleanSpec.php
@@ -13,7 +13,7 @@ class BooleanSpec extends ObjectBehavior
 
     function it_has_message()
     {
-        $this->message->shouldBe('Attribute or field "%attribute%" expects a boolean as data, "%givenType%" given.');
+        $this->message->shouldBe('Property "%attribute%" expects a boolean as data, "%givenType%" given.');
     }
 
     function it_is_a_validator_constraint()

--- a/src/Pim/Component/Catalog/spec/Validator/Constraints/IsStringSpec.php
+++ b/src/Pim/Component/Catalog/spec/Validator/Constraints/IsStringSpec.php
@@ -13,7 +13,7 @@ class IsStringSpec extends ObjectBehavior
 
     function it_has_message()
     {
-        $this->message->shouldBe('Attribute or field "%attribute%" expects a string as data, "%givenType%" given.');
+        $this->message->shouldBe('Property "%attribute%" expects a string as data, "%givenType%" given.');
     }
 
     function it_is_a_validator_constraint()

--- a/src/Pim/Component/Connector/Processor/Denormalization/JobInstanceProcessor.php
+++ b/src/Pim/Component/Connector/Processor/Denormalization/JobInstanceProcessor.php
@@ -10,7 +10,7 @@ use Akeneo\Component\Batch\Job\JobRegistry;
 use Akeneo\Component\Batch\Model\JobInstance;
 use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
 use Akeneo\Component\StorageUtils\Detacher\ObjectDetacherInterface;
-use Akeneo\Component\StorageUtils\Exception\ObjectUpdaterException;
+use Akeneo\Component\StorageUtils\Exception\PropertyException;
 use Akeneo\Component\StorageUtils\Factory\SimpleFactoryInterface;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
@@ -86,7 +86,7 @@ class JobInstanceProcessor extends AbstractProcessor implements ItemProcessorInt
 
         try {
             $this->updater->update($entity, $item);
-        } catch (ObjectUpdaterException $exception) {
+        } catch (PropertyException $exception) {
             $this->skipItemWithMessage($item, $exception->getMessage(), $exception);
         }
 

--- a/src/Pim/Component/Connector/Processor/Denormalization/Processor.php
+++ b/src/Pim/Component/Connector/Processor/Denormalization/Processor.php
@@ -5,7 +5,7 @@ namespace Pim\Component\Connector\Processor\Denormalization;
 use Akeneo\Component\Batch\Item\ItemProcessorInterface;
 use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
 use Akeneo\Component\StorageUtils\Detacher\ObjectDetacherInterface;
-use Akeneo\Component\StorageUtils\Exception\ObjectUpdaterException;
+use Akeneo\Component\StorageUtils\Exception\PropertyException;
 use Akeneo\Component\StorageUtils\Factory\SimpleFactoryInterface;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
@@ -64,7 +64,7 @@ class Processor extends AbstractProcessor implements ItemProcessorInterface, Ste
 
         try {
             $this->updater->update($entity, $item);
-        } catch (ObjectUpdaterException $exception) {
+        } catch (PropertyException $exception) {
             $this->skipItemWithMessage($item, $exception->getMessage(), $exception);
         }
 

--- a/src/Pim/Component/Connector/Processor/Denormalization/ProductAssociationProcessor.php
+++ b/src/Pim/Component/Connector/Processor/Denormalization/ProductAssociationProcessor.php
@@ -5,7 +5,7 @@ namespace Pim\Component\Connector\Processor\Denormalization;
 use Akeneo\Component\Batch\Item\ItemProcessorInterface;
 use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
 use Akeneo\Component\StorageUtils\Detacher\ObjectDetacherInterface;
-use Akeneo\Component\StorageUtils\Exception\ObjectUpdaterException;
+use Akeneo\Component\StorageUtils\Exception\PropertyException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Pim\Component\Catalog\Comparator\Filter\ProductFilterInterface;
@@ -103,7 +103,7 @@ class ProductAssociationProcessor extends AbstractProcessor implements ItemProce
 
         try {
             $this->updateProduct($product, $item);
-        } catch (ObjectUpdaterException $exception) {
+        } catch (PropertyException $exception) {
             $this->detachProduct($product);
             $this->skipItemWithMessage($item, $exception->getMessage(), $exception);
         }
@@ -132,7 +132,7 @@ class ProductAssociationProcessor extends AbstractProcessor implements ItemProce
      * @param ProductInterface $product
      * @param array            $item
      *
-     * @throws ObjectUpdaterException
+     * @throws PropertyException
      */
     protected function updateProduct(ProductInterface $product, array $item)
     {

--- a/src/Pim/Component/Connector/Processor/Denormalization/ProductProcessor.php
+++ b/src/Pim/Component/Connector/Processor/Denormalization/ProductProcessor.php
@@ -5,7 +5,7 @@ namespace Pim\Component\Connector\Processor\Denormalization;
 use Akeneo\Component\Batch\Item\ItemProcessorInterface;
 use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
 use Akeneo\Component\StorageUtils\Detacher\ObjectDetacherInterface;
-use Akeneo\Component\StorageUtils\Exception\ObjectUpdaterException;
+use Akeneo\Component\StorageUtils\Exception\PropertyException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Pim\Component\Catalog\Builder\ProductBuilderInterface;
@@ -108,7 +108,7 @@ class ProductProcessor extends AbstractProcessor implements ItemProcessorInterfa
 
         try {
             $this->updateProduct($product, $filteredItem);
-        } catch (ObjectUpdaterException $exception) {
+        } catch (PropertyException $exception) {
             $this->detachProduct($product);
             $this->skipItemWithMessage($item, $exception->getMessage(), $exception);
         }
@@ -193,7 +193,7 @@ class ProductProcessor extends AbstractProcessor implements ItemProcessorInterfa
      * @param ProductInterface $product
      * @param array            $filteredItem
      *
-     * @throws ObjectUpdaterException
+     * @throws PropertyException
      */
     protected function updateProduct(ProductInterface $product, array $filteredItem)
     {

--- a/src/Pim/Component/Connector/Validator/Constraints/FilterDataValidator.php
+++ b/src/Pim/Component/Connector/Validator/Constraints/FilterDataValidator.php
@@ -2,7 +2,7 @@
 
 namespace Pim\Component\Connector\Validator\Constraints;
 
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
+use Akeneo\Component\StorageUtils\Exception\PropertyException;
 use Pim\Component\Catalog\Query\ProductQueryBuilderFactory;
 use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\Validator\Constraint;
@@ -50,7 +50,7 @@ class FilterDataValidator extends ConstraintValidator
             try {
                 $context = isset($data['context']) ? $data['context'] : [];
                 $pqb->addFilter($data['field'], $data['operator'], $data['value'], $context);
-            } catch (InvalidArgumentException $exception) {
+            } catch (PropertyException $exception) {
                 $this->context->buildViolation(
                         $this->translator->trans(
                             sprintf('pim_catalog.constraint.%s', $exception->getCode())

--- a/src/Pim/Component/ReferenceData/Updater/Setter/ReferenceDataCollectionSetter.php
+++ b/src/Pim/Component/ReferenceData/Updater/Setter/ReferenceDataCollectionSetter.php
@@ -99,9 +99,9 @@ class ReferenceDataCollectionSetter extends AbstractAttributeSetter
 
         foreach ($data as $key => $value) {
             if (!is_string($value)) {
-                throw InvalidPropertyTypeException::arrayStringKeyExpected(
+                throw InvalidPropertyTypeException::validArrayStructureExpected(
                     $attribute->getCode(),
-                    $key,
+                    sprintf('one of the "%s" values is not a scalar', $attribute->getCode()),
                     static::class,
                     $data
                 );

--- a/src/Pim/Component/ReferenceData/Updater/Setter/ReferenceDataSetter.php
+++ b/src/Pim/Component/ReferenceData/Updater/Setter/ReferenceDataSetter.php
@@ -5,7 +5,6 @@ namespace Pim\Component\ReferenceData\Updater\Setter;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Pim\Component\Catalog\Builder\ProductBuilderInterface;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Updater\Setter\AbstractAttributeSetter;

--- a/src/Pim/Component/ReferenceData/spec/Updater/Setter/ReferenceDataCollectionSetterSpec.php
+++ b/src/Pim/Component/ReferenceData/spec/Updater/Setter/ReferenceDataCollectionSetterSpec.php
@@ -109,6 +109,24 @@ class ReferenceDataCollectionSetterSpec extends ObjectBehavior
         ]);
     }
 
+    function it_throws_an_exception_if_data_is_an_array_but_does_not_contain_a_string(
+        ProductInterface $product,
+        AttributeInterface $attribute
+    ) {
+        $attribute->getCode()->willReturn('attribute_code');
+
+        $this->shouldThrow(
+            InvalidPropertyTypeException::validArrayStructureExpected(
+                'attribute_code',
+                'one of the "attribute_code" values is not a scalar',
+                'Pim\Component\ReferenceData\Updater\Setter\ReferenceDataCollectionSetter',
+                ['string', 12]
+            )
+        )->during('setAttributeData', [
+            $product, $attribute, ['string', 12], ['locale' => 'fr_FR', 'scope' => 'mobile']
+        ]);
+    }
+
     function it_throws_an_exception_if_product_value_method_is_not_implemented(
         $repositoryResolver,
         ObjectRepository $repository,

--- a/src/Pim/Component/ReferenceData/spec/Updater/Setter/ReferenceDataSetterSpec.php
+++ b/src/Pim/Component/ReferenceData/spec/Updater/Setter/ReferenceDataSetterSpec.php
@@ -7,7 +7,6 @@ use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Doctrine\Common\Persistence\ObjectRepository;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Builder\ProductBuilderInterface;
-use Pim\Component\Catalog\Exception\InvalidArgumentException;
 use Pim\Component\Catalog\Model\AbstractProductValue;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\ProductInterface;


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

For the `api-web` branch, we need to apply the new exceptions on the PQB, but the naming of them is blocking. As we work always on properties, we choose `PropertyException`, but if you find a better naming, no pb :)


[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
