### PR TITLE
PIM-6402: Clean attribute properties according to new validation rules during migration

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -10,6 +10,7 @@
 - PIM-6314: Fix parameters inversion in Pim\Component\Catalog\Builder\ProductBuilder::createProductValue
 - PIM-6381: Fix `Delete` button is visible on channel create screen
 - PIM-6398: Fix Summernote (WYSIWYG) style (backport GITHUB-6101 into 1.7)
+- PIM-6402: Clean attribute properties according to new validation rules during migration
 
 # 1.7.3 (2017-04-14)
 

--- a/upgrades/schema/Version_1_7_20170504175205_clean_attribute_properties.php
+++ b/upgrades/schema/Version_1_7_20170504175205_clean_attribute_properties.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Pim\Upgrade\Schema;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+use Pim\Component\Catalog\AttributeTypes;
+use Pim\Upgrade\SchemaHelper;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+class Version_1_7_20170504175205_clean_attribute_properties extends AbstractMigration implements ContainerAwareInterface
+{
+    /** @var ContainerInterface */
+    protected $container;
+
+    /**
+     * @param ContainerInterface|null $container
+     */
+    public function setContainer(ContainerInterface $container = null)
+    {
+        $this->container = $container;
+    }
+
+    public function up(Schema $schema)
+    {
+        $tableHelper = new SchemaHelper($this->container);
+        $attributeTable = $tableHelper->getTableOrCollection('attribute');
+
+        $this->addSql(
+            sprintf('UPDATE %s SET max_characters = NULL WHERE attribute_type NOT IN (?, ?, ?)', $attributeTable),
+            [AttributeTypes::IDENTIFIER, AttributeTypes::TEXT, AttributeTypes::TEXTAREA]
+        );
+
+        $this->addSql(
+            sprintf('UPDATE %s SET validation_rule = NULL WHERE attribute_type NOT IN (?, ?)', $attributeTable),
+            [AttributeTypes::IDENTIFIER, AttributeTypes::TEXT]
+        );
+
+        $this->addSql(
+            sprintf('UPDATE %s SET validation_regexp = NULL WHERE attribute_type NOT IN (?, ?)', $attributeTable),
+            [AttributeTypes::IDENTIFIER, AttributeTypes::TEXT]
+        );
+
+        $this->addSql(
+            sprintf('UPDATE %s SET wysiwyg_enabled = NULL WHERE attribute_type != ?', $attributeTable),
+            [AttributeTypes::TEXTAREA]
+        );
+
+        $this->addSql(
+            sprintf('UPDATE %s SET decimals_allowed = NULL WHERE attribute_type NOT IN (?, ?, ?)', $attributeTable),
+            [AttributeTypes::NUMBER, AttributeTypes::METRIC, AttributeTypes::PRICE_COLLECTION]
+        );
+
+        $this->addSql(
+            sprintf('UPDATE %s SET negative_allowed = NULL WHERE attribute_type NOT IN (?, ?)', $attributeTable),
+            [AttributeTypes::NUMBER, AttributeTypes::METRIC]
+        );
+    }
+
+    public function down(Schema $schema)
+    {
+        $this->throwIrreversibleMigrationException();
+    }
+}


### PR DESCRIPTION
Clean attributes when migrating from 1.6 to 1.7.
Related to validation rules change done in 1.7.