### PR TITLE
PIM-6240: fix undefined channel on mass edit

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -5,6 +5,7 @@
 - PIM-6270: Fix sequential edit style
 - PIM-6265: Fix user menu navigation
 - GITHUB-5307: Fix sort order in field "Attribute group"
+- PIM-6240: Display the code instead of undefined if channel's locale is not filled for the given locale
 
 # 1.7.1 (2017-03-23)
 

--- a/features/mass-action/edit_common_attributes.feature
+++ b/features/mass-action/edit_common_attributes.feature
@@ -248,3 +248,19 @@ Feature: Edit common attributes of many products at once
     And attribute Comment of "sandals" should be "$(echo "shell_injection" > shell_injection.txt)"
     And attribute Comment of "sneakers" should be "$(echo "shell_injection" > shell_injection.txt)"
     And file "%web%shell_injection.txt" should not exist
+
+  @jira https://akeneo.atlassian.net/browse/PIM-6240
+  Scenario: Allow editing all attributes on configuration screen
+    Given I am on the "tablet" channel page
+    Then I should see the Code field
+    And the field Code should be disabled
+    When I fill in the following information:
+      | English (United States) | |
+    And I press the "Save" button
+    Then I should not see the text "My tablet"
+    And I am on the products page
+    And I select rows boots, sandals and sneakers
+    And I press "Change product information" on the "Bulk Actions" dropdown button
+    When I choose the "Edit common attributes" operation
+    Then I should see the text "[tablet]"
+    And I should not see the text "undefined"

--- a/src/Pim/Bundle/EnrichBundle/Resources/views/MassEditAction/product/configure/edit-common-attributes.html.twig
+++ b/src/Pim/Bundle/EnrichBundle/Resources/views/MassEditAction/product/configure/edit-common-attributes.html.twig
@@ -16,14 +16,16 @@
                     'pim/fetcher-registry',
                     'pim/form-builder',
                     'oro/mediator',
-                    'pim/user-context'
+                    'pim/user-context',
+                    'pim/i18n'
                 ],
                 function (
                         $,
                         FetcherRegistry,
                         FormBuilder,
                         mediator,
-                        UserContext
+                        UserContext,
+                        i18n
                 ) {
                     $(function () {
                         var userData = "{{ form.vars.data.getValues|escape('js') }}";
@@ -57,7 +59,11 @@
 
                                 $('#mass-edit-common-attribute-description').html(_.__(
                                     'pim_enrich.mass_edit_action.edit_common_attributes.description',
-                                    {'locale': locale.label, 'channel': channel.labels[UserContext.get('catalogLocale')]}
+                                    {'locale': locale.label, 'channel': i18n.getLabel(
+                                        channel.labels,
+                                        UserContext.get('catalogLocale'),
+                                        channel.code
+                                    )}
                                 ));
                             });
                         });


### PR DESCRIPTION
**Definition Of Done (for Core Developer only)**

When the chosen channel doesn't has a scope for the selected locale it was displaying "undefined".
The fix now display the code instead of undefined.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | No
| Added Behats                      | Yes
| Changelog updated                 | Yes
| Review and 2 GTM                  | Todo