### PR TITLE
Make DB container names unique in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -180,9 +180,9 @@ def runIntegrationTest(phpVersion, storage) {
     node('docker') {
         deleteDir()
         try {
-            docker.image("mongo:2.4").withRun("--name mongodb", "--smallfiles") {
-                docker.image("mysql:5.5").withRun("--name mysql -e MYSQL_ROOT_PASSWORD=root -e MYSQL_USER=akeneo_pim -e MYSQL_PASSWORD=akeneo_pim -e MYSQL_DATABASE=akeneo_pim", "--sql_mode=ERROR_FOR_DIVISION_BY_ZERO,NO_ZERO_IN_DATE,NO_ZERO_DATE,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION") {
-                    docker.image("carcel/php:${phpVersion}").inside("--link mysql:mysql --link mongodb:mongodb -v /home/akeneo/.composer:/home/akeneo/.composer -e COMPOSER_HOME=/home/akeneo/.composer") {
+            docker.image("mongo:2.4").withRun("--name ${env.BRANCH_NAME}-mongodb", "--smallfiles") {
+                docker.image("mysql:5.5").withRun("--name ${env.BRANCH_NAME}-mysql -e MYSQL_ROOT_PASSWORD=root -e MYSQL_USER=akeneo_pim -e MYSQL_PASSWORD=akeneo_pim -e MYSQL_DATABASE=akeneo_pim", "--sql_mode=ERROR_FOR_DIVISION_BY_ZERO,NO_ZERO_IN_DATE,NO_ZERO_DATE,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION") {
+                    docker.image("carcel/php:${phpVersion}").inside("--link ${env.BRANCH_NAME}-mysql:mysql --link ${env.BRANCH_NAME}-mongodb:mongodb -v /home/akeneo/.composer:/home/akeneo/.composer -e COMPOSER_HOME=/home/akeneo/.composer") {
                         unstash "pim_community_dev"
 
                         if (phpVersion != "5.6") {


### PR DESCRIPTION
**Description**

There is a regular problem with integration tests, with the MongoDB and MySQL containers not being destroyed on the Jenkins slaves, making next builds failing.

This PR make sure both MySQL and MongoDB container names are unique to each builds to avoid this problem ever again.

Correct cleaning of the slaves will be done in another PR.

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
