### PR TITLE
Fix paths of image attributes at pim_catalog_product_template

### DIFF
--- a/upgrades/schema/Version_1_7_20161009194818_product_template.php
+++ b/upgrades/schema/Version_1_7_20161009194818_product_template.php
@@ -11,7 +11,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * As standard format has been changed, we have to update the table `pim_catalog_product_template` to update keys of
- * `metric` and `price` attributes (`data` has been changed to `amount`).
+ * `metric` and `price` attributes (`data` has been changed to `amount`). Also `image` attributes should be fixed.
  */
 class Version_1_7_20161009194818_product_template extends AbstractMigration implements ContainerAwareInterface
 {
@@ -34,10 +34,10 @@ class Version_1_7_20161009194818_product_template extends AbstractMigration impl
         $schemaHelper = new SchemaHelper($this->container);
 
         $attributes = $this->container->get('pim_catalog.repository.attribute')->findBy([
-            'type' => [AttributeTypes::METRIC, AttributeTypes::PRICE_COLLECTION]
+            'type' => [AttributeTypes::METRIC, AttributeTypes::PRICE_COLLECTION, AttributeTypes::IMAGE]
         ]);
 
-        $attributeCodes = ['metric' => [], 'price' => []];
+        $attributeCodes = ['metric' => [], 'price' => [], 'image' => []];
         foreach ($attributes as $attribute) {
             if (AttributeTypes::METRIC === $attribute->getAttributeType()) {
                 $attributeCodes['metric'][] = $attribute->getCode();
@@ -45,6 +45,10 @@ class Version_1_7_20161009194818_product_template extends AbstractMigration impl
 
             if (AttributeTypes::PRICE_COLLECTION === $attribute->getAttributeType()) {
                 $attributeCodes['price'][] = $attribute->getCode();
+            }
+
+            if (AttributeTypes::IMAGE === $attribute->getAttributeType()) {
+                $attributeCodes['image'][] = $attribute->getCode();
             }
         }
 
@@ -66,6 +70,8 @@ class Version_1_7_20161009194818_product_template extends AbstractMigration impl
                                     unset($data['data'][$indexPrice]['data']);
                                 }
                             }
+                        } elseif (in_array($code, $attributeCodes['image'])) {
+                            $data['data'] = isset($data['data']['filePath']) ? $data['data']['filePath'] : null;
                         }
 
                         $values[$code][$index] = $data;


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

[//]: <> (What does this Pull Request do? reference the related issue?)

Migrating from `v.1.6` to `v1.7` I've got error: `Property "image" expects a string as data, "array" given.`

Paths of `image` attributes must be fixed when migrating product templates to `v1.7`

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -
