### PR TITLE
PIM-6085: Fix import association step when custom column header is used.

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -1,11 +1,12 @@
 # 1.7.x
 
-## Bug fixes
+## Bug Fixes
 
-- PIM-6207: correctly dismiss "Unsaved changes" message on system configuration
-- PIM-6213: remove ticks on published form
-- PIM-6242: fix UI glitch on TWA completeness filter search field
-- PIM-6239: translate scope with catalog locale
+- PIM-6085: Association import step is not working with custom column name.
+- PIM-6207: Correctly dismiss "Unsaved changes" message on system configuration.
+- PIM-6213: Remove ticks on published form
+- PIM-6242: Fix UI glitch on TWA completeness filter search field
+- PIM-6239: Translate scope with catalog locale
 
 # 1.7.0 (2017-03-14)
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -182,9 +182,9 @@ def runIntegrationTest(phpVersion, storage) {
     node('docker') {
         deleteDir()
         try {
-            docker.image("mongo:2.4").withRun("--name ${env.BRANCH_NAME}-mongodb", "--smallfiles") {
-                docker.image("mysql:5.5").withRun("--name ${env.BRANCH_NAME}-mysql -e MYSQL_ROOT_PASSWORD=root -e MYSQL_USER=akeneo_pim -e MYSQL_PASSWORD=akeneo_pim -e MYSQL_DATABASE=akeneo_pim", "--sql_mode=ERROR_FOR_DIVISION_BY_ZERO,NO_ZERO_IN_DATE,NO_ZERO_DATE,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION") {
-                    docker.image("carcel/php:${phpVersion}").inside("--link ${env.BRANCH_NAME}-mysql:mysql --link ${env.BRANCH_NAME}-mongodb:mongodb -v /home/akeneo/.composer:/home/akeneo/.composer -e COMPOSER_HOME=/home/akeneo/.composer") {
+            docker.image("mongo:2.4").withRun("--name ${env.BRANCH_NAME}-${env.BUILD_NUMBER}-mongodb", "--smallfiles") {
+                docker.image("mysql:5.5").withRun("--name ${env.BRANCH_NAME}-${env.BUILD_NUMBER}-mysql -e MYSQL_ROOT_PASSWORD=root -e MYSQL_USER=akeneo_pim -e MYSQL_PASSWORD=akeneo_pim -e MYSQL_DATABASE=akeneo_pim", "--sql_mode=ERROR_FOR_DIVISION_BY_ZERO,NO_ZERO_IN_DATE,NO_ZERO_DATE,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION") {
+                    docker.image("carcel/php:${phpVersion}").inside("--link ${env.BRANCH_NAME}-${env.BUILD_NUMBER}-mysql:mysql --link ${env.BRANCH_NAME}-${env.BUILD_NUMBER}-mongodb:mongodb -v /home/akeneo/.composer:/home/akeneo/.composer -e COMPOSER_HOME=/home/akeneo/.composer") {
                         unstash "pim_community_dev"
 
                         if (phpVersion != "5.6") {

--- a/features/channel/display_channel_on_datagrid.feature
+++ b/features/channel/display_channel_on_datagrid.feature
@@ -6,10 +6,8 @@ Feature: Display channels on the datagrid
 
   Background:
     Given a "footwear" catalog configuration
-    And the following locale accesses:
-      | locale | user group | access |
-      | es_MX  | All        | view   |
 
+  @ce
   Scenario: Display code of channel if no translation is available for the UI language
     Given I am logged in as "Julia"
     When I am on the products page

--- a/features/import/product/import_products.feature
+++ b/features/import/product/import_products.feature
@@ -326,3 +326,20 @@ Feature: Execute a job
       | channel | locale | state   | missing_values                        | ratio |
       | mobile  | en_US  | success |                                       | 100%  |
       | tablet  | en_US  | warning | Weather conditions, Rating, Side view | 67%   |
+
+  @jira https://akeneo.atlassian.net/browse/PIM-6085
+  Scenario: Successfully import product associations with modified column name
+    Given the following CSV file to import:
+      """
+      sku;family;groups;categories;name-en_US;description-en_US-tablet;price;size;color
+      SKU-001;boots;similar_boots;winter_boots;Donec;dictum magna. Ut tincidunt orci quis lectus. Nullam suscipit, est;"100 EUR, 90 USD";40;
+      SKU-002;sneakers;;winter_boots;Donex;Pellentesque habitant morbi tristique senectus et netus et malesuada fames;"100 EUR, 90 USD";37;red
+      """
+    And the following job "csv_footwear_product_import" configuration:
+      | filePath          | %file to import% |
+      | enabledComparison | yes              |
+      | categoriesColumn  | catégories       |
+      | groupsColumn      | groupes          |
+    When I am on the "csv_footwear_product_import" import job page
+    And I launch the import job
+    And I wait for the "csv_footwear_product_import" job to finish

--- a/features/import/product/import_products.feature
+++ b/features/import/product/import_products.feature
@@ -331,7 +331,7 @@ Feature: Execute a job
   Scenario: Successfully import product associations with modified column name
     Given the following CSV file to import:
       """
-      sku;famille;groupes;catégories;name-en_US;description-en_US-tablet;price;size;color
+      sku;family;groupes;catégories;name-en_US;description-en_US-tablet;price;size;color
       SKU-001;boots;similar_boots;winter_boots;Donec;dictum magna. Ut tincidunt orci quis lectus. Nullam suscipit, est;"100 EUR, 90 USD";40;
       SKU-002;sneakers;;winter_boots;Donex;Pellentesque habitant morbi tristique senectus et netus et malesuada fames;"100 EUR, 90 USD";37;red
       """

--- a/features/import/product/import_products.feature
+++ b/features/import/product/import_products.feature
@@ -331,7 +331,7 @@ Feature: Execute a job
   Scenario: Successfully import product associations with modified column name
     Given the following CSV file to import:
       """
-      sku;family;groups;categories;name-en_US;description-en_US-tablet;price;size;color
+      sku;famille;groupes;catégories;name-en_US;description-en_US-tablet;price;size;color
       SKU-001;boots;similar_boots;winter_boots;Donec;dictum magna. Ut tincidunt orci quis lectus. Nullam suscipit, est;"100 EUR, 90 USD";40;
       SKU-002;sneakers;;winter_boots;Donex;Pellentesque habitant morbi tristique senectus et netus et malesuada fames;"100 EUR, 90 USD";37;red
       """
@@ -343,3 +343,5 @@ Feature: Execute a job
     When I am on the "csv_footwear_product_import" import job page
     And I launch the import job
     And I wait for the "csv_footwear_product_import" job to finish
+    Then I should not see the text "The fields \"catégories, famille, groupes\" do not exist"
+    Then there should be 2 products

--- a/features/import/product/xlsx/import_products.feature
+++ b/features/import/product/xlsx/import_products.feature
@@ -93,7 +93,7 @@ Feature: Import XLSX products
   Scenario: Successfully import product associations with modified column name
     Given the following XLSX file to import:
       """
-      sku;family;groups;categories;name-en_US;description-en_US-tablet;price;size;color
+      sku;famille;groupes;catégories;name-en_US;description-en_US-tablet;price;size;color
       SKU-001;boots;similar_boots;winter_boots;Donec;dictum magna. Ut tincidunt orci quis lectus. Nullam suscipit, est;"100 EUR, 90 USD";40;
       SKU-002;sneakers;;winter_boots;Donex;Pellentesque habitant morbi tristique senectus et netus et malesuada fames;"100 EUR, 90 USD";37;red
       """
@@ -105,3 +105,5 @@ Feature: Import XLSX products
     When I am on the "xlsx_footwear_product_import" import job page
     And I launch the import job
     And I wait for the "xlsx_footwear_product_import" job to finish
+    Then I should not see the text "The fields \"catégories, famille, groupes\" do not exist"
+    Then there should be 2 products

--- a/features/import/product/xlsx/import_products.feature
+++ b/features/import/product/xlsx/import_products.feature
@@ -93,7 +93,7 @@ Feature: Import XLSX products
   Scenario: Successfully import product associations with modified column name
     Given the following XLSX file to import:
       """
-      sku;famille;groupes;catégories;name-en_US;description-en_US-tablet;price;size;color
+      sku;family;groupes;catégories;name-en_US;description-en_US-tablet;price;size;color
       SKU-001;boots;similar_boots;winter_boots;Donec;dictum magna. Ut tincidunt orci quis lectus. Nullam suscipit, est;"100 EUR, 90 USD";40;
       SKU-002;sneakers;;winter_boots;Donex;Pellentesque habitant morbi tristique senectus et netus et malesuada fames;"100 EUR, 90 USD";37;red
       """

--- a/features/import/product/xlsx/import_products.feature
+++ b/features/import/product/xlsx/import_products.feature
@@ -88,3 +88,20 @@ Feature: Import XLSX products
     Then there should be 1 products
     And the product "renault-kangoo" should have the following value:
       | rating | [5] |
+
+  @jira https://akeneo.atlassian.net/browse/PIM-6085
+  Scenario: Successfully import product associations with modified column name
+    Given the following XLSX file to import:
+      """
+      sku;family;groups;categories;name-en_US;description-en_US-tablet;price;size;color
+      SKU-001;boots;similar_boots;winter_boots;Donec;dictum magna. Ut tincidunt orci quis lectus. Nullam suscipit, est;"100 EUR, 90 USD";40;
+      SKU-002;sneakers;;winter_boots;Donex;Pellentesque habitant morbi tristique senectus et netus et malesuada fames;"100 EUR, 90 USD";37;red
+      """
+    And the following job "xlsx_footwear_product_import" configuration:
+      | filePath          | %file to import% |
+      | enabledComparison | yes              |
+      | categoriesColumn  | catégories       |
+      | groupsColumn      | groupes          |
+    When I am on the "xlsx_footwear_product_import" import job page
+    And I launch the import job
+    And I wait for the "xlsx_footwear_product_import" job to finish

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/readers.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/readers.yml
@@ -15,6 +15,7 @@ parameters:
 
     pim_connector.reader.file.xlsx.class: Pim\Component\Connector\Reader\File\Xlsx\Reader
     pim_connector.reader.file.xlsx_product.class: Pim\Component\Connector\Reader\File\Xlsx\ProductReader
+    pim_connector.reader.file.xlsx_association.class: Pim\Component\Connector\Reader\File\Xlsx\ProductAssociationReader
 
     pim_connector.reader.file.yaml.class: Pim\Component\Connector\Reader\File\Yaml\Reader
 
@@ -243,12 +244,10 @@ services:
             - '@pim_connector.array_converter.flat_to_standard.association_type'
 
     pim_connector.reader.file.xlsx_association:
-        class: '%pim_connector.reader.file.xlsx_product.class%'
+        class: '%pim_connector.reader.file.xlsx_association.class%'
         arguments:
-           - '@pim_connector.reader.file.xlsx_iterator_factory'
-           - '@pim_connector.array_converter.flat_to_standard.product_delocalized'
-           - '@pim_connector.reader.file.media_path_transformer'
-           - []
+            - '@pim_connector.reader.file.xlsx_iterator_factory'
+            - '@pim_connector.array_converter.flat_to_standard.product_association'
 
     pim_connector.reader.file.xlsx_group:
         class: '%pim_connector.reader.file.xlsx.class%'

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/readers.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/readers.yml
@@ -243,10 +243,12 @@ services:
             - '@pim_connector.array_converter.flat_to_standard.association_type'
 
     pim_connector.reader.file.xlsx_association:
-        class: '%pim_connector.reader.file.xlsx.class%'
+        class: '%pim_connector.reader.file.xlsx_product.class%'
         arguments:
-            - '@pim_connector.reader.file.xlsx_iterator_factory'
-            - '@pim_connector.array_converter.flat_to_standard.product_association'
+           - '@pim_connector.reader.file.xlsx_iterator_factory'
+           - '@pim_connector.array_converter.flat_to_standard.product_delocalized'
+           - '@pim_connector.reader.file.media_path_transformer'
+           - []
 
     pim_connector.reader.file.xlsx_group:
         class: '%pim_connector.reader.file.xlsx.class%'

--- a/src/Pim/Bundle/ImportExportBundle/Controller/JobProfileController.php
+++ b/src/Pim/Bundle/ImportExportBundle/Controller/JobProfileController.php
@@ -135,7 +135,6 @@ class JobProfileController
     /**
      * Show a job instance
      *
-     * @param Request $request
      * @param string  $code
      *
      * @return Response

--- a/src/Pim/Component/Connector/Reader/File/Csv/ProductAssociationReader.php
+++ b/src/Pim/Component/Connector/Reader/File/Csv/ProductAssociationReader.php
@@ -23,6 +23,20 @@ class ProductAssociationReader extends Reader implements
      */
     protected function getArrayConverterOptions()
     {
-        return ['with_associations' => true];
+        $jobParameters = $this->stepExecution->getJobParameters();
+
+        return [
+            // for the array converters
+            'mapping'           => [
+                $jobParameters->get('familyColumn')     => 'family',
+                $jobParameters->get('categoriesColumn') => 'categories',
+                $jobParameters->get('groupsColumn')     => 'groups'
+            ],
+            'with_associations' => true,
+
+            // for the delocalization
+            'decimal_separator' => $jobParameters->get('decimalSeparator'),
+            'date_format'       => $jobParameters->get('dateFormat')
+        ];
     }
 }

--- a/src/Pim/Component/Connector/Reader/File/Xlsx/ProductAssociationReader.php
+++ b/src/Pim/Component/Connector/Reader/File/Xlsx/ProductAssociationReader.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Pim\Component\Connector\Reader\File\Xlsx;
+
+use Akeneo\Component\Batch\Item\FlushableInterface;
+use Akeneo\Component\Batch\Item\ItemReaderInterface;
+use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
+
+/**
+ * Product Association XLSX reader
+ *
+ * @author    Olivier Soulet <olivier.soulet@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ProductAssociationReader extends Reader implements
+    ItemReaderInterface,
+    StepExecutionAwareInterface,
+    FlushableInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function getArrayConverterOptions()
+    {
+        $jobParameters = $this->stepExecution->getJobParameters();
+
+        return [
+            // for the array converters
+            'mapping'           => [
+                $jobParameters->get('familyColumn')     => 'family',
+                $jobParameters->get('categoriesColumn') => 'categories',
+                $jobParameters->get('groupsColumn')     => 'groups'
+            ],
+            'with_associations' => true,
+
+            // for the delocalization
+            'decimal_separator' => $jobParameters->get('decimalSeparator'),
+            'date_format'       => $jobParameters->get('dateFormat')
+        ];
+    }
+}

--- a/src/Pim/Component/Connector/spec/Reader/File/Csv/ProductAssociationReaderSpec.php
+++ b/src/Pim/Component/Connector/spec/Reader/File/Csv/ProductAssociationReaderSpec.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace spec\Pim\Component\Connector\Reader\File\Csv;
+
+use Akeneo\Component\Batch\Item\FlushableInterface;
+use Akeneo\Component\Batch\Item\ItemReaderInterface;
+use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Connector\ArrayConverter\ArrayConverterInterface;
+use Pim\Component\Connector\Reader\File\Csv\ProductAssociationReader;
+use Pim\Component\Connector\Reader\File\Csv\Reader;
+use Pim\Component\Connector\Reader\File\FileIteratorFactory;
+
+class  ProductAssociationReaderSpec extends ObjectBehavior
+{
+    function let(
+        FileIteratorFactory $fileIteratorFactory,
+        ArrayConverterInterface $converter
+    ) {
+        $this->beConstructedWith($fileIteratorFactory, $converter);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(ProductAssociationReader::class);
+    }
+
+    function it_is_a_csv_reader()
+    {
+        $this->shouldHaveType(Reader::class);
+    }
+
+    function it_should_implement()
+    {
+        $this->shouldImplement(ItemReaderInterface::class);
+        $this->shouldImplement(StepExecutionAwareInterface::class);
+        $this->shouldImplement(FlushableInterface::class);
+    }
+}

--- a/src/Pim/Component/Connector/spec/Reader/File/Xlsx/ProductAssociationReaderSpec.php
+++ b/src/Pim/Component/Connector/spec/Reader/File/Xlsx/ProductAssociationReaderSpec.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace spec\Pim\Component\Connector\Reader\File\Csv;
+namespace spec\Pim\Component\Connector\Reader\File\Xlsx;
 
 use Akeneo\Component\Batch\Item\FlushableInterface;
 use Akeneo\Component\Batch\Item\ItemReaderInterface;
 use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Connector\ArrayConverter\ArrayConverterInterface;
-use Pim\Component\Connector\Reader\File\Csv\ProductAssociationReader;
-use Pim\Component\Connector\Reader\File\Csv\Reader;
+use Pim\Component\Connector\Reader\File\Xlsx\ProductAssociationReader;
+use Pim\Component\Connector\Reader\File\Xlsx\Reader;
 use Pim\Component\Connector\Reader\File\FileIteratorFactory;
 
 class ProductAssociationReaderSpec extends ObjectBehavior


### PR DESCRIPTION
When changing the category/group/family headers label on the job profile, the association step is not working anymore cf (https://akeneo.atlassian.net/browse/PIM-6085)

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | No
| Added Behats                      | Yes
| Added integration tests           | No
| Changelog updated                 | Yes
| Review and 2 GTM                  | Todo
