### PR TITLE
Fix JobIntance class hardcoded

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -3,6 +3,7 @@
 ## Bug Fixes
 
 - PIM-6394: Fix email validation when creating a user in order to be less restrictive
+- GITHUB-6161: Fix JobInstance class hardcoded in `Akeneo\Bundle\BatchBundle\Command\BatchCommand::execute`
 
 # 1.7.4 (2017-05-10)
 
@@ -17,7 +18,6 @@
 - PIM-6381: Fix `Delete` button is visible on channel create screen
 - PIM-6398: Fix Summernote (WYSIWYG) style (backport GITHUB-6101 into 1.7)
 - PIM-6402: Clean attribute properties according to new validation rules during migration
-- PIM-6159: Fix JobInstance class hardcoded in Akeneo\Bundle\BatchBundle\Command\BatchCommand::execute
 
 # 1.7.3 (2017-04-14)
 

--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -17,6 +17,7 @@
 - PIM-6381: Fix `Delete` button is visible on channel create screen
 - PIM-6398: Fix Summernote (WYSIWYG) style (backport GITHUB-6101 into 1.7)
 - PIM-6402: Clean attribute properties according to new validation rules during migration
+- PIM-6159: Fix JobInstance class hardcoded in Akeneo\Bundle\BatchBundle\Command\BatchCommand::execute
 
 # 1.7.3 (2017-04-14)
 

--- a/src/Akeneo/Bundle/BatchBundle/Command/BatchCommand.php
+++ b/src/Akeneo/Bundle/BatchBundle/Command/BatchCommand.php
@@ -79,9 +79,10 @@ class BatchCommand extends ContainerAwareCommand
         }
 
         $code = $input->getArgument('code');
+        $jobInstanceClass = $this->getContainer()->getParameter('akeneo_batch.entity.job_instance.class');
         $jobInstance = $this
             ->getJobManager()
-            ->getRepository('Akeneo\Component\Batch\Model\JobInstance')
+            ->getRepository($jobInstanceClass)
             ->findOneByCode($code);
 
         if (!$jobInstance) {


### PR DESCRIPTION
Fix JobInstance class hardcoded in
Akeneo\Bundle\BatchBundle\Command\BatchCommand::execute

**Description (for Contributor and Core Developer)**

In the BatchCommand, to retrieve the JobInstanceRepository the class 'Akeneo\Component\Batch\Model\JobInstance' was hardcoded,
instead to ask for the parameter 'akeneo_batch.entity.job_instance.class'

The related issue is [here](https://github.com/akeneo/pim-community-dev/issues/6159)

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | Ok
| Review and 2 GTM                  | Ok
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed

This contribution closes https://github.com/akeneo/pim-community-dev/issues/6159