### PR TITLE
Fix ci

### DIFF
--- a/features/localization/product/validation/validate_price_attributes.feature
+++ b/features/localization/product/validation/validate_price_attributes.feature
@@ -74,7 +74,8 @@ Feature: Validate localized price attributes of a product
     And I change the "Taxe" to "qux EUR"
     And I save the product
     Then I should see validation tooltip "Cette valeur doit être un nombre."
-    And there should be 1 error in the "[other]" tab
+    Then I should see validation tooltip "Cette valeur doit être supérieure ou égale à 10."
+    And there should be 2 error in the "[other]" tab
 
   Scenario: Validate the decimal separator constraint of price attribute
     Given I change the "Taxe" to "50.50 EUR"

--- a/features/product/validation/validate_metric_attributes.feature
+++ b/features/product/validation/validate_metric_attributes.feature
@@ -77,4 +77,5 @@ Feature: Validate metric attributes of a product
     Given I change the Power to "bar Watt"
     And I save the product
     Then I should see validation tooltip "This value should be a valid number."
-    And there should be 1 error in the "Other" tab
+    Then I should see validation tooltip "This value should be -100 or less."
+    And there should be 2 error in the "Other" tab

--- a/features/product/validation/validate_price_attributes.feature
+++ b/features/product/validation/validate_price_attributes.feature
@@ -74,4 +74,5 @@ Feature: Validate price attributes of a product
     And I change the "Tax" to "qux EUR"
     And I save the product
     Then I should see validation tooltip "This value should be a valid number."
-    And there should be 1 error in the "Other" tab
+    Then I should see validation tooltip "This value should be 10 or more."
+    And there should be 2 error in the "Other" tab

--- a/src/Pim/Bundle/EnrichBundle/spec/Normalizer/FamilyNormalizerSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Normalizer/FamilyNormalizerSpec.php
@@ -101,6 +101,9 @@ class FamilyNormalizerSpec extends ObjectBehavior
         $collectionFilter->filterCollection([$name, $description, $price], 'pim.internal_api.attribute.view')
             ->willReturn([$name, $price]);
 
+        $attributeRepository->findBy(['code' =>['name', 'price']])->willReturn([$name, $price]);
+        $collectionFilter->filterCollection([$name, $price], 'pim.internal_api.attribute.view')
+            ->willReturn([$name, $price]);
 
         $translationNormalizer->normalize(Argument::cetera())->willReturn([]);
         $family->getCode()->willReturn('tshirts');

--- a/src/Pim/Bundle/UserBundle/spec/Doctrine/ORM/Repository/UserRepositorySpec.php
+++ b/src/Pim/Bundle/UserBundle/spec/Doctrine/ORM/Repository/UserRepositorySpec.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace spec\Pim\Bundle\UserBundle\Entity\Repository;
+namespace spec\Pim\Bundle\UserBundle\Doctrine\ORM\Repository;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver\Statement;

--- a/src/Pim/Component/Catalog/Validator/Constraints/RangeValidator.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/RangeValidator.php
@@ -59,7 +59,7 @@ class RangeValidator extends BaseRangeValidator
      */
     protected function validateData($value, Constraint $constraint)
     {
-        if (null === $value || !is_numeric($value)) {
+        if (null === $value) {
             return;
         }
 


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

- fix specs & behats
- remove `is_numeric`. That should not have committed, I pushed a wrong commit when I switched on my mongo instance... sorry guys, but CI yesterday made me do some shits...
 
[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
