### PR TITLE
PIM-6393: behat about context kept when creating new category tree

### DIFF
--- a/features/Pim/Behat/Context/Domain/TreeContext.php
+++ b/features/Pim/Behat/Context/Domain/TreeContext.php
@@ -82,6 +82,24 @@ class TreeContext extends PimContext
     }
 
     /**
+     * @param string $tree
+     *
+     * @Then /^The tree "([^"]*)" should be open$/
+     */
+    public function theTreeShouldBeOpen($tree)
+    {
+        $categoryTree = $this->getCurrentPage()
+            ->getElement('Category tree');
+        $openTree = $categoryTree->findOpenTree();
+
+        if ($openTree !== $tree) {
+            throw $this->getMainContext()->createExpectationException(
+                sprintf('Expecting to see tree "%s" open, found "%s".', $tree, $openTree)
+            );
+        }
+    }
+
+    /**
      * @Given /^I blur the category node$/
      */
     public function iBlurTheNode()

--- a/features/Pim/Behat/Decorator/Tree/JsTreeDecorator.php
+++ b/features/Pim/Behat/Decorator/Tree/JsTreeDecorator.php
@@ -28,6 +28,18 @@ class JsTreeDecorator extends ElementDecorator
     }
 
     /**
+     * @return string
+     */
+    public function findOpenTree()
+    {
+        $tree = $this->spin(function () {
+            return $this->find('css', sprintf('.jstree-tree-toolbar .select2-choice .select2-chosen'));
+        }, 'Cannot find the open tree');
+
+        return $tree->getText();
+    }
+
+    /**
      * This method is spinned because the refresh of the tree result in a WebDriver\Exception\NoSuchElement
      * exception if the tree was found then immediately refreshed.
      *

--- a/features/category/create_a_category.feature
+++ b/features/category/create_a_category.feature
@@ -13,7 +13,9 @@ Feature: Create a category
     When I fill in the following information:
       | Code | shoe |
     And I save the category
-    Then I should be on the category "shoe" edit page
+    Then I should not see the text "There are unsaved changes."
+    And I should be on the category "shoe" edit page
+    And The tree "[shoe]" should be open
     And I should see "Tree successfully created"
 
   Scenario: Create a category node


### PR DESCRIPTION
In Enterprise when you create a new category tree the context of the tree was not switch to the new tree.
A behat was missing even and can be applied directly in CE.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | OK
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

