### PR TITLE
PIM-6118: Avoid BC breaks in minor release

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -21,16 +21,6 @@
 - PIM-6199: Fix product mass edit attribute add select clickable on confirmation page
 - PIM-6282: Fix attribute menu Firefox bug
 
-## BC breaks
-
-### Classes
-
-- Remove class `Pim\Bundle\EnrichBundle\Form\Type\AttributeRequirementType`
-
-### Constructors
-
-- Change the constructor of `Pim\Bundle\EnrichBundle\MassEditAction\Operation\SetAttributeRequirements` to remove `Pim\Component\Catalog\Repository\AttributeRepositoryInterface` and remove `Pim\Component\Catalog\Factory\AttributeRequirementFactory`
-
 # 1.7.1 (2017-03-23)
 
 ## Bug Fixes

--- a/src/Pim/Bundle/EnrichBundle/Form/Type/AttributeRequirementType.php
+++ b/src/Pim/Bundle/EnrichBundle/Form/Type/AttributeRequirementType.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Pim\Bundle\EnrichBundle\Form\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Attribute requirement form type
+ *
+ * @deprecated Will be removed in 1.8, is not used anymore
+ * @author     Gildas Quemener <gildas@akeneo.com>
+ * @copyright  2013 Akeneo SAS (http://www.akeneo.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class AttributeRequirementType extends AbstractType
+{
+    /** @var string */
+    protected $dataClass;
+
+    /**
+     * @param string $dataClass
+     */
+    public function __construct($dataClass)
+    {
+        $this->dataClass = $dataClass;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        if ($options['keep_non_required']) {
+            // Hidden value is used to store 1 or 0 and send the "uncheck" value
+            // (which is impossible to do with a checkbox)
+            $builder->add('required', 'hidden');
+        } else {
+            $builder->add('required', 'checkbox');
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function finishView(FormView $view, FormInterface $form, array $options)
+    {
+        $view['required']->vars['keep_non_required'] = $options['keep_non_required'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(
+            [
+                'data_class'        => $this->dataClass,
+                'keep_non_required' => false,
+            ]
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'pim_enrich_attribute_requirement';
+    }
+}

--- a/src/Pim/Bundle/EnrichBundle/MassEditAction/Operation/SetAttributeRequirements.php
+++ b/src/Pim/Bundle/EnrichBundle/MassEditAction/Operation/SetAttributeRequirements.php
@@ -2,7 +2,9 @@
 
 namespace Pim\Bundle\EnrichBundle\MassEditAction\Operation;
 
+use Pim\Component\Catalog\Factory\AttributeRequirementFactory;
 use Pim\Component\Catalog\Model\ChannelInterface;
+use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
 use Pim\Component\Catalog\Repository\ChannelRepositoryInterface;
 
 /**
@@ -21,16 +23,34 @@ class SetAttributeRequirements extends AbstractMassEditOperation
     protected $channelRepository;
 
     /**
+     * @var AttributeRepositoryInterface
+     * @deprecated Will be removed in 1.8, avoid usage of this property
+     */
+    protected $attributeRepository;
+
+    /**
+     * @var        AttributeRequirementFactory
+     * @deprecated Will be removed in 1.8, avoid usage of this property
+     */
+    protected $factory;
+
+    /**
      * @param ChannelRepositoryInterface   $channelRepository
+     * @param AttributeRepositoryInterface $attributeRepository
+     * @param AttributeRequirementFactory  $factory
      * @param string                       $jobInstanceCode
      */
     public function __construct(
         ChannelRepositoryInterface $channelRepository,
+        AttributeRepositoryInterface $attributeRepository,
+        AttributeRequirementFactory $factory,
         $jobInstanceCode
     ) {
         parent::__construct($jobInstanceCode);
 
         $this->channelRepository = $channelRepository;
+        $this->attributeRepository = $attributeRepository;
+        $this->factory = $factory;
     }
 
     /**

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_types.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_types.yml
@@ -18,6 +18,7 @@ parameters:
     pim_enrich.form.type.available_attributes.class:                Pim\Bundle\EnrichBundle\Form\Type\AvailableAttributesType
     pim_enrich.form.type.attribute_property_available_locale.class: Pim\Bundle\EnrichBundle\Form\Type\AttributeProperty\AvailableLocalesType
     pim_enrich.form.type.attribute_property_options.class:          Pim\Bundle\EnrichBundle\Form\Type\AttributeProperty\OptionsType
+    pim_enrich.form.type.attribute_requirement.class:               Pim\Bundle\EnrichBundle\Form\Type\AttributeRequirementType
     pim_enrich.form.type.localized_collection.class:                Pim\Bundle\EnrichBundle\Form\Type\LocalizedCollectionType
 
     pim_enrich.form.type.light_entity.class: Pim\Bundle\EnrichBundle\Form\Type\LightEntityType
@@ -94,6 +95,14 @@ services:
             - '%pim_catalog.entity.family.class%'
         tags:
             - { name: form.type, alias: pim_enrich_family }
+
+    # @deprecated Will be removed in 1.8, is not used anymore
+    pim_enrich.form.type.attribute_requirement:
+        class: '%pim_enrich.form.type.attribute_requirement.class%'
+        arguments:
+            - '%pim_catalog.entity.attribute_requirement.class%'
+        tags:
+            - { name: form.type, alias: pim_enrich_attribute_requirement }
 
     pim_enrich.form.type.category:
         class: '%pim_enrich.form.type.category.class%'

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/mass_actions.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/mass_actions.yml
@@ -155,6 +155,8 @@ services:
         class: '%pim_enrich.mass_edit_action.set_attribute_requirements.class%'
         arguments:
             - '@pim_catalog.repository.channel'
+            - '@pim_catalog.repository.attribute'
+            - '@pim_catalog.factory.attribute_requirement'
             - 'set_attribute_requirements'
         tags:
             -

--- a/src/Pim/Bundle/EnrichBundle/spec/MassEditAction/Operation/SetAttributeRequirementsSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/MassEditAction/Operation/SetAttributeRequirementsSpec.php
@@ -3,20 +3,29 @@
 namespace spec\Pim\Bundle\EnrichBundle\MassEditAction\Operation;
 
 use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Factory\AttributeRequirementFactory;
 use Pim\Component\Catalog\Model\ChannelInterface;
+use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
 use Pim\Component\Catalog\Repository\ChannelRepositoryInterface;
 
 class SetAttributeRequirementsSpec extends ObjectBehavior
 {
     function let(
         ChannelRepositoryInterface $channelRepository,
+        AttributeRepositoryInterface $attributeRepository,
+        AttributeRequirementFactory $factory,
         ChannelInterface $channelA,
         ChannelInterface $channelB
     ) {
         $channelA->getCode()->willReturn('channel_a');
         $channelB->getCode()->willReturn('channel_b');
         $channelRepository->findAll()->willReturn([$channelA, $channelB]);
-        $this->beConstructedWith($channelRepository, 'set_attribute_requirements');
+        $this->beConstructedWith(
+            $channelRepository,
+            $attributeRepository,
+            $factory,
+            'set_attribute_requirements'
+        );
     }
 
     function it_is_a_mass_edit_operation()


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

PIM-6118 introduced some BC breaks. This PR is to avoid BC breaks in 1.7 and use `soft deprecation` instead

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
