### PR TITLE
API-114: remove sort on identifier to improve performance

### DIFF
--- a/src/Pim/Bundle/ApiBundle/Controller/ProductController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/ProductController.php
@@ -503,11 +503,6 @@ class ProductController
                 $pqb->addFilter($propertyCode, $filter['operator'], $value, $context);
             }
         }
-
-        $identifierCode = $this->attributeRepository->getIdentifierCode();
-        if (null !== $identifierCode) {
-            $pqb->addSorter($identifierCode, 'asc');
-        }
     }
 
     /**

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessListProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessListProductIntegration.php
@@ -1173,13 +1173,13 @@ JSON;
         "items" : [
             {
                 "_links" : {
-                    "self" : {"href" : "http://localhost/api/rest/v1/products/product_china"}
+                    "self" : {"href" : "http://localhost/api/rest/v1/products/localizable_and_scopable"}
                 },
-                "identifier"    : "product_china",
+                "identifier"    : "localizable_and_scopable",
                 "family"        : null,
                 "groups"        : [],
                 "variant_group" : null,
-                "categories"    : ["master_china"],
+                "categories"    : ["categoryA", "master_china"],
                 "enabled"       : true,
                 "values"        : [],
                 "created"       : "2017-01-23T11:44:25+01:00",
@@ -1188,13 +1188,13 @@ JSON;
             },
             {
                 "_links" : {
-                    "self" : {"href" : "http://localhost/api/rest/v1/products/product_without_category"}
+                    "self" : {"href" : "http://localhost/api/rest/v1/products/scopable"}
                 },
-                "identifier"    : "product_without_category",
+                "identifier"    : "scopable",
                 "family"        : null,
                 "groups"        : [],
                 "variant_group" : null,
-                "categories"    : [],
+                "categories"    : ["categoryA1", "categoryA2"],
                 "enabled"       : true,
                 "values"        : [],
                 "created"       : "2017-01-23T11:44:25+01:00",
@@ -1338,6 +1338,13 @@ JSON;
                 $expected['_embedded']['items'][$index] = $this->sanitizeMediaAttributeData($expected['_embedded']['items'][$index]);
             }
         }
+
+        $sortValues = function ($a, $b) {
+            return $a['identifier'] > $b['identifier'] ? 1 : -1;
+        };
+
+        usort($result['_embedded']['items'], $sortValues);
+        usort($expected['_embedded']['items'], $sortValues);
 
         $this->assertJsonStringEqualsJsonString(json_encode($expected), json_encode($result));
     }


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

Remove the sort on identifier on product list to improve performances (It was quite naive/very stupid to do that :p). 
With the sort, it take 20 secondes to get 10 products (on medium catalog). Without, only 1 seconde :)

About the sort on integration test, there is a diff between ORM & Mongo, products are not sorted as the same way... To have tests green in two storages, I have to sort the result.

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
