### PR TITLE
PIM-6283: Correctly reset state of pageable-collection when switching grids

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -8,6 +8,7 @@
 - PIM-6240: Display the code instead of undefined if channel's locale is not filled for the given locale
 - PIM-6071: Hide add option icon for non-editable fields
 - PIM-6275: Fix variations not visible on Variant Group properties tab
+- PIM-6283: Fix a bug where SKUs of products in the Variant Group edit page were not displayed
 
 # 1.7.1 (2017-03-23)
 

--- a/features/enrich/variant-group/edit_variant_browse_products.feature
+++ b/features/enrich/variant-group/edit_variant_browse_products.feature
@@ -56,3 +56,20 @@ Feature: Edit a variant group adding/removing products
     And I should not see products MUG_A1, MUG_A3, MUG_A4, MUG_B1, MUG_B2, MUG_C1, MUG_C3, MUG_C4, MUG_D1 and MUG_D2
     And the rows "MUG_A2, MUG_C2 and POSTIT" should not be checked
     And I should see the columns In group, SKU, Color, Size, Label, Family, Status, Complete, Created at and Updated at
+
+  @jira https://akeneo.atlassian.net/browse/PIM-6283
+  Scenario: Successfully display SKUs of products
+    And I am on the variant groups page
+    And I click on the "MUG" row
+    Then the row "MUG_B1" should contain:
+      | column | value  |
+      | SKU    | MUG_B1 |
+    And the row "MUG_B2" should contain:
+      | column | value  |
+      | SKU    | MUG_B2 |
+    And the row "MUG_D1" should contain:
+      | column | value  |
+      | SKU    | MUG_D1 |
+    And the row "MUG_D2" should contain:
+      | column | value  |
+      | SKU    | MUG_D2 |

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/pageable-collection.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/pageable-collection.js
@@ -79,6 +79,8 @@ function(_, Backbone, BackbonePageableCollection, app) {
          * @param options
          */
         initialize: function(models, options) {
+            this.state = {};
+
             options = options || {};
             if (options.state) {
                 if (options.state.sorters) {


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When we instanciate a datagrid, we instanciate a new PageableCollection.
It's done [HERE](https://github.com/akeneo/pim-community-dev/blob/1.7/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid-builder.js#L105) in the `datagrid-builder.js`:
```js
collection = new PageableCollection(this.$el.data('data'), options);
```

The problem is that **a reference to the old `this` of existing `PageableCollection` was kept**, so the state, columns etc... 

When we call `new PageableCollection`, backbone calls `initialize` (see [HERE](https://github.com/akeneo/pim-community-dev/blob/1.7/src/Pim/Bundle/UIBundle/Resources/public/lib/backbone/backbone.js#L561)), that **we must** override to initialize our own stuff, aka **our state of the collection**.

_PS: It should fix several side effects we never spotted when we jump from grid to grid 💃_ 

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | OK
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
