### PR TITLE
Prevent the creation of session in the API and optimize session management in listeners

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/EventListener/TranslateFlashMessagesSubscriber.php
+++ b/src/Pim/Bundle/EnrichBundle/EventListener/TranslateFlashMessagesSubscriber.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Bundle\EnrichBundle\EventListener;
 
+use FOS\RestBundle\FOSRestBundle;
 use Pim\Bundle\EnrichBundle\Flash\Message;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\KernelEvent;
@@ -51,7 +52,9 @@ class TranslateFlashMessagesSubscriber implements EventSubscriberInterface
      */
     public function translate(KernelEvent $event)
     {
-        if (!$event->getRequest()->hasSession()) {
+        $request = $event->getRequest();
+
+        if ($request->attributes->has(FOSRestBundle::ZONE_ATTRIBUTE)) {
             return;
         }
 

--- a/src/Pim/Bundle/EnrichBundle/EventListener/UserContextListener.php
+++ b/src/Pim/Bundle/EnrichBundle/EventListener/UserContextListener.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Bundle\EnrichBundle\EventListener;
 
+use FOS\RestBundle\FOSRestBundle;
 use Pim\Bundle\CatalogBundle\Context\CatalogContext;
 use Pim\Bundle\UserBundle\Context\UserContext;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -76,7 +77,12 @@ class UserContextListener implements EventSubscriberInterface
      */
     public function onKernelRequest(GetResponseEvent $event)
     {
-        if (HttpKernel::MASTER_REQUEST !== $event->getRequestType() || null === $this->tokenStorage->getToken()) {
+        $request = $event->getRequest();
+
+        if (HttpKernel::MASTER_REQUEST !== $event->getRequestType()
+            || $request->attributes->has(FOSRestBundle::ZONE_ATTRIBUTE)
+            || null === $this->tokenStorage->getToken()
+        ) {
             return;
         }
 

--- a/src/Pim/Bundle/EnrichBundle/spec/EventListener/TranslateFlashMessagesSubscriberSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/EventListener/TranslateFlashMessagesSubscriberSpec.php
@@ -45,7 +45,7 @@ class TranslateFlashMessagesSubscriberSpec extends ObjectBehavior
     ) {
         $event->getRequest()->willReturn($request);
         $event->getRequestType()->willReturn(HttpKernelInterface::MASTER_REQUEST);
-        $request->hasSession()->willReturn(true);
+        $request->hasPreviousSession()->willReturn(true);
         $request->getSession()->willReturn($session);
         $session->getFlashBag()->willReturn($flashBag);
 

--- a/src/Pim/Bundle/UserBundle/Context/UserContext.php
+++ b/src/Pim/Bundle/UserBundle/Context/UserContext.php
@@ -319,7 +319,7 @@ class UserContext
     protected function getSessionLocale()
     {
         $request = $this->getCurrentRequest();
-        if (null !== $request) {
+        if (null !== $request && $request->hasPreviousSession()) {
             $localeCode = $request->getSession()->get('dataLocale');
             if (null !== $localeCode) {
                 $locale = $this->localeRepository->findOneByIdentifier($localeCode);

--- a/src/Pim/Bundle/UserBundle/EventListener/LocaleListener.php
+++ b/src/Pim/Bundle/UserBundle/EventListener/LocaleListener.php
@@ -22,5 +22,6 @@ class LocaleListener
 
         $event->getRequest()->getSession()->remove('dataLocale');
         $event->getRequest()->getSession()->set('_locale', $user->getUiLocale()->getCode());
+        $event->getRequest()->getSession()->save();
     }
 }

--- a/src/Pim/Bundle/UserBundle/EventSubscriber/LocaleSubscriber.php
+++ b/src/Pim/Bundle/UserBundle/EventSubscriber/LocaleSubscriber.php
@@ -3,6 +3,7 @@
 namespace Pim\Bundle\UserBundle\EventSubscriber;
 
 use Doctrine\ORM\EntityManager;
+use FOS\RestBundle\FOSRestBundle;
 use Pim\Bundle\UserBundle\Event\UserEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
@@ -62,6 +63,11 @@ class LocaleSubscriber implements EventSubscriberInterface
     public function onKernelRequest(GetResponseEvent $event)
     {
         $request = $event->getRequest();
+
+        if ($request->attributes->has(FOSRestBundle::ZONE_ATTRIBUTE)) {
+            return;
+        }
+
         $locale = $this->getLocale($request);
 
         if (null !== $locale) {

--- a/src/Pim/Bundle/UserBundle/spec/EventSubscriber/LocaleSubscriberSpec.php
+++ b/src/Pim/Bundle/UserBundle/spec/EventSubscriber/LocaleSubscriberSpec.php
@@ -3,12 +3,14 @@
 namespace spec\Pim\Bundle\UserBundle\EventSubscriber;
 
 use Doctrine\ORM\EntityManager;
+use FOS\RestBundle\FOSRestBundle;
 use Oro\Bundle\ConfigBundle\Entity\ConfigValue;
 use Oro\Bundle\ConfigBundle\Entity\Repository\ConfigValueRepository;
 use PhpSpec\ObjectBehavior;
 use Pim\Bundle\UserBundle\Entity\UserInterface;
 use Pim\Component\Catalog\Model\LocaleInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
+use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
@@ -30,11 +32,16 @@ class LocaleSubscriberSpec extends ObjectBehavior
     function it_sets_locale_on_kernel_request(
         GetResponseEvent $event,
         Request $request,
+        ParameterBag $attributes,
         SessionInterface $session
     ) {
+        $request->attributes = $attributes;
+        $attributes->has(FOSRestBundle::ZONE_ATTRIBUTE)->willReturn(false);
         $event->getRequest()->willReturn($request);
+        $request->hasPreviousSession()->willReturn(true);
         $request->getSession()->willReturn($session);
         $session->get('_locale')->willReturn('fr_FR');
+        $session->save()->shouldBeCalled();
         $request->setLocale('fr_FR')->shouldBeCalled();
 
         $this->onKernelRequest($event);


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

When you request the API, you always create a new session (GET, POST, PATCH).
Therefore, the table `pim_session` has a lot of lines for nothing.
Moreover, it's not logic because an API should be stateless and a cookie is returned in the response.

**Cause:**

It's due to the fact that there are some listeners opening a session.
These listeners are useless for the API, because the standard format is not dependent on the user or the locale. The standard format always returns the same data.

- The first commit prevents this behavior. It will not return anymore a cookie in the API response, and it will not create a session in the database for each request.

- The second commit is an optimization.
When you call `$request->getSession()`, it always creates a session in the database, and lock it.
Then, every concurrent request is waiting to get this lock, and it blocks the whole process.

Several `getSession`are done in controllers, and I think we should let it like this.
But put it in listeners means that you always lock a session, even if your request does not use session anymore later.

Then, we should close it after use in listeners. 
The price to re-open a session in some controllers is not very high compared to lock the session for each request (using a session or not).



[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | -
| Added integration tests           | Todo
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
