### PR TITLE
AMS-27: add mark on uncomplete fields

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -1,5 +1,9 @@
 # 1.7.x
 
+## Functional improvements
+
+- AMS-27: Add badges next to fields to inform the user that the field need to be filled.
+
 ## Web API
 
 - API-47: Use OAuth2 to authenticate users on the web API

--- a/features/Context/Page/Base/Form.php
+++ b/features/Context/Page/Base/Form.php
@@ -161,12 +161,26 @@ class Form extends Base
     public function visitGroup($group)
     {
         $this->spin(function () use ($group) {
-            $group = $this->find('css', sprintf($this->elements['Group']['css'], $group));
-            if (null !== $group && $group->isVisible()) {
+            $group = $this->findGroup($group);
+            if ($group->isVisible()) {
                 $group->click();
 
                 return true;
             }
+        }, sprintf('Cannot click the group "%s".', $group));
+    }
+
+    /**
+     * Get the specified group
+     *
+     * @param string $group
+     */
+    public function findGroup($group)
+    {
+        return $this->spin(function () use ($group) {
+            $group = $this->find('css', sprintf($this->elements['Group']['css'], $group));
+
+            return $group;
         }, sprintf('Cannot find the group "%s".', $group));
     }
 

--- a/features/Context/WebUser.php
+++ b/features/Context/WebUser.php
@@ -824,21 +824,25 @@ class WebUser extends RawMinkContext
      */
     public function iChangeTheTo($field, $value = null, $language = null)
     {
-        if (null !== $language) {
-            try {
-                $field = $this->spin(function () use ($field, $language) {
-                    return $this->getCurrentPage()->getFieldLocator($field, $this->getLocaleCode($language));
-                }, sprintf('Cannot find "%s" field', $field));
-            } catch (\BadMethodCallException $e) {
-                // Use default $field if current page does not provide a getFieldLocator method
-            }
-        }
-
         $value = $value !== null ? $value : $this->getInvalidValueFor(
             sprintf('%s.%s', $this->getNavigationContext()->currentPage, $field)
         );
 
-        $this->getCurrentPage()->fillField($field, $value);
+        $this->spin(function () use ($field, $value, $language) {
+            if (null !== $language) {
+                try {
+                    $field = $this->spin(function () use ($field, $language) {
+                        return $this->getCurrentPage()->getFieldLocator($field, $this->getLocaleCode($language));
+                    }, sprintf('Cannot find "%s" field', $field));
+                } catch (\BadMethodCallException $e) {
+                    // Use default $field if current page does not provide a getFieldLocator method
+                }
+            }
+
+            $this->getCurrentPage()->fillField($field, $value);
+
+            return true;
+        }, sprintf('Cannot fill the field "%s"', $field));
     }
 
     /**

--- a/features/Pim/Behat/Context/Domain/Enrich/AttributeTabContext.php
+++ b/features/Pim/Behat/Context/Domain/Enrich/AttributeTabContext.php
@@ -2,11 +2,14 @@
 
 namespace Pim\Behat\Context\Domain\Enrich;
 
+use Context\Spin\SpinCapableTrait;
 use Context\Spin\TimeoutException;
 use Pim\Behat\Context\PimContext;
 
 class AttributeTabContext extends PimContext
 {
+    use SpinCapableTrait;
+
     /**
      * @When /^I open the comparison panel$/
      */
@@ -75,6 +78,68 @@ class AttributeTabContext extends PimContext
     public function theComparisonValueShouldBe($fieldName, $expected)
     {
         $this->getCurrentPage()->compareFieldValue($fieldName, $expected, true);
+    }
+
+    /**
+     * @param string $fieldName
+     * @param mixed  $not
+     *
+     * @Then /^the ([^"]*) field should (not )?be highlighted$/
+     */
+    public function theFieldShouldBeHighlighted($fieldName, $not = null)
+    {
+        $field = $this->getCurrentPage()->findField($fieldName);
+        try {
+            $badge = $this->spin(function () use ($field) {
+                return $field->getParent()->getParent()->find('css', '.AknBadge--highlight');
+            }, 'Cannot find the badge element');
+        } catch (TimeoutException $e) {
+            if ('not ' !== $not) {
+                throw $e;
+            } else {
+                return true;
+            }
+        }
+
+        if ('not ' === $not) {
+            throw $this->getMainContext()->createExpectationException(
+                sprintf(
+                    'Expected to not see the field "%s" highlighted.',
+                    $fieldName
+                )
+            );
+        }
+    }
+
+    /**
+     * @param string $groupName
+     * @param mixed  $not
+     *
+     * @Then /^the ([^"]*) group should (not )?be highlighted$/
+     */
+    public function theGroupShouldBeHighlighted($groupName, $not = null)
+    {
+        $group = $this->getCurrentPage()->findGroup($groupName);
+        try {
+            $badge = $this->spin(function () use ($group) {
+                return $group->getParent()->find('css', '.AknBadge--highlight');
+            }, 'Cannot find the badge element');
+        } catch (TimeoutException $e) {
+            if ('not ' !== $not) {
+                throw $e;
+            } else {
+                return true;
+            }
+        }
+
+        if ('not ' === $not) {
+            throw $this->getMainContext()->createExpectationException(
+                sprintf(
+                    'Expected to see the group "%s" highlighted.',
+                    $groupName
+                )
+            );
+        }
     }
 
     /**

--- a/features/Pim/Behat/Context/Domain/Enrich/AttributeTabContext.php
+++ b/features/Pim/Behat/Context/Domain/Enrich/AttributeTabContext.php
@@ -77,7 +77,11 @@ class AttributeTabContext extends PimContext
      */
     public function theComparisonValueShouldBe($fieldName, $expected)
     {
-        $this->getCurrentPage()->compareFieldValue($fieldName, $expected, true);
+        $this->spin(function () use ($fieldName, $expected) {
+            $this->getCurrentPage()->compareFieldValue($fieldName, $expected, true);
+
+            return true;
+        }, sprintf('Cannot compare product value for "%s" field', $fieldName));
     }
 
     /**
@@ -91,7 +95,7 @@ class AttributeTabContext extends PimContext
         $field = $this->getCurrentPage()->findField($fieldName);
         try {
             $badge = $this->spin(function () use ($field) {
-                return $field->getParent()->getParent()->find('css', '.AknBadge--highlight');
+                return $field->getParent()->getParent()->find('css', '.AknBadge--highlight:not(.AknBadge--light)');
             }, 'Cannot find the badge element');
         } catch (TimeoutException $e) {
             if ('not ' !== $not) {
@@ -104,7 +108,7 @@ class AttributeTabContext extends PimContext
         if ('not ' === $not) {
             throw $this->getMainContext()->createExpectationException(
                 sprintf(
-                    'Expected to not see the field "%s" highlighted.',
+                    'Expected to not see the field "%s" not highlighted.',
                     $fieldName
                 )
             );
@@ -122,7 +126,7 @@ class AttributeTabContext extends PimContext
         $group = $this->getCurrentPage()->findGroup($groupName);
         try {
             $badge = $this->spin(function () use ($group) {
-                return $group->getParent()->find('css', '.AknBadge--highlight');
+                return $group->getParent()->find('css', '.AknBadge--highlight:not(.AknBadge--light)');
             }, 'Cannot find the badge element');
         } catch (TimeoutException $e) {
             if ('not ' !== $not) {
@@ -135,7 +139,7 @@ class AttributeTabContext extends PimContext
         if ('not ' === $not) {
             throw $this->getMainContext()->createExpectationException(
                 sprintf(
-                    'Expected to see the group "%s" highlighted.',
+                    'Expected to see the group "%s" not highlighted.',
                     $groupName
                 )
             );
@@ -159,19 +163,17 @@ class AttributeTabContext extends PimContext
      */
     public function iShouldNotSeeTheComparisonField($fieldLabel)
     {
-        try {
-            $this->getCurrentPage()
-                ->getElement('Attribute tab')
-                ->getComparisonFieldContainer($fieldLabel);
-        } catch (TimeoutException $e) {
-            return true;
-        }
-
-        throw $this->getMainContext()->createExpectationException(
-            sprintf(
-                'Expected to not see the field "%s".',
-                $fieldLabel
-            )
-        );
+        $this->spin(function () use ($fieldLabel) {
+            try {
+                $this->getCurrentPage()
+                    ->getElement('Attribute tab')
+                    ->getComparisonFieldContainer($fieldLabel);
+            } catch (TimeoutException $e) {
+                return true;
+            }
+        }, sprintf(
+            'Expected to not see the field "%s".',
+            $fieldLabel
+        ));
     }
 }

--- a/features/product/completeness/display_completeness.feature
+++ b/features/product/completeness/display_completeness.feature
@@ -36,6 +36,15 @@ Feature: Display the completeness of a product
       | tablet  | fr_FR  | warning | Description, Side view | 78%   |
     When I am on the products page
     Then I am on the "sandals" product page
+    Then the Name field should be highlighted
+    Then the Description field should be highlighted
+    Then the Manufacturer field should not be highlighted
+    Then the SKU field should not be highlighted
+    Then the Product information group should be highlighted
+    Then the Marketing group should be highlighted
+    Then the Sizes group should be highlighted
+    Then the Colors group should not be highlighted
+    Then the Media group should be highlighted
     And I open the "Completeness" panel
     Then I should see the "en_US" completeness in position 1
     And The completeness "fr_FR" should be closed

--- a/features/product/completeness/display_completeness.feature
+++ b/features/product/completeness/display_completeness.feature
@@ -36,15 +36,15 @@ Feature: Display the completeness of a product
       | tablet  | fr_FR  | warning | Description, Side view | 78%   |
     When I am on the products page
     Then I am on the "sandals" product page
-    Then the Name field should be highlighted
-    Then the Description field should be highlighted
-    Then the Manufacturer field should not be highlighted
-    Then the SKU field should not be highlighted
-    Then the Product information group should be highlighted
-    Then the Marketing group should be highlighted
-    Then the Sizes group should be highlighted
-    Then the Colors group should not be highlighted
-    Then the Media group should be highlighted
+    And the Name field should be highlighted
+    And the Description field should be highlighted
+    And the Manufacturer field should not be highlighted
+    And the SKU field should not be highlighted
+    And the Product information group should be highlighted
+    And the Marketing group should be highlighted
+    And the Sizes group should be highlighted
+    And the Colors group should not be highlighted
+    And the Media group should be highlighted
     And I open the "Completeness" panel
     Then I should see the "en_US" completeness in position 1
     And The completeness "fr_FR" should be closed

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_edit.yml
@@ -207,6 +207,12 @@ extensions:
         targetZone: self
         position: 100
 
+    pim-product-edit-form-completeness-filter:
+        module: pim/product-edit-form/attributes/completeness
+        parent: pim-product-edit-form-attributes
+        targetZone: self
+        position: 100
+
     pim-product-edit-form-localizable:
         module: pim/product-edit-form/attributes/localizable
         parent: pim-product-edit-form-attributes

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
@@ -102,7 +102,7 @@ config:
                             list: pim_enrich_channel_rest_index
                             get: pim_enrich_channel_rest_get
                 locale:
-                    module: pim/base-fetcher
+                    module: pim/locale-fetcher
                     options:
                         urls:
                             list: pim_enrich_locale_rest_index
@@ -215,6 +215,7 @@ config:
         pim/base-fetcher:            pimenrich/js/fetcher/base-fetcher
         pim/attribute-fetcher:       pimenrich/js/fetcher/attribute-fetcher
         pim/attribute-group-fetcher: pimenrich/js/fetcher/attribute-group-fetcher
+        pim/locale-fetcher:          pimenrich/js/fetcher/locale-fetcher
         pim/completeness-fetcher:    pimenrich/js/fetcher/completeness-fetcher
         pim/product-fetcher:         pimenrich/js/fetcher/product-fetcher
         pim/variant-group-fetcher:   pimenrich/js/fetcher/variant-group-fetcher

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
@@ -296,6 +296,7 @@ config:
         pim/product-edit-form/attributes/validation-error: pimenrich/js/product/form/attributes/validation-error
         pim/product-edit-form/attributes/variant-group:    pimenrich/js/product/form/attributes/variant-group
         pim/product-edit-form/attributes/locale-specific:  pimenrich/js/product/form/attributes/locale-specific
+        pim/product-edit-form/attributes/completeness:     pimenrich/js/product/form/attributes/completeness
         pim/product-edit-form/attributes/localizable:      pimenrich/js/product/form/attributes/localizable
         pim/product-edit-form/categories:                  pimenrich/js/product/form/categories
         pim/product-edit-form/associations:                pimenrich/js/product/form/associations
@@ -369,6 +370,7 @@ config:
 
         # Product edit form
         pim/field-manager: pimenrich/js/product/field-manager
+        pim/provider/to-fill-field-provider: pimenrich/js/provider/to-fill-field-provider
 
         # Product create form
         pim/product-create:      pimenrich/js/product/create/create

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/fetcher/locale-fetcher.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/fetcher/locale-fetcher.js
@@ -1,0 +1,45 @@
+'use strict';
+
+define([
+        'jquery',
+        'pim/base-fetcher',
+        'routing'
+
+    ], function (
+        $,
+        BaseFetcher,
+        Routing
+    ) {
+        return BaseFetcher.extend({
+            entityActivatedListPromise: null,
+            /**
+             * @param {Object} options
+             */
+            initialize: function (options) {
+                this.options = options || {};
+            },
+
+            /**
+             * Fetch an element based on its identifier
+             *
+             * @param {string} identifier
+             *
+             * @return {Promise}
+             */
+            fetchActivated: function () {
+                if (!this.entityActivatedListPromise) {
+                    if (!_.has(this.options.urls, 'list')) {
+                        return $.Deferred().reject().promise();
+                    }
+
+                    this.entityActivatedListPromise = $.getJSON(
+                        Routing.generate(this.options.urls.list),
+                        {activated: true}
+                    ).then(_.identity).promise();
+                }
+
+                return this.entityActivatedListPromise;
+            }
+        });
+    }
+);

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes.js
@@ -211,7 +211,7 @@ define(
 
                 $.when(
                     FetcherRegistry.getFetcher('attribute').fetchByIdentifiers(attributeCodes),
-                    FetcherRegistry.getFetcher('locale').search({'activated': true}),
+                    FetcherRegistry.getFetcher('locale').fetchActivated(),
                     FetcherRegistry.getFetcher('channel').fetchAll(),
                     FetcherRegistry.getFetcher('currency').fetchAll()
                 ).then(function (attributes, locales, channels, currencies) {

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes/attribute-group-selector.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes/attribute-group-selector.js
@@ -93,7 +93,6 @@ define(
                         );
                     }));
 
