### PR TITLE
TIP-717: Remove unused parameter from it_provides_current_locale

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/spec/Helper/LocaleHelperSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Helper/LocaleHelperSpec.php
@@ -18,7 +18,7 @@ class LocaleHelperSpec extends ObjectBehavior
         $this->beConstructedWith($userContext, $localeRepository);
     }
 
-    function it_provides_current_locale($en)
+    function it_provides_current_locale()
     {
         $this->getCurrentLocaleCode()->shouldReturn('en_US');
     }


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**
This PR is for experimental purposes. It removes an unused parameter from the test function `it_provides_current_locale`

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Ok
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
