### PR TITLE
TIP-322: fix wrong arguments order for InvalidPropertyException::expectedFromPreviousException calls

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/OptionFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Filter/OptionFilter.php
@@ -63,9 +63,9 @@ class OptionFilter extends AbstractAttributeFilter implements AttributeFilterInt
             $options = $this->resolver->resolve($options);
         } catch (\Exception $e) {
             throw InvalidPropertyException::expectedFromPreviousException(
-                $e,
                 $attribute->getCode(),
-                static::class
+                static::class,
+                $e
             );
         }
 

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/OptionFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/OptionFilter.php
@@ -62,9 +62,9 @@ class OptionFilter extends AbstractAttributeFilter implements AttributeFilterInt
             $options = $this->resolver->resolve($options);
         } catch (\Exception $e) {
             throw InvalidPropertyException::expectedFromPreviousException(
-                $e,
                 $attribute->getCode(),
-                static::class
+                static::class,
+                $e
             );
         }
 

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/OptionsFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/OptionsFilter.php
@@ -62,9 +62,9 @@ class OptionsFilter extends AbstractAttributeFilter implements AttributeFilterIn
             $options = $this->resolver->resolve($options);
         } catch (\Exception $e) {
             throw InvalidPropertyException::expectedFromPreviousException(
-                $e,
                 $attribute->getCode(),
-                static::class
+                static::class,
+                $e
             );
         }
 

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/StringFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/StringFilter.php
@@ -55,9 +55,9 @@ class StringFilter extends AbstractAttributeFilter implements AttributeFilterInt
             $options = $this->resolver->resolve($options);
         } catch (\Exception $e) {
             throw InvalidPropertyException::expectedFromPreviousException(
-                $e,
                 $attribute->getCode(),
-                static::class
+                static::class,
+                $e
             );
         }
 

--- a/src/Pim/Bundle/ReferenceDataBundle/Doctrine/ORM/Filter/ReferenceDataFilter.php
+++ b/src/Pim/Bundle/ReferenceDataBundle/Doctrine/ORM/Filter/ReferenceDataFilter.php
@@ -71,9 +71,9 @@ class ReferenceDataFilter extends AbstractAttributeFilter implements AttributeFi
             $options = $this->optionsResolver->resolve($options);
         } catch (\Exception $e) {
             throw InvalidPropertyException::expectedFromPreviousException(
-                $e,
                 $attribute->getCode(),
-                static::class
+                static::class,
+                $e
             );
         }
 


### PR DESCRIPTION
InvalidPropertyException::expectedFromPreviousException expects previous exception as 3rd argument, fixed cases passes it as first

Discovered this issue using the web API, i got 500 server error due to,
``̀`
[2017-03-13 12:44:22] request.CRITICAL: Uncaught PHP Exception Symfony\Component\Debug\Exception\FatalThrowableError: "Type error: Argument 3 passed to Akeneo\Component\StorageUtils\Exception\InvalidPropertyException::expectedFromPreviousException() must be an instance of Exception, string given, called in /home/nico/git/pim-ce-17-orm/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/OptionFilter.php on line 67" at /home/nico/git/pim-ce-17-orm/src/Akeneo/Component/StorageUtils/Exception/InvalidPropertyException.php line 224 {"exception":"[object] (Symfony\\Component\\Debug\\Exception\\FatalThrowableError(code: 0): Type error: Argument 3 passed to Akeneo\\Component\\StorageUtils\\Exception\\InvalidPropertyException::expectedFromPreviousException() must be an instance of Exception, string given, called in /home/nico/git/pim-ce-17-orm/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/OptionFilter.php on line 67 at /home/nico/git/pim-ce-17-orm/src/Akeneo/Component/StorageUtils/Exception/InvalidPropertyException.php:224)"} []
```

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | ?
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
