### PR TITLE
PIM-6210: fix unused fields on import profiles

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -1,3 +1,9 @@
+# 1.7.0-BETA3
+
+## Bug Fixes
+
+- PIM-6210: fix unused fields on import profiles
+
 # 1.7.0-BETA2 (2017-03-06)
 
 # 1.7.0-BETA1 (2017-03-02)
@@ -279,7 +285,7 @@
 - Change exception `\InvalidArgumentException` by `Akeneo\Component\StorageUtils\Exception\PropertyException` thrown by `Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface:update()`
 - Change exception `Pim\Component\Catalog\Exception\InvalidArgumentException` and `\RuntimeException` by `Akeneo\Component\StorageUtils\Exception\PropertyException` thrown by `Pim\Component\Catalog\Updater\Copier\AttributeCopierInterface:copyAttributeData()`
 - Change exception `Pim\Component\Catalog\Exception\InvalidArgumentException` and `\RuntimeException` by `Akeneo\Component\StorageUtils\Exception\PropertyException` thrown by `Pim\Component\Catalog\Updater\Copier\FieldCopierInterface:copyFieldData()`
-- Replace arguments `$action, $type` by `$className` (string) on `Pim\Component\Catalog\Exception\InvalidArgumentException` 
+- Replace arguments `$action, $type` by `$className` (string) on `Pim\Component\Catalog\Exception\InvalidArgumentException`
 - Add exception `Akeneo\Component\StorageUtils\Exception\PropertyException` thrown by `Pim\Component\Catalog\Updater\Adder\AttributeAdderInterface:addAttributeData()`
 - Add exception `Akeneo\Component\StorageUtils\Exception\PropertyException` thrown by `Pim\Component\Catalog\Updater\Adder\FieldAdderInterface:addFieldData()`
 - Add exception `Akeneo\Component\StorageUtils\Exception\PropertyException` thrown by `Pim\Component\Catalog\Updater\Remover\AttributeRemoverInterface:removeAttributeData()`

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_base_import_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_base_import_edit.yml
@@ -65,21 +65,10 @@ extensions:
             label: pim_enrich.form.job_instance.tab.properties.file_path.title
             tooltip: pim_enrich.form.job_instance.tab.properties.file_path.help
 
-    pim-job-instance-csv-base-import-show-properties-escape:
-        module: pim/job/common/edit/field/text
-        parent: pim-job-instance-csv-base-import-show-properties
-        position: 130
-        targetZone: global-settings
-        config:
-            fieldCode: configuration.escape
-            readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.escape.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.escape.help
-
     pim-job-instance-csv-base-import-edit-properties-file-upload:
         module: pim/job/common/edit/field/switch
         parent: pim-job-instance-csv-base-import-edit-properties
-        position: 140
+        position: 130
         targetZone: global-settings
         config:
             fieldCode: configuration.uploadAllowed
@@ -90,7 +79,7 @@ extensions:
     pim-job-instance-csv-base-import-edit-properties-delimiter:
         module: pim/job/common/edit/field/text
         parent: pim-job-instance-csv-base-import-edit-properties
-        position: 150
+        position: 140
         targetZone: global-settings
         config:
             fieldCode: configuration.delimiter
@@ -101,13 +90,24 @@ extensions:
     pim-job-instance-csv-base-import-edit-properties-enclosure:
         module: pim/job/common/edit/field/text
         parent: pim-job-instance-csv-base-import-edit-properties
-        position: 160
+        position: 150
         targetZone: global-settings
         config:
             fieldCode: configuration.enclosure
             readOnly: false
             label: pim_enrich.form.job_instance.tab.properties.enclosure.title
             tooltip: pim_enrich.form.job_instance.tab.properties.enclosure.help
+
+    pim-job-instance-csv-base-import-edit-properties-escape:
+        module: pim/job/common/edit/field/text
+        parent: pim-job-instance-csv-base-import-edit-properties
+        position: 160
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.escape
+            readOnly: false
+            label: pim_enrich.form.job_instance.tab.properties.escape.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.escape.help
 
     pim-job-instance-csv-base-import-edit-label:
         module: pim/job/common/edit/label

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_base_import_show.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_base_import_show.yml
@@ -66,16 +66,16 @@ extensions:
             label: pim_enrich.form.job_instance.tab.properties.file_path.title
             tooltip: pim_enrich.form.job_instance.tab.properties.file_path.help
 
-    pim-job-instance-csv-base-import-show-properties-escape:
-        module: pim/job/common/edit/field/text
+    pim-job-instance-csv-base-import-show-properties-file-upload:
+        module: pim/job/common/edit/field/switch
         parent: pim-job-instance-csv-base-import-show-properties
         position: 130
         targetZone: global-settings
         config:
-            fieldCode: configuration.escape
+            fieldCode: configuration.uploadAllowed
             readOnly: true
-            label: pim_enrich.form.job_instance.tab.properties.escape.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.escape.help
+            label: pim_enrich.form.job_instance.tab.properties.upload_allowed.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.upload_allowed.help
 
     pim-job-instance-csv-base-import-show-properties-delimiter:
         module: pim/job/common/edit/field/text
@@ -99,16 +99,16 @@ extensions:
             label: pim_enrich.form.job_instance.tab.properties.enclosure.title
             tooltip: pim_enrich.form.job_instance.tab.properties.enclosure.help
 
-    pim-job-instance-csv-base-import-show-properties-file-upload:
-        module: pim/job/common/edit/field/switch
+    pim-job-instance-csv-base-import-show-properties-escape:
+        module: pim/job/common/edit/field/text
         parent: pim-job-instance-csv-base-import-show-properties
         position: 160
         targetZone: global-settings
         config:
-            fieldCode: configuration.uploadAllowed
+            fieldCode: configuration.escape
             readOnly: true
-            label: pim_enrich.form.job_instance.tab.properties.upload_allowed.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.upload_allowed.help
+            label: pim_enrich.form.job_instance.tab.properties.escape.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.escape.help
 
     pim-job-instance-csv-base-import-show-label:
         module: pim/job/common/edit/label

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_export_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_export_edit.yml
@@ -64,28 +64,6 @@ extensions:
             label: pim_enrich.form.job_instance.tab.properties.label.title
             readOnly: false
 
-    pim-job-instance-csv-product-export-edit-properties-decimal-separator:
-        module: pim/job/common/edit/field/decimal-separator
-        parent: pim-job-instance-csv-product-export-edit-properties
-        position: 100
-        targetZone: global-settings
-        config:
-            fieldCode: configuration.decimalSeparator
-            readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.decimal_separator.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.decimal_separator.help
-
-    pim-job-instance-csv-product-export-edit-properties-date-format:
-        module: pim/job/product/edit/field/date-format
-        parent: pim-job-instance-csv-product-export-edit-properties
-        position: 110
-        targetZone: global-settings
-        config:
-            fieldCode: configuration.dateFormat
-            readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.date_format.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.date_format.help
-
     pim-job-instance-csv-product-export-edit-properties-file-path:
         module: pim/job/common/edit/field/text
         parent: pim-job-instance-csv-product-export-edit-properties
@@ -97,10 +75,32 @@ extensions:
             label: pim_enrich.form.job_instance.tab.properties.file_path.title
             tooltip: pim_enrich.form.job_instance.tab.properties.file_path.help
 
+    pim-job-instance-csv-product-export-edit-properties-decimal-separator:
+        module: pim/job/common/edit/field/decimal-separator
+        parent: pim-job-instance-csv-product-export-edit-properties
+        position: 130
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.decimalSeparator
+            readOnly: false
+            label: pim_enrich.form.job_instance.tab.properties.decimal_separator.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.decimal_separator.help
+
+    pim-job-instance-csv-product-export-edit-properties-date-format:
+        module: pim/job/product/edit/field/date-format
+        parent: pim-job-instance-csv-product-export-edit-properties
+        position: 140
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.dateFormat
+            readOnly: false
+            label: pim_enrich.form.job_instance.tab.properties.date_format.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.date_format.help
+
     pim-job-instance-csv-product-export-edit-properties-delimiter:
         module: pim/job/common/edit/field/text
         parent: pim-job-instance-csv-product-export-edit-properties
-        position: 130
+        position: 150
         targetZone: global-settings
         config:
             fieldCode: configuration.delimiter
@@ -111,7 +111,7 @@ extensions:
     pim-job-instance-csv-product-export-edit-properties-enclosure:
         module: pim/job/common/edit/field/text
         parent: pim-job-instance-csv-product-export-edit-properties
-        position: 140
+        position: 160
         targetZone: global-settings
         config:
             fieldCode: configuration.enclosure
@@ -122,7 +122,7 @@ extensions:
     pim-job-instance-csv-product-export-edit-properties-with-header:
         module: pim/job/common/edit/field/switch
         parent: pim-job-instance-csv-product-export-edit-properties
-        position: 150
+        position: 170
         targetZone: global-settings
         config:
             fieldCode: configuration.withHeader
@@ -133,7 +133,7 @@ extensions:
     pim-job-instance-csv-product-export-edit-properties-with-media:
         module: pim/job/common/edit/field/switch
         parent: pim-job-instance-csv-product-export-edit-properties
-        position: 160
+        position: 180
         targetZone: global-settings
         config:
             fieldCode: configuration.with_media

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_export_show.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_export_show.yml
@@ -59,28 +59,6 @@ extensions:
             label: pim_enrich.form.job_instance.tab.properties.label.title
             readOnly: true
 
-    pim-job-instance-csv-product-export-show-properties-decimal-separator:
-        module: pim/job/common/edit/field/decimal-separator
-        parent: pim-job-instance-csv-product-export-show-properties
-        position: 100
-        targetZone: global-settings
-        config:
-            fieldCode: configuration.decimalSeparator
-            readOnly: true
-            label: pim_enrich.form.job_instance.tab.properties.decimal_separator.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.decimal_separator.help
-
-    pim-job-instance-csv-product-export-show-properties-date-format:
-        module: pim/job/product/edit/field/date-format
-        parent: pim-job-instance-csv-product-export-show-properties
-        position: 110
-        targetZone: global-settings
-        config:
-            fieldCode: configuration.dateFormat
-            readOnly: true
-            label: pim_enrich.form.job_instance.tab.properties.date_format.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.date_format.help
-
     pim-job-instance-csv-product-export-show-properties-file-path:
         module: pim/job/common/edit/field/text
         parent: pim-job-instance-csv-product-export-show-properties
@@ -92,10 +70,32 @@ extensions:
             label: pim_enrich.form.job_instance.tab.properties.file_path.title
             tooltip: pim_enrich.form.job_instance.tab.properties.file_path.help
 
+    pim-job-instance-csv-product-export-show-properties-decimal-separator:
+        module: pim/job/common/edit/field/decimal-separator
+        parent: pim-job-instance-csv-product-export-show-properties
+        position: 130
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.decimalSeparator
+            readOnly: true
+            label: pim_enrich.form.job_instance.tab.properties.decimal_separator.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.decimal_separator.help
+
+    pim-job-instance-csv-product-export-show-properties-date-format:
+        module: pim/job/product/edit/field/date-format
+        parent: pim-job-instance-csv-product-export-show-properties
+        position: 140
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.dateFormat
+            readOnly: true
+            label: pim_enrich.form.job_instance.tab.properties.date_format.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.date_format.help
+
     pim-job-instance-csv-product-export-show-properties-delimiter:
         module: pim/job/common/edit/field/text
         parent: pim-job-instance-csv-product-export-show-properties
-        position: 130
+        position: 150
         targetZone: global-settings
         config:
             fieldCode: configuration.delimiter
@@ -106,7 +106,7 @@ extensions:
     pim-job-instance-csv-product-export-show-properties-enclosure:
         module: pim/job/common/edit/field/text
         parent: pim-job-instance-csv-product-export-show-properties
-        position: 140
+        position: 160
         targetZone: global-settings
         config:
             fieldCode: configuration.enclosure
@@ -117,7 +117,7 @@ extensions:
     pim-job-instance-csv-product-export-show-properties-with-header:
         module: pim/job/common/edit/field/switch
         parent: pim-job-instance-csv-product-export-show-properties
-        position: 150
+        position: 170
         targetZone: global-settings
         config:
             fieldCode: configuration.withHeader
@@ -128,7 +128,7 @@ extensions:
     pim-job-instance-csv-product-export-show-properties-with-media:
         module: pim/job/common/edit/field/switch
         parent: pim-job-instance-csv-product-export-show-properties
-        position: 160
+        position: 180
         targetZone: global-settings
         config:
             fieldCode: configuration.with_media

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_import_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_import_edit.yml
@@ -52,29 +52,6 @@ extensions:
         config:
             fieldCode: label
             label: pim_enrich.form.job_instance.tab.properties.label.title
-            readOnly: false
-
-    pim-job-instance-csv-product-import-edit-properties-decimal-separator:
-        module: pim/job/common/edit/field/decimal-separator
-        parent: pim-job-instance-csv-product-import-edit-properties
-        position: 100
-        targetZone: global-settings
-        config:
-            fieldCode: configuration.decimalSeparator
-            readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.decimal_separator.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.decimal_separator.help
-
-    pim-job-instance-csv-product-import-edit-properties-date-format:
-        module: pim/job/product/edit/field/date-format
-        parent: pim-job-instance-csv-product-import-edit-properties
-        position: 110
-        targetZone: global-settings
-        config:
-            fieldCode: configuration.dateFormat
-            readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.date_format.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.date_format.help
 
     pim-job-instance-csv-product-import-edit-properties-file-path:
         module: pim/job/common/edit/field/text
@@ -87,10 +64,22 @@ extensions:
             label: pim_enrich.form.job_instance.tab.properties.file_path.title
             tooltip: pim_enrich.form.job_instance.tab.properties.file_path.help
 
+    pim-job-instance-csv-product-import-edit-properties-file-upload:
+        module: pim/job/common/edit/field/switch
+        parent: pim-job-instance-csv-product-import-edit-properties
+        position: 130
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.uploadAllowed
+            readOnly: false
+            label: pim_enrich.form.job_instance.tab.properties.upload_allowed.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.upload_allowed.help
+            readOnly: false
+
     pim-job-instance-csv-product-import-edit-properties-delimiter:
         module: pim/job/common/edit/field/text
         parent: pim-job-instance-csv-product-import-edit-properties
-        position: 130
+        position: 140
         targetZone: global-settings
         config:
             fieldCode: configuration.delimiter
@@ -101,24 +90,13 @@ extensions:
     pim-job-instance-csv-product-import-edit-properties-enclosure:
         module: pim/job/common/edit/field/text
         parent: pim-job-instance-csv-product-import-edit-properties
-        position: 140
+        position: 150
         targetZone: global-settings
         config:
             fieldCode: configuration.enclosure
             readOnly: false
             label: pim_enrich.form.job_instance.tab.properties.enclosure.title
             tooltip: pim_enrich.form.job_instance.tab.properties.enclosure.help
-
-    pim-job-instance-csv-product-import-edit-properties-with-header:
-        module: pim/job/common/edit/field/switch
-        parent: pim-job-instance-csv-product-import-edit-properties
-        position: 150
-        targetZone: global-settings
-        config:
-            fieldCode: configuration.withHeader
-            readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.with_header.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.with_header.help
 
     pim-job-instance-csv-product-import-edit-properties-escape:
         module: pim/job/common/edit/field/text
@@ -131,32 +109,43 @@ extensions:
             label: pim_enrich.form.job_instance.tab.properties.escape.title
             tooltip: pim_enrich.form.job_instance.tab.properties.escape.help
 
-    pim-job-instance-csv-product-import-edit-properties-with-media:
-        module: pim/job/common/edit/field/switch
-        parent: pim-job-instance-csv-product-import-edit-properties
-        position: 160
-        targetZone: global-settings
-        config:
-            fieldCode: configuration.with_media
-            readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.with_media.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.with_media.help
-
-    pim-job-instance-csv-product-import-edit-properties-file-upload:
-        module: pim/job/common/edit/field/switch
+    pim-job-instance-csv-product-import-edit-properties-decimal-separator:
+        module: pim/job/common/edit/field/decimal-separator
         parent: pim-job-instance-csv-product-import-edit-properties
         position: 170
         targetZone: global-settings
         config:
-            fieldCode: configuration.uploadAllowed
+            fieldCode: configuration.decimalSeparator
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.upload_allowed.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.upload_allowed.help
+            label: pim_enrich.form.job_instance.tab.properties.decimal_separator.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.decimal_separator.help
+
+    pim-job-instance-csv-product-import-edit-properties-date-format:
+        module: pim/job/product/edit/field/date-format
+        parent: pim-job-instance-csv-product-import-edit-properties
+        position: 180
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.dateFormat
+            readOnly: false
+            label: pim_enrich.form.job_instance.tab.properties.date_format.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.date_format.help
+
+    pim-job-instance-csv-product-import-edit-properties-enabled:
+        module: pim/job/common/edit/field/switch
+        parent: pim-job-instance-csv-product-import-edit-properties
+        position: 190
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.enabled
+            readOnly: false
+            label: pim_enrich.form.job_instance.tab.properties.enabled.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.enabled.help
 
     pim-job-instance-csv-product-import-edit-properties-categories-column:
         module: pim/job/common/edit/field/text
         parent: pim-job-instance-csv-product-import-edit-properties
-        position: 180
+        position: 200
         targetZone: global-settings
         config:
             fieldCode: configuration.categoriesColumn
@@ -167,7 +156,7 @@ extensions:
     pim-job-instance-csv-product-import-edit-properties-family-column:
         module: pim/job/common/edit/field/text
         parent: pim-job-instance-csv-product-import-edit-properties
-        position: 190
+        position: 210
         targetZone: global-settings
         config:
             fieldCode: configuration.familyColumn
@@ -178,7 +167,7 @@ extensions:
     pim-job-instance-csv-product-import-edit-properties-groups-column:
         module: pim/job/common/edit/field/text
         parent: pim-job-instance-csv-product-import-edit-properties
-        position: 200
+        position: 220
         targetZone: global-settings
         config:
             fieldCode: configuration.groupsColumn
@@ -186,21 +175,10 @@ extensions:
             label: pim_enrich.form.job_instance.tab.properties.groups_column.title
             tooltip: pim_enrich.form.job_instance.tab.properties.groups_column.help
 
-    pim-job-instance-csv-product-import-edit-properties-enabled:
-        module: pim/job/common/edit/field/switch
-        parent: pim-job-instance-csv-product-import-edit-properties
-        position: 200
-        targetZone: global-settings
-        config:
-            fieldCode: configuration.enabled
-            readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.enabled.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.enabled.help
-
     pim-job-instance-csv-product-import-edit-properties-enabled-comparison:
         module: pim/job/common/edit/field/switch
         parent: pim-job-instance-csv-product-import-edit-properties
-        position: 210
+        position: 230
         targetZone: global-settings
         config:
             fieldCode: configuration.enabledComparison
@@ -211,7 +189,7 @@ extensions:
     pim-job-instance-csv-product-import-edit-properties-real-time-versioning:
         module: pim/job/common/edit/field/switch
         parent: pim-job-instance-csv-product-import-edit-properties
-        position: 220
+        position: 240
         targetZone: global-settings
         config:
             fieldCode: configuration.realTimeVersioning

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_import_show.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_import_show.yml
@@ -67,10 +67,21 @@ extensions:
             label: pim_enrich.form.job_instance.tab.properties.file_path.title
             tooltip: pim_enrich.form.job_instance.tab.properties.file_path.help
 
+    pim-job-instance-csv-product-import-show-properties-file-upload:
+        module: pim/job/common/edit/field/switch
+        parent: pim-job-instance-csv-product-import-show-properties
+        position: 130
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.uploadAllowed
+            readOnly: true
+            label: pim_enrich.form.job_instance.tab.properties.upload_allowed.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.upload_allowed.help
+
     pim-job-instance-csv-product-import-show-properties-delimiter:
         module: pim/job/common/edit/field/text
         parent: pim-job-instance-csv-product-import-show-properties
-        position: 130
+        position: 140
         targetZone: global-settings
         config:
             fieldCode: configuration.delimiter
@@ -81,7 +92,7 @@ extensions:
     pim-job-instance-csv-product-import-show-properties-enclosure:
         module: pim/job/common/edit/field/text
         parent: pim-job-instance-csv-product-import-show-properties
-        position: 140
+        position: 150
         targetZone: global-settings
         config:
             fieldCode: configuration.enclosure
@@ -89,32 +100,10 @@ extensions:
             label: pim_enrich.form.job_instance.tab.properties.enclosure.title
             tooltip: pim_enrich.form.job_instance.tab.properties.enclosure.help
 
-    pim-job-instance-csv-product-import-show-properties-decimal-separator:
-        module: pim/job/common/edit/field/decimal-separator
-        parent: pim-job-instance-csv-product-import-show-properties
-        position: 150
-        targetZone: global-settings
-        config:
-            fieldCode: configuration.decimalSeparator
-            readOnly: true
-            label: pim_enrich.form.job_instance.tab.properties.decimal_separator.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.decimal_separator.help
-
-    pim-job-instance-csv-product-import-show-properties-with-header:
-        module: pim/job/common/edit/field/switch
-        parent: pim-job-instance-csv-product-import-show-properties
-        position: 160
-        targetZone: global-settings
-        config:
-            fieldCode: configuration.withHeader
-            readOnly: true
-            label: pim_enrich.form.job_instance.tab.properties.with_header.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.with_header.help
-
     pim-job-instance-csv-product-import-show-properties-escape:
         module: pim/job/common/edit/field/text
         parent: pim-job-instance-csv-product-import-show-properties
-        position: 170
+        position: 160
         targetZone: global-settings
         config:
             fieldCode: configuration.escape
@@ -122,10 +111,43 @@ extensions:
             label: pim_enrich.form.job_instance.tab.properties.escape.title
             tooltip: pim_enrich.form.job_instance.tab.properties.escape.help
 
