### PR TITLE
Be able to configure installer data from environment

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -136,7 +136,8 @@
                 "database_port": "PIM_DATABASE_PORT",
                 "database_name": "PIM_DATABASE_NAME",
                 "database_user": "PIM_DATABASE_USER",
-                "database_password": "PIM_DATABASE_PASSWORD"
+                "database_password": "PIM_DATABASE_PASSWORD",
+                "installer_data": "PIM_INSTALLER_DATA"
             }
         },
         "branch-alias": {


### PR DESCRIPTION
Hello,

this is an extract of https://github.com/akeneo/pim-community-dev/pull/5871.

The idea is be able to select the ``installer_data`` without have to edit a configuration file. This is also a good practice as stated in the 12 factors app manifesto (https://12factor.net/config).

What do you think?

```bash
~$: PIM_INSTALLER_DATA=PimInstallerBundle:minimal
~$: php app/console pim:install # will use the minimal set of fixtures instead of Icecat
```