### PR TITLE
Api 31 : add get list of attribute options in the API

### DIFF
--- a/src/Pim/Bundle/ApiBundle/Controller/AttributeController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/AttributeController.php
@@ -150,13 +150,16 @@ class AttributeController
         $offset = $queryParameters['limit'] * ($queryParameters['page'] - 1);
         $attributes = $this->repository->searchAfterOffset([], [], $queryParameters['limit'], $offset);
 
+        $parameters = [
+            'query_parameters'    => array_merge($request->query->all(), $queryParameters),
+            'list_route_name'     => 'pim_api_attribute_list',
+            'item_route_name'     => 'pim_api_attribute_get',
+        ];
+
         $paginatedAttributes = $this->paginator->paginate(
             $this->normalizer->normalize($attributes, 'external_api'),
-            array_merge($request->query->all(), $queryParameters),
-            $this->repository->count(),
-            'pim_api_attribute_list',
-            'pim_api_attribute_get',
-            'code'
+            $parameters,
+            $this->repository->count()
         );
 
         return new JsonResponse($paginatedAttributes);

--- a/src/Pim/Bundle/ApiBundle/Controller/AttributeOptionController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/AttributeOptionController.php
@@ -10,7 +10,10 @@ use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Oro\Bundle\SecurityBundle\Annotation\AclAncestor;
 use Pim\Bundle\CatalogBundle\Version;
 use Pim\Component\Api\Exception\DocumentedHttpException;
+use Pim\Component\Api\Exception\PaginationParametersException;
 use Pim\Component\Api\Exception\ViolationHttpException;
+use Pim\Component\Api\Pagination\HalPaginator;
+use Pim\Component\Api\Pagination\ParameterValidatorInterface;
 use Pim\Component\Api\Repository\ApiResourceRepositoryInterface;
 use Pim\Component\Api\Repository\AttributeRepositoryInterface;
 use Pim\Component\Catalog\Model\AttributeInterface;
@@ -19,6 +22,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 use Symfony\Component\Routing\RouterInterface;
@@ -56,6 +60,15 @@ class AttributeOptionController
     /** @var RouterInterface */
     protected $router;
 
+    /** @var HalPaginator */
+    protected $paginator;
+
+    /** @var ParameterValidatorInterface */
+    protected $parameterValidator;
+
+    /** @var array */
+    protected $apiConfiguration;
+
     /** @var array */
     protected $supportedAttributeTypes;
 
@@ -71,6 +84,9 @@ class AttributeOptionController
      * @param ValidatorInterface             $validator
      * @param SaverInterface                 $saver
      * @param RouterInterface                $router
+     * @param HalPaginator                   $paginator
+     * @param ParameterValidatorInterface    $parameterValidator
+     * @param array                          $apiConfiguration
      * @param array                          $supportedAttributeTypes
      * @param string                         $urlDocumentation
      */
@@ -83,6 +99,9 @@ class AttributeOptionController
         ValidatorInterface $validator,
         SaverInterface $saver,
         RouterInterface $router,
+        HalPaginator $paginator,
+        ParameterValidatorInterface $parameterValidator,
+        array $apiConfiguration,
         array $supportedAttributeTypes,
         $urlDocumentation
     ) {
@@ -94,6 +113,9 @@ class AttributeOptionController
         $this->validator = $validator;
         $this->saver = $saver;
         $this->router = $router;
+        $this->paginator = $paginator;
+        $this->parameterValidator = $parameterValidator;
+        $this->apiConfiguration = $apiConfiguration;
         $this->supportedAttributeTypes = $supportedAttributeTypes;
         $this->urlDocumentation = sprintf($urlDocumentation, substr(Version::VERSION, 0, 3));
     }
@@ -101,7 +123,7 @@ class AttributeOptionController
     /**
      * @param Request $request
      * @param string  $attributeCode
-     * @param string  $optionCode
+     * @param string  $code
      *
      * @throws NotFoundHttpException
      *
@@ -109,17 +131,17 @@ class AttributeOptionController
      *
      * @AclAncestor("pim_api_attribute_option_list")
      */
-    public function getAction(Request $request, $attributeCode, $optionCode)
+    public function getAction(Request $request, $attributeCode, $code)
     {
         $attribute = $this->getAttribute($attributeCode);
         $this->isAttributeSupportingOptions($attribute);
 
-        $attributeOption = $this->attributeOptionsRepository->findOneByIdentifier($attributeCode . '.' . $optionCode);
+        $attributeOption = $this->attributeOptionsRepository->findOneByIdentifier($attributeCode . '.' . $code);
         if (null === $attributeOption) {
             throw new NotFoundHttpException(
                 sprintf(
                     'Attribute option "%s" does not exist or is not an option of the attribute "%s".',
-                    $optionCode,
+                    $code,
                     $attributeCode
                 )
             );
@@ -128,6 +150,53 @@ class AttributeOptionController
         $attributeOptionApi = $this->normalizer->normalize($attributeOption, 'external_api');
 
         return new JsonResponse($attributeOptionApi);
+    }
+
+    /**
+     * @param Request $request
+     * @param string  $attributeCode
+     *
+     * @throws HttpException
+     *
+     * @return JsonResponse
+     *
+     * @AclAncestor("pim_api_attribute_option_list")
+     */
+    public function listAction(Request $request, $attributeCode)
+    {
+        $attribute = $this->getAttribute($attributeCode);
+        $this->isAttributeSupportingOptions($attribute);
+
+        $queryParameters = [
+            'page'  => $request->query->get('page', 1),
+            'limit' => $request->query->get('limit', $this->apiConfiguration['pagination']['limit_by_default'])
+        ];
+
+        try {
+            $this->parameterValidator->validate($queryParameters);
+        } catch (PaginationParametersException $e) {
+            throw new UnprocessableEntityHttpException($e->getMessage(), $e);
+        }
+
+        $criteria['attribute'] = $attribute->getId();
+
+        $offset = $queryParameters['limit'] * ($queryParameters['page'] - 1);
+        $attributeOptions = $this->attributeOptionsRepository->searchAfterOffset($criteria, [], $queryParameters['limit'], $offset);
+
+        $parameters = [
+            'query_parameters'    => array_merge($request->query->all(), $queryParameters),
+            'uri_parameters'      => ['attributeCode' => $attributeCode],
+            'list_route_name'     => 'pim_api_attribute_option_list',
+            'item_route_name'     => 'pim_api_attribute_option_get',
+        ];
+
+        $paginatedAttributeOptions = $this->paginator->paginate(
+            $this->normalizer->normalize($attributeOptions, 'external_api'),
+            $parameters,
+            $this->attributeOptionsRepository->count($criteria)
+        );
+
+        return new JsonResponse($paginatedAttributeOptions);
     }
 
     /**
@@ -178,7 +247,7 @@ class AttributeOptionController
      *
      * @throws NotFoundHttpException
      *
-     * @return mixed
+     * @return AttributeInterface
      */
     protected function getAttribute($attributeCode)
     {
@@ -197,7 +266,7 @@ class AttributeOptionController
      *
      * @throws NotFoundHttpException
      */
-    protected function isAttributeSupportingOptions($attribute)
+    protected function isAttributeSupportingOptions(AttributeInterface $attribute)
     {
         $attributeType = $attribute->getAttributeType();
         if (!in_array($attributeType, $this->supportedAttributeTypes)) {
@@ -274,7 +343,7 @@ class AttributeOptionController
             'pim_api_attribute_option_get',
             [
                 'attributeCode' => $attribute->getCode(),
-                'optionCode'    => $attributeOption->getCode(),
+                'code'    => $attributeOption->getCode(),
             ],
             true
         );

--- a/src/Pim/Bundle/ApiBundle/Controller/CategoryController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/CategoryController.php
@@ -152,13 +152,16 @@ class CategoryController
         $order = ['root' => 'ASC', 'left' => 'ASC'];
         $categories = $this->repository->searchAfterOffset([], $order, $queryParameters['limit'], $offset);
 
+        $parameters = [
+            'query_parameters'    => array_merge($request->query->all(), $queryParameters),
+            'list_route_name'     => 'pim_api_category_list',
+            'item_route_name'     => 'pim_api_category_get',
+        ];
+
         $paginatedCategories = $this->paginator->paginate(
             $this->normalizer->normalize($categories, 'external_api'),
-            array_merge($request->query->all(), $queryParameters),
-            $this->repository->count(),
-            'pim_api_category_list',
-            'pim_api_category_get',
-            'code'
+            $parameters,
+            $this->repository->count()
         );
 
         return new JsonResponse($paginatedCategories);

--- a/src/Pim/Bundle/ApiBundle/Controller/ChannelController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/ChannelController.php
@@ -102,13 +102,16 @@ class ChannelController
         $count = $this->repository->count();
         $channels = $this->repository->searchAfterOffset([], ['code' => 'ASC'], $queryParameters['limit'], $offset);
 
+        $parameters = [
+            'query_parameters' => array_merge($request->query->all(), $queryParameters),
+            'list_route_name'  => 'pim_api_channel_list',
+            'item_route_name'  => 'pim_api_channel_get',
+        ];
+
         $paginatedChannels = $this->paginator->paginate(
             $this->normalizer->normalize($channels, 'external_api'),
-            array_merge($request->query->all(), $queryParameters),
-            $count,
-            'pim_api_channel_list',
-            'pim_api_channel_get',
-            'code'
+            $parameters,
+            $count
         );
 
         return new JsonResponse($paginatedChannels);

--- a/src/Pim/Bundle/ApiBundle/Controller/FamilyController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/FamilyController.php
@@ -150,13 +150,16 @@ class FamilyController
         $offset = $queryParameters['limit'] * ($queryParameters['page'] - 1);
         $families = $this->repository->searchAfterOffset([], [], $queryParameters['limit'], $offset);
 
+        $parameters = [
+            'query_parameters'    => array_merge($request->query->all(), $queryParameters),
+            'list_route_name'     => 'pim_api_family_list',
+            'item_route_name'     => 'pim_api_family_get',
+        ];
+
         $paginatedFamilies = $this->paginator->paginate(
             $this->normalizer->normalize($families, 'external_api'),
-            array_merge($request->query->all(), $queryParameters),
-            $this->repository->count(),
-            'pim_api_family_list',
-            'pim_api_family_get',
-            'code'
+            $parameters,
+            $this->repository->count()
         );
 
         return new JsonResponse($paginatedFamilies);

--- a/src/Pim/Bundle/ApiBundle/Controller/LocaleController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/LocaleController.php
@@ -110,13 +110,16 @@ class LocaleController
             $offset
         );
 
+        $parameters = [
+            'query_parameters' => array_merge($request->query->all(), $queryParameters),
+            'list_route_name'  => 'pim_api_locale_list',
+            'item_route_name'  => 'pim_api_locale_get',
+        ];
+
         $paginatedLocales = $this->paginator->paginate(
             $this->normalizer->normalize($locales, 'external_api'),
-            array_merge($request->query->all(), $queryParameters),
-            $this->repository->count($criterias),
-            'pim_api_locale_list',
-            'pim_api_locale_get',
-            'code'
+            $parameters,
+            $this->repository->count($criterias)
         );
 
         return new JsonResponse($paginatedLocales);

--- a/src/Pim/Bundle/ApiBundle/Controller/ProductController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/ProductController.php
@@ -197,13 +197,17 @@ class ProductController
         $products = $this->productRepository->searchAfterOffset($pqb, $queryParameters['limit'], $offset);
         $count = $this->productRepository->count($pqb);
 
+        $parameters = [
+            'query_parameters'    => array_merge($request->query->all(), $queryParameters),
+            'list_route_name'     => 'pim_api_product_list',
+            'item_route_name'     => 'pim_api_product_get',
+            'item_identifier_key' => 'identifier',
+        ];
+
         $paginatedProducts = $this->paginator->paginate(
             $this->normalizer->normalize($products, 'external_api', $normalizerOptions),
-            array_merge($request->query->all(), $queryParameters),
-            $count,
-            'pim_api_product_list',
-            'pim_api_product_get',
-            'identifier'
+            $parameters,
+            $count
         );
 
         return new JsonResponse($paginatedProducts);

--- a/src/Pim/Bundle/ApiBundle/Doctrine/ORM/Repository/ApiResourceRepository.php
+++ b/src/Pim/Bundle/ApiBundle/Doctrine/ORM/Repository/ApiResourceRepository.php
@@ -80,7 +80,7 @@ class ApiResourceRepository extends EntityRepository implements ApiResourceRepos
             }
 
             return (int) $qb
-                ->select('COUNT(DISTINCT r.id)')
+                ->select('COUNT(r.id)')
                 ->getQuery()
                 ->getSingleScalarResult();
         } catch (UnexpectedResultException $e) {

--- a/src/Pim/Bundle/ApiBundle/Doctrine/ORM/Repository/AttributeRepository.php
+++ b/src/Pim/Bundle/ApiBundle/Doctrine/ORM/Repository/AttributeRepository.php
@@ -80,7 +80,7 @@ class AttributeRepository extends EntityRepository implements AttributeRepositor
             }
 
             return (int) $qb
-                ->select('COUNT(DISTINCT r.id)')
+                ->select('COUNT(r.id)')
                 ->getQuery()
                 ->getSingleScalarResult();
         } catch (UnexpectedResultException $e) {

--- a/src/Pim/Bundle/ApiBundle/Resources/config/controllers.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/controllers.yml
@@ -66,6 +66,9 @@ services:
             - '@validator'
             - '@pim_catalog.saver.attribute_option'
             - '@router'
+            - '@pim_api.pagination.paginator'
+            - '@pim_api.pagination.parameter_validator'
+            - '%pim_api.configuration%'
             - ['pim_catalog_simpleselect', 'pim_catalog_multiselect']
             - 'https://docs.akeneo.com/%s/reference/standard_format/other_entities.html#attribute-option'
 

--- a/src/Pim/Bundle/ApiBundle/Resources/config/routing/attribute.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/routing/attribute.yml
@@ -18,12 +18,17 @@ pim_api_attribute_get:
     defaults: { _controller: pim_api.controller.attribute:getAction, _format: json }
     methods: [GET]
 
+pim_api_attribute_option_list:
+    path: /attributes/{attributeCode}/options
+    defaults: { _controller: pim_api.controller.attribute_option:listAction, _format: json }
+    methods: [GET]
+
 pim_api_attribute_option_create:
     path: /attributes/{attributeCode}/options
     defaults: { _controller: pim_api.controller.attribute_option:createAction, _format: json }
     methods: [POST]
 
 pim_api_attribute_option_get:
-    path: /attributes/{attributeCode}/options/{optionCode}
+    path: /attributes/{attributeCode}/options/{code}
     defaults: { _controller: pim_api.controller.attribute_option:getAction, _format: json }
     methods: [GET]

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/AttributeOption/ListAttributeOptionIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Rest/AttributeOption/ListAttributeOptionIntegration.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Pim\Bundle\ApiBundle\tests\integration\Controller\Rest\AttributeOption;
+
+use Akeneo\Test\Integration\Configuration;
+use Pim\Bundle\ApiBundle\tests\integration\ApiTestCase;
+use Pim\Bundle\CatalogBundle\Version;
+use Symfony\Component\HttpFoundation\Response;
+
+class ListAttributeOptionIntegration extends ApiTestCase
+{
+    public function testListAttributeOptions()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $client->request('GET', 'api/rest/v1/attributes/a_simple_select/options');
+
+        $expected =
+<<<JSON
+    {
+        "_links": {
+            "self": {
+                "href": "http://localhost/api/rest/v1/attributes/a_simple_select/options?page=1&limit=10"
+            },
+            "last": {
+                "href": "http://localhost/api/rest/v1/attributes/a_simple_select/options?page=1&limit=10"
+            },
+            "first": {
+                "href": "http://localhost/api/rest/v1/attributes/a_simple_select/options?page=1&limit=10"
+            }
+        },
+        "current_page": 1,
+        "pages_count": 1,
+        "items_count": 2,
+        "_embedded": {
+            "items": [
+                {
+                    "_links": {
+                        "self": {
+                            "href": "http://localhost/api/rest/v1/attributes/a_simple_select/options/optionA"
+                        }
+                    },
+                    "code": "optionA",
+                    "attribute": "a_simple_select",
+                    "sort_order": 10,
+                    "labels": {"en_US": "Option A"}
+                },
+                {
+                    "_links": {
+                        "self": {
+                            "href": "http://localhost/api/rest/v1/attributes/a_simple_select/options/optionB"
+                        }
+                    },
+                    "code": "optionB",
+                    "attribute": "a_simple_select",
+                    "sort_order": 20,
+                    "labels": {"en_US": "Option B"}
+                }
+            ]
+        }
+    }
+JSON;
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertJsonStringEqualsJsonString($expected, $response->getContent());
+    }
+
+    public function testOutOfRangeListAttributeOptions()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $client->request('GET', 'api/rest/v1/attributes/a_simple_select/options?limit=10&page=2');
+
+        $expected =
+<<<JSON
+    {
+        "_links": {
+            "self": {
+                "href": "http://localhost/api/rest/v1/attributes/a_simple_select/options?limit=10&page=2"
+            },
+            "last": {
+                "href": "http://localhost/api/rest/v1/attributes/a_simple_select/options?limit=10&page=1"
+            },
+            "first": {
+                "href": "http://localhost/api/rest/v1/attributes/a_simple_select/options?limit=10&page=1"
+            }
+        },
+        "current_page": 2,
+        "pages_count": 1,
+        "items_count": 2,
+        "_embedded": {
+            "items": []
+        }
+    }
+JSON;
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertJsonStringEqualsJsonString($expected, $response->getContent());
+    }
+
+    public function testAttributeNotFound()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $client->request('GET', 'api/rest/v1/attributes/not_found/options');
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
+        $content = json_decode($response->getContent(), true);
+        $this->assertCount(2, $content, 'response contains 2 items');
+        $this->assertSame(Response::HTTP_NOT_FOUND, $content['code']);
+        $this->assertSame('Attribute "not_found" does not exist.', $content['message']);
+    }
+
+    public function testAttributeNotSupportingOptions()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $client->request('GET', 'api/rest/v1/attributes/sku/options');
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
+        $content = json_decode($response->getContent(), true);
+        $this->assertCount(2, $content, 'response contains 2 items');
+        $this->assertSame(Response::HTTP_NOT_FOUND, $content['code']);
+        $this->assertSame(
+            'Attribute "sku" does not support options. Only attributes of type "pim_catalog_simpleselect", "pim_catalog_multiselect" support options.',
+            $content['message']
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return new Configuration(
+            [Configuration::getTechnicalCatalogPath()],
+            false
+        );
+    }
+}

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/RootEndpointIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/RootEndpointIntegration.php
@@ -72,12 +72,16 @@ class RootEndpointIntegration extends ApiTestCase
                 "route": "/api/rest/v1/attributes/{code}",
                 "methods": ["GET"]
             },
