### PR TITLE
PIM-6161: Fix tooltips and validation errors rendering on Import/Export builder

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -2,6 +2,7 @@
 
 ## Bug Fixes
 
+- PIM-6161: Fix Tooltips and errors rendering on Import/Export Builder
 - GITHUB-5038: Fixed job name visibility checker to also check additional config
 - GITHUB-5062: Fixed unit conversion for ElectricCharge, cheers @gplanchat!
 - GITHUB-5294: Fixed infinite loading if no attribute is configured as a product identifier, cheers @gplanchat!

--- a/features/Context/AssertionContext.php
+++ b/features/Context/AssertionContext.php
@@ -98,6 +98,20 @@ class AssertionContext extends RawMinkContext
     }
 
     /**
+     * @param string $message
+     *
+     * @Then /^I should see the tooltip "([^"]*)"$/
+     */
+    public function iShouldSeeTheTooltip($message)
+    {
+        $this->spin(function () use ($message) {
+            $tooltipMessages = $this->getCurrentPage()->getTooltipMessages();
+
+            return in_array($message, $tooltipMessages);
+        }, sprintf('Expecting to see tooltip "%s", not found', $message));
+    }
+
+    /**
      * @param string $error
      *
      * @Then /^I should not see(?: a)? validation (?:error|tooltip) "([^"]*)"$/

--- a/features/Context/Page/Base/Form.php
+++ b/features/Context/Page/Base/Form.php
@@ -44,8 +44,9 @@ class Form extends Base
                 'Save'                            => ['css' => '.AknButton--apply'],
                 'Panel sidebar'                   => [
                     'css'        => '.edit-form > .content',
-                    'decorators' => ['Pim\Behat\Decorator\Page\PanelableDecorator']
-                ]
+                    'decorators' => ['Pim\Behat\Decorator\Page\PanelableDecorator'],
+                ],
+                'Tooltips'                         => ['css' => '.icon-info-sign'],
             ],
             $this->elements
         );
@@ -243,6 +244,23 @@ class Form extends Base
         }
 
         return $errors;
+    }
+
+    /**
+     * Get tooltips messages
+     *
+     * @return string[]
+     */
+    public function getTooltipMessages()
+    {
+        $tooltips = $this->findAll('css', $this->elements['Tooltips']['css']);
+
+        $messages = [];
+        foreach ($tooltips as $tooltip) {
+            $messages[] = $tooltip->getAttribute('data-original-title');
+        }
+
+        return $messages;
     }
 
     /**

--- a/features/export/product-export-builder/show_tooltips_and_errors.feature
+++ b/features/export/product-export-builder/show_tooltips_and_errors.feature
@@ -1,0 +1,40 @@
+@javascript
+Feature: Show tooltips and validation errors on export builder
+  In order to know what I can put in the product export builder fields
+  As a product manager
+  I need to be able to configure a product export by reading the tooltips and validation errors
+
+  Background:
+    Given a "footwear" catalog configuration
+
+  Scenario: Successfully show tooltips on export builder
+    Given I am logged in as "Julia"
+    When I am on the "csv_footwear_product_export" export job edit page
+    Then I should see the tooltip "Determine the decimal separator"
+    And I should see the tooltip "Determine the format of date fields"
+    And I should see the tooltip "Where to write the generated file on the file system"
+    And I should see the tooltip "One character used to set the field delimiter"
+    And I should see the tooltip "One character used to set the field enclosure"
+    And I should see the tooltip "Whether or not to print the column name"
+    And I should see the tooltip "Whether or not to export product files and images"
+    When I visit the "Content" tab
+    Then I should see the tooltip "The channel defines the scope for product values, the locales used to select data, and the tree used to select products."
+    And I should see the tooltip "The locales defines the localized product values to export. Ex: only product information in French."
+    And I should see the tooltip "Select the product information to export. Ex: only the technical attributes."
+    And I should see the tooltip "Select the products to export by their family. Ex: Export only the shoes and dresses."
+    And I should see the tooltip "Select the products to export by their status. Ex: Export products whatsoever their status."
+    And I should see the tooltip "Select the products to export by their completeness."
+    And I should see the tooltip "Use the product categories in the tree (defined by the channel above) to select the products to export"
+    And I should see the tooltip "Identifiers of products you want to export separated by commas, spaces or line breaks"
+
+  Scenario: Succefully show error messages on export builder
+    Given I am logged in as "Julia"
+    When I am on the "csv_footwear_product_export" export job edit page
+    And I change the Label to ""
+    And I change the Delimiter to ""
+    And I change the Enclosure to ""
+    When I press "Save"
+    Then I should see the text "The job profile could not be updated."
+    And I should see the text "This value should not be blank."
+    And I should see the text "The value must be one of , or ; or |"
+    And I should see the text "The value must be one of \" or '"

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_base_export_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_base_export_edit.yml
@@ -63,7 +63,7 @@ extensions:
             fieldCode: configuration.filePath
             readOnly: false
             label: pim_enrich.form.job_instance.tab.properties.file_path.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.filePath.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.file_path.help
 
     pim-job-instance-csv-base-export-edit-properties-delimiter:
         module: pim/job/common/edit/field/text
@@ -74,7 +74,7 @@ extensions:
             fieldCode: configuration.delimiter
             readOnly: false
             label: pim_enrich.form.job_instance.tab.properties.delimiter.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.delimiter.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.delimiter.help
 
     pim-job-instance-csv-base-export-edit-properties-enclosure:
         module: pim/job/common/edit/field/text
@@ -85,7 +85,7 @@ extensions:
             fieldCode: configuration.enclosure
             readOnly: false
             label: pim_enrich.form.job_instance.tab.properties.enclosure.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.enclosure.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.enclosure.help
 
     pim-job-instance-csv-base-export-edit-properties-with-header:
         module: pim/job/common/edit/field/switch
@@ -96,7 +96,7 @@ extensions:
             fieldCode: configuration.withHeader
             readOnly: false
             label: pim_enrich.form.job_instance.tab.properties.with_header.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.withHeader.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.with_header.help
 
     pim-job-instance-csv-base-export-edit-label:
         module: pim/job/common/edit/label

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_base_export_show.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_base_export_show.yml
@@ -58,7 +58,7 @@ extensions:
             fieldCode: configuration.filePath
             readOnly: true
             label: pim_enrich.form.job_instance.tab.properties.file_path.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.filePath.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.file_path.help
 
     pim-job-instance-csv-base-export-show-properties-delimiter:
         module: pim/job/common/edit/field/text
@@ -69,7 +69,7 @@ extensions:
             fieldCode: configuration.delimiter
             readOnly: true
             label: pim_enrich.form.job_instance.tab.properties.delimiter.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.delimiter.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.delimiter.help
 
     pim-job-instance-csv-base-export-show-properties-enclosure:
         module: pim/job/common/edit/field/text
@@ -80,7 +80,7 @@ extensions:
             fieldCode: configuration.enclosure
             readOnly: true
             label: pim_enrich.form.job_instance.tab.properties.enclosure.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.enclosure.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.enclosure.help
 
     pim-job-instance-csv-base-export-show-properties-with-header:
         module: pim/job/common/edit/field/switch
@@ -91,7 +91,7 @@ extensions:
             fieldCode: configuration.withHeader
             readOnly: true
             label: pim_enrich.form.job_instance.tab.properties.with_header.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.withHeader.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.with_header.help
 
     pim-job-instance-csv-base-export-show-label:
         module: pim/job/common/edit/label

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_base_import_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_base_import_edit.yml
@@ -63,7 +63,7 @@ extensions:
             fieldCode: configuration.filePath
             readOnly: false
             label: pim_enrich.form.job_instance.tab.properties.file_path.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.filePath.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.file_path.help
 
     pim-job-instance-csv-base-import-show-properties-escape:
         module: pim/job/common/edit/field/text
@@ -74,7 +74,7 @@ extensions:
             fieldCode: configuration.escape
             readOnly: false
             label: pim_enrich.form.job_instance.tab.properties.escape.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.escape.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.escape.help
 
     pim-job-instance-csv-base-import-edit-properties-file-upload:
         module: pim/job/common/edit/field/switch
@@ -85,7 +85,7 @@ extensions:
             fieldCode: configuration.uploadAllowed
             readOnly: false
             label: pim_enrich.form.job_instance.tab.properties.upload_allowed.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.uploadAllowed.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.upload_allowed.help
 
     pim-job-instance-csv-base-import-edit-properties-delimiter:
         module: pim/job/common/edit/field/text
@@ -96,7 +96,7 @@ extensions:
             fieldCode: configuration.delimiter
             readOnly: false
             label: pim_enrich.form.job_instance.tab.properties.delimiter.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.delimiter.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.delimiter.help
 
     pim-job-instance-csv-base-import-edit-properties-enclosure:
         module: pim/job/common/edit/field/text
@@ -107,7 +107,7 @@ extensions:
             fieldCode: configuration.enclosure
             readOnly: false
             label: pim_enrich.form.job_instance.tab.properties.enclosure.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.enclosure.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.enclosure.help
 
     pim-job-instance-csv-base-import-edit-label:
         module: pim/job/common/edit/label

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_base_import_show.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_base_import_show.yml
@@ -64,7 +64,7 @@ extensions:
             fieldCode: configuration.filePath
             readOnly: true
             label: pim_enrich.form.job_instance.tab.properties.file_path.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.filePath.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.file_path.help
 
     pim-job-instance-csv-base-import-show-properties-escape:
         module: pim/job/common/edit/field/text
@@ -75,7 +75,7 @@ extensions:
             fieldCode: configuration.escape
             readOnly: true
             label: pim_enrich.form.job_instance.tab.properties.escape.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.escape.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.escape.help
 
     pim-job-instance-csv-base-import-show-properties-delimiter:
         module: pim/job/common/edit/field/text
@@ -86,7 +86,7 @@ extensions:
             fieldCode: configuration.delimiter
             readOnly: true
             label: pim_enrich.form.job_instance.tab.properties.delimiter.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.delimiter.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.delimiter.help
 
     pim-job-instance-csv-base-import-show-properties-enclosure:
         module: pim/job/common/edit/field/text
@@ -97,7 +97,7 @@ extensions:
             fieldCode: configuration.enclosure
             readOnly: true
             label: pim_enrich.form.job_instance.tab.properties.enclosure.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.enclosure.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.enclosure.help
 
     pim-job-instance-csv-base-import-show-properties-file-upload:
         module: pim/job/common/edit/field/switch
@@ -108,7 +108,7 @@ extensions:
             fieldCode: configuration.uploadAllowed
             readOnly: true
             label: pim_enrich.form.job_instance.tab.properties.upload_allowed.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.uploadAllowed.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.upload_allowed.help
 
     pim-job-instance-csv-base-import-show-label:
         module: pim/job/common/edit/label

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_export_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_export_edit.yml
@@ -73,7 +73,7 @@ extensions:
             fieldCode: configuration.decimalSeparator
             readOnly: false
             label: pim_enrich.form.job_instance.tab.properties.decimal_separator.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.decimal_separator.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.decimal_separator.help
 
     pim-job-instance-csv-product-export-edit-properties-date-format:
         module: pim/job/product/edit/field/date-format
@@ -84,7 +84,7 @@ extensions:
             fieldCode: configuration.dateFormat
             readOnly: false
             label: pim_enrich.form.job_instance.tab.properties.date_format.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.date_format.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.date_format.help
 
     pim-job-instance-csv-product-export-edit-properties-file-path:
         module: pim/job/common/edit/field/text
@@ -95,7 +95,7 @@ extensions:
             fieldCode: configuration.filePath
             readOnly: false
             label: pim_enrich.form.job_instance.tab.properties.file_path.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.file_path.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.file_path.help
 
     pim-job-instance-csv-product-export-edit-properties-delimiter:
         module: pim/job/common/edit/field/text
@@ -106,7 +106,7 @@ extensions:
             fieldCode: configuration.delimiter
             readOnly: false
             label: pim_enrich.form.job_instance.tab.properties.delimiter.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.delimiter.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.delimiter.help
 
     pim-job-instance-csv-product-export-edit-properties-enclosure:
         module: pim/job/common/edit/field/text
@@ -117,7 +117,7 @@ extensions:
             fieldCode: configuration.enclosure
             readOnly: false
             label: pim_enrich.form.job_instance.tab.properties.enclosure.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.enclosure.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.enclosure.help
 
     pim-job-instance-csv-product-export-edit-properties-with-header:
         module: pim/job/common/edit/field/switch
@@ -128,7 +128,7 @@ extensions:
             fieldCode: configuration.withHeader
             readOnly: false
             label: pim_enrich.form.job_instance.tab.properties.with_header.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.with_header.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.with_header.help
 
     pim-job-instance-csv-product-export-edit-properties-with-media:
         module: pim/job/common/edit/field/switch
@@ -139,7 +139,7 @@ extensions:
             fieldCode: configuration.with_media
             readOnly: false
             label: pim_enrich.form.job_instance.tab.properties.with_media.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.with_media.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.with_media.help
 
     pim-job-instance-csv-product-export-edit-content-structure:
         module: pim/job/product/edit/content/structure

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_export_show.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_export_show.yml
@@ -68,7 +68,7 @@ extensions:
             fieldCode: configuration.decimalSeparator
             readOnly: true
             label: pim_enrich.form.job_instance.tab.properties.decimal_separator.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.decimal_separator.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.decimal_separator.help
 
     pim-job-instance-csv-product-export-show-properties-date-format:
         module: pim/job/product/edit/field/date-format
@@ -79,7 +79,7 @@ extensions:
             fieldCode: configuration.dateFormat
             readOnly: true
             label: pim_enrich.form.job_instance.tab.properties.date_format.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.date_format.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.date_format.help
 
     pim-job-instance-csv-product-export-show-properties-file-path:
         module: pim/job/common/edit/field/text
@@ -90,7 +90,7 @@ extensions:
             fieldCode: configuration.filePath
             readOnly: true
             label: pim_enrich.form.job_instance.tab.properties.file_path.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.file_path.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.file_path.help
 
     pim-job-instance-csv-product-export-show-properties-delimiter:
         module: pim/job/common/edit/field/text
@@ -101,7 +101,7 @@ extensions:
             fieldCode: configuration.delimiter
             readOnly: true
             label: pim_enrich.form.job_instance.tab.properties.delimiter.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.delimiter.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.delimiter.help
 
     pim-job-instance-csv-product-export-show-properties-enclosure:
         module: pim/job/common/edit/field/text
@@ -112,7 +112,7 @@ extensions:
             fieldCode: configuration.enclosure
             readOnly: true
             label: pim_enrich.form.job_instance.tab.properties.enclosure.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.enclosure.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.enclosure.help
 
     pim-job-instance-csv-product-export-show-properties-with-header:
         module: pim/job/common/edit/field/switch
@@ -123,7 +123,7 @@ extensions:
             fieldCode: configuration.withHeader
             readOnly: true
             label: pim_enrich.form.job_instance.tab.properties.with_header.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.with_header.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.with_header.help
 
     pim-job-instance-csv-product-export-show-properties-with-media:
         module: pim/job/common/edit/field/switch
@@ -134,7 +134,7 @@ extensions:
             fieldCode: configuration.with_media
             readOnly: true
             label: pim_enrich.form.job_instance.tab.properties.with_media.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.with_media.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.with_media.help
 
     pim-job-instance-csv-product-export-show-content-structure:
         module: pim/job/product/edit/content/structure

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_import_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_import_edit.yml
@@ -63,7 +63,7 @@ extensions:
             fieldCode: configuration.decimalSeparator
             readOnly: false
             label: pim_enrich.form.job_instance.tab.properties.decimal_separator.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.decimal_separator.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.decimal_separator.help
 
     pim-job-instance-csv-product-import-edit-properties-date-format:
         module: pim/job/product/edit/field/date-format
@@ -74,7 +74,7 @@ extensions:
             fieldCode: configuration.dateFormat
             readOnly: false
             label: pim_enrich.form.job_instance.tab.properties.date_format.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.date_format.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.date_format.help
 
     pim-job-instance-csv-product-import-edit-properties-file-path:
         module: pim/job/common/edit/field/text
@@ -85,7 +85,7 @@ extensions:
             fieldCode: configuration.filePath
             readOnly: false
             label: pim_enrich.form.job_instance.tab.properties.file_path.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.file_path.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.file_path.help
 
     pim-job-instance-csv-product-import-edit-properties-delimiter:
         module: pim/job/common/edit/field/text
@@ -96,7 +96,7 @@ extensions:
             fieldCode: configuration.delimiter
             readOnly: false
             label: pim_enrich.form.job_instance.tab.properties.delimiter.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.delimiter.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.delimiter.help
 
     pim-job-instance-csv-product-import-edit-properties-enclosure:
         module: pim/job/common/edit/field/text
@@ -107,7 +107,7 @@ extensions:
             fieldCode: configuration.enclosure
             readOnly: false
             label: pim_enrich.form.job_instance.tab.properties.enclosure.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.enclosure.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.enclosure.help
 
     pim-job-instance-csv-product-import-edit-properties-with-header:
         module: pim/job/common/edit/field/switch
@@ -118,7 +118,7 @@ extensions:
             fieldCode: configuration.withHeader
             readOnly: false
             label: pim_enrich.form.job_instance.tab.properties.with_header.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.with_header.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.with_header.help
 
     pim-job-instance-csv-product-import-edit-properties-escape:
         module: pim/job/common/edit/field/text
@@ -129,7 +129,7 @@ extensions:
             fieldCode: configuration.escape
             readOnly: false
             label: pim_enrich.form.job_instance.tab.properties.escape.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.escape.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.escape.help
 
     pim-job-instance-csv-product-import-edit-properties-with-media:
         module: pim/job/common/edit/field/switch
@@ -140,7 +140,7 @@ extensions:
             fieldCode: configuration.with_media
             readOnly: false
             label: pim_enrich.form.job_instance.tab.properties.with_media.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.with_media.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.with_media.help
 
     pim-job-instance-csv-product-import-edit-properties-file-upload:
         module: pim/job/common/edit/field/switch
@@ -151,7 +151,7 @@ extensions:
             fieldCode: configuration.uploadAllowed
             readOnly: false
             label: pim_enrich.form.job_instance.tab.properties.upload_allowed.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.uploadAllowed.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.upload_allowed.help
 
     pim-job-instance-csv-product-import-edit-properties-categories-column:
         module: pim/job/common/edit/field/text
@@ -162,7 +162,7 @@ extensions:
             fieldCode: configuration.categoriesColumn
             readOnly: false
             label: pim_enrich.form.job_instance.tab.properties.categories_column.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.categoriesColumn.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.categories_column.help
 
     pim-job-instance-csv-product-import-edit-properties-family-column:
         module: pim/job/common/edit/field/text
@@ -173,7 +173,7 @@ extensions:
             fieldCode: configuration.familyColumn
             readOnly: false
             label: pim_enrich.form.job_instance.tab.properties.family_column.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.familyColumn.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.family_column.help
 
     pim-job-instance-csv-product-import-edit-properties-groups-column:
         module: pim/job/common/edit/field/text
@@ -184,7 +184,7 @@ extensions:
             fieldCode: configuration.groupsColumn
             readOnly: false
             label: pim_enrich.form.job_instance.tab.properties.groups_column.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.groupsColumn.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.groups_column.help
 
     pim-job-instance-csv-product-import-edit-properties-enabled:
         module: pim/job/common/edit/field/switch
@@ -195,7 +195,7 @@ extensions:
             fieldCode: configuration.enabled
             readOnly: false
             label: pim_enrich.form.job_instance.tab.properties.enabled.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.enabled.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.enabled.help
 
     pim-job-instance-csv-product-import-edit-properties-enabled-comparison:
         module: pim/job/common/edit/field/switch
@@ -206,7 +206,7 @@ extensions:
             fieldCode: configuration.enabledComparison
             readOnly: false
             label: pim_enrich.form.job_instance.tab.properties.enabled_comparison.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.enabledComparison.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.enabled_comparison.help
 
     pim-job-instance-csv-product-import-edit-properties-real-time-versioning:
         module: pim/job/common/edit/field/switch
@@ -217,7 +217,7 @@ extensions:
             fieldCode: configuration.realTimeVersioning
             readOnly: false
             label: pim_enrich.form.job_instance.tab.properties.real_time_versioning.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.realTimeVersioning.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.real_time_versioning.help
 
     pim-job-instance-csv-product-import-edit-label:
         module: pim/job/common/edit/label
@@ -275,3 +275,7 @@ extensions:
         position: 900
         config:
             entity: pim_enrich.entity.job_instance.title
+
+    pim-job-instance-csv-product-import-edit-validation:
+        module: pim/job/common/edit/validation
+        parent: pim-job-instance-csv-product-import-edit

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_import_show.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_import_show.yml
@@ -65,7 +65,7 @@ extensions:
             fieldCode: configuration.filePath
             readOnly: true
             label: pim_enrich.form.job_instance.tab.properties.file_path.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.filePath.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.file_path.help
 
     pim-job-instance-csv-product-import-show-properties-delimiter:
         module: pim/job/common/edit/field/text
@@ -76,7 +76,7 @@ extensions:
             fieldCode: configuration.delimiter
             readOnly: true
             label: pim_enrich.form.job_instance.tab.properties.delimiter.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.delimiter.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.delimiter.help
 
     pim-job-instance-csv-product-import-show-properties-enclosure:
         module: pim/job/common/edit/field/text
@@ -87,7 +87,7 @@ extensions:
             fieldCode: configuration.enclosure
             readOnly: true
             label: pim_enrich.form.job_instance.tab.properties.enclosure.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.enclosure.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.enclosure.help
 
     pim-job-instance-csv-product-import-show-properties-decimal-separator:
         module: pim/job/common/edit/field/decimal-separator
@@ -98,7 +98,7 @@ extensions:
             fieldCode: configuration.decimalSeparator
             readOnly: true
             label: pim_enrich.form.job_instance.tab.properties.decimal_separator.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.decimal_separator.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.decimal_separator.help
 
     pim-job-instance-csv-product-import-show-properties-with-header:
         module: pim/job/common/edit/field/switch
@@ -109,7 +109,7 @@ extensions:
             fieldCode: configuration.withHeader
             readOnly: true
             label: pim_enrich.form.job_instance.tab.properties.with_header.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.with_header.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.with_header.help
 
     pim-job-instance-csv-product-import-show-properties-escape:
         module: pim/job/common/edit/field/text
@@ -120,7 +120,7 @@ extensions:
             fieldCode: configuration.escape
             readOnly: true
             label: pim_enrich.form.job_instance.tab.properties.escape.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.escape.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.escape.help
 
     pim-job-instance-csv-product-import-show-properties-categories-column:
         module: pim/job/common/edit/field/text
@@ -131,7 +131,7 @@ extensions:
             fieldCode: configuration.categoriesColumn
             readOnly: true
             label: pim_enrich.form.job_instance.tab.properties.categories_column.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.categoriesColumn.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.categories_column.help
 
     pim-job-instance-csv-product-import-show-properties-family-column:
         module: pim/job/common/edit/field/text
@@ -142,7 +142,7 @@ extensions:
             fieldCode: configuration.familyColumn
             readOnly: true
             label: pim_enrich.form.job_instance.tab.properties.family_column.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.familyColumn.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.family_column.help
 
     pim-job-instance-csv-product-import-show-properties-groups-column:
         module: pim/job/common/edit/field/text
@@ -153,7 +153,7 @@ extensions:
             fieldCode: configuration.groupsColumn
             readOnly: true
             label: pim_enrich.form.job_instance.tab.properties.groups_column.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.groupsColumn.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.groups_column.help
 
     pim-job-instance-csv-product-import-show-properties-enabled:
         module: pim/job/common/edit/field/switch
@@ -164,7 +164,7 @@ extensions:
             fieldCode: configuration.enabled
             readOnly: true
             label: pim_enrich.form.job_instance.tab.properties.enabled.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.enabled.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.enabled.help
 
     pim-job-instance-csv-product-import-show-properties-date-format:
         module: pim/job/product/edit/field/date-format
@@ -175,7 +175,7 @@ extensions:
             fieldCode: configuration.dateFormat
             readOnly: true
             label: pim_enrich.form.job_instance.tab.properties.date_format.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.date_format.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.date_format.help
 
     pim-job-instance-csv-product-import-show-properties-enabled-comparison:
         module: pim/job/common/edit/field/switch
@@ -186,7 +186,7 @@ extensions:
             fieldCode: configuration.enabledComparison
             readOnly: true
             label: pim_enrich.form.job_instance.tab.properties.enabled_comparison.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.enabledComparison.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.enabled_comparison.help
 
     pim-job-instance-csv-product-import-show-properties-real-time-versioning:
         module: pim/job/common/edit/field/switch
@@ -197,7 +197,7 @@ extensions:
             fieldCode: configuration.realTimeVersioning
             readOnly: true
             label: pim_enrich.form.job_instance.tab.properties.real_time_versioning.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.realTimeVersioning.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.real_time_versioning.help
 
     pim-job-instance-csv-product-import-show-properties-file-upload:
         module: pim/job/common/edit/field/switch
@@ -208,7 +208,7 @@ extensions:
             fieldCode: configuration.uploadAllowed
             readOnly: true
             label: pim_enrich.form.job_instance.tab.properties.upload_allowed.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.uploadAllowed.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.upload_allowed.help
 
     pim-job-instance-csv-product-import-show-label:
         module: pim/job/common/edit/label

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_base_export_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_base_export_edit.yml
@@ -63,7 +63,7 @@ extensions:
             fieldCode: configuration.filePath
             readOnly: false
             label: pim_enrich.form.job_instance.tab.properties.file_path.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.filePath.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.file_path.help
 
     pim-job-instance-xlsx-base-export-edit-properties-lines-per-file:
         module: pim/job/common/edit/field/text
@@ -74,7 +74,7 @@ extensions:
             fieldCode: configuration.linesPerFile
             readOnly: false
             label: pim_enrich.form.job_instance.tab.properties.lines_per_file.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.lines_per_file.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.lines_per_file.help
 
     pim-job-instance-xlsx-base-export-edit-properties-with-header:
         module: pim/job/common/edit/field/switch
@@ -85,7 +85,7 @@ extensions:
             fieldCode: configuration.withHeader
             readOnly: false
             label: pim_enrich.form.job_instance.tab.properties.with_header.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.withHeader.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.with_header.help
 
     pim-job-instance-xlsx-base-export-edit-label:
         module: pim/job/common/edit/label

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_base_export_show.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_base_export_show.yml
@@ -58,7 +58,7 @@ extensions:
             fieldCode: configuration.filePath
             readOnly: true
             label: pim_enrich.form.job_instance.tab.properties.file_path.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.filePath.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.file_path.help
 
     pim-job-instance-xlsx-base-export-show-properties-lines-per-file:
         module: pim/job/common/edit/field/text
@@ -69,7 +69,7 @@ extensions:
             fieldCode: configuration.linesPerFile
             readOnly: true
             label: pim_enrich.form.job_instance.tab.properties.lines_per_file.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.lines_per_file.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.lines_per_file.help
 
     pim-job-instance-xlsx-base-export-show-properties-with-header:
         module: pim/job/common/edit/field/switch
@@ -80,7 +80,7 @@ extensions:
             fieldCode: configuration.withHeader
             readOnly: true
             label: pim_enrich.form.job_instance.tab.properties.with_header.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.withHeader.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.with_header.help
 
     pim-job-instance-xlsx-base-export-show-label:
         module: pim/job/common/edit/label

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_base_import_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_base_import_edit.yml
@@ -63,7 +63,7 @@ extensions:
             fieldCode: configuration.filePath
             readOnly: false
             label: pim_enrich.form.job_instance.tab.properties.file_path.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.filePath.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.file_path.help
 
     pim-job-instance-xlsx-base-import-edit-properties-file-upload:
         module: pim/job/common/edit/field/switch
@@ -74,7 +74,7 @@ extensions:
             fieldCode: configuration.uploadAllowed
             readOnly: false
             label: pim_enrich.form.job_instance.tab.properties.upload_allowed.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.uploadAllowed.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.upload_allowed.help
 
     pim-job-instance-xlsx-base-import-edit-label:
         module: pim/job/common/edit/label

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_base_import_show.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_base_import_show.yml
@@ -64,7 +64,7 @@ extensions:
             fieldCode: configuration.filePath
             readOnly: true
             label: pim_enrich.form.job_instance.tab.properties.file_path.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.filePath.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.file_path.help
 
     pim-job-instance-xlsx-base-import-show-properties-file-upload:
         module: pim/job/common/edit/field/switch
@@ -75,7 +75,7 @@ extensions:
             fieldCode: configuration.uploadAllowed
             readOnly: true
             label: pim_enrich.form.job_instance.tab.properties.upload_allowed.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.uploadAllowed.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.upload_allowed.help
 
     pim-job-instance-xlsx-base-import-show-label:
         module: pim/job/common/edit/label

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_export_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_export_edit.yml
@@ -73,7 +73,7 @@ extensions:
             fieldCode: configuration.decimalSeparator
             readOnly: false
             label: pim_enrich.form.job_instance.tab.properties.decimal_separator.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.decimal_separator.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.decimal_separator.help
 
     pim-job-instance-xlsx-product-export-edit-properties-date-format:
         module: pim/job/product/edit/field/date-format
@@ -84,7 +84,7 @@ extensions:
             fieldCode: configuration.dateFormat
             readOnly: false
             label: pim_enrich.form.job_instance.tab.properties.date_format.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.date_format.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.date_format.help
 
     pim-job-instance-xlsx-product-export-edit-properties-file-path:
         module: pim/job/common/edit/field/text
@@ -95,7 +95,7 @@ extensions:
             fieldCode: configuration.filePath
             readOnly: false
             label: pim_enrich.form.job_instance.tab.properties.file_path.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.file_path.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.file_path.help
 
     pim-job-instance-xlsx-product-export-edit-properties-lines-per-file:
         module: pim/job/common/edit/field/text
@@ -106,7 +106,7 @@ extensions:
             fieldCode: configuration.linesPerFile
             readOnly: false
             label: pim_enrich.form.job_instance.tab.properties.lines_per_file.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.lines_per_file.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.lines_per_file.help
 
     pim-job-instance-xlsx-product-export-edit-properties-with-header:
         module: pim/job/common/edit/field/switch
@@ -117,7 +117,7 @@ extensions:
             fieldCode: configuration.withHeader
             readOnly: false
             label: pim_enrich.form.job_instance.tab.properties.with_header.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.with_header.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.with_header.help
 
     pim-job-instance-xlsx-product-export-edit-properties-with-media:
         module: pim/job/common/edit/field/switch
@@ -128,7 +128,7 @@ extensions:
             fieldCode: configuration.with_media
             readOnly: false
             label: pim_enrich.form.job_instance.tab.properties.with_media.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.with_media.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.with_media.help
 
     pim-job-instance-xlsx-product-export-edit-content-structure:
         module: pim/job/product/edit/content/structure

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_export_show.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_export_show.yml
@@ -68,7 +68,7 @@ extensions:
             fieldCode: configuration.decimalSeparator
             readOnly: true
             label: pim_enrich.form.job_instance.tab.properties.decimal_separator.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.decimal_separator.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.decimal_separator.help
 
     pim-job-instance-xlsx-product-export-show-properties-date-format:
         module: pim/job/product/edit/field/date-format
@@ -79,7 +79,7 @@ extensions:
             fieldCode: configuration.dateFormat
             readOnly: true
             label: pim_enrich.form.job_instance.tab.properties.date_format.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.date_format.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.date_format.help
 
     pim-job-instance-xlsx-product-export-show-properties-file-path:
         module: pim/job/common/edit/field/text
@@ -90,7 +90,7 @@ extensions:
             fieldCode: configuration.filePath
             readOnly: true
             label: pim_enrich.form.job_instance.tab.properties.file_path.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.file_path.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.file_path.help
 
     pim-job-instance-xlsx-product-export-show-properties-lines-per-file:
         module: pim/job/common/edit/field/text
@@ -101,7 +101,7 @@ extensions:
             fieldCode: configuration.linesPerFile
             readOnly: true
             label: pim_enrich.form.job_instance.tab.properties.lines_per_file.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.lines_per_file.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.lines_per_file.help
 
     pim-job-instance-xlsx-product-export-show-properties-with-header:
         module: pim/job/common/edit/field/switch
@@ -112,7 +112,7 @@ extensions:
             fieldCode: configuration.withHeader
             readOnly: true
             label: pim_enrich.form.job_instance.tab.properties.with_header.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.with_header.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.with_header.help
 
     pim-job-instance-xlsx-product-export-show-properties-with-media:
         module: pim/job/common/edit/field/switch
@@ -123,7 +123,7 @@ extensions:
             fieldCode: configuration.with_media
             readOnly: true
             label: pim_enrich.form.job_instance.tab.properties.with_media.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.with_media.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.with_media.help
 
     pim-job-instance-xlsx-product-export-show-content-structure:
         module: pim/job/product/edit/content/structure

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_import_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_import_edit.yml
@@ -63,7 +63,7 @@ extensions:
             fieldCode: configuration.filePath
             readOnly: false
             label: pim_enrich.form.job_instance.tab.properties.file_path.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.file_path.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.file_path.help
 
     pim-job-instance-xlsx-product-import-edit-properties-with-header:
         module: pim/job/common/edit/field/switch
@@ -74,7 +74,7 @@ extensions:
             fieldCode: configuration.withHeader
             readOnly: false
             label: pim_enrich.form.job_instance.tab.properties.with_header.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.with_header.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.with_header.help
 
     pim-job-instance-xlsx-product-import-edit-properties-with-media:
         module: pim/job/common/edit/field/switch
@@ -85,7 +85,7 @@ extensions:
             fieldCode: configuration.with_media
             readOnly: false
             label: pim_enrich.form.job_instance.tab.properties.with_media.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.with_media.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.with_media.help
 
     pim-job-instance-xlsx-product-import-edit-properties-file-upload:
         module: pim/job/common/edit/field/switch
@@ -96,7 +96,7 @@ extensions:
             fieldCode: configuration.uploadAllowed
             readOnly: false
             label: pim_enrich.form.job_instance.tab.properties.upload_allowed.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.uploadAllowed.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.upload_allowed.help
 
     pim-job-instance-xlsx-product-import-edit-properties-date-format:
         module: pim/job/product/edit/field/date-format
@@ -107,7 +107,7 @@ extensions:
             fieldCode: configuration.dateFormat
             readOnly: true
             label: pim_enrich.form.job_instance.tab.properties.date_format.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.date_format.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.date_format.help
 
     pim-job-instance-xlsx-product-import-edit-properties-categories-column:
         module: pim/job/common/edit/field/text
@@ -118,7 +118,7 @@ extensions:
             fieldCode: configuration.categoriesColumn
             readOnly: false
             label: pim_enrich.form.job_instance.tab.properties.categories_column.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.categoriesColumn.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.categories_column.help
 
     pim-job-instance-xlsx-product-import-edit-properties-family-column:
         module: pim/job/common/edit/field/text
@@ -129,7 +129,7 @@ extensions:
             fieldCode: configuration.familyColumn
             readOnly: false
             label: pim_enrich.form.job_instance.tab.properties.family_column.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.familyColumn.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.family_column.help
 
     pim-job-instance-xlsx-product-import-edit-properties-groups-column:
         module: pim/job/common/edit/field/text
@@ -140,7 +140,7 @@ extensions:
             fieldCode: configuration.groupsColumn
             readOnly: false
             label: pim_enrich.form.job_instance.tab.properties.groups_column.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.groupsColumn.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.groups_column.help
 
     pim-job-instance-xlsx-product-import-edit-properties-enabled:
         module: pim/job/common/edit/field/switch
@@ -151,7 +151,7 @@ extensions:
             fieldCode: configuration.enabled
             readOnly: false
             label: pim_enrich.form.job_instance.tab.properties.enabled.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.enabled.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.enabled.help
 
     pim-job-instance-xlsx-product-import-edit-properties-enabled-comparison:
         module: pim/job/common/edit/field/switch
@@ -162,7 +162,7 @@ extensions:
             fieldCode: configuration.enabledComparison
             readOnly: false
             label: pim_enrich.form.job_instance.tab.properties.enabled_comparison.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.enabledComparison.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.enabled_comparison.help
 
     pim-job-instance-xlsx-product-import-edit-properties-real-time-versioning:
         module: pim/job/common/edit/field/switch
@@ -173,7 +173,7 @@ extensions:
             fieldCode: configuration.realTimeVersioning
             readOnly: false
             label: pim_enrich.form.job_instance.tab.properties.real_time_versioning.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.realTimeVersioning.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.real_time_versioning.help
 
     pim-job-instance-xlsx-product-import-edit-label:
         module: pim/job/common/edit/label
@@ -231,3 +231,7 @@ extensions:
         position: 900
         config:
             entity: pim_enrich.entity.job_instance.title
+
+    pim-job-instance-xlsx-product-import-edit-validation:
+        module: pim/job/common/edit/validation
+        parent: pim-job-instance-xlsx-product-import-edit

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_import_show.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_import_show.yml
@@ -65,7 +65,7 @@ extensions:
             fieldCode: configuration.filePath
             readOnly: true
             label: pim_enrich.form.job_instance.tab.properties.file_path.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.filePath.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.file_path.help
 
     pim-job-instance-xlsx-product-import-show-properties-with-header:
         module: pim/job/common/edit/field/switch
@@ -76,7 +76,7 @@ extensions:
             fieldCode: configuration.withHeader
             readOnly: true
             label: pim_enrich.form.job_instance.tab.properties.with_header.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.with_header.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.with_header.help
 
     pim-job-instance-xlsx-product-import-show-properties-categories-column:
         module: pim/job/common/edit/field/text
@@ -87,7 +87,7 @@ extensions:
             fieldCode: configuration.categoriesColumn
             readOnly: true
             label: pim_enrich.form.job_instance.tab.properties.categories_column.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.categoriesColumn.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.categories_column.help
 
     pim-job-instance-xlsx-product-import-show-properties-family-column:
         module: pim/job/common/edit/field/text
@@ -98,7 +98,7 @@ extensions:
             fieldCode: configuration.familyColumn
             readOnly: true
             label: pim_enrich.form.job_instance.tab.properties.family_column.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.familyColumn.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.family_column.help
 
     pim-job-instance-xlsx-product-import-show-properties-groups-column:
         module: pim/job/common/edit/field/text
@@ -109,7 +109,7 @@ extensions:
             fieldCode: configuration.groupsColumn
             readOnly: true
             label: pim_enrich.form.job_instance.tab.properties.groups_column.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.groupsColumn.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.groups_column.help
 
     pim-job-instance-xlsx-product-import-show-properties-enabled:
         module: pim/job/common/edit/field/switch
@@ -120,7 +120,7 @@ extensions:
             fieldCode: configuration.enabled
             readOnly: true
             label: pim_enrich.form.job_instance.tab.properties.enabled.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.enabled.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.enabled.help
 
     pim-job-instance-xlsx-product-import-show-properties-date-format:
         module: pim/job/product/edit/field/date-format
@@ -131,7 +131,7 @@ extensions:
             fieldCode: configuration.dateFormat
             readOnly: true
             label: pim_enrich.form.job_instance.tab.properties.date_format.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.date_format.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.date_format.help
 
     pim-job-instance-xlsx-product-import-show-properties-enabled-comparison:
         module: pim/job/common/edit/field/switch
@@ -142,7 +142,7 @@ extensions:
             fieldCode: configuration.enabledComparison
             readOnly: true
             label: pim_enrich.form.job_instance.tab.properties.enabled_comparison.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.enabledComparison.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.enabled_comparison.help
 
     pim-job-instance-xlsx-product-import-show-properties-real-time-versioning:
         module: pim/job/common/edit/field/switch
@@ -153,7 +153,7 @@ extensions:
             fieldCode: configuration.realTimeVersioning
             readOnly: true
             label: pim_enrich.form.job_instance.tab.properties.real_time_versioning.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.realTimeVersioning.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.real_time_versioning.help
 
     pim-job-instance-xlsx-product-import-show-properties-file-upload:
         module: pim/job/common/edit/field/switch
@@ -164,7 +164,7 @@ extensions:
             fieldCode: configuration.uploadAllowed
             readOnly: true
             label: pim_enrich.form.job_instance.tab.properties.upload_allowed.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.uploadAllowed.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.upload_allowed.help
 
     pim-job-instance-xlsx-product-import-show-label:
         module: pim/job/common/edit/label

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/yml_base_export_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/yml_base_export_edit.yml
@@ -63,7 +63,7 @@ extensions:
             fieldCode: configuration.filePath
             readOnly: false
             label: pim_enrich.form.job_instance.tab.properties.file_path.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.filePath.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.file_path.help
 
     pim-job-instance-yml-base-export-edit-label:
         module: pim/job/common/edit/label

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/yml_base_export_show.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/yml_base_export_show.yml
@@ -58,7 +58,7 @@ extensions:
             fieldCode: configuration.filePath
             readOnly: true
             label: pim_enrich.form.job_instance.tab.properties.file_path.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.filePath.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.file_path.help
 
     pim-job-instance-yml-base-export-show-label:
         module: pim/job/common/edit/label

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/yml_base_import_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/yml_base_import_edit.yml
@@ -63,7 +63,7 @@ extensions:
             fieldCode: configuration.filePath
             readOnly: false
             label: pim_enrich.form.job_instance.tab.properties.file_path.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.filePath.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.file_path.help
 
     pim-job-instance-yml-base-import-edit-properties-file-upload:
         module: pim/job/common/edit/field/switch
@@ -74,7 +74,7 @@ extensions:
             fieldCode: configuration.uploadAllowed
             readOnly: false
             label: pim_enrich.form.job_instance.tab.properties.upload_allowed.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.uploadAllowed.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.upload_allowed.help
 
     pim-job-instance-yml-base-import-edit-label:
         module: pim/job/common/edit/label

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/yml_base_import_show.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/yml_base_import_show.yml
@@ -64,7 +64,7 @@ extensions:
             fieldCode: configuration.filePath
             readOnly: true
             label: pim_enrich.form.job_instance.tab.properties.file_path.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.filePath.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.file_path.help
 
     pim-job-instance-yml-base-import-show-properties-file-upload:
         module: pim/job/common/edit/field/switch
@@ -75,7 +75,7 @@ extensions:
             fieldCode: configuration.uploadAllowed
             readOnly: true
             label: pim_enrich.form.job_instance.tab.properties.upload_allowed.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.help.uploadAllowed.help
+            tooltip: pim_enrich.form.job_instance.tab.properties.upload_allowed.help
 
     pim-job-instance-yml-base-import-show-label:
         module: pim/job/common/edit/label

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/export/common/edit/field/field.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/export/common/edit/field/field.html
@@ -13,8 +13,8 @@
         <span class="below-input-elements-container">
             <% if (null !== error) { %>
             <span class="validation-container">
-                <span class="validation-errors">
-                    <span>
+                <span class="AknFieldContainer-validationErrors validation-errors">
+                    <span class="AknFieldContainer-validationError">
                         <i class="icon-warning-sign"></i> <span class="error-message"><%- error %></span>
                     </span>
                 </span>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/export/common/edit/field/text.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/export/common/edit/field/text.html
@@ -1,1 +1,1 @@
-<input class="AknTextField" title="<%- __(config.label) %>" id="jobInstance_<%- config.fieldCode.replace('.', '_') %>" value="<%- value %>" type="text" name="job-instance-code" <%- true === config.readOnly ? 'readonly disabled' : '' %>/>
+<input class="AknTextField" title="<%- __(config.label) %>" id="jobInstance_<%- config.fieldCode.replace('.', '_') %>" value="<%- value %>" type="text" name="jobInstance_<%- config.fieldCode.replace('.', '_') %>" <%- true === config.readOnly ? 'readonly disabled' : '' %>/>

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
@@ -289,6 +289,7 @@ pim_enrich:
         job_instance:
             info:
                 update_failed: The job profile could not be updated.
+                update_successful: The job profile has been successfully updated.
     confirmation:
         leave:           Are you sure you want to leave this page?
         discard_changes: You will lose changes to the {{ entity }} if you leave the page.


### PR DESCRIPTION
On Import/Export builder the tooltips and errors validation messages were not well rendering, this PR fix the previously presented issues.

 Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | Ok
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