-                    this.$el.empty();
                     this.$el.html(this.template({
                         current: this.getCurrent(),
                         elements: this.getElements(),
@@ -104,7 +103,6 @@ define(
                     }));
 
                     this.delegateEvents();
-
                 }.bind(this));
 
                 return this;

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes/attribute-group-selector.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes/attribute-group-selector.js
@@ -9,14 +9,16 @@
  */
 define(
     [
+        'jquery',
         'underscore',
         'pim/form/common/group-selector',
         'pim/attribute-group-manager',
         'text!pim/template/form/tab/attribute/attribute-group-selector',
         'pim/user-context',
-        'pim/i18n'
+        'pim/i18n',
+        'pim/provider/to-fill-field-provider'
     ],
-    function (_, GroupSelectorForm, AttributeGroupManager, template, UserContext, i18n) {
+    function ($, _, GroupSelectorForm, AttributeGroupManager, template, UserContext, i18n, toFillFieldProvider) {
         return GroupSelectorForm.extend({
             template: _.template(template),
 
@@ -26,6 +28,8 @@ define(
             configure: function () {
                 this.listenTo(this.getRoot(), 'pim_enrich:form:entity:validation_error', this.onValidationError);
                 this.listenTo(this.getRoot(), 'pim_enrich:form:entity:post_fetch', this.onPostFetch);
+                this.listenTo(UserContext, 'change:catalogLocale', this.render);
+                this.listenTo(UserContext, 'change:catalogScope', this.render);
 
                 return GroupSelectorForm.prototype.configure.apply(this, arguments);
             },
@@ -78,16 +82,30 @@ define(
              * {@inheritdoc}
              */
             render: function () {
-                this.$el.empty();
-                this.$el.html(this.template({
-                    current: this.getCurrent(),
-                    elements: this.getElements(),
-                    badges: this.badges,
-                    locale: UserContext.get('catalogLocale'),
-                    i18n: i18n
-                }));
+                $.when(
+                    toFillFieldProvider.getFields(this.getRoot(), this.getFormData()),
+                    AttributeGroupManager.getAttributeGroupsForObject(this.getFormData())
+                ).then(function (attributes, attributeGroups) {
+                    var toFillAttributeGroups = _.uniq(_.map(attributes, function (attribute) {
+                        return AttributeGroupManager.getAttributeGroupForAttribute(
+                            attributeGroups,
+                            attribute
+                        );
+                    }));
 
-                this.delegateEvents();
+                    this.$el.empty();
+                    this.$el.html(this.template({
+                        current: this.getCurrent(),
+                        elements: this.getElements(),
+                        badges: this.badges,
+                        locale: UserContext.get('catalogLocale'),
+                        toFillAttributeGroups: toFillAttributeGroups,
+                        i18n: i18n
+                    }));
+
+                    this.delegateEvents();
+
+                }.bind(this));
 
                 return this;
             }

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/manager/attribute-manager.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/manager/attribute-manager.js
@@ -187,7 +187,6 @@ define([
                         price = { amount: null, currency: currency.code };
                         prices.push(price);
                     }
-
                 });
 
                 return _.sortBy(prices, 'currency');

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/manager/product-manager.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/manager/product-manager.js
@@ -24,7 +24,7 @@ define([
                     .then(function (productAttributeCodes) {
                         return $.when(
                             FetcherRegistry.getFetcher('attribute').fetchByIdentifiers(productAttributeCodes),
-                            FetcherRegistry.getFetcher('locale').search({'activated': true}),
+                            FetcherRegistry.getFetcher('locale').fetchActivated(),
                             FetcherRegistry.getFetcher('channel').fetchAll(),
                             FetcherRegistry.getFetcher('currency').fetchAll(),
                             FetcherRegistry.getFetcher('association-type').fetchAll()

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/manager/variant-group-manager.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/manager/variant-group-manager.js
@@ -24,7 +24,7 @@ define([
                     .then(function (productAttributeCodes) {
                         return $.when(
                             FetcherRegistry.getFetcher('attribute').fetchByIdentifiers(productAttributeCodes),
-                            FetcherRegistry.getFetcher('locale').search({'activated': true}),
+                            FetcherRegistry.getFetcher('locale').fetchActivated(),
                             FetcherRegistry.getFetcher('channel').fetchAll(),
                             FetcherRegistry.getFetcher('currency').fetchAll()
                         );

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/price-collection-field.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/price-collection-field.js
@@ -21,7 +21,7 @@ define([
             'change .field-input:first input[type="text"]': 'updateModel'
         },
         renderInput: function (context) {
-            context.value.amount = _.sortBy(context.value.amount, 'currency');
+            context.value.data = _.sortBy(context.value.data, 'currency');
 
             return this.fieldTemplate(context);
         },

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/attributes/completeness.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/attributes/completeness.js
@@ -1,0 +1,92 @@
+'use strict';
+/**
+ * completeness filter extension
+ *
+ * @author    Julien Sanchez <julien@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+define(
+    [
+        'jquery',
+        'underscore',
+        'pim/form',
+        'pim/fetcher-registry',
+        'pim/user-context',
+        'pim/provider/to-fill-field-provider'
+    ],
+    function ($, _, BaseForm, fetcherRegistry, UserContext, toFillFieldProvider) {
+        return BaseForm.extend({
+            configure: function () {
+                this.listenTo(this.getRoot(), 'pim_enrich:form:field:extension:add', this.addFieldExtension);
+                this.listenTo(this.getRoot(), 'pim_enrich:form:field:to-fill-filter', this.addFieldFilter);
+
+                return BaseForm.prototype.configure.apply(this, arguments);
+            },
+
+            /**
+             * Add filter on field if the user doesn't have the right to edit it.
+             *
+             * @param {object} event
+             */
+            addFieldFilter: function (event) {
+                event.filters.push(fetcherRegistry.getFetcher('product-completeness').fetchForProduct(
+                    this.getFormData().meta.id,
+                    this.getFormData().family
+                ).then(function (completenesses) {
+                    if (null === completenesses.family) {
+                        return $.Deferred().resolve([]);
+                    }
+
+                    var localeCompleteness = _.findWhere(
+                        completenesses.completenesses,
+                        {locale: UserContext.get('catalogLocale')}
+                    );
+
+                    if (undefined === localeCompleteness ||
+                        undefined === localeCompleteness.channels[UserContext.get('catalogScope')]
+                    ) {
+                        return $.Deferred().resolve([]);
+                    }
+
+                    var missingAttributeCodes = _.pluck(
+                        localeCompleteness.channels[UserContext.get('catalogScope')].missing,
+                        'code'
+                    );
+
+                    return fetcherRegistry.getFetcher('attribute').fetchByIdentifiers(missingAttributeCodes);
+                })
+                .then(function (missingAttributes) {
+                    return function (attributes) {
+                        return _.filter(missingAttributes, function (missingAttribute) {
+                            return _.contains(_.pluck(attributes, 'code'), missingAttribute.code);
+                        });
+                    };
+                }));
+            },
+
+            /**
+             * {@inheritDoc}
+             */
+            addFieldExtension: function (event) {
+                event.promises.push(
+                    toFillFieldProvider.getFields(this.getRoot(), this.getFormData()).then(function (fields) {
+                        var field = event.field;
+
+                        if (_.contains(fields, field.attribute.code)) {
+                            field.addElement(
+                                'badge',
+                                'completeness',
+                                '<span class="AknBadge AknBadge--round AknBadge--highlight"></span>'
+                            );
+                        }
+
+                        return event;
+                    }.bind(this))
+                );
+
+                return this;
+            }
+        });
+    }
+);

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/locale-switcher.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/locale-switcher.js
@@ -47,7 +47,7 @@ define(
              * @returns {Promise}
              */
             getDisplayedLocales: function () {
-                return FetcherRegistry.getFetcher('locale').search({'activated': true});
+                return FetcherRegistry.getFetcher('locale').fetchActivated();
             },
 
             /**

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/panel/completeness.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/panel/completeness.js
@@ -53,7 +53,7 @@ define(
                 if (this.getFormData().meta) {
                     $.when(
                         this.fetchCompleteness(),
-                        FetcherRegistry.getFetcher('locale').search({'activated': true})
+                        FetcherRegistry.getFetcher('locale').fetchActivated()
                     ).then(function (completeness, locales) {
                         this.$el.html(
                             this.template({

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/panel/completeness.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/panel/completeness.js
@@ -35,7 +35,7 @@ define(
                     label: _.__('pim_enrich.form.product.panel.completeness.title')
                 });
 
-                this.listenTo(this.getRoot(), 'pim_enrich:form:entity:post_fetch', this.update);
+                this.listenTo(this.getRoot(), 'pim_enrich:form:entity:post_fetch', this.render);
                 this.listenTo(this.getRoot(), 'pim_enrich:form:change-family:after', this.onChangeFamily);
                 this.listenTo(UserContext, 'change:catalogLocale', this.render);
 
@@ -125,17 +125,6 @@ define(
                         scope: event.currentTarget.dataset.channel
                     }
                 );
-            },
-
-            /**
-             * Update the completeness by fetching it from the backend
-             */
-            update: function () {
-                if (this.getFormData().meta) {
-                    FetcherRegistry.getFetcher('product-completeness').clear(this.getFormData().meta.id);
-                }
-
-                this.render();
             },
 
             /**

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/save.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/save.js
@@ -18,7 +18,8 @@ define(
         'pim/saver/product',
         'pim/field-manager',
         'pim/i18n',
-        'pim/user-context'
+        'pim/user-context',
+        'pim/fetcher-registry'
     ],
     function (
         $,
@@ -30,7 +31,8 @@ define(
         ProductSaver,
         FieldManager,
         i18n,
-        UserContext
+        UserContext,
+        FetcherRegistry
     ) {
         return BaseSave.extend({
             updateSuccessMessage: __('pim_enrich.entity.product.info.update_successful'),
@@ -75,6 +77,8 @@ define(
                         this.postSave();
 
                         this.setData(data, options);
+
+                        FetcherRegistry.getFetcher('product-completeness').clear(this.getFormData().meta.id);
                         this.getRoot().trigger('pim_enrich:form:entity:post_fetch', data);
                     }.bind(this))
                     .fail(this.fail.bind(this))

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/provider/to-fill-field-provider.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/provider/to-fill-field-provider.js
@@ -1,0 +1,54 @@
+'use strict';
+/**
+ * Attribute group selector extension
+ *
+ * @author    Julien Sanchez <julien@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+define(
+    [
+        'jquery',
+        'underscore',
+        'oro/mediator',
+        'pim/attribute-manager',
+        'pim/fetcher-registry'
+    ],
+    function ($, _, mediator, attributeManager, fetcherRegistry) {
+        return {
+            /**
+             * Get list of fields that need to be field to complete the product
+             *
+             * @param {object} root
+             * @param {object} product
+             *
+             * @return {promise}
+             */
+            getFields: function (root, product) {
+                var filterPromises = [];
+                root.trigger(
+                    'pim_enrich:form:field:to-fill-filter',
+                    {'filters': filterPromises}
+                );
+
+                return $.when.apply($, filterPromises).then(function () {
+                    return arguments;
+                }).then(function (filters) {
+                    return attributeManager.getAttributes(product)
+                        .then(function (attributeCodes) {
+                            return fetcherRegistry.getFetcher('attribute').fetchByIdentifiers(attributeCodes);
+                        })
+                        .then(function (attributesToFilter) {
+                            var filteredAttributes = _.reduce(filters, function (attributes, filter) {
+                                return filter(attributes);
+                            }, attributesToFilter);
+
+                            return _.map(filteredAttributes, function (attribute) {
+                                return attribute.code;
+                            });
+                        });
+                });
+            }
+        };
+    }
+);

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/provider/to-fill-field-provider.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/provider/to-fill-field-provider.js
@@ -17,7 +17,7 @@ define(
     function ($, _, mediator, attributeManager, fetcherRegistry) {
         return {
             /**
-             * Get list of fields that need to be field to complete the product
+             * Get list of fields that need to be filled to complete the product
              *
              * @param {object} root
              * @param {object} product

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/form/tab/attributes/attribute-group-selector.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/form/tab/attributes/attribute-group-selector.html
@@ -4,6 +4,10 @@
         <a class="AknVerticalNavtab-link <%- current === element.code ? 'AknVerticalNavtab-link--active' : '' %>">
             <span class="group-label"><%- i18n.getLabel(element.labels, locale, element.code) %></span>
             <span class="badge-elements-container">
+                <span
+                    class="AknBadge AknBadge--round AknBadge--highlight AknBadge--<%- !_.contains(toFillAttributeGroups, element.code) ? 'light' : '' %>"
+                >
+                </span>
                 <% _.each(badges[element.code], function(badge, type) { %>
                     <span class="AknBadge AknBadge--<%- type %> <%- type %>-badge label"><%- badge %></span>
                 <% }) %>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/form/tab/attributes/attribute-group-selector.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/form/tab/attributes/attribute-group-selector.html
@@ -5,7 +5,7 @@
             <span class="group-label"><%- i18n.getLabel(element.labels, locale, element.code) %></span>
             <span class="badge-elements-container">
                 <span
-                    class="AknBadge AknBadge--round AknBadge--highlight AknBadge--<%- !_.contains(toFillAttributeGroups, element.code) ? 'light' : '' %>"
+                    class="AknBadge AknBadge--round AknBadge--highlight <%- !_.contains(toFillAttributeGroups, element.code) ? 'AknBadge--light' : '' %>"
                 >
                 </span>
                 <% _.each(badges[element.code], function(badge, type) { %>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/field/field.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/field/field.html
@@ -1,6 +1,7 @@
 <div class="<%- type %> AknComparableFields-item AknFieldContainer original-field <%- editMode %>">
     <div class="AknFieldContainer-header">
         <label class="AknFieldContainer-label" for="<%- fieldId %>">
+            <span class="badge-elements-container"></span>
             <%- label %>
             <span class="label-elements-container"></span>
         </label>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/field/text.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/field/text.html
@@ -1,1 +1,1 @@
-<input id="<%- fieldId %>" class="AknTextField" type="text" data-locale="<%- value.locale %>" data-scope="<%- value.scope %>" value="<%- value.data %>" <%- editMode === 'view' ? 'disabled' : '' %>/>
+<input id="<%- fieldId %>" class="AknTextField <%- context.isRequired ? 'AknTextField--required' : '' %>" type="text" data-locale="<%- value.locale %>" data-scope="<%- value.scope %>" value="<%- value.data %>" <%- editMode === 'view' ? 'disabled' : '' %>/>

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/Badge.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/Badge.less
@@ -70,6 +70,18 @@
     }
   }
 
+  &--highlight {
+    background: @AknOrange;
+  }
+
+  &--light {
+    opacity: 0.2;
+  }
+
+  &--round {
+    border-radius: 10px;
+  }
+
   &--grey &-icon {
     color: white;
   }


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

This PR add a little marker on the pef to inform the user that he have to fill the fields of the product to complete it.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | OK
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | OK
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
