### PR TITLE
PIM-5709: Fix clicking date picker also opens date picker in compare panel

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -6,6 +6,7 @@
 - PIM-6324: Fix invalid field focus after creating an attribute with missing data
 - PIM-6286: Fix User repository
 - GITHUB-6061: Fix menu display for big words
+- PIM-5709: Fix clicking date picker also opens date picker in compare panel
 
 # 1.7.2 (2017-04-07)
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/date-field.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/date-field.js
@@ -38,7 +38,7 @@ define(
             renderInput: function (context) {
                 return this.fieldTemplate(context);
             },
-            click: function () {
+            click: function (event) {
                 var clickedElement = $(event.currentTarget).parent();
                 var picker = this.$('.datetimepicker');
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/date-field.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/date-field.js
@@ -37,9 +37,13 @@ define(
                 return this.fieldTemplate(context);
             },
             click: function () {
-                Datepicker.init(this.$('.datetimepicker'), this.datetimepickerOptions).datetimepicker('show');
+                var clickedElement = $(event.currentTarget).parent();
+                var picker = this.$('.datetimepicker')
 
-                this.$('.datetimepicker').on('changeDate', function (e) {
+                Datepicker.init(picker, this.datetimepickerOptions);
+                clickedElement.datetimepicker('show');
+
+                picker.on('changeDate', function (e) {
                     this.setCurrentValue(this.$(e.target).find('input[type="text"]').val());
                 }.bind(this));
             },

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/date-field.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/date-field.js
@@ -9,6 +9,7 @@
  */
 define(
     [
+        'jquery',
         'pim/field',
         'underscore',
         'text!pim/template/product/field/date',
@@ -16,6 +17,7 @@ define(
         'pim/date-context'
     ],
     function (
+        $,
         Field,
         _,
         fieldTemplate,
@@ -38,7 +40,7 @@ define(
             },
             click: function () {
                 var clickedElement = $(event.currentTarget).parent();
-                var picker = this.$('.datetimepicker')
+                var picker = this.$('.datetimepicker');
 
                 Datepicker.init(picker, this.datetimepickerOptions);
                 clickedElement.datetimepicker('show');


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

This PR fixes a bug where opening the date picker on the product edit page also opens the copied picker in the compare panel. This fix initializes both date pickers in the `date-field` view but only triggers the `show` event on the one that was clicked (instead of both)

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed