### PR TITLE
Merge branch 1.6 into 1.7

### DIFF
--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -1,4 +1,10 @@
-# 1.5.x
+# 1.5.24 (2017-06-28)
+
+## Bug fixes
+
+- PIM-6462: Fix a memory leak when import products with files in ODM
+
+# 1.5.23 (2017-06-23)
 
 ## Bug fixes
 

--- a/src/Akeneo/Bundle/StorageUtilsBundle/Doctrine/Common/Detacher/ObjectDetacher.php
+++ b/src/Akeneo/Bundle/StorageUtilsBundle/Doctrine/Common/Detacher/ObjectDetacher.php
@@ -11,6 +11,7 @@ use Doctrine\Common\Util\ClassUtils;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ORM\PersistentCollection as ORMPersistentCollection;
 use Doctrine\ORM\UnitOfWork;
+use Pim\Component\Catalog\Model\ProductInterface;
 
 /**
  * Detacher, detaches an object from its ObjectManager
@@ -163,8 +164,8 @@ class ObjectDetacher implements ObjectDetacherInterface, BulkObjectDetacherInter
     /**
      * Do detach objects on DocumentManager
      *
-     * @param document $document
-     * @param array    $visited   Prevent infinite recursion
+     * @param mixed $document
+     * @param array $visited  Prevent infinite recursion
      */
     protected function doDetach($document, array &$visited)
     {
@@ -178,5 +179,14 @@ class ObjectDetacher implements ObjectDetacherInterface, BulkObjectDetacherInter
         $visited[$oid] = $document;
 
         $documentManager->detach($document);
+
+        if ($document instanceof ProductInterface) {
+            foreach ($document->getValues() as $value) {
+                if (null !== $value->getMedia()) {
+                    $mediaManager = $this->getObjectManager($value->getMedia());
+                    $mediaManager->detach($value->getMedia());
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Description

This merge contains a small fix from 1.5, and a huge change on the Jenkinsfile (done on 1.5 and 1.6 too). We now only run the CI with PHP 5.6, MySQL 5.5 and MongoDB 2.4, the only supported versions for Akeneo PIM 1.7.

This makes the pipeline cleaner and faster. However, this does not prevent us to do experiments (other MySQL or MongoDB versions, for instance), by simply doing a PR where we set the version we want in the Jenkinsfile.

But there is simply no reason to propose choices on the versions for stable versions of the PIM. However the choices will remain on master (to introduce PHP 7.2 when it will be available, for instance).

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
