### PR TITLE
PIM-6249: correctly load more results from select2 when needed

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -13,6 +13,7 @@
 - PIM-6258: Fix permissions issue for listing locales, associations, families to display correctly the pef
 - PIM-6253: Add missing permissions on entities of the API
 - PIM-6252: Fix Summernote (WYSIWYG) style
+- PIM-6249: Correctly load more results from select2 when needed in the View Selector
 
 # 1.7.0 (2017-03-14)
 

--- a/features/product/edit_product.feature
+++ b/features/product/edit_product.feature
@@ -103,12 +103,13 @@ Feature: Edit a product
 
   @jira https://akeneo.atlassian.net/browse/PIM-6258
   Scenario: Successfully view a product even if permissions on locales channels and families are revoked
-    Given I am on the "Catalog manager" role page
-    When I visit the "Permissions" tab
+    Given I am logged in as "Peter"
+    When I am on the "Catalog manager" role page
+    And I visit the "Permissions" tab
     And I revoke rights to group Association types
     And I revoke rights to group Channels
     And I revoke rights to group Families
     And I revoke rights to group Locales
     And I save the role
-    And I edit the "rangers" product
-    Then I should see the text "Rangers"
+    And I edit the "sandal" product
+    Then I should see the text "Sandal"


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This PR fix the way we detect more results for the select2, plus it adds a method to get the "resultsPerPage" attribute to override it in EE.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | N
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
