### PR TITLE
Fix js translations for Crowdin

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
@@ -113,8 +113,8 @@ pim_enrich:
             delete.label: Delete
             delete.error: Error during item deletion
         delete:
-            confirm.content: "Are you sure you want to delete this {{ itemName }}? It is not possible to undo this action"
-            confirm.title: "Delete this {{ itemName }}"
+            confirm.content: Are you sure you want to delete this {{ itemName }}? It is not possible to undo this action
+            confirm.title: Delete this {{ itemName }}
 
     navigation:
         link:
@@ -169,7 +169,7 @@ pim_enrich:
                 groups:
                     title: Groups
                     modal:
-                        title: "Group {{ group }}"
+                        title: Group {{ group }}
                         view_group: View group
                         group_label: Label
                         more_products: '{{ count }} more products...'
@@ -198,7 +198,7 @@ pim_enrich:
             label: Label
     confirmation:
         leave:           Are you sure you want to leave this page?
-        discard_changes: "You will lose changes to the {{ entity }} if you leave the page."
+        discard_changes: You will lose changes to the {{ entity }} if you leave the page.
         delete_item:     Confirm deletion
         delete:
             product_attribute: Are you sure you want to delete this attribute from the product?
@@ -249,8 +249,8 @@ pim_enrich:
             sequential_edit:
                 info:
                     products: products
-                    previous: "Skip back to {{ product }} without saving."
-                    next: "Skip to {{ product }} without saving."
+                    previous: Skip back to {{ product }} without saving.
+                    next: Skip to {{ product }} without saving.
                 btn:
                     save_and_next: Save and next
                     save_and_finish: Save and finish
@@ -283,4 +283,4 @@ pim_enrich:
             description: The selected product's attributes will be edited with the following data for the locale <span class="highlight">{{ locale }}</span> and the channel <span class="highlight">{{ channel }}</span>, chosen in the products grid.
 
 pim_enrich.error:
-    exception.title: "Oh snap! A {{ status_code }} error occured..."
+    exception.title: Oh snap! A {{ status_code }} error occured...

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
@@ -113,8 +113,8 @@ pim_enrich:
             delete.label: Delete
             delete.error: Error during item deletion
         delete:
-            confirm.content: Are you sure you want to delete this {{ itemName }}? It is not possible to undo this action
-            confirm.title: Delete this {{ itemName }}
+            confirm.content: "Are you sure you want to delete this {{ itemName }}? It is not possible to undo this action"
+            confirm.title: "Delete this {{ itemName }}"
 
     navigation:
         link:
@@ -154,7 +154,7 @@ pim_enrich:
                 deletion_failed: The product could not be deleted.
                 update_successful: Product successfully updated.
                 update_failed: The product could not be updated.
-                field_not_ready: The product cannot be saved right now. The following fields are not ready: {{ fields }}
+                field_not_ready: "The product cannot be saved right now. The following fields are not ready: {{ fields }}"
                 already_in_upload: A file is already in upload for this attribute in the locale "{{ locale }}" and scope "{{ scope }}"
             error:
                 upload: An error occured during the file upload
@@ -169,7 +169,7 @@ pim_enrich:
                 groups:
                     title: Groups
                     modal:
-                        title: Group {{ group }}
+                        title: "Group {{ group }}"
                         view_group: View group
                         group_label: Label
                         more_products: '{{ count }} more products...'
@@ -198,7 +198,7 @@ pim_enrich:
             label: Label
     confirmation:
         leave:           Are you sure you want to leave this page?
-        discard_changes: You will lose changes to the {{ entity }} if you leave the page.
+        discard_changes: "You will lose changes to the {{ entity }} if you leave the page."
         delete_item:     Confirm deletion
         delete:
             product_attribute: Are you sure you want to delete this attribute from the product?
@@ -249,8 +249,8 @@ pim_enrich:
             sequential_edit:
                 info:
                     products: products
-                    previous: Skip back to {{ product }} without saving.
-                    next: Skip to {{ product }} without saving.
+                    previous: "Skip back to {{ product }} without saving."
+                    next: "Skip to {{ product }} without saving."
                 btn:
                     save_and_next: Save and next
                     save_and_finish: Save and finish
@@ -283,4 +283,4 @@ pim_enrich:
             description: The selected product's attributes will be edited with the following data for the locale <span class="highlight">{{ locale }}</span> and the channel <span class="highlight">{{ channel }}</span>, chosen in the products grid.
 
 pim_enrich.error:
-    exception.title: Oh snap! A {{ status_code }} error occured...
+    exception.title: "Oh snap! A {{ status_code }} error occured..."


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

[//]: <> (What does this Pull Request do? reference the related issue?)

This PR fixes translations that are parsed incorrectly for Crowdin. 

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
