### PR TITLE
PIM-6284: Scopable information are not displayed anymore nearby scopable fields

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -18,6 +18,7 @@
 - PIM-6274: Successfully validate products with a custom validation on identifier
 - PIM-6199: Fix product mass edit attribute add select clickable on confirmation page
 - PIM-6282: Fix attribute menu Firefox bug
+- PIM-6284: Fix display of scopable information for fields
 
 ## BC breaks
 

--- a/features/Context/WebUser.php
+++ b/features/Context/WebUser.php
@@ -746,6 +746,32 @@ class WebUser extends RawMinkContext
     }
 
     /**
+     * @param string $label
+     * @param string $scope
+     *
+     * @Then /^the field ([^"]*) should display the ([^"]*) scope label$/
+     *
+     * @throws \LogicException
+     * @throws ExpectationException
+     */
+    public function theFieldShouldDisplayTheScopeLabel($label, $scope)
+    {
+        $fieldContainer = $this->getCurrentPage()->findFieldContainer($label);
+        $scopeLabel = $fieldContainer->find('css', '.field-scope')->getText();
+
+        if ($scopeLabel !== $scope) {
+            throw $this->createExpectationException(
+                sprintf(
+                    'Scope label %s is not displayed for %s. %s is displayed instead.',
+                    $scope,
+                    $label,
+                    $scopeLabel
+                )
+            );
+        }
+    }
+
+    /**
      * @param string $field
      * @param string $scope
      * @param string $value
@@ -973,7 +999,7 @@ class WebUser extends RawMinkContext
             }
         }
     }
-    
+
     /**
      * @param string $attributes
      *

--- a/features/Context/WebUser.php
+++ b/features/Context/WebUser.php
@@ -1000,7 +1000,6 @@ class WebUser extends RawMinkContext
         }
     }
 
-
     /**
      * @param string $attributes
      *

--- a/features/Context/WebUser.php
+++ b/features/Context/WebUser.php
@@ -1000,6 +1000,7 @@ class WebUser extends RawMinkContext
         }
     }
 
+
     /**
      * @param string $attributes
      *

--- a/features/product/edit_product_with_localizable_and_scopable_attribute_options.feature
+++ b/features/product/edit_product_with_localizable_and_scopable_attribute_options.feature
@@ -33,10 +33,12 @@ Feature: Edit a product with localizable and scopable attribute options
   Scenario: I should not lost data when switching scope on scopable and localizable simple select
     Given I edit the "rick_morty" product
     And I add available attribute Simple
+    Then the field Simple should display the Print scope label
     And I change the Simple to "US1"
     When I save the product
     Then I should see the flash message "Product successfully updated"
     Given I switch the scope to "ecommerce"
+    Then the field Simple should display the Ecommerce scope label
     And I change the Simple to "US2"
     And I switch the scope to "print"
     When I switch the scope to "ecommerce"

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes.js
@@ -23,7 +23,8 @@ define(
         'pim/security-context',
         'text!pim/template/form/tab/attributes',
         'pim/dialog',
-        'oro/messenger'
+        'oro/messenger',
+        'pim/i18n'
     ],
     function (
         $,
@@ -40,7 +41,8 @@ define(
         SecurityContext,
         formTemplate,
         Dialog,
-        messenger
+        messenger,
+        i18n
     ) {
         return BaseForm.extend({
             template: _.template(formTemplate),
@@ -166,12 +168,13 @@ define(
                     );
                 }).then(function (field, channels, isOptional) {
                     var scope = _.findWhere(channels, { code: UserContext.get('catalogScope') });
+                    var uiLocale = UserContext.get('uiLocale');
 
                     field.setContext({
                         locale: UserContext.get('catalogLocale'),
                         scope: scope.code,
-                        scopeLabel: scope.labels,
-                        uiLocale: UserContext.get('uiLocale'),
+                        scopeLabel: i18n.getLabel(scope.labels, uiLocale, scope.code),
+                        uiLocale: uiLocale,
                         optional: isOptional,
                         removable: SecurityContext.isGranted(this.config.removeAttributeACL)
                     });

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes.js
@@ -174,7 +174,7 @@ define(
                         locale: UserContext.get('catalogLocale'),
                         scope: scope.code,
                         scopeLabel: i18n.getLabel(scope.labels, uiLocale, scope.code),
-                        uiLocale: uiLocale,
+                        uiLocale: UserContext.get('catalogLocale'),
                         optional: isOptional,
                         removable: SecurityContext.isGranted(this.config.removeAttributeACL)
                     });

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes.js
@@ -170,7 +170,7 @@ define(
                     field.setContext({
                         locale: UserContext.get('catalogLocale'),
                         scope: scope.code,
-                        scopeLabel: scope.label,
+                        scopeLabel: scope.labels,
                         uiLocale: UserContext.get('catalogLocale'),
                         optional: isOptional,
                         removable: SecurityContext.isGranted(this.config.removeAttributeACL)

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes.js
@@ -171,7 +171,7 @@ define(
                         locale: UserContext.get('catalogLocale'),
                         scope: scope.code,
                         scopeLabel: scope.labels,
-                        uiLocale: UserContext.get('catalogLocale'),
+                        uiLocale: UserContext.get('uiLocale'),
                         optional: isOptional,
                         removable: SecurityContext.isGranted(this.config.removeAttributeACL)
                     });

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes/copy.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes/copy.js
@@ -130,6 +130,7 @@ define(
 
                     copyField.setContext({
                         locale: this.locale,
+                        uiLocale:  UserContext.get('uiLocale'),
                         scope: this.scope,
                         scopeLabel: this.scopeLabel
                     });

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes/copy.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes/copy.js
@@ -19,7 +19,8 @@ define(
         'pim/field-manager',
         'pim/attribute-manager',
         'pim/user-context',
-        'pim/fetcher-registry'
+        'pim/fetcher-registry',
+        'pim/i18n'
     ],
     function (
         $,
@@ -31,7 +32,8 @@ define(
         FieldManager,
         AttributeManager,
         UserContext,
-        FetcherRegistry
+        FetcherRegistry,
+        i18n
     ) {
         return BaseForm.extend({
             template: _.template(template),
@@ -127,12 +129,12 @@ define(
                 if (!_.has(this.copyFields, code)) {
                     var sourceData = this.getSourceData();
                     var copyField = new CopyField(field.attribute);
+                    var uiLocale = UserContext.get('uiLocale');
 
                     copyField.setContext({
                         locale: this.locale,
-                        uiLocale:  UserContext.get('uiLocale'),
                         scope: this.scope,
-                        scopeLabel: this.scopeLabel
+                        scopeLabel: i18n.getLabel(this.scopeLabel, uiLocale, this.scope)
                     });
                     copyField.setValues(sourceData[code]);
                     copyField.setField(field);

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes/copy.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes/copy.js
@@ -331,8 +331,7 @@ define(
             getScopeLabel: function (scopeCode) {
                 return FetcherRegistry.getFetcher('channel').fetchAll().then(function (channels) {
                     var scope = _.findWhere(channels, { code: scopeCode });
-
-                    return scope.label;
+                    return scope.labels;
                 });
             }
         });

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/form/tab/attributes/copy-field.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/form/tab/attributes/copy-field.html
@@ -6,7 +6,7 @@
             <span class="AknFieldContainer-fieldInfo field-info">
                 <% if (attribute.localizable || attribute.scopable) { %>
                     <span class="field-context">
-                        <% if (attribute.scopable) { %> <span><%- context.scopeLabel %></span> <% } %>
+                        <% if (attribute.scopable) { %> <span class="field-context-scope"><%- i18n.getLabel(context.scopeLabel, context.locale, context.scope) %></span> <% } %>
                         <% if (attribute.localizable) { %> <span><%= i18n.getFlag(context.locale) %></span> <% } %>
                     </span>
                 <% } %>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/form/tab/attributes/copy-field.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/form/tab/attributes/copy-field.html
@@ -6,7 +6,7 @@
             <span class="AknFieldContainer-fieldInfo field-info">
                 <% if (attribute.localizable || attribute.scopable) { %>
                     <span class="field-context">
-                        <% if (attribute.scopable) { %> <span><%- i18n.getLabel(context.scopeLabel, context.locale, context.scope) %></span> <% } %>
+                        <% if (attribute.scopable) { %> <span><%- i18n.getLabel(context.scopeLabel, context.uiLocale, context.scope) %></span> <% } %>
                         <% if (attribute.localizable) { %> <span><%= i18n.getFlag(context.locale) %></span> <% } %>
                     </span>
                 <% } %>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/form/tab/attributes/copy-field.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/form/tab/attributes/copy-field.html
@@ -6,7 +6,7 @@
             <span class="AknFieldContainer-fieldInfo field-info">
                 <% if (attribute.localizable || attribute.scopable) { %>
                     <span class="field-context">
-                        <% if (attribute.scopable) { %> <span class="field-context-scope"><%- i18n.getLabel(context.scopeLabel, context.locale, context.scope) %></span> <% } %>
+                        <% if (attribute.scopable) { %> <span><%- i18n.getLabel(context.scopeLabel, context.locale, context.scope) %></span> <% } %>
                         <% if (attribute.localizable) { %> <span><%= i18n.getFlag(context.locale) %></span> <% } %>
                     </span>
                 <% } %>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/form/tab/attributes/copy-field.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/form/tab/attributes/copy-field.html
@@ -6,7 +6,7 @@
             <span class="AknFieldContainer-fieldInfo field-info">
                 <% if (attribute.localizable || attribute.scopable) { %>
                     <span class="field-context">
-                        <% if (attribute.scopable) { %> <span><%- i18n.getLabel(context.scopeLabel, context.uiLocale, context.scope) %></span> <% } %>
+                        <% if (attribute.scopable) { %> <span><%- context.scopeLabel %></span> <% } %>
                         <% if (attribute.localizable) { %> <span><%= i18n.getFlag(context.locale) %></span> <% } %>
                     </span>
                 <% } %>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/field/field.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/field/field.html
@@ -8,7 +8,7 @@
         <span class="AknFieldContainer-fieldInfo field-info">
             <% if (attribute.localizable || attribute.scopable) { %>
                 <span class="field-context">
-                    <% if (attribute.scopable) { %> <span><%- i18n.getLabel(context.scopeLabel, context.uiLocale, context.scope) %></span> <% } %>
+                    <% if (attribute.scopable) { %> <span class="field-scope"><%- i18n.getLabel(context.scopeLabel, context.uiLocale, context.scope) %></span> <% } %>
                     <% if (attribute.localizable) { %> <span><%= i18n.getFlag(context.locale) %></span> <% } %>
                 </span>
             <% } %>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/field/field.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/field/field.html
@@ -8,7 +8,7 @@
         <span class="AknFieldContainer-fieldInfo field-info">
             <% if (attribute.localizable || attribute.scopable) { %>
                 <span class="field-context">
-                    <% if (attribute.scopable) { %> <span class="field-context-scope"><%- i18n.getLabel(context.scopeLabel, context.uiLocale, context.scope) %></span> <% } %>
+                    <% if (attribute.scopable) { %> <span><%- i18n.getLabel(context.scopeLabel, context.uiLocale, context.scope) %></span> <% } %>
                     <% if (attribute.localizable) { %> <span><%= i18n.getFlag(context.locale) %></span> <% } %>
                 </span>
             <% } %>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/field/field.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/field/field.html
@@ -8,7 +8,7 @@
         <span class="AknFieldContainer-fieldInfo field-info">
             <% if (attribute.localizable || attribute.scopable) { %>
                 <span class="field-context">
-                    <% if (attribute.scopable) { %> <span class="field-scope"><%- i18n.getLabel(context.scopeLabel, context.uiLocale, context.scope) %></span> <% } %>
+                    <% if (attribute.scopable) { %> <span class="field-scope"><%- context.scopeLabel %></span> <% } %>
                     <% if (attribute.localizable) { %> <span><%= i18n.getFlag(context.locale) %></span> <% } %>
                 </span>
             <% } %>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/field/field.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/field/field.html
@@ -8,7 +8,7 @@
         <span class="AknFieldContainer-fieldInfo field-info">
             <% if (attribute.localizable || attribute.scopable) { %>
                 <span class="field-context">
-                    <% if (attribute.scopable) { %> <span><%- context.scopeLabel %></span> <% } %>
+                    <% if (attribute.scopable) { %> <span class="field-context-scope"><%- i18n.getLabel(context.scopeLabel, context.uiLocale, context.scope) %></span> <% } %>
                     <% if (attribute.localizable) { %> <span><%= i18n.getFlag(context.locale) %></span> <% } %>
                 </span>
             <% } %>


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

This PR fixes an issue where the scope information for attribute fields (e.g. 'ecommerce, print, mobile' on a description field) was no longer being displayed. 

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | OK
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) |  -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
