### PR TITLE
PIM-6418: Fix URL too long in variant group datagrid

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -1,3 +1,9 @@
+# 1.6.x
+
+## Bug fixes
+
+- PIM-6418: Fix URL too long in variant group datagrid
+
 # 1.6.15 (2017-05-18)
 
 ## Bug fixes

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/grid.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/grid.js
@@ -32,6 +32,13 @@ define([
                 });
                 this.options   = options;
 
+                /*
+                 * Removing to be sure that this property will not be used in URLs generated to load the data
+                 * The selection is never used back side to load the data and it can generate an URL too long.
+                 * The rightful usages of the selection are done with the property "this.selection"
+                 */
+                delete this.options.selection;
+
                 mediator.on('datagrid:selectModel:' + this.alias, function (model) {
                     this.addElement(model.get('id'));
                 }.bind(this));


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

The URI generated to load the products in the variant groups Datagrid can be too long if there are a lot of products. Indeed, each product selection is added as an array parameter to the URI.

Given that this parameters are not used to load the datagrid elements (regardless of the entity). The solution is to remove them from the URI generation. It can be done in the Datagrid initialization by removing the property  `selection` from `options`. It hasn't consequences because the selection is handled in a specific attribute of the Datagrid (see line https://github.com/akeneo/pim-community-dev/blob/817d68366dcf2ed94dc465deded0d239c1fae6f1/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/grid.js#L29)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed

This will fix issue https://github.com/akeneo/pim-community-dev/issues/6153