### PR TITLE
Use "Europe/Paris" timezone for the integration tests of the API

### DIFF
--- a/app/phpunit.xml.dist
+++ b/app/phpunit.xml.dist
@@ -12,6 +12,7 @@
     bootstrap="./autoload.php">
 
     <php>
+        <ini name="date.timezone" value="Europe/Paris"/>
         <ini name="intl.default_locale" value="en"/>
         <ini name="intl.error_level" value="0"/>
         <ini name="memory_limit" value="-1"/>

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -32,8 +32,6 @@ abstract class TestCase extends KernelTestCase
      */
     protected function setUp()
     {
-        date_default_timezone_set('Europe/Paris');
-
         static::bootKernel(['debug' => false]);
 
         $configuration = $this->getConfiguration();


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

In `ListAttributeIntegration`, tests having a date fail if your php.ini is set with a timezone different from "Europe/Paris".

In a more general way, API tests are coupled to the timezone "Europe/Paris". The timezone for those tests sould be set with "Europe/Paris".

It does not fail on the CI, despite the fact the CI is set with "Etc/Utc", because a previous TestCase already set the time zone of the process with "Europe/Paris".

https://github.com/akeneo/pim-community-dev/blob/master/tests/TestCase.php#L35

Then, you have a clear side-effect of a test on another one...

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | -
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
