### PR TITLE
Fix filters on products list

### DIFF
--- a/src/Pim/Bundle/ApiBundle/Controller/ProductController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/ProductController.php
@@ -20,6 +20,7 @@ use Pim\Component\Api\Repository\ProductRepositoryInterface;
 use Pim\Component\Catalog\Builder\ProductBuilderInterface;
 use Pim\Component\Catalog\Comparator\Filter\ProductFilterInterface;
 use Pim\Component\Catalog\Exception\InvalidOperatorException;
+use Pim\Component\Catalog\Exception\ObjectNotFoundException;
 use Pim\Component\Catalog\Exception\UnsupportedFilterException;
 use Pim\Component\Catalog\Model\ChannelInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
@@ -192,6 +193,8 @@ class ProductController
         } catch (UnsupportedFilterException $e) {
             throw new UnprocessableEntityHttpException($e->getMessage(), $e);
         } catch (InvalidOperatorException $e) {
+            throw new UnprocessableEntityHttpException($e->getMessage(), $e);
+        } catch (ObjectNotFoundException $e) {
             throw new UnprocessableEntityHttpException($e->getMessage(), $e);
         }
 

--- a/src/Pim/Bundle/ApiBundle/Controller/ProductController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/ProductController.php
@@ -509,7 +509,11 @@ class ProductController
 
                 $context['locale'] = isset($filter['locale']) ? $filter['locale'] : $request->query->get('search_locale');
                 $context['scope'] = isset($filter['scope']) ? $filter['scope'] : $request->query->get('search_scope');
-                $context['locales'] = isset($filter['locales']) ? $filter['locales'] : null;
+
+                if (isset($filter['locales'])) {
+                    $context['locales'] = $filter['locales'];
+                }
+
                 $value = isset($filter['value']) ? $filter['value'] : null;
 
                 $pqb->addFilter($propertyCode, $filter['operator'], $value, $context);

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/ErrorListProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/ErrorListProductIntegration.php
@@ -122,6 +122,14 @@ class ErrorListProductIntegration extends AbstractProductTestCase
         $client = $this->createAuthenticatedClient();
 
         $client->request('GET', '/api/rest/v1/products?search={"completeness":[{"operator":"GREATER THAN ON ALL LOCALES", "scope":"ecommerce", "value":100}]}');
+        $this->assert($client, 'Property "completeness" expects an array with the key "locales" as data.');
+    }
+
+    public function testSearchWithLocalesAsAString()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $client->request('GET', '/api/rest/v1/products?search={"completeness":[{"operator":"GREATER THAN ON ALL LOCALES", "scope":"ecommerce", "value":100, "locales":"fr_FR"}]}');
         $this->assert($client, 'Property "completeness" expects an array of arrays as data.');
     }
 
@@ -173,6 +181,14 @@ class ErrorListProductIntegration extends AbstractProductTestCase
 
         $client->request('GET', '/api/rest/v1/products?search_scope=not_found&search={"a_scopable_image":[{"operator":"CONTAINS", "value":"text"}]}');
         $this->assert($client, 'Attribute "a_scopable_image" expects an existing scope, "not_found" given.');
+    }
+
+    public function testSearchWithObjectNotFound()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $client->request('GET', '/api/rest/v1/products?search={"categories":[{"operator":"IN","value":["not_found"]}]}');
+        $this->assert($client, 'Object "category" with code "not_found" does not exist');
     }
 
     public function testSearchIsNotAnArray()

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessListProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessListProductIntegration.php
@@ -1436,7 +1436,7 @@ JSON;
     {
         $result = json_decode($response->getContent(), true);
         $expected = json_decode($expected, true);
-print_r($result);
+
         foreach ($result['_embedded']['items'] as $index => $product) {
             $product = $this->sanitizeDateFields($product);
             $result['_embedded']['items'][$index] = $this->sanitizeMediaAttributeData($product);

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessListProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessListProductIntegration.php
@@ -1402,6 +1402,31 @@ JSON;
         $this->assertResponse($client->getResponse(), $expected);
     }
 
+    public function testListProductsWithCompletenessPQBFilters()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $search = '{"completeness":[{"operator":"GREATER THAN ON ALL LOCALES","value":50,"locales":["fr_FR"],"scope":"ecommerce"}],"categories":[{"operator":"IN", "value":["categoryB"]}], "a_yes_no":[{"operator":"=","value":true}]}';
+        $client->request('GET', 'api/rest/v1/products?search=' . $search);
+        $searchEncoded = urlencode($search);
+        $expected = <<<JSON
+{
+    "_links": {
+        "self"  : {"href" : "http://localhost/api/rest/v1/products?search=${searchEncoded}&page=1&limit=10"},
+        "first" : {"href" : "http://localhost/api/rest/v1/products?search=${searchEncoded}&page=1&limit=10"},
+        "last"  : {"href" : "http://localhost/api/rest/v1/products?search=${searchEncoded}&page=1&limit=10"}
+    },
+    "current_page" : 1,
+    "pages_count"  : 1,
+    "items_count"  : 0,
+    "_embedded"    : {
+        "items" : []
+    }
+}
+JSON;
+
+        $this->assertResponse($client->getResponse(), $expected);
+    }
 
     /**
      * @param Response $response
@@ -1411,7 +1436,7 @@ JSON;
     {
         $result = json_decode($response->getContent(), true);
         $expected = json_decode($expected, true);
-
+print_r($result);
         foreach ($result['_embedded']['items'] as $index => $product) {
             $product = $this->sanitizeDateFields($product);
             $result['_embedded']['items'][$index] = $this->sanitizeMediaAttributeData($product);


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

A couple of issues,

First,
```
./get_products --host http://pim-ce-17-orm.local/app_dev.php --accesstoken ODg5Yjg4NzhhY2IzODA4NDRhMzk2NjdhZmE0YmNiMDExZmUyYzdiODIzZDc2NjZlZDg0OWVkODFjYmUwOWViZg --search '{"categories":[{"operator":"IN","value":["winter_collection"]}]}'
if winter_collection does not exists the response is the following one,
{"code":500,"message":"Internal Server Error"}
[2017-03-13 14:35:40] request.CRITICAL: Uncaught PHP Exception Pim\Component\Catalog\Exception\ObjectNotFoundException: "Object "category" with code "winter_collection" does not exist" at /home/nico/git/pim-ce-17-orm/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Filter/ObjectIdResolver.php line 59 {"exception":"[object] (Pim\\Component\\Catalog\\Exception\\ObjectNotFoundException(code: 0): Object \"category\" with code \"winter_collection\" does not exist at /home/nico/git/pim-ce-17-orm/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Filter/ObjectIdResolver.php:59)"} []
```

Second,

```
nico@nico-laptop:~/git/akeneo-web-api-playground/go$ ./get_products --host http://pim-ce-17-orm.local/app_dev.php  --accesstoken ODg5Yjg4NzhhY2IzODA4NDRhMzk2NjdhZmE0YmNiMDExZmUyYzdiODIzZDc2NjZlZDg0OWVkODFjYmUwOWViZg --search '{"sku":[{"operator":"CONTAINS","value":"AKNTS_WPS"}]}'
{"code":422,"message":"The option \"locales\" does not exist. Defined options are: \"field\", \"locale\", \"scope\"."}

[2:24]  
commenting "//$context['locales'] = isset($filter['locales']) ? $filter['locales'] : null;" it works, only used by completeness
```


**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
