### PR TITLE
PIM-6405: display channel's label in the completeness panel of the PEF

### DIFF
--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-6395: Fix MongoDB query built to fetch products in a LazyCollection
+- PIM:6405: display channel's label instead of channel's code in the completeness panel of the PEF
 
 # 1.5.21 (2017-04-28)
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -144,7 +144,7 @@ def runPhpUnitTest(phpVersion) {
                 sh "./bin/phpunit -c app/phpunit.xml.dist --testsuite PIM_Unit_Test --log-junit app/build/logs/phpunit.xml"
             }
         } finally {
-            sh "sed -i \"s/testcase name=\\\"/testcase name=\\\"[php-${phpVersion}] /\" app/build/logs/*.xml"
+            sh "find app/build/logs -name \"*.xml\" | xargs sed -i \"s/testcase name=\\\"/testcase name=\\\"[php-${phpVersion}] /\""
             junit "app/build/logs/*.xml"
             deleteDir()
         }
@@ -167,7 +167,7 @@ def runPhpSpecTest(phpVersion) {
                 sh "./bin/phpspec run --no-interaction --format=junit > app/build/logs/phpspec.xml"
             }
         } finally {
-            sh "sed -i \"s/testcase name=\\\"/testcase name=\\\"[php-${phpVersion}] /\" app/build/logs/*.xml"
+            sh "find app/build/logs/ -name \"*.xml\" | xargs sed -i \"s/testcase name=\\\"/testcase name=\\\"[php-${phpVersion}] /\""
             junit "app/build/logs/*.xml"
             deleteDir()
         }
@@ -188,7 +188,7 @@ def runPhpCsFixerTest() {
                 sh "./bin/php-cs-fixer fix --diff --dry-run --format=junit --config=.php_cs.php > app/build/logs/phpcs.xml"
             }
         } finally {
-            sh "sed -i \"s/testcase name=\\\"/testcase name=\\\"[php-cs-fixer] /\" app/build/logs/*.xml"
+            sh "find app/build/logs/ -name \"*.xml\" | xargs sed -i \"s/testcase name=\\\"/testcase name=\\\"[php-cs-fixer] /\""
             junit "app/build/logs/*.xml"
             deleteDir()
         }
@@ -234,7 +234,7 @@ def runBehatTest(edition, storage, features) {
             try {
                 sh "php /var/lib/distributed-ci/dci-master/bin/build ${env.WORKSPACE}/behat-${edition}-${storage} ${env.BUILD_NUMBER} ${storage} ${features} ${env.JOB_NAME} 5 5.6 5.5 \"${tags}\" \"behat-${edition}-${storage}\" --exit_on_failure"
             } finally {
-                sh "sed -i \"s/ name=\\\"/ name=\\\"[${edition}-${storage}] /\" app/build/logs/behat/*.xml"
+                sh "find app/build/logs/behat/ -name \"*.xml\" | xargs sed -i \"s/ name=\\\"/ name=\\\"[${edition}-${storage}] /\""
                 junit 'app/build/logs/behat/*.xml'
                 archiveArtifacts allowEmptyArchive: true, artifacts: 'app/build/screenshots/*.png'
                 deleteDir()

--- a/features/product/completeness/display_completeness.feature
+++ b/features/product/completeness/display_completeness.feature
@@ -172,3 +172,18 @@ Feature: Display the completeness of a product
     When I open the "Completeness" panel
     And I click on the missing "side_view" value for "en_US" locale and "tablet" channel
     Then I should be on the "Media" attribute group
+
+  @jira https://akeneo.atlassian.net/browse/PIM-6405
+  Scenario: Successfully display the completeness with channel's label
+    Given I am logged in as "Peter"
+    And I am on the "tablet" channel page
+    Then I should see the Code field
+    And the field Code should be disabled
+    When I fill in the following information:
+      | Default label | Tablette |
+    And I press the "Save" button
+    Then I should see "Tablette"
+    Given I am on the "sneakers" product page
+    When I open the "Completeness" panel
+    Then I should see the completeness summary
+    And I should see the text "Tablette"

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/panel/completeness.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/panel/completeness.js
@@ -53,13 +53,15 @@ define(
                 if (this.getFormData().meta) {
                     $.when(
                         this.fetchCompleteness(),
+                        FetcherRegistry.getFetcher('channel').fetchAll(),
                         FetcherRegistry.getFetcher('locale').fetchAll()
-                    ).then(function (completeness, locales) {
+                    ).then(function (completeness, channels, locales) {
                         this.$el.html(
                             this.template({
                                 hasFamily: this.getFormData().family !== null,
                                 completenesses: this.sortCompleteness(completeness.completenesses),
                                 i18n: i18n,
+                                channels: channels,
                                 locales: locales,
                                 catalogLocale: UserContext.get('catalogLocale')
                             })

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/panel/completeness.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/panel/completeness.html
@@ -24,7 +24,7 @@
                 <% _.each(locale['channels'], function(channelCompleteness) { %>
                     <% if (channelCompleteness.completeness) { %>
                         <div>
-                            <span class="channel" data-channel="<%- channelCompleteness.completeness['channel'] %>"><%- channelCompleteness.completeness['channel'] %></span>
+                            <span class="channel" data-channel="<%- channelCompleteness.completeness.channel %>"><%- _.findWhere(channels, {code: channelCompleteness.completeness.channel}).label %></span>
                             <span class="literal-progress"><%- channelCompleteness.completeness.ratio %>%</span>
                             <div class="progress <%- channelCompleteness.completeness.ratio === 100 ? 'progress-success' : 'progress-warning' %>">
                                 <div class="bar" data-ratio="<%- channelCompleteness.completeness.ratio %>" style="width: <%- channelCompleteness.completeness.ratio %>%;"></div>


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**
When displaying the completeness in the PEF, it was the code of the channel that was displayed.
It should be the channel's label. This PR fixes that.

Note : it's already ok in 1.7

Note 2 : I've improved the way to parse behat XML files in the Jenkins file because I had an exception. See https://github.com/akeneo/pim-enterprise-dev/pull/2792.

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Ok
| Added Behats                      | Ok
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
