### PR TITLE
Disable AttributeOption code edition

### DIFF
--- a/features/Context/Page/Attribute/Creation.php
+++ b/features/Context/Page/Attribute/Creation.php
@@ -112,21 +112,6 @@ class Creation extends Form
     }
 
     /**
-     * Edit an attribute option
-     *
-     * @param string $name
-     * @param string $newValue
-     */
-    public function editOption($name, $newValue)
-    {
-        $row = $this->getOptionElement($name);
-
-        $row->find('css', '.edit-row')->click();
-        $row->find('css', '.attribute_option_code')->setValue($newValue);
-        $row->find('css', '.update-row')->click();
-    }
-
-    /**
      * Edit and cancel edition on an attribute option
      *
      * @param string $name
@@ -137,7 +122,7 @@ class Creation extends Form
         $row = $this->getOptionElement($name);
 
         $row->find('css', '.edit-row')->click();
-        $row->find('css', '.attribute_option_code')->setValue($newValue);
+        $row->find('css', '.attribute-option-value:first-child')->setValue($newValue);
         $row->find('css', '.show-row')->click();
     }
 

--- a/features/Context/WebUser.php
+++ b/features/Context/WebUser.php
@@ -1359,19 +1359,7 @@ class WebUser extends RawMinkContext
      * @param string $oldOptionName
      * @param string $newOptionName
      *
-     * @Given /^I edit the "([^"]*)" option and turn it to "([^"]*)"$/
-     */
-    public function iEditTheFollowingAttributeOptions($oldOptionName, $newOptionName)
-    {
-        $this->getCurrentPage()->editOption($oldOptionName, $newOptionName);
-        $this->wait();
-    }
-
-    /**
-     * @param string $oldOptionName
-     * @param string $newOptionName
-     *
-     * @Given /^I edit the code "([^"]*)" to turn it to "([^"]*)" and cancel$/
+     * @Given /^I edit the attribute option "([^"]*)" to turn it to "([^"]*)" and cancel$/
      */
     public function iEditAndCancelToEditTheFollowingAttributeOptions($oldOptionName, $newOptionName)
     {
@@ -1397,7 +1385,7 @@ class WebUser extends RawMinkContext
     }
 
     /**
-     * @param string locator
+     * @param string $locator
      *
      * @When /^I hover over the element "([^"]*)"$/
      */

--- a/features/attribute/option/edit_attribute_options_02.feature
+++ b/features/attribute/option/edit_attribute_options_02.feature
@@ -26,23 +26,13 @@ Feature: Edit attribute options
       | red   |
       | blue  |
       | green |
-    And I edit the code "green" to turn it to "yellow" and cancel
+    And I edit the attribute option "green" to turn it to "yellow" and cancel
     Then I should see a confirm dialog with the following content:
       | title   | Cancel modification                                                                                    |
       | content | Warning, you will lose unsaved data. Are you sure you want to cancel modification on this new option ? |
     And I confirm the cancellation
     Then I should see "green"
     But I should not see "yellow"
-
-  Scenario: Successfully edit some attribute options
-    Given I create the following attribute options:
-      | Code  |
-      | red   |
-      | blue  |
-      | green |
-    And I edit the "green" option and turn it to "yellow"
-    Then I should see "yellow"
-    Then I should not see "green"
 
   @jira https://akeneo.atlassian.net/browse/PIM-6002
   Scenario: Successfully edit an attribute option value containing a quote
@@ -52,5 +42,5 @@ Feature: Edit attribute options
       | blue  | blue  |
       | green | green |
     And I save the attribute
-    And I edit the code "red" to turn it to "red" and cancel
-    Then I should see the text "r\"ed"
+    And I edit the attribute option "red" to turn it to "red" and cancel
+    Then I should not see the text "r\"ed"

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/attribute-option/edit.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/attribute-option/edit.html
@@ -1,10 +1,15 @@
 <td class="AknGrid-bodyCell field-cell">
     <div class="AknFieldContainer AknFieldContainer--withoutMargin">
         <div class="AknFieldContainer-inputContainer">
-            <input type="text" class="AknTextField attribute_option_code exclude" value="<%- item.code %>"/>
-            <div class="AknFieldContainer-iconsContainer">
-                <i class="AknIconButton AknIconButton--important AknIconButton--hide icon-warning-sign validation-tooltip" data-placement="top" data-toggle="tooltip"></i>
-            </div>
+            <% if (item.id) { %>
+                <input type="hidden" class="attribute_option_code" value="<%- item.code %>"/>
+                <span class="option-code"><%- item.code %></span>
+            <% } else { %>
+                <input type="text" class="AknTextField attribute_option_code exclude" value="<%- item.code %>"/>
+                <div class="AknFieldContainer-iconsContainer">
+                    <i class="AknIconButton AknIconButton--important AknIconButton--hide icon-warning-sign validation-tooltip" data-placement="top" data-toggle="tooltip"></i>
+                </div>
+            <% } %>
         </div>
     </div>
 </td>


### PR DESCRIPTION
To be consistent with API (seen with POs), it's not allowed anymore to edit code of attributeoptions via UI.
Validation on backend is already done by @ahocquard .