### PR TITLE
Remove useless composer global require

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -178,10 +178,9 @@ def runPhpCsFixerTest(version) {
                 }
 
                 sh "composer update --optimize-autoloader --no-interaction --no-progress --prefer-dist"
-                sh "composer global require friendsofphp/php-cs-fixer ^2.0"
                 sh "touch app/config/parameters_test.yml"
                 sh "mkdir -p app/build/logs/"
-                sh "/home/akeneo/.composer/vendor/friendsofphp/php-cs-fixer/php-cs-fixer fix --diff --format=junit --config=.php_cs.dist > app/build/logs/phpcs.xml"
+                sh "./bin/php-cs-fixer fix --diff --format=junit --config=.php_cs.dist > app/build/logs/phpcs.xml"
             }
         } finally {
             sh "sed -i \"s/testcase name=\\\"/testcase name=\\\"[php-${version}] /\" app/build/logs/*.xml"


### PR DESCRIPTION
## Description

`php-cs-fixer` 2.0 is required by `akeneo/php-coupling-detector`, so no need to perform a global requirement anymore.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | -
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
