### PR TITLE
Avoid to raise an exception in behats by testing the command in background

### DIFF
--- a/features/Context/CommandContext.php
+++ b/features/Context/CommandContext.php
@@ -222,13 +222,19 @@ class CommandContext extends PimContext
     /**
      * Runs app/console $command in the test environment
      *
-     * @When /^I run '([^\']*)'$/
+     * @When /^I run '([^\']*)'( in background)?$/
      *
-     * @param string $command
+     * @param string      $command
+     * @param string|null $command
      */
-    public function iRun($command)
+    public function iRun($command, $background)
     {
         $commandLauncher = $this->getService('pim_catalog.command_launcher');
-        $commandLauncher->executeForeground($this->replacePlaceholders($command));
+
+        if (null === $background) {
+            $commandLauncher->executeForeground($this->replacePlaceholders($command));
+        } else {
+            $commandLauncher->executeBackground($this->replacePlaceholders($command));
+        }
     }
 }

--- a/features/technical/security.feature
+++ b/features/technical/security.feature
@@ -6,5 +6,7 @@ Feature: Security
   @jira https://akeneo.atlassian.net/browse/PIM-6062
   Scenario: Fail when trying to inject command
     Given file "%tmp%/this_will_raise_an_error.txt" should not exist
-    When I run '$(touch %tmp%/this_will_raise_an_error.txt)'
+    When I run '$(touch %tmp%/this_will_raise_an_error.txt)' in background
+    # This wait is exceptional, as otherwise we have an Exception if launched in foreground.
+    And I wait 3 seconds
     Then file "%tmp%/this_will_raise_an_error.txt" should not exist


### PR DESCRIPTION
On the current CI, this behat passes but it raises an Exception (which is normal):

![behat](https://cloud.githubusercontent.com/assets/301169/24257470/4779cd38-0feb-11e7-9c38-3a7201724d6c.png)

Now the CI detects if there is an Exception, so it fails.
To avoid this, we launch the command in background and explicitly wait to test the file.

Pair fixed with @pierallard 💃 