### PR TITLE
PIM-6322: Add output for attribute option form validation

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -7,6 +7,7 @@
 - PIM-6286: Fix User repository
 - GITHUB-6061: Fix menu display for big words
 - PIM-5709: Fix clicking date picker also opens date picker in compare panel
+- PIM-6322: Add output for attribute option form validation
 
 # 1.7.2 (2017-04-07)
 

--- a/features/attribute/option/create_attribute_options.feature
+++ b/features/attribute/option/create_attribute_options.feature
@@ -54,3 +54,14 @@ Feature: Create attribute options
     And I save the attribute
     Then the Options section should contain 4 options
 
+    @jira https://akeneo.atlassian.net/browse/PIM-6322
+    Scenario: Successfully display validation message for empty attribute option code
+      Given the following attributes:
+        | code | type                     | localizable | scopable | group |
+        | size | pim_catalog_simpleselect | 0           | 0        | other |
+      And I am on the "size" attribute page
+      When I visit the "Values" tab
+      And I create the following attribute options:
+        | Code |
+        | shoe size |
+      Then I should see validation tooltip "Option code may contain only letters, numbers and underscores"

--- a/features/attribute/option/create_attribute_options.feature
+++ b/features/attribute/option/create_attribute_options.feature
@@ -62,6 +62,6 @@ Feature: Create attribute options
       And I am on the "size" attribute page
       When I visit the "Values" tab
       And I create the following attribute options:
-        | Code |
+        | Code      |
         | shoe size |
       Then I should see validation tooltip "Option code may contain only letters, numbers and underscores"

--- a/src/Pim/Bundle/EnrichBundle/Controller/AttributeOptionController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/AttributeOptionController.php
@@ -225,7 +225,20 @@ class AttributeOptionController
             return new JsonResponse($option);
         }
 
-        return $this->viewHandler->handle(RestView::create($form));
+        return new JsonResponse($this->getFormErrors($form), 400);
+    }
+
+    protected function getFormErrors($form)
+    {
+        $errors = array();
+
+        foreach ($form as $child) {
+            foreach ($child->getErrors(true) as $error) {
+                $errors[$child->getName()] = $error->getMessage();
+            }
+        }
+
+        return $errors;
     }
 
     /**

--- a/src/Pim/Bundle/EnrichBundle/Controller/AttributeOptionController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/AttributeOptionController.php
@@ -228,9 +228,16 @@ class AttributeOptionController
         return new JsonResponse($this->getFormErrors($form), 400);
     }
 
+    /**
+     * Parse form errors and return as an object
+     *
+     * @param FormInterface $form
+     *
+     * @return object
+     */
     protected function getFormErrors($form)
     {
-        $errors = array();
+        $errors = [];
 
         foreach ($form as $child) {
             foreach ($child->getErrors(true) as $error) {

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/attribute-option/create.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/attribute-option/create.js
@@ -65,14 +65,10 @@ define(
                         }).fail(function (xhr) {
                             var response = xhr.responseJSON;
 
-                            if (response.children &&
-                                response.children.code &&
-                                response.children.code.errors &&
-                                response.children.code.errors.length
-                            ) {
+                            if (response.code) {
                                 form.$('input[name="code"]').after(
                                     this.errorTemplate({
-                                        errors: response.children.code.errors
+                                        errors: [response.code]
                                     })
                                 );
                             } else {

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/pim-attributeoptionview.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/pim-attributeoptionview.js
@@ -154,31 +154,27 @@ define(
                             this.clean();
                             this.stopEditItem();
                         }.bind(this),
-                        error: function (data, xhr) {
-                            this.inLoading(false);
-
-                            var response = xhr.responseJSON;
-
-                            if (response.children &&
-                                response.children.code &&
-                                response.children.code.errors &&
-                                response.children.code.errors.length > 0
-                            ) {
-                                var message = response.children.code.errors.join('<br/>');
-                                this.$el.find('.validation-tooltip')
-                                    .removeClass('AknIconButton--hide')
-                                    .tooltip('destroy')
-                                    .tooltip({title: message})
-                                    .tooltip('show');
-                            } else {
-                                Dialog.alert(
-                                    __('alert.attribute_option.error_occured_during_submission'),
-                                    __('error.saving.attribute_option')
-                                );
-                            }
-                        }.bind(this)
+                        error: this.showValidationErrors.bind(this)
                     }
                 );
+            },
+            showValidationErrors: function (data, xhr) {
+                this.inLoading(false);
+
+                var response = xhr.responseJSON;
+
+                if (response.code) {
+                    this.$el.find('.validation-tooltip')
+                        .removeClass('AknIconButton--hide')
+                        .tooltip('destroy')
+                        .tooltip({title: response.code})
+                        .tooltip('show');
+                } else {
+                    Dialog.alert(
+                        __('alert.attribute_option.error_occured_during_submission'),
+                        __('error.saving.attribute_option')
+                    );
+                }
             },
             cancelSubmit: function (e) {
                 if (e.keyCode === 13) {

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/pim-attributeoptionview.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/pim-attributeoptionview.js
@@ -165,9 +165,9 @@ define(
 
                 if (response.code) {
                     this.$el.find('.validation-tooltip')
+                        .attr('data-original-title', response.code)
                         .removeClass('AknIconButton--hide')
                         .tooltip('destroy')
-                        .tooltip({title: response.code})
                         .tooltip('show');
                 } else {
                     Dialog.alert(


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

This PR updates the controller and js for attribute options to display form validation errors (fixing a regression from 1.6).

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | OK
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
