### PR TITLE
Api 106 : prevent to delete labels on entities of the API

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -245,6 +245,8 @@
 - Change the constructor of `Pim\Component\Catalog\Updater\ChannelUpdater` to add `Pim\Component\Catalog\Repositor\AttributeRepositoryInterface` and add `Akeneo\Bundle\MeasureBundle\Manager\MeasureManager`
 - Change the constructor of `Pim\Component\Catalog\Denormalizer\Standard\ProductValueDenormalizer` to add `Pim\Component\Catalog\Factory\ProductValueFactory`
 - Change the constructor of `Pim\Component\Catalog\Builder\ProductBuilder` to add `Pim\Component\Catalog\Factory\ProductValueFactory`
+- Change the constructor of `Pim\Component\Catalog\Updater\FamilyUpdater` to add `Akeneo\Component\Localization\TranslatableUpdater`
+- Change the constructor of `Pim\Component\Catalog\Updater\AttributeUpdater` to add `Akeneo\Component\Localization\TranslatableUpdater`
 - Change the constructor of `Pim\Bundle\FilterBundle\Filter\Product\InGroupFilter` to add `Pim\Bundle\CatalogBundle\Doctrine\Common\Filter\ObjectCodeResolver`
 - Change the constructor of `Pim\Component\Connector\Writer\File\Yaml\Writer` to add `Pim\Component\Connector\ArrayConverter\ArrayConverterInterface`
 - Change the constructor of `Pim\Bundle\VersioningBundle\Normalizer\Flat\AssociationTypeNormalizer` to add `Symfony\Component\Serializer\Normalizer\NormalizerInterface`

--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -245,8 +245,6 @@
 - Change the constructor of `Pim\Component\Catalog\Updater\ChannelUpdater` to add `Pim\Component\Catalog\Repositor\AttributeRepositoryInterface` and add `Akeneo\Bundle\MeasureBundle\Manager\MeasureManager`
 - Change the constructor of `Pim\Component\Catalog\Denormalizer\Standard\ProductValueDenormalizer` to add `Pim\Component\Catalog\Factory\ProductValueFactory`
 - Change the constructor of `Pim\Component\Catalog\Builder\ProductBuilder` to add `Pim\Component\Catalog\Factory\ProductValueFactory`
-- Change the constructor of `Pim\Component\Catalog\Updater\FamilyUpdater` to add `Akeneo\Component\Localization\TranslatableUpdater`
-- Change the constructor of `Pim\Component\Catalog\Updater\AttributeUpdater` to add `Akeneo\Component\Localization\TranslatableUpdater`
 - Change the constructor of `Pim\Bundle\FilterBundle\Filter\Product\InGroupFilter` to add `Pim\Bundle\CatalogBundle\Doctrine\Common\Filter\ObjectCodeResolver`
 - Change the constructor of `Pim\Component\Connector\Writer\File\Yaml\Writer` to add `Pim\Component\Connector\ArrayConverter\ArrayConverterInterface`
 - Change the constructor of `Pim\Bundle\VersioningBundle\Normalizer\Flat\AssociationTypeNormalizer` to add `Symfony\Component\Serializer\Normalizer\NormalizerInterface`

--- a/src/Akeneo/Component/Localization/TranslatableUpdater.php
+++ b/src/Akeneo/Component/Localization/TranslatableUpdater.php
@@ -22,9 +22,11 @@ class TranslatableUpdater
     public function update(TranslatableInterface $object, array $data)
     {
         foreach ($data as $localeCode => $label) {
-            $object->setLocale($localeCode);
-            $translation = $object->getTranslation();
-            $translation->setLabel($label);
+            if (null !== $label && '' !== $label) {
+                $object->setLocale($localeCode);
+                $translation = $object->getTranslation();
+                $translation->setLabel($label);
+            }
         }
     }
 }

--- a/src/Akeneo/Component/Localization/spec/TranslatableUpdaterSpec.php
+++ b/src/Akeneo/Component/Localization/spec/TranslatableUpdaterSpec.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace spec\Akeneo\Component\Localization;
+
+use Akeneo\Component\Localization\Model\TranslatableInterface;
+use Akeneo\Component\Localization\Model\TranslationInterface;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class TranslatableUpdaterSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Akeneo\Component\Localization\TranslatableUpdater');
+    }
+
+    function it_does_no_set_a_new_label_when_the_new_label_is_blank(
+        TranslatableInterface $object,
+        LabelTranslationInterface $translation
+    ) {
+        $object->setLocale(Argument::cetera())->shouldNotBeCalled();
+        $object->getTranslation()->shouldNotBeCalled();
+        $translation->setLabel(Argument::cetera())->shouldNotBeCalled();
+
+        $this->update($object, ['en_US' => '']);
+    }
+
+    function it_does_no_set_a_new_label_when_the_new_label_is_null(
+        TranslatableInterface $object,
+        LabelTranslationInterface $translation
+    ) {
+        $object->setLocale(Argument::cetera())->shouldNotBeCalled();
+        $object->getTranslation()->shouldNotBeCalled();
+        $translation->setLabel(Argument::cetera())->shouldNotBeCalled();
+
+        $this->update($object, ['en_US' => null]);
+    }
+
+    function it_set_a_new_label_when_the_new_label_is_not_empty(
+        TranslatableInterface $object,
+        LabelTranslationInterface $translation
+    ) {
+        $object->setLocale('en_US')->shouldBeCalled();
+        $object->getTranslation()->willReturn($translation);
+        $translation->setLabel('foo')->shouldBeCalled();
+
+        $this->update($object, ['en_US' => 'foo']);
+    }
+}
+
+interface LabelTranslationInterface extends TranslationInterface
+{
+    public function getLabel();
+
+    public function setLabel($label);
+}

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Attribute/CreateAttributeIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Attribute/CreateAttributeIntegration.php
@@ -160,6 +160,63 @@ JSON;
         $this->assertSame($attributeStandard, $normalizer->normalize($attribute));
     }
 
+    public function testAttributeCreationWithEmptyLabels()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data =
+<<<JSON
+    {
+        "code":"empty_label_attribute",
+        "type":"pim_catalog_text",
+        "group":"attributeGroupA",
+        "labels": {
+            "en_US": null,
+            "fr_FR": ""
+        }
+    }
+JSON;
+
+        $client->request('POST', 'api/rest/v1/attributes', [], [], [], $data);
+
+        $attribute = $this->get('pim_catalog.repository.attribute')->findOneByIdentifier('empty_label_attribute');
+
+        $attributeStandard = [
+            'code'                   => 'empty_label_attribute',
+            'type'                   => 'pim_catalog_text',
+            'group'                  => 'attributeGroupA',
+            'unique'                 => false,
+            'useable_as_grid_filter' => false,
+            'allowed_extensions'     => [],
+            'metric_family'          => null,
+            'default_metric_unit'    => null,
+            'reference_data_name'    => null,
+            'available_locales'      => [],
+            'max_characters'         => null,
+            'validation_rule'        => null,
+            'validation_regexp'      => null,
+            'wysiwyg_enabled'        => null,
+            'number_min'             => null,
+            'number_max'             => null,
+            'decimals_allowed'       => null,
+            'negative_allowed'       => null,
+            'date_min'               => null,
+            'date_max'               => null,
+            'max_file_size'          => null,
+            'minimum_input_length'   => null,
+            'sort_order'             => 0,
+            'localizable'            => false,
+            'scopable'               => false,
+            'labels'                 => [],
+        ];
+        $normalizer = $this->get('pim_catalog.normalizer.standard.attribute');
+
+        $response = $client->getResponse();
+
+        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+        $this->assertSame($attributeStandard, $normalizer->normalize($attribute));
+    }
+
     public function testResponseWhenContentIsEmpty()
     {
         $client = $this->createAuthenticatedClient();
@@ -548,28 +605,6 @@ JSON;
         "code":"unknown_locale",
         "type":"pim_catalog_text",
         "group":"attributeGroupA",
-        "unique":false,
-        "useable_as_grid_filter":false,
-        "allowed_extensions":[],
-        "metric_family":null,
-        "default_metric_unit":null,
-        "reference_data_name":null,
-        "available_locales":[],
-        "max_characters":null,
-        "validation_rule":null,
-        "validation_regexp":null,
-        "wysiwyg_enabled":null,
-        "number_min":null,
-        "number_max":null,
-        "decimals_allowed":null,
-        "negative_allowed":null,
-        "date_min":null,
-        "date_max":null,
-        "max_file_size":null,
-        "minimum_input_length":null,
-        "sort_order":12,
-        "localizable":false,
-        "scopable":false,
         "labels": {
             "":"label"
         }
@@ -604,28 +639,6 @@ JSON;
         "code":"unknown_locale",
         "type":"pim_catalog_text",
         "group":"attributeGroupA",
-        "unique":false,
-        "useable_as_grid_filter":false,
-        "allowed_extensions":[],
-        "metric_family":null,
-        "default_metric_unit":null,
-        "reference_data_name":null,
-        "available_locales":[],
-        "max_characters":null,
-        "validation_rule":null,
-        "validation_regexp":null,
-        "wysiwyg_enabled":null,
-        "number_min":null,
-        "number_max":null,
-        "decimals_allowed":null,
-        "negative_allowed":null,
-        "date_min":null,
-        "date_max":null,
-        "max_file_size":null,
-        "minimum_input_length":null,
-        "sort_order":12,
-        "localizable":false,
-        "scopable":false,
         "labels": {
             "foo": "label"
         }
@@ -657,7 +670,7 @@ JSON;
     {
         return new Configuration(
             [Configuration::getTechnicalCatalogPath()],
-            false
+            true
         );
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Attribute/PartialUpdateAttributeIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Attribute/PartialUpdateAttributeIntegration.php
@@ -6,7 +6,7 @@ use Akeneo\Test\Integration\Configuration;
 use Pim\Bundle\ApiBundle\tests\integration\ApiTestCase;
 use Symfony\Component\HttpFoundation\Response;
 
-class PartialUpdateAttributeIntergration extends ApiTestCase
+class PartialUpdateAttributeIntegration extends ApiTestCase
 {
     public function testHttpHeadersInResponseWhenAnAttributeIsUpdated()
     {
@@ -80,15 +80,15 @@ JSON;
             'max_characters'         => null,
             'validation_rule'        => null,
             'validation_regexp'      => null,
-            'wysiwyg_enabled'        => false,
+            'wysiwyg_enabled'        => null,
             'number_min'             => null,
             'number_max'             => null,
-            'decimals_allowed'       => false,
-            'negative_allowed'       => false,
+            'decimals_allowed'       => null,
+            'negative_allowed'       => null,
             'date_min'               => null,
             'date_max'               => null,
             'max_file_size'          => null,
-            'minimum_input_length'   => 0,
+            'minimum_input_length'   => null,
             'sort_order'             => 0,
             'localizable'            => false,
             'scopable'               => false,
@@ -112,7 +112,7 @@ JSON;
             'message' => 'Validation failed.',
             'errors'  => [
                 [
-                    'property' => 'attributeType',
+                    'property' => 'type',
                     'message'  => 'This value should not be blank.',
                 ],
                 [
@@ -158,15 +158,15 @@ JSON;
             'max_characters'         => null,
             'validation_rule'        => null,
             'validation_regexp'      => null,
-            'wysiwyg_enabled'        => false,
+            'wysiwyg_enabled'        => null,
             'number_min'             => null,
             'number_max'             => null,
-            'decimals_allowed'       => false,
-            'negative_allowed'       => false,
+            'decimals_allowed'       => null,
+            'negative_allowed'       => null,
             'date_min'               => null,
             'date_max'               => null,
             'max_file_size'          => null,
-            'minimum_input_length'   => 0,
+            'minimum_input_length'   => null,
             'sort_order'             => 0,
             'localizable'            => false,
             'scopable'               => false,
@@ -207,15 +207,15 @@ JSON;
             'max_characters'         => null,
             'validation_rule'        => null,
             'validation_regexp'      => null,
-            'wysiwyg_enabled'        => false,
+            'wysiwyg_enabled'        => null,
             'number_min'             => null,
             'number_max'             => null,
-            'decimals_allowed'       => false,
-            'negative_allowed'       => false,
+            'decimals_allowed'       => null,
+            'negative_allowed'       => null,
             'date_min'               => null,
             'date_max'               => null,
             'max_file_size'          => null,
-            'minimum_input_length'   => 0,
+            'minimum_input_length'   => null,
             'sort_order'             => 0,
             'localizable'            => false,
             'scopable'               => false,
@@ -234,32 +234,32 @@ JSON;
 
         $data = '{}';
 
-        $client->request('PATCH', 'api/rest/v1/attributes/an_incomplete_text', [], [], [], $data);
+        $client->request('PATCH', 'api/rest/v1/attributes/a_metric', [], [], [], $data);
 
-        $attribute = $this->get('pim_catalog.repository.attribute')->findOneByIdentifier('an_incomplete_text');
+        $attribute = $this->get('pim_catalog.repository.attribute')->findOneByIdentifier('a_metric');
         $attributeStandard = [
-            'code'                   => 'an_incomplete_text',
-            'type'                   => 'pim_catalog_text',
-            'group'                  => 'attributeGroupA',
+            'code'                   => 'a_metric',
+            'type'                   => 'pim_catalog_metric',
+            'group'                  => 'attributeGroupB',
             'unique'                 => false,
             'useable_as_grid_filter' => false,
             'allowed_extensions'     => [],
-            'metric_family'          => null,
-            'default_metric_unit'    => null,
+            'metric_family'          => 'Power',
+            'default_metric_unit'    => 'KILOWATT',
             'reference_data_name'    => null,
             'available_locales'      => [],
             'max_characters'         => null,
             'validation_rule'        => null,
             'validation_regexp'      => null,
-            'wysiwyg_enabled'        => false,
+            'wysiwyg_enabled'        => null,
             'number_min'             => null,
             'number_max'             => null,
-            'decimals_allowed'       => false,
+            'decimals_allowed'       => true,
             'negative_allowed'       => false,
             'date_min'               => null,
             'date_max'               => null,
             'max_file_size'          => null,
-            'minimum_input_length'   => 0,
+            'minimum_input_length'   => null,
             'sort_order'             => 0,
             'localizable'            => false,
             'scopable'               => false,
@@ -279,41 +279,39 @@ JSON;
         $data =
 <<<JSON
     {
-        "code":"an_incomplete_text",
-        "type":"pim_catalog_text",
+        "code":"a_metric",
+        "type":"pim_catalog_metric",
         "group":"attributeGroupA",
-        "max_characters": 100,
-        "metric_family": null,
-        "default_metric_unit": null
+        "default_metric_unit":"WATT" 
     }
 JSON;
 
-        $client->request('PATCH', 'api/rest/v1/attributes/an_incomplete_text', [], [], [], $data);
+        $client->request('PATCH', 'api/rest/v1/attributes/a_metric', [], [], [], $data);
 
-        $attribute = $this->get('pim_catalog.repository.attribute')->findOneByIdentifier('an_incomplete_text');
+        $attribute = $this->get('pim_catalog.repository.attribute')->findOneByIdentifier('a_metric');
         $attributeStandard = [
-            'code'                   => 'an_incomplete_text',
-            'type'                   => 'pim_catalog_text',
+            'code'                   => 'a_metric',
+            'type'                   => 'pim_catalog_metric',
             'group'                  => 'attributeGroupA',
             'unique'                 => false,
             'useable_as_grid_filter' => false,
             'allowed_extensions'     => [],
-            'metric_family'          => null,
-            'default_metric_unit'    => null,
+            'metric_family'          => 'Power',
+            'default_metric_unit'    => 'WATT',
             'reference_data_name'    => null,
             'available_locales'      => [],
-            'max_characters'         => 100,
+            'max_characters'         => null,
             'validation_rule'        => null,
             'validation_regexp'      => null,
-            'wysiwyg_enabled'        => false,
+            'wysiwyg_enabled'        => null,
             'number_min'             => null,
             'number_max'             => null,
-            'decimals_allowed'       => false,
+            'decimals_allowed'       => true,
             'negative_allowed'       => false,
             'date_min'               => null,
             'date_max'               => null,
             'max_file_size'          => null,
-            'minimum_input_length'   => 0,
+            'minimum_input_length'   => null,
             'sort_order'             => 0,
             'localizable'            => false,
             'scopable'               => false,
@@ -333,38 +331,38 @@ JSON;
         $data =
 <<<JSON
     {
-        "type":"pim_catalog_text",
+        "type":"pim_catalog_metric",
         "group":"attributeGroupA",
-        "max_characters": 150
+        "default_metric_unit":"WATT" 
     }
 JSON;
 
-        $client->request('PATCH', 'api/rest/v1/attributes/an_incomplete_text', [], [], [], $data);
+        $client->request('PATCH', 'api/rest/v1/attributes/a_metric', [], [], [], $data);
 
-        $attribute = $this->get('pim_catalog.repository.attribute')->findOneByIdentifier('an_incomplete_text');
+        $attribute = $this->get('pim_catalog.repository.attribute')->findOneByIdentifier('a_metric');
         $attributeStandard = [
-            'code'                   => 'an_incomplete_text',
-            'type'                   => 'pim_catalog_text',
+            'code'                   => 'a_metric',
+            'type'                   => 'pim_catalog_metric',
             'group'                  => 'attributeGroupA',
             'unique'                 => false,
             'useable_as_grid_filter' => false,
             'allowed_extensions'     => [],
-            'metric_family'          => null,
-            'default_metric_unit'    => null,
+            'metric_family'          => 'Power',
+            'default_metric_unit'    => 'WATT',
             'reference_data_name'    => null,
             'available_locales'      => [],
-            'max_characters'         => 150,
+            'max_characters'         => null,
             'validation_rule'        => null,
             'validation_regexp'      => null,
-            'wysiwyg_enabled'        => false,
+            'wysiwyg_enabled'        => null,
             'number_min'             => null,
             'number_max'             => null,
-            'decimals_allowed'       => false,
+            'decimals_allowed'       => true,
             'negative_allowed'       => false,
             'date_min'               => null,
             'date_max'               => null,
             'max_file_size'          => null,
-            'minimum_input_length'   => 0,
+            'minimum_input_length'   => null,
             'sort_order'             => 0,
             'localizable'            => false,
             'scopable'               => false,
@@ -433,7 +431,7 @@ JSON;
             ],
         ];
 
-        $client->request('PATCH', 'api/rest/v1/attributes/an_incomplete_text', [], [], [], $data);
+        $client->request('PATCH', 'api/rest/v1/attributes/a_metric', [], [], [], $data);
 
         $response = $client->getResponse();
         $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
@@ -481,7 +479,7 @@ JSON;
 
         $expectedContent = [
             'code'    => 422,
-            'message' => 'Property "labels" expects an array. Check the standard format documentation.',
+            'message' => 'Property "labels" expects an array as data, "NULL" given. Check the standard format documentation.',
             '_links'  => [
                 'documentation' => [
                     'href' => 'http://api.akeneo.com/api-reference.html#patch_attributes__code_'
@@ -526,7 +524,7 @@ JSON;
     {
         return new Configuration(
             [Configuration::getTechnicalCatalogPath()],
-            false
+            true
         );
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AttributeOption/CreateAttributeOptionIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AttributeOption/CreateAttributeOptionIntegration.php
@@ -130,6 +130,43 @@ JSON;
         $this->assertSame($attributeOptionStandard, $normalizer->normalize($attributeOption));
     }
 
+    public function testAttributeOptionCreationWithEmptyLabels()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data =
+<<<JSON
+    {
+        "code":"empty_labels",
+        "attribute":"a_multi_select",
+        "sort_order":30,
+        "labels":{
+            "en_US": null,
+            "fr_FR": ""
+        }
+    }
+JSON;
+
+        $client->request('POST', 'api/rest/v1/attributes/a_multi_select/options', [], [], [], $data);
+
+        $attributeOption = $this->get('pim_catalog.repository.attribute_option')
+            ->findOneByIdentifier('a_multi_select.empty_labels');
+
+        $attributeOptionStandard = [
+            'code'       => 'empty_labels',
+            'attribute'  => 'a_multi_select',
+            'sort_order' => 30,
+            'labels'     => [],
+        ];
+        $normalizer = $this->get('pim_catalog.normalizer.standard.attribute_option');
+
+        $response = $client->getResponse();
+
+        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+        $this->assertSame($attributeOptionStandard, $normalizer->normalize($attributeOption));
+    }
+
+
     public function testResponseWhenContentIsInvalid()
     {
         $client = $this->createAuthenticatedClient();

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AttributeOption/PartialUpdateAttributeOptionIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AttributeOption/PartialUpdateAttributeOptionIntegration.php
@@ -299,6 +299,38 @@ JSON;
         $this->assertSame($attributeOptionStandard, $normalizer->normalize($attributeOption));
     }
 
+    public function testPartialUpdateWithEmptyLabels()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data =
+<<<JSON
+    {
+        "labels":{"en_US": null}
+    }
+JSON;
+
+        $client->request('PATCH', 'api/rest/v1/attributes/a_multi_select/options/optionA', [], [], [], $data);
+
+        $attributeOption = $this->get('pim_catalog.repository.attribute_option')
+            ->findOneByIdentifier('a_multi_select.optionA');
+
+        $attributeOptionStandard = [
+            'code'       => 'optionA',
+            'attribute'  => 'a_multi_select',
+            'sort_order' => 10,
+            'labels'     => [
+                'en_US' => 'Option A',
+            ],
+        ];
+        $normalizer = $this->get('pim_catalog.normalizer.standard.attribute_option');
+
+        $response = $client->getResponse();
+
+        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        $this->assertSame($attributeOptionStandard, $normalizer->normalize($attributeOption));
+    }
+
     public function testResponseWhenContentIsEmpty()
     {
         $client = $this->createAuthenticatedClient();

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Category/CreateCategoryIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Category/CreateCategoryIntegration.php
@@ -87,6 +87,39 @@ JSON;
         $this->assertSame($categoryStandard, $normalizer->normalize($category));
     }
 
+    public function testCategoryCreationWithEmptyLabels()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data =
+<<<JSON
+    {
+        "code": "empty_label_category",
+        "parent": "master",
+        "labels": {
+            "en_US": "US label",
+            "fr_FR": null,
+            "de_DE": "" 
+        }
+    }
+JSON;
+        $client->request('POST', 'api/rest/v1/categories', [], [], [], $data);
+
+        $category = $this->get('pim_catalog.repository.category')->findOneByIdentifier('empty_label_category');
+        $categoryStandard = [
+            'code'   => 'empty_label_category',
+            'parent' => 'master',
+            'labels' => [
+                'en_US' => 'US label'
+            ],
+        ];
+        $normalizer = $this->get('pim_catalog.normalizer.standard.category');
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+        $this->assertSame($categoryStandard, $normalizer->normalize($category));
+    }
+
     public function testResponseWhenContentIsEmpty()
     {
         $client = $this->createAuthenticatedClient();

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Category/PartialUpdateCategoryIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Category/PartialUpdateCategoryIntegration.php
@@ -248,6 +248,37 @@ JSON;
         $this->assertSame($categoryStandard, $normalizer->normalize($category));
     }
 
+    public function testPartialUpdateWithEmptyLabels()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data =
+<<<JSON
+    {
+        "labels": {
+            "en_US": null,
+            "fr_FR":"" 
+        }
+    }
+JSON;
+        $client->request('PATCH', 'api/rest/v1/categories/categoryA', [], [], [], $data);
+
+        $category = $this->get('pim_catalog.repository.category')->findOneByIdentifier('categoryA');
+        $categoryStandard = [
+            'code'   => 'categoryA',
+            'parent' => 'master',
+            'labels' => [
+                'en_US' => 'Category A',
+                'fr_FR' => 'Catégorie A',
+            ],
+        ];
+        $normalizer = $this->get('pim_catalog.normalizer.standard.category');
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        $this->assertSame($categoryStandard, $normalizer->normalize($category));
+    }
+
     public function testResponseWhenContentIsEmpty()
     {
         $client = $this->createAuthenticatedClient();
@@ -411,7 +442,7 @@ JSON;
     {
         return new Configuration(
             [Configuration::getTechnicalCatalogPath()],
-            false
+            true
         );
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Family/PartialUpdateFamilyIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Family/PartialUpdateFamilyIntegration.php
@@ -308,6 +308,41 @@ JSON;
         $this->assertSame($familyStandard, $normalizer->normalize($family));
     }
 
+    public function testPartialUpdateWithEmptyLabels()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data =
+<<<JSON
+    {
+        "labels": {
+            "en_US": null,
+            "fr_FR": ""
+        }
+    }
+JSON;
+
+        $client->request('PATCH', 'api/rest/v1/families/familyA2', [], [], [], $data);
+
+        $family = $this->get('pim_catalog.repository.family')->findOneByIdentifier('familyA2');
+        $familyStandard = [
+            'code'                   => 'familyA2',
+            'attributes'             => ['a_metric', 'a_number_float', 'sku'],
+            'attribute_as_label'     => 'sku',
+            'attribute_requirements' => [
+                'ecommerce'       => ['a_metric', 'sku'],
+                'ecommerce_china' => ['sku'],
+                'tablet'          => ['a_number_float', 'sku'],
+            ],
+            'labels'                 => [],
+        ];
+        $normalizer = $this->get('pim_catalog.normalizer.standard.family');
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        $this->assertSame($familyStandard, $normalizer->normalize($family));
+    }
+
     public function testResponseWhenContentIsEmpty()
     {
         $client = $this->createAuthenticatedClient();
@@ -437,7 +472,7 @@ JSON;
     {
         return new Configuration(
             [Configuration::getTechnicalCatalogPath()],
-            false
+            true
         );
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/updaters.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/updaters.yml
@@ -115,6 +115,7 @@ services:
             - '@pim_catalog.repository.attribute_group'
             - '@pim_catalog.repository.locale'
             - '@pim_catalog.registry.attribute_type'
+            - '@pim_localization.updater.translatable'
 
     pim_catalog.updater.category:
         class: '%akeneo_classification.updater.category.class%'
@@ -137,6 +138,7 @@ services:
             - '@pim_catalog.repository.channel'
             - '@pim_catalog.factory.attribute_requirement'
             - '@pim_catalog.repository.attribute_requirement'
+            - '@pim_localization.updater.translatable'
 
     pim_catalog.updater.channel:
         class: '%pim_catalog.updater.channel.class%'

--- a/src/Pim/Component/Catalog/Updater/AttributeOptionUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/AttributeOptionUpdater.php
@@ -129,9 +129,11 @@ class AttributeOptionUpdater implements ObjectUpdaterInterface
 
         if ('labels' === $field) {
             foreach ($data as $localeCode => $label) {
-                $attributeOption->setLocale($localeCode);
-                $translation = $attributeOption->getTranslation();
-                $translation->setLabel($label);
+                if (null !== $label && '' !== $label) {
+                    $attributeOption->setLocale($localeCode);
+                    $translation = $attributeOption->getTranslation();
+                    $translation->setLabel($label);
+                }
             }
         }
 

--- a/src/Pim/Component/Catalog/Updater/AttributeUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/AttributeUpdater.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Component\Catalog\Updater;
 
+use Akeneo\Component\Localization\TranslatableUpdater;
 use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
@@ -38,20 +39,26 @@ class AttributeUpdater implements ObjectUpdaterInterface
     /** @var PropertyAccessor */
     protected $accessor;
 
+    /** @var TranslatableUpdater */
+    protected $translatableUpdater;
+
     /**
      * @param AttributeGroupRepositoryInterface $attrGroupRepo
      * @param LocaleRepositoryInterface         $localeRepository
      * @param AttributeTypeRegistry             $registry
+     * @param TranslatableUpdater               $translatableUpdater
      */
     public function __construct(
         AttributeGroupRepositoryInterface $attrGroupRepo,
         LocaleRepositoryInterface $localeRepository,
-        AttributeTypeRegistry $registry
+        AttributeTypeRegistry $registry,
+        TranslatableUpdater $translatableUpdater
     ) {
         $this->attrGroupRepo = $attrGroupRepo;
         $this->localeRepository = $localeRepository;
         $this->registry = $registry;
         $this->accessor = PropertyAccess::createPropertyAccessor();
+        $this->translatableUpdater = $translatableUpdater;
     }
 
     /**
@@ -152,7 +159,7 @@ class AttributeUpdater implements ObjectUpdaterInterface
                 $this->setType($attribute, $data);
                 break;
             case 'labels':
-                $this->setLabels($attribute, $data);
+                $this->translatableUpdater->update($attribute, $data);
                 break;
             case 'group':
                 $this->setGroup($attribute, $data);
@@ -203,21 +210,6 @@ class AttributeUpdater implements ObjectUpdaterInterface
             $this->accessor->setValue($attribute, $field, $data);
         } catch (NoSuchPropertyException $e) {
             throw UnknownPropertyException::unknownProperty($field, $e);
-        }
-    }
-
-    /**
-     * @param AttributeInterface $attribute
-     * @param array              $data
-     */
-    protected function setLabels(AttributeInterface $attribute, array $data)
-    {
-        foreach ($data as $localeCode => $label) {
-            if (null !== $label && '' !== $label) {
-                $attribute->setLocale($localeCode);
-                $translation = $attribute->getTranslation();
-                $translation->setLabel($label);
-            }
         }
     }
 

--- a/src/Pim/Component/Catalog/Updater/FamilyUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/FamilyUpdater.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Component\Catalog\Updater;
 
+use Akeneo\Component\Localization\TranslatableUpdater;
 use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
@@ -49,19 +50,24 @@ class FamilyUpdater implements ObjectUpdaterInterface
     /** @var AttributeRequirementRepositoryInterface */
     protected $requirementRepo;
 
+    /** @var TranslatableUpdater */
+    protected $translatableUpdater;
+
     /**
      * @param IdentifiableObjectRepositoryInterface   $familyRepository
      * @param AttributeRepositoryInterface            $attributeRepository
      * @param ChannelRepositoryInterface              $channelRepository
      * @param AttributeRequirementFactory             $attrRequiFactory
      * @param AttributeRequirementRepositoryInterface $requirementRepo
+     * @param TranslatableUpdater                     $translatableUpdater
      */
     public function __construct(
         IdentifiableObjectRepositoryInterface $familyRepository,
         AttributeRepositoryInterface $attributeRepository,
         ChannelRepositoryInterface $channelRepository,
         AttributeRequirementFactory $attrRequiFactory,
-        AttributeRequirementRepositoryInterface $requirementRepo
+        AttributeRequirementRepositoryInterface $requirementRepo,
+        TranslatableUpdater $translatableUpdater
     ) {
         $this->accessor = PropertyAccess::createPropertyAccessor();
         $this->familyRepository = $familyRepository;
@@ -69,6 +75,7 @@ class FamilyUpdater implements ObjectUpdaterInterface
         $this->channelRepository = $channelRepository;
         $this->attrRequiFactory = $attrRequiFactory;
         $this->requirementRepo = $requirementRepo;
+        $this->translatableUpdater = $translatableUpdater;
     }
 
     /**
@@ -184,7 +191,7 @@ class FamilyUpdater implements ObjectUpdaterInterface
     {
         switch ($field) {
             case 'labels':
-                $this->setLabels($family, $data);
+                $this->translatableUpdater->update($family, $data);
                 break;
             case 'attribute_requirements':
                 $this->setAttributeRequirements($family, $data);
@@ -213,19 +220,6 @@ class FamilyUpdater implements ObjectUpdaterInterface
             $this->accessor->setValue($attribute, $field, $data);
         } catch (NoSuchPropertyException $e) {
             throw UnknownPropertyException::unknownProperty($field, $e);
-        }
-    }
-
-    /**
-     * @param FamilyInterface $family
-     * @param array           $data
-     */
-    protected function setLabels(FamilyInterface $family, array $data)
-    {
-        foreach ($data as $localeCode => $label) {
-            $family->setLocale($localeCode);
-            $translation = $family->getTranslation();
-            $translation->setLabel($label);
         }
     }
 

--- a/src/Pim/Component/Catalog/spec/Updater/AttributeOptionUpdaterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/AttributeOptionUpdaterSpec.php
@@ -72,6 +72,38 @@ class AttributeOptionUpdaterSpec extends ObjectBehavior
         );
     }
 
+    function it_does_not_update_empty_labels(
+        $attributeRepository,
+        AttributeOptionInterface $attributeOption,
+        AttributeInterface $attribute,
+        AttributeOptionValueInterface $attributeOptionValue
+    ) {
+        $attributeOption->getId()->willReturn(null);
+        $attributeOption->getAttribute()->willReturn(null);
+
+        $attributeOption->setCode('mycode')->shouldBeCalled();
+        $attributeRepository->findOneByIdentifier('myattribute')->willReturn($attribute);
+        $attributeOption->setAttribute($attribute)->shouldBeCalled();
+
+        $attributeOption->setLocale('de_DE')->shouldNotBeCalled();
+        $attributeOption->setLocale('fr_FR')->shouldNotBeCalled();
+        $attributeOption->getTranslation()->shouldNotBeCalled();
+        $attributeOptionValue->setLabel(null)->shouldNotBeCalled();
+        $attributeOptionValue->setLabel('')->shouldNotBeCalled();
+
+        $this->update(
+            $attributeOption,
+            [
+                'code' => 'mycode',
+                'attribute' => 'myattribute',
+                'labels' => [
+                    'de_DE' => null,
+                    'fr_FR' => '',
+                ]
+            ]
+        );
+    }
+
     function it_throws_an_exception_when_attribute_does_not_exist(
         $attributeRepository,
         AttributeOptionInterface $attributeOption

--- a/src/Pim/Component/Catalog/spec/Updater/AttributeUpdaterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/AttributeUpdaterSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Pim\Component\Catalog\Updater;
 
+use Akeneo\Component\Localization\TranslatableUpdater;
 use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
@@ -22,9 +23,10 @@ class AttributeUpdaterSpec extends ObjectBehavior
     function let(
         AttributeGroupRepositoryInterface $attrGroupRepo,
         LocaleRepositoryInterface $localeRepository,
-        AttributeTypeRegistry $registry
+        AttributeTypeRegistry $registry,
+        TranslatableUpdater $translatableUpdater
     ) {
-        $this->beConstructedWith($attrGroupRepo, $localeRepository, $registry);
+        $this->beConstructedWith($attrGroupRepo, $localeRepository, $registry, $translatableUpdater);
     }
 
     function it_is_initializable()
@@ -53,6 +55,7 @@ class AttributeUpdaterSpec extends ObjectBehavior
     function it_updates_a_new_attribute(
         $attrGroupRepo,
         $registry,
+        $translatableUpdater,
         AttributeInterface $attribute,
         AttributeTranslation $translation,
         AttributeGroupInterface $attributeGroup,
@@ -69,12 +72,7 @@ class AttributeUpdaterSpec extends ObjectBehavior
             'date_min' => '2016-12-12T00:00:00+01:00'
         ];
 
-        $attribute->setLocale('en_US')->shouldBeCalled();
-        $attribute->setLocale('fr_FR')->shouldBeCalled();
-        $attribute->getTranslation()->willReturn($translation);
-
-        $translation->setLabel('Test1')->shouldBeCalled();
-        $translation->setLabel('Test2')->shouldBeCalled();
+        $translatableUpdater->update($attribute, ['en_US' => 'Test1', 'fr_FR' => 'Test2']);
 
         $attrGroupRepo->findOneByIdentifier('marketing')->willReturn($attributeGroup);
         $attribute->setGroup($attributeGroup)->shouldBeCalled();
@@ -96,6 +94,7 @@ class AttributeUpdaterSpec extends ObjectBehavior
     function it_throws_an_exception_if_no_groups_found(
         $attrGroupRepo,
         $registry,
+        $translatableUpdater,
         AttributeInterface $attribute,
         AttributeTranslation $translation,
         AttributeTypeInterface $attributeType
@@ -109,12 +108,7 @@ class AttributeUpdaterSpec extends ObjectBehavior
             'type' => 'pim_catalog_text'
         ];
 
-        $attribute->setLocale('en_US')->shouldBeCalled();
-        $attribute->setLocale('fr_FR')->shouldBeCalled();
-        $attribute->getTranslation()->willReturn($translation);
-
-        $translation->setLabel('Test1')->shouldBeCalled();
-        $translation->setLabel('Test2')->shouldBeCalled();
+        $translatableUpdater->update($attribute, ['en_US' => 'Test1', 'fr_FR' => 'Test2']);
 
         $attrGroupRepo->findOneByIdentifier('marketing')->willReturn(null);
         $registry->get('pim_catalog_text')->willReturn($attributeType);

--- a/src/Pim/Component/Catalog/spec/Updater/FamilyUpdaterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/FamilyUpdaterSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Pim\Component\Catalog\Updater;
 
+use Akeneo\Component\Localization\TranslatableUpdater;
 use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
@@ -28,14 +29,16 @@ class FamilyUpdaterSpec extends ObjectBehavior
         AttributeRepositoryInterface $attributeRepository,
         ChannelRepositoryInterface $channelRepository,
         AttributeRequirementFactory $attrRequiFactory,
-        AttributeRequirementRepositoryInterface $attributeRequirementRepo
+        AttributeRequirementRepositoryInterface $attributeRequirementRepo,
+        TranslatableUpdater $translatableUpdater
     ) {
         $this->beConstructedWith(
             $familyRepository,
             $attributeRepository,
             $channelRepository,
             $attrRequiFactory,
-            $attributeRequirementRepo
+            $attributeRequirementRepo,
+            $translatableUpdater
         );
     }
 
@@ -66,6 +69,7 @@ class FamilyUpdaterSpec extends ObjectBehavior
         $attrRequiFactory,
         $channelRepository,
         $attributeRequirementRepo,
+        $translatableUpdater,
         FamilyTranslation $translation,
         FamilyInterface $family,
         AttributeRepositoryInterface $attributeRepository,
@@ -164,12 +168,8 @@ class FamilyUpdaterSpec extends ObjectBehavior
         $family->addAttribute($skuAttribute)->shouldBeCalled();
         $family->addAttribute($skuAttribute)->shouldBeCalled();
 
-        $family->setLocale('en_US')->shouldBeCalled();
-        $family->setLocale('fr_FR')->shouldBeCalled();
-        $family->getTranslation()->willReturn($translation);
 
-        $translation->setLabel('label en us');
-        $translation->setLabel('label fr fr');
+        $translatableUpdater->update($family, ['fr_FR' => 'Moniteurs', 'en_US' => 'PC Monitors'])->shouldBeCalled();
 
         $family->addAttribute($skuAttribute)->shouldBeCalled();
         $family->addAttribute($nameAttribute)->shouldBeCalled();


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

Validated by PO :
It should be not possible to delete a label on the entities of the API : 
- category
- attributes
- attribute options
- family

I fixed the `PartialUpdateAttributeIntegration` because there was a typo in the name (PartialUpdateAttributeIntergration) and it was never launched by the CI.

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | -
| Added integration tests           | Ok
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
