### PR TITLE
Api 112 : add a patch operation on a list of products/categories/attributes/families

### DIFF
--- a/app/config/pim_parameters.yml
+++ b/app/config/pim_parameters.yml
@@ -48,3 +48,9 @@ parameters:
 
     # Number of items returned by default if limit is not filled in request
     api_pagination_limit_by_default: 10
+
+    # Maximum length in bytes of the resource's json representation when updating a list of resources
+    api_input_buffer_size: 1000000
+
+    # Maximum number of resources when updating a list of resources
+    api_input_max_resources_number: 100

--- a/src/Pim/Bundle/ApiBundle/Controller/AttributeController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/AttributeController.php
@@ -9,6 +9,7 @@ use Akeneo\Component\StorageUtils\Saver\SaverInterface;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Oro\Bundle\SecurityBundle\Annotation\AclAncestor;
 use Pim\Bundle\ApiBundle\Documentation;
+use Pim\Bundle\ApiBundle\Stream\StreamResourceResponse;
 use Pim\Component\Api\Exception\DocumentedHttpException;
 use Pim\Component\Api\Exception\PaginationParametersException;
 use Pim\Component\Api\Exception\ViolationHttpException;
@@ -20,6 +21,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 use Symfony\Component\Routing\RouterInterface;
@@ -63,6 +65,9 @@ class AttributeController
     /** @var ParameterValidator */
     protected $parameterValidator;
 
+    /** @var StreamResourceResponse */
+    protected $partialUpdateStreamResource;
+
     /**
      * @param AttributeRepositoryInterface $repository
      * @param NormalizerInterface          $normalizer
@@ -73,6 +78,7 @@ class AttributeController
      * @param RouterInterface              $router
      * @param HalPaginator                 $paginator
      * @param ParameterValidator           $parameterValidator
+     * @param StreamResourceResponse       $partialUpdateStreamResource
      * @param array                        $apiConfiguration
      */
     public function __construct(
@@ -85,6 +91,7 @@ class AttributeController
         RouterInterface $router,
         HalPaginator $paginator,
         ParameterValidator $parameterValidator,
+        StreamResourceResponse $partialUpdateStreamResource,
         array $apiConfiguration
     ) {
         $this->repository = $repository;
@@ -96,6 +103,7 @@ class AttributeController
         $this->router = $router;
         $this->parameterValidator = $parameterValidator;
         $this->paginator = $paginator;
+        $this->partialUpdateStreamResource = $partialUpdateStreamResource;
         $this->apiConfiguration = $apiConfiguration;
     }
 
@@ -180,6 +188,21 @@ class AttributeController
         $this->saver->save($attribute);
 
         $response = $this->getResponse($attribute, Response::HTTP_CREATED);
+
+        return $response;
+    }
+
+    /**
+     * @param Request $request
+     *
+     * @throws HttpException
+     *
+     * @return Response
+     */
+    public function partialUpdateListAction(Request $request)
+    {
+        $resource = $request->getContent(true);
+        $response = $this->partialUpdateStreamResource->streamResponse($resource);
 
         return $response;
     }

--- a/src/Pim/Bundle/ApiBundle/Controller/CategoryController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/CategoryController.php
@@ -10,6 +10,7 @@ use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Gedmo\Exception\UnexpectedValueException;
 use Oro\Bundle\SecurityBundle\Annotation\AclAncestor;
 use Pim\Bundle\ApiBundle\Documentation;
+use Pim\Bundle\ApiBundle\Stream\StreamResourceResponse;
 use Pim\Component\Api\Exception\DocumentedHttpException;
 use Pim\Component\Api\Exception\PaginationParametersException;
 use Pim\Component\Api\Exception\ViolationHttpException;
@@ -21,6 +22,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 use Symfony\Component\Routing\RouterInterface;
@@ -61,6 +63,9 @@ class CategoryController
     /** @var ParameterValidator */
     protected $parameterValidator;
 
+    /** @var StreamResourceResponse */
+    protected $partialUpdateStreamResource;
+
     /** @var array */
     protected $apiConfiguration;
 
@@ -74,6 +79,7 @@ class CategoryController
      * @param RouterInterface                $router
      * @param HalPaginator                   $paginator
      * @param ParameterValidator             $parameterValidator
+     * @param StreamResourceResponse         $partialUpdateStreamResource
      * @param array                          $apiConfiguration
      */
     public function __construct(
@@ -86,6 +92,7 @@ class CategoryController
         RouterInterface $router,
         HalPaginator $paginator,
         ParameterValidator $parameterValidator,
+        StreamResourceResponse $partialUpdateStreamResource,
         array $apiConfiguration
     ) {
         $this->repository = $repository;
@@ -97,6 +104,7 @@ class CategoryController
         $this->router = $router;
         $this->parameterValidator = $parameterValidator;
         $this->paginator = $paginator;
+        $this->partialUpdateStreamResource = $partialUpdateStreamResource;
         $this->apiConfiguration = $apiConfiguration;
     }
 
@@ -182,6 +190,21 @@ class CategoryController
         $this->saver->save($category);
 
         $response = $this->getResponse($category, Response::HTTP_CREATED);
+
+        return $response;
+    }
+
+    /**
+     * @param Request $request
+     *
+     * @throws HttpException
+     *
+     * @return Response
+     */
+    public function partialUpdateListAction(Request $request)
+    {
+        $resource = $request->getContent(true);
+        $response = $this->partialUpdateStreamResource->streamResponse($resource);
 
         return $response;
     }

--- a/src/Pim/Bundle/ApiBundle/Controller/FamilyController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/FamilyController.php
@@ -3,12 +3,12 @@
 namespace Pim\Bundle\ApiBundle\Controller;
 
 use Akeneo\Component\StorageUtils\Exception\PropertyException;
-use Akeneo\Component\StorageUtils\Exception\UnknownPropertyException;
 use Akeneo\Component\StorageUtils\Factory\SimpleFactoryInterface;
 use Akeneo\Component\StorageUtils\Saver\SaverInterface;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Oro\Bundle\SecurityBundle\Annotation\AclAncestor;
 use Pim\Bundle\ApiBundle\Documentation;
+use Pim\Bundle\ApiBundle\Stream\StreamResourceResponse;
 use Pim\Component\Api\Exception\DocumentedHttpException;
 use Pim\Component\Api\Exception\PaginationParametersException;
 use Pim\Component\Api\Exception\ViolationHttpException;
@@ -20,6 +20,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 use Symfony\Component\Routing\RouterInterface;
@@ -60,6 +61,9 @@ class FamilyController
     /** @var ParameterValidator */
     protected $parameterValidator;
 
+    /** @var StreamResourceResponse */
+    protected $partialUpdateStreamResource;
+
     /** @var array */
     protected $apiConfiguration;
 
@@ -73,6 +77,7 @@ class FamilyController
      * @param RouterInterface                $router
      * @param HalPaginator                   $paginator
      * @param ParameterValidator             $parameterValidator
+     * @param StreamResourceResponse         $partialUpdateStreamResource
      * @param array                          $apiConfiguration
      */
     public function __construct(
@@ -85,6 +90,7 @@ class FamilyController
         RouterInterface $router,
         HalPaginator $paginator,
         ParameterValidator $parameterValidator,
+        StreamResourceResponse $partialUpdateStreamResource,
         array $apiConfiguration
     ) {
         $this->repository = $repository;
@@ -96,6 +102,7 @@ class FamilyController
         $this->router = $router;
         $this->paginator = $paginator;
         $this->parameterValidator = $parameterValidator;
+        $this->partialUpdateStreamResource = $partialUpdateStreamResource;
         $this->apiConfiguration = $apiConfiguration;
     }
 
@@ -180,6 +187,21 @@ class FamilyController
         $this->saver->save($family);
 
         $response = $this->getResponse($family, Response::HTTP_CREATED);
+
+        return $response;
+    }
+
+    /**
+     * @param Request $request
+     *
+     * @throws HttpException
+     *
+     * @return Response
+     */
+    public function partialUpdateListAction(Request $request)
+    {
+        $resource = $request->getContent(true);
+        $response = $this->partialUpdateStreamResource->streamResponse($resource);
 
         return $response;
     }

--- a/src/Pim/Bundle/ApiBundle/DependencyInjection/Configuration.php
+++ b/src/Pim/Bundle/ApiBundle/DependencyInjection/Configuration.php
@@ -27,10 +27,17 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('limit_by_default')->end()
                     ->end()
                     ->validate()
-                    ->ifTrue(function ($v) {
-                        return $v['limit_max'] < $v['limit_by_default'];
-                    })
-                    ->thenInvalid('API configuration: "limit_by_default" cannot be greater than "limit_max.')
+                        ->ifTrue(function ($v) {
+                            return $v['limit_max'] < $v['limit_by_default'];
+                        })
+                        ->thenInvalid('API configuration: "limit_by_default" cannot be greater than "limit_max.')
+                    ->end()
+                ->end()
+                ->arrayNode('input')
+                    ->children()
+                        ->scalarNode('buffer_size')->end()
+                        ->scalarNode('max_resources_number')->end()
+                    ->end()
                 ->end()
             ->end();
 

--- a/src/Pim/Bundle/ApiBundle/DependencyInjection/PimApiExtension.php
+++ b/src/Pim/Bundle/ApiBundle/DependencyInjection/PimApiExtension.php
@@ -33,6 +33,7 @@ class PimApiExtension extends Extension
         $loader->load('repositories.yml');
         $loader->load('security.yml');
         $loader->load('serializers.yml');
+        $loader->load('stream.yml');
 
         $this->loadStorageDriver($container);
     }

--- a/src/Pim/Bundle/ApiBundle/Resources/config/api.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/api.yml
@@ -2,3 +2,6 @@ pim_api:
     pagination:
         limit_max: '%api_pagination_limit_max%'
         limit_by_default: '%api_pagination_limit_by_default%'
+    input:
+        buffer_size: '%api_input_buffer_size%'
+        max_resources_number: '%api_input_max_resources_number%'

--- a/src/Pim/Bundle/ApiBundle/Resources/config/controllers.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/controllers.yml
@@ -37,6 +37,7 @@ services:
             - '@router'
             - '@pim_api.pagination.paginator'
             - '@pim_api.pagination.parameter_validator'
+            - '@pim_api.stream.family_partial_update_stream'
             - '%pim_api.configuration%'
 
     pim_api.controller.attribute:

--- a/src/Pim/Bundle/ApiBundle/Resources/config/controllers.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/controllers.yml
@@ -53,6 +53,7 @@ services:
             - '@router'
             - '@pim_api.pagination.paginator'
             - '@pim_api.pagination.parameter_validator'
+            - '@pim_api.stream.attribute_partial_update_stream'
             - '%pim_api.configuration%'
 
     pim_api.controller.attribute_option:

--- a/src/Pim/Bundle/ApiBundle/Resources/config/controllers.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/controllers.yml
@@ -23,6 +23,7 @@ services:
             - '@router'
             - '@pim_api.pagination.paginator'
             - '@pim_api.pagination.parameter_validator'
+            - '@pim_api.stream.category_partial_update_stream'
             - '%pim_api.configuration%'
 
     pim_api.controller.family:

--- a/src/Pim/Bundle/ApiBundle/Resources/config/controllers.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/controllers.yml
@@ -111,6 +111,7 @@ services:
             - '@pim_catalog.saver.product'
             - '@router'
             - '@pim_catalog.comparator.filter.product'
+            - '@pim_api.stream.product_partial_update_stream'
             - '%pim_api.configuration%'
 
     pim_api.controller.root_endpoint:

--- a/src/Pim/Bundle/ApiBundle/Resources/config/routing/attribute.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/routing/attribute.yml
@@ -18,6 +18,11 @@ pim_api_attribute_get:
     defaults: { _controller: pim_api.controller.attribute:getAction, _format: json }
     methods: [GET]
 
+pim_api_attribute_partial_update_list:
+    path: /attributes
+    defaults: { _controller: pim_api.controller.attribute:partialUpdateListAction, _format: json }
+    methods: [PATCH]
+
 pim_api_attribute_option_list:
     path: /attributes/{attributeCode}/options
     defaults: { _controller: pim_api.controller.attribute_option:listAction, _format: json }

--- a/src/Pim/Bundle/ApiBundle/Resources/config/routing/category.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/routing/category.yml
@@ -17,3 +17,8 @@ pim_api_category_partial_update:
     path: /categories/{code}
     defaults: { _controller: pim_api.controller.category:partialUpdateAction, _format: json}
     methods: [PATCH]
+
+pim_api_category_partial_update_list:
+    path: /categories
+    defaults: { _controller: pim_api.controller.category:partialUpdateListAction, _format: json }
+    methods: [PATCH]

--- a/src/Pim/Bundle/ApiBundle/Resources/config/routing/family.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/routing/family.yml
@@ -17,3 +17,8 @@ pim_api_family_partial_update:
     path: /families/{code}
     defaults: { _controller: pim_api.controller.family:partialUpdateAction, _format: json }
     methods: [PATCH]
+
+pim_api_family_partial_update_list:
+    path: /families
+    defaults: { _controller: pim_api.controller.family:partialUpdateListAction, _format: json }
+    methods: [PATCH]

--- a/src/Pim/Bundle/ApiBundle/Resources/config/routing/product.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/routing/product.yml
@@ -18,6 +18,11 @@ pim_api_product_partial_update:
     defaults: { _controller: pim_api.controller.product:partialUpdateAction, _format: json }
     methods: [PATCH]
 
+pim_api_product_partial_update_list:
+    path: /products
+    defaults: { _controller: pim_api.controller.product:partialUpdateListAction, _format: json }
+    methods: [PATCH]
+
 pim_api_product_delete:
     path: /products/{code}
     defaults: { _controller: pim_api.controller.product:deleteAction, _format: json }

--- a/src/Pim/Bundle/ApiBundle/Resources/config/stream.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/stream.yml
@@ -19,3 +19,12 @@ services:
             - '%pim_api.configuration%'
             - 'pim_api.controller.family:partialUpdateAction'
             - 'code'
+
+    pim_api.stream.category_partial_update_stream:
+        class: '%pim_api.stream.stream_resource_response.class%'
+        arguments:
+            - '@http_kernel'
+            - '@pim_catalog.validator.unique_value_set'
+            - '%pim_api.configuration%'
+            - 'pim_api.controller.category:partialUpdateAction'
+            - 'code'

--- a/src/Pim/Bundle/ApiBundle/Resources/config/stream.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/stream.yml
@@ -1,0 +1,12 @@
+parameters:
+    pim_api.stream.stream_resource_response.class: Pim\Bundle\ApiBundle\Stream\StreamResourceResponse
+
+services:
+    pim_api.stream.product_partial_update_stream:
+        class: '%pim_api.stream.stream_resource_response.class%'
+        arguments:
+            - '@http_kernel'
+            - '@pim_catalog.validator.unique_value_set'
+            - '%pim_api.configuration%'
+            - 'pim_api.controller.product:partialUpdateAction'
+            - 'identifier'

--- a/src/Pim/Bundle/ApiBundle/Resources/config/stream.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/stream.yml
@@ -10,3 +10,12 @@ services:
             - '%pim_api.configuration%'
             - 'pim_api.controller.product:partialUpdateAction'
             - 'identifier'
+
+    pim_api.stream.family_partial_update_stream:
+        class: '%pim_api.stream.stream_resource_response.class%'
+        arguments:
+            - '@http_kernel'
+            - '@pim_catalog.validator.unique_value_set'
+            - '%pim_api.configuration%'
+            - 'pim_api.controller.family:partialUpdateAction'
+            - 'code'

--- a/src/Pim/Bundle/ApiBundle/Resources/config/stream.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/stream.yml
@@ -28,3 +28,12 @@ services:
             - '%pim_api.configuration%'
             - 'pim_api.controller.category:partialUpdateAction'
             - 'code'
+
+    pim_api.stream.attribute_partial_update_stream:
+        class: '%pim_api.stream.stream_resource_response.class%'
+        arguments:
+            - '@http_kernel'
+            - '@pim_catalog.validator.unique_value_set'
+            - '%pim_api.configuration%'
+            - 'pim_api.controller.attribute:partialUpdateAction'
+            - 'code'

--- a/src/Pim/Bundle/ApiBundle/Stream/StreamResourceResponse.php
+++ b/src/Pim/Bundle/ApiBundle/Stream/StreamResourceResponse.php
@@ -29,7 +29,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
  */
 class StreamResourceResponse
 {
-    const CONTENT_TYPE = 'application/vnd.akeneopim+json';
+    const CONTENT_TYPE = 'application/vnd.akeneo.collection+json';
 
     /** @var HttpKernelInterface */
     protected $httpKernel;

--- a/src/Pim/Bundle/ApiBundle/Stream/StreamResourceResponse.php
+++ b/src/Pim/Bundle/ApiBundle/Stream/StreamResourceResponse.php
@@ -1,0 +1,246 @@
+<?php
+
+namespace Pim\Bundle\ApiBundle\Stream;
+
+use Pim\Component\Catalog\Validator\UniqueValuesSet;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+/**
+ * Read the php input line by line, and forward the content of each line to a controller.
+ * Only a single line is loaded in memory at a time.
+ *
+ * Each line represents the content of a subrequest that will be forwarded to a controller.
+ * Each response's content of a subrequest is then flushed in the global response, as a stream.
+ *
+ * Therefore, response's headers of the different subrequests are not returned, only the content.
+ *
+ * Do note that headers of the global response can not be changed as soon as you are streaming the response's content,
+ * even if you have an error. This is due to the HTTP protocol.
+ *
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class StreamResourceResponse
+{
+    const CONTENT_TYPE = 'application/vnd.akeneopim+json';
+
+    /** @var HttpKernelInterface */
+    protected $httpKernel;
+
+    /** @var UniqueValuesSet */
+    protected $uniqueValuesSet;
+
+    /** @var string */
+    protected $controllerName;
+
+    /** @var string */
+    protected $identifierKey;
+
+    /** @var array */
+    protected $configuration;
+
+    /**
+     * @param HttpKernelInterface $httpKernel
+     * @param UniqueValuesSet     $uniqueValuesSet
+     * @param array               $configuration
+     * @param string              $controllerName
+     * @param string              $identifierKey
+     */
+    public function __construct(
+        HttpKernelInterface $httpKernel,
+        UniqueValuesSet $uniqueValuesSet,
+        array $configuration,
+        $controllerName,
+        $identifierKey
+    ) {
+        $this->httpKernel = $httpKernel;
+        $this->uniqueValuesSet = $uniqueValuesSet;
+        $this->configuration = $configuration;
+        $this->controllerName = $controllerName;
+        $this->identifierKey = $identifierKey;
+    }
+
+    /**
+     * @param resource $resource resource containing the whole data to process
+     *
+     * @throws HttpException
+     *
+     * @return StreamedResponse
+     */
+    public function streamResponse($resource)
+    {
+        $response = new StreamedResponse();
+        $response->headers->set('Content-Type', static::CONTENT_TYPE);
+
+        $this->checkLineNumberInInput($resource);
+
+        $response->setCallback(function () use ($resource) {
+            rewind($resource);
+
+            $lineNumber = 1;
+            $bufferSize = $this->configuration['input']['buffer_size'];
+            $line = stream_get_line($resource, $bufferSize + 1, PHP_EOL);
+
+            while (false !== $line) {
+                try {
+                    $this->checkLineLength($line, $resource);
+
+                    $data = json_decode($line, true);
+                    if (null === $data) {
+                        throw new BadRequestHttpException('Invalid json message received');
+                    }
+
+                    if (!isset($data[$this->identifierKey]) || '' === trim($data[$this->identifierKey])) {
+                        throw new UnprocessableEntityHttpException(sprintf('%s is missing.', ucfirst($this->identifierKey)));
+                    }
+
+                    $response = [
+                        'line'               => $lineNumber,
+                        $this->identifierKey => $data[$this->identifierKey],
+                    ];
+
+                    $subResponse = $this->forward(['code' => $data[$this->identifierKey]], $line);
+
+                    if ('' !== $subResponse->getContent()) {
+                        $response =  array_merge($response, json_decode($subResponse->getContent(), true));
+                    } else {
+                        $response['code'] = $subResponse->getStatusCode();
+                    }
+                } catch (HttpException $e) {
+                    $response = [
+                        'line'    => $lineNumber,
+                        'code'    => $e->getStatusCode(),
+                        'message' => $e->getMessage(),
+                    ];
+                }
+
+                $this->uniqueValuesSet->reset();
+                $this->flushOutputBuffer($response, $lineNumber);
+                $lineNumber++;
+                $line = stream_get_line($resource, $bufferSize + 1, PHP_EOL);
+            }
+        });
+
+        return $response;
+    }
+
+    /**
+     * Checks that the number of resources to process is inferior to the maximum allowed.
+     *
+     * @param resource $resource
+     *
+     * @throws HttpException
+     */
+    protected function checkLineNumberInInput($resource)
+    {
+        $maxNumberResources = $this->configuration['input']['max_resources_number'];
+
+        $lineNumber = 0;
+
+        while (false !== $this->getNextLine($resource)) {
+            $lineNumber++;
+            if ($lineNumber > $maxNumberResources) {
+                throw new HttpException(
+                    Response::HTTP_REQUEST_ENTITY_TOO_LARGE,
+                    sprintf('Too many resources to process, %s is the maximum allowed.', $maxNumberResources)
+                );
+            }
+        }
+    }
+
+    /**
+     * Forwards the request to another controller.
+     *
+     * Forwarding the request allows to get the same response as a single request,
+     * passing through the kernel and therefore the listeners.
+     *
+     * It would not be possible to do that by calling directly the controller.
+     *
+     * @param array  $uriParameters uri parameters of the controller
+     * @param string $content       content of the subrequest
+     *
+     * @return Response A Response instance
+     */
+    public function forward($uriParameters, $content)
+    {
+        $parameters = array_merge(['_controller' => $this->controllerName], $uriParameters);
+        $subRequest = new Request([], [], $parameters, [], [], [], $content);
+        $subRequest->setRequestFormat('json');
+        $response = $this->httpKernel->handle($subRequest, HttpKernelInterface::SUB_REQUEST);
+
+        return $response;
+    }
+
+    /**
+     * Returns the current line.
+     * If the line is too long for the buffer, consumes the rest of the line.
+     *
+     * @param resource $resource
+     *
+     * @return string content of the line, truncated by the buffer size if the line is too long
+     */
+    protected function getNextLine($resource)
+    {
+        $bufferSize = $this->configuration['input']['buffer_size'];
+
+        $line = stream_get_line($resource, $bufferSize + 1, PHP_EOL);
+        $buffer = $line;
+
+        while (strlen($buffer) > $bufferSize) {
+            $buffer = stream_get_line($resource, $bufferSize + 1, PHP_EOL);
+        }
+
+        return $line;
+    }
+
+    /**
+     * Checks the length of the line.
+     *
+     * If the line is too long for the buffer, consumes the rest of the line
+     * and throws an error 413.
+     *
+     * @param string   $line
+     * @param resource $resource
+     *
+     * @throws HttpException
+     */
+    protected function checkLineLength($line, $resource)
+    {
+        $bufferSize = $this->configuration['input']['buffer_size'];
+
+        $bufferSizeExceeded = strlen($line) > $bufferSize;
+        $buffer = $line;
+
+        while (strlen($buffer) > $bufferSize) {
+            $buffer = stream_get_line($resource, $bufferSize + 1, PHP_EOL);
+        }
+
+        if ($bufferSizeExceeded) {
+            throw new HttpException(Response::HTTP_REQUEST_ENTITY_TOO_LARGE, 'Line is too long.');
+        }
+    }
+
+    /**
+     * Flushes the buffer with the content encoded with JSON.
+     * A carriage return is added to separate the response's content
+     * from the next subrequest's response.
+     *
+     * @param array $content
+     * @param int   $lineNumber
+     */
+    protected function flushOutputBuffer($content, $lineNumber)
+    {
+        $jsonContent = 1 === $lineNumber ? json_encode($content) : PHP_EOL . json_encode($content);
+
+        echo $jsonContent;
+        ob_flush();
+        flush();
+    }
+}

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Attribute/PartialUpdateListAttributeIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Attribute/PartialUpdateListAttributeIntegration.php
@@ -290,7 +290,7 @@ JSON;
 <<<JSON
     {
         "code": 415,
-        "message": "\"application\/json\" in \"Content-Type\" header is not valid. Only \"application\/vnd.akeneopim+json\" is allowed."
+        "message": "\"application\/json\" in \"Content-Type\" header is not valid. Only \"application\/vnd.akeneo.collection+json\" is allowed."
     }
 JSON;
 

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Attribute/PartialUpdateListAttributeIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Attribute/PartialUpdateListAttributeIntegration.php
@@ -1,0 +1,387 @@
+<?php
+
+namespace Pim\Bundle\ApiBundle\tests\integration\Controller\Attribute;
+
+use Akeneo\Test\Integration\Configuration;
+use Pim\Bundle\ApiBundle\Stream\StreamResourceResponse;
+use Pim\Bundle\ApiBundle\tests\integration\ApiTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+class PartialUpdateListAttributeIntegration extends ApiTestCase
+{
+    public function testCreateAndUpdateAListOfAttributes()
+    {
+        $data =
+<<<JSON
+    {"code": "an_image","max_file_size": 800}
+    {"code": "picture","allowed_extensions":["jpg","gif"],"type":"pim_catalog_image","group":"other"}
+JSON;
+
+        $expectedContent =
+<<<JSON
+{"line":1,"code":"an_image","status_code":204}
+{"line":2,"code":"picture","status_code":201}
+JSON;
+
+        $response = $this->executeStreamRequest('PATCH', 'api/rest/v1/attributes', [], [], [], $data);
+        $httpResponse = $response['http_response'];
+
+        $this->assertSame(Response::HTTP_OK, $httpResponse->getStatusCode());
+        $this->assertSame($expectedContent, $response['content']);
+        $this->assertArrayHasKey('content-type', $httpResponse->headers->all());
+        $this->assertSame(StreamResourceResponse::CONTENT_TYPE, $httpResponse->headers->get('content-type'));
+
+        $expectedAttributes = [
+            'an_image' => [
+                'code'                   => 'an_image',
+                'type'                   => 'pim_catalog_image',
+                'group'                  => 'attributeGroupB',
+                'unique'                 => false,
+                'useable_as_grid_filter' => false,
+                'allowed_extensions'     => ['jpg', 'gif', 'png'],
+                'metric_family'          => null,
+                'default_metric_unit'    => null,
+                'reference_data_name'    => null,
+                'available_locales'      => [],
+                'max_characters'         => null,
+                'validation_rule'        => null,
+                'validation_regexp'      => null,
+                'wysiwyg_enabled'        => null,
+                'number_min'             => null,
+                'number_max'             => null,
+                'decimals_allowed'       => null,
+                'negative_allowed'       => null,
+                'date_min'               => null,
+                'date_max'               => null,
+                'max_file_size'          => '800.00',
+                'minimum_input_length'   => null,
+                'sort_order'             => 0,
+                'localizable'            => false,
+                'scopable'               => false,
+                'labels'                 => []
+            ],
+            'picture' => [
+                'code'                   => 'picture',
+                'type'                   => 'pim_catalog_image',
+                'group'                  => 'other',
+                'unique'                 => false,
+                'useable_as_grid_filter' => false,
+                'allowed_extensions'     => ['jpg', 'gif'],
+                'metric_family'          => null,
+                'default_metric_unit'    => null,
+                'reference_data_name'    => null,
+                'available_locales'      => [],
+                'max_characters'         => null,
+                'validation_rule'        => null,
+                'validation_regexp'      => null,
+                'wysiwyg_enabled'        => null,
+                'number_min'             => null,
+                'number_max'             => null,
+                'decimals_allowed'       => null,
+                'negative_allowed'       => null,
+                'date_min'               => null,
+                'date_max'               => null,
+                'max_file_size'          => null,
+                'minimum_input_length'   => null,
+                'sort_order'             => 0,
+                'localizable'            => false,
+                'scopable'               => false,
+                'labels'                 => []
+            ]
+        ];
+
+        $this->assertSameAttributes($expectedAttributes['an_image'], 'an_image');
+        $this->assertSameAttributes($expectedAttributes['picture'], 'picture');
+    }
+
+    public function testCreateAndUpdateSameAttribute()
+    {
+        $data =
+<<<JSON
+    {"code": "an_attribute","type":"pim_catalog_text","group":"other"}
+    {"code": "an_attribute"}
+JSON;
+
+        $expectedContent =
+<<<JSON
+{"line":1,"code":"an_attribute","status_code":201}
+{"line":2,"code":"an_attribute","status_code":204}
+JSON;
+
+        $response = $this->executeStreamRequest('PATCH', 'api/rest/v1/attributes', [], [], [], $data);
+        $httpResponse = $response['http_response'];
+
+        $this->assertSame(Response::HTTP_OK, $httpResponse->getStatusCode());
+        $this->assertSame($expectedContent, $response['content']);
+    }
+
+    public function testPartialUpdateListWithMaxNumberOfResourcesAllowed()
+    {
+        $maxNumberResources = $this->getMaxNumberResources();
+
+        for ($i = 0; $i < $maxNumberResources; $i++) {
+            $data[] = sprintf('{"code": "my_code_%s", "type":"pim_catalog_text","group":"other"}', $i);
+        }
+        $data = implode(PHP_EOL, $data);
+
+        for ($i = 0; $i < $maxNumberResources; $i++) {
+            $expectedContent[] = sprintf('{"line":%s,"code":"my_code_%s","status_code":201}', $i + 1, $i);
+        }
+        $expectedContent = implode(PHP_EOL, $expectedContent);
+
+        $response = $this->executeStreamRequest('PATCH', 'api/rest/v1/attributes', [], [], [], $data);
+        $httpResponse = $response['http_response'];
+
+        $this->assertSame(Response::HTTP_OK, $httpResponse->getStatusCode());
+        $this->assertSame($expectedContent, $response['content']);
+    }
+
+    public function testPartialUpdateListWithTooManyResources()
+    {
+        $client = $this->createAuthenticatedClient();
+        $client->setServerParameter('CONTENT_TYPE', StreamResourceResponse::CONTENT_TYPE);
+
+        $maxNumberResources = $this->getMaxNumberResources();
+
+        for ($i = 0; $i < $maxNumberResources + 1; $i++) {
+            $data[] = sprintf('{"identifier": "my_code_%s"}', $i);
+        }
+        $data = implode(PHP_EOL, $data);
+
+        $expectedContent =
+<<<JSON
+    {
+        "code": 413,
+        "message": "Too many resources to process, ${maxNumberResources} is the maximum allowed."
+    }
+JSON;
+
+        $client->request('PATCH', 'api/rest/v1/attributes', [], [], [], $data);
+
+        $response = $client->getResponse();
+        $this->assertJsonStringEqualsJsonString($expectedContent, $response->getContent());
+        $this->assertSame(Response::HTTP_REQUEST_ENTITY_TOO_LARGE, $response->getStatusCode());
+    }
+
+    public function testPartialUpdateListWithInvalidAndTooLongLines()
+    {
+        $line = [
+            'invalid_json_1'  => str_repeat('a', $this->getBufferSize() - 1),
+            'invalid_json_2'  => str_repeat('a', $this->getBufferSize()),
+            'invalid_json_3'  => '',
+            'line_too_long_1' => '{"code":"foo"}' . str_repeat('a', $this->getBufferSize()),
+            'line_too_long_2' => '{"code":"foo"}' . str_repeat(' ', $this->getBufferSize()),
+            'line_too_long_3' => str_repeat('a', $this->getBufferSize() + 1),
+            'line_too_long_4' => str_repeat('a', $this->getBufferSize() + 2),
+            'line_too_long_5' => str_repeat('a', $this->getBufferSize() * 2),
+            'line_too_long_6' => str_repeat('a', $this->getBufferSize() * 5),
+            'invalid_json_4'  => str_repeat('a', $this->getBufferSize()),
+        ];
+
+        $data =
+<<<JSON
+${line['invalid_json_1']}
+${line['invalid_json_2']}
+${line['invalid_json_3']}
+${line['line_too_long_1']}
+${line['line_too_long_2']}
+${line['line_too_long_3']}
+${line['line_too_long_4']}
+${line['line_too_long_5']}
+${line['line_too_long_6']}
+${line['invalid_json_4']}
+JSON;
+
+        $expectedContent =
+<<<JSON
+{"line":1,"status_code":400,"message":"Invalid json message received"}
+{"line":2,"status_code":400,"message":"Invalid json message received"}
+{"line":3,"status_code":400,"message":"Invalid json message received"}
+{"line":4,"status_code":413,"message":"Line is too long."}
+{"line":5,"status_code":413,"message":"Line is too long."}
+{"line":6,"status_code":413,"message":"Line is too long."}
+{"line":7,"status_code":413,"message":"Line is too long."}
+{"line":8,"status_code":413,"message":"Line is too long."}
+{"line":9,"status_code":413,"message":"Line is too long."}
+{"line":10,"status_code":400,"message":"Invalid json message received"}
+JSON;
+
+        $response = $this->executeStreamRequest('PATCH', 'api/rest/v1/attributes', [], [], [], $data);
+        $httpResponse = $response['http_response'];
+
+
+        $this->assertSame($expectedContent, $response['content']);
+        $this->assertSame(Response::HTTP_OK, $httpResponse->getStatusCode());
+    }
+
+    public function testErrorWhenIdentifierIsMissing()
+    {
+        $data =
+<<<JSON
+    {"identifier": "my_identifier"}
+    {"code": null}
+    {"code": ""}
+    {"code": " "}
+    {}
+JSON;
+
+        $expectedContent =
+<<<JSON
+{"line":1,"status_code":422,"message":"Code is missing."}
+{"line":2,"status_code":422,"message":"Code is missing."}
+{"line":3,"status_code":422,"message":"Code is missing."}
+{"line":4,"status_code":422,"message":"Code is missing."}
+{"line":5,"status_code":422,"message":"Code is missing."}
+JSON;
+
+        $response = $this->executeStreamRequest('PATCH', 'api/rest/v1/attributes', [], [], [], $data);
+        $httpResponse = $response['http_response'];
+
+        $this->assertSame(Response::HTTP_OK, $httpResponse->getStatusCode());
+        $this->assertSame($expectedContent, $response['content']);
+    }
+
+    public function testUpdateAttributeWhenUpdaterFailed()
+    {
+        $data =
+<<<JSON
+    {"code": "foo", "type":"bar"}
+JSON;
+
+        $expectedContent =
+<<<JSON
+{"line":1,"code":"foo","status_code":422,"message":"Property \"type\" expects a valid attribute type. The attribute type does not exist, \"bar\" given. Check the standard format documentation.","_links":{"documentation":{"href":"http:\/\/api.akeneo.com\/api-reference.html#patch_attributes__code_"}}}
+JSON;
+
+        $response = $this->executeStreamRequest('PATCH', 'api/rest/v1/attributes', [], [], [], $data);
+        $httpResponse = $response['http_response'];
+
+        $this->assertSame(Response::HTTP_OK, $httpResponse->getStatusCode());
+        $this->assertSame($expectedContent, $response['content']);
+    }
+
+    public function testUpdateAttributeWhenValidationFailed()
+    {
+        $data =
+<<<JSON
+    {"code": "foo,", "type":"pim_catalog_text","group":"other"}
+JSON;
+
+        $expectedContent =
+<<<JSON
+{"line":1,"code":"foo,","status_code":422,"message":"Validation failed.","errors":[{"property":"code","message":"Attribute code may contain only letters, numbers and underscores"}]}
+JSON;
+
+        $response = $this->executeStreamRequest('PATCH', 'api/rest/v1/attributes', [], [], [], $data);
+        $httpResponse = $response['http_response'];
+
+        $this->assertSame(Response::HTTP_OK, $httpResponse->getStatusCode());
+        $this->assertSame($expectedContent, $response['content']);
+    }
+
+    public function testPartialUpdateListWithBadContentType()
+    {
+        $data =
+<<<JSON
+    {"code": "my_code"}
+JSON;
+
+        $expectedContent =
+<<<JSON
+    {
+        "code": 415,
+        "message": "\"application\/json\" in \"Content-Type\" header is not valid. Only \"application\/vnd.akeneopim+json\" is allowed."
+    }
+JSON;
+
+        $client = $this->createAuthenticatedClient();
+        $client->setServerParameter('CONTENT_TYPE', 'application/json');
+        $client->request('PATCH', 'api/rest/v1/attributes', [], [], [], $data);
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_UNSUPPORTED_MEDIA_TYPE, $response->getStatusCode());
+        $this->assertJsonStringEqualsJsonString($expectedContent, $response->getContent());
+    }
+
+    protected function getBufferSize()
+    {
+        return $this->getParameter('api_input_buffer_size');
+    }
+
+    protected function getMaxNumberResources()
+    {
+        return $this->getParameter('api_input_max_resources_number');
+    }
+
+    /**
+     * Execute a request where the response is streamed by chunk.
+     *
+     * The whole content of the request and the whole content of the response
+     * are loaded in memory.
+     * Therefore, do not use this function on with an high input/output volumetry.
+     *
+     * @param string $method
+     * @param string $uri
+     * @param array  $parameters
+     * @param array  $files
+     * @param array  $server
+     * @param string $content
+     * @param bool   $changeHistory
+     *
+     * @return array
+     */
+    protected function executeStreamRequest(
+        $method,
+        $uri,
+        array $parameters = [],
+        array $files = [],
+        array $server = [],
+        $content = null,
+        $changeHistory = true
+    ) {
+        $streamedContent = '';
+
+        ob_start(function($buffer) use (&$streamedContent) {
+            $streamedContent .= $buffer;
+
+            return '';
+        });
+
+        $client = $this->createAuthenticatedClient();
+        $client->setServerParameter('CONTENT_TYPE', StreamResourceResponse::CONTENT_TYPE);
+        $client->request($method, $uri, $parameters, $files, $server, $content, $changeHistory);
+
+        ob_end_flush();
+
+        $response = [
+            'http_response' => $client->getResponse(),
+            'content'       => $streamedContent,
+        ];
+
+        return $response;
+    }
+
+    /**
+     * @param array  $expectedAttribute normalized data of the attribute that should be created
+     * @param string $code             code of the attribute that should be created
+     */
+    protected function assertSameAttributes(array $expectedAttribute, $code)
+    {
+        $attribute = $this->get('pim_catalog.repository.attribute')->findOneByIdentifier($code);
+        $normalizer = $this->get('pim_catalog.normalizer.standard.attribute');
+        $standardizedAttribute = $normalizer->normalize($attribute);
+
+        $this->assertSame($expectedAttribute, $standardizedAttribute);
+    }
+
+    /**
+     * @return Configuration
+     */
+    protected function getConfiguration()
+    {
+        return new Configuration(
+            [Configuration::getTechnicalCatalogPath()],
+            true
+        );
+    }
+}

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Category/PartialUpdateListCategoryIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Category/PartialUpdateListCategoryIntegration.php
@@ -246,7 +246,7 @@ JSON;
 <<<JSON
     {
         "code": 415,
-        "message": "\"application\/json\" in \"Content-Type\" header is not valid. Only \"application\/vnd.akeneopim+json\" is allowed."
+        "message": "\"application\/json\" in \"Content-Type\" header is not valid. Only \"application\/vnd.akeneo.collection+json\" is allowed."
     }
 JSON;
 

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Category/PartialUpdateListCategoryIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Category/PartialUpdateListCategoryIntegration.php
@@ -1,0 +1,343 @@
+<?php
+
+namespace Pim\Bundle\ApiBundle\tests\integration\Controller\Category;
+
+use Akeneo\Test\Integration\Configuration;
+use Pim\Bundle\ApiBundle\Stream\StreamResourceResponse;
+use Pim\Bundle\ApiBundle\tests\integration\ApiTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+class PartialUpdateListCategoryIntegration extends ApiTestCase
+{
+    public function testCreateAndUpdateAListOfCategories()
+    {
+        $data =
+<<<JSON
+    {"code": "categoryA2","labels":{"en_US":"category A2"}}
+    {"code": "categoryC","parent":"master"}
+JSON;
+
+        $expectedContent =
+<<<JSON
+{"line":1,"code":"categoryA2","status_code":204}
+{"line":2,"code":"categoryC","status_code":201}
+JSON;
+
+        $response = $this->executeStreamRequest('PATCH', 'api/rest/v1/categories', [], [], [], $data);
+        $httpResponse = $response['http_response'];
+
+        $this->assertSame(Response::HTTP_OK, $httpResponse->getStatusCode());
+        $this->assertSame($expectedContent, $response['content']);
+        $this->assertArrayHasKey('content-type', $httpResponse->headers->all());
+        $this->assertSame(StreamResourceResponse::CONTENT_TYPE, $httpResponse->headers->get('content-type'));
+
+        $expectedCategories = [
+            'categoryA2' => [
+                'code'   => 'categoryA2',
+                'parent' => 'categoryA',
+                'labels' => [
+                    'en_US' => 'category A2'
+                ]
+            ],
+            'categoryC' => [
+                'code'   => 'categoryC',
+                'parent' => 'master',
+                'labels' => []
+            ]
+        ];
+
+        $this->assertSameCategories($expectedCategories['categoryA2'], 'categoryA2');
+        $this->assertSameCategories($expectedCategories['categoryC'], 'categoryC');
+    }
+
+    public function testCreateAndUpdateSameCategory()
+    {
+        $data =
+<<<JSON
+    {"code": "categoryC"}
+    {"code": "categoryC"}
+JSON;
+
+        $expectedContent =
+<<<JSON
+{"line":1,"code":"categoryC","status_code":201}
+{"line":2,"code":"categoryC","status_code":204}
+JSON;
+
+        $response = $this->executeStreamRequest('PATCH', 'api/rest/v1/categories', [], [], [], $data);
+        $httpResponse = $response['http_response'];
+
+        $this->assertSame(Response::HTTP_OK, $httpResponse->getStatusCode());
+        $this->assertSame($expectedContent, $response['content']);
+    }
+
+    public function testPartialUpdateListWithMaxNumberOfResourcesAllowed()
+    {
+        $maxNumberResources = $this->getMaxNumberResources();
+
+        for ($i = 0; $i < $maxNumberResources; $i++) {
+            $data[] = sprintf('{"code": "my_code_%s"}', $i);
+        }
+        $data = implode(PHP_EOL, $data);
+
+        for ($i = 0; $i < $maxNumberResources; $i++) {
+            $expectedContent[] = sprintf('{"line":%s,"code":"my_code_%s","status_code":201}', $i + 1, $i);
+        }
+        $expectedContent = implode(PHP_EOL, $expectedContent);
+
+        $response = $this->executeStreamRequest('PATCH', 'api/rest/v1/categories', [], [], [], $data);
+        $httpResponse = $response['http_response'];
+
+        $this->assertSame(Response::HTTP_OK, $httpResponse->getStatusCode());
+        $this->assertSame($expectedContent, $response['content']);
+    }
+
+    public function testPartialUpdateListWithTooManyResources()
+    {
+        $client = $this->createAuthenticatedClient();
+        $client->setServerParameter('CONTENT_TYPE', StreamResourceResponse::CONTENT_TYPE);
+
+        $maxNumberResources = $this->getMaxNumberResources();
+
+        for ($i = 0; $i < $maxNumberResources + 1; $i++) {
+            $data[] = sprintf('{"identifier": "my_code_%s"}', $i);
+        }
+        $data = implode(PHP_EOL, $data);
+
+        $expectedContent =
+<<<JSON
+    {
+        "code": 413,
+        "message": "Too many resources to process, ${maxNumberResources} is the maximum allowed."
+    }
+JSON;
+
+        $client->request('PATCH', 'api/rest/v1/categories', [], [], [], $data);
+
+        $response = $client->getResponse();
+        $this->assertJsonStringEqualsJsonString($expectedContent, $response->getContent());
+        $this->assertSame(Response::HTTP_REQUEST_ENTITY_TOO_LARGE, $response->getStatusCode());
+    }
+
+    public function testPartialUpdateListWithInvalidAndTooLongLines()
+    {
+        $line = [
+            'invalid_json_1'  => str_repeat('a', $this->getBufferSize() - 1),
+            'invalid_json_2'  => str_repeat('a', $this->getBufferSize()),
+            'invalid_json_3'  => '',
+            'line_too_long_1' => '{"code":"foo"}' . str_repeat('a', $this->getBufferSize()),
+            'line_too_long_2' => '{"code":"foo"}' . str_repeat(' ', $this->getBufferSize()),
+            'line_too_long_3' => str_repeat('a', $this->getBufferSize() + 1),
+            'line_too_long_4' => str_repeat('a', $this->getBufferSize() + 2),
+            'line_too_long_5' => str_repeat('a', $this->getBufferSize() * 2),
+            'line_too_long_6' => str_repeat('a', $this->getBufferSize() * 5),
+            'invalid_json_4'  => str_repeat('a', $this->getBufferSize()),
+        ];
+
+        $data =
+<<<JSON
+${line['invalid_json_1']}
+${line['invalid_json_2']}
+${line['invalid_json_3']}
+${line['line_too_long_1']}
+${line['line_too_long_2']}
+${line['line_too_long_3']}
+${line['line_too_long_4']}
+${line['line_too_long_5']}
+${line['line_too_long_6']}
+${line['invalid_json_4']}
+JSON;
+
+        $expectedContent =
+<<<JSON
+{"line":1,"status_code":400,"message":"Invalid json message received"}
+{"line":2,"status_code":400,"message":"Invalid json message received"}
+{"line":3,"status_code":400,"message":"Invalid json message received"}
+{"line":4,"status_code":413,"message":"Line is too long."}
+{"line":5,"status_code":413,"message":"Line is too long."}
+{"line":6,"status_code":413,"message":"Line is too long."}
+{"line":7,"status_code":413,"message":"Line is too long."}
+{"line":8,"status_code":413,"message":"Line is too long."}
+{"line":9,"status_code":413,"message":"Line is too long."}
+{"line":10,"status_code":400,"message":"Invalid json message received"}
+JSON;
+
+        $response = $this->executeStreamRequest('PATCH', 'api/rest/v1/categories', [], [], [], $data);
+        $httpResponse = $response['http_response'];
+
+
+        $this->assertSame($expectedContent, $response['content']);
+        $this->assertSame(Response::HTTP_OK, $httpResponse->getStatusCode());
+    }
+
+    public function testErrorWhenIdentifierIsMissing()
+    {
+        $data =
+<<<JSON
+    {"identifier": "my_identifier"}
+    {"code": null}
+    {"code": ""}
+    {"code": " "}
+    {}
+JSON;
+
+        $expectedContent =
+<<<JSON
+{"line":1,"status_code":422,"message":"Code is missing."}
+{"line":2,"status_code":422,"message":"Code is missing."}
+{"line":3,"status_code":422,"message":"Code is missing."}
+{"line":4,"status_code":422,"message":"Code is missing."}
+{"line":5,"status_code":422,"message":"Code is missing."}
+JSON;
+
+        $response = $this->executeStreamRequest('PATCH', 'api/rest/v1/categories', [], [], [], $data);
+        $httpResponse = $response['http_response'];
+
+        $this->assertSame(Response::HTTP_OK, $httpResponse->getStatusCode());
+        $this->assertSame($expectedContent, $response['content']);
+    }
+
+    public function testUpdateCategoryWhenUpdaterFailed()
+    {
+        $data =
+<<<JSON
+    {"code": "foo", "parent":"bar"}
+JSON;
+
+        $expectedContent =
+<<<JSON
+{"line":1,"code":"foo","status_code":422,"message":"Property \"parent\" expects a valid category code. The category does not exist, \"bar\" given. Check the standard format documentation.","_links":{"documentation":{"href":"http:\/\/api.akeneo.com\/api-reference.html#patch_categories__code_"}}}
+JSON;
+
+        $response = $this->executeStreamRequest('PATCH', 'api/rest/v1/categories', [], [], [], $data);
+        $httpResponse = $response['http_response'];
+
+        $this->assertSame(Response::HTTP_OK, $httpResponse->getStatusCode());
+        $this->assertSame($expectedContent, $response['content']);
+    }
+
+    public function testUpdateCategoryWhenValidationFailed()
+    {
+        $data =
+<<<JSON
+    {"code": "foo,"}
+JSON;
+
+        $expectedContent =
+<<<JSON
+{"line":1,"code":"foo,","status_code":422,"message":"Validation failed.","errors":[{"property":"code","message":"Category code may contain only letters, numbers and underscores"}]}
+JSON;
+
+        $response = $this->executeStreamRequest('PATCH', 'api/rest/v1/categories', [], [], [], $data);
+        $httpResponse = $response['http_response'];
+
+        $this->assertSame(Response::HTTP_OK, $httpResponse->getStatusCode());
+        $this->assertSame($expectedContent, $response['content']);
+    }
+
+    public function testPartialUpdateListWithBadContentType()
+    {
+        $data =
+<<<JSON
+    {"code": "my_code"}
+JSON;
+
+        $expectedContent =
+<<<JSON
+    {
+        "code": 415,
+        "message": "\"application\/json\" in \"Content-Type\" header is not valid. Only \"application\/vnd.akeneopim+json\" is allowed."
+    }
+JSON;
+
+        $client = $this->createAuthenticatedClient();
+        $client->setServerParameter('CONTENT_TYPE', 'application/json');
+        $client->request('PATCH', 'api/rest/v1/categories', [], [], [], $data);
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_UNSUPPORTED_MEDIA_TYPE, $response->getStatusCode());
+        $this->assertJsonStringEqualsJsonString($expectedContent, $response->getContent());
+    }
+
+    protected function getBufferSize()
+    {
+        return $this->getParameter('api_input_buffer_size');
+    }
+
+    protected function getMaxNumberResources()
+    {
+        return $this->getParameter('api_input_max_resources_number');
+    }
+
+    /**
+     * Execute a request where the response is streamed by chunk.
+     *
+     * The whole content of the request and the whole content of the response
+     * are loaded in memory.
+     * Therefore, do not use this function on with an high input/output volumetry.
+     *
+     * @param string $method
+     * @param string $uri
+     * @param array  $parameters
+     * @param array  $files
+     * @param array  $server
+     * @param string $content
+     * @param bool   $changeHistory
+     *
+     * @return array
+     */
+    protected function executeStreamRequest(
+        $method,
+        $uri,
+        array $parameters = [],
+        array $files = [],
+        array $server = [],
+        $content = null,
+        $changeHistory = true
+    ) {
+        $streamedContent = '';
+
+        ob_start(function($buffer) use (&$streamedContent) {
+            $streamedContent .= $buffer;
+
+            return '';
+        });
+
+        $client = $this->createAuthenticatedClient();
+        $client->setServerParameter('CONTENT_TYPE', StreamResourceResponse::CONTENT_TYPE);
+        $client->request($method, $uri, $parameters, $files, $server, $content, $changeHistory);
+
+        ob_end_flush();
+
+        $response = [
+            'http_response' => $client->getResponse(),
+            'content'       => $streamedContent,
+        ];
+
+        return $response;
+    }
+
+    /**
+     * @param array  $expectedCategory normalized data of the category that should be created
+     * @param string $code             code of the category that should be created
+     */
+    protected function assertSameCategories(array $expectedCategory, $code)
+    {
+        $category = $this->get('pim_catalog.repository.category')->findOneByIdentifier($code);
+        $normalizer = $this->get('pim_catalog.normalizer.standard.category');
+        $standardizedCategory = $normalizer->normalize($category);
+
+        $this->assertSame($expectedCategory, $standardizedCategory);
+    }
+
+    /**
+     * @return Configuration
+     */
+    protected function getConfiguration()
+    {
+        return new Configuration(
+            [Configuration::getTechnicalCatalogPath()],
+            true
+        );
+    }
+}

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Family/PartialUpdateListFamilyIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Family/PartialUpdateListFamilyIntegration.php
@@ -260,7 +260,7 @@ JSON;
 <<<JSON
     {
         "code": 415,
-        "message": "\"application\/json\" in \"Content-Type\" header is not valid. Only \"application\/vnd.akeneopim+json\" is allowed."
+        "message": "\"application\/json\" in \"Content-Type\" header is not valid. Only \"application\/vnd.akeneo.collection+json\" is allowed."
     }
 JSON;
 

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Family/PartialUpdateListFamilyIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Family/PartialUpdateListFamilyIntegration.php
@@ -1,0 +1,357 @@
+<?php
+
+namespace Pim\Bundle\ApiBundle\tests\integration\Controller\Family;
+
+use Akeneo\Test\Integration\Configuration;
+use Pim\Bundle\ApiBundle\Stream\StreamResourceResponse;
+use Pim\Bundle\ApiBundle\tests\integration\ApiTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+class PartialUpdateListFamilyIntegration extends ApiTestCase
+{
+    public function testCreateAndUpdateAListOfFamilies()
+    {
+        $data =
+<<<JSON
+    {"code": "familyA1","labels":{"en_US":"family A1"}}
+    {"code": "familyC","attributes":["a_yes_no"],"attribute_as_label":"sku"}
+JSON;
+
+        $expectedContent =
+<<<JSON
+{"line":1,"code":"familyA1","status_code":204}
+{"line":2,"code":"familyC","status_code":201}
+JSON;
+
+
+        $response = $this->executeStreamRequest('PATCH', 'api/rest/v1/families', [], [], [], $data);
+        $httpResponse = $response['http_response'];
+
+        $this->assertSame(Response::HTTP_OK, $httpResponse->getStatusCode());
+        $this->assertSame($expectedContent, $response['content']);
+        $this->assertArrayHasKey('content-type', $httpResponse->headers->all());
+        $this->assertSame(StreamResourceResponse::CONTENT_TYPE, $httpResponse->headers->get('content-type'));
+
+        $expectedFamilies = [
+            'familyA1' => [
+                'code'                   => 'familyA1',
+                'attributes'             => ['a_date', 'a_file', 'a_localizable_image', 'sku'],
+                'attribute_as_label'     => 'sku',
+                'attribute_requirements' => [
+                    'ecommerce'       => ['a_date', 'a_file', 'sku'],
+                    'ecommerce_china' => ['sku'],
+                    'tablet'          => ['a_file', 'a_localizable_image', 'sku']
+                ],
+                'labels'                 => [
+                    'en_US' => 'family A1'
+                ]
+            ],
+            'familyC' => [
+                'code'                   => 'familyC',
+                'attributes'             => ['a_yes_no', 'sku'],
+                'attribute_as_label'     => 'sku',
+                'attribute_requirements' => [
+                    'ecommerce'       => ['sku'],
+                    'ecommerce_china' => ['sku'],
+                    'tablet'          => ['sku']
+                ],
+                'labels'                 => []
+            ]
+        ];
+
+        $this->assertSameFamilies($expectedFamilies['familyA1'], 'familyA1');
+        $this->assertSameFamilies($expectedFamilies['familyC'], 'familyC');
+    }
+
+    public function testCreateAndUpdateSameFamily()
+    {
+        $data =
+<<<JSON
+    {"code": "familyC"}
+    {"code": "familyC"}
+JSON;
+
+        $expectedContent =
+<<<JSON
+{"line":1,"code":"familyC","status_code":201}
+{"line":2,"code":"familyC","status_code":204}
+JSON;
+
+
+        $response = $this->executeStreamRequest('PATCH', 'api/rest/v1/families', [], [], [], $data);
+        $httpResponse = $response['http_response'];
+
+        $this->assertSame(Response::HTTP_OK, $httpResponse->getStatusCode());
+        $this->assertSame($expectedContent, $response['content']);
+    }
+
+    public function testPartialUpdateListWithMaxNumberOfResourcesAllowed()
+    {
+        $maxNumberResources = $this->getMaxNumberResources();
+
+        for ($i = 0; $i < $maxNumberResources; $i++) {
+            $data[] = sprintf('{"code": "my_code_%s"}', $i);
+        }
+        $data = implode(PHP_EOL, $data);
+
+        for ($i = 0; $i < $maxNumberResources; $i++) {
+            $expectedContent[] = sprintf('{"line":%s,"code":"my_code_%s","status_code":201}', $i + 1, $i);
+        }
+        $expectedContent = implode(PHP_EOL, $expectedContent);
+
+        $response = $this->executeStreamRequest('PATCH', 'api/rest/v1/families', [], [], [], $data);
+        $httpResponse = $response['http_response'];
+
+        $this->assertSame(Response::HTTP_OK, $httpResponse->getStatusCode());
+        $this->assertSame($expectedContent, $response['content']);
+    }
+
+    public function testPartialUpdateListWithTooManyResources()
+    {
+        $client = $this->createAuthenticatedClient();
+        $client->setServerParameter('CONTENT_TYPE', StreamResourceResponse::CONTENT_TYPE);
+
+        $maxNumberResources = $this->getMaxNumberResources();
+
+        for ($i = 0; $i < $maxNumberResources + 1; $i++) {
+            $data[] = sprintf('{"identifier": "my_code_%s"}', $i);
+        }
+        $data = implode(PHP_EOL, $data);
+
+        $expectedContent =
+<<<JSON
+    {
+        "code": 413,
+        "message": "Too many resources to process, ${maxNumberResources} is the maximum allowed."
+    }
+JSON;
+
+        $client->request('PATCH', 'api/rest/v1/families', [], [], [], $data);
+
+        $response = $client->getResponse();
+        $this->assertJsonStringEqualsJsonString($expectedContent, $response->getContent());
+        $this->assertSame(Response::HTTP_REQUEST_ENTITY_TOO_LARGE, $response->getStatusCode());
+    }
+
+    public function testPartialUpdateListWithInvalidAndTooLongLines()
+    {
+        $line = [
+            'invalid_json_1'  => str_repeat('a', $this->getBufferSize() - 1),
+            'invalid_json_2'  => str_repeat('a', $this->getBufferSize()),
+            'invalid_json_3'  => '',
+            'line_too_long_1' => '{"code":"foo"}' . str_repeat('a', $this->getBufferSize()),
+            'line_too_long_2' => '{"code":"foo"}' . str_repeat(' ', $this->getBufferSize()),
+            'line_too_long_3' => str_repeat('a', $this->getBufferSize() + 1),
+            'line_too_long_4' => str_repeat('a', $this->getBufferSize() + 2),
+            'line_too_long_5' => str_repeat('a', $this->getBufferSize() * 2),
+            'line_too_long_6' => str_repeat('a', $this->getBufferSize() * 5),
+            'invalid_json_4'  => str_repeat('a', $this->getBufferSize()),
+        ];
+
+        $data =
+<<<JSON
+${line['invalid_json_1']}
+${line['invalid_json_2']}
+${line['invalid_json_3']}
+${line['line_too_long_1']}
+${line['line_too_long_2']}
+${line['line_too_long_3']}
+${line['line_too_long_4']}
+${line['line_too_long_5']}
+${line['line_too_long_6']}
+${line['invalid_json_4']}
+JSON;
+
+        $expectedContent =
+<<<JSON
+{"line":1,"status_code":400,"message":"Invalid json message received"}
+{"line":2,"status_code":400,"message":"Invalid json message received"}
+{"line":3,"status_code":400,"message":"Invalid json message received"}
+{"line":4,"status_code":413,"message":"Line is too long."}
+{"line":5,"status_code":413,"message":"Line is too long."}
+{"line":6,"status_code":413,"message":"Line is too long."}
+{"line":7,"status_code":413,"message":"Line is too long."}
+{"line":8,"status_code":413,"message":"Line is too long."}
+{"line":9,"status_code":413,"message":"Line is too long."}
+{"line":10,"status_code":400,"message":"Invalid json message received"}
+JSON;
+
+        $response = $this->executeStreamRequest('PATCH', 'api/rest/v1/families', [], [], [], $data);
+        $httpResponse = $response['http_response'];
+
+
+        $this->assertSame($expectedContent, $response['content']);
+        $this->assertSame(Response::HTTP_OK, $httpResponse->getStatusCode());
+    }
+
+    public function testErrorWhenIdentifierIsMissing()
+    {
+        $data =
+<<<JSON
+    {"identifier": "my_identifier"}
+    {"code": null}
+    {"code": ""}
+    {"code": " "}
+    {}
+JSON;
+
+        $expectedContent =
+<<<JSON
+{"line":1,"status_code":422,"message":"Code is missing."}
+{"line":2,"status_code":422,"message":"Code is missing."}
+{"line":3,"status_code":422,"message":"Code is missing."}
+{"line":4,"status_code":422,"message":"Code is missing."}
+{"line":5,"status_code":422,"message":"Code is missing."}
+JSON;
+
+        $response = $this->executeStreamRequest('PATCH', 'api/rest/v1/families', [], [], [], $data);
+        $httpResponse = $response['http_response'];
+
+        $this->assertSame(Response::HTTP_OK, $httpResponse->getStatusCode());
+        $this->assertSame($expectedContent, $response['content']);
+    }
+
+    public function testUpdateFamilyWhenUpdaterFailed()
+    {
+        $data =
+<<<JSON
+    {"code": "foo", "attributes":"bar"}
+JSON;
+
+        $expectedContent =
+<<<JSON
+{"line":1,"code":"foo","status_code":422,"message":"Property \"attributes\" expects an array as data, \"string\" given. Check the standard format documentation.","_links":{"documentation":{"href":"http:\/\/api.akeneo.com\/api-reference.html#patch_families__code_"}}}
+JSON;
+
+        $response = $this->executeStreamRequest('PATCH', 'api/rest/v1/families', [], [], [], $data);
+        $httpResponse = $response['http_response'];
+
+        $this->assertSame(Response::HTTP_OK, $httpResponse->getStatusCode());
+        $this->assertSame($expectedContent, $response['content']);
+    }
+
+    public function testUpdateFamilyWhenValidationFailed()
+    {
+        $data =
+<<<JSON
+    {"code": "foo,"}
+JSON;
+
+        $expectedContent =
+<<<JSON
+{"line":1,"code":"foo,","status_code":422,"message":"Validation failed.","errors":[{"property":"code","message":"Family code may contain only letters, numbers and underscores"}]}
+JSON;
+
+        $response = $this->executeStreamRequest('PATCH', 'api/rest/v1/families', [], [], [], $data);
+        $httpResponse = $response['http_response'];
+
+        $this->assertSame(Response::HTTP_OK, $httpResponse->getStatusCode());
+        $this->assertSame($expectedContent, $response['content']);
+    }
+
+    public function testPartialUpdateListWithBadContentType()
+    {
+        $data =
+<<<JSON
+    {"code": "my_code"}
+JSON;
+
+        $expectedContent =
+<<<JSON
+    {
+        "code": 415,
+        "message": "\"application\/json\" in \"Content-Type\" header is not valid. Only \"application\/vnd.akeneopim+json\" is allowed."
+    }
+JSON;
+
+        $client = $this->createAuthenticatedClient();
+        $client->setServerParameter('CONTENT_TYPE', 'application/json');
+        $client->request('PATCH', 'api/rest/v1/families', [], [], [], $data);
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_UNSUPPORTED_MEDIA_TYPE, $response->getStatusCode());
+        $this->assertJsonStringEqualsJsonString($expectedContent, $response->getContent());
+    }
+
+    protected function getBufferSize()
+    {
+        return $this->getParameter('api_input_buffer_size');
+    }
+
+    protected function getMaxNumberResources()
+    {
+        return $this->getParameter('api_input_max_resources_number');
+    }
+
+    /**
+     * Execute a request where the response is streamed by chunk.
+     *
+     * The whole content of the request and the whole content of the response
+     * are loaded in memory.
+     * Therefore, do not use this function on with an high input/output volumetry.
+     *
+     * @param string $method
+     * @param string $uri
+     * @param array  $parameters
+     * @param array  $files
+     * @param array  $server
+     * @param string $content
+     * @param bool   $changeHistory
+     *
+     * @return array
+     */
+    protected function executeStreamRequest(
+        $method,
+        $uri,
+        array $parameters = [],
+        array $files = [],
+        array $server = [],
+        $content = null,
+        $changeHistory = true
+    ) {
+        $streamedContent = '';
+
+        ob_start(function($buffer) use (&$streamedContent) {
+            $streamedContent .= $buffer;
+
+            return '';
+        });
+
+        $client = $this->createAuthenticatedClient();
+        $client->setServerParameter('CONTENT_TYPE', StreamResourceResponse::CONTENT_TYPE);
+        $client->request($method, $uri, $parameters, $files, $server, $content, $changeHistory);
+
+        ob_end_flush();
+
+        $response = [
+            'http_response' => $client->getResponse(),
+            'content'       => $streamedContent,
+        ];
+
+        return $response;
+    }
+
+    /**
+     * @param array  $expectedFamily normalized data of the family that should be created
+     * @param string $code           code of the family that should be created
+     */
+    protected function assertSameFamilies(array $expectedFamily, $code)
+    {
+        $family = $this->get('pim_catalog.repository.family')->findOneByIdentifier($code);
+        $normalizer = $this->get('pim_catalog.normalizer.standard.family');
+        $standardizedFamily = $normalizer->normalize($family);
+
+        $this->assertSame($expectedFamily, $standardizedFamily);
+    }
+
+    /**
+     * @return Configuration
+     */
+    protected function getConfiguration()
+    {
+        return new Configuration(
+            [Configuration::getTechnicalCatalogPath()],
+            true
+        );
+    }
+}

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateListProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateListProductIntegration.php
@@ -4,7 +4,6 @@ namespace Pim\Bundle\ApiBundle\tests\integration\Controller\Product;
 
 use Akeneo\Test\Integration\Configuration;
 use Pim\Bundle\ApiBundle\Stream\StreamResourceResponse;
-use Pim\Bundle\CatalogBundle\Version;
 use Symfony\Component\HttpFoundation\Response;
 
 class PartialUpdateListProductIntegration extends AbstractProductTestCase
@@ -238,13 +237,10 @@ JSON;
     {"identifier": "foo", "variant_group":"bar"}
 JSON;
 
-
-        $version = substr(Version::VERSION, 0, 3);
         $expectedContent =
 <<<JSON
-{"line":1,"identifier":"foo","code":422,"message":"Property \"variant_group\" expects a valid variant group code. The variant group does not exist, \"bar\" given. Check the standard format documentation.","_links":{"documentation":{"href":"https:\/\/docs.akeneo.com\/${version}\/reference\/standard_format\/products.html"}}}
+{"line":1,"identifier":"foo","code":422,"message":"Property \"variant_group\" expects a valid variant group code. The variant group does not exist, \"bar\" given. Check the standard format documentation.","_links":{"documentation":{"href":"http://api.akeneo.com/api-reference.html#patch_products__code_"}}}
 JSON;
-
 
         $response = $this->executeStreamRequest('PATCH', 'api/rest/v1/products', [], [], [], $data);
         $httpResponse = $response['http_response'];

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateListProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateListProductIntegration.php
@@ -30,8 +30,8 @@ JSON;
 
         $expectedContent =
 <<<JSON
-{"line":1,"identifier":"product_family","code":204}
-{"line":2,"identifier":"my_identifier","code":201}
+{"line":1,"identifier":"product_family","status_code":204}
+{"line":2,"identifier":"my_identifier","status_code":201}
 JSON;
 
 
@@ -92,8 +92,8 @@ JSON;
 
         $expectedContent =
 <<<JSON
-{"line":1,"identifier":"my_identifier","code":201}
-{"line":2,"identifier":"my_identifier","code":204}
+{"line":1,"identifier":"my_identifier","status_code":201}
+{"line":2,"identifier":"my_identifier","status_code":204}
 JSON;
 
 
@@ -114,7 +114,7 @@ JSON;
         $data = implode(PHP_EOL, $data);
 
         for ($i = 0; $i < $maxNumberResources; $i++) {
-            $expectedContent[] = sprintf('{"line":%s,"identifier":"my_identifier_%s","code":201}', $i + 1, $i);
+            $expectedContent[] = sprintf('{"line":%s,"identifier":"my_identifier_%s","status_code":201}', $i + 1, $i);
         }
         $expectedContent = implode(PHP_EOL, $expectedContent);
 
@@ -183,16 +183,16 @@ JSON;
 
         $expectedContent =
 <<<JSON
-{"line":1,"code":400,"message":"Invalid json message received"}
-{"line":2,"code":400,"message":"Invalid json message received"}
-{"line":3,"code":400,"message":"Invalid json message received"}
-{"line":4,"code":413,"message":"Line is too long."}
-{"line":5,"code":413,"message":"Line is too long."}
-{"line":6,"code":413,"message":"Line is too long."}
-{"line":7,"code":413,"message":"Line is too long."}
-{"line":8,"code":413,"message":"Line is too long."}
-{"line":9,"code":413,"message":"Line is too long."}
-{"line":10,"code":400,"message":"Invalid json message received"}
+{"line":1,"status_code":400,"message":"Invalid json message received"}
+{"line":2,"status_code":400,"message":"Invalid json message received"}
+{"line":3,"status_code":400,"message":"Invalid json message received"}
+{"line":4,"status_code":413,"message":"Line is too long."}
+{"line":5,"status_code":413,"message":"Line is too long."}
+{"line":6,"status_code":413,"message":"Line is too long."}
+{"line":7,"status_code":413,"message":"Line is too long."}
+{"line":8,"status_code":413,"message":"Line is too long."}
+{"line":9,"status_code":413,"message":"Line is too long."}
+{"line":10,"status_code":400,"message":"Invalid json message received"}
 JSON;
 
         $response = $this->executeStreamRequest('PATCH', 'api/rest/v1/products', [], [], [], $data);
@@ -216,11 +216,11 @@ JSON;
 
         $expectedContent =
 <<<JSON
-{"line":1,"code":422,"message":"Identifier is missing."}
-{"line":2,"code":422,"message":"Identifier is missing."}
-{"line":3,"code":422,"message":"Identifier is missing."}
-{"line":4,"code":422,"message":"Identifier is missing."}
-{"line":5,"code":422,"message":"Identifier is missing."}
+{"line":1,"status_code":422,"message":"Identifier is missing."}
+{"line":2,"status_code":422,"message":"Identifier is missing."}
+{"line":3,"status_code":422,"message":"Identifier is missing."}
+{"line":4,"status_code":422,"message":"Identifier is missing."}
+{"line":5,"status_code":422,"message":"Identifier is missing."}
 JSON;
 
         $response = $this->executeStreamRequest('PATCH', 'api/rest/v1/products', [], [], [], $data);
@@ -239,7 +239,7 @@ JSON;
 
         $expectedContent =
 <<<JSON
-{"line":1,"identifier":"foo","code":422,"message":"Property \"variant_group\" expects a valid variant group code. The variant group does not exist, \"bar\" given. Check the standard format documentation.","_links":{"documentation":{"href":"http://api.akeneo.com/api-reference.html#patch_products__code_"}}}
+{"line":1,"identifier":"foo","status_code":422,"message":"Property \"variant_group\" expects a valid variant group code. The variant group does not exist, \"bar\" given. Check the standard format documentation.","_links":{"documentation":{"href":"http:\/\/api.akeneo.com\/api-reference.html#patch_products__code_"}}}
 JSON;
 
         $response = $this->executeStreamRequest('PATCH', 'api/rest/v1/products', [], [], [], $data);
@@ -258,7 +258,7 @@ JSON;
 
         $expectedContent =
 <<<JSON
-{"line":1,"identifier":"foo,","code":422,"message":"Validation failed.","errors":[{"field":"identifier","message":"This field should not contain any comma or semicolon."}]}
+{"line":1,"identifier":"foo,","status_code":422,"message":"Validation failed.","errors":[{"property":"identifier","message":"This field should not contain any comma or semicolon."}]}
 JSON;
 
 

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateListProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateListProductIntegration.php
@@ -1,0 +1,387 @@
+<?php
+
+namespace Pim\Bundle\ApiBundle\tests\integration\Controller\Product;
+
+use Akeneo\Test\Integration\Configuration;
+use Pim\Bundle\ApiBundle\Stream\StreamResourceResponse;
+use Pim\Bundle\CatalogBundle\Version;
+use Symfony\Component\HttpFoundation\Response;
+
+class PartialUpdateListProductIntegration extends AbstractProductTestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->createProduct('product_family', [
+            'family' => 'familyA2',
+        ]);
+    }
+
+    public function testCreateAndUpdateAListOfProducts()
+    {
+        $data =
+<<<JSON
+    {"identifier": "product_family", "family": "familyA1"}
+    {"identifier": "my_identifier", "family": "familyA2"}
+JSON;
+
+        $expectedContent =
+<<<JSON
+{"line":1,"identifier":"product_family","code":204}
+{"line":2,"identifier":"my_identifier","code":201}
+JSON;
+
+
+        $response = $this->executeStreamRequest('PATCH', 'api/rest/v1/products', [], [], [], $data);
+        $httpResponse = $response['http_response'];
+
+        $this->assertSame(Response::HTTP_OK, $httpResponse->getStatusCode());
+        $this->assertSame($expectedContent, $response['content']);
+        $this->assertArrayHasKey('content-type', $httpResponse->headers->all());
+        $this->assertSame(StreamResourceResponse::CONTENT_TYPE, $httpResponse->headers->get('content-type'));
+
+        $expectedProducts = [
+            'product_family' => [
+                'identifier'    => 'product_family',
+                'family'        => 'familyA1',
+                'groups'        => [],
+                'variant_group' => null,
+                'categories'    => [],
+                'enabled'       => true,
+                'values'        => [
+                    'sku' => [
+                        ['locale' => null, 'scope' => null, 'data' => 'product_family'],
+                    ],
+                ],
+                'created'       => '2016-06-14T13:12:50+02:00',
+                'updated'       => '2016-06-14T13:12:50+02:00',
+                'associations'  => [],
+            ],
+            'my_identifier'  => [
+                'identifier'    => 'my_identifier',
+                'family'        => 'familyA2',
+                'groups'        => [],
+                'variant_group' => null,
+                'categories'    => [],
+                'enabled'       => true,
+                'values'        => [
+                    'sku' => [
+                        ['locale' => null, 'scope' => null, 'data' => 'my_identifier'],
+                    ],
+                ],
+                'created'       => '2016-06-14T13:12:50+02:00',
+                'updated'       => '2016-06-14T13:12:50+02:00',
+                'associations'  => [],
+            ],
+        ];
+
+        $this->assertSameProducts($expectedProducts['product_family'], 'product_family');
+        $this->assertSameProducts($expectedProducts['my_identifier'], 'my_identifier');
+    }
+
+    public function testCreateAndUpdateSameProduct()
+    {
+        $data =
+<<<JSON
+    {"identifier": "my_identifier"}
+    {"identifier": "my_identifier"}
+JSON;
+
+        $expectedContent =
+<<<JSON
+{"line":1,"identifier":"my_identifier","code":201}
+{"line":2,"identifier":"my_identifier","code":204}
+JSON;
+
+
+        $response = $this->executeStreamRequest('PATCH', 'api/rest/v1/products', [], [], [], $data);
+        $httpResponse = $response['http_response'];
+
+        $this->assertSame(Response::HTTP_OK, $httpResponse->getStatusCode());
+        $this->assertSame($expectedContent, $response['content']);
+    }
+
+    public function testPartialUpdateListWithMaxNumberOfResourcesAllowed()
+    {
+        $maxNumberResources = $this->getMaxNumberResources();
+
+        for ($i = 0; $i < $maxNumberResources; $i++) {
+            $data[] = sprintf('{"identifier": "my_identifier_%s"}', $i);
+        }
+        $data = implode(PHP_EOL, $data);
+
+        for ($i = 0; $i < $maxNumberResources; $i++) {
+            $expectedContent[] = sprintf('{"line":%s,"identifier":"my_identifier_%s","code":201}', $i + 1, $i);
+        }
+        $expectedContent = implode(PHP_EOL, $expectedContent);
+
+        $response = $this->executeStreamRequest('PATCH', 'api/rest/v1/products', [], [], [], $data);
+        $httpResponse = $response['http_response'];
+
+        $this->assertSame(Response::HTTP_OK, $httpResponse->getStatusCode());
+        $this->assertSame($expectedContent, $response['content']);
+    }
+
+    public function testPartialUpdateListWithTooManyResources()
+    {
+        $client = $this->createAuthenticatedClient();
+        $client->setServerParameter('CONTENT_TYPE', StreamResourceResponse::CONTENT_TYPE);
+
+        $maxNumberResources = $this->getMaxNumberResources();
+
+        for ($i = 0; $i < $maxNumberResources + 1; $i++) {
+            $data[] = sprintf('{"identifier": "my_identifier_%s"}', $i);
+        }
+        $data = implode(PHP_EOL, $data);
+
+        $expectedContent =
+<<<JSON
+    {
+        "code": 413,
+        "message": "Too many resources to process, ${maxNumberResources} is the maximum allowed."
+    }
+JSON;
+
+        $client->request('PATCH', 'api/rest/v1/products', [], [], [], $data);
+
+        $response = $client->getResponse();
+        $this->assertJsonStringEqualsJsonString($expectedContent, $response->getContent());
+        $this->assertSame(Response::HTTP_REQUEST_ENTITY_TOO_LARGE, $response->getStatusCode());
+    }
+
+    public function testPartialUpdateListWithInvalidAndTooLongLines()
+    {
+        $line = [
+            'invalid_json_1'  => str_repeat('a', $this->getBufferSize() - 1),
+            'invalid_json_2'  => str_repeat('a', $this->getBufferSize()),
+            'invalid_json_3'  => '',
+            'line_too_long_1' => '{"identifier":"foo"}' . str_repeat('a', $this->getBufferSize()),
+            'line_too_long_2' => '{"identifier":"foo"}' . str_repeat(' ', $this->getBufferSize()),
+            'line_too_long_3' => str_repeat('a', $this->getBufferSize() + 1),
+            'line_too_long_4' => str_repeat('a', $this->getBufferSize() + 2),
+            'line_too_long_5' => str_repeat('a', $this->getBufferSize() * 2),
+            'line_too_long_6' => str_repeat('a', $this->getBufferSize() * 5),
+            'invalid_json_4'  => str_repeat('a', $this->getBufferSize()),
+        ];
+
+        $data =
+<<<JSON
+${line['invalid_json_1']}
+${line['invalid_json_2']}
+${line['invalid_json_3']}
+${line['line_too_long_1']}
+${line['line_too_long_2']}
+${line['line_too_long_3']}
+${line['line_too_long_4']}
+${line['line_too_long_5']}
+${line['line_too_long_6']}
+${line['invalid_json_4']}
+JSON;
+
+        $expectedContent =
+<<<JSON
+{"line":1,"code":400,"message":"Invalid json message received"}
+{"line":2,"code":400,"message":"Invalid json message received"}
+{"line":3,"code":400,"message":"Invalid json message received"}
+{"line":4,"code":413,"message":"Line is too long."}
+{"line":5,"code":413,"message":"Line is too long."}
+{"line":6,"code":413,"message":"Line is too long."}
+{"line":7,"code":413,"message":"Line is too long."}
+{"line":8,"code":413,"message":"Line is too long."}
+{"line":9,"code":413,"message":"Line is too long."}
+{"line":10,"code":400,"message":"Invalid json message received"}
+JSON;
+
+        $response = $this->executeStreamRequest('PATCH', 'api/rest/v1/products', [], [], [], $data);
+        $httpResponse = $response['http_response'];
+
+
+        $this->assertSame($expectedContent, $response['content']);
+        $this->assertSame(Response::HTTP_OK, $httpResponse->getStatusCode());
+    }
+
+    public function testErrorWhenIdentifierIsMissing()
+    {
+        $data =
+<<<JSON
+    {"code": "my_identifier"}
+    {"identifier": null}
+    {"identifier": ""}
+    {"identifier": " "}
+    {}
+JSON;
+
+        $expectedContent =
+<<<JSON
+{"line":1,"code":422,"message":"Identifier is missing."}
+{"line":2,"code":422,"message":"Identifier is missing."}
+{"line":3,"code":422,"message":"Identifier is missing."}
+{"line":4,"code":422,"message":"Identifier is missing."}
+{"line":5,"code":422,"message":"Identifier is missing."}
+JSON;
+
+        $response = $this->executeStreamRequest('PATCH', 'api/rest/v1/products', [], [], [], $data);
+        $httpResponse = $response['http_response'];
+
+        $this->assertSame(Response::HTTP_OK, $httpResponse->getStatusCode());
+        $this->assertSame($expectedContent, $response['content']);
+    }
+
+    public function testUpdateWhenUpdaterFailed()
+    {
+        $data =
+<<<JSON
+    {"identifier": "foo", "variant_group":"bar"}
+JSON;
+
+
+        $version = substr(Version::VERSION, 0, 3);
+        $expectedContent =
+<<<JSON
+{"line":1,"identifier":"foo","code":422,"message":"Property \"variant_group\" expects a valid variant group code. The variant group does not exist, \"bar\" given. Check the standard format documentation.","_links":{"documentation":{"href":"https:\/\/docs.akeneo.com\/${version}\/reference\/standard_format\/products.html"}}}
+JSON;
+
+
+        $response = $this->executeStreamRequest('PATCH', 'api/rest/v1/products', [], [], [], $data);
+        $httpResponse = $response['http_response'];
+
+        $this->assertSame(Response::HTTP_OK, $httpResponse->getStatusCode());
+        $this->assertSame($expectedContent, $response['content']);
+    }
+
+    public function testUpdateWhenValidationFailed()
+    {
+        $data =
+<<<JSON
+    {"identifier": "foo,"}
+JSON;
+
+        $expectedContent =
+<<<JSON
+{"line":1,"identifier":"foo,","code":422,"message":"Validation failed.","errors":[{"field":"identifier","message":"This field should not contain any comma or semicolon."}]}
+JSON;
+
+
+        $response = $this->executeStreamRequest('PATCH', 'api/rest/v1/products', [], [], [], $data);
+        $httpResponse = $response['http_response'];
+
+        $this->assertSame(Response::HTTP_OK, $httpResponse->getStatusCode());
+        $this->assertSame($expectedContent, $response['content']);
+    }
+
+    public function testPartialUpdateListWithBadContentType()
+    {
+        $data =
+<<<JSON
+    {"identifier": "my_identifier"}
+JSON;
+
+        $expectedContent =
+<<<JSON
+    {
+        "code": 415,
+        "message": "\"application\/json\" in \"Content-Type\" header is not valid. Only \"application\/vnd.akeneopim+json\" is allowed."
+    }
+JSON;
+
+        $client = $this->createAuthenticatedClient();
+        $client->setServerParameter('CONTENT_TYPE', 'application/json');
+        $client->request('PATCH', 'api/rest/v1/products', [], [], [], $data);
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_UNSUPPORTED_MEDIA_TYPE, $response->getStatusCode());
+        $this->assertJsonStringEqualsJsonString($expectedContent, $response->getContent());
+    }
+
+    protected function getBufferSize()
+    {
+        return $this->getParameter('api_input_buffer_size');
+    }
+
+    protected function getMaxNumberResources()
+    {
+        return $this->getParameter('api_input_max_resources_number');
+    }
+
+    /**
+     * Execute a request where the response is streamed by chunk.
+     *
+     * The whole content of the request and the whole content of the response
+     * are loaded in memory.
+     * Therefore, do not use this function on with an high input/output volumetry.
+     *
+     * @param string $method
+     * @param string $uri
+     * @param array  $parameters
+     * @param array  $files
+     * @param array  $server
+     * @param string $content
+     * @param bool   $changeHistory
+     *
+     * @return array
+     */
+    protected function executeStreamRequest(
+        $method,
+        $uri,
+        array $parameters = [],
+        array $files = [],
+        array $server = [],
+        $content = null,
+        $changeHistory = true
+    ) {
+        $streamedContent = '';
+
+        ob_start(function($buffer) use (&$streamedContent) {
+            $streamedContent .= $buffer;
+
+            return '';
+        });
+
+        $client = $this->createAuthenticatedClient();
+        $client->setServerParameter('CONTENT_TYPE', StreamResourceResponse::CONTENT_TYPE);
+        $client->request($method, $uri, $parameters, $files, $server, $content, $changeHistory);
+
+        ob_end_flush();
+
+        $response = [
+            'http_response' => $client->getResponse(),
+            'content'       => $streamedContent,
+        ];
+
+        return $response;
+    }
+
+    /**
+     * @param array  $expectedProduct normalized data of the product that should be created
+     * @param string $identifier      identifier of the product that should be created
+     */
+    protected function assertSameProducts(array $expectedProduct, $identifier)
+    {
+        $product = $this->get('pim_catalog.repository.product')->findOneByIdentifier($identifier);
+        $normalizer = $this->get('pim_catalog.normalizer.standard.product');
+        $standardizedProduct = $normalizer->normalize($product);
+
+        $standardizedProduct = static::sanitizeDateFields($standardizedProduct);
+        $expectedProduct = static::sanitizeDateFields($expectedProduct);
+
+        $standardizedProduct = static::sanitizeMediaAttributeData($standardizedProduct);
+        $expectedProduct = static::sanitizeMediaAttributeData($expectedProduct);
+
+        $this->assertSame($expectedProduct, $standardizedProduct);
+    }
+
+    /**
+     * @return Configuration
+     */
+    protected function getConfiguration()
+    {
+        return new Configuration(
+            [Configuration::getTechnicalCatalogPath()],
+            true
+        );
+    }
+}

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateListProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateListProductIntegration.php
@@ -280,7 +280,7 @@ JSON;
 <<<JSON
     {
         "code": 415,
-        "message": "\"application\/json\" in \"Content-Type\" header is not valid. Only \"application\/vnd.akeneopim+json\" is allowed."
+        "message": "\"application\/json\" in \"Content-Type\" header is not valid. Only \"application\/vnd.akeneo.collection+json\" is allowed."
     }
 JSON;
 

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateProductIntegration.php
@@ -686,7 +686,7 @@ JSON;
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
             'associations'  => [
-                'PACK'   => ['groups'   => ['groupA'], 'products' => ['product_categories', 'product_family']],
+                'PACK'   => ['groups'   => ['groupA'], 'products' => ['product_family', 'product_categories']],
                 'X_SELL' => ['groups'   => ['groupA'], 'products' => ['product_categories']],
             ],
         ];

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateProductIntegration.php
@@ -686,7 +686,7 @@ JSON;
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
             'associations'  => [
-                'PACK'   => ['groups'   => ['groupA'], 'products' => ['product_family', 'product_categories']],
+                'PACK'   => ['groups'   => ['groupA'], 'products' => ['product_categories', 'product_family']],
                 'X_SELL' => ['groups'   => ['groupA'], 'products' => ['product_categories']],
             ],
         ];

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/RootEndpointIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/RootEndpointIntegration.php
@@ -116,6 +116,10 @@ class RootEndpointIntegration extends ApiTestCase
                 "route": "/api/rest/v1/products/{code}",
                 "methods": ["PATCH"]
             },
+            "pim_api_product_partial_update_list": {
+                "route": "/api/rest/v1/products",
+                "methods": ["PATCH"]
+            },
             "pim_api_locale_list": {
                 "route": "/api/rest/v1/locales",
                 "methods": ["GET"]

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/RootEndpointIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/RootEndpointIntegration.php
@@ -40,6 +40,10 @@ class RootEndpointIntegration extends ApiTestCase
                 "route": "/api/rest/v1/categories/{code}",
                 "methods": ["PATCH"]
             },
+            "pim_api_category_partial_update_list": {
+                "route": "/api/rest/v1/categories",
+                "methods": ["PATCH"]
+            },
             "pim_api_family_list": {
                 "route": "/api/rest/v1/families",
                 "methods": ["GET"]
@@ -54,6 +58,10 @@ class RootEndpointIntegration extends ApiTestCase
             },
             "pim_api_family_partial_update": {
                 "route": "/api/rest/v1/families/{code}",
+                "methods": ["PATCH"]
+            },
+            "pim_api_family_partial_update_list": {
+                "route": "/api/rest/v1/families",
                 "methods": ["PATCH"]
             },
             "pim_api_attribute_list": {
@@ -71,6 +79,10 @@ class RootEndpointIntegration extends ApiTestCase
             "pim_api_attribute_get": {
                 "route": "/api/rest/v1/attributes/{code}",
                 "methods": ["GET"]
+            },
+            "pim_api_attribute_partial_update_list": {
+                "route": "/api/rest/v1/attributes",
+                "methods": ["PATCH"]
             },
             "pim_api_attribute_option_list": {
                 "route": "/api/rest/v1/attributes/{attributeCode}/options",

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/bundles/fos_rest.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/bundles/fos_rest.yml
@@ -13,7 +13,7 @@ fos_rest:
     format_listener:
         rules:
             - { path: '^/api/rest/v\d+/media-files', methods: ['POST'], priorities: ['form_data'], fallback_format: json, prefer_extension: true }
-            - { path: '^/api/rest/v\d+/products$', methods: ['PATCH'], priorities: ['akeneo_multi_json'], fallback_format: akeneo_multi_json, prefer_extension: true }
+            - { path: '^/api/rest/v\d+/products|families$', methods: ['PATCH'], priorities: ['akeneo_multi_json'], fallback_format: akeneo_multi_json, prefer_extension: true }
             - { path: '^/api', priorities: ['json'], fallback_format: json, prefer_extension: true }
             - { path: '', stop: true }
     body_listener:

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/bundles/fos_rest.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/bundles/fos_rest.yml
@@ -9,9 +9,11 @@ fos_rest:
             json: true
         mime_types:
             form_data: ['multipart/form-data']
+            akeneo_multi_json: ['application/vnd.akeneopim+json']
     format_listener:
         rules:
             - { path: '^/api/rest/v\d+/media-files', methods: ['POST'], priorities: ['form_data'], fallback_format: json, prefer_extension: true }
+            - { path: '^/api/rest/v\d+/products$', methods: ['PATCH'], priorities: ['akeneo_multi_json'], fallback_format: akeneo_multi_json, prefer_extension: true }
             - { path: '^/api', priorities: ['json'], fallback_format: json, prefer_extension: true }
             - { path: '', stop: true }
     body_listener:

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/bundles/fos_rest.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/bundles/fos_rest.yml
@@ -9,7 +9,7 @@ fos_rest:
             json: true
         mime_types:
             form_data: ['multipart/form-data']
-            akeneo_multi_json: ['application/vnd.akeneopim+json']
+            akeneo_multi_json: ['application/vnd.akeneo.collection+json']
     format_listener:
         rules:
             - { path: '^/api/rest/v\d+/media-files', methods: ['POST'], priorities: ['form_data'], fallback_format: json, prefer_extension: true }

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/bundles/fos_rest.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/bundles/fos_rest.yml
@@ -13,7 +13,7 @@ fos_rest:
     format_listener:
         rules:
             - { path: '^/api/rest/v\d+/media-files', methods: ['POST'], priorities: ['form_data'], fallback_format: json, prefer_extension: true }
-            - { path: '^/api/rest/v\d+/products|families$', methods: ['PATCH'], priorities: ['akeneo_multi_json'], fallback_format: akeneo_multi_json, prefer_extension: true }
+            - { path: '^/api/rest/v\d+/products|families|categories$', methods: ['PATCH'], priorities: ['akeneo_multi_json'], fallback_format: akeneo_multi_json, prefer_extension: true }
             - { path: '^/api', priorities: ['json'], fallback_format: json, prefer_extension: true }
             - { path: '', stop: true }
     body_listener:

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/bundles/fos_rest.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/bundles/fos_rest.yml
@@ -13,7 +13,7 @@ fos_rest:
     format_listener:
         rules:
             - { path: '^/api/rest/v\d+/media-files', methods: ['POST'], priorities: ['form_data'], fallback_format: json, prefer_extension: true }
-            - { path: '^/api/rest/v\d+/products|families|categories|attributes$', methods: ['PATCH'], priorities: ['akeneo_multi_json'], fallback_format: akeneo_multi_json, prefer_extension: true }
+            - { path: '^/api/rest/v\d+/(products|families|categories|attributes)$', methods: ['PATCH'], priorities: ['akeneo_multi_json'], fallback_format: akeneo_multi_json, prefer_extension: true }
             - { path: '^/api', priorities: ['json'], fallback_format: json, prefer_extension: true }
             - { path: '', stop: true }
     body_listener:

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/bundles/fos_rest.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/bundles/fos_rest.yml
@@ -13,7 +13,7 @@ fos_rest:
     format_listener:
         rules:
             - { path: '^/api/rest/v\d+/media-files', methods: ['POST'], priorities: ['form_data'], fallback_format: json, prefer_extension: true }
-            - { path: '^/api/rest/v\d+/products|families|categories$', methods: ['PATCH'], priorities: ['akeneo_multi_json'], fallback_format: akeneo_multi_json, prefer_extension: true }
+            - { path: '^/api/rest/v\d+/products|families|categories|attributes$', methods: ['PATCH'], priorities: ['akeneo_multi_json'], fallback_format: akeneo_multi_json, prefer_extension: true }
             - { path: '^/api', priorities: ['json'], fallback_format: json, prefer_extension: true }
             - { path: '', stop: true }
     body_listener:


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

In order to update a list of products in one request, a PATCH on a list of products has been added in this PR.

Each line of the body should represent a standardized product in JSON.
```
{"identifier":"id_1"}
{"identifier":"id_2"}
```

Then, each line is processed one by one and forwarded in the unitary PATCH.
The response of each subrequest is returned line by line (and streamed) : 
```
{"code" :201, "line": 1, "identifier": "id_1"}
{"code" :201, "line": 2, "identifier": "id_2"}
```

Initially, there was no limit on the number of products to import, because it is processing line by line, and so, the content is never fully loaded in memory.

However, it implies a lot of tests and customization of the stack Apache + Php (max_execution_time, max_input_time, maybe some timeout parameters in Apache, etc).

Therefore, for the time being, we have added a limitation on the maximum of products that can be processed in one request (100 by default).

The MIME type of the format (a JSON per line) is `application/vnd.akeneopim+json`, but it's not definitive.

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | Ok
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
