### PR TITLE
PIM-6071: add control on attribute having same code as association type

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -1,3 +1,9 @@
+# 1.6.*
+
+## Bug fixes
+
+- PIM-6071: add control on attribute having same code as association type
+
 # 1.6.12 (2017-02-28)
 
 ## Bug fixes

--- a/features/import/edit_an_import.feature
+++ b/features/import/edit_an_import.feature
@@ -48,6 +48,7 @@ Feature: Edit an import
     And I should see "Decimal separator dot (.)"
     And I should see "Date format yyyy-mm-dd"
 
+  @javascript
   Scenario: Successfully display a dialog when we quit a page with unsaved changes
     Given I am on the "csv_footwear_product_import" import job edit page
     When I fill in the following information:

--- a/features/import/product/import_products_with_associations.feature
+++ b/features/import/product/import_products_with_associations.feature
@@ -182,3 +182,28 @@ Feature: Execute a job
       | type   | products |
       | X_SELL | SKU-002  |
       | UPSELL | SKU-003  |
+
+  @jira https://akeneo.atlassian.net/browse/PIM-6071
+  Scenario: Successfully import product associations with an attribute having the same code
+    Given the following product:
+      | sku     | name-en_US |
+      | SKU-001 | sku-001    |
+      | SKU-002 | sku-002    |
+      | SKU-003 | sku-003    |
+    Given the following association type:
+      | code |
+      | sku  |
+    And the following CSV file to import:
+      """
+      sku;sku-products
+      SKU-001;SKU-003
+      """
+    And the following job "csv_footwear_product_import" configuration:
+      | filePath          | %file to import% |
+      | enabledComparison | yes              |
+    When I am on the "csv_footwear_product_import" import job page
+    And I launch the import job
+    And I wait for the "csv_footwear_product_import" job to finish
+    Then the product "SKU-001" should have the following associations:
+      | type   | products |
+      | sku    | SKU-003  |

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/array_converters.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/array_converters.yml
@@ -282,6 +282,7 @@ services:
             - '@pim_catalog.repository.attribute'
             - '@pim_catalog.repository.channel'
             - '@pim_catalog.repository.locale'
+            - '@pim_connector.array_converter.flat_to_standard.product.association_columns_resolver'
 
     # product value converters
     pim_connector.array_converter.flat_to_standard.product.value_converter.registry:

--- a/src/Pim/Bundle/UIBundle/Resources/views/Form/pim-fields.html.twig
+++ b/src/Pim/Bundle/UIBundle/Resources/views/Form/pim-fields.html.twig
@@ -416,3 +416,8 @@
 {% block select_family_type_row %}
     {{ block('form_row_field') }}
 {% endblock %}
+
+{%- block form_widget_simple -%}
+    {%- set type = type|default('text') -%}
+    <input type="{{ type }}" {{ block('widget_attributes') }} {% if value == '\\' or value is not empty %}value="{{ value }}" {% endif %}/>
+{%- endblock form_widget_simple -%}


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

If you had a association type with the same code as an attribute the improt process was failing. This PR intent to fix this problem.

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added Behats                      | OK
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
