### PR TITLE
PIM-6254: Fix pagination on the API when filters are applied

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -5,6 +5,7 @@
 - PIM-6394: Fix email validation when creating a user in order to be less restrictive
 - GITHUB-6161: Fix JobInstance class hardcoded in `Akeneo\Bundle\BatchBundle\Command\BatchCommand::execute`
 - GITHUB-6151: Fix Mongo TimestampableSubscriber to properly update the CreatedAt date of a product
+- PIM-6254: Fix pagination on the API when filters are applied
 
 # 1.7.4 (2017-05-10)
 

--- a/src/Pim/Bundle/ApiBundle/Doctrine/ORM/Repository/ApiResourceRepository.php
+++ b/src/Pim/Bundle/ApiBundle/Doctrine/ORM/Repository/ApiResourceRepository.php
@@ -63,6 +63,7 @@ class ApiResourceRepository extends EntityRepository implements ApiResourceRepos
         }
 
         return $qb->setMaxResults($limit)
+            ->groupBy('r.id')
             ->getQuery()
             ->execute();
     }

--- a/src/Pim/Bundle/ApiBundle/Doctrine/ORM/Repository/AttributeRepository.php
+++ b/src/Pim/Bundle/ApiBundle/Doctrine/ORM/Repository/AttributeRepository.php
@@ -63,6 +63,7 @@ class AttributeRepository extends EntityRepository implements AttributeRepositor
         }
 
         return $qb->setMaxResults($limit)
+            ->groupBy('r.id')
             ->getQuery()
             ->execute();
     }

--- a/src/Pim/Bundle/ApiBundle/Doctrine/ORM/Repository/ProductRepository.php
+++ b/src/Pim/Bundle/ApiBundle/Doctrine/ORM/Repository/ProductRepository.php
@@ -50,6 +50,7 @@ class ProductRepository extends EntityRepository implements ProductRepositoryInt
 
         return $qb
             ->orderBy(sprintf('%s.id', $rootAlias), 'ASC')
+            ->groupBy(sprintf('%s.id', $rootAlias))
             ->setMaxResults($limit)
             ->setFirstResult($offset)
             ->getQuery()
@@ -72,6 +73,7 @@ class ProductRepository extends EntityRepository implements ProductRepositoryInt
 
         return $qb
             ->orderBy(sprintf('%s.id', $rootAlias), 'ASC')
+            ->groupBy(sprintf('%s.id', $rootAlias))
             ->setMaxResults($limit)
             ->getQuery()
             ->execute();

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/AbstractProductTestCase.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/AbstractProductTestCase.php
@@ -5,6 +5,7 @@ namespace Pim\Bundle\ApiBundle\tests\integration\Controller\Product;
 use Akeneo\Test\Integration\DateSanitizer;
 use Akeneo\Test\Integration\MediaSanitizer;
 use Pim\Bundle\ApiBundle\tests\integration\ApiTestCase;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * @author    Marie Bochu <marie.bochu@akeneo.com>
@@ -70,5 +71,27 @@ abstract class AbstractProductTestCase extends ApiTestCase
         }
 
         return $data;
+    }
+
+    /**
+     * @param Response $response
+     * @param array    $expected
+     */
+    protected function assertListResponse(Response $response, $expected)
+    {
+        $result = json_decode($response->getContent(), true);
+        $expected = json_decode($expected, true);
+
+        foreach ($result['_embedded']['items'] as $index => $product) {
+            $product = $this->sanitizeDateFields($product);
+            $result['_embedded']['items'][$index] = $this->sanitizeMediaAttributeData($product);
+
+            if (isset($expected['_embedded']['items'][$index])) {
+                $expected['_embedded']['items'][$index] = $this->sanitizeDateFields($expected['_embedded']['items'][$index]);
+                $expected['_embedded']['items'][$index] = $this->sanitizeMediaAttributeData($expected['_embedded']['items'][$index]);
+            }
+        }
+
+        $this->assertEquals($expected, $result);
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/ListProductWithCompletenessIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/ListProductWithCompletenessIntegration.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace Pim\Bundle\ApiBundle\tests\integration\Controller\Product;
+
+use Akeneo\Test\Integration\Configuration;
+use Doctrine\Common\Collections\Collection;
+
+class ListProductWithCompletenessIntegration extends AbstractProductTestCase
+{
+    /** @var Collection */
+    private $products;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        // product complete, whatever the scope
+        $this->createProduct('product_complete', [
+            'family'     => 'familyA2',
+            'categories' => ['categoryA', 'categoryB', 'master'],
+            'values'     => [
+                'a_metric' => [
+                    ['data' => ['amount' => 1, 'unit' => 'WATT'], 'locale' => null, 'scope' => null]
+                ],
+                'a_number_float' => [
+                    ['data' => '12.05', 'locale' => null, 'scope' => null]
+                ]
+            ]
+        ]);
+
+        // product complete only on en_US-tablet & en-US-ecommerce
+        $this->createProduct('product_complete_en_locale', [
+            'family'     => 'familyA1',
+            'categories' => ['categoryA', 'master', 'master_china'],
+            'values'     => [
+                'a_localizable_image' => [
+                    ['data' => $this->getFixturePath('akeneo.jpg'), 'locale' => 'en_US', 'scope' => null],
+                ],
+                'a_date' => [
+                    ['data' => '2016-06-28', 'locale' => null, 'scope' => null]
+                ],
+                'a_file' => [
+                    ['data' => $this->getFixturePath('akeneo.txt'), 'locale' => null, 'scope' => null],
+                ]
+            ]
+        ]);
+
+        // product incomplete
+        $this->createProduct('product_incomplete', [
+            'family'     => 'familyA',
+            'categories' => ['categoryA', 'master', 'master_china'],
+            'values'     => [
+                'a_file' => [
+                    ['data' => $this->getFixturePath('akeneo.txt'), 'locale' => null, 'scope' => null],
+                ]
+            ]
+        ]);
+
+        $this->products = $this->get('pim_catalog.repository.product')->findAll();
+    }
+
+    public function testPaginationWithCompletenessFilter()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $search = '{"completeness":[{"operator":"=","value":100,"scope":"ecommerce"}]}';
+        $client->request('GET', 'api/rest/v1/products?scope=ecommerce&locales=en_US&limit=2&search=' . $search);
+        $searchEncoded = urlencode($search);
+        $expected = <<<JSON
+{
+    "_links": {
+        "self": {"href": "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=2&scope=ecommerce&locales=en_US&search=${searchEncoded}"},
+        "first": {"href": "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=2&scope=ecommerce&locales=en_US&search=${searchEncoded}"},
+        "next": {"href": "http://localhost/api/rest/v1/products?page=2&with_count=false&pagination_type=page&limit=2&scope=ecommerce&locales=en_US&search=${searchEncoded}"}
+    },
+    "current_page" : 1,
+    "_embedded"    : {
+		"items": [
+		    {
+		        "_links":{
+		            "self":{
+		                "href": "http:\/\/localhost\/api\/rest\/v1\/products\/product_complete"
+		            }
+		        },
+		        "identifier": "product_complete",
+		        "family": "familyA2",
+		        "groups": [],
+		        "variant_group": null,
+		        "categories": ["categoryA","categoryB","master"],
+		        "enabled": true,
+		        "values": {
+		            "a_metric": [
+		                {"locale": null, "scope": null, "data": {"amount": "1.0000", "unit":"WATT"}}
+		            ],
+		            "a_number_float": [
+		                {"locale": null, "scope": null, "data": "12.0500"}
+		            ]
+		        },
+		        "created": "2017-03-17T16:11:46+01:00",
+		        "updated": "2017-03-17T16:11:46+01:00",
+		        "associations": {}
+		    },
+		    {
+		        "_links": {
+		            "self": {"href": "http:\/\/localhost\/api\/rest\/v1\/products\/product_complete_en_locale"}
+		        },
+		        "identifier": "product_complete_en_locale",
+		        "family": "familyA1",
+		        "groups": [],
+		        "variant_group": null,
+		        "categories": ["categoryA","master","master_china"],
+		        "enabled": true,
+		        "values": {
+		            "a_localizable_image":[
+		                {
+		                    "locale": "en_US",
+		                    "scope": null,
+		                    "data": "6\/c\/3\/d\/6c3d4fe7736d7c51ac75a089fe4b1ad0409270e2_akeneo.jpg",
+		                    "_links": {
+		                        "download": {
+		                            "href": "http:\/\/localhost\/api\/rest\/v1\/media-files\/6\/c\/3\/d\/6c3d4fe7736d7c51ac75a089fe4b1ad0409270e2_akeneo.jpg\/download"
+		                        }
+		                    }
+		                }
+		            ],
+                    "a_date": [
+                        {"locale": null, "scope": null, "data": "2016-06-28T00:00:00+02:00"}
+                    ],
+                    "a_file":[
+                        {
+                            "locale": null,
+                            "scope": null,
+                            "data": "9\/7\/a\/9\/97a97e0c6ecf25e8620ad49e98dd8cbf951a963e_akeneo.txt",
+                            "_links":{
+                                "download": {
+                                    "href": "http:\/\/localhost\/api\/rest\/v1\/media-files\/9\/7\/a\/9\/97a97e0c6ecf25e8620ad49e98dd8cbf951a963e_akeneo.txt\/download"
+                                }
+                            }
+                        }
+                    ]
+		        },
+                "created": "2017-03-17T16:11:46+01:00",
+                "updated": "2017-03-17T16:11:46+01:00",
+                "associations": []
+		    }
+		]
+    }
+}
+JSON;
+
+        $this->assertListResponse($client->getResponse(), $expected);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+    }
+}

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessListProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessListProductIntegration.php
@@ -4,7 +4,6 @@ namespace Pim\Bundle\ApiBundle\tests\integration\Controller\Product;
 
 use Akeneo\Test\Integration\Configuration;
 use Doctrine\Common\Collections\Collection;
-use Symfony\Component\HttpFoundation\Response;
 
 class SuccessListProductIntegration extends AbstractProductTestCase
 {
@@ -128,7 +127,7 @@ class SuccessListProductIntegration extends AbstractProductTestCase
 }
 JSON;
 
-        $this->assertResponse($client->getResponse(), $expected);
+        $this->assertListResponse($client->getResponse(), $expected);
     }
 
     public function testDefaultPaginationFirstPageListProductsWithCount()
@@ -156,7 +155,7 @@ JSON;
 }
 JSON;
 
-        $this->assertResponse($client->getResponse(), $expected);
+        $this->assertListResponse($client->getResponse(), $expected);
     }
 
     public function testDefaultPaginationLastPageListProductsWithCount()
@@ -185,7 +184,7 @@ JSON;
 }
 JSON;
 
-        $this->assertResponse($client->getResponse(), $expected);
+        $this->assertListResponse($client->getResponse(), $expected);
     }
 
     /**
@@ -292,7 +291,7 @@ JSON;
 }
 JSON;
 
-        $this->assertResponse($client->getResponse(), $expected);
+        $this->assertListResponse($client->getResponse(), $expected);
     }
 
     /**
@@ -408,7 +407,7 @@ JSON;
 }
 JSON;
 
-        $this->assertResponse($client->getResponse(), $expected);
+        $this->assertListResponse($client->getResponse(), $expected);
     }
 
     /**
@@ -513,7 +512,7 @@ JSON;
 }
 JSON;
 
-        $this->assertResponse($client->getResponse(), $expected);
+        $this->assertListResponse($client->getResponse(), $expected);
     }
 
     /**
@@ -576,7 +575,7 @@ JSON;
 }
 JSON;
 
-        $this->assertResponse($client->getResponse(), $expected);
+        $this->assertListResponse($client->getResponse(), $expected);
     }
 
     /**
@@ -703,7 +702,7 @@ JSON;
 }
 JSON;
 
-        $this->assertResponse($client->getResponse(), $expected);
+        $this->assertListResponse($client->getResponse(), $expected);
     }
 
     public function testOffsetPaginationListProductsWithFilteredAttributes()
@@ -823,7 +822,7 @@ JSON;
 }
 JSON;
 
-        $this->assertResponse($client->getResponse(), $expected);
+        $this->assertListResponse($client->getResponse(), $expected);
     }
 
     public function testOffsetPaginationListProductsWithChannelLocalesAndAttributesParams()
@@ -932,7 +931,7 @@ JSON;
 }
 JSON;
 
-        $this->assertResponse($client->getResponse(), $expected);
+        $this->assertListResponse($client->getResponse(), $expected);
     }
 
     public function testTheSecondPageOfTheListOfProductsWithOffsetPaginationWithoutCount()
@@ -986,7 +985,7 @@ JSON;
 }
 JSON;
 
-        $this->assertResponse($client->getResponse(), $expected);
+        $this->assertListResponse($client->getResponse(), $expected);
     }
 
     public function testOutOfRangeProductsList()
@@ -1009,7 +1008,7 @@ JSON;
 }
 JSON;
 
-        $this->assertResponse($client->getResponse(), $expected);
+        $this->assertListResponse($client->getResponse(), $expected);
     }
 
     public function testOffsetPaginationListProductsWithSearch()
@@ -1066,7 +1065,7 @@ JSON;
 }
 JSON;
 
-        $this->assertResponse($client->getResponse(), $expected);
+        $this->assertListResponse($client->getResponse(), $expected);
     }
 
     public function testOffsetPaginationListProductsWithMultiplePQBFilters()
@@ -1089,7 +1088,7 @@ JSON;
 }
 JSON;
 
-        $this->assertResponse($client->getResponse(), $expected);
+        $this->assertListResponse($client->getResponse(), $expected);
     }
 
     public function testListProductsWithCompletenessPQBFilters()
@@ -1112,7 +1111,7 @@ JSON;
 }
 JSON;
 
-        $this->assertResponse($client->getResponse(), $expected);
+        $this->assertListResponse($client->getResponse(), $expected);
     }
     /**
      * Get all products, whatever locale, scope, category with a search after pagination
@@ -1142,7 +1141,7 @@ JSON;
 }
 JSON;
 
-        $this->assertResponse($client->getResponse(), $expected);
+        $this->assertListResponse($client->getResponse(), $expected);
     }
 
     public function testSearchAfterPaginationListProductsWithNextLink()
@@ -1173,7 +1172,7 @@ JSON;
 }
 JSON;
 
-        $this->assertResponse($client->getResponse(), $expected);
+        $this->assertListResponse($client->getResponse(), $expected);
     }
 
     public function testSearchAfterPaginationLastPageOfTheListOfProducts()
@@ -1200,29 +1199,7 @@ JSON;
 }
 JSON;
 
-        $this->assertResponse($client->getResponse(), $expected);
-    }
-
-    /**
-     * @param Response $response
-     * @param array    $expected
-     */
-    private function assertResponse(Response $response, $expected)
-    {
-        $result = json_decode($response->getContent(), true);
-        $expected = json_decode($expected, true);
-
-        foreach ($result['_embedded']['items'] as $index => $product) {
-            $product = $this->sanitizeDateFields($product);
-            $result['_embedded']['items'][$index] = $this->sanitizeMediaAttributeData($product);
-
-            if (isset($expected['_embedded']['items'][$index])) {
-                $expected['_embedded']['items'][$index] = $this->sanitizeDateFields($expected['_embedded']['items'][$index]);
-                $expected['_embedded']['items'][$index] = $this->sanitizeMediaAttributeData($expected['_embedded']['items'][$index]);
-            }
-        }
-
-        $this->assertEquals($expected, $result);
+        $this->assertListResponse($client->getResponse(), $expected);
     }
 
     /**


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

Add missing groupBy to fix products returned on list when filters are applied 


[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
