### PR TITLE
PIM-6376: Purge scheduled queries after they are executed

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -1,3 +1,9 @@
+# 1.6.x
+
+## Bug fixes
+
+- PIM-6376: MongoDB timeout on attribute option import
+
 # 1.6.14 (2017-04-21)
 
 ## Bug fixes

--- a/features/Context/Page/Attribute/Creation.php
+++ b/features/Context/Page/Attribute/Creation.php
@@ -110,12 +110,12 @@ class Creation extends Form
     }
 
     /**
-     * Edit an attribute option
+     * Edit an attribute option code
      *
      * @param string $name
      * @param string $newValue
      */
-    public function editOption($name, $newValue)
+    public function editOptionCode($name, $newValue)
     {
         $row = $this->getOptionElement($name);
 
@@ -137,6 +137,25 @@ class Creation extends Form
         $row->find('css', '.edit-row')->click();
         $row->find('css', '.attribute_option_code')->setValue($newValue);
         $row->find('css', '.btn.show-row')->click();
+    }
+
+    /**
+     * Edit an attribute option
+     *
+     * @param string $code
+     * @param array  $labels
+     */
+    public function editOption($code, array $labels = [])
+    {
+        $row = $this->getOptionElement($code);
+
+        $row->find('css', '.edit-row')->click();
+
+        foreach ($labels as $locale => $value) {
+            $row->find('css', sprintf('.attribute-option-value[data-locale="%s"]', $locale))->setValue($value);
+        }
+
+        $row->find('css', '.btn.update-row')->click();
     }
 
     /**

--- a/features/Context/WebUser.php
+++ b/features/Context/WebUser.php
@@ -1278,6 +1278,22 @@ class WebUser extends RawMinkContext
     /**
      * @param TableNode $table
      *
+     * @When /^I edit the following attribute options?:$/
+     */
+    public function iEditTheFollowingAttributeOptionValue(TableNode $table)
+    {
+        foreach ($table->getHash() as $data) {
+            $code = $data['Code'];
+            unset($data['Code']);
+
+            $this->getCurrentPage()->editOption($code, $data);
+            $this->wait();
+        }
+    }
+
+    /**
+     * @param TableNode $table
+     *
      * @When /^I add an empty attribute option$/
      * @When /^I add the following attribute option:$/
      */
@@ -1306,11 +1322,11 @@ class WebUser extends RawMinkContext
      * @param string $oldOptionName
      * @param string $newOptionName
      *
-     * @Given /^I edit the "([^"]*)" option and turn it to "([^"]*)"$/
+     * @Given /^I edit the "([^"]*)" option code and turn it to "([^"]*)"$/
      */
-    public function iEditTheFollowingAttributeOptions($oldOptionName, $newOptionName)
+    public function iEditTheFollowingAttributeOptionCode($oldOptionName, $newOptionName)
     {
-        $this->getCurrentPage()->editOption($oldOptionName, $newOptionName);
+        $this->getCurrentPage()->editOptionCode($oldOptionName, $newOptionName);
         $this->wait();
     }
 

--- a/features/attribute/option/edit_attribute_options_02.feature
+++ b/features/attribute/option/edit_attribute_options_02.feature
@@ -17,10 +17,10 @@ Feature: Edit attribute options
     Then I should see "To manage options, please save the attribute first"
     And I save the attribute
     Then I should see the flash message "Attribute successfully created"
-    And I check the "Automatic option sorting" switch
 
   Scenario: Successfully cancel while editing some attribute options
-    Given I create the following attribute options:
+    Given I check the "Automatic option sorting" switch
+    And I create the following attribute options:
       | Code  |
       | red   |
       | blue  |
@@ -34,18 +34,20 @@ Feature: Edit attribute options
     But I should not see "yellow"
 
   Scenario: Successfully edit some attribute options
-    Given I create the following attribute options:
+    Given I check the "Automatic option sorting" switch
+    And I create the following attribute options:
       | Code  |
       | red   |
       | blue  |
       | green |
-    And I edit the "green" option and turn it to "yellow"
+    And I edit the "green" option code and turn it to "yellow"
     Then I should see "yellow"
     Then I should not see "green"
 
   @jira https://akeneo.atlassian.net/browse/PIM-6002
   Scenario: Successfully edit an attribute option value containing a quote
-    Given I create the following attribute options:
+    Given I check the "Automatic option sorting" switch
+    And I create the following attribute options:
       | Code  | en_US |
       | red   | r"ed  |
       | blue  | blue  |
@@ -53,3 +55,26 @@ Feature: Edit attribute options
     And I save the attribute
     And I edit the code "red" to turn it to "red" and cancel
     Then I should see the text "r\"ed"
+
+  Scenario: Edit an option value of an attribute of type "Multi select" is successfully impacted to the products
+    Given the following attribute:
+      | code   | label  | type   |
+      | colors | Colors | multiselect |
+    And I am on the "colors" attribute page
+    And I visit the "Values" tab
+    And I create the following attribute options:
+      | Code  | en_US |
+      | red   | Red   |
+      | blue  | Blue  |
+      | green | Green |
+    And I save the attribute
+    And the following product:
+      | sku | colors |
+      | shoe_42 | Red, Green |
+    When I am on the "colors" attribute page
+    And I visit the "Values" tab
+    And I edit the following attribute option:
+      | Code  | en_US    |
+      | red   | Reeed !  |
+    And I am on the "shoe_42" product page
+    Then I should see "Reeed !"

--- a/src/Pim/Bundle/CatalogBundle/EventSubscriber/MongoDBODM/UpdateNormalizedProductDataSubscriber.php
+++ b/src/Pim/Bundle/CatalogBundle/EventSubscriber/MongoDBODM/UpdateNormalizedProductDataSubscriber.php
@@ -79,7 +79,10 @@ class UpdateNormalizedProductDataSubscriber implements EventSubscriber
      */
     public function postFlush(PostFlushEventArgs $args)
     {
-        $this->executeQueries();
+        if ($this->hasScheduledQueries()) {
+            $this->executeQueries();
+            $this->purgeScheduledQueries();
+        }
     }
 
     /**
@@ -166,5 +169,23 @@ class UpdateNormalizedProductDataSubscriber implements EventSubscriber
 
             $collection->update($query, $compObject, $options);
         }
+    }
+
+    /**
+     * Determine if there are scheduled queries
+     *
+     * @return bool
+     */
+    protected function hasScheduledQueries()
+    {
+        return !empty($this->scheduledQueries);
+    }
+
+    /**
+     * Purge scheduled queries
+     */
+    protected function purgeScheduledQueries()
+    {
+        $this->scheduledQueries = [];
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/model/doctrine/ProductValue.mongodb.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/model/doctrine/ProductValue.mongodb.yml
@@ -1,5 +1,11 @@
 Pim\Component\Catalog\Model\ProductValue:
     type: embeddedDocument
+    indexes:
+        optionIds:
+            options:
+                background: true
+            keys:
+                optionIds: 1
     fields:
         id:
             id: true

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/storage_driver/doctrine/mongodb-odm.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/storage_driver/doctrine/mongodb-odm.yml
@@ -446,6 +446,7 @@ services:
         arguments:
             - '%pim_catalog.entity.attribute_option_value.class%'
             - 'value'
+            - '@pim_catalog.mongodb.normalizer.normalized_data.attribute_option'
         tags:
             - { name: pim_catalog.mongodb_odm_query_generator }
 

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/QueryGenerator/MultipleOptionValueUpdatedQueryGeneratorSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/QueryGenerator/MultipleOptionValueUpdatedQueryGeneratorSpec.php
@@ -7,19 +7,21 @@ use Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\NamingUtility;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\AttributeOptionInterface;
 use Pim\Component\Catalog\Model\AttributeOptionValueInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class MultipleOptionValueUpdatedQueryGeneratorSpec extends ObjectBehavior
 {
-    function let(NamingUtility $namingUtility)
+    function let(NamingUtility $namingUtility, NormalizerInterface $attributeOptionNormalizer)
     {
-        $this->beConstructedWith($namingUtility, 'Pim\Bundle\CatalogBundle\Model\AttributeOptionValue', 'value');
+        $this->beConstructedWith($namingUtility, 'Pim\Bundle\CatalogBundle\Model\AttributeOptionValue', 'value', $attributeOptionNormalizer);
     }
 
     function it_generates_a_query_to_update_product_select_attributes(
         $namingUtility,
         AttributeOptionValueInterface $bleu,
         AttributeOptionInterface $blue,
-        AttributeInterface $color
+        AttributeInterface $color,
+        $attributeOptionNormalizer
     ) {
         $bleu->getOption()->willReturn($blue);
         $bleu->getLocale()->willReturn('fr_FR');
@@ -29,17 +31,76 @@ class MultipleOptionValueUpdatedQueryGeneratorSpec extends ObjectBehavior
             ->willReturn(['normalizedData.color-fr_FR', 'normalizedData.color-en_US']);
 
         $blue->getCode()->willReturn('blue');
+        $blue->getId()->willReturn('42');
+
+        $attributeOptionNormalized = [
+            'id' => 42,
+            'code' => 'blue',
+            'optionValues' => [
+                'en_US' => [
+                    'value' => 'Blue',
+                    'locale' => 'en_US',
+                ],
+                'fr_FR' => [
+                    'value' => 'Bleus',
+                    'locale' => 'fr_FR',
+                ],
+            ]
+        ];
+
+        $attributeOptionNormalizer
+            ->normalize($blue)
+            ->willReturn($attributeOptionNormalized);
+
         $this->generateQuery($bleu, 'value', 'Bleu', 'Bleus')->shouldReturn([
             [
-                ['normalizedData.color-fr_FR' => ['$elemMatch' => ['code' => 'blue']]],
-                ['$set' => ['normalizedData.color-fr_FR.$.optionValues.fr_FR.value' => 'Bleus']],
-                ['multiple' => true]
+                [
+                    '$and' => [
+                        ['values.optionIds' => 42],
+                        ['normalizedData.color-fr_FR' => ['$elemMatch' => ['code' => 'blue']]]
+                    ]
+                ],
+                ['$push' => ['normalizedData.color-fr_FR' => $attributeOptionNormalized]],
+                ['multiple' => true],
             ],
             [
-                ['normalizedData.color-en_US' => ['$elemMatch' => ['code' => 'blue']]],
-                ['$set' => ['normalizedData.color-en_US.$.optionValues.fr_FR.value' => 'Bleus']],
-                ['multiple' => true]
-            ]
+                ['values.optionIds' => 42],
+                [
+                    '$pull' => [
+                        'normalizedData.color-fr_FR' => [
+                            '$and' => [
+                                ['code' => 'blue'],
+                                ['optionValues.fr_FR.value' => 'Bleu']
+                            ]
+                        ]
+                    ]
+                ],
+                ['multiple' => true],
+            ],
+            [
+                [
+                    '$and' => [
+                        ['values.optionIds' => 42],
+                        ['normalizedData.color-en_US' => ['$elemMatch' => ['code' => 'blue']]]
+                    ]
+                ],
+                ['$push' => ['normalizedData.color-en_US' => $attributeOptionNormalized]],
+                ['multiple' => true],
+            ],
+            [
+                ['values.optionIds' => 42],
+                [
+                    '$pull' => [
+                        'normalizedData.color-en_US' => [
+                            '$and' => [
+                                ['code' => 'blue'],
+                                ['optionValues.fr_FR.value' => 'Bleu']
+                            ]
+                        ]
+                    ]
+                ],
+                ['multiple' => true],
+            ],
         ]);
     }
 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

In UpdateNormalizedProductDataSubscriber the scheduled queries built to update products in MongoDB are not purged after they are executed.

Yet they are executed when a Doctrine event "postFlush" is sent. So, during the complete process of an attribute options import job, three event "postFlush" are sent, and then all of this queries are exectued three times.

This fix should improve the execution time of the imports of attributes and attributes options where the values are updated. And this should decrease the load on MongoDB during this imports jobs.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
