### PR TITLE
Show warning instead of an error (if update message missing)

### DIFF
--- a/src/Pim/Bundle/UIBundle/Resources/public/js/pim-formupdatelistener.js
+++ b/src/Pim/Bundle/UIBundle/Resources/public/js/pim-formupdatelistener.js
@@ -8,7 +8,7 @@ define(
             this.updated = false;
             var message = $form.attr('data-updated-message');
             if (!message) {
-                console.error('FormUpdateListener: message not provided.');
+                console.warn('FormUpdateListener: message not provided.');
                 return;
             }
             var title = $form.attr('data-updated-title');


### PR DESCRIPTION
This PR prevents the javascript to console an error if the flash message is missing (but logs a warning on the console)