### PR TITLE
PIM-6375: Fix empty tags and content not being saved in wysiwyg 

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -1,3 +1,9 @@
+# 1.6.x
+
+## Bug fixes
+
+- PIM-6375: Fix empty tags and content not being saved in wysiwyg
+
 # 1.6.13 (2017-03-29)
 
 ## Bug fixes

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/wysiwyg-field.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/wysiwyg-field.js
@@ -59,8 +59,8 @@ define(
 
             cleanEmptyInput: function () {
                 var textarea = this.$('.field-input:first textarea:first');
-                var editorCode = $.parseHTML(textarea.code());
-                var textIsEmpty = $(editorCode).text().length === 0;
+                var editorHTML = $.parseHTML(textarea.code());
+                var textIsEmpty = $(editorHTML).text().length === 0;
 
                 if (textIsEmpty) {
                     textarea.code('');
@@ -73,6 +73,7 @@ define(
             updateModel: function () {
                 var data = this.$('.field-input:first textarea:first').code();
                 data = '' === data ? this.attribute.empty_value : data;
+
                 this.setCurrentValue(data);
             },
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/wysiwyg-field.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/wysiwyg-field.js
@@ -9,12 +9,14 @@
  */
 define(
     [
+        'jquery',
         'pim/field',
         'underscore',
         'text!pim/template/product/field/textarea',
         'summernote'
     ],
     function (
+        $,
         Field,
         _,
         fieldTemplate
@@ -46,7 +48,7 @@ define(
                         ['insert', ['link']],
                         ['view', ['codeview']]
                     ],
-                    callbacks: {},
+                    callbacks: {}
                 })
                 .on('summernote.blur', this.updateModel.bind(this))
                 .on('summernote.keyup', this.removeEmptyTags.bind(this));

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/wysiwyg-field.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/wysiwyg-field.js
@@ -50,28 +50,30 @@ define(
                 })
                 .on('summernote.blur', this.updateModel.bind(this))
                 .on('summernote.keyup', this.cleanEmptyInput.bind(this));
+
+                this.$('.note-codable').on('blur', function () {
+                    this.cleanEmptyInput();
+                    this.updateModel();
+                }.bind(this));
             },
 
             cleanEmptyInput: function () {
                 var isEmpty = $.summernote.core.dom.isEmpty;
-                var editorElement = this.$('.note-editable').get(0)
-                var editorCode = $.parseHTML(this.editorCode());
+                var textarea = this.$('.field-input:first textarea:first');
+                var editorElement = this.$('.note-editable').get(0);
+                var editorCode = $.parseHTML(textarea.code());
                 var textIsEmpty = $(editorCode).text().length === 0;
 
                 if (isEmpty(editorElement) || textIsEmpty) {
-                    this.editorCode('');
+                    textarea.code('');
                 }
-            },
-
-            editorCode: function (content) {
-                return this.$('.field-input:first textarea:first').code(content);
             },
 
             /**
              * @inheritDoc
              */
             updateModel: function () {
-                var data = this.editorCode();
+                var data = this.$('.field-input:first textarea:first').code();
                 data = '' === data ? this.attribute.empty_value : data;
                 this.setCurrentValue(data);
             },

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/wysiwyg-field.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/wysiwyg-field.js
@@ -58,13 +58,11 @@ define(
             },
 
             cleanEmptyInput: function () {
-                var isEmpty = $.summernote.core.dom.isEmpty;
                 var textarea = this.$('.field-input:first textarea:first');
-                var editorElement = this.$('.note-editable').get(0);
                 var editorCode = $.parseHTML(textarea.code());
                 var textIsEmpty = $(editorCode).text().length === 0;
 
-                if (isEmpty(editorElement) || textIsEmpty) {
+                if (textIsEmpty) {
                     textarea.code('');
                 }
             },

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/wysiwyg-field.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/wysiwyg-field.js
@@ -36,7 +36,7 @@ define(
              * @inheritDoc
              */
             postRender: function () {
-                var editor = this.$('textarea').summernote({
+                this.$('textarea').summernote({
                     disableResizeEditor: true,
                     height: 200,
                     iconPrefix: 'icon-',
@@ -50,33 +50,28 @@ define(
                 })
                 .on('summernote.blur', this.updateModel.bind(this))
                 .on('summernote.keyup', this.cleanEmptyInput.bind(this));
-
             },
 
             cleanEmptyInput: function () {
                 var isEmpty = $.summernote.core.dom.isEmpty;
                 var editorElement = this.$('.note-editable').get(0)
-                var editorCode = $.parseHTML(this.getCode());
+                var editorCode = $.parseHTML(this.editorCode());
                 var textIsEmpty = $(editorCode).text().length === 0;
 
                 if (isEmpty(editorElement) || textIsEmpty) {
-                    this.setCode('');
+                    this.editorCode('');
                 }
             },
 
-            setCode: function (content) {
-                return this.$('.field-input:first textarea:first').code(content)
-            },
-
-            getCode: function () {
-                return this.$('.field-input:first textarea:first').code();
+            editorCode: function (content) {
+                return this.$('.field-input:first textarea:first').code(content);
             },
 
             /**
              * @inheritDoc
              */
             updateModel: function () {
-                var data = this.getCode();
+                var data = this.editorCode();
                 data = '' === data ? this.attribute.empty_value : data;
                 this.setCurrentValue(data);
             },

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/wysiwyg-field.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/wysiwyg-field.js
@@ -36,7 +36,7 @@ define(
              * @inheritDoc
              */
             postRender: function () {
-                this.$('textarea').summernote({
+                var editor = this.$('textarea').summernote({
                     disableResizeEditor: true,
                     height: 200,
                     iconPrefix: 'icon-',
@@ -45,17 +45,39 @@ define(
                         ['para', ['ul', 'ol']],
                         ['insert', ['link']],
                         ['view', ['codeview']]
-                    ]
-                }).on('summernote.blur', this.updateModel.bind(this));
+                    ],
+                    callbacks: {},
+                })
+                .on('summernote.blur', this.updateModel.bind(this))
+                .on('summernote.keyup', this.cleanEmptyInput.bind(this));
+
+            },
+
+            cleanEmptyInput: function () {
+                var isEmpty = $.summernote.core.dom.isEmpty;
+                var editorElement = this.$('.note-editable').get(0)
+                var editorCode = $.parseHTML(this.getCode());
+                var textIsEmpty = $(editorCode).text().length === 0;
+
+                if (isEmpty(editorElement) || textIsEmpty) {
+                    this.setCode('');
+                }
+            },
+
+            setCode: function (content) {
+                return this.$('.field-input:first textarea:first').code(content)
+            },
+
+            getCode: function () {
+                return this.$('.field-input:first textarea:first').code();
             },
 
             /**
              * @inheritDoc
              */
             updateModel: function () {
-                var data = this.$('.field-input:first textarea:first').code();
+                var data = this.getCode();
                 data = '' === data ? this.attribute.empty_value : data;
-
                 this.setCurrentValue(data);
             },
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/wysiwyg-field.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/wysiwyg-field.js
@@ -49,15 +49,15 @@ define(
                     callbacks: {},
                 })
                 .on('summernote.blur', this.updateModel.bind(this))
-                .on('summernote.keyup', this.cleanEmptyInput.bind(this));
+                .on('summernote.keyup', this.removeEmptyTags.bind(this));
 
                 this.$('.note-codable').on('blur', function () {
-                    this.cleanEmptyInput();
+                    this.removeEmptyTags();
                     this.updateModel();
                 }.bind(this));
             },
 
-            cleanEmptyInput: function () {
+            removeEmptyTags: function () {
                 var textarea = this.$('.field-input:first textarea:first');
                 var editorHTML = $.parseHTML(textarea.code());
                 var textIsEmpty = $(editorHTML).text().length === 0;


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

This PR fixes two issues in the summernote wysiwyg editor: 
1. Where the editor leaves empty tags (e.g. `<p><br/><p>` in the code view, even when all content has been removed in the editing view. This was fixed by manually cleaning the empty tags onkeyup/onblur 

2. Where the corresponding model does not get updated after making an edit in the code view. This was fixed by triggering the `updateModel` method when the code view editor loses focus (like how the editing view works). 

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
