### PR TITLE
API-76: Adds filtering on locales for API

### DIFF
--- a/src/Pim/Bundle/ApiBundle/Controller/LocaleController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/LocaleController.php
@@ -82,7 +82,8 @@ class LocaleController
      */
     public function listAction(Request $request)
     {
-        $criterias = $this->prepareSearchCriterias($request);
+        $searchCriterias = $this->validateSearchCriterias($request);
+        $criterias = $this->prepareSearchCriterias($searchCriterias);
 
         $queryParameters = [];
         $queryParameters['page'] = $request->query->get('page', 1);
@@ -125,12 +126,8 @@ class LocaleController
      * @throws BadRequestHttpException
      * @return array
      */
-    protected function prepareSearchCriterias(Request $request)
+    protected function validateSearchCriterias(Request $request)
     {
-        $criterias = [];
-        if (!$request->query->has('search')) {
-            return $criterias;
-        }
         $searchString = $request->query->get('search', '');
         $searchParameters = json_decode($searchString, true);
 
@@ -184,11 +181,29 @@ class LocaleController
                         )
                     );
                 }
-
-                $criterias['activated'] = $searchOperator['value'];
             }
         }
 
-        return $criterias;
+        return $searchParameters;
+    }
+
+    /**
+     * Prepares search criterias
+     * For now, only enabled filter with operator "=" are managed
+     * Value is a boolean
+     *
+     * @param array $searchParameters
+     *
+     * @return array
+     */
+    protected function prepareSearchCriterias(array $searchParameters)
+    {
+        if (empty($searchParameters)) {
+            return [];
+        }
+
+        return [
+            'activated' => $searchParameters['enabled'][0]['value']
+        ];
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Locale/FilterLocaleIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Locale/FilterLocaleIntegration.php
@@ -1,0 +1,312 @@
+<?php
+
+namespace Pim\Bundle\ApiBundle\tests\integration\Controller\Locale;
+
+use Akeneo\Test\Integration\Configuration;
+use Pim\Bundle\ApiBundle\tests\integration\ApiTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+class FilterLocaleIntegration extends ApiTestCase
+{
+    public function testFilterActivatedLocales()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $filters = [
+            'enabled' => [['operator' => '=', 'value' => true]]
+        ];
+        $searchString = urlencode(json_encode($filters));
+        $filterLocaleUrl = sprintf('api/rest/v1/locales?search=%s', $searchString);
+        $client->request('GET', $filterLocaleUrl);
+
+        $standardLocales = [
+            '_links'       => [
+                'self'  => [
+                    'href' => sprintf('http://localhost/api/rest/v1/locales?search=%s&page=1&limit=10', $searchString)
+                ],
+                'first' => [
+                    'href' => sprintf('http://localhost/api/rest/v1/locales?search=%s&page=1&limit=10', $searchString)
+                ],
+                'last'  => [
+                    'href' => sprintf('http://localhost/api/rest/v1/locales?search=%s&page=1&limit=10', $searchString)
+                ],
+            ],
+            'current_page' => 1,
+            'pages_count'  => 1,
+            'items_count'  => 4,
+            '_embedded'    => [
+                'items' => [
+                    [
+                        '_links' => [
+                            'self' => ['href' => 'http://localhost/api/rest/v1/locales/de_DE']
+                        ],
+                        'code'    => 'de_DE',
+                        'enabled' => true,
+                    ],
+                    [
+                        '_links' => [
+                            'self' => ['href' => 'http://localhost/api/rest/v1/locales/en_US']
+                        ],
+                        'code'    => 'en_US',
+                        'enabled' => true,
+                    ],
+                    [
+                        '_links' => [
+                            'self' => ['href' => 'http://localhost/api/rest/v1/locales/fr_FR']
+                        ],
+                        'code'    => 'fr_FR',
+                        'enabled' => true,
+                    ],
+                    [
+                        '_links' => [
+                            'self' => ['href' => 'http://localhost/api/rest/v1/locales/zh_CN']
+                        ],
+                        'code'    => 'zh_CN',
+                        'enabled' => true,
+                    ],
+                ]
+            ]
+        ];
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+
+        $this->assertSame($standardLocales, json_decode($response->getContent(), true));
+    }
+
+    public function testFilterDeactivatedLocales()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $filters = [
+            'enabled' => [['operator' => '=', 'value' => false]]
+        ];
+        $searchString = urlencode(json_encode($filters));
+        $filterLocaleUrl = sprintf('api/rest/v1/locales?search=%s', $searchString);
+        $client->request('GET', $filterLocaleUrl);
+
+        $standardLocales = [
+            '_links'       => [
+                'self'  => [
+                    'href' => sprintf('http://localhost/api/rest/v1/locales?search=%s&page=1&limit=10', $searchString)
+                ],
+                'first' => [
+                    'href' => sprintf('http://localhost/api/rest/v1/locales?search=%s&page=1&limit=10', $searchString)
+                ],
+                'last'  => [
+                    'href' => sprintf('http://localhost/api/rest/v1/locales?search=%s&page=2&limit=10', $searchString)
+                ],
+                'next'  => [
+                    'href' => sprintf('http://localhost/api/rest/v1/locales?search=%s&page=2&limit=10', $searchString)
+                ],
+            ],
+            'current_page' => 1,
+            'pages_count'  => 2,
+            'items_count'  => 11,
+            '_embedded'    => [
+                'items' => [
+                    [
+                        '_links' => [
+                            'self' => ['href' => 'http://localhost/api/rest/v1/locales/af_ZA']
+                        ],
+                        'code'    => 'af_ZA',
+                        'enabled' => false,
+                    ],
+                    [
+                        '_links' => [
+                            'self' => ['href' => 'http://localhost/api/rest/v1/locales/de_CH']
+                        ],
+                        'code'    => 'de_CH',
+                        'enabled' => false,
+                    ],
+                    [
+                        '_links' => [
+                            'self' => ['href' => 'http://localhost/api/rest/v1/locales/en_GB']
+                        ],
+                        'code'    => 'en_GB',
+                        'enabled' => false,
+                    ],
+                    [
+                        '_links' => [
+                            'self' => ['href' => 'http://localhost/api/rest/v1/locales/es_ES']
+                        ],
+                        'code'    => 'es_ES',
+                        'enabled' => false,
+                    ],
+                    [
+                        '_links' => [
+                            'self' => ['href' => 'http://localhost/api/rest/v1/locales/fr_BE']
+                        ],
+                        'code'    => 'fr_BE',
+                        'enabled' => false,
+                    ],
+                    [
+                        '_links' => [
+                            'self' => ['href' => 'http://localhost/api/rest/v1/locales/fr_CA']
+                        ],
+                        'code'    => 'fr_CA',
+                        'enabled' => false,
+                    ],
+                    [
+                        '_links' => [
+                            'self' => ['href' => 'http://localhost/api/rest/v1/locales/fr_CH']
+                        ],
+                        'code'    => 'fr_CH',
+                        'enabled' => false,
+                    ],
+                    [
+                        '_links' => [
+                            'self' => ['href' => 'http://localhost/api/rest/v1/locales/fr_LU']
+                        ],
+                        'code'    => 'fr_LU',
+                        'enabled' => false,
+                    ],
+                    [
+                        '_links' => [
+                            'self' => ['href' => 'http://localhost/api/rest/v1/locales/fr_MC']
+                        ],
+                        'code'    => 'fr_MC',
+                        'enabled' => false,
+                    ],
+                    [
+                        '_links' => [
+                            'self' => ['href' => 'http://localhost/api/rest/v1/locales/fy_NL']
+                        ],
+                        'code'    => 'fy_NL',
+                        'enabled' => false,
+                    ],
+                ]
+            ]
+        ];
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+
+        $this->assertSame($standardLocales, json_decode($response->getContent(), true));
+    }
+
+    public function testFilterOnNonAuthorizedField()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $filters = [
+            'non_authorized' => [['operator' => '=', 'value' => false]]
+        ];
+        $searchString = urlencode(json_encode($filters));
+        $filterLocaleUrl = sprintf('api/rest/v1/locales?search=%s', $searchString);
+        $client->request('GET', $filterLocaleUrl);
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $content = json_decode($response->getContent(), true);
+        $this->assertCount(2, $content, 'response contains 2 items');
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $content['code']);
+        $this->assertSame(
+            'Filter on property "non_authorized" is not supported or does not support operator "=".',
+            $content['message']
+        );
+    }
+
+    public function testFilterOnInvalidJson()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $searchString = urlencode('{"enabled":[{"operator":"=","value\': "]}');
+        $filterLocaleUrl = sprintf('api/rest/v1/locales?search=%s', $searchString);
+        $client->request('GET', $filterLocaleUrl);
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+        $content = json_decode($response->getContent(), true);
+        $this->assertCount(2, $content, 'response contains 2 items');
+        $this->assertSame(Response::HTTP_BAD_REQUEST, $content['code']);
+        $this->assertSame('Search query parameter should be valid JSON.', $content['message']);
+    }
+
+    public function testFilterMissingOperatorAndValueFields()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $filters = [
+            'enabled' => []
+        ];
+        $searchString = urlencode(json_encode($filters));
+        $filterLocaleUrl = sprintf('api/rest/v1/locales?search=%s', $searchString);
+        $client->request('GET', $filterLocaleUrl);
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $content = json_decode($response->getContent(), true);
+        $this->assertCount(2, $content, 'response contains 2 items');
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $content['code']);
+        $this->assertSame('Operator and value are missing for the property "enabled".', $content['message']);
+    }
+
+    public function testFilterMissingOperatorField()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $filters = [
+            'enabled' => [['value' => true]]
+        ];
+        $searchString = urlencode(json_encode($filters));
+        $filterLocaleUrl = sprintf('api/rest/v1/locales?search=%s', $searchString);
+        $client->request('GET', $filterLocaleUrl);
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $content = json_decode($response->getContent(), true);
+        $this->assertCount(2, $content, 'response contains 2 items');
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $content['code']);
+        $this->assertSame('Operator is missing for the property "enabled".', $content['message']);
+    }
+
+    public function testFilterMissingValueField()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $filters = [
+            'enabled' => [['operator' => '=']]
+        ];
+        $searchString = urlencode(json_encode($filters));
+        $filterLocaleUrl = sprintf('api/rest/v1/locales?search=%s', $searchString);
+        $client->request('GET', $filterLocaleUrl);
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $content = json_decode($response->getContent(), true);
+        $this->assertCount(2, $content, 'response contains 2 items');
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $content['code']);
+        $this->assertSame('Value is missing for the property "enabled".', $content['message']);
+    }
+
+    public function testEnableFilterWithANonBooleanValue()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $filters = [
+            'enabled' => [['operator' => '=', 'value' => 'non_boolean']]
+        ];
+        $searchString = urlencode(json_encode($filters));
+        $filterLocaleUrl = sprintf('api/rest/v1/locales?search=%s', $searchString);
+        $client->request('GET', $filterLocaleUrl);
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $content = json_decode($response->getContent(), true);
+        $this->assertCount(2, $content, 'response contains 2 items');
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $content['code']);
+        $this->assertSame('Filter "enabled" with operator "=" expects a boolean value', $content['message']);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return new Configuration(
+            [Configuration::getTechnicalCatalogPath()],
+            false
+        );
+    }
+}

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Locale/FilterLocaleIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Locale/FilterLocaleIntegration.php
@@ -12,7 +12,7 @@ class FilterLocaleIntegration extends ApiTestCase
     {
         $client = $this->createAuthenticatedClient();
 
-        $searchString = '{"enabled":[{"operator":"=","value":true}]}';
+        $searchString = urlencode('{"enabled":[{"operator":"=","value":true}]}');
         $filterLocaleUrl = sprintf('api/rest/v1/locales?search=%s', $searchString);
         $client->request('GET', $filterLocaleUrl);
 
@@ -75,7 +75,7 @@ class FilterLocaleIntegration extends ApiTestCase
     {
         $client = $this->createAuthenticatedClient();
 
-        $searchString = '{"enabled":[{"operator":"=","value":false}]}';
+        $searchString = urlencode('{"enabled":[{"operator":"=","value":false}]}');
         $filterLocaleUrl = sprintf('api/rest/v1/locales?search=%s', $searchString);
         $client->request('GET', $filterLocaleUrl);
 
@@ -258,12 +258,7 @@ class FilterLocaleIntegration extends ApiTestCase
     {
         $client = $this->createAuthenticatedClient();
 
-        $filters = [
-            'enabled' => [['value' => true]]
-        ];
-        $searchString = urlencode(json_encode($filters));
-        var_dump(json_encode($filters));
-
+        $searchString = '{"enabled":[{"value":true}]}';
         $filterLocaleUrl = sprintf('api/rest/v1/locales?search=%s', $searchString);
         $client->request('GET', $filterLocaleUrl);
 
@@ -279,11 +274,7 @@ class FilterLocaleIntegration extends ApiTestCase
     {
         $client = $this->createAuthenticatedClient();
 
-        $filters = [
-            'enabled' => [['operator' => '=']]
-        ];
-        $searchString = urlencode(json_encode($filters));
-        var_dump(json_encode($filters));
+        $searchString = '{"enabled":[{"operator":"="}]}';
         $filterLocaleUrl = sprintf('api/rest/v1/locales?search=%s', $searchString);
         $client->request('GET', $filterLocaleUrl);
 
@@ -299,11 +290,7 @@ class FilterLocaleIntegration extends ApiTestCase
     {
         $client = $this->createAuthenticatedClient();
 
-        $filters = [
-            'enabled' => [['operator' => '=', 'value' => 'non_boolean']]
-        ];
-        $searchString = urlencode(json_encode($filters));
-        var_dump(json_encode($filters));
+        $searchString = '{"enabled":[{"operator":"=","value":"non_boolean"}]}';
         $filterLocaleUrl = sprintf('api/rest/v1/locales?search=%s', $searchString);
         $client->request('GET', $filterLocaleUrl);
 


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

This PR allows to filter on locales through the API. There is only one filter available and it concerns activated locales.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | OK
| Changelog updated                 | -
| Review and 2 GTM                  | In progress
| Micro Demo to the PO (Story only) | OK
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
