### PR TITLE
PIM-6274: Successfully validate products with a custom validation on …

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -9,6 +9,7 @@
 - PIM-6071: Hide add option icon for non-editable fields
 - PIM-6275: Fix variations not visible on Variant Group properties tab
 - PIM-6283: Fix a bug where SKUs of products in the Variant Group edit page were not displayed
+- PIM-6274: Successfully validate products with a custom validation on identifier
 
 # 1.7.1 (2017-03-23)
 

--- a/features/mass-action/edit_common_attributes.feature
+++ b/features/mass-action/edit_common_attributes.feature
@@ -264,3 +264,19 @@ Feature: Edit common attributes of many products at once
     When I choose the "Edit common attributes" operation
     Then I should see the text "[tablet]"
     And I should not see the text "undefined"
+
+  @jira https://akeneo.atlassian.net/browse/PIM-6274
+  Scenario: Successfully validate products with a custom validation on identifier
+    Given I am on the "SKU" attribute page
+    When I fill in the following information:
+      | Validation rule   | Regular expression |
+      | Validation regexp | /^\d+$/            |
+    And I press the "Save" button
+    And I should not see the text "There are unsaved changes."
+    And I am on the products page
+    Given I select rows boots, sandals and sneakers
+    When I press "Change product information" on the "Bulk Actions" dropdown button
+    And I choose the "Edit common attributes" operation
+    And I display the Name attribute
+    And I move on to the next step
+    Then I should not see the text "There are errors in the attributes form"

--- a/src/Pim/Bundle/EnrichBundle/MassEditAction/Operation/EditCommonAttributes.php
+++ b/src/Pim/Bundle/EnrichBundle/MassEditAction/Operation/EditCommonAttributes.php
@@ -11,6 +11,7 @@ use Pim\Component\Catalog\Localization\Localizer\LocalizerRegistryInterface;
 use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
 use Pim\Component\Enrich\Converter\ConverterInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
 use Symfony\Component\Validator\Constraints\IsTrue;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
@@ -229,6 +230,9 @@ class EditCommonAttributes extends AbstractMassEditOperation
         $product = $this->productBuilder->createProduct('FAKE_SKU_FOR_MASS_EDIT_VALIDATION_' . microtime());
         $this->productUpdater->update($product, ['values' => $data]);
         $violations = $this->productValidator->validate($product);
+
+        $violations = $this->removeIdentifierViolations($violations);
+
         $violations->addAll($this->localizedConverter->getViolations());
 
         $errors = ['values' => $this->internalNormalizer->normalize(
@@ -331,5 +335,24 @@ class EditCommonAttributes extends AbstractMassEditOperation
         }
 
         return $data;
+    }
+
+    /**
+     * Remove all violations related to identifier
+     *
+     * @param ConstraintViolationListInterface $violations
+     *
+     * @return ConstraintViolationListInterface
+     */
+    protected function removeIdentifierViolations(ConstraintViolationListInterface $violations)
+    {
+        $identifierPath = sprintf('values[%s]', $this->attributeRepository->getIdentifierCode());
+        foreach ($violations as $offset => $violation) {
+            if (0 === strpos($violation->getPropertyPath(), $identifierPath)) {
+                $violations->remove($offset);
+            }
+        }
+
+        return $violations;
     }
 }


### PR DESCRIPTION
…identifier

[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

This PR remove validation problem that occures when you try to launch a mass edit with a regex validation on the identifier. The problem that to validate the mass edit operation, we create a product with a fake identifier that doesn't pass the regex validation. 

With this pull request, we remove all validation linked to identifier.

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | NA
| Added Behats                      | OK
| Added integration tests           | NA
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
