### PR TITLE
PIM-6433: Prevent the insertion of duplicate multi-reference data code to break an import

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -1,15 +1,21 @@
+# 1.6.x
+
+## Bug fixes
+
+- PIM-6433: Fix product import reference data multi with duplicate code options
+
 # 1.6.16 (2017-05-24)
 
 ## Bug fixes
 
 - PIM-6418: Fix URL too long in variant group datagrid
+- GITHUB-5451: Update akeneo_batch.yml sender email, cheers @julienquetil!
 
 # 1.6.15 (2017-05-18)
 
 ## Bug fixes
 
 - PIM-6376: Fix slow MongoDB queries when editing attribute options
-- GITHUB-5451: Update akeneo_batch.yml sender email, cheers @julienquetil!
 
 # 1.6.14 (2017-04-21)
 

--- a/features/reference-data/import/import_products.feature
+++ b/features/reference-data/import/import_products.feature
@@ -69,3 +69,24 @@ Feature: Execute a job
       | sole_fabric              |              |
       | lace_fabric-en_US-tablet | Kevlar, Jute |
       | lace_fabric-en_US-mobile | Kevlar, Jute |
+
+  @jira https://akeneo.atlassian.net/browse/PIM-6433
+  Scenario: Successfully update an existing product with duplicate reference data code
+    Given the following product:
+      | sku     | sole_fabric |
+      | SKU-001 |             |
+    And the following CSV file to import:
+    """
+    sku;sole_fabric
+    SKU-001;PVC,PVC
+    """
+    And the following job "csv_footwear_product_import" configuration:
+      | filePath | %file to import% |
+    When I am on the "csv_footwear_product_import" import job page
+    And I launch the import job
+    And I wait for the "csv_footwear_product_import" job to finish
+    Then I should see "processed 1"
+    And I should see "skipped product (no differences) 1"
+    And there should be 1 product
+    And the product "SKU-001" should have the following values:
+      | sole_fabric              | PVC          |

--- a/src/Acme/Bundle/AppBundle/Model/ProductValue.php
+++ b/src/Acme/Bundle/AppBundle/Model/ProductValue.php
@@ -63,7 +63,9 @@ class ProductValue extends PimProductValue
      */
     public function addFabric(Fabric $fabric)
     {
-        $this->fabrics->add($fabric);
+        if (!$this->fabrics->contains($fabric)) {
+            $this->fabrics->add($fabric);
+        }
     }
 
     /**


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When importing a csv product file with a multi select reference data option code appearing twice or more for one attribute. The import job fails with an error:

`Exception SQL raised : Duplicate entry in the table that stores the values of the ref data.`

This PR intends to fix this issue by fixing the product value override to check if the reference data we want to add already exists before adding it to the multi select list.

This PR is mostly for educational purpose, so that integrators can rely on this code sample to create their on reference data correctly.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
