### PR TITLE
PIM-6229: Fix badge orange color

### DIFF
--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/Badge.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/Badge.less
@@ -49,11 +49,11 @@
   }
 
   &--warning {
-    background: @AknOrange;
-    color: white;
+    background: lighten(@AknOrange, 20%);
+    color: darken(@AknOrange, 30%);
 
     &:hover {
-      background: darken(@AknOrange, 10%);
+      background: lighten(@AknOrange, 10%);
     }
   }
 


### PR DESCRIPTION
Before
![selection_043](https://cloud.githubusercontent.com/assets/1590933/23794630/5f4907d0-0591-11e7-888c-e404e6d087e5.png)
After
![selection_044](https://cloud.githubusercontent.com/assets/1590933/23794632/62104a00-0591-11e7-8ac2-2f2faeee7cb3.png)
