### PR TITLE
PIM-6285: The header Accept must be ignored in API for writing

### DIFF
--- a/src/Pim/Bundle/ApiBundle/DependencyInjection/Compiler/ContentTypeNegotiatorPass.php
+++ b/src/Pim/Bundle/ApiBundle/DependencyInjection/Compiler/ContentTypeNegotiatorPass.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Pim\Bundle\ApiBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\DefinitionDecorator;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Compiler pass to add rules to the content type negotiator.
+ *
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ContentTypeNegotiatorPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('pim_api.negotiator.content_type_negotiator')) {
+            return;
+        }
+
+        $configuration = $container->getParameter('pim_api.configuration');
+        $rules = $configuration['content_type_negotiator']['rules'];
+        foreach ($rules as $rule) {
+            $this->addRule($rule, $container);
+        }
+    }
+
+    private function addRule(array $rule, ContainerBuilder $container)
+    {
+        $matcher = $this->createRequestMatcher(
+            $container,
+            $rule['path'],
+            $rule['host'],
+            $rule['methods']
+        );
+
+        $container->getDefinition('pim_api.negotiator.content_type_negotiator')
+            ->addMethodCall('add', ['matcher' => $matcher, 'rule' => $rule]);
+    }
+
+    private function createRequestMatcher(ContainerBuilder $container, $path = null, $host = null, $methods = null)
+    {
+        $arguments = [$path, $host, $methods];
+        $serialized = serialize($arguments);
+        $id = 'pim_api.content_type_negotiator.request_matcher.'.md5($serialized).sha1($serialized);
+
+        if (!$container->hasDefinition($id)) {
+            $container
+                ->setDefinition($id, new DefinitionDecorator('fos_rest.format_request_matcher'))
+                ->setArguments($arguments);
+        }
+
+        return new Reference($id);
+    }
+}

--- a/src/Pim/Bundle/ApiBundle/DependencyInjection/Configuration.php
+++ b/src/Pim/Bundle/ApiBundle/DependencyInjection/Configuration.php
@@ -39,6 +39,23 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('max_resources_number')->end()
                     ->end()
                 ->end()
+                ->arrayNode('content_type_negotiator')
+                    ->children()
+                        ->arrayNode('rules')
+                            ->prototype('array')
+                                ->children()
+                                    ->scalarNode('path')->defaultNull()->info('URL path info')->end()
+                                    ->scalarNode('host')->defaultNull()->info('URL host name')->end()
+                                    ->variableNode('methods')->defaultNull()->info('Method for URL')->end()
+                                    ->booleanNode('stop')->defaultFalse()->end()
+                                    ->arrayNode('content_types')
+                                        ->prototype('scalar')->end()
+                                    ->end()
+                                ->end()
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
             ->end();
 
         return $treeBuilder;

--- a/src/Pim/Bundle/ApiBundle/DependencyInjection/PimApiExtension.php
+++ b/src/Pim/Bundle/ApiBundle/DependencyInjection/PimApiExtension.php
@@ -30,6 +30,7 @@ class PimApiExtension extends Extension
         $loader->load('event_subscribers.yml');
         $loader->load('hateoas.yml');
         $loader->load('normalizers.yml');
+        $loader->load('negotiators.yml');
         $loader->load('repositories.yml');
         $loader->load('security.yml');
         $loader->load('serializers.yml');

--- a/src/Pim/Bundle/ApiBundle/Negotiator/ContentTypeNegotiator.php
+++ b/src/Pim/Bundle/ApiBundle/Negotiator/ContentTypeNegotiator.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Pim\Bundle\ApiBundle\Negotiator;
+
+use FOS\RestBundle\Util\StopFormatListenerException;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+
+/**
+ * Content type negotiator to get the allowed content types for a given request,
+ * thanks to symfony request matcher.
+ *
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ContentTypeNegotiator implements ContentTypeNegotiatorInterface
+{
+    /** @var array */
+    protected $map = [];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getContentTypes(Request $request)
+    {
+        foreach ($this->map as $elements) {
+            if (!$elements['request_matcher']->matches($request)) {
+                continue;
+            }
+
+            $rule = $elements['rule'];
+
+            if (!empty($rule['stop'])) {
+                throw new StopFormatListenerException('Stopped content type negotiator');
+            }
+
+            return $rule['content_types'];
+        }
+    }
+
+    /**
+     * Add a request matcher and the associated rule.
+     *
+     * @param RequestMatcherInterface $requestMatcher
+     * @param array                   $rule
+     */
+    public function add(RequestMatcherInterface $requestMatcher, array $rule)
+    {
+        $this->map[] = ['request_matcher' => $requestMatcher, 'rule' => $rule];
+    }
+}

--- a/src/Pim/Bundle/ApiBundle/Negotiator/ContentTypeNegotiatorInterface.php
+++ b/src/Pim/Bundle/ApiBundle/Negotiator/ContentTypeNegotiatorInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Pim\Bundle\ApiBundle\Negotiator;
+
+use FOS\RestBundle\Util\StopFormatListenerException;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Content type negotiator aims to get the allowed content types for a given request.
+ *
+ * FosRestBundle allows to provide the best accept type given a request.
+ * The goal of this interface is to do the same thing for the content types.
+ *
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface ContentTypeNegotiatorInterface
+{
+    /**
+     * Returns the content types allowed for a given request.
+     *
+     * @param Request $request
+     *
+     * @throws StopFormatListenerException
+     *
+     * @return string[] array of content types
+     */
+    public function getContentTypes(Request $request);
+}

--- a/src/Pim/Bundle/ApiBundle/PimApiBundle.php
+++ b/src/Pim/Bundle/ApiBundle/PimApiBundle.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Bundle\ApiBundle;
 
+use Pim\Bundle\ApiBundle\DependencyInjection\Compiler\ContentTypeNegotiatorPass;
 use Pim\Bundle\CatalogBundle\DependencyInjection\Compiler\RegisterSerializerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -15,6 +16,7 @@ class PimApiBundle extends Bundle
     {
         $container
             ->addCompilerPass(new RegisterSerializerPass('pim_external_api_exception_serializer'))
+            ->addCompilerPass(new ContentTypeNegotiatorPass())
         ;
     }
 }

--- a/src/Pim/Bundle/ApiBundle/Resources/config/api.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/api.yml
@@ -5,3 +5,9 @@ pim_api:
     input:
         buffer_size: '%api_input_buffer_size%'
         max_resources_number: '%api_input_max_resources_number%'
+    content_type_negotiator:
+        rules:
+            - { path: '^/api/rest/v\d+/media-files', methods: ['POST'], content_types:['multipart/form-data']}
+            - { path: '^/api/rest/v\d+/(products|families|categories|attributes)$', methods: ['PATCH'], content_types:['application/vnd.akeneo.collection+json'] }
+            - { path: '^/api', content_types:['application/json'] }
+            - { path: '', stop: true }

--- a/src/Pim/Bundle/ApiBundle/Resources/config/event_subscribers.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/event_subscribers.yml
@@ -6,5 +6,6 @@ services:
         class: '%pim_api.event_subscriber.check_headers_request.class%'
         arguments:
             - '@fos_rest.format_negotiator'
+            - '@pim_api.negotiator.content_type_negotiator'
         tags:
             - { name: kernel.event_subscriber, event: kernel.request, method: onKernelRequest }

--- a/src/Pim/Bundle/ApiBundle/Resources/config/negotiators.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/negotiators.yml
@@ -1,0 +1,6 @@
+parameters:
+    pim_api.negotiator.content_type_negotiator.class: Pim\Bundle\ApiBundle\Negotiator\ContentTypeNegotiator
+
+services:
+    pim_api.negotiator.content_type_negotiator:
+        class: '%pim_api.negotiator.content_type_negotiator.class%'


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

When you create a media with the API, the header “Accept” should be silently ignored because it’s useless. 

Only the header Content-type should be set with 'multipart/form-data'.
But internally, this "Accept" header should be set to guess the content-type... and it should not.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | Todo
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
