### PR TITLE
[Contribution] Add subscriber to lock/unlock batch job commands

### DIFF
--- a/src/Akeneo/Bundle/BatchBundle/AkeneoBatchBundle.php
+++ b/src/Akeneo/Bundle/BatchBundle/AkeneoBatchBundle.php
@@ -28,6 +28,7 @@ class AkeneoBatchBundle extends Bundle
             ->addCompilerPass(new Compiler\RegisterNotifiersPass())
             ->addCompilerPass(new Compiler\PushBatchLogHandlerPass())
             ->addCompilerPass(new Compiler\RegisterJobsPass())
+            ->addCompilerPass(new Compiler\RegisterLockPass())
             ->addCompilerPass(new Compiler\RegisterJobParametersPass('default_values_provider'))
             ->addCompilerPass(new Compiler\RegisterJobParametersPass('constraint_collection_provider'))
             ->addCompilerPass(

--- a/src/Akeneo/Bundle/BatchBundle/DependencyInjection/Compiler/RegisterLockPass.php
+++ b/src/Akeneo/Bundle/BatchBundle/DependencyInjection/Compiler/RegisterLockPass.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Akeneo\Bundle\BatchBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Compiler pass to register locked jobs to the registry
+ *
+ * @author    Benoit Wannepain <bwannepain@kaliop.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class RegisterLockPass implements CompilerPassInterface
+{
+    const SUBSCRIBER_ID = 'akeneo_batch.lock_subscriber';
+    const SERVICE_TAG = 'akeneo_batch.job';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition(self::SUBSCRIBER_ID)) {
+            return;
+        }
+
+        $subscriberDefinition = $container->getDefinition(self::SUBSCRIBER_ID);
+        foreach ($container->findTaggedServiceIds(self::SERVICE_TAG) as $serviceId => $tags) {
+            foreach ($tags as $tag) {
+                if (isset($tag['lock']) && $tag['lock']) {
+                    $serviceDefinition = $container->getDefinition($serviceId);
+                    $subscriberDefinition->addMethodCall(
+                        'registerJobCode',
+                        [$serviceDefinition->getArgument(0)]
+                    );
+                }
+            }
+        }
+    }
+}

--- a/src/Akeneo/Bundle/BatchBundle/EventListener/LockSubscriber.php
+++ b/src/Akeneo/Bundle/BatchBundle/EventListener/LockSubscriber.php
@@ -1,0 +1,117 @@
+<?php
+
+
+namespace Akeneo\Bundle\BatchBundle\EventListener;
+
+use Akeneo\Component\Batch\Event\BatchCommandEvent;
+use Akeneo\Component\Batch\Event\EventInterface;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Filesystem\LockHandler;
+
+/**
+ * Subscriber to lock and unlock commands
+ *
+ * @author    Benoit Wannepain <benoit.wannepain@kaliop.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class LockSubscriber implements EventSubscriberInterface
+{
+    const AKENEO_BATCH_JOB = 'akeneo:batch:job';
+
+    /** @var array */
+    protected $managedJobCodes;
+
+    /** @var LockHandler */
+    protected $lockHandler;
+
+    /**
+     * LockSubscriber constructor.
+     */
+    public function __construct()
+    {
+        $this->managedJobCodes = [];
+    }
+
+    /**
+     * @param string $jobCode
+     */
+    public function registerJobCode($jobCode)
+    {
+        $this->managedJobCodes[] = $jobCode;
+    }
+
+    /**
+     * Returns an array of event names this subscriber wants to listen to.
+     *
+     * @return array The event names to listen to
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            EventInterface::BATCH_COMMAND_START => 'onCommandStart',
+            EventInterface::BATCH_COMMAND_TERMINATE => 'onCommandTerminate',
+        ];
+    }
+
+    /**
+     * @param BatchCommandEvent $event
+     */
+    public function onCommandStart(BatchCommandEvent $event)
+    {
+        if (false === $this->supportsCommand($event)) {
+            return;
+        }
+
+        $output = $event->getOutput();
+        $this->lockHandler = new LockHandler(md5($this->getJobName($event)) . '.lock');
+        if (!$this->lockHandler->lock()) {
+            $output->writeln('<error>Command already locked</error>');
+            $event->disableCommand();
+        } else {
+            $output->writeln('<info>Command locked</info>');
+        }
+    }
+
+    /**
+     * @param BatchCommandEvent $event
+     */
+    public function onCommandTerminate(BatchCommandEvent $event)
+    {
+        if (false === $this->supportsCommand($event) || null === $this->lockHandler) {
+            return;
+        }
+
+        $this->lockHandler->release();
+        $output = $event->getOutput();
+        $output->writeln('<info>Command unlocked</info>');
+    }
+
+    /**
+     * @param BatchCommandEvent $event
+     * @return bool
+     */
+    protected function supportsCommand(BatchCommandEvent $event)
+    {
+        if ($event->getCommand()->getName() !== self::AKENEO_BATCH_JOB) {
+            return false;
+        }
+
+        $input = $event->getInput();
+        if ($input->hasOption('no-lock') && $input->getOption('no-lock')) {
+            return false;
+        }
+
+        return in_array($this->getJobName($event), $this->managedJobCodes);
+    }
+
+    /**
+     * @param BatchCommandEvent $event
+     * @return string
+     */
+    protected function getJobName(BatchCommandEvent $event)
+    {
+        return $event->getJobInstance()->getJobName();
+    }
+}

--- a/src/Akeneo/Bundle/BatchBundle/Resources/config/services.yml
+++ b/src/Akeneo/Bundle/BatchBundle/Resources/config/services.yml
@@ -2,6 +2,7 @@ parameters:
     akeneo_batch.job_instance_factory.class:                  Akeneo\Bundle\BatchBundle\Job\JobInstanceFactory
     akeneo_batch.logger_subscriber.class:                     Akeneo\Bundle\BatchBundle\EventListener\LoggerSubscriber
     akeneo_batch.notification_subscriber.class:               Akeneo\Bundle\BatchBundle\EventListener\NotificationSubscriber
+    akeneo_batch.lock_subscriber.class:                       Akeneo\Bundle\BatchBundle\EventListener\LockSubscriber
     akeneo_batch.logger.batch_log_handler.class:              Akeneo\Bundle\BatchBundle\Monolog\Handler\BatchLogHandler
     akeneo_batch.mail_notifier.class:                         Akeneo\Bundle\BatchBundle\Notification\MailNotifier
     akeneo_batch.set_job_execution_log_file_subscriber.class: Akeneo\Bundle\BatchBundle\EventListener\SetJobExecutionLogFileSubscriber
@@ -24,6 +25,11 @@ services:
         tags:
             - { name: kernel.event_subscriber }
             - { name: monolog.logger, channel: batch }
+
+    akeneo_batch.lock_subscriber:
+        class: '%akeneo_batch.lock_subscriber.class%'
+        tags:
+            - { name: kernel.event_subscriber }
 
     akeneo_batch.notification_subscriber:
         class: '%akeneo_batch.notification_subscriber.class%'

--- a/src/Akeneo/Component/Batch/Event/BatchCommandEvent.php
+++ b/src/Akeneo/Component/Batch/Event/BatchCommandEvent.php
@@ -1,0 +1,47 @@
+<?php
+
+
+namespace Akeneo\Component\Batch\Event;
+
+use Akeneo\Component\Batch\Model\JobInstance;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Event\ConsoleCommandEvent;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @author    Benoit Wannepain <benoit.wannepain@kaliop.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class BatchCommandEvent extends ConsoleCommandEvent
+{
+    /** @var JobInstance  */
+    private $jobInstance;
+
+    /**
+     * BatchCommandEvent constructor.
+     * @param Command $command
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @param JobInstance $jobInstance
+     */
+    public function __construct(
+        Command $command,
+        InputInterface $input,
+        OutputInterface $output,
+        JobInstance $jobInstance
+    ) {
+        parent::__construct($command, $input, $output);
+
+        $this->jobInstance = $jobInstance;
+    }
+
+    /**
+     * @return JobInstance
+     */
+    public function getJobInstance()
+    {
+        return $this->jobInstance;
+    }
+}

--- a/src/Akeneo/Component/Batch/Event/EventInterface.php
+++ b/src/Akeneo/Component/Batch/Event/EventInterface.php
@@ -11,6 +11,10 @@ namespace Akeneo\Component\Batch\Event;
  */
 interface EventInterface
 {
+    /** BatchCommand execution events */
+    const BATCH_COMMAND_START = 'akeneo.batch.command_start';
+    const BATCH_COMMAND_TERMINATE = 'akeneo.batch.command_terminate';
+
     /** Job execution events */
     const BEFORE_JOB_EXECUTION = 'akeneo_batch.before_job_execution';
     const JOB_EXECUTION_STOPPED = 'akeneo_batch.job_execution_stopped';


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**
Add the possibility to lock a batch job to avoid concurrency:

- Add a 'lock' attribute to the 'akeneo_batch.job' tag. It's not mandatory and false by default. Its value is boolean true or false. Batch job services tagged with the 'lock' attribute will be registered in a compiler pass to the LockSubscriber, that will handle locking and unlocking
- Add a 'no-lock' option the BatchCommand, to skip locking even if the job is configured to be locked.


[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | TODO
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | TODO
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
