### PR TITLE
Allow Create Oauth command to return XML and json

### DIFF
--- a/src/Pim/Bundle/ApiBundle/Command/CreateClientCommand.php
+++ b/src/Pim/Bundle/ApiBundle/Command/CreateClientCommand.php
@@ -3,6 +3,7 @@
 namespace Pim\Bundle\ApiBundle\Command;
 
 use OAuth2\OAuth2;
+use Pim\Bundle\ApiBundle\Entity\Client;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -46,6 +47,13 @@ class CreateClientCommand extends ContainerAwareCommand
                 InputOption::VALUE_REQUIRED,
                 'Sets a label to ease the administration of client ids.'
             )
+            ->addOption(
+                'format',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'The output format (txt, json or xml)',
+                'txt'
+            )
         ;
     }
 
@@ -66,17 +74,60 @@ class CreateClientCommand extends ContainerAwareCommand
 
         $clientManager->updateClient($client);
 
-        $output->writeln([
-            'A new client has been added.',
-            sprintf('client_id: <info>%s</info>', $client->getPublicId()),
-            sprintf('secret: <info>%s</info>', $client->getSecret()),
-        ]);
-
-        $label = $client->getLabel();
-        if (null !== $label) {
-            $output->writeln(sprintf('label: <info>%s</info>', $label));
-        }
+        $this->displayOutput($output, $client, $input->getOption('format'));
 
         return 0;
+    }
+
+
+    /**
+     * Returns the output into the selected format.
+     * @param OutputInterface $output
+     * @param Client $client
+     * @param string $format
+     */
+    private function displayOutput(OutputInterface $output, Client $client, $format)
+    {
+        $serializer = $this->getContainer()->get('pim_serializer');
+        $credentials = [
+            'client_id' => $client->getPublicId(),
+            'secret'    => $client->getSecret()
+        ];
+
+        $hasLabel = (null !== $client->getLabel());
+
+        if ($hasLabel) {
+            $credentials['label'] = addslashes($client->getLabel());
+        }
+
+        switch ($format) {
+            case 'xml':
+                $xmlContent = $serializer->encode(
+                    $credentials,
+                    'xml' ,
+                    [
+                        'xml_root_node_name' => 'credentials',
+                        'xml_encoding' => 'UTF-8'
+                    ]
+                );
+
+                $output->writeln($xmlContent);
+                break;
+            case 'json':
+                $jsonContent = $serializer->encode($credentials, 'json');
+
+                $output->writeln($jsonContent);
+                break;
+            default:
+                $output->writeln([
+                    'A new client has been added.',
+                    sprintf('client_id: <info>%s</info>', $credentials['client_id']),
+                    sprintf('secret: <info>%s</info>', $credentials['secret']),
+                ]);
+
+                if ($hasLabel) {
+                    $output->writeln(sprintf('label: <info>%s</info>', $credentials['label']));
+                }
+        }
     }
 }

--- a/src/Pim/Bundle/ApiBundle/spec/Command/CreateClientCommandSpec.php
+++ b/src/Pim/Bundle/ApiBundle/spec/Command/CreateClientCommandSpec.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace spec\Pim\Bundle\ApiBundle\Command;
+
+use OAuth2\OAuth2;
+use Prophecy\Argument;
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\ApiBundle\Entity\Client;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use FOS\OAuthServerBundle\Model\ClientManagerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+class CreateClientCommandSpec extends ObjectBehavior
+{
+    function let(InputInterface $input, Client $client, EncoderInterface $encoder)
+    {
+        $input->bind(Argument::cetera())->willReturn();
+        $input->getArgument(Argument::cetera())->willReturn(Argument::cetera());
+        $input->hasArgument(Argument::cetera())->willReturn(true);
+        $input->isInteractive()->willReturn(false);
+
+        $input->getOption('format')->willReturn('xml');
+        $input->getOption('redirect_uri')->willReturn([]);
+        $input->getOption('grant_type')->willReturn([]);
+        $input->hasOption('label')->willReturn(false);
+        $input->validate()->willReturn();
+
+        $client->getLabel()->willReturn(null);
+        $client->setRedirectUris([])->willReturn();
+        $client->setAllowedGrantTypes(Argument::cetera())->willReturn();
+        $client->getPublicId()->willReturn();
+        $client->getSecret()->willReturn();
+
+        $encoder->encode(Argument::cetera())->willReturn();
+    }
+
+    function it_is_a_container_aware_command()
+    {
+        $this->shouldHaveType('Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand');
+    }
+
+    function it_has_a_name()
+    {
+        $this->getName()->shouldReturn('pim:oauth-server:create-client');
+    }
+
+    function it_runs_the_fos_client_manager_and_serializer(
+        ClientManagerInterface $clientManager,
+        ContainerInterface $container,
+        EncoderInterface $encoder,
+        InputInterface $input,
+        OutputInterface $output,
+        Client $client
+    )
+    {
+        $container->get('fos_oauth_server.client_manager.default')->willReturn($clientManager);
+        $container->get('pim_serializer')->willReturn($encoder);
+
+        $clientManager->createClient()->shouldBeCalled()->willReturn($client);
+        $clientManager->updateClient($client)->shouldBeCalled();
+
+        $encoder->encode(Argument::cetera())->shouldBeCalled();
+
+        $this->setContainer($container);
+        $this->run($input, $output);
+    }
+
+    function it_runs_the_fos_client_manager_only(
+        ClientManagerInterface $clientManager,
+        ContainerInterface $container,
+        EncoderInterface $encoder,
+        InputInterface $input,
+        OutputInterface $output,
+        Client $client
+    )
+    {
+        $input->getOption('format')->willReturn('txt');
+        $container->get('fos_oauth_server.client_manager.default')->willReturn($clientManager);
+
+        // prophecy can't mock Serializer::encode as it is final method
+        $container->get('pim_serializer')->willReturn($encoder);
+
+        $clientManager->createClient()->shouldBeCalled()->willReturn($client);
+        $clientManager->updateClient($client)->shouldBeCalled();
+
+        $encoder->encode(Argument::cetera())->shouldNotBeCalled();
+
+        $this->setContainer($container);
+        $this->run($input, $output);
+    }
+}


### PR DESCRIPTION
Hello,

discussing with @pardahlman who is doing great job on C# client for Akeneo API, we have found a little improvement to do.

The idea here is that we can only retrieve Oauth credentials using the Akeneo console, and text format is easy to read but hard to validate. We'd like to provide a simple and validable XML output.

Of course, It need to be discussed.

Before:

![before](https://cloud.githubusercontent.com/assets/1247388/25378967/c9715a5c-29ab-11e7-8a77-e25f7572e62d.PNG)

After:

`app/console pim:oauth-server:create-client --format=xml`

![xml](https://cloud.githubusercontent.com/assets/1247388/25378988/d86693f6-29ab-11e7-81fc-8d70d4314f59.PNG)

`app/console pim:oauth-server:create-client --format=json`

![json](https://cloud.githubusercontent.com/assets/1247388/25379003/e11e33dc-29ab-11e7-9063-2a029b0703ea.PNG)

`app/console pim:oauth-server:create-client`

![after](https://cloud.githubusercontent.com/assets/1247388/25379040/f7a1b278-29ab-11e7-947f-63c6c74d0218.PNG)

> Why do we need that?

This is not a good practice at all to manipulate a string output from a command to get credentials from an application using regular expressions, because we assume the rendering - the view - won't change. XML is a great format, because it represent the contract we have with our customers. We provide a `client` and a `secret` in `credentials` parent node and this won't change, *never*.

This means any people from any platform and language can retrieve this credentials easily.



