### PR TITLE
PIM-6324: Fix missing error message after creating an attribute with invalid data

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -3,7 +3,7 @@
 ## Bug Fixes
 
 - PIM-6277: Use catalogLocale for channel and scopable attribute labels
-- PIM-6324: Fix missing error message after creating an attribute with invalid data
+- PIM-6324: Fix invalid field focus after creating an attribute with missing data
 
 # 1.7.2 (2017-04-07)
 

--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -3,6 +3,7 @@
 ## Bug Fixes
 
 - PIM-6277: Use catalogLocale for channel and scopable attribute labels
+- PIM-6324: Fix missing error message after creating an attribute with invalid data
 
 # 1.7.2 (2017-04-07)
 

--- a/features/attribute/create_text_attribute.feature
+++ b/features/attribute/create_text_attribute.feature
@@ -39,3 +39,11 @@ Feature: Create an attribute
       | Code | short_description |
     And I save the attribute
     Then I should see validation error "This value should not be blank."
+
+  @jira https://akeneo.atlassian.net/browse/PIM-6324
+  Scenario: Successfully switch to tab with an invalid field
+      Given I visit the "Values" tab
+      And I save the attribute
+      Then I should see the Code field
+      Then I should be on the "Parameters" tab
+      And I should see validation error "This value should not be blank."

--- a/src/Pim/Bundle/EnrichBundle/Resources/views/Attribute/_js-handler.html.twig
+++ b/src/Pim/Bundle/EnrichBundle/Resources/views/Attribute/_js-handler.html.twig
@@ -9,7 +9,25 @@ require(
             // Get form name
             var formName = '#{{ form.vars.id }}';
 
-            var $optionList;
+            function getFirstInvalidField() {
+                var container = $('.field-input.validation-error', formName).first();
+                return $('input', container);
+            }
+
+            function getParentTabLink(field) {
+                var paneId = $(field).parents('.tab-pane').attr('id');
+                return $('.AknHorizontalNavtab-link[href="#'+ paneId +'"]');
+            }
+
+            function focusInvalidField() {
+                var invalidField = getFirstInvalidField();
+                var parentTab = getParentTabLink(invalidField);
+
+                parentTab.trigger('click');
+                invalidField.trigger('focus');
+            }
+
+            $(formName).on('refresh', focusInvalidField);
 
             function initializeForm() {
                 var $switch = $(formName+'_autoOptionSorting')

--- a/src/Pim/Bundle/EnrichBundle/Resources/views/Attribute/_js-handler.html.twig
+++ b/src/Pim/Bundle/EnrichBundle/Resources/views/Attribute/_js-handler.html.twig
@@ -11,11 +11,13 @@ require(
 
             function getFirstInvalidField() {
                 var container = $('.field-input.validation-error', formName).first();
+
                 return $('input', container);
             }
 
             function getParentTabLink(field) {
                 var paneId = $(field).parents('.tab-pane').attr('id');
+
                 return $('.AknHorizontalNavtab-link[href="#'+ paneId +'"]');
             }
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/views/Attribute/form.html.twig
+++ b/src/Pim/Bundle/EnrichBundle/Resources/views/Attribute/form.html.twig
@@ -59,30 +59,5 @@
 {% block head_script_component %}
     {{ parent() }}
 
-    <script type="text/javascript">
-        'use strict';
-
-        var form = $('#{{ form.vars.id }}');
-
-        var getInvalidField = function () {
-            var container = $('.field-input.validation-error', form).first();
-            return $('input', container);
-        };
-
-        var getParentTabLink = function (field) {
-            var paneId = $(field).parents('.tab-pane').attr('id');
-            return $('.AknHorizontalNavtab-link[href="#'+ paneId +'"]');
-        };
-
-        var focusInvalidField = function () {
-            var invalidField = getInvalidField();
-            var parentTab = getParentTabLink(invalidField);
-            parentTab.trigger('click');
-            invalidField.trigger('focus');
-        };
-
-        form.on('refresh', focusInvalidField);
-    </script>
-
     {% include 'PimEnrichBundle:Attribute:_js-handler.html.twig' with measures %}
 {% endblock %}

--- a/src/Pim/Bundle/EnrichBundle/Resources/views/Attribute/form.html.twig
+++ b/src/Pim/Bundle/EnrichBundle/Resources/views/Attribute/form.html.twig
@@ -58,6 +58,5 @@
 
 {% block head_script_component %}
     {{ parent() }}
-
     {% include 'PimEnrichBundle:Attribute:_js-handler.html.twig' with measures %}
 {% endblock %}

--- a/src/Pim/Bundle/EnrichBundle/Resources/views/Attribute/form.html.twig
+++ b/src/Pim/Bundle/EnrichBundle/Resources/views/Attribute/form.html.twig
@@ -58,5 +58,31 @@
 
 {% block head_script_component %}
     {{ parent() }}
+
+    <script type="text/javascript">
+        'use strict';
+
+        var form = $('#{{ form.vars.id }}');
+
+        var getInvalidField = function () {
+            var container = $('.field-input.validation-error', form).first();
+            return $('input', container);
+        };
+
+        var getParentTabLink = function (field) {
+            var paneId = $(field).parents('.tab-pane').attr('id');
+            return $('.AknHorizontalNavtab-link[href="#'+ paneId +'"]');
+        };
+
+        var focusInvalidField = function () {
+            var invalidField = getInvalidField();
+            var parentTab = getParentTabLink(invalidField);
+            parentTab.trigger('click');
+            invalidField.trigger('focus');
+        };
+
+        form.on('refresh', focusInvalidField);
+    </script>
+
     {% include 'PimEnrichBundle:Attribute:_js-handler.html.twig' with measures %}
 {% endblock %}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This PR fixes an issue in the attribute creation form when trying to submit an attribute with missing data (code, group). It adds back the behaviour of switching to the correct tab and focusing on the invalid field after submission.  This behaviour was previously removed with JSFV here - https://github.com/akeneo/pim-community-dev/pull/5863

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | OK
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
