### PR TITLE
Fix phpdoc typo

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/AttributeOptionSearchableRepository.php
+++ b/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/AttributeOptionSearchableRepository.php
@@ -31,7 +31,7 @@ class AttributeOptionSearchableRepository implements SearchableRepositoryInterfa
     /**
      * TODO Remove null default on last parameter on master branch
      *
-     * @param ObjectManager                $entityManager
+     * @param EntityManagerInterface       $entityManager
      * @param string                       $entityName
      * @param AttributeRepositoryInterface $attributeRepository
      */
@@ -109,7 +109,7 @@ class AttributeOptionSearchableRepository implements SearchableRepositoryInterfa
     /**
      * @param string $attributeIdentifier
      *
-     * @returns boolean
+     * @return bool
      */
     protected function isAttributeAutoSorted($attributeIdentifier)
     {


### PR DESCRIPTION
## Description

Fix a missed comment in https://github.com/akeneo/pim-community-dev/pull/6325

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | -
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
