### PR TITLE
[PIM-6399]

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -15,6 +15,7 @@
 - PIM-6434: Fix attribute group order in Product Edit Form
 - PIM-6436: Fix attribute group limit in Product Edit Form
 - PIM-6428: Fix usage of unique attributes on Product Edit Form and Family edition
+- PIM-6399: Stores images as PNG instead of JPG
 
 # 1.7.4 (2017-05-10)
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/bundles/liip_imagine.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/bundles/liip_imagine.yml
@@ -3,25 +3,25 @@ liip_imagine:
     filter_sets:
         avatar_med:
             quality:          95
-            format:           jpg
+            format:           png
             filters:
                 thumbnail:    { size: [58, 58], mode: outbound }
                 strip:        ~
         preview:
             quality:          95
-            format:           jpg
+            format:           png
             filters:
                 thumbnail:    { size: [900, 600], mode: inset }
                 strip:        ~
         thumbnail:
             quality:          95
-            format:           jpg
+            format:           png
             filters:
                 thumbnail:    { size: [320, 240], mode: outbound }
                 strip:        ~
         thumbnail_small:
             quality:          95
-            format:           jpg
+            format:           png
             filters:
                 thumbnail:    { size: [80, 120], mode: inset }
                 strip:        ~


### PR DESCRIPTION
This PR changes the thumbnails format to PNG instead of JPG
The issue was that transparent background were deleted on the transformation.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | y
| Review and 2 GTM                  | Todo
| Migration script                  | -
| Tech Doc                          | -