### PR TITLE
PIM 6429 : Improve the loading of the completeness widget on dashboard

### DIFF
--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -1,3 +1,9 @@
+# 1.5.x
+
+## Bug fixes
+
+- PIM-6429: Improve the loading of the completeness widget on dashboard in ORM
+
 # 1.5.22 (2017-05-22)
 
 ## Bug fixes

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/CompletenessRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/CompletenessRepository.php
@@ -38,16 +38,27 @@ class CompletenessRepository implements CompletenessRepositoryInterface
 
     /**
      * {@inheritdoc}
+     *
+     * The request selects at first in an optimised subquery all the enabled product for a given channel.
+     * It eliminates duplicates in this subquery for performance concern, by using DISTINCT instead of GROUP BY, which is faster in that case.
+     * After that, it joins with the table channel to get the label. It does not get the label in the subquery for performance concern.
      */
     public function getProductsCountPerChannels()
     {
         $sql = <<<SQL
-SELECT ch.label, COUNT(DISTINCT p.id) as total FROM pim_catalog_channel ch
-    JOIN %category_table% ca ON ca.root = ch.category_id
-    JOIN %category_join_table% cp ON cp.category_id = ca.id
-    JOIN %product_table% p ON p.id = cp.product_id
-    WHERE p.is_enabled = 1
-    GROUP BY ch.id, ch.label
+        SELECT co.label, co.total FROM
+        (
+            SELECT ch.id, ch.label, COUNT(p.id) as total
+            FROM (
+                SELECT DISTINCT ch.id as channel_id, p.id FROM pim_catalog_channel ch
+                JOIN %category_table% ca ON ca.root = ch.category_id
+                JOIN %category_join_table% cp ON cp.category_id = ca.id
+                JOIN %product_table% p ON p.id = cp.product_id
+                WHERE p.is_enabled = 1
+            ) as p
+            JOIN pim_catalog_channel ch on ch.id = p.channel_id 
+            GROUP BY ch.id, ch.label
+        ) as co;
 SQL;
 
         $sql = $this->applyTableNames($sql);
@@ -60,20 +71,31 @@ SQL;
 
     /**
      * {@inheritdoc}
+     *
+     * The request selects at first in an optimised subquery all the enabled product for a given channel.
+     * It eliminates duplicates in this subquery for performance concern, by using DISTINCT instead of GROUP BY, which is faster in that case.
+     * After that, it joins with the other tables to get the locale code, the channel label, and filter to get only the complete products.
      */
     public function getCompleteProductsCountPerChannels()
     {
         $sql = <<<SQL
-    SELECT ch.label, lo.code as locale, COUNT(DISTINCT co.product_id) as total FROM pim_catalog_channel ch
-    JOIN %category_table% ca ON ca.root = ch.category_id
-    JOIN %category_join_table% cp ON cp.category_id = ca.id
-    JOIN %product_table% p ON p.id = cp.product_id
-    JOIN pim_catalog_channel_locale cl ON cl.channel_id = ch.id
-    JOIN pim_catalog_locale lo ON lo.id = cl.locale_id
-    LEFT JOIN pim_catalog_completeness co
-        ON co.locale_id = lo.id AND co.channel_id = ch.id AND co.product_id = p.id AND co.ratio = 100
-    WHERE p.is_enabled = 1
-    GROUP BY ch.id, lo.id, ch.label, lo.code
+        SELECT co.label, co.code as locale, co.total FROM (
+            SELECT ch.id as channel_id, lo.id as locale_id, ch.label, lo.code, COUNT(co.product_id) as total 
+            FROM 
+            (
+                SELECT DISTINCT ch.id as channel_id, p.id FROM pim_catalog_channel ch
+                JOIN %category_table% ca ON ca.root = ch.category_id
+                JOIN %category_join_table% cp ON cp.category_id = ca.id
+                JOIN %product_table% p ON p.id = cp.product_id
+                WHERE p.is_enabled = 1
+            ) as p 
+            JOIN pim_catalog_channel ch on ch.id = p.channel_id
+            JOIN pim_catalog_channel_locale cl ON cl.channel_id = ch.id
+            JOIN pim_catalog_locale lo ON lo.id = cl.locale_id
+            LEFT JOIN pim_catalog_completeness co
+            ON co.locale_id = lo.id AND co.channel_id = ch.id AND co.product_id = p.id AND co.ratio = 100
+            GROUP BY ch.id, lo.id, ch.label, lo.code 
+        ) as co;
 SQL;
         $sql = $this->applyTableNames($sql);
 


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

The widget of the completeness could take a lot of time to be displayed (200 seconds for a client).
It is due to an unoptimised SQL request.
It's a big problem, because during this time, the session is locked. So, the PIM is totally unavailable for the user (even with a refresh).

This problem has already been raised in this ticket: https://github.com/akeneo/pim-community-dev/issues/3771

**1. First point that this PR intends to resolve: [ABORTED]**

_IMPORTANT : This commit will be done on master due to race conditions on the CI.
It needs more investigation and it probably implies more stuff to do, so I prefer to not take the risk to apply it in a patch._

Failing scenarios:

- features/proposal/notification_preferences.feature:40
- features/permissions/category/enforce_no_permissions_for_category.feature:15
- vendor/akeneo/pim-community-dev/features/acl/enforce_acl_on_history.feature:7
- features/permissions/category/define_permissions_for_category.feature:22
- vendor/akeneo/pim-community-dev/features/category/display_category_history.feature:7
- features/localization/proposal/display_localized_numbers_in_proposals.feature:29  


A request should not block all the other concurrent requests by locking the session, except if that session is used in a controller.

For that, a listener is in charge to close the session before calling a controller. It applies for every routes, and so, it fixes the problem for every potential long running request.
If the controller is using the session (flashbag for example), the session handler will re-open it automatically, so don't worry :)

Impact : a completeness SQL request that is taking 200 sec to be calculated will not prevent the UI to work (tested and validated) by locking the session. 
It can have a real benefit in term of performance for the whole UI of the PIM.

Note: this solution has been discussed with @BitOne and @jjanvier and it is a first step to improve our session management.

**2. Second point that this PR intends to resolve:**

The original request to calculate the completeness is slow due to the DISTINCT in the count.

```
    SELECT ch.label, lo.code as locale, COUNT(DISTINCT co.product_id) as total FROM pim_catalog_channel ch
    JOIN %category_table% ca ON ca.root = ch.category_id
    JOIN %category_join_table% cp ON cp.category_id = ca.id
    JOIN %product_table% p ON p.id = cp.product_id
    JOIN pim_catalog_channel_locale cl ON cl.channel_id = ch.id
    JOIN pim_catalog_locale lo ON lo.id = cl.locale_id
    LEFT JOIN pim_catalog_completeness co
        ON co.locale_id = lo.id AND co.channel_id = ch.id AND co.product_id = p.id AND co.ratio = 100
    WHERE p.is_enabled = 1
    GROUP BY ch.id, lo.id, ch.label, lo.code
```
Actually, it was performing a distinct (= a sort) for each combinaison [channel, locale , product_id] to eliminate duplicate product ids. And that is very greedy in time + memory !

You can have duplicate combinaisons of [channel, product id]  because a product can be several times in a category tree associated to a channel.

The optimisation is to eliminate the duplicate combinaison of [channel, product] before performing any join to the other table, thanks to this subrequest:
```
    SELECT DISTINCT ch.id as channel_id, p.id FROM pim_catalog_channel ch
    JOIN %category_table% ca ON ca.root = ch.category_id
    JOIN %category_join_table% cp ON cp.category_id = ca.id
    JOIN %product_table% p ON p.id = cp.product_id
    WHERE p.is_enabled = 1
```

The performance on a database with 3 channels, 6 locales, 18900 products, 90 attributes, 15 families, 9 users:
Improved from 200 sec to 1,5 sec without any index.

I've improved the first request "getProductsCountPerChannels" as well. It took 3,5 sec. Compared to the initial 200 seconds of the other request, it was not a big deal. But compared to the 1,5 sec of the request after optimisation, it sounds not logical because the request is simpler.
Now, on the same volumetry, the request take 250ms instead of 3,5.

Last thing, the request are ok with the ONLY_FULL_GROUP_BY activated on mysql.

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
