### PR TITLE
Allow to run the CI with Mongo 3.4

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/IndexCreator.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/IndexCreator.php
@@ -290,10 +290,16 @@ class IndexCreator
         ];
 
         foreach ($fields as $field) {
-            $collection->ensureIndex(
-                [$field => $indexType],
-                $indexOptions
-            );
+            try {
+                $collection->ensureIndex(
+                    [$field => $indexType],
+                    $indexOptions
+                );
+            } catch (\MongoResultException $e) {
+                $this->logger->error($e->getMessage());
+
+                return;
+            }
         }
     }
 


### PR DESCRIPTION
## Description

### What is the problem?

We cannot use MongoDB 3.x natively, because native PHP packages from Debian 8 use "ext-mongo" 1.5, the old legacy [MongoDB driver](https://secure.php.net/manual/en/book.mongo.php), and this extension is only compatible with MongoDB 2.4 and 2.6.

However, it seems that the only method that really do not work is `$collection->getIndexInfo()`, called by our `IndexCreator` [here](https://github.com/akeneo/pim-community-dev/pull/6296/files#diff-99f42ccc8fae424876840be3441c407aR278). We use this method to count the number of created index, and stop the creation when we reach the limit of MongoDB (64 indexes). However, with MongoDB 3.x, this method always return 0 :/.

### Solution

The trick here is to catch in the IndexCreator the MongoDB exception that is raised when limit is reached, and stop the index creation. This exception only happen with MongoDB 3.x, so the behavior of the PIM do not change with MongoDB 2.4 or 2.6.

The PR also update the Jenkinsfile to be able to choose between MongoDB 2.4 and 3.4 (other choices could be added), and the DCI was already updated to use this change (with a default value to 2.4, to be able to run CI for PIM 1.5 and 1.6): https://github.com/akeneo/continuous-integration.

### What's next

This, of course, does not mean we are going to support officially MongoDB 3.x, just to ensure it can work (and according to CI results, it does!).

This fix is kind of a hack, even if it has no impact with MongoDB 2.4. A proper solution would be to test PHP 5.6 with the new [MongoDB driver](https://secure.php.net/manual/en/set.mongodb.php) 1.2 (the only version compatible from MongoDB 2.4 to 3.4). This works on my machine, but needs a lot of adaptation on the DCI to be able to run a full behat testing, so it is not for today :).

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
