### PR TITLE
API-30: catch exception from gedmo when a category is updated

### DIFF
--- a/src/Pim/Bundle/ApiBundle/Controller/CategoryController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/CategoryController.php
@@ -8,6 +8,7 @@ use Akeneo\Component\StorageUtils\Exception\UnknownPropertyException;
 use Akeneo\Component\StorageUtils\Factory\SimpleFactoryInterface;
 use Akeneo\Component\StorageUtils\Saver\SaverInterface;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
+use Gedmo\Exception\UnexpectedValueException;
 use Oro\Bundle\SecurityBundle\Annotation\AclAncestor;
 use Pim\Bundle\CatalogBundle\Version;
 use Pim\Component\Api\Exception\DocumentedHttpException;
@@ -185,7 +186,11 @@ class CategoryController
         $this->updateCategory($category, $data);
         $this->validateCategory($category, $data);
 
-        $this->saver->save($category);
+        try {
+            $this->saver->save($category);
+        } catch (UnexpectedValueException $e) {
+            throw new UnprocessableEntityHttpException($e->getMessage(), $e);
+        }
 
         $status = $isCreation ? Response::HTTP_CREATED : Response::HTTP_NO_CONTENT;
         $response = $this->getResponse($category, $status);

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Category/PartialUpdateCategoryIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Category/PartialUpdateCategoryIntegration.php
@@ -393,6 +393,20 @@ JSON;
         $this->assertSame($expectedContent, json_decode($response->getContent(), true));
     }
 
+    public function testResponseWhenParentIsMovedInChildren()
+    {
+        $client = $this->createAuthenticatedClient();
+        $categoryId = $this->get('pim_catalog.repository.category')->findOneByIdentifier('master')->getId();
+
+        $data = '{"parent": "categoryA"}';
+        $expectedContent = sprintf('{"code":422, "message": "Cannot set child as parent to node: %d"}', $categoryId);
+        $client->request('PATCH', 'api/rest/v1/categories/master', [], [], [], $data);
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertJsonStringEqualsJsonString($expectedContent, $response->getContent());
+    }
+
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
