### PR TITLE
[PIM-6420] Fix autosorting of attribute options

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -1,3 +1,9 @@
+# 1.7.x
+
+## Bug Fixes
+
+- PIM-6420: Fix autosorting of attribute options
+
 # 1.7.5 (2017-06-02)
 
 ## Bug Fixes

--- a/features/Context/DataGridContext.php
+++ b/features/Context/DataGridContext.php
@@ -769,8 +769,10 @@ class DataGridContext extends RawMinkContext implements PageObjectAwareInterface
 
     /**
      * @param boolean $not
-     * @param string  $option
-     * @param string  $filterName
+     * @param string $option
+     * @param string $filterName
+     *
+     * @throws ExpectationException
      *
      * @Given /^I should( not)? see the available option "([^"]*)" in the filter "([^"]*)"$/
      */

--- a/features/Context/Page/Base/Form.php
+++ b/features/Context/Page/Base/Form.php
@@ -494,25 +494,41 @@ class Form extends Base
      * @param string $label
      * @param array  $choices
      * @param bool   $isExpected
+     * @param bool   $strict
      *
      * @throws ExpectationException
      */
-    public function checkFieldChoices($label, array $choices, $isExpected = true)
+    public function checkFieldChoices($label, array $choices, $isExpected = true, $strict = false)
     {
-        $labelElement = $this->extractLabelElement($label);
-        $container = $this->getClosest($labelElement, 'AknFieldContainer');
-        $select2 = $this->spin(function () use ($container) {
-            return $container->find('css', '.select2');
+
+        $select2 = $this->spin(function () use ($label) {
+            $labelElement = $this->extractLabelElement($label);
+            $container = $this->getClosest($labelElement, 'AknFieldContainer');
+            if (null === $container) {
+                return false;
+            }
+
+            return $container->find('css', '.select2, .select2-default');
         }, 'Impossible to find the select');
         $select2 = $this->decorate($select2, [Select2Decorator::class]);
         $selectChoices = $select2->getAvailableValues();
+
         if ($isExpected) {
+            if ($strict) {
+                if ($selectChoices !== $choices) {
+                    throw new ExpectationException(sprintf(
+                        'Expecting to see exactly %s, %s found',
+                        json_encode($choices),
+                        json_encode($selectChoices)
+                    ), $this->getSession());
+                }
+            }
             foreach ($choices as $choice) {
                 if (!in_array($choice, $selectChoices)) {
                     throw new ExpectationException(sprintf(
                         'Expecting to find choice "%s" in field "%s"',
                         $choice,
-                        $labelElement
+                        $label
                     ), $this->getSession());
                 }
             }
@@ -522,7 +538,7 @@ class Form extends Base
                     throw new ExpectationException(sprintf(
                         'Choice "%s" should not be in available for field "%s"',
                         $choice,
-                        $labelElement
+                        $label
                     ), $this->getSession());
                 }
             }
@@ -623,9 +639,9 @@ class Form extends Base
                 return $element->find('css', sprintf('label:contains("%s")', $labelContent));
             }, sprintf('Cannot find "%s" label', $labelContent));
         } else {
-            $labeParts = explode(' ', $labelContent);
-            $channel   = in_array(reset($labeParts), ['mobile', 'ecommerce', 'print', 'tablet']) ?
-                reset($labeParts) :
+            $labelParts = explode(' ', $labelContent);
+            $channel   = in_array(reset($labelParts), ['mobile', 'ecommerce', 'print', 'tablet']) ?
+                reset($labelParts) :
                 null;
 
             if (null !== $channel) {

--- a/features/Context/Page/Base/Form.php
+++ b/features/Context/Page/Base/Form.php
@@ -500,7 +500,6 @@ class Form extends Base
      */
     public function checkFieldChoices($label, array $choices, $isExpected = true, $strict = false)
     {
-
         $select2 = $this->spin(function () use ($label) {
             $labelElement = $this->extractLabelElement($label);
             $container = $this->getClosest($labelElement, 'AknFieldContainer');
@@ -513,16 +512,15 @@ class Form extends Base
         $select2 = $this->decorate($select2, [Select2Decorator::class]);
         $selectChoices = $select2->getAvailableValues();
 
-        if ($isExpected) {
-            if ($strict) {
-                if ($selectChoices !== $choices) {
-                    throw new ExpectationException(sprintf(
-                        'Expecting to see exactly %s, %s found',
-                        json_encode($choices),
-                        json_encode($selectChoices)
-                    ), $this->getSession());
-                }
+        if ($isExpected && true === $strict) {
+            if ($selectChoices !== $choices) {
+                throw new ExpectationException(sprintf(
+                    'Expecting to see exactly %s, %s found',
+                    json_encode($choices),
+                    json_encode($selectChoices)
+                ), $this->getSession());
             }
+        } elseif ($isExpected) {
             foreach ($choices as $choice) {
                 if (!in_array($choice, $selectChoices)) {
                     throw new ExpectationException(sprintf(

--- a/features/Context/WebUser.php
+++ b/features/Context/WebUser.php
@@ -712,14 +712,15 @@ class WebUser extends RawMinkContext
 
     /**
      * @param string $not
+     * @param string $ordered
      * @param string $choices
      * @param string $label
      *
-     * @Then /^I should(?P<not> not)? see the choices? (?P<choices>.+) in (?P<label>.+)$/
+     * @Then /^I should(?P<not> not)? see the(?P<ordered> ordered)? choices? (?P<choices>.+) in (?P<label>.+)$/
      */
-    public function iShouldSeeTheChoicesInField($not, $choices, $label)
+    public function iShouldSeeTheChoicesInField($not, $choices, $label, $ordered = null)
     {
-        $this->getCurrentPage()->checkFieldChoices($label, $this->listToArray($choices), !$not);
+        $this->getCurrentPage()->checkFieldChoices($label, $this->listToArray($choices), !$not, $ordered !== null);
     }
 
     /**
@@ -1202,22 +1203,19 @@ class WebUser extends RawMinkContext
     }
 
     /**
-     * @Then /^I should see reorder handles$/
+     * @param string|null $not
+     *
+     * @throws ExpectationException
+     *
+     * @Then /^I should( not)? see reorder handles$/
      */
-    public function iShouldSeeReorderHandles()
+    public function iShouldSeeReorderHandles($not = null)
     {
-        if ($this->getCurrentPage()->countOrderableOptions() <= 0) {
-            throw $this->createExpectationException('No reorder handle found');
-        }
-    }
-
-    /**
-     * @Then /^I should not see reorder handles$/
-     */
-    public function iShouldNotSeeReorderHandles()
-    {
-        if ($this->getCurrentPage()->countOrderableOptions() > 0) {
-            throw $this->createExpectationException('Reorder handle was not expected');
+        $count = $this->getCurrentPage()->countOrderableOptions();
+        if ((null === $not && $count <= 0) || (null !== $not && $count > 0)) {
+            throw $this->createExpectationException(
+                sprintf("Expected to%s see reorder handle, %d found", $not, $count)
+            );
         }
     }
 

--- a/features/attribute/option/sort_attribute_options.feature
+++ b/features/attribute/option/sort_attribute_options.feature
@@ -13,18 +13,39 @@ Feature: Sort attribute options
       | Code            | size  |
       | Attribute group | Other |
     And I visit the "Values" tab
-    Then I should see the "Options" section
-    Then I should see "To manage options, please save the attribute first"
+    And I should see the "Options" section
+    And I should see "To manage options, please save the attribute first"
     And I save the attribute
-    Then I should see the flash message "Attribute successfully created"
-    And I check the "Automatic option sorting" switch
+    And I should see the flash message "Attribute successfully created"
 
   Scenario: Auto sorting disable reorder
-    Given I create the following attribute options:
+    Given I check the "Automatic option sorting" switch
+    When I create the following attribute options:
       | Code        |
       | small_size  |
       | medium_size |
       | large_size  |
     Then I should not see reorder handles
-    Given I uncheck the "Automatic option sorting" switch
+    And I should see "large_size medium_size small_size"
+    When I uncheck the "Automatic option sorting" switch
     Then I should see reorder handles
+    And I should see "small_size medium_size large_size"
+
+  Scenario: Display attribute options ordered in PEF
+    Given I check the "Automatic option sorting" switch
+    When I create the following attribute options:
+      | Code        |
+      | small_size  |
+      | medium_size |
+      | large_size  |
+    And I save the attribute
+    And I should not see the text "There are unsaved changes"
+    And I am on the products page
+    And I create a new product
+    And I fill in the following information in the popin:
+      | SKU | a_product |
+    And I press the "Save" button in the popin
+    And I should be on the product "a_product" edit page
+    And I add available attributes size
+    And I should see the ordered choices [large_size], [medium_size], [small_size] in size
+    

--- a/features/attribute/option/sort_attribute_options.feature
+++ b/features/attribute/option/sort_attribute_options.feature
@@ -47,5 +47,4 @@ Feature: Sort attribute options
     And I press the "Save" button in the popin
     And I should be on the product "a_product" edit page
     And I add available attributes size
-    And I should see the ordered choices [large_size], [medium_size], [small_size] in size
-    
+    Then I should see the ordered choices [large_size], [medium_size], [small_size] in size

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/repositories.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/repositories.yml
@@ -139,3 +139,4 @@ services:
         arguments:
             - '@doctrine.orm.entity_manager'
             - '%pim_catalog.entity.attribute_option.class%'
+            - '@pim_catalog.repository.attribute'

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/pim-attributeoptionview.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/pim-attributeoptionview.js
@@ -153,6 +153,9 @@ define(
                             this.model.set(editedModel.attributes);
                             this.clean();
                             this.stopEditItem();
+                            if (!this.parent.sortable) {
+                                this.parent.render();
+                            }
                         }.bind(this),
                         error: this.showValidationErrors.bind(this)
                     }
@@ -223,7 +226,7 @@ define(
 
         var ItemCollectionView = Backbone.View.extend({
             tagName: 'table',
-            className: 'AknGrid table attribute-option-view',
+            className: 'AknGrid AknGrid--unclickable table attribute-option-view',
             template: _.template(
                 '<!-- Pim/Bundle/EnrichBundle/Resources/public/js/pim-attributeoptionview.js -->' +
                 '<colgroup>' +
@@ -287,7 +290,11 @@ define(
                     code_label: __('Code')
                 }));
 
-                _.each(this.collection.models, function (attributeOptionItem) {
+
+
+                _.each(_.sortBy(this.collection.models, function (attributeOptionItem) {
+                    return !this.sortable ? attributeOptionItem.attributes.code : 0;
+                }.bind(this)), function (attributeOptionItem) {
                     this.addItem({item: attributeOptionItem});
                 }.bind(this));
 
@@ -498,6 +505,7 @@ define(
 
             mediator.on('attribute:auto_option_sorting:changed', function (autoSorting) {
                 itemCollectionView.updateSortableStatus(!autoSorting);
+                itemCollectionView.render();
             }.bind(this));
         };
     }

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/pim-attributeoptionview.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/pim-attributeoptionview.js
@@ -290,10 +290,8 @@ define(
                     code_label: __('Code')
                 }));
 
-
-
                 _.each(_.sortBy(this.collection.models, function (attributeOptionItem) {
-                    return !this.sortable ? attributeOptionItem.attributes.code : 0;
+                    return this.sortable ? 0 : attributeOptionItem.attributes.code;
                 }.bind(this)), function (attributeOptionItem) {
                     this.addItem({item: attributeOptionItem});
                 }.bind(this));

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/attribute-option/show.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/attribute-option/show.html
@@ -1,5 +1,5 @@
 <td class="AknGrid-bodyCell">
-    <span class="handle"><i class="icon-reorder"></i></span>
+    <span class="handle ui-sortable-handle"><i class="icon-reorder"></i></span>
     <span class="option-code"><%- item.code %></span>
 </td>
 <% _.each(locales, function (locale) { %>

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/lib/jquery-ui.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/lib/jquery-ui.less
@@ -8,3 +8,8 @@
 .ui-sortable-handle {
   cursor: move;
 }
+
+.ui-sortable.ui-sortable-disabled .ui-sortable-handle {
+  display: none;
+}
+


### PR DESCRIPTION
If fixes the autosort at 2 places:
- on attribute edition, you can enable/disable autosort, and it displays result in the list directly. Old order are kept, so you can disable autosort to get back to old one.
- on PEF, attributes are displayed ordered when option is enabled.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | y
| Added integration tests           | -
| Changelog updated                 | y
| Review and 2 GTM                  | Todo
| Migration script                  | -
| Tech Doc                          | -
