### PR TITLE
PIM-6413: Fix to ensure that attribute options codes are no longer up…

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -10,6 +10,7 @@
 - GITHUB-6069: Fix Pim\Bundle\EnrichBundle\Controller\Rest\JobInstanceController::getValidationErrors by preventing to fail when no raw parameters are defined for the job, cheers @aistis-!
 - PIM-6392: Fix output buffering error when updating a list of resources from the API
 - PIM-6426: Fix issue when downloading a media file while output buffering is disabled
+- PIM-6413: Fix to ensure that attribute options codes are no longer updated in MongoDB
 
 # 1.7.4 (2017-05-10)
 

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/storage_driver/doctrine/mongodb-odm.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/storage_driver/doctrine/mongodb-odm.yml
@@ -46,10 +46,8 @@ parameters:
     pim_catalog.mongodb_odm_query_generator.family_deleted.class:                Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\QueryGenerator\FamilyDeletedQueryGenerator
     pim_catalog.mongodb_odm_query_generator.family_label_updated.class:          Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\QueryGenerator\FamilyLabelUpdatedQueryGenerator
     pim_catalog.mongodb_odm_query_generator.family_label_deleted.class:          Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\QueryGenerator\FamilyLabelDeletedQueryGenerator
-    pim_catalog.mongodb_odm_query_generator.option_code_updated.class:           Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\QueryGenerator\OptionCodeUpdatedQueryGenerator
     pim_catalog.mongodb_odm_query_generator.option_deleted.class:                Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\QueryGenerator\OptionDeletedQueryGenerator
     pim_catalog.mongodb_odm_query_generator.option_value_updated.class:          Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\QueryGenerator\OptionValueUpdatedQueryGenerator
-    pim_catalog.mongodb_odm_query_generator.multiple_option_code_updated.class:  Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\QueryGenerator\MultipleOptionCodeUpdatedQueryGenerator
     pim_catalog.mongodb_odm_query_generator.multiple_option_deleted.class:       Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\QueryGenerator\MultipleOptionDeletedQueryGenerator
     pim_catalog.mongodb_odm_query_generator.multiple_option_value_updated.class: Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\QueryGenerator\MultipleOptionValueUpdatedQueryGenerator
 
@@ -407,15 +405,6 @@ services:
         tags:
             - { name: pim_catalog.mongodb_odm_query_generator }
 
-    pim_catalog.mongodb_odm_query_generator.option_code_updated:
-        class: '%pim_catalog.mongodb_odm_query_generator.option_code_updated.class%'
-        parent: pim_catalog.mongodb_odm_query_generator.abstract_normalized_data
-        arguments:
-            - '%pim_catalog.entity.attribute_option.class%'
-            - 'code'
-        tags:
-            - { name: pim_catalog.mongodb_odm_query_generator }
-
     pim_catalog.mongodb_odm_query_generator.option_deleted:
         class: '%pim_catalog.mongodb_odm_query_generator.option_deleted.class%'
         parent: pim_catalog.mongodb_odm_query_generator.abstract_normalized_data
@@ -430,15 +419,6 @@ services:
         arguments:
             - '%pim_catalog.entity.attribute_option_value.class%'
             - 'value'
-        tags:
-            - { name: pim_catalog.mongodb_odm_query_generator }
-
-    pim_catalog.mongodb_odm_query_generator.multiple_option_code_updated:
-        class: '%pim_catalog.mongodb_odm_query_generator.multiple_option_code_updated.class%'
-        parent: pim_catalog.mongodb_odm_query_generator.abstract_normalized_data
-        arguments:
-            - '%pim_catalog.entity.attribute_option.class%'
-            - 'code'
         tags:
             - { name: pim_catalog.mongodb_odm_query_generator }
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When an option is added to a simple/multi select attribute from a product, all the products that are linked to the attribute are updated in MongoDB. The option code is updated alone (not the id nor the labels) in the normalized data. So all this products have inconsistencies between values and normalized data.

This is done by two query generators, one for simple select, and one for multi select. Their behavior was to update the normalized data when a attribute option code is updated. However, since several months, the attribute option code has been made immutable. 

This two query generators have no longer reasons to exists. Rather than fix them, i'ts better to remove them. To avoid a BC break in a patch, I remove only their service declarations, and the classes will be removed into the master branch.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
