### PR TITLE
API-110: transform doctrine fields into standard format fields

### DIFF
--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/CreateProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/CreateProductIntegration.php
@@ -771,7 +771,7 @@ JSON;
             'message' => 'Validation failed.',
             'errors'  => [
                 [
-                    'field'   => 'values[sku].varchar',
+                    'field'   => 'identifier',
                     'message' => 'This value should not be blank.',
                 ],
             ],
@@ -796,9 +796,65 @@ JSON;
             'message' => 'Validation failed.',
             'errors'  => [
                 [
-                    'field'   => 'values[sku].varchar',
+                    'field'   => 'identifier',
                     'message' => 'This value should not be blank.',
                 ],
+            ],
+        ];
+
+        $response = $client->getResponse();
+
+        $this->assertSame($expectedContent, json_decode($response->getContent(), true));
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+    }
+
+    public function testResponseWhenAttributeValidationFailed()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data =
+<<<JSON
+    {
+        "identifier": "wrong_amount",
+        "values": {
+            "a_scopable_price": [{
+                "locale": null,
+                "scope": "ecommerce",
+                "data": [
+                    { "amount": "string", "currency": "EUR" },
+                    { "amount": 12, "currency": "USD" }
+                ]
+            }],
+            "a_number_float_negative":[{
+                "locale": null,
+                "scope": null,
+                "data": -300
+            }]
+        }
+    }
+JSON;
+
+        $client->request('POST', 'api/rest/v1/products', [], [], [], $data);
+
+        $expectedContent = [
+            'code'    => 422,
+            'message' => 'Validation failed.',
+            'errors'  => [
+                [
+                    'field'     => 'values',
+                    'message'   => 'This value should be a valid number.',
+                    'attribute' => 'a_scopable_price',
+                    'locale'    => null,
+                    'scope'     => 'ecommerce',
+                    'currency'  => 'EUR'
+                ],
+                [
+                    'field'     => 'values',
+                    'message'   => 'This value should be -250 or more.',
+                    'attribute' => 'a_number_float_negative',
+                    'locale'    => null,
+                    'scope'     => null
+                ]
             ],
         ];
 
@@ -826,7 +882,7 @@ JSON;
             'message' => 'Validation failed.',
             'errors'  => [
                 [
-                    'field'   => 'values[sku]',
+                    'field'   => 'identifier',
                     'message' => 'The value simple is already set on another product for the unique attribute sku',
                 ],
             ],

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Attribute/CreateAttributeIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Attribute/CreateAttributeIntegration.php
@@ -602,7 +602,7 @@ JSON;
             'message' => 'Validation failed.',
             'errors'  => [
                 [
-                    'field'   => 'translations[0].locale',
+                    'field'   => 'labels',
                     'message' => 'The locale "" does not exist.',
                 ],
             ],
@@ -658,7 +658,7 @@ JSON;
             'message' => 'Validation failed.',
             'errors'  => [
                 [
-                    'field'   => 'translations[0].locale',
+                    'field'   => 'labels',
                     'message' => 'The locale "foo" does not exist.',
                 ],
             ],

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Category/CreateCategoryIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Category/CreateCategoryIntegration.php
@@ -258,7 +258,7 @@ JSON;
             'message' => 'Validation failed.',
             'errors'  => [
                 [
-                    'field'   => 'translations[0].locale',
+                    'field'   => 'labels',
                     'message' => 'The locale "" does not exist.',
                 ],
             ],
@@ -290,7 +290,7 @@ JSON;
             'message' => 'Validation failed.',
             'errors'  => [
                 [
-                    'field'   => 'translations[0].locale',
+                    'field'   => 'labels',
                     'message' => 'The locale "foo" does not exist.',
                 ],
             ],

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Family/CreateFamilyIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Family/CreateFamilyIntegration.php
@@ -275,7 +275,7 @@ JSON;
             'message' => 'Validation failed.',
             'errors'  => [
                 [
-                    'field'   => 'translations[0].locale',
+                    'field'   => 'labels',
                     'message' => 'The locale "" does not exist.',
                 ],
             ],
@@ -307,7 +307,7 @@ JSON;
             'message' => 'Validation failed.',
             'errors'  => [
                 [
-                    'field'   => 'translations[0].locale',
+                    'field'   => 'labels',
                     'message' => 'The locale "foo" does not exist.',
                 ],
             ],

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/validation/attribute.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/validation/attribute.yml
@@ -168,7 +168,8 @@ Pim\Bundle\CatalogBundle\Entity\AttributeTranslation:
             - Length:
                 max: 100
         locale:
-            - Pim\Component\Catalog\Validator\Constraints\Locale: ~
+            - Pim\Component\Catalog\Validator\Constraints\Locale:
+                propertyPath: labels
 
 Pim\Bundle\CatalogBundle\Entity\AttributeOption:
     constraints:

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/validation/category.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/validation/category.yml
@@ -21,4 +21,5 @@ Pim\Bundle\CatalogBundle\Entity\CategoryTranslation:
             - Length:
                 max: 100
         locale:
-            - Pim\Component\Catalog\Validator\Constraints\Locale: ~
+            - Pim\Component\Catalog\Validator\Constraints\Locale:
+                propertyPath: labels

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/validation/family.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/validation/family.yml
@@ -23,4 +23,5 @@ Pim\Bundle\CatalogBundle\Entity\FamilyTranslation:
             - Length:
                 max: 100
         locale:
-            - Pim\Component\Catalog\Validator\Constraints\Locale: ~
+            - Pim\Component\Catalog\Validator\Constraints\Locale:
+                propertyPath: labels

--- a/src/Pim/Component/Api/Normalizer/Exception/ViolationNormalizer.php
+++ b/src/Pim/Component/Api/Normalizer/Exception/ViolationNormalizer.php
@@ -2,8 +2,13 @@
 
 namespace Pim\Component\Api\Normalizer\Exception;
 
+use Doctrine\Common\Inflector\Inflector;
 use Pim\Component\Api\Exception\ViolationHttpException;
+use Pim\Component\Catalog\AttributeTypes;
+use Pim\Component\Catalog\Model\ProductInterface;
+use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Validator\ConstraintViolationInterface;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
 
 /**
@@ -47,10 +52,72 @@ class ViolationNormalizer implements NormalizerInterface
     protected function normalizeViolations(ConstraintViolationListInterface $violations)
     {
         $errors = [];
+
         foreach ($violations as $violation) {
-            $errors[] = ['field' => $violation->getPropertyPath(), 'message' => $violation->getMessage()];
+            $error = [
+                'field'   => Inflector::tableize($violation->getPropertyPath()),
+                'message' => $violation->getMessage()
+            ];
+
+            if ($violation->getRoot() instanceof ProductInterface &&
+                1 === preg_match('|^values\[(?P<attribute>[a-z0-9-_]+)|i', $violation->getPropertyPath(), $matches)) {
+                $error = $this->getProductValuesErrors($violation, $matches['attribute']);
+            }
+
+            $errors[] = $error;
         }
 
         return $errors;
+    }
+
+    /**
+     * Constraints for product values are not displayed correctly.
+     * For instance, an error for attribute "a_text" will be displayed like that: "values[a_text-fr_FR-ecommerce].varchar"
+     * In the API, the same error will be:
+     * [
+     *    "field": "values",
+     *    "attribute": "a_text",
+     *    "locale": "fr_FR",
+     *    "scope": "ecommerce",
+     *    "message": "..."
+     * ]
+     *
+     * Exception for identifier attribute (which is displayed like "values[sku].varchar"), we will return information like that:
+     * [
+     *    "field": "identifier",
+     *    "message": "..."
+     * ]
+     *
+     * @param ConstraintViolationInterface $violation
+     * @param string                       $attributeCode
+     *
+     * @return array
+     */
+    protected function getProductValuesErrors(ConstraintViolationInterface $violation, $attributeCode)
+    {
+        $productValue = $violation->getRoot()->getValues()[$attributeCode];
+        $attributeType = $productValue->getAttribute()->getAttributeType();
+
+        if (AttributeTypes::IDENTIFIER === $attributeType) {
+            return [
+                'field'     => 'identifier',
+                'message'   => $violation->getMessage()
+            ];
+        }
+
+        $error = [
+            'field'     => 'values',
+            'message'   => $violation->getMessage(),
+            'attribute' => $productValue->getAttribute()->getCode(),
+            'locale'    => $productValue->getLocale(),
+            'scope'     => $productValue->getScope()
+        ];
+
+        if (AttributeTypes::PRICE_COLLECTION === $attributeType &&
+            null !== $violation->getInvalidValue()->getCurrency()) {
+            $error['currency'] = $violation->getInvalidValue()->getCurrency();
+        }
+
+        return $error;
     }
 }

--- a/src/Pim/Component/Api/spec/Normalizer/Exception/ViolationNormalizerSpec.php
+++ b/src/Pim/Component/Api/spec/Normalizer/Exception/ViolationNormalizerSpec.php
@@ -4,6 +4,9 @@ namespace spec\Pim\Component\Api\Normalizer\Exception;
 
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Api\Exception\ViolationHttpException;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\ProductInterface;
+use Pim\Component\Catalog\Model\ProductValueInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationList;
@@ -23,6 +26,118 @@ class ViolationNormalizerSpec extends ObjectBehavior
             'errors'  => [
                 ['field' => 'code', 'message' => 'Not Blank'],
                 ['field' => 'name', 'message' => 'Too long']
+            ]
+        ]);
+    }
+
+    function it_normalizes_an_exception_with_error_on_product_identifier(
+        ViolationHttpException $exception,
+        ConstraintViolationList $constraintViolation,
+        ConstraintViolation $violationCode,
+        ProductInterface $product,
+        \ArrayIterator $iterator,
+        \ArrayIterator $productValues,
+        ProductValueInterface $identifier,
+        AttributeInterface $attribute
+    ) {
+        $attribute->getAttributeType()->willReturn('pim_catalog_identifier');
+        $attribute->getCode()->willReturn('identifier');
+        $identifier->getAttribute()->willReturn($attribute);
+        $product->getValues()->willReturn($productValues);
+        $productValues->rewind()->willReturn($identifier);
+        $valueCount = 1;
+        $productValues->valid()->will(
+            function () use (&$valueCount) {
+                return $valueCount-- > 0;
+            }
+        );
+        $productValues->current()->willReturn($identifier);
+        $productValues->offsetGet('sku')->willReturn($identifier);
+        $productValues->next()->willReturn(null);
+
+        $violationCode->getRoot()->willReturn($product);
+        $violationCode->getMessage()->willReturn('Not Blank');
+        $violationCode->getPropertyPath()->willReturn('values[sku].varchar');
+
+        $constraintViolation->getIterator()->willReturn($iterator);
+        $iterator->rewind()->willReturn($violationCode);
+        $valueCount = 1;
+        $iterator->valid()->will(
+            function () use (&$valueCount) {
+                return $valueCount-- > 0;
+            }
+        );
+        $iterator->current()->willReturn($violationCode);
+        $iterator->next()->willReturn(null);
+
+        $exception->getViolations()->willReturn($constraintViolation);
+        $exception->getStatusCode()->willReturn(422);
+
+        $this->normalize($exception)->shouldReturn([
+            'code'    => Response::HTTP_UNPROCESSABLE_ENTITY,
+            'message' => '',
+            'errors'  => [
+                ['field' => 'identifier', 'message' => 'Not Blank'],
+            ]
+        ]);
+    }
+
+    function it_normalizes_an_exception_with_error_on_attribute_localizable_and_scopable(
+        ViolationHttpException $exception,
+        ConstraintViolationList $constraintViolation,
+        ConstraintViolation $violationDescription,
+        ProductInterface $product,
+        \ArrayIterator $iterator,
+        \ArrayIterator $productValues,
+        ProductValueInterface $description,
+        AttributeInterface $attribute
+    ) {
+        $attribute->getAttributeType()->willReturn('pim_catalog_text');
+        $attribute->getCode()->willReturn('description');
+        $description->getAttribute()->willReturn($attribute);
+        $description->getLocale()->willReturn('en_US');
+        $description->getScope()->willReturn('ecommerce');
+        $product->getValues()->willReturn($productValues);
+        $productValues->rewind()->willReturn($description);
+        $valueCount = 1;
+        $productValues->valid()->will(
+            function () use (&$valueCount) {
+                return $valueCount-- > 0;
+            }
+        );
+        $productValues->current()->willReturn($description);
+        $productValues->offsetGet('description-en_US-ecommerce')->willReturn($description);
+        $productValues->next()->willReturn(null);
+
+        $violationDescription->getRoot()->willReturn($product);
+        $violationDescription->getMessage()->willReturn('Not Blank');
+        $violationDescription->getPropertyPath()->willReturn('values[description-en_US-ecommerce].varchar');
+
+        $constraintViolation->getIterator()->willReturn($iterator);
+        $iterator->rewind()->willReturn($violationDescription);
+        $valueCount = 1;
+        $iterator->valid()->will(
+            function () use (&$valueCount) {
+                return $valueCount-- > 0;
+            }
+        );
+        $iterator->current()->willReturn($violationDescription);
+        $iterator->next()->willReturn(null);
+
+        $exception->getViolations()->willReturn($constraintViolation);
+        $exception->getStatusCode()->willReturn(422);
+
+        $this->normalize($exception)->shouldReturn([
+            'code'    => Response::HTTP_UNPROCESSABLE_ENTITY,
+            'message' => '',
+            'errors'  => [
+                [
+                    'field'     => 'values',
+                    'message'   => 'Not Blank',
+                    'attribute' => 'description',
+                    'locale'    => 'en_US',
+                    'scope'     => 'ecommerce'
+                ],
             ]
         ]);
     }

