### PR TITLE
TIP-744: install the database if it does not exist with pim:install

### DIFF
--- a/app/PimRequirements.php
+++ b/app/PimRequirements.php
@@ -159,8 +159,7 @@ class PimRequirements extends OroRequirements
     {
         return new PDO(
             sprintf(
-                'mysql:dbname=%s;host=%s',
-                $parameters['parameters']['database_name'],
+                'mysql:host=%s',
                 $parameters['parameters']['database_host']
             ),
             $parameters['parameters']['database_user'],

--- a/src/Pim/Bundle/InstallerBundle/Command/DatabaseCommand.php
+++ b/src/Pim/Bundle/InstallerBundle/Command/DatabaseCommand.php
@@ -2,7 +2,7 @@
 
 namespace Pim\Bundle\InstallerBundle\Command;
 
-use Akeneo\Bundle\StorageUtilsBundle\DependencyInjection\AkeneoStorageUtilsExtension;
+use Doctrine\DBAL\Exception\ConnectionException;
 use Pim\Bundle\InstallerBundle\CommandExecutor;
 use Pim\Bundle\InstallerBundle\Event\InstallerEvents;
 use Pim\Bundle\InstallerBundle\FixtureLoader\FixtureJobLoader;
@@ -78,7 +78,7 @@ class DatabaseCommand extends ContainerAwareCommand
                 $connection->connect();
             }
             $this->commandExecutor->runCommand('doctrine:database:drop', ['--force' => true]);
-        } catch (\PDOException $e) {
+        } catch (ConnectionException $e) {
             $output->writeln('<error>Database does not exist yet</error>');
         }
 


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

There is a regression since the merge of PHP 7.1 support into master.
The database was not created if it does not exist when we are installing the pim with `pim:install`.

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
