### PR TITLE
API-106: Delete labels in the entities of API

### DIFF
--- a/features/attribute/option/import_attribute_options.feature
+++ b/features/attribute/option/import_attribute_options.feature
@@ -19,6 +19,7 @@ Feature: Import attribute options
       """
       code;attribute;sort_order;label-en_US
       kiwi;fruit;0;
+      Converse;manufacturer;0;
       """
     And the following job "csv_footwear_option_import" configuration:
       | filePath | %file to import% |
@@ -35,3 +36,6 @@ Feature: Import attribute options
     When I add available attributes fruit
     And I change the "[fruit]" to "[kiwi]"
     Then I should see the text "[kiwi]"
+    When I add available attributes Manufacturer
+    And I change the "Manufacturer" to "[Converse]"
+    Then I should see the text "[Converse]"

--- a/features/import/import_categories.feature
+++ b/features/import/import_categories.feature
@@ -97,3 +97,21 @@ Feature: Import categories
       | laptops     | Laptops     | computers |
       | hard_drives | Hard drives | laptops   |
       | pc          | PC          | computers |
+
+    Scenario: Import categories with empty labels
+      Given the "footwear" catalog configuration
+      And I am logged in as "Julia"
+      And the following CSV file to import:
+      """
+      code;parent;label-en_US
+      spring_collection;2014_collection;
+      summer_collection;2014_collection;
+      """
+      And the following job "csv_footwear_category_import" configuration:
+        | filePath | %file to import% |
+      When I am on the "csv_footwear_category_import" import job page
+      And I launch the import job
+      And I wait for the "csv_footwear_category_import" job to finish
+      And I am on the categories page
+      Then I should see the text "[spring_collection]"
+      And I should see the text "[summer_collection]"

--- a/src/Akeneo/Component/Localization/TranslatableUpdater.php
+++ b/src/Akeneo/Component/Localization/TranslatableUpdater.php
@@ -24,7 +24,12 @@ class TranslatableUpdater
         foreach ($data as $localeCode => $label) {
             $object->setLocale($localeCode);
             $translation = $object->getTranslation();
-            $translation->setLabel($label);
+
+            if (null === $label || '' === $label) {
+                $object->removeTranslation($translation);
+            } else {
+                $translation->setLabel($label);
+            }
         }
     }
 }

--- a/src/Akeneo/Component/Localization/spec/TranslatableUpdaterSpec.php
+++ b/src/Akeneo/Component/Localization/spec/TranslatableUpdaterSpec.php
@@ -4,6 +4,7 @@ namespace spec\Akeneo\Component\Localization;
 
 use Akeneo\Component\Localization\Model\TranslatableInterface;
 use Akeneo\Component\Localization\Model\TranslationInterface;
+use Akeneo\Component\Localization\TranslatableUpdater;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
@@ -11,7 +12,7 @@ class TranslatableUpdaterSpec extends ObjectBehavior
 {
     function it_is_initializable()
     {
-        $this->shouldHaveType('Akeneo\Component\Localization\TranslatableUpdater');
+        $this->shouldHaveType(TranslatableUpdater::class);
     }
 
     function it_removes_the_translation_when_the_new_label_is_null(

--- a/src/Akeneo/Component/Localization/spec/TranslatableUpdaterSpec.php
+++ b/src/Akeneo/Component/Localization/spec/TranslatableUpdaterSpec.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace spec\Akeneo\Component\Localization;
+
+use Akeneo\Component\Localization\Model\TranslatableInterface;
+use Akeneo\Component\Localization\Model\TranslationInterface;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class TranslatableUpdaterSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Akeneo\Component\Localization\TranslatableUpdater');
+    }
+
+    function it_removes_the_translation_when_the_new_label_is_null(
+        TranslatableInterface $object,
+        LabelTranslationInterface $translation
+    ) {
+        $object->setLocale('en_US')->shouldBeCalled();
+        $object->getTranslation()->willReturn($translation);
+        $object->removeTranslation($translation)->shouldBeCalled();
+
+        $this->update($object, ['en_US' => null]);
+    }
+
+    function it_removes_the_translation_when_the_new_label_is_empty(
+        TranslatableInterface $object,
+        LabelTranslationInterface $translation
+    ) {
+        $object->setLocale('en_US')->shouldBeCalled();
+        $object->getTranslation()->willReturn($translation);
+        $object->removeTranslation($translation)->shouldBeCalled();
+
+        $this->update($object, ['en_US' => '']);
+    }
+
+    function it_set_a_new_label_when_the_new_label_is_not_empty(
+        TranslatableInterface $object,
+        LabelTranslationInterface $translation
+    ) {
+        $object->setLocale('en_US')->shouldBeCalled();
+        $object->getTranslation()->willReturn($translation);
+        $translation->setLabel('foo')->shouldBeCalled();
+
+        $this->update($object, ['en_US' => 'foo']);
+    }
+}
+
+interface LabelTranslationInterface extends TranslationInterface
+{
+    public function getLabel();
+
+    public function setLabel($label);
+}

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Attribute/CreateAttributeIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Attribute/CreateAttributeIntegration.php
@@ -160,6 +160,63 @@ JSON;
         $this->assertSame($attributeStandard, $normalizer->normalize($attribute));
     }
 
