### PR TITLE
PIM-6462: Detach Product Media in ObjectDetacher for avoid leak in MongoDb Storage

### DIFF
--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -1,3 +1,9 @@
+# 1.5.x
+
+## Bug fixes
+
+- PIM-6462: Fix a memory leak when import products with files in ODM
+
 # 1.5.23 (2017-06-23)
 
 ## Bug fixes

--- a/src/Akeneo/Bundle/StorageUtilsBundle/Doctrine/Common/Detacher/ObjectDetacher.php
+++ b/src/Akeneo/Bundle/StorageUtilsBundle/Doctrine/Common/Detacher/ObjectDetacher.php
@@ -12,6 +12,7 @@ use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\PersistentCollection;
 use Doctrine\ORM\PersistentCollection as ORMPersistentCollection;
 use Doctrine\ORM\UnitOfWork;
+use Pim\Component\Catalog\Model\ProductInterface;
 
 /**
  * Detacher, detaches an object from its ObjectManager
@@ -181,6 +182,15 @@ class ObjectDetacher implements ObjectDetacherInterface, BulkObjectDetacherInter
         $documentManager->detach($document);
 
         $this->cascadeDetach($document, $visited);
+
+        if ($document instanceof ProductInterface) {
+            foreach ($document->getValues() as $value) {
+                if (null !== $value->getMedia()) {
+                    $mediaManager = $this->getObjectManager($value->getMedia());
+                    $mediaManager->detach($value->getMedia());
+                }
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Fix doctrine/mongodb-odm storage memory leak on product import with media, FileInfo object related to product media were not properly detached (Product stored in mongo and FileInfo stored in mysql) and stay in memory.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
