### PR TITLE
PIM-6250: fix attribute export

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -8,6 +8,7 @@
 - PIM-6242: Fix UI glitch on TWA completeness filter search field
 - PIM-6239: Translate scope with catalog locale
 - GITHUB-3435: Sort order products datagrid `Manage filter` options
+- PIM-6250: Fix attribute export.
 - GITHUB-5538: User without permissions access to import/export jobs through `Process tracker`
 - PIM-6253: Add missing permissions on entities of the API
 

--- a/features/Context/catalog/footwear/attributes.csv
+++ b/features/Context/catalog/footwear/attributes.csv
@@ -1,27 +1,27 @@
-type;code;label-en_US;group;unique;useable_as_grid_filter;allowed_extensions;metric_family;default_metric_unit;reference_data_name;localizable;scopable;required;sort_order;label-fr_FR;max_characters;number_min;number_max;decimals_allowed;negative_allowed;max_file_size
-pim_catalog_identifier;sku;SKU;info;1;1;;;;;0;0;1;1;;;;;;;
-pim_catalog_text;name;Name;info;0;1;;;;;1;0;0;2;;;;;;;
-pim_catalog_simpleselect;manufacturer;Manufacturer;info;0;1;;;;;0;0;0;3;;;;;;;
-pim_catalog_multiselect;weather_conditions;Weather conditions;info;0;1;;;;;0;0;0;4;;;;;;;
-pim_catalog_textarea;description;Description;info;0;1;;;;;1;1;0;5;;1000;;;;;
-pim_catalog_text;comment;Comment;other;0;1;;;;;0;0;0;7;;255;;;;;
-pim_catalog_price_collection;price;Price;marketing;0;1;;;;;0;0;0;1;;;1;200;1;;
-pim_catalog_simpleselect;rating;Rating;marketing;0;1;;;;;0;0;0;2;;;;;;;
-pim_catalog_image;side_view;Side view;media;0;0;gif,png,jpeg,jpg;;;;0;0;0;1;;;;;;;1
-pim_catalog_image;top_view;Top view;media;0;0;gif,png,jpeg,jpg;;;;0;0;0;2;;;;;;;1
-pim_catalog_simpleselect;size;Size;sizes;0;1;;;;;0;0;0;1;;;;;;;
-pim_catalog_simpleselect;color;Color;colors;0;1;;;;;0;0;0;1;;;;;;;
-pim_catalog_simpleselect;lace_color;Lace color;colors;0;1;;;;;0;0;0;2;;;;;;;
-pim_catalog_metric;length;Length;info;0;0;;Length;CENTIMETER;;0;0;0;10;Longueur;;;;0;0;
-pim_catalog_metric;volume;Volume;info;0;0;;Volume;CUBIC_MILLIMETER;;0;0;0;20;Volume;;;;0;0;
-pim_catalog_number;number_in_stock;Number in stock;other;0;0;;;;;0;0;0;8;;;;;0;0;
-pim_catalog_date;destocking_date;Destocking date;other;0;1;;;;;0;0;0;25;Date de déstockage;;;;;;
-pim_catalog_boolean;handmade;Handmade;other;0;1;;;;;0;0;0;30;;;;;;;
-pim_reference_data_simpleselect;heel_color;Heel color;other;0;1;;;;color;0;0;0;30;;;;;;;
-pim_reference_data_simpleselect;sole_color;Sole color;other;0;1;;;;color;0;0;0;35;;;;;;;
-pim_reference_data_simpleselect;cap_color;Cap color;other;0;1;;;;color;1;1;0;35;;;;;;;
-pim_reference_data_multiselect;sole_fabric;Sole fabric;other;0;1;;;;fabrics;0;0;0;40;;;;;;;
-pim_reference_data_multiselect;lace_fabric;Lace fabric;other;0;1;;;;fabrics;1;1;0;45;;;;;;;
-pim_catalog_number;rate_sale;Rate of sale;marketing;0;1;;;;;0;0;0;1;Taux de vente;;;;1;0;
-pim_catalog_metric;weight;Weight;info;0;1;;Weight;GRAM;;0;0;0;30;Poids;;;;1;0;
-pim_catalog_text;123;Attribute 123;other;0;1;;;;;0;0;0;1;;255;;;;;
+type;code;label-en_US;group;unique;useable_as_grid_filter;allowed_extensions;metric_family;default_metric_unit;reference_data_name;localizable;scopable;required;sort_order;label-fr_FR;max_characters;number_min;number_max;decimals_allowed;negative_allowed;max_file_size;wysiwyg_enabled
+pim_catalog_identifier;sku;SKU;info;1;1;;;;;0;0;1;1;;;;;;;;
+pim_catalog_text;name;Name;info;0;1;;;;;1;0;0;2;;;;;;;;
+pim_catalog_simpleselect;manufacturer;Manufacturer;info;0;1;;;;;0;0;0;3;;;;;;;;
+pim_catalog_multiselect;weather_conditions;Weather conditions;info;0;1;;;;;0;0;0;4;;;;;;;;
+pim_catalog_textarea;description;Description;info;0;1;;;;;1;1;0;5;;1000;;;;;;1
+pim_catalog_text;comment;Comment;other;0;1;;;;;0;0;0;7;;255;;;;;;
+pim_catalog_price_collection;price;Price;marketing;0;1;;;;;0;0;0;1;;;1;200;1;;;
+pim_catalog_simpleselect;rating;Rating;marketing;0;1;;;;;0;0;0;2;;;;;;;;
+pim_catalog_image;side_view;Side view;media;0;0;gif,png,jpeg,jpg;;;;0;0;0;1;;;;;;;1;
+pim_catalog_image;top_view;Top view;media;0;0;gif,png,jpeg,jpg;;;;0;0;0;2;;;;;;;1;
+pim_catalog_simpleselect;size;Size;sizes;0;1;;;;;0;0;0;1;;;;;;;;
+pim_catalog_simpleselect;color;Color;colors;0;1;;;;;0;0;0;1;;;;;;;;
+pim_catalog_simpleselect;lace_color;Lace color;colors;0;1;;;;;0;0;0;2;;;;;;;;
+pim_catalog_metric;length;Length;info;0;0;;Length;CENTIMETER;;0;0;0;10;Longueur;;;;0;0;;
+pim_catalog_metric;volume;Volume;info;0;0;;Volume;CUBIC_MILLIMETER;;0;0;0;20;Volume;;;;0;0;;
+pim_catalog_number;number_in_stock;Number in stock;other;0;0;;;;;0;0;0;8;;;;;0;0;;
+pim_catalog_date;destocking_date;Destocking date;other;0;1;;;;;0;0;0;25;Date de déstockage;;;;;;;
+pim_catalog_boolean;handmade;Handmade;other;0;1;;;;;0;0;0;30;;;;;;;;
+pim_reference_data_simpleselect;heel_color;Heel color;other;0;1;;;;color;0;0;0;30;;;;;;;;
+pim_reference_data_simpleselect;sole_color;Sole color;other;0;1;;;;color;0;0;0;35;;;;;;;;
+pim_reference_data_simpleselect;cap_color;Cap color;other;0;1;;;;color;1;1;0;35;;;;;;;;
+pim_reference_data_multiselect;sole_fabric;Sole fabric;other;0;1;;;;fabrics;0;0;0;40;;;;;;;;
+pim_reference_data_multiselect;lace_fabric;Lace fabric;other;0;1;;;;fabrics;1;1;0;45;;;;;;;;
+pim_catalog_number;rate_sale;Rate of sale;marketing;0;1;;;;;0;0;0;1;Taux de vente;;;;1;0;;
+pim_catalog_metric;weight;Weight;info;0;1;;Weight;GRAM;;0;0;0;30;Poids;;;;1;0;;
+pim_catalog_text;123;Attribute 123;other;0;1;;;;;0;0;0;1;;255;;;;;;

--- a/features/export/export_attributes.feature
+++ b/features/export/export_attributes.feature
@@ -20,7 +20,7 @@ Feature: Export attributes
     pim_catalog_text;name;Name;info;;0;1;;;;;;0;;;;;;;;;;;0;1;0;0;0
     pim_catalog_simpleselect;manufacturer;Manufacturer;info;;0;1;;;;;;0;;;;;;;;;;;0;0;0;0;0
     pim_catalog_multiselect;weather_conditions;"Weather conditions";info;;0;1;;;;;;0;;;;;;;;;;;0;0;0;0;0
-    pim_catalog_textarea;description;Description;info;;0;1;;;;;;1000;;;;;;;;;;;0;1;1;0;0
+    pim_catalog_textarea;description;Description;info;;0;1;;;;;;1000;;;1;;;;;;;;0;1;1;0;0
     pim_catalog_text;comment;Comment;other;;0;1;;;;;;255;;;;;;;;;;;0;0;0;0;0
     pim_catalog_price_collection;price;Price;marketing;;0;1;;;;;;0;;;;1.0000;200.0000;1;;;;;0;0;0;0;0
     pim_catalog_simpleselect;rating;Rating;marketing;;0;1;;;;;;0;;;;;;;;;;;0;0;0;0;0
@@ -43,4 +43,3 @@ Feature: Export attributes
     pim_catalog_metric;weight;Weight;info;;0;1;;Weight;GRAM;;;0;;;;;;1;;;;;0;0;0;0;0
     pim_catalog_text;123;"Attribute 123";other;;0;1;;;;;;255;;;;;;;;;;;0;0;0;0;0
     """
-

--- a/src/Pim/Component/Catalog/Normalizer/Standard/AttributeNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Standard/AttributeNormalizer.php
@@ -48,7 +48,7 @@ class AttributeNormalizer implements NormalizerInterface
             'default_metric_unit'    => '' === $attribute->getDefaultMetricUnit() ?
                 null : $attribute->getDefaultMetricUnit(),
             'reference_data_name'    => $attribute->getReferenceDataName(),
-            'available_locales'      => $attribute->getLocaleSpecificCodes(),
+            'available_locales'      => $attribute->getAvailableLocaleCodes(),
             'max_characters'         => null === $attribute->getMaxCharacters() ?
                 null : (int) $attribute->getMaxCharacters(),
             'validation_rule'        => '' === $attribute->getValidationRule() ? null : $attribute->getValidationRule(),

--- a/src/Pim/Component/Catalog/spec/Normalizer/Standard/AttributeNormalizerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Normalizer/Standard/AttributeNormalizerSpec.php
@@ -53,7 +53,7 @@ class AttributeNormalizerSpec extends ObjectBehavior
         $attribute->getReferenceDataName()->willReturn(null);
         $attribute->isLocalizable()->willReturn(false);
         $attribute->isScopable()->willReturn(false);
-        $attribute->getLocaleSpecificCodes()->willReturn([]);
+        $attribute->getAvailableLocaleCodes()->willReturn([]);
         $attribute->getMaxCharacters()->willReturn(null);
         $attribute->getValidationRule()->willReturn(null);
         $attribute->getValidationRegexp()->willReturn(null);
@@ -124,7 +124,7 @@ class AttributeNormalizerSpec extends ObjectBehavior
         $attribute->getReferenceDataName()->willReturn('color');
         $attribute->isLocalizable()->willReturn(true);
         $attribute->isScopable()->willReturn(true);
-        $attribute->getLocaleSpecificCodes()->willReturn(['en_US', 'fr_FR']);
+        $attribute->getAvailableLocaleCodes()->willReturn(['en_US', 'fr_FR']);
         $attribute->getMaxCharacters()->willReturn(255);
         $attribute->getValidationRule()->willReturn('email');
         $attribute->getValidationRegexp()->willReturn('[0-9]*');

--- a/src/Pim/Component/Connector/ArrayConverter/StandardToFlat/Attribute.php
+++ b/src/Pim/Component/Connector/ArrayConverter/StandardToFlat/Attribute.php
@@ -42,6 +42,11 @@ class Attribute extends AbstractSimpleArrayConverter implements ArrayConverterIn
                 $convertedItem[$property] = implode(',', $data);
                 break;
             case in_array($property, $this->booleanFields):
+                if (null === $data) {
+                    $convertedItem[$property] = '';
+                    break;
+                }
+
                 $convertedItem[$property] = (true === $data) ? '1' : '0';
                 break;
             default:

--- a/src/Pim/Component/Connector/spec/ArrayConverter/StandardToFlat/AttributeSpec.php
+++ b/src/Pim/Component/Connector/spec/ArrayConverter/StandardToFlat/AttributeSpec.php
@@ -82,4 +82,21 @@ class AttributeSpec extends ObjectBehavior
 
         $this->convert($item)->shouldReturn($expected);
     }
+
+    function it_converts_from_standard_to_flat_format_with_null_values()
+    {
+        $expected = [
+            'wysiwyg_enabled'  => '',
+            'decimals_allowed' => '',
+            'negative_allowed' => '',
+        ];
+
+        $item = [
+            'wysiwyg_enabled'  => null,
+            'decimals_allowed' => null,
+            'negative_allowed' => null,
+        ];
+
+        $this->convert($item)->shouldReturn($expected);
+    }
 }


### PR DESCRIPTION
**Definition Of Done (for Core Developer only)**

When you export attribute and reimport it, you got some errors.

Depending on the attribute type I have errors on these properties, for instance for SKU:
wysiwygEnabled: This value should be null.:
decimalsAllowed: This value should be null.:
negativeAllowed: This value should be null.:

As this values are not null but they should be null as they are not using the wysiwyg or decimals values. (like the text attribute)

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Yes
| Added Behats                      | Yes
| Changelog updated                 | Yes
| Review and 2 GTM                  | Todo