### PR TITLE
PIM-6378: Fix translations for channel labels in export builder

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -1,3 +1,10 @@
+# 1.7.x
+
+## Bug Fixes
+
+- PIM-6322: Add output for attribute option form validation
+- PIM-6378: Fix translations for channel labels in export builder
+
 # 1.7.3 (2017-04-14)
 
 ## Bug Fixes
@@ -7,7 +14,6 @@
 - PIM-6286: Fix User repository
 - GITHUB-6061: Fix menu display for big words
 - PIM-5709: Fix clicking date picker also opens date picker in compare panel
-- PIM-6322: Add output for attribute option form validation
 
 # 1.7.2 (2017-04-07)
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/job/product/edit/content/structure/scope.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/job/product/edit/content/structure/scope.js
@@ -15,7 +15,8 @@ define(
         'pim/form',
         'pim/fetcher-registry',
         'pim/user-context',
-        'jquery.select2'
+        'jquery.select2',
+        'pim/i18n'
     ],
     function (
         $,
@@ -24,7 +25,9 @@ define(
         template,
         BaseForm,
         fetcherRegistry,
-        UserContext
+        UserContext,
+        select2,
+        i18n
     ) {
         return BaseForm.extend({
             config: {},
@@ -61,8 +64,7 @@ define(
                         this.template({
                             isEditable: this.isEditable(),
                             __: __,
-                            locale: UserContext.get('uiLocale'),
-                            channels: channels,
+                            channels: this.setChannelLabels(channels),
                             scope: this.getScope(),
                             errors: this.getParent().getValidationErrorsForField('scope')
                         })
@@ -78,6 +80,22 @@ define(
                 }.bind(this));
 
                 return this;
+            },
+
+            /**
+             * Sets fallback labels for channels without a translation
+             *
+             * @param {Array} channels
+             *
+             * @return {Array}
+             */
+            setChannelLabels: function (channels) {
+                var locale = UserContext.get('uiLocale');
+
+                return _.map(channels, function (channel) {
+                    channel.label = i18n.getLabel(channel.labels, locale, channel.code);
+                    return channel;
+                });
             },
 
             /**

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/job/product/edit/content/structure/scope.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/job/product/edit/content/structure/scope.js
@@ -94,6 +94,7 @@ define(
 
                 return _.map(channels, function (channel) {
                     channel.label = i18n.getLabel(channel.labels, locale, channel.code);
+
                     return channel;
                 });
             },

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/export/product/edit/content/structure/scope.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/export/product/edit/content/structure/scope.html
@@ -6,7 +6,7 @@
 <div class="AknFieldContainer-inputContainer">
     <select class="select2" <%- isEditable ? '' : 'disabled' %> id="pim_enrich.export.product.filter.channel">
         <% _.each(channels, function (channel) { %>
-            <option value="<%- channel.code %>" <%- channel.code === scope ? 'selected' : '' %>><%- channel.labels[locale] %></option>
+            <option value="<%- channel.code %>" <%- channel.code === scope ? 'selected' : '' %>><%- channel.label %></option>
         <% }); %>
     </select>
     <div class="AknFieldContainer-iconsContainer icons-container">


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

This PR fixes a bug in the channel selector for export profiles. It adds a code fallback for each channel when translations are missing. See #6004 

Before:
<img width="535" alt="7eb39128-14ad-11e7-8d18-452157106c0e" src="https://cloud.githubusercontent.com/assets/1336344/25137964/83654eda-2459-11e7-869a-c02c0f0227a2.png">

After: 
![screen shot 2017-04-18 at 16 40 21](https://cloud.githubusercontent.com/assets/1336344/25137978/8c575146-2459-11e7-9b5c-3e1d8a171504.png)



[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           |  -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
