### PR TITLE
PIM-6395: Fix MongoDB query built to fetch products in a LazyCollection

### DIFF
--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -1,3 +1,9 @@
+# 1.5.x
+
+## Bug fixes
+
+- PIM-6395: Fix MongoDB query built to fetch products in a LazyCollection
+
 # 1.5.21 (2017-04-28)
 
 ## Bug fixes

--- a/src/Pim/Bundle/CatalogBundle/EventSubscriber/MongoDBODM/SetProductsSubscriber.php
+++ b/src/Pim/Bundle/CatalogBundle/EventSubscriber/MongoDBODM/SetProductsSubscriber.php
@@ -86,7 +86,7 @@ class SetProductsSubscriber implements EventSubscriber
                                 $this
                                     ->registry
                                     ->getRepository($this->productClass)
-                                    ->findBy([$property => [$entity->getId()]])
+                                    ->findBy([$property => $entity->getId()])
                             );
                         }
                     )


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

The problem occurs when the method "getProducts()" is called on an entity "Category" or "Group" to fetch products which are in several categories or groups.

The request built to fetch products in MongoDB on a lazy loading way is wrong. The value of the parameter used to find products must not be embedded in an array. Otherwise all the elements of the parameter should be setted, which it's not the desired behavior.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
