### PR TITLE
Allow Create Oauth command to return a validable format (XML, Json)

### DIFF
--- a/src/Pim/Bundle/ApiBundle/Command/CreateClientCommand.php
+++ b/src/Pim/Bundle/ApiBundle/Command/CreateClientCommand.php
@@ -84,7 +84,7 @@ class CreateClientCommand extends ContainerAwareCommand
      * Returns the output into the selected format.
      * @param OutputInterface $output
      * @param ClientInterface $client
-     * @param $format
+     * @param string $format
      */
     private function displayOutput(OutputInterface $output, ClientInterface $client, $format)
     {

--- a/src/Pim/Bundle/ApiBundle/Command/CreateClientCommand.php
+++ b/src/Pim/Bundle/ApiBundle/Command/CreateClientCommand.php
@@ -3,7 +3,7 @@
 namespace Pim\Bundle\ApiBundle\Command;
 
 use OAuth2\OAuth2;
-use  FOS\OAuthServerBundle\Model\ClientInterface;
+use FOS\OAuthServerBundle\Model\ClientInterface;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;

--- a/src/Pim/Bundle/ApiBundle/Command/CreateClientCommand.php
+++ b/src/Pim/Bundle/ApiBundle/Command/CreateClientCommand.php
@@ -52,7 +52,7 @@ class CreateClientCommand extends ContainerAwareCommand
                 null,
                 InputOption::VALUE_REQUIRED,
                 'The output format (txt or xml)',
-                'xml'
+                'txt'
             )
         ;
     }


### PR DESCRIPTION
Hello,

discussing with @pardahlman who is doing great job on C# client for Akeneo API, we have found a little improvement to do.

The idea here is that we can only retrieve Oauth credentials using the Akeneo console, and text format is easy to read but hard to validate. We'd like to provide a simple and validable XML output.

Of course, It need to be discussed.

Before:

![before](https://cloud.githubusercontent.com/assets/1247388/25378967/c9715a5c-29ab-11e7-8a77-e25f7572e62d.PNG)

After:

`app/console pim:oauth-server:create-client --format=xml`

![xml](https://cloud.githubusercontent.com/assets/1247388/25378988/d86693f6-29ab-11e7-81fc-8d70d4314f59.PNG)

`app/console pim:oauth-server:create-client --format=json`

![json](https://cloud.githubusercontent.com/assets/1247388/25379003/e11e33dc-29ab-11e7-9063-2a029b0703ea.PNG)

`app/console pim:oauth-server:create-client`

![after](https://cloud.githubusercontent.com/assets/1247388/25379040/f7a1b278-29ab-11e7-947f-63c6c74d0218.PNG)

> Why do we need that?

This is not a good practice at all to manipulate a string output from a command to get credentials from an application using regular expressions, because we assume the rendering - the view - won't change. XML is a great format, because it represent the contract we have with our customers. We provide a `client` and a `secret` in `credentials` parent node and this won't change, *never*.

This means any people from any platform and language can retrieve this credentials easily.



