### PR TITLE
PIM-DOCS-565 : Fix PimRequirements, php-exif is required

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -13,6 +13,7 @@
 - PIM-6413: Fix to ensure that attribute options codes are no longer updated in MongoDB
 - PIM-6285: Fix content type validation in the API
 - PIM-6434: Fix attribute group order in Product Edit Form
+- PIM-DOC-565 : Fix PimRequirements need exif
 
 # 1.7.4 (2017-05-10)
 

--- a/app/PimRequirements.php
+++ b/app/PimRequirements.php
@@ -62,6 +62,12 @@ class PimRequirements extends OroRequirements
             'Install and enable <strong>bcmath</strong> extension'
         );
 
+        $this->addPimRequirement(
+            function_exists('exif_read_data'),
+            'Extension exif should be installed',
+            'Install and enable <strong>exif</strong> extension'
+        );
+
         // Check directories
         foreach ($directoriesToCheck as $directoryToCheck) {
             $this->addPimRequirement(


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

Look at this issue : https://github.com/akeneo/pim-docs/issues/565
So I reproduct the bug on my local. When I upload an image on a product with exif disable, I dont have the preview. And when exif is actived, the preview is here :)
Also, in demo.akeneo.com, the exif extension is enabled too.
So I add php-exif in PimRequirements ;) 
And I will add it in pim-docs : system-requirements.

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
