### PR TITLE
Deactivate integration tests for PHP 7.1

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -115,7 +115,9 @@ if (launchIntegrationTests.equals("yes")) {
 
         tasks["phpunit-5.6-orm"] = {runIntegrationTest("5.6", "orm")}
         tasks["phpunit-7.0-orm"] = {runIntegrationTest("7.0", "orm")}
-        tasks["phpunit-7.1-orm"] = {runIntegrationTest("7.1", "orm")}
+
+        // Temporarily deactivate integration tests with PHP 7.1 because of stability issues
+        // tasks["phpunit-7.1-orm"] = {runIntegrationTest("7.1", "orm")}
         // tasks["phpunit-5.6-odm"] = {runIntegrationTest("5.6", "odm")}
         // tasks["phpunit-7.0-odm"] = {runIntegrationTest("7.0", "odm")}
         // tasks["phpunit-7.1-odm"] = {runIntegrationTest("7.1", "odm")}


### PR DESCRIPTION
Due to stability issues in PHP 7.1 (mostly on new integration tests on completeness) we try to deactivate it temporarily and run it only in 5.6 and 7.0.