### PR TITLE
Improve performance for rendering last jobs

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/JobExecutionRepository.php
+++ b/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/JobExecutionRepository.php
@@ -83,7 +83,7 @@ class JobExecutionRepository extends EntityRepository implements DatagridReposit
             ->leftJoin('e.stepExecutions', 's')
             ->leftJoin('s.warnings', 'w')
             ->groupBy('e.id')
-            ->orderBy('e.startTime', 'DESC')
+            ->orderBy('e.id', 'DESC')
             ->setMaxResults(10);
 
         if (!empty($types)) {

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/job_tracker.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/job_tracker.yml
@@ -43,7 +43,7 @@ datagrid:
                 user:
                     data_name: user
                 started_at:
-                    data_name: startTime
+                    data_name: e.id
                 status:
                     data_name: statusLabel
                 warning:


### PR DESCRIPTION
Since updating from Akeneo 1.6 to 1.7 the rendering of the last jobs (last operations widget, Process tracker) got really slow for us. 
Our users have used the import/export feature extensively, so our MySQL job tables are huge and the new feature with counting the warnings take time. `akeneo_batch_warning` has about 4,000,000 rows.

We could use the `id` (primary key) instead of `startTime` (without any index) for the order to prevent a full table scan. 

Before this small change the query to get the last 25 jobs in the process tracker takes unbelievable 77 seconds. After the change the query takes 60ms (!) => it's now 1200x :-o faster for us.