### PR TITLE
Fix translation for Crowdin

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Resources/translations/validators.en.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/translations/validators.en.yml
@@ -12,7 +12,7 @@ This value should not be blank:                                                 
 Option code may contain only letters, numbers and underscores:                            Option code may contain only letters, numbers and underscores
 Option code may contain only letters (at least one), numbers and underscores:             Option code may contain only letters (at least one), numbers and underscores
 This value should not be a decimal.:                                                      This value should not be a decimal.
-The file extension is not allowed (allowed extensions: %extensions%).:                    The file extension is not allowed (allowed extensions: %extensions%).
+"The file extension is not allowed (allowed extensions: %extensions%).":                  The file extension is not allowed (allowed extensions: %extensions%).
 The value %value% is already set on another product for the unique attribute %attribute%: The value %value% is already set on another product for the unique attribute %attribute%
 regex.comma_or_semicolon.message:                                                         This field should not contain any comma or semicolon.
 file.extensions.message:                                                                  'The file extension is not allowed (allowed extensions: %extensions%).'


### PR DESCRIPTION
It fixes the YAML (not very well parsed by the Crowdin parser)
See this : https://crowdin.com/translate/akeneo/all/en-fr#q=%25extensions