### PR TITLE
PIM-6200: Fix remove and save buttons on view selector

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -4,6 +4,7 @@
 
 - PIM-6210: fix unused fields on import profiles
 - PIM-6203: Fix various design bugs
+- PIM-6200: Only the owner of a view can save and remove it.
 
 # 1.7.0-BETA2 (2017-03-06)
 
@@ -286,7 +287,7 @@
 - Change exception `\InvalidArgumentException` by `Akeneo\Component\StorageUtils\Exception\PropertyException` thrown by `Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface:update()`
 - Change exception `Pim\Component\Catalog\Exception\InvalidArgumentException` and `\RuntimeException` by `Akeneo\Component\StorageUtils\Exception\PropertyException` thrown by `Pim\Component\Catalog\Updater\Copier\AttributeCopierInterface:copyAttributeData()`
 - Change exception `Pim\Component\Catalog\Exception\InvalidArgumentException` and `\RuntimeException` by `Akeneo\Component\StorageUtils\Exception\PropertyException` thrown by `Pim\Component\Catalog\Updater\Copier\FieldCopierInterface:copyFieldData()`
-- Replace arguments `$action, $type` by `$className` (string) on `Pim\Component\Catalog\Exception\InvalidArgumentException`
+- Replace arguments `$action, $type` by `$className` (string) on `Pim\Component\Catalog\Exception\InvalidArgumentException` 
 - Add exception `Akeneo\Component\StorageUtils\Exception\PropertyException` thrown by `Pim\Component\Catalog\Updater\Adder\AttributeAdderInterface:addAttributeData()`
 - Add exception `Akeneo\Component\StorageUtils\Exception\PropertyException` thrown by `Pim\Component\Catalog\Updater\Adder\FieldAdderInterface:addFieldData()`
 - Add exception `Akeneo\Component\StorageUtils\Exception\PropertyException` thrown by `Pim\Component\Catalog\Updater\Remover\AttributeRemoverInterface:removeAttributeData()`

--- a/features/Context/DataGridContext.php
+++ b/features/Context/DataGridContext.php
@@ -1029,6 +1029,26 @@ class DataGridContext extends RawMinkContext implements PageObjectAwareInterface
     }
 
     /**
+     * @Then /^I should not be able to remove the view$/
+     */
+    public function iShouldNotBeAbleToRemoveTheView()
+    {
+        if (true === $this->getCurrentPage()->isViewDeletable()) {
+            throw $this->createExpectationException('The current view should not be allowed to be removed.');
+        }
+    }
+
+    /**
+     * @Then /^I should not be able to save the view$/
+     */
+    public function iShouldNotBeAbleToSaveTheView()
+    {
+        if (true === $this->getCurrentPage()->isViewCanBeSaved()) {
+            throw $this->createExpectationException('The current view should not be allowed to be saved.');
+        }
+    }
+
+    /**
      * @param TableNode $table
      *
      * @return Then[]

--- a/features/Pim/Behat/Decorator/Page/GridCapableDecorator.php
+++ b/features/Pim/Behat/Decorator/Page/GridCapableDecorator.php
@@ -136,6 +136,42 @@ class GridCapableDecorator extends ElementDecorator
     }
 
     /**
+     * Is the remove button available for the current view ?
+     */
+    public function isViewDeletable()
+    {
+        $selector = $this->selectors['Remove view button'];
+
+        try {
+            return $this->spin(function () use ($selector) {
+                $button = $this->find('css', $selector);
+
+                return $button ? true : false;
+            }, sprintf('Remove view button not found (%s).', $selector));
+        } catch (TimeoutException $e) {
+            return false;
+        }
+    }
+
+    /**
+     * Is the save button available for the current view ?
+     */
+    public function isViewCanBeSaved()
+    {
+        $selector = $this->selectors['Save view button'];
+
+        try {
+            return $this->spin(function () use ($selector) {
+                $button = $this->find('css', $selector);
+
+                return $button ? true : false;
+            }, sprintf('Save view button not found (%s).', $selector));
+        } catch (TimeoutException $e) {
+            return false;
+        }
+    }
+
+    /**
      * Returns the currently visible grid, if there is one
      *
      * @return NodeElement

--- a/features/datagrid/datagrid_views.feature
+++ b/features/datagrid/datagrid_views.feature
@@ -92,6 +92,25 @@ Feature: Datagrid views
     But I should not see "Boots only"
     And I should see products black-boots, purple-sneakers and black-sneakers
 
+  Scenario: Can not delete nor save a view that is not mine
+    Given I am on the products page
+    And I filter by "family" with operator "in list" and value "Boots"
+    And I create the view:
+      | new-view-label | Boots only |
+    Then I should be on the products page
+    And I should see the flash message "Datagrid view successfully created"
+    And I should see the text "Boots only"
+    And I should see product black-boots
+    But I should not see products purple-sneakers and black-sneakers
+    When I logout
+    And I am logged in as "Julia"
+    And I am on the products page
+    And I apply the "Boots only" view
+    Then I should be on the products page
+    And I should not be able to remove the view
+    When I filter by "family" with operator "in list" and value "Sneakers"
+    Then I should not be able to save the view
+
   Scenario: Keep view per page
     Given I am on the products page
     When I change the page size to 25

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/grid/view-selector-remove-view.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/grid/view-selector-remove-view.js
@@ -16,6 +16,7 @@ define(
         'pim/form',
         'text!pim/template/grid/view-selector/remove-view',
         'pim/dialog',
+        'pim/user-context',
         'pim/remover/datagrid-view',
         'oro/messenger'
     ],
@@ -26,6 +27,7 @@ define(
         BaseForm,
         template,
         Dialog,
+        UserContext,
         DatagridViewRemover,
         messenger
     ) {
@@ -41,7 +43,10 @@ define(
              * {@inheritdoc}
              */
             render: function () {
-                if ('view' !== this.getRoot().currentViewType || this.getRoot().currentView.id === 0) {
+                if ('view' !== this.getRoot().currentViewType ||
+                    this.getRoot().currentView.id === 0 ||
+                    UserContext.get('meta').id !== this.getRoot().currentView.owner_id
+                ) {
                     this.$el.html('');
 
                     return this;

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/grid/view-selector-save-view.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/grid/view-selector-save-view.js
@@ -19,6 +19,7 @@ define(
         'pim/datagrid/state',
         'pim/dialog',
         'routing',
+        'pim/user-context',
         'pim/saver/datagrid-view',
         'oro/messenger'
     ],
@@ -31,6 +32,7 @@ define(
         DatagridState,
         Dialog,
         Routing,
+        UserContext,
         DatagridViewSaver,
         messenger
     ) {
@@ -55,7 +57,9 @@ define(
              * {@inheritdoc}
              */
             render: function () {
-                if ('view' !== this.getRoot().currentViewType) {
+                if ('view' !== this.getRoot().currentViewType ||
+                    UserContext.get('meta').id !== this.getRoot().currentView.owner_id
+                ) {
                     this.$el.html('');
 
                     return;


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Bug:  You can now edit or delete another user's view (it does not have to be set as your grid default view).

FIX: only view's creator can edit or delete their views.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | OK
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
