### PR TITLE
Put completeness in product meta, to avoid a fetch after product loading

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Resources/config/controllers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/controllers.yml
@@ -418,6 +418,12 @@ services:
             - '@pim_catalog.localization.localizer.converter'
             - '@pim_catalog.comparator.filter.product'
             - '@pim_enrich.converter.enrich_to_standard.product_value'
+            - '@pim_catalog.manager.completeness'
+            - '@pim_catalog.object_manager.product'
+            - '@pim_catalog.repository.channel'
+            - '@pim_catalog.filter.chained'
+            - '@pim_enrich.normalizer.completeness_collection'
+            - '%pim_catalog_product_storage_driver%'
 
     pim_enrich.controller.rest.product_category:
         class: '%pim_enrich.controller.rest.product_category.class%'

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/attributes/completeness.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/attributes/completeness.js
@@ -30,10 +30,10 @@ define(
              * @param {object} event
              */
             addFieldFilter: function (event) {
-                event.filters.push(fetcherRegistry.getFetcher('product-completeness').fetchForProduct(
-                    this.getFormData().meta.id,
-                    this.getFormData().family
-                ).then(function (completenesses) {
+                event.filters.push($.Deferred().resolve({
+                    completenesses: this.getFormData().meta.completenesses,
+                    family: this.getFormData().family
+                }).then(function (completenesses) {
                     if (null === completenesses.family) {
                         return $.Deferred().resolve([]);
                     }


### PR DESCRIPTION
Put completeness in product meta, to avoid a fetch after product loading

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Ok
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
