### PR TITLE
API-101: Control access to a resource via ACLs

### DIFF
--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -48,6 +48,7 @@ security:
             pattern:                        ^/api
             fos_oauth:                      true
             stateless:                      true
+            access_denied_handler:          pim_api.security.access_denied_handler
 
         main:
             pattern:                        ^/

--- a/src/Oro/Bundle/SecurityBundle/Exception/AccessDeniedException.php
+++ b/src/Oro/Bundle/SecurityBundle/Exception/AccessDeniedException.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Oro\Bundle\SecurityBundle\Exception;
+
+use Symfony\Component\Security\Core\Exception\AccessDeniedException as BaseAccessDeniedException;
+
+/**
+ * @author    Yohan Blain <yohan.blain@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class AccessDeniedException extends BaseAccessDeniedException
+{
+    /** @var string */
+    protected $controllerClass;
+
+    /** @var string */
+    protected $method;
+
+    /**
+     * @param string $controllerClass
+     * @param string $method
+     *
+     * @return AccessDeniedException
+     */
+    public static function create($controllerClass, $method)
+    {
+        return new self($controllerClass, $method, sprintf('Access denied to %s::%s.', $controllerClass, $method));
+    }
+
+    /**
+     * @param string     $controllerClass
+     * @param string     $method
+     * @param string     $message
+     * @param \Exception $previous
+     */
+    public function __construct($controllerClass, $method, $message, \Exception $previous = null)
+    {
+        parent::__construct($message, $previous);
+
+        $this->controllerClass = $controllerClass;
+        $this->method = $method;
+    }
+
+    /**
+     * @return string
+     */
+    public function getControllerClass()
+    {
+        return $this->controllerClass;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMethod()
+    {
+        return $this->method;
+    }
+}

--- a/src/Pim/Bundle/ApiBundle/Controller/ChannelController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/ChannelController.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Bundle\ApiBundle\Controller;
 
+use Oro\Bundle\SecurityBundle\Annotation\AclAncestor;
 use Pim\Component\Api\Exception\PaginationParametersException;
 use Pim\Component\Api\Pagination\HalPaginator;
 use Pim\Component\Api\Pagination\ParameterValidatorInterface;
@@ -73,8 +74,10 @@ class ChannelController
      * @param Request $request
      *
      * @throws UnprocessableEntityHttpException
+     *
      * @return JsonResponse
      *
+     * @AclAncestor("pim_api_channel_list")
      */
     public function listAction(Request $request)
     {

--- a/src/Pim/Bundle/ApiBundle/Controller/Rest/AttributeController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/Rest/AttributeController.php
@@ -7,6 +7,7 @@ use Akeneo\Component\StorageUtils\Exception\UnknownPropertyException;
 use Akeneo\Component\StorageUtils\Factory\SimpleFactoryInterface;
 use Akeneo\Component\StorageUtils\Saver\SaverInterface;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
+use Oro\Bundle\SecurityBundle\Annotation\AclAncestor;
 use Pim\Bundle\CatalogBundle\Version;
 use Pim\Component\Api\Exception\DocumentedHttpException;
 use Pim\Component\Api\Exception\ViolationHttpException;
@@ -90,6 +91,8 @@ class AttributeController
      * @throws NotFoundHttpException
      *
      * @return JsonResponse
+     *
+     * @AclAncestor("pim_api_attribute_list")
      */
     public function getAction(Request $request, $code)
     {
@@ -107,6 +110,8 @@ class AttributeController
      * @param Request $request
      *
      * @return JsonResponse
+     *
+     * @AclAncestor("pim_api_attribute_list")
      */
     public function listAction(Request $request)
     {
@@ -134,6 +139,8 @@ class AttributeController
      * @throws UnprocessableEntityHttpException
      *
      * @return Response
+     *
+     * @AclAncestor("pim_api_attribute_edit")
      */
     public function createAction(Request $request)
     {

--- a/src/Pim/Bundle/ApiBundle/Controller/Rest/AttributeOptionController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/Rest/AttributeOptionController.php
@@ -7,6 +7,7 @@ use Akeneo\Component\StorageUtils\Exception\UnknownPropertyException;
 use Akeneo\Component\StorageUtils\Factory\SimpleFactoryInterface;
 use Akeneo\Component\StorageUtils\Saver\SaverInterface;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
+use Oro\Bundle\SecurityBundle\Annotation\AclAncestor;
 use Pim\Bundle\CatalogBundle\Version;
 use Pim\Component\Api\Exception\DocumentedHttpException;
 use Pim\Component\Api\Exception\ViolationHttpException;
@@ -105,6 +106,8 @@ class AttributeOptionController
      * @throws NotFoundHttpException
      *
      * @return JsonResponse
+     *
+     * @AclAncestor("pim_api_attribute_option_list")
      */
     public function getAction(Request $request, $attributeCode, $optionCode)
     {
@@ -132,6 +135,8 @@ class AttributeOptionController
      * @param string  $attributeCode
      *
      * @return Response
+     *
+     * @AclAncestor("pim_api_attribute_option_edit")
      */
     public function createAction(Request $request, $attributeCode)
     {

--- a/src/Pim/Bundle/ApiBundle/Controller/Rest/CategoryController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/Rest/CategoryController.php
@@ -8,6 +8,7 @@ use Akeneo\Component\StorageUtils\Exception\UnknownPropertyException;
 use Akeneo\Component\StorageUtils\Factory\SimpleFactoryInterface;
 use Akeneo\Component\StorageUtils\Saver\SaverInterface;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
+use Oro\Bundle\SecurityBundle\Annotation\AclAncestor;
 use Pim\Bundle\CatalogBundle\Version;
 use Pim\Component\Api\Exception\DocumentedHttpException;
 use Pim\Component\Api\Exception\ViolationHttpException;
@@ -90,6 +91,8 @@ class CategoryController
      * @throws NotFoundHttpException
      *
      * @return JsonResponse
+     *
+     * @AclAncestor("pim_api_category_list")
      */
     public function getAction(Request $request, $code)
     {
@@ -107,6 +110,8 @@ class CategoryController
      * @param Request $request
      *
      * @return JsonResponse
+     *
+     * @AclAncestor("pim_api_category_list")
      */
     public function listAction(Request $request)
     {
@@ -134,6 +139,8 @@ class CategoryController
      * @throws UnprocessableEntityHttpException
      *
      * @return Response
+     *
+     * @AclAncestor("pim_api_category_edit")
      */
     public function createAction(Request $request)
     {
@@ -158,6 +165,8 @@ class CategoryController
      * @throws UnprocessableEntityHttpException
      *
      * @return Response
+     *
+     * @AclAncestor("pim_api_category_edit")
      */
     public function partialUpdateAction(Request $request, $code)
     {

--- a/src/Pim/Bundle/ApiBundle/Controller/Rest/FamilyController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/Rest/FamilyController.php
@@ -7,6 +7,7 @@ use Akeneo\Component\StorageUtils\Exception\UnknownPropertyException;
 use Akeneo\Component\StorageUtils\Factory\SimpleFactoryInterface;
 use Akeneo\Component\StorageUtils\Saver\SaverInterface;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
+use Oro\Bundle\SecurityBundle\Annotation\AclAncestor;
 use Pim\Bundle\CatalogBundle\Version;
 use Pim\Component\Api\Exception\DocumentedHttpException;
 use Pim\Component\Api\Exception\ViolationHttpException;
@@ -90,6 +91,8 @@ class FamilyController
      * @throws NotFoundHttpException
      *
      * @return JsonResponse
+     *
+     * @AclAncestor("pim_api_family_list")
      */
     public function getAction(Request $request, $code)
     {
@@ -107,6 +110,8 @@ class FamilyController
      * @param Request $request
      *
      * @return JsonResponse
+     *
+     * @AclAncestor("pim_api_family_list")
      */
     public function listAction(Request $request)
     {
@@ -134,6 +139,8 @@ class FamilyController
      * @throws UnprocessableEntityHttpException
      *
      * @return JsonResponse
+     *
+     * @AclAncestor("pim_api_family_edit")
      */
     public function createAction(Request $request)
     {
@@ -157,6 +164,8 @@ class FamilyController
      * @throws UnprocessableEntityHttpException
      *
      * @return JsonResponse
+     *
+     * @AclAncestor("pim_api_family_edit")
      */
     public function partialUpdateAction(Request $request, $code)
     {

--- a/src/Pim/Bundle/ApiBundle/Resources/config/security.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/security.yml
@@ -1,5 +1,6 @@
 parameters:
     pim_api.security.voter.action_acl.class: Pim\Bundle\ApiBundle\Security\ActionAclVoter
+    pim_api.security.access_denied_handler.class: Pim\Bundle\ApiBundle\Security\AccessDeniedHandler
 
 services:
     pim_api.security.acl.voter.overall_access:
@@ -9,3 +10,6 @@ services:
             - 'pim_api_overall_access'
         tags:
             - { name: security.voter, priority: 200 }
+
+    pim_api.security.access_denied_handler:
+        class: '%pim_api.security.access_denied_handler.class%'

--- a/src/Pim/Bundle/ApiBundle/Resources/translations/messages.en.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/translations/messages.en.yml
@@ -1,7 +1,23 @@
 pim_api:
     acl:
         rights: Web API permissions
+        attribute:
+            edit: Create and update attributes
+            list: List attributes
+        attribute_option:
+            edit: Create and update attribute options
+            list: List attribute options
+        category:
+            edit: Create and update categories
+            list: List categories
+        family:
+            edit: Create and update families
+            list: List families
     acl_group:
         overall_access: Overall Web API access
+        attribute: Attributes
+        attribute_option: Attribute options
+        category: Categories
+        family: Families
 
 rights.api: Web API permissions

--- a/src/Pim/Bundle/ApiBundle/Security/AccessDeniedHandler.php
+++ b/src/Pim/Bundle/ApiBundle/Security/AccessDeniedHandler.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Pim\Bundle\ApiBundle\Security;
+
+use Doctrine\Common\Inflector\Inflector;
+use Oro\Bundle\SecurityBundle\Exception\AccessDeniedException as OroAccessDeniedException;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Symfony\Component\Security\Http\Authorization\AccessDeniedHandlerInterface;
+
+/**
+ * Handler responsible for returning a response with accurate error message when the user doesn't have the permission
+ * to access certain parts of the API.
+ *
+ * @author    Yohan Blain <yohan.blain@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class AccessDeniedHandler implements AccessDeniedHandlerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(Request $request, AccessDeniedException $exception)
+    {
+        return new JsonResponse(
+            [
+                'code'    => Response::HTTP_FORBIDDEN,
+                'message' => $this->getMessage($request, $exception)
+            ],
+            Response::HTTP_FORBIDDEN
+        );
+    }
+
+    protected function getMessage(Request $request, AccessDeniedException $exception)
+    {
+        if ($exception instanceof OroAccessDeniedException) {
+            $actionName = 'GET' === $request->getMethod() ? 'list' : 'create or update';
+
+            preg_match('`\\\\(\w+)Controller`', $exception->getControllerClass(), $matches);
+            $entityName = str_replace('_', ' ', Inflector::tableize(Inflector::pluralize($matches[1])));
+
+            return sprintf('Access forbidden. You are not allowed to %s %s.', $actionName, $entityName);
+        }
+
+        return 'You are not allowed to access the web API.';
+    }
+}

--- a/src/Pim/Bundle/ApiBundle/tests/integration/ApiTestCase.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/ApiTestCase.php
@@ -109,7 +109,7 @@ abstract class ApiTestCase extends WebTestCase
     /**
      * Creates a new OAuth client and returns its client id and secret.
      *
-     * @return array
+     * @return string[]
      */
     protected function createOAuthClient()
     {
@@ -135,7 +135,7 @@ abstract class ApiTestCase extends WebTestCase
      * @param string $username
      * @param string $password
      *
-     * @return array
+     * @return string[]
      */
     protected function authenticate($clientId, $secret, $username, $password)
     {

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Security/AuthorizationIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Security/AuthorizationIntegration.php
@@ -13,11 +13,11 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class AuthorizationIntegration extends ApiTestCase
 {
-    public function testAccessGranted()
+    public function testOverallAccessGranted()
     {
         $client = $this->createAuthenticatedClient();
 
-        $client->request('GET', 'api/rest/v1/categories/master');
+        $client->request('GET', '/api/rest/v1/categories/master');
 
         $standardCategory = [
             'code'   => 'master',
@@ -30,15 +30,317 @@ class AuthorizationIntegration extends ApiTestCase
         $this->assertSame($standardCategory, json_decode($response->getContent(), true));
     }
 
-    public function testAccessDenied()
+    public function testOverallAccessDenied()
     {
-        $client = $this->createAuthenticatedClient([], [], null, null, 'julia', 'julia');
+        $client = $this->createAuthenticatedClient([], [], null, null, 'mary', 'mary');
 
-        $client->request('GET', 'api/rest/v1/categories/master');
+        $client->request('GET', '/api/rest/v1/categories/master');
 
         $expectedResponse = [
             'code'    => 403,
-            'message' => 'Access Denied.',
+            'message' => 'You are not allowed to access the web API.',
+        ];
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
+        $this->assertSame($expectedResponse, json_decode($response->getContent(), true));
+    }
+
+    public function testAccessGrantedForListingAttributes()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $client->request('GET', '/api/rest/v1/attributes');
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+    }
+
+    public function testAccessDeniedForListingAttributes()
+    {
+        $client = $this->createAuthenticatedClient([], [], null, null, 'julia', 'julia');
+
+        $client->request('GET', '/api/rest/v1/attributes');
+
+        $expectedResponse = [
+            'code'    => 403,
+            'message' => 'Access forbidden. You are not allowed to list attributes.',
+        ];
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
+        $this->assertSame($expectedResponse, json_decode($response->getContent(), true));
+    }
+
+    public function testAccessGrantedForEditingAttributes()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data =
+<<<JSON
+    {
+        "code":"an_incomplete_text",
+        "type":"pim_catalog_text",
+        "group":"attributeGroupA"
+    }
+JSON;
+
+        $client->request('POST', '/api/rest/v1/attributes', [], [], [], $data);
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+    }
+
+    public function testAccessDeniedForEditingAttributes()
+    {
+        $client = $this->createAuthenticatedClient([], [], null, null, 'julia', 'julia');
+
+        $data =
+<<<JSON
+    {
+        "code":"an_incomplete_text",
+        "type":"pim_catalog_text",
+        "group":"attributeGroupA"
+    }
+JSON;
+
+        $client->request('POST', '/api/rest/v1/attributes', [], [], [], $data);
+
+        $expectedResponse = [
+            'code'    => 403,
+            'message' => 'Access forbidden. You are not allowed to create or update attributes.',
+        ];
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
+        $this->assertSame($expectedResponse, json_decode($response->getContent(), true));
+    }
+
+    public function testAccessGrantedForListingAttributeOptions()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $client->request('GET', '/api/rest/v1/attributes/a_multi_select/options/optionA');
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+    }
+
+    public function testAccessDeniedForListingAttributeOptions()
+    {
+        $client = $this->createAuthenticatedClient([], [], null, null, 'julia', 'julia');
+
+        $client->request('GET', '/api/rest/v1/attributes/a_multi_select/options/optionA');
+
+        $expectedResponse = [
+            'code'    => 403,
+            'message' => 'Access forbidden. You are not allowed to list attribute options.',
+        ];
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
+        $this->assertSame($expectedResponse, json_decode($response->getContent(), true));
+    }
+
+    public function testAccessGrantedForEditingAttributeOptions()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data =
+<<<JSON
+    {
+        "code":"optionC",
+        "attribute":"a_multi_select",
+        "sort_order":30,
+        "labels":{"en_US":"Option C"}
+    }
+JSON;
+
+        $client->request('POST', '/api/rest/v1/attributes/a_multi_select/options', [], [], [], $data);
+
+        $response = $client->getResponse();
+
+        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+    }
+
+    public function testAccessDeniedForEditingAttributeOptions()
+    {
+        $client = $this->createAuthenticatedClient([], [], null, null, 'julia', 'julia');
+
+        $data =
+<<<JSON
+    {
+        "code":"optionC",
+        "attribute":"a_multi_select",
+        "sort_order":30,
+        "labels":{"en_US":"Option C"}
+    }
+JSON;
+
+        $client->request('POST', '/api/rest/v1/attributes/a_multi_select/options', [], [], [], $data);
+
+        $expectedResponse = [
+            'code'    => 403,
+            'message' => 'Access forbidden. You are not allowed to create or update attribute options.',
+        ];
+
+        $response = $client->getResponse();
+
+        $this->assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
+        $this->assertSame($expectedResponse, json_decode($response->getContent(), true));
+    }
+
+    public function testAccessGrantedForListingCategories()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $client->request('GET', '/api/rest/v1/categories');
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+    }
+
+    public function testAccessDeniedForListingCategories()
+    {
+        $client = $this->createAuthenticatedClient([], [], null, null, 'julia', 'julia');
+
+        $client->request('GET', '/api/rest/v1/categories');
+
+        $expectedResponse = [
+            'code'    => 403,
+            'message' => 'Access forbidden. You are not allowed to list categories.',
+        ];
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
+        $this->assertSame($expectedResponse, json_decode($response->getContent(), true));
+    }
+
+    public function testAccessGrantedForEditingCategories()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data =
+<<<JSON
+    {
+        "code": "new_category"
+    }
+JSON;
+
+        $client->request('POST', '/api/rest/v1/categories', [], [], [], $data);
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+    }
+
+    public function testAccessDeniedForEditingCategories()
+    {
+        $client = $this->createAuthenticatedClient([], [], null, null, 'julia', 'julia');
+
+        $data =
+<<<JSON
+    {
+        "code": "super_new_category"
+    }
+JSON;
+
+        $client->request('POST', '/api/rest/v1/categories', [], [], [], $data);
+
+        $expectedResponse = [
+            'code'    => 403,
+            'message' => 'Access forbidden. You are not allowed to create or update categories.',
+        ];
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
+        $this->assertSame($expectedResponse, json_decode($response->getContent(), true));
+    }
+
+    public function testAccessGrantedForListingChannels()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $client->request('GET', '/api/rest/v1/channels');
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+    }
+
+    public function testAccessDeniedForListingChannels()
+    {
+        $client = $this->createAuthenticatedClient([], [], null, null, 'julia', 'julia');
+
+        $client->request('GET', '/api/rest/v1/channels');
+
+        $expectedResponse = [
+            'code'    => 403,
+            'message' => 'Access forbidden. You are not allowed to list channels.',
+        ];
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
+        $this->assertSame($expectedResponse, json_decode($response->getContent(), true));
+    }
+
+    public function testAccessGrantedForListingFamilies()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $client->request('GET', '/api/rest/v1/families');
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+    }
+
+    public function testAccessDeniedForListingFamilies()
+    {
+        $client = $this->createAuthenticatedClient([], [], null, null, 'julia', 'julia');
+
+        $client->request('GET', '/api/rest/v1/families');
+
+        $expectedResponse = [
+            'code'    => 403,
+            'message' => 'Access forbidden. You are not allowed to list families.',
+        ];
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
+        $this->assertSame($expectedResponse, json_decode($response->getContent(), true));
+    }
+
+    public function testAccessGrantedForEditingFamilies()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data =
+<<<JSON
+    {
+        "code": "new_family"
+    }
+JSON;
+
+        $client->request('POST', '/api/rest/v1/families', [], [], [], $data);
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+    }
+
+    public function testAccessDeniedForEditingFamilies()
+    {
+        $client = $this->createAuthenticatedClient([], [], null, null, 'julia', 'julia');
+
+        $data =
+<<<JSON
+    {
+        "code": "super_new_family"
+    }
+JSON;
+
+        $client->request('POST', '/api/rest/v1/families', [], [], [], $data);
+
+        $expectedResponse = [
+            'code'    => 403,
+            'message' => 'Access forbidden. You are not allowed to create or update families.',
         ];
 
         $response = $client->getResponse();

--- a/src/Pim/Bundle/UserBundle/Resources/views/Role/update.html.twig
+++ b/src/Pim/Bundle/UserBundle/Resources/views/Role/update.html.twig
@@ -132,6 +132,7 @@
                 </div>
 
                 {% set groups = acl_groups() %}
+                {% set groupNames = acl_group_names() %}
 
                 {% for privilegeBlock, privilegeConfig in privilegesConfig %}
                     {% if groups[privilegeBlock] is defined %}
@@ -202,7 +203,7 @@
                                                 <h3 class="AknTabHeader-title">{{ 'System'|trans }}</h3>
                                             </div>
                                             <div class="AknFormContainer AknFormContainer--withPadding acl-group">
-                                                {% for child in form[privilegeBlock].children if child.vars.value.group not in groups and (child.vars.value.extensionKey != 'entity' or child.vars.value.identity.name == '(default)') %}
+                                                {% for child in form[privilegeBlock].children if child.vars.value.group not in groupNames and (child.vars.value.extensionKey != 'entity' or child.vars.value.identity.name == '(default)') %}
                                                     {{ form_widget(child) }}
                                                 {% endfor %}
                                             </div>

--- a/src/Pim/Bundle/UserBundle/Twig/AclGroupsExtension.php
+++ b/src/Pim/Bundle/UserBundle/Twig/AclGroupsExtension.php
@@ -38,16 +38,39 @@ class AclGroupsExtension extends \Twig_Extension
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('acl_groups', [$this, 'getAclGroups'])
+            new \Twig_SimpleFunction('acl_groups', [$this, 'getAclGroups']),
+            new \Twig_SimpleFunction('acl_group_names', [$this, 'getAclGroupNames']),
         ];
     }
 
     /**
-     * Get acl groups
+     * Get ACL groups.
      *
      * @return string[]
      */
     public function getAclGroups()
+    {
+        $config = $this->getConfig();
+
+        return $this->getSortedGroups($config);
+    }
+
+    /**
+     * Get ACL group names.
+     *
+     * @return string[]
+     */
+    public function getAclGroupNames()
+    {
+        $config = $this->getConfig();
+
+        return array_keys($config);
+    }
+
+    /**
+     * @return array
+     */
+    protected function getConfig()
     {
         $config = [];
         foreach ($this->bundles as $class) {
@@ -58,7 +81,7 @@ class AclGroupsExtension extends \Twig_Extension
             }
         }
 
-        return $this->getSortedGroups($config);
+        return $config;
     }
 
     /**
@@ -72,7 +95,7 @@ class AclGroupsExtension extends \Twig_Extension
     protected function getSortedGroups($config)
     {
         $groups = $this->getGroups($config);
-        $groups= $this->sortGroups($groups);
+        $groups = $this->sortGroups($groups);
 
         return $groups;
     }

--- a/src/Pim/Bundle/UserBundle/spec/Twig/AclGroupsExtensionSpec.php
+++ b/src/Pim/Bundle/UserBundle/spec/Twig/AclGroupsExtensionSpec.php
@@ -25,8 +25,9 @@ class AclGroupsExtensionSpec extends ObjectBehavior
     {
         $functions = $this->getFunctions();
 
-        $functions->shouldHaveCount(1);
+        $functions->shouldHaveCount(2);
         $functions[0]->shouldBeAnInstanceOf('\Twig_SimpleFunction');
+        $functions[1]->shouldBeAnInstanceOf('\Twig_SimpleFunction');
     }
 
     function it_provides_a_sorted_list_of_defined_acl_groups()

--- a/tests/catalog/technical/acl.sql
+++ b/tests/catalog/technical/acl.sql
@@ -9,13 +9,28 @@
 /*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
 /*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
 
+-- The following ACL setup means:
+-- Admins: all API rights granted
+-- Managers: overall API access granted but all rights on entities (list and edit) denied
+-- Redactors: overall API access denied
 
 --
 -- Dumping data for table `acl_classes`
 --
 
 /*!40000 ALTER TABLE `acl_classes` DISABLE KEYS */;
-INSERT INTO `acl_classes` VALUES (2,'pim_api_overall_access');
+INSERT INTO `acl_classes` VALUES
+    (1,'pim_api_overall_access'),
+    (2,'pim_api_attribute_list'),
+    (3,'pim_api_attribute_edit'),
+    (4,'pim_api_attribute_option_list'),
+    (5,'pim_api_attribute_option_edit'),
+    (6,'pim_api_category_list'),
+    (7,'pim_api_category_edit'),
+    (8,'pim_api_channel_list'),
+    (9,'pim_api_family_list'),
+    (10,'pim_api_family_edit')
+;
 /*!40000 ALTER TABLE `acl_classes` ENABLE KEYS */;
 
 --
@@ -23,7 +38,18 @@ INSERT INTO `acl_classes` VALUES (2,'pim_api_overall_access');
 --
 
 /*!40000 ALTER TABLE `acl_entries` DISABLE KEYS */;
-INSERT INTO `acl_entries` VALUES (7,2,NULL,2,NULL,1,0,1,'all',0,0),(8,2,NULL,3,NULL,0,0,1,'all',0,0);
+INSERT INTO `acl_entries` VALUES
+    (1,2,NULL,2,NULL,0,0,1,'all',0,0),
+    (2,3,NULL,2,NULL,0,0,1,'all',0,0),
+    (3,4,NULL,2,NULL,0,0,1,'all',0,0),
+    (4,5,NULL,2,NULL,0,0,1,'all',0,0),
+    (5,6,NULL,2,NULL,0,0,1,'all',0,0),
+    (6,7,NULL,2,NULL,0,0,1,'all',0,0),
+    (7,8,NULL,2,NULL,0,0,1,'all',0,0),
+    (8,9,NULL,2,NULL,0,0,1,'all',0,0),
+    (9,10,NULL,2,NULL,0,0,1,'all',0,0),
+    (10,1,NULL,3,NULL,0,0,1,'all',0,0)
+;
 /*!40000 ALTER TABLE `acl_entries` ENABLE KEYS */;
 
 --
@@ -31,7 +57,18 @@ INSERT INTO `acl_entries` VALUES (7,2,NULL,2,NULL,1,0,1,'all',0,0),(8,2,NULL,3,N
 --
 
 /*!40000 ALTER TABLE `acl_object_identities` DISABLE KEYS */;
-INSERT INTO `acl_object_identities` VALUES (3,NULL,2,'action',1);
+INSERT INTO `acl_object_identities` VALUES
+    (1,NULL,1,'action',1),
+    (2,NULL,2,'action',1),
+    (3,NULL,3,'action',1),
+    (4,NULL,4,'action',1),
+    (5,NULL,5,'action',1),
+    (6,NULL,6,'action',1),
+    (7,NULL,7,'action',1),
+    (8,NULL,8,'action',1),
+    (9,NULL,9,'action',1),
+    (10,NULL,10,'action',1)
+;
 /*!40000 ALTER TABLE `acl_object_identities` ENABLE KEYS */;
 
 --
@@ -39,7 +76,18 @@ INSERT INTO `acl_object_identities` VALUES (3,NULL,2,'action',1);
 --
 
 /*!40000 ALTER TABLE `acl_object_identity_ancestors` DISABLE KEYS */;
-INSERT INTO `acl_object_identity_ancestors` VALUES (3,3);
+INSERT INTO `acl_object_identity_ancestors` VALUES
+    (1,1),
+    (2,2),
+    (3,3),
+    (4,4),
+    (5,5),
+    (6,6),
+    (7,7),
+    (8,8),
+    (9,9),
+    (10,10)
+;
 /*!40000 ALTER TABLE `acl_object_identity_ancestors` ENABLE KEYS */;
 
 

--- a/tests/catalog/technical/users.csv
+++ b/tests/catalog/technical/users.csv
@@ -1,3 +1,4 @@
 username;first_name;last_name;email;password;catalog_locale;user_locale;catalog_scope;default_tree;roles;groups;enabled
 admin;John;Doe;admin@example.com;admin;en_US;en_US;ecommerce;master;ROLE_ADMINISTRATOR;IT support;1
 julia;Julia;Stark;julia@example.com;julia;en_US;en_US;ecommerce;master;ROLE_CATALOG_MANAGER;Manager;1
+mary;Mary;Smith;mary@example.com;mary;en_US;en_US;ecommerce;master;ROLE_USER;Redactor;1


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Apply permissions on each entity type (attributes, categories, etc.).

Not sure about how error messages are built in the AccessDeniedHandler, it looks not very robust.
Another solution would be to set hardcoded messages in controllers and access it via reflection. Let me know what you think. (edit: fixed with Doctrine Inflector)

This PR also contains a fix of the permissions edit form (inside the role form).

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | OK
| Changelog updated                 | -
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | OK
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
