### PR TITLE
PIM-6271: Mass edit - attribute group switch unlocks the form

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -20,6 +20,7 @@
 - PIM-6274: Successfully validate products with a custom validation on identifier
 - PIM-6199: Fix product mass edit attribute add select clickable on confirmation page
 - PIM-6282: Fix attribute menu Firefox bug
+- PIM-6284: Fix display of scopable information for fields
 
 ## BC breaks
 

--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -21,6 +21,7 @@
 - PIM-6199: Fix product mass edit attribute add select clickable on confirmation page
 - PIM-6282: Fix attribute menu Firefox bug
 - PIM-6284: Fix display of scopable information for fields
+- PIM-6271: Fix locking fields in mass edit product form
 
 ## BC breaks
 

--- a/features/Context/AssertionContext.php
+++ b/features/Context/AssertionContext.php
@@ -240,7 +240,7 @@ class AssertionContext extends RawMinkContext
             if (!$field) {
                 throw $this->createExpectationException(sprintf('Expecting to see field "%s".', $fieldName));
             }
-            if (!$field->hasAttribute('disabled')) {
+            if (!$field->hasAttribute('disabled') && !$field->hasAttribute('readonly')) {
                 throw $this->createExpectationException(sprintf('Expecting field "%s" to be disabled.', $fieldName));
             }
         }

--- a/features/Context/WebUser.php
+++ b/features/Context/WebUser.php
@@ -746,6 +746,32 @@ class WebUser extends RawMinkContext
     }
 
     /**
+     * @param string $label
+     * @param string $scope
+     *
+     * @Then /^the field ([^"]*) should display the ([^"]*) scope label$/
+     *
+     * @throws \LogicException
+     * @throws ExpectationException
+     */
+    public function theFieldShouldDisplayTheScopeLabel($label, $scope)
+    {
+        $fieldContainer = $this->getCurrentPage()->findFieldContainer($label);
+        $scopeLabel = $fieldContainer->find('css', '.field-scope')->getText();
+
+        if ($scopeLabel !== $scope) {
+            throw $this->createExpectationException(
+                sprintf(
+                    'Scope label %s is not displayed for %s. %s is displayed instead.',
+                    $scope,
+                    $label,
+                    $scopeLabel
+                )
+            );
+        }
+    }
+
+    /**
      * @param string $field
      * @param string $scope
      * @param string $value
@@ -973,7 +999,7 @@ class WebUser extends RawMinkContext
             }
         }
     }
-    
+
     /**
      * @param string $attributes
      *

--- a/features/mass-action/edit_common_attributes.feature
+++ b/features/mass-action/edit_common_attributes.feature
@@ -314,3 +314,16 @@ Feature: Edit common attributes of many products at once
     And I change the "Name" to "boots"
     And I move to the confirm page
     Then The available attributes button should be disabled
+
+  @jira https://akeneo.atlassian.net/browse/PIM-6271
+  Scenario: Successfully keep mass edit form fields disabled after switching groups
+    Given I am on the products page
+    And I select rows boots, sandals and sneakers
+    And I press "Change product information" on the "Bulk Actions" dropdown button
+    When I choose the "Edit common attributes" operation
+    And I display the Price attribute
+    And I display the Name attribute
+    And I move to the confirm page
+    Then the field Name should be disabled
+    When I visit the "Marketing" group
+    Then the field Price should be disabled

--- a/features/product/edit_product_with_localizable_and_scopable_attribute_options.feature
+++ b/features/product/edit_product_with_localizable_and_scopable_attribute_options.feature
@@ -33,10 +33,12 @@ Feature: Edit a product with localizable and scopable attribute options
   Scenario: I should not lost data when switching scope on scopable and localizable simple select
     Given I edit the "rick_morty" product
     And I add available attribute Simple
+    Then the field Simple should display the Print scope label
     And I change the Simple to "US1"
     When I save the product
     Then I should see the flash message "Product successfully updated"
     Given I switch the scope to "ecommerce"
+    Then the field Simple should display the Ecommerce scope label
     And I change the Simple to "US2"
     And I switch the scope to "print"
     When I switch the scope to "ecommerce"

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes.js
@@ -45,7 +45,6 @@ define(
         i18n
     ) {
         return BaseForm.extend({
-            locked: false,
             template: _.template(formTemplate),
             className: 'tabbable tabs-left object-attributes',
             events: {
@@ -70,9 +69,6 @@ define(
                     code: this.code,
                     label: _.__(this.config.tabTitle)
                 });
-
-                mediator.on('mass-edit:form:lock', this.onLock.bind(this));
-                mediator.on('mass-edit:form:unlock', this.onUnlock.bind(this));
 
                 UserContext.off('change:catalogLocale change:catalogScope', this.render);
                 this.listenTo(UserContext, 'change:catalogLocale change:catalogScope', this.render);
@@ -100,14 +96,6 @@ define(
                 }.bind(this));
 
                 return BaseForm.prototype.configure.apply(this, arguments);
-            },
-
-            onLock: function () {
-                this.locked = true;
-            },
-
-            onUnlock: function () {
-                this.locked = false;
             },
 
             /**
@@ -146,13 +134,7 @@ define(
                             $valuesPanel.empty();
 
                             FieldManager.clearVisibleFields();
-                            _.each(fields, function (field) {
-                                if (field.canBeSeen()) {
-                                    field.render(!this.locked);
-                                    FieldManager.addVisibleField(field.attribute.code);
-                                    $valuesPanel.append(field.$el);
-                                }
-                            }.bind(this));
+                            _.each(fields, this.appendField.bind(this, $valuesPanel));
                         }.bind(this));
                     this.delegateEvents();
 
@@ -160,6 +142,21 @@ define(
                 }.bind(this));
 
                 return this;
+            },
+
+            /**
+             * Append a field to the panel
+             *
+             * @param {jQueryElement} panel
+             * @param {Object} field
+             *
+             */
+            appendField: function(panel, field) {
+                if (field.canBeSeen()) {
+                    field.render();
+                    FieldManager.addVisibleField(field.attribute.code);
+                    panel.append(field.$el);
+                }
             },
 
             /**

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes.js
@@ -45,7 +45,7 @@ define(
         i18n
     ) {
         return BaseForm.extend({
-            enabled: true,
+            locked: false,
             template: _.template(formTemplate),
             className: 'tabbable tabs-left object-attributes',
             events: {
@@ -102,20 +102,18 @@ define(
                 return BaseForm.prototype.configure.apply(this, arguments);
             },
 
-            onLock: function() {
-                this.enabled = false;
+            onLock: function () {
+                this.locked = true;
             },
 
-            onUnlock: function() {
-                this.enabled = true;
+            onUnlock: function () {
+                this.locked = false;
             },
 
             /**
              * {@inheritdoc}
              */
             render: function () {
-                var formisEnabled = this.enabled;
-
                 if (!this.configured || this.rendering) {
                     return this;
                 }
@@ -150,9 +148,7 @@ define(
                             FieldManager.clearVisibleFields();
                             _.each(fields, function (field) {
                                 if (field.canBeSeen()) {
-                                    field.setEditable(formisEnabled);
-                                    field.renderEnabled = formisEnabled;
-                                    field.render();
+                                    field.render(!this.locked);
                                     FieldManager.addVisibleField(field.attribute.code);
                                     $valuesPanel.append(field.$el);
                                 }
@@ -185,8 +181,6 @@ define(
                 }).then(function (field, channels, isOptional) {
                     var scope = _.findWhere(channels, { code: UserContext.get('catalogScope') });
                     var uiLocale = UserContext.get('uiLocale');
-
-                    field.editable = false;
 
                     field.setContext({
                         locale: UserContext.get('catalogLocale'),

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes.js
@@ -23,7 +23,8 @@ define(
         'pim/security-context',
         'text!pim/template/form/tab/attributes',
         'pim/dialog',
-        'oro/messenger'
+        'oro/messenger',
+        'pim/i18n'
     ],
     function (
         $,
@@ -40,7 +41,8 @@ define(
         SecurityContext,
         formTemplate,
         Dialog,
-        messenger
+        messenger,
+        i18n
     ) {
         return BaseForm.extend({
             template: _.template(formTemplate),
@@ -166,11 +168,12 @@ define(
                     );
                 }).then(function (field, channels, isOptional) {
                     var scope = _.findWhere(channels, { code: UserContext.get('catalogScope') });
+                    var uiLocale = UserContext.get('uiLocale');
 
                     field.setContext({
                         locale: UserContext.get('catalogLocale'),
                         scope: scope.code,
-                        scopeLabel: scope.label,
+                        scopeLabel: i18n.getLabel(scope.labels, uiLocale, scope.code),
                         uiLocale: UserContext.get('catalogLocale'),
                         optional: isOptional,
                         removable: SecurityContext.isGranted(this.config.removeAttributeACL)

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes.js
@@ -151,7 +151,7 @@ define(
              * @param {Object} field
              *
              */
-            appendField: function(panel, field) {
+            appendField: function (panel, field) {
                 if (field.canBeSeen()) {
                     field.render();
                     FieldManager.addVisibleField(field.attribute.code);

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes.js
@@ -72,7 +72,7 @@ define(
                 });
 
                 mediator.on('mass-edit:form:lock', this.onLock.bind(this));
-                mediator.on('mass-edit:form:unlock', this.onLock.bind(this));
+                mediator.on('mass-edit:form:unlock', this.onUnlock.bind(this));
 
                 UserContext.off('change:catalogLocale change:catalogScope', this.render);
                 this.listenTo(UserContext, 'change:catalogLocale change:catalogScope', this.render);

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes/copy.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes/copy.js
@@ -19,7 +19,8 @@ define(
         'pim/field-manager',
         'pim/attribute-manager',
         'pim/user-context',
-        'pim/fetcher-registry'
+        'pim/fetcher-registry',
+        'pim/i18n'
     ],
     function (
         $,
@@ -31,7 +32,8 @@ define(
         FieldManager,
         AttributeManager,
         UserContext,
-        FetcherRegistry
+        FetcherRegistry,
+        i18n
     ) {
         return BaseForm.extend({
             template: _.template(template),
@@ -127,11 +129,12 @@ define(
                 if (!_.has(this.copyFields, code)) {
                     var sourceData = this.getSourceData();
                     var copyField = new CopyField(field.attribute);
+                    var uiLocale = UserContext.get('uiLocale');
 
                     copyField.setContext({
                         locale: this.locale,
                         scope: this.scope,
-                        scopeLabel: this.scopeLabel
+                        scopeLabel: i18n.getLabel(this.scopeLabel, uiLocale, this.scope)
                     });
                     copyField.setValues(sourceData[code]);
                     copyField.setField(field);
@@ -331,8 +334,7 @@ define(
             getScopeLabel: function (scopeCode) {
                 return FetcherRegistry.getFetcher('channel').fetchAll().then(function (channels) {
                     var scope = _.findWhere(channels, { code: scopeCode });
-
-                    return scope.label;
+                    return scope.labels;
                 });
             }
         });

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/field.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/field.js
@@ -38,6 +38,7 @@ define([
             editable: true,
             ready: true,
             valid: true,
+            locked: false,
 
             /**
              * Initialize this field
@@ -60,12 +61,8 @@ define([
              *
              * @returns {Object}
              */
-            render: function (editable) {
-                if (typeof editable === 'undefined') {
-                    editable = true;
-                }
-
-                this.setEditable(editable);
+            render: function () {
+                this.setEditable(!this.locked);
                 this.setValid(true);
                 this.elements = {};
                 var promises  = [];
@@ -252,6 +249,15 @@ define([
              */
             setEditable: function (editable) {
                 this.editable = editable;
+            },
+
+            /**
+             * Set this field as locked
+             *
+             * @param {boolean} locked
+             */
+            setLocked: function (locked) {
+                this.locked = locked;
             },
 
             /**

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/field.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/field.js
@@ -38,7 +38,6 @@ define([
             editable: true,
             ready: true,
             valid: true,
-            renderEnabled: true,
 
             /**
              * Initialize this field
@@ -61,12 +60,13 @@ define([
              *
              * @returns {Object}
              */
-            render: function () {
-                if (this.renderEnabled) {
-                    this.setEditable(true);
-                    this.setValid(true);
+            render: function (editable) {
+                if (_.isUndefined(editable)) {
+                    editable = true;
                 }
 
+                this.setEditable(editable);
+                this.setValid(true);
                 this.elements = {};
                 var promises  = [];
                 mediator.trigger('pim_enrich:form:field:extension:add', {'field': this, 'promises': promises});

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/field.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/field.js
@@ -38,6 +38,7 @@ define([
             editable: true,
             ready: true,
             valid: true,
+            renderEnabled: true,
 
             /**
              * Initialize this field
@@ -61,8 +62,11 @@ define([
              * @returns {Object}
              */
             render: function () {
-                this.setEditable(true);
-                this.setValid(true);
+                if (this.renderEnabled) {
+                    this.setEditable(true);
+                    this.setValid(true);
+                }
+
                 this.elements = {};
                 var promises  = [];
                 mediator.trigger('pim_enrich:form:field:extension:add', {'field': this, 'promises': promises});
@@ -71,7 +75,6 @@ define([
                     .then(this.getTemplateContext.bind(this))
                     .then(function (templateContext) {
                         this.$el.html(this.template(templateContext));
-
                         this.$('.original-field .field-input').append(this.renderInput(templateContext));
 
                         this.renderElements();

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/field.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/field.js
@@ -61,7 +61,7 @@ define([
              * @returns {Object}
              */
             render: function (editable) {
-                if (_.isUndefined(editable)) {
+                if (typeof editable === 'undefined') {
                     editable = true;
                 }
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/mass-edit/attributes.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/mass-edit/attributes.js
@@ -31,7 +31,7 @@ define(
              *
              * {@inheritdoc}
              */
-            configure: function() {
+            configure: function () {
                 mediator.on('mass-edit:form:lock', this.onLock.bind(this));
                 mediator.on('mass-edit:form:unlock', this.onUnlock.bind(this));
 
@@ -43,7 +43,7 @@ define(
              * @param  {jQueryElement} panel Attribute panel element
              * @param  {Object} field Attribute field
              */
-            appendField: function(panel, field) {
+            appendField: function (panel, field) {
                 if (field.canBeSeen()) {
                     field.render(!this.locked);
                     FieldManager.addVisibleField(field.attribute.code);

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/mass-edit/attributes.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/mass-edit/attributes.js
@@ -45,7 +45,8 @@ define(
              */
             appendField: function (panel, field) {
                 if (field.canBeSeen()) {
-                    field.render(!this.locked);
+                    field.setLocked(this.locked);
+                    field.render();
                     FieldManager.addVisibleField(field.attribute.code);
                     panel.append(field.$el);
                 }

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/mass-edit/attributes.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/mass-edit/attributes.js
@@ -27,6 +27,31 @@ define(
             locked: false,
 
             /**
+             * Listen to mass edit form unlock and lock events
+             *
+             * {@inheritdoc}
+             */
+            configure: function() {
+                mediator.on('mass-edit:form:lock', this.onLock.bind(this));
+                mediator.on('mass-edit:form:unlock', this.onUnlock.bind(this));
+
+                return BaseAttributes.prototype.configure.apply(this, arguments);
+            },
+
+            /**
+             * Override for field render to maintain form locked state
+             * @param  {jQueryElement} panel Attribute panel element
+             * @param  {Object} field Attribute field
+             */
+            appendField: function(panel, field) {
+                if (field.canBeSeen()) {
+                    field.render(!this.locked);
+                    FieldManager.addVisibleField(field.attribute.code);
+                    panel.append(field.$el);
+                }
+            },
+
+            /**
              * Set mass edit form as locked
              *
              * {@inheritdoc}
@@ -43,30 +68,6 @@ define(
             onUnlock: function () {
                 this.locked = false;
                 this.render();
-            },
-
-            /**
-             * Listen to mass edit form unlock and lock events
-             *
-             * {@inheritdoc}
-             */
-            configure: function() {
-                mediator.on('mass-edit:form:lock', this.onLock.bind(this));
-                mediator.on('mass-edit:form:unlock', this.onUnlock.bind(this));
-                return BaseAttributes.prototype.configure.apply(this, arguments);
-            },
-
-            /**
-             * Override for field render to maintain form locked state
-             * @param  {jQueryElement} panel Attribute panel element
-             * @param  {Object} field Attribute field
-             */
-            appendField: function(panel, field) {
-                if (field.canBeSeen()) {
-                    field.render(!this.locked);
-                    FieldManager.addVisibleField(field.attribute.code);
-                    panel.append(field.$el);
-                }
             },
 
             /**

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/mass-edit/attributes.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/mass-edit/attributes.js
@@ -14,14 +14,61 @@ define(
     [
         'pim/field-manager',
         'pim/security-context',
-        'pim/form/common/attributes'
+        'pim/form/common/attributes',
+        'oro/mediator'
     ],
     function (
         FieldManager,
         SecurityContext,
-        BaseAttributes
+        BaseAttributes,
+        mediator
     ) {
         return BaseAttributes.extend({
+            locked: false,
+
+            /**
+             * Set mass edit form as locked
+             *
+             * {@inheritdoc}
+             */
+            onLock: function () {
+                this.locked = true;
+            },
+
+            /**
+             * Set mass edit form as unlocked
+             *
+             * {@inheritdoc}
+             */
+            onUnlock: function () {
+                this.locked = false;
+                this.render();
+            },
+
+            /**
+             * Listen to mass edit form unlock and lock events
+             *
+             * {@inheritdoc}
+             */
+            configure: function() {
+                mediator.on('mass-edit:form:lock', this.onLock.bind(this));
+                mediator.on('mass-edit:form:unlock', this.onUnlock.bind(this));
+                return BaseAttributes.prototype.configure.apply(this, arguments);
+            },
+
+            /**
+             * Override for field render to maintain form locked state
+             * @param  {jQueryElement} panel Attribute panel element
+             * @param  {Object} field Attribute field
+             */
+            appendField: function(panel, field) {
+                if (field.canBeSeen()) {
+                    field.render(!this.locked);
+                    FieldManager.addVisibleField(field.attribute.code);
+                    panel.append(field.$el);
+                }
+            },
+
             /**
              * {@inheritdoc}
              */

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/field/field.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/field/field.html
@@ -8,7 +8,7 @@
         <span class="AknFieldContainer-fieldInfo field-info">
             <% if (attribute.localizable || attribute.scopable) { %>
                 <span class="field-context">
-                    <% if (attribute.scopable) { %> <span><%- context.scopeLabel %></span> <% } %>
+                    <% if (attribute.scopable) { %> <span class="field-scope"><%- context.scopeLabel %></span> <% } %>
                     <% if (attribute.localizable) { %> <span><%= i18n.getFlag(context.locale) %></span> <% } %>
                 </span>
             <% } %>


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

This PR fixes a bug on the mass edit common attributes screen where fields become re-enabled after switching attribute groups. It happens because the fields are re-rendered after the switch, and the field render method sets them as editable by default.

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | OK
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
