### PR TITLE
PIM-6146: Fix javascript error when having more than 20 attributes groups in the family page

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -4,6 +4,7 @@
 
 - PIM-6394: Fix email validation when creating a user in order to be less restrictive
 - GITHUB-6161: Fix JobInstance class hardcoded in `Akeneo\Bundle\BatchBundle\Command\BatchCommand::execute`
+- PIM-6146: Fix javascript error when having more than 20 attributes groups in the family page
 
 # 1.7.4 (2017-05-10)
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

A javascript error occurs in the family page when there are more than 20 attribute groups, and another attribute is added through attribute groups.

This javascript function that display the attributes try to fetch all the attribute groups. But without criteria the server set a default limit to the result. The solution is to fetch only the attribute codes we need using their codes.

By fixing this bug I realize that the sorting of the attribute groups is broken. This will be fix in another ticket, and the code portion removed meanwhile.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
