### PR TITLE
TIP-763: fix once and for all memory leaks in products' import

### DIFF
--- a/CHANGELOG-1.8.md
+++ b/CHANGELOG-1.8.md
@@ -22,6 +22,7 @@
 
 ### Constructors
 
+- Change the constructor of `Pim\Component\Connector\Writer\Database\ProductWriter` to replace `Akeneo\Component\StorageUtils\Detacher\BulkObjectDetacherInterface` by `Akeneo\Component\StorageUtils\Cache\CacheClearerInterface`.
 - Change the constructor of `Pim\Component\Catalog\Updater\AttributeGroupUpdater` to add `Akeneo\Component\Localization\TranslatableUpdater`
 - Change the constructor of `Pim\Bundle\EnrichBundle\Controller\JobTrackerController` to add `Oro\Bundle\SecurityBundle\SecurityFacade` and add an associative array
 - Change the constructor of `Pim\Bundle\ApiBundle\Controller\ProductController` to remove `Pim\Component\Api\Pagination\PaginatorInterface`

--- a/src/Pim/Bundle/ConnectorBundle/DependencyInjection/PimConnectorExtension.php
+++ b/src/Pim/Bundle/ConnectorBundle/DependencyInjection/PimConnectorExtension.php
@@ -25,6 +25,7 @@ class PimConnectorExtension extends Extension
         $loader->load('analyzers.yml');
         $loader->load('archiving.yml');
         $loader->load('array_converters.yml');
+        $loader->load('doctrine.yml');
         $loader->load('factories.yml');
         $loader->load('items.yml');
         $loader->load('jobs.yml');

--- a/src/Pim/Bundle/ConnectorBundle/Doctrine/UnitOfWorkAndRepositoriesClearer.php
+++ b/src/Pim/Bundle/ConnectorBundle/Doctrine/UnitOfWorkAndRepositoriesClearer.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Pim\Bundle\ConnectorBundle\Doctrine;
+
+use Akeneo\Component\StorageUtils\Cache\CacheClearerInterface;
+use Akeneo\Component\StorageUtils\Repository\CachedObjectRepositoryInterface;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Clear Doctrine's Unit of Work and all cached repositories registered here.
+ * This is only used by bulk operations.
+ *
+ * For instance {@see \Pim\Component\Connector\Writer\Database\ProductWriter} for more information.
+ *
+ * @author    Julien Janvier <j.janvier@gmail.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class UnitOfWorkAndRepositoriesClearer implements CacheClearerInterface
+{
+    /** @var CachedObjectRepositoryInterface[] */
+    protected $cachedRepositoriesToClear;
+
+    /** @var EntityManagerInterface */
+    protected $entityManager;
+
+    /**
+     * @param EntityManagerInterface            $entityManager
+     * @param CachedObjectRepositoryInterface[] $cachedRepositoriesToClear
+     */
+    public function __construct(EntityManagerInterface $entityManager, array $cachedRepositoriesToClear)
+    {
+        $this->cachedRepositoriesToClear = $cachedRepositoriesToClear;
+        $this->entityManager = $entityManager;
+    }
+
+    public function clear()
+    {
+        foreach ($this->cachedRepositoriesToClear as $repository) {
+            $repository->clear();
+        }
+
+        $this->entityManager->clear();
+    }
+}

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/doctrine.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/doctrine.yml
@@ -1,0 +1,15 @@
+parameters:
+    pim_connector.doctrine.cache_clearer.class: 'Pim\Bundle\ConnectorBundle\Doctrine\UnitOfWorkAndRepositoriesClearer'
+
+services:
+    pim_connector.doctrine.cache_clearer:
+        class: '%pim_connector.doctrine.cache_clearer.class%'
+        arguments:
+            - '@doctrine.orm.entity_manager'
+            -
+                - '@pim_catalog.repository.cached_attribute'
+                - '@pim_catalog.repository.cached_attribute_option'
+                - '@pim_catalog.repository.cached_family'
+                - '@pim_catalog.repository.cached_category'
+                - '@pim_catalog.repository.cached_channel'
+                - '@pim_catalog.repository.cached_locale'

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/writers.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/writers.yml
@@ -47,7 +47,7 @@ services:
         arguments:
             - '@pim_versioning.manager.version'
             - '@pim_catalog.saver.product'
-            - '@akeneo_storage_utils.doctrine.object_detacher'
+            - '@pim_connector.doctrine.cache_clearer'
 
     pim_connector.writer.database.product_association:
         class: '%pim_connector.writer.database.product_association.class%'

--- a/src/Pim/Bundle/ConnectorBundle/spec/Doctrine/UnitOfWorkAndRepositoriesClearerSpec.php
+++ b/src/Pim/Bundle/ConnectorBundle/spec/Doctrine/UnitOfWorkAndRepositoriesClearerSpec.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace spec\Pim\Bundle\ConnectorBundle\Doctrine;
+
+use Akeneo\Component\StorageUtils\Repository\CachedObjectRepositoryInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use PhpSpec\ObjectBehavior;
+
+class UnitOfWorkAndRepositoriesClearerSpec extends ObjectBehavior
+{
+    function let(
+        EntityManagerInterface $entityManager,
+        CachedObjectRepositoryInterface $localeRepository,
+        CachedObjectRepositoryInterface $currencyRepository
+    ) {
+        $this->beConstructedWith($entityManager, [$localeRepository, $currencyRepository]);
+    }
+
+    function it_clears_both_uow_and_repositories($entityManager, $localeRepository, $currencyRepository)
+    {
+        $localeRepository->clear()->shouldBeCalled();
+        $currencyRepository->clear()->shouldBeCalled();
+        $entityManager->clear()->shouldBeCalled();
+
+        $this->clear();
+    }
+}

--- a/src/Pim/Component/Connector/Writer/Database/ProductWriter.php
+++ b/src/Pim/Component/Connector/Writer/Database/ProductWriter.php
@@ -5,7 +5,7 @@ namespace Pim\Component\Connector\Writer\Database;
 use Akeneo\Component\Batch\Item\ItemWriterInterface;
 use Akeneo\Component\Batch\Model\StepExecution;
 use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
-use Akeneo\Component\StorageUtils\Detacher\BulkObjectDetacherInterface;
+use Akeneo\Component\StorageUtils\Cache\CacheClearerInterface;
 use Akeneo\Component\StorageUtils\Saver\BulkSaverInterface;
 use Pim\Bundle\VersioningBundle\Manager\VersionManager;
 use Pim\Component\Catalog\Model\ProductInterface;
@@ -28,24 +28,24 @@ class ProductWriter implements ItemWriterInterface, StepExecutionAwareInterface
     /** @var BulkSaverInterface */
     protected $productSaver;
 
-    /** @var BulkObjectDetacherInterface */
-    protected $detacher;
+    /** @var CacheClearerInterface */
+    protected $cacheClearer;
 
     /**
      * Constructor
      *
-     * @param VersionManager              $versionManager
-     * @param BulkSaverInterface          $productSaver
-     * @param BulkObjectDetacherInterface $detacher
+     * @param VersionManager        $versionManager
+     * @param BulkSaverInterface    $productSaver
+     * @param CacheClearerInterface $cacheClearer
      */
     public function __construct(
         VersionManager $versionManager,
         BulkSaverInterface $productSaver,
-        BulkObjectDetacherInterface $detacher
+        CacheClearerInterface $cacheClearer
     ) {
         $this->versionManager = $versionManager;
         $this->productSaver = $productSaver;
-        $this->detacher = $detacher;
+        $this->cacheClearer = $cacheClearer;
     }
 
     /**
@@ -61,7 +61,7 @@ class ProductWriter implements ItemWriterInterface, StepExecutionAwareInterface
         }
 
         $this->productSaver->saveAll($items);
-        $this->detacher->detachAll($items);
+        $this->cacheClearer->clear();
     }
 
     /**

--- a/src/Pim/Component/Connector/spec/Writer/Database/ProductWriterSpec.php
+++ b/src/Pim/Component/Connector/spec/Writer/Database/ProductWriterSpec.php
@@ -4,7 +4,7 @@ namespace spec\Pim\Component\Connector\Writer\Database;
 
 use Akeneo\Component\Batch\Job\JobParameters;
 use Akeneo\Component\Batch\Model\StepExecution;
-use Akeneo\Component\StorageUtils\Detacher\BulkObjectDetacherInterface;
+use Akeneo\Component\StorageUtils\Cache\CacheClearerInterface;
 use Akeneo\Component\StorageUtils\Saver\BulkSaverInterface;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Model\ProductInterface;
@@ -15,10 +15,10 @@ class ProductWriterSpec extends ObjectBehavior
     function let(
         VersionManager $versionManager,
         BulkSaverInterface $productSaver,
-        BulkObjectDetacherInterface $detacher,
+        CacheClearerInterface $cacheClearer,
         StepExecution $stepExecution
     ) {
-        $this->beConstructedWith($versionManager, $productSaver, $detacher);
+        $this->beConstructedWith($versionManager, $productSaver, $cacheClearer);
         $this->setStepExecution($stepExecution);
     }
 


### PR DESCRIPTION
Currently, in the master branch, this import leaks again. We introduced regressions with the new systems about completenesses and unique data.

This PR aims to fix once and for all the problem by clearing the UoW each time we write products (at each bulk of the batch). We also have to clear all the data we have kept in our cached repositories (we could totally optimize this part, but we'll see later).

This PR works perfectly. I imported 50K products (medium catalog) without any problem.

Others PRs are planned to improve the import time.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Y
| Added Behats                      | 
| Added integration tests           | 
| Changelog updated                 | Y
| Review and 2 GTM                  | 
| Micro Demo to the PO (Story only) | 
| Migration script                  | -
| Tech Doc                          | -