+    public function testAttributeCreationWithEmptyLabels()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data =
+<<<JSON
+    {
+        "code":"empty_label_attribute",
+        "type":"pim_catalog_text",
+        "group":"attributeGroupA",
+        "labels": {
+            "en_US": null,
+            "fr_FR": ""
+        }
+    }
+JSON;
+
+        $client->request('POST', 'api/rest/v1/attributes', [], [], [], $data);
+
+        $attribute = $this->get('pim_catalog.repository.attribute')->findOneByIdentifier('empty_label_attribute');
+
+        $attributeStandard = [
+            'code'                   => 'empty_label_attribute',
+            'type'                   => 'pim_catalog_text',
+            'group'                  => 'attributeGroupA',
+            'unique'                 => false,
+            'useable_as_grid_filter' => false,
+            'allowed_extensions'     => [],
+            'metric_family'          => null,
+            'default_metric_unit'    => null,
+            'reference_data_name'    => null,
+            'available_locales'      => [],
+            'max_characters'         => null,
+            'validation_rule'        => null,
+            'validation_regexp'      => null,
+            'wysiwyg_enabled'        => null,
+            'number_min'             => null,
+            'number_max'             => null,
+            'decimals_allowed'       => null,
+            'negative_allowed'       => null,
+            'date_min'               => null,
+            'date_max'               => null,
+            'max_file_size'          => null,
+            'minimum_input_length'   => null,
+            'sort_order'             => 0,
+            'localizable'            => false,
+            'scopable'               => false,
+            'labels'                 => [],
+        ];
+        $normalizer = $this->get('pim_catalog.normalizer.standard.attribute');
+
+        $response = $client->getResponse();
+
+        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+        $this->assertSame($attributeStandard, $normalizer->normalize($attribute));
+    }
+
     public function testResponseWhenContentIsEmpty()
     {
         $client = $this->createAuthenticatedClient();
@@ -548,28 +605,6 @@ JSON;
         "code":"unknown_locale",
         "type":"pim_catalog_text",
         "group":"attributeGroupA",
-        "unique":false,
-        "useable_as_grid_filter":false,
-        "allowed_extensions":[],
-        "metric_family":null,
-        "default_metric_unit":null,
-        "reference_data_name":null,
-        "available_locales":[],
-        "max_characters":null,
-        "validation_rule":null,
-        "validation_regexp":null,
-        "wysiwyg_enabled":null,
-        "number_min":null,
-        "number_max":null,
-        "decimals_allowed":null,
-        "negative_allowed":null,
-        "date_min":null,
-        "date_max":null,
-        "max_file_size":null,
-        "minimum_input_length":null,
-        "sort_order":12,
-        "localizable":false,
-        "scopable":false,
         "labels": {
             "":"label"
         }
@@ -604,28 +639,6 @@ JSON;
         "code":"unknown_locale",
         "type":"pim_catalog_text",
         "group":"attributeGroupA",
-        "unique":false,
-        "useable_as_grid_filter":false,
-        "allowed_extensions":[],
-        "metric_family":null,
-        "default_metric_unit":null,
-        "reference_data_name":null,
-        "available_locales":[],
-        "max_characters":null,
-        "validation_rule":null,
-        "validation_regexp":null,
-        "wysiwyg_enabled":null,
-        "number_min":null,
-        "number_max":null,
-        "decimals_allowed":null,
-        "negative_allowed":null,
-        "date_min":null,
-        "date_max":null,
-        "max_file_size":null,
-        "minimum_input_length":null,
-        "sort_order":12,
-        "localizable":false,
-        "scopable":false,
         "labels": {
             "foo": "label"
         }
@@ -657,7 +670,7 @@ JSON;
     {
         return new Configuration(
             [Configuration::getTechnicalCatalogPath()],
-            false
+            true
         );
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Attribute/PartialUpdateAttributeIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Attribute/PartialUpdateAttributeIntegration.php
@@ -375,6 +375,73 @@ JSON;
         $this->assertSame($attributeStandard, $normalizer->normalize($attribute));
     }
 
+    public function testAttributePartialUpdateWithEmptyLabels()
+    {
+        $initLabels = [
+            'labels' => [
+                'en_US' => 'Family A2 US',
+                'fr_FR' => 'Family A2 FR',
+                'de_DE' => 'Family A2 DE',
+            ],
+        ];
+
+        $attribute = $this->get('pim_catalog.repository.attribute')->findOneByIdentifier('a_text');
+        $this->get('pim_catalog.updater.attribute')->update($attribute, $initLabels);
+        $this->get('pim_catalog.saver.attribute')->save($attribute);
+
+        $data =
+<<<JSON
+    {
+        "labels": {
+            "en_US": null,
+            "fr_FR": ""
+        }
+    }
+JSON;
+
+        $attributeStandard = [
+            'code'                   => 'a_text',
+            'type'                   => 'pim_catalog_text',
+            'group'                  => 'attributeGroupA',
+            'unique'                 => false,
+            'useable_as_grid_filter' => false,
+            'allowed_extensions'     => [],
+            'metric_family'          => null,
+            'default_metric_unit'    => null,
+            'reference_data_name'    => null,
+            'available_locales'      => [],
+            'max_characters'         => 200,
+            'validation_rule'        => null,
+            'validation_regexp'      => null,
+            'wysiwyg_enabled'        => null,
+            'number_min'             => null,
+            'number_max'             => null,
+            'decimals_allowed'       => null,
+            'negative_allowed'       => null,
+            'date_min'               => null,
+            'date_max'               => null,
+            'max_file_size'          => null,
+            'minimum_input_length'   => null,
+            'sort_order'             => 6,
+            'localizable'            => false,
+            'scopable'               => false,
+            'labels'                 => [
+                'de_DE' => 'Family A2 DE',
+            ],
+        ];
+
+        $client = $this->createAuthenticatedClient();
+        $normalizer = $this->get('pim_catalog.normalizer.standard.attribute');
+
+        $client->request('PATCH', 'api/rest/v1/attributes/a_text', [], [], [], $data);
+
+        $response = $client->getResponse();
+        $attribute = $this->get('pim_catalog.repository.attribute')->findOneByIdentifier('a_text');
+
+        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        $this->assertSame($attributeStandard, $normalizer->normalize($attribute));
+    }
+
     public function testResponseWhenContentIsEmpty()
     {
         $client = $this->createAuthenticatedClient();

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AttributeOption/CreateAttributeOptionIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AttributeOption/CreateAttributeOptionIntegration.php
@@ -130,6 +130,43 @@ JSON;
         $this->assertSame($attributeOptionStandard, $normalizer->normalize($attributeOption));
     }
 
+    public function testAttributeOptionCreationWithEmptyLabels()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data =
+<<<JSON
+    {
+        "code":"empty_labels",
+        "attribute":"a_multi_select",
+        "sort_order":30,
+        "labels":{
+            "en_US": null,
+            "fr_FR": ""
+        }
+    }
+JSON;
+
+        $client->request('POST', 'api/rest/v1/attributes/a_multi_select/options', [], [], [], $data);
+
+        $attributeOption = $this->get('pim_catalog.repository.attribute_option')
+            ->findOneByIdentifier('a_multi_select.empty_labels');
+
+        $attributeOptionStandard = [
+            'code'       => 'empty_labels',
+            'attribute'  => 'a_multi_select',
+            'sort_order' => 30,
+            'labels'     => [],
+        ];
+        $normalizer = $this->get('pim_catalog.normalizer.standard.attribute_option');
+
+        $response = $client->getResponse();
+
+        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+        $this->assertSame($attributeOptionStandard, $normalizer->normalize($attributeOption));
+    }
+
+
     public function testResponseWhenContentIsInvalid()
     {
         $client = $this->createAuthenticatedClient();

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AttributeOption/PartialUpdateAttributeOptionIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AttributeOption/PartialUpdateAttributeOptionIntegration.php
@@ -299,6 +299,38 @@ JSON;
         $this->assertSame($attributeOptionStandard, $normalizer->normalize($attributeOption));
     }
 
+    public function testPartialUpdateWithEmptyLabels()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data =
+<<<JSON
+    {
+        "labels":{"en_US": null}
+    }
+JSON;
+
+        $client->request('PATCH', 'api/rest/v1/attributes/a_multi_select/options/optionA', [], [], [], $data);
+
+        $attributeOption = $this->get('pim_catalog.repository.attribute_option')
+            ->findOneByIdentifier('a_multi_select.optionA');
+
+        $attributeOptionStandard = [
+            'code'       => 'optionA',
+            'attribute'  => 'a_multi_select',
+            'sort_order' => 10,
+            'labels'     => [
+                'en_US' => 'Option A',
+            ],
+        ];
+        $normalizer = $this->get('pim_catalog.normalizer.standard.attribute_option');
+
+        $response = $client->getResponse();
+
+        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        $this->assertSame($attributeOptionStandard, $normalizer->normalize($attributeOption));
+    }
+
     public function testResponseWhenContentIsEmpty()
     {
         $client = $this->createAuthenticatedClient();

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AttributeOption/PartialUpdateAttributeOptionIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AttributeOption/PartialUpdateAttributeOptionIntegration.php
@@ -306,7 +306,10 @@ JSON;
         $data =
 <<<JSON
     {
-        "labels":{"en_US": null}
+        "labels": {
+            "en_US": null,
+            "fr_FR": ""
+        }
     }
 JSON;
 
@@ -319,9 +322,7 @@ JSON;
             'code'       => 'optionA',
             'attribute'  => 'a_multi_select',
             'sort_order' => 10,
-            'labels'     => [
-                'en_US' => 'Option A',
-            ],
+            'labels'     => [],
         ];
         $normalizer = $this->get('pim_catalog.normalizer.standard.attribute_option');
 

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Category/CreateCategoryIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Category/CreateCategoryIntegration.php
@@ -87,6 +87,39 @@ JSON;
         $this->assertSame($categoryStandard, $normalizer->normalize($category));
     }
 
+    public function testCategoryCreationWithEmptyLabels()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data =
+<<<JSON
+    {
+        "code": "empty_label_category",
+        "parent": "master",
+        "labels": {
+            "en_US": "US label",
+            "fr_FR": null,
+            "de_DE": "" 
+        }
+    }
+JSON;
+        $client->request('POST', 'api/rest/v1/categories', [], [], [], $data);
+
+        $category = $this->get('pim_catalog.repository.category')->findOneByIdentifier('empty_label_category');
+        $categoryStandard = [
+            'code'   => 'empty_label_category',
+            'parent' => 'master',
+            'labels' => [
+                'en_US' => 'US label'
+            ],
+        ];
+        $normalizer = $this->get('pim_catalog.normalizer.standard.category');
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+        $this->assertSame($categoryStandard, $normalizer->normalize($category));
+    }
+
     public function testResponseWhenContentIsEmpty()
     {
         $client = $this->createAuthenticatedClient();

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Category/PartialUpdateCategoryIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Category/PartialUpdateCategoryIntegration.php
@@ -248,6 +248,34 @@ JSON;
         $this->assertSame($categoryStandard, $normalizer->normalize($category));
     }
 
+    public function testPartialUpdateWithEmptyLabels()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data =
+<<<JSON
+    {
+        "labels": {
+            "en_US": null,
+            "fr_FR":"" 
+        }
+    }
+JSON;
+        $client->request('PATCH', 'api/rest/v1/categories/categoryA', [], [], [], $data);
+
+        $category = $this->get('pim_catalog.repository.category')->findOneByIdentifier('categoryA');
+        $categoryStandard = [
+            'code'   => 'categoryA',
+            'parent' => 'master',
+            'labels' => [],
+        ];
+        $normalizer = $this->get('pim_catalog.normalizer.standard.category');
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        $this->assertSame($categoryStandard, $normalizer->normalize($category));
+    }
+
     public function testResponseWhenContentIsEmpty()
     {
         $client = $this->createAuthenticatedClient();
@@ -411,7 +439,7 @@ JSON;
     {
         return new Configuration(
             [Configuration::getTechnicalCatalogPath()],
-            false
+            true
         );
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Family/PartialUpdateFamilyIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Family/PartialUpdateFamilyIntegration.php
@@ -308,6 +308,41 @@ JSON;
         $this->assertSame($familyStandard, $normalizer->normalize($family));
     }
 
+    public function testPartialUpdateWithEmptyLabels()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data =
+<<<JSON
+    {
+        "labels": {
+            "en_US": null,
+            "fr_FR": ""
+        }
+    }
+JSON;
+
+        $client->request('PATCH', 'api/rest/v1/families/familyA2', [], [], [], $data);
+
+        $family = $this->get('pim_catalog.repository.family')->findOneByIdentifier('familyA2');
+        $familyStandard = [
+            'code'                   => 'familyA2',
+            'attributes'             => ['a_metric', 'a_number_float', 'sku'],
+            'attribute_as_label'     => 'sku',
+            'attribute_requirements' => [
+                'ecommerce'       => ['a_metric', 'sku'],
+                'ecommerce_china' => ['sku'],
+                'tablet'          => ['a_number_float', 'sku'],
+            ],
+            'labels'                 => [],
+        ];
+        $normalizer = $this->get('pim_catalog.normalizer.standard.family');
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        $this->assertSame($familyStandard, $normalizer->normalize($family));
+    }
+
     public function testResponseWhenContentIsEmpty()
     {
         $client = $this->createAuthenticatedClient();
@@ -437,7 +472,7 @@ JSON;
     {
         return new Configuration(
             [Configuration::getTechnicalCatalogPath()],
-            false
+            true
         );
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Family/PartialUpdateFamilyIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Family/PartialUpdateFamilyIntegration.php
@@ -310,6 +310,18 @@ JSON;
 
     public function testPartialUpdateWithEmptyLabels()
     {
+        $initLabels = [
+            'labels' => [
+                'en_US' => 'Family A2 US',
+                'fr_FR' => 'Family A2 FR',
+                'de_DE' => 'Family A2 DE',
+            ],
+        ];
+
+        $family = $this->get('pim_catalog.repository.family')->findOneByIdentifier('familyA2');
+        $this->get('pim_catalog.updater.family')->update($family, $initLabels);
+        $this->get('pim_catalog.saver.family')->save($family);
+
         $client = $this->createAuthenticatedClient();
 
         $data =
@@ -334,7 +346,9 @@ JSON;
                 'ecommerce_china' => ['sku'],
                 'tablet'          => ['a_number_float', 'sku'],
             ],
-            'labels'                 => [],
+            'labels'                 => [
+                'de_DE' => 'Family A2 DE',
+            ],
         ];
         $normalizer = $this->get('pim_catalog.normalizer.standard.family');
 

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/QueryGenerator/FamilyLabelDeletedQueryGenerator.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/QueryGenerator/FamilyLabelDeletedQueryGenerator.php
@@ -6,7 +6,7 @@ namespace Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\QueryGenerator;
  * Family label deleted query generator
  *
  * @author    Laurent Petard <laurent.petard@akeneo.com>
- * @copyright 2014 Akeneo SAS (http://www.akeneo.com)
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 class FamilyLabelDeletedQueryGenerator extends AbstractQueryGenerator

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/QueryGenerator/FamilyLabelDeletedQueryGenerator.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/QueryGenerator/FamilyLabelDeletedQueryGenerator.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\QueryGenerator;
+
+/**
+ * Family label deleted query generator
+ *
+ * @author    Laurent Petard <laurent.petard@akeneo.com>
+ * @copyright 2014 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class FamilyLabelDeletedQueryGenerator extends AbstractQueryGenerator
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function generateQuery($entity, $field, $oldValue, $newValue)
+    {
+        return [[
+            ['family' => $entity->getForeignKey()->getId()],
+            [
+                '$unset' => [
+                    sprintf('normalizedData.family.labels.%s', $entity->getLocale()) => ''
+                ]
+            ],
+            ['multiple' => true]
+        ]];
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/EventSubscriber/MongoDBODM/UpdateNormalizedProductDataSubscriber.php
+++ b/src/Pim/Bundle/CatalogBundle/EventSubscriber/MongoDBODM/UpdateNormalizedProductDataSubscriber.php
@@ -72,6 +72,10 @@ class UpdateNormalizedProductDataSubscriber implements EventSubscriber
         foreach ($uow->getScheduledCollectionUpdates() as $entity) {
             $this->scheduleQueriesAfterUpdate($entity, $uow->getEntityChangeSet($entity));
         }
+
+        foreach ($uow->getScheduledEntityInsertions() as $entity) {
+            $this->scheduleQueriesAfterUpdate($entity, $uow->getEntityChangeSet($entity));
+        }
     }
 
     /**

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/doctrine/Attribute.orm.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/doctrine/Attribute.orm.yml
@@ -146,6 +146,7 @@ Pim\Bundle\CatalogBundle\Entity\Attribute:
             cascade:
                 - persist
                 - detach
+            orphanRemoval: true
     manyToOne:
         group:
             targetEntity: Pim\Component\Catalog\Model\AttributeGroupInterface

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/doctrine/AttributeOption.orm.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/doctrine/AttributeOption.orm.yml
@@ -38,3 +38,4 @@ Pim\Bundle\CatalogBundle\Entity\AttributeOption:
                 - remove
                 - detach
             mappedBy: option
+            orphanRemoval: true

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/doctrine/Category.orm.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/doctrine/Category.orm.yml
@@ -51,6 +51,7 @@ Pim\Bundle\CatalogBundle\Entity\Category:
             cascade:
                 - persist
                 - detach
+            orphanRemoval: true
         channels:
             targetEntity: Pim\Component\Catalog\Model\ChannelInterface
             mappedBy: category

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/doctrine/Family.orm.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/doctrine/Family.orm.yml
@@ -45,6 +45,7 @@ Pim\Bundle\CatalogBundle\Entity\Family:
                 - persist
                 - detach
                 - remove
+            orphanRemoval: true
         requirements:
             targetEntity: Pim\Component\Catalog\Model\AttributeRequirementInterface
             mappedBy: family

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/storage_driver/doctrine/mongodb-odm.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/storage_driver/doctrine/mongodb-odm.yml
@@ -45,6 +45,7 @@ parameters:
     pim_catalog.mongodb_odm_query_generator.attribute_deleted.class:             Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\QueryGenerator\AttributeDeletedQueryGenerator
     pim_catalog.mongodb_odm_query_generator.family_deleted.class:                Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\QueryGenerator\FamilyDeletedQueryGenerator
     pim_catalog.mongodb_odm_query_generator.family_label_updated.class:          Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\QueryGenerator\FamilyLabelUpdatedQueryGenerator
+    pim_catalog.mongodb_odm_query_generator.family_label_deleted.class:          Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\QueryGenerator\FamilyLabelDeletedQueryGenerator
     pim_catalog.mongodb_odm_query_generator.option_code_updated.class:           Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\QueryGenerator\OptionCodeUpdatedQueryGenerator
     pim_catalog.mongodb_odm_query_generator.option_deleted.class:                Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\QueryGenerator\OptionDeletedQueryGenerator
     pim_catalog.mongodb_odm_query_generator.option_value_updated.class:          Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\QueryGenerator\OptionValueUpdatedQueryGenerator
@@ -395,6 +396,14 @@ services:
         arguments:
             - 'Pim\Bundle\CatalogBundle\Entity\FamilyTranslation'
             - 'label'
+        tags:
+            - { name: pim_catalog.mongodb_odm_query_generator }
+
+    pim_catalog.mongodb_odm_query_generator.family_label_deleted:
+        class: '%pim_catalog.mongodb_odm_query_generator.family_label_deleted.class%'
+        parent: pim_catalog.mongodb_odm_query_generator.abstract_normalized_data
+        arguments:
+            - 'Pim\Bundle\CatalogBundle\Entity\FamilyTranslation'
         tags:
             - { name: pim_catalog.mongodb_odm_query_generator }
 

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/storage_driver/doctrine/mongodb-odm.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/storage_driver/doctrine/mongodb-odm.yml
@@ -403,7 +403,7 @@ services:
         class: '%pim_catalog.mongodb_odm_query_generator.family_label_deleted.class%'
         parent: pim_catalog.mongodb_odm_query_generator.abstract_normalized_data
         arguments:
-            - 'Pim\Bundle\CatalogBundle\Entity\FamilyTranslation'
+            - '%pim_catalog.entity.family_translation.class%'
         tags:
             - { name: pim_catalog.mongodb_odm_query_generator }
 

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/updaters.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/updaters.yml
@@ -115,6 +115,7 @@ services:
             - '@pim_catalog.repository.attribute_group'
             - '@pim_catalog.repository.locale'
             - '@pim_catalog.registry.attribute_type'
+            - '@pim_localization.updater.translatable'
 
     pim_catalog.updater.category:
         class: '%akeneo_classification.updater.category.class%'
@@ -137,6 +138,7 @@ services:
             - '@pim_catalog.repository.channel'
             - '@pim_catalog.factory.attribute_requirement'
             - '@pim_catalog.repository.attribute_requirement'
+            - '@pim_localization.updater.translatable'
 
     pim_catalog.updater.channel:
         class: '%pim_catalog.updater.channel.class%'

--- a/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/AttributeOptionSearchableRepository.php
+++ b/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/AttributeOptionSearchableRepository.php
@@ -42,7 +42,7 @@ class AttributeOptionSearchableRepository implements SearchableRepositoryInterfa
         $qb = $this->entityManager->createQueryBuilder();
 
         $qb->select('o')
-            ->addSelect('v')
+            ->distinct()
             ->from($this->entityName, 'o')
             ->leftJoin('o.optionValues', 'v')
             ->leftJoin('o.attribute', 'a')

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/multi-select-field.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/multi-select-field.js
@@ -96,7 +96,6 @@ define(
                                     search: term,
                                     options: {
                                         limit: 20,
-                                        locale: UserContext.get('catalogLocale'),
                                         page: page
                                     }
                                 };

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/simple-select-field.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/simple-select-field.js
@@ -81,7 +81,6 @@ define(
                                     search: term,
                                     options: {
                                         limit: 20,
-                                        locale: UserContext.get('catalogLocale'),
                                         page: page
                                     }
                                 };

--- a/src/Pim/Component/Catalog/Updater/AttributeOptionUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/AttributeOptionUpdater.php
@@ -129,9 +129,11 @@ class AttributeOptionUpdater implements ObjectUpdaterInterface
 
         if ('labels' === $field) {
             foreach ($data as $localeCode => $label) {
-                $attributeOption->setLocale($localeCode);
-                $translation = $attributeOption->getTranslation();
-                $translation->setLabel($label);
+                if (null !== $label && '' !== $label) {
+                    $attributeOption->setLocale($localeCode);
+                    $translation = $attributeOption->getTranslation();
+                    $translation->setLabel($label);
+                }
             }
         }
 

--- a/src/Pim/Component/Catalog/Updater/AttributeOptionUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/AttributeOptionUpdater.php
@@ -129,9 +129,12 @@ class AttributeOptionUpdater implements ObjectUpdaterInterface
 
         if ('labels' === $field) {
             foreach ($data as $localeCode => $label) {
-                if (null !== $label && '' !== $label) {
-                    $attributeOption->setLocale($localeCode);
-                    $translation = $attributeOption->getTranslation();
+                $attributeOption->setLocale($localeCode);
+                $translation = $attributeOption->getTranslation();
+
+                if (null === $label || '' === $label) {
+                    $attributeOption->removeOptionValue($translation);
+                } else {
                     $translation->setLabel($label);
                 }
             }

--- a/src/Pim/Component/Catalog/Updater/AttributeUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/AttributeUpdater.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Component\Catalog\Updater;
 
+use Akeneo\Component\Localization\TranslatableUpdater;
 use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
@@ -38,20 +39,26 @@ class AttributeUpdater implements ObjectUpdaterInterface
     /** @var PropertyAccessor */
     protected $accessor;
 
+    /** @var TranslatableUpdater */
+    protected $translatableUpdater;
+
     /**
      * @param AttributeGroupRepositoryInterface $attrGroupRepo
      * @param LocaleRepositoryInterface         $localeRepository
      * @param AttributeTypeRegistry             $registry
+     * @param TranslatableUpdater               $translatableUpdater
      */
     public function __construct(
         AttributeGroupRepositoryInterface $attrGroupRepo,
         LocaleRepositoryInterface $localeRepository,
-        AttributeTypeRegistry $registry
+        AttributeTypeRegistry $registry,
+        TranslatableUpdater $translatableUpdater = null
     ) {
         $this->attrGroupRepo = $attrGroupRepo;
         $this->localeRepository = $localeRepository;
         $this->registry = $registry;
         $this->accessor = PropertyAccess::createPropertyAccessor();
+        $this->translatableUpdater = $translatableUpdater;
     }
 
     /**
@@ -152,7 +159,7 @@ class AttributeUpdater implements ObjectUpdaterInterface
                 $this->setType($attribute, $data);
                 break;
             case 'labels':
-                $this->setLabels($attribute, $data);
+                $this->translatableUpdater->update($attribute, $data);
                 break;
             case 'group':
                 $this->setGroup($attribute, $data);
@@ -203,21 +210,6 @@ class AttributeUpdater implements ObjectUpdaterInterface
             $this->accessor->setValue($attribute, $field, $data);
         } catch (NoSuchPropertyException $e) {
             throw UnknownPropertyException::unknownProperty($field, $e);
-        }
-    }
-
-    /**
-     * @param AttributeInterface $attribute
-     * @param array              $data
-     */
-    protected function setLabels(AttributeInterface $attribute, array $data)
-    {
-        foreach ($data as $localeCode => $label) {
-            if (null !== $label && '' !== $label) {
-                $attribute->setLocale($localeCode);
-                $translation = $attribute->getTranslation();
-                $translation->setLabel($label);
-            }
         }
     }
 

--- a/src/Pim/Component/Catalog/Updater/FamilyUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/FamilyUpdater.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Component\Catalog\Updater;
 
+use Akeneo\Component\Localization\TranslatableUpdater;
 use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
@@ -49,19 +50,24 @@ class FamilyUpdater implements ObjectUpdaterInterface
     /** @var AttributeRequirementRepositoryInterface */
     protected $requirementRepo;
 
+    /** @var TranslatableUpdater */
+    protected $translatableUpdater;
+
     /**
      * @param IdentifiableObjectRepositoryInterface   $familyRepository
      * @param AttributeRepositoryInterface            $attributeRepository
      * @param ChannelRepositoryInterface              $channelRepository
      * @param AttributeRequirementFactory             $attrRequiFactory
      * @param AttributeRequirementRepositoryInterface $requirementRepo
+     * @param TranslatableUpdater                     $translatableUpdater
      */
     public function __construct(
         IdentifiableObjectRepositoryInterface $familyRepository,
         AttributeRepositoryInterface $attributeRepository,
         ChannelRepositoryInterface $channelRepository,
         AttributeRequirementFactory $attrRequiFactory,
-        AttributeRequirementRepositoryInterface $requirementRepo
+        AttributeRequirementRepositoryInterface $requirementRepo,
+        TranslatableUpdater $translatableUpdater = null
     ) {
         $this->accessor = PropertyAccess::createPropertyAccessor();
         $this->familyRepository = $familyRepository;
@@ -69,6 +75,7 @@ class FamilyUpdater implements ObjectUpdaterInterface
         $this->channelRepository = $channelRepository;
         $this->attrRequiFactory = $attrRequiFactory;
         $this->requirementRepo = $requirementRepo;
+        $this->translatableUpdater = $translatableUpdater;
     }
 
     /**
@@ -184,7 +191,7 @@ class FamilyUpdater implements ObjectUpdaterInterface
     {
         switch ($field) {
             case 'labels':
-                $this->setLabels($family, $data);
+                $this->translatableUpdater->update($family, $data);
                 break;
             case 'attribute_requirements':
                 $this->setAttributeRequirements($family, $data);
@@ -213,19 +220,6 @@ class FamilyUpdater implements ObjectUpdaterInterface
             $this->accessor->setValue($attribute, $field, $data);
         } catch (NoSuchPropertyException $e) {
             throw UnknownPropertyException::unknownProperty($field, $e);
-        }
-    }
-
-    /**
-     * @param FamilyInterface $family
-     * @param array           $data
-     */
-    protected function setLabels(FamilyInterface $family, array $data)
-    {
-        foreach ($data as $localeCode => $label) {
-            $family->setLocale($localeCode);
-            $translation = $family->getTranslation();
-            $translation->setLabel($label);
         }
     }
 

--- a/src/Pim/Component/Catalog/spec/Updater/AttributeOptionUpdaterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/AttributeOptionUpdaterSpec.php
@@ -72,6 +72,38 @@ class AttributeOptionUpdaterSpec extends ObjectBehavior
         );
     }
 
+    function it_does_not_update_empty_labels(
+        $attributeRepository,
+        AttributeOptionInterface $attributeOption,
+        AttributeInterface $attribute,
+        AttributeOptionValueInterface $attributeOptionValue
+    ) {
+        $attributeOption->getId()->willReturn(null);
+        $attributeOption->getAttribute()->willReturn(null);
+
+        $attributeOption->setCode('mycode')->shouldBeCalled();
+        $attributeRepository->findOneByIdentifier('myattribute')->willReturn($attribute);
+        $attributeOption->setAttribute($attribute)->shouldBeCalled();
+
+        $attributeOption->setLocale('de_DE')->shouldNotBeCalled();
+        $attributeOption->setLocale('fr_FR')->shouldNotBeCalled();
+        $attributeOption->getTranslation()->shouldNotBeCalled();
+        $attributeOptionValue->setLabel(null)->shouldNotBeCalled();
+        $attributeOptionValue->setLabel('')->shouldNotBeCalled();
+
+        $this->update(
+            $attributeOption,
+            [
+                'code' => 'mycode',
+                'attribute' => 'myattribute',
+                'labels' => [
+                    'de_DE' => null,
+                    'fr_FR' => '',
+                ]
+            ]
+        );
+    }
+
     function it_throws_an_exception_when_attribute_does_not_exist(
         $attributeRepository,
         AttributeOptionInterface $attributeOption

--- a/src/Pim/Component/Catalog/spec/Updater/AttributeOptionUpdaterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/AttributeOptionUpdaterSpec.php
@@ -72,33 +72,39 @@ class AttributeOptionUpdaterSpec extends ObjectBehavior
         );
     }
 
-    function it_does_not_update_empty_labels(
-        $attributeRepository,
+    function it_removes_the_translation_when_the_new_label_is_empty(
         AttributeOptionInterface $attributeOption,
-        AttributeInterface $attribute,
         AttributeOptionValueInterface $attributeOptionValue
     ) {
-        $attributeOption->getId()->willReturn(null);
-        $attributeOption->getAttribute()->willReturn(null);
-
-        $attributeOption->setCode('mycode')->shouldBeCalled();
-        $attributeRepository->findOneByIdentifier('myattribute')->willReturn($attribute);
-        $attributeOption->setAttribute($attribute)->shouldBeCalled();
-
-        $attributeOption->setLocale('de_DE')->shouldNotBeCalled();
-        $attributeOption->setLocale('fr_FR')->shouldNotBeCalled();
-        $attributeOption->getTranslation()->shouldNotBeCalled();
-        $attributeOptionValue->setLabel(null)->shouldNotBeCalled();
+        $attributeOption->setLocale('fr_FR')->shouldBeCalled();
+        $attributeOption->getTranslation()->willReturn($attributeOptionValue);
         $attributeOptionValue->setLabel('')->shouldNotBeCalled();
+        $attributeOption->removeOptionValue($attributeOptionValue)->shouldBeCalled();
 
         $this->update(
             $attributeOption,
             [
-                'code' => 'mycode',
-                'attribute' => 'myattribute',
                 'labels' => [
-                    'de_DE' => null,
                     'fr_FR' => '',
+                ]
+            ]
+        );
+    }
+
+    function it_removes_the_translation_when_the_new_label_is_null(
+        AttributeOptionInterface $attributeOption,
+        AttributeOptionValueInterface $attributeOptionValue
+    ) {
+        $attributeOption->setLocale('fr_FR')->shouldBeCalled();
+        $attributeOption->getTranslation()->willReturn($attributeOptionValue);
+        $attributeOptionValue->setLabel(null)->shouldNotBeCalled();
+        $attributeOption->removeOptionValue($attributeOptionValue)->shouldBeCalled();
+
+        $this->update(
+            $attributeOption,
+            [
+                'labels' => [
+                    'fr_FR' => null,
                 ]
             ]
         );

--- a/src/Pim/Component/Catalog/spec/Updater/AttributeUpdaterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/AttributeUpdaterSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Pim\Component\Catalog\Updater;
 
+use Akeneo\Component\Localization\TranslatableUpdater;
 use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
@@ -22,9 +23,10 @@ class AttributeUpdaterSpec extends ObjectBehavior
     function let(
         AttributeGroupRepositoryInterface $attrGroupRepo,
         LocaleRepositoryInterface $localeRepository,
-        AttributeTypeRegistry $registry
+        AttributeTypeRegistry $registry,
+        TranslatableUpdater $translatableUpdater
     ) {
-        $this->beConstructedWith($attrGroupRepo, $localeRepository, $registry);
+        $this->beConstructedWith($attrGroupRepo, $localeRepository, $registry, $translatableUpdater);
     }
 
     function it_is_initializable()
@@ -53,6 +55,7 @@ class AttributeUpdaterSpec extends ObjectBehavior
     function it_updates_a_new_attribute(
         $attrGroupRepo,
         $registry,
+        $translatableUpdater,
         AttributeInterface $attribute,
         AttributeTranslation $translation,
         AttributeGroupInterface $attributeGroup,
@@ -69,12 +72,7 @@ class AttributeUpdaterSpec extends ObjectBehavior
             'date_min' => '2016-12-12T00:00:00+01:00'
         ];
 
-        $attribute->setLocale('en_US')->shouldBeCalled();
-        $attribute->setLocale('fr_FR')->shouldBeCalled();
-        $attribute->getTranslation()->willReturn($translation);
-
-        $translation->setLabel('Test1')->shouldBeCalled();
-        $translation->setLabel('Test2')->shouldBeCalled();
+        $translatableUpdater->update($attribute, ['en_US' => 'Test1', 'fr_FR' => 'Test2']);
 
         $attrGroupRepo->findOneByIdentifier('marketing')->willReturn($attributeGroup);
         $attribute->setGroup($attributeGroup)->shouldBeCalled();
@@ -96,6 +94,7 @@ class AttributeUpdaterSpec extends ObjectBehavior
     function it_throws_an_exception_if_no_groups_found(
         $attrGroupRepo,
         $registry,
+        $translatableUpdater,
         AttributeInterface $attribute,
         AttributeTranslation $translation,
         AttributeTypeInterface $attributeType
@@ -109,12 +108,7 @@ class AttributeUpdaterSpec extends ObjectBehavior
             'type' => 'pim_catalog_text'
         ];
 
-        $attribute->setLocale('en_US')->shouldBeCalled();
-        $attribute->setLocale('fr_FR')->shouldBeCalled();
-        $attribute->getTranslation()->willReturn($translation);
-
-        $translation->setLabel('Test1')->shouldBeCalled();
-        $translation->setLabel('Test2')->shouldBeCalled();
+        $translatableUpdater->update($attribute, ['en_US' => 'Test1', 'fr_FR' => 'Test2']);
 
         $attrGroupRepo->findOneByIdentifier('marketing')->willReturn(null);
         $registry->get('pim_catalog_text')->willReturn($attributeType);

--- a/src/Pim/Component/Catalog/spec/Updater/FamilyUpdaterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/FamilyUpdaterSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Pim\Component\Catalog\Updater;
 
+use Akeneo\Component\Localization\TranslatableUpdater;
 use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
@@ -28,14 +29,16 @@ class FamilyUpdaterSpec extends ObjectBehavior
         AttributeRepositoryInterface $attributeRepository,
         ChannelRepositoryInterface $channelRepository,
         AttributeRequirementFactory $attrRequiFactory,
-        AttributeRequirementRepositoryInterface $attributeRequirementRepo
+        AttributeRequirementRepositoryInterface $attributeRequirementRepo,
+        TranslatableUpdater $translatableUpdater
     ) {
         $this->beConstructedWith(
             $familyRepository,
             $attributeRepository,
             $channelRepository,
             $attrRequiFactory,
-            $attributeRequirementRepo
+            $attributeRequirementRepo,
+            $translatableUpdater
         );
     }
 
@@ -66,6 +69,7 @@ class FamilyUpdaterSpec extends ObjectBehavior
         $attrRequiFactory,
         $channelRepository,
         $attributeRequirementRepo,
+        $translatableUpdater,
         FamilyTranslation $translation,
         FamilyInterface $family,
         AttributeRepositoryInterface $attributeRepository,
@@ -164,12 +168,8 @@ class FamilyUpdaterSpec extends ObjectBehavior
         $family->addAttribute($skuAttribute)->shouldBeCalled();
         $family->addAttribute($skuAttribute)->shouldBeCalled();
 
-        $family->setLocale('en_US')->shouldBeCalled();
-        $family->setLocale('fr_FR')->shouldBeCalled();
-        $family->getTranslation()->willReturn($translation);
 
-        $translation->setLabel('label en us');
-        $translation->setLabel('label fr fr');
+        $translatableUpdater->update($family, ['fr_FR' => 'Moniteurs', 'en_US' => 'PC Monitors'])->shouldBeCalled();
 
         $family->addAttribute($skuAttribute)->shouldBeCalled();
         $family->addAttribute($nameAttribute)->shouldBeCalled();

--- a/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Category.php
+++ b/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Category.php
@@ -55,9 +55,7 @@ class Category implements ArrayConverterInterface
 
         $convertedItem = ['labels' => []];
         foreach ($item as $field => $data) {
-            if ('' !== $data) {
-                $convertedItem = $this->convertField($convertedItem, $field, $data);
-            }
+            $convertedItem = $this->convertField($convertedItem, $field, $data);
         }
 
         return $convertedItem;
@@ -76,10 +74,10 @@ class Category implements ArrayConverterInterface
             $labelTokens = explode('-', $field);
             $labelLocale = $labelTokens[1];
             $convertedItem['labels'][$labelLocale] = $data;
-        } elseif ('code' === $field) {
+        } elseif ('code' === $field && '' !== $data) {
             $convertedItem[$field] = (string) $data;
-        } elseif ('parent' === $field) {
-            $convertedItem[$field] = '' === $data ? null : $data;
+        } elseif ('parent' === $field && '' !== $data) {
+            $convertedItem[$field] = $data;
         }
 
         return $convertedItem;


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

Validated by PO :

When you import an empty label or set a label to `null` or "" with the API , it should  delete the label in the database. 
Before this PR, there were different behaviours : sometimes it was impossible to delete labels, sometimes it was possible...

For the moment, only the following entities have been modified (=entities of the API) :

- category
- attributes
- attribute options
- family

Note: the UI does not delete the labels and the behaviour is not very consistent with import/API.
It will be handle by opening tickets to the support.

UI does not work as the import/API because it does not use updaters, but Symfony forms.

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Ok
| Added Behats                      | Ok
| Added integration tests           | Ok
| Changelog updated                 | -
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
