### PR TITLE
PIM-6159: Fix number comparator when removing numeric value in the PEF

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -4,6 +4,7 @@
 
 - PIM-6149: Remove version number displayed on login page
 - PIM-6157: Improve product exports speed
+- PIM-6159: Fix number comparator when removing numeric value in the PEF
 
 ## Bug fixes
 

--- a/src/Pim/Component/Catalog/Comparator/Attribute/NumberComparator.php
+++ b/src/Pim/Component/Catalog/Comparator/Attribute/NumberComparator.php
@@ -40,7 +40,7 @@ class NumberComparator implements ComparatorInterface
         $default = ['locale' => null, 'scope' => null, 'data' => null];
         $originals = array_merge($default, $originals);
 
-        if (null === $data['data'] && null === $originals['data']['data']) {
+        if (null === $data['data'] && null === $originals['data']) {
             return null;
         }
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When removing a numeric value in the PEF, it might not work and leave the previous value. This was caused by a typo and worked because of a silent Warning PHP Message:
```php
$originals = ['locale' => null, "scope" => null, "data" => 2];

var_dump(null === $originals['data']['data']);
// bool(true)

$originals = ['locale' => null, "scope" => null, "data" => '2'];

var_dump(null === $originals['data']['data']);
// PHP Warning:  Illegal string offset 'data' in /home/acme/test.php on line 9
// PHP Stack trace:
// PHP   1. {main}() /home/acme/test.php:0
// bool(false)
```

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | Yes
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
