### PR TITLE
Rework fixtures loading in integration tests & process isolation

### DIFF
--- a/app/phpunit.xml.dist
+++ b/app/phpunit.xml.dist
@@ -6,7 +6,7 @@
     convertErrorsToExceptions="true"
     convertNoticesToExceptions="true"
     convertWarningsToExceptions="true"
-    processIsolation="false"
+    processIsolation="true"
     stopOnFailure="false"
     syntaxCheck="false"
     bootstrap="./autoload.php">

--- a/src/Pim/Bundle/ApiBundle/tests/integration/ApiTestCase.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/ApiTestCase.php
@@ -24,25 +24,6 @@ abstract class ApiTestCase extends WebTestCase
     const USERNAME = 'admin';
     const PASSWORD = 'admin';
 
-    /** @var int Count of executed tests inside the same test class */
-    protected static $count = 0;
-
-    /** @var string[] */
-    protected static $accessTokens;
-
-    /** @var string[] */
-    protected static $refreshTokens;
-
-    /**
-     * {@inheritdoc}
-     */
-    public static function setUpBeforeClass()
-    {
-        self::$count = 0;
-        static::$accessTokens = [];
-        static::$refreshTokens = [];
-    }
-
     /**
      * @return Configuration
      */
@@ -53,18 +34,12 @@ abstract class ApiTestCase extends WebTestCase
      */
     protected function setUp()
     {
-        static::bootKernel();
+        static::bootKernel(['debug' => false]);
 
         $configuration = $this->getConfiguration();
-
-        self::$count++;
-
-        if ($configuration->isDatabasePurgedForEachTest() || 1 === self::$count) {
-            $this->getDatabaseSchemaHandler()->reset();
-
-            $fixturesLoader = $this->getFixturesLoader($configuration);
-            $fixturesLoader->load();
-        }
+        $databaseSchemaHandler = $this->getDatabaseSchemaHandler();
+        $fixturesLoader = $this->getFixturesLoader($configuration, $databaseSchemaHandler);
+        $fixturesLoader->load();
     }
 
     /**
@@ -76,6 +51,8 @@ abstract class ApiTestCase extends WebTestCase
      * @param string $secret
      * @param string $username
      * @param string $password
+     * @param string $accessToken
+     * @param string $refreshToken
      *
      * @return Client
      */
@@ -85,20 +62,20 @@ abstract class ApiTestCase extends WebTestCase
         $clientId = null,
         $secret = null,
         $username = self::USERNAME,
-        $password = self::PASSWORD
+        $password = self::PASSWORD,
+        $accessToken = null,
+        $refreshToken = null
     ) {
-        if (!isset(static::$accessTokens[$username]) || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            if (null === $clientId || null === $secret) {
-                list($clientId, $secret) = $this->createOAuthClient();
-            }
+        if (null === $clientId || null === $secret) {
+            list($clientId, $secret) = $this->createOAuthClient();
+        }
 
-            $tokens = $this->authenticate($clientId, $secret, $username, $password);
-            static::$accessTokens[$username] = $tokens[0];
-            static::$refreshTokens[$username] = $tokens[1];
+        if (null === $accessToken || null === $refreshToken) {
+            list($accessToken, $refreshToken) = $this->authenticate($clientId, $secret, $username, $password);
         }
 
         $client = static::createClient($options, $server);
-        $client->setServerParameter('HTTP_AUTHORIZATION', 'Bearer '.static::$accessTokens[$username]);
+        $client->setServerParameter('HTTP_AUTHORIZATION', 'Bearer '.$accessToken);
 
         if (!isset($server['CONTENT_TYPE'])) {
             $client->setServerParameter('CONTENT_TYPE', 'application/json');
@@ -204,13 +181,14 @@ abstract class ApiTestCase extends WebTestCase
     }
 
     /**
-     * @param Configuration $configuration
+     * @param Configuration         $configuration
+     * @param DatabaseSchemaHandler $databaseSchemaHandler
      *
      * @return FixturesLoader
      */
-    protected function getFixturesLoader(Configuration $configuration)
+    protected function getFixturesLoader(Configuration $configuration, DatabaseSchemaHandler $databaseSchemaHandler)
     {
-        return new FixturesLoader(static::$kernel, $configuration);
+        return new FixturesLoader(static::$kernel, $configuration, $databaseSchemaHandler);
     }
 
     /**

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Attribute/CreateAttributeIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Attribute/CreateAttributeIntegration.php
@@ -668,9 +668,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()],
-            true
-        );
+        return new Configuration([Configuration::getTechnicalCatalogPath()]);
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Attribute/GetAttributeIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Attribute/GetAttributeIntegration.php
@@ -69,9 +69,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()],
-            false
-        );
+        return new Configuration([Configuration::getTechnicalCatalogPath()]);
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Attribute/ListAttributeIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Attribute/ListAttributeIntegration.php
@@ -580,9 +580,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()],
-            false
-        );
+        return new Configuration([Configuration::getTechnicalCatalogPath()]);
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Attribute/PartialUpdateAttributeIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Attribute/PartialUpdateAttributeIntegration.php
@@ -589,9 +589,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()],
-            true
-        );
+        return new Configuration([Configuration::getTechnicalCatalogPath()]);
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Attribute/PartialUpdateListAttributeIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Attribute/PartialUpdateListAttributeIntegration.php
@@ -375,13 +375,10 @@ JSON;
     }
 
     /**
-     * @return Configuration
+     * {@inheritdoc}
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()],
-            true
-        );
+        return new Configuration([Configuration::getTechnicalCatalogPath()]);
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AttributeOption/CreateAttributeOptionIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AttributeOption/CreateAttributeOptionIntegration.php
@@ -383,9 +383,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()],
-            false
-        );
+        return new Configuration([Configuration::getTechnicalCatalogPath()]);
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AttributeOption/GetAttributeOptionIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AttributeOption/GetAttributeOptionIntegration.php
@@ -93,9 +93,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()],
-            false
-        );
+        return new Configuration([Configuration::getTechnicalCatalogPath()]);
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AttributeOption/ListAttributeOptionIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AttributeOption/ListAttributeOptionIntegration.php
@@ -179,9 +179,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()],
-            false
-        );
+        return new Configuration([Configuration::getTechnicalCatalogPath()]);
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AttributeOption/PartialUpdateAttributeOptionIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AttributeOption/PartialUpdateAttributeOptionIntegration.php
@@ -590,9 +590,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()],
-           true
-        );
+        return new Configuration([Configuration::getTechnicalCatalogPath()]);
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Category/CreateCategoryIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Category/CreateCategoryIntegration.php
@@ -338,9 +338,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()],
-            false
-        );
+        return new Configuration([Configuration::getTechnicalCatalogPath()]);
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Category/GetCategoryIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Category/GetCategoryIntegration.php
@@ -68,9 +68,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()],
-            false
-        );
+        return new Configuration([Configuration::getTechnicalCatalogPath()]);
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Category/ListCategoryIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Category/ListCategoryIntegration.php
@@ -229,9 +229,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()],
-            false
-        );
+        return new Configuration([Configuration::getTechnicalCatalogPath()]);
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Category/PartialUpdateCategoryIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Category/PartialUpdateCategoryIntegration.php
@@ -437,9 +437,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()],
-            true
-        );
+        return new Configuration([Configuration::getTechnicalCatalogPath()]);
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Category/PartialUpdateListCategoryIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Category/PartialUpdateListCategoryIntegration.php
@@ -331,13 +331,10 @@ JSON;
     }
 
     /**
-     * @return Configuration
+     * {@inheritdoc}
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()],
-            true
-        );
+        return new Configuration([Configuration::getTechnicalCatalogPath()]);
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Channel/GetChannelIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Channel/GetChannelIntegration.php
@@ -52,9 +52,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()],
-            false
-        );
+        return new Configuration([Configuration::getTechnicalCatalogPath()]);
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Channel/ListChannelIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Channel/ListChannelIntegration.php
@@ -212,9 +212,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()],
-            false
-        );
+        return new Configuration([Configuration::getTechnicalCatalogPath()]);
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Family/CreateFamilyIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Family/CreateFamilyIntegration.php
@@ -371,9 +371,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()],
-            false
-        );
+        return new Configuration([Configuration::getTechnicalCatalogPath()]);
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Family/GetFamilyIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Family/GetFamilyIntegration.php
@@ -110,9 +110,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()],
-            false
-        );
+        return new Configuration([Configuration::getTechnicalCatalogPath()]);
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Family/ListFamilyIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Family/ListFamilyIntegration.php
@@ -152,9 +152,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()],
-            false
-        );
+        return new Configuration([Configuration::getTechnicalCatalogPath()]);
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Family/PartialUpdateFamilyIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Family/PartialUpdateFamilyIntegration.php
@@ -484,9 +484,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()],
-            true
-        );
+        return new Configuration([Configuration::getTechnicalCatalogPath()]);
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Family/PartialUpdateListFamilyIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Family/PartialUpdateListFamilyIntegration.php
@@ -345,13 +345,10 @@ JSON;
     }
 
     /**
-     * @return Configuration
+     * {@inheritdoc}
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()],
-            true
-        );
+        return new Configuration([Configuration::getTechnicalCatalogPath()]);
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Locale/FilterLocaleIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Locale/FilterLocaleIntegration.php
@@ -297,9 +297,6 @@ class FilterLocaleIntegration extends ApiTestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()],
-            false
-        );
+        return new Configuration([Configuration::getTechnicalCatalogPath()]);
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Locale/GetLocaleIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Locale/GetLocaleIntegration.php
@@ -59,9 +59,6 @@ class GetLocaleIntegration extends ApiTestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()],
-            false
-        );
+        return new Configuration([Configuration::getTechnicalCatalogPath()]);
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Locale/ListLocaleIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Locale/ListLocaleIntegration.php
@@ -231,9 +231,6 @@ class ListLocaleIntegration extends ApiTestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()],
-            false
-        );
+        return new Configuration([Configuration::getTechnicalCatalogPath()]);
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Media/AbstractMediaFileTestCase.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Media/AbstractMediaFileTestCase.php
@@ -11,14 +11,11 @@ abstract class AbstractMediaFileTestCase extends ApiTestCase
     private $filePaths = [];
 
     /**
-     * @return Configuration
+     * {@inheritdoc}
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()],
-            false
-        );
+        return new Configuration([Configuration::getTechnicalCatalogPath()]);
     }
 
     /**

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Media/CreateMediaFileIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Media/CreateMediaFileIntegration.php
@@ -281,11 +281,9 @@ JSON;
         $this->fileRepository = $this->get('pim_api.repository.media_file');
         $this->productRepository = $this->get('pim_api.repository.product');
 
-        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $product = $this->get('pim_catalog.builder.product')->createProduct('foo');
-            $this->get('pim_catalog.saver.product')->save($product);
-            $this->get('akeneo_storage_utils.doctrine.object_detacher')->detach($product);
-        }
+        $product = $this->get('pim_catalog.builder.product')->createProduct('foo');
+        $this->get('pim_catalog.saver.product')->save($product);
+        $this->get('akeneo_storage_utils.doctrine.object_detacher')->detach($product);
 
         $this->files['image'] = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'akeneo.jpg';
         copy($this->getFixturePath('akeneo.jpg'), $this->files['image']);
@@ -298,13 +296,10 @@ JSON;
     }
 
     /**
-     * @return Configuration
+     * {@inheritdoc}
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()],
-            true
-        );
+        return new Configuration([Configuration::getTechnicalCatalogPath()]);
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Media/DownloadMediaFileIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Media/DownloadMediaFileIntegration.php
@@ -13,9 +13,7 @@ class DownloadMediaFileIntegration extends AbstractMediaFileTestCase
     {
         parent::setUp();
 
-        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->createMedia(new \SplFileInfo($this->getFixturePath('akeneo.jpg')));
-        }
+        $this->createMedia(new \SplFileInfo($this->getFixturePath('akeneo.jpg')));
     }
 
     public function testDownloadAMediaFile()

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Media/GetMediaFileIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Media/GetMediaFileIntegration.php
@@ -12,9 +12,7 @@ class GetMediaFileIntegration extends AbstractMediaFileTestCase
     {
         parent::setUp();
 
-        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->createMedia(new \SplFileInfo($this->getFixturePath('akeneo.jpg')));
-        }
+        $this->createMedia(new \SplFileInfo($this->getFixturePath('akeneo.jpg')));
     }
 
     public function testGetAMediaFile()

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Media/ListMediaFileIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Media/ListMediaFileIntegration.php
@@ -2,7 +2,6 @@
 
 namespace Pim\Bundle\ApiBundle\tests\integration\Controller\Media;
 
-use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\MediaSanitizer;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -12,11 +11,9 @@ class ListMediaFileIntegration extends AbstractMediaFileTestCase
     {
         parent::setUp();
 
-        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->createMedia(new \SplFileInfo($this->getFixturePath('akeneo.jpg')));
-            $this->createMedia(new \SplFileInfo($this->getFixturePath('ziggy.png')));
-            $this->createMedia(new \SplFileInfo($this->getFixturePath('akeneo.txt')));
-        }
+        $this->createMedia(new \SplFileInfo($this->getFixturePath('akeneo.jpg')));
+        $this->createMedia(new \SplFileInfo($this->getFixturePath('ziggy.png')));
+        $this->createMedia(new \SplFileInfo($this->getFixturePath('akeneo.txt')));
     }
 
     public function testListMediaFiles()
@@ -187,16 +184,5 @@ JSON;
         }
 
         return $data;
-    }
-
-    /**
-     * @return Configuration
-     */
-    protected function getConfiguration()
-    {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()],
-            true
-        );
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/AbstractProductTestCase.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/AbstractProductTestCase.php
@@ -2,7 +2,6 @@
 
 namespace Pim\Bundle\ApiBundle\tests\integration\Controller\Product;
 
-use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\DateSanitizer;
 use Akeneo\Test\Integration\MediaSanitizer;
 use Pim\Bundle\ApiBundle\tests\integration\ApiTestCase;
@@ -14,17 +13,6 @@ use Pim\Bundle\ApiBundle\tests\integration\ApiTestCase;
  */
 abstract class AbstractProductTestCase extends ApiTestCase
 {
-    /**
-     * @return Configuration
-     */
-    protected function getConfiguration()
-    {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()],
-            false
-        );
-    }
-
     /**
      * @param string $identifier
      * @param array  $data

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/CreateProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/CreateProductIntegration.php
@@ -982,13 +982,10 @@ JSON;
     }
 
     /**
-     * @return Configuration
+     * {@inheritdoc}
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()],
-            true
-        );
+        return new Configuration([Configuration::getTechnicalCatalogPath()]);
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/DeleteProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/DeleteProductIntegration.php
@@ -8,14 +8,11 @@ use Symfony\Component\HttpFoundation\Response;
 class DeleteProductIntegration extends AbstractProductTestCase
 {
     /**
-     * @return Configuration
+     * {@inheritdoc}
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalSqlCatalogPath()],
-            false
-        );
+        return new Configuration([Configuration::getTechnicalSqlCatalogPath()]);
     }
 
     public function testDeleteAProduct()

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/ErrorListProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/ErrorListProductIntegration.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Bundle\ApiBundle\tests\integration\Controller\Product;
 
+use Akeneo\Test\Integration\Configuration;
 use Symfony\Bundle\FrameworkBundle\Client;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -228,5 +229,12 @@ class ErrorListProductIntegration extends AbstractProductTestCase
         $this->assertCount(2, $content);
         $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $content['code']);
         $this->assertSame($message, $content['message']);
+    }
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return new Configuration([Configuration::getTechnicalCatalogPath()]);
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/GetProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/GetProductIntegration.php
@@ -224,14 +224,11 @@ class GetProductIntegration extends AbstractProductTestCase
     }
 
     /**
-     * @return Configuration
+     * {@inheritdoc}
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalSqlCatalogPath()],
-            false
-        );
+        return new Configuration([Configuration::getTechnicalSqlCatalogPath()]);
     }
 
     /**

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateListProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateListProductIntegration.php
@@ -371,13 +371,10 @@ JSON;
     }
 
     /**
-     * @return Configuration
+     * {@inheritdoc}
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()],
-            true
-        );
+        return new Configuration([Configuration::getTechnicalCatalogPath()]);
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateProductIntegration.php
@@ -1449,13 +1449,10 @@ JSON;
 
 
     /**
-     * @return Configuration
+     * {@inheritdoc}
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()],
-            true
-        );
+        return new Configuration([Configuration::getTechnicalCatalogPath()]);
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessListProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessListProductIntegration.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Bundle\ApiBundle\tests\integration\Controller\Product;
 
+use Akeneo\Test\Integration\Configuration;
 use Doctrine\Common\Collections\Collection;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -17,85 +18,83 @@ class SuccessListProductIntegration extends AbstractProductTestCase
     {
         parent::setUp();
 
-        if (1 === self::$count) {
-            // no locale, no scope, 1 category
-            $this->createProduct('simple', [
-                'categories' => ['master'],
-                'values'     => [
-                    'a_metric' => [
-                        ['data' => ['amount' => 10, 'unit' => 'KILOWATT'], 'locale' => null, 'scope' => null]
+        // no locale, no scope, 1 category
+        $this->createProduct('simple', [
+            'categories' => ['master'],
+            'values'     => [
+                'a_metric' => [
+                    ['data' => ['amount' => 10, 'unit' => 'KILOWATT'], 'locale' => null, 'scope' => null]
+                ],
+                'a_text' => [
+                    ['data' => 'Text', 'locale' => null, 'scope' => null]
+                ]
+            ]
+        ]);
+
+        // localizable, categorized in 1 tree (master)
+        $this->createProduct('localizable', [
+            'categories' => ['categoryB'],
+            'values'     => [
+                'a_localizable_image' => [
+                    ['data' => $this->getFixturePath('akeneo.jpg'), 'locale' => 'en_US', 'scope' => null],
+                    ['data' => $this->getFixturePath('akeneo.jpg'), 'locale' => 'fr_FR', 'scope' => null],
+                    ['data' => $this->getFixturePath('akeneo.jpg'), 'locale' => 'zh_CN', 'scope' => null]
+                ]
+            ]
+        ]);
+
+        // scopable, categorized in 1 tree (master)
+        $this->createProduct('scopable', [
+            'categories' => ['categoryA1', 'categoryA2'],
+            'values'     => [
+                'a_scopable_price' => [
+                    [
+                        'locale' => null,
+                        'scope'  => 'ecommerce',
+                        'data'   => [
+                            ['amount' => '10.50', 'currency' => 'EUR'],
+                            ['amount' => '11.50', 'currency' => 'USD'],
+                            ['amount' => '78.77', 'currency' => 'CNY']
+                        ]
                     ],
-                    'a_text' => [
-                        ['data' => 'Text', 'locale' => null, 'scope' => null]
-                    ]
-                ]
-            ]);
-
-            // localizable, categorized in 1 tree (master)
-            $this->createProduct('localizable', [
-                'categories' => ['categoryB'],
-                'values'     => [
-                    'a_localizable_image' => [
-                        ['data' => $this->getFixturePath('akeneo.jpg'), 'locale' => 'en_US', 'scope' => null],
-                        ['data' => $this->getFixturePath('akeneo.jpg'), 'locale' => 'fr_FR', 'scope' => null],
-                        ['data' => $this->getFixturePath('akeneo.jpg'), 'locale' => 'zh_CN', 'scope' => null]
-                    ]
-                ]
-            ]);
-
-            // scopable, categorized in 1 tree (master)
-            $this->createProduct('scopable', [
-                'categories' => ['categoryA1', 'categoryA2'],
-                'values'     => [
-                    'a_scopable_price' => [
-                        [
-                            'locale' => null,
-                            'scope'  => 'ecommerce',
-                            'data'   => [
-                                ['amount' => '10.50', 'currency' => 'EUR'],
-                                ['amount' => '11.50', 'currency' => 'USD'],
-                                ['amount' => '78.77', 'currency' => 'CNY']
-                            ]
-                        ],
-                        [
-                            'locale' => null,
-                            'scope'  => 'tablet',
-                            'data'   => [
-                                ['amount' => '10.50', 'currency' => 'EUR'],
-                                ['amount' => '11.50', 'currency' => 'USD'],
-                                ['amount' => '78.77', 'currency' => 'CNY']
-                            ]
+                    [
+                        'locale' => null,
+                        'scope'  => 'tablet',
+                        'data'   => [
+                            ['amount' => '10.50', 'currency' => 'EUR'],
+                            ['amount' => '11.50', 'currency' => 'USD'],
+                            ['amount' => '78.77', 'currency' => 'CNY']
                         ]
                     ]
                 ]
-            ]);
+            ]
+        ]);
 
-            // localizable & scopable, categorized in 2 trees (master and master_china)
-            $this->createProduct('localizable_and_scopable', [
-                'categories' => ['categoryA', 'master_china'],
-                'values'     => [
-                    'a_localized_and_scopable_text_area' => [
-                        ['data' => 'Big description', 'locale' => 'en_US', 'scope' => 'ecommerce'],
-                        ['data' => 'Medium description', 'locale' => 'en_US', 'scope' => 'tablet'],
-                        ['data' => 'Grande description', 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
-                        ['data' => 'Description moyenne', 'locale' => 'fr_FR', 'scope' => 'tablet'],
-                        ['data' => 'hum...', 'locale' => 'zh_CN', 'scope' => 'ecommerce_china'],
-                    ]
+        // localizable & scopable, categorized in 2 trees (master and master_china)
+        $this->createProduct('localizable_and_scopable', [
+            'categories' => ['categoryA', 'master_china'],
+            'values'     => [
+                'a_localized_and_scopable_text_area' => [
+                    ['data' => 'Big description', 'locale' => 'en_US', 'scope' => 'ecommerce'],
+                    ['data' => 'Medium description', 'locale' => 'en_US', 'scope' => 'tablet'],
+                    ['data' => 'Grande description', 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
+                    ['data' => 'Description moyenne', 'locale' => 'fr_FR', 'scope' => 'tablet'],
+                    ['data' => 'hum...', 'locale' => 'zh_CN', 'scope' => 'ecommerce_china'],
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('product_china', [
-                'categories' => ['master_china']
-            ]);
+        $this->createProduct('product_china', [
+            'categories' => ['master_china']
+        ]);
 
-            $this->createProduct('product_without_category', [
-                'values' => [
-                    'a_yes_no' => [
-                        ['data' => true, 'locale' => null, 'scope' => null]
-                    ]
+        $this->createProduct('product_without_category', [
+            'values' => [
+                'a_yes_no' => [
+                    ['data' => true, 'locale' => null, 'scope' => null]
                 ]
-            ]);
-        }
+            ]
+        ]);
 
         $this->products = $this->get('pim_catalog.repository.product')->findAll();
     }
@@ -1463,5 +1462,12 @@ JSON;
 JSON;
 
         return $standardizedProducts;
+    }
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return new Configuration([Configuration::getTechnicalCatalogPath()]);
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/RootEndpointIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/RootEndpointIntegration.php
@@ -170,9 +170,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()],
-            false
-        );
+        return new Configuration([Configuration::getTechnicalCatalogPath()]);
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Token/GetAccessTokenIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Token/GetAccessTokenIntegration.php
@@ -280,9 +280,6 @@ class GetAccessTokenIntegration extends ApiTestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()],
-            false
-        );
+        return new Configuration([Configuration::getTechnicalCatalogPath()]);
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Token/RefreshTokenIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Token/RefreshTokenIntegration.php
@@ -11,12 +11,23 @@ class RefreshTokenIntegration extends ApiTestCase
     public function testRefreshToken()
     {
         list($clientId, $secret) = $this->createOAuthClient();
-        $client = $this->createAuthenticatedClient([], [], $clientId, $secret);
+        list($accessToken, $refreshToken) = $this->authenticate($clientId, $secret, self::USERNAME, self::PASSWORD);
+
+        $client = $this->createAuthenticatedClient(
+            [],
+            [],
+            $clientId,
+            $secret,
+            self::USERNAME,
+            self::PASSWORD,
+            $accessToken,
+            $refreshToken
+        );
 
         $client->request('POST', 'api/oauth/v1/token',
             [
                 'grant_type'    => 'refresh_token',
-                'refresh_token' => static::$refreshTokens[self::USERNAME],
+                'refresh_token' => $refreshToken,
             ],
             [],
             [
@@ -92,9 +103,6 @@ class RefreshTokenIntegration extends ApiTestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()],
-            false
-        );
+        return new Configuration([Configuration::getTechnicalCatalogPath()]);
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/EventSubscriber/CheckHeadersRequestSubscriberIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/EventSubscriber/CheckHeadersRequestSubscriberIntegration.php
@@ -129,9 +129,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()],
-            false
-        );
+        return new Configuration([Configuration::getTechnicalCatalogPath()]);
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Security/AttributeAuthorizationIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Security/AttributeAuthorizationIntegration.php
@@ -204,9 +204,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()],
-            false
-        );
+        return new Configuration([Configuration::getTechnicalCatalogPath()]);
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Security/AttributeOptionAuthorizationIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Security/AttributeOptionAuthorizationIntegration.php
@@ -167,9 +167,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()],
-            false
-        );
+        return new Configuration([Configuration::getTechnicalCatalogPath()]);
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Security/CategoryAuthorizationIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Security/CategoryAuthorizationIntegration.php
@@ -200,9 +200,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()],
-            false
-        );
+        return new Configuration([Configuration::getTechnicalCatalogPath()]);
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Security/ChannelAuthorizationIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Security/ChannelAuthorizationIntegration.php
@@ -87,9 +87,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()],
-            false
-        );
+        return new Configuration([Configuration::getTechnicalCatalogPath()]);
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Security/FamilyAuthorizationIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Security/FamilyAuthorizationIntegration.php
@@ -200,9 +200,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()],
-            false
-        );
+        return new Configuration([Configuration::getTechnicalCatalogPath()]);
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Security/LocaleAuthorizationIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Security/LocaleAuthorizationIntegration.php
@@ -87,9 +87,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()],
-            false
-        );
+        return new Configuration([Configuration::getTechnicalCatalogPath()]);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AbstractCompletenessIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AbstractCompletenessIntegration.php
@@ -21,10 +21,7 @@ abstract class AbstractCompletenessIntegration extends TestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getMinimalCatalogPath()],
-            true
-        );
+        return new Configuration([Configuration::getMinimalCatalogPath()]);
     }
 
     /**

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/ReferenceDataMultiAttributeTypeCompletenessIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/ReferenceDataMultiAttributeTypeCompletenessIntegration.php
@@ -115,9 +115,9 @@ class ReferenceDataMultiAttributeTypeCompletenessIntegration extends AbstractCom
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getMinimalCatalogPath(), Configuration::getReferenceDataFixtures()],
-            true
-        );
+        return new Configuration([
+            Configuration::getMinimalCatalogPath(),
+            Configuration::getReferenceDataFixtures()
+        ]);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/ReferenceDataSimpleAttributeTypeCompletenessIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/ReferenceDataSimpleAttributeTypeCompletenessIntegration.php
@@ -113,9 +113,9 @@ class ReferenceDataSimpleAttributeTypeCompletenessIntegration extends AbstractCo
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getMinimalCatalogPath(), Configuration::getReferenceDataFixtures()],
-            true
-        );
+        return new Configuration([
+            Configuration::getMinimalCatalogPath(),
+            Configuration::getReferenceDataFixtures()
+        ]);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/CompletenessForLocalisableAttributeIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/CompletenessForLocalisableAttributeIntegration.php
@@ -167,10 +167,7 @@ class CompletenessForLocalisableAttributeIntegration extends AbstractCompletenes
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getMinimalCatalogPath()],
-            true
-        );
+        return new Configuration([Configuration::getMinimalCatalogPath()]);
     }
 
     /**

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/CompletenessForNonRequiredAttributeIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/CompletenessForNonRequiredAttributeIntegration.php
@@ -106,9 +106,6 @@ class CompletenessForNonRequiredAttributeIntegration extends AbstractCompletenes
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getMinimalCatalogPath()],
-            true
-        );
+        return new Configuration([Configuration::getMinimalCatalogPath()]);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/CompletenessForScopableAndLocalisableAttributeIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/CompletenessForScopableAndLocalisableAttributeIntegration.php
@@ -141,7 +141,6 @@ class CompletenessForScopableAndLocalisableAttributeIntegration extends Abstract
     {
         return new Configuration(
             [Configuration::getFunctionalCatalog('footwear')],
-            true,
             [Configuration::getFunctionalFixtures()]
         );
     }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/AbstractFilterTestCase.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/AbstractFilterTestCase.php
@@ -18,10 +18,7 @@ abstract class AbstractFilterTestCase extends TestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()],
-            false
-        );
+        return new Configuration([Configuration::getTechnicalCatalogPath()]);
     }
 
     /**

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Boolean/BooleanFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Boolean/BooleanFilterIntegration.php
@@ -16,19 +16,17 @@ class BooleanFilterIntegration extends AbstractFilterTestCase
     {
         parent::setUp();
 
-        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->createProduct('yes', [
-                'values' => [
-                    'a_yes_no' => [['data' => true, 'locale' => null, 'scope' => null]]
-                ]
-            ]);
+        $this->createProduct('yes', [
+            'values' => [
+                'a_yes_no' => [['data' => true, 'locale' => null, 'scope' => null]]
+            ]
+        ]);
 
-            $this->createProduct('no', [
-                'values' => [
-                    'a_yes_no' => [['data' => false, 'locale' => null, 'scope' => null]]
-                ]
-            ]);
-        }
+        $this->createProduct('no', [
+            'values' => [
+                'a_yes_no' => [['data' => false, 'locale' => null, 'scope' => null]]
+            ]
+        ]);
     }
 
     public function testOperatorEquals()

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Boolean/LocalizableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Boolean/LocalizableFilterIntegration.php
@@ -17,32 +17,30 @@ class LocalizableFilterIntegration extends AbstractFilterTestCase
     {
         parent::setUp();
 
-        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->createAttribute([
-                'code'                => 'a_localizable_yes_no',
-                'type'                => AttributeTypes::BOOLEAN,
-                'localizable'         => true,
-                'scopable'            => false,
-            ]);
+        $this->createAttribute([
+            'code'                => 'a_localizable_yes_no',
+            'type'                => AttributeTypes::BOOLEAN,
+            'localizable'         => true,
+            'scopable'            => false,
+        ]);
 
-            $this->createProduct('product_one', [
-                'values' => [
-                    'a_localizable_yes_no' => [
-                        ['data' => true, 'locale' => 'en_US', 'scope' => null],
-                        ['data' => false, 'locale' => 'fr_FR', 'scope' => null],
-                    ]
+        $this->createProduct('product_one', [
+            'values' => [
+                'a_localizable_yes_no' => [
+                    ['data' => true, 'locale' => 'en_US', 'scope' => null],
+                    ['data' => false, 'locale' => 'fr_FR', 'scope' => null],
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('product_two', [
-                'values' => [
-                    'a_localizable_yes_no' => [
-                        ['data' => true, 'locale' => 'en_US', 'scope' => null],
-                        ['data' => true, 'locale' => 'fr_FR', 'scope' => null]
-                    ]
+        $this->createProduct('product_two', [
+            'values' => [
+                'a_localizable_yes_no' => [
+                    ['data' => true, 'locale' => 'en_US', 'scope' => null],
+                    ['data' => true, 'locale' => 'fr_FR', 'scope' => null]
                 ]
-            ]);
-        }
+            ]
+        ]);
     }
 
     public function testOperatorEquals()

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Boolean/LocalizableScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Boolean/LocalizableScopableFilterIntegration.php
@@ -17,35 +17,33 @@ class LocalizableScopableFilterIntegration extends AbstractFilterTestCase
     {
         parent::setUp();
 
-        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->createAttribute([
-                'code'                => 'a_localizable_scopable_yes_no',
-                'type'                => AttributeTypes::BOOLEAN,
-                'localizable'         => true,
-                'scopable'            => true,
-            ]);
+        $this->createAttribute([
+            'code'                => 'a_localizable_scopable_yes_no',
+            'type'                => AttributeTypes::BOOLEAN,
+            'localizable'         => true,
+            'scopable'            => true,
+        ]);
 
-            $this->createProduct('product_one', [
-                'values' => [
-                    'a_localizable_scopable_yes_no' => [
-                        ['data' => true, 'locale' => 'en_US', 'scope' => 'ecommerce'],
-                        ['data' => true, 'locale' => 'en_US', 'scope' => 'tablet'],
-                        ['data' => true, 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
-                        ['data' => false, 'locale' => 'fr_FR', 'scope' => 'tablet']
-                    ]
+        $this->createProduct('product_one', [
+            'values' => [
+                'a_localizable_scopable_yes_no' => [
+                    ['data' => true, 'locale' => 'en_US', 'scope' => 'ecommerce'],
+                    ['data' => true, 'locale' => 'en_US', 'scope' => 'tablet'],
+                    ['data' => true, 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
+                    ['data' => false, 'locale' => 'fr_FR', 'scope' => 'tablet']
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('product_two', [
-                'values' => [
-                    'a_localizable_scopable_yes_no' => [
-                        ['data' => true, 'locale' => 'en_US', 'scope' => 'ecommerce'],
-                        ['data' => true, 'locale' => 'en_US', 'scope' => 'tablet'],
-                        ['data' => true, 'locale' => 'fr_FR', 'scope' => 'ecommerce']
-                    ]
+        $this->createProduct('product_two', [
+            'values' => [
+                'a_localizable_scopable_yes_no' => [
+                    ['data' => true, 'locale' => 'en_US', 'scope' => 'ecommerce'],
+                    ['data' => true, 'locale' => 'en_US', 'scope' => 'tablet'],
+                    ['data' => true, 'locale' => 'fr_FR', 'scope' => 'ecommerce']
                 ]
-            ]);
-        }
+            ]
+        ]);
     }
 
     public function testOperatorEquals()

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Boolean/ScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Boolean/ScopableFilterIntegration.php
@@ -17,32 +17,30 @@ class ScopableFilterIntegration extends AbstractFilterTestCase
     {
         parent::setUp();
 
-        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->createAttribute([
-                'code'                => 'a_scopable_yes_no',
-                'type'                => AttributeTypes::BOOLEAN,
-                'localizable'         => false,
-                'scopable'            => true,
-            ]);
+        $this->createAttribute([
+            'code'                => 'a_scopable_yes_no',
+            'type'                => AttributeTypes::BOOLEAN,
+            'localizable'         => false,
+            'scopable'            => true,
+        ]);
 
-            $this->createProduct('product_one', [
-                'values' => [
-                    'a_scopable_yes_no' => [
-                        ['data' => true, 'scope' => 'ecommerce', 'locale' => null],
-                        ['data' => false, 'scope' => 'tablet', 'locale' => null]
-                    ]
+        $this->createProduct('product_one', [
+            'values' => [
+                'a_scopable_yes_no' => [
+                    ['data' => true, 'scope' => 'ecommerce', 'locale' => null],
+                    ['data' => false, 'scope' => 'tablet', 'locale' => null]
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('product_two', [
-                'values' => [
-                    'a_scopable_yes_no' => [
-                        ['data' => true, 'scope' => 'ecommerce', 'locale' => null],
-                        ['data' => true, 'scope' => 'tablet', 'locale' => null],
-                    ]
+        $this->createProduct('product_two', [
+            'values' => [
+                'a_scopable_yes_no' => [
+                    ['data' => true, 'scope' => 'ecommerce', 'locale' => null],
+                    ['data' => true, 'scope' => 'tablet', 'locale' => null],
                 ]
-            ]);
-        }
+            ]
+        ]);
     }
 
     public function testOperatorEquals()

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/CategoryFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/CategoryFilterIntegration.php
@@ -74,9 +74,6 @@ class CategoryFilterIntegration extends AbstractFilterTestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalSqlCatalogPath()],
-            false
-        );
+        return new Configuration([Configuration::getTechnicalSqlCatalogPath()]);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/CompletenessFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/CompletenessFilterIntegration.php
@@ -27,51 +27,49 @@ class CompletenessFilterIntegration extends AbstractFilterTestCase
     {
         parent::setUp();
 
-        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $family = $this->get('pim_catalog.factory.family')->create();
-            $this->get('pim_catalog.updater.family')->update($family, [
-                'code'                   => 'familyB',
-                'attributes'             => ['sku', 'a_metric', 'a_localized_and_scopable_text_area', 'a_scopable_price'],
-                'attribute_requirements' => [
-                    'tablet'    => ['sku', 'a_metric', 'a_localized_and_scopable_text_area', 'a_scopable_price'],
-                    'ecommerce' => ['sku', 'a_metric', 'a_scopable_price'],
-                ]
-            ]);
-            $this->get('pim_catalog.saver.family')->save($family);
+        $family = $this->get('pim_catalog.factory.family')->create();
+        $this->get('pim_catalog.updater.family')->update($family, [
+            'code'                   => 'familyB',
+            'attributes'             => ['sku', 'a_metric', 'a_localized_and_scopable_text_area', 'a_scopable_price'],
+            'attribute_requirements' => [
+                'tablet'    => ['sku', 'a_metric', 'a_localized_and_scopable_text_area', 'a_scopable_price'],
+                'ecommerce' => ['sku', 'a_metric', 'a_scopable_price'],
+            ]
+        ]);
+        $this->get('pim_catalog.saver.family')->save($family);
 
-            $this->createProduct('product_one', [
-                'family' => 'familyB',
-                'values' => [
-                    'a_metric' => [['data' => ['amount' => 15, 'unit' => 'WATT'], 'locale' => null, 'scope' => null]]
-                ]
-            ]);
+        $this->createProduct('product_one', [
+            'family' => 'familyB',
+            'values' => [
+                'a_metric' => [['data' => ['amount' => 15, 'unit' => 'WATT'], 'locale' => null, 'scope' => null]]
+            ]
+        ]);
 
-            $this->createProduct('product_two', [
-                'family' => 'familyB',
-                'values' => [
-                    'a_metric'                           => [['data' => ['amount' => 15, 'unit' => 'WATT'], 'locale' => null, 'scope' => null]],
-                    'a_localized_and_scopable_text_area' => [['data' => 'text', 'locale' => 'en_US', 'scope' => 'tablet']],
-                    'a_scopable_price'                   => [
-                        [
-                            'data'      => [
-                                ['amount' => 15, 'currency' => 'EUR'],
-                                ['amount' => 15.5, 'currency' => 'USD']
-                            ], 'locale' => null, 'scope' => 'tablet'
-                        ]
-                    ],
-                ]
-            ]);
+        $this->createProduct('product_two', [
+            'family' => 'familyB',
+            'values' => [
+                'a_metric'                           => [['data' => ['amount' => 15, 'unit' => 'WATT'], 'locale' => null, 'scope' => null]],
+                'a_localized_and_scopable_text_area' => [['data' => 'text', 'locale' => 'en_US', 'scope' => 'tablet']],
+                'a_scopable_price'                   => [
+                    [
+                        'data'      => [
+                            ['amount' => 15, 'currency' => 'EUR'],
+                            ['amount' => 15.5, 'currency' => 'USD']
+                        ], 'locale' => null, 'scope' => 'tablet'
+                    ]
+                ],
+            ]
+        ]);
 
-            $this->createProduct('empty_product', [
-                'family' => 'familyB',
-            ]);
+        $this->createProduct('empty_product', [
+            'family' => 'familyB',
+        ]);
 
-            $this->createProduct('no_family', [
-                'values' => [
-                    'a_metric' => [['data' => ['amount' => 10, 'unit' => 'WATT'], 'locale' => null, 'scope' => null]]
-                ]
-            ]);
-        }
+        $this->createProduct('no_family', [
+            'values' => [
+                'a_metric' => [['data' => ['amount' => 10, 'unit' => 'WATT'], 'locale' => null, 'scope' => null]]
+            ]
+        ]);
     }
 
     public function testOperatorInferior()

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Date/DateFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Date/DateFilterIntegration.php
@@ -16,25 +16,23 @@ class DateFilterIntegration extends AbstractFilterTestCase
     {
         parent::setUp();
 
-        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->createProduct('product_one', [
-                'values' => [
-                    'a_date' => [
-                        ['data' => '2017-02-06', 'locale' => null, 'scope' => null]
-                    ]
+        $this->createProduct('product_one', [
+            'values' => [
+                'a_date' => [
+                    ['data' => '2017-02-06', 'locale' => null, 'scope' => null]
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('product_two', [
-                'values' => [
-                    'a_date' => [
-                        ['data' => '2017-02-27', 'locale' => null, 'scope' => null]
-                    ]
+        $this->createProduct('product_two', [
+            'values' => [
+                'a_date' => [
+                    ['data' => '2017-02-27', 'locale' => null, 'scope' => null]
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('empty_product', []);
-        }
+        $this->createProduct('empty_product', []);
     }
 
     public function testOperatorInferior()

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Date/LocalizableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Date/LocalizableFilterIntegration.php
@@ -17,34 +17,32 @@ class LocalizableFilterIntegration extends AbstractFilterTestCase
     {
         parent::setUp();
 
-        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->createAttribute([
-                'code'                => 'a_localizable_date',
-                'type'                => AttributeTypes::DATE,
-                'localizable'         => true,
-                'scopable'            => false
-            ]);
+        $this->createAttribute([
+            'code'                => 'a_localizable_date',
+            'type'                => AttributeTypes::DATE,
+            'localizable'         => true,
+            'scopable'            => false
+        ]);
 
-            $this->createProduct('product_one', [
-                'values' => [
-                    'a_localizable_date' => [
-                        ['data' => '2016-04-23', 'locale' => 'en_US', 'scope' => null],
-                        ['data' => '2016-05-23', 'locale' => 'fr_FR', 'scope' => null]
-                    ]
+        $this->createProduct('product_one', [
+            'values' => [
+                'a_localizable_date' => [
+                    ['data' => '2016-04-23', 'locale' => 'en_US', 'scope' => null],
+                    ['data' => '2016-05-23', 'locale' => 'fr_FR', 'scope' => null]
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('product_two', [
-                'values' => [
-                    'a_localizable_date' => [
-                        ['data' => '2016-09-23', 'locale' => 'en_US', 'scope' => null],
-                        ['data' => '2016-09-23', 'locale' => 'fr_FR', 'scope' => null]
-                    ]
+        $this->createProduct('product_two', [
+            'values' => [
+                'a_localizable_date' => [
+                    ['data' => '2016-09-23', 'locale' => 'en_US', 'scope' => null],
+                    ['data' => '2016-09-23', 'locale' => 'fr_FR', 'scope' => null]
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('empty_product', []);
-        }
+        $this->createProduct('empty_product', []);
     }
 
     public function testOperatorInferior()

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Date/LocalizableScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Date/LocalizableScopableFilterIntegration.php
@@ -17,37 +17,35 @@ class LocalizableScopableFilterIntegration extends AbstractFilterTestCase
     {
         parent::setUp();
 
-        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->createAttribute([
-                'code'                => 'a_localizable_scopable_date',
-                'type'                => AttributeTypes::DATE,
-                'localizable'         => true,
-                'scopable'            => true
-            ]);
+        $this->createAttribute([
+            'code'                => 'a_localizable_scopable_date',
+            'type'                => AttributeTypes::DATE,
+            'localizable'         => true,
+            'scopable'            => true
+        ]);
 
-            $this->createProduct('product_one', [
-                'values' => [
-                    'a_localizable_scopable_date' => [
-                        ['data' => '2016-04-23', 'locale' => 'en_US', 'scope' => 'ecommerce'],
-                        ['data' => '2016-04-23', 'locale' => 'en_US', 'scope' => 'tablet'],
-                        ['data' => '2016-05-23', 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
-                        ['data' => '2016-05-23', 'locale' => 'fr_FR', 'scope' => 'tablet'],
-                    ]
+        $this->createProduct('product_one', [
+            'values' => [
+                'a_localizable_scopable_date' => [
+                    ['data' => '2016-04-23', 'locale' => 'en_US', 'scope' => 'ecommerce'],
+                    ['data' => '2016-04-23', 'locale' => 'en_US', 'scope' => 'tablet'],
+                    ['data' => '2016-05-23', 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
+                    ['data' => '2016-05-23', 'locale' => 'fr_FR', 'scope' => 'tablet'],
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('product_two', [
-                'values' => [
-                    'a_localizable_scopable_date' => [
-                        ['data' => '2016-09-23', 'locale' => 'en_US', 'scope' => 'ecommerce'],
-                        ['data' => '2016-09-23', 'locale' => 'en_US', 'scope' => 'tablet'],
-                        ['data' => '2016-09-23', 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
-                    ]
+        $this->createProduct('product_two', [
+            'values' => [
+                'a_localizable_scopable_date' => [
+                    ['data' => '2016-09-23', 'locale' => 'en_US', 'scope' => 'ecommerce'],
+                    ['data' => '2016-09-23', 'locale' => 'en_US', 'scope' => 'tablet'],
+                    ['data' => '2016-09-23', 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('empty_product', []);
-        }
+        $this->createProduct('empty_product', []);
     }
 
     public function testOperatorInferior()

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Date/ScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Date/ScopableFilterIntegration.php
@@ -17,33 +17,31 @@ class ScopableFilterIntegration extends AbstractFilterTestCase
     {
         parent::setUp();
 
-        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->createAttribute([
-                'code'                => 'a_scopable_date',
-                'type'                => AttributeTypes::DATE,
-                'localizable'         => false,
-                'scopable'            => true
-            ]);
+        $this->createAttribute([
+            'code'                => 'a_scopable_date',
+            'type'                => AttributeTypes::DATE,
+            'localizable'         => false,
+            'scopable'            => true
+        ]);
 
-            $this->createProduct('product_one', [
-                'values' => [
-                    'a_scopable_date' => [
-                        ['data' => '2016-04-23', 'scope' => 'ecommerce', 'locale' => null],
-                        ['data' => '2016-04-23', 'scope' => 'tablet', 'locale' => null],
-                    ]
+        $this->createProduct('product_one', [
+            'values' => [
+                'a_scopable_date' => [
+                    ['data' => '2016-04-23', 'scope' => 'ecommerce', 'locale' => null],
+                    ['data' => '2016-04-23', 'scope' => 'tablet', 'locale' => null],
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('product_two', [
-                'values' => [
-                    'a_scopable_date' => [
-                        ['data' => '2016-09-23', 'scope' => 'ecommerce', 'locale' => null],
-                    ]
+        $this->createProduct('product_two', [
+            'values' => [
+                'a_scopable_date' => [
+                    ['data' => '2016-09-23', 'scope' => 'ecommerce', 'locale' => null],
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('empty_product', []);
-        }
+        $this->createProduct('empty_product', []);
     }
 
     public function testOperatorInferior()

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/DateTimeFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/DateTimeFilterIntegration.php
@@ -125,9 +125,6 @@ class DateTimeFilterIntegration extends AbstractFilterTestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalSqlCatalogPath()],
-            false
-        );
+        return new Configuration([Configuration::getTechnicalSqlCatalogPath()]);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/FamilyFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/FamilyFilterIntegration.php
@@ -16,11 +16,9 @@ class FamilyFilterIntegration extends AbstractFilterTestCase
     {
         parent::setUp();
 
-        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $family = $this->get('pim_catalog.factory.family')->create();
-            $this->get('pim_catalog.updater.family')->update($family, ['code' => 'familyB']);
-            $this->get('pim_catalog.saver.family')->save($family);
-        }
+        $family = $this->get('pim_catalog.factory.family')->create();
+        $this->get('pim_catalog.updater.family')->update($family, ['code' => 'familyB']);
+        $this->get('pim_catalog.saver.family')->save($family);
     }
 
     public function testOperatorIn()
@@ -79,9 +77,6 @@ class FamilyFilterIntegration extends AbstractFilterTestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalSqlCatalogPath()],
-            false
-        );
+        return new Configuration([Configuration::getTechnicalSqlCatalogPath()]);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/GroupsFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/GroupsFilterIntegration.php
@@ -16,14 +16,12 @@ class GroupsFilterIntegration extends AbstractFilterTestCase
     {
         parent::setUp();
 
-        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $group = $this->get('pim_catalog.factory.group')->create();
-            $this->get('pim_catalog.updater.group')->update($group, [
-                'code' => 'groupC',
-                'type' => 'RELATED'
-            ]);
-            $this->get('pim_catalog.saver.group')->save($group);
-        }
+        $group = $this->get('pim_catalog.factory.group')->create();
+        $this->get('pim_catalog.updater.group')->update($group, [
+            'code' => 'groupC',
+            'type' => 'RELATED'
+        ]);
+        $this->get('pim_catalog.saver.group')->save($group);
     }
 
     public function testOperatorIn()
@@ -85,9 +83,6 @@ class GroupsFilterIntegration extends AbstractFilterTestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalSqlCatalogPath()],
-            false
-        );
+        return new Configuration([Configuration::getTechnicalSqlCatalogPath()]);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Media/LocalizableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Media/LocalizableFilterIntegration.php
@@ -17,34 +17,32 @@ class LocalizableFilterIntegration extends AbstractFilterTestCase
     {
         parent::setUp();
 
-        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->createAttribute([
-                'code'                => 'a_localizable_media',
-                'type'                => AttributeTypes::IMAGE,
-                'localizable'         => true,
-                'scopable'            => false
-            ]);
+        $this->createAttribute([
+            'code'                => 'a_localizable_media',
+            'type'                => AttributeTypes::IMAGE,
+            'localizable'         => true,
+            'scopable'            => false
+        ]);
 
-            $this->createProduct('product_one', [
-                'values' => [
-                    'a_localizable_image' => [
-                        ['data' => $this->getFixturePath('akeneo.jpg'), 'locale' => 'en_US', 'scope' => null],
-                        ['data' => $this->getFixturePath('ziggy.png'), 'locale' => 'fr_FR', 'scope' => null],
-                    ]
+        $this->createProduct('product_one', [
+            'values' => [
+                'a_localizable_image' => [
+                    ['data' => $this->getFixturePath('akeneo.jpg'), 'locale' => 'en_US', 'scope' => null],
+                    ['data' => $this->getFixturePath('ziggy.png'), 'locale' => 'fr_FR', 'scope' => null],
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('product_two', [
-                'values' => [
-                    'a_localizable_image' => [
-                        ['data' => $this->getFixturePath('ziggy.png'), 'locale' => 'en_US', 'scope' => null],
-                        ['data' => $this->getFixturePath('ziggy.png'), 'locale' => 'fr_FR', 'scope' => null],
-                    ]
+        $this->createProduct('product_two', [
+            'values' => [
+                'a_localizable_image' => [
+                    ['data' => $this->getFixturePath('ziggy.png'), 'locale' => 'en_US', 'scope' => null],
+                    ['data' => $this->getFixturePath('ziggy.png'), 'locale' => 'fr_FR', 'scope' => null],
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('empty_product', []);
-        }
+        $this->createProduct('empty_product', []);
     }
 
     public function testOperatorStartWith()

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Media/LocalizableScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Media/LocalizableScopableFilterIntegration.php
@@ -16,30 +16,28 @@ class LocalizableScopableFilterIntegration extends AbstractFilterTestCase
     {
         parent::setUp();
 
-        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->createProduct('product_one', [
-                'values' => [
-                    'a_localizable_scopable_image' => [
-                        ['data' => $this->getFixturePath('akeneo.jpg'), 'locale' => 'en_US', 'scope' => 'ecommerce'],
-                        ['data' => $this->getFixturePath('akeneo.jpg'), 'locale' => 'en_US', 'scope' => 'tablet'],
-                        ['data' => $this->getFixturePath('ziggy.png'), 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
-                        ['data' => $this->getFixturePath('ziggy.png'), 'locale' => 'fr_FR', 'scope' => 'tablet'],
-                    ]
+        $this->createProduct('product_one', [
+            'values' => [
+                'a_localizable_scopable_image' => [
+                    ['data' => $this->getFixturePath('akeneo.jpg'), 'locale' => 'en_US', 'scope' => 'ecommerce'],
+                    ['data' => $this->getFixturePath('akeneo.jpg'), 'locale' => 'en_US', 'scope' => 'tablet'],
+                    ['data' => $this->getFixturePath('ziggy.png'), 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
+                    ['data' => $this->getFixturePath('ziggy.png'), 'locale' => 'fr_FR', 'scope' => 'tablet'],
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('product_two', [
-                'values' => [
-                    'a_localizable_scopable_image' => [
-                        ['data' => $this->getFixturePath('ziggy.png'), 'locale' => 'en_US', 'scope' => 'ecommerce'],
-                        ['data' => $this->getFixturePath('ziggy.png'), 'locale' => 'en_US', 'scope' => 'tablet'],
-                        ['data' => $this->getFixturePath('ziggy.png'), 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
-                    ]
+        $this->createProduct('product_two', [
+            'values' => [
+                'a_localizable_scopable_image' => [
+                    ['data' => $this->getFixturePath('ziggy.png'), 'locale' => 'en_US', 'scope' => 'ecommerce'],
+                    ['data' => $this->getFixturePath('ziggy.png'), 'locale' => 'en_US', 'scope' => 'tablet'],
+                    ['data' => $this->getFixturePath('ziggy.png'), 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('empty_product', []);
-        }
+        $this->createProduct('empty_product', []);
     }
 
     public function testOperatorStartWith()

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Media/MediaFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Media/MediaFilterIntegration.php
@@ -16,25 +16,23 @@ class MediaFilterIntegration extends AbstractFilterTestCase
     {
         parent::setUp();
 
-        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->createProduct('akeneo', [
-                'values' => [
-                    'an_image' => [
-                        ['data' => $this->getFixturePath('akeneo.jpg'), 'locale' => null, 'scope' => null]
-                    ]
+        $this->createProduct('akeneo', [
+            'values' => [
+                'an_image' => [
+                    ['data' => $this->getFixturePath('akeneo.jpg'), 'locale' => null, 'scope' => null]
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('ziggy', [
-                'values' => [
-                    'an_image' => [
-                        ['data' => $this->getFixturePath('ziggy.png'), 'locale' => null, 'scope' => null]
-                    ]
+        $this->createProduct('ziggy', [
+            'values' => [
+                'an_image' => [
+                    ['data' => $this->getFixturePath('ziggy.png'), 'locale' => null, 'scope' => null]
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('empty_product', []);
-        }
+        $this->createProduct('empty_product', []);
     }
 
     public function testOperatorStartWith()

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Media/ScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Media/ScopableFilterIntegration.php
@@ -17,34 +17,32 @@ class ScopableFilterIntegration extends AbstractFilterTestCase
     {
         parent::setUp();
 
-        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->createAttribute([
-                'code'                => 'a_localizable_media',
-                'type'                => AttributeTypes::IMAGE,
-                'localizable'         => false,
-                'scopable'            => true
-            ]);
+        $this->createAttribute([
+            'code'                => 'a_localizable_media',
+            'type'                => AttributeTypes::IMAGE,
+            'localizable'         => false,
+            'scopable'            => true
+        ]);
 
-            $this->createProduct('product_one', [
-                'values' => [
-                    'a_scopable_image' => [
-                        ['data' => $this->getFixturePath('akeneo.jpg'), 'scope' => 'ecommerce', 'locale' => null],
-                        ['data' => $this->getFixturePath('ziggy.png'), 'scope' => 'tablet', 'locale' => null],
-                    ]
+        $this->createProduct('product_one', [
+            'values' => [
+                'a_scopable_image' => [
+                    ['data' => $this->getFixturePath('akeneo.jpg'), 'scope' => 'ecommerce', 'locale' => null],
+                    ['data' => $this->getFixturePath('ziggy.png'), 'scope' => 'tablet', 'locale' => null],
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('product_two', [
-                'values' => [
-                    'a_scopable_image' => [
-                        ['data' => $this->getFixturePath('ziggy.png'), 'scope' => 'ecommerce', 'locale' => null],
-                        ['data' => $this->getFixturePath('ziggy.png'), 'scope' => 'tablet', 'locale' => null],
-                    ]
+        $this->createProduct('product_two', [
+            'values' => [
+                'a_scopable_image' => [
+                    ['data' => $this->getFixturePath('ziggy.png'), 'scope' => 'ecommerce', 'locale' => null],
+                    ['data' => $this->getFixturePath('ziggy.png'), 'scope' => 'tablet', 'locale' => null],
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('empty_product', []);
-        }
+        $this->createProduct('empty_product', []);
     }
 
     public function testOperatorStartWith()

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Metric/LocalizableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Metric/LocalizableFilterIntegration.php
@@ -17,36 +17,34 @@ class LocalizableFilterIntegration extends AbstractFilterTestCase
     {
         parent::setUp();
 
-        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->createAttribute([
-                'code'                => 'a_localizable_metric',
-                'type'                => AttributeTypes::METRIC,
-                'localizable'         => true,
-                'decimals_allowed'    => false,
-                'metric_family'       => 'Length',
-                'default_metric_unit' => 'METER',
-            ]);
+        $this->createAttribute([
+            'code'                => 'a_localizable_metric',
+            'type'                => AttributeTypes::METRIC,
+            'localizable'         => true,
+            'decimals_allowed'    => false,
+            'metric_family'       => 'Length',
+            'default_metric_unit' => 'METER',
+        ]);
 
-            $this->createProduct('product_one', [
-                'values' => [
-                    'a_localizable_metric' => [
-                        ['data' => ['amount' => 20, 'unit' => 'METER'], 'locale' => 'en_US', 'scope' => null],
-                        ['data' => ['amount' => 21, 'unit' => 'METER'], 'locale' => 'fr_FR', 'scope' => null]
-                    ]
+        $this->createProduct('product_one', [
+            'values' => [
+                'a_localizable_metric' => [
+                    ['data' => ['amount' => 20, 'unit' => 'METER'], 'locale' => 'en_US', 'scope' => null],
+                    ['data' => ['amount' => 21, 'unit' => 'METER'], 'locale' => 'fr_FR', 'scope' => null]
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('product_two', [
-                'values' => [
-                    'a_localizable_metric' => [
-                        ['data' => ['amount' => 10, 'unit' => 'METER'], 'locale' => 'en_US', 'scope' => null],
-                        ['data' => ['amount' => 1, 'unit' => 'METER'], 'locale' => 'fr_FR', 'scope' => null]
-                    ]
+        $this->createProduct('product_two', [
+            'values' => [
+                'a_localizable_metric' => [
+                    ['data' => ['amount' => 10, 'unit' => 'METER'], 'locale' => 'en_US', 'scope' => null],
+                    ['data' => ['amount' => 1, 'unit' => 'METER'], 'locale' => 'fr_FR', 'scope' => null]
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('empty_product', []);
-        }
+        $this->createProduct('empty_product', []);
     }
 
     public function testOperatorInferior()

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Metric/LocalizableScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Metric/LocalizableScopableFilterIntegration.php
@@ -17,40 +17,38 @@ class LocalizableScopableFilterIntegration extends AbstractFilterTestCase
     {
         parent::setUp();
 
-        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->createAttribute([
-                'code'                => 'a_scopable_localizable_metric',
-                'type'                => AttributeTypes::METRIC,
-                'localizable'         => true,
-                'scopable'            => true,
-                'decimals_allowed'    => true,
-                'metric_family'       => 'Power',
-                'default_metric_unit' => 'KILOWATT'
-            ]);
+        $this->createAttribute([
+            'code'                => 'a_scopable_localizable_metric',
+            'type'                => AttributeTypes::METRIC,
+            'localizable'         => true,
+            'scopable'            => true,
+            'decimals_allowed'    => true,
+            'metric_family'       => 'Power',
+            'default_metric_unit' => 'KILOWATT'
+        ]);
 
-            $this->createProduct('product_one', [
-                'values' => [
-                    'a_scopable_localizable_metric' => [
-                        ['data' => ['amount' => '-5.00', 'unit' => 'KILOWATT'], 'locale' => 'en_US', 'scope' => 'ecommerce'],
-                        ['data' => ['amount' => '14', 'unit' => 'KILOWATT'], 'locale' => 'en_US', 'scope' => 'tablet'],
-                        ['data' => ['amount' => '100', 'unit' => 'KILOWATT'], 'locale' => 'fr_FR', 'scope' => 'tablet'],
-                    ],
-                ]
-            ]);
+        $this->createProduct('product_one', [
+            'values' => [
+                'a_scopable_localizable_metric' => [
+                    ['data' => ['amount' => '-5.00', 'unit' => 'KILOWATT'], 'locale' => 'en_US', 'scope' => 'ecommerce'],
+                    ['data' => ['amount' => '14', 'unit' => 'KILOWATT'], 'locale' => 'en_US', 'scope' => 'tablet'],
+                    ['data' => ['amount' => '100', 'unit' => 'KILOWATT'], 'locale' => 'fr_FR', 'scope' => 'tablet'],
+                ],
+            ]
+        ]);
 
-            $this->createProduct('product_two', [
-                'values' => [
-                    'a_scopable_localizable_metric' => [
-                        ['data' => ['amount' => '-5.00', 'unit' => 'KILOWATT'], 'locale' => 'en_US', 'scope' => 'ecommerce'],
-                        ['data' => ['amount' => '10', 'unit' => 'KILOWATT'], 'locale' => 'en_US', 'scope' => 'tablet'],
-                        ['data' => ['amount' => '75', 'unit' => 'KILOWATT'], 'locale' => 'fr_FR', 'scope' => 'tablet'],
-                        ['data' => ['amount' => '75', 'unit' => 'KILOWATT'], 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
-                    ],
-                ]
-            ]);
+        $this->createProduct('product_two', [
+            'values' => [
+                'a_scopable_localizable_metric' => [
+                    ['data' => ['amount' => '-5.00', 'unit' => 'KILOWATT'], 'locale' => 'en_US', 'scope' => 'ecommerce'],
+                    ['data' => ['amount' => '10', 'unit' => 'KILOWATT'], 'locale' => 'en_US', 'scope' => 'tablet'],
+                    ['data' => ['amount' => '75', 'unit' => 'KILOWATT'], 'locale' => 'fr_FR', 'scope' => 'tablet'],
+                    ['data' => ['amount' => '75', 'unit' => 'KILOWATT'], 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
+                ],
+            ]
+        ]);
 
-            $this->createProduct('empty_product', []);
-        }
+        $this->createProduct('empty_product', []);
     }
 
     public function testOperatorInferior()

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Metric/MetricFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Metric/MetricFilterIntegration.php
@@ -16,25 +16,23 @@ class MetricFilterIntegration extends AbstractFilterTestCase
     {
         parent::setUp();
 
-        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->createProduct('product_one', [
-                'values' => [
-                    'a_metric' => [
-                        ['data' => ['amount' => '10.55', 'unit' => 'KILOWATT'], 'locale' => null, 'scope' => null]
-                    ]
+        $this->createProduct('product_one', [
+            'values' => [
+                'a_metric' => [
+                    ['data' => ['amount' => '10.55', 'unit' => 'KILOWATT'], 'locale' => null, 'scope' => null]
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('product_two', [
-                'values' => [
-                    'a_metric' => [
-                        ['data' => ['amount' => '15', 'unit' => 'KILOWATT'], 'locale' => null, 'scope' => null]
-                    ]
+        $this->createProduct('product_two', [
+            'values' => [
+                'a_metric' => [
+                    ['data' => ['amount' => '15', 'unit' => 'KILOWATT'], 'locale' => null, 'scope' => null]
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('empty_product', []);
-        }
+        $this->createProduct('empty_product', []);
     }
 
     public function testOperatorInferior()

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Metric/ScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Metric/ScopableFilterIntegration.php
@@ -17,37 +17,35 @@ class ScopableFilterIntegration extends AbstractFilterTestCase
     {
         parent::setUp();
 
-        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->createAttribute([
-                'code'                => 'a_scopable_metric',
-                'type'                => AttributeTypes::METRIC,
-                'localizable'         => false,
-                'scopable'            => true,
-                'decimals_allowed'    => true,
-                'metric_family'       => 'Length',
-                'default_metric_unit' => 'METER'
-            ]);
+        $this->createAttribute([
+            'code'                => 'a_scopable_metric',
+            'type'                => AttributeTypes::METRIC,
+            'localizable'         => false,
+            'scopable'            => true,
+            'decimals_allowed'    => true,
+            'metric_family'       => 'Length',
+            'default_metric_unit' => 'METER'
+        ]);
 
-            $this->createProduct('product_one', [
-                'values' => [
-                    'a_scopable_metric' => [
-                        ['data' => ['amount' => '10.55', 'unit' => 'CENTIMETER'], 'locale' => null, 'scope' => 'ecommerce'],
-                        ['data' => ['amount' => '25', 'unit' => 'CENTIMETER'], 'locale' => null, 'scope' => 'tablet']
-                    ]
+        $this->createProduct('product_one', [
+            'values' => [
+                'a_scopable_metric' => [
+                    ['data' => ['amount' => '10.55', 'unit' => 'CENTIMETER'], 'locale' => null, 'scope' => 'ecommerce'],
+                    ['data' => ['amount' => '25', 'unit' => 'CENTIMETER'], 'locale' => null, 'scope' => 'tablet']
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('product_two', [
-                'values' => [
-                    'a_scopable_metric' => [
-                        ['data' => ['amount' => '2', 'unit' => 'CENTIMETER'], 'locale' => null, 'scope' => 'ecommerce'],
-                        ['data' => ['amount' => '30', 'unit' => 'CENTIMETER'], 'locale' => null, 'scope' => 'tablet']
-                    ]
+        $this->createProduct('product_two', [
+            'values' => [
+                'a_scopable_metric' => [
+                    ['data' => ['amount' => '2', 'unit' => 'CENTIMETER'], 'locale' => null, 'scope' => 'ecommerce'],
+                    ['data' => ['amount' => '30', 'unit' => 'CENTIMETER'], 'locale' => null, 'scope' => 'tablet']
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('empty_product', []);
-        }
+        $this->createProduct('empty_product', []);
     }
 
     public function testOperatorInferior()

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Number/LocalizableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Number/LocalizableFilterIntegration.php
@@ -17,34 +17,32 @@ class LocalizableFilterIntegration extends AbstractFilterTestCase
     {
         parent::setUp();
 
-        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->createAttribute([
-                'code'                => 'a_localizable_number',
-                'type'                => AttributeTypes::NUMBER,
-                'localizable'         => true,
-                'scopable'            => false,
-                'negative_allowed'    => true
-            ]);
+        $this->createAttribute([
+            'code'                => 'a_localizable_number',
+            'type'                => AttributeTypes::NUMBER,
+            'localizable'         => true,
+            'scopable'            => false,
+            'negative_allowed'    => true
+        ]);
 
-            $this->createProduct('product_one', [
-                'values' => [
-                    'a_localizable_number' => [
-                        ['data' => -15, 'locale' => 'en_US', 'scope' => null],
-                        ['data' => -14, 'locale' => 'fr_FR', 'scope' => null]
-                    ]
+        $this->createProduct('product_one', [
+            'values' => [
+                'a_localizable_number' => [
+                    ['data' => -15, 'locale' => 'en_US', 'scope' => null],
+                    ['data' => -14, 'locale' => 'fr_FR', 'scope' => null]
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('product_two', [
-                'values' => [
-                    'a_localizable_number' => [
-                        ['data' => 19, 'locale' => 'en_US', 'scope' => null]
-                    ]
+        $this->createProduct('product_two', [
+            'values' => [
+                'a_localizable_number' => [
+                    ['data' => 19, 'locale' => 'en_US', 'scope' => null]
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('empty_product', []);
-        }
+        $this->createProduct('empty_product', []);
     }
 
     public function testOperatorInferior()

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Number/LocalizableScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Number/LocalizableScopableFilterIntegration.php
@@ -17,38 +17,36 @@ class LocalizableScopableFilterIntegration extends AbstractFilterTestCase
     {
         parent::setUp();
 
-        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->createAttribute([
-                'code'                => 'a_localizable_scopable_number',
-                'type'                => AttributeTypes::NUMBER,
-                'localizable'         => true,
-                'scopable'            => true,
-                'negative_allowed'    => true
-            ]);
+        $this->createAttribute([
+            'code'                => 'a_localizable_scopable_number',
+            'type'                => AttributeTypes::NUMBER,
+            'localizable'         => true,
+            'scopable'            => true,
+            'negative_allowed'    => true
+        ]);
 
-            $this->createProduct('product_one', [
-                'values' => [
-                    'a_localizable_scopable_number' => [
-                        ['data' => -15, 'locale' => 'en_US', 'scope' => 'ecommerce'],
-                        ['data' => -15, 'locale' => 'en_US', 'scope' => 'tablet'],
-                        ['data' => -14, 'locale' => 'fr_FR', 'scope' => 'tablet']
-                    ]
+        $this->createProduct('product_one', [
+            'values' => [
+                'a_localizable_scopable_number' => [
+                    ['data' => -15, 'locale' => 'en_US', 'scope' => 'ecommerce'],
+                    ['data' => -15, 'locale' => 'en_US', 'scope' => 'tablet'],
+                    ['data' => -14, 'locale' => 'fr_FR', 'scope' => 'tablet']
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('product_two', [
-                'values' => [
-                    'a_localizable_scopable_number' => [
-                        ['data' => 19, 'locale' => 'en_US', 'scope' => 'ecommerce'],
-                        ['data' => 19, 'locale' => 'en_US', 'scope' => 'tablet'],
-                        ['data' => 19, 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
-                        ['data' => 19, 'locale' => 'fr_FR', 'scope' => 'tablet']
-                    ]
+        $this->createProduct('product_two', [
+            'values' => [
+                'a_localizable_scopable_number' => [
+                    ['data' => 19, 'locale' => 'en_US', 'scope' => 'ecommerce'],
+                    ['data' => 19, 'locale' => 'en_US', 'scope' => 'tablet'],
+                    ['data' => 19, 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
+                    ['data' => 19, 'locale' => 'fr_FR', 'scope' => 'tablet']
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('empty_product', []);
-        }
+        $this->createProduct('empty_product', []);
     }
 
     public function testOperatorInferior()

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Number/NumberFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Number/NumberFilterIntegration.php
@@ -16,25 +16,23 @@ class NumberFilterIntegration extends AbstractFilterTestCase
     {
         parent::setUp();
 
-        if (1 === self::$count) {
-            $this->createProduct('product_one', [
-                'values' => [
-                    'a_number_float_negative' => [
-                        ['data' => -15.5, 'locale' => null, 'scope' => null]
-                    ]
+        $this->createProduct('product_one', [
+            'values' => [
+                'a_number_float_negative' => [
+                    ['data' => -15.5, 'locale' => null, 'scope' => null]
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('product_two', [
-                'values' => [
-                    'a_number_float_negative' => [
-                        ['data' => 19.0, 'locale' => null, 'scope' => null]
-                    ]
+        $this->createProduct('product_two', [
+            'values' => [
+                'a_number_float_negative' => [
+                    ['data' => 19.0, 'locale' => null, 'scope' => null]
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('empty_product', []);
-        }
+        $this->createProduct('empty_product', []);
     }
 
     public function testOperatorInferior()

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Number/ScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Number/ScopableFilterIntegration.php
@@ -17,34 +17,32 @@ class ScopableFilterIntegration extends AbstractFilterTestCase
     {
         parent::setUp();
 
-        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->createAttribute([
-                'code'                => 'a_scopable_number',
-                'type'                => AttributeTypes::NUMBER,
-                'localizable'         => false,
-                'scopable'            => true,
-                'negative_allowed'    => true
-            ]);
+        $this->createAttribute([
+            'code'                => 'a_scopable_number',
+            'type'                => AttributeTypes::NUMBER,
+            'localizable'         => false,
+            'scopable'            => true,
+            'negative_allowed'    => true
+        ]);
 
-            $this->createProduct('product_one', [
-                'values' => [
-                    'a_scopable_number' => [
-                        ['data' => -15, 'locale' => null, 'scope' => 'ecommerce'],
-                        ['data' => -14, 'locale' => null, 'scope' => 'tablet']
-                    ]
+        $this->createProduct('product_one', [
+            'values' => [
+                'a_scopable_number' => [
+                    ['data' => -15, 'locale' => null, 'scope' => 'ecommerce'],
+                    ['data' => -14, 'locale' => null, 'scope' => 'tablet']
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('product_two', [
-                'values' => [
-                    'a_scopable_number' => [
-                        ['data' => 19, 'locale' => null, 'scope' => 'tablet']
-                    ]
+        $this->createProduct('product_two', [
+            'values' => [
+                'a_scopable_number' => [
+                    ['data' => 19, 'locale' => null, 'scope' => 'tablet']
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('empty_product', []);
-        }
+        $this->createProduct('empty_product', []);
     }
 
     public function testOperatorInferior()

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Option/LocalizableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Option/LocalizableFilterIntegration.php
@@ -17,44 +17,42 @@ class LocalizableFilterIntegration extends AbstractFilterTestCase
     {
         parent::setUp();
 
-        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->createAttribute([
-                'code'                => 'a_localizable_simple_select',
-                'type'                => AttributeTypes::OPTION_SIMPLE_SELECT,
-                'localizable'         => true,
-                'scopable'            => false
-            ]);
+        $this->createAttribute([
+            'code'                => 'a_localizable_simple_select',
+            'type'                => AttributeTypes::OPTION_SIMPLE_SELECT,
+            'localizable'         => true,
+            'scopable'            => false
+        ]);
 
-            $this->createAttributeOption([
-                'attribute' => 'a_localizable_simple_select',
-                'code'      => 'orange'
-            ]);
+        $this->createAttributeOption([
+            'attribute' => 'a_localizable_simple_select',
+            'code'      => 'orange'
+        ]);
 
-            $this->createAttributeOption([
-                'attribute' => 'a_localizable_simple_select',
-                'code'      => 'black'
-            ]);
+        $this->createAttributeOption([
+            'attribute' => 'a_localizable_simple_select',
+            'code'      => 'black'
+        ]);
 
-            $this->createProduct('product_one', [
-                'values' => [
-                    'a_localizable_simple_select' => [
-                        ['data' => 'orange', 'locale' => 'en_US', 'scope' => null],
-                        ['data' => 'black', 'locale' => 'fr_FR', 'scope' => null]
-                    ]
+        $this->createProduct('product_one', [
+            'values' => [
+                'a_localizable_simple_select' => [
+                    ['data' => 'orange', 'locale' => 'en_US', 'scope' => null],
+                    ['data' => 'black', 'locale' => 'fr_FR', 'scope' => null]
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('product_two', [
-                'values' => [
-                    'a_localizable_simple_select' => [
-                        ['data' => 'black', 'locale' => 'en_US', 'scope' => null],
-                        ['data' => 'black', 'locale' => 'fr_FR', 'scope' => null]
-                    ]
+        $this->createProduct('product_two', [
+            'values' => [
+                'a_localizable_simple_select' => [
+                    ['data' => 'black', 'locale' => 'en_US', 'scope' => null],
+                    ['data' => 'black', 'locale' => 'fr_FR', 'scope' => null]
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('empty_product', []);
-        }
+        $this->createProduct('empty_product', []);
     }
 
     public function testOperatorIn()

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Option/LocalizableScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Option/LocalizableScopableFilterIntegration.php
@@ -17,48 +17,46 @@ class LocalizableScopableFilterIntegration extends AbstractFilterTestCase
     {
         parent::setUp();
 
-        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->createAttribute([
-                'code'                => 'a_localizable_scopable_simple_select',
-                'type'                => AttributeTypes::OPTION_SIMPLE_SELECT,
-                'localizable'         => true,
-                'scopable'            => true
-            ]);
+        $this->createAttribute([
+            'code'                => 'a_localizable_scopable_simple_select',
+            'type'                => AttributeTypes::OPTION_SIMPLE_SELECT,
+            'localizable'         => true,
+            'scopable'            => true
+        ]);
 
-            $this->createAttributeOption([
-                'attribute' => 'a_localizable_scopable_simple_select',
-                'code'      => 'orange'
-            ]);
+        $this->createAttributeOption([
+            'attribute' => 'a_localizable_scopable_simple_select',
+            'code'      => 'orange'
+        ]);
 
-            $this->createAttributeOption([
-                'attribute' => 'a_localizable_scopable_simple_select',
-                'code'      => 'black'
-            ]);
+        $this->createAttributeOption([
+            'attribute' => 'a_localizable_scopable_simple_select',
+            'code'      => 'black'
+        ]);
 
-            $this->createProduct('product_one', [
-                'values' => [
-                    'a_localizable_scopable_simple_select' => [
-                        ['data' => 'orange', 'locale' => 'en_US', 'scope' => 'ecommerce'],
-                        ['data' => 'orange', 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
-                        ['data' => 'black', 'locale' => 'en_US', 'scope' => 'tablet'],
-                        ['data' => 'black', 'locale' => 'fr_FR', 'scope' => 'tablet'],
-                    ]
+        $this->createProduct('product_one', [
+            'values' => [
+                'a_localizable_scopable_simple_select' => [
+                    ['data' => 'orange', 'locale' => 'en_US', 'scope' => 'ecommerce'],
+                    ['data' => 'orange', 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
+                    ['data' => 'black', 'locale' => 'en_US', 'scope' => 'tablet'],
+                    ['data' => 'black', 'locale' => 'fr_FR', 'scope' => 'tablet'],
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('product_two', [
-                'values' => [
-                    'a_localizable_scopable_simple_select' => [
-                        ['data' => 'black', 'locale' => 'en_US', 'scope' => 'ecommerce'],
-                        ['data' => 'black', 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
-                        ['data' => 'black', 'locale' => 'en_US', 'scope' => 'tablet'],
-                        ['data' => 'black', 'locale' => 'fr_FR', 'scope' => 'tablet'],
-                    ]
+        $this->createProduct('product_two', [
+            'values' => [
+                'a_localizable_scopable_simple_select' => [
+                    ['data' => 'black', 'locale' => 'en_US', 'scope' => 'ecommerce'],
+                    ['data' => 'black', 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
+                    ['data' => 'black', 'locale' => 'en_US', 'scope' => 'tablet'],
+                    ['data' => 'black', 'locale' => 'fr_FR', 'scope' => 'tablet'],
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('empty_product', []);
-        }
+        $this->createProduct('empty_product', []);
     }
 
     public function testOperatorIn()

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Option/OptionFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Option/OptionFilterIntegration.php
@@ -16,35 +16,33 @@ class OptionFilterIntegration extends AbstractFilterTestCase
     {
         parent::setUp();
 
-        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->createAttributeOption([
-               'attribute' => 'a_simple_select',
-               'code'      => 'orange'
-            ]);
+        $this->createAttributeOption([
+           'attribute' => 'a_simple_select',
+           'code'      => 'orange'
+        ]);
 
-            $this->createAttributeOption([
-                'attribute' => 'a_simple_select',
-                'code'      => 'black'
-            ]);
+        $this->createAttributeOption([
+            'attribute' => 'a_simple_select',
+            'code'      => 'black'
+        ]);
 
-            $this->createProduct('product_one', [
-                'values' => [
-                    'a_simple_select' => [
-                        ['data' => 'orange', 'locale' => null, 'scope' => null]
-                    ]
+        $this->createProduct('product_one', [
+            'values' => [
+                'a_simple_select' => [
+                    ['data' => 'orange', 'locale' => null, 'scope' => null]
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('product_two', [
-                'values' => [
-                    'a_simple_select' => [
-                        ['data' => 'black', 'locale' => null, 'scope' => null]
-                    ]
+        $this->createProduct('product_two', [
+            'values' => [
+                'a_simple_select' => [
+                    ['data' => 'black', 'locale' => null, 'scope' => null]
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('empty_product', []);
-        }
+        $this->createProduct('empty_product', []);
     }
 
     public function testOperatorIn()

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Option/ScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Option/ScopableFilterIntegration.php
@@ -17,43 +17,41 @@ class ScopableFilterIntegration extends AbstractFilterTestCase
     {
         parent::setUp();
 
-        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->createAttribute([
-                'code'                => 'a_select_scopable_simple_select',
-                'type'                => AttributeTypes::OPTION_SIMPLE_SELECT,
-                'localizable'         => false,
-                'scopable'            => true
-            ]);
+        $this->createAttribute([
+            'code'                => 'a_select_scopable_simple_select',
+            'type'                => AttributeTypes::OPTION_SIMPLE_SELECT,
+            'localizable'         => false,
+            'scopable'            => true
+        ]);
 
-            $this->createAttributeOption([
-                'attribute' => 'a_select_scopable_simple_select',
-                'code'      => 'orange'
-            ]);
+        $this->createAttributeOption([
+            'attribute' => 'a_select_scopable_simple_select',
+            'code'      => 'orange'
+        ]);
 
-            $this->createAttributeOption([
-                'attribute' => 'a_select_scopable_simple_select',
-                'code'      => 'black'
-            ]);
+        $this->createAttributeOption([
+            'attribute' => 'a_select_scopable_simple_select',
+            'code'      => 'black'
+        ]);
 
-            $this->createProduct('product_one', [
-                'values' => [
-                    'a_select_scopable_simple_select' => [
-                        ['data' => 'orange', 'locale' => null, 'scope' => 'ecommerce']
-                    ]
+        $this->createProduct('product_one', [
+            'values' => [
+                'a_select_scopable_simple_select' => [
+                    ['data' => 'orange', 'locale' => null, 'scope' => 'ecommerce']
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('product_two', [
-                'values' => [
-                    'a_select_scopable_simple_select' => [
-                        ['data' => 'black', 'locale' => null, 'scope' => 'ecommerce'],
-                        ['data' => 'black', 'locale' => null, 'scope' => 'tablet']
-                    ]
+        $this->createProduct('product_two', [
+            'values' => [
+                'a_select_scopable_simple_select' => [
+                    ['data' => 'black', 'locale' => null, 'scope' => 'ecommerce'],
+                    ['data' => 'black', 'locale' => null, 'scope' => 'tablet']
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('empty_product', []);
-        }
+        $this->createProduct('empty_product', []);
     }
 
     public function testOperatorIn()

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Options/LocalizableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Options/LocalizableFilterIntegration.php
@@ -17,49 +17,47 @@ class LocalizableFilterIntegration extends AbstractFilterTestCase
     {
         parent::setUp();
 
-        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->createAttribute([
-                'code'                => 'a_localizable_multi_select',
-                'type'                => AttributeTypes::OPTION_MULTI_SELECT,
-                'localizable'         => true,
-                'scopable'            => false
-            ]);
+        $this->createAttribute([
+            'code'                => 'a_localizable_multi_select',
+            'type'                => AttributeTypes::OPTION_MULTI_SELECT,
+            'localizable'         => true,
+            'scopable'            => false
+        ]);
 
-            $this->createAttributeOption([
-                'attribute' => 'a_localizable_multi_select',
-                'code'      => 'orange'
-            ]);
+        $this->createAttributeOption([
+            'attribute' => 'a_localizable_multi_select',
+            'code'      => 'orange'
+        ]);
 
-            $this->createAttributeOption([
-                'attribute' => 'a_localizable_multi_select',
-                'code'      => 'black'
-            ]);
+        $this->createAttributeOption([
+            'attribute' => 'a_localizable_multi_select',
+            'code'      => 'black'
+        ]);
 
-            $this->createAttributeOption([
-                'attribute' => 'a_localizable_multi_select',
-                'code'      => 'purple'
-            ]);
+        $this->createAttributeOption([
+            'attribute' => 'a_localizable_multi_select',
+            'code'      => 'purple'
+        ]);
 
-            $this->createProduct('product_one', [
-                'values' => [
-                    'a_localizable_multi_select' => [
-                        ['data' => ['orange'], 'locale' => 'en_US', 'scope' => null],
-                        ['data' => ['black', 'purple'], 'locale' => 'fr_FR', 'scope' => null]
-                    ]
+        $this->createProduct('product_one', [
+            'values' => [
+                'a_localizable_multi_select' => [
+                    ['data' => ['orange'], 'locale' => 'en_US', 'scope' => null],
+                    ['data' => ['black', 'purple'], 'locale' => 'fr_FR', 'scope' => null]
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('product_two', [
-                'values' => [
-                    'a_localizable_multi_select' => [
-                        ['data' => ['black', 'orange'], 'locale' => 'en_US', 'scope' => null],
-                        ['data' => ['black', 'orange'], 'locale' => 'fr_FR', 'scope' => null]
-                    ]
+        $this->createProduct('product_two', [
+            'values' => [
+                'a_localizable_multi_select' => [
+                    ['data' => ['black', 'orange'], 'locale' => 'en_US', 'scope' => null],
+                    ['data' => ['black', 'orange'], 'locale' => 'fr_FR', 'scope' => null]
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('empty_product', []);
-        }
+        $this->createProduct('empty_product', []);
     }
 
     public function testOperatorIn()

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Options/LocalizableScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Options/LocalizableScopableFilterIntegration.php
@@ -17,53 +17,51 @@ class LocalizableScopableFilterIntegration extends AbstractFilterTestCase
     {
         parent::setUp();
 
-        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->createAttribute([
-                'code'                => 'a_localizable_scopable_multi_select',
-                'type'                => AttributeTypes::OPTION_MULTI_SELECT,
-                'localizable'         => true,
-                'scopable'            => true
-            ]);
+        $this->createAttribute([
+            'code'                => 'a_localizable_scopable_multi_select',
+            'type'                => AttributeTypes::OPTION_MULTI_SELECT,
+            'localizable'         => true,
+            'scopable'            => true
+        ]);
 
-            $this->createAttributeOption([
-                'attribute' => 'a_localizable_scopable_multi_select',
-                'code'      => 'orange'
-            ]);
+        $this->createAttributeOption([
+            'attribute' => 'a_localizable_scopable_multi_select',
+            'code'      => 'orange'
+        ]);
 
-            $this->createAttributeOption([
-                'attribute' => 'a_localizable_scopable_multi_select',
-                'code'      => 'black'
-            ]);
+        $this->createAttributeOption([
+            'attribute' => 'a_localizable_scopable_multi_select',
+            'code'      => 'black'
+        ]);
 
-            $this->createAttributeOption([
-                'attribute' => 'a_localizable_scopable_multi_select',
-                'code'      => 'purple'
-            ]);
+        $this->createAttributeOption([
+            'attribute' => 'a_localizable_scopable_multi_select',
+            'code'      => 'purple'
+        ]);
 
-            $this->createProduct('product_one', [
-                'values' => [
-                    'a_localizable_scopable_multi_select' => [
-                        ['data' => ['orange'], 'locale' => 'en_US', 'scope' => 'ecommerce'],
-                        ['data' => ['orange'], 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
-                        ['data' => ['black'], 'locale' => 'en_US', 'scope' => 'tablet'],
-                        ['data' => ['black'], 'locale' => 'fr_FR', 'scope' => 'tablet'],
-                    ]
+        $this->createProduct('product_one', [
+            'values' => [
+                'a_localizable_scopable_multi_select' => [
+                    ['data' => ['orange'], 'locale' => 'en_US', 'scope' => 'ecommerce'],
+                    ['data' => ['orange'], 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
+                    ['data' => ['black'], 'locale' => 'en_US', 'scope' => 'tablet'],
+                    ['data' => ['black'], 'locale' => 'fr_FR', 'scope' => 'tablet'],
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('product_two', [
-                'values' => [
-                    'a_localizable_scopable_multi_select' => [
-                        ['data' => ['black', 'purple'], 'locale' => 'en_US', 'scope' => 'ecommerce'],
-                        ['data' => ['black', 'purple'], 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
-                        ['data' => ['black', 'purple'], 'locale' => 'en_US', 'scope' => 'tablet'],
-                        ['data' => ['black', 'purple'], 'locale' => 'fr_FR', 'scope' => 'tablet'],
-                    ]
+        $this->createProduct('product_two', [
+            'values' => [
+                'a_localizable_scopable_multi_select' => [
+                    ['data' => ['black', 'purple'], 'locale' => 'en_US', 'scope' => 'ecommerce'],
+                    ['data' => ['black', 'purple'], 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
+                    ['data' => ['black', 'purple'], 'locale' => 'en_US', 'scope' => 'tablet'],
+                    ['data' => ['black', 'purple'], 'locale' => 'fr_FR', 'scope' => 'tablet'],
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('empty_product', []);
-        }
+        $this->createProduct('empty_product', []);
     }
 
     public function testOperatorIn()

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Options/OptionsFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Options/OptionsFilterIntegration.php
@@ -16,40 +16,38 @@ class OptionsFilterIntegration extends AbstractFilterTestCase
     {
         parent::setUp();
 
-        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->createAttributeOption([
-               'attribute' => 'a_multi_select',
-               'code'      => 'orange'
-            ]);
+        $this->createAttributeOption([
+           'attribute' => 'a_multi_select',
+           'code'      => 'orange'
+        ]);
 
-            $this->createAttributeOption([
-                'attribute' => 'a_multi_select',
-                'code'      => 'black'
-            ]);
+        $this->createAttributeOption([
+            'attribute' => 'a_multi_select',
+            'code'      => 'black'
+        ]);
 
-            $this->createAttributeOption([
-                'attribute' => 'a_multi_select',
-                'code'      => 'purple'
-            ]);
+        $this->createAttributeOption([
+            'attribute' => 'a_multi_select',
+            'code'      => 'purple'
+        ]);
 
-            $this->createProduct('product_one', [
-                'values' => [
-                    'a_multi_select' => [
-                        ['data' => ['orange'], 'locale' => null, 'scope' => null]
-                    ]
+        $this->createProduct('product_one', [
+            'values' => [
+                'a_multi_select' => [
+                    ['data' => ['orange'], 'locale' => null, 'scope' => null]
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('product_two', [
-                'values' => [
-                    'a_multi_select' => [
-                        ['data' => ['black', 'purple'], 'locale' => null, 'scope' => null]
-                    ]
+        $this->createProduct('product_two', [
+            'values' => [
+                'a_multi_select' => [
+                    ['data' => ['black', 'purple'], 'locale' => null, 'scope' => null]
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('empty_product', []);
-        }
+        $this->createProduct('empty_product', []);
     }
 
     public function testOperatorIn()

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Options/ScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Options/ScopableFilterIntegration.php
@@ -17,48 +17,46 @@ class ScopableFilterIntegration extends AbstractFilterTestCase
     {
         parent::setUp();
 
-        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->createAttribute([
-                'code'                => 'a_scopable_multi_select',
-                'type'                => AttributeTypes::OPTION_MULTI_SELECT,
-                'localizable'         => false,
-                'scopable'            => true
-            ]);
+        $this->createAttribute([
+            'code'                => 'a_scopable_multi_select',
+            'type'                => AttributeTypes::OPTION_MULTI_SELECT,
+            'localizable'         => false,
+            'scopable'            => true
+        ]);
 
-            $this->createAttributeOption([
-                'attribute' => 'a_scopable_multi_select',
-                'code'      => 'orange'
-            ]);
+        $this->createAttributeOption([
+            'attribute' => 'a_scopable_multi_select',
+            'code'      => 'orange'
+        ]);
 
-            $this->createAttributeOption([
-                'attribute' => 'a_scopable_multi_select',
-                'code'      => 'black'
-            ]);
+        $this->createAttributeOption([
+            'attribute' => 'a_scopable_multi_select',
+            'code'      => 'black'
+        ]);
 
-            $this->createAttributeOption([
-                'attribute' => 'a_scopable_multi_select',
-                'code'      => 'purple'
-            ]);
+        $this->createAttributeOption([
+            'attribute' => 'a_scopable_multi_select',
+            'code'      => 'purple'
+        ]);
 
-            $this->createProduct('product_one', [
-                'values' => [
-                    'a_scopable_multi_select' => [
-                        ['data' => ['orange'], 'locale' => null, 'scope' => 'ecommerce']
-                    ]
+        $this->createProduct('product_one', [
+            'values' => [
+                'a_scopable_multi_select' => [
+                    ['data' => ['orange'], 'locale' => null, 'scope' => 'ecommerce']
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('product_two', [
-                'values' => [
-                    'a_scopable_multi_select' => [
-                        ['data' => ['black', 'purple'], 'locale' => null, 'scope' => 'ecommerce'],
-                        ['data' => ['black', 'purple'], 'locale' => null, 'scope' => 'tablet']
-                    ]
+        $this->createProduct('product_two', [
+            'values' => [
+                'a_scopable_multi_select' => [
+                    ['data' => ['black', 'purple'], 'locale' => null, 'scope' => 'ecommerce'],
+                    ['data' => ['black', 'purple'], 'locale' => null, 'scope' => 'tablet']
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('empty_product', []);
-        }
+        $this->createProduct('empty_product', []);
     }
 
     public function testOperatorIn()

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Price/LocalizableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Price/LocalizableFilterIntegration.php
@@ -17,34 +17,32 @@ class LocalizableFilterIntegration extends AbstractFilterTestCase
     {
         parent::setUp();
 
-        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->createAttribute([
-                'code'                => 'a_localizable_price',
-                'type'                => AttributeTypes::PRICE_COLLECTION,
-                'localizable'         => true,
-                'scopable'            => false
-            ]);
+        $this->createAttribute([
+            'code'                => 'a_localizable_price',
+            'type'                => AttributeTypes::PRICE_COLLECTION,
+            'localizable'         => true,
+            'scopable'            => false
+        ]);
 
-            $this->createProduct('product_one', [
-                'values' => [
-                    'a_localizable_price' => [
-                        ['data' => [['amount' => 20, 'currency' => 'EUR']], 'locale' => 'en_US', 'scope' => null],
-                        ['data' => [['amount' => 21, 'currency' => 'EUR']], 'locale' => 'fr_FR', 'scope' => null]
-                    ]
+        $this->createProduct('product_one', [
+            'values' => [
+                'a_localizable_price' => [
+                    ['data' => [['amount' => 20, 'currency' => 'EUR']], 'locale' => 'en_US', 'scope' => null],
+                    ['data' => [['amount' => 21, 'currency' => 'EUR']], 'locale' => 'fr_FR', 'scope' => null]
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('product_two', [
-                'values' => [
-                    'a_localizable_price' => [
-                        ['data' => [['amount' => 10, 'currency' => 'EUR']], 'locale' => 'en_US', 'scope' => null],
-                        ['data' => [['amount' => 1, 'currency' => 'EUR']], 'locale' => 'fr_FR', 'scope' => null]
-                    ]
+        $this->createProduct('product_two', [
+            'values' => [
+                'a_localizable_price' => [
+                    ['data' => [['amount' => 10, 'currency' => 'EUR']], 'locale' => 'en_US', 'scope' => null],
+                    ['data' => [['amount' => 1, 'currency' => 'EUR']], 'locale' => 'fr_FR', 'scope' => null]
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('empty_product', []);
-        }
+        $this->createProduct('empty_product', []);
     }
 
     public function testOperatorInferior()

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Price/LocalizableScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Price/LocalizableScopableFilterIntegration.php
@@ -17,38 +17,36 @@ class LocalizableScopableFilterIntegration extends AbstractFilterTestCase
     {
         parent::setUp();
 
-        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->createAttribute([
-                'code'                => 'a_scopable_localizable_price',
-                'type'                => AttributeTypes::PRICE_COLLECTION,
-                'localizable'         => true,
-                'scopable'            => true,
-                'decimals_allowed'    => true
-            ]);
+        $this->createAttribute([
+            'code'                => 'a_scopable_localizable_price',
+            'type'                => AttributeTypes::PRICE_COLLECTION,
+            'localizable'         => true,
+            'scopable'            => true,
+            'decimals_allowed'    => true
+        ]);
 
-            $this->createProduct('product_one', [
-                'values' => [
-                    'a_scopable_localizable_price' => [
-                        ['data' => [['amount' => '-5.00', 'currency' => 'USD']], 'locale' => 'en_US', 'scope' => 'ecommerce'],
-                        ['data' => [['amount' => '14', 'currency' => 'USD']], 'locale' => 'en_US', 'scope' => 'tablet'],
-                        ['data' => [['amount' => '100', 'currency' => 'USD']], 'locale' => 'fr_FR', 'scope' => 'tablet'],
-                    ],
-                ]
-            ]);
+        $this->createProduct('product_one', [
+            'values' => [
+                'a_scopable_localizable_price' => [
+                    ['data' => [['amount' => '-5.00', 'currency' => 'USD']], 'locale' => 'en_US', 'scope' => 'ecommerce'],
+                    ['data' => [['amount' => '14', 'currency' => 'USD']], 'locale' => 'en_US', 'scope' => 'tablet'],
+                    ['data' => [['amount' => '100', 'currency' => 'USD']], 'locale' => 'fr_FR', 'scope' => 'tablet'],
+                ],
+            ]
+        ]);
 
-            $this->createProduct('product_two', [
-                'values' => [
-                    'a_scopable_localizable_price' => [
-                        ['data' => [['amount' => '-5.00', 'currency' => 'USD']], 'locale' => 'en_US', 'scope' => 'ecommerce'],
-                        ['data' => [['amount' => '10', 'currency' => 'USD']], 'locale' => 'en_US', 'scope' => 'tablet'],
-                        ['data' => [['amount' => '75', 'currency' => 'USD']], 'locale' => 'fr_FR', 'scope' => 'tablet'],
-                        ['data' => [['amount' => '75', 'currency' => 'USD']], 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
-                    ],
-                ]
-            ]);
+        $this->createProduct('product_two', [
+            'values' => [
+                'a_scopable_localizable_price' => [
+                    ['data' => [['amount' => '-5.00', 'currency' => 'USD']], 'locale' => 'en_US', 'scope' => 'ecommerce'],
+                    ['data' => [['amount' => '10', 'currency' => 'USD']], 'locale' => 'en_US', 'scope' => 'tablet'],
+                    ['data' => [['amount' => '75', 'currency' => 'USD']], 'locale' => 'fr_FR', 'scope' => 'tablet'],
+                    ['data' => [['amount' => '75', 'currency' => 'USD']], 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
+                ],
+            ]
+        ]);
 
-            $this->createProduct('empty_product', []);
-        }
+        $this->createProduct('empty_product', []);
     }
 
     public function testOperatorInferior()

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Price/PriceFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Price/PriceFilterIntegration.php
@@ -16,28 +16,26 @@ class PriceFilterIntegration extends AbstractFilterTestCase
     {
         parent::setUp();
 
-        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->createProduct('product_one', [
-                'values' => [
-                    'a_price' => [
-                        ['data' => [
-                            ['amount' => '10.55', 'currency' => 'EUR'],
-                            ['amount' => '11', 'currency' => 'USD']
-                        ], 'locale' => null, 'scope' => null]
-                    ]
+        $this->createProduct('product_one', [
+            'values' => [
+                'a_price' => [
+                    ['data' => [
+                        ['amount' => '10.55', 'currency' => 'EUR'],
+                        ['amount' => '11', 'currency' => 'USD']
+                    ], 'locale' => null, 'scope' => null]
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('product_two', [
-                'values' => [
-                    'a_price' => [
-                        ['data' => [['amount' => '15', 'currency' => 'EUR']], 'locale' => null, 'scope' => null]
-                    ]
+        $this->createProduct('product_two', [
+            'values' => [
+                'a_price' => [
+                    ['data' => [['amount' => '15', 'currency' => 'EUR']], 'locale' => null, 'scope' => null]
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('empty_product', []);
-        }
+        $this->createProduct('empty_product', []);
     }
 
     public function testOperatorInferior()

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Price/ScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Price/ScopableFilterIntegration.php
@@ -16,30 +16,28 @@ class ScopableFilterIntegration extends AbstractFilterTestCase
     {
         parent::setUp();
 
-        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->createProduct('product_one', [
-                'values' => [
-                    'a_scopable_price' => [
-                        ['data' => [['amount' => '10.55', 'currency' => 'EUR']], 'locale' => null, 'scope' => 'ecommerce'],
-                        ['data' => [['amount' => '25', 'currency' => 'USD']], 'locale' => null, 'scope' => 'tablet']
-                    ]
+        $this->createProduct('product_one', [
+            'values' => [
+                'a_scopable_price' => [
+                    ['data' => [['amount' => '10.55', 'currency' => 'EUR']], 'locale' => null, 'scope' => 'ecommerce'],
+                    ['data' => [['amount' => '25', 'currency' => 'USD']], 'locale' => null, 'scope' => 'tablet']
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('product_two', [
-                'values' => [
-                    'a_scopable_price' => [
-                        ['data' => [
-                            ['amount' => '2', 'currency' => 'EUR'],
-                            ['amount' => '2.2', 'currency' => 'USD']
-                        ], 'locale' => null, 'scope' => 'ecommerce'],
-                        ['data' => [['amount' => '30', 'currency' => 'EUR']], 'locale' => null, 'scope' => 'tablet']
-                    ]
+        $this->createProduct('product_two', [
+            'values' => [
+                'a_scopable_price' => [
+                    ['data' => [
+                        ['amount' => '2', 'currency' => 'EUR'],
+                        ['amount' => '2.2', 'currency' => 'USD']
+                    ], 'locale' => null, 'scope' => 'ecommerce'],
+                    ['data' => [['amount' => '30', 'currency' => 'EUR']], 'locale' => null, 'scope' => 'tablet']
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('empty_product', []);
-        }
+        $this->createProduct('empty_product', []);
     }
 
     public function testOperatorInferior()

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/String/LocalizableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/String/LocalizableFilterIntegration.php
@@ -17,43 +17,41 @@ class LocalizableFilterIntegration extends AbstractFilterTestCase
     {
         parent::setUp();
 
-        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->createAttribute([
-                'code'                => 'a_localizable_text',
-                'type'                => AttributeTypes::TEXT,
-                'localizable'         => true,
-                'scopable'            => false,
-            ]);
+        $this->createAttribute([
+            'code'                => 'a_localizable_text',
+            'type'                => AttributeTypes::TEXT,
+            'localizable'         => true,
+            'scopable'            => false,
+        ]);
 
-            $this->createProduct('cat', [
-                'values' => [
-                    'a_localizable_text' => [
-                        ['data' => 'black cat', 'locale' => 'en_US', 'scope' => null],
-                        ['data' => 'chat noir', 'locale' => 'fr_FR', 'scope' => null],
-                    ]
+        $this->createProduct('cat', [
+            'values' => [
+                'a_localizable_text' => [
+                    ['data' => 'black cat', 'locale' => 'en_US', 'scope' => null],
+                    ['data' => 'chat noir', 'locale' => 'fr_FR', 'scope' => null],
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('cattle', [
-                'values' => [
-                    'a_localizable_text' => [
-                        ['data' => 'cattle', 'locale' => 'en_US', 'scope' => null],
-                        ['data' => 'cattle', 'locale' => 'fr_FR', 'scope' => null]
-                    ]
+        $this->createProduct('cattle', [
+            'values' => [
+                'a_localizable_text' => [
+                    ['data' => 'cattle', 'locale' => 'en_US', 'scope' => null],
+                    ['data' => 'cattle', 'locale' => 'fr_FR', 'scope' => null]
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('dog', [
-                'values' => [
-                    'a_localizable_text' => [
-                        ['data' => 'just a dog...', 'locale' => 'en_US', 'scope' => null],
-                        ['data' => 'juste un chien', 'locale' => 'fr_FR', 'scope' => null]
-                    ]
+        $this->createProduct('dog', [
+            'values' => [
+                'a_localizable_text' => [
+                    ['data' => 'just a dog...', 'locale' => 'en_US', 'scope' => null],
+                    ['data' => 'juste un chien', 'locale' => 'fr_FR', 'scope' => null]
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('empty_product', []);
-        }
+        $this->createProduct('empty_product', []);
     }
 
     public function testOperatorStartsWith()

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/String/LocalizableScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/String/LocalizableScopableFilterIntegration.php
@@ -17,49 +17,47 @@ class LocalizableScopableFilterIntegration extends AbstractFilterTestCase
     {
         parent::setUp();
 
-        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->createAttribute([
-                'code'                => 'a_localizable_scopable_text',
-                'type'                => AttributeTypes::TEXT,
-                'localizable'         => true,
-                'scopable'            => true,
-            ]);
+        $this->createAttribute([
+            'code'                => 'a_localizable_scopable_text',
+            'type'                => AttributeTypes::TEXT,
+            'localizable'         => true,
+            'scopable'            => true,
+        ]);
 
-            $this->createProduct('cat', [
-                'values' => [
-                    'a_localizable_scopable_text' => [
-                        ['data' => 'black cat', 'locale' => 'en_US', 'scope' => 'ecommerce'],
-                        ['data' => 'cat', 'locale' => 'en_US', 'scope' => 'tablet'],
-                        ['data' => 'chat noir', 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
-                        ['data' => 'chat', 'locale' => 'fr_FR', 'scope' => 'tablet']
-                    ]
+        $this->createProduct('cat', [
+            'values' => [
+                'a_localizable_scopable_text' => [
+                    ['data' => 'black cat', 'locale' => 'en_US', 'scope' => 'ecommerce'],
+                    ['data' => 'cat', 'locale' => 'en_US', 'scope' => 'tablet'],
+                    ['data' => 'chat noir', 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
+                    ['data' => 'chat', 'locale' => 'fr_FR', 'scope' => 'tablet']
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('cattle', [
-                'values' => [
-                    'a_localizable_scopable_text' => [
-                        ['data' => 'cattle', 'locale' => 'en_US', 'scope' => 'ecommerce'],
-                        ['data' => 'cattle', 'locale' => 'en_US', 'scope' => 'tablet'],
-                        ['data' => 'bétail', 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
-                        ['data' => 'bétail', 'locale' => 'fr_FR', 'scope' => 'tablet']
-                    ]
+        $this->createProduct('cattle', [
+            'values' => [
+                'a_localizable_scopable_text' => [
+                    ['data' => 'cattle', 'locale' => 'en_US', 'scope' => 'ecommerce'],
+                    ['data' => 'cattle', 'locale' => 'en_US', 'scope' => 'tablet'],
+                    ['data' => 'bétail', 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
+                    ['data' => 'bétail', 'locale' => 'fr_FR', 'scope' => 'tablet']
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('dog', [
-                'values' => [
-                    'a_localizable_scopable_text' => [
-                        ['data' => 'just a dog...', 'locale' => 'en_US', 'scope' => 'ecommerce'],
-                        ['data' => 'dog', 'locale' => 'en_US', 'scope' => 'tablet'],
-                        ['data' => 'juste un chien...', 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
-                        ['data' => 'chien', 'locale' => 'fr_FR', 'scope' => 'tablet']
-                    ]
+        $this->createProduct('dog', [
+            'values' => [
+                'a_localizable_scopable_text' => [
+                    ['data' => 'just a dog...', 'locale' => 'en_US', 'scope' => 'ecommerce'],
+                    ['data' => 'dog', 'locale' => 'en_US', 'scope' => 'tablet'],
+                    ['data' => 'juste un chien...', 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
+                    ['data' => 'chien', 'locale' => 'fr_FR', 'scope' => 'tablet']
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('empty_product', []);
-        }
+        $this->createProduct('empty_product', []);
     }
 
     public function testOperatorStartsWith()

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/String/ScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/String/ScopableFilterIntegration.php
@@ -17,43 +17,41 @@ class ScopableFilterIntegration extends AbstractFilterTestCase
     {
         parent::setUp();
 
-        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->createAttribute([
-                'code'                => 'a_scopable_text',
-                'type'                => AttributeTypes::TEXT,
-                'localizable'         => false,
-                'scopable'            => true,
-            ]);
+        $this->createAttribute([
+            'code'                => 'a_scopable_text',
+            'type'                => AttributeTypes::TEXT,
+            'localizable'         => false,
+            'scopable'            => true,
+        ]);
 
-            $this->createProduct('cat', [
-                'values' => [
-                    'a_scopable_text' => [
-                        ['data' => 'black cat', 'locale' => null, 'scope' => 'ecommerce'],
-                        ['data' => 'cat', 'locale' => null, 'scope' => 'tablet'],
-                    ]
+        $this->createProduct('cat', [
+            'values' => [
+                'a_scopable_text' => [
+                    ['data' => 'black cat', 'locale' => null, 'scope' => 'ecommerce'],
+                    ['data' => 'cat', 'locale' => null, 'scope' => 'tablet'],
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('cattle', [
-                'values' => [
-                    'a_scopable_text' => [
-                        ['data' => 'cattle', 'locale' => null, 'scope' => 'ecommerce'],
-                        ['data' => 'cattle', 'locale' => null, 'scope' => 'tablet']
-                    ]
+        $this->createProduct('cattle', [
+            'values' => [
+                'a_scopable_text' => [
+                    ['data' => 'cattle', 'locale' => null, 'scope' => 'ecommerce'],
+                    ['data' => 'cattle', 'locale' => null, 'scope' => 'tablet']
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('dog', [
-                'values' => [
-                    'a_scopable_text' => [
-                        ['data' => 'just a dog...', 'locale' => null, 'scope' => 'ecommerce'],
-                        ['data' => 'dog', 'locale' => null, 'scope' => 'tablet']
-                    ]
+        $this->createProduct('dog', [
+            'values' => [
+                'a_scopable_text' => [
+                    ['data' => 'just a dog...', 'locale' => null, 'scope' => 'ecommerce'],
+                    ['data' => 'dog', 'locale' => null, 'scope' => 'tablet']
                 ]
-            ]);
+            ]
+        ]);
 
-            $this->createProduct('empty_product', []);
-        }
+        $this->createProduct('empty_product', []);
     }
 
     public function testOperatorStartsWith()

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/String/StringFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/String/StringFilterIntegration.php
@@ -16,27 +16,25 @@ class StringFilterIntegration extends AbstractFilterTestCase
     {
         parent::setUp();
 
-        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $this->createProduct('cat', [
-                'values' => [
-                    'a_text' => [['data' => 'cat', 'locale' => null, 'scope' => null]]
-                ]
-            ]);
+        $this->createProduct('cat', [
+            'values' => [
+                'a_text' => [['data' => 'cat', 'locale' => null, 'scope' => null]]
+            ]
+        ]);
 
-            $this->createProduct('cattle', [
-                'values' => [
-                    'a_text' => [['data' => 'cattle', 'locale' => null, 'scope' => null]]
-                ]
-            ]);
+        $this->createProduct('cattle', [
+            'values' => [
+                'a_text' => [['data' => 'cattle', 'locale' => null, 'scope' => null]]
+            ]
+        ]);
 
-            $this->createProduct('dog', [
-                'values' => [
-                    'a_text' => [['data' => 'dog', 'locale' => null, 'scope' => null]]
-                ]
-            ]);
+        $this->createProduct('dog', [
+            'values' => [
+                'a_text' => [['data' => 'dog', 'locale' => null, 'scope' => null]]
+            ]
+        ]);
 
-            $this->createProduct('empty_product', []);
-        }
+        $this->createProduct('empty_product', []);
     }
 
     public function testOperatorStartsWith()

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/ProductQueryBuilderIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/ProductQueryBuilderIntegration.php
@@ -85,10 +85,7 @@ class ProductQueryBuilderIntegration extends TestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()],
-            true
-        );
+        return new Configuration([Configuration::getTechnicalCatalogPath()]);
     }
 
     /**

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Validation/Attribute/AbstractAttributeTestCase.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Validation/Attribute/AbstractAttributeTestCase.php
@@ -434,9 +434,6 @@ abstract class AbstractAttributeTestCase extends TestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()],
-            false
-        );
+        return new Configuration([Configuration::getTechnicalCatalogPath()]);
     }
 }

--- a/src/Pim/Bundle/VersioningBundle/tests/integration/Normalizer/Flat/AbstractFlatNormalizerTestCase.php
+++ b/src/Pim/Bundle/VersioningBundle/tests/integration/Normalizer/Flat/AbstractFlatNormalizerTestCase.php
@@ -12,11 +12,11 @@ use Akeneo\Test\Integration\TestCase;
  */
 abstract class AbstractFlatNormalizerTestCase extends TestCase
 {
+    /**
+     * {@inheritdoc}
+     */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()],
-            false
-        );
+        return new Configuration([Configuration::getTechnicalCatalogPath()]);
     }
 }

--- a/src/Pim/Component/Api/tests/integration/Normalizer/AbstractNormalizerTestCase.php
+++ b/src/Pim/Component/Api/tests/integration/Normalizer/AbstractNormalizerTestCase.php
@@ -12,11 +12,11 @@ use Akeneo\Test\Integration\TestCase;
  */
 abstract class AbstractNormalizerTestCase extends TestCase
 {
+    /**
+     * {@inheritdoc}
+     */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()],
-            false
-        );
+        return new Configuration([Configuration::getTechnicalCatalogPath()]);
     }
 }

--- a/src/Pim/Component/Api/tests/integration/Normalizer/ProductNormalizerIntegration.php
+++ b/src/Pim/Component/Api/tests/integration/Normalizer/ProductNormalizerIntegration.php
@@ -13,12 +13,12 @@ use Pim\Component\Catalog\Model\ProductInterface;
  */
 class ProductNormalizerIntegration extends TestCase
 {
+    /**
+     * {@inheritdoc}
+     */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalSqlCatalogPath()],
-            false
-        );
+        return new Configuration([Configuration::getTechnicalSqlCatalogPath()]);
     }
 
     public function testEmptyDisabledProduct()

--- a/src/Pim/Component/Catalog/tests/integration/Normalizer/Standard/AbstractStandardNormalizerTestCase.php
+++ b/src/Pim/Component/Catalog/tests/integration/Normalizer/Standard/AbstractStandardNormalizerTestCase.php
@@ -12,11 +12,11 @@ use Akeneo\Test\Integration\TestCase;
  */
 abstract class AbstractStandardNormalizerTestCase extends TestCase
 {
+    /**
+     * {@inheritdoc}
+     */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()],
-            false
-        );
+        return new Configuration([Configuration::getTechnicalCatalogPath()]);
     }
 }

--- a/src/Pim/Component/Catalog/tests/integration/Normalizer/Standard/ProductStandardIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Normalizer/Standard/ProductStandardIntegration.php
@@ -13,12 +13,12 @@ use Pim\Component\Catalog\Model\ProductInterface;
  */
 class ProductStandardIntegration extends TestCase
 {
+    /**
+     * {@inheritdoc}
+     */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalSqlCatalogPath()],
-            false
-        );
+        return new Configuration([Configuration::getTechnicalSqlCatalogPath()]);
     }
 
     public function testEmptyDisabledProduct()

--- a/src/Pim/Component/Catalog/tests/integration/Updater/Copier/MediaAttributeCopierIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Updater/Copier/MediaAttributeCopierIntegration.php
@@ -14,12 +14,12 @@ use Pim\Component\Catalog\Model\ProductInterface;
  */
 class MediaAttributeCopierIntegration extends TestCase
 {
+    /**
+     * {@inheritdoc}
+     */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()],
-            false
-        );
+        return new Configuration([Configuration::getTechnicalCatalogPath()]);
     }
 
     public function testCopyToMediaWithLocale()

--- a/src/Pim/Component/Catalog/tests/integration/Updater/Setter/MediaAttributeSetterIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Updater/Setter/MediaAttributeSetterIntegration.php
@@ -13,12 +13,12 @@ use Akeneo\Test\Integration\TestCase;
  */
 class MediaAttributeSetterIntegration extends TestCase
 {
+    /**
+     * {@inheritdoc}
+     */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()],
-            false
-        );
+        return new Configuration([Configuration::getTechnicalCatalogPath()]);
     }
 
     public function testLocalizableMedia()

--- a/tests/Configuration.php
+++ b/tests/Configuration.php
@@ -4,8 +4,7 @@ namespace Akeneo\Test\Integration;
 
 /**
  * Configuration of a TestCase.
- * Here is defined the catalog that has to be loaded, the directories of the fixtures and tells if the database
- * should be purged between each test.
+ * Here is defined the catalog that has to be loaded and the directories of the fixtures.
  *
  * @author    Julien Janvier <j.janvier@gmail.com>
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
@@ -13,9 +12,6 @@ namespace Akeneo\Test\Integration;
  */
 class Configuration
 {
-    /** @var bool */
-    protected $purgeDatabaseForEachTest;
-
     /** @var array */
     protected $catalogDirectories;
 
@@ -24,17 +20,11 @@ class Configuration
 
     /**
      * @param array      $catalogDirectories       The catalog directories to load
-     * @param bool       $purgeDatabaseForEachTest If you don't need to purge database between each test in the
-     *                                             same test class, set to false
      * @param array|null $fixtureDirectories       The fixtures directories. Will look at least in "test/fixtures/".
      *
      * @throws \Exception
      */
-    public function __construct(
-        array $catalogDirectories,
-        $purgeDatabaseForEachTest = true,
-        array $fixtureDirectories = null
-    ) {
+    public function __construct(array $catalogDirectories, array $fixtureDirectories = null) {
         $this->catalogDirectories = $catalogDirectories;
         foreach ($this->catalogDirectories as $catalogDirectory) {
             if (!is_dir($catalogDirectory)) {
@@ -56,16 +46,6 @@ class Configuration
                 throw new \Exception(sprintf('The fixture directory "%s" does not exist.', $fixtureDirectory));
             }
         }
-
-        $this->purgeDatabaseForEachTest = $purgeDatabaseForEachTest;
-    }
-
-    /**
-     * @return bool
-     */
-    public function isDatabasePurgedForEachTest()
-    {
-        return $this->purgeDatabaseForEachTest;
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -11,17 +11,6 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
  */
 abstract class TestCase extends KernelTestCase
 {
-    /** @var int Count of executed tests inside the same test class */
-    protected static $count = 0;
-
-    /**
-     * {@inheritdoc}
-     */
-    public static function setUpBeforeClass()
-    {
-        self::$count = 0;
-    }
-
     /**
      * @return Configuration
      */
@@ -35,15 +24,9 @@ abstract class TestCase extends KernelTestCase
         static::bootKernel(['debug' => false]);
 
         $configuration = $this->getConfiguration();
-
-        self::$count++;
-
-        if ($configuration->isDatabasePurgedForEachTest() || 1 === self::$count) {
-            $this->getDatabaseSchemaHandler()->reset();
-
-            $fixturesLoader = $this->getFixturesLoader($configuration);
-            $fixturesLoader->load();
-        }
+        $databaseSchemaHandler = $this->getDatabaseSchemaHandler();
+        $fixturesLoader = $this->getFixturesLoader($configuration, $databaseSchemaHandler);
+        $fixturesLoader->load();
     }
 
     /**
@@ -86,13 +69,14 @@ abstract class TestCase extends KernelTestCase
     }
 
     /**
-     * @param Configuration $configuration
+     * @param Configuration         $configuration
+     * @param DatabaseSchemaHandler $databaseSchemaHandler
      *
      * @return FixturesLoader
      */
-    protected function getFixturesLoader(Configuration $configuration)
+    protected function getFixturesLoader(Configuration $configuration, DatabaseSchemaHandler $databaseSchemaHandler)
     {
-        return new FixturesLoader(static::$kernel, $configuration);
+        return new FixturesLoader(static::$kernel, $configuration, $databaseSchemaHandler);
     }
 
     /**


### PR DESCRIPTION
## The current situation
When we started to write integration tests we chose to set up fixtures using the installer. It was kind of a quick win, and it was the guarantee to have exactly what we want in the database.
The major drawback was that running all import jobs is a quite long process, so we couldn't afford to run it for each test. We usually run it only at the beginning of a test case (class).

Consequences:
- Some tests that modify the data in database are heavily coupled.
- It's almost impossible to run the tests in `process-isolation` mode because it's waaaay too slow.
- The test case classes are stateful and difficult to maintain.
- We need to write homemade components to clean only specific data (e.g. permissions).

## The proposed solution
The main idea here is to **drop the database at the beginning of each test**. Then, since installing the fixtures via the installer is slow, have some sort of "cache" (a database dump) created on-the-fly after the first installer run. What typically happens is:
1. test A starts with catalog "technical"
2. the installer runs
3. the dump is created for catalog "technical"
4. test A finishes
5. test B starts with catalog "technical"
6. a dump is found so the installer is not run, the db is dropped and the dump is loaded

The advantages are:
- We can now run the tests in `process-isolation` mode, **which fixes "segmentation fault" errors** and other kind of surprises, like data kept in static class properties. It also guarantee that tests are really independent (it also means more parallelizable in the future).
- When you write tests you don't have to worry anymore about "should I reset the db for each test?", all tests have the same behavior now. The only thing that can still be configurable by test case is which catalog to use.
- The code is simpler and more maintainable.
- Still no SQL fixtures to maintain.
- Dumps are really like a cache, the tests will still run correctly if you disable it (it will just be super slow) and it's still possible to run them without the `process-isolation` option if you need to.
- It's faster. For example on the last 1.7 nightly build, integration tests ran in 36 minutes, on this PR they ran in 18 minutes. And it can still be speeded up if needed imho.

## Missing
- MongoDB implementation (but we don't run integration tests with it for the moment)
- Dump files are never cleaned. Any idea on who should do it and when?

PR for EE coming soon, after the principle is ok for everybody.