### PR TITLE
PIM-6285: fix content type validation in the API

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -8,6 +8,7 @@
 - PIM-6254: Fix pagination on the API when filters are applied
 - PIM-6196: Fix collection filters used on `Family` screen
 - GITHUB-6069: Fix Pim\Bundle\EnrichBundle\Controller\Rest\JobInstanceController::getValidationErrors by preventing to fail when no raw parameters are defined for the job, cheers @aistis-!
+- PIM-6285: fix content type validation in the API
 
 # 1.7.4 (2017-05-10)
 

--- a/src/Pim/Bundle/ApiBundle/DependencyInjection/Compiler/ContentTypeNegotiatorPass.php
+++ b/src/Pim/Bundle/ApiBundle/DependencyInjection/Compiler/ContentTypeNegotiatorPass.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Pim\Bundle\ApiBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\DefinitionDecorator;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Compiler pass to add rules to the content type negotiator.
+ *
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ContentTypeNegotiatorPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('pim_api.negotiator.content_type_negotiator')) {
+            return;
+        }
+
+        $configuration = $container->getParameter('pim_api.configuration');
+        $rules = $configuration['content_type_negotiator']['rules'];
+        foreach ($rules as $rule) {
+            $this->addRule($rule, $container);
+        }
+    }
+
+    private function addRule(array $rule, ContainerBuilder $container)
+    {
+        $matcher = $this->createRequestMatcher(
+            $container,
+            $rule['path'],
+            $rule['host'],
+            $rule['methods']
+        );
+
+        $container->getDefinition('pim_api.negotiator.content_type_negotiator')
+            ->addMethodCall('add', ['matcher' => $matcher, 'rule' => $rule]);
+    }
+
+    private function createRequestMatcher(ContainerBuilder $container, $path = null, $host = null, $methods = null)
+    {
+        $arguments = [$path, $host, $methods];
+        $serialized = serialize($arguments);
+        $id = 'pim_api.content_type_negotiator.request_matcher.'.md5($serialized).sha1($serialized);
+
+        if (!$container->hasDefinition($id)) {
+            $container
+                ->setDefinition($id, new DefinitionDecorator('fos_rest.format_request_matcher'))
+                ->setArguments($arguments);
+        }
+
+        return new Reference($id);
+    }
+}

--- a/src/Pim/Bundle/ApiBundle/DependencyInjection/Configuration.php
+++ b/src/Pim/Bundle/ApiBundle/DependencyInjection/Configuration.php
@@ -39,6 +39,23 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('max_resources_number')->end()
                     ->end()
                 ->end()
+                ->arrayNode('content_type_negotiator')
+                    ->children()
+                        ->arrayNode('rules')
+                            ->prototype('array')
+                                ->children()
+                                    ->scalarNode('path')->defaultNull()->info('URL path info')->end()
+                                    ->scalarNode('host')->defaultNull()->info('URL host name')->end()
+                                    ->variableNode('methods')->defaultNull()->info('Method for URL')->end()
+                                    ->booleanNode('stop')->defaultFalse()->end()
+                                    ->arrayNode('content_types')
+                                        ->prototype('scalar')->end()
+                                    ->end()
+                                ->end()
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
             ->end();
 
         return $treeBuilder;

--- a/src/Pim/Bundle/ApiBundle/DependencyInjection/PimApiExtension.php
+++ b/src/Pim/Bundle/ApiBundle/DependencyInjection/PimApiExtension.php
@@ -30,6 +30,7 @@ class PimApiExtension extends Extension
         $loader->load('event_subscribers.yml');
         $loader->load('hateoas.yml');
         $loader->load('normalizers.yml');
+        $loader->load('negotiators.yml');
         $loader->load('repositories.yml');
         $loader->load('security.yml');
         $loader->load('serializers.yml');

--- a/src/Pim/Bundle/ApiBundle/EventSubscriber/CheckHeadersRequestSubscriber.php
+++ b/src/Pim/Bundle/ApiBundle/EventSubscriber/CheckHeadersRequestSubscriber.php
@@ -5,6 +5,8 @@ namespace Pim\Bundle\ApiBundle\EventSubscriber;
 use FOS\RestBundle\FOSRestBundle;
 use FOS\RestBundle\Negotiation\FormatNegotiator;
 use FOS\RestBundle\Util\StopFormatListenerException;
+use Pim\Bundle\ApiBundle\Negotiator\ContentTypeNegotiator;
+use Pim\Bundle\ApiBundle\Negotiator\ContentTypeNegotiatorInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\Exception\NotAcceptableHttpException;
@@ -26,12 +28,19 @@ class CheckHeadersRequestSubscriber implements EventSubscriberInterface
     /** @var FormatNegotiator */
     protected $formatNegotiator;
 
+    /** @var ContentTypeNegotiatorInterface */
+    protected $contentTypeNegotiator;
+
     /**
-     * @param FormatNegotiator $formatNegotiator
+     * @param FormatNegotiator               $formatNegotiator
+     * @param ContentTypeNegotiatorInterface $contentTypeNegotiator
      */
-    public function __construct(FormatNegotiator $formatNegotiator)
-    {
+    public function __construct(
+        FormatNegotiator $formatNegotiator,
+        ContentTypeNegotiatorInterface $contentTypeNegotiator = null
+    ) {
         $this->formatNegotiator = $formatNegotiator;
+        $this->contentTypeNegotiator = $contentTypeNegotiator;
     }
 
     /**
@@ -45,9 +54,12 @@ class CheckHeadersRequestSubscriber implements EventSubscriberInterface
     }
 
     /**
-     * Check the headers in Request
+     * Check the content-type and accept-type headers in the request.
      *
      * @param GetResponseEvent $event The event
+     *
+     * @throws NotAcceptableHttpException
+     * @throws UnsupportedMediaTypeHttpException
      */
     public function onKernelRequest(GetResponseEvent $event)
     {
@@ -60,17 +72,17 @@ class CheckHeadersRequestSubscriber implements EventSubscriberInterface
         }
 
         try {
-            $best = $this->formatNegotiator->getBest($request->headers->get('accept'));
-
-            if (null === $best) {
-                return;
-            }
-
             if ('GET' === $request->getMethod()) {
+                $bestAcceptType = $this->formatNegotiator->getBest($request->headers->get('accept'));
+
+                if (null === $bestAcceptType) {
+                    return;
+                }
+
                 $accept = $request->headers->get('accept', null);
-                if (null !== $accept && $accept !== $best->getValue() && !preg_match('|\*\/\*|', $accept)) {
+                if (null !== $accept && $accept !== $bestAcceptType->getValue() && !preg_match('|\*\/\*|', $accept)) {
                     throw new NotAcceptableHttpException(
-                        sprintf('"%s" in "Accept" header is not valid. Only "%s" is allowed.', $accept, $best->getValue())
+                        sprintf('"%s" in "Accept" header is not valid. Only "%s" is allowed.', $accept, $bestAcceptType->getValue())
                     );
                 }
 
@@ -78,22 +90,26 @@ class CheckHeadersRequestSubscriber implements EventSubscriberInterface
             }
 
             if (in_array($request->getMethod(), ['PUT', 'PATCH', 'POST'])) {
-                $contentType = $request->headers->get('content-type');
-                if (null === $contentType) {
+                $contentType = trim(strtok($request->headers->get('content-type'), ';'));
+                $allowedContentTypes = $this->contentTypeNegotiator->getContentTypes($request);
+
+                if ("" === $contentType) {
                     throw new UnsupportedMediaTypeHttpException(
                         sprintf(
                             'The "Content-Type" header is missing. "%s" has to be specified as value.',
-                            $best->getValue()
+                            implode('" or "', $allowedContentTypes)
                         )
                     );
                 }
 
-                if (false === strpos($contentType, $best->getValue())) {
+                if (!empty($allowedContentTypes) && !in_array($contentType, $allowedContentTypes)) {
+                    $plurial = count($allowedContentTypes) > 1 ? 'are' : 'is';
                     throw new UnsupportedMediaTypeHttpException(
                         sprintf(
-                            '"%s" in "Content-Type" header is not valid. Only "%s" is allowed.',
+                            '"%s" in "Content-Type" header is not valid. Only "%s" %s allowed.',
                             $contentType,
-                            $best->getValue()
+                            implode('" or "', $allowedContentTypes),
+                            $plurial
                         )
                     );
                 }

--- a/src/Pim/Bundle/ApiBundle/Negotiator/ContentTypeNegotiator.php
+++ b/src/Pim/Bundle/ApiBundle/Negotiator/ContentTypeNegotiator.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Pim\Bundle\ApiBundle\Negotiator;
+
+use FOS\RestBundle\Util\StopFormatListenerException;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+
+/**
+ * Content type negotiator to get the allowed content types for a given request,
+ * thanks to symfony request matcher.
+ *
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ContentTypeNegotiator implements ContentTypeNegotiatorInterface
+{
+    /** @var array */
+    protected $map = [];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getContentTypes(Request $request)
+    {
+        foreach ($this->map as $elements) {
+            if (!$elements['request_matcher']->matches($request)) {
+                continue;
+            }
+
+            $rule = $elements['rule'];
+
+            if (!empty($rule['stop'])) {
+                throw new StopFormatListenerException('Stopped content type negotiator');
+            }
+
+            return $rule['content_types'];
+        }
+
+        return [];
+    }
+
+    /**
+     * Add a request matcher and the associated rule.
+     *
+     * @param RequestMatcherInterface $requestMatcher
+     * @param array                   $rule
+     */
+    public function add(RequestMatcherInterface $requestMatcher, array $rule)
+    {
+        $this->map[] = ['request_matcher' => $requestMatcher, 'rule' => $rule];
+    }
+}

--- a/src/Pim/Bundle/ApiBundle/Negotiator/ContentTypeNegotiatorInterface.php
+++ b/src/Pim/Bundle/ApiBundle/Negotiator/ContentTypeNegotiatorInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Pim\Bundle\ApiBundle\Negotiator;
+
+use FOS\RestBundle\Util\StopFormatListenerException;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Content type negotiator aims to get the allowed content types for a given request.
+ *
+ * FosRestBundle allows to provide the best accept type given a request.
+ * The goal of this interface is to do the same thing for the content types.
+ *
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface ContentTypeNegotiatorInterface
+{
+    /**
+     * Returns the content types allowed for a given request.
+     *
+     * @param Request $request
+     *
+     * @throws StopFormatListenerException
+     *
+     * @return string[] array of content types
+     */
+    public function getContentTypes(Request $request);
+}

--- a/src/Pim/Bundle/ApiBundle/PimApiBundle.php
+++ b/src/Pim/Bundle/ApiBundle/PimApiBundle.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Bundle\ApiBundle;
 
+use Pim\Bundle\ApiBundle\DependencyInjection\Compiler\ContentTypeNegotiatorPass;
 use Pim\Bundle\CatalogBundle\DependencyInjection\Compiler\RegisterSerializerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -15,6 +16,7 @@ class PimApiBundle extends Bundle
     {
         $container
             ->addCompilerPass(new RegisterSerializerPass('pim_external_api_exception_serializer'))
+            ->addCompilerPass(new ContentTypeNegotiatorPass())
         ;
     }
 }

--- a/src/Pim/Bundle/ApiBundle/Resources/config/api.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/api.yml
@@ -5,3 +5,9 @@ pim_api:
     input:
         buffer_size: '%api_input_buffer_size%'
         max_resources_number: '%api_input_max_resources_number%'
+    content_type_negotiator:
+        rules:
+            - { path: '^/api/rest/v\d+/media-files', methods: ['POST'], content_types:['multipart/form-data']}
+            - { path: '^/api/rest/v\d+/(products|families|categories|attributes)$', methods: ['PATCH'], content_types:['application/vnd.akeneo.collection+json'] }
+            - { path: '^/api', content_types:['application/json'] }
+            - { path: '', stop: true }

--- a/src/Pim/Bundle/ApiBundle/Resources/config/event_subscribers.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/event_subscribers.yml
@@ -6,5 +6,6 @@ services:
         class: '%pim_api.event_subscriber.check_headers_request.class%'
         arguments:
             - '@fos_rest.format_negotiator'
+            - '@pim_api.negotiator.content_type_negotiator'
         tags:
             - { name: kernel.event_subscriber, event: kernel.request, method: onKernelRequest }

--- a/src/Pim/Bundle/ApiBundle/Resources/config/negotiators.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/negotiators.yml
@@ -1,0 +1,6 @@
+parameters:
+    pim_api.negotiator.content_type_negotiator.class: Pim\Bundle\ApiBundle\Negotiator\ContentTypeNegotiator
+
+services:
+    pim_api.negotiator.content_type_negotiator:
+        class: '%pim_api.negotiator.content_type_negotiator.class%'

--- a/src/Pim/Bundle/ApiBundle/spec/EventSubscriber/CheckHeadersRequestSubscriberSpec.php
+++ b/src/Pim/Bundle/ApiBundle/spec/EventSubscriber/CheckHeadersRequestSubscriberSpec.php
@@ -6,6 +6,7 @@ use FOS\RestBundle\FOSRestBundle;
 use FOS\RestBundle\Negotiation\FormatNegotiator;
 use Negotiation\AcceptHeader;
 use PhpSpec\ObjectBehavior;
+use Pim\Bundle\ApiBundle\Negotiator\ContentTypeNegotiatorInterface;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
@@ -16,9 +17,12 @@ use Symfony\Component\HttpKernel\KernelEvents;
 
 class CheckHeadersRequestSubscriberSpec extends ObjectBehavior
 {
-    public function let(FormatNegotiator $formatNegotiator, GetResponseEvent $event)
-    {
-        $this->beConstructedWith($formatNegotiator);
+    public function let(
+        FormatNegotiator $formatNegotiator,
+        ContentTypeNegotiatorInterface $contentTypeNegotiator,
+        GetResponseEvent $event
+    ) {
+        $this->beConstructedWith($formatNegotiator, $contentTypeNegotiator);
     }
 
     public function it_subscribes_to_prePersist()
@@ -27,7 +31,7 @@ class CheckHeadersRequestSubscriberSpec extends ObjectBehavior
             ->shouldReturn([KernelEvents::REQUEST => 'onKernelRequest']);
     }
 
-    public function it_successfully_valid_default_accept_header(
+    public function it_successfully_validates_default_accept_header(
         $event,
         $formatNegotiator,
         Request $request,
@@ -51,7 +55,7 @@ class CheckHeadersRequestSubscriberSpec extends ObjectBehavior
         $this->onKernelRequest($event)->shouldReturn(null);
     }
 
-    public function it_successfully_valid_json_accept_header(
+    public function it_successfully_validates_json_accept_header(
         $event,
         $formatNegotiator,
         Request $request,
@@ -100,18 +104,13 @@ class CheckHeadersRequestSubscriberSpec extends ObjectBehavior
             ->during('onKernelRequest', [$event]);
     }
 
-    public function it_successfully_valid_json_content_type_header(
+    public function it_successfully_validates_json_content_type_header(
         $event,
-        $formatNegotiator,
+        $contentTypeNegotiator,
         Request $request,
         ParameterBag $headers,
-        ParameterBag $attributes,
-        CustomAcceptHeader $best
+        ParameterBag $attributes
     ) {
-        $formatNegotiator->getBest(null)->willReturn($best);
-        $headers->get('accept')->willReturn(null);
-        $best->getValue()->willReturn('application/json');
-
         $event->getRequest()->willReturn($request);
         $request->getMethod()->willReturn('POST');
         $event->getRequestType()->willReturn(HttpKernelInterface::MASTER_REQUEST);
@@ -120,23 +119,42 @@ class CheckHeadersRequestSubscriberSpec extends ObjectBehavior
         $attributes->has(FOSRestBundle::ZONE_ATTRIBUTE)->willReturn(true);
 
         $request->headers = $headers;
-        $headers->get('content-type', null)->willReturn('application/json');
+        $headers->get('content-type')->willReturn('application/json');
+
+        $contentTypeNegotiator->getContentTypes($request)->willReturn(['application/json', 'application/xml']);
 
         $this->onKernelRequest($event)->shouldReturn(null);
     }
 
-    public function it_throws_an_exception_when_content_type_header_is_xml(
+    public function it_successfully_validates_form_data_content_type_header(
         $event,
-        $formatNegotiator,
+        $contentTypeNegotiator,
         Request $request,
         ParameterBag $headers,
-        ParameterBag $attributes,
-        CustomAcceptHeader $best
+        ParameterBag $attributes
     ) {
-        $formatNegotiator->getBest(null)->willReturn($best);
-        $headers->get('accept')->willReturn(null);
-        $best->getValue()->willReturn('application/json');
+        $event->getRequest()->willReturn($request);
+        $request->getMethod()->willReturn('POST');
+        $event->getRequestType()->willReturn(HttpKernelInterface::MASTER_REQUEST);
 
+        $request->attributes = $attributes;
+        $attributes->has(FOSRestBundle::ZONE_ATTRIBUTE)->willReturn(true);
+
+        $request->headers = $headers;
+        $headers->get('content-type')->willReturn('multipart/form-data; boundary=foo');
+
+        $contentTypeNegotiator->getContentTypes($request)->willReturn(['multipart/form-data']);
+
+        $this->onKernelRequest($event)->shouldReturn(null);
+    }
+
+    public function it_throws_an_exception_when_content_type_header_is_xml_instead_of_json(
+        $event,
+        $contentTypeNegotiator,
+        Request $request,
+        ParameterBag $headers,
+        ParameterBag $attributes
+    ) {
         $event->getRequest()->willReturn($request);
         $request->getMethod()->willReturn('POST');
         $event->getRequestType()->willReturn(HttpKernelInterface::MASTER_REQUEST);
@@ -147,23 +165,43 @@ class CheckHeadersRequestSubscriberSpec extends ObjectBehavior
         $request->headers = $headers;
         $headers->get('content-type', null)->willReturn('application/xml');
 
+        $contentTypeNegotiator->getContentTypes($request)->willReturn(['application/json']);
+
         $this->shouldThrow(new UnsupportedMediaTypeHttpException('"application/xml" in "Content-Type" header is not valid. Only "application/json" is allowed.'))
+            ->during('onKernelRequest', [$event]);
+    }
+
+    public function it_throws_an_exception_when_content_type_header_is_xml_instead_of_json_or_form_data(
+        $event,
+        $contentTypeNegotiator,
+        Request $request,
+        ParameterBag $headers,
+        ParameterBag $attributes
+    ) {
+        $event->getRequest()->willReturn($request);
+        $request->getMethod()->willReturn('POST');
+        $event->getRequestType()->willReturn(HttpKernelInterface::MASTER_REQUEST);
+
+        $request->attributes = $attributes;
+        $attributes->has(FOSRestBundle::ZONE_ATTRIBUTE)->willReturn(true);
+
+        $request->headers = $headers;
+        $headers->get('content-type', null)->willReturn('application/xml');
+
+        $contentTypeNegotiator->getContentTypes($request)->willReturn(['application/json', 'multipart/form-data']);
+
+        $this->shouldThrow(new UnsupportedMediaTypeHttpException('"application/xml" in "Content-Type" header is not valid. Only "application/json" or "multipart/form-data" are allowed.'))
             ->during('onKernelRequest', [$event]);
     }
 
 
     public function it_throws_an_exception_when_content_type_is_missing(
         $event,
-        $formatNegotiator,
+        $contentTypeNegotiator,
         Request $request,
         ParameterBag $headers,
-        ParameterBag $attributes,
-        CustomAcceptHeader $best
+        ParameterBag $attributes
     ) {
-        $formatNegotiator->getBest(null)->willReturn($best);
-        $headers->get('accept')->willReturn(null);
-        $best->getValue()->willReturn('application/json');
-
         $event->getRequest()->willReturn($request);
         $request->getMethod()->willReturn('POST');
         $event->getRequestType()->willReturn(HttpKernelInterface::MASTER_REQUEST);
@@ -174,11 +212,13 @@ class CheckHeadersRequestSubscriberSpec extends ObjectBehavior
         $request->headers = $headers;
         $headers->get('content-type', null)->willReturn();
 
-        $this->shouldThrow(new UnsupportedMediaTypeHttpException('The "Content-Type" header is missing. "application/json" has to be specified as value.'))
+        $contentTypeNegotiator->getContentTypes($request)->willReturn(['application/json', 'application/xml']);
+
+        $this->shouldThrow(new UnsupportedMediaTypeHttpException('The "Content-Type" header is missing. "application/json" or "application/xml" has to be specified as value.'))
             ->during('onKernelRequest', [$event]);
     }
 
-    public function it_stops_if_uri_is_not_in_api(
+    public function it_stops_if_uri_is_not_in_api_with_get_request(
         $event,
         $formatNegotiator,
         ParameterBag $headers,
@@ -191,12 +231,30 @@ class CheckHeadersRequestSubscriberSpec extends ObjectBehavior
         $headers->get('accept')->willReturn('');
         $event->getRequest()->willReturn($request);
         $event->getRequestType()->willReturn(HttpKernelInterface::MASTER_REQUEST);
+        $request->getMethod()->willReturn('GET');
 
         $request->attributes = $attributes;
         $attributes->has(FOSRestBundle::ZONE_ATTRIBUTE)->willReturn(true);
 
-        $best->getValue()->shouldNotBeCalled();
-        $request->getMethod()->shouldNotBeCalled();
+        $this->onKernelRequest($event)->shouldReturn(null);
+    }
+
+    public function it_stops_if_uri_is_not_in_api_with_patch_request(
+        $event,
+        $contentTypeNegotiator,
+        ParameterBag $headers,
+        Request $request,
+        ParameterBag $attributes
+    ) {
+        $contentTypeNegotiator->getContentTypes($request)->willThrow('FOS\RestBundle\Util\StopFormatListenerException');
+        $request->headers = $headers;
+        $headers->get('content-type')->willReturn('');
+        $event->getRequest()->willReturn($request);
+        $event->getRequestType()->willReturn(HttpKernelInterface::MASTER_REQUEST);
+        $request->getMethod()->willReturn('PATCH');
+
+        $request->attributes = $attributes;
+        $attributes->has(FOSRestBundle::ZONE_ATTRIBUTE)->willReturn(true);
 
         $this->onKernelRequest($event)->shouldReturn(null);
     }

--- a/src/Pim/Bundle/ApiBundle/spec/Negotiator/ContentTypeNegotiatorSpec.php
+++ b/src/Pim/Bundle/ApiBundle/spec/Negotiator/ContentTypeNegotiatorSpec.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace spec\Pim\Bundle\ApiBundle\Negotiator;
+
+use FOS\RestBundle\Util\StopFormatListenerException;
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\ApiBundle\Negotiator\ContentTypeNegotiator;
+use Pim\Bundle\ApiBundle\Negotiator\ContentTypeNegotiatorInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+
+class ContentTypeNegotiatorSpec extends ObjectBehavior
+{
+    public function let(RequestMatcherInterface $requestMatcher1, RequestMatcherInterface $requestMatcher2)
+    {
+        $this->add($requestMatcher1, ['content_types' => ['application/json']]);
+        $this->add($requestMatcher2, ['stop' => true]);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(ContentTypeNegotiator::class);
+        $this->shouldBeAnInstanceOf(ContentTypeNegotiatorInterface::class);
+    }
+
+    public function it_returns_content_types_for_a_matching_request($requestMatcher1, Request $request)
+    {
+        $requestMatcher1->matches($request)->willReturn(true);
+
+        $this->getContentTypes($request)->shouldReturn(['application/json']);
+    }
+
+    public function it_throws_stop_format_exception_when_matching_request_with_stop_rule(
+        $requestMatcher1,
+        $requestMatcher2,
+        Request $request
+    ) {
+        $requestMatcher1->matches($request)->willReturn(false);
+        $requestMatcher2->matches($request)->willReturn(true);
+
+        $this
+            ->shouldThrow(new StopFormatListenerException('Stopped content type negotiator'))
+            ->during('getContentTypes', [$request]);
+    }
+}


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

Fos Rest Bundle allows to get the best "Accept-Type" given a request.
It allows to do it thanks to https://github.com/akeneo/pim-community-dev/blob/1.7/src/Pim/Bundle/EnrichBundle/Resources/config/bundles/fos_rest.yml#L15

Unfortunately, this feature is not designed for the validation of the content-type.
We used it to validate it, it was working "by luck", because we had only one content type accepted per endpoint for the moment. But it leads to some weird behavior.

This misuse is problematic, because we have to put the accept header at "*/*" for some POST endpoints, like with this issue : https://github.com/akeneo/pim-community-dev/issues/6118

Accept-header is useless with POST query (except if the post query returns a body, but that was not case in the ticket above).

Moreover, we can't accept different content-types for one single endpoint with the actual behavior. 

To fix that, I've redefined a proper configuration for the content types, based on the same stack of the rest bundle but simplified.

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Ok
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | Ok
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
