### PR TITLE
TIP-705: Add tests filters do not support operator should throw

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Boolean/BooleanFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Boolean/BooleanFilterIntegration.php
@@ -66,4 +66,13 @@ class BooleanFilterIntegration extends AbstractFilterTestCase
     {
         $this->execute([['a_yes_no', Operators::NOT_EQUAL, null]]);
     }
+
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage Filter on property "a_yes_no" is not supported or does not support operator "CONTAINS"
+     */
+    public function testErrorOperatorNotSupported()
+    {
+        $this->execute([['a_yes_no', Operators::CONTAINS, true]]);
+    }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/CategoryFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/CategoryFilterIntegration.php
@@ -61,6 +61,15 @@ class CategoryFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage Filter on property "categories" is not supported or does not support operator ">="
+     */
+    public function testErrorOperatorNotSupported()
+    {
+        $this->execute([['categories', Operators::GREATER_OR_EQUAL_THAN, ['categoryA1']]]);
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function getConfiguration()

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Date/DateFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Date/DateFilterIntegration.php
@@ -135,4 +135,13 @@ class DateFilterIntegration extends AbstractFilterTestCase
     {
         $this->execute([['a_date', Operators::BETWEEN, '2016-12-12T00:00:00']]);
     }
+
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage Filter on property "a_date" is not supported or does not support operator "CONTAINS"
+     */
+    public function testErrorOperatorNotSupported()
+    {
+        $this->execute([['a_date', Operators::CONTAINS, '2017-02-07']]);
+    }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/DateTimeFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/DateTimeFilterIntegration.php
@@ -112,6 +112,15 @@ class DateTimeFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage Filter on property "updated" is not supported or does not support operator ">="
+     */
+    public function testErrorOperatorNotSupported()
+    {
+        $this->execute([['updated', Operators::GREATER_OR_EQUAL_THAN, ['2016-08-29 00:00:01']]]);
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function getConfiguration()

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/FamilyFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/FamilyFilterIntegration.php
@@ -66,6 +66,15 @@ class FamilyFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage Filter on property "family" is not supported or does not support operator "BETWEEN"
+     */
+    public function testErrorOperatorNotSupported()
+    {
+        $this->execute([['family', Operators::BETWEEN, 'familyA']]);
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function getConfiguration()

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/GroupsFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/GroupsFilterIntegration.php
@@ -72,6 +72,15 @@ class GroupsFilterIntegration extends AbstractFilterTestCase
     }
 
     /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage Filter on property "groups" is not supported or does not support operator "BETWEEN"
+     */
+    public function testErrorOperatorNotSupported()
+    {
+        $this->execute([['groups', Operators::BETWEEN, 'groupB']]);
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function getConfiguration()

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Media/MediaFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Media/MediaFilterIntegration.php
@@ -108,4 +108,13 @@ class MediaFilterIntegration extends AbstractFilterTestCase
     {
         $this->execute([['an_image', Operators::CONTAINS, []]]);
     }
+
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage Filter on property "an_image" is not supported or does not support operator "BETWEEN"
+     */
+    public function testErrorOperatorNotSupported()
+    {
+        $this->execute([['an_image', Operators::BETWEEN, 'ziggy.png']]);
+    }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Metric/MetricFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Metric/MetricFilterIntegration.php
@@ -144,4 +144,13 @@ class MetricFilterIntegration extends AbstractFilterTestCase
     {
         $this->execute([['a_metric', Operators::NOT_EQUAL, ['amount' => 10, 'unit' => 'NOT_FOUND']]]);
     }
+
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage Filter on property "a_metric" is not supported or does not support operator "BETWEEN"
+     */
+    public function testErrorOperatorNotSupported()
+    {
+        $this->execute([['a_metric', Operators::BETWEEN, ['amount' => 15, 'unit' => 'KILOWATT']]]);
+    }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Number/NumberFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Number/NumberFilterIntegration.php
@@ -117,4 +117,13 @@ class NumberFilterIntegration extends AbstractFilterTestCase
     {
         $this->execute([['a_number_float_negative', Operators::NOT_EQUAL, 'string']]);
     }
+
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage Filter on property "a_number_float_negative" is not supported or does not support operator "BETWEEN"
+     */
+    public function testErrorOperatorNotSupported()
+    {
+        $this->execute([['a_number_float_negative', Operators::BETWEEN, '-15.5']]);
+    }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Option/OptionFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Option/OptionFilterIntegration.php
@@ -94,4 +94,13 @@ class OptionFilterIntegration extends AbstractFilterTestCase
     {
         $this->execute([['a_simple_select', Operators::IN_LIST, ['NOT_FOUND']]]);
     }
+
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage Filter on property "a_simple_select" is not supported or does not support operator "BETWEEN"
+     */
+    public function testErrorOperatorNotSupported()
+    {
+        $this->execute([['a_simple_select', Operators::BETWEEN, ['NOT_FOUND']]]);
+    }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Options/OptionsFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Options/OptionsFilterIntegration.php
@@ -102,4 +102,13 @@ class OptionsFilterIntegration extends AbstractFilterTestCase
     {
         $this->execute([['a_multi_select', Operators::IN_LIST, ['NOT_FOUND']]]);
     }
+
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage Filter on property "a_multi_select" is not supported or does not support operator "BETWEEN"
+     */
+    public function testErrorOperatorNotSupported()
+    {
+        $this->execute([['a_multi_select', Operators::BETWEEN, ['orange', 'black']]]);
+    }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Price/PriceFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Price/PriceFilterIntegration.php
@@ -171,4 +171,13 @@ class PriceFilterIntegration extends AbstractFilterTestCase
     {
         $this->execute([['a_price', Operators::NOT_EQUAL, ['amount' => 10, 'currency' => 'NOT_FOUND']]]);
     }
+
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage Filter on property "a_price" is not supported or does not support operator "BETWEEN"
+     */
+    public function testErrorOperatorNotSupported()
+    {
+        $this->execute([['a_price', Operators::BETWEEN, ['amount' => 15, 'currency' => 'EUR']]]);
+    }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/String/StringFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/String/StringFilterIntegration.php
@@ -116,4 +116,13 @@ class StringFilterIntegration extends AbstractFilterTestCase
     {
         $this->execute([['a_text', Operators::NOT_EQUAL, [[]]]]);
     }
+
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage Filter on property "a_text" is not supported or does not support operator ">="
+     */
+    public function testErrorOperatorNotSupported()
+    {
+        $this->execute([['a_text', Operators::GREATER_OR_EQUAL_THAN, 'dog']]);
+    }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/ProductQueryBuilderIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/ProductQueryBuilderIntegration.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\PQB;
+
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Pim\Component\Catalog\Query\Filter\Operators;
+
+/**
+ * Tests that queries results executed by combining filters with different operators are consistent.
+ *
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ProductQueryBuilderIntegration extends TestCase
+{
+
+    /**
+     * Combines several filters and operator to find the product
+     */
+    public function testComplexQuery1()
+    {
+        $foundProductQuery = $this->get('pim_catalog.query.product_query_builder_factory')->create();
+        $foundProductQuery->addFilter('family', Operators::IN_LIST, ['familyA']);
+        $foundProductQuery->addFilter('a_file', Operators::ENDS_WITH, '.txt');
+        $foundProductQuery->addFilter('a_localizable_image', Operators::CONTAINS, 'akeneo', ['locale' => 'en_US']);
+        $foundProductQuery->addFilter('a_regexp', Operators::CONTAINS, '+', ['locale' => 'en_US']);
+        $foundProductQuery->addFilter('a_scopable_price', Operators::GREATER_THAN, ['amount' => 13, 'currency' => 'USD'], ['scope' => 'ecommerce']);
+        $foundProductQuery->addFilter('a_localized_and_scopable_text_area', Operators::EQUALS, 'Mon textarea localisé et scopable ecommerce', ['locale' => 'fr_FR', 'scope' => 'ecommerce']);
+
+        $productsFound = $foundProductQuery->execute();
+        $this->assertProductFound($productsFound);
+
+        $notFoundProductQuery = $this->get('pim_catalog.query.product_query_builder_factory')->create();
+        // Operator changed
+        $foundProductQuery->addFilter('family', Operators::IS_EMPTY, null);
+
+        $notFoundProductQuery->addFilter('a_file', Operators::STARTS_WITH, '.txt');
+        $notFoundProductQuery->addFilter('a_localizable_image', Operators::CONTAINS, 'akeneo', ['locale' => 'en_US']);
+        $notFoundProductQuery->addFilter('a_regexp', Operators::CONTAINS, '+', ['locale' => 'en_US']);
+        $notFoundProductQuery->addFilter('a_scopable_price', Operators::GREATER_THAN, ['amount' => 13, 'currency' => 'USD'], ['scope' => 'ecommerce']);
+        $notFoundProductQuery->addFilter('a_localized_and_scopable_text_area', Operators::EQUALS, 'Mon textarea localisé et scopable ecommerce', ['locale' => 'fr_FR', 'scope' => 'ecommerce']);
+
+        $notFoundProducts = $notFoundProductQuery->execute();
+        $this->assertCount(0, $notFoundProducts);
+    }
+
+    /**
+     * Combines several filters to find the product (using EMPTY like operators)
+     */
+    public function testComplexQueryWithEmptyOperator()
+    {
+        $foundProductQuery = $this->get('pim_catalog.query.product_query_builder_factory')->create();
+        $foundProductQuery->addFilter('categories', Operators::UNCLASSIFIED, null);
+        $foundProductQuery->addFilter('a_scopable_price', Operators::IS_EMPTY, ['amount' => '', 'currency' => ''], ['scope' => 'tablet']);
+        $foundProductQuery->addFilter('a_localized_and_scopable_text_area', Operators::IS_NOT_EMPTY, null, ['locale' => 'en_US', 'scope' => 'ecommerce']);
+
+        $productsFound = $foundProductQuery->execute();
+        $this->assertProductFound($productsFound);
+
+        $notFoundProductQuery = $this->get('pim_catalog.query.product_query_builder_factory')->create();
+        // Operator changed
+        $notFoundProductQuery->addFilter('categories', Operators::IN_CHILDREN_LIST, ['master']);
+        $foundProductQuery->addFilter('a_scopable_price', Operators::IS_EMPTY, ['amount' => '', 'currency' => ''], ['scope' => 'tablet']);
+        $foundProductQuery->addFilter('a_localized_and_scopable_text_area', Operators::IS_NOT_EMPTY, null, ['locale' => 'en_US', 'scope' => 'ecommerce']);
+
+        $notFoundProducts = $notFoundProductQuery->execute();
+        $this->assertCount(0, $notFoundProducts);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return new Configuration(
+            [Configuration::getTechnicalCatalogPath()],
+            true
+        );
+    }
+
+    /**
+     * Product anatomy
+     * - a field
+     * - a non-scopable/non-localizable attribute
+     * - a localizable attribute
+     * - a locale specific attribute
+     * - a scopable attribute
+     * - a localizable/scopable attribute
+     *
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $product = $this->get('pim_catalog.builder.product')->createProduct('complex_product_1', 'familyA');
+        $this->get('pim_catalog.updater.product')->update(
+            $product,
+            [
+                'values' => [
+                    'a_file' => [
+                        [
+                            'locale' => null,
+                            'scope'  => null,
+                            'data'   => $this->getFixturePath('akeneo.txt'),
+                        ],
+                    ],
+
+                    'a_localizable_image'                => [
+                        [
+                            'locale' => 'en_US',
+                            'scope'  => null,
+                            'data'   => $this->getFixturePath('akeneo.jpg'),
+                        ],
+                        [
+                            'locale' => 'fr_FR',
+                            'scope'  => null,
+                            'data'   => $this->getFixturePath('akeneo.jpg'),
+                        ],
+                    ],
+                    'a_regexp'                           => [
+                        [
+                            'locale' => null,
+                            'scope'  => null,
+                            'data'   => '\w+ .*',
+                        ],
+                    ],
+                    'a_scopable_price'                   => [
+                        [
+                            'locale' => null,
+                            'scope'  => 'ecommerce',
+                            'data'   => [
+                                [
+                                    'amount'   => 12,
+                                    'currency' => 'EUR',
+                                ],
+                                [
+                                    'amount'   => 14,
+                                    'currency' => 'USD',
+                                ],
+                            ],
+                        ],
+                    ],
+                    'a_localized_and_scopable_text_area' => [
+                        [
+                            'locale' => 'fr_FR',
+                            'scope'  => 'ecommerce',
+                            'data'   => 'Mon textarea localisé et scopable ecommerce',
+                        ],
+                        [
+                            'locale' => 'en_US',
+                            'scope'  => 'ecommerce',
+                            'data'   => 'My localizable and scopable textearea ecommerce',
+                        ],
+                        [
+                            'locale' => 'fr_FR',
+                            'scope'  => 'tablet',
+                            'data'   => 'Mon textarea localisé et scopable tablet',
+                        ],
+                        [
+                            'locale' => 'en_US',
+                            'scope'  => 'tablet',
+                            'data'   => 'My localizable and scopable textearea tablet',
+                        ],
+                    ],
+                ],
+            ]
+        );
+
+        $this->get('pim_catalog.saver.product')->save($product);
+    }
+
+    /**
+     * @param $products
+     */
+    protected function assertProductFound($products)
+    {
+        $this->assertCount(1, $products);
+
+        foreach ($products as $product) {
+            $this->assertEquals('complex_product_1', $product->getIdentifier());
+        }
+    }
+}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

- [X] Add one test case on the pqb filter that should throw when an operator is not supported
- [ ] Add a complex pqb query

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | Ok
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
