### PR TITLE
Split integration tests in smaller suites

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -113,11 +113,31 @@ if (launchIntegrationTests.equals("yes")) {
     stage("Integration tests") {
         def tasks = [:]
 
-        tasks["phpunit-5.6-orm"] = {runIntegrationTest("5.6", "orm")}
-        tasks["phpunit-7.0-orm"] = {runIntegrationTest("7.0", "orm")}
+        tasks["phpunit-5.6-orm-api-base"] = {runIntegrationTest("5.6", "orm", "PIM_Api_Base_Integration_Test")}
+        tasks["phpunit-5.6-orm-api-controllers"] = {runIntegrationTest("5.6", "orm", "PIM_Api_Bundle_Controllers_Integration_Test")}
+        tasks["phpunit-5.6-orm-api-controllers-catalog"] = {runIntegrationTest("5.6", "orm", "PIM_Api_Bundle_Controllers_Catalog_Integration_Test")}
+        tasks["phpunit-5.6-orm-api-controller-product"] = {runIntegrationTest("5.6", "orm", "PIM_Api_Bundle_Controller_Product_Integration_Test")}
+        tasks["phpunit-5.6-orm-catalog"] = {runIntegrationTest("5.6", "orm", "PIM_Catalog_Integration_Test")}
+        tasks["phpunit-5.6-orm-completeness"] = {runIntegrationTest("5.6", "orm", "PIM_Catalog_Completeness_Integration_Test")}
+        tasks["phpunit-5.6-orm-pqb"] = {runIntegrationTest("5.6", "orm", "PIM_Catalog_PQB_Integration_Test")}
 
-        // Temporarily deactivate integration tests with PHP 7.1 because of stability issues
-        // tasks["phpunit-7.1-orm"] = {runIntegrationTest("7.1", "orm")}
+        tasks["phpunit-7.0-orm-api-base"] = {runIntegrationTest("7.0", "orm", "PIM_Api_Base_Integration_Test")}
+        tasks["phpunit-7.0-orm-api-controllers"] = {runIntegrationTest("7.0", "orm", "PIM_Api_Bundle_Controllers_Integration_Test")}
+        tasks["phpunit-7.0-orm-api-controllers-catalog"] = {runIntegrationTest("7.0", "orm", "PIM_Api_Bundle_Controllers_Catalog_Integration_Test")}
+        tasks["phpunit-7.0-orm-api-controller-product"] = {runIntegrationTest("7.0", "orm", "PIM_Api_Bundle_Controller_Product_Integration_Test")}
+        tasks["phpunit-7.0-orm-catalog"] = {runIntegrationTest("7.0", "orm", "PIM_Catalog_Integration_Test")}
+        tasks["phpunit-7.0-orm-completeness"] = {runIntegrationTest("7.0", "orm", "PIM_Catalog_Completeness_Integration_Test")}
+        tasks["phpunit-7.0-orm-pqb"] = {runIntegrationTest("7.0", "orm", "PIM_Catalog_PQB_Integration_Test")}
+
+        tasks["phpunit-7.1-orm-api-base"] = {runIntegrationTest("7.1", "orm", "PIM_Api_Base_Integration_Test")}
+        tasks["phpunit-7.1-orm-api-controllers"] = {runIntegrationTest("7.1", "orm", "PIM_Api_Bundle_Controllers_Integration_Test")}
+        tasks["phpunit-7.1-orm-api-controllers-catalog"] = {runIntegrationTest("7.1", "orm", "PIM_Api_Bundle_Controllers_Catalog_Integration_Test")}
+        tasks["phpunit-7.1-orm-api-controller-product"] = {runIntegrationTest("7.1", "orm", "PIM_Api_Bundle_Controller_Product_Integration_Test")}
+        tasks["phpunit-7.1-orm-catalog"] = {runIntegrationTest("7.1", "orm", "PIM_Catalog_Integration_Test")}
+        // tasks["phpunit-7.1-orm-completeness"] = {runIntegrationTest("7.1", "orm", "PIM_Catalog_Completeness_Integration_Test")}
+        tasks["phpunit-7.1-orm-pqb"] = {runIntegrationTest("7.1", "orm", "PIM_Catalog_PQB_Integration_Test")}
+
+        // Temporarily deactivate integration tests with MongoDB because of stability issues
         // tasks["phpunit-5.6-odm"] = {runIntegrationTest("5.6", "odm")}
         // tasks["phpunit-7.0-odm"] = {runIntegrationTest("7.0", "odm")}
         // tasks["phpunit-7.1-odm"] = {runIntegrationTest("7.1", "odm")}
@@ -184,7 +204,7 @@ def runPhpUnitTest(phpVersion) {
     }
 }
 
-def runIntegrationTest(phpVersion, storage) {
+def runIntegrationTest(phpVersion, storage, testSuiteName) {
     node('docker') {
         deleteDir()
         try {
@@ -212,7 +232,7 @@ def runIntegrationTest(phpVersion, storage) {
                         sh "./app/console --env=test pim:install --force"
 
                         sh "mkdir -p app/build/logs/"
-                        sh "./bin/phpunit -c app/phpunit.xml.dist --testsuite PIM_Integration_Test --log-junit app/build/logs/phpunit_integration.xml"
+                        sh "./bin/phpunit -c app/phpunit.xml.dist --testsuite ${testSuiteName} --log-junit app/build/logs/phpunit_integration.xml"
                     }
                 }
             }
@@ -220,7 +240,7 @@ def runIntegrationTest(phpVersion, storage) {
             sh "docker stop \$(docker ps -a -q) || true"
             sh "docker rm \$(docker ps -a -q) || true"
             sh "docker volume rm \$(docker volume ls -q) || true"
-            sh "sed -i \"s/testcase name=\\\"/testcase name=\\\"[php-${phpVersion}-${storage}] /\" app/build/logs/*.xml"
+            sh "sed -i \"s/testcase name=\\\"/testcase name=\\\"[php-${phpVersion}-${storage}-${testSuiteName}] /\" app/build/logs/*.xml"
 
             junit "app/build/logs/*.xml"
             deleteDir()

--- a/app/phpunit.xml.dist
+++ b/app/phpunit.xml.dist
@@ -21,14 +21,54 @@
 
     <testsuites>
 
-        <!-- PIM test suites -->
+        <!-- Legacy PIM phpunit unit tests -->
         <testsuite name="PIM_Unit_Test">
             <directory suffix="Test.php">../src/Pim/Bundle/*Bundle/Tests/Unit</directory>
         </testsuite>
 
+        <!-- Complete suite for PIM integration tests -->
         <testsuite name="PIM_Integration_Test">
             <directory suffix="Integration.php">../src/Pim/Component/*/tests/integration</directory>
             <directory suffix="Integration.php">../src/Pim/Bundle/*Bundle/tests/integration</directory>
+        </testsuite>
+
+        <!-- Set of small suites for PIM integration tests -->
+        <testsuite name="PIM_Api_Base_Integration_Test">
+            <directory suffix="Integration.php">../src/Pim/Component/Api/tests/integration</directory>
+            <directory suffix="Integration.php">../src/Pim/Bundle/ApiBundle/tests/integration/EventSubscriber</directory>
+            <directory suffix="Integration.php">../src/Pim/Bundle/ApiBundle/tests/integration/Security</directory>
+            <file>../src/Pim/Bundle/ApiBundle/tests/integration/Controller/RootEndpointIntegration.php</file>
+        </testsuite>
+
+        <testsuite name="PIM_Api_Bundle_Controllers_Integration_Test">
+            <directory suffix="Integration.php">../src/Pim/Bundle/ApiBundle/tests/integration/Controller/Channel</directory>
+            <directory suffix="Integration.php">../src/Pim/Bundle/ApiBundle/tests/integration/Controller/Locale</directory>
+            <directory suffix="Integration.php">../src/Pim/Bundle/ApiBundle/tests/integration/Controller/Media</directory>
+            <directory suffix="Integration.php">../src/Pim/Bundle/ApiBundle/tests/integration/Controller/Token</directory>
+        </testsuite>
+
+        <testsuite name="PIM_Api_Bundle_Controllers_Catalog_Integration_Test">
+            <directory suffix="Integration.php">../src/Pim/Bundle/ApiBundle/tests/integration/Controller/Attribute</directory>
+            <directory suffix="Integration.php">../src/Pim/Bundle/ApiBundle/tests/integration/Controller/AttributeOption</directory>
+            <directory suffix="Integration.php">../src/Pim/Bundle/ApiBundle/tests/integration/Controller/Category</directory>
+            <directory suffix="Integration.php">../src/Pim/Bundle/ApiBundle/tests/integration/Controller/Family</directory>
+        </testsuite>
+
+        <testsuite name="PIM_Api_Bundle_Controller_Product_Integration_Test">
+            <directory suffix="Integration.php">../src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product</directory>
+        </testsuite>
+
+        <testsuite name="PIM_Catalog_Integration_Test">
+            <directory suffix="Integration.php">../src/Pim/Bundle/CatalogBundle/tests/integration/Validation</directory>
+            <directory suffix="Integration.php">../src/Pim/Component/Catalog/tests/integration</directory>
+        </testsuite>
+
+        <testsuite name="PIM_Catalog_Completeness_Integration_Test">
+            <directory suffix="Integration.php">../src/Pim/Bundle/CatalogBundle/tests/integration/Completeness</directory>
+        </testsuite>
+
+        <testsuite name="PIM_Catalog_PQB_Integration_Test">
+            <directory suffix="Integration.php">../src/Pim/Bundle/CatalogBundle/tests/integration/PQB</directory>
         </testsuite>
 
     </testsuites>


### PR DESCRIPTION
## Description

As the integration tests takes a very long time to run on the CI (almost one hour on PHP 5.6), we try in this PR to split them in smaller suites (the split is still open to discussion and can change), and run them in parallel on the Jenkins docker slaves.

Build result with this Jenkinsfile:
https://core-ci.akeneo.com/blue/organizations/jenkins/akeneo%2Fpim-community-dev/detail/PR-5988/12/pipeline/57

The longest suite is `PIM_Api_Bundle_Controllers_Base_Integration_Test` in PHP 5.6, taking 10 minutes to execute (so this is the time the "integration test" stage take).

Completeness in PHP 7.1 is commented as there is still an issue with it. It will be addressed in another PR.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
