### PR TITLE
PIM-6129: Fix memory leak on import/export warnings

### DIFF
--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -4,6 +4,7 @@
 
 - PIM-6429: Improve the loading of the completeness widget on dashboard in ORM
 - PIM-6399: Stores images as PNG instead of JPG
+- PIM-6129: Fix a memory leak when import or exports contains too much warnings
 
 # 1.5.22 (2017-05-22)
 

--- a/spec/Akeneo/Component/Batch/Step/ItemStepSpec.php
+++ b/spec/Akeneo/Component/Batch/Step/ItemStepSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Akeneo\Component\Batch\Step;
 
+use Akeneo\Bundle\BatchBundle\Job\DoctrineJobRepository;
 use Akeneo\Component\Batch\Event\EventInterface;
 use Akeneo\Component\Batch\Item\InvalidItemException;
 use Akeneo\Component\Batch\Item\ItemProcessorInterface;
@@ -89,7 +90,7 @@ class ItemStepSpec extends ObjectBehavior
         $writer,
         StepExecution $execution,
         EventDispatcherInterface $dispatcher,
-        JobRepositoryInterface $repository,
+        DoctrineJobRepository $repository,
         BatchStatus $status,
         ExitStatus $exitStatus
     ) {
@@ -113,7 +114,7 @@ class ItemStepSpec extends ObjectBehavior
 
         // second batch
         $processor->process('r4')->shouldBeCalled()->willThrow(new InvalidItemException('my msg', ['r4']));
-        $execution->addWarning(Argument::any(), Argument::any(), Argument::any(), Argument::any())->shouldBeCalled();
+        $repository->insertWarning(Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any())->shouldBeCalled();
         $dispatcher->dispatch(Argument::any(), Argument::any())->shouldBeCalled();
 
         $processor->process(null)->shouldNotBeCalled();

--- a/src/Akeneo/Bundle/BatchBundle/Job/DoctrineJobRepository.php
+++ b/src/Akeneo/Bundle/BatchBundle/Job/DoctrineJobRepository.php
@@ -8,6 +8,7 @@ use Akeneo\Component\Batch\Model\JobInstance;
 use Akeneo\Component\Batch\Model\StepExecution;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\PersistentCollection;
 
 /**
  * Class peristing JobExecution and StepExecution states.
@@ -106,5 +107,52 @@ class DoctrineJobRepository implements JobRepositoryInterface
     {
         $this->jobManager->persist($stepExecution);
         $this->jobManager->flush($stepExecution);
+    }
+
+    /**
+     * To avoid memory leak, we insert the warnings directly in database without
+     * creating a Warning entity (as it is cascade persist from the JobExecution,
+     * there is no way to save them then detach them without huge BC break).
+     *
+     * Then we need to reinitialize the warnings persistent collection, so it is
+     * not systematically empty, resulting in an always successful notification
+     * at the end of the batch job.
+     *
+     * As the warnings are extra-lazy, in a persistent collection, this do not
+     * cause a new memory leak.
+     *
+     * @param StepExecution $stepExecution
+     * @param string        $warningName
+     * @param string        $reason
+     * @param array         $reasonParameters
+     * @param array         $item
+     *
+     * @todo Add interface on master (or find a proper way to do this as it is kind of a dirty hack).
+     */
+    public function insertWarning(
+        StepExecution $stepExecution,
+        $warningName,
+        $reason,
+        $reasonParameters = [],
+        $item = []
+    ) {
+        $sqlQuery = <<<SQL
+INSERT INTO akeneo_batch_warning (step_execution_id, name, reason, reason_parameters, item)
+VALUES (:step_execution_id, :name, :reason, :reason_parameters, :item)
+SQL;
+
+        $connection = $this->jobManager->getConnection();
+
+        $statement = $connection->prepare($sqlQuery);
+        $statement->bindValue('step_execution_id', $stepExecution->getId());
+        $statement->bindValue('name', $warningName);
+        $statement->bindValue('reason', $reason);
+        $statement->bindValue('reason_parameters', $reasonParameters, 'array');
+        $statement->bindValue('item', $item, 'array');
+        $statement->execute();
+
+        if ($stepExecution->getWarnings() instanceof PersistentCollection) {
+            $stepExecution->getWarnings()->setInitialized(false);
+        }
     }
 }

--- a/src/Akeneo/Component/Batch/Step/ItemStep.php
+++ b/src/Akeneo/Component/Batch/Step/ItemStep.php
@@ -278,7 +278,14 @@ class ItemStep extends AbstractStep
             $warningName = get_class($element);
         }
 
-        $stepExecution->addWarning($warningName, $e->getMessage(), $e->getMessageParameters(), $e->getItem());
+        $this->jobRepository->insertWarning(
+            $stepExecution,
+            $warningName,
+            $e->getMessage(),
+            $e->getMessageParameters(),
+            $e->getItem()
+        );
+
         $this->dispatchInvalidItemEvent(
             get_class($element),
             $e->getMessage(),


### PR DESCRIPTION
## Description

There is a memory leak, both on imports and exports, caused by batch [Warnings](https://github.com/akeneo/pim-community-dev/blob/1.5/src/Akeneo/Component/Batch/Model/Warning.php).

As they are added to the current step execution, in an ArrayCollection (so managed by Doctrine), [here](https://github.com/akeneo/pim-community-dev/blob/1.5/src/Akeneo/Component/Batch/Model/StepExecution.php#L453), you will end up with as many `Warning` entities in memory than you have in your import => memory leak!

The idea of this PR is to not create any `Warning` entities anymore (leaving the ArrayCollection empty), and instead inserting them directly in database.

This allows us not to do any BC break, and to keep current behavior on warning display.

Thanks to @momoss who locate the notification problem (sorry dude, I had to squash the commits, it became a mess!) and to @BitOne for the `PersistentCollection` reinitialization!

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