+            "pim_api_attribute_option_list": {
+                "route": "/api/rest/v1/attributes/{attributeCode}/options",
+                "methods": ["GET"]
+            },
             "pim_api_attribute_option_create": {
                 "route": "/api/rest/v1/attributes/{attributeCode}/options",
                 "methods": ["POST"]
             },
             "pim_api_attribute_option_get": {
-                "route": "/api/rest/v1/attributes/{attributeCode}/options/{optionCode}",
+                "route": "/api/rest/v1/attributes/{attributeCode}/options/{code}",
                 "methods": ["GET"]
             },
             "pim_api_channel_list": {

--- a/src/Pim/Component/Api/Hal/HalResource.php
+++ b/src/Pim/Component/Api/Hal/HalResource.php
@@ -35,7 +35,7 @@ class HalResource
     public function __construct($url, array $links, array $embedded, array $data)
     {
         if (array_key_exists('_links', $data) || array_key_exists('_embedded', $data)) {
-            throw new ReservedPropertyKeyException('Resource data could not contain a reserved HAL property key.');
+            throw new ReservedPropertyKeyException('Resource data cannot contain a reserved HAL property key.');
         }
 
         $this->data = $data;

--- a/src/Pim/Component/Api/Pagination/HalPaginator.php
+++ b/src/Pim/Component/Api/Pagination/HalPaginator.php
@@ -2,8 +2,10 @@
 
 namespace Pim\Component\Api\Pagination;
 
+use Pim\Component\Api\Exception\PaginationParametersException;
 use Pim\Component\Api\Hal\HalResource;
 use Pim\Component\Api\Hal\Link;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RouterInterface;
 
@@ -19,47 +21,77 @@ class HalPaginator implements PaginatorInterface
     /** @var RouterInterface */
     protected $router;
 
+    /** @var OptionsResolver */
+    protected $resolver;
     /**
      * @param RouterInterface $router
      */
     public function __construct(RouterInterface $router)
     {
+        $this->resolver = new OptionsResolver();
+        $this->resolver->setDefaults([
+            'uri_parameters'      => [],
+            'item_identifier_key' => 'code',
+        ]);
+
+        $this->resolver->setRequired([
+            'query_parameters',
+            'list_route_name',
+            'item_route_name',
+        ]);
+
+        $this->resolver->setAllowedTypes('uri_parameters', 'array');
+        $this->resolver->setAllowedTypes('item_identifier_key', 'string');
+        $this->resolver->setAllowedTypes('query_parameters', 'array');
+        $this->resolver->setAllowedTypes('list_route_name', 'string');
+        $this->resolver->setAllowedTypes('item_route_name', 'string');
+
         $this->router = $router;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function paginate(array $items, array $parameters, $count, $listRouteName, $itemRouteName, $itemIdentifier)
+    public function paginate(array $items, array $parameters, $count)
     {
+        try {
+            $parameters = $this->resolver->resolve($parameters);
+        } catch (\InvalidArgumentException $e) {
+            throw new PaginationParametersException($e->getMessage(), $e->getCode(), $e);
+        }
+
         $data = [
-            'current_page' => (int) $parameters['page'],
-            'pages_count'  => $this->getLastPage($parameters['limit'], $count),
+            'current_page' => (int) $parameters['query_parameters']['page'],
+            'pages_count'  => $this->getLastPage($parameters['query_parameters']['limit'], $count),
             'items_count'  => $count,
         ];
 
         $embedded = [];
         foreach ($items as $item) {
-            $resourceItem = $this->createResource($itemRouteName, ['code' => $item[$itemIdentifier]], $item);
+            $itemIdentifier = $item[$parameters['item_identifier_key']];
+            $itemUriParameters = array_merge($parameters['uri_parameters'], ['code' => $itemIdentifier]);
+            $resourceItem = $this->createResource($parameters['item_route_name'], $itemUriParameters, $item);
             $embedded[] = $resourceItem;
         }
 
+        $uriParameters = array_merge($parameters['uri_parameters'], $parameters['query_parameters']);
+
         $links = [
-            $this->createFirstLink($listRouteName, $parameters),
-            $this->createLastLink($listRouteName, $parameters, $count),
+            $this->createFirstLink($parameters['list_route_name'], $uriParameters),
+            $this->createLastLink($parameters['list_route_name'], $uriParameters, $count),
         ];
 
-        $previousLink = $this->createPreviousLink($listRouteName, $parameters, $count);
+        $previousLink = $this->createPreviousLink($parameters['list_route_name'], $uriParameters, $count);
         if (null !== $previousLink) {
             $links[] = $previousLink;
         }
 
-        $nextLink = $this->createNextLink($listRouteName, $parameters, $count);
+        $nextLink = $this->createNextLink($parameters['list_route_name'], $uriParameters, $count);
         if (null !== $nextLink) {
             $links[] = $nextLink;
         }
 
-        $collection = $this->createResource($listRouteName, $parameters, $data, $links, ['items' => $embedded]);
+        $collection = $this->createResource($parameters['list_route_name'], $uriParameters, $data, $links, ['items' => $embedded]);
 
         return $collection->toArray();
     }

--- a/src/Pim/Component/Api/Pagination/PaginatorInterface.php
+++ b/src/Pim/Component/Api/Pagination/PaginatorInterface.php
@@ -2,6 +2,8 @@
 
 namespace Pim\Component\Api\Pagination;
 
+use Pim\Component\Api\Exception\PaginationParametersException;
+
 /**
  * Paginator interface.
  *
@@ -17,14 +19,13 @@ interface PaginatorInterface
      *
      * Items should be already normalized.
      *
-     * @param array  $items          normalized items of the collection to render
-     * @param array  $parameters     parameters of the pagination, such as request parameters
-     * @param int    $count          total number of items without pagination
-     * @param string $listRouteName  route name of the collection
-     * @param string $itemRouteName  route name of the items in the collection
-     * @param string $itemIdentifier identifier key of an item
+     * @param array $items      normalized items of the collection to render
+     * @param array $parameters parameters to generate the different urls, such as uri parameters and query parameters
+     * @param int   $count      total number of items without pagination
+     *
+     * @throws PaginationParametersException if a parameter is either invalid, undefined parameter or missing
      *
      * @return array
      */
-    public function paginate(array $items, array $parameters, $count, $listRouteName, $itemRouteName, $itemIdentifier);
+    public function paginate(array $items, array $parameters, $count);
 }

--- a/src/Pim/Component/Api/spec/Hal/HalResourceSpec.php
+++ b/src/Pim/Component/Api/spec/Hal/HalResourceSpec.php
@@ -134,7 +134,7 @@ class HalResourceSpec extends ObjectBehavior
     function it_throws_an_exception_when_data_use_a_reserved_hal_property()
     {
         $this
-            ->shouldThrow(new ReservedPropertyKeyException('Resource data could not contain a reserved HAL property key.'))
+            ->shouldThrow(new ReservedPropertyKeyException('Resource data cannot contain a reserved HAL property key.'))
             ->during('__construct', ['http://akeneo.com/self', [], ['items' => []], ['_links' => 'links']]);
     }
 }

--- a/src/Pim/Component/Api/spec/Pagination/HalPaginatorSpec.php
+++ b/src/Pim/Component/Api/spec/Pagination/HalPaginatorSpec.php
@@ -3,11 +3,9 @@
 namespace spec\Pim\Component\Api\Pagination;
 
 use PhpSpec\ObjectBehavior;
-use Pim\Component\Api\Pagination\ParameterValidatorInterface;
-use Prophecy\Argument;
+use Pim\Component\Api\Exception\PaginationParametersException;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RouterInterface;
-use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class HalPaginatorSpec extends ObjectBehavior
 {
@@ -31,66 +29,55 @@ class HalPaginatorSpec extends ObjectBehavior
     {
         // links
         $router
-            ->generate('category_list_route', ['page' => 3, 'limit'=> 100], UrlGeneratorInterface::ABSOLUTE_URL)
-            ->willReturn('http://akeneo.com/api/rest/v1/categories/?limit=100&page=3');
+            ->generate('attribute_option_list_route', ['attributeCode' => 'a_multi_select', 'page' => 3, 'limit'=> 100], UrlGeneratorInterface::ABSOLUTE_URL)
+            ->willReturn('http://akeneo.com/api/rest/v1/attributes/a_multi_select/options?limit=100&page=3');
 
         $router
-            ->generate('category_list_route', ['page' => 1, 'limit'=> 100], UrlGeneratorInterface::ABSOLUTE_URL)
-            ->willReturn('http://akeneo.com/api/rest/v1/categories/?limit=100&page=1');
+            ->generate('attribute_option_list_route', ['attributeCode' => 'a_multi_select', 'page' => 1, 'limit'=> 100], UrlGeneratorInterface::ABSOLUTE_URL)
+            ->willReturn('http://akeneo.com/api/rest/v1/attributes/a_multi_select/options?limit=100&page=1');
 
         $router
-            ->generate('category_list_route', ['page' => 10, 'limit'=> 100], UrlGeneratorInterface::ABSOLUTE_URL)
-            ->willReturn('http://akeneo.com/api/rest/v1/categories/?limit=100&page=10');
+            ->generate('attribute_option_list_route', ['attributeCode' => 'a_multi_select', 'page' => 10, 'limit'=> 100], UrlGeneratorInterface::ABSOLUTE_URL)
+            ->willReturn('http://akeneo.com/api/rest/v1/attributes/a_multi_select/options?limit=100&page=10');
 
         $router
-            ->generate('category_list_route', ['page' => 2, 'limit'=> 100], UrlGeneratorInterface::ABSOLUTE_URL)
-            ->willReturn('http://akeneo.com/api/rest/v1/categories/?limit=100&page=2');
+            ->generate('attribute_option_list_route', ['attributeCode' => 'a_multi_select', 'page' => 2, 'limit'=> 100], UrlGeneratorInterface::ABSOLUTE_URL)
+            ->willReturn('http://akeneo.com/api/rest/v1/attributes/a_multi_select/options?limit=100&page=2');
 
         $router
-            ->generate('category_list_route', ['page' => 4, 'limit'=> 100], UrlGeneratorInterface::ABSOLUTE_URL)
-            ->willReturn('http://akeneo.com/api/rest/v1/categories/?limit=100&page=4');
+            ->generate('attribute_option_list_route', ['attributeCode' => 'a_multi_select', 'page' => 4, 'limit'=> 100], UrlGeneratorInterface::ABSOLUTE_URL)
+            ->willReturn('http://akeneo.com/api/rest/v1/attributes/a_multi_select/options?limit=100&page=4');
 
         // embedded
         $router
-            ->generate('category_item_route', ['code' => 'master'], UrlGeneratorInterface::ABSOLUTE_URL)
-            ->willReturn('http://akeneo.com/api/rest/v1/categories/master');
+            ->generate('attribute_option_item_route', ['attributeCode' => 'a_multi_select', 'code' => 'optionA'], UrlGeneratorInterface::ABSOLUTE_URL)
+            ->willReturn('http://akeneo.com/api/rest/v1/attributes/a_multi_select/options/optionA');
 
         $router
-            ->generate('category_item_route', ['code' => 'sales'], UrlGeneratorInterface::ABSOLUTE_URL)
-            ->willReturn('http://akeneo.com/api/rest/v1/categories/sales');
-
-        $options = [
-            'page'  => 3,
-            'limit' => 100,
-        ];
+            ->generate('attribute_option_item_route', ['attributeCode' => 'a_multi_select', 'code' => 'optionB'], UrlGeneratorInterface::ABSOLUTE_URL)
+            ->willReturn('http://akeneo.com/api/rest/v1/attributes/a_multi_select/options/optionB');
 
         $standardItems = [
-            [
-                'code'   => 'master',
-                'parent' => null,
-            ],
-            [
-                'code'   => 'sales',
-                'parent' => 'master',
-            ],
+            ['code'   => 'optionA'],
+            ['code'   => 'optionB'],
         ];
 
         $expectedItems = [
             '_links'       => [
                 'self'     => [
-                    'href' => 'http://akeneo.com/api/rest/v1/categories/?limit=100&page=3',
+                    'href' => 'http://akeneo.com/api/rest/v1/attributes/a_multi_select/options?limit=100&page=3',
                 ],
                 'first'    => [
-                    'href' => 'http://akeneo.com/api/rest/v1/categories/?limit=100&page=1',
+                    'href' => 'http://akeneo.com/api/rest/v1/attributes/a_multi_select/options?limit=100&page=1',
                 ],
                 'last'     => [
-                    'href' => 'http://akeneo.com/api/rest/v1/categories/?limit=100&page=10',
+                    'href' => 'http://akeneo.com/api/rest/v1/attributes/a_multi_select/options?limit=100&page=10',
                 ],
                 'previous' => [
-                    'href' => 'http://akeneo.com/api/rest/v1/categories/?limit=100&page=2',
+                    'href' => 'http://akeneo.com/api/rest/v1/attributes/a_multi_select/options?limit=100&page=2',
                 ],
                 'next'     => [
-                    'href' => 'http://akeneo.com/api/rest/v1/categories/?limit=100&page=4',
+                    'href' => 'http://akeneo.com/api/rest/v1/attributes/a_multi_select/options?limit=100&page=4',
                 ],
             ],
             'current_page' => 3,
@@ -101,30 +88,33 @@ class HalPaginatorSpec extends ObjectBehavior
                     [
                         '_links' => [
                             'self' => [
-                                'href' => 'http://akeneo.com/api/rest/v1/categories/master',
+                                'href' => 'http://akeneo.com/api/rest/v1/attributes/a_multi_select/options/optionA',
                             ],
                         ],
-                        'code'   => 'master',
-                        'parent' => null,
+                        'code'   => 'optionA',
                     ],
                     [
                         '_links' => [
                             'self' => [
-                                'href' => 'http://akeneo.com/api/rest/v1/categories/sales',
+                                'href' => 'http://akeneo.com/api/rest/v1/attributes/a_multi_select/options/optionB',
                             ],
                         ],
-                        'code'   => 'sales',
-                        'parent' => 'master',
+                        'code'   => 'optionB',
                     ],
                 ],
             ],
         ];
 
-        $this
-            ->paginate($standardItems, $options, 990, 'category_list_route', 'category_item_route', 'code', [])
-            ->shouldReturn($expectedItems);
-    }
+        $parameters = [
+            'uri_parameters'      => ['attributeCode' => 'a_multi_select'],
+            'query_parameters'    => ['page' => 3, 'limit' => 100],
+            'list_route_name'     => 'attribute_option_list_route',
+            'item_route_name'     => 'attribute_option_item_route',
+            'item_identifier_key' => 'code',
+        ];
 
+        $this->paginate($standardItems, $parameters, 990)->shouldReturn($expectedItems);
+    }
 
     function it_paginates_without_previous_link_when_first_page($normalizer, $router)
     {
@@ -149,11 +139,6 @@ class HalPaginatorSpec extends ObjectBehavior
         $router
             ->generate('category_item_route', ['code' => 'sales'], UrlGeneratorInterface::ABSOLUTE_URL)
             ->willReturn('http://akeneo.com/api/rest/v1/categories/sales');
-
-        $options = [
-            'page'  => 1,
-            'limit' => 100,
-        ];
 
         $standardItems = [
             [
@@ -208,9 +193,13 @@ class HalPaginatorSpec extends ObjectBehavior
             ],
         ];
 
-        $this
-            ->paginate($standardItems, $options, 990, 'category_list_route', 'category_item_route', 'code', [])
-            ->shouldReturn($expectedItems);
+        $parameters = [
+            'query_parameters'    => ['page' => 1, 'limit' => 100],
+            'list_route_name'     => 'category_list_route',
+            'item_route_name'     => 'category_item_route',
+        ];
+
+        $this->paginate($standardItems, $parameters, 990)->shouldReturn($expectedItems);
     }
 
     function it_paginates_without_next_link_when_last_page($normalizer, $router)
@@ -236,11 +225,6 @@ class HalPaginatorSpec extends ObjectBehavior
         $router
             ->generate('category_item_route', ['code' => 'sales'], UrlGeneratorInterface::ABSOLUTE_URL)
             ->willReturn('http://akeneo.com/api/rest/v1/categories/sales');
-
-        $options = [
-            'page'  => 10,
-            'limit' => 100,
-        ];
 
         $standardItems = [
             [
@@ -295,9 +279,14 @@ class HalPaginatorSpec extends ObjectBehavior
             ],
         ];
 
-        $this
-            ->paginate($standardItems, $options, 990, 'category_list_route', 'category_item_route', 'code', [])
-            ->shouldReturn($expectedItems);
+
+        $parameters = [
+            'query_parameters'    => ['page' => 10, 'limit' => 100],
+            'list_route_name'     => 'category_list_route',
+            'item_route_name'     => 'category_item_route',
+        ];
+
+        $this->paginate($standardItems, $parameters, 990)->shouldReturn($expectedItems);
     }
 
     function it_paginates_without_previous_and_next_link_when_nonexistent_page($normalizer, $router)
@@ -314,11 +303,6 @@ class HalPaginatorSpec extends ObjectBehavior
         $router
             ->generate('category_list_route', ['page' => 10, 'limit'=> 100], UrlGeneratorInterface::ABSOLUTE_URL)
             ->willReturn('http://akeneo.com/api/rest/v1/categories/?limit=100&page=10');
-
-        $options = [
-            'page'  => 11,
-            'limit' => 100,
-        ];
 
         $expectedItems = [
             '_links'       => [
@@ -340,9 +324,13 @@ class HalPaginatorSpec extends ObjectBehavior
             ],
         ];
 
-        $this
-            ->paginate([], $options, 990, 'category_list_route', 'category_item_route', 'code', [])
-            ->shouldReturn($expectedItems);
+        $parameters = [
+            'query_parameters'    => ['page' => 11, 'limit' => 100],
+            'list_route_name'     => 'category_list_route',
+            'item_route_name'     => 'category_item_route',
+        ];
+
+        $this->paginate([], $parameters, 990)->shouldReturn($expectedItems);
     }
 
     function it_paginates_with_one_page_when_total_items_equals_zero($normalizer, $router)
@@ -351,11 +339,6 @@ class HalPaginatorSpec extends ObjectBehavior
         $router
             ->generate('category_list_route', ['page' => 1, 'limit'=> 100], UrlGeneratorInterface::ABSOLUTE_URL)
             ->willReturn('http://akeneo.com/api/rest/v1/categories/?limit=100&page=1');
-
-        $options = [
-            'page'  => 1,
-            'limit' => 100,
-        ];
 
         $expectedItems = [
             '_links'       => [
@@ -377,8 +360,23 @@ class HalPaginatorSpec extends ObjectBehavior
             ],
         ];
 
-        $this
-            ->paginate([], $options, 0, 'category_list_route', 'category_item_route', 'code', [])
-            ->shouldReturn($expectedItems);
+        $parameters = [
+            'query_parameters'    => ['page' => 1, 'limit' => 100],
+            'list_route_name'     => 'category_list_route',
+            'item_route_name'     => 'category_item_route',
+        ];
+
+        $this->paginate([], $parameters, 0)->shouldReturn($expectedItems);
     }
+
+    function it_throws_an_exception_when_unknown_parameter_given()
+    {
+        $this->shouldThrow(PaginationParametersException::class)->during('paginate', [[], ['foo' => 'bar'], 0]);
+    }
+
+    function it_throws_an_exception_when_a_parameter_is_missing()
+    {
+        $this->shouldThrow(PaginationParametersException::class)->during('paginate', [[], [], 0]);
+    }
+
 }


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | Ok
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
