### PR TITLE
TIP-763: significant and easy improvements regarding products import

### DIFF
--- a/features/Context/CatalogConfigurationContext.php
+++ b/features/Context/CatalogConfigurationContext.php
@@ -56,6 +56,8 @@ class CatalogConfigurationContext extends RawMinkContext
         $this->initializeReferenceRepository();
 
         $this->loadCatalog($this->getConfigurationFiles($catalog));
+        
+        $this->getMainContext()->getContainer()->get('pim_connector.doctrine.cache_clearer')->clear();
     }
 
     /**

--- a/features/Context/WebUser.php
+++ b/features/Context/WebUser.php
@@ -1872,6 +1872,8 @@ class WebUser extends RawMinkContext
 
             return $jobExecution && !$jobExecution->isRunning();
         }, sprintf('The job execution of "%s" was too long', $code));
+
+        $this->getMainContext()->getContainer()->get('pim_connector.doctrine.cache_clearer')->clear();
     }
 
     /**

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/factories.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/factories.yml
@@ -197,7 +197,7 @@ services:
         class: '%pim_catalog.factory.product_value.option.class%'
         public: false
         arguments:
-            - '@pim_catalog.repository.attribute_option'
+            - '@pim_catalog.repository.cached_attribute_option'
             - '%pim_catalog.entity.product_value.option.class%'
             - 'pim_catalog_simpleselect'
         tags:
@@ -207,7 +207,7 @@ services:
         class: '%pim_catalog.factory.product_value.options.class%'
         public: false
         arguments:
-            - '@pim_catalog.repository.attribute_option'
+            - '@pim_catalog.repository.cached_attribute_option'
             - '%pim_catalog.entity.product_value.options.class%'
             - 'pim_catalog_multiselect'
         tags:

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/factories.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/factories.yml
@@ -86,7 +86,7 @@ services:
     pim_catalog.factory.price:
         class: '%pim_catalog.factory.price.class%'
         arguments:
-            - '@pim_catalog.repository.currency'
+            - '@pim_catalog.repository.cached_currency'
             - '%pim_catalog.entity.product_price.class%'
 
     pim_catalog.factory.group:

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/repositories.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/repositories.yml
@@ -157,3 +157,8 @@ services:
         class: '%akeneo_storage_utils.repository.base_cached_object.class%'
         arguments:
             - '@pim_catalog.repository.locale'
+
+    pim_catalog.repository.cached_currency:
+        class: '%akeneo_storage_utils.repository.base_cached_object.class%'
+        arguments:
+            - '@pim_catalog.repository.currency'

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/array_converters.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/array_converters.yml
@@ -286,9 +286,9 @@ services:
     pim_connector.array_converter.flat_to_standard.product.attribute_column_info_extractor:
         class: '%pim_connector.array_converter.flat_to_standard.product.attribute_column_info_extractor.class%'
         arguments:
-            - '@pim_catalog.repository.attribute'
-            - '@pim_catalog.repository.channel'
-            - '@pim_catalog.repository.locale'
+            - '@pim_catalog.repository.cached_attribute'
+            - '@pim_catalog.repository.cached_channel'
+            - '@pim_catalog.repository.cached_locale'
             - '@pim_connector.array_converter.flat_to_standard.product.association_columns_resolver'
 
     # product value converters

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/doctrine.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/doctrine.yml
@@ -13,3 +13,4 @@ services:
                 - '@pim_catalog.repository.cached_category'
                 - '@pim_catalog.repository.cached_channel'
                 - '@pim_catalog.repository.cached_locale'
+                - '@pim_catalog.repository.cached_currency'

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/steps.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/steps.yml
@@ -1,6 +1,7 @@
 parameters:
     pim_connector.step.validator.class: Pim\Component\Connector\Step\ValidatorStep
     pim_connector.step.tasklet.class:   Pim\Component\Connector\Step\TaskletStep
+    pim_connector.step.product.import.bulk_size: 1000
 
 services:
     # Validator steps -------------------------------------------------------------------------------------------------
@@ -72,6 +73,7 @@ services:
             - '@pim_connector.reader.file.csv_product'
             - '@pim_connector.processor.denormalization.product'
             - '@pim_connector.writer.database.product'
+            - '%pim_connector.step.product.import.bulk_size%'
 
     pim_connector.step.csv_product.import_associations:
         class: '%pim_connector.step.item_step.class%'
@@ -348,6 +350,7 @@ services:
             - '@pim_connector.reader.file.xlsx_product'
             - '@pim_connector.processor.denormalization.product'
             - '@pim_connector.writer.database.product'
+            - '%pim_connector.step.product.import.bulk_size%'
 
     pim_connector.step.xlsx_product.import_associations:
         class: '%pim_connector.step.item_step.class%'

--- a/src/Pim/Component/Catalog/Factory/PriceFactory.php
+++ b/src/Pim/Component/Catalog/Factory/PriceFactory.php
@@ -3,8 +3,8 @@
 namespace Pim\Component\Catalog\Factory;
 
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Pim\Component\Catalog\Model\ProductPriceInterface;
-use Pim\Component\Catalog\Repository\CurrencyRepositoryInterface;
 
 /**
  * Creates and configures a price instance.
@@ -15,17 +15,17 @@ use Pim\Component\Catalog\Repository\CurrencyRepositoryInterface;
  */
 class PriceFactory
 {
-    /** @var CurrencyRepositoryInterface */
+    /** @var IdentifiableObjectRepositoryInterface */
     protected $currencyRepository;
 
     /** @var string */
     protected $priceClass;
 
     /**
-     * @param CurrencyRepositoryInterface $currencyRepository
-     * @param string                      $priceClass
+     * @param IdentifiableObjectRepositoryInterface $currencyRepository
+     * @param string                                $priceClass
      */
-    public function __construct(CurrencyRepositoryInterface $currencyRepository, $priceClass)
+    public function __construct(IdentifiableObjectRepositoryInterface $currencyRepository, $priceClass)
     {
         $this->currencyRepository = $currencyRepository;
         $this->priceClass = $priceClass;

--- a/src/Pim/Component/Catalog/Factory/ProductValue/OptionProductValueFactory.php
+++ b/src/Pim/Component/Catalog/Factory/ProductValue/OptionProductValueFactory.php
@@ -2,12 +2,11 @@
 
 namespace Pim\Component\Catalog\Factory\ProductValue;
 
-use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
+use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Pim\Component\Catalog\Exception\InvalidOptionException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\AttributeOptionInterface;
-use Pim\Component\Catalog\Repository\AttributeOptionRepositoryInterface;
 
 /**
  * Factory that creates option (simple-select) product values.
@@ -20,7 +19,7 @@ use Pim\Component\Catalog\Repository\AttributeOptionRepositoryInterface;
  */
 class OptionProductValueFactory implements ProductValueFactoryInterface
 {
-    /** @var AttributeOptionRepositoryInterface */
+    /** @var IdentifiableObjectRepositoryInterface */
     protected $attrOptionRepository;
 
     /** @var string */
@@ -30,12 +29,12 @@ class OptionProductValueFactory implements ProductValueFactoryInterface
     protected $supportedAttributeType;
 
     /**
-     * @param AttributeOptionRepositoryInterface $attrOptionRepository
-     * @param string                             $productValueClass
-     * @param string                             $supportedAttributeType
+     * @param IdentifiableObjectRepositoryInterface $attrOptionRepository
+     * @param string                                $productValueClass
+     * @param string                                $supportedAttributeType
      */
     public function __construct(
-        AttributeOptionRepositoryInterface $attrOptionRepository,
+        IdentifiableObjectRepositoryInterface $attrOptionRepository,
         $productValueClass,
         $supportedAttributeType
     ) {

--- a/src/Pim/Component/Catalog/Factory/ProductValue/OptionsProductValueFactory.php
+++ b/src/Pim/Component/Catalog/Factory/ProductValue/OptionsProductValueFactory.php
@@ -3,10 +3,10 @@
 namespace Pim\Component\Catalog\Factory\ProductValue;
 
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
+use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Pim\Component\Catalog\Exception\InvalidOptionException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\AttributeOptionInterface;
-use Pim\Component\Catalog\Repository\AttributeOptionRepositoryInterface;
 
 /**
  * Factory that creates options (multi-select) product values.
@@ -19,7 +19,7 @@ use Pim\Component\Catalog\Repository\AttributeOptionRepositoryInterface;
  */
 class OptionsProductValueFactory implements ProductValueFactoryInterface
 {
-    /** @var AttributeOptionRepositoryInterface */
+    /** @var IdentifiableObjectRepositoryInterface */
     protected $attrOptionRepository;
 
     /** @var string */
@@ -29,12 +29,12 @@ class OptionsProductValueFactory implements ProductValueFactoryInterface
     protected $supportedAttributeType;
 
     /**
-     * @param AttributeOptionRepositoryInterface $attrOptionRepository
+     * @param IdentifiableObjectRepositoryInterface $attrOptionRepository
      * @param string $productValueClass
      * @param $supportedAttributeType
      */
     public function __construct(
-        AttributeOptionRepositoryInterface $attrOptionRepository,
+        IdentifiableObjectRepositoryInterface $attrOptionRepository,
         $productValueClass,
         $supportedAttributeType
     ) {

--- a/src/Pim/Component/Catalog/Localization/Localizer/AttributeConverter.php
+++ b/src/Pim/Component/Catalog/Localization/Localizer/AttributeConverter.php
@@ -25,6 +25,9 @@ class AttributeConverter implements AttributeConverterInterface
     /** @var ConstraintViolationListInterface */
     protected $violations;
 
+    /** @var array[] */
+    protected $attributeTypeByCodes;
+
     /**
      * @param LocalizerRegistryInterface   $localizerRegistry
      * @param AttributeRepositoryInterface $attributeRepository
@@ -35,6 +38,7 @@ class AttributeConverter implements AttributeConverterInterface
     ) {
         $this->localizerRegistry = $localizerRegistry;
         $this->attributeRepository = $attributeRepository;
+        $this->attributeTypeByCodes = [];
     }
 
     /**
@@ -43,11 +47,11 @@ class AttributeConverter implements AttributeConverterInterface
     public function convertToDefaultFormats(array $items, array $options = [])
     {
         $this->violations = new ConstraintViolationList();
-        $attributeTypes = $this->attributeRepository->getAttributeTypeByCodes(array_keys($items));
+        $this->cacheAttributeTypeByCodes(array_keys($items));
 
         foreach ($items as $code => $item) {
-            if (isset($attributeTypes[$code])) {
-                $localizer = $this->localizerRegistry->getLocalizer($attributeTypes[$code]);
+            if (isset($this->attributeTypeByCodes[$code])) {
+                $localizer = $this->localizerRegistry->getLocalizer($this->attributeTypeByCodes[$code]);
 
                 if (null !== $localizer) {
                     foreach ($item as $index => $data) {
@@ -128,11 +132,11 @@ class AttributeConverter implements AttributeConverterInterface
      */
     public function convertToLocalizedFormats(array $items, array $options = [])
     {
-        $attributeTypes = $this->attributeRepository->getAttributeTypeByCodes(array_keys($items));
+        $this->cacheAttributeTypeByCodes(array_keys($items));
 
         foreach ($items as $code => $item) {
-            if (isset($attributeTypes[$code])) {
-                $localizer = $this->localizerRegistry->getLocalizer($attributeTypes[$code]);
+            if (isset($this->attributeTypeByCodes[$code])) {
+                $localizer = $this->localizerRegistry->getLocalizer($this->attributeTypeByCodes[$code]);
 
                 if (null !== $localizer) {
                     foreach ($item as $index => $data) {
@@ -188,5 +192,16 @@ class AttributeConverter implements AttributeConverterInterface
         }
 
         return sprintf('values[%s]', $path);
+    }
+
+    /**
+     * @param array $codes
+     */
+    private function cacheAttributeTypeByCodes(array $codes)
+    {
+        $codesToFetch = array_diff($codes, array_keys($this->attributeTypeByCodes));
+
+        // we can have numeric keys here, we can't use array_merge :(
+        $this->attributeTypeByCodes += $this->attributeRepository->getAttributeTypeByCodes($codesToFetch);
     }
 }

--- a/src/Pim/Component/Catalog/spec/Factory/PriceFactorySpec.php
+++ b/src/Pim/Component/Catalog/spec/Factory/PriceFactorySpec.php
@@ -3,15 +3,15 @@
 namespace spec\Pim\Component\Catalog\Factory;
 
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use PhpSpec\ObjectBehavior;
 use Pim\Bundle\CatalogBundle\Entity\Currency;
 use Pim\Component\Catalog\Factory\PriceFactory;
 use Pim\Component\Catalog\Model\ProductPrice;
-use Pim\Component\Catalog\Repository\CurrencyRepositoryInterface;
 
 class PriceFactorySpec extends ObjectBehavior
 {
-    function let(CurrencyRepositoryInterface $currencyRepository)
+    function let(IdentifiableObjectRepositoryInterface $currencyRepository)
     {
         $this->beConstructedWith($currencyRepository, ProductPrice::class);
     }

--- a/src/Pim/Component/Catalog/spec/Factory/ProductValue/OptionProductValueFactorySpec.php
+++ b/src/Pim/Component/Catalog/spec/Factory/ProductValue/OptionProductValueFactorySpec.php
@@ -4,17 +4,17 @@ namespace spec\Pim\Component\Catalog\Factory\ProductValue;
 
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
+use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Factory\ProductValue\OptionProductValueFactory;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\AttributeOptionInterface;
 use Pim\Component\Catalog\ProductValue\ScalarProductValue;
-use Pim\Component\Catalog\Repository\AttributeOptionRepositoryInterface;
 use Prophecy\Argument;
 
 class OptionProductValueFactorySpec extends ObjectBehavior
 {
-    function let(AttributeOptionRepositoryInterface $attrOptionRepository)
+    function let(IdentifiableObjectRepositoryInterface $attrOptionRepository)
     {
         $this->beConstructedWith($attrOptionRepository, ScalarProductValue::class, 'pim_catalog_simpleselect');
     }

--- a/src/Pim/Component/Catalog/spec/Factory/ProductValue/OptionsProductValueFactorySpec.php
+++ b/src/Pim/Component/Catalog/spec/Factory/ProductValue/OptionsProductValueFactorySpec.php
@@ -4,18 +4,17 @@ namespace spec\Pim\Component\Catalog\Factory\ProductValue;
 
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
-use Doctrine\Common\Collections\ArrayCollection;
+use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Factory\ProductValue\OptionsProductValueFactory;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\AttributeOptionInterface;
 use Pim\Component\Catalog\ProductValue\ScalarProductValue;
-use Pim\Component\Catalog\Repository\AttributeOptionRepositoryInterface;
 use Prophecy\Argument;
 
 class OptionsProductValueFactorySpec extends ObjectBehavior
 {
-    function let(AttributeOptionRepositoryInterface $attributeOptionRepository)
+    function let(IdentifiableObjectRepositoryInterface $attributeOptionRepository)
     {
         $this->beConstructedWith($attributeOptionRepository, ScalarProductValue::class, 'pim_catalog_multiselect');
     }

--- a/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Product/AttributeColumnInfoExtractor.php
+++ b/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Product/AttributeColumnInfoExtractor.php
@@ -2,11 +2,8 @@
 
 namespace Pim\Component\Connector\ArrayConverter\FlatToStandard\Product;
 
+use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Pim\Component\Catalog\Model\AttributeInterface;
-use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
-use Pim\Component\Catalog\Repository\ChannelRepositoryInterface;
-use Pim\Component\Catalog\Repository\LocaleRepositoryInterface;
-use Pim\Component\Connector\ArrayConverter\FlatToStandard\Product\AssociationColumnsResolver;
 
 /**
  * Extracts attribute field information
@@ -21,13 +18,13 @@ class AttributeColumnInfoExtractor
     const FIELD_SEPARATOR = '-';
     const UNIT_SEPARATOR = ' ';
 
-    /** @var AttributeRepositoryInterface */
+    /** @var IdentifiableObjectRepositoryInterface */
     protected $attributeRepository;
 
-    /** @var ChannelRepositoryInterface */
+    /** @var IdentifiableObjectRepositoryInterface */
     protected $channelRepository;
 
-    /** @var LocaleRepositoryInterface */
+    /** @var IdentifiableObjectRepositoryInterface */
     protected $localeRepository;
 
     /** @var AssociationColumnsResolver */
@@ -40,15 +37,15 @@ class AttributeColumnInfoExtractor
     protected $excludedFieldNames;
 
     /**
-     * @param AttributeRepositoryInterface $attributeRepository
-     * @param ChannelRepositoryInterface   $channelRepository
-     * @param LocaleRepositoryInterface    $localeRepository
-     * @param AssociationColumnsResolver   $assoColumnResolver
+     * @param IdentifiableObjectRepositoryInterface $attributeRepository
+     * @param IdentifiableObjectRepositoryInterface $channelRepository
+     * @param IdentifiableObjectRepositoryInterface $localeRepository
+     * @param AssociationColumnsResolver            $assoColumnResolver
      */
     public function __construct(
-        AttributeRepositoryInterface $attributeRepository,
-        ChannelRepositoryInterface $channelRepository,
-        LocaleRepositoryInterface $localeRepository,
+        IdentifiableObjectRepositoryInterface $attributeRepository,
+        IdentifiableObjectRepositoryInterface $channelRepository,
+        IdentifiableObjectRepositoryInterface $localeRepository,
         AssociationColumnsResolver $assoColumnResolver = null
     ) {
         $this->attributeRepository = $attributeRepository;
@@ -88,7 +85,6 @@ class AttributeColumnInfoExtractor
         if (!isset($this->fieldNameInfoCache[$fieldName]) && !in_array($fieldName, $this->excludedFieldNames)) {
             $explodedFieldName = explode(self::FIELD_SEPARATOR, $fieldName);
             $attributeCode = $explodedFieldName[0];
-            // TODO: We re-fetch attribute here but we did a findAll in another service (╯°□°)╯︵ ┻━┻
             $attribute = $this->attributeRepository->findOneByIdentifier($attributeCode);
 
             if (null !== $attribute) {

--- a/src/Pim/Component/Connector/spec/ArrayConverter/FlatToStandard/Product/AttributeColumnInfoExtractorSpec.php
+++ b/src/Pim/Component/Connector/spec/ArrayConverter/FlatToStandard/Product/AttributeColumnInfoExtractorSpec.php
@@ -2,13 +2,11 @@
 
 namespace spec\Pim\Component\Connector\ArrayConverter\FlatToStandard\Product;
 
+use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\ChannelInterface;
 use Pim\Component\Catalog\Model\LocaleInterface;
-use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
-use Pim\Component\Catalog\Repository\ChannelRepositoryInterface;
-use Pim\Component\Catalog\Repository\LocaleRepositoryInterface;
 use Pim\Component\Connector\ArrayConverter\FlatToStandard\Product\AssociationColumnsResolver;
 
 class AttributeColumnInfoExtractorSpec extends ObjectBehavior
@@ -19,9 +17,9 @@ class AttributeColumnInfoExtractorSpec extends ObjectBehavior
     const LOCALE_CLASS = 'Pim\Bundle\CatalogBundle\Entity\Locale';
 
     function let(
-        AttributeRepositoryInterface $attributeRepository,
-        ChannelRepositoryInterface $channelRepository,
-        LocaleRepositoryInterface $localeRepository,
+        IdentifiableObjectRepositoryInterface $attributeRepository,
+        IdentifiableObjectRepositoryInterface $channelRepository,
+        IdentifiableObjectRepositoryInterface $localeRepository,
         AssociationColumnsResolver $assoColumnResolver
     ) {
         $this->beConstructedWith($attributeRepository, $channelRepository, $localeRepository, $assoColumnResolver);


### PR DESCRIPTION
The following benchmarks have been executed with a subset of the medium catalog (10K products), on my local machine. Soon, we'll perform benchmarks on a proper environment to get more reliable results.

## TL;DR

Before this PR, on master: 13:30
With this PR: 9:07
PIM 1.7  with Mongo and PHP 7.1: 10:51

We could go further in the enhancements, but the results are good enough for now. Even if the completeness is calculated in a POO way and if products are indexed in ES, with this PR, we are faster than PIM 1.7 with PHP 7.1. And we still have plenty of ways to improve the imports:
- continue to track "avoidable" MySQL queries
- find PHP hotspots with Blackfire

If somebody is interested by this topic, I'd be more than happy to help him/her :)

## Improvements and results

Before this PR:
```
jjanvier:pcd$ /usr/bin/time php7.1 app/console akeneo:batch:job csv_product_import -e prod                                                                           {master}
[2017-06-12 16:08:43] batch.DEBUG: Job execution starting: startTime=, endTime=, updatedTime=, status=2, exitStatus=[UNKNOWN] , exitDescription=[], job=[csv_product_import] [] []
[2017-06-12 16:08:43] batch.INFO: Step execution starting: id=0, name=[validation], status=[2], exitCode=[EXECUTING], exitDescription=[] [] []
[2017-06-12 16:08:43] batch.DEBUG: Step execution success: id= 36 [] []
[2017-06-12 16:08:43] batch.DEBUG: Step execution complete: id=36, name=[validation], status=[1], exitCode=[EXECUTING], exitDescription=[] [] []
[2017-06-12 16:08:43] batch.INFO: Step execution starting: id=0, name=[import], status=[2], exitCode=[EXECUTING], exitDescription=[] [] []
[2017-06-12 16:20:21] batch.DEBUG: Step execution success: id= 37 [] []
[2017-06-12 16:20:21] batch.DEBUG: Step execution complete: id=37, name=[import], status=[1], exitCode=[EXECUTING], exitDescription=[] [] []
[2017-06-12 16:20:21] batch.INFO: Step execution starting: id=0, name=[import_associations], status=[2], exitCode=[EXECUTING], exitDescription=[] [] []
[2017-06-12 16:22:13] batch.DEBUG: Step execution success: id= 38 [] []
[2017-06-12 16:22:13] batch.DEBUG: Step execution complete: id=38, name=[import_associations], status=[1], exitCode=[EXECUTING], exitDescription=[] [] []
[2017-06-12 16:22:13] batch.DEBUG: Upgrading JobExecution status: startTime=2017-06-12T14:08:43+00:00, endTime=, updatedTime=, status=3, exitStatus=[UNKNOWN] , exitDescription=[], job=[csv_product_import] [] []
Import csv_product_import has been successfully executed.
416.71user 12.69system 13:30.95elapsed 52%CPU (0avgtext+0avgdata 394200maxresident)k
368inputs+56760outputs (40major+139261minor)pagefaults 0swaps
```

After this PR:
```
jjanvier:pcd$ /usr/bin/time php7.1 app/console akeneo:batch:job csv_product_import -e prod                                                                          {TIP-749}
[2017-06-12 19:11:31] batch.DEBUG: Job execution starting: startTime=, endTime=, updatedTime=, status=2, exitStatus=[UNKNOWN] , exitDescription=[], job=[csv_product_import] [] []
[2017-06-12 19:11:31] batch.INFO: Step execution starting: id=0, name=[validation], status=[2], exitCode=[EXECUTING], exitDescription=[] [] []
[2017-06-12 19:11:31] batch.DEBUG: Step execution success: id= 36 [] []
[2017-06-12 19:11:31] batch.DEBUG: Step execution complete: id=36, name=[validation], status=[1], exitCode=[EXECUTING], exitDescription=[] [] []
[2017-06-12 19:11:31] batch.INFO: Step execution starting: id=0, name=[import], status=[2], exitCode=[EXECUTING], exitDescription=[] [] []
[2017-06-12 19:19:25] batch.DEBUG: Step execution success: id= 37 [] []
[2017-06-12 19:19:25] batch.DEBUG: Step execution complete: id=37, name=[import], status=[1], exitCode=[EXECUTING], exitDescription=[] [] []
[2017-06-12 19:19:25] batch.INFO: Step execution starting: id=0, name=[import_associations], status=[2], exitCode=[EXECUTING], exitDescription=[] [] []
[2017-06-12 19:20:28] batch.DEBUG: Step execution success: id= 38 [] []
[2017-06-12 19:20:28] batch.DEBUG: Step execution complete: id=38, name=[import_associations], status=[1], exitCode=[EXECUTING], exitDescription=[] [] []
[2017-06-12 19:20:28] batch.DEBUG: Upgrading JobExecution status: startTime=2017-06-12T17:11:31+00:00, endTime=, updatedTime=, status=3, exitStatus=[UNKNOWN] , exitDescription=[], job=[csv_product_import] [] []
Import csv_product_import has been successfully executed.
395.64user 4.96system 8:57.82elapsed 74%CPU (0avgtext+0avgdata 603040maxresident)k
35784inputs+56760outputs (127major+146913minor)pagefaults 0swaps
```

## Explanations

### Hunting MySQL queries
With @BitOne we noticed that during a products import, MySQL was consuming ~40% of the CPU, which is not a regular situation for a PHP application. It clearly indicated a bottleneck on the MySQL side. By using some black voodoo CTO magic, we have been able to extract the top 10 MySQL queries that were executed during this 10K import (see below). Some easy hotspots have been identified and fixed by this PR.


Here are the top 13 SQL queries that were or are executed during the import:

 
| status | number of executions | query 
| ------ | -------------------- | ---------------------------
| deleted by https://github.com/akeneo/pim-community-dev/pull/6267/commits/5081e1f2715043c591f02093e91a0a3c3b5def50 | ~~329802~~ | ~~SELECT p0_.id AS id_0, p0_.code AS code_1, p0_.sort_order AS sort_order_2, p0_.attribute_id AS attribute_id_3 FROM pim_catalog_attribute_option p0_ INNER JOIN pim_catalog_attribute p1_ ON p0_.attribute_id = p1_.id WHERE p1_.code = 'S' AND p0_.code = 'S'~~
| deleted by https://github.com/akeneo/pim-community-dev/pull/6267/commits/22916d401373324bffeb43990dc2bf5374ff66a5 | ~~294840~~ | ~~SELECT t0.id AS id_1, t0.code AS code_2, t0.is_activated AS is_activated_3 FROM pim_catalog_currency t0 WHERE t0.code = 'S' LIMIT N~~
| OK     |  99990 | INSERT INTO pim_catalog_completeness (ratio, missing_count, required_count, locale_id, channel_id, product_id) VALUES (N, N, N, N, N, N)
| OK     |  48880 | INSERT INTO pim_catalog_completeness_missing_attribute (completeness_id, missing_attribute_id) VALUES (N, N)
| OK     |  19998 | INSERT INTO pim_catalog_category_product (product_id, category_id) VALUES (N, N)
| OK     |  19998 | SELECT t0.id AS id_1, t0.is_enabled AS is_enabled_2, t0.identifier AS identifier_3, t0.raw_values AS raw_values_4, t0.created AS created_5, t0.updated AS updated_6, t0.family_id AS family_id_7 FROM pim_catalog_product t0 WHERE t0.identifier = 'S' LIMIT N
| OK     |  19998 | SELECT t0.id AS id_1, t0.association_type_id AS association_type_id_2, t0.owner_id AS owner_id_3 FROM pim_catalog_association t0 WHERE t0.owner_id = N
| deleted by https://github.com/akeneo/pim-community-dev/pull/6267/commits/f656af46f9b5123a217ec0287bfd55823dd4a6ed  |  ~~19998~~ | ~~SELECT p0_.code AS code_0, p0_.attribute_type AS attribute_type_1 FROM pim_catalog_attribute p0_ WHERE p0_.code IN ('S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S')~~
| reduced by https://github.com/akeneo/pim-community-dev/pull/6267/commits/8797614518e3e8fd0778741fb649add932bb3617  |  ~~14358~~ 13794 | SELECT t0.id AS id_1, t0.sort_order AS sort_order_2, t0.useable_as_grid_filter AS useable_as_grid_filter_3, t0.max_characters AS max_characters_4, t0.validation_rule AS validation_rule_5, t0.validation_regexp AS validation_regexp_6, t0.wysiwyg_enabled AS wysiwyg_enabled_7, t0.number_min AS number_min_8, t0.number_max AS number_max_9, t0.decimals_allowed AS decimals_allowed_10, t0.negative_allowed AS negative_allowed_11, t0.date_min AS date_min_12, t0.date_max AS date_max_13, t0.metric_family AS metric_family_14, t0.default_metric_unit AS default_metric_unit_15, t0.max_file_size AS max_file_size_16, t0.allowed_extensions AS allowed_extensions_17, t0.minimumInputLength AS minimumInputLength_18, t0.is_required AS is_required_19, t0.is_unique AS is_unique_20, t0.is_localizable AS is_localizable_21, t0.is_scopable AS is_scopable_22, t0.code AS code_23, t0.entity_type AS entity_type_24, t0.attribute_type AS attribute_type_25, t0.backend_type AS backend_type_26, t0.properties AS properties_27, t0.created AS created_28, t0.updated AS updated_29, t0.group_id AS group_id_30 FROM pim_catalog_attribute t0 WHERE t0.code = 'S' LIMIT N
|        |  12238 | SELECT t0.id AS id_1, t0.code AS code_2, t0.created AS created_3, t0.root AS root_4, t0.lvl AS lvl_5, t0.lft AS lft_6, t0.rgt AS rgt_7, t0.parent_id AS parent_id_8 FROM pim_catalog_category t0 WHERE t0.code = 'S' LIMIT N
| didn't find this simple one :( |  10000 | SELECT p0_.code AS code_0 FROM pim_catalog_locale p0_ WHERE p0_.is_activated = N ORDER BY p0_.code ASC
| wtf?  | 9999    | UPDATE pim_catalog_product SET updated = 'S' WHERE id = N
|       | 9999    | SELECT t0.id AS id_1, t0.sort_order AS sort_order_2, t0.useable_as_grid_filter AS useable_as_grid_filter_3, t0.max_characters AS max_characters_4, t0.validation_rule AS validation_rule_5, t0.validation_regexp AS validation_regexp_6, t0.wysiwyg_enabled AS wysiwyg_enabled_7, t0.number_min AS number_min_8, t0.number_max AS number_max_9, t0.decimals_allowed AS decimals_allowed_10, t0.negative_allowed AS negative_allowed_11, t0.date_min AS date_min_12, t0.date_max AS date_max_13, t0.metric_family AS metric_family_14, t0.default_metric_unit AS default_metric_unit_15, t0.max_file_size AS max_file_size_16, t0.allowed_extensions AS allowed_extensions_17, t0.minimumInputLength AS minimumInputLength_18, t0.is_required AS is_required_19, t0.is_unique AS is_unique_20, t0.is_localizable AS is_localizable_21, t0.is_scopable AS is_scopable_22, t0.code AS code_23, t0.entity_type AS entity_type_24, t0.attribute_type AS attribute_type_25, t0.backend_type AS backend_type_26, t0.properties AS properties_27, t0.created AS created_28, t0.updated AS updated_29, t0.group_id AS group_id_30 FROM pim_catalog_attribute t0 WHERE t0.attribute_type = 'S' LIMIT N


### Using more memory

Currently, on master, the medium catalog product import consumes few memory. 
As the PHP CLI requirement for the next version of the PIM will be 1GB (validated by Benoit), I decided to increase the bulk size of the product import (and only _this_ bulk size): from 100 to 1000. We have more objects at the same time in memory, but as we flush less often, the import is faster. 

This bulk size is tweakable! Which means, a customer can fine tune this parameter to enhance the performances of its products import.

Memory used (from `top`):

|           | VIRT     |    RES  |   SHR   |  %CPU | %MEM     
| -------- | ---------- | --------- |  --------- | ---------- | --------- 
| master  | 564.7m  | 128.4m | 66.3m   | 60.5     | 1.6   
| this PR | 769.9m | 334.2m | 66.4m   | 83.3     |  4.2                                                                                                     

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | - 
| Changelog updated                 | -
| Review and 2 GTM                  | 
| Micro Demo to the PO (Story only) | 
| Migration script                  | -
| Tech Doc                          | -

