### PR TITLE
PIM-6387: fix HTTP code returned when the token is invalid or expired

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -5,6 +5,7 @@
 - PIM-6322: Add output for attribute option form validation
 - PIM-6378: Fix translations for channel labels in export builder
 - PIM-6377: Fix potential notice in price property formatter
+- PIM-6387: Fix HTTP code returned when the token is invalid or expired
 
 # 1.7.3 (2017-04-14)
 

--- a/src/Pim/Bundle/ApiBundle/Security/OAuth2.php
+++ b/src/Pim/Bundle/ApiBundle/Security/OAuth2.php
@@ -4,7 +4,8 @@ namespace Pim\Bundle\ApiBundle\Security;
 
 use OAuth2\OAuth2 as BaseOAuth2;
 use OAuth2\OAuth2AuthenticateException;
-use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 
 /**
  * @author    Marie Bochu <marie.bochu@akeneo.com>
@@ -21,7 +22,7 @@ class OAuth2 extends BaseOAuth2
         try {
             return parent::verifyAccessToken($tokenParam, $scope);
         } catch (OAuth2AuthenticateException $e) {
-            throw new UnprocessableEntityHttpException($e->getDescription(), $e);
+            throw new HttpException(Response::HTTP_UNAUTHORIZED, $e->getDescription(), $e);
         }
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Token/GetAccessTokenIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Token/GetAccessTokenIntegration.php
@@ -259,6 +259,22 @@ class GetAccessTokenIntegration extends ApiTestCase
         $this->assertArrayNotHasKey('refresh_token', $responseBody);
     }
 
+    public function testInvalidToken()
+    {
+        $client = ApiTestCase::createClient();
+
+        $client->request('GET', 'api/rest/v1/products/foo', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer invalidToken',
+            'CONTENT_TYPE' => 'application/json',
+        ]);
+
+        $response = $client->getResponse();
+        $responseBody = json_decode($response->getContent(), true);
+
+        $this->assertSame(Response::HTTP_UNAUTHORIZED, $response->getStatusCode());
+        $this->assertSame('The access token provided is invalid.', $responseBody['message']);
+    }
+
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When requesting the API, when the token has expired or is invalid, the HTTP status returned should be 401 instead of 422.

This is done by throwing an "UnauthorizedHttpException" during the verification of the access token. This exception need a parameter to build the HTTP header "WWW-Authenticate" which is fetched by the OAuth exception.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | OK
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
