### PR TITLE
PIM-6205: Add missing style for asset collection field rendering on view mode

### DIFF
--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/product-edit-form/AssetCollectionField.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/product-edit-form/AssetCollectionField.less
@@ -16,9 +16,7 @@
   &-list {
     display: flex;
     flex-wrap: wrap;
-    padding: 10px;
-    margin-right: -10px;
-    margin-bottom: -10px;
+    padding: 5px;
     min-height: @itemHeight;
   }
 
@@ -27,8 +25,7 @@
     border: 1px solid @AknBorderColor;
     padding: 10px;
     text-align: center;
-    margin-right: 10px;
-    margin-bottom: 10px;
+    margin: 5px;
     position: relative;
   }
 
@@ -51,5 +48,23 @@
 
   &--withoutBorder &-list {
     padding: 0;
+  }
+
+   &-header {
+     &--disabled {
+       display: none;
+     }
+  }
+
+   &-list {
+     &--disabled {
+       background: @AknDisabledInputColor;
+     }
+  }
+
+  &-listItem {
+    &--disabled {
+      color: @AknLightFontColor;
+    }
   }
 }


### PR DESCRIPTION
Add missing style for asset collection field rendering on view mode
| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
