### PR TITLE
Display channel code if no translation available in the UI Locale

### DIFF
--- a/features/channel/display_channel_on_datagrid.feature
+++ b/features/channel/display_channel_on_datagrid.feature
@@ -1,0 +1,21 @@
+@javascript
+Feature: Display channels on the datagrid
+  In order to display existing channels
+  As a user
+  I need to be able to display available channels on the datagrid
+
+  Background:
+    Given a "footwear" catalog configuration
+
+  Scenario: Display code of channel if no translation is available for the UI language
+    Given I am logged in as "Julia"
+    When I am on the products page
+    Then I should see the text "Tablet"
+    When I am on the my account page
+    And I press the "Edit" button
+    And I visit the "Interfaces" tab
+    And I fill in the following information:
+      | UI locale | Spanish (Mexico) |
+    And I press the "Save" button
+    And I am on the products page
+    Then I should see the text "[tablet]"

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/ChannelRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/ChannelRepository.php
@@ -122,10 +122,9 @@ class ChannelRepository extends EntityRepository implements ChannelRepositoryInt
     public function getLabelsIndexedByCode($localeCode)
     {
         $qb = $this->createQueryBuilder('c');
-        $qb->leftJoin('c.translations', 'tr');
-        $qb->select('c.code, tr.label');
+        $qb->leftJoin('c.translations', 'tr', 'WITH', 'tr.locale = :userLocaleCode');
+        $qb->select('c.code, COALESCE(NULLIF(tr.label, \'\'), CONCAT(\'[\', c.code, \']\')) as label');
 
-        $qb->where('tr.locale = :userLocaleCode');
         $qb->setParameter('userLocaleCode', $localeCode);
 
         $channels = $qb->getQuery()->getArrayResult();


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Since #5467, we now use UI locale correctly.
Problem is that, if no translation is available for channel label, it's silently failing on the grid and the scope selector is broken.

This PR makes consistent behavior of label of scope like other entities: if no translation is available for the UI locale, it fallbacks on the code.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | OK
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