--- a/src/Pim/Component/Catalog/Updater/Setter/TextAttributeSetter.php
+++ b/src/Pim/Component/Catalog/Updater/Setter/TextAttributeSetter.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Component\Catalog\Updater\Setter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Pim\Component\Catalog\Builder\ProductBuilderInterface;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
@@ -43,6 +44,7 @@ class TextAttributeSetter extends AbstractAttributeSetter
     ) {
         $options = $this->resolver->resolve($options);
         $this->checkLocaleAndScope($attribute, $options['locale'], $options['scope']);
+        $this->checkData($attribute, $data);
 
         $this->setData($product, $attribute, $data, $options['locale'], $options['scope']);
     }
@@ -65,6 +67,22 @@ class TextAttributeSetter extends AbstractAttributeSetter
         if (is_string($data) && '' === trim($data)) {
             $data = null;
         }
+
         $value->setData($data);
+    }
+
+    /**
+     * Check if data is valid
+     *
+     * @param AttributeInterface $attribute
+     * @param mixed              $data
+     *
+     * @throws InvalidPropertyTypeException
+     */
+    protected function checkData(AttributeInterface $attribute, $data)
+    {
+        if (!is_string($data) && null !== $data) {
+            throw InvalidPropertyTypeException::stringExpected($attribute->getCode(), static::class, $data);
+        }
     }
 }

--- a/src/Pim/Component/Catalog/Validator/ConstraintGuesser/MetricGuesser.php
+++ b/src/Pim/Component/Catalog/Validator/ConstraintGuesser/MetricGuesser.php
@@ -21,9 +21,9 @@ class MetricGuesser implements ConstraintGuesserInterface
      */
     public function guessConstraints(AttributeInterface $attribute)
     {
-        return [
-            new ValidMetric()
-        ];
+        $numericGuesser = new NumericGuesser();
+
+        return array_merge([new ValidMetric()], $numericGuesser->guessConstraints($attribute));
     }
 
     /**

--- a/src/Pim/Component/Catalog/Validator/Constraints/Locale.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/Locale.php
@@ -15,4 +15,7 @@ class Locale extends Constraint
 {
     /** @var string */
     public $message = 'The locale "%locale%" does not exist.';
+
+    /** @var string */
+    public $propertyPath = null;
 }

--- a/src/Pim/Component/Catalog/Validator/Constraints/LocaleValidator.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/LocaleValidator.php
@@ -33,6 +33,15 @@ class LocaleValidator extends ConstraintValidator
     {
         $locale = $this->localeRepository->findOneByIdentifier($value);
         if (null === $locale) {
+            if (null !== $constraint->propertyPath) {
+                $this->context->setNode(
+                    $value,
+                    $this->context->getObject(),
+                    $this->context->getMetadata(),
+                    $constraint->propertyPath
+                );
+            }
+
             $this->context->buildViolation(
                 $constraint->message,
                 ['%locale%' => $value]

--- a/src/Pim/Component/Catalog/Validator/Constraints/RangeValidator.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/RangeValidator.php
@@ -66,10 +66,7 @@ class RangeValidator extends BaseRangeValidator
         $message = null;
         $params = [];
 
-        if (!is_numeric($value)) {
-            $message = $constraint->invalidMessage;
-            $params = ['{{ value }}' => $value];
-        } elseif (null !== $constraint->max && $value > $constraint->max) {
+        if (null !== $constraint->max && $value > $constraint->max) {
             $message = $constraint->maxMessage;
             $params = [
                 '{{ value }}' => $value,

--- a/src/Pim/Component/Catalog/spec/Updater/Setter/TextAttributeSetterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Setter/TextAttributeSetterSpec.php
@@ -3,6 +3,7 @@
 namespace spec\Pim\Component\Catalog\Updater\Setter;
 
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Builder\ProductBuilderInterface;
 use Pim\Component\Catalog\Model\AttributeInterface;
@@ -87,7 +88,6 @@ class TextAttributeSetterSpec extends ObjectBehavior
         AttributeInterface $attribute,
         ProductInterface $product1,
         ProductInterface $product2,
-        ProductInterface $product3,
         $builder,
         ProductValue $productValue
     ) {
@@ -219,5 +219,19 @@ class TextAttributeSetterSpec extends ObjectBehavior
                 $e
             )
         )->during('setAttributeData', [$product, $attribute, '', ['locale' => null, 'scope' => 'ecommerce']]);
+    }
+
+    function it_throws_an_exception_when_data_is_not_a_string(
+        AttributeInterface $attribute,
+        ProductInterface $product
+    ) {
+        $attribute->getCode()->willReturn('attributeCode');
+        $this->shouldThrow(
+            InvalidPropertyTypeException::stringExpected(
+                'attributeCode',
+                'Pim\Component\Catalog\Updater\Setter\TextAttributeSetter',
+                []
+            )
+        )->during('setAttributeData', [$product, $attribute, [], ['locale' => null, 'scope' => 'ecommerce']]);
     }
 }

--- a/src/Pim/Component/Catalog/spec/Validator/ConstraintGuesser/MetricGuesserSpec.php
+++ b/src/Pim/Component/Catalog/spec/Validator/ConstraintGuesser/MetricGuesserSpec.php
@@ -34,9 +34,11 @@ class MetricGuesserSpec extends ObjectBehavior
     {
         $constraints = $this->guessConstraints($attribute);
 
-        $constraints->shouldHaveCount(1);
+        $constraints->shouldHaveCount(2);
 
         $constraint = $constraints[0];
         $constraint->shouldBeAnInstanceOf('Pim\Component\Catalog\Validator\Constraints\ValidMetric');
+        $constraint = $constraints[1];
+        $constraint->shouldBeAnInstanceOf('Pim\Component\Catalog\Validator\Constraints\IsNumeric');
     }
 }


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

Sorry, there is some baby fix in this PR, but when I added tests, I found some bugs :)
The point `1` is the initial PR, points `2` & `3` concern bugs fix.

1) Currently, when the standard format is submitted but contain errors, fields returned are doctrine fields (eg. `metricFamily`), not standard format fields (eg. `metric_mamily`).

This PR fix it, it's not an ideal solution as we could have some fields in doctrine which are completely different in the standard format, but for the moment, it's work...

About the propertyPath added in LocaleValidator, without it when a label is wrong, previous message was `translations[0].locale` which means nothing for a user.
I founded this way, but if you have a better solution, I take it.
The other crappy way is to have a mapping directly in ViolationNormalizer :disappointed:

2) About Metric/Price guessers, there was a constraint duplicated for price attribute (we checked twice the value was a numeric, fist time in a isNumericValidator, second time in RangeValidator), so in the response of the API, there was the same error twice.

3) I found a little bug on the TextAttributeSetter, there was no check on type

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
