### PR TITLE
PIM-6265: Fix user menu navigation

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -1,3 +1,9 @@
+# 1.7.x
+
+## Bug Fixes
+
+- PIM-6265: Fix user menu navigation
+
 # 1.7.1 (2017-03-23)
 
 ## Bug Fixes

--- a/src/Oro/Bundle/UserBundle/Resources/config/navigation.yml
+++ b/src/Oro/Bundle/UserBundle/Resources/config/navigation.yml
@@ -56,7 +56,7 @@ oro_menu_config:
             label: 'My User'
             route: 'oro_user_profile_view'
             linkAttributes:
-                class: 'AknDropdown-menuLink'
+                class: 'AknDropdown-menuLink no-hash'
             extras:
                 position: 10
 


### PR DESCRIPTION
Wrong behavior introduced by BEM
We have to remove the hashnav from user menu to avoid glitches. (1.6 was like this)

No need for CI IMHO.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | y
| Review and 2 GTM                  | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
