### PR TITLE
GITHUB-5949 - Allow to delete import/export profile on the profile page

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -17,6 +17,7 @@
 - PIM-6283: Fix a bug where SKUs of products in the Variant Group edit page were not displayed
 - PIM-6274: Successfully validate products with a custom validation on identifier
 - PIM-6199: Fix product mass edit attribute add select clickable on confirmation page
+- GITHUB-6105: Fix the deletion of a job instance (import/export) from the job edit page
 
 ## BC breaks
 

--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -17,7 +17,7 @@
 - PIM-6283: Fix a bug where SKUs of products in the Variant Group edit page were not displayed
 - PIM-6274: Successfully validate products with a custom validation on identifier
 - PIM-6199: Fix product mass edit attribute add select clickable on confirmation page
-- GITHUB-6105: Fix the deletion of a job instance (import/export) from the job edit page
+- GITHUB-6105: Fix the deletion of a job instance (import/export) from the job edit page, cheers @BatsaxIV !
 
 ## BC breaks
 

--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -17,7 +17,7 @@
 - PIM-6283: Fix a bug where SKUs of products in the Variant Group edit page were not displayed
 - PIM-6274: Successfully validate products with a custom validation on identifier
 - PIM-6199: Fix product mass edit attribute add select clickable on confirmation page
-- GITHUB-6105: Fix the deletion of a job instance (import/export) from the job edit page, cheers @BatsaxIV !
+- GITHUB-5949: Fix the deletion of a job instance (import/export) from the job edit page, cheers @BatsaxIV !
 
 ## BC breaks
 

--- a/features/export/delete_an_export.feature
+++ b/features/export/delete_an_export.feature
@@ -11,15 +11,24 @@ Feature: Delete export
     And I am on the exports page
     When I change the page size to 100
     Then the grid should contain 23 elements
-    When I delete the "csv_footwear_product_export" job
 
-  Scenario: Successfully delete an export job
-    Given I confirm the deletion
+  Scenario: Successfully delete an export job from the export grid
+    Given I delete the "csv_footwear_product_export" job
+    When I confirm the deletion
     Then I should see the flash message "Export profile successfully removed"
     And the grid should contain 22 elements
     And I should not see export profile "csv_footwear_product_export"
 
   Scenario: Successfully cancel the deletion of an export job
-    Given I cancel the deletion
+    Given I delete the "csv_footwear_product_export" job
+    When I cancel the deletion
     Then the grid should contain 23 elements
     And I should see export profile "csv_footwear_product_export"
+
+  Scenario: Successfully delete an export job from the job edit page
+    Given I am on the "csv_footwear_product_export" import job edit page
+    When I press the "Delete" button
+    And I confirm the deletion
+    Then I should see the flash message "Job instance successfully removed"
+    And the grid should contain 22 elements
+    And I should not see export profile "csv_footwear_product_export"

--- a/features/import/delete_an_import.feature
+++ b/features/import/delete_an_import.feature
@@ -11,7 +11,7 @@ Feature: Delete import
     And I am on the imports page
     And I change the page size to 25
 
-  Scenario: Successfully delete a CSV import job
+  Scenario: Successfully delete a CSV import job from the jobs page
     Given I delete the "csv_footwear_product_import" job
     When I confirm the deletion
     Then I should see the flash message "Import profile successfully removed"
@@ -23,3 +23,11 @@ Feature: Delete import
     When I cancel the deletion
     Then the grid should contain 27 elements
     And I should see import profile "csv_footwear_product_import"
+
+  Scenario: Successfully delete a CSV import job from the job edit page
+    Given I am on the "csv_footwear_product_import" import job edit page
+    When I press the "Delete" button
+    And I confirm the deletion
+    Then I should see the flash message "Job instance successfully removed"
+    And the grid should contain 26 elements
+    And I should not see import profile "csv_footwear_product_import"

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/remover/job-instance-export-remover.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/remover/job-instance-export-remover.js
@@ -23,7 +23,7 @@ define([
              * {@inheritdoc}
              */
             getUrl: function (code) {
-                return Routing.generate(module.config().url, {identifier: code});
+                return Routing.generate(module.config().url, {code: code});
             }
         });
     }

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/remover/job-instance-import-remover.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/remover/job-instance-import-remover.js
@@ -23,7 +23,7 @@ define([
              * {@inheritdoc}
              */
             getUrl: function (code) {
-                return Routing.generate(module.config().url, {identifier: code});
+                return Routing.generate(module.config().url, {code: code});
             }
         });
     }

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
@@ -14,6 +14,7 @@ confirmation:
         export profile:   Are you sure you want to delete this export profile?
         user:             Are you sure you want to delete this user?
         role:             Are you sure you want to delete this role?
+        job_instance:     Are you sure you want to delete this job instance ?
 
 pim_datagrid:
     mass_action_group:
@@ -59,6 +60,8 @@ flash:
         removed: User successfully removed
     role:
         removed: Role successfully removed
+    job_instance:
+        removed: Job instance successfully removed
 
 error:
     creating:

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
@@ -14,7 +14,7 @@ confirmation:
         export profile:   Are you sure you want to delete this export profile?
         user:             Are you sure you want to delete this user?
         role:             Are you sure you want to delete this role?
-        job_instance:     Are you sure you want to delete this job instance ?
+        job_instance:     Are you sure you want to delete this job instance?
 
 pim_datagrid:
     mass_action_group:


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**
Fix https://github.com/akeneo/pim-community-dev/issues/5949 - Allow to delete import/export profile on the profile page

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | Ok
| Added integration tests           | -
| Changelog updated                 | Ok
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
