### PR TITLE
Backport GITHUB-6101 - Fix ol/ul in WYSIWYG

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -9,6 +9,7 @@
 - PIM-6388: Fix parameters inversion in Pim\Component\Catalog\Builder\ProductBuilder::createProductValue
 - PIM-6314: Fix parameters inversion in Pim\Component\Catalog\Builder\ProductBuilder::createProductValue
 - PIM-6381: Fix `Delete` button is visible on channel create screen
+- PIM-6398: Fix Summernote (WYSIWYG) style (backport GITHUB-6101 into 1.7)
 
 # 1.7.3 (2017-04-14)
 

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/lib/summernote.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/lib/summernote.less
@@ -4,6 +4,26 @@
   width: 100%;
   border-color: @AknBorderColor;
   border-radius: 2px;
+
+  .note-editable {
+    ol {
+      list-style-type: decimal;
+      margin-left: 1em;
+
+      > li {
+        list-style-type: decimal;
+      }
+    }
+
+    ul {
+      list-style-type: disc;
+      margin-left: 1em;
+
+      > li {
+        list-style-type: disc;
+      }
+    }
+  }
 }
 
 .note-editor .note-toolbar {


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**
Backport the fix https://github.com/akeneo/pim-community-dev/pull/6121 in order to fix this issue : https://github.com/akeneo/pim-community-dev/issues/6101


[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | Ok
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
