### PR TITLE
PIM-5962: Fix NumberLocalizer, force negative symbol to '-'

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -3,6 +3,7 @@
 ## Bug Fixes
 
 - PIM-6420: Fix autosorting of attribute options
+- PIM-5962: Fix NumberLocalizer, force negative symbol to '-'
 
 # 1.7.5 (2017-06-02)
 
@@ -24,7 +25,7 @@
 - PIM-6399: Stores images as PNG instead of JPG
 - PIM-6414: Fix datetime filter display issue
 - PIM-6384: Fix product export builder localisable and scopable fields display issue
-- IM-809: Fix missing shadows behind dialog popins
+- PIM-809: Fix missing shadows behind dialog popins
 - PIM-6423: Fix select2 display on attribute edition
 
 # 1.7.4 (2017-05-10)

--- a/src/Akeneo/Component/Localization/Localizer/NumberLocalizer.php
+++ b/src/Akeneo/Component/Localization/Localizer/NumberLocalizer.php
@@ -60,6 +60,10 @@ class NumberLocalizer implements LocalizerInterface
                 $numberFormatter->setAttribute(\NumberFormatter::MAX_FRACTION_DIGITS, 4);
             }
 
+            if (0 > $number) {
+                $numberFormatter->setSymbol(\NumberFormatter::MINUS_SIGN_SYMBOL, '-');
+            }
+
             return $numberFormatter->format($number);
         }
 
@@ -89,7 +93,7 @@ class NumberLocalizer implements LocalizerInterface
             return str_replace($matchesNumber['decimal'], static::DEFAULT_DECIMAL_SEPARATOR, $number);
         }
 
-        return (string) $number;
+        return (string)$number;
     }
 
     /**
@@ -97,7 +101,7 @@ class NumberLocalizer implements LocalizerInterface
      */
     public function validate($number, $attributeCode, array $options = [])
     {
-        if (null === $number || ''  === $number || is_int($number) || is_float($number)) {
+        if (null === $number || '' === $number || is_int($number) || is_float($number)) {
             return null;
         }
 


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**
From : https://github.com/akeneo/pim-community-dev/issues/5962
Force negative symbol with '-'

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | Ok
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
