### PR TITLE
PIM-6153: Allow to send empty array in PriceFilter value for EMPTY and NOT EMPTY operators

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/PriceFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/PriceFilter.php
@@ -54,6 +54,14 @@ class PriceFilter extends AbstractAttributeFilter implements AttributeFilterInte
         $this->checkLocaleAndScope($attribute, $locale, $scope);
 
         if (Operators::IS_EMPTY === $operator || Operators::IS_NOT_EMPTY === $operator) {
+            if (!array_key_exists('amount', $value)) {
+                $value['amount'] = null;
+            }
+            if (!array_key_exists('currency', $value)) {
+                $value['currency'] = '';
+            } else {
+                $this->checkCurrency($attribute, $value);
+            }
             $this->addEmptyTypeFilter($attribute, $value, $operator, $locale, $scope);
         } else {
             $this->checkValue($attribute, $value);
@@ -197,7 +205,18 @@ class PriceFilter extends AbstractAttributeFilter implements AttributeFilterInte
                 $data
             );
         }
+        $this->checkCurrency($attribute, $data);
+    }
 
+    /**
+     * @param AttributeInterface $attribute
+     * @param array              $data
+     *
+     * @throws InvalidPropertyTypeException
+     * @throws InvalidPropertyException
+     */
+    protected function checkCurrency(AttributeInterface $attribute, $data)
+    {
         if (!is_string($data['currency'])) {
             throw InvalidPropertyTypeException::validArrayStructureExpected(
                 $attribute->getCode(),
@@ -207,7 +226,9 @@ class PriceFilter extends AbstractAttributeFilter implements AttributeFilterInte
             );
         }
 
-        if (!in_array($data['currency'], $this->currencyRepository->getActivatedCurrencyCodes())) {
+        if (!in_array($data['currency'], $this->currencyRepository->getActivatedCurrencyCodes()) &&
+            '' !== $data['currency']
+        ) {
             throw InvalidPropertyException::validEntityCodeExpected(
                 $attribute->getCode(),
                 'currency',

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/PriceFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Filter/PriceFilterSpec.php
@@ -221,6 +221,98 @@ class PriceFilterSpec extends ObjectBehavior
         $this->addAttributeFilter($price, 'EMPTY', $value);
     }
 
+    function it_adds_an_empty_filter_in_the_query_without_values(
+        QueryBuilder $queryBuilder,
+        AttributeInterface $price,
+        Expr $expr,
+        Comparison $comparison
+    ) {
+        $price->getId()->willReturn(42);
+        $price->getCode()->willReturn('price');
+        $price->getBackendType()->willReturn('prices');
+        $price->isLocalizable()->willReturn(false);
+        $price->isScopable()->willReturn(false);
+
+        $queryBuilder->expr()->willReturn(new Expr());
+        $queryBuilder->getRootAlias()->willReturn('p');
+
+        $queryBuilder->leftJoin('p.values', Argument::any(), 'WITH', Argument::any())->shouldBeCalled();
+
+        $queryBuilder->leftJoin(Argument::any(), Argument::any())->shouldBeCalled();
+        $queryBuilder->expr()->willReturn($expr);
+
+        $expr->literal('')->willReturn('');
+        $expr->eq(Argument::any(), '')->willReturn($comparison);
+        $expr->isNull(Argument::any())->willReturn('filterPprice.data IS NOT NULL');
+        $expr->isNull(Argument::any())->willReturn('filterPprice.id IS NOT NULL');
+        $expr->orX(Argument::any(), Argument::any())->shouldBeCalled();
+        $queryBuilder->andWhere(null)->shouldBeCalled();
+
+        $this->addAttributeFilter($price, 'EMPTY', []);
+    }
+
+    function it_adds_an_empty_filter_in_the_query_without_amount(
+        $currencyRepository,
+        QueryBuilder $queryBuilder,
+        AttributeInterface $price,
+        Expr $expr,
+        Comparison $comparison
+    ) {
+        $price->getId()->willReturn(42);
+        $price->getCode()->willReturn('price');
+        $price->getBackendType()->willReturn('prices');
+        $price->isLocalizable()->willReturn(false);
+        $price->isScopable()->willReturn(false);
+
+        $queryBuilder->expr()->willReturn(new Expr());
+        $queryBuilder->getRootAlias()->willReturn('p');
+
+        $queryBuilder->leftJoin('p.values', Argument::any(), 'WITH', Argument::any())->shouldBeCalled();
+        $currencyRepository->getActivatedCurrencyCodes()->willReturn(['EUR', 'USD']);
+
+        $queryBuilder->leftJoin(Argument::any(), Argument::any())->shouldBeCalled();
+        $queryBuilder->expr()->willReturn($expr);
+
+        $expr->literal('EUR')->willReturn('EUR');
+        $expr->eq(Argument::any(), 'EUR')->willReturn($comparison);
+        $expr->isNull(Argument::any())->willReturn('filterPprice.data IS NOT NULL');
+        $expr->isNull(Argument::any())->willReturn('filterPprice.id IS NOT NULL');
+        $expr->orX(Argument::any(), Argument::any())->shouldBeCalled();
+        $queryBuilder->andWhere(null)->shouldBeCalled();
+
+        $this->addAttributeFilter($price, 'EMPTY', ['currency' => 'EUR']);
+    }
+
+    function it_adds_an_empty_filter_in_the_query_without_currency(
+        QueryBuilder $queryBuilder,
+        AttributeInterface $price,
+        Expr $expr,
+        Comparison $comparison
+    ) {
+        $price->getId()->willReturn(42);
+        $price->getCode()->willReturn('price');
+        $price->getBackendType()->willReturn('prices');
+        $price->isLocalizable()->willReturn(false);
+        $price->isScopable()->willReturn(false);
+
+        $queryBuilder->expr()->willReturn(new Expr());
+        $queryBuilder->getRootAlias()->willReturn('p');
+
+        $queryBuilder->leftJoin('p.values', Argument::any(), 'WITH', Argument::any())->shouldBeCalled();
+
+        $queryBuilder->leftJoin(Argument::any(), Argument::any())->shouldBeCalled();
+        $queryBuilder->expr()->willReturn($expr);
+
+        $expr->literal('')->willReturn('');
+        $expr->eq(Argument::any(), '')->willReturn($comparison);
+        $expr->isNull(Argument::any())->willReturn('filterPprice.data IS NOT NULL');
+        $expr->isNull(Argument::any())->willReturn('filterPprice.id IS NOT NULL');
+        $expr->orX(Argument::any(), Argument::any())->shouldBeCalled();
+        $queryBuilder->andWhere(null)->shouldBeCalled();
+
+        $this->addAttributeFilter($price, 'EMPTY', ['amount' => null]);
+    }
+
     function it_adds_a_not_empty_filter_in_the_query(
         $currencyRepository,
         QueryBuilder $queryBuilder,
@@ -252,6 +344,96 @@ class PriceFilterSpec extends ObjectBehavior
         $queryBuilder->andWhere(null)->shouldBeCalled();
 
         $this->addAttributeFilter($price, 'NOT EMPTY', $value);
+    }
+
+    function it_adds_a_not_empty_filter_in_the_query_without_values(
+        QueryBuilder $queryBuilder,
+        AttributeInterface $price,
+        Expr $expr,
+        Comparison $comparison
+    ) {
+        $price->getId()->willReturn(42);
+        $price->getCode()->willReturn('price');
+        $price->getBackendType()->willReturn('prices');
+        $price->isLocalizable()->willReturn(false);
+        $price->isScopable()->willReturn(false);
+
+        $queryBuilder->expr()->willReturn(new Expr());
+        $queryBuilder->getRootAlias()->willReturn('p');
+
+        $queryBuilder->leftJoin('p.values', Argument::any(), 'WITH', Argument::any())->shouldBeCalled();
+
+        $queryBuilder->leftJoin(Argument::any(), Argument::any())->shouldBeCalled();
+        $queryBuilder->expr()->willReturn($expr);
+
+        $expr->literal('')->willReturn('');
+        $expr->eq(Argument::any(), '')->willReturn($comparison);
+        $expr->isNotNull(Argument::any())->shouldBeCalledTimes(2);
+        $expr->andX(Argument::any(), Argument::any())->shouldBeCalled();
+        $queryBuilder->andWhere(null)->shouldBeCalled();
+
+        $this->addAttributeFilter($price, 'NOT EMPTY', []);
+    }
+
+    function it_adds_a_not_empty_filter_in_the_query_without_currency(
+        QueryBuilder $queryBuilder,
+        AttributeInterface $price,
+        Expr $expr,
+        Comparison $comparison
+    ) {
+        $price->getId()->willReturn(42);
+        $price->getCode()->willReturn('price');
+        $price->getBackendType()->willReturn('prices');
+        $price->isLocalizable()->willReturn(false);
+        $price->isScopable()->willReturn(false);
+
+        $queryBuilder->expr()->willReturn(new Expr());
+        $queryBuilder->getRootAlias()->willReturn('p');
+
+        $queryBuilder->leftJoin('p.values', Argument::any(), 'WITH', Argument::any())->shouldBeCalled();
+
+        $queryBuilder->leftJoin(Argument::any(), Argument::any())->shouldBeCalled();
+        $queryBuilder->expr()->willReturn($expr);
+
+        $expr->literal('')->willReturn('');
+        $expr->eq(Argument::any(), '')->willReturn($comparison);
+        $expr->isNotNull(Argument::any())->shouldBeCalledTimes(2);
+        $expr->andX(Argument::any(), Argument::any())->shouldBeCalled();
+        $queryBuilder->andWhere(null)->shouldBeCalled();
+
+        $this->addAttributeFilter($price, 'NOT EMPTY', ['amount' => null]);
+    }
+
+    function it_adds_a_not_empty_filter_in_the_query_without_amount(
+        $currencyRepository,
+        QueryBuilder $queryBuilder,
+        AttributeInterface $price,
+        Expr $expr,
+        Comparison $comparison
+    ) {
+        $price->getId()->willReturn(42);
+        $price->getCode()->willReturn('price');
+        $price->getBackendType()->willReturn('prices');
+        $price->isLocalizable()->willReturn(false);
+        $price->isScopable()->willReturn(false);
+
+        $queryBuilder->expr()->willReturn(new Expr());
+        $queryBuilder->getRootAlias()->willReturn('p');
+
+        $currencyRepository->getActivatedCurrencyCodes()->willReturn(['EUR', 'USD']);
+
+        $queryBuilder->leftJoin('p.values', Argument::any(), 'WITH', Argument::any())->shouldBeCalled();
+
+        $queryBuilder->leftJoin(Argument::any(), Argument::any())->shouldBeCalled();
+        $queryBuilder->expr()->willReturn($expr);
+
+        $expr->literal('EUR')->willReturn('EUR');
+        $expr->eq(Argument::any(), 'EUR')->willReturn($comparison);
+        $expr->isNotNull(Argument::any())->shouldBeCalledTimes(2);
+        $expr->andX(Argument::any(), Argument::any())->shouldBeCalled();
+        $queryBuilder->andWhere(null)->shouldBeCalled();
+
+        $this->addAttributeFilter($price, 'NOT EMPTY', ['currency' => 'EUR']);
     }
 
     function it_adds_a_not_equal_filter_in_the_query(

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Price/LocalizableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Price/LocalizableFilterIntegration.php
@@ -108,6 +108,9 @@ class LocalizableFilterIntegration extends AbstractFilterTestCase
     {
         $result = $this->execute([['a_localizable_price', Operators::IS_EMPTY, ['amount' => '', 'currency' => ''], ['locale' => 'en_US']]]);
         $this->assert($result, ['empty_product']);
+
+        $result = $this->execute([['a_localizable_price', Operators::IS_EMPTY, [], ['locale' => 'en_US']]]);
+        $this->assert($result, ['empty_product']);
     }
 
     public function testOperatorNotEmpty()
@@ -119,6 +122,9 @@ class LocalizableFilterIntegration extends AbstractFilterTestCase
         $this->assert($result, []);
 
         $result = $this->execute([['a_localizable_price', Operators::IS_NOT_EMPTY, ['amount' => '', 'currency' => ''], ['locale' => 'en_US']]]);
+        $this->assert($result, []);
+
+        $result = $this->execute([['a_localizable_price', Operators::IS_NOT_EMPTY, [], ['locale' => 'en_US']]]);
         $this->assert($result, []);
     }
 

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Price/LocalizableScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Price/LocalizableScopableFilterIntegration.php
@@ -163,6 +163,14 @@ class LocalizableScopableFilterIntegration extends AbstractFilterTestCase
             ['locale' => 'en_US', 'scope' => 'tablet']
         ]]);
         $this->assert($result, ['empty_product']);
+
+        $result = $this->execute([[
+            'a_scopable_localizable_price',
+            Operators::IS_EMPTY,
+            [],
+            ['locale' => 'en_US', 'scope' => 'tablet']
+        ]]);
+        $this->assert($result, ['empty_product']);
     }
 
     public function testOperatorNotEmpty()
@@ -171,6 +179,14 @@ class LocalizableScopableFilterIntegration extends AbstractFilterTestCase
             'a_scopable_localizable_price',
             Operators::IS_NOT_EMPTY,
             ['amount' => '', 'currency' => ''],
+            ['locale' => 'en_US', 'scope' => 'tablet']
+        ]]);
+        $this->assert($result, []);
+
+        $result = $this->execute([[
+            'a_scopable_localizable_price',
+            Operators::IS_NOT_EMPTY,
+            [],
             ['locale' => 'en_US', 'scope' => 'tablet']
         ]]);
         $this->assert($result, []);

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Price/PriceFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Price/PriceFilterIntegration.php
@@ -114,6 +114,9 @@ class PriceFilterIntegration extends AbstractFilterTestCase
 
     public function testOperatorEmpty()
     {
+        $result = $this->execute([['a_price', Operators::IS_EMPTY, []]]);
+        $this->assert($result, ['empty_product']);
+
         $result = $this->execute([['a_price', Operators::IS_EMPTY, ['amount' => '', 'currency' => '']]]);
         $this->assert($result, ['empty_product']);
     }
@@ -127,6 +130,9 @@ class PriceFilterIntegration extends AbstractFilterTestCase
         $this->assert($result, ['product_one']);
 
         $result = $this->execute([['a_price', Operators::IS_NOT_EMPTY, ['amount' => '', 'currency' => '']]]);
+        $this->assert($result, []);
+
+        $result = $this->execute([['a_price', Operators::IS_NOT_EMPTY, []]]);
         $this->assert($result, []);
     }
 

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Price/ScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Price/ScopableFilterIntegration.php
@@ -97,11 +97,17 @@ class ScopableFilterIntegration extends AbstractFilterTestCase
     {
         $result = $this->execute([['a_scopable_price', Operators::IS_EMPTY, ['amount' => '', 'currency' => ''], ['scope' => 'tablet']]]);
         $this->assert($result, ['empty_product']);
+
+        $result = $this->execute([['a_scopable_price', Operators::IS_EMPTY, [], ['scope' => 'tablet']]]);
+        $this->assert($result, ['empty_product']);
     }
 
     public function testOperatorNotEmpty()
     {
         $result = $this->execute([['a_scopable_price', Operators::IS_NOT_EMPTY, ['amount' => '', 'currency' => ''], ['scope' => 'tablet']]]);
+        $this->assert($result, []);
+
+        $result = $this->execute([['a_scopable_price', Operators::IS_NOT_EMPTY, [], ['scope' => 'tablet']]]);
         $this->assert($result, []);
 
         $result = $this->execute([['a_scopable_price', Operators::IS_NOT_EMPTY, ['amount' => '', 'currency' => 'EUR'], ['scope' => 'tablet']]]);


### PR DESCRIPTION
**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | OK
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
