### PR TITLE
PIM-6275: Fix variations not visible on Variant Group properties tab

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -7,6 +7,7 @@
 - GITHUB-5307: Fix sort order in field "Attribute group"
 - PIM-6240: Display the code instead of undefined if channel's locale is not filled for the given locale
 - PIM-6071: Hide add option icon for non-editable fields
+- PIM-6275: Fix variations not visible on Variant Group properties tab
 
 # 1.7.1 (2017-03-23)
 

--- a/features/Context/ViewSelectorContext.php
+++ b/features/Context/ViewSelectorContext.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Context;
+
+use Context\Spin\SpinCapableTrait;
+use Pim\Behat\Context\PimContext;
+
+/**
+ * @author    Adrien Pétremann <adrien.petremann@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class ViewSelectorContext extends PimContext
+{
+    use SpinCapableTrait;
+
+    /**
+     * @Given /^I open the view selector$/
+     */
+    public function iOpenTheViewSelector()
+    {
+        $this->getCurrentPage()->getViewSelector()->click();
+    }
+
+    /**
+     * @Given /^I filter view selector with name "([^"]*)"$/
+     *
+     * @param string $name
+     */
+    public function iFilterViewSelectorWithName($name)
+    {
+        $this->getCurrentPage()->getViewSelector()->search($name);
+    }
+
+    /**
+     * @Given /^I should be on the view "([^"]*)"$/
+     *
+     * @param string $viewName
+     *
+     * @throws \UnexpectedValueException
+     */
+    public function iShouldBeOnTheView($viewName)
+    {
+        $this->spin(function () {
+            $loadingMask = $this->getCurrentPage()->find('css', '.hash-loading-mask .loading-mask');
+
+            return (null !== $loadingMask && !$loadingMask->isVisible());
+        }, 'Grid loading mask is still visible.');
+
+        $currentViewName = $this->getCurrentPage()->getViewSelector()->getCurrentValue();
+
+        if ($currentViewName !== $viewName) {
+            throw new \UnexpectedValueException(
+                sprintf(
+                    'Expecting to be on the view "%s", but current view is "%s".',
+                    $viewName,
+                    $currentViewName
+                )
+            );
+        }
+    }
+}

--- a/features/Pim/Behat/Decorator/Field/Select2Decorator.php
+++ b/features/Pim/Behat/Decorator/Field/Select2Decorator.php
@@ -234,4 +234,18 @@ class Select2Decorator extends ElementDecorator
             )
         );
     }
+
+    /**
+     * Get the current value for the Select2
+     *
+     * @return string
+     */
+    public function getCurrentValue()
+    {
+        $input = $this->spin(function () {
+            return $this->find('css', '.select2-selection-label-view');
+        }, 'Cannot find the Select2 current selection input');
+
+        return $input->getText();
+    }
 }

--- a/features/enrich/variant-group/display_variant_group.feature
+++ b/features/enrich/variant-group/display_variant_group.feature
@@ -1,0 +1,14 @@
+@javascript
+Feature: Display a variant group
+  In order to display information about a variant group
+  As a product manager
+  I need to have access to a variant group information and properties
+
+  Background:
+    Given a "footwear" catalog configuration
+
+  Scenario: Successfully display axis of variation of a variant group
+    Given I am logged in as "Julia"
+    And I am on the "caterpillar_boots" variant group page
+    And I visit the "Properties" tab
+    Then I should see the text "color size"

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/variant-group/tab/properties/general.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/variant-group/tab/properties/general.html
@@ -35,7 +35,7 @@
             </div>
             <div class="AknFieldContainer-inputContainer">
                 <select id="pim_enrich_variant_group_form_axis" readonly="readonly" disabled="disabled" class="select2 input-large" multiple>
-                    <% _.each(model.axis, function (axis) { %>
+                    <% _.each(model.axes, function (axis) { %>
                         <option selected><%- axis %></option>
                     <% }) %>
                 </select>


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

There was a typo in the "axes" attribute of a variant group.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | OK
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
