### PR TITLE
PIM-6252: Fix summernote style

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -11,6 +11,7 @@
 - PIM-6250: Fix attribute export.
 - GITHUB-5538: User without permissions access to import/export jobs through `Process tracker`
 - PIM-6253: Add missing permissions on entities of the API
+- PIM-6252: Fix Summernote (WYSIWYG) style
 
 # 1.7.0 (2017-03-14)
 

--- a/src/Pim/Bundle/UIBundle/Resources/config/assets.yml
+++ b/src/Pim/Bundle/UIBundle/Resources/config/assets.yml
@@ -25,6 +25,7 @@ css:
         - bundles/pimui/less/lib/tabs.less
         - bundles/pimui/less/lib/wizard.less
         - bundles/pimui/less/lib/select2.less
+        - bundles/pimui/less/lib/summernote.less
 
     bem:
         - bundles/pimui/less/base/general.less

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/lib/summernote.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/lib/summernote.less
@@ -1,0 +1,47 @@
+@import '../base/variables';
+
+.note-editor {
+  width: 100%;
+  border-color: @AknBorderColor;
+  border-radius: 2px;
+}
+
+.note-editor .note-toolbar {
+  padding: 5px;
+  background: lighten(@AknGrey, 30%);
+  border-color: @AknBorderColor;
+}
+
+.note-toolbar > .btn-group {
+  margin-top: 0;
+
+  & + & {
+    margin-top: 5px;
+  }
+
+  button {
+    background: white;
+    border: 1px solid @AknBorderColor;
+    border-radius: 2px;
+    height: @AknLittleButtonSize;
+    width: @AknLittleButtonSize;
+    cursor: pointer;
+    color: @AknDefaultFontColor;
+
+    &:hover {
+      background: @AknDefaultHoverBackground;
+    }
+
+    & + button {
+      border-left: none;
+    }
+  }
+}
+
+.note-editor .note-toolbar {
+  display: flex;
+}
+
+.note-popover .popover .popover-content, .note-toolbar {
+  padding: 0;
+}


### PR DESCRIPTION
This PR fix Summernote style

Before / After:

![beforeafter](https://cloud.githubusercontent.com/assets/1590933/24145752/e4bd5318-0e32-11e7-9480-0acc9e4170c1.png)


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | y
| Review and 2 GTM                  | Todo
| Migration script                  | -
| Tech Doc                          | -