### PR TITLE
Api 36 : add attribute option patch in api

### DIFF
--- a/src/Pim/Bundle/ApiBundle/Resources/config/routing/attribute.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/routing/attribute.yml
@@ -8,7 +8,7 @@ pim_api_attribute_create:
     defaults: { _controller: pim_api.controller.attribute:createAction, _format: json }
     methods: [POST]
 
-pim_api_attribute_update:
+pim_api_attribute_partial_update:
     path: /attributes/{code}
     defaults: { _controller: pim_api.controller.attribute:partialUpdateAction, _format: json }
     methods: [PATCH]
@@ -27,6 +27,11 @@ pim_api_attribute_option_create:
     path: /attributes/{attributeCode}/options
     defaults: { _controller: pim_api.controller.attribute_option:createAction, _format: json }
     methods: [POST]
+
+pim_api_attribute_option_partial_update:
+    path: /attributes/{attributeCode}/options/{optionCode}
+    defaults: { _controller: pim_api.controller.attribute_option:partialUpdateAction, _format: json }
+    methods: [PATCH]
 
 pim_api_attribute_option_get:
     path: /attributes/{attributeCode}/options/{code}

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AttributeOption/PartialUpdateAttributeOptionIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AttributeOption/PartialUpdateAttributeOptionIntegration.php
@@ -1,0 +1,569 @@
+<?php
+
+namespace Pim\Bundle\ApiBundle\tests\integration\Controller\AttributeOption;
+
+use Akeneo\Test\Integration\Configuration;
+use Pim\Bundle\ApiBundle\tests\integration\ApiTestCase;
+use Pim\Bundle\CatalogBundle\Version;
+use Symfony\Component\HttpFoundation\Response;
+
+class PartialUpdateAttributeOptionIntegration extends ApiTestCase
+{
+    public function testHttpHeadersInResponseWhenAnAttributeOptionIsUpdated()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data =
+<<<JSON
+    {
+        "code": "optionA"
+    }
+JSON;
+
+        $client->request('PATCH', 'api/rest/v1/attributes/a_multi_select/options/optionA', [], [], [], $data);
+
+        $response = $client->getResponse();
+        $this->assertSame('', $response->getContent());
+        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        $this->assertArrayHasKey('location', $response->headers->all());
+        $this->assertSame('http://localhost/api/rest/v1/attributes/a_multi_select/options/optionA', $response->headers->get('location'));
+    }
+
+    public function testHttpHeadersInResponseWhenAnAttributeOptionIsCreated()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data =
+<<<JSON
+    {
+        "code":"newOption",
+        "attribute":"a_multi_select",
+        "sort_order":30,
+        "labels":{"en_US":"new option"}
+    }
+JSON;
+
+        $client->request('PATCH', 'api/rest/v1/attributes/a_multi_select/options/newOption', [], [], [], $data);
+
+        $response = $client->getResponse();
+
+        $this->assertSame('', $response->getContent());
+        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+        $this->assertArrayHasKey('location', $response->headers->all());
+        $this->assertSame(
+            'http://localhost/api/rest/v1/attributes/a_multi_select/options/newOption',
+            $response->headers->get('location')
+        );
+    }
+
+    public function testStandardFormatWhenAnAttributeOptionIsCreatedButIncompleted()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data =
+<<<JSON
+    {
+        "code":"newOption",
+        "attribute":"a_multi_select"
+    }
+JSON;
+        $client->request('PATCH', 'api/rest/v1/attributes/a_multi_select/options/newOption', [], [], [], $data);
+
+        $attributeOption = $this->get('pim_catalog.repository.attribute_option')
+            ->findOneByIdentifier('a_multi_select.newOption');
+
+        $attributeOptionStandard = [
+            'code'       => 'newOption',
+            'attribute'  => 'a_multi_select',
+            'sort_order' => 1,
+            'labels'     => [],
+        ];
+        $normalizer = $this->get('pim_catalog.normalizer.standard.attribute_option');
+
+        $response = $client->getResponse();
+
+        $this->assertSame($attributeOptionStandard, $normalizer->normalize($attributeOption));
+        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+    }
+
+    public function testStandardFormatWhenAnAttributeOptionIsCreatedWithAnEmptyContent()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data = '{}';
+
+        $client->request('PATCH', 'api/rest/v1/attributes/a_multi_select/options/newOption', [], [], [], $data);
+
+        $attributeOption = $this->get('pim_catalog.repository.attribute_option')
+            ->findOneByIdentifier('a_multi_select.newOption');
+
+        $attributeOptionStandard = [
+            'code'       => 'newOption',
+            'attribute'  => 'a_multi_select',
+            'sort_order' => 1,
+            'labels'     => [],
+        ];
+        $normalizer = $this->get('pim_catalog.normalizer.standard.attribute_option');
+
+        $response = $client->getResponse();
+
+        $this->assertSame($attributeOptionStandard, $normalizer->normalize($attributeOption));
+        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+    }
+
+    public function testStandardFormatWhenAnAttributeOptionIsCreatedWithOptionCode()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data =
+<<<JSON
+    {
+        "code":"newOption"
+    }
+JSON;
+
+        $client->request('PATCH', 'api/rest/v1/attributes/a_multi_select/options/newOption', [], [], [], $data);
+
+        $attributeOption = $this->get('pim_catalog.repository.attribute_option')
+            ->findOneByIdentifier('a_multi_select.newOption');
+
+        $attributeOptionStandard = [
+            'code'       => 'newOption',
+            'attribute'  => 'a_multi_select',
+            'sort_order' => 1,
+            'labels'     => [],
+        ];
+        $normalizer = $this->get('pim_catalog.normalizer.standard.attribute_option');
+
+        $response = $client->getResponse();
+
+        $this->assertSame($attributeOptionStandard, $normalizer->normalize($attributeOption));
+        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+    }
+
+    public function testStandardFormatWhenAnAttributeOptionIsCreatedWithAttributeCode()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data =
+<<<JSON
+    {
+        "attribute":"a_multi_select"
+    }
+JSON;
+
+        $client->request('PATCH', 'api/rest/v1/attributes/a_multi_select/options/newOption', [], [], [], $data);
+
+        $attributeOption = $this->get('pim_catalog.repository.attribute_option')
+            ->findOneByIdentifier('a_multi_select.newOption');
+
+        $attributeOptionStandard = [
+            'code'       => 'newOption',
+            'attribute'  => 'a_multi_select',
+            'sort_order' => 1,
+            'labels'     => [],
+        ];
+        $normalizer = $this->get('pim_catalog.normalizer.standard.attribute_option');
+
+        $response = $client->getResponse();
+
+        $this->assertSame($attributeOptionStandard, $normalizer->normalize($attributeOption));
+        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+    }
+
+    public function testCompleteAttributeOptionCreation()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data =
+<<<JSON
+    {
+        "code":"optionE",
+        "attribute":"a_multi_select",
+        "sort_order":30,
+        "labels":{"en_US":"Option E"}
+    }
+JSON;
+
+        $client->request('PATCH', 'api/rest/v1/attributes/a_multi_select/options/optionE', [], [], [], $data);
+
+        $attributeOption = $this->get('pim_catalog.repository.attribute_option')
+            ->findOneByIdentifier('a_multi_select.optionE');
+
+        $attributeOptionStandard = [
+            'code'       => 'optionE',
+            'attribute'  => 'a_multi_select',
+            'sort_order' => 30,
+            'labels'     => [
+                'en_US' => 'Option E',
+            ],
+        ];
+        $normalizer = $this->get('pim_catalog.normalizer.standard.attribute_option');
+
+        $response = $client->getResponse();
+
+        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+        $this->assertSame($attributeOptionStandard, $normalizer->normalize($attributeOption));
+    }
+
+    public function testPartialUpdateWithAnEmptyContent()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data = '{}';
+
+        $client->request('PATCH', 'api/rest/v1/attributes/a_multi_select/options/optionA', [], [], [], $data);
+
+        $attributeOption = $this->get('pim_catalog.repository.attribute_option')
+            ->findOneByIdentifier('a_multi_select.optionA');
+
+        $attributeOptionStandard = [
+            'code'       => 'optionA',
+            'attribute'  => 'a_multi_select',
+            'sort_order' => 10,
+            'labels'     => [
+                'en_US' => 'Option A',
+            ],
+        ];
+        $normalizer = $this->get('pim_catalog.normalizer.standard.attribute_option');
+
+        $response = $client->getResponse();
+
+        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        $this->assertSame($attributeOptionStandard, $normalizer->normalize($attributeOption));
+    }
+
+    public function testPartialUpdateWithAnAttributeCode()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data =
+<<<JSON
+    {
+        "attribute":"a_multi_select",
+        "sort_order":"100"
+    }
+JSON;
+
+        $client->request('PATCH', 'api/rest/v1/attributes/a_multi_select/options/optionA', [], [], [], $data);
+
+        $attributeOption = $this->get('pim_catalog.repository.attribute_option')
+            ->findOneByIdentifier('a_multi_select.optionA');
+
+        $attributeOptionStandard = [
+            'code'       => 'optionA',
+            'attribute'  => 'a_multi_select',
+            'sort_order' => 100,
+            'labels'     => [
+                'en_US' => 'Option A',
+            ],
+        ];
+        $normalizer = $this->get('pim_catalog.normalizer.standard.attribute_option');
+
+        $response = $client->getResponse();
+
+        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        $this->assertSame($attributeOptionStandard, $normalizer->normalize($attributeOption));
+    }
+
+    public function testPartialUpdateWithAnOptionCode()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data =
+<<<JSON
+    {
+        "code":"optionA",
+        "labels":{"fr_FR":"Option A fr"}
+    }
+JSON;
+
+        $client->request('PATCH', 'api/rest/v1/attributes/a_multi_select/options/optionA', [], [], [], $data);
+
+        $attributeOption = $this->get('pim_catalog.repository.attribute_option')
+            ->findOneByIdentifier('a_multi_select.optionA');
+
+        $attributeOptionStandard = [
+            'code'       => 'optionA',
+            'attribute'  => 'a_multi_select',
+            'sort_order' => 10,
+            'labels'     => [
+                'en_US' => 'Option A',
+                'fr_FR' => 'Option A fr',
+            ],
+        ];
+        $normalizer = $this->get('pim_catalog.normalizer.standard.attribute_option');
+
+        $response = $client->getResponse();
+
+        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        $this->assertSame($attributeOptionStandard, $normalizer->normalize($attributeOption));
+    }
+
+    public function testResponseWhenContentIsEmpty()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data = '';
+
+        $expectedContent =
+<<<JSON
+    {
+        "message" : "Invalid json message received",
+        "code" : 400
+    }
+JSON;
+
+        $client->request('PATCH', 'api/rest/v1/attributes/a_multi_select/options/optionA', [], [], [], $data);
+        $response = $client->getResponse();
+        $this->assertJsonStringEqualsJsonString($expectedContent, $response->getContent());
+        $this->assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+    }
+
+    public function testResponseWhenAttributeDoesNotExist()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data =
+<<<JSON
+    {
+        "attribute":"an_unknown_multi_select"
+    }
+JSON;
+
+        $expectedContent =
+<<<JSON
+    {
+        "message" : "Attribute \"an_unknown_multi_select\" does not exist.",
+        "code" : 404
+    }
+JSON;
+
+        $client->request('PATCH', 'api/rest/v1/attributes/an_unknown_multi_select/options/optionA', [], [], [], $data);
+        $response = $client->getResponse();
+        $this->assertJsonStringEqualsJsonString($expectedContent, $response->getContent());
+        $this->assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
+    }
+
+    public function testResponseWhenAttributeDoesNotSupportOptions()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data =
+<<<JSON
+    {
+        "attribute":"sku"
+    }
+JSON;
+
+        $expectedContent =
+<<<JSON
+    {
+        "code": 422,
+        "message": "Validation failed.",
+        "errors": [{
+            "field": "attribute",
+            "message": "Attribute \"sku\" does not support options. Only attributes of type \"pim_catalog_simpleselect\", \"pim_catalog_multiselect\" support options"
+        }]
+    }
+JSON;
+
+        $client->request('PATCH', 'api/rest/v1/attributes/sku/options/optionA', [], [], [], $data);
+        $response = $client->getResponse();
+
+        $this->assertJsonStringEqualsJsonString($expectedContent, $response->getContent());
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+    }
+
+    public function testPartialUpdateOfTheAttributeCodeAndOptionCode()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data =
+<<<JSON
+    {
+        "code":"newOptionCode",
+        "attribute":"a_simple_select"
+    }
+JSON;
+
+        $expectedContent =
+<<<JSON
+    {
+    	"code": 422,
+    	"message": "Validation failed.",
+    	"errors": [{
+    		"field": "code",
+    		"message": "This property cannot be changed."
+    	},{
+    		"field": "attribute",
+    		"message": "This property cannot be changed."
+    	}]
+    }
+JSON;
+
+        $client->request('PATCH', 'api/rest/v1/attributes/a_multi_select/options/optionA', [], [], [], $data);
+        $response = $client->getResponse();
+        $this->assertJsonStringEqualsJsonString($expectedContent, $response->getContent());
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+    }
+
+    public function testCreateWhenAttributeInUriIsNotIdenticalToAttributeInBody()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data =
+<<<JSON
+    {
+        "attribute":"a_simple_select"
+    }
+JSON;
+
+        $expectedContent =
+<<<JSON
+    {
+      "message" : "The attribute code \"a_simple_select\" provided in the request body must match the attribute code \"a_multi_select\" provided in the url.",
+      "code" : 422
+    }
+JSON;
+
+        $client->request('PATCH', 'api/rest/v1/attributes/a_multi_select/options/newOption', [], [], [], $data);
+        $response = $client->getResponse();
+        $this->assertJsonStringEqualsJsonString($expectedContent, $response->getContent());
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+    }
+
+    public function testCreateWhenCodeInUriIsNotIdenticalToCodeInBod()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data =
+<<<JSON
+    {
+        "code":"foo"
+    }
+JSON;
+
+        $expectedContent =
+<<<JSON
+    {
+      "message" : "The option code \"foo\" provided in the request body must match the option code \"newOption\" provided in the url.",
+      "code" : 422
+    }
+JSON;
+
+        $client->request('PATCH', 'api/rest/v1/attributes/a_multi_select/options/newOption', [], [], [], $data);
+        $response = $client->getResponse();
+        $this->assertJsonStringEqualsJsonString($expectedContent, $response->getContent());
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+    }
+
+    public function testResponseWhenAPropertyIsNotExpected()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data =
+<<<JSON
+    {
+        "attribute":"a_multi_select",
+        "extra_property": null
+    }
+JSON;
+
+        $version = substr(Version::VERSION, 0, 3);
+        $expectedContent =
+<<<JSON
+    {
+    	"message": "Property \"extra_property\" does not exist. Check the standard format documentation.",
+    	"_links": {
+    		"documentation": {
+    			"href": "https://docs.akeneo.com/${version}/reference/standard_format/other_entities.html#attribute-option"
+    		}
+    	},
+    	"code": 422
+    }
+JSON;
+
+        $client->request('PATCH', 'api/rest/v1/attributes/a_multi_select/options/optionA', [], [], [], $data);
+
+        $response = $client->getResponse();
+        $this->assertJsonStringEqualsJsonString($expectedContent, $response->getContent());
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+    }
+
+    public function testResponseWhenLabelsIsNull()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data =
+<<<JSON
+    {
+        "attribute":"a_multi_select",
+        "labels": null
+    }
+JSON;
+
+        $version = substr(Version::VERSION, 0, 3);
+        $expectedContent =
+<<<JSON
+    {
+        "code": 422,
+        "message": "Property \"labels\" expects an array as data, \"NULL\" given. Check the standard format documentation.",
+        "_links": {
+            "documentation": {
+                "href": "https:\/\/docs.akeneo.com\/${version}\/reference\/standard_format\/other_entities.html#attribute-option"
+            }
+        }
+    }
+JSON;
+
+        $client->request('PATCH', 'api/rest/v1/attributes/a_multi_select/options/optionA', [], [], [], $data);
+
+        $response = $client->getResponse();
+        $this->assertJsonStringEqualsJsonString($expectedContent, $response->getContent());
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+    }
+
+    public function testResponseWhenLocaleDoesNotExist()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data =
+<<<JSON
+    {
+        "labels": {
+            "foo": "bar"
+         }
+    }
+JSON;
+
+        $expectedContent =
+<<<JSON
+    {
+        "code": 422,
+        "message": "Validation failed.",
+        "errors": [{
+            "field": "labels",
+            "message": "The locale \"foo\" does not exist."
+        }]
+    }
+JSON;
+
+        $client->request('PATCH', 'api/rest/v1/attributes/a_multi_select/options/optionA', [], [], [], $data);
+
+        $response = $client->getResponse();
+        $this->assertJsonStringEqualsJsonString($expectedContent, $response->getContent());
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return new Configuration(
+            [Configuration::getTechnicalCatalogPath()],
+           true
+        );
+    }
+}

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/AttributeOption/GetAttributeOptionIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/AttributeOption/GetAttributeOptionIntegration.php
@@ -14,18 +14,21 @@ class GetAttributeOptionIntegration extends ApiTestCase
 
         $client->request('GET', 'api/rest/v1/attributes/a_multi_select/options/optionA');
 
-        $standardAttributeOption = [
-            'code'       => 'optionA',
-            'attribute'  => 'a_multi_select',
-            'sort_order' => 10,
-            'labels'     => [
-                'en_US' => 'Option A',
-            ],
-        ];
+        $expectedContent =
+<<<JSON
+    {
+        "code" : "optionA",
+        "sort_order" : 10,
+        "attribute" : "a_multi_select",
+        "labels" : {
+          "en_US" : "Option A"
+        }
+    }
+JSON;
 
         $response = $client->getResponse();
+        $this->assertJsonStringEqualsJsonString($expectedContent, $response->getContent());
         $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
-        $this->assertSame($standardAttributeOption, json_decode($response->getContent(), true));
     }
 
     public function testNotFoundAnAttribute()
@@ -34,12 +37,17 @@ class GetAttributeOptionIntegration extends ApiTestCase
 
         $client->request('GET', 'api/rest/v1/attributes/not_found/options/not_found');
 
+        $expectedContent =
+<<<JSON
+    {
+      "message" : "Attribute \"not_found\" does not exist.",
+      "code" : 404
+    }
+JSON;
+
         $response = $client->getResponse();
+        $this->assertJsonStringEqualsJsonString($expectedContent, $response->getContent());
         $this->assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
-        $content = json_decode($response->getContent(), true);
-        $this->assertCount(2, $content, 'response contains 2 items');
-        $this->assertSame(Response::HTTP_NOT_FOUND, $content['code']);
-        $this->assertSame('Attribute "not_found" does not exist.', $content['message']);
     }
 
     public function testNotSupportedOptionsAttribute()
@@ -48,15 +56,17 @@ class GetAttributeOptionIntegration extends ApiTestCase
 
         $client->request('GET', 'api/rest/v1/attributes/sku/options/sku');
 
+        $expectedContent =
+<<<JSON
+    {
+      "message" : "Attribute \"sku\" does not support options. Only attributes of type \"pim_catalog_simpleselect\", \"pim_catalog_multiselect\" support options.",
+      "code" : 404
+    }
+JSON;
+
         $response = $client->getResponse();
+        $this->assertJsonStringEqualsJsonString($expectedContent, $response->getContent());
         $this->assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
-        $content = json_decode($response->getContent(), true);
-        $this->assertCount(2, $content, 'response contains 2 items');
-        $this->assertSame(Response::HTTP_NOT_FOUND, $content['code']);
-        $this->assertSame(
-            'Attribute "sku" does not support options. Only attributes of type "pim_catalog_simpleselect", "pim_catalog_multiselect" support options.',
-            $content['message']
-        );
     }
 
     public function testNotExistingOptionsAttribute()
@@ -64,15 +74,18 @@ class GetAttributeOptionIntegration extends ApiTestCase
         $client = $this->createAuthenticatedClient();
 
         $client->request('GET', 'api/rest/v1/attributes/a_multi_select/options/not_existing_option');
+
+        $expectedContent =
+<<<JSON
+    {
+      "message" : "Attribute option \"not_existing_option\" does not exist or is not an option of the attribute \"a_multi_select\".",
+      "code" : 404
+    }
+JSON;
+
         $response = $client->getResponse();
+        $this->assertJsonStringEqualsJsonString($expectedContent, $response->getContent());
         $this->assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
-        $content = json_decode($response->getContent(), true);
-        $this->assertCount(2, $content, 'response contains 2 items');
-        $this->assertSame(Response::HTTP_NOT_FOUND, $content['code']);
-        $this->assertSame(
-            'Attribute option "not_existing_option" does not exist or is not an option of the attribute "a_multi_select".',
-            $content['message']
-        );
     }
 
     /**

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Category/PartialUpdateCategoryIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/Category/PartialUpdateCategoryIntegration.php
@@ -26,7 +26,7 @@ JSON;
         $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
         $this->assertArrayHasKey('location', $response->headers->all());
         $this->assertSame('http://localhost/api/rest/v1/categories/categoryA1', $response->headers->get('location'));
-        $this->assertSame(null, json_decode($response->getContent(), true));
+        $this->assertSame('', $response->getContent());
     }
 
     public function testHttpHeadersInResponseWhenACategoryIsCreated()

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/RootEndpointIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/RootEndpointIntegration.php
@@ -64,7 +64,7 @@ class RootEndpointIntegration extends ApiTestCase
                 "route": "/api/rest/v1/attributes",
                 "methods": ["POST"]
             },
-            "pim_api_attribute_update": {
+            "pim_api_attribute_partial_update": {
                 "route": "/api/rest/v1/attributes/{code}",
                 "methods": ["PATCH"]
             },
@@ -83,6 +83,10 @@ class RootEndpointIntegration extends ApiTestCase
             "pim_api_attribute_option_get": {
                 "route": "/api/rest/v1/attributes/{attributeCode}/options/{code}",
                 "methods": ["GET"]
+            },
+            "pim_api_attribute_option_partial_update": {
+                "route": "/api/rest/v1/attributes/{attributeCode}/options/{optionCode}",
+                "methods": ["PATCH"]
             },
             "pim_api_channel_list": {
                 "route": "/api/rest/v1/channels",

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/validation/attribute.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/validation/attribute.yml
@@ -424,7 +424,13 @@ Pim\Bundle\CatalogBundle\Entity\AttributeOption:
         - Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity:
             - code
             - attribute
-        - Pim\Component\Catalog\Validator\Constraints\AttributeTypeForOption : ~
+        - Pim\Component\Catalog\Validator\Constraints\AttributeTypeForOption:
+            payload:
+              standardPropertyName: attribute
+        - Pim\Component\Catalog\Validator\Constraints\Immutable:
+            properties:
+                - code
+                - attribute
     properties:
         code:
             - NotBlank: ~
@@ -436,3 +442,17 @@ Pim\Bundle\CatalogBundle\Entity\AttributeOption:
         attribute:
             - NotBlank: ~
             - Valid: ~
+        optionValues:
+            - Valid: ~
+
+Pim\Bundle\CatalogBundle\Entity\AttributeOptionValue:
+    properties:
+        value:
+            - Length:
+                max: 100
+                payload:
+                  standardPropertyName: labels
+        locale:
+            - Pim\Component\Catalog\Validator\Constraints\Locale:
+                payload:
+                  standardPropertyName: labels

--- a/src/Pim/Component/Catalog/Updater/AttributeOptionUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/AttributeOptionUpdater.php
@@ -56,14 +56,9 @@ class AttributeOptionUpdater implements ObjectUpdaterInterface
             );
         }
 
-        $isNew = $attributeOption->getId() === null;
-        $readOnlyFields = ['attribute', 'code'];
         foreach ($data as $field => $value) {
             $this->validateDataType($field, $value);
-            $isReadOnlyField = in_array($field, $readOnlyFields);
-            if ($isNew || !$isReadOnlyField) {
-                $this->setData($attributeOption, $field, $value);
-            }
+            $this->setData($attributeOption, $field, $value);
         }
 
         return $this;

--- a/src/Pim/Component/Catalog/Validator/Constraints/AttributeTypeForOption.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/AttributeTypeForOption.php
@@ -14,7 +14,10 @@ use Symfony\Component\Validator\Constraint;
 class AttributeTypeForOption extends Constraint
 {
     /** @var string */
-    public $invalidAttributeMessage = 'Invalid type for attribute "%attribute%", it cannot be used with options';
+    public $invalidAttributeMessage = 'Attribute "%attribute%" does not support options. Only attributes of type "%attribute_types%" support options';
+
+    /** @var string */
+    public $propertyPath = null;
 
     /**
      * {@inheritdoc}

--- a/src/Pim/Component/Catalog/Validator/Constraints/AttributeTypeForOptionValidator.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/AttributeTypeForOptionValidator.php
@@ -27,7 +27,7 @@ class AttributeTypeForOptionValidator extends ConstraintValidator
             $attribute = $attributeOption->getAttribute();
             $authorizedTypes = [AttributeTypes::OPTION_SIMPLE_SELECT, AttributeTypes::OPTION_MULTI_SELECT];
             if (null !== $attribute && !in_array($attribute->getType(), $authorizedTypes)) {
-                $this->addInvalidAttributeViolation($constraint, $attributeOption);
+                $this->addInvalidAttributeViolation($constraint, $attributeOption, $authorizedTypes);
             }
         }
     }
@@ -35,16 +35,22 @@ class AttributeTypeForOptionValidator extends ConstraintValidator
     /**
      * @param AttributeTypeForOption   $constraint
      * @param AttributeOptionInterface $option
+     * @param string[]                 $authorizedTypes
      */
     protected function addInvalidAttributeViolation(
         AttributeTypeForOption $constraint,
-        AttributeOptionInterface $option
+        AttributeOptionInterface $option,
+        array $authorizedTypes
     ) {
-        $this->context->buildViolation(
-            $constraint->invalidAttributeMessage,
-            [
-                '%attribute%' => $option->getAttribute()->getCode()
-            ]
-        )->addViolation();
+        $this->context
+            ->buildViolation(
+                $constraint->invalidAttributeMessage,
+                [
+                    '%attribute%'       => $option->getAttribute()->getCode(),
+                    '%attribute_types%' => implode('", "', $authorizedTypes),
+                ]
+            )
+            ->atPath($constraint->propertyPath)
+            ->addViolation();
     }
 }

