### PR TITLE
TIP-694: Add completeness integration tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -175,7 +175,7 @@ def runIntegrationTest(phpVersion, storage) {
         deleteDir()
         try {
             docker.image("mongo:2.4").withRun("--name mongodb", "--smallfiles") {
-                docker.image("mysql:5.5").withRun("--name mysql -e MYSQL_ROOT_PASSWORD=root -e MYSQL_USER=akeneo_pim -e MYSQL_PASSWORD=akeneo_pim -e MYSQL_DATABASE=akeneo_pim") {
+                docker.image("mysql:5.5").withRun("--name mysql -e MYSQL_ROOT_PASSWORD=root -e MYSQL_USER=akeneo_pim -e MYSQL_PASSWORD=akeneo_pim -e MYSQL_DATABASE=akeneo_pim", "--sql_mode=ERROR_FOR_DIVISION_BY_ZERO,NO_ZERO_IN_DATE,NO_ZERO_DATE,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION") {
                     docker.image("carcel/php:${phpVersion}").inside("--link mysql:mysql --link mongodb:mongodb -v /home/akeneo/.composer:/home/akeneo/.composer -e COMPOSER_HOME=/home/akeneo/.composer") {
                         unstash "pim_community_dev"
 

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AbstractCompletenessIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AbstractCompletenessIntegration.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\Completeness;
+
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\FamilyInterface;
+use Pim\Component\Catalog\Model\LocaleInterface;
+use Pim\Component\Catalog\Model\ProductInterface;
+
+/**
+ * @author    Julien Janvier <j.janvier@gmail.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+abstract class AbstractCompletenessIntegration extends TestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return new Configuration(
+            [Configuration::getMinimalCatalogPath()],
+            true
+        );
+    }
+
+    /**
+     * @param string $code
+     * @param string $type
+     * @param bool   $localisable
+     * @param bool   $scopable
+     * @param array  $localesSpecific
+     *
+     * @return AttributeInterface
+     */
+    protected function createAttribute(
+        $code,
+        $type,
+        $localisable = false,
+        $scopable = false,
+        array $localesSpecific = []
+    ) {
+        $attributeFactory = $this->get('pim_catalog.factory.attribute');
+        $attributeSaver = $this->get('pim_catalog.saver.attribute');
+
+        $attribute = $attributeFactory->createAttribute($type);
+        $attribute->setCode($code);
+        $attribute->setLocalizable($localisable);
+        $attribute->setScopable($scopable);
+        foreach ($localesSpecific as $locale) {
+            $attribute->addAvailableLocale($locale);
+        }
+
+        $attributeSaver->save($attribute);
+
+        return $attribute;
+    }
+
+    /**
+     * @param FamilyInterface $family
+     * @param string          $code
+     * @param array           $standardValues
+     *
+     * @return ProductInterface
+     */
+    protected function createProductWithStandardValues(FamilyInterface $family, $code, $standardValues = [])
+    {
+        $product = $this->get('pim_catalog.builder.product')->createProduct($code, $family->getCode());
+        $this->get('pim_catalog.updater.product')->update($product, $standardValues);
+        $this->get('pim_catalog.saver.product')->save($product);
+
+        return $product;
+    }
+
+    /**
+     * @param string $familyCode
+     * @param string $channelCode
+     * @param string $attributeCode
+     * @param string $attributeType
+     * @param bool $localisable
+     * @param bool $scopable
+     * @param LocaleInterface[] $localesSpecific
+     *
+     * @return FamilyInterface
+     */
+    protected function createFamilyWithRequirement(
+        $familyCode,
+        $channelCode,
+        $attributeCode,
+        $attributeType,
+        $localisable = false,
+        $scopable = false,
+        array $localesSpecific = []
+    ) {
+        $channel = $this->get('pim_catalog.repository.channel')->findOneByIdentifier($channelCode);
+        $attribute = $this->createAttribute($attributeCode, $attributeType, $localisable, $scopable, $localesSpecific);
+
+        $requirement = $this->get('pim_catalog.factory.attribute_requirement')
+            ->createAttributeRequirement($attribute, $channel, true);
+
+        $family = $this->findOrCreateFamily($familyCode);
+        $family->addAttribute($attribute);
+        $family->addAttributeRequirement($requirement);
+        $this->get('pim_catalog.saver.family')->save($family);
+
+        return $family;
+    }
+
+    /**
+     * @param string $familyCode
+     * @param string $channelCode
+     * @param string $attributeCode
+     *
+     * @return FamilyInterface
+     */
+    protected function addFamilyRequirement($familyCode, $channelCode, $attributeCode)
+    {
+        $channel = $this->get('pim_catalog.repository.channel')->findOneByIdentifier($channelCode);
+        $attribute = $this->get('pim_catalog.repository.attribute')->findOneByIdentifier($attributeCode);
+
+        $requirement = $this->get('pim_catalog.factory.attribute_requirement')
+            ->createAttributeRequirement($attribute, $channel, true);
+
+        $family = $this->get('pim_catalog.repository.family')->findOneByIdentifier($familyCode);
+        $family->addAttribute($attribute);
+        $family->addAttributeRequirement($requirement);
+        $this->get('pim_catalog.saver.family')->save($family);
+
+        return $family;
+    }
+
+    /**
+     * @param string $code
+     *
+     * @return FamilyInterface
+     */
+    private function findOrCreateFamily($code)
+    {
+        $family = $this->get('pim_catalog.repository.family')->findOneByIdentifier($code);
+        if (null === $family) {
+            $family = $this->get('pim_catalog.factory.family')->create();
+            $family->setCode($code);
+        }
+
+        return $family;
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AbstractCompletenessPerAttributeTypeIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AbstractCompletenessPerAttributeTypeIntegration.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\Completeness;
+
+use Pim\Component\Catalog\Model\ProductInterface;
+
+/**
+ * Abstract class to check that the completeness has been well calculated for each attribute type of the PIM.
+ *
+ * We test from the minimal catalog that contains only one channel with one activated locale.
+ * For each attribute type, we create an attribute. Then, we create a family where the attribute is required.
+ * We create two products of this family, one with the required attribute filled in, the other without.
+ * Finally we test the completeness calculation of those two products.
+ *
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+abstract class AbstractCompletenessPerAttributeTypeIntegration extends AbstractCompletenessIntegration
+{
+    /**
+     * Here, the identifier and the attribute should be filled in.
+     * Which means, there should be 0 missing, and 2 required.
+     *
+     * @param ProductInterface $product
+     */
+    protected function assertComplete(ProductInterface $product)
+    {
+        $completenesses = $product->getCompletenesses()->toArray();
+        $this->assertNotNull($completenesses);
+        $this->assertCount(1, $completenesses);
+
+        $completeness = current($completenesses);
+
+        $this->assertNotNull($completeness->getLocale());
+        $this->assertEquals('en_US', $completeness->getLocale()->getCode());
+        $this->assertNotNull($completeness->getChannel());
+        $this->assertEquals('ecommerce', $completeness->getChannel()->getCode());
+        $this->assertEquals(100, $completeness->getRatio());
+        $this->assertEquals(2, $completeness->getRequiredCount());
+        $this->assertEquals(0, $completeness->getMissingCount());
+    }
+
+    /**
+     * Here, only the identifier should be filled in.
+     * Which means, there should be 1 missing, and 2 required.
+     *
+     * @param ProductInterface $product
+     */
+    protected function assertNotComplete(ProductInterface $product)
+    {
+        $completenesses = $product->getCompletenesses()->toArray();
+        $this->assertNotNull($completenesses);
+        $this->assertCount(1, $completenesses);
+
+        $completeness = current($completenesses);
+
+        $this->assertNotNull($completeness->getLocale());
+        $this->assertEquals('en_US', $completeness->getLocale()->getCode());
+        $this->assertNotNull($completeness->getChannel());
+        $this->assertEquals('ecommerce', $completeness->getChannel()->getCode());
+        $this->assertEquals(50, $completeness->getRatio());
+        $this->assertEquals(2, $completeness->getRequiredCount());
+        $this->assertEquals(1, $completeness->getMissingCount());
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/BooleanAttributeTypeCompletenessIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/BooleanAttributeTypeCompletenessIntegration.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\Completeness\AttributeType;
+
+use Pim\Bundle\CatalogBundle\tests\integration\Completeness\AbstractCompletenessPerAttributeTypeIntegration;
+use Pim\Component\Catalog\AttributeTypes;
+use Pim\Component\Catalog\Model\ProductInterface;
+
+/**
+ * Checks that the completeness has been well calculated for boolean attribute type.
+ *
+ * @author    Damien Carcel (damien.carcel@akeneo.com)
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class BooleanAttributeTypeCompletenessIntegration extends AbstractCompletenessPerAttributeTypeIntegration
+{
+    public function testCompleteBoolean()
+    {
+        $family = $this->createFamilyWithRequirement(
+            'another_family',
+            'ecommerce',
+            'a_boolean',
+            AttributeTypes::BOOLEAN
+        );
+
+        $productComplete = $this->createProductWithStandardValues(
+            $family,
+            'product_complete_true',
+            [
+                'values' => [
+                    'a_boolean' => [
+                        [
+                            'locale' => null,
+                            'scope'  => null,
+                            'data'   => true,
+                        ],
+                    ],
+                ],
+            ]
+        );
+        $this->assertComplete($productComplete);
+
+        $productCompleteFalse = $this->createProductWithStandardValues(
+            $family,
+            'product_complete_false',
+            [
+                'values' => [
+                    'a_boolean' => [
+                        [
+                            'locale' => null,
+                            'scope'  => null,
+                            'data'   => false,
+                        ],
+                    ],
+                ],
+            ]
+        );
+        $this->assertComplete($productCompleteFalse);
+    }
+
+    public function testNotCompleteBoolean()
+    {
+        $family = $this->createFamilyWithRequirement(
+            'another_family',
+            'ecommerce',
+            'a_boolean',
+            AttributeTypes::BOOLEAN
+        );
+
+        $productDataNull = $this->createProductWithStandardValues(
+            $family,
+            'product_data_null',
+            [
+                'values' => [
+                    'a_boolean' => [
+                        [
+                            'locale' => null,
+                            'scope'  => null,
+                            'data'   => null,
+                        ],
+                    ],
+                ],
+            ]
+        );
+        $this->assertNotComplete($productDataNull);
+
+        $productWithoutValues = $this->createProductWithStandardValues($family, 'product_without_values');
+        // TODO: This is not as it should be, but inevitable because of PIM-6056
+        // TODO: When PIM-6056 is fixed, we should be able to use "assertNotComplete"
+        $this->assertComplete($productWithoutValues);
+        $this->assertBooleanValueIsFalse($productWithoutValues, 'a_boolean');
+    }
+
+    /**
+     * For now, when creating an empty boolean product value, it is automatically
+     * set to false by the product builder.
+     *
+     * @todo To remove once PIM-6056 is fixed.
+     *
+     * @param ProductInterface $product
+     * @param string           $attributeCode
+     */
+    private function assertBooleanValueIsFalse(ProductInterface $product, $attributeCode)
+    {
+        $booleanValue = $product->getValue($attributeCode, null, null);
+        $this->assertFalse($booleanValue->getData());
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/DateAttributeTypeCompletenessIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/DateAttributeTypeCompletenessIntegration.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\Completeness\AttributeType;
+
+use Pim\Bundle\CatalogBundle\tests\integration\Completeness\AbstractCompletenessPerAttributeTypeIntegration;
+use Pim\Component\Catalog\AttributeTypes;
+
+/**
+ * Checks that the completeness has been well calculated for date attribute type.
+ *
+ * @author    Damien Carcel (damien.carcel@akeneo.com)
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class DateAttributeTypeCompletenessIntegration extends AbstractCompletenessPerAttributeTypeIntegration
+{
+    public function testCompleteDate()
+    {
+        $family = $this->createFamilyWithRequirement(
+            'another_family',
+            'ecommerce',
+            'a_date',
+            AttributeTypes::DATE
+        );
+
+        $productComplete = $this->createProductWithStandardValues(
+            $family,
+            'product_complete',
+            [
+                'values' => [
+                    'a_date' => [
+                        [
+                            'locale' => null,
+                            'scope'  => null,
+                            'data'   => '2012-08-05',
+                        ],
+                    ],
+                ],
+            ]
+        );
+
+        $this->assertComplete($productComplete);
+    }
+
+    public function testNotCompleteDate()
+    {
+        $family = $this->createFamilyWithRequirement(
+            'another_family',
+            'ecommerce',
+            'a_date',
+            AttributeTypes::DATE
+        );
+
+        $productDataNull = $this->createProductWithStandardValues(
+            $family,
+            'product_data_null',
+            [
+                'values' => [
+                    'a_date' => [
+                        [
+                            'locale' => null,
+                            'scope'  => null,
+                            'data'   => null,
+                        ],
+                    ],
+                ],
+            ]
+        );
+        $this->assertNotComplete($productDataNull);
+
+        $productWithoutValues = $this->createProductWithStandardValues($family, 'product_without_values');
+        $this->assertNotComplete($productWithoutValues);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/FileAttributeTypeCompletenessIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/FileAttributeTypeCompletenessIntegration.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\Completeness\AttributeType;
+
+use Pim\Bundle\CatalogBundle\tests\integration\Completeness\AbstractCompletenessPerAttributeTypeIntegration;
+use Pim\Component\Catalog\AttributeTypes;
+
+/**
+ * Checks that the completeness has been well calculated for file attribute type.
+ *
+ * @author    Damien Carcel (damien.carcel@akeneo.com)
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class FileAttributeTypeCompletenessIntegration extends AbstractCompletenessPerAttributeTypeIntegration
+{
+    public function testCompleteFile()
+    {
+        $family = $this->createFamilyWithRequirement(
+            'another_family',
+            'ecommerce',
+            'a_file',
+            AttributeTypes::FILE
+        );
+
+        $productComplete = $this->createProductWithStandardValues(
+            $family,
+            'product_complete',
+            [
+                'values' => [
+                    'a_file' => [
+                        [
+                            'locale' => null,
+                            'scope'  => null,
+                            'data'   => $this->getFixturePath('akeneo.txt'),
+                        ],
+                    ],
+                ],
+            ]
+        );
+
+        $this->assertComplete($productComplete);
+    }
+
+    public function testNotCompleteFile()
+    {
+        $family = $this->createFamilyWithRequirement(
+            'another_family',
+            'ecommerce',
+            'a_file',
+            AttributeTypes::FILE
+        );
+
+        $productDataNull = $this->createProductWithStandardValues(
+            $family,
+            'product_data_null',
+            [
+                'values' => [
+                    'a_file' => [
+                        [
+                            'locale' => null,
+                            'scope'  => null,
+                            'data'   => null,
+                        ],
+                    ],
+                ],
+            ]
+        );
+        $this->assertNotComplete($productDataNull);
+
+        $productWithoutValues = $this->createProductWithStandardValues($family, 'product_without_values');
+        $this->assertNotComplete($productWithoutValues);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/IdentifierAttributeTypeCompletenessIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/IdentifierAttributeTypeCompletenessIntegration.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\Completeness\AttributeType;
+
+use Pim\Bundle\CatalogBundle\tests\integration\Completeness\AbstractCompletenessPerAttributeTypeIntegration;
+use Pim\Component\Catalog\Model\FamilyInterface;
+use Pim\Component\Catalog\Model\ProductInterface;
+
+/**
+ * Checks that the completeness has been well calculated for identifier attribute type.
+ * The family that is created here has the "sku" (and ONLY the "sku") as required attribute.
+ *
+ * @author    Damien Carcel (damien.carcel@akeneo.com)
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class IdentifierAttributeTypeCompletenessIntegration extends AbstractCompletenessPerAttributeTypeIntegration
+{
+    public function testCompleteIdentifier()
+    {
+        $family = $this->createFamily('another_family');
+
+        $productComplete = $this->createProductWithStandardValues(
+            $family,
+            'product_complete',
+            [
+                'values' => [
+                    'sku' => [
+                        [
+                            'locale' => null,
+                            'scope'  => null,
+                            'data'   => 'foo',
+                        ],
+                    ],
+                ],
+            ]
+        );
+
+        $this->assertComplete($productComplete);
+    }
+
+    /**
+     * @param string $familyCode
+     *
+     * @return FamilyInterface
+     */
+    private function createFamily($familyCode)
+    {
+        $family = $this->get('pim_catalog.factory.family')->create();
+        $family->setCode($familyCode);
+        $this->get('pim_catalog.saver.family')->save($family);
+
+        return $family;
+    }
+
+    /**
+     * Here, the "sku" should be filled in.
+     * Which means, there should be 0 missing, and 1 required.
+     *
+     * @param ProductInterface $product
+     */
+    protected function assertComplete(ProductInterface $product)
+    {
+        $completenesses = $product->getCompletenesses()->toArray();
+        $this->assertNotNull($completenesses);
+        $this->assertCount(1, $completenesses);
+
+        $completeness = current($completenesses);
+
+        $this->assertNotNull($completeness->getLocale());
+        $this->assertEquals('en_US', $completeness->getLocale()->getCode());
+        $this->assertNotNull($completeness->getChannel());
+        $this->assertEquals('ecommerce', $completeness->getChannel()->getCode());
+        $this->assertEquals(100, $completeness->getRatio());
+        $this->assertEquals(1, $completeness->getRequiredCount());
+        $this->assertEquals(0, $completeness->getMissingCount());
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/ImageAttributeTypeCompletenessIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/ImageAttributeTypeCompletenessIntegration.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\Completeness\AttributeType;
+
+use Pim\Bundle\CatalogBundle\tests\integration\Completeness\AbstractCompletenessPerAttributeTypeIntegration;
+use Pim\Component\Catalog\AttributeTypes;
+
+/**
+ * Checks that the completeness has been well calculated for image attribute type.
+ *
+ * @author    Damien Carcel (damien.carcel@akeneo.com)
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class ImageAttributeTypeCompletenessIntegration extends AbstractCompletenessPerAttributeTypeIntegration
+{
+    public function testCompleteImage()
+    {
+        $family = $this->createFamilyWithRequirement(
+            'another_family',
+            'ecommerce',
+            'an_image',
+            AttributeTypes::IMAGE
+        );
+
+        $productComplete = $this->createProductWithStandardValues(
+            $family,
+            'product_complete',
+            [
+                'values' => [
+                    'an_image' => [
+                        [
+                            'locale' => null,
+                            'scope'  => null,
+                            'data'   => $this->getFixturePath('akeneo.jpg'),
+                        ],
+                    ],
+                ],
+            ]
+        );
+
+        $this->assertComplete($productComplete);
+    }
+
+    public function testNotCompleteImage()
+    {
+        $family = $this->createFamilyWithRequirement(
+            'another_family',
+            'ecommerce',
+            'an_image',
+            AttributeTypes::IMAGE
+        );
+
+        $productDataNull = $this->createProductWithStandardValues(
+            $family,
+            'product_empty',
+            [
+                'values' => [
+                    'an_image' => [
+                        [
+                            'locale' => null,
+                            'scope'  => null,
+                            'data'   => null,
+                        ],
+                    ],
+                ],
+            ]
+        );
+        $this->assertNotComplete($productDataNull);
+
+        $productWithoutValues = $this->createProductWithStandardValues($family, 'product_without_values');
+        $this->assertNotComplete($productWithoutValues);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/MetricAttributeTypeCompletenessIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/MetricAttributeTypeCompletenessIntegration.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\Completeness\AttributeType;
+
+use Pim\Bundle\CatalogBundle\tests\integration\Completeness\AbstractCompletenessPerAttributeTypeIntegration;
+use Pim\Component\Catalog\AttributeTypes;
+
+/**
+ * Checks that the completeness has been well calculated for metric attribute type.
+ *
+ * @author    Damien Carcel (damien.carcel@akeneo.com)
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class MetricAttributeTypeCompletenessIntegration extends AbstractCompletenessPerAttributeTypeIntegration
+{
+    public function testCompleteMetric()
+    {
+        $family = $this->createFamilyWithRequirement(
+            'another_family',
+            'ecommerce',
+            'a_metric',
+            AttributeTypes::METRIC
+        );
+
+        $this->configureMetricFamilyForAttribute('a_metric', 'Length');
+
+        $productComplete = $this->createProductWithStandardValues(
+            $family,
+            'product_complete',
+            [
+                'values' => [
+                    'a_metric' => [
+                        [
+                            'locale' => null,
+                            'scope'  => null,
+                            'data'   => ['amount' => 12, 'unit' => 'METER'],
+                        ],
+                    ],
+                ],
+            ]
+        );
+        $this->assertComplete($productComplete);
+
+        $productAmountZero = $this->createProductWithStandardValues(
+            $family,
+            'product_amount_zero',
+            [
+                'values' => [
+                    'a_metric' => [
+                        [
+                            'locale' => null,
+                            'scope'  => null,
+                            'data'   => ['amount' => 0, 'unit' => 'METER'],
+                        ],
+                    ],
+                ],
+            ]
+        );
+        $this->assertComplete($productAmountZero);
+    }
+
+    public function testNotCompleteMetric()
+    {
+        $family = $this->createFamilyWithRequirement(
+            'another_family',
+            'ecommerce',
+            'a_metric',
+            AttributeTypes::METRIC
+        );
+
+        $this->configureMetricFamilyForAttribute('a_metric', 'Length');
+
+        $productDataNull = $this->createProductWithStandardValues(
+            $family,
+            'product_data_null',
+            [
+                'values' => [
+                    'a_metric' => [
+                        [
+                            'locale' => null,
+                            'scope'  => null,
+                            'data'   => null,
+                        ],
+                    ],
+                ],
+            ]
+        );
+        $this->assertNotComplete($productDataNull);
+
+        $productAmountNull = $this->createProductWithStandardValues(
+            $family,
+            'product_amount_null',
+            [
+                'values' => [
+                    'a_metric' => [
+                        [
+                            'locale' => null,
+                            'scope'  => null,
+                            'data'   => ['amount' => null, 'unit' => 'METER'],
+                        ],
+                    ],
+                ],
+            ]
+        );
+        $this->assertNotComplete($productAmountNull);
+
+        $productAmountAndUnitNull = $this->createProductWithStandardValues(
+            $family,
+            'product_amount_and_unit_null',
+            [
+                'values' => [
+                    'a_metric' => [
+                        [
+                            'locale' => null,
+                            'scope'  => null,
+                            'data'   => ['amount' => null, 'unit' => null],
+                        ],
+                    ],
+                ],
+            ]
+        );
+        $this->assertNotComplete($productAmountAndUnitNull);
+    }
+
+    private function configureMetricFamilyForAttribute($code, $metricFamily)
+    {
+        $metric = $this->get('pim_catalog.repository.attribute')->findOneByIdentifier($code);
+        $metric->setMetricFamily($metricFamily);
+        $this->get('pim_catalog.saver.attribute')->save($metric);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/NumberAttributeTypeCompletenessIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/NumberAttributeTypeCompletenessIntegration.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\Completeness\AttributeType;
+
+use Pim\Bundle\CatalogBundle\tests\integration\Completeness\AbstractCompletenessPerAttributeTypeIntegration;
+use Pim\Component\Catalog\AttributeTypes;
+
+/**
+ * Checks that the completeness has been well calculated for number attribute type.
+ *
+ * @author    Damien Carcel (damien.carcel@akeneo.com)
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class NumberAttributeTypeCompletenessIntegration extends AbstractCompletenessPerAttributeTypeIntegration
+{
+    public function testCompleteNumber()
+    {
+        $family = $this->createFamilyWithRequirement(
+            'another_family',
+            'ecommerce',
+            'a_number_integer',
+            AttributeTypes::NUMBER
+        );
+
+        $productComplete = $this->createProductWithStandardValues(
+            $family,
+            'product_complete',
+            [
+                'values' => [
+                    'a_number_integer' => [
+                        [
+                            'locale' => null,
+                            'scope'  => null,
+                            'data'   => 42,
+                        ],
+                    ],
+                ],
+            ]
+        );
+        $this->assertComplete($productComplete);
+
+        $productCompleteWithZero = $this->createProductWithStandardValues(
+            $family,
+            'product_complete_with_zero',
+            [
+                'values' => [
+                    'a_number_integer' => [
+                        [
+                            'locale' => null,
+                            'scope'  => null,
+                            'data'   => 0,
+                        ],
+                    ],
+                ],
+            ]
+        );
+        $this->assertComplete($productCompleteWithZero);
+    }
+
+    public function testNotCompleteNumber()
+    {
+        $family = $this->createFamilyWithRequirement(
+            'another_family',
+            'ecommerce',
+            'a_number_integer',
+            AttributeTypes::NUMBER
+        );
+
+        $productDataNull = $this->createProductWithStandardValues(
+            $family,
+            'product_data_null',
+            [
+                'values' => [
+                    'a_number_integer' => [
+                        [
+                            'locale' => null,
+                            'scope'  => null,
+                            'data'   => null,
+                        ],
+                    ],
+                ],
+            ]
+        );
+        $this->assertNotComplete($productDataNull);
+
+        $productWithoutValue = $this->createProductWithStandardValues($family, 'product_without_values');
+        $this->assertNotComplete($productWithoutValue);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/OptionAttributeTypeCompletenessIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/OptionAttributeTypeCompletenessIntegration.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\Completeness\AttributeType;
+
+use Pim\Bundle\CatalogBundle\tests\integration\Completeness\AbstractCompletenessPerAttributeTypeIntegration;
+use Pim\Component\Catalog\AttributeTypes;
+
+/**
+ * Checks that the completeness has been well calculated for simple select attribute type.
+ *
+ * @author    Damien Carcel (damien.carcel@akeneo.com)
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class OptionAttributeTypeCompletenessIntegration extends AbstractCompletenessPerAttributeTypeIntegration
+{
+    public function testCompleteOption()
+    {
+        $family = $this->get('pim_catalog.repository.family')->findOneByIdentifier('simple_select_family');
+
+        $productComplete = $this->createProductWithStandardValues(
+            $family,
+            'product_complete',
+            [
+                'values' => [
+                    'a_simple_select' => [
+                        [
+                            'locale' => null,
+                            'scope'  => null,
+                            'data'   => 'red_option',
+                        ],
+                    ],
+                ],
+            ]
+        );
+
+        $this->assertComplete($productComplete);
+    }
+
+    public function testNotCompleteOption()
+    {
+        $family = $this->get('pim_catalog.repository.family')->findOneByIdentifier('simple_select_family');
+
+        $productDataNull = $this->createProductWithStandardValues(
+            $family,
+            'product_null',
+            [
+                'values' => [
+                    'a_simple_select' => [
+                        [
+                            'locale' => null,
+                            'scope'  => null,
+                            'data'   => null,
+                        ],
+                    ],
+                ],
+            ]
+        );
+
+        $this->assertNotComplete($productDataNull);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->createFamilyWithRequirement(
+            'simple_select_family',
+            'ecommerce',
+            'a_simple_select',
+            AttributeTypes::OPTION_SIMPLE_SELECT
+        );
+
+        $aSimpleSelect = $this->get('pim_catalog.repository.attribute')->findOneByIdentifier('a_simple_select');
+
+        $redOption = $this->get('pim_catalog.factory.attribute_option')->create();
+        $redOption->setCode('red_option');
+        $redOption->setAttribute($aSimpleSelect);
+
+        $optionSaver = $this->get('pim_catalog.saver.attribute_option');
+        $optionSaver->save($redOption);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/OptionsAttributeTypeCompletenessIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/OptionsAttributeTypeCompletenessIntegration.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\Completeness\AttributeType;
+
+use Pim\Bundle\CatalogBundle\tests\integration\Completeness\AbstractCompletenessPerAttributeTypeIntegration;
+use Pim\Component\Catalog\AttributeTypes;
+
+/**
+ * Checks that the completeness has been well calculated for multi select attribute type.
+ *
+ * @author    Damien Carcel (damien.carcel@akeneo.com)
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class OptionsAttributeTypeCompletenessIntegration extends AbstractCompletenessPerAttributeTypeIntegration
+{
+    public function testCompleteOptions()
+    {
+        $family = $this->get('pim_catalog.repository.family')->findOneByIdentifier('another_family');
+
+        $productComplete = $this->createProductWithStandardValues(
+            $family,
+            'product_complete',
+            [
+                'values' => [
+                    'a_multi_select' => [
+                        [
+                            'locale' => null,
+                            'scope'  => null,
+                            'data'   => ['red_option', 'green_option'],
+                        ],
+                    ],
+                ],
+            ]
+        );
+        $this->assertComplete($productComplete);
+
+        $productCompleteOneOption = $this->createProductWithStandardValues(
+            $family,
+            'product_complete_one_option',
+            [
+                'values' => [
+                    'a_multi_select' => [
+                        [
+                            'locale' => null,
+                            'scope'  => null,
+                            'data'   => ['blue_option'],
+                        ],
+                    ],
+                ],
+            ]
+        );
+        $this->assertComplete($productCompleteOneOption);
+    }
+
+    public function testNotCompleteOptions()
+    {
+        $family = $this->get('pim_catalog.repository.family')->findOneByIdentifier('another_family');
+
+        $productDataEmptyArray = $this->createProductWithStandardValues(
+            $family,
+            'product_data_empty_array',
+            [
+                'values' => [
+                    'a_multi_select' => [
+                        [
+                            'locale' => null,
+                            'scope'  => null,
+                            'data'   => [],
+                        ],
+                    ],
+                ],
+            ]
+        );
+        $this->assertNotComplete($productDataEmptyArray);
+
+//        TODO: This cannot work now, but will on TIP-613. Test is added now so it will not forgotten.
+//        $productDataNull = $this->createProductWithStandardValues(
+//            $family,
+//            'product_data_null',
+//            [
+//                'values' => [
+//                    'a_multi_select' => [
+//                        [
+//                            'locale' => null,
+//                            'scope'  => null,
+//                            'data'   => null,
+//                        ],
+//                    ],
+//                ],
+//            ]
+//        );
+//        $this->assertNotComplete($productDataNull);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->createFamilyWithRequirement(
+            'another_family',
+            'ecommerce',
+            'a_multi_select',
+            AttributeTypes::OPTION_MULTI_SELECT
+        );
+
+        $aMultiSelect = $this->get('pim_catalog.repository.attribute')->findOneByIdentifier('a_multi_select');
+
+        $redOption = $this->get('pim_catalog.factory.attribute_option')->create();
+        $redOption->setCode('red_option');
+        $redOption->setAttribute($aMultiSelect);
+
+        $greenOption = $this->get('pim_catalog.factory.attribute_option')->create();
+        $greenOption->setCode('green_option');
+        $greenOption->setAttribute($aMultiSelect);
+
+        $blueOption = $this->get('pim_catalog.factory.attribute_option')->create();
+        $blueOption->setCode('blue_option');
+        $blueOption->setAttribute($aMultiSelect);
+
+        $optionSaver = $this->get('pim_catalog.saver.attribute_option');
+        $optionSaver->save($redOption);
+        $optionSaver->save($greenOption);
+        $optionSaver->save($blueOption);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/PriceCollectionAttributeTypeCompletenessIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/PriceCollectionAttributeTypeCompletenessIntegration.php
@@ -1,0 +1,397 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\Completeness\AttributeType;
+
+use Pim\Bundle\CatalogBundle\tests\integration\Completeness\AbstractCompletenessIntegration;
+use Pim\Component\Catalog\AttributeTypes;
+use Pim\Component\Catalog\Model\ChannelInterface;
+use Pim\Component\Catalog\Model\CompletenessInterface;
+use Pim\Component\Catalog\Model\CurrencyInterface;
+use Pim\Component\Catalog\Model\ProductInterface;
+
+/**
+ * Checks that the completeness has been well calculated for price collection attribute type.
+ * The minimal catalog has originally one channel "ecommerce", with one currency "USD".
+ * For these tests, we added:
+ *      - the channel "print" with the currency "EUR"
+ *      - the channel "tablet" with the currencies "USD" and "EUR"
+ *
+ * A "price" price collection attribute is required on the 3 channels.
+ *
+ * @author    Damien Carcel (damien.carcel@akeneo.com)
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class PriceCollectionAttributeTypeCompletenessIntegration extends AbstractCompletenessIntegration
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->createChannelWithCurrencies('print', 'master', ['EUR']);
+        $this->createChannelWithCurrencies('tablet', 'master', ['USD', 'EUR']);
+
+        $this->createFamilyWithRequirement(
+            'another_family',
+            'ecommerce',
+            'a_price_collection',
+            AttributeTypes::PRICE_COLLECTION
+        );
+
+        $this->addFamilyRequirement('another_family', 'print', 'a_price_collection');
+        $this->addFamilyRequirement('another_family', 'tablet', 'a_price_collection');
+    }
+
+    public function testCompletePriceCollectionAllChannels()
+    {
+        $family = $this->get('pim_catalog.repository.family')->findOneByIdentifier('another_family');
+
+        $productCompleteAllChannels = $this->createProductWithStandardValues(
+            $family,
+            'product_complete_all_channels',
+            [
+                'values' => [
+                    'a_price_collection' => [
+                        [
+                            'locale' => null,
+                            'scope'  => null,
+                            'data'   => [
+                                [
+                                    'amount'   => 42,
+                                    'currency' => 'USD',
+                                ],
+                                [
+                                    'amount'   => 69,
+                                    'currency' => 'EUR',
+                                ],
+                            ],
+                        ],
+                    ]
+                ],
+            ]
+        );
+        $this->assertCompleteOnChannel($productCompleteAllChannels, 'ecommerce');
+        $this->assertCompleteOnChannel($productCompleteAllChannels, 'print');
+        $this->assertCompleteOnChannel($productCompleteAllChannels, 'tablet');
+
+        $productAllChannelsAmountsZero = $this->createProductWithStandardValues(
+            $family,
+            'product_complete_all_channels_amounts_zero',
+            [
+                'values' => [
+                    'a_price_collection' => [
+                        [
+                            'locale' => null,
+                            'scope'  => null,
+                            'data'   => [
+                                [
+                                    'amount'   => 0,
+                                    'currency' => 'USD',
+                                ],
+                                [
+                                    'amount'   => 0,
+                                    'currency' => 'EUR',
+                                ],
+                            ],
+                        ],
+                    ]
+                ],
+            ]
+        );
+        $this->assertCompleteOnChannel($productAllChannelsAmountsZero, 'ecommerce');
+        $this->assertCompleteOnChannel($productAllChannelsAmountsZero, 'print');
+        $this->assertCompleteOnChannel($productAllChannelsAmountsZero, 'tablet');
+    }
+
+    public function testCompletePriceCollectionTakingCurrenciesOfTheChannelIntoAccount()
+    {
+        $family = $this->get('pim_catalog.repository.family')->findOneByIdentifier('another_family');
+
+        $productCompleteEcommerce = $this->createProductWithStandardValues(
+            $family,
+            'product_complete_ecommerce',
+            [
+                'values' => [
+                    'a_price_collection' => [
+                        [
+                            'locale' => null,
+                            'scope'  => null,
+                            'data'   => [
+                                [
+                                    'amount'   => 42,
+                                    'currency' => 'USD',
+                                ],
+                            ],
+                        ],
+                    ]
+                ],
+            ]
+        );
+        $this->assertCompleteOnChannel($productCompleteEcommerce, 'ecommerce');
+        $this->assertNotCompleteOnChannel($productCompleteEcommerce, 'print');
+        $this->assertNotCompleteOnChannel($productCompleteEcommerce, 'tablet');
+
+        $productCompletePrint = $this->createProductWithStandardValues(
+            $family,
+            'product_complete_print',
+            [
+                'values' => [
+                    'a_price_collection' => [
+                        [
+                            'locale' => null,
+                            'scope'  => null,
+                            'data'   => [
+                                [
+                                    'amount'   => 42,
+                                    'currency' => 'EUR',
+                                ],
+                            ],
+                        ],
+                    ]
+                ],
+            ]
+        );
+        $this->assertNotCompleteOnChannel($productCompletePrint, 'ecommerce');
+        $this->assertCompleteOnChannel($productCompletePrint, 'print');
+        $this->assertNotCompleteOnChannel($productCompletePrint, 'tablet');
+    }
+
+    public function testNotCompletePriceCollection()
+    {
+        $family = $this->get('pim_catalog.repository.family')->findOneByIdentifier('another_family');
+
+        $productWithoutValues = $this->createProductWithStandardValues($family, 'product_without_values');
+        $this->assertNotCompleteOnChannel($productWithoutValues, 'ecommerce');
+        $this->assertNotCompleteOnChannel($productWithoutValues, 'print');
+        $this->assertNotCompleteOnChannel($productWithoutValues, 'tablet');
+
+        $productAmountsNull = $this->createProductWithStandardValues(
+            $family,
+            'product_amounts_null',
+            [
+                'values' => [
+                    'a_price_collection' => [
+                        [
+                            'locale' => null,
+                            'scope'  => null,
+                            'data'   => [
+                                [
+                                    'amount'   => null,
+                                    'currency' => 'USD',
+                                ],
+                                [
+                                    'amount'   => null,
+                                    'currency' => 'EUR',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ]
+        );
+        $this->assertNotCompleteOnChannel($productAmountsNull, 'ecommerce');
+        $this->assertNotCompleteOnChannel($productAmountsNull, 'print');
+        $this->assertNotCompleteOnChannel($productAmountsNull, 'tablet');
+
+        $productAmountNull = $this->createProductWithStandardValues(
+            $family,
+            'product_amount_null',
+            [
+                'values' => [
+                    'a_price_collection' => [
+                        [
+                            'locale' => null,
+                            'scope'  => null,
+                            'data'   => [
+                                [
+                                    'amount'   => 7,
+                                    'currency' => 'USD',
+                                ],
+                                [
+                                    'amount'   => null,
+                                    'currency' => 'EUR',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ]
+        );
+        $this->assertCompleteOnChannel($productAmountNull, 'ecommerce');
+        $this->assertNotCompleteOnChannel($productAmountNull, 'print');
+        $this->assertNotCompleteOnChannel($productAmountNull, 'tablet');
+
+        $productCurrencyEmptyString = $this->createProductWithStandardValues(
+            $family,
+            'product_currency_empty_string',
+            [
+                'values' => [
+                    'a_price_collection' => [
+                        [
+                            'locale' => null,
+                            'scope'  => null,
+                            'data'   => [
+                                [
+                                    'amount'   => 7,
+                                    'currency' => 'USD',
+                                ],
+                                [
+                                    'amount'   => 87,
+                                    'currency' => '',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ]
+        );
+        $this->assertCompleteOnChannel($productCurrencyEmptyString, 'ecommerce');
+        $this->assertNotCompleteOnChannel($productCurrencyEmptyString, 'print');
+        $this->assertNotCompleteOnChannel($productCurrencyEmptyString, 'tablet');
+
+        $productMissingPrice = $this->createProductWithStandardValues(
+            $family,
+            'product_missing_price',
+            [
+                'values' => [
+                    'a_price_collection' => [
+                        [
+                            'locale' => null,
+                            'scope'  => null,
+                            'data'   => [
+                                [
+                                    'amount'   => 67,
+                                    'currency' => 'USD',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ]
+        );
+        $this->assertCompleteOnChannel($productMissingPrice, 'ecommerce');
+        $this->assertNotCompleteOnChannel($productMissingPrice, 'print');
+        $this->assertNotCompleteOnChannel($productMissingPrice, 'tablet');    }
+
+    /**
+     * @param string $channelCode
+     * @param string $categoryCode
+     * @param array  $currencyCodes
+     *
+     * @return ChannelInterface
+     * @internal param array $localeCodes
+     */
+    private function createChannelWithCurrencies($channelCode, $categoryCode, array $currencyCodes)
+    {
+        $category = $this->get('pim_catalog.repository.category')->findOneByIdentifier($categoryCode);
+
+        $channel = $this->get('pim_catalog.factory.channel')->create();
+        $channel->setCode($channelCode);
+        $channel->setCategory($category);
+
+        foreach ($currencyCodes as $currencyCode) {
+            $currency = $this->findOrCreateCurrency($currencyCode);
+            $channel->addCurrency($currency);
+        }
+
+        $locale = $this->get('pim_catalog.repository.locale')->findOneByIdentifier('en_US');
+        $channel->addLocale($locale);
+
+        $this->get('pim_catalog.saver.channel')->save($channel);
+
+        return $channel;
+    }
+
+    /**
+     * @param string $code
+     *
+     * @return CurrencyInterface
+     */
+    private function findOrCreateCurrency($code)
+    {
+        $currency = $this->get('pim_catalog.repository.currency')->findOneByIdentifier($code);
+        if (null === $currency) {
+            $currency = $this->get('pim_catalog.factory.currency')->create();
+            $currency->setCode($code);
+            $currency->setActivated(true);
+            $this->get('pim_catalog.saver.currency')->save($currency);
+
+        }
+
+        return $currency;
+    }
+
+    /**
+     * Here, the identifier and the attribute should be filled in.
+     * Which means, there should be 0 missing, and 2 required.
+     *
+     * @param ProductInterface $product
+     * @param string           $channelCode
+     */
+    protected function assertCompleteOnChannel(ProductInterface $product, $channelCode)
+    {
+        $completenesses = $product->getCompletenesses()->toArray();
+        $this->assertNotNull($completenesses);
+        $this->assertCount(3, $completenesses);
+
+        $completeness = $this->getCompletenessByChannel($product, $channelCode);
+
+        $this->assertNotNull($completeness->getLocale());
+        $this->assertEquals('en_US', $completeness->getLocale()->getCode());
+        $this->assertNotNull($completeness->getChannel());
+        $this->assertEquals($channelCode, $completeness->getChannel()->getCode());
+        $this->assertEquals(100, $completeness->getRatio());
+        $this->assertEquals(2, $completeness->getRequiredCount());
+        $this->assertEquals(0, $completeness->getMissingCount());
+    }
+
+    /**
+     * Here, only the identifier should be filled in.
+     * Which means, there should be 1 missing, and 2 required.
+     *
+     * @param ProductInterface $product
+     * @param string           $channelCode
+     */
+    protected function assertNotCompleteOnChannel(ProductInterface $product, $channelCode)
+    {
+        $completenesses = $product->getCompletenesses()->toArray();
+        $this->assertNotNull($completenesses);
+        $this->assertCount(3, $completenesses);
+
+        $completeness = $this->getCompletenessByChannel($product, $channelCode);
+
+        $this->assertNotNull($completeness->getLocale());
+        $this->assertEquals('en_US', $completeness->getLocale()->getCode());
+        $this->assertNotNull($completeness->getChannel());
+        $this->assertEquals($channelCode, $completeness->getChannel()->getCode());
+        $this->assertEquals(50, $completeness->getRatio());
+        $this->assertEquals(2, $completeness->getRequiredCount());
+        $this->assertEquals(1, $completeness->getMissingCount());
+    }
+
+    /**
+     * @param ProductInterface $product
+     * @param string           $channelCode
+     *
+     * @throws \Exception
+     * @return CompletenessInterface
+     */
+    protected function getCompletenessByChannel(ProductInterface $product, $channelCode)
+    {
+        $completenesses = $product->getCompletenesses()->toArray();
+
+        foreach ($completenesses as $completeness) {
+            if ($channelCode === $completeness->getChannel()->getCode()) {
+                return $completeness;
+            }
+        }
+
+        throw new \Exception(
+            sprintf(
+                'No completeness found for the product "%s" and the channel "%s"',
+                $product->getIdentifier(),
+                $channelCode
+            )
+        );
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/ReferenceDataMultiAttributeTypeCompletenessIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/ReferenceDataMultiAttributeTypeCompletenessIntegration.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\Completeness\AttributeType;
+
+use Akeneo\Test\Integration\Configuration;
+use Pim\Bundle\CatalogBundle\tests\integration\Completeness\AbstractCompletenessPerAttributeTypeIntegration;
+use Pim\Component\Catalog\AttributeTypes;
+
+/**
+ * Checks that the completeness has been well calculated for multi reference data attribute type.
+ *
+ * @author    Damien Carcel (damien.carcel@akeneo.com)
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class ReferenceDataMultiAttributeTypeCompletenessIntegration extends AbstractCompletenessPerAttributeTypeIntegration
+{
+    public function testCompleteMultiSelectReferenceData()
+    {
+        $family = $this->createFamilyWithRequirement(
+            'another_family',
+            'ecommerce',
+            'a_multi_select_reference_data',
+            AttributeTypes::REFERENCE_DATA_MULTI_SELECT
+        );
+
+        $productComplete = $this->createProductWithStandardValues(
+            $family,
+            'product_complete',
+            [
+                'values' => [
+                    'a_multi_select_reference_data' => [
+                        [
+                            'locale' => null,
+                            'scope'  => null,
+                            'data'   => ['zorbeez'],
+                        ],
+                    ],
+                ],
+            ]
+        );
+
+
+        $this->assertComplete($productComplete);
+    }
+
+    public function testNotCompleteMultiSelectReferenceData()
+    {
+        $family = $this->createFamilyWithRequirement(
+            'another_family',
+            'ecommerce',
+            'a_multi_select_reference_data',
+            AttributeTypes::REFERENCE_DATA_MULTI_SELECT
+        );
+
+//        TODO: This cannot work now, but will on TIP-613. Test is added now so it will not forgotten.
+//        $productDataNull = $this->createProductWithStandardValues(
+//            $family,
+//            'product_data_null',
+//            [
+//                'values' => [
+//                    'a_multi_select_reference_data' => [
+//                        [
+//                            'locale' => null,
+//                            'scope'  => null,
+//                            'data'   => null,
+//                        ],
+//                    ],
+//                ],
+//            ]
+//        );
+//        $this->assertNotComplete($productDataNull);
+
+        $productDataEmptyArray = $this->createProductWithStandardValues(
+            $family,
+            'product_data_empty_array',
+            [
+                'values' => [
+                    'a_multi_select_reference_data' => [
+                        [
+                            'locale' => null,
+                            'scope'  => null,
+                            'data'   => [],
+                        ],
+                    ],
+                ],
+            ]
+        );
+        $this->assertNotComplete($productDataEmptyArray);
+
+        $productWithoutValues = $this->createProductWithStandardValues($family, 'product_without_values');
+        $this->assertNotComplete($productWithoutValues);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function createAttribute(
+        $code,
+        $type,
+        $localisable = false,
+        $scopable = false,
+        array $localesSpecific = []
+    ) {
+        $attribute = parent::createAttribute($code, $type);
+
+        $attribute->setReferenceDataName('fabrics');
+        $this->get('pim_catalog.saver.attribute')->save($attribute);
+
+        return $attribute;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return new Configuration(
+            [Configuration::getMinimalCatalogPath(), Configuration::getReferenceDataFixtures()],
+            true
+        );
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/ReferenceDataSimpleAttributeTypeCompletenessIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/ReferenceDataSimpleAttributeTypeCompletenessIntegration.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\Completeness\AttributeType;
+
+use Akeneo\Test\Integration\Configuration;
+use Pim\Bundle\CatalogBundle\tests\integration\Completeness\AbstractCompletenessPerAttributeTypeIntegration;
+use Pim\Component\Catalog\AttributeTypes;
+
+/**
+ * Checks that the completeness has been well calculated for simple reference data attribute type.
+ *
+ * @author    Damien Carcel (damien.carcel@akeneo.com)
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class ReferenceDataSimpleAttributeTypeCompletenessIntegration extends AbstractCompletenessPerAttributeTypeIntegration
+{
+    public function testCompleteSimpleSelectReferenceData()
+    {
+        $family = $this->createFamilyWithRequirement(
+            'another_family',
+            'ecommerce',
+            'a_simple_select_reference_data',
+            AttributeTypes::REFERENCE_DATA_SIMPLE_SELECT
+        );
+
+        $productComplete = $this->createProductWithStandardValues(
+            $family,
+            'product_complete',
+            [
+                'values' => [
+                    'a_simple_select_reference_data' => [
+                        [
+                            'locale' => null,
+                            'scope'  => null,
+                            'data'   => 'zomp',
+                        ],
+                    ],
+                ],
+            ]
+        );
+
+        $this->assertComplete($productComplete);
+    }
+
+    public function testNotCompleteSimpleSelectReferenceData()
+    {
+        $family = $this->createFamilyWithRequirement(
+            'another_family',
+            'ecommerce',
+            'a_simple_select_reference_data',
+            AttributeTypes::REFERENCE_DATA_SIMPLE_SELECT
+        );
+
+        $productDataNull = $this->createProductWithStandardValues(
+            $family,
+            'product_data_null',
+            [
+                'values' => [
+                    'a_simple_select_reference_data' => [
+                        [
+                            'locale' => null,
+                            'scope'  => null,
+                            'data'   => null,
+                        ],
+                    ],
+                ],
+            ]
+        );
+        $this->assertNotComplete($productDataNull);
+
+        $productDataEmptyString = $this->createProductWithStandardValues(
+            $family,
+            'product_data_empty_string',
+            [
+                'values' => [
+                    'a_simple_select_reference_data' => [
+                        [
+                            'locale' => null,
+                            'scope'  => null,
+                            'data'   => '',
+                        ],
+                    ],
+                ],
+            ]
+        );
+        $this->assertNotComplete($productDataEmptyString);
+
+        $productWithoutValues = $this->createProductWithStandardValues($family, 'product_without_values');
+        $this->assertNotComplete($productWithoutValues);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function createAttribute(
+        $code,
+        $type,
+        $localisable = false,
+        $scopable = false,
+        array $localesSpecific = []
+    ) {
+        $attribute = parent::createAttribute($code, $type);
+
+        $attribute->setReferenceDataName('color');
+        $this->get('pim_catalog.saver.attribute')->save($attribute);
+
+        return $attribute;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return new Configuration(
+            [Configuration::getMinimalCatalogPath(), Configuration::getReferenceDataFixtures()],
+            true
+        );
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/TextAttributeTypeCompletenessIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/TextAttributeTypeCompletenessIntegration.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\Completeness\AttributeType;
+
+use Pim\Bundle\CatalogBundle\tests\integration\Completeness\AbstractCompletenessPerAttributeTypeIntegration;
+use Pim\Component\Catalog\AttributeTypes;
+
+/**
+ * Checks that the completeness has been well calculated for text attribute type.
+ *
+ * @author    Damien Carcel (damien.carcel@akeneo.com)
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class TextAttributeTypeCompletenessIntegration extends AbstractCompletenessPerAttributeTypeIntegration
+{
+    public function testCompleteText()
+    {
+        $family = $this->createFamilyWithRequirement(
+            'another_family',
+            'ecommerce',
+            'a_text',
+            AttributeTypes::TEXT
+        );
+
+        $productComplete = $this->createProductWithStandardValues(
+            $family,
+            'product_complete',
+            [
+                'values' => [
+                    'a_text' => [
+                        [
+                            'locale' => null,
+                            'scope'  => null,
+                            'data'   => 'foo bar',
+                        ],
+                    ],
+                ],
+            ]
+        );
+
+        $this->assertComplete($productComplete);
+    }
+
+    public function testNotCompleteText()
+    {
+        $family = $this->createFamilyWithRequirement(
+            'another_family',
+            'ecommerce',
+            'a_text',
+            AttributeTypes::TEXT
+        );
+
+        $productDataNull = $this->createProductWithStandardValues(
+            $family,
+            'product_data_null',
+            [
+                'values' => [
+                    'a_text' => [
+                        [
+                            'locale' => null,
+                            'scope'  => null,
+                            'data'   => null,
+                        ],
+                    ],
+                ],
+            ]
+        );
+        $this->assertNotComplete($productDataNull);
+
+        $productDataEmptyString = $this->createProductWithStandardValues(
+            $family,
+            'product_data_empty_string',
+            [
+                'values' => [
+                    'a_text' => [
+                        [
+                            'locale' => null,
+                            'scope'  => null,
+                            'data'   => '',
+                        ],
+                    ],
+                ],
+            ]
+        );
+        $this->assertNotComplete($productDataEmptyString);
+
+        $productWithoutValue = $this->createProductWithStandardValues($family, 'product_without_values');
+        $this->assertNotComplete($productWithoutValue);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/TextareaAttributeTypeCompletenessIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/TextareaAttributeTypeCompletenessIntegration.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\Completeness\AttributeType;
+
+use Pim\Bundle\CatalogBundle\tests\integration\Completeness\AbstractCompletenessPerAttributeTypeIntegration;
+use Pim\Component\Catalog\AttributeTypes;
+
+/**
+ * Checks that the completeness has been well calculated for textarea attribute type.
+ *
+ * @author    Damien Carcel (damien.carcel@akeneo.com)
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class TextareaAttributeTypeCompletenessIntegration extends AbstractCompletenessPerAttributeTypeIntegration
+{
+    public function testCompleteTextarea()
+    {
+        $family = $this->createFamilyWithRequirement(
+            'another_family',
+            'ecommerce',
+            'a_text_area',
+            AttributeTypes::TEXTAREA
+        );
+
+        $productComplete = $this->createProductWithStandardValues(
+            $family,
+            'product_complete',
+            [
+                'values' => [
+                    'a_text_area' => [
+                        [
+                            'locale' => null,
+                            'scope'  => null,
+                            'data'   => 'foo bar',
+                        ],
+                    ],
+                ],
+            ]
+        );
+
+        $this->assertComplete($productComplete);
+    }
+
+    public function testNotCompleteTextarea()
+    {
+        $family = $this->createFamilyWithRequirement(
+            'another_family',
+            'ecommerce',
+            'a_text_area',
+            AttributeTypes::TEXTAREA
+        );
+
+        $productDataNull = $this->createProductWithStandardValues(
+            $family,
+            'product_data_null',
+            [
+                'values' => [
+                    'a_text_area' => [
+                        [
+                            'locale' => null,
+                            'scope'  => null,
+                            'data'   => null,
+                        ],
+                    ],
+                ],
+            ]
+        );
+        $this->assertNotComplete($productDataNull);
+
+        $productDataEmptyString = $this->createProductWithStandardValues(
+            $family,
+            'product_data_empty_string',
+            [
+                'values' => [
+                    'a_text_area' => [
+                        [
+                            'locale' => null,
+                            'scope'  => null,
+                            'data'   => '',
+                        ],
+                    ],
+                ],
+            ]
+        );
+        $this->assertNotComplete($productDataEmptyString);
+
+        $productWithoutValue = $this->createProductWithStandardValues($family, 'product_without_values');
+        $this->assertNotComplete($productWithoutValue);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/CompletenessForLocalisableAttributeIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/CompletenessForLocalisableAttributeIntegration.php
@@ -1,0 +1,237 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\Completeness;
+
+use Akeneo\Test\Integration\Configuration;
+use Pim\Component\Catalog\AttributeTypes;
+use Pim\Component\Catalog\Model\CompletenessInterface;
+use Pim\Component\Catalog\Model\ProductInterface;
+
+/**
+ * Checks that the completeness has been well calculated for localisable and locale specific attribute types.
+ *
+ * We test from the minimal catalog that contains only 1 channel. The locales fr_FR and en_US are activated.
+ *
+ * The completeness calculation is tested for:
+ *      - 1 localisable attribute
+ *      - 1 locale specific attribute
+ *
+ * For each test, we create a family where the attribute is required.
+ * Then, we create two products of this family, one with the required attribute filled in, the other without.
+ * Finally we test the completeness calculation of those two products.
+ *
+ * @author    Julien Janvier <j.janvier@gmail.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class CompletenessForLocalisableAttributeIntegration extends AbstractCompletenessIntegration
+{
+    public function testLocalisable()
+    {
+        $family = $this->createFamilyWithRequirement(
+            'another_family',
+            'ecommerce',
+            'a_text',
+            AttributeTypes::TEXT,
+            true
+        );
+
+        $product = $this->createProductWithStandardValues(
+            $family,
+            'another_product',
+            [
+                'values' => [
+                    'a_text' => [
+                        [
+                            'locale' => 'en_US',
+                            'scope'  => null,
+                            'data'   => 'just a text'
+                        ],
+                        [
+                            'locale' => 'fr_FR',
+                            'scope'  => null,
+                            'data'   => null
+                        ],
+                    ]
+                ]
+            ]
+        );
+
+        $this->assertComplete($product, 'en_US', 2);
+        $this->assertNotComplete($product, 'fr_FR', 2);
+    }
+
+    public function testNotCompleteLocaleSpecificNoLocale()
+    {
+        $fr = $this->get('pim_catalog.repository.locale')->findOneByIdentifier('fr_FR');
+
+        $family = $this->createFamilyWithRequirement(
+            'another_family',
+            'ecommerce',
+            'a_text',
+            AttributeTypes::TEXT,
+            true,
+            false,
+            [$fr]
+        );
+
+        $productLocaleSpecificNoLocale = $this->createProductWithStandardValues(
+            $family,
+            'product_locale_specific_no_locale'
+        );
+        $this->assertNotComplete($productLocaleSpecificNoLocale, 'fr_FR', 2);
+        $this->assertComplete($productLocaleSpecificNoLocale, 'en_US', 1);
+    }
+
+    public function testNotCompleteLocaleSpecificLocaleEmpty()
+    {
+        $fr = $this->get('pim_catalog.repository.locale')->findOneByIdentifier('fr_FR');
+
+        $family = $this->createFamilyWithRequirement(
+            'another_family',
+            'ecommerce',
+            'a_text',
+            AttributeTypes::TEXT,
+            true,
+            false,
+            [$fr]
+        );
+
+        $productLocaleSpecificLocaleEmpty = $this->createProductWithStandardValues(
+            $family,
+            'product_locale_specific_locale_empty',
+            [
+                'values' => [
+                    'a_text' => [
+                        [
+                            'locale' => 'fr_FR',
+                            'scope'  => null,
+                            'data'   => null
+                        ],
+                    ]
+                ]
+            ]
+        );
+        $this->assertNotComplete($productLocaleSpecificLocaleEmpty, 'fr_FR', 2);
+        $this->assertComplete($productLocaleSpecificLocaleEmpty, 'en_US', 1);
+    }
+
+    public function testCompleteLocaleSpecific()
+    {
+        $fr = $this->get('pim_catalog.repository.locale')->findOneByIdentifier('fr_FR');
+
+        $family = $this->createFamilyWithRequirement(
+            'another_family',
+            'ecommerce',
+            'a_text',
+            AttributeTypes::TEXT,
+            true,
+            false,
+            [$fr]
+        );
+
+        $productComplete = $this->createProductWithStandardValues(
+            $family,
+            'product_complete',
+            [
+                'values' => [
+                    'a_text' => [
+                        [
+                            'locale' => 'fr_FR',
+                            'scope'  => null,
+                            'data'   => 'juste un texte'
+                        ],
+                    ]
+                ]
+            ]
+        );
+        $this->assertComplete($productComplete, 'fr_FR', 2);
+        $this->assertComplete($productComplete, 'en_US', 1);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $fr = $this->get('pim_catalog.repository.locale')->findOneByIdentifier('fr_FR');
+        $ecommerce = $this->get('pim_catalog.repository.channel')->findOneByIdentifier('ecommerce');
+        $ecommerce->addLocale($fr);
+        $this->get('pim_catalog.saver.channel')->save($ecommerce);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return new Configuration(
+            [Configuration::getMinimalCatalogPath()],
+            true
+        );
+    }
+
+    /**
+     * @param ProductInterface $product
+     * @param string           $localeCode
+     *
+     * @throws \Exception
+     * @return CompletenessInterface
+     */
+    private function getCompletenessByLocaleCode(ProductInterface $product, $localeCode)
+    {
+        $completenesses = $product->getCompletenesses()->toArray();
+
+        foreach ($completenesses as $completeness) {
+            if ($localeCode === $completeness->getLocale()->getCode()) {
+                return $completeness;
+            }
+        }
+
+        throw new \Exception(sprintf('No completeness for the locale "%s"', $localeCode));
+    }
+
+    /**
+     * @param ProductInterface $product
+     * @param string           $localeCode
+     * @param int              $requiredCount
+     */
+    private function assertNotComplete(ProductInterface $product, $localeCode, $requiredCount)
+    {
+        $completenesses = $product->getCompletenesses()->toArray();
+        $this->assertNotNull($completenesses);
+        $this->assertCount(2, $completenesses);
+
+        $completeness = $this->getCompletenessByLocaleCode($product, $localeCode);
+        $this->assertNotNull($completeness->getLocale());
+        $this->assertEquals($localeCode, $completeness->getLocale()->getCode());
+        $this->assertNotNull($completeness->getChannel());
+        $this->assertEquals('ecommerce', $completeness->getChannel()->getCode());
+        $this->assertEquals(50, $completeness->getRatio());
+        $this->assertEquals($requiredCount, $completeness->getRequiredCount());
+        $this->assertEquals(1, $completeness->getMissingCount());
+    }
+
+    /**
+     * @param ProductInterface $product
+     * @param string           $localeCode
+     * @param int              $requiredCount
+     */
+    private function assertComplete(ProductInterface $product, $localeCode, $requiredCount)
+    {
+        $completenesses = $product->getCompletenesses()->toArray();
+        $this->assertNotNull($completenesses);
+        $this->assertCount(2, $completenesses);
+
+        $completeness = $this->getCompletenessByLocaleCode($product, $localeCode);
+        $this->assertNotNull($completeness->getLocale());
+        $this->assertEquals($localeCode, $completeness->getLocale()->getCode());
+        $this->assertNotNull($completeness->getChannel());
+        $this->assertEquals('ecommerce', $completeness->getChannel()->getCode());
+        $this->assertEquals(100, $completeness->getRatio());
+        $this->assertEquals($requiredCount, $completeness->getRequiredCount());
+        $this->assertEquals(0, $completeness->getMissingCount());
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/CompletenessForNonRequiredAttributeIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/CompletenessForNonRequiredAttributeIntegration.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\Completeness;
+
+use Akeneo\Test\Integration\Configuration;
+use Pim\Component\Catalog\AttributeTypes;
+use Pim\Component\Catalog\Model\ProductInterface;
+
+/**
+ * Filling in non required attributes should not have any impact on the completeness results.
+ *
+ * @author    Julien Janvier <j.janvier@gmail.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class CompletenessForNonRequiredAttributeIntegration extends AbstractCompletenessIntegration
+{
+    public function testAttributeNotRequiredByFamily()
+    {
+        $family = $this->get('pim_catalog.factory.family')->create();
+        $family->setCode('family_without_any_attribute_requirements');
+        $this->get('pim_catalog.saver.family')->save($family);
+
+        $this->createAttribute('a_text', AttributeTypes::TEXT);
+        $this->createAttribute('a_number', AttributeTypes::NUMBER);
+
+        $product = $this->createProductWithStandardValues(
+            $family,
+            'always_complete_product',
+            [
+                'values' => [
+                    'a_text'   => [
+                        [
+                            'locale' => null,
+                            'scope'  => null,
+                            'data'   => 'This is some text',
+                        ],
+                    ],
+                    'a_number' => [
+                        [
+                            'locale' => null,
+                            'scope'  => null,
+                            'data'   => null,
+                        ],
+                    ],
+                ],
+            ]
+        );
+
+        $this->assertComplete($product, 1);
+    }
+
+    public function testAttributeRequiredByFamily()
+    {
+        $family = $this->createFamilyWithRequirement(
+            'another_family',
+            'ecommerce',
+            'a_text',
+            AttributeTypes::TEXT
+        );
+
+        $product = $this->createProductWithStandardValues(
+            $family,
+            'product_complete',
+            [
+                'values' => [
+                    'a_text' => [
+                        [
+                            'locale' => null,
+                            'scope'  => null,
+                            'data'   => 'Some text for ecommerce channel'
+                        ],
+                    ]
+                ]
+            ]
+        );
+
+        $this->assertComplete($product, 2);
+    }
+
+    /**
+     * @param ProductInterface $product
+     * @param int              $requiredCount
+     *
+     * @internal param string $localeCode
+     */
+    private function assertComplete(ProductInterface $product, $requiredCount)
+    {
+        $completenesses = $product->getCompletenesses()->toArray();
+        $this->assertNotNull($completenesses);
+        $this->assertCount(1, $completenesses);
+
+        $completeness = current($completenesses);
+
+        $this->assertNotNull($completeness->getLocale());
+        $this->assertEquals('en_US', $completeness->getLocale()->getCode());
+        $this->assertNotNull($completeness->getChannel());
+        $this->assertEquals('ecommerce', $completeness->getChannel()->getCode());
+        $this->assertEquals(100, $completeness->getRatio());
+        $this->assertEquals($requiredCount, $completeness->getRequiredCount());
+        $this->assertEquals(0, $completeness->getMissingCount());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return new Configuration(
+            [Configuration::getMinimalCatalogPath()],
+            true
+        );
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/CompletenessForScopableAndLocalisableAttributeIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/CompletenessForScopableAndLocalisableAttributeIntegration.php
@@ -1,0 +1,294 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\Completeness;
+
+use Akeneo\Test\Integration\Configuration;
+use Pim\Component\Catalog\Model\CompletenessInterface;
+use Pim\Component\Catalog\Model\ProductInterface;
+
+/**
+ * Checks that the completeness has been well calculated for localisable and scopable attributes.
+ *
+ * We test from the footwear catalog that contains 2 channels, with 2 activated locales for each channel.
+ *
+ * @author    Julien Janvier <j.janvier@gmail.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class CompletenessForScopableAndLocalisableAttributeIntegration extends AbstractCompletenessIntegration
+{
+    public function testProductIncomplete()
+    {
+        $sandalsFamily = $this->get('pim_catalog.repository.family')->findOneByIdentifier('sandals');
+
+        $sandals = $this->createProductWithStandardValues(
+            $sandalsFamily,
+            'sandals',
+            ['values' => $this->getSandalStandardValues()]
+        );
+
+        $completenesses = $sandals->getCompletenesses()->toArray();
+        $this->assertNotNull($completenesses);
+        $this->assertCount(4, $completenesses);
+
+        $completeness = $this->getCompletenessByChannelAndLocaleCodes($sandals, 'mobile', 'en_US');
+        $this->assertNotNull($completeness->getLocale());
+        $this->assertEquals('en_US', $completeness->getLocale()->getCode());
+        $this->assertNotNull($completeness->getChannel());
+        $this->assertEquals('mobile', $completeness->getChannel()->getCode());
+        $this->assertEquals(40, $completeness->getRatio());
+        $this->assertEquals(5, $completeness->getRequiredCount());
+        $this->assertEquals(3, $completeness->getMissingCount());
+
+        $completeness = $this->getCompletenessByChannelAndLocaleCodes($sandals, 'tablet', 'en_US');
+        $this->assertNotNull($completeness->getLocale());
+        $this->assertEquals('en_US', $completeness->getLocale()->getCode());
+        $this->assertNotNull($completeness->getChannel());
+        $this->assertEquals('tablet', $completeness->getChannel()->getCode());
+        $this->assertEquals(25, $completeness->getRatio());
+        $this->assertEquals(8, $completeness->getRequiredCount());
+        $this->assertEquals(6, $completeness->getMissingCount());
+
+        $completeness = $this->getCompletenessByChannelAndLocaleCodes($sandals, 'mobile', 'fr_FR');
+        $this->assertNotNull($completeness->getLocale());
+        $this->assertEquals('fr_FR', $completeness->getLocale()->getCode());
+        $this->assertNotNull($completeness->getChannel());
+        $this->assertEquals('mobile', $completeness->getChannel()->getCode());
+        $this->assertEquals(60, $completeness->getRatio());
+        $this->assertEquals(5, $completeness->getRequiredCount());
+        $this->assertEquals(2, $completeness->getMissingCount());
+
+        $completeness = $this->getCompletenessByChannelAndLocaleCodes($sandals, 'tablet', 'fr_FR');
+        $this->assertNotNull($completeness->getLocale());
+        $this->assertEquals('fr_FR', $completeness->getLocale()->getCode());
+        $this->assertNotNull($completeness->getChannel());
+        $this->assertEquals('tablet', $completeness->getChannel()->getCode());
+        $this->assertEquals(50, $completeness->getRatio());
+        $this->assertEquals(8, $completeness->getRequiredCount());
+        $this->assertEquals(4, $completeness->getMissingCount());
+    }
+
+    public function testProductCompleteOnOneChannel()
+    {
+        $sneakersFamily = $this->get('pim_catalog.repository.family')->findOneByIdentifier('sneakers');
+
+        $sandals = $this->createProductWithStandardValues(
+            $sneakersFamily,
+            'sneakers',
+            ['values' => $this->getSneakerStandardValues()]
+        );
+
+        $completenesses = $sandals->getCompletenesses()->toArray();
+        $this->assertNotNull($completenesses);
+        $this->assertCount(4, $completenesses);
+
+        $completeness = $this->getCompletenessByChannelAndLocaleCodes($sandals, 'mobile', 'en_US');
+        $this->assertNotNull($completeness->getLocale());
+        $this->assertEquals('en_US', $completeness->getLocale()->getCode());
+        $this->assertNotNull($completeness->getChannel());
+        $this->assertEquals('mobile', $completeness->getChannel()->getCode());
+        $this->assertEquals(100, $completeness->getRatio());
+        $this->assertEquals(5, $completeness->getRequiredCount());
+        $this->assertEquals(0, $completeness->getMissingCount());
+
+        $completeness = $this->getCompletenessByChannelAndLocaleCodes($sandals, 'tablet', 'en_US');
+        $this->assertNotNull($completeness->getLocale());
+        $this->assertEquals('en_US', $completeness->getLocale()->getCode());
+        $this->assertNotNull($completeness->getChannel());
+        $this->assertEquals('tablet', $completeness->getChannel()->getCode());
+        $this->assertEquals(89, $completeness->getRatio());
+        $this->assertEquals(9, $completeness->getRequiredCount());
+        $this->assertEquals(1, $completeness->getMissingCount());
+
+        $completeness = $this->getCompletenessByChannelAndLocaleCodes($sandals, 'mobile', 'fr_FR');
+        $this->assertNotNull($completeness->getLocale());
+        $this->assertEquals('fr_FR', $completeness->getLocale()->getCode());
+        $this->assertNotNull($completeness->getChannel());
+        $this->assertEquals('mobile', $completeness->getChannel()->getCode());
+        $this->assertEquals(100, $completeness->getRatio());
+        $this->assertEquals(5, $completeness->getRequiredCount());
+        $this->assertEquals(0, $completeness->getMissingCount());
+
+        $completeness = $this->getCompletenessByChannelAndLocaleCodes($sandals, 'tablet', 'fr_FR');
+        $this->assertNotNull($completeness->getLocale());
+        $this->assertEquals('fr_FR', $completeness->getLocale()->getCode());
+        $this->assertNotNull($completeness->getChannel());
+        $this->assertEquals('tablet', $completeness->getChannel()->getCode());
+        $this->assertEquals(78, $completeness->getRatio());
+        $this->assertEquals(9, $completeness->getRequiredCount());
+        $this->assertEquals(2, $completeness->getMissingCount());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $fr = $this->get('pim_catalog.repository.locale')->findOneByIdentifier('fr_FR');
+        $channels = $this->get('pim_catalog.repository.channel')->findAll();
+        foreach ($channels as $channel) {
+            $channel->addLocale($fr);
+        }
+        $this->get('pim_catalog.saver.channel')->saveAll($channels);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return new Configuration(
+            [Configuration::getFunctionalCatalog('footwear')],
+            true,
+            [Configuration::getFunctionalFixtures()]
+        );
+    }
+
+    /**
+     * @param ProductInterface $product
+     * @param string           $channelCode
+     * @param string           $localeCode
+     *
+     * @return CompletenessInterface
+     * @throws \Exception
+     */
+    private function getCompletenessByChannelAndLocaleCodes(ProductInterface $product, $channelCode, $localeCode)
+    {
+        $completenesses = $product->getCompletenesses()->toArray();
+
+        foreach ($completenesses as $completeness) {
+            if ($localeCode === $completeness->getLocale()->getCode() &&
+                $channelCode === $completeness->getChannel()->getCode()) {
+                return $completeness;
+            }
+        }
+
+        throw new \Exception(sprintf(
+            'No completeness for the channel "%s" and locale "%s"',
+            $channelCode,
+            $localeCode
+        ));
+    }
+
+    private function getSandalStandardValues()
+    {
+        return [
+            'color' => [
+                [
+                    'locale' => null,
+                    'scope'  => null,
+                    'data'   => 'white'
+                ],
+            ],
+            'name' => [
+                [
+                    'locale' => 'fr_FR',
+                    'scope'  => null,
+                    'data'   => 'Sandales'
+                ],
+            ],
+            'description' => [
+                [
+                    'locale' => 'fr_FR',
+                    'scope'  => 'mobile',
+                    'data'   => 'Super sandales !'
+                ],
+                [
+                    'locale' => 'fr_FR',
+                    'scope'  => 'tablet',
+                    'data'   => 'Des sandales magiques !'
+                ],
+            ],
+        ];
+    }
+
+    private function getSneakerStandardValues()
+    {
+        return [
+            'manufacturer' => [
+                [
+                    'locale' => null,
+                    'scope'  => null,
+                    'data'   => 'converse'
+                ],
+            ],
+            'weather_conditions' => [
+                [
+                    'locale' => null,
+                    'scope'  => null,
+                    'data'   => ['hot']
+                ],
+            ],
+            'color' => [
+                [
+                    'locale' => null,
+                    'scope'  => null,
+                    'data'   => 'blue'
+                ],
+            ],
+            'name' => [
+                [
+                    'locale' => 'en_US',
+                    'scope'  => null,
+                    'data'   => 'Sneakers'
+                ],
+                [
+                    'locale' => 'fr_FR',
+                    'scope'  => null,
+                    'data'   => 'Espadrilles'
+                ],
+            ],
+            'price' => [
+                [
+                    'locale' => null,
+                    'scope'  => null,
+                    'data'   => [
+                        ['amount' => 69, 'currency' => 'EUR'],
+                        ['amount' => 99, 'currency' => 'USD'],
+                    ]
+
+                ],
+            ],
+            'rating' => [
+                [
+                    'locale' => null,
+                    'scope'  => null,
+                    'data'   => 4
+                ],
+            ],
+            'size' => [
+                [
+                    'locale' => null,
+                    'scope'  => null,
+                    'data'   => 43
+                ],
+            ],
+            'lace_color' => [
+                [
+                    'locale' => null,
+                    'scope'  => null,
+                    'data'   => 'laces_white'
+                ],
+            ],
+            'description' => [
+                [
+                    'locale' => 'en_US',
+                    'scope'  => 'mobile',
+                    'data'   => 'Great sneakers'
+                ],
+                [
+                    'locale' => 'en_US',
+                    'scope'  => 'tablet',
+                    'data'   => 'Really great sneakers'
+                ],
+                [
+                    'locale' => 'fr_FR',
+                    'scope'  => 'mobile',
+                    'data'   => 'Grandes espadrilles'
+                ],
+            ],
+        ];
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/CompletenessForScopableAttributeIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/CompletenessForScopableAttributeIntegration.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\Completeness;
+
+use Pim\Component\Catalog\AttributeTypes;
+use Pim\Component\Catalog\Model\ProductInterface;
+
+/**
+ * Checks that the completeness has been well calculated for scopable attribute types.
+ *
+ * We test from the minimal catalog that contains only one channel, with one locale activated.
+ *
+ * For each test, we create a family where the scopable attribute is required.
+ *
+ * @author    Julien Janvier <j.janvier@gmail.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class CompletenessForScopableAttributeIntegration extends AbstractCompletenessIntegration
+{
+    public function testCompleteScopable()
+    {
+        $family = $this->createFamilyWithRequirement(
+            'another_family',
+            'ecommerce',
+            'a_text',
+            AttributeTypes::TEXT,
+            false,
+            true
+        );
+
+        $product = $this->createProductWithStandardValues(
+            $family,
+            'another_product',
+            [
+                'values' => [
+                    'a_text' => [
+                        [
+                            'locale' => null,
+                            'scope'  => 'ecommerce',
+                            'data'   => 'just a text'
+                        ],
+                    ]
+                ]
+            ]
+        );
+
+        $this->assertComplete($product, 'ecommerce');
+    }
+
+    public function testNotCompleteScopable()
+    {
+        $family = $this->createFamilyWithRequirement(
+            'another_family',
+            'ecommerce',
+            'a_text',
+            AttributeTypes::TEXT,
+            false,
+            true
+        );
+
+        $productWithoutValues = $this->createProductWithStandardValues($family, 'product_witout_values');
+        $this->assertNotComplete($productWithoutValues, 'ecommerce');
+
+        $productDataEmpty = $this->createProductWithStandardValues(
+            $family,
+            'product_data_empty',
+            [
+                'values' => [
+                    'a_text' => [
+                        [
+                            'locale' => null,
+                            'scope'  => 'ecommerce',
+                            'data'   => null
+                        ],
+                    ]
+                ]
+            ]
+        );
+        $this->assertNotComplete($productDataEmpty, 'ecommerce');
+    }
+
+    /**
+     * @param ProductInterface $product
+     * @param string           $channelCode
+     */
+    private function assertNotComplete(ProductInterface $product, $channelCode)
+    {
+        $completenesses = $product->getCompletenesses()->toArray();
+        $this->assertNotNull($completenesses);
+        $this->assertCount(1, $completenesses);
+
+        $completeness = current($completenesses);
+        $this->assertNotNull($completeness->getLocale());
+        $this->assertEquals('en_US', $completeness->getLocale()->getCode());
+        $this->assertNotNull($completeness->getChannel());
+        $this->assertEquals($channelCode, $completeness->getChannel()->getCode());
+        $this->assertEquals(50, $completeness->getRatio());
+        $this->assertEquals(2, $completeness->getRequiredCount());
+        $this->assertEquals(1, $completeness->getMissingCount());
+    }
+
+    /**
+     * @param ProductInterface $product
+     * @param string           $channelCode
+     */
+    private function assertComplete(ProductInterface $product, $channelCode)
+    {
+        $completenesses = $product->getCompletenesses()->toArray();
+        $this->assertNotNull($completenesses);
+        $this->assertCount(1, $completenesses);
+
+        $completeness = current($completenesses);
+        $this->assertNotNull($completeness->getLocale());
+        $this->assertEquals('en_US', $completeness->getLocale()->getCode());
+        $this->assertNotNull($completeness->getChannel());
+        $this->assertEquals($channelCode, $completeness->getChannel()->getCode());
+        $this->assertEquals(100, $completeness->getRatio());
+        $this->assertEquals(2, $completeness->getRequiredCount());
+        $this->assertEquals(0, $completeness->getMissingCount());
+    }
+}

--- a/src/Pim/Component/Catalog/Validator/AttributeValidatorHelper.php
+++ b/src/Pim/Component/Catalog/Validator/AttributeValidatorHelper.php
@@ -22,10 +22,10 @@ class AttributeValidatorHelper
     protected $scopeRepository;
 
     /** @var array */
-    protected static $localeCodes;
+    protected $localeCodes;
 
     /** @var array */
-    protected static $scopeCodes;
+    protected $scopeCodes;
 
     /**
      * @param LocaleRepositoryInterface  $localeRepository
@@ -72,11 +72,11 @@ class AttributeValidatorHelper
             );
         }
 
-        if (null === static::$localeCodes) {
-            static::$localeCodes = $this->getActivatedLocaleCodes();
+        if (null === $this->localeCodes) {
+            $this->localeCodes = $this->getActivatedLocaleCodes();
         }
 
-        if (!in_array($locale, static::$localeCodes)) {
+        if (!in_array($locale, $this->localeCodes)) {
             throw new \LogicException(
                 sprintf(
                     'Attribute "%s" expects an existing and activated locale, "%s" given.',
@@ -152,11 +152,11 @@ class AttributeValidatorHelper
             );
         }
 
-        if (null === static::$scopeCodes) {
-            static::$scopeCodes = $this->getScopeCodes();
+        if (null === $this->scopeCodes) {
+            $this->scopeCodes = $this->getScopeCodes();
         }
 
-        if (!in_array($scope, static::$scopeCodes)) {
+        if (!in_array($scope, $this->scopeCodes)) {
             throw new \LogicException(
                 sprintf(
                     'Attribute "%s" expects an existing scope, "%s" given.',

--- a/src/Pim/Component/Catalog/spec/Validator/AttributeValidatorHelperSpec.php
+++ b/src/Pim/Component/Catalog/spec/Validator/AttributeValidatorHelperSpec.php
@@ -130,8 +130,8 @@ class AttributeValidatorHelperSpec extends ObjectBehavior
 class InitializedAttributeValidatorHelper extends AttributeValidatorHelper
 {
     /** @var array */
-    protected static $localeCodes = ['en_US', 'fr_FR'];
+    protected $localeCodes = ['en_US', 'fr_FR'];
 
     /** @var array */
-    protected static $scopeCodes = ['ecommerce', 'tablet'];
+    protected $scopeCodes = ['ecommerce', 'tablet'];
 }

--- a/src/Pim/Component/Catalog/tests/integration/Normalizer/Standard/CategoryIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Normalizer/Standard/CategoryIntegration.php
@@ -11,8 +11,6 @@ use Pim\Component\Catalog\tests\integration\Normalizer\Standard\AbstractStandard
  */
 class CategoryIntegration extends AbstractStandardNormalizerTestCase
 {
-    protected $purgeDatabaseForEachTest = false;
-
     public function testCategoryRoot()
     {
         $expected = [

--- a/src/Pim/Component/Catalog/tests/integration/Normalizer/Standard/DateTimeIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Normalizer/Standard/DateTimeIntegration.php
@@ -11,8 +11,6 @@ use Pim\Component\Catalog\tests\integration\Normalizer\Standard\AbstractStandard
  */
 class DateTimeIntegration extends AbstractStandardNormalizerTestCase
 {
-    protected $purgeDatabaseForEachTest = false;
-
     public function testDateTimeWithParisTimezone()
     {
         $datetime = new \DateTime('2015-01-01 23:50:00');

--- a/tests/Configuration.php
+++ b/tests/Configuration.php
@@ -105,6 +105,50 @@ class Configuration
     /**
      * @return string
      */
+    public static function getMinimalCatalogPath()
+    {
+        return realpath(self::getRootDirectory() . DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR . 'Pim' .
+            DIRECTORY_SEPARATOR . 'Bundle' . DIRECTORY_SEPARATOR . 'InstallerBundle' . DIRECTORY_SEPARATOR .
+            'Resources' . DIRECTORY_SEPARATOR . 'fixtures' . DIRECTORY_SEPARATOR . 'minimal');
+    }
+
+    /**
+     * @return string
+     */
+    public static function getReferenceDataFixtures()
+    {
+        return realpath(self::getRootDirectory() . DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR . 'Acme' .
+            DIRECTORY_SEPARATOR . 'Bundle' . DIRECTORY_SEPARATOR . 'AppBundle' . DIRECTORY_SEPARATOR . 'Resources' .
+            DIRECTORY_SEPARATOR . 'fixtures');
+    }
+
+    /**
+     * Returns the path to a given functional (aka behat) catalog.
+     *
+     * @param $catalog
+     *
+     * @return string
+     */
+    public static function getFunctionalCatalog($catalog)
+    {
+        return realpath(self::getRootDirectory(). DIRECTORY_SEPARATOR . 'features'. DIRECTORY_SEPARATOR . 'Context' .
+            DIRECTORY_SEPARATOR .'catalog'. DIRECTORY_SEPARATOR . $catalog);
+    }
+
+    /**
+     * Returns the path to a functional (aka behat) fixture folder.
+     *
+     * @return string
+     */
+    public static function getFunctionalFixtures()
+    {
+        return realpath(self::getRootDirectory(). DIRECTORY_SEPARATOR . 'features'. DIRECTORY_SEPARATOR . 'Context' .
+            DIRECTORY_SEPARATOR .'fixtures');
+    }
+
+    /**
+     * @return string
+     */
     private static function getRootDirectory()
     {
         return realpath(__DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR);

--- a/tests/FixturesLoader.php
+++ b/tests/FixturesLoader.php
@@ -252,7 +252,7 @@ class FixturesLoader
             if (false === $realFilePath = realpath($rawFilePath)) {
                 continue;
             }
-            $files[] = $rawFilePath;
+            $files[] = $realFilePath;
         }
 
         return $files;


### PR DESCRIPTION
(we'll squash commits before merging)

**Description (for Contributor and Core Developer)**

Add integration tests regarding the Completeness feature, it takes into account how the completeness is calculated given:
- the available attribute types in the PIM
- the localizable specificity of an attribute (as well as locale specific)
- the scopable specificity of an attribute
- the locale/scope specificities mixed
- the non required attributes do not influence the calculation

The goal is to be able to refactor the completeness without any fear of breaking something.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | Ok
| Changelog updated                 | -
| Review and 2 GTM                  | 
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -
