### PR TITLE
PIM-6167: Fix regression on attribute form: type must be readonly

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Resources/views/Attribute/_js-handler.html.twig
+++ b/src/Pim/Bundle/EnrichBundle/Resources/views/Attribute/_js-handler.html.twig
@@ -21,7 +21,7 @@ require(
                         mediator.trigger('attribute:auto_option_sorting:changed', data.value);
                     });
 
-                $(formName+'_attributeType').select2('readonly', true);
+                $(formName+'_type').select2('readonly', true);
 
                 // Enable/disable scope and localizable fields according to unique field value
                 $(formName+'_unique').closest('.has-switch').on('switch-change', function (e, data) {


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Fixes a regression introduced by https://github.com/akeneo/pim-community-dev/pull/5727.