### PR TITLE
Small fixes

### DIFF
--- a/features/Context/AssertionContext.php
+++ b/features/Context/AssertionContext.php
@@ -46,6 +46,9 @@ class AssertionContext extends RawMinkContext
      */
     public function assertPageNotContainsText($text)
     {
+        //Remove unecessary escaped antislashes
+        $text = str_replace('\\"', '"', $text);
+        $text = strip_tags($text);
         $this->spin(function () use ($text) {
             $this->assertSession()->pageTextNotContains($text);
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/formatter/date-formatter.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/formatter/date-formatter.js
@@ -48,9 +48,11 @@ define([
                 var options = $.extend({}, this.datetimepickerOptions, {format: fromFormat});
                 var fakeDatepicker = Datepicker.init($('<input>'), options).data('datetimepicker');
 
-                fakeDatepicker.setValue(date);
-                fakeDatepicker.format = toFormat;
-                fakeDatepicker._compileFormat();
+                if (null !== fakeDatepicker.parseDate(date)) {
+                    fakeDatepicker.setValue(date);
+                    fakeDatepicker.format = toFormat;
+                    fakeDatepicker._compileFormat();
+                }
 
                 return fakeDatepicker.formatDate(fakeDatepicker.getDate());
             }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This PR fixes 2 small things:
- Properly clean backslashes for the "I should not see the text" (copy paste from "I should see the text)
- Don't set value to the fake datepicker of the DateFormatter if the value can't be properly parsed by the Bootstrap Datepicker. This is to fix all the `WARNING: Encountered a JS error: 'TypeError: d is null'` we had in some behats.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
