### PR TITLE
Use kernel.logs_dir instead of kernel.root_dir in SimpleJobLauncher

### DIFF
--- a/CHANGELOG-1.8.md
+++ b/CHANGELOG-1.8.md
@@ -15,3 +15,4 @@
 - Change the constructor of `Pim\Bundle\EnrichBundle\Controller\JobTrackerController` to add `Oro\Bundle\SecurityBundle\SecurityFacade` and add an associative array 
 - Change the constructor of `Pim\Component\Catalog\Updater\FamilyUpdater` to add `Akeneo\Component\Localization\TranslatableUpdater`
 - Change the constructor of `Pim\Component\Catalog\Updater\AttributeUpdater` to add `Akeneo\Component\Localization\TranslatableUpdater`
+- Change the constructor of `Akeneo\Bundle\BatchBundle\Launcher\SimpleJobLauncher` to add `kernel.logs_dir`

--- a/src/Akeneo/Bundle/BatchBundle/Launcher/SimpleJobLauncher.php
+++ b/src/Akeneo/Bundle/BatchBundle/Launcher/SimpleJobLauncher.php
@@ -32,6 +32,9 @@ class SimpleJobLauncher implements JobLauncherInterface
     /** @var string */
     protected $environment;
 
+    /** @var string */
+    protected $logDir;
+
     /**
      * Constructor
      *
@@ -40,19 +43,22 @@ class SimpleJobLauncher implements JobLauncherInterface
      * @param JobRegistry            $jobRegistry
      * @param string                 $rootDir
      * @param string                 $environment
+     * @param string                 $logDir
      */
     public function __construct(
         JobRepositoryInterface $jobRepository,
         JobParametersFactory $jobParametersFactory,
         JobRegistry $jobRegistry,
         $rootDir,
-        $environment
+        $environment,
+        $logDir
     ) {
         $this->jobRepository = $jobRepository;
         $this->jobParametersFactory = $jobParametersFactory;
         $this->jobRegistry = $jobRegistry;
         $this->rootDir = $rootDir;
         $this->environment = $environment;
+        $this->logDir = $logDir;
     }
 
     /**
@@ -72,7 +78,7 @@ class SimpleJobLauncher implements JobLauncherInterface
 
         $encodedConfiguration = json_encode($configuration, JSON_HEX_APOS);
         $cmd = sprintf(
-            '%s %s/console akeneo:batch:job --env=%s %s %s %s %s >> %s/logs/batch_execute.log 2>&1',
+            '%s %s/console akeneo:batch:job --env=%s %s %s %s %s >> %s/batch_execute.log 2>&1',
             $pathFinder->find(),
             $this->rootDir,
             $this->environment,
@@ -80,7 +86,7 @@ class SimpleJobLauncher implements JobLauncherInterface
             escapeshellarg($jobInstance->getCode()),
             $executionId,
             !empty($configuration) ? sprintf('--config=%s', escapeshellarg($encodedConfiguration)) : '',
-            $this->rootDir
+            $this->logDir
         );
 
         $this->launchInBackground($cmd);

--- a/src/Akeneo/Bundle/BatchBundle/Resources/config/services.yml
+++ b/src/Akeneo/Bundle/BatchBundle/Resources/config/services.yml
@@ -68,3 +68,4 @@ services:
             - '@akeneo_batch.job.job_registry'
             - '%kernel.root_dir%'
             - '%kernel.environment%'
+            - '%kernel.logs_dir%'

--- a/src/Akeneo/Bundle/BatchBundle/spec/Launcher/SimpleJobLauncherSpec.php
+++ b/src/Akeneo/Bundle/BatchBundle/spec/Launcher/SimpleJobLauncherSpec.php
@@ -14,7 +14,7 @@ class SimpleJobLauncherSpec extends ObjectBehavior
         JobParametersFactory $jobParametersFactory,
         JobRegistry $jobRegistry
     ) {
-        $this->beConstructedWith($jobRepository, $jobParametersFactory, $jobRegistry, '/', 'prod');
+        $this->beConstructedWith($jobRepository, $jobParametersFactory, $jobRegistry, '/', 'prod', '/logs');
     }
 
     function it_is_a_job_launcher()


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

[//]: <> (What does this Pull Request do? reference the related issue?)
Fix issue #5212 
SimpleJobLauncher use a kernel.logs_dir instead of kernel.root_dir for logs
