### PR TITLE
Fix use of "grunt" and "php-cs-fixer" on CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,10 +10,10 @@ stage("Checkout") {
     milestone 1
     if (env.BRANCH_NAME =~ /^PR-/) {
         userInput = input(message: 'Launch tests?', parameters: [
-            choice(choices: 'yes\nno', description: 'Run unit tests', name: 'launchUnitTests'),
-            choice(choices: 'yes\nno', description: 'Run functional tests', name: 'launchBehatTests'),
-            string(defaultValue: 'odm,orm', description: 'Storage used for the build (comma separated values)', name: 'storages'),
-            string(defaultValue: 'ee,ce', description: 'PIM edition the tests should run to (comma separated values)', name: 'editions'),
+            choice(choices: 'yes\nno', description: 'Run unit tests and code style checks', name: 'launchUnitTests'),
+            choice(choices: 'yes\nno', description: 'Run behat tests', name: 'launchBehatTests'),
+            string(defaultValue: 'odm,orm', description: 'Storage used for the behat tests (comma separated values)', name: 'storages'),
+            string(defaultValue: 'ee,ce', description: 'PIM edition the behat tests should run on (comma separated values)', name: 'editions'),
             string(defaultValue: 'features,vendor/akeneo/pim-community-dev/features', description: 'Behat scenarios to build', name: 'features')
         ])
 
@@ -46,9 +46,11 @@ stage("Checkout") {
             deleteDir()
             docker.image("carcel/php:5.6").inside("-v /home/akeneo/.composer:/home/akeneo/.composer -e COMPOSER_HOME=/home/akeneo/.composer") {
                 unstash "pim_community_dev"
+
                 sh "composer update --optimize-autoloader --no-interaction --no-progress --prefer-dist"
                 sh "app/console oro:requirejs:generate-config"
                 sh "app/console assets:install"
+
                 stash "pim_community_dev_full"
             }
             deleteDir()
@@ -60,9 +62,11 @@ stage("Checkout") {
                 deleteDir()
                 docker.image("carcel/php:5.6").inside("-v /home/akeneo/.composer:/home/akeneo/.composer -e COMPOSER_HOME=/home/akeneo/.composer") {
                     unstash "pim_enterprise_dev"
+
                     sh "php -d memory_limit=-1 /usr/local/bin/composer update --optimize-autoloader --no-interaction --no-progress --prefer-dist"
                     sh "app/console oro:requirejs:generate-config"
                     sh "app/console assets:install"
+
                     stash "pim_enterprise_dev_full"
                 }
                 deleteDir()
@@ -81,13 +85,14 @@ if (launchUnitTests.equals("yes")) {
         tasks["phpunit-5.5"] = {runPhpUnitTest("5.5")}
         tasks["phpunit-5.6"] = {runPhpUnitTest("5.6")}
         tasks["phpunit-7.0"] = {runPhpUnitTest("7.0")}
+
         tasks["phpspec-5.4"] = {runPhpSpecTest("5.4")}
         tasks["phpspec-5.5"] = {runPhpSpecTest("5.5")}
         tasks["phpspec-5.6"] = {runPhpSpecTest("5.6")}
         tasks["phpspec-7.0"] = {runPhpSpecTest("7.0")}
-        tasks["php-cs-fixer-5.5"] = {runPhpCsFixerTest("5.5")}
-        tasks["php-cs-fixer-5.6"] = {runPhpCsFixerTest("5.6")}
-        tasks["php-cs-fixer-7.0"] = {runPhpCsFixerTest("7.0")}
+
+        tasks["php-cs-fixer"] = {runPhpCsFixerTest()}
+
         tasks["grunt"] = {runGruntTest()}
 
         parallel tasks
@@ -114,7 +119,8 @@ def runGruntTest() {
             docker.image('digitallyseamless/nodejs-bower-grunt').inside("") {
                 unstash "pim_community_dev_full"
                 sh "npm install"
-                sh "grunt --force"
+
+                sh "grunt"
             }
         } finally {
             deleteDir()
@@ -132,9 +138,9 @@ def runPhpUnitTest(phpVersion) {
                 if (phpVersion == "7.0") {
                     sh "composer remove --dev --no-update doctrine/mongodb-odm-bundle;"
                 }
-
                 sh "composer update --optimize-autoloader --no-interaction --no-progress --prefer-dist"
                 sh "mkdir -p app/build/logs/"
+
                 sh "./bin/phpunit -c app/phpunit.xml.dist --testsuite PIM_Unit_Test --log-junit app/build/logs/phpunit.xml"
             }
         } finally {
@@ -155,9 +161,9 @@ def runPhpSpecTest(phpVersion) {
                 if (phpVersion == "7.0") {
                     sh "composer remove --dev --no-update doctrine/mongodb-odm-bundle;"
                 }
-
                 sh "composer update --optimize-autoloader --no-interaction --no-progress --prefer-dist"
                 sh "mkdir -p app/build/logs/"
+
                 sh "./bin/phpspec run --no-interaction --format=junit > app/build/logs/phpspec.xml"
             }
         } finally {
@@ -168,23 +174,21 @@ def runPhpSpecTest(phpVersion) {
     }
 }
 
-def runPhpCsFixerTest(phpVersion) {
+def runPhpCsFixerTest() {
     node('docker') {
         deleteDir()
         try {
-            docker.image("carcel/php:${phpVersion}").inside("-v /home/akeneo/.composer:/home/akeneo/.composer -e COMPOSER_HOME=/home/akeneo/.composer") {
+            docker.image("carcel/php:7.0").inside("-v /home/akeneo/.composer:/home/akeneo/.composer -e COMPOSER_HOME=/home/akeneo/.composer") {
                 unstash "pim_community_dev"
 
-                if (phpVersion == "7.0") {
-                    sh "composer remove --dev --no-update doctrine/mongodb-odm-bundle;"
-                }
-
+                sh "composer remove --dev --no-update doctrine/mongodb-odm-bundle;"
                 sh "composer update --optimize-autoloader --no-interaction --no-progress --prefer-dist"
                 sh "mkdir -p app/build/logs/"
+
                 sh "./bin/php-cs-fixer fix --diff --dry-run --format=junit --config=.php_cs.php > app/build/logs/phpcs.xml"
             }
         } finally {
-            sh "sed -i \"s/testcase name=\\\"/testcase name=\\\"[php-${phpVersion}] /\" app/build/logs/*.xml"
+            sh "sed -i \"s/testcase name=\\\"/testcase name=\\\"[php-cs-fixer] /\" app/build/logs/*.xml"
             junit "app/build/logs/*.xml"
             deleteDir()
         }


### PR DESCRIPTION
**Description**

Currently, our CSS+JS tests are run with the command `grunt --force`. This allows us to run all the tests even if there are errors. But the problem is the CI is always green even when there are errors, so this is not good!

In this PR, the tests are only run with the command `grunt`. It will be up to the developer to run all the tests locally to ensure everything is fixed.

I also remove the multiple runs of `php-cs-fixer` to keep only one, with PHP 7 (fastest execution).

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
