### PR TITLE
GITHUB-6151: Fix MongoDB Timestampable subscriber

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -4,6 +4,7 @@
 
 - PIM-6394: Fix email validation when creating a user in order to be less restrictive
 - GITHUB-6161: Fix JobInstance class hardcoded in `Akeneo\Bundle\BatchBundle\Command\BatchCommand::execute`
+- GITHUB-6151: Fix Mongo TimestampableSubscriber to properly update the CreatedAt date of a product
 
 # 1.7.4 (2017-05-10)
 

--- a/src/Pim/Bundle/CatalogBundle/EventSubscriber/MongoDBODM/TimestampableSubscriber.php
+++ b/src/Pim/Bundle/CatalogBundle/EventSubscriber/MongoDBODM/TimestampableSubscriber.php
@@ -47,7 +47,7 @@ class TimestampableSubscriber implements EventSubscriberInterface
             return;
         }
 
-        if (null !== $object->getId()) {
+        if (null === $object->getId()) {
             $object->setCreated(new \DateTime('now', new \DateTimeZone('UTC')));
         }
 

--- a/src/Pim/Bundle/CatalogBundle/spec/EventSubscriber/MongoDBODM/TimestampableSubscriberSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/EventSubscriber/MongoDBODM/TimestampableSubscriberSpec.php
@@ -35,7 +35,7 @@ class TimestampableSubscriberSpec extends ObjectBehavior
         $event->getSubject()->willReturn($product);
         $product->getId()->willReturn(null);
 
-        $product->setCreated()->shouldNotBeCalled();
+        $product->setCreated(Argument::type('\DateTime'))->shouldBeCalled();
         $product->setUpdated(Argument::type('\DateTime'))->shouldBeCalled();
 
         $this->updateProductTimestamp($event);
@@ -46,7 +46,7 @@ class TimestampableSubscriberSpec extends ObjectBehavior
         $product->getId()->willReturn('sku-1');
         $event->getSubject()->willReturn($product);
 
-        $product->setCreated(Argument::type('\DateTime'))->shouldBeCalled();
+        $product->setCreated()->shouldNotBeCalled();
         $product->setUpdated(Argument::type('\DateTime'))->shouldBeCalled();
 
         $this->updateProductTimestamp($event);


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

PIM Version: 1.7.4

When updating existing product using ProductSaver, the created field of the product gets also updated.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Ok
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | Ok
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
