### PR TITLE
PIM-6394: Fix email validation when creating a user in order to be less restrictive

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -1,3 +1,9 @@
+# 1.7.x
+
+## Bug Fixes
+
+- PIM-6394: Fix email validation when creating a user in order to be less restrictive
+
 # 1.7.4 (2017-05-10)
 
 ## Bug Fixes

--- a/features/user/create_and_delete_user.feature
+++ b/features/user/create_and_delete_user.feature
@@ -19,11 +19,28 @@ Feature: Create a user
       | Status            | Inactive |
     And I scroll down
     And I fill in the following information:
-      | E-mail | jack@example.com |
+      | E-mail | jack+doe@example.com |
     And I visit the "Groups and Roles" tab
     And I select the role "User"
     When I save the user
     Then there should be a "jack" user
+
+  Scenario: Fail to create a user with an invalid email address
+    Given I am on the user creation page
+    And I fill in the following information:
+      | Username          | jack     |
+      | First name        | Jack     |
+      | Last name         | Doe      |
+      | Password          | DoeDoe   |
+      | Re-enter password | DoeDoe   |
+      | Status            | Inactive |
+    And I scroll down
+    And I fill in the following information:
+      | E-mail | jack..doe@example.com |
+    And I visit the "Groups and Roles" tab
+    And I select the role "User"
+    When I save the user
+    Then I should see a validation tooltip "This value is not a valid email address."
 
   Scenario: Successfully delete a user
     Given I am on the users page

--- a/src/Pim/Bundle/JsFormValidationBundle/Resources/views/Constraints/EmailValidator.js.twig
+++ b/src/Pim/Bundle/JsFormValidationBundle/Resources/views/Constraints/EmailValidator.js.twig
@@ -1,0 +1,19 @@
+function Email(field, params)
+{
+    var value = field && field.nodeName ? {{ getJsFormElementValue('field') }} : field;
+
+    if (isNotDefined(value)) {
+        return true;
+    }
+
+    value = String(value);
+
+    // @see http://emailregex.com
+    var pattern = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*))@([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}$/;
+
+    if (pattern.test(value)) {
+        return true;
+    }
+
+    return getComputeMessage(params.message);
+}


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

When creating a user in the UI, email format is too restrictive or not enough : 

- _foo+bar@akeneo.com_ is a valid email but not accepted by the PIM due to the '+'
- _foo+bar@akeneo.intern_ is a valid email but not accepted by the PIM due to 6 characters at the end
- _foo..bar@akeneo.com_ is valid and should not (two consecutive dots)

It's due to the regex in _JsFormValidationBundle_ : 

`
/^([a-zA-Z0-9_\.\-])+\@(([a-zA-Z0-9\-])+\.)+([a-zA-Z0-9]{2,4})$/
`

Validation has been overrided with a far better regex to validate emails, coming from emailregex.com : 

`/^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/`

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | Ok
| Added integration tests           | -
| Changelog updated                 | Ok
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
