### PR TITLE
Avoid fatal error in processor if step execution is not set

### DIFF
--- a/src/Pim/Component/Connector/Processor/Denormalization/AbstractProcessor.php
+++ b/src/Pim/Component/Connector/Processor/Denormalization/AbstractProcessor.php
@@ -89,10 +89,9 @@ abstract class AbstractProcessor implements StepExecutionAwareInterface
             $this->stepExecution->incrementSummaryInfo('skip');
         }
 
-        $invalidItem = new FileInvalidItem(
-            $item,
-            ($this->stepExecution->getSummaryInfo('item_position'))
-        );
+        $itemPosition = null !== $this->stepExecution ? $this->stepExecution->getSummaryInfo('item_position') : 0;
+
+        $invalidItem = new FileInvalidItem($item, $itemPosition);
 
         throw new InvalidItemException($message, $invalidItem, [], 0, $previousException);
     }
@@ -115,9 +114,11 @@ abstract class AbstractProcessor implements StepExecutionAwareInterface
             $this->stepExecution->incrementSummaryInfo('skip');
         }
 
+        $itemPosition = null !== $this->stepExecution ? $this->stepExecution->getSummaryInfo('item_position') : 0;
+
         throw new InvalidItemFromViolationsException(
             $violations,
-            new FileInvalidItem($item, ($this->stepExecution->getSummaryInfo('item_position'))),
+            new FileInvalidItem($item, $itemPosition),
             [],
             0,
             $previousException


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Denormalization processors are built in a way that allow us to use them without setting any step execution in it (as it's done by a setter and not passed in the constructor).
However there is still some parts that expect `$this->stepExecution` to be always set. As a result, when we use processors inside Behat contexts for example, we can get fatal errors.

This PR fixes this case. Of course the way to go would be to redesign the batch component, this is the easiest fix without breaking everything.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
