### PR TITLE
PIM-6239: translate scope with catalog locale

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -5,6 +5,7 @@
 - PIM-6207: correctly dismiss "Unsaved changes" message on system configuration
 - PIM-6213: remove ticks on published form
 - PIM-6242: fix UI glitch on TWA completeness filter search field
+- PIM-6239: translate scope with catalog locale
 
 # 1.7.0 (2017-03-14)
 

--- a/features/channel/display_channel_on_datagrid.feature
+++ b/features/channel/display_channel_on_datagrid.feature
@@ -6,16 +6,18 @@ Feature: Display channels on the datagrid
 
   Background:
     Given a "footwear" catalog configuration
+    And the following locale accesses:
+      | locale | user group | access |
+      | es_MX  | All        | view   |
 
   Scenario: Display code of channel if no translation is available for the UI language
     Given I am logged in as "Julia"
     When I am on the products page
     Then I should see the text "Tablet"
-    When I am on the my account page
-    And I press the "Edit" button
-    And I visit the "Interfaces" tab
-    And I fill in the following information:
-      | UI locale | Spanish (Mexico) |
+    When I am on the "tablet" channel page
+    And I change the "Locales" to "English (United States), Spanish (Mexico)"
     And I press the "Save" button
-    And I am on the products page
+    Then I should not see the text "There are unsaved changes."
+    When I am on the products page
+    And I switch the locale to "es_MX"
     Then I should see the text "[tablet]"

--- a/features/mass-action/edit_common_attributes_scopable_localizable.feature
+++ b/features/mass-action/edit_common_attributes_scopable_localizable.feature
@@ -36,7 +36,7 @@ Feature: Edit common attributes of many products at once
     And I select rows black_jacket and white_jacket
     And I press "Change product information" on the "Bulk Actions" dropdown button
     And I choose the "Edit common attributes" operation
-    Then I should see the text "The selected product's attributes will be edited with the following data for the locale German (Germany) and the channel Ecommerce, chosen in the products grid."
+    Then I should see the text "The selected product's attributes will be edited with the following data for the locale Deutsch (Deutschland) and the channel Ecommerce, chosen in the products grid."
     When I display the Name attribute
     And I change the "Name" to "Une veste"
     And I move on to the next step

--- a/features/user/edit_user.feature
+++ b/features/user/edit_user.feature
@@ -30,7 +30,7 @@ Feature: Edit a user
     Then I should see the flash message "User saved"
     When I am on the products page
     Then I should see the text "Products de"
-    And I should see the text "Print"
+    And I should see the text "Drucken"
     And I should see the text "2015 Männer-Kollektion"
     And I should see the text "2015 Damenkollektion"
     And I should see the filters name, family and sku

--- a/src/Pim/Bundle/CatalogBundle/Helper/LocaleHelper.php
+++ b/src/Pim/Bundle/CatalogBundle/Helper/LocaleHelper.php
@@ -44,7 +44,7 @@ class LocaleHelper
      */
     public function getCurrentLocaleCode()
     {
-        return $this->userContext->getUiLocale()->getCode();
+        return $this->userContext->getCurrentLocale()->getCode();
     }
 
     /**

--- a/src/Pim/Bundle/CatalogBundle/spec/Helper/LocaleHelperSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Helper/LocaleHelperSpec.php
@@ -13,7 +13,7 @@ class LocaleHelperSpec extends ObjectBehavior
     function let(UserContext $userContext, LocaleRepositoryInterface $localeRepository, LocaleInterface $en)
     {
         $en->getCode()->willReturn('en_US');
-        $userContext->getUiLocale()->willReturn($en);
+        $userContext->getCurrentLocale()->willReturn($en);
 
         $this->beConstructedWith($userContext, $localeRepository);
     }

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/association_product.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/association_product.yml
@@ -124,7 +124,7 @@ datagrid:
                     data_name: values.scope
                     options:
                         field_options:
-                            choices: '@pim_catalog.repository.channel->getLabelsIndexedByCode(@pim_user.context.user->getUiLocaleCode())'
+                            choices: '@pim_catalog.repository.channel->getLabelsIndexedByCode(@pim_user.context.user->getCurrentLocaleCode())'
                 category:
                     type:      product_category
                     label:     Category

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product.yml
@@ -254,7 +254,7 @@ datagrid:
                     data_name: values.scope
                     options:
                         field_options:
-                            choices: '@pim_catalog.repository.channel->getLabelsIndexedByCode(@pim_user.context.user->getUiLocaleCode())'
+                            choices: '@pim_catalog.repository.channel->getLabelsIndexedByCode(@pim_user.context.user->getCurrentLocaleCode())'
                 completeness:
                     type:      product_completeness
                     label:     Complete

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product_group.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product_group.yml
@@ -127,4 +127,4 @@ datagrid:
                     data_name: values.scope
                     options:
                         field_options:
-                            choices: '@pim_catalog.repository.channel->getLabelsIndexedByCode(@pim_user.context.user->getUiLocaleCode())'
+                            choices: '@pim_catalog.repository.channel->getLabelsIndexedByCode(@pim_user.context.user->getCurrentLocaleCode())'

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product_variant_group.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product_variant_group.yml
@@ -128,4 +128,4 @@ datagrid:
                     data_name: values.scope
                     options:
                         field_options:
-                            choices: '@pim_catalog.repository.channel->getLabelsIndexedByCode(@pim_user.context.user->getUiLocaleCode())'
+                            choices: '@pim_catalog.repository.channel->getLabelsIndexedByCode(@pim_user.context.user->getCurrentLocaleCode())'

--- a/src/Pim/Bundle/EnrichBundle/Resources/views/MassEditAction/product/configure/edit-common-attributes.html.twig
+++ b/src/Pim/Bundle/EnrichBundle/Resources/views/MassEditAction/product/configure/edit-common-attributes.html.twig
@@ -57,7 +57,7 @@
 
                                 $('#mass-edit-common-attribute-description').html(_.__(
                                     'pim_enrich.mass_edit_action.edit_common_attributes.description',
-                                    {'locale': locale.label, 'channel': channel.labels[UserContext.get('uiLocale')]}
+                                    {'locale': locale.label, 'channel': channel.labels[UserContext.get('catalogLocale')]}
                                 ));
                             });
                         });


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Translate the channel with the catalog locale everywhere in the PIM

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | OK
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
