### PR TITLE
IM-825: allow concurrent AJAX request by closing the session in a listener

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -1,3 +1,9 @@
+# 2.0.x
+
+## Improvements
+
+- IM-825: allow concurrent AJAX requests by closing the session in a listener
+
 # 2.0.6 (2017-11-03)
 
 ## Better manage products with variants!

--- a/features/Context/FixturesContext.php
+++ b/features/Context/FixturesContext.php
@@ -1174,17 +1174,28 @@ class FixturesContext extends BaseFixturesContext
      */
     public function theFileOfShouldBe($attribute, $products, $filename)
     {
-        foreach ($this->listToArray($products) as $identifier) {
-            $productValue = $this->getProductValue($identifier, strtolower($attribute));
-            $media        = $productValue->getData();
-            if ('' === trim($filename)) {
-                if ($media) {
-                    assertNull($media->getOriginalFilename());
+        $this->getMainContext()->getSubcontext('hook')->clearUOW();
+
+        $this->spin(function () use ($attribute, $products, $filename) {
+            foreach ($this->listToArray($products) as $identifier) {
+                $productValue = $this->getProductValue($identifier, strtolower($attribute));
+                $media = $productValue->getData();
+                if ('' === trim($filename)) {
+                    if ($media) {
+                        assertNull($media->getOriginalFilename());
+                    }
+                } else {
+                    assertEquals($filename, $media->getOriginalFilename());
                 }
-            } else {
-                assertEquals($filename, $media->getOriginalFilename());
             }
-        }
+
+            return true;
+        }, sprintf(
+            'Cannot assert that the value for the attribute "%s" is "%s" for the products "%s"',
+            $attribute,
+            $filename,
+            implode(',', $this->listToArray($products))
+        ));
     }
 
     /**

--- a/features/Context/Page/Base/Grid.php
+++ b/features/Context/Page/Base/Grid.php
@@ -967,7 +967,11 @@ class Grid extends Index
      */
     public function openColumnsPopin()
     {
-        $this->getElement('Configure columns')->click();
+        return $this->spin(function () {
+            $this->getElement('Configure columns')->click();
+
+            return true;
+        }, 'Cannot open the column configuration popin.');
     }
 
     /**

--- a/features/datagrid/datagrid_views.feature
+++ b/features/datagrid/datagrid_views.feature
@@ -190,7 +190,7 @@ Feature: Datagrid views
     When I fill in the following information:
       | Default product grid view | With name |
     And I press the "Save" button
-    And I am on the products grid
+    Then I should not see the text "There are unsaved changes."
     And I logout
     And I am logged in as "Mary"
     And I am on the products grid

--- a/src/Pim/Bundle/EnrichBundle/EventListener/CloseSessionListener.php
+++ b/src/Pim/Bundle/EnrichBundle/EventListener/CloseSessionListener.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Pim\Bundle\EnrichBundle\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Session\Storage\Handler\NativeSessionHandler;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Aims to close the session after that all listeners have been executed before calling the controller.
+ *
+ * Symfony opens automatically a session, for each request, at the very beginning. To open a session, it tries to get a lock.
+ * If a concurrent request has already got the lock, the actual request is pending.
+ * Therefore, it's not possible to execute concurrent requests due to this lock, which is very costly in term of performance.
+ * Moreover, it can block the user interface if a request is taking too much time to execute.
+ *
+ * By default, Symfony writes the session data and close the session only at the end of the request.
+ * By writing the session data and closing the session just before calling the controller,
+ * it allows the concurrent request to access to the session data.
+ *
+ * Do note that if the controller reads or writes the session data, the session handler will automatically re-open the session.
+ *
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class CloseSessionListener implements EventSubscriberInterface
+{
+    /** @var NativeSessionHandler */
+    protected $sessionHandler;
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            KernelEvents::REQUEST => ['closeSession', -100]
+        ];
+    }
+
+    /**
+     * Save and close the session.
+     *
+     * @param GetResponseEvent $event
+     */
+    public function closeSession(GetResponseEvent $event) : void
+    {
+        if (!$event->getRequest()->hasSession()) {
+            return;
+        }
+
+        $session = $event->getRequest()->getSession();
+        if ($session->isStarted()) {
+            $session->save();
+        }
+    }
+}

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/event_listeners.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/event_listeners.yml
@@ -1,4 +1,5 @@
 parameters:
+    pim_enrich.event_listener.close_session.class:              Pim\Bundle\EnrichBundle\EventListener\CloseSessionListener
     pim_enrich.event_listener.user_context.class:               Pim\Bundle\EnrichBundle\EventListener\UserContextListener
     pim_enrich.event_listener.request.class:                    Pim\Bundle\EnrichBundle\EventListener\RequestListener
     pim_enrich.event_subscriber.translate_flash_messages.class: Pim\Bundle\EnrichBundle\EventListener\TranslateFlashMessagesSubscriber
@@ -8,6 +9,11 @@ parameters:
     security.exception_listener.class: Pim\Bundle\EnrichBundle\Security\Firewall\ExceptionListener
 
 services:
+    pim_enrich.event_listener.close_session:
+        class: %pim_enrich.event_listener.close_session.class%
+        tags:
+            - { name: kernel.event_subscriber }
+
     # User context listener
     stof_doctrine_extensions.event_listener.locale:
         class: '%pim_enrich.event_listener.user_context.class%'

--- a/src/Pim/Bundle/EnrichBundle/spec/EventListener/CloseSessionListenerSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/EventListener/CloseSessionListenerSpec.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace spec\Pim\Bundle\EnrichBundle\EventListener;
+
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class CloseSessionListenerSpec extends ObjectBehavior
+{
+    function it_is_an_event_subscriber()
+    {
+        $this->shouldBeAnInstanceOf(EventSubscriberInterface::class);
+    }
+
+    function it_subscribes_to_kernel_request()
+    {
+        $this->getSubscribedEvents()->shouldReturn([KernelEvents::REQUEST => ['closeSession', -100]]);
+    }
+
+    function it_closes_an_opened_session(GetResponseEvent $event, Request $request, SessionInterface $session)
+    {
+        $event->getRequest()->willReturn($request);
+        $request->hasSession()->willReturn(true);
+        $request->getSession()->willReturn($session);
+        $session->isStarted()->willReturn(true);
+        $session->save()->shouldBeCalled();
+
+        $this->closeSession($event);
+    }
+
+    function it_does_not_close_session_if_no_session_in_the_request(
+        GetResponseEvent $event,
+        Request $request
+    ) {
+        $event->getRequest()->willReturn($request);
+        $request->hasSession()->willReturn(false);
+        $request->getSession()->shouldNotBeCalled();
+
+        $this->closeSession($event);
+    }
+
+    function it_does_not_close_session_if_session_is_not_started(
+        GetResponseEvent $event,
+        Request $request,
+        SessionInterface $session
+    ) {
+        $event->getRequest()->willReturn($request);
+        $request->hasSession()->willReturn(true);
+        $request->getSession()->willReturn($session);
+        $session->isStarted()->willReturn(false);
+        $session->save()->shouldNotBeCalled();
+
+        $this->closeSession($event);
+    }
+}

--- a/src/Pim/Bundle/UserBundle/Context/UserContext.php
+++ b/src/Pim/Bundle/UserBundle/Context/UserContext.php
@@ -113,8 +113,9 @@ class UserContext
             throw new \LogicException('There are no activated locales');
         }
 
-        if (null !== $this->getCurrentRequest()) {
+        if (null !== $this->getCurrentRequest() && $this->getCurrentRequest()->hasSession()) {
             $this->getCurrentRequest()->getSession()->set('dataLocale', $locale->getCode());
+            $this->getCurrentRequest()->getSession()->save();
         }
 
         return $locale;
@@ -319,7 +320,7 @@ class UserContext
     protected function getSessionLocale()
     {
         $request = $this->getCurrentRequest();
-        if (null !== $request) {
+        if (null !== $request && $request->hasSession()) {
             $localeCode = $request->getSession()->get('dataLocale');
             if (null !== $localeCode) {
                 $locale = $this->localeRepository->findOneByIdentifier($localeCode);

--- a/src/Pim/Bundle/UserBundle/spec/Context/UserContextSpec.php
+++ b/src/Pim/Bundle/UserBundle/spec/Context/UserContextSpec.php
@@ -44,7 +44,7 @@ class UserContextSpec extends ObjectBehavior
 
         $requestStack->getCurrentRequest()->willReturn($request);
         $request->getSession()->willReturn($session);
-        $session->set('dataLocale', Argument::any())->willReturn(null);
+        $request->hasSession()->willReturn(true);
 
         $en->getCode()->willReturn('en_US');
         $fr->getCode()->willReturn('fr_FR');
@@ -73,9 +73,12 @@ class UserContextSpec extends ObjectBehavior
         );
     }
 
-    function it_provides_locale_from_the_request_if_it_has_been_set($request, $fr)
+    function it_provides_locale_from_the_request_if_it_has_been_set($request, $fr, $session)
     {
         $request->get('dataLocale')->willReturn('fr_FR');
+
+        $session->set('dataLocale', 'fr_FR')->shouldBeCalled();
+        $session->save()->shouldBeCalled();
 
         $this->getCurrentLocale()->shouldReturn($fr);
     }
@@ -87,6 +90,9 @@ class UserContextSpec extends ObjectBehavior
     ) {
         $request->get('dataLocale')->willReturn(null);
         $session->get('dataLocale')->willReturn('fr_FR');
+
+        $session->set('dataLocale', 'fr_FR')->shouldBeCalled();
+        $session->save()->shouldBeCalled();
 
         $this->getCurrentLocale()->shouldReturn($fr);
     }
@@ -101,6 +107,9 @@ class UserContextSpec extends ObjectBehavior
         $session->get('dataLocale')->willReturn(null);
         $user->getCatalogLocale()->willReturn($de);
 
+        $session->set('dataLocale', 'de_DE')->shouldBeCalled();
+        $session->save()->shouldBeCalled();
+
         $this->getCurrentLocale()->shouldReturn($de);
     }
 
@@ -112,6 +121,10 @@ class UserContextSpec extends ObjectBehavior
     ) {
         $request->get('dataLocale')->willReturn(null);
         $session->get('dataLocale')->willReturn(null);
+
+        $session->set('dataLocale', 'en_US')->shouldBeCalled();
+        $session->save()->shouldBeCalled();
+
         $user->getCatalogLocale()->willReturn(null);
 
         $this->getCurrentLocale()->shouldReturn($en);
@@ -143,6 +156,10 @@ class UserContextSpec extends ObjectBehavior
         $request->get('dataLocale')->willReturn(null);
         $session->get('dataLocale')->willReturn(null);
         $user->getCatalogLocale()->willReturn(null);
+
+
+        $session->set('dataLocale', 'en_US')->shouldBeCalled();
+        $session->save()->shouldBeCalled();
 
         $this->getCurrentLocaleCode()->shouldReturn('en_US');
     }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

To not delete!

ETA: end September
Done: Green CI :)

### Goal of this PR

Solution validated by @BitOne and @jjanvier

This PR aims to resolve:

- Concurrent AJAX requests

Concurrent AJAX requests are not really executed in parallel, due to lock on sessions.
So, even if the requests are sent in parallel, they are really executed on the server one after the other.
Screenshot here: https://akeneo.atlassian.net/browse/PIM-4153?jql=text%20~%20%22non-blocking%22

- Long request should not freeze the PIM

If a pending request is taking too much time, it freezes the PIM: the PIM is totally unavailable for the user (even with a refresh).

Of course, a request taking too much time should not happen. But if it occurs, it should not freeze the PIM anyway. 

See this ticket for example: https://akeneo.atlassian.net/browse/PIM-6429

Indeed, the request keeps the lock on the session. So, all the future request are waiting to get the lock on the session, resulting in the famous message "Lock wait timeout exceeded; try restarting transaction”.

### Solution

Session is opened in different listeners, for all requests, by Symfony (authentication) and by us, before going to the controller part.

This code open automatically a session: `$event->getRequest()->getSession()`. It means we can close a session whenever you want, Symfony will re-open it automatically.

Closing the session in each listeners is not a solution, because a new developer on the project can add a listener opening a session and forget to close it. 

So, it has been chosen to close the session at the end of the listeners executed before the controllers.

Moreover, the only part where we are re-opening the session ((except flash messages) in the PIM is in the function `getLocale()`.
So, we close the session in the function.

Do note that we don't close the session when putting message in FlashBag because it's generally done in controllers, and it means the request will be ended soon. 

### Drawback
It can generate "race conditions" in our behat tests.
Why ? Imagine a scenario with a first step A and second step B.

- Before this PR

The HTTP request of the step B is blocked until the execution of the HTTP request of the step A. Thanks to the locking session.

- After this PR

The HTTP request of the step B is **not** blocked by the HTTP request of the step A. So, if the step A is a `save`, step B has maybe not the saved data. And the behat fails. 

@anaelChardan did a great work with the migration Behat 2 -> Behat 3. Therefore, we should not have so many race conditions.

### PR already GTM in a another ticket

This fix was already GTM in this ticket : https://github.com/akeneo/pim-community-dev/pull/6204
It was a big stuff to put it in a patch, and CI was red due to race conditions (see above).

So, I've choosen to do it on master. After all, it's an improvement.

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
