### PR TITLE
Use required php-cs-fixer

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -107,8 +107,7 @@ def runUnitTest(phpVersion) {
             sh "./bin/phpspec run --no-interaction --format=junit > app/build/logs/phpspec.xml || true"
 
             if (phpVersion != "5.4") {
-                sh "composer global require friendsofphp/php-cs-fixer ^2.0"
-                sh "/home/akeneo/.composer/vendor/friendsofphp/php-cs-fixer/php-cs-fixer fix --diff --format=junit --config=.php_cs.dist > app/build/logs/phpcs.xml || true"
+                sh "./bin/php-cs-fixer fix --diff --format=junit --config=.php_cs.dist > app/build/logs/phpcs.xml || true"
             }
 
             sh "sed -i \"s/testcase name=\\\"/testcase name=\\\"[php-${phpVersion}] /\" app/build/logs/*.xml"


### PR DESCRIPTION
**Description**

`php-cs-fixer` is provided by the dependencies of `akeneo/php-decoupling-detector`.

Rather than installing `php-cs-fixer` it during the CI build to have the 2.x version, it has been updated in  `akeneo/php-decoupling-detector` and can now be used directly.

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed