### PR TITLE
PIM-6151: disable the loading messages by default

### DIFF
--- a/features/Context/WebUser.php
+++ b/features/Context/WebUser.php
@@ -2516,7 +2516,8 @@ class WebUser extends RawMinkContext
      *
      * @return integer
      */
-    protected function getTabErrorsCount($tab) {
+    protected function getTabErrorsCount($tab)
+    {
         $badge = $tab->find('css', '.invalid-badge');
 
         return (null === $badge) ? 0 : intval($badge->getText());

--- a/features/Pim/Behat/Context/NavigationContext.php
+++ b/features/Pim/Behat/Context/NavigationContext.php
@@ -369,6 +369,22 @@ class NavigationContext extends PimContext implements PageObjectAwareInterface
     }
 
     /**
+     * @Then /^I should not see a nice loading message$/
+     */
+    public function iShouldNotSeeANiceLoadingMessage()
+    {
+        $messageNode = $this->spin(function () {
+            return $this->getSession()
+                ->getPage()
+                ->find('css', $this->elements['Loading message']['css']);
+        }, 'Unable to find any loading message');
+
+        $message = trim($messageNode->getHtml());
+
+        assertEquals('Loading ...', $message, 'The loading message should equals the default value');
+    }
+
+    /**
      * @param string  $pageName
      * @param array   $options
      * @param boolean $wait     should the script wait for the page to load

--- a/features/dashboard/loading_message.feature
+++ b/features/dashboard/loading_message.feature
@@ -1,10 +1,10 @@
 @javascript
-Feature: Display an happy message during loading screen
-  In order to feel better when I log in
+Feature: Does not display an happy message during loading screen
+  In order to see the default message when I log in
   As a regular user
-  I would like to see a nice message
+  I would not like to see a nice message by default
 
-  Scenario: Display loading message
+  Scenario: Does not display loading message by default
     Given a "default" catalog configuration
     When I am logged in as "Mary"
-    Then I should see a nice loading message
+    Then I should not see a nice loading message

--- a/src/Oro/Bundle/ConfigBundle/Controller/Rest/ConfigurationController.php
+++ b/src/Oro/Bundle/ConfigBundle/Controller/Rest/ConfigurationController.php
@@ -31,11 +31,16 @@ class ConfigurationController
 
     /**
      * @param ConfigManager $configManager
+     * @param FileLocator   $fileLocator
      * @param string        $loadingMessagesFile
      * @param array         $options
      */
-    public function __construct(ConfigManager $configManager, FileLocator $fileLocator, $loadingMessagesFile, array $options = [])
-    {
+    public function __construct(
+        ConfigManager $configManager,
+        FileLocator $fileLocator,
+        $loadingMessagesFile,
+        array $options = []
+    ) {
         $this->configManager = $configManager;
         $this->fileLocator = $fileLocator;
         $this->loadingMessagesFile = $loadingMessagesFile;

--- a/src/Pim/Bundle/UIBundle/DependencyInjection/Configuration.php
+++ b/src/Pim/Bundle/UIBundle/DependencyInjection/Configuration.php
@@ -29,7 +29,7 @@ class Configuration implements ConfigurationInterface
                     ->end()
                 ->end();
 
-        SettingsBuilder::append($rootNode, ['loading_message_enabled' => ['value' => true]]);
+        SettingsBuilder::append($rootNode, ['loading_message_enabled' => ['value' => false]]);
 
         return $treeBuilder;
     }


### PR DESCRIPTION
On a fresh new 1.7 install, go to System/Configuration and under menu Loading Messages, you’ll see that the yes/no is set on "No" but the Loading messages do appear.
The feature should be deactivated by default when the PIM is installed.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | No
| Added Behats                      | Yes
| Added integration tests           | No
| Changelog updated                 | No
| Review and 2 GTM                  | 1/2
