### PR TITLE
API-123: change "field" to "property" in error response

### DIFF
--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Attribute/CreateAttributeIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Attribute/CreateAttributeIntegration.php
@@ -212,8 +212,8 @@ JSON;
             'message' => 'Validation failed.',
             'errors'  => [
                 [
-                    'field'   => 'code',
-                    'message' => 'This value is already used.',
+                    'property' => 'code',
+                    'message'  => 'This value is already used.',
                 ]
             ],
         ];
@@ -581,8 +581,8 @@ JSON;
             'message' => 'Validation failed.',
             'errors'  => [
                 [
-                    'field'   => 'labels',
-                    'message' => 'The locale "" does not exist.',
+                    'property' => 'labels',
+                    'message'  => 'The locale "" does not exist.',
                 ],
             ],
         ];
@@ -637,8 +637,8 @@ JSON;
             'message' => 'Validation failed.',
             'errors'  => [
                 [
-                    'field'   => 'labels',
-                    'message' => 'The locale "foo" does not exist.',
+                    'property' => 'labels',
+                    'message'  => 'The locale "foo" does not exist.',
                 ],
             ],
         ];

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Attribute/PartialUpdateAttributeIntergration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Attribute/PartialUpdateAttributeIntergration.php
@@ -112,12 +112,12 @@ JSON;
             'message' => 'Validation failed.',
             'errors'  => [
                 [
-                    'field'   => 'attributeType',
-                    'message' => 'This value should not be blank.',
+                    'property' => 'attributeType',
+                    'message'  => 'This value should not be blank.',
                 ],
                 [
-                    'field'   => 'group',
-                    'message' => 'This value should not be blank.',
+                    'property' => 'group',
+                    'message'  => 'This value should not be blank.',
                 ],
             ],
         ];
@@ -427,8 +427,8 @@ JSON;
             'message' => 'Validation failed.',
             'errors'  => [
                 [
-                    'field'   => 'code',
-                    'message' => 'This property cannot be changed.',
+                    'property' => 'code',
+                    'message'  => 'This property cannot be changed.',
                 ],
             ],
         ];

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AttributeOption/CreateAttributeOptionIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AttributeOption/CreateAttributeOptionIntegration.php
@@ -182,7 +182,7 @@ JSON;
     {
     	"message": "Validation failed.",
     	"errors": [{
-    		"field": "code",
+    		"property": "code",
     		"message": "This value should not be blank."
     	}],
     	"code": 422
@@ -239,7 +239,7 @@ JSON;
         "code": 422,
         "message": "Validation failed.",
         "errors": [{
-            "field": "attribute",
+            "property": "attribute",
             "message": "Attribute \"sku\" does not support options. Only attributes of type \"pim_catalog_simpleselect\", \"pim_catalog_multiselect\" support options"
         }]
     }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AttributeOption/PartialUpdateAttributeOptionIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AttributeOption/PartialUpdateAttributeOptionIntegration.php
@@ -361,7 +361,7 @@ JSON;
         "code": 422,
         "message": "Validation failed.",
         "errors": [{
-            "field": "attribute",
+            "property": "attribute",
             "message": "Attribute \"sku\" does not support options. Only attributes of type \"pim_catalog_simpleselect\", \"pim_catalog_multiselect\" support options"
         }]
     }
@@ -392,10 +392,10 @@ JSON;
     	"code": 422,
     	"message": "Validation failed.",
     	"errors": [{
-    		"field": "code",
+    		"property": "code",
     		"message": "This property cannot be changed."
     	},{
-    		"field": "attribute",
+    		"property": "attribute",
     		"message": "This property cannot be changed."
     	}]
     }
@@ -539,7 +539,7 @@ JSON;
         "code": 422,
         "message": "Validation failed.",
         "errors": [{
-            "field": "labels",
+            "property": "labels",
             "message": "The locale \"foo\" does not exist."
         }]
     }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Category/CreateCategoryIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Category/CreateCategoryIntegration.php
@@ -137,8 +137,8 @@ JSON;
             'message' => 'Validation failed.',
             'errors'  => [
                 [
-                    'field'   => 'code',
-                    'message' => 'This value is already used.',
+                    'property' => 'code',
+                    'message'  => 'This value is already used.',
                 ]
             ],
         ];
@@ -166,8 +166,8 @@ JSON;
             'message' => 'Validation failed.',
             'errors'  => [
                 [
-                    'field'   => 'code',
-                    'message' => 'This value should not be blank.',
+                    'property' => 'code',
+                    'message'  => 'This value should not be blank.',
                 ],
             ],
         ];
