### PR TITLE
[GITHUB-6061] Fix menu display for big words

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -5,6 +5,7 @@
 - PIM-6277: Use catalogLocale for channel and scopable attribute labels
 - PIM-6324: Fix invalid field focus after creating an attribute with missing data
 - PIM-6286: Fix User repository
+- GITHUB-6061: Fix menu display for big words
 
 # 1.7.2 (2017-04-07)
 

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/MainMenu.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/MainMenu.less
@@ -25,6 +25,7 @@
     display: block;
     color: white;
     transition: background 0.1s ease;
+    white-space: nowrap;
   }
 
   &-link.active {
@@ -39,8 +40,8 @@
   }
 
   &-level2 {
-    width: @submenuWidth;
-    right: -@submenuWidth;
+    width: auto;
+    left: 100%;
     margin-top: -(@submenuHeight + 2px);
   }
 


### PR DESCRIPTION
Solves this issue:
https://github.com/akeneo/pim-community-dev/issues/6061

No CI needed.

![screenshot from 2017-04-14 10 10 31](https://cloud.githubusercontent.com/assets/1590933/25037673/bd71004a-20fa-11e7-864e-3a8017adc4be.png)
