### PR TITLE
PIM-6071 - Hide add option icon for non-editable fields

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/multi-select-field.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/multi-select-field.js
@@ -48,10 +48,10 @@ define(
              */
             getTemplateContext: function () {
                 return Field.prototype.getTemplateContext.apply(this, arguments).then(function (templateContext) {
-                    templateContext.userCanAddOption = SecurityContext.isGranted('pim_enrich_attribute_edit');
+                    templateContext.userCanAddOption = this.editable;
 
                     return templateContext;
-                });
+                }.bind(this));
             },
 
             /**

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/simple-select-field.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/simple-select-field.js
@@ -35,10 +35,9 @@ define(
              */
             getTemplateContext: function () {
                 return Field.prototype.getTemplateContext.apply(this, arguments).then(function (templateContext) {
-                    templateContext.userCanAddOption = SecurityContext.isGranted('pim_enrich_attribute_edit');
-
+                    templateContext.userCanAddOption = this.editable;
                     return templateContext;
-                });
+                }.bind(this));
             },
 
             /**


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
