### PR TITLE
Fix coupling detector issues & rules for akeneo components

### DIFF
--- a/.php_cd.php
+++ b/.php_cd.php
@@ -50,13 +50,14 @@ $cAkeneoRules = [
         RuleInterface::TYPE_ONLY,
         'this component have no real existence, it should be merged into Batch'
     ),
-/*      new Rule(
+    new Rule(
         'Akeneo\Component\FileStorage',
         array_merge($cDeps, [
             'League\Flysystem',  // used as base file storage system
+            'Symfony\Component\HttpFoundation', // used to handle uploaded files & stream response
         ]),
         RuleInterface::TYPE_ONLY
-    ),*/
+    ),
     new Rule(
         'Akeneo\Component\Localization',
             array_merge($cDeps, [

--- a/.php_cd.php
+++ b/.php_cd.php
@@ -49,9 +49,14 @@ $cAkeneoRules = [
             'League\Flysystem',  // used as base file storage system
         ]),
         RuleInterface::TYPE_ONLY
+    ),*/
+    new Rule(
+        'Akeneo\Component\Localization',
+            array_merge($cDeps, [
+                'Symfony\Component\Translation', // to translate units of the metric attribute types
+            ]),
+            RuleInterface::TYPE_ONLY
     ),
-    new Rule('Akeneo\Component\Localization', $cDeps, RuleInterface::TYPE_ONLY),
-*/
     new Rule('Akeneo\Component\StorageUtils', $cDeps, RuleInterface::TYPE_ONLY),
     new Rule('Akeneo\Component\Versioning', $cDeps, RuleInterface::TYPE_ONLY),
 ];
@@ -83,14 +88,7 @@ $cPimRules = [
         RuleInterface::TYPE_ONLY
     ),
 */
-    new Rule(
-        'Pim\Component\Localization',
-        array_merge($cDeps, [
-            'Pim\Component\Catalog',         // because ;)
-            'Symfony\Component\Translation', // to translate units of the metric attribute types
-        ]),
-        RuleInterface::TYPE_ONLY
-    ),
+
     new Rule(
         'Pim\Component\ReferenceData',
         array_merge($cDeps, [

--- a/.php_cd.php
+++ b/.php_cd.php
@@ -42,8 +42,15 @@ $cAkeneoRules = [
         ]),
         RuleInterface::TYPE_ONLY
     ),
-/*    new Rule('Akeneo\Component\Console', $cDeps, RuleInterface::TYPE_ONLY, 'have no real existence, should be merged into Batch'),
-      new Rule(
+    new Rule(
+        'Akeneo\Component\Console',
+        array_merge($cDeps, [
+            'Symfony\Component\Process' // used in CommandLauncher
+        ]),
+        RuleInterface::TYPE_ONLY,
+        'this component have no real existence, it should be merged into Batch'
+    ),
+/*      new Rule(
         'Akeneo\Component\FileStorage',
         array_merge($cDeps, [
             'League\Flysystem',  // used as base file storage system


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

 - Re-enable / fix coupling detector rules regarding all Akeneo components
 - To prevent the introduction of future coupling regression

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
