### PR TITLE
Warning when installing the 1.7 version : fix variant groups spec 

### DIFF
--- a/src/Pim/Bundle/VersioningBundle/Normalizer/Flat/VariantGroupNormalizer.php
+++ b/src/Pim/Bundle/VersioningBundle/Normalizer/Flat/VariantGroupNormalizer.php
@@ -64,29 +64,6 @@ class VariantGroupNormalizer extends BaseNormalizer
     }
 
     /**
-     * Generate an array representing the list of variant group values in flat array
-     *
-     * @param array $variantGroupValues
-     * @param array $context
-     *
-     * @return array
-     */
-    protected function normalizeValues(array $variantGroupValues, array $context = [])
-    {
-        $flatValues = [];
-
-        foreach ($variantGroupValues as $attributeCode => $variantGroupValue) {
-            $flatValues += $this->valuesNormalizer->normalize(
-                [$attributeCode => $variantGroupValue],
-                'flat',
-                $context
-            );
-        }
-
-        return $flatValues;
-    }
-
-    /**
      * @param array $labels
      *
      * @return array

--- a/src/Pim/Component/Catalog/Normalizer/Standard/VariantGroupNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Standard/VariantGroupNormalizer.php
@@ -13,6 +13,9 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
  */
 class VariantGroupNormalizer implements NormalizerInterface
 {
+    /** @var string[] */
+    protected $supportedFormats = ['standard'];
+
     /** @var NormalizerInterface */
     protected $translationNormalizer;
 
@@ -56,7 +59,7 @@ class VariantGroupNormalizer implements NormalizerInterface
      */
     public function supportsNormalization($data, $format = null)
     {
-        return $data instanceof GroupInterface && $data->getType()->isVariant() && 'standard' === $format;
+        return $data instanceof GroupInterface && $data->getType()->isVariant() && in_array($format, $this->supportedFormats);
     }
 
     /**


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

When you install the PIM, a warning is raised when it generates the autoloader file.
There were two classes with the same name in the spec : `VariantGroupNormalizerSpec` and `GroupNormalizerSpec`.

Actually, the VariantGroupNormalizer was not tested correctly for the versioning.
This PR fixes that problem.

Moreover, I've deleted a function that was not used.

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Ok
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
