### PR TITLE
Fix integration tests in mongo 

### DIFF
--- a/STANDARD_FORMAT.md
+++ b/STANDARD_FORMAT.md
@@ -150,6 +150,8 @@ Each element in the array "groups" represents the *code* of the *Pim\Component\C
 
 Each element in the array "products" represents the *identifier* of the *Pim\Component\Catalog\Model\ProductInterface*
 
+If an association type does not contain neither element in groups, nor element in products, it is not returned.
+
 
 ### Product values
 

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Media/CreateMediaFileIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Media/CreateMediaFileIntegration.php
@@ -91,7 +91,7 @@ class CreateMediaFileIntegration extends ApiTestCase
     "message": "Validation failed.",
     "errors": [
         {
-            "field": "values",
+            "property": "values",
             "message": "The file extension is not allowed (allowed extensions: jpg, gif, png).",
             "attribute": "an_image",
             "locale": null,

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/CreateProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/CreateProductIntegration.php
@@ -242,18 +242,6 @@ JSON;
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
             'associations'  => [
-                "PACK"         => [
-                    "groups"   => [],
-                    "products" => [],
-                ],
-                "SUBSTITUTION" => [
-                    "groups"   => [],
-                    "products" => [],
-                ],
-                "UPSELL"       => [
-                    "groups"   => [],
-                    "products" => [],
-                ],
                 "X_SELL"       => [
                     "groups"   => ["groupA"],
                     "products" => ["simple"],

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/CreateProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/CreateProductIntegration.php
@@ -987,6 +987,9 @@ JSON;
         $standardizedProduct = static::sanitizeMediaAttributeData($standardizedProduct);
         $expectedProduct = static::sanitizeMediaAttributeData($expectedProduct);
 
+        ksort($expectedProduct['values']);
+        ksort($standardizedProduct['values']);
+
         $this->assertSame($expectedProduct, $standardizedProduct);
     }
 

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/GetProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/GetProductIntegration.php
@@ -248,6 +248,9 @@ class GetProductIntegration extends AbstractProductTestCase
         $expected = $this->sanitizeDateFields($expected);
         $expected = $this->sanitizeMediaAttributeData($expected);
 
+        ksort($expected['values']);
+        ksort($result['values']);
+
         $this->assertSame($expected, $result);
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateProductIntegration.php
@@ -1460,6 +1460,9 @@ JSON;
         $standardizedProduct = static::sanitizeMediaAttributeData($standardizedProduct);
         $expectedProduct = static::sanitizeMediaAttributeData($expectedProduct);
 
+        ksort($expectedProduct['values']);
+        ksort($standardizedProduct['values']);
+
         $this->assertSame($expectedProduct, $standardizedProduct);
     }
 

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateProductIntegration.php
@@ -37,10 +37,7 @@ class PartialUpdateProductIntegration extends AbstractProductTestCase
 
         $this->createProduct('product_associations', [
             'associations'  => [
-                'PACK'         => ['groups'   => [], 'products' => []],
-                'SUBSTITUTION' => ['groups'   => [], 'products' => []],
-                'UPSELL'       => ['groups'   => [], 'products' => []],
-                'X_SELL'       => ['groups'   => ['groupA'], 'products' => ['product_categories']],
+                'X_SELL' => ['groups'   => ['groupA'], 'products' => ['product_categories']],
             ],
         ]);
 
@@ -70,10 +67,7 @@ class PartialUpdateProductIntegration extends AbstractProductTestCase
                 ],
             ],
             'associations'  => [
-                'PACK'         => ['groups'   => [], 'products' => []],
-                'SUBSTITUTION' => ['groups'   => [], 'products' => []],
-                'UPSELL'       => ['groups'   => [], 'products' => []],
-                'X_SELL'       => ['groups'   => ['groupA'], 'products' => ['product_categories']],
+                'X_SELL' => ['groups'   => ['groupA'], 'products' => ['product_categories']],
             ],
         ]);
     }
@@ -692,10 +686,8 @@ JSON;
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
             'associations'  => [
-                'PACK'         => ['groups'   => ['groupA'], 'products' => ['product_categories', 'product_family']],
-                'SUBSTITUTION' => ['groups'   => [], 'products' => []],
-                'UPSELL'       => ['groups'   => [], 'products' => []],
-                'X_SELL'       => ['groups'   => ['groupA'], 'products' => ['product_categories']],
+                'PACK'   => ['groups'   => ['groupA'], 'products' => ['product_categories', 'product_family']],
+                'X_SELL' => ['groups'   => ['groupA'], 'products' => ['product_categories']],
             ],
         ];
 
@@ -739,10 +731,7 @@ JSON;
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
             'associations'  => [
-                'PACK'         => ['groups'   => [], 'products' => []],
-                'SUBSTITUTION' => ['groups'   => [], 'products' => []],
-                'UPSELL'       => ['groups'   => [], 'products' => []],
-                'X_SELL'       => ['groups'   => [], 'products' => ['product_categories']],
+                'X_SELL' => ['groups'   => [], 'products' => ['product_categories']],
             ],
         ];
 
@@ -790,12 +779,7 @@ JSON;
             ],
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
-            'associations'  => [
-                'PACK'         => ['groups'   => [], 'products' => []],
-                'SUBSTITUTION' => ['groups'   => [], 'products' => []],
-                'UPSELL'       => ['groups'   => [], 'products' => []],
-                'X_SELL'       => ['groups'   => [], 'products' => []],
-            ],
+            'associations'  => [],
         ];
 
         $response = $client->getResponse();
@@ -1163,10 +1147,7 @@ JSON;
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
             'associations'  => [
-                'PACK'         => ['groups'   => [], 'products' => []],
-                'SUBSTITUTION' => ['groups'   => [], 'products' => []],
-                'UPSELL'       => ['groups'   => [], 'products' => []],
-                'X_SELL'       => ['groups'   => ['groupA'], 'products' => ['product_categories']],
+                'X_SELL' => ['groups'   => ['groupA'], 'products' => ['product_categories']],
             ],
         ];
 

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/AbstractFilterTestCase.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/AbstractFilterTestCase.php
@@ -83,6 +83,9 @@ abstract class AbstractFilterTestCase extends TestCase
             $products[] = $product->getIdentifier()->getData();
         }
 
+        sort($products);
+        sort($expected);
+
         $this->assertSame($products, $expected);
     }
 }

--- a/src/Pim/Component/Api/tests/integration/Normalizer/ProductNormalizerIntegration.php
+++ b/src/Pim/Component/Api/tests/integration/Normalizer/ProductNormalizerIntegration.php
@@ -356,6 +356,13 @@ class ProductNormalizerIntegration extends TestCase
         $expected = $this->sanitizeDateFields($expected);
         $expected = $this->sanitizeMediaAttributeData($expected);
 
+        if (is_array($expected['values'])) {
+            ksort($expected['values']);
+        }
+        if (is_array($result['values'])) {
+            ksort($result['values']);
+        }
+
         $this->assertEquals($expected, $result);
     }
 

--- a/src/Pim/Component/Catalog/Normalizer/Standard/Product/AssociationsNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Standard/Product/AssociationsNormalizer.php
@@ -22,16 +22,18 @@ class AssociationsNormalizer implements NormalizerInterface
         $data = [];
 
         foreach ($product->getAssociations() as $association) {
-            $code = $association->getAssociationType()->getCode();
+            if ($association->getGroups()->count() > 0 || $association->getProducts()->count() > 0) {
+                $code = $association->getAssociationType()->getCode();
 
-            $data[$code]['groups'] = [];
-            foreach ($association->getGroups() as $group) {
-                $data[$code]['groups'][] = $group->getCode();
-            }
+                $data[$code]['groups'] = [];
+                foreach ($association->getGroups() as $group) {
+                    $data[$code]['groups'][] = $group->getCode();
+                }
 
-            $data[$code]['products'] = [];
-            foreach ($association->getProducts() as $product) {
-                $data[$code]['products'][] = $product->getReference();
+                $data[$code]['products'] = [];
+                foreach ($association->getProducts() as $product) {
+                    $data[$code]['products'][] = $product->getReference();
+                }
             }
         }
 

--- a/src/Pim/Component/Catalog/spec/Normalizer/Standard/Product/AssociationsNormalizerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Normalizer/Standard/Product/AssociationsNormalizerSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Pim\Component\Catalog\Normalizer\Standard\Product;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Pim\Component\Catalog\Model\AssociationInterface;
 use Pim\Component\Catalog\Model\AssociationTypeInterface;
 use Pim\Component\Catalog\Model\GroupInterface;
@@ -36,19 +37,43 @@ class AssociationsNormalizerSpec extends ObjectBehavior
         AssociationTypeInterface $associationType1,
         AssociationTypeInterface $associationType2,
         GroupInterface $group1,
-        ProductInterface $productAssociated
+        ProductInterface $productAssociated,
+        \ArrayIterator $association1Iterator,
+        \ArrayIterator $association2Iterator
     ) {
         $group1->getCode()->willReturn('group_code');
         $associationType1->getCode()->willReturn('XSELL');
         $association1->getAssociationType()->willReturn($associationType1);
-        $association1->getGroups()->willReturn([$group1]);
-        $association1->getProducts()->willReturn([]);
+        $association1->getGroups()->willReturn($association1Iterator);
+        $association1->getProducts()->willReturn(new ArrayCollection());
+
+        $association1Iterator->rewind()->willReturn($group1);
+        $valueCount = 1;
+        $association1Iterator->valid()->will(
+            function () use (&$valueCount) {
+                return $valueCount-- > 0;
+            }
+        );
+        $association1Iterator->current()->willReturn($group1);
+        $association1Iterator->next()->willReturn(null);
+        $association1Iterator->count()->willReturn(1);
 
         $productAssociated->getReference()->willReturn('product_code');
         $associationType2->getCode()->willReturn('PACK');
         $association2->getAssociationType()->willReturn($associationType2);
-        $association2->getGroups()->willReturn([]);
-        $association2->getProducts()->willReturn([$productAssociated]);
+        $association2->getGroups()->willReturn(new ArrayCollection());
+        $association2->getProducts()->willReturn($association2Iterator);
+
+        $association2Iterator->rewind()->willReturn($productAssociated);
+        $valueCount2 = 1;
+        $association2Iterator->valid()->will(
+            function () use (&$valueCount2) {
+                return $valueCount2-- > 0;
+            }
+        );
+        $association2Iterator->current()->willReturn($productAssociated);
+        $association2Iterator->next()->willReturn(null);
+        $association2Iterator->count()->willReturn(1);
 
         $product->getAssociations()->willReturn([$association1, $association2]);
 

--- a/src/Pim/Component/Catalog/tests/integration/Normalizer/Standard/ProductStandardIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Normalizer/Standard/ProductStandardIntegration.php
@@ -269,6 +269,9 @@ class ProductStandardIntegration extends TestCase
         $expected = $this->sanitizeDateFields($expected);
         $expected = $this->sanitizeMediaAttributeData($expected);
 
+        ksort($expected['values']);
+        ksort($result['values']);
+
         $this->assertSame($expected, $result);
     }
 

--- a/tests/catalog/technical_sql/200_products.json
+++ b/tests/catalog/technical_sql/200_products.json
@@ -1,13 +1,13 @@
 db.pim_catalog_product.insert({
   "_id" : ObjectId("57f6c4e9b392ea5f146b2087"),
   "enabled" : false,
-  "created" : ISODate("2016-10-06T21:40:57Z"),
-  "updated" : ISODate("2016-10-06T21:40:57Z"),
+  "created" : ISODate("2016-08-04T14:28:51Z"),
+  "updated" : ISODate("2016-08-04T01:28:51Z"),
   "groupIds" : [ ],
   "categoryIds" : [ ],
   "normalizedData" : {
-    "created" : NumberLong(1475790057),
-    "updated" : NumberLong(1475790057),
+    "created" : NumberLong(1470313731),
+    "updated" : NumberLong(1470266931),
     "sku" : "bar",
     "completenesses" : [ ],
     "enabled" : false
@@ -29,13 +29,13 @@ db.pim_catalog_product.insert({
 db.pim_catalog_product.insert({
   "_id" : ObjectId("57f6c51fb392ea7d286b208a"),
   "enabled" : true,
-  "created" : ISODate("2016-10-06T21:41:51Z"),
-  "updated" : ISODate("2016-10-06T21:41:51Z"),
+  "created" : ISODate("2016-08-25T01:28:51Z"),
+  "updated" : ISODate("2016-08-25T00:00:00Z"),
   "groupIds" : [ ],
   "categoryIds" : [ ],
   "normalizedData" : {
-    "created" : NumberLong(1475790111),
-    "updated" : NumberLong(1475790111),
+    "created" : NumberLong(1472081331),
+    "updated" : NumberLong(1472076000),
     "sku" : "baz",
     "completenesses" : [ ],
     "enabled" : true
@@ -56,8 +56,8 @@ db.pim_catalog_product.insert({
 
 db.pim_catalog_product.insert({
   "_id" : ObjectId("57f6c66cb392eae7456b2087"),
-  "created" : ISODate("2016-10-06T21:47:24Z"),
-  "updated" : ISODate("2016-10-07T21:33:56Z"),
+  "created" : ISODate("2016-08-29T14:28:51Z"),
+  "updated" : ISODate("2016-08-29T00:00:00Z"),
   "family" : NumberLong(466),
   "enabled" : true,
   "groupIds" : [
@@ -454,8 +454,8 @@ db.pim_catalog_product.insert({
     "in_group_240" : true,
     "in_group_241" : true,
     "in_group_239" : true,
-    "created" : NumberLong(1475790444),
-    "updated" : NumberLong(1475876036),
+    "created" : NumberLong(1472473731),
+    "updated" : NumberLong(1472421600),
     "sku" : "foo",
     "a_date" : NumberLong(1465768800),
     "a_metric" : {


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

Fix integration tests on mongo:
- I fixed "updated" & "created" dates which were differents between mongo & orm fixtures files 
- Product values were not sorted in the same way in mongo. I added a `ksort` on the expected result and the result to work around the pb
- In the product standard format, associations were not consistent. When a product had no association, we returned:
```
"associations" => []
```
but when an association was added, we returned:
```
"associations": [
   "PACK" => ["groups" => [], "products" => []],
   "SUBSTITUTION" => ["groups" => [], "products" => []],
   "UPSELL" => ["groups" => [], "products" => ["foo"]],
   "PACK" => ["groups" => [], "products" => []]
]
```
This behavior can change between orm & mongo...
I fixed a rule (validated by PO): when an association type has no group & no product, we do not return it.

:warning: 
There are still some fails on price PQB filter, results are not the same between ORM & mongo. @solivier is working on it ;) :jetpack:

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
