### PR TITLE
Prepare to run integration tests on both ORM and ODM

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,7 +42,7 @@ stage("Checkout") {
         checkout scm
         stash "pim_community_dev"
 
-        if (editions.contains('ee')  && 'yes' == launchBehatTests) {
+        if (editions.contains('ee') && 'yes' == launchBehatTests) {
            checkout([$class: 'GitSCM',
              branches: [[name: '1.7']],
              userRemoteConfigs: [[credentialsId: 'github-credentials', url: 'https://github.com/akeneo/pim-enterprise-dev.git']]
@@ -108,9 +108,12 @@ if (launchIntegrationTests.equals("yes")) {
     stage("Integration tests") {
         def tasks = [:]
 
-        tasks["phpunit-5.6"] = {runIntegrationTest("5.6")}
-        tasks["phpunit-7.0"] = {runIntegrationTest("7.0")}
-        tasks["phpunit-7.1"] = {runIntegrationTest("7.1")}
+        tasks["phpunit-5.6-orm"] = {runIntegrationTest("5.6", "orm")}
+        tasks["phpunit-7.0-orm"] = {runIntegrationTest("7.0", "orm")}
+        tasks["phpunit-7.1-orm"] = {runIntegrationTest("7.1", "orm")}
+        // tasks["phpunit-5.6-odm"] = {runIntegrationTest("5.6", "odm")}
+        // tasks["phpunit-7.0-odm"] = {runIntegrationTest("7.0", "odm")}
+        // tasks["phpunit-7.1-odm"] = {runIntegrationTest("7.1", "odm")}
 
         parallel tasks
     }
@@ -152,7 +155,7 @@ def runPhpUnitTest(phpVersion) {
                 unstash "pim_community_dev"
 
                 if (phpVersion != "5.6") {
-                    sh "composer require --no-update alcaeus/mongo-php-adapter"
+                    sh "composer require --no-update --ignore-platform-reqs alcaeus/mongo-php-adapter"
                 }
 
                 sh "composer update --ignore-platform-reqs --optimize-autoloader --no-interaction --no-progress --prefer-dist"
@@ -167,29 +170,40 @@ def runPhpUnitTest(phpVersion) {
     }
 }
 
-def runIntegrationTest(phpVersion) {
+def runIntegrationTest(phpVersion, storage) {
     node('docker') {
         deleteDir()
         try {
-            docker.image("mysql:5.5").withRun("--name mysql -e MYSQL_ROOT_PASSWORD=root -e MYSQL_USER=akeneo_pim -e MYSQL_PASSWORD=akeneo_pim -e MYSQL_DATABASE=akeneo_pim") {
-                docker.image("carcel/php:${phpVersion}").inside("--link mysql:mysql -v /home/akeneo/.composer:/home/akeneo/.composer -e COMPOSER_HOME=/home/akeneo/.composer") {
-                    unstash "pim_community_dev"
+            docker.image("mongo:2.4").withRun("--name mongodb", "--smallfiles") {
+                docker.image("mysql:5.5").withRun("--name mysql -e MYSQL_ROOT_PASSWORD=root -e MYSQL_USER=akeneo_pim -e MYSQL_PASSWORD=akeneo_pim -e MYSQL_DATABASE=akeneo_pim") {
+                    docker.image("carcel/php:${phpVersion}").inside("--link mysql:mysql --link mongodb:mongodb -v /home/akeneo/.composer:/home/akeneo/.composer -e COMPOSER_HOME=/home/akeneo/.composer") {
+                        unstash "pim_community_dev"
 
-                    if (phpVersion != "5.6") {
-                        sh "composer require --no-update alcaeus/mongo-php-adapter"
+                        if (phpVersion != "5.6") {
+                            sh "composer require --no-update --ignore-platform-reqs alcaeus/mongo-php-adapter"
+                        }
+
+                        sh "composer update --ignore-platform-reqs --optimize-autoloader --no-interaction --no-progress --prefer-dist"
+                        sh "cp app/config/parameters_test.yml.dist app/config/parameters_test.yml"
+                        sh "sed -i 's/database_host:     localhost/database_host:     mysql/' app/config/parameters_test.yml"
+
+                        // Activate MongoDB if needed
+                        if ('odm' == storage) {
+                           sh "sed -i \"s@// new Doctrine@new Doctrine@g\" app/AppKernel.php"
+                           sh "sed -i \"s@# mongodb_database: .*@mongodb_database: akeneo_pim@g\" app/config/pim_parameters.yml"
+                           sh "sed -i \"s@# mongodb_server: .*@mongodb_server: 'mongodb://mongodb:27017'@g\" app/config/pim_parameters.yml"
+                           sh "printf \"    pim_catalog_product_storage_driver: doctrine/mongodb-odm\n\" >> app/config/parameters_test.yml"
+                        }
+
+                        sh "./app/console --env=test pim:install --force"
+
+                        sh "mkdir -p app/build/logs/"
+                        sh "./bin/phpunit -c app/phpunit.travis.xml --testsuite PIM_Integration_Test --log-junit app/build/logs/phpunit_integration.xml"
                     }
-
-                    sh "composer update --ignore-platform-reqs --optimize-autoloader --no-interaction --no-progress --prefer-dist"
-                    sh "cp app/config/parameters_test.yml.dist app/config/parameters_test.yml"
-                    sh "sed -i 's/database_host:     localhost/database_host:     mysql/' app/config/parameters_test.yml"
-                    sh "./app/console --env=test pim:install --force"
-
-                    sh "mkdir -p app/build/logs/"
-                    sh "./bin/phpunit -c app/phpunit.travis.xml --testsuite PIM_Integration_Test --log-junit app/build/logs/phpunit_integration.xml"
                 }
             }
         } finally {
-            sh "sed -i \"s/testcase name=\\\"/testcase name=\\\"[php-${phpVersion}] /\" app/build/logs/*.xml"
+            sh "sed -i \"s/testcase name=\\\"/testcase name=\\\"[php-${phpVersion}-${storage}] /\" app/build/logs/*.xml"
             junit "app/build/logs/*.xml"
             deleteDir()
         }
@@ -204,7 +218,7 @@ def runPhpSpecTest(phpVersion) {
                 unstash "pim_community_dev"
 
                 if (phpVersion != "5.6") {
-                    sh "composer require --no-update alcaeus/mongo-php-adapter"
+                    sh "composer require --no-update --ignore-platform-reqs alcaeus/mongo-php-adapter"
                 }
 
                 sh "composer update --ignore-platform-reqs --optimize-autoloader --no-interaction --no-progress --prefer-dist"

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -32,6 +32,8 @@ abstract class TestCase extends KernelTestCase
      */
     protected function setUp()
     {
+        date_default_timezone_set('Europe/Paris');
+
         static::bootKernel(['debug' => false]);
 
         $configuration = $this->getConfiguration();


### PR DESCRIPTION
## Description

This PR prepare the field to run the integration tests on our new Jenkins CI 1.2 both in ORM and ODM.
As for now, they are broken in ODM, their launch is commented in the Jenkinsfile so this PR can be merged. It is indeed needed for the EE PR, that works.

Integration tests will be fixed on ODM in another PR.

It also sets the date/time zone on "Europe/Paris" (because it is what was expected by the CI). This way, the tests will run the same on a system with a different configured date/time zone.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
