### PR TITLE
PIM-5448: Add class on multiselect filter view presentation

### DIFF
--- a/src/Oro/Bundle/NavigationBundle/Entity/Builder/ItemFactory.php
+++ b/src/Oro/Bundle/NavigationBundle/Entity/Builder/ItemFactory.php
@@ -2,7 +2,6 @@
 
 namespace Oro\Bundle\NavigationBundle\Entity\Builder;
 
-
 class ItemFactory
 {
     /**

--- a/src/Oro/Bundle/SecurityBundle/Tests/Unit/Acl/Cache/FilesystemCacheTest.php
+++ b/src/Oro/Bundle/SecurityBundle/Tests/Unit/Acl/Cache/FilesystemCacheTest.php
@@ -2,7 +2,6 @@
 
 namespace Oro\Bundle\SecurityBundle\Tests\Unit\Acl\Cache;
 
-
 class FilesystemCacheTest extends \PHPUnit_Framework_TestCase
 {
     /**

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/QueryGenerator/AttributeDeletedQueryGenerator.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/QueryGenerator/AttributeDeletedQueryGenerator.php
@@ -2,7 +2,6 @@
 
 namespace Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\QueryGenerator;
 
-
 /**
  * Attribute deleted query generator
  *

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/multiselect-decorator.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/multiselect-decorator.js
@@ -89,6 +89,7 @@ function($, _, mediator) {
         setViewDesign: function(view) {
             view.$('.ui-multiselect').removeClass('ui-widget').removeClass('ui-state-default');
             view.$('.ui-multiselect span.ui-icon').remove();
+            view.$('span').addClass('filter-criteria-hint');
         },
 
         /**


### PR DESCRIPTION
All grid filter current value span have class 'filter-criteria-hint' , add this on multiselect filter

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Ok
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
