### PR TITLE
PIM-6196: Do not filter attributes in family enrich normalizer

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -6,6 +6,7 @@
 - GITHUB-6161: Fix JobInstance class hardcoded in `Akeneo\Bundle\BatchBundle\Command\BatchCommand::execute`
 - GITHUB-6151: Fix Mongo TimestampableSubscriber to properly update the CreatedAt date of a product
 - PIM-6254: Fix pagination on the API when filters are applied
+- PIM-6196: Fix collection filters used on `Family` screen
 
 # 1.7.4 (2017-05-10)
 

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/AttributeGroupController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/AttributeGroupController.php
@@ -57,6 +57,7 @@ class AttributeGroupController
     public function indexAction(Request $request)
     {
         $options = [];
+        $useCollectionFilter = true;
 
         if ($request->request->has('identifiers')) {
             $options['identifiers'] = explode(',', $request->request->get('identifiers'));
@@ -67,6 +68,10 @@ class AttributeGroupController
                 ',',
                 $request->request->get('attribute_groups')
             );
+        }
+
+        if ($request->request->has('no_filters')) {
+            $useCollectionFilter = !$request->request->get('no_filters');
         }
 
         if (empty($options)) {
@@ -85,14 +90,16 @@ class AttributeGroupController
                 $options
             );
 
-        $filteredAttributeGroups = $this->collectionFilter->filterCollection(
-            $attributeGroups,
-            'pim.internal_api.attribute_group.view'
-        );
+        if ($useCollectionFilter) {
+            $attributeGroups = $this->collectionFilter->filterCollection(
+                $attributeGroups,
+                'pim.internal_api.attribute_group.view'
+            );
+        }
 
         $normalizedAttributeGroups = [];
 
-        foreach ($filteredAttributeGroups as $attributeGroup) {
+        foreach ($attributeGroups as $attributeGroup) {
             $normalizedAttributeGroups[$attributeGroup->getCode()] = $this->normalizer
                 ->normalize($attributeGroup, 'standard');
         }

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/AttributeGroupController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/AttributeGroupController.php
@@ -57,7 +57,6 @@ class AttributeGroupController
     public function indexAction(Request $request)
     {
         $options = [];
-        $useCollectionFilter = true;
 
         if ($request->request->has('identifiers')) {
             $options['identifiers'] = explode(',', $request->request->get('identifiers'));
@@ -70,9 +69,7 @@ class AttributeGroupController
             );
         }
 
-        if ($request->request->has('no_filters')) {
-            $useCollectionFilter = !$request->request->get('no_filters');
-        }
+        $applyFilters = $request->request->getBoolean('apply_filters', true);
 
         if (empty($options)) {
             $options = $request->request->get(
@@ -90,7 +87,7 @@ class AttributeGroupController
                 $options
             );
 
-        if ($useCollectionFilter) {
+        if ($applyFilters) {
             $attributeGroups = $this->collectionFilter->filterCollection(
                 $attributeGroups,
                 'pim.internal_api.attribute_group.view'

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/FamilyController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/FamilyController.php
@@ -132,7 +132,7 @@ class FamilyController
     public function getAction(Request $request, $identifier)
     {
         $family = $this->familyRepository->findOneByIdentifier($identifier);
-        $noFilters = $request->query->getBoolean('no_filters');
+        $applyFilters = $request->query->getBoolean('apply_filters', true);
 
         if (null === $family) {
             throw new NotFoundHttpException(sprintf('Family with code "%s" not found', $identifier));
@@ -142,7 +142,7 @@ class FamilyController
             $this->normalizer->normalize(
                 $family,
                 'internal_api',
-                ['no_filters' => $noFilters]
+                ['apply_filters' => $applyFilters]
             )
         );
     }

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/FamilyController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/FamilyController.php
@@ -132,7 +132,7 @@ class FamilyController
     public function getAction(Request $request, $identifier)
     {
         $family = $this->familyRepository->findOneByIdentifier($identifier);
-        $noFilter = (bool) $request->get('no_filter');
+        $noFilter = (bool) $request->get('no_filters');
 
         if (null === $family) {
             throw new NotFoundHttpException(sprintf('Family with code "%s" not found', $identifier));
@@ -142,7 +142,7 @@ class FamilyController
             $this->normalizer->normalize(
                 $family,
                 'internal_api',
-                ['no_filter' => $noFilter]
+                ['no_filters' => $noFilter]
             )
         );
     }

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/FamilyController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/FamilyController.php
@@ -129,15 +129,22 @@ class FamilyController
      *
      * @return JsonResponse
      */
-    public function getAction($identifier)
+    public function getAction(Request $request, $identifier)
     {
         $family = $this->familyRepository->findOneByIdentifier($identifier);
+        $noFilter = (bool) $request->get('no_filter');
 
         if (null === $family) {
             throw new NotFoundHttpException(sprintf('Family with code "%s" not found', $identifier));
         }
 
-        return new JsonResponse($this->normalizer->normalize($family, 'internal_api'));
+        return new JsonResponse(
+            $this->normalizer->normalize(
+                $family,
+                'internal_api',
+                ['no_filter' => $noFilter]
+            )
+        );
     }
 
     /**

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/FamilyController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/FamilyController.php
@@ -132,7 +132,7 @@ class FamilyController
     public function getAction(Request $request, $identifier)
     {
         $family = $this->familyRepository->findOneByIdentifier($identifier);
-        $noFilter = (bool) $request->get('no_filters');
+        $noFilters = $request->query->getBoolean('no_filters');
 
         if (null === $family) {
             throw new NotFoundHttpException(sprintf('Family with code "%s" not found', $identifier));
@@ -142,7 +142,7 @@ class FamilyController
             $this->normalizer->normalize(
                 $family,
                 'internal_api',
-                ['no_filters' => $noFilter]
+                ['no_filters' => $noFilters]
             )
         );
     }

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/FamilyNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/FamilyNormalizer.php
@@ -70,9 +70,7 @@ class FamilyNormalizer implements NormalizerInterface
             $context
         );
 
-        $normalizedFamily['attributes'] = $this->normalizeAttributes(
-            $normalizedFamily['attributes']
-        );
+        $normalizedFamily['attributes'] = $this->normalizeAttributes($family);
 
         $normalizedFamily['attribute_requirements'] = $this->normalizeRequirements(
             $normalizedFamily['attribute_requirements']
@@ -108,13 +106,13 @@ class FamilyNormalizer implements NormalizerInterface
     /**
      * Fetches attributes by code and normalizes them
      *
-     * @param array $codes
+     * @param FamilyInterface $family
      *
      * @return array
      */
-    protected function normalizeAttributes($codes)
+    protected function normalizeAttributes(FamilyInterface $family)
     {
-        $attributes = $this->attributeRepository->findBy(['code' => $codes]);
+        $attributes = $this->attributeRepository->findAttributesByFamily($family);
 
         $normalizedAttributes = [];
         foreach ($attributes as $attribute) {

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/FamilyNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/FamilyNormalizer.php
@@ -41,7 +41,6 @@ class FamilyNormalizer implements NormalizerInterface
     /**
      * @param NormalizerInterface          $familyNormalizer
      * @param NormalizerInterface          $translationNormalizer
-     * @param CollectionFilterInterface    $collectionFilter
      * @param AttributeRepositoryInterface $attributeRepository
      * @param VersionManager               $versionManager
      * @param NormalizerInterface          $versionNormalizer
@@ -49,14 +48,12 @@ class FamilyNormalizer implements NormalizerInterface
     public function __construct(
         NormalizerInterface $familyNormalizer,
         NormalizerInterface $translationNormalizer,
-        CollectionFilterInterface $collectionFilter,
         AttributeRepositoryInterface $attributeRepository,
         VersionManager $versionManager,
         NormalizerInterface $versionNormalizer
     ) {
         $this->familyNormalizer = $familyNormalizer;
         $this->translationNormalizer = $translationNormalizer;
-        $this->collectionFilter = $collectionFilter;
         $this->attributeRepository = $attributeRepository;
         $this->versionManager = $versionManager;
         $this->versionNormalizer = $versionNormalizer;
@@ -117,10 +114,7 @@ class FamilyNormalizer implements NormalizerInterface
      */
     protected function normalizeAttributes($codes)
     {
-        $attributes = $this->collectionFilter->filterCollection(
-            $this->attributeRepository->findBy(['code' => $codes]),
-            'pim.internal_api.attribute.view'
-        );
+        $attributes = $this->attributeRepository->findBy(['code' => $codes]);
 
         $normalizedAttributes = [];
         foreach ($attributes as $attribute) {
@@ -150,14 +144,11 @@ class FamilyNormalizer implements NormalizerInterface
         $result = [];
 
         foreach ($requirements as $channel => $attributeCodes) {
-            $filteredAttributes = $this->collectionFilter->filterCollection(
-                $this->attributeRepository->findBy(['code' => $attributeCodes]),
-                'pim.internal_api.attribute.view'
-            );
+            $attributes = $this->attributeRepository->findBy(['code' => $attributeCodes]);
 
             $result[$channel] = array_map(function ($attribute) {
                 return $attribute->getCode();
-            }, $filteredAttributes);
+            }, $attributes);
         }
 
         return $result;

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/FamilyNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/FamilyNormalizer.php
@@ -70,15 +70,15 @@ class FamilyNormalizer implements NormalizerInterface
      */
     public function normalize($family, $format = null, array $context = array())
     {
-        if (array_key_exists('no_filter', $context) &&
-            true === $context['no_filter']) {
+        if (array_key_exists('no_filters', $context) &&
+            true === $context['no_filters']) {
             $this->toBeFiltered = false;
         }
 
         $normalizedFamily = $this->familyNormalizer->normalize(
             $family,
             'standard',
-            $context
+            []
         );
 
         $normalizedFamily['attributes'] = $this->normalizeAttributes($family);

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/FamilyNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/FamilyNormalizer.php
@@ -38,22 +38,28 @@ class FamilyNormalizer implements NormalizerInterface
     /** @var NormalizerInterface */
     protected $versionNormalizer;
 
+    /** @var bool */
+    protected $toBeFiltered = true;
+
     /**
-     * @param NormalizerInterface          $familyNormalizer
-     * @param NormalizerInterface          $translationNormalizer
+     * @param NormalizerInterface $familyNormalizer
+     * @param NormalizerInterface $translationNormalizer
+     * @param CollectionFilterInterface $collectionFilter
      * @param AttributeRepositoryInterface $attributeRepository
-     * @param VersionManager               $versionManager
-     * @param NormalizerInterface          $versionNormalizer
+     * @param VersionManager $versionManager
+     * @param NormalizerInterface $versionNormalizer
      */
     public function __construct(
         NormalizerInterface $familyNormalizer,
         NormalizerInterface $translationNormalizer,
+        CollectionFilterInterface $collectionFilter,
         AttributeRepositoryInterface $attributeRepository,
         VersionManager $versionManager,
         NormalizerInterface $versionNormalizer
     ) {
         $this->familyNormalizer = $familyNormalizer;
         $this->translationNormalizer = $translationNormalizer;
+        $this->collectionFilter = $collectionFilter;
         $this->attributeRepository = $attributeRepository;
         $this->versionManager = $versionManager;
         $this->versionNormalizer = $versionNormalizer;
@@ -64,6 +70,11 @@ class FamilyNormalizer implements NormalizerInterface
      */
     public function normalize($family, $format = null, array $context = array())
     {
+        if (array_key_exists('no_filter', $context) &&
+            true === $context['no_filter']) {
+            $this->toBeFiltered = false;
+        }
+
         $normalizedFamily = $this->familyNormalizer->normalize(
             $family,
             'standard',
@@ -113,12 +124,13 @@ class FamilyNormalizer implements NormalizerInterface
     protected function normalizeAttributes(FamilyInterface $family)
     {
         $attributes = $this->attributeRepository->findAttributesByFamily($family);
+        $attributes = $this->applyFilters($attributes);
 
         $normalizedAttributes = [];
         foreach ($attributes as $attribute) {
             $normalizedAttributes[] = [
                 'code' => $attribute->getCode(),
-                'type' => $attribute->getAttributeType(),
+                'type' => $attribute->getType(),
                 'group_code' => $attribute->getGroup()->getCode(),
                 'labels' => $this->translationNormalizer->normalize($attribute, 'standard', []),
                 'sort_order' => $attribute->getSortOrder(),
@@ -143,6 +155,7 @@ class FamilyNormalizer implements NormalizerInterface
 
         foreach ($requirements as $channel => $attributeCodes) {
             $attributes = $this->attributeRepository->findBy(['code' => $attributeCodes]);
+            $attributes = $this->applyFilters($attributes);
 
             $result[$channel] = array_map(function ($attribute) {
                 return $attribute->getCode();
@@ -150,5 +163,24 @@ class FamilyNormalizer implements NormalizerInterface
         }
 
         return $result;
+    }
+
+    /**
+     * Applies attribute view collection filters
+     *
+     * @param array $attributes
+     *
+     * @return array mixed
+     */
+    protected function applyFilters($attributes)
+    {
+        if (true === $this->toBeFiltered) {
+            return $this->collectionFilter->filterCollection(
+                $attributes,
+                'pim.internal_api.attribute.view'
+            );
+        }
+
+        return $attributes;
     }
 }

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/normalizers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/normalizers.yml
@@ -85,7 +85,6 @@ services:
         arguments:
             - '@pim_catalog.normalizer.standard.family'
             - '@pim_catalog.normalizer.standard.translation'
-            - '@pim_catalog.filter.chained'
             - '@pim_catalog.repository.attribute'
             - '@pim_versioning.manager.version'
             - '@pim_enrich.normalizer.version'

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/normalizers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/normalizers.yml
@@ -85,6 +85,7 @@ services:
         arguments:
             - '@pim_catalog.normalizer.standard.family'
             - '@pim_catalog.normalizer.standard.translation'
+            - '@pim_catalog.filter.chained'
             - '@pim_catalog.repository.attribute'
             - '@pim_versioning.manager.version'
             - '@pim_enrich.normalizer.version'

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/family/form/attributes/attributes.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/family/form/attributes/attributes.js
@@ -151,6 +151,9 @@ define([
                     return this.attributeGroups;
                 }
 
+                if (0 === attributeGroupsToFetch.length) {
+                    return FetcherRegistry.getFetcher('attribute-group').fetchAll();
+                }
                 this.attributeGroups = FetcherRegistry.getFetcher('attribute-group')
                     .search({
                         options: {

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/family/form/attributes/attributes.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/family/form/attributes/attributes.js
@@ -103,7 +103,6 @@ define([
                     this.getAttributeGroups(attributeGroupsToFetch)
                 ).then(function (channels, attributeGroups) {
                     this.channels = channels;
-
                     var groupedAttributes = _.groupBy(data.attributes, function (attribute) {
                         return attribute.group_code;
                     });
@@ -147,13 +146,15 @@ define([
              * @return {Promise}
              */
             getAttributeGroups: function (attributeGroupsToFetch) {
-                if (null !== this.attributeGroups) {
-                    return this.attributeGroups;
-                }
-
                 if (0 === attributeGroupsToFetch.length) {
                     return FetcherRegistry.getFetcher('attribute-group').fetchAll();
                 }
+
+                if (null !== this.attributeGroups &&
+                    attributeGroupsToFetch.length === this.attributeGroups.length) {
+                    return this.attributeGroups;
+                }
+
                 this.attributeGroups = FetcherRegistry.getFetcher('attribute-group')
                     .search({
                         options: {

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/family/form/attributes/attributes.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/family/form/attributes/attributes.js
@@ -95,7 +95,7 @@ define([
 
                 $.when(
                     FetcherRegistry.getFetcher('channel').fetchAll(),
-                    FetcherRegistry.getFetcher('attribute-group').fetchAll()
+                    FetcherRegistry.getFetcher('attribute-group').fetchAll({no_filters: true})
                 ).then(function (channels, attributeGroups) {
                     this.channels = channels;
                     this.attributeGroups = attributeGroups;
@@ -297,7 +297,8 @@ define([
                             options: {
                                 identifiers: event.codes,
                                 limit: event.codes.length
-                            }
+                            },
+                            no_filters: true
                         }),
                     FetcherRegistry.getFetcher('attribute').getIdentifierAttribute()
                 ).then(function (attributeGroups, identifier) {

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/fetcher/base-fetcher.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/fetcher/base-fetcher.js
@@ -95,7 +95,8 @@ define(['jquery', 'underscore', 'backbone', 'routing'], function ($, _, Backbone
          *
          * @return {Promise}
          */
-        fetchByIdentifiers: function (identifiers) {
+        fetchByIdentifiers: function (identifiers, options) {
+            options = options || {};
             if (0 === identifiers.length) {
                 return $.Deferred().resolve([]).promise();
             }
@@ -106,8 +107,8 @@ define(['jquery', 'underscore', 'backbone', 'routing'], function ($, _, Backbone
             }
 
             return $.when(
-                    this.getJSON(this.options.urls.list, { identifiers: uncachedIdentifiers.join(',') })
-                        .then(_.identity),
+                this.getJSON(this.options.urls.list, _.extend({ identifiers: uncachedIdentifiers.join(',') }, options)
+                    ).then(_.identity),
                     this.getIdentifierField()
                 ).then(function (entities, identifierCode) {
                     _.each(entities, function (entity) {

--- a/src/Pim/Bundle/EnrichBundle/Resources/views/Family/edit.html.twig
+++ b/src/Pim/Bundle/EnrichBundle/Resources/views/Family/edit.html.twig
@@ -31,7 +31,8 @@
                                     FetcherRegistry.initialize().done(function () {
                                         FetcherRegistry.getFetcher('family').fetch(code, {
                                             cached: false,
-                                            generateMissing: true
+                                            generateMissing: true,
+                                            no_filter: true,
                                         }).then(function (family) {
                                             var label = _.escape(
                                                 i18n.getLabel(

--- a/src/Pim/Bundle/EnrichBundle/Resources/views/Family/edit.html.twig
+++ b/src/Pim/Bundle/EnrichBundle/Resources/views/Family/edit.html.twig
@@ -32,7 +32,7 @@
                                         FetcherRegistry.getFetcher('family').fetch(code, {
                                             cached: false,
                                             generateMissing: true,
-                                            no_filters: true,
+                                            apply_filters: false,
                                         }).then(function (family) {
                                             var label = _.escape(
                                                 i18n.getLabel(

--- a/src/Pim/Bundle/EnrichBundle/Resources/views/Family/edit.html.twig
+++ b/src/Pim/Bundle/EnrichBundle/Resources/views/Family/edit.html.twig
@@ -32,7 +32,7 @@
                                         FetcherRegistry.getFetcher('family').fetch(code, {
                                             cached: false,
                                             generateMissing: true,
-                                            no_filter: true,
+                                            no_filters: true,
                                         }).then(function (family) {
                                             var label = _.escape(
                                                 i18n.getLabel(

--- a/src/Pim/Bundle/EnrichBundle/spec/Normalizer/FamilyNormalizerSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Normalizer/FamilyNormalizerSpec.php
@@ -63,7 +63,6 @@ class FamilyNormalizerSpec extends ObjectBehavior
             'code'                   => 'tshirts',
             'attributes'             => [
                 'name',
-                'price',
             ],
             'attribute_as_label'     => 'name',
             'attribute_requirements' => [
@@ -87,13 +86,10 @@ class FamilyNormalizerSpec extends ObjectBehavior
 
         $familyNormalizer->normalize($family, 'standard', [])->willReturn($normalizedFamily);
 
-        $normalizedFamily['attributes'] = ['name', 'price'];
-
         $familyNormalizer->normalize($family, 'standard', [])->shouldBeCalled();
 
-        $attributeRepository->findBy(['code' =>['name', 'price']])->willReturn([$name, $price]);
-
-        $attributeRepository->findBy(['code' =>['name', 'price']])->willReturn([$name, $price]);
+        $attributeRepository->findAttributesByFamily($family)->willReturn([$name, $price]);
+        $attributeRepository->findBy(['code' => ['name', 'price']])->willReturn([$name, $price]);
 
         $translationNormalizer->normalize(Argument::cetera())->willReturn([]);
         $family->getCode()->willReturn('tshirts');

--- a/src/Pim/Bundle/EnrichBundle/spec/Normalizer/FamilyNormalizerSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Normalizer/FamilyNormalizerSpec.php
@@ -86,9 +86,9 @@ class FamilyNormalizerSpec extends ObjectBehavior
             ]
         ];
 
-        $familyNormalizer->normalize($family, 'standard', [])->willReturn($normalizedFamily);
+        $familyNormalizer->normalize($family, 'standard', ['apply_filters' => false])->willReturn($normalizedFamily);
 
-        $familyNormalizer->normalize($family, 'standard', [])->shouldBeCalled();
+        $familyNormalizer->normalize($family, 'standard', ['apply_filters' => false])->shouldBeCalled();
 
         $attributeRepository->findAttributesByFamily($family)->willReturn([$name, $price]);
         $attributeRepository->findBy(['code' => ['name', 'price']])->willReturn([$name, $price]);
@@ -112,7 +112,7 @@ class FamilyNormalizerSpec extends ObjectBehavior
         $versionManager->getOldestLogEntry($family)->shouldBeCalled();
         $versionManager->getNewestLogEntry($family)->shouldBeCalled();
 
-        $this->normalize($family, null, ['no_filters' => true])->shouldReturn(
+        $this->normalize($family, null, ['apply_filters' => false])->shouldReturn(
             [
                 'code'                   => 'tshirts',
                 'attributes'             => [

--- a/src/Pim/Bundle/EnrichBundle/spec/Normalizer/FamilyNormalizerSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Normalizer/FamilyNormalizerSpec.php
@@ -100,19 +100,19 @@ class FamilyNormalizerSpec extends ObjectBehavior
         $marketingAttributeGroup->getCode()->willReturn('marketing');
 
         $name->getCode()->willReturn('name');
-        $name->getAttributeType()->willReturn('pim_catalog_text');
+        $name->getType()->willReturn('pim_catalog_text');
         $name->getGroup()->willReturn($marketingAttributeGroup);
         $name->getSortOrder()->willReturn(1);
 
         $price->getCode()->willReturn('price');
-        $price->getAttributeType()->willReturn('pim_catalog_price_collection');
+        $price->getType()->willReturn('pim_catalog_price_collection');
         $price->getGroup()->willReturn($marketingAttributeGroup);
         $price->getSortOrder()->willReturn(3);
 
         $versionManager->getOldestLogEntry($family)->shouldBeCalled();
         $versionManager->getNewestLogEntry($family)->shouldBeCalled();
 
-        $this->normalize($family)->shouldReturn(
+        $this->normalize($family, null, ['no_filters' => true])->shouldReturn(
             [
                 'code'                   => 'tshirts',
                 'attributes'             => [

--- a/src/Pim/Bundle/EnrichBundle/spec/Normalizer/FamilyNormalizerSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Normalizer/FamilyNormalizerSpec.php
@@ -17,6 +17,7 @@ class FamilyNormalizerSpec extends ObjectBehavior
     function let(
         NormalizerInterface $familyNormalizer,
         NormalizerInterface $translationNormalizer,
+        CollectionFilterInterface $collectionFilter,
         AttributeRepositoryInterface $attributeRepository,
         VersionManager $versionManager,
         NormalizerInterface $versionNormalizer
@@ -24,6 +25,7 @@ class FamilyNormalizerSpec extends ObjectBehavior
         $this->beConstructedWith(
             $familyNormalizer,
             $translationNormalizer,
+            $collectionFilter,
             $attributeRepository,
             $versionManager,
             $versionNormalizer

--- a/src/Pim/Bundle/EnrichBundle/spec/Normalizer/FamilyNormalizerSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Normalizer/FamilyNormalizerSpec.php
@@ -17,7 +17,6 @@ class FamilyNormalizerSpec extends ObjectBehavior
     function let(
         NormalizerInterface $familyNormalizer,
         NormalizerInterface $translationNormalizer,
-        CollectionFilterInterface $collectionFilter,
         AttributeRepositoryInterface $attributeRepository,
         VersionManager $versionManager,
         NormalizerInterface $versionNormalizer
@@ -25,7 +24,6 @@ class FamilyNormalizerSpec extends ObjectBehavior
         $this->beConstructedWith(
             $familyNormalizer,
             $translationNormalizer,
-            $collectionFilter,
             $attributeRepository,
             $versionManager,
             $versionNormalizer
@@ -52,13 +50,11 @@ class FamilyNormalizerSpec extends ObjectBehavior
     function it_normalizes_family(
         AttributeRepositoryInterface $attributeRepository,
         AttributeGroupInterface $marketingAttributeGroup,
-        $collectionFilter,
         FamilyInterface $family,
         NormalizerInterface $translationNormalizer,
         NormalizerInterface $familyNormalizer,
         VersionManager $versionManager,
         AttributeInterface $name,
-        AttributeInterface $description,
         AttributeInterface $price
     ) {
         $family->getId()->willReturn(1);
@@ -67,7 +63,6 @@ class FamilyNormalizerSpec extends ObjectBehavior
             'code'                   => 'tshirts',
             'attributes'             => [
                 'name',
-                'description',
                 'price',
             ],
             'attribute_as_label'     => 'name',
@@ -92,18 +87,13 @@ class FamilyNormalizerSpec extends ObjectBehavior
 
         $familyNormalizer->normalize($family, 'standard', [])->willReturn($normalizedFamily);
 
-        $normalizedFamily['attributes'] = ['name', 'description', 'price'];
+        $normalizedFamily['attributes'] = ['name', 'price'];
 
         $familyNormalizer->normalize($family, 'standard', [])->shouldBeCalled();
 
-        $attributeRepository->findBy(['code' =>['name', 'description', 'price']])->willReturn([$name, $description, $price]);
-
-        $collectionFilter->filterCollection([$name, $description, $price], 'pim.internal_api.attribute.view')
-            ->willReturn([$name, $price]);
+        $attributeRepository->findBy(['code' =>['name', 'price']])->willReturn([$name, $price]);
 
         $attributeRepository->findBy(['code' =>['name', 'price']])->willReturn([$name, $price]);
-        $collectionFilter->filterCollection([$name, $price], 'pim.internal_api.attribute.view')
-            ->willReturn([$name, $price]);
 
         $translationNormalizer->normalize(Argument::cetera())->willReturn([]);
         $family->getCode()->willReturn('tshirts');


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

- attributes should not be filtered when normalizing

Bug fix solution was discussed with @skeleton and @juliensnz 
The most painful in current state is that we introduce `apply_filters` request param to return filetered/unfiltered collection in response.
After discussion with Marie we came to opinion that it is not good to mix filtered/unfiltered sets in one action. And it would be good to use two different routes to fetched filtered attribute groups and unfiltered. And this way we get obtain ability to filter attribute groups and check user permissions to fetch unfiltered attribute groups in another action.
Problematic part is that we do not "use" actions directly in UI but through fetchers. And updating fetcher to work with different routes for the same type of action would break consistency we currently have in fetchers.
That is why, PR was pre-reviewed and discussed with @juliensnz and as a result we came to:
`option like "no_filter" seems horrible but it's ok`

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added Behats                      | OK
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed

This fixes https://github.com/akeneo/pim-community-dev/issues/6086