### PR TITLE
PIM-5962: add clean product template command

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Command/CleanProductTemplateCommand.php
+++ b/src/Pim/Bundle/CatalogBundle/Command/CleanProductTemplateCommand.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\Command;
+
+use Pim\Component\Catalog\AttributeTypes;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Clean product templates after attribute/locale/scope/currency deletion
+ *
+ * @author    Julien Sanchez <julien@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ */
+class CleanProductTemplateCommand extends ContainerAwareCommand
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('pim:product-template:clean-values')
+            ->setDescription('Clean removed elements from product templates');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $productTemplateRepository = $this->getContainer()->get('pim_catalog.repository.product_template');
+        $attributeRepository = $this->getContainer()->get('pim_catalog.repository.attribute');
+        $objectManager = $this->getContainer()->get('doctrine.orm.entity_manager');
+        $serializer = $this->getContainer()->get('pim_serializer');
+        $localeCodes = $this->getContainer()->get('pim_catalog.repository.locale')->getActivatedLocaleCodes();
+        $channels = $this->getContainer()->get('pim_catalog.repository.channel')->getFullChannels();
+        $channelCodes = $this->getContainer()->get('pim_catalog.repository.channel')->getChannelCodes();
+        $currencies = $this->getContainer()->get('pim_catalog.repository.currency')->getActivatedCurrencyCodes();
+        $objectDetacher = $this->getContainer()->get('akeneo_storage_utils.doctrine.object_detacher');
+
+        $output->writeln('<info>Start of the cleaning process<info>');
+        $productTemplates = $productTemplateRepository->findAll();
+
+        $channelLocales = [];
+        foreach ($channels as $channel) {
+            $channelLocales[$channel->getCode()] = $channel->getLocaleCodes();
+        }
+
+        var_dump($channelLocales);
+
+        $processedTemplates = [];
+        foreach ($productTemplates as $productTemplate) {
+            $cleanData = [];
+            foreach ($productTemplate->getValuesData() as $attributeCode => $values) {
+                $attribute = $attributeRepository->findOneByIdentifier($attributeCode);
+                if ($attribute->isLocaleSpecific()) {
+                    $values = array_filter($values, function ($value) use ($attribute) {
+                        return in_array($value['locale'], $attribute->getLocaleSpecificCodes());
+                    });
+                }
+
+                if ($attribute->isScopable()) {
+                    $values = array_filter($values, function ($value) use ($channelCodes) {
+                        return in_array($value['scope'], $channelCodes);
+                    });
+                }
+
+                if ($attribute->isLocalizable()) {
+                    $values = array_filter($values, function ($value) use ($localeCodes, $channelLocales, $attribute) {
+                        $valueLocales = $attribute->isScopable() ? $channelLocales[$value['scope']] : $localeCodes;
+                        return in_array($value['locale'], $valueLocales);
+                    });
+                }
+
+                if (AttributeTypes::PRICE_COLLECTION === $attribute->getAttributeType()) {
+                    $values = array_map(function ($value) use ($currencies) {
+                        $value['data'] = array_filter($value['data'], function ($data) use ($currencies) {
+                            return in_array($data['currency'], $currencies);
+                        });
+
+                        return $value;
+                    }, $values);
+                }
+
+                $cleanData[$attributeCode] = $values;
+            }
+
+            $productTemplate->setValuesData($cleanData);
+            $objectManager->persist($productTemplate);
+
+            $processedTemplates[] = $productTemplate;
+            if (0 === (count($processedTemplates) % 100)) {
+                $objectManager->flush();
+                $objectDetacher->detachAll($processedTemplates);
+                $processedTemplates = [];
+            }
+        }
+
+        $objectManager->flush();
+        $output->writeln('<info>Locale specific data well cleaned<info>');
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Command/CleanProductTemplateCommand.php
+++ b/src/Pim/Bundle/CatalogBundle/Command/CleanProductTemplateCommand.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  * Clean product templates after attribute/locale/scope/currency deletion
  *
  * @author    Julien Sanchez <julien@akeneo.com>
- * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  */
 class CleanProductTemplateCommand extends ContainerAwareCommand
 {
@@ -31,7 +31,7 @@ class CleanProductTemplateCommand extends ContainerAwareCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $productTemplateRepository = $this->getContainer()->get('pim_catalog.repository.product_template');
-        $attributeRepository = $this->getContainer()->get('pim_catalog.repository.attribute');
+        $attributeRepository = $this->getContainer()->get('pim_catalog.repository.cached_attribute');
         $objectManager = $this->getContainer()->get('doctrine.orm.entity_manager');
         $serializer = $this->getContainer()->get('pim_serializer');
         $localeCodes = $this->getContainer()->get('pim_catalog.repository.locale')->getActivatedLocaleCodes();
@@ -47,8 +47,6 @@ class CleanProductTemplateCommand extends ContainerAwareCommand
         foreach ($channels as $channel) {
             $channelLocales[$channel->getCode()] = $channel->getLocaleCodes();
         }
-
-        var_dump($channelLocales);
 
         $processedTemplates = [];
         foreach ($productTemplates as $productTemplate) {
@@ -99,6 +97,6 @@ class CleanProductTemplateCommand extends ContainerAwareCommand
         }
 
         $objectManager->flush();
-        $output->writeln('<info>Locale specific data well cleaned<info>');
+        $output->writeln('<info>Product templates well cleaned<info>');
     }
 }

--- a/src/Pim/Bundle/EnrichBundle/Controller/JobTrackerController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/JobTrackerController.php
@@ -125,7 +125,7 @@ class JobTrackerController extends Controller
             throw new NotFoundHttpException('Akeneo\Component\Batch\Model\JobExecution entity not found');
         }
 
-        if (!$this->isGranted($jobExecution)) {
+        if (!$this->isJobGranted($jobExecution)) {
             throw new AccessDeniedException();
         }
 
@@ -184,7 +184,7 @@ class JobTrackerController extends Controller
             throw new NotFoundHttpException('Akeneo\Component\Batch\Model\JobExecution entity not found');
         }
 
-        if (!$this->isGranted($jobExecution)) {
+        if (!$this->isJobGranted($jobExecution)) {
             throw new AccessDeniedException();
         }
 
@@ -213,7 +213,7 @@ class JobTrackerController extends Controller
             throw new NotFoundHttpException('Akeneo\Component\Batch\Model\JobExecution entity not found');
         }
 
-        if (!$this->isGranted($jobExecution)) {
+        if (!$this->isJobGranted($jobExecution)) {
             throw new AccessDeniedException();
         }
 
@@ -245,7 +245,7 @@ class JobTrackerController extends Controller
      *
      * @return bool
      */
-    protected function isGranted($jobExecution)
+    protected function isJobGranted($jobExecution)
     {
         if ((null === $this->securityFacade) || (null === $this->jobSecurityMapping)) {
             return true;

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/channel/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/channel/edit.yml
@@ -33,7 +33,7 @@ extensions:
         parent: pim-channel-edit-form
         targetZone: buttons
         aclResourceId: pim_enrich_channel_remove
-        position: 100
+        position: 90
         config:
             trans:
                 title: confirmation.remove.channel

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/manager/attribute-manager.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/manager/attribute-manager.js
@@ -179,17 +179,18 @@ define([
              * @return {Array}
              */
             generateMissingPrices: function (prices, currencies) {
-                prices = prices || [];
+                var generatedPrices = [];
                 _.each(currencies, function (currency) {
                     var price = _.findWhere(prices, { currency: currency.code });
 
                     if (!price) {
                         price = { amount: null, currency: currency.code };
-                        prices.push(price);
                     }
+
+                    generatedPrices.push(price);
                 });
 
-                return _.sortBy(prices, 'currency');
+                return _.sortBy(generatedPrices, 'currency');
             },
 
             /**


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

Using the PIM, there is some situations where you can have broken product templates. For example, if you created a localizable attribute, add it to a variant group then removed it to create a new one with the same code but not localizable this time. This can result into a situation where then product cannot be updated nor imported as the product template cannot be applied.

In this PR I add a command to clean product templates. This is clearly a maintenance situation and should not be used on a daily basis.

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
