### PR TITLE
TIP-694: isolate integration test files

### DIFF
--- a/src/Pim/Bundle/ApiBundle/tests/integration/ApiTestCase.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/ApiTestCase.php
@@ -198,7 +198,7 @@ abstract class ApiTestCase extends WebTestCase
      */
     protected function getDatabasePurger()
     {
-        return new DatabasePurger(static::$kernel->getContainer());
+        return new DatabasePurger(static::$kernel);
     }
 
     /**
@@ -208,7 +208,7 @@ abstract class ApiTestCase extends WebTestCase
      */
     protected function getFixturesLoader(Configuration $configuration)
     {
-        return new FixturesLoader(static::$kernel->getContainer(), $configuration);
+        return new FixturesLoader(static::$kernel, $configuration);
     }
 
     /**

--- a/src/Pim/Bundle/ApiBundle/tests/integration/ApiTestCase.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/ApiTestCase.php
@@ -4,7 +4,7 @@ namespace Pim\Bundle\ApiBundle\tests\integration;
 
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\ConnectionCloser;
-use Akeneo\Test\Integration\DatabasePurger;
+use Akeneo\Test\Integration\DatabaseSchemaHandler;
 use Akeneo\Test\Integration\FixturesLoader;
 use Symfony\Bundle\FrameworkBundle\Client;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
@@ -60,8 +60,7 @@ abstract class ApiTestCase extends WebTestCase
         self::$count++;
 
         if ($configuration->isDatabasePurgedForEachTest() || 1 === self::$count) {
-            $databasePurger = $this->getDatabasePurger();
-            $databasePurger->purge();
+            $this->getDatabaseSchemaHandler()->reset();
 
             $fixturesLoader = $this->getFixturesLoader($configuration);
             $fixturesLoader->load();
@@ -194,11 +193,11 @@ abstract class ApiTestCase extends WebTestCase
     }
 
     /**
-     * @return DatabasePurger
+     * @return DatabaseSchemaHandler
      */
-    protected function getDatabasePurger()
+    protected function getDatabaseSchemaHandler()
     {
-        return new DatabasePurger(static::$kernel);
+        return new DatabaseSchemaHandler(static::$kernel);
     }
 
     /**

--- a/tests/DatabaseSchemaHandler.php
+++ b/tests/DatabaseSchemaHandler.php
@@ -30,12 +30,22 @@ class DatabaseSchemaHandler
         $this->cli->setAutoExit(false);
     }
 
+    /**
+     * Drop and recreate the database schema.
+     *
+     * @throws \RuntimeException
+     */
     public function reset()
     {
         $this->drop();
         $this->create();
     }
 
+    /**
+     * Drop the database schema.
+     *
+     * @throws \RuntimeException
+     */
     private function drop()
     {
         $input = new ArrayInput([
@@ -48,10 +58,15 @@ class DatabaseSchemaHandler
         $exitCode = $this->cli->run($input, $output);
 
         if (0 !== $exitCode) {
-            throw new \Exception(sprintf('Impossible to drop the database schema! "%s"', $output->fetch()));
+            throw new \RuntimeException(sprintf('Impossible to drop the database schema! "%s"', $output->fetch()));
         }
     }
 
+    /**
+     * Create the database schema.
+     *
+     * @throws \RuntimeException
+     */
     private function create()
     {
         $input = new ArrayInput([
@@ -63,7 +78,7 @@ class DatabaseSchemaHandler
         $exitCode = $this->cli->run($input, $output);
 
         if (0 !== $exitCode) {
-            throw new \Exception(sprintf('Impossible to create the database schema! "%s"', $output->fetch()));
+            throw new \RuntimeException(sprintf('Impossible to create the database schema! "%s"', $output->fetch()));
         }
     }
 }

--- a/tests/FixturesLoader.php
+++ b/tests/FixturesLoader.php
@@ -101,7 +101,7 @@ class FixturesLoader
      *
      * @param array $files
      *
-     * @throws \Exception
+     * @throws \RuntimeException
      */
     protected function loadImportFiles(array $files)
     {
@@ -139,7 +139,7 @@ class FixturesLoader
             $exitCode = $this->cli->run($input, $output);
 
             if (0 !== $exitCode) {
-                throw new \Exception(sprintf('Catalog not installable! "%s"', $output->fetch()));
+                throw new \RuntimeException(sprintf('Catalog not installable! "%s"', $output->fetch()));
             }
         }
 

--- a/tests/FixturesLoader.php
+++ b/tests/FixturesLoader.php
@@ -55,7 +55,6 @@ class FixturesLoader
      */
     public function load()
     {
-        $this->createSchema();
         $files = $this->getFilesToLoad($this->configuration->getCatalogDirectories());
         $filesByType = $this->getFilesToLoadByType($files);
 
@@ -257,20 +256,5 @@ class FixturesLoader
         }
 
         return $files;
-    }
-
-    private function createSchema()
-    {
-        $input = new ArrayInput([
-            'command' => 'doctrine:schema:create',
-            '--env' => 'test',
-        ]);
-        $output = new BufferedOutput();
-
-        $exitCode = $this->cli->run($input, $output);
-
-        if (0 !== $exitCode) {
-            throw new \Exception(sprintf('Catalog not installable! "%s"', $output->fetch()));
-        }
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -85,7 +85,7 @@ abstract class TestCase extends KernelTestCase
      */
     protected function getDatabasePurger()
     {
-        return new DatabasePurger(static::$kernel->getContainer());
+        return new DatabasePurger(static::$kernel);
     }
 
     /**
@@ -95,7 +95,7 @@ abstract class TestCase extends KernelTestCase
      */
     protected function getFixturesLoader(Configuration $configuration)
     {
-        return new FixturesLoader(static::$kernel->getContainer(), $configuration);
+        return new FixturesLoader(static::$kernel, $configuration);
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -41,8 +41,7 @@ abstract class TestCase extends KernelTestCase
         self::$count++;
 
         if ($configuration->isDatabasePurgedForEachTest() || 1 === self::$count) {
-            $databasePurger = $this->getDatabasePurger();
-            $databasePurger->purge();
+            $this->getDatabaseSchemaHandler()->reset();
 
             $fixturesLoader = $this->getFixturesLoader($configuration);
             $fixturesLoader->load();
@@ -81,11 +80,11 @@ abstract class TestCase extends KernelTestCase
     }
 
     /**
-     * @return DatabasePurger
+     * @return DatabaseSchemaHandler
      */
-    protected function getDatabasePurger()
+    protected function getDatabaseSchemaHandler()
     {
-        return new DatabasePurger(static::$kernel);
+        return new DatabaseSchemaHandler(static::$kernel);
     }
 
     /**


### PR DESCRIPTION
As a first step to make our integration tests independent, I propose, that at the beginning of each test (except if you decided to put the option `purgeDatabaseForEachTest` to false):
 - really drop the whole database schema
 - recreate the database schema 

This is just a first step, to be able to merge https://github.com/akeneo/pim-community-dev/pull/5775. With that PR, tests will be slower for sure. But this is just temporary.

What we could do after the 1.7 release is setting up a 1 day squad on this topic. Its goal would be:
- be able to launch really independent tests (with `--process-isolation` for instance, or something else). For that, we need to fix our tests.
- optimize the loading of the database which is very time consuming (see the ideas of Juju and Marie) 
- run the integration tests on Mongo
- handle EE correctly (extension points?)
    - every tests should use the PermissionsCleaner
    - schema should be totally wiped out (currently TWA needs to purge manually some tables)


(and if you're interested to work on this topic, please put a :+1: on the PR)