### PR TITLE
TIP-749: Fix ES index mapping total fields limit

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Resources/elasticsearch/index_configuration.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/elasticsearch/index_configuration.yml
@@ -202,3 +202,8 @@ settings:
                 char_filter: ['html_strip', 'newline_pattern']
                 type: 'custom'
                 tokenizer: 'standard'
+    mapping:
+        # ES default value is 1000. This value can be too low for big catalogs.
+        # For more information see https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping.html#mapping-limit-settings
+        total_fields:
+            limit: 3000

--- a/src/Pim/Component/Catalog/Builder/ProductBuilder.php
+++ b/src/Pim/Component/Catalog/Builder/ProductBuilder.php
@@ -286,7 +286,7 @@ class ProductBuilder implements ProductBuilderInterface
                 $requiredValues = $this->valuesResolver->resolveEligibleValues([$attribute]);
 
                 foreach ($requiredValues as $value) {
-                    $this->addOrReplaceValue($product, $attribute, $value['scope'], $value['locale'], false);
+                    $this->addOrReplaceValue($product, $attribute, $value['locale'], $value['scope'], false);
                 }
             }
         }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

In ES 5.X was introduced the settings `mapping.total_fields.limit`. Its default value is set to 1000.
see the PR https://github.com/elastic/elasticsearch/pull/17357.

In this PR, we bump up this settings to:
- Number of fields in large catalog: 1284 (counting the columns in a CSV file)
- Multiplied by 2 (=2568) and rounded up to 3000.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          |  Todo

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
