### PR TITLE
Fix fixtures loading

### DIFF
--- a/src/Pim/Component/Catalog/Validator/AttributeValidatorHelper.php
+++ b/src/Pim/Component/Catalog/Validator/AttributeValidatorHelper.php
@@ -22,10 +22,10 @@ class AttributeValidatorHelper
     protected $scopeRepository;
 
     /** @var array */
-    protected static $localeCodes;
+    protected $localeCodes;
 
     /** @var array */
-    protected static $scopeCodes;
+    protected $scopeCodes;
 
     /**
      * @param LocaleRepositoryInterface  $localeRepository
@@ -72,11 +72,11 @@ class AttributeValidatorHelper
             );
         }
 
-        if (null === static::$localeCodes) {
-            static::$localeCodes = $this->getActivatedLocaleCodes();
+        if (null === $this->localeCodes) {
+            $this->localeCodes = $this->getActivatedLocaleCodes();
         }
 
-        if (!in_array($locale, static::$localeCodes)) {
+        if (!in_array($locale, $this->localeCodes)) {
             throw new \LogicException(
                 sprintf(
                     'Attribute "%s" expects an existing and activated locale, "%s" given.',
@@ -152,11 +152,11 @@ class AttributeValidatorHelper
             );
         }
 
-        if (null === static::$scopeCodes) {
-            static::$scopeCodes = $this->getScopeCodes();
+        if (null === $this->scopeCodes) {
+            $this->scopeCodes = $this->getScopeCodes();
         }
 
-        if (!in_array($scope, static::$scopeCodes)) {
+        if (!in_array($scope, $this->scopeCodes)) {
             throw new \LogicException(
                 sprintf(
                     'Attribute "%s" expects an existing scope, "%s" given.',

--- a/src/Pim/Component/Catalog/spec/Validator/AttributeValidatorHelperSpec.php
+++ b/src/Pim/Component/Catalog/spec/Validator/AttributeValidatorHelperSpec.php
@@ -130,8 +130,8 @@ class AttributeValidatorHelperSpec extends ObjectBehavior
 class InitializedAttributeValidatorHelper extends AttributeValidatorHelper
 {
     /** @var array */
-    protected static $localeCodes = ['en_US', 'fr_FR'];
+    protected $localeCodes = ['en_US', 'fr_FR'];
 
     /** @var array */
-    protected static $scopeCodes = ['ecommerce', 'tablet'];
+    protected $scopeCodes = ['ecommerce', 'tablet'];
 }


### PR DESCRIPTION
That validator is state full, the locale and the channel are kept in memory. For example, we try to import several catalogs for our integration tests:

* First import with ecommerce and tablet
* Second import with ecommerce and mobile. For this import channels are not reset, the validator still keeps ecommerce and tablet.

I don't know why that var is static, perhaps for performance? 

**Definition Of Done (for Core Developer only)**

| Q | A
| --------------------------------- | ---
| Added Specs | -
| Added Behats | -
| Added integration tests | -
| Changelog updated | -
| Review and 2 GTM | -
| Micro Demo to the PO (Story only) | -
| Migration script | -
| Tech Doc | -
