### PR TITLE
API-77: add root endpoint on API

### DIFF
--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -44,6 +44,10 @@ security:
             pattern:                        ^/api/oauth/v1/token
             security:                       false
 
+        api_index:
+            pattern:                        ^/api/rest/v1$
+            security:                       false
+
         api:
             pattern:                        ^/api
             fos_oauth:                      true
@@ -67,4 +71,5 @@ security:
 
     access_control:
         - { path: ^/admin/, role: ROLE_ADMIN }
+        - { path: ^/api/rest/v1$, role: IS_AUTHENTICATED_ANONYMOUSLY }
         - { path: ^/api/, role: pim_api_overall_access }

--- a/src/Pim/Bundle/ApiBundle/Controller/AttributeController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/AttributeController.php
@@ -289,7 +289,7 @@ class AttributeController
     protected function getResponse(AttributeInterface $attribute, $status)
     {
         $response = new Response(null, $status);
-        $url = $this->router->generate('pim_api_rest_attribute_get', ['code' => $attribute->getCode()], true);
+        $url = $this->router->generate('pim_api_attribute_get', ['code' => $attribute->getCode()], true);
         $response->headers->set('Location', $url);
 
         return $response;

--- a/src/Pim/Bundle/ApiBundle/Controller/AttributeOptionController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/AttributeOptionController.php
@@ -271,7 +271,7 @@ class AttributeOptionController
     {
         $response = new Response(null, Response::HTTP_CREATED);
         $route = $this->router->generate(
-            'pim_api_rest_attribute_option_get',
+            'pim_api_attribute_option_get',
             [
                 'attributeCode' => $attribute->getCode(),
                 'optionCode'    => $attributeOption->getCode(),

--- a/src/Pim/Bundle/ApiBundle/Controller/CategoryController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/CategoryController.php
@@ -268,7 +268,7 @@ class CategoryController
     protected function getCreateResponse(CategoryInterface $category)
     {
         $response = new Response(null, Response::HTTP_CREATED);
-        $route = $this->router->generate('pim_api_rest_category_get', ['code' => $category->getCode()], true);
+        $route = $this->router->generate('pim_api_category_get', ['code' => $category->getCode()], true);
         $response->headers->set('Location', $route);
 
         return $response;
@@ -284,7 +284,7 @@ class CategoryController
     protected function getUpdateResponse(CategoryInterface $category)
     {
         $response = new Response(null, Response::HTTP_NO_CONTENT);
-        $route = $this->router->generate('pim_api_rest_category_get', ['code' => $category->getCode()], true);
+        $route = $this->router->generate('pim_api_category_get', ['code' => $category->getCode()], true);
         $response->headers->set('Location', $route);
 
         return $response;

--- a/src/Pim/Bundle/ApiBundle/Controller/ChannelController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/ChannelController.php
@@ -103,8 +103,8 @@ class ChannelController
             $channelsApi,
             array_merge($request->query->all(), $queryParameters),
             $count,
-            'pim_api_rest_channel_list',
-            'pim_api_rest_channel_get',
+            'pim_api_channel_list',
+            'pim_api_channel_get',
             'code'
         );
 

--- a/src/Pim/Bundle/ApiBundle/Controller/FamilyController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/FamilyController.php
@@ -267,7 +267,7 @@ class FamilyController
     protected function getCreateResponse(FamilyInterface $family)
     {
         $response = new Response(null, Response::HTTP_CREATED);
-        $route = $this->router->generate('pim_api_rest_family_get', ['code' => $family->getCode()], true);
+        $route = $this->router->generate('pim_api_family_get', ['code' => $family->getCode()], true);
         $response->headers->set('Location', $route);
 
         return $response;
@@ -283,7 +283,7 @@ class FamilyController
     protected function getUpdateResponse(FamilyInterface $family)
     {
         $response = new Response(null, Response::HTTP_NO_CONTENT);
-        $route = $this->router->generate('pim_api_rest_family_get', ['code' => $family->getCode()], true);
+        $route = $this->router->generate('pim_api_family_get', ['code' => $family->getCode()], true);
         $response->headers->set('Location', $route);
 
         return $response;

--- a/src/Pim/Bundle/ApiBundle/Controller/RootEndpointController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/RootEndpointController.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Pim\Bundle\ApiBundle\Controller;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Router;
+
+/**
+ * Root endpoint to show all API routes
+ *
+ * @author    Marie Bochu <marie.bochu@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class RootEndpointController
+{
+    /** @var Router */
+    protected $router;
+
+    /**
+     * @param Router $router
+     */
+    public function __construct(Router $router)
+    {
+        $this->router = $router;
+    }
+
+    /**
+     * @param Request $request
+     *
+     * @return JsonResponse
+     */
+    public function getAction(Request $request)
+    {
+        $routes = $this->router->getRouteCollection();
+
+        $apiRoutes = [
+            'host'           => $request->getSchemeAndHttpHost(),
+            'authentication' => [],
+            'routes'         => []
+        ];
+
+        $routes->remove($request->attributes->get('_route'));
+
+        foreach ($routes as $key => $route) {
+            if (0 === strpos($route->getPath(), '/api')) {
+                $type = 0 === strpos($route->getPath(), '/api/oauth') ? 'authentication' : 'routes';
+
+                $apiRoutes[$type][$key] = [
+                    'route'   => $route->getPath(),
+                    'methods' => $route->getMethods()
+                ];
+            }
+        }
+
+        return new JsonResponse($apiRoutes);
+    }
+}

--- a/src/Pim/Bundle/ApiBundle/Resources/config/controllers.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/controllers.yml
@@ -6,6 +6,7 @@ parameters:
     pim_api.controller.channel.class: Pim\Bundle\ApiBundle\Controller\ChannelController
     pim_api.controller.token.class: Pim\Bundle\ApiBundle\Controller\TokenController
     pim_api.controller.product.class: Pim\Bundle\ApiBundle\Controller\ProductController
+    pim_api.controller.root_endpoint.class: Pim\Bundle\ApiBundle\Controller\RootEndpointController
 
 services:
     pim_api.controller.category:
@@ -91,3 +92,8 @@ services:
             - '@router'
             - '@pim_catalog.comparator.filter.product'
             - 'https://docs.akeneo.com/%s/reference/standard_format/products.html'
+
+    pim_api.controller.root_endpoint:
+        class: '%pim_api.controller.root_endpoint.class%'
+        arguments:
+            - '@router'

--- a/src/Pim/Bundle/ApiBundle/Resources/config/routing.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/routing.yml
@@ -22,3 +22,7 @@ fos_oauth_server_token:
     path: /oauth/v1/token
     defaults: { _controller: pim_api.controller.token:tokenAction }
     methods: [POST]
+
+endpoint:
+    resource: '@PimApiBundle/Resources/config/routing/endpoint.yml'
+    prefix: /rest

--- a/src/Pim/Bundle/ApiBundle/Resources/config/routing/attribute.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/routing/attribute.yml
@@ -1,29 +1,29 @@
-pim_api_rest_attribute_list:
+pim_api_attribute_list:
     path: /attributes
     defaults: { _controller: pim_api.controller.attribute:listAction, _format: json }
     methods: [GET]
 
-pim_api_rest_attribute_create:
+pim_api_attribute_create:
     path: /attributes
     defaults: { _controller: pim_api.controller.attribute:createAction, _format: json }
     methods: [POST]
 
-pim_api_rest_attribute_update:
+pim_api_attribute_update:
     path: /attributes/{code}
     defaults: { _controller: pim_api.controller.attribute:partialUpdateAction, _format: json }
     methods: [PATCH]
 
-pim_api_rest_attribute_get:
+pim_api_attribute_get:
     path: /attributes/{code}
     defaults: { _controller: pim_api.controller.attribute:getAction, _format: json }
     methods: [GET]
 
-pim_api_rest_attribute_option_create:
+pim_api_attribute_option_create:
     path: /attributes/{attributeCode}/options
     defaults: { _controller: pim_api.controller.attribute_option:createAction, _format: json }
     methods: [POST]
 
-pim_api_rest_attribute_option_get:
+pim_api_attribute_option_get:
     path: /attributes/{attributeCode}/options/{optionCode}
     defaults: { _controller: pim_api.controller.attribute_option:getAction, _format: json }
     methods: [GET]

--- a/src/Pim/Bundle/ApiBundle/Resources/config/routing/category.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/routing/category.yml
@@ -1,19 +1,19 @@
-pim_api_rest_category_list:
+pim_api_category_list:
     path: /categories
     defaults: { _controller: pim_api.controller.category:listAction, _format: json }
     methods: [GET]
 
-pim_api_rest_category_get:
+pim_api_category_get:
     path: /categories/{code}
     defaults: { _controller: pim_api.controller.category:getAction, _format: json }
     methods: [GET]
 
-pim_api_rest_controller_create:
+pim_api_category_create:
     path: /categories
     defaults: { _controller: pim_api.controller.category:createAction, _format: json}
     methods: [POST]
 
-pim_api_rest_controller_partial_update:
+pim_api_category_partial_update:
     path: /categories/{code}
     defaults: { _controller: pim_api.controller.category:partialUpdateAction, _format: json}
     methods: [PATCH]

--- a/src/Pim/Bundle/ApiBundle/Resources/config/routing/channel.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/routing/channel.yml
@@ -1,9 +1,9 @@
-pim_api_rest_channel_list:
+pim_api_channel_list:
     path: /channels
     defaults: { _controller: pim_api.controller.channel:listAction, _format: json }
     methods: [GET]
 
-pim_api_rest_channel_get:
+pim_api_channel_get:
     path: /channels/{code}
     defaults: { _controller: pim_api.controller.channel:getAction, _format: json }
     methods: [GET]

--- a/src/Pim/Bundle/ApiBundle/Resources/config/routing/endpoint.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/routing/endpoint.yml
@@ -1,4 +1,4 @@
-pim_api_rest_root_endpoint:
+pim_api_root_endpoint:
     path: v1
     defaults: { _controller: pim_api.controller.root_endpoint:getAction, _format: json }
     methods: [GET]

--- a/src/Pim/Bundle/ApiBundle/Resources/config/routing/endpoint.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/routing/endpoint.yml
@@ -1,0 +1,4 @@
+pim_api_rest_root_endpoint:
+    path: v1
+    defaults: { _controller: pim_api.controller.root_endpoint:getAction, _format: json }
+    methods: [GET]

--- a/src/Pim/Bundle/ApiBundle/Resources/config/routing/family.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/routing/family.yml
@@ -1,19 +1,19 @@
-pim_api_rest_family_list:
+pim_api_family_list:
     path: /families
     defaults: { _controller: pim_api.controller.family:listAction, _format: json }
     methods: [GET]
 
-pim_api_rest_family_get:
+pim_api_family_get:
     path: /families/{code}
     defaults: { _controller: pim_api.controller.family:getAction, _format: json }
     methods: [GET]
 
-pim_api_rest_family_create:
+pim_api_family_create:
     path: /families
     defaults: { _controller: pim_api.controller.family:createAction, _format: json }
     methods: [POST]
 
-pim_api_rest_family_partial_update:
+pim_api_family_partial_update:
     path: /families/{code}
     defaults: { _controller: pim_api.controller.family:partialUpdateAction, _format: json }
     methods: [PATCH]

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/RootEndpointIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/RootEndpointIntegration.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Pim\Bundle\ApiBundle\tests\integration\Controller;
+
+use Akeneo\Test\Integration\Configuration;
+use Pim\Bundle\ApiBundle\tests\integration\ApiTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+class RootEndpointIntegration extends ApiTestCase
+{
+    public function testGetEndpoint()
+    {
+        $client = static::createClient();
+        $client->request('GET', 'api/rest/v1');
+
+        $expected =
+<<<JSON
+    {
+        "host": "http://localhost",
+        "authentication": {
+            "fos_oauth_server_token": {
+                "route": "/api/oauth/v1/token",
+                "methods": ["POST"]
+            }
+        },
+        "routes": {
+            "pim_api_rest_category_list": {
+                "route": "/api/rest/v1/categories",
+                "methods": ["GET"]
+            },
+            "pim_api_rest_category_get": {
+                "route": "/api/rest/v1/categories/{code}",
+                "methods": ["GET"]
+            },
+            "pim_api_rest_controller_create": {
+                "route": "/api/rest/v1/categories",
+                "methods": ["POST"]
+            },
+            "pim_api_rest_controller_partial_update": {
+                "route": "/api/rest/v1/categories/{code}",
+                "methods": ["PATCH"]
+            },
+            "pim_api_rest_family_list": {
+                "route": "/api/rest/v1/families",
+                "methods": ["GET"]
+            },
+            "pim_api_rest_family_get": {
+                "route": "/api/rest/v1/families/{code}",
+                "methods": ["GET"]
+            },
+            "pim_api_rest_family_create": {
+                "route": "/api/rest/v1/families",
+                "methods": ["POST"]
+            },
+            "pim_api_rest_family_partial_update": {
+                "route": "/api/rest/v1/families/{code}",
+                "methods": ["PATCH"]
+            },
+            "pim_api_rest_attribute_list": {
+                "route": "/api/rest/v1/attributes",
+                "methods": ["GET"]
+            },
+            "pim_api_rest_attribute_create": {
+                "route": "/api/rest/v1/attributes",
+                "methods": ["POST"]
+            },
+            "pim_api_rest_attribute_update": {
+                "route": "/api/rest/v1/attributes/{code}",
+                "methods": ["PATCH"]
+            },
+            "pim_api_rest_attribute_get": {
+                "route": "/api/rest/v1/attributes/{code}",
+                "methods": ["GET"]
+            },
+            "pim_api_rest_attribute_option_create": {
+                "route": "/api/rest/v1/attributes/{attributeCode}/options",
+                "methods": ["POST"]
+            },
+            "pim_api_rest_attribute_option_get": {
+                "route": "/api/rest/v1/attributes/{attributeCode}/options/{optionCode}",
+                "methods": ["GET"]
+            },
+            "pim_api_rest_channel_list": {
+                "route": "/api/rest/v1/channels",
+                "methods": ["GET"]
+            },
+            "pim_api_rest_channel_get": {
+                "route": "/api/rest/v1/channels/{code}",
+                "methods": ["GET"]
+            },
+            "pim_api_product_list": {
+                "route": "/api/rest/v1/products",
+                "methods": ["GET"]
+            },
+            "pim_api_product_get": {
+                "route": "/api/rest/v1/products/{code}",
+                "methods": ["GET"]
+            },
+            "pim_api_product_delete": {
+                "route": "/api/rest/v1/products/{code}",
+                "methods": ["DELETE"]
+            }
+        }
+    }
+JSON;
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertJsonStringEqualsJsonString($expected, $response->getContent());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return new Configuration(
+            [Configuration::getTechnicalCatalogPath()],
+            false
+        );
+    }
+}

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/RootEndpointIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/RootEndpointIntegration.php
@@ -24,67 +24,67 @@ class RootEndpointIntegration extends ApiTestCase
             }
         },
         "routes": {
-            "pim_api_rest_category_list": {
+            "pim_api_category_list": {
                 "route": "/api/rest/v1/categories",
                 "methods": ["GET"]
             },
-            "pim_api_rest_category_get": {
+            "pim_api_category_get": {
                 "route": "/api/rest/v1/categories/{code}",
                 "methods": ["GET"]
             },
-            "pim_api_rest_controller_create": {
+            "pim_api_category_create": {
                 "route": "/api/rest/v1/categories",
                 "methods": ["POST"]
             },
-            "pim_api_rest_controller_partial_update": {
+            "pim_api_category_partial_update": {
                 "route": "/api/rest/v1/categories/{code}",
                 "methods": ["PATCH"]
             },
-            "pim_api_rest_family_list": {
+            "pim_api_family_list": {
                 "route": "/api/rest/v1/families",
                 "methods": ["GET"]
             },
-            "pim_api_rest_family_get": {
+            "pim_api_family_get": {
                 "route": "/api/rest/v1/families/{code}",
                 "methods": ["GET"]
             },
-            "pim_api_rest_family_create": {
+            "pim_api_family_create": {
                 "route": "/api/rest/v1/families",
                 "methods": ["POST"]
             },
-            "pim_api_rest_family_partial_update": {
+            "pim_api_family_partial_update": {
                 "route": "/api/rest/v1/families/{code}",
                 "methods": ["PATCH"]
             },
-            "pim_api_rest_attribute_list": {
+            "pim_api_attribute_list": {
                 "route": "/api/rest/v1/attributes",
                 "methods": ["GET"]
             },
-            "pim_api_rest_attribute_create": {
+            "pim_api_attribute_create": {
                 "route": "/api/rest/v1/attributes",
                 "methods": ["POST"]
             },
-            "pim_api_rest_attribute_update": {
+            "pim_api_attribute_update": {
                 "route": "/api/rest/v1/attributes/{code}",
                 "methods": ["PATCH"]
             },
-            "pim_api_rest_attribute_get": {
+            "pim_api_attribute_get": {
                 "route": "/api/rest/v1/attributes/{code}",
                 "methods": ["GET"]
             },
-            "pim_api_rest_attribute_option_create": {
+            "pim_api_attribute_option_create": {
                 "route": "/api/rest/v1/attributes/{attributeCode}/options",
                 "methods": ["POST"]
             },
-            "pim_api_rest_attribute_option_get": {
+            "pim_api_attribute_option_get": {
                 "route": "/api/rest/v1/attributes/{attributeCode}/options/{optionCode}",
                 "methods": ["GET"]
             },
-            "pim_api_rest_channel_list": {
+            "pim_api_channel_list": {
                 "route": "/api/rest/v1/channels",
                 "methods": ["GET"]
             },
-            "pim_api_rest_channel_get": {
+            "pim_api_channel_get": {
                 "route": "/api/rest/v1/channels/{code}",
                 "methods": ["GET"]
             },
@@ -95,6 +95,10 @@ class RootEndpointIntegration extends ApiTestCase
             "pim_api_product_get": {
                 "route": "/api/rest/v1/products/{code}",
                 "methods": ["GET"]
+            },
+            "pim_api_product_create": {
+                "route": "/api/rest/v1/products",
+                "methods": ["POST"]
             },
             "pim_api_product_delete": {
                 "route": "/api/rest/v1/products/{code}",


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

Add a root endpoint to help userw to discover all routes in the API.

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
