### PR TITLE
Fix #5941 Objects was not being detached on VariantGroupImport.

### DIFF
--- a/spec/Pim/Component/Connector/Writer/Doctrine/VariantGroupWriterSpec.php
+++ b/spec/Pim/Component/Connector/Writer/Doctrine/VariantGroupWriterSpec.php
@@ -58,7 +58,8 @@ class VariantGroupWriterSpec extends ObjectBehavior
         ProductInterface $productOne,
         ProductInterface $productTwo,
         $productTplApplier,
-        $stepExecution
+        $stepExecution,
+        $detacher
     ) {
         $variantGroup->getId()->willReturn(42);
         $stepExecution->incrementSummaryInfo('process')->shouldBeCalled();
@@ -75,6 +76,7 @@ class VariantGroupWriterSpec extends ObjectBehavior
             ->shouldBeCalled();
 
         $stepExecution->incrementSummaryInfo('update_products', 2)->shouldBeCalled();
+        $detacher->detachAll(Argument::any())->shouldBeCalled();
 
         $this->write([$variantGroup]);
     }
@@ -86,7 +88,8 @@ class VariantGroupWriterSpec extends ObjectBehavior
         ProductInterface $validProduct,
         ProductInterface $invalidProduct,
         $productTplApplier,
-        $stepExecution
+        $stepExecution,
+        $detacher
     ) {
         $variantGroup->getId()->willReturn(42);
         $stepExecution->incrementSummaryInfo('process')->shouldBeCalled();
@@ -105,6 +108,7 @@ class VariantGroupWriterSpec extends ObjectBehavior
         $stepExecution->incrementSummaryInfo('update_products', 1)->shouldBeCalled();
         $stepExecution->incrementSummaryInfo('skip_products', 1)->shouldBeCalled();
         $stepExecution->addWarning(Argument::cetera())->shouldBeCalled();
+        $detacher->detachAll(Argument::any())->shouldBeCalled();
 
         $this->write([$variantGroup]);
     }

--- a/src/Pim/Component/Connector/Writer/Doctrine/VariantGroupWriter.php
+++ b/src/Pim/Component/Connector/Writer/Doctrine/VariantGroupWriter.php
@@ -103,6 +103,7 @@ class VariantGroupWriter extends BaseWriter
                 if ($nbSkipped > 0) {
                     $this->incrementSkippedProductsCount($skippedMessages, $nbSkipped);
                 }
+                $this->bulkDetacher->detachAll($products->toArray());
             }
         }
     }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Use DetachAll for VariantGroups.

It was taking more than 1Gb to process 200 variant groups. Now it is just 200Mb.

* Updated tests.

There is a failing test on the branch 1.5. @nidup 