### PR TITLE
PIM-6377: add sanity check in price property formatter

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -4,6 +4,7 @@
 
 - PIM-6322: Add output for attribute option form validation
 - PIM-6378: Fix translations for channel labels in export builder
+- PIM-6377: Fix potential notice in price property formatter
 
 # 1.7.3 (2017-04-14)
 

--- a/src/Pim/Bundle/DataGridBundle/Extension/Formatter/Property/ProductValue/PriceProperty.php
+++ b/src/Pim/Bundle/DataGridBundle/Extension/Formatter/Property/ProductValue/PriceProperty.php
@@ -45,8 +45,12 @@ class PriceProperty extends FieldProperty
         $data = $this->getBackendData($value);
 
         foreach ($data as $index => $price) {
-            $data[$index]['amount'] = $price['data'];
-            unset($price['data']);
+            if (array_key_exists('data', $price)) {
+                $data[$index]['amount'] = $price['data'];
+                unset($price['data']);
+            } else {
+                $data[$index]['amount'] = null;
+            }
         }
 
         return $this->presenter->present($data, ['locale' => $this->translator->getLocale()]);


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Price field does not appear on the variation datagrid.

It happens only for MongoDB storage, when there are no property data set for a price.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