+    pim-job-instance-csv-product-import-show-properties-decimal-separator:
+        module: pim/job/common/edit/field/decimal-separator
+        parent: pim-job-instance-csv-product-import-show-properties
+        position: 170
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.decimalSeparator
+            readOnly: true
+            label: pim_enrich.form.job_instance.tab.properties.decimal_separator.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.decimal_separator.help
+
+    pim-job-instance-csv-product-import-show-properties-date-format:
+        module: pim/job/product/edit/field/date-format
+        parent: pim-job-instance-csv-product-import-show-properties
+        position: 180
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.dateFormat
+            readOnly: true
+            label: pim_enrich.form.job_instance.tab.properties.date_format.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.date_format.help
+
+    pim-job-instance-csv-product-import-show-properties-enabled:
+        module: pim/job/common/edit/field/switch
+        parent: pim-job-instance-csv-product-import-show-properties
+        position: 190
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.enabled
+            readOnly: true
+            label: pim_enrich.form.job_instance.tab.properties.enabled.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.enabled.help
+
     pim-job-instance-csv-product-import-show-properties-categories-column:
         module: pim/job/common/edit/field/text
         parent: pim-job-instance-csv-product-import-show-properties
-        position: 180
+        position: 200
         targetZone: global-settings
         config:
             fieldCode: configuration.categoriesColumn
@@ -136,7 +158,7 @@ extensions:
     pim-job-instance-csv-product-import-show-properties-family-column:
         module: pim/job/common/edit/field/text
         parent: pim-job-instance-csv-product-import-show-properties
-        position: 190
+        position: 210
         targetZone: global-settings
         config:
             fieldCode: configuration.familyColumn
@@ -147,7 +169,7 @@ extensions:
     pim-job-instance-csv-product-import-show-properties-groups-column:
         module: pim/job/common/edit/field/text
         parent: pim-job-instance-csv-product-import-show-properties
-        position: 200
+        position: 220
         targetZone: global-settings
         config:
             fieldCode: configuration.groupsColumn
@@ -155,32 +177,10 @@ extensions:
             label: pim_enrich.form.job_instance.tab.properties.groups_column.title
             tooltip: pim_enrich.form.job_instance.tab.properties.groups_column.help
 
-    pim-job-instance-csv-product-import-show-properties-enabled:
-        module: pim/job/common/edit/field/switch
-        parent: pim-job-instance-csv-product-import-show-properties
-        position: 210
-        targetZone: global-settings
-        config:
-            fieldCode: configuration.enabled
-            readOnly: true
-            label: pim_enrich.form.job_instance.tab.properties.enabled.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.enabled.help
-
-    pim-job-instance-csv-product-import-show-properties-date-format:
-        module: pim/job/product/edit/field/date-format
-        parent: pim-job-instance-csv-product-import-show-properties
-        position: 230
-        targetZone: global-settings
-        config:
-            fieldCode: configuration.dateFormat
-            readOnly: true
-            label: pim_enrich.form.job_instance.tab.properties.date_format.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.date_format.help
-
     pim-job-instance-csv-product-import-show-properties-enabled-comparison:
         module: pim/job/common/edit/field/switch
         parent: pim-job-instance-csv-product-import-show-properties
-        position: 210
+        position: 230
         targetZone: global-settings
         config:
             fieldCode: configuration.enabledComparison
@@ -191,24 +191,13 @@ extensions:
     pim-job-instance-csv-product-import-show-properties-real-time-versioning:
         module: pim/job/common/edit/field/switch
         parent: pim-job-instance-csv-product-import-show-properties
-        position: 220
+        position: 240
         targetZone: global-settings
         config:
             fieldCode: configuration.realTimeVersioning
             readOnly: true
             label: pim_enrich.form.job_instance.tab.properties.real_time_versioning.title
             tooltip: pim_enrich.form.job_instance.tab.properties.real_time_versioning.help
-
-    pim-job-instance-csv-product-import-show-properties-file-upload:
-        module: pim/job/common/edit/field/switch
-        parent: pim-job-instance-csv-product-import-show-properties
-        position: 230
-        targetZone: global-settings
-        config:
-            fieldCode: configuration.uploadAllowed
-            readOnly: true
-            label: pim_enrich.form.job_instance.tab.properties.upload_allowed.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.upload_allowed.help
 
     pim-job-instance-csv-product-import-show-label:
         module: pim/job/common/edit/label

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_base_export_show.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_base_export_show.yml
@@ -74,7 +74,7 @@ extensions:
     pim-job-instance-xlsx-base-export-show-properties-with-header:
         module: pim/job/common/edit/field/switch
         parent: pim-job-instance-xlsx-base-export-show-properties
-        position: 160
+        position: 140
         targetZone: global-settings
         config:
             fieldCode: configuration.withHeader

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_base_import_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_base_import_edit.yml
@@ -68,7 +68,7 @@ extensions:
     pim-job-instance-xlsx-base-import-edit-properties-file-upload:
         module: pim/job/common/edit/field/switch
         parent: pim-job-instance-xlsx-base-import-edit-properties
-        position: 140
+        position: 130
         targetZone: global-settings
         config:
             fieldCode: configuration.uploadAllowed

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_base_import_show.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_base_import_show.yml
@@ -69,7 +69,7 @@ extensions:
     pim-job-instance-xlsx-base-import-show-properties-file-upload:
         module: pim/job/common/edit/field/switch
         parent: pim-job-instance-xlsx-base-import-show-properties
-        position: 160
+        position: 130
         targetZone: global-settings
         config:
             fieldCode: configuration.uploadAllowed

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_export_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_export_edit.yml
@@ -64,28 +64,6 @@ extensions:
             label: pim_enrich.form.job_instance.tab.properties.label.title
             readOnly: false
 
-    pim-job-instance-csv-product-export-edit-properties-decimal-separator:
-        module: pim/job/common/edit/field/decimal-separator
-        parent: pim-job-instance-csv-product-export-edit-properties
-        position: 100
-        targetZone: global-settings
-        config:
-            fieldCode: configuration.decimalSeparator
-            readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.decimal_separator.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.decimal_separator.help
-
-    pim-job-instance-xlsx-product-export-edit-properties-date-format:
-        module: pim/job/product/edit/field/date-format
-        parent: pim-job-instance-xlsx-product-export-edit-properties
-        position: 110
-        targetZone: global-settings
-        config:
-            fieldCode: configuration.dateFormat
-            readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.date_format.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.date_format.help
-
     pim-job-instance-xlsx-product-export-edit-properties-file-path:
         module: pim/job/common/edit/field/text
         parent: pim-job-instance-xlsx-product-export-edit-properties
@@ -97,10 +75,32 @@ extensions:
             label: pim_enrich.form.job_instance.tab.properties.file_path.title
             tooltip: pim_enrich.form.job_instance.tab.properties.file_path.help
 
+    pim-job-instance-csv-product-export-edit-properties-decimal-separator:
+        module: pim/job/common/edit/field/decimal-separator
+        parent: pim-job-instance-csv-product-export-edit-properties
+        position: 130
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.decimalSeparator
+            readOnly: false
+            label: pim_enrich.form.job_instance.tab.properties.decimal_separator.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.decimal_separator.help
+
+    pim-job-instance-xlsx-product-export-edit-properties-date-format:
+        module: pim/job/product/edit/field/date-format
+        parent: pim-job-instance-xlsx-product-export-edit-properties
+        position: 140
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.dateFormat
+            readOnly: false
+            label: pim_enrich.form.job_instance.tab.properties.date_format.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.date_format.help
+
     pim-job-instance-xlsx-product-export-edit-properties-lines-per-file:
         module: pim/job/common/edit/field/text
         parent: pim-job-instance-xlsx-product-export-edit-properties
-        position: 130
+        position: 150
         targetZone: global-settings
         config:
             fieldCode: configuration.linesPerFile
@@ -111,7 +111,7 @@ extensions:
     pim-job-instance-xlsx-product-export-edit-properties-with-header:
         module: pim/job/common/edit/field/switch
         parent: pim-job-instance-xlsx-product-export-edit-properties
-        position: 140
+        position: 160
         targetZone: global-settings
         config:
             fieldCode: configuration.withHeader
@@ -122,7 +122,7 @@ extensions:
     pim-job-instance-xlsx-product-export-edit-properties-with-media:
         module: pim/job/common/edit/field/switch
         parent: pim-job-instance-xlsx-product-export-edit-properties
-        position: 150
+        position: 170
         targetZone: global-settings
         config:
             fieldCode: configuration.with_media

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_export_show.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_export_show.yml
@@ -59,28 +59,6 @@ extensions:
             label: pim_enrich.form.job_instance.tab.properties.label.title
             readOnly: true
 
-    pim-job-instance-csv-product-export-show-properties-decimal-separator:
-        module: pim/job/common/edit/field/decimal-separator
-        parent: pim-job-instance-csv-product-export-show-properties
-        position: 100
-        targetZone: global-settings
-        config:
-            fieldCode: configuration.decimalSeparator
-            readOnly: true
-            label: pim_enrich.form.job_instance.tab.properties.decimal_separator.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.decimal_separator.help
-
-    pim-job-instance-xlsx-product-export-show-properties-date-format:
-        module: pim/job/product/edit/field/date-format
-        parent: pim-job-instance-xlsx-product-export-show-properties
-        position: 110
-        targetZone: global-settings
-        config:
-            fieldCode: configuration.dateFormat
-            readOnly: true
-            label: pim_enrich.form.job_instance.tab.properties.date_format.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.date_format.help
-
     pim-job-instance-xlsx-product-export-show-properties-file-path:
         module: pim/job/common/edit/field/text
         parent: pim-job-instance-xlsx-product-export-show-properties
@@ -92,10 +70,32 @@ extensions:
             label: pim_enrich.form.job_instance.tab.properties.file_path.title
             tooltip: pim_enrich.form.job_instance.tab.properties.file_path.help
 
+    pim-job-instance-csv-product-export-show-properties-decimal-separator:
+        module: pim/job/common/edit/field/decimal-separator
+        parent: pim-job-instance-csv-product-export-show-properties
+        position: 130
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.decimalSeparator
+            readOnly: true
+            label: pim_enrich.form.job_instance.tab.properties.decimal_separator.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.decimal_separator.help
+
+    pim-job-instance-xlsx-product-export-show-properties-date-format:
+        module: pim/job/product/edit/field/date-format
+        parent: pim-job-instance-xlsx-product-export-show-properties
+        position: 140
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.dateFormat
+            readOnly: true
+            label: pim_enrich.form.job_instance.tab.properties.date_format.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.date_format.help
+
     pim-job-instance-xlsx-product-export-show-properties-lines-per-file:
         module: pim/job/common/edit/field/text
         parent: pim-job-instance-xlsx-product-export-show-properties
-        position: 130
+        position: 150
         targetZone: global-settings
         config:
             fieldCode: configuration.linesPerFile
@@ -106,7 +106,7 @@ extensions:
     pim-job-instance-xlsx-product-export-show-properties-with-header:
         module: pim/job/common/edit/field/switch
         parent: pim-job-instance-xlsx-product-export-show-properties
-        position: 140
+        position: 160
         targetZone: global-settings
         config:
             fieldCode: configuration.withHeader
@@ -117,7 +117,7 @@ extensions:
     pim-job-instance-xlsx-product-export-show-properties-with-media:
         module: pim/job/common/edit/field/switch
         parent: pim-job-instance-xlsx-product-export-show-properties
-        position: 150
+        position: 170
         targetZone: global-settings
         config:
             fieldCode: configuration.with_media

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_import_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_import_edit.yml
@@ -65,32 +65,10 @@ extensions:
             label: pim_enrich.form.job_instance.tab.properties.file_path.title
             tooltip: pim_enrich.form.job_instance.tab.properties.file_path.help
 
-    pim-job-instance-xlsx-product-import-edit-properties-with-header:
-        module: pim/job/common/edit/field/switch
-        parent: pim-job-instance-xlsx-product-import-edit-properties
-        position: 130
-        targetZone: global-settings
-        config:
-            fieldCode: configuration.withHeader
-            readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.with_header.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.with_header.help
-
-    pim-job-instance-xlsx-product-import-edit-properties-with-media:
-        module: pim/job/common/edit/field/switch
-        parent: pim-job-instance-xlsx-product-import-edit-properties
-        position: 140
-        targetZone: global-settings
-        config:
-            fieldCode: configuration.with_media
-            readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.with_media.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.with_media.help
-
     pim-job-instance-xlsx-product-import-edit-properties-file-upload:
         module: pim/job/common/edit/field/switch
         parent: pim-job-instance-xlsx-product-import-edit-properties
-        position: 150
+        position: 130
         targetZone: global-settings
         config:
             fieldCode: configuration.uploadAllowed
@@ -101,7 +79,7 @@ extensions:
     pim-job-instance-xlsx-product-import-edit-properties-date-format:
         module: pim/job/product/edit/field/date-format
         parent: pim-job-instance-xlsx-product-import-edit-properties
-        position: 160
+        position: 140
         targetZone: global-settings
         config:
             fieldCode: configuration.dateFormat
@@ -109,10 +87,21 @@ extensions:
             label: pim_enrich.form.job_instance.tab.properties.date_format.title
             tooltip: pim_enrich.form.job_instance.tab.properties.date_format.help
 
+    pim-job-instance-xlsx-product-import-edit-properties-enabled:
+        module: pim/job/common/edit/field/switch
+        parent: pim-job-instance-xlsx-product-import-edit-properties
+        position: 150
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.enabled
+            readOnly: false
+            label: pim_enrich.form.job_instance.tab.properties.enabled.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.enabled.help
+
     pim-job-instance-xlsx-product-import-edit-properties-categories-column:
         module: pim/job/common/edit/field/text
         parent: pim-job-instance-xlsx-product-import-edit-properties
-        position: 170
+        position: 160
         targetZone: global-settings
         config:
             fieldCode: configuration.categoriesColumn
@@ -123,7 +112,7 @@ extensions:
     pim-job-instance-xlsx-product-import-edit-properties-family-column:
         module: pim/job/common/edit/field/text
         parent: pim-job-instance-xlsx-product-import-edit-properties
-        position: 180
+        position: 170
         targetZone: global-settings
         config:
             fieldCode: configuration.familyColumn
@@ -134,7 +123,7 @@ extensions:
     pim-job-instance-xlsx-product-import-edit-properties-groups-column:
         module: pim/job/common/edit/field/text
         parent: pim-job-instance-xlsx-product-import-edit-properties
-        position: 190
+        position: 180
         targetZone: global-settings
         config:
             fieldCode: configuration.groupsColumn
@@ -142,21 +131,10 @@ extensions:
             label: pim_enrich.form.job_instance.tab.properties.groups_column.title
             tooltip: pim_enrich.form.job_instance.tab.properties.groups_column.help
 
-    pim-job-instance-xlsx-product-import-edit-properties-enabled:
-        module: pim/job/common/edit/field/switch
-        parent: pim-job-instance-xlsx-product-import-edit-properties
-        position: 200
-        targetZone: global-settings
-        config:
-            fieldCode: configuration.enabled
-            readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.enabled.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.enabled.help
-
     pim-job-instance-xlsx-product-import-edit-properties-enabled-comparison:
         module: pim/job/common/edit/field/switch
         parent: pim-job-instance-xlsx-product-import-edit-properties
-        position: 210
+        position: 190
         targetZone: global-settings
         config:
             fieldCode: configuration.enabledComparison
@@ -167,7 +145,7 @@ extensions:
     pim-job-instance-xlsx-product-import-edit-properties-real-time-versioning:
         module: pim/job/common/edit/field/switch
         parent: pim-job-instance-xlsx-product-import-edit-properties
-        position: 220
+        position: 200
         targetZone: global-settings
         config:
             fieldCode: configuration.realTimeVersioning

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_import_show.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_import_show.yml
@@ -67,21 +67,21 @@ extensions:
             label: pim_enrich.form.job_instance.tab.properties.file_path.title
             tooltip: pim_enrich.form.job_instance.tab.properties.file_path.help
 
-    pim-job-instance-xlsx-product-import-show-properties-with-header:
+    pim-job-instance-xlsx-product-import-show-properties-file-upload:
         module: pim/job/common/edit/field/switch
         parent: pim-job-instance-xlsx-product-import-show-properties
-        position: 160
+        position: 130
         targetZone: global-settings
         config:
-            fieldCode: configuration.withHeader
+            fieldCode: configuration.uploadAllowed
             readOnly: true
-            label: pim_enrich.form.job_instance.tab.properties.with_header.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.with_header.help
+            label: pim_enrich.form.job_instance.tab.properties.upload_allowed.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.upload_allowed.help
 
     pim-job-instance-xlsx-product-import-show-properties-categories-column:
         module: pim/job/common/edit/field/text
         parent: pim-job-instance-xlsx-product-import-show-properties
-        position: 180
+        position: 140
         targetZone: global-settings
         config:
             fieldCode: configuration.categoriesColumn
@@ -89,10 +89,32 @@ extensions:
             label: pim_enrich.form.job_instance.tab.properties.categories_column.title
             tooltip: pim_enrich.form.job_instance.tab.properties.categories_column.help
 
+    pim-job-instance-xlsx-product-import-show-properties-date-format:
+        module: pim/job/product/edit/field/date-format
+        parent: pim-job-instance-xlsx-product-import-show-properties
+        position: 150
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.dateFormat
+            readOnly: true
+            label: pim_enrich.form.job_instance.tab.properties.date_format.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.date_format.help
+
+    pim-job-instance-xlsx-product-import-show-properties-enabled:
+        module: pim/job/common/edit/field/switch
+        parent: pim-job-instance-xlsx-product-import-show-properties
+        position: 160
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.enabled
+            readOnly: true
+            label: pim_enrich.form.job_instance.tab.properties.enabled.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.enabled.help
+
     pim-job-instance-xlsx-product-import-show-properties-family-column:
         module: pim/job/common/edit/field/text
         parent: pim-job-instance-xlsx-product-import-show-properties
-        position: 190
+        position: 170
         targetZone: global-settings
         config:
             fieldCode: configuration.familyColumn
@@ -103,7 +125,7 @@ extensions:
     pim-job-instance-xlsx-product-import-show-properties-groups-column:
         module: pim/job/common/edit/field/text
         parent: pim-job-instance-xlsx-product-import-show-properties
-        position: 200
+        position: 180
         targetZone: global-settings
         config:
             fieldCode: configuration.groupsColumn
@@ -111,32 +133,10 @@ extensions:
             label: pim_enrich.form.job_instance.tab.properties.groups_column.title
             tooltip: pim_enrich.form.job_instance.tab.properties.groups_column.help
 
-    pim-job-instance-xlsx-product-import-show-properties-enabled:
-        module: pim/job/common/edit/field/switch
-        parent: pim-job-instance-xlsx-product-import-show-properties
-        position: 210
-        targetZone: global-settings
-        config:
-            fieldCode: configuration.enabled
-            readOnly: true
-            label: pim_enrich.form.job_instance.tab.properties.enabled.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.enabled.help
-
-    pim-job-instance-xlsx-product-import-show-properties-date-format:
-        module: pim/job/product/edit/field/date-format
-        parent: pim-job-instance-xlsx-product-import-show-properties
-        position: 230
-        targetZone: global-settings
-        config:
-            fieldCode: configuration.dateFormat
-            readOnly: true
-            label: pim_enrich.form.job_instance.tab.properties.date_format.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.date_format.help
-
     pim-job-instance-xlsx-product-import-show-properties-enabled-comparison:
         module: pim/job/common/edit/field/switch
         parent: pim-job-instance-xlsx-product-import-show-properties
-        position: 210
+        position: 190
         targetZone: global-settings
         config:
             fieldCode: configuration.enabledComparison
@@ -147,24 +147,13 @@ extensions:
     pim-job-instance-xlsx-product-import-show-properties-real-time-versioning:
         module: pim/job/common/edit/field/switch
         parent: pim-job-instance-xlsx-product-import-show-properties
-        position: 220
+        position: 200
         targetZone: global-settings
         config:
             fieldCode: configuration.realTimeVersioning
             readOnly: true
             label: pim_enrich.form.job_instance.tab.properties.real_time_versioning.title
             tooltip: pim_enrich.form.job_instance.tab.properties.real_time_versioning.help
-
-    pim-job-instance-xlsx-product-import-show-properties-file-upload:
-        module: pim/job/common/edit/field/switch
-        parent: pim-job-instance-xlsx-product-import-show-properties
-        position: 230
-        targetZone: global-settings
-        config:
-            fieldCode: configuration.uploadAllowed
-            readOnly: true
-            label: pim_enrich.form.job_instance.tab.properties.upload_allowed.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.upload_allowed.help
 
     pim-job-instance-xlsx-product-import-show-label:
         module: pim/job/common/edit/label

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/yml_base_export_show.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/yml_base_export_show.yml
@@ -52,7 +52,7 @@ extensions:
     pim-job-instance-yml-base-export-show-properties-file-path:
         module: pim/job/common/edit/field/text
         parent: pim-job-instance-yml-base-export-show-properties
-        position: 120
+        position: 100
         targetZone: global-settings
         config:
             fieldCode: configuration.filePath

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/yml_base_import_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/yml_base_import_edit.yml
@@ -68,7 +68,7 @@ extensions:
     pim-job-instance-yml-base-import-edit-properties-file-upload:
         module: pim/job/common/edit/field/switch
         parent: pim-job-instance-yml-base-import-edit-properties
-        position: 140
+        position: 130
         targetZone: global-settings
         config:
             fieldCode: configuration.uploadAllowed

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/yml_base_import_show.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/yml_base_import_show.yml
@@ -69,7 +69,7 @@ extensions:
     pim-job-instance-yml-base-import-show-properties-file-upload:
         module: pim/job/common/edit/field/switch
         parent: pim-job-instance-yml-base-import-show-properties
-        position: 160
+        position: 130
         targetZone: global-settings
         config:
             fieldCode: configuration.uploadAllowed


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

This PR removes the unused parameters from import.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
