### PR TITLE
Change response on connection error

### DIFF
--- a/src/Pim/Bundle/ApiBundle/Resources/config/security.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/security.yml
@@ -1,6 +1,7 @@
 parameters:
     pim_api.security.voter.action_acl.class: Pim\Bundle\ApiBundle\Security\ActionAclVoter
     pim_api.security.access_denied_handler.class: Pim\Bundle\ApiBundle\Security\AccessDeniedHandler
+    fos_oauth_server.server.class: Pim\Bundle\ApiBundle\Security\OAuth2
 
 services:
     pim_api.security.acl.voter.overall_access:

--- a/src/Pim/Bundle/ApiBundle/Security/OAuth2.php
+++ b/src/Pim/Bundle/ApiBundle/Security/OAuth2.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Pim\Bundle\ApiBundle\Security;
+
+use OAuth2\OAuth2 as BaseOAuth2;
+use OAuth2\OAuth2AuthenticateException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+
+/**
+ * @author    Marie Bochu <marie.bochu@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class OAuth2 extends BaseOAuth2
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function verifyAccessToken($tokenParam, $scope = null)
+    {
+        try {
+            return parent::verifyAccessToken($tokenParam, $scope);
+        } catch (OAuth2AuthenticateException $e) {
+            throw new UnprocessableEntityHttpException($e->getDescription(), $e);
+        }
+    }
+}


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

FosOAuthBundle returns this structure when there is an error on connection:
```
{
  "error": "invalid_grant",
  "error_description": "The access token provided has expired."
}
```

It does not match with our standard, so I catch the OAuth2AuthenticateException to return:
```
{
  "code": 422,
  "message": "The access token provided is invalid."
}
```
[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
