### PR TITLE
PIM-6277: Use catalogLocale for channel and scopable attribute labels 

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -23,6 +23,7 @@
 - PIM-6284: Fix display of scopable information for fields
 - PIM-6309: Enlarge the attribute type selection panel
 - PIM-6271: Fix locking fields in mass edit product form
+- PIM-6277: Use catalogLocale for channel and scopable attribute labels
 
 # 1.7.1 (2017-03-23)
 

--- a/features/product/completeness/display_completeness.feature
+++ b/features/product/completeness/display_completeness.feature
@@ -182,7 +182,7 @@ Feature: Display the completeness of a product
     And I switch the locale to "fr_FR"
     Then I should see the "fr_FR" completeness in position 1
     And The completeness "en_US" should be closed
-    Then The label for the "tablet" channel for "fr_FR" locale should be "Tablet"
+    Then The label for the "tablet" channel for "fr_FR" locale should be "Tablette"
     When I am on the "tablet" channel page
     Then I fill in the following information:
       | French (France) |  |
@@ -191,4 +191,4 @@ Feature: Display the completeness of a product
     When I am on the "sneakers" product page
     And I open the "Completeness" panel
     And I switch the locale to "fr_FR"
-    Then The label for the "tablet" channel for "fr_FR" locale should be "Tablet"
+    Then The label for the "tablet" channel for "fr_FR" locale should be "[tablet]"

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes.js
@@ -177,13 +177,13 @@ define(
                     );
                 }).then(function (field, channels, isOptional) {
                     var scope = _.findWhere(channels, { code: UserContext.get('catalogScope') });
-                    var uiLocale = UserContext.get('uiLocale');
+                    var catalogLocale = UserContext.get('catalogLocale');
 
                     field.setContext({
-                        locale: UserContext.get('catalogLocale'),
+                        locale: catalogLocale,
                         scope: scope.code,
-                        scopeLabel: i18n.getLabel(scope.labels, uiLocale, scope.code),
-                        uiLocale: UserContext.get('catalogLocale'),
+                        scopeLabel: i18n.getLabel(scope.labels, catalogLocale, scope.code),
+                        uiLocale: catalogLocale,
                         optional: isOptional,
                         removable: SecurityContext.isGranted(this.config.removeAttributeACL)
                     });

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes/copy.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes/copy.js
@@ -129,12 +129,11 @@ define(
                 if (!_.has(this.copyFields, code)) {
                     var sourceData = this.getSourceData();
                     var copyField = new CopyField(field.attribute);
-                    var uiLocale = UserContext.get('uiLocale');
 
                     copyField.setContext({
                         locale: this.locale,
                         scope: this.scope,
-                        scopeLabel: i18n.getLabel(this.scopeLabel, uiLocale, this.scope)
+                        scopeLabel: i18n.getLabel(this.scopeLabel, this.locale, this.scope)
                     });
                     copyField.setValues(sourceData[code]);
                     copyField.setField(field);

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/panel/completeness.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/panel/completeness.html
@@ -25,7 +25,7 @@
                     <% if (channelCompleteness.completeness) { %>
                         <div class="AknCompletenessBlock-channel">
                             <span class="AknCompletenessBlock-channelTitle channel" data-channel="<%- channelCompleteness.completeness['channel_code'] %>">
-                                <%- i18n.getLabel(channelCompleteness.completeness['channel_labels'], uiLocale, channelCompleteness.completeness['channel_code']) %>
+                                <%- i18n.getLabel(channelCompleteness.completeness['channel_labels'], catalogLocale, channelCompleteness.completeness['channel_code']) %>
                             </span>
                             <div class="AknCompletenessBlock-progressContainer">
                                 <div class="AknCompletenessBlock-progress AknProgress progress <%- channelCompleteness.completeness.ratio === 100 ? 'AknProgress--apply' : 'AknProgress--warning' %>">


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

This PR reverses changes made in https://github.com/akeneo/pim-community-dev/pull/6034 and https://github.com/akeneo/pim-community-dev/pull/5997 to use the catalogLocale to translate labels rather than uiLocale. 

Before:
![localisation issues on pef](https://cloud.githubusercontent.com/assets/1336344/24802386/1c31fd30-1ba8-11e7-8b06-a1a7a8761445.png)

After:
![screen shot 2017-04-07 at 14 58 28](https://cloud.githubusercontent.com/assets/1336344/24802394/2472d366-1ba8-11e7-9690-77136f71128d.png)

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | OK
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