--- a/src/Pim/Component/Catalog/spec/Updater/AttributeOptionUpdaterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/AttributeOptionUpdaterSpec.php
@@ -105,36 +105,7 @@ class AttributeOptionUpdaterSpec extends ObjectBehavior
             ]
         );
     }
-
-    function it_does_not_update_readonly_fields_on_an_existing_attribute_option(
-        AttributeOptionInterface $attributeOption,
-        AttributeOptionValueInterface $attributeOptionValue
-    ) {
-        $attributeOption->getId()->willReturn(42);
-        $attributeOption->getAttribute()->willReturn(null);
-
-        // read only fields
-        $attributeOption->setCode('mycode')->shouldNotBeCalled();
-        $attributeOption->setAttribute(Argument::any())->shouldNotBeCalled();
-
-        $attributeOption->setSortOrder(12)->shouldBeCalled();
-        $attributeOption->setLocale('de_DE')->shouldBeCalled();
-        $attributeOption->getTranslation()->willReturn($attributeOptionValue);
-        $attributeOptionValue->setLabel('210 x 1219 mm')->shouldBeCalled();
-
-        $this->update(
-            $attributeOption,
-            [
-                'code' => 'mycode',
-                'attribute' => 'myattribute',
-                'sort_order' => 12,
-                'labels' => [
-                    'de_DE' => '210 x 1219 mm'
-                ]
-            ]
-        );
-    }
-
+    
     function it_throws_an_exception_when_code_is_not_scalar(AttributeOptionInterface $attributeOption)
     {
         $values = [

--- a/src/Pim/Component/Catalog/spec/Validator/Constraints/AttributeTypeForOptionValidatorSpec.php
+++ b/src/Pim/Component/Catalog/spec/Validator/Constraints/AttributeTypeForOptionValidatorSpec.php
@@ -51,13 +51,17 @@ class AttributeTypeForOptionValidatorSpec extends ObjectBehavior
         $attributeOption->getAttribute()->willReturn($notAllowedAttribute);
         $notAllowedAttribute->getType()->willReturn(AttributeTypes::TEXT);
         $notAllowedAttribute->getCode()->willReturn('attributeCode');
+        $constraint->propertyPath = 'path';
 
         $violationData = [
-            '%attribute%' => 'attributeCode'
+            '%attribute%'       => 'attributeCode',
+            '%attribute_types%' => 'pim_catalog_simpleselect", "pim_catalog_multiselect',
         ];
         $context->buildViolation($constraint->invalidAttributeMessage, $violationData)
             ->shouldBeCalled()
             ->willReturn($violation);
+        $violation->atPath('path')->shouldBeCalled()->willReturn($violation);
+        $violation->addViolation()->shouldBeCalled();
 
         $this->validate($attributeOption, $constraint);
     }


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

Add attribute option PATCH in Api.

Some changes have been done in the Post method too :
The attribute is optional in the body in patch and post, because it's already provided in the url.

I've changed every attribute option tests (GET, POST, PATCH) to assert on JSON instead of PHP array, in a specific commit.


[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | Ok
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
