### PR TITLE
PIM-6258: fix permission issue

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -10,7 +10,7 @@
 - GITHUB-3435: Sort order products datagrid `Manage filter` options
 - PIM-6250: Fix attribute export.
 - GITHUB-5538: User without permissions access to import/export jobs through `Process tracker`
-- PIM-6258: Fix permission issue
+- PIM-6258: Fix permissions issue for listing locales, associations, families to display correctly the pef
 - PIM-6253: Add missing permissions on entities of the API
 
 # 1.7.0 (2017-03-14)

--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -10,6 +10,7 @@
 - GITHUB-3435: Sort order products datagrid `Manage filter` options
 - PIM-6250: Fix attribute export.
 - GITHUB-5538: User without permissions access to import/export jobs through `Process tracker`
+- PIM-6258: Fix permission issue
 - PIM-6253: Add missing permissions on entities of the API
 
 # 1.7.0 (2017-03-14)

--- a/features/product/edit_product.feature
+++ b/features/product/edit_product.feature
@@ -110,5 +110,5 @@ Feature: Edit a product
     And I revoke rights to group Families
     And I revoke rights to group Locales
     And I save the role
-    Then I edit the "rangers" product
-    And I should see the text "Rangers"
+    And I edit the "rangers" product
+    Then I should see the text "Rangers"

--- a/features/product/edit_product.feature
+++ b/features/product/edit_product.feature
@@ -100,3 +100,15 @@ Feature: Edit a product
     And I am on the "sandal" product page
     Then I switch the scope to "channel_code"
     And I should see the text "The channel label"
+
+  @jira https://akeneo.atlassian.net/browse/PIM-6258
+  Scenario: Successfully view a product even if permissions on locales channels and families are revoked
+    Given I am on the "Catalog manager" role page
+    When I visit the "Permissions" tab
+    And I revoke rights to group Association types
+    And I revoke rights to group Channels
+    And I revoke rights to group Families
+    And I revoke rights to group Locales
+    And I save the role
+    Then I edit the "rangers" product
+    And I should see the text "Rangers"

--- a/src/Pim/Bundle/EnrichBundle/Controller/LocaleController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/LocaleController.php
@@ -20,7 +20,7 @@ class LocaleController
      * @Template
      * @AclAncestor("pim_enrich_locale_index")
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return array
      */
     public function indexAction()
     {

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/AssociationTypeController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/AssociationTypeController.php
@@ -50,6 +50,11 @@ class AssociationTypeController
     /**
      * @param AssociationTypeRepositoryInterface $associationTypeRepo
      * @param NormalizerInterface                $normalizer
+     * @param RemoverInterface                   $remover
+     * @param ObjectUpdaterInterface             $updater
+     * @param SaverInterface                     $saver
+     * @param ValidatorInterface                 $validator
+     * @param UserContext                        $userContext
      */
     public function __construct(
         AssociationTypeRepositoryInterface $associationTypeRepo,
@@ -71,8 +76,6 @@ class AssociationTypeController
 
     /**
      * @return JsonResponse
-     *
-     * @AclAncestor("pim_enrich_associationtype_index")
      */
     public function indexAction()
     {

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/ChannelController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/ChannelController.php
@@ -79,8 +79,6 @@ class ChannelController
     /**
      * Lists all channels
      *
-     * @AclAncestor("pim_enrich_channel_index")
-     *
      * @return JsonResponse
      */
     public function indexAction()
@@ -94,8 +92,6 @@ class ChannelController
 
     /**
      * Gets channel by code value
-     *
-     * @AclAncestor("pim_enrich_channel_index")
      *
      * @param string $identifier
      *

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/FamilyController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/FamilyController.php
@@ -2,7 +2,6 @@
 
 namespace Pim\Bundle\EnrichBundle\Controller\Rest;
 
-use Akeneo\Component\StorageUtils\Exception\ObjectUpdaterException;
 use Akeneo\Component\StorageUtils\Remover\RemoverInterface;
 use Akeneo\Component\StorageUtils\Saver\SaverInterface;
 use Oro\Bundle\SecurityBundle\Annotation\AclAncestor;
@@ -98,8 +97,6 @@ class FamilyController
     /**
      * Get the family collection
      *
-     * @AclAncestor("pim_enrich_family_index")
-     *
      * @param Request $request
      *
      * @return JsonResponse
@@ -127,8 +124,6 @@ class FamilyController
 
     /**
      * Get a single family
-     *
-     * @AclAncestor("pim_enrich_family_index")
      *
      * @param int $identifier
      *
@@ -187,7 +182,7 @@ class FamilyController
     /**
      * Gets family
      *
-     * @param $code
+     * @param string $code
      *
      * @throws HttpExceptionInterface
      *
@@ -211,8 +206,6 @@ class FamilyController
      *
      * @param Request         $request
      * @param FamilyInterface $family
-     *
-     * @throws ObjectUpdaterException
      *
      * @return JsonResponse
      */


### PR DESCRIPTION
While accessing the PEF, the UI calls rest routes for listing locales, associations, families and more. If there are no permission on this groups it returns a 403.


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | No
| Added Behats                      | Yes
| Added integration tests           | No
| Changelog updated                 | Yes
| Review and 2 GTM                  | Todo