### PR TITLE
PIM-6213: remove ticks on variant group form

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-6207: correctly dismiss "Unsaved changes" message on system configuration
+- PIM-6213: remove ticks on published form
 
 # 1.7.0 (2017-03-14)
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/variant-group/form/no-attribute.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/variant-group/form/no-attribute.js
@@ -9,12 +9,14 @@
  */
 define(
     [
+        'jquery',
         'underscore',
         'oro/translator',
         'pim/form',
         'text!pim/template/variant-group/form/no-attribute'
     ],
     function (
+        $,
         _,
         __,
         BaseForm,
@@ -29,6 +31,7 @@ define(
              */
             configure: function () {
                 this.listenTo(this.getRoot(), 'pim_enrich:form:entity:update_state', this.render);
+                this.listenTo(this.getRoot(), 'pim_enrich:form:field:to-fill-filter', this.addFieldFilter);
 
                 BaseForm.prototype.configure.apply(this, arguments);
             },
@@ -47,6 +50,17 @@ define(
                 }
 
                 return this;
+            },
+
+            /**
+             * Add filter on field to make it readonly.
+             *
+             * @param {object} event
+             */
+            addFieldFilter: function (event) {
+                event.filters.push($.Deferred().resolve(function () {
+                    return [];
+                }));
             }
         });
     }


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
