### PR TITLE
PIM-6381: Remove delete button on channel create screen

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -7,6 +7,8 @@
 - PIM-6377: Fix potential notice in price property formatter
 - PIM-6387: Fix HTTP code returned when the token is invalid or expired
 - PIM-6388: Fix parameters inversion in Pim\Component\Catalog\Builder\ProductBuilder::createProductValue
+- PIM-6314: Fix parameters inversion in Pim\Component\Catalog\Builder\ProductBuilder::createProductValue
+- PIM-6381: Fix `Delete` button is visible on channel create screen
 
 # 1.7.3 (2017-04-14)
 

--- a/features/channel/create_channel.feature
+++ b/features/channel/create_channel.feature
@@ -31,3 +31,10 @@ Feature: Create a channel
       | Locales       | French          |
     And I press the "Save" button
     Then I should see the text "This value should not be blank."
+
+  @jira https://akeneo.atlassian.net/browse/PIM-6381
+  Scenario: Do not show delete button when creating channel
+    Given a "footwear" catalog configuration
+    And I am logged in as "Peter"
+    When I am on the channel creation page
+    Then I should not see the "Delete" button

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/channel/create.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/channel/create.yml
@@ -28,20 +28,6 @@ extensions:
         config:
             backUrl: pim_enrich_channel_index
 
-    pim-channel-create-form-delete:
-        module: pim/channel-edit-form/delete
-        parent: pim-channel-create-form
-        targetZone: buttons
-        aclResourceId: pim_enrich_channel_remove
-        position: 100
-        config:
-            trans:
-                title: confirmation.remove.channel
-                content: pim_enrich.confirmation.delete_item
-                success: flash.channel.removed
-                fail: error.removing.channel
-            redirect: pim_enrich_channel_index
-
     pim-channel-create-form-save-buttons:
         module: pim/form/common/save-buttons
         parent: pim-channel-create-form


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

Delete button should not be showed on create screen.

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | OK
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