@@ -255,8 +255,8 @@ JSON;
             'message' => 'Validation failed.',
             'errors'  => [
                 [
-                    'field'   => 'labels',
-                    'message' => 'The locale "" does not exist.',
+                    'property' => 'labels',
+                    'message'  => 'The locale "" does not exist.',
                 ],
             ],
         ];
@@ -287,8 +287,8 @@ JSON;
             'message' => 'Validation failed.',
             'errors'  => [
                 [
-                    'field'   => 'labels',
-                    'message' => 'The locale "foo" does not exist.',
+                    'property' => 'labels',
+                    'message'  => 'The locale "foo" does not exist.',
                 ],
             ],
         ];

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Category/PartialUpdateCategoryIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Category/PartialUpdateCategoryIntegration.php
@@ -298,8 +298,8 @@ JSON;
             'message' => 'Validation failed.',
             'errors'  => [
                 [
-                    'field'   => 'code',
-                    'message' => 'This property cannot be changed.',
+                    'property' => 'code',
+                    'message'  => 'This property cannot be changed.',
                 ],
             ],
         ];

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Family/CreateFamilyIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Family/CreateFamilyIntegration.php
@@ -154,8 +154,8 @@ JSON;
             'message' => 'Validation failed.',
             'errors'  => [
                 [
-                    'field'   => 'code',
-                    'message' => 'This value is already used.',
+                    'property' => 'code',
+                    'message'  => 'This value is already used.',
                 ],
             ],
         ];
@@ -188,19 +188,19 @@ JSON;
     "message": "Validation failed.",
     "errors": [
         {
-            "field":"attribute_requirements",
+            "property":"attribute_requirements",
             "message":"The attribute \"a_text\" cannot be an attribute required for the channel \"ecommerce\" as it does not belong to this family"
         },
         {
-            "field":"attribute_as_label",
+            "property":"attribute_as_label",
             "message":"Property 'attribute_as_label' must belong to the family"
         },
         {
-            "field":"attribute_as_label",
+            "property":"attribute_as_label",
             "message":"Property 'attribute_as_label' only supports 'pim_catalog_text' and 'pim_catalog_identifier' attribute types for the family"
         },
         {
-            "field":"code",
+            "property":"code",
             "message":"This value should not be blank."
         }
     ]
@@ -289,8 +289,8 @@ JSON;
             'message' => 'Validation failed.',
             'errors'  => [
                 [
-                    'field'   => 'labels',
-                    'message' => 'The locale "" does not exist.',
+                    'property' => 'labels',
+                    'message'  => 'The locale "" does not exist.',
                 ],
             ],
         ];
@@ -321,8 +321,8 @@ JSON;
             'message' => 'Validation failed.',
             'errors'  => [
                 [
-                    'field'   => 'labels',
-                    'message' => 'The locale "foo" does not exist.',
+                    'property' => 'labels',
+                    'message'  => 'The locale "foo" does not exist.',
                 ],
             ],
         ];

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Family/PartialUpdateFamilyIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Family/PartialUpdateFamilyIntegration.php
@@ -357,12 +357,12 @@ JSON;
             'message' => 'Validation failed.',
             'errors'  => [
                 [
-                    'field'   => 'code',
-                    'message' => 'This property cannot be changed.',
+                    'property' => 'code',
+                    'message'  => 'This property cannot be changed.',
                 ],
                 [
-                    'field'   => 'code',
-                    'message' => 'Family code may contain only letters, numbers and underscores',
+                    'property' => 'code',
+                    'message'  => 'Family code may contain only letters, numbers and underscores',
                 ],
             ],
         ];

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/CreateProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/CreateProductIntegration.php
@@ -770,7 +770,7 @@ JSON;
             'message' => 'Validation failed.',
             'errors'  => [
                 [
-                    'field'   => 'identifier',
+                    'property'   => 'identifier',
                     'message' => 'This value should not be blank.',
                 ],
             ],
@@ -795,8 +795,8 @@ JSON;
             'message' => 'Validation failed.',
             'errors'  => [
                 [
-                    'field'   => 'identifier',
-                    'message' => 'This value should not be blank.',
+                    'property' => 'identifier',
+                    'message'  => 'This value should not be blank.',
                 ],
             ],
         ];
@@ -842,15 +842,15 @@ JSON;
     "message": "Validation failed.",
     "errors": [
         {
-            "field": "variant_group",
+            "property": "variant_group",
             "message": "The product \"wrong_amount\" is in the variant group \"variantB\" but it misses the following axes: a_simple_select."
         },
         {
-            "field": "variant_group",
+            "property": "variant_group",
             "message": "Product \"wrong_amount\" should have value for axis \"a_simple_select\" of variant group \"Variant B\""
         },
         {
-            "field": "values",
+            "property": "values",
             "message": "This value should be a valid number.",
             "attribute": "a_scopable_price",
             "locale": null,
@@ -858,7 +858,7 @@ JSON;
             "currency": "EUR"
         },
         {
-            "field": "values",
+            "property": "values",
             "message": "This value should be -250 or more.",
             "attribute": "a_number_float_negative",
             "locale": null,
@@ -892,8 +892,8 @@ JSON;
             'message' => 'Validation failed.',
             'errors'  => [
                 [
-                    'field'   => 'identifier',
-                    'message' => 'The value simple is already set on another product for the unique attribute sku',
+                    'property' => 'identifier',
+                    'message'  => 'The value simple is already set on another product for the unique attribute sku',
                 ],
             ],
         ];

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateProductIntegration.php
@@ -321,8 +321,8 @@ JSON;
             'message' => 'Validation failed.',
             'errors'  => [
                 [
-                    'field'   => 'identifier',
-                    'message' => 'This value should not be blank.',
+                    'property' => 'identifier',
+                    'message'  => 'This value should not be blank.',
                 ],
             ],
         ];
@@ -1303,8 +1303,8 @@ JSON;
             'message' => 'Validation failed.',
             'errors'  => [
                 [
-                    'field'   => 'identifier',
-                    'message' => 'The value product_family is already set on another product for the unique attribute sku',
+                    'property' => 'identifier',
+                    'message'  => 'The value product_family is already set on another product for the unique attribute sku',
                 ],
             ],
         ];

--- a/src/Pim/Component/Api/Normalizer/Exception/ViolationNormalizer.php
+++ b/src/Pim/Component/Api/Normalizer/Exception/ViolationNormalizer.php
@@ -54,8 +54,8 @@ class ViolationNormalizer implements NormalizerInterface
 
         foreach ($violations as $violation) {
             $error = [
-                'field'   => $this->getErrorField($violation),
-                'message' => $violation->getMessage()
+                'property' => $this->getErrorField($violation),
+                'message'  => $violation->getMessage()
             ];
 
             if ($violation->getRoot() instanceof ProductInterface &&
@@ -119,13 +119,13 @@ class ViolationNormalizer implements NormalizerInterface
 
         if (AttributeTypes::IDENTIFIER === $attributeType) {
             return [
-                'field'     => 'identifier',
+                'property'  => 'identifier',
                 'message'   => $violation->getMessage()
             ];
         }
 
         $error = [
-            'field'     => 'values',
+            'property'  => 'values',
             'message'   => $violation->getMessage(),
             'attribute' => $productValue->getAttribute()->getCode(),
             'locale'    => $productValue->getLocale(),

--- a/src/Pim/Component/Api/spec/Normalizer/Exception/ViolationNormalizerSpec.php
+++ b/src/Pim/Component/Api/spec/Normalizer/Exception/ViolationNormalizerSpec.php
@@ -25,8 +25,8 @@ class ViolationNormalizerSpec extends ObjectBehavior
             'code'    => Response::HTTP_UNPROCESSABLE_ENTITY,
             'message' => 'Validation failed.',
             'errors'  => [
-                ['field' => 'code', 'message' => 'Not Blank'],
-                ['field' => 'name', 'message' => 'Too long']
+                ['property' => 'code', 'message' => 'Not Blank'],
+                ['property' => 'name', 'message' => 'Too long']
             ]
         ]);
     }
@@ -81,7 +81,7 @@ class ViolationNormalizerSpec extends ObjectBehavior
             'code'    => Response::HTTP_UNPROCESSABLE_ENTITY,
             'message' => '',
             'errors'  => [
-                ['field' => 'identifier', 'message' => 'Not Blank'],
+                ['property' => 'identifier', 'message' => 'Not Blank'],
             ]
         ]);
     }
@@ -139,7 +139,7 @@ class ViolationNormalizerSpec extends ObjectBehavior
             'message' => '',
             'errors'  => [
                 [
-                    'field'     => 'values',
+                    'property'  => 'values',
                     'message'   => 'Not Blank',
                     'attribute' => 'description',
                     'locale'    => 'en_US',
@@ -183,7 +183,7 @@ class ViolationNormalizerSpec extends ObjectBehavior
             'message' => '',
             'errors'  => [
                 [
-                    'field'     => 'labels',
+                    'property'  => 'labels',
                     'message'   => 'The locale "ab_CD" does not exist.',
                 ],
             ]


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

Our beloved product owner wants to change "field" to "property" in error response :)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
