### PR TITLE
PIM-6309: Enlarge the attribute type selection panel

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -21,6 +21,7 @@
 - PIM-6199: Fix product mass edit attribute add select clickable on confirmation page
 - PIM-6282: Fix attribute menu Firefox bug
 - PIM-6284: Fix display of scopable information for fields
+- PIM-6309: Enlarge the attribute type selection panel
 
 ## BC breaks
 

--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -24,16 +24,6 @@
 - PIM-6309: Enlarge the attribute type selection panel
 - PIM-6271: Fix locking fields in mass edit product form
 
-## BC breaks
-
-### Classes
-
-- Remove class `Pim\Bundle\EnrichBundle\Form\Type\AttributeRequirementType`
-
-### Constructors
-
-- Change the constructor of `Pim\Bundle\EnrichBundle\MassEditAction\Operation\SetAttributeRequirements` to remove `Pim\Component\Catalog\Repository\AttributeRepositoryInterface` and remove `Pim\Component\Catalog\Factory\AttributeRequirementFactory`
-
 # 1.7.1 (2017-03-23)
 
 ## Bug Fixes

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/lib/modal.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/lib/modal.less
@@ -8,8 +8,8 @@
   position: fixed;
   left: 50%;
   z-index: 1050;
-  width: 560px;
-  margin-left: -280px;
+  width: 800px;
+  margin-left: -400px;
   background-color: white;
   transform: translate(0, -50%);
 


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

This PR updates the CSS for the attribute selection panel to increase the width from 560px to 800px.

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
