### PR TITLE
PIM-6470: Correctly translate default filters on user profile

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -3,6 +3,7 @@
 ## Bug Fixes
 
 - PIM-6420: Fix autosorting of attribute options
+- PIM-6470: Correctly translate default filters on user profile
 
 # 1.7.5 (2017-06-02)
 

--- a/src/Pim/Bundle/DataGridBundle/Twig/FilterExtension.php
+++ b/src/Pim/Bundle/DataGridBundle/Twig/FilterExtension.php
@@ -51,6 +51,8 @@ class FilterExtension extends Twig_Extension
             throw new \LogicException(sprintf('Attribute "%s" does not exists', $code));
         }
 
+        $label = $this->container->get('translator')->trans($label);
+
         return $label;
     }
 

--- a/src/Pim/Bundle/DataGridBundle/spec/Twig/FilterExtensionSpec.php
+++ b/src/Pim/Bundle/DataGridBundle/spec/Twig/FilterExtensionSpec.php
@@ -9,16 +9,19 @@ use Oro\Bundle\DataGridBundle\Extension\Acceptor;
 use PhpSpec\ObjectBehavior;
 use Pim\Bundle\DataGridBundle\Datagrid\Configuration\Product\FiltersConfigurator;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class FilterExtensionSpec extends ObjectBehavior
 {
     function let(
         ContainerInterface $container,
         FiltersConfigurator $configurator,
+        TranslatorInterface $translator,
         Manager $manager
     ) {
         $container->get('oro_datagrid.datagrid.manager')->willReturn($manager);
         $container->get('pim_datagrid.datagrid.configuration.product.filters_configurator')->willReturn($configurator);
+        $container->get('translator')->willReturn($translator);
         $this->beConstructedWith($container);
     }
 
@@ -58,6 +61,7 @@ class FilterExtensionSpec extends ObjectBehavior
     function it_gives_the_label_of_a_filter(
         $manager,
         $configurator,
+        $translator,
         DatagridInterface $datagrid,
         Acceptor $acceptor,
         DatagridConfiguration $configuration
@@ -67,6 +71,7 @@ class FilterExtensionSpec extends ObjectBehavior
         $manager->getDatagrid('product-grid')->willReturn($datagrid);
         $configurator->configure($configuration)->shouldBeCalled();
         $configuration->offsetGetByPath('[filters][columns][foo][label]')->willReturn('Foo');
+        $translator->trans('Foo')->willReturn('Foo');
 
         $this->filterLabel('foo')->shouldReturn('Foo');
     }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Default product filters on user profile were correctly translated if they were not attribute.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | N
| Added Behats                      | Y (EE)
| Added integration tests           | N
| Changelog updated                 | Y
| Review and 2 GTM                  | Todo
| Migration script                  | -
| Tech Doc                          | -