### PR TITLE
GITHUB-5937 - Remove mcrypt requirement

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -28,10 +28,6 @@
 
 - Change the constructor of `Pim\Bundle\EnrichBundle\MassEditAction\Operation\SetAttributeRequirements` to remove `Pim\Component\Catalog\Repository\AttributeRepositoryInterface` and remove `Pim\Component\Catalog\Factory\AttributeRequirementFactory`
 
-## Requirements
-
-- GITHUB-5937: Remove the need to have mcrypt installed
-
 # 1.7.1 (2017-03-23)
 
 ## Bug Fixes

--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -28,6 +28,10 @@
 
 - Change the constructor of `Pim\Bundle\EnrichBundle\MassEditAction\Operation\SetAttributeRequirements` to remove `Pim\Component\Catalog\Repository\AttributeRepositoryInterface` and remove `Pim\Component\Catalog\Factory\AttributeRequirementFactory`
 
+## Requirements
+
+- GITHUB-5937: Remove the need to have mcrypt installed
+
 # 1.7.1 (2017-03-23)
 
 ## Bug Fixes

--- a/CHANGELOG-1.8.md
+++ b/CHANGELOG-1.8.md
@@ -17,3 +17,7 @@
 - Change the constructor of `Pim\Component\Catalog\Updater\FamilyUpdater` to add `Akeneo\Component\Localization\TranslatableUpdater`
 - Change the constructor of `Pim\Component\Catalog\Updater\AttributeUpdater` to add `Akeneo\Component\Localization\TranslatableUpdater`
 - Change the constructor of `Akeneo\Bundle\BatchBundle\Launcher\SimpleJobLauncher` to add `kernel.logs_dir`
+
+## Requirements
+
+- GITHUB-5937: Remove the need to have mcrypt installed

--- a/app/OroRequirements.php
+++ b/app/OroRequirements.php
@@ -40,12 +40,6 @@ class OroRequirements extends SymfonyRequirements
         );
 
         $this->addOroRequirement(
-            function_exists('mcrypt_encrypt'),
-            'mcrypt_encrypt() should be available',
-            'Install and enable the <strong>Mcrypt</strong> extension.'
-        );
-
-        $this->addOroRequirement(
             class_exists('Locale'),
             'intl extension should be available',
             'Install and enable the <strong>intl</strong> extension.'


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
Fix https://github.com/akeneo/pim-community-dev/issues/5937 by removing mcrypt requirement.

After searching any mcrypt function on the project, it does not seem to be used (as stated by @gquemener and @a2xchip).

I've added a **Requirements** part in the Changelog, not really sure where to do add this modification, is this correct?

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
