### PR TITLE
GITHUB-6101 - Fix ol/ul in WYSIWYG

### DIFF
--- a/CHANGELOG-1.8.md
+++ b/CHANGELOG-1.8.md
@@ -22,3 +22,7 @@
 ## Requirements
 
 - GITHUB-5937: Remove the need to have mcrypt installed
+
+## Bug Fixes
+
+- GITHUB-6101: Fix Summernote (WYSIWYG) style

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/lib/summernote.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/lib/summernote.less
@@ -4,6 +4,26 @@
   width: 100%;
   border-color: @AknBorderColor;
   border-radius: 2px;
+
+  .note-editable {
+    ol {
+      list-style-type: decimal;
+      margin-left: 1em;
+
+      > li {
+        list-style-type: decimal;
+      }
+    }
+
+    ul {
+      list-style-type: disc;
+      margin-left: 1em;
+
+      > li {
+        list-style-type: disc;
+      }
+    }
+  }
 }
 
 .note-editor .note-toolbar {


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**
Attempt to fix #6101 by adding two rules (ul/ol) in the summernote to display the **list-style-type** that was previously settled to none in
https://github.com/akeneo/pim-community-dev/blob/master/src/Pim/Bundle/UIBundle/Resources/public/less/base/general.less#L53

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | -
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
