### PR TITLE
PIM-6271: Mass edit - attribute group switch unlocks the form

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -21,6 +21,7 @@
 - PIM-6199: Fix product mass edit attribute add select clickable on confirmation page
 - PIM-6282: Fix attribute menu Firefox bug
 - PIM-6284: Fix display of scopable information for fields
+- PIM-6271: Fix locking fields in mass edit product form
 
 ## BC breaks
 

--- a/features/Context/AssertionContext.php
+++ b/features/Context/AssertionContext.php
@@ -240,7 +240,7 @@ class AssertionContext extends RawMinkContext
             if (!$field) {
                 throw $this->createExpectationException(sprintf('Expecting to see field "%s".', $fieldName));
             }
-            if (!$field->hasAttribute('disabled')) {
+            if (!$field->hasAttribute('disabled') && !$field->hasAttribute('readonly')) {
                 throw $this->createExpectationException(sprintf('Expecting field "%s" to be disabled.', $fieldName));
             }
         }

--- a/features/mass-action/edit_common_attributes.feature
+++ b/features/mass-action/edit_common_attributes.feature
@@ -314,3 +314,16 @@ Feature: Edit common attributes of many products at once
     And I change the "Name" to "boots"
     And I move to the confirm page
     Then The available attributes button should be disabled
+
+  @jira https://akeneo.atlassian.net/browse/PIM-6271
+  Scenario: Successfully keep mass edit form fields disabled after switching groups
+    Given I am on the products page
+    And I select rows boots, sandals and sneakers
+    And I press "Change product information" on the "Bulk Actions" dropdown button
+    When I choose the "Edit common attributes" operation
+    And I display the Price attribute
+    And I display the Name attribute
+    And I move to the confirm page
+    Then the field Name should be disabled
+    When I visit the "Marketing" group
+    Then the field Price should be disabled

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes.js
@@ -134,13 +134,7 @@ define(
                             $valuesPanel.empty();
 
                             FieldManager.clearVisibleFields();
-                            _.each(fields, function (field) {
-                                if (field.canBeSeen()) {
-                                    field.render();
-                                    FieldManager.addVisibleField(field.attribute.code);
-                                    $valuesPanel.append(field.$el);
-                                }
-                            }.bind(this));
+                            _.each(fields, this.appendField.bind(this, $valuesPanel));
                         }.bind(this));
                     this.delegateEvents();
 
@@ -148,6 +142,21 @@ define(
                 }.bind(this));
 
                 return this;
+            },
+
+            /**
+             * Append a field to the panel
+             *
+             * @param {jQueryElement} panel
+             * @param {Object} field
+             *
+             */
+            appendField: function (panel, field) {
+                if (field.canBeSeen()) {
+                    field.render();
+                    FieldManager.addVisibleField(field.attribute.code);
+                    panel.append(field.$el);
+                }
             },
 
             /**
@@ -178,6 +187,7 @@ define(
                         optional: isOptional,
                         removable: SecurityContext.isGranted(this.config.removeAttributeACL)
                     });
+
                     field.setValues(values);
 
                     return field;

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/field.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/field.js
@@ -38,6 +38,7 @@ define([
             editable: true,
             ready: true,
             valid: true,
+            locked: false,
 
             /**
              * Initialize this field
@@ -61,7 +62,7 @@ define([
              * @returns {Object}
              */
             render: function () {
-                this.setEditable(true);
+                this.setEditable(!this.locked);
                 this.setValid(true);
                 this.elements = {};
                 var promises  = [];
@@ -71,7 +72,6 @@ define([
                     .then(this.getTemplateContext.bind(this))
                     .then(function (templateContext) {
                         this.$el.html(this.template(templateContext));
-
                         this.$('.original-field .field-input').append(this.renderInput(templateContext));
 
                         this.renderElements();
@@ -249,6 +249,15 @@ define([
              */
             setEditable: function (editable) {
                 this.editable = editable;
+            },
+
+            /**
+             * Set this field as locked
+             *
+             * @param {boolean} locked
+             */
+            setLocked: function (locked) {
+                this.locked = locked;
             },
 
             /**

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/mass-edit/attributes.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/mass-edit/attributes.js
@@ -14,14 +14,63 @@ define(
     [
         'pim/field-manager',
         'pim/security-context',
-        'pim/form/common/attributes'
+        'pim/form/common/attributes',
+        'oro/mediator'
     ],
     function (
         FieldManager,
         SecurityContext,
-        BaseAttributes
+        BaseAttributes,
+        mediator
     ) {
         return BaseAttributes.extend({
+            locked: false,
+
+            /**
+             * Listen to mass edit form unlock and lock events
+             *
+             * {@inheritdoc}
+             */
+            configure: function () {
+                mediator.on('mass-edit:form:lock', this.onLock.bind(this));
+                mediator.on('mass-edit:form:unlock', this.onUnlock.bind(this));
+
+                return BaseAttributes.prototype.configure.apply(this, arguments);
+            },
+
+            /**
+             * Override for field render to maintain form locked state
+             * @param  {jQueryElement} panel Attribute panel element
+             * @param  {Object} field Attribute field
+             */
+            appendField: function (panel, field) {
+                if (field.canBeSeen()) {
+                    field.setLocked(this.locked);
+                    field.render();
+                    FieldManager.addVisibleField(field.attribute.code);
+                    panel.append(field.$el);
+                }
+            },
+
+            /**
+             * Set mass edit form as locked
+             *
+             * {@inheritdoc}
+             */
+            onLock: function () {
+                this.locked = true;
+            },
+
+            /**
+             * Set mass edit form as unlocked
+             *
+             * {@inheritdoc}
+             */
+            onUnlock: function () {
+                this.locked = false;
+                this.render();
+            },
+
             /**
              * {@inheritdoc}
              */


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

This PR fixes a bug on the mass edit common attributes screen where fields become re-enabled after switching attribute groups. It happens because the fields are re-rendered after the switch, and the field render method sets them as editable by default.

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | OK
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
