### PR TITLE
GITHUB-6065: Shows the loading mask on file upload in imports

### DIFF
--- a/CHANGELOG-1.8.md
+++ b/CHANGELOG-1.8.md
@@ -10,6 +10,7 @@
 - TIP-724: Refactoring of the 'Settings/Association types' index screen using 'pim/common/grid'
 - TIP-725: Generalization of the refactoring made in the TIP-724 for all screen containing a simple grid 
 - TIP-734: Menu and index page is now using the new PEF architecture
+- GITHUB-6174: Show a loading mask during the file upload in the import jobs
 
 ## BC breaks
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/job/common/edit/upload-launch.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/job/common/edit/upload-launch.js
@@ -45,7 +45,7 @@ define(
                     var formData = new FormData();
                     formData.append('file', this.getFormData().file);
 
-                    this.showLoadingMask();
+                    router.showLoadingMask();
 
                     $.ajax({
                         url: this.getUrl(),
@@ -61,7 +61,7 @@ define(
                     .fail(function () {
                         messenger.notificationFlashMessage('error', __('pim_enrich.form.job_instance.fail.launch'));
                     })
-                    .always(this.hideLoadingMask.bind(this));
+                    .always(router.hideLoadingMask());
                 } else {
                     $.post(this.getUrl(), {method: 'POST'}).
                         then(function (response) {

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/job/common/edit/upload-launch.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/job/common/edit/upload-launch.js
@@ -45,6 +45,8 @@ define(
                     var formData = new FormData();
                     formData.append('file', this.getFormData().file);
 
+                    this.showLoadingMask();
+
                     $.ajax({
                         url: this.getUrl(),
                         method: 'POST',
@@ -58,7 +60,8 @@ define(
                     }.bind(this))
                     .fail(function () {
                         messenger.notificationFlashMessage('error', __('pim_enrich.form.job_instance.fail.launch'));
-                    });
+                    })
+                    .always(this.hideLoadingMask.bind(this));
                 } else {
                     $.post(this.getUrl(), {method: 'POST'}).
                         then(function (response) {


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Shows a loading mask on file upload during import. 

Thanks to SimonCarre for raising the fix and proposing a fix from which this PR is inpired https://github.com/akeneo/pim-community-dev/pull/6065

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
