### PR TITLE
PIM-6392: Response contains unexpected HTML when updating a list of resources

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -8,6 +8,7 @@
 - PIM-6254: Fix pagination on the API when filters are applied
 - PIM-6196: Fix collection filters used on `Family` screen
 - GITHUB-6069: Fix Pim\Bundle\EnrichBundle\Controller\Rest\JobInstanceController::getValidationErrors by preventing to fail when no raw parameters are defined for the job, cheers @aistis-!
+- PIM-6392: Fix output buffering error when updating a list of resources from the API
 
 # 1.7.4 (2017-05-10)
 

--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -9,6 +9,7 @@
 - PIM-6196: Fix collection filters used on `Family` screen
 - GITHUB-6069: Fix Pim\Bundle\EnrichBundle\Controller\Rest\JobInstanceController::getValidationErrors by preventing to fail when no raw parameters are defined for the job, cheers @aistis-!
 - PIM-6392: Fix output buffering error when updating a list of resources from the API
+- PIM-6426: Fix issue when downloading a media file while output buffering is disabled
 
 # 1.7.4 (2017-05-10)
 

--- a/src/Akeneo/Component/FileStorage/StreamedFileResponse.php
+++ b/src/Akeneo/Component/FileStorage/StreamedFileResponse.php
@@ -28,11 +28,11 @@ class StreamedFileResponse extends StreamedResponse
         }
 
         $callback = function () use ($resource) {
-            while (!feof($resource)) {
-                $buffer = fread($resource, StreamedFileResponse::CHUNK);
-                echo $buffer;
-                ob_flush();
-            }
+            $out = fopen('php://output', 'wb');
+
+            stream_copy_to_stream($resource, $out);
+
+            fclose($out);
             fclose($resource);
         };
 

--- a/src/Pim/Bundle/ApiBundle/Stream/StreamResourceResponse.php
+++ b/src/Pim/Bundle/ApiBundle/Stream/StreamResourceResponse.php
@@ -83,6 +83,7 @@ class StreamResourceResponse
 
         $response->setCallback(function () use ($resource) {
             rewind($resource);
+            $this->ensureOutputBufferingIsStarted();
 
             $lineNumber = 1;
             $bufferSize = $this->configuration['input']['buffer_size'];
@@ -247,5 +248,18 @@ class StreamResourceResponse
         echo $jsonContent;
         ob_flush();
         flush();
+    }
+
+    /**
+     * The directive "ouput_buffering" could be disabled in the php configuration of some providers.
+     * In this case, we have to start the output buffering manually.
+     * Do note that is not possible to close all the output buffers before flushing the data,
+     * because it's needed for the tests.
+     */
+    protected function ensureOutputBufferingIsStarted()
+    {
+        if (0 === ob_get_level()) {
+            ob_start();
+        }
     }
 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Two fixes for the same problem: When the PHP function `ob_flush` is called while the output buffering is disabled, then a PHP Notice is raised.

The output buffering is activated by default, but it can be disabled via the directive `output_buffering` in PHP configuration for some providers.

It happened when updating a list of resources with the API. In this case the flush is needed for the tests, so we start manually the buffering if it's not.

It also happened for the same reason when downloading a media file. In this case the flush was not required. So we have removed the flush and took advantage of this fix to improve the way to download the files.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
