### PR TITLE
PIM-6071: Hide add option icon for non-editable fields

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -6,6 +6,7 @@
 - PIM-6265: Fix user menu navigation
 - GITHUB-5307: Fix sort order in field "Attribute group"
 - PIM-6240: Display the code instead of undefined if channel's locale is not filled for the given locale
+- PIM-6071: Hide add option icon for non-editable fields
 
 # 1.7.1 (2017-03-23)
 

--- a/features/Context/WebUser.php
+++ b/features/Context/WebUser.php
@@ -1150,6 +1150,25 @@ class WebUser extends RawMinkContext
     }
 
     /**
+     * @param string $field
+     *
+     * @Then /^I should not see the add option link for the "([^"]*)" attribute$/
+     *
+     * @throws ExpectationException
+     */
+    public function iShouldNotSeeTheAddOptionLinkFor($field)
+    {
+        if (null !== $this->getCurrentPage()->getAddOptionLinkFor($field)) {
+            throw $this->createExpectationException(
+                sprintf(
+                    'Add option link should not be displayed for attribute "%s".',
+                    $field
+                )
+            );
+        }
+    }
+
+    /**
      * @Then /^I should see reorder handles$/
      */
     public function iShouldSeeReorderHandles()

--- a/features/product/ensure_variant_read_only.feature
+++ b/features/product/ensure_variant_read_only.feature
@@ -8,27 +8,30 @@ Feature: Disable attribute fields updated by a variant group
     Given the "default" catalog configuration
     And I add the "english" locale to the "mobile" channel
     And the following attributes:
-      | code        | label-en_US | type                         | scopable | localizable | metric_family | default_metric_unit | group | decimals_allowed | negative_allowed |
-      | options     | Options     | pim_catalog_multiselect      | 1        | 0           |               |                     | other |                  |                  |
-      | color       | Color       | pim_catalog_simpleselect     | 0        | 0           |               |                     | other |                  |                  |
-      | name        | Name        | pim_catalog_text             | 0        | 1           |               |                     | other |                  |                  |
-      | description | Description | pim_catalog_textarea         | 0        | 0           |               |                     | other |                  |                  |
-      | dimension   | Dimension   | pim_catalog_number           | 1        | 1           |               |                     | other | 0                | 0                |
-      | price       | Price       | pim_catalog_price_collection | 0        | 0           |               |                     | other | 0                |                  |
-      | length      | Length      | pim_catalog_metric           | 0        | 0           | Length        | CENTIMETER          | other | 0                | 0                |
+      | code             | label-en_US     | type                         | scopable | localizable | metric_family | default_metric_unit | group | decimals_allowed | negative_allowed |
+      | options          | Options         | pim_catalog_multiselect      | 1        | 0           |               |                     | other |                  |                  |
+      | color            | Color           | pim_catalog_simpleselect     | 0        | 0           |               |                     | other |                  |                  |
+      | name             | Name            | pim_catalog_text             | 0        | 1           |               |                     | other |                  |                  |
+      | description      | Description     | pim_catalog_textarea         | 0        | 0           |               |                     | other |                  |                  |
+      | dimension        | Dimension       | pim_catalog_number           | 1        | 1           |               |                     | other | 0                | 0                |
+      | price            | Price           | pim_catalog_price_collection | 0        | 0           |               |                     | other | 0                |                  |
+      | length           | Length          | pim_catalog_metric           | 0        | 0           | Length        | CENTIMETER          | other | 0                | 0                |
+      | tshirt_material  | Tshirt Material | pim_catalog_simpleselect     | 0        | 0           |               |                     | other |                  |                  |
     And the following "options" attribute options: Blue
     And the following "color" attribute options: Red, black and Green
+    And the following "tshirt_material" attribute options: Cotton, Wool
     And the following variant groups:
       | code          | label-en_US    | axis  | type    |
       | tshirt_akeneo | Akeneo T-Shirt | color | VARIANT |
     And the following variant group values:
-      | group         | attribute   | value            | locale | scope     |
-      | tshirt_akeneo | name        | Great sneakers   | fr_FR  |           |
-      | tshirt_akeneo | dimension   | 12               | en_US  | ecommerce |
-      | tshirt_akeneo | options     | blue             |        | mobile    |
-      | tshirt_akeneo | description | nice description |        |           |
-      | tshirt_akeneo | price-EUR   | 10.0             |        |           |
-      | tshirt_akeneo | length      | 15.0 CENTIMETER  |        |           |
+      | group         | attribute       | value            | locale | scope     |
+      | tshirt_akeneo | name            | Great sneakers   | fr_FR  |           |
+      | tshirt_akeneo | dimension       | 12               | en_US  | ecommerce |
+      | tshirt_akeneo | options         | blue             |        | mobile    |
+      | tshirt_akeneo | description     | nice description |        |           |
+      | tshirt_akeneo | price-EUR       | 10.0             |        |           |
+      | tshirt_akeneo | length          | 15.0 CENTIMETER  |        |           |
+      | tshirt_akeneo | tshirt_material | Cotton           |        |           |
     And the following products:
       | sku  | color | groups        |
       | sku1 | red   | tshirt_akeneo |
@@ -36,5 +39,7 @@ Feature: Disable attribute fields updated by a variant group
     When I am on the "sku1" product page
     And I switch the scope to "mobile"
     Then the fields Options, Dimension, Price in EUR, Length should be disabled
+    Then I should not see the add option link for the "Options" attribute
+    Then I should not see the add option link for the "Tshirt Material" attribute
     Given I switch the locale to "fr_FR"
     Then the field name should be disabled

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/multi-select-field.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/multi-select-field.js
@@ -48,10 +48,10 @@ define(
              */
             getTemplateContext: function () {
                 return Field.prototype.getTemplateContext.apply(this, arguments).then(function (templateContext) {
-                    templateContext.userCanAddOption = SecurityContext.isGranted('pim_enrich_attribute_edit');
+                    templateContext.userCanAddOption = this.editable;
 
                     return templateContext;
-                });
+                }.bind(this));
             },
 
             /**

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/multi-select-field.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/multi-select-field.js
@@ -48,8 +48,8 @@ define(
              */
             getTemplateContext: function () {
                 return Field.prototype.getTemplateContext.apply(this, arguments).then(function (templateContext) {
-                    templateContext.userCanAddOption = this.editable && SecurityContext.isGranted('pim_enrich_attribute_edit');
-
+                    var isAllowed = SecurityContext.isGranted('pim_enrich_attribute_edit');
+                    templateContext.userCanAddOption = this.editable && isAllowed;
                     return templateContext;
                 }.bind(this));
             },

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/multi-select-field.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/multi-select-field.js
@@ -48,7 +48,7 @@ define(
              */
             getTemplateContext: function () {
                 return Field.prototype.getTemplateContext.apply(this, arguments).then(function (templateContext) {
-                    templateContext.userCanAddOption = this.editable;
+                    templateContext.userCanAddOption = this.editable && SecurityContext.isGranted('pim_enrich_attribute_edit');
 
                     return templateContext;
                 }.bind(this));

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/simple-select-field.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/simple-select-field.js
@@ -35,7 +35,8 @@ define(
              */
             getTemplateContext: function () {
                 return Field.prototype.getTemplateContext.apply(this, arguments).then(function (templateContext) {
-                    templateContext.userCanAddOption = this.editable && SecurityContext.isGranted('pim_enrich_attribute_edit');
+                    var isAllowed = SecurityContext.isGranted('pim_enrich_attribute_edit');
+                    templateContext.userCanAddOption = this.editable && isAllowed;
                     return templateContext;
                 }.bind(this));
             },

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/simple-select-field.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/simple-select-field.js
@@ -35,7 +35,7 @@ define(
              */
             getTemplateContext: function () {
                 return Field.prototype.getTemplateContext.apply(this, arguments).then(function (templateContext) {
-                    templateContext.userCanAddOption = this.editable;
+                    templateContext.userCanAddOption = this.editable && SecurityContext.isGranted('pim_enrich_attribute_edit');
                     return templateContext;
                 }.bind(this));
             },

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/simple-select-field.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/simple-select-field.js
@@ -35,10 +35,9 @@ define(
              */
             getTemplateContext: function () {
                 return Field.prototype.getTemplateContext.apply(this, arguments).then(function (templateContext) {
-                    templateContext.userCanAddOption = SecurityContext.isGranted('pim_enrich_attribute_edit');
-
+                    templateContext.userCanAddOption = this.editable;
                     return templateContext;
-                });
+                }.bind(this));
             },
 
             /**


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

[//]: <> (What does this Pull Request do? reference the related issue?)
This PR updates simple-select-field and multi-select field to hide the 'add an option' buttons for disabled fields.  

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | OK
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
