### PR TITLE
Improve scalability of integration tests

### DIFF
--- a/app/phpunit.xml.dist
+++ b/app/phpunit.xml.dist
@@ -29,59 +29,7 @@
 
         <!-- Complete suite for PIM integration tests -->
         <testsuite name="PIM_Integration_Test">
-            <directory suffix="Integration.php">../src/Pim/Component/*/tests/integration</directory>
-            <directory suffix="Integration.php">../src/Pim/Bundle/*Bundle/tests/integration</directory>
-            <directory suffix="Integration.php">../src/Akeneo/Bundle/*Bundle/tests/integration</directory>
+            <file></file>
         </testsuite>
-
-        <!-- Set of small suites for PIM integration tests -->
-        <testsuite name="Akeneo_Integration_Test">
-            <directory suffix="Integration.php">../src/Akeneo/Bundle/*/tests/integration</directory>
-        </testsuite>
-
-        <testsuite name="PIM_Api_Base_Integration_Test">
-            <directory suffix="Integration.php">../src/Pim/Component/Api/tests/integration</directory>
-            <directory suffix="Integration.php">../src/Pim/Bundle/ApiBundle/tests/integration/EventSubscriber</directory>
-            <directory suffix="Integration.php">../src/Pim/Bundle/ApiBundle/tests/integration/Security</directory>
-            <file>../src/Pim/Bundle/ApiBundle/tests/integration/Controller/RootEndpointIntegration.php</file>
-        </testsuite>
-
-        <testsuite name="PIM_Api_Bundle_Controllers_Integration_Test">
-            <directory suffix="Integration.php">../src/Pim/Bundle/ApiBundle/tests/integration/Controller/Channel</directory>
-            <directory suffix="Integration.php">../src/Pim/Bundle/ApiBundle/tests/integration/Controller/Locale</directory>
-            <directory suffix="Integration.php">../src/Pim/Bundle/ApiBundle/tests/integration/Controller/Media</directory>
-            <directory suffix="Integration.php">../src/Pim/Bundle/ApiBundle/tests/integration/Controller/Currency</directory>
-            <directory suffix="Integration.php">../src/Pim/Bundle/ApiBundle/tests/integration/Controller/Token</directory>
-            <directory suffix="Integration.php">../src/Pim/Bundle/ApiBundle/tests/integration/Controller/AssociationType</directory>
-        </testsuite>
-
-        <testsuite name="PIM_Api_Bundle_Controllers_Catalog_Integration_Test">
-            <directory suffix="Integration.php">../src/Pim/Bundle/ApiBundle/tests/integration/Controller/Attribute</directory>
-            <directory suffix="Integration.php">../src/Pim/Bundle/ApiBundle/tests/integration/Controller/AttributeGroup</directory>
-            <directory suffix="Integration.php">../src/Pim/Bundle/ApiBundle/tests/integration/Controller/AttributeOption</directory>
-            <directory suffix="Integration.php">../src/Pim/Bundle/ApiBundle/tests/integration/Controller/Category</directory>
-            <directory suffix="Integration.php">../src/Pim/Bundle/ApiBundle/tests/integration/Controller/Family</directory>
-        </testsuite>
-
-        <testsuite name="PIM_Api_Bundle_Controller_Product_Integration_Test">
-            <directory suffix="Integration.php">../src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product</directory>
-        </testsuite>
-
-        <testsuite name="PIM_Catalog_Integration_Test">
-            <directory suffix="Integration.php">../src/Pim/Bundle/CatalogBundle/tests/integration/Validation</directory>
-            <directory suffix="Integration.php">../src/Pim/Component/Catalog/tests/integration</directory>
-        </testsuite>
-
-        <testsuite name="PIM_Catalog_Completeness_Integration_Test">
-            <directory suffix="Integration.php">../src/Pim/Bundle/CatalogBundle/tests/integration/Completeness</directory>
-        </testsuite>
-
-        <testsuite name="PIM_Catalog_PQB_Integration_Test">
-            <directory suffix="Integration.php">../src/Pim/Bundle/CatalogBundle/tests/integration/PQB</directory>
-            <directory suffix="Integration.php">../src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch</directory>
-            <directory suffix="Integration.php">../src/Pim/Bundle/ReferenceDataBundle/tests/integration/PQB</directory>
-            <directory suffix="Integration.php">../src/Pim/Bundle/EnrichBundle/Tests/integration/PQB</directory>
-        </testsuite>
-
     </testsuites>
 </phpunit>

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AbstractCompletenessTestCase.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AbstractCompletenessTestCase.php
@@ -15,7 +15,7 @@ use Pim\Component\Catalog\Model\ProductInterface;
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-abstract class AbstractCompletenessIntegration extends TestCase
+abstract class AbstractCompletenessTestCase extends TestCase
 {
     /**
      * {@inheritdoc}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/AbstractCompletenessPerAttributeTypeTestCase.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/AbstractCompletenessPerAttributeTypeTestCase.php
@@ -2,7 +2,7 @@
 
 namespace Pim\Bundle\CatalogBundle\tests\integration\Completeness\AttributeType;
 
-use Pim\Bundle\CatalogBundle\tests\integration\Completeness\AbstractCompletenessIntegration;
+use Pim\Bundle\CatalogBundle\tests\integration\Completeness\AbstractCompletenessTestCase;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 
@@ -18,7 +18,7 @@ use Pim\Component\Catalog\Model\ProductInterface;
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-abstract class AbstractCompletenessPerAttributeTypeIntegration extends AbstractCompletenessIntegration
+abstract class AbstractCompletenessPerAttributeTypeTestCase extends AbstractCompletenessTestCase
 {
     /**
      * Here, the identifier and the attribute should be filled in.

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/BooleanAttributeTypeCompletenessIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/BooleanAttributeTypeCompletenessIntegration.php
@@ -12,7 +12,7 @@ use Pim\Component\Catalog\Model\ProductInterface;
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
-class BooleanAttributeTypeCompletenessIntegration extends AbstractCompletenessPerAttributeTypeIntegration
+class BooleanAttributeTypeCompletenessIntegration extends AbstractCompletenessPerAttributeTypeTestCase
 {
     public function testCompleteBoolean()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/DateAttributeTypeCompletenessIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/DateAttributeTypeCompletenessIntegration.php
@@ -11,7 +11,7 @@ use Pim\Component\Catalog\AttributeTypes;
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
-class DateAttributeTypeCompletenessIntegration extends AbstractCompletenessPerAttributeTypeIntegration
+class DateAttributeTypeCompletenessIntegration extends AbstractCompletenessPerAttributeTypeTestCase
 {
     public function testCompleteDate()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/FileAttributeTypeCompletenessIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/FileAttributeTypeCompletenessIntegration.php
@@ -11,7 +11,7 @@ use Pim\Component\Catalog\AttributeTypes;
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
-class FileAttributeTypeCompletenessIntegration extends AbstractCompletenessPerAttributeTypeIntegration
+class FileAttributeTypeCompletenessIntegration extends AbstractCompletenessPerAttributeTypeTestCase
 {
     public function testCompleteFile()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/IdentifierAttributeTypeCompletenessIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/IdentifierAttributeTypeCompletenessIntegration.php
@@ -13,7 +13,7 @@ use Pim\Component\Catalog\Model\ProductInterface;
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
-class IdentifierAttributeTypeCompletenessIntegration extends AbstractCompletenessPerAttributeTypeIntegration
+class IdentifierAttributeTypeCompletenessIntegration extends AbstractCompletenessPerAttributeTypeTestCase
 {
     public function testCompleteIdentifier()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/ImageAttributeTypeCompletenessIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/ImageAttributeTypeCompletenessIntegration.php
@@ -11,7 +11,7 @@ use Pim\Component\Catalog\AttributeTypes;
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
-class ImageAttributeTypeCompletenessIntegration extends AbstractCompletenessPerAttributeTypeIntegration
+class ImageAttributeTypeCompletenessIntegration extends AbstractCompletenessPerAttributeTypeTestCase
 {
     public function testCompleteImage()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/MetricAttributeTypeCompletenessIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/MetricAttributeTypeCompletenessIntegration.php
@@ -11,7 +11,7 @@ use Pim\Component\Catalog\AttributeTypes;
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
-class MetricAttributeTypeCompletenessIntegration extends AbstractCompletenessPerAttributeTypeIntegration
+class MetricAttributeTypeCompletenessIntegration extends AbstractCompletenessPerAttributeTypeTestCase
 {
     public function testCompleteMetric()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/NumberAttributeTypeCompletenessIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/NumberAttributeTypeCompletenessIntegration.php
@@ -11,7 +11,7 @@ use Pim\Component\Catalog\AttributeTypes;
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
-class NumberAttributeTypeCompletenessIntegration extends AbstractCompletenessPerAttributeTypeIntegration
+class NumberAttributeTypeCompletenessIntegration extends AbstractCompletenessPerAttributeTypeTestCase
 {
     public function testCompleteNumber()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/OptionAttributeTypeCompletenessIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/OptionAttributeTypeCompletenessIntegration.php
@@ -11,7 +11,7 @@ use Pim\Component\Catalog\AttributeTypes;
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
-class OptionAttributeTypeCompletenessIntegration extends AbstractCompletenessPerAttributeTypeIntegration
+class OptionAttributeTypeCompletenessIntegration extends AbstractCompletenessPerAttributeTypeTestCase
 {
     public function testCompleteOption()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/OptionsAttributeTypeCompletenessIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/OptionsAttributeTypeCompletenessIntegration.php
@@ -11,7 +11,7 @@ use Pim\Component\Catalog\AttributeTypes;
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
-class OptionsAttributeTypeCompletenessIntegration extends AbstractCompletenessPerAttributeTypeIntegration
+class OptionsAttributeTypeCompletenessIntegration extends AbstractCompletenessPerAttributeTypeTestCase
 {
     public function testCompleteOptions()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/PriceCollectionAttributeTypeCompletenessIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/PriceCollectionAttributeTypeCompletenessIntegration.php
@@ -2,7 +2,7 @@
 
 namespace Pim\Bundle\CatalogBundle\tests\integration\Completeness\AttributeType;
 
-use Pim\Bundle\CatalogBundle\tests\integration\Completeness\AbstractCompletenessIntegration;
+use Pim\Bundle\CatalogBundle\tests\integration\Completeness\AbstractCompletenessTestCase;
 use Pim\Component\Catalog\AttributeTypes;
 use Pim\Component\Catalog\Model\ChannelInterface;
 use Pim\Component\Catalog\Model\CompletenessInterface;
@@ -22,7 +22,7 @@ use Pim\Component\Catalog\Model\ProductInterface;
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
-class PriceCollectionAttributeTypeCompletenessIntegration extends AbstractCompletenessIntegration
+class PriceCollectionAttributeTypeCompletenessIntegration extends AbstractCompletenessTestCase
 {
     /**
      * {@inheritdoc}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/ReferenceDataMultiAttributeTypeCompletenessIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/ReferenceDataMultiAttributeTypeCompletenessIntegration.php
@@ -12,7 +12,7 @@ use Pim\Component\Catalog\AttributeTypes;
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
-class ReferenceDataMultiAttributeTypeCompletenessIntegration extends AbstractCompletenessPerAttributeTypeIntegration
+class ReferenceDataMultiAttributeTypeCompletenessIntegration extends AbstractCompletenessPerAttributeTypeTestCase
 {
     public function testCompleteMultiSelectReferenceData()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/ReferenceDataSimpleAttributeTypeCompletenessIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/ReferenceDataSimpleAttributeTypeCompletenessIntegration.php
@@ -12,7 +12,7 @@ use Pim\Component\Catalog\AttributeTypes;
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
-class ReferenceDataSimpleAttributeTypeCompletenessIntegration extends AbstractCompletenessPerAttributeTypeIntegration
+class ReferenceDataSimpleAttributeTypeCompletenessIntegration extends AbstractCompletenessPerAttributeTypeTestCase
 {
     public function testCompleteSimpleSelectReferenceData()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/TextAttributeTypeCompletenessIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/TextAttributeTypeCompletenessIntegration.php
@@ -11,7 +11,7 @@ use Pim\Component\Catalog\AttributeTypes;
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
-class TextAttributeTypeCompletenessIntegration extends AbstractCompletenessPerAttributeTypeIntegration
+class TextAttributeTypeCompletenessIntegration extends AbstractCompletenessPerAttributeTypeTestCase
 {
     public function testCompleteText()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/TextareaAttributeTypeCompletenessIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/TextareaAttributeTypeCompletenessIntegration.php
@@ -11,7 +11,7 @@ use Pim\Component\Catalog\AttributeTypes;
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
-class TextareaAttributeTypeCompletenessIntegration extends AbstractCompletenessPerAttributeTypeIntegration
+class TextareaAttributeTypeCompletenessIntegration extends AbstractCompletenessPerAttributeTypeTestCase
 {
     public function testCompleteTextarea()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/CompletenessFloorRoundedRatioIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/CompletenessFloorRoundedRatioIntegration.php
@@ -5,7 +5,7 @@ namespace Pim\Bundle\CatalogBundle\tests\integration\Completeness;
 
 use Pim\Component\Catalog\AttributeTypes;
 
-class CompletenessFloorRoundedRatioIntegration extends AbstractCompletenessIntegration
+class CompletenessFloorRoundedRatioIntegration extends AbstractCompletenessTestCase
 {
     public function testFloorRoundedRatio()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/CompletenessForLocalisableAttributeIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/CompletenessForLocalisableAttributeIntegration.php
@@ -24,7 +24,7 @@ use Pim\Component\Catalog\Model\ProductInterface;
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class CompletenessForLocalisableAttributeIntegration extends AbstractCompletenessIntegration
+class CompletenessForLocalisableAttributeIntegration extends AbstractCompletenessTestCase
 {
     public function testLocalisable()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/CompletenessForNonRequiredAttributeIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/CompletenessForNonRequiredAttributeIntegration.php
@@ -13,7 +13,7 @@ use Pim\Component\Catalog\Model\ProductInterface;
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class CompletenessForNonRequiredAttributeIntegration extends AbstractCompletenessIntegration
+class CompletenessForNonRequiredAttributeIntegration extends AbstractCompletenessTestCase
 {
     public function testAttributeNotRequiredByFamily()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/CompletenessForScopableAndLocalisableAttributeIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/CompletenessForScopableAndLocalisableAttributeIntegration.php
@@ -15,7 +15,7 @@ use Pim\Component\Catalog\Model\ProductInterface;
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class CompletenessForScopableAndLocalisableAttributeIntegration extends AbstractCompletenessIntegration
+class CompletenessForScopableAndLocalisableAttributeIntegration extends AbstractCompletenessTestCase
 {
     public function testProductIncomplete()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/CompletenessForScopableAttributeIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/CompletenessForScopableAttributeIntegration.php
@@ -16,7 +16,7 @@ use Pim\Component\Catalog\Model\ProductInterface;
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class CompletenessForScopableAttributeIntegration extends AbstractCompletenessIntegration
+class CompletenessForScopableAttributeIntegration extends AbstractCompletenessTestCase
 {
     public function testCompleteScopable()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Doctrine/Common/Saver/IndexingProductIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Doctrine/Common/Saver/IndexingProductIntegration.php
@@ -28,14 +28,32 @@ class IndexingProductIntegration extends TestCase
 
         $this->get('pim_catalog.saver.product')->saveAll($products);
 
-        $indexedProductFoo = $this->esClient->get(self::DOCUMENT_TYPE, 'foo');
-        $this->assertTrue($indexedProductFoo['found']);
+        $indexedProductFoo = $this->esClient->search(self::DOCUMENT_TYPE, [
+            'query' => [
+                'term' => [
+                    'identifier' => 'foo'
+                ]
+            ]
+        ]);
+        $this->assertSame(1, $indexedProductFoo['hits']['total']);
 
-        $indexedProductBar = $this->esClient->get(self::DOCUMENT_TYPE, 'bar');
-        $this->assertTrue($indexedProductBar['found']);
+        $indexedProductBar = $this->esClient->search(self::DOCUMENT_TYPE, [
+            'query' => [
+                'term' => [
+                    'identifier' => 'bar'
+                ]
+            ]
+        ]);
+        $this->assertSame(1, $indexedProductBar['hits']['total']);
 
-        $indexedProductBaz = $this->esClient->get(self::DOCUMENT_TYPE, 'baz');
-        $this->assertTrue($indexedProductBaz['found']);
+        $indexedProductBaz = $this->esClient->search(self::DOCUMENT_TYPE, [
+            'query' => [
+                'term' => [
+                    'identifier' => 'baz'
+                ]
+            ]
+        ]);
+        $this->assertSame(1, $indexedProductBaz['hits']['total']);
     }
 
     public function testIndexingProductOnUnitarySave()
@@ -43,8 +61,17 @@ class IndexingProductIntegration extends TestCase
         $product = $this->productBuilder->createProduct('bat');
         $this->get('pim_catalog.saver.product')->save($product);
 
-        $indexedProduct = $this->esClient->get(self::DOCUMENT_TYPE, 'bat');
-        $this->assertTrue($indexedProduct['found']);
+        $this->esClient->refreshIndex();
+
+        $indexedProduct = $this->esClient->search(self::DOCUMENT_TYPE, [
+            'query' => [
+                'term' => [
+                    'identifier' => 'bat'
+                ]
+            ]
+        ]);
+
+        $this->assertSame(1, $indexedProduct['hits']['total']);
     }
 
     /**
@@ -63,6 +90,6 @@ class IndexingProductIntegration extends TestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()], false);
+        return new Configuration([Configuration::getTechnicalCatalogPath()]);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Doctrine/Common/Saver/ProductSaverIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Doctrine/Common/Saver/ProductSaverIntegration.php
@@ -25,10 +25,10 @@ class ProductSaverIntegration extends TestCase
         $rawValues = json_decode($jsonRawValues, true);
         NormalizedProductCleaner::cleanOnlyValues($rawValues);
 
-        $storageValues = $this->getStorageValuesWithAllAttributes();
-        NormalizedProductCleaner::cleanOnlyValues($storageValues);
+        $expectedRawValues = $this->getStorageValuesWithAllAttributes();
+        NormalizedProductCleaner::cleanOnlyValues($expectedRawValues);
 
-        $this->assertEquals($storageValues, $rawValues);
+        $this->assertSame($expectedRawValues, $rawValues);
     }
 
     /**
@@ -36,10 +36,7 @@ class ProductSaverIntegration extends TestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalSqlCatalogPath()],
-            false
-        );
+        return new Configuration([Configuration::getTechnicalSqlCatalogPath()]);
     }
 
     /**
@@ -299,7 +296,7 @@ class ProductSaverIntegration extends TestCase
                     '<all_locales>' => [
                         'amount'    => -20,
                         'unit'      => 'CELSIUS',
-                        'base_data' => '253.15',
+                        'base_data' => '253.150000000000',
                         'base_unit' => 'KELVIN',
                         'family'    => 'Temperature',
                     ],
@@ -310,7 +307,7 @@ class ProductSaverIntegration extends TestCase
                     '<all_locales>' => [
                         'amount'    => '-20.5000',
                         'unit'      => 'CELSIUS',
-                        'base_data' => '252.65',
+                        'base_data' => '252.650000000000',
                         'base_unit' => 'KELVIN',
                         'family'    => 'Temperature',
                     ],
@@ -420,6 +417,11 @@ class ProductSaverIntegration extends TestCase
                     'en_US' => 'a text area for tablets in English',
                     'fr_FR' => 'une zone de texte pour les tablettes en français',
 
+                ],
+            ],
+            'sku' => [
+                '<all_channels>' => [
+                    '<all_locales>' => 'just-a-product-with-all-possible-values',
                 ],
             ],
         ];

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/AbstractPimCatalogTestCase.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/AbstractPimCatalogTestCase.php
@@ -16,7 +16,7 @@ use Akeneo\Test\Integration\TestCase;
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-abstract class AbstractPimCatalogIntegration extends TestCase
+abstract class AbstractPimCatalogTestCase extends TestCase
 {
     const DOCUMENT_TYPE = 'pim_catalog_product';
 

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/PimCatalogFamilyIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/PimCatalogFamilyIntegration.php
@@ -7,7 +7,7 @@ namespace Pim\Bundle\CatalogBundle\tests\integration\Elasticsearch\IndexConfigur
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
-class PimCatalogFamilyIntegration extends AbstractPimCatalogIntegration
+class PimCatalogFamilyIntegration extends AbstractPimCatalogTestCase
 {
     public function testInListOperator()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/PimCatalogMediaIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/PimCatalogMediaIntegration.php
@@ -7,7 +7,7 @@ namespace Pim\Bundle\CatalogBundle\tests\integration\ElasticSearch\IndexConfigur
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
-class PimCatalogMediaIntegration extends AbstractPimCatalogIntegration
+class PimCatalogMediaIntegration extends AbstractPimCatalogTestCase
 {
     public function testStartWithOperator()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/PimCatalogMediaIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/PimCatalogMediaIntegration.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Pim\Bundle\CatalogBundle\tests\integration\ElasticSearch\IndexConfiguration;
+namespace Pim\Bundle\CatalogBundle\tests\integration\Elasticsearch\IndexConfiguration;
 
 /**
  * @author    Damien Carcel (damien.carcel@akeneo.com)

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/PimCatalogMetricIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/PimCatalogMetricIntegration.php
@@ -10,7 +10,7 @@ namespace Pim\Bundle\CatalogBundle\tests\integration\Elasticsearch\IndexConfigur
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class PimCatalogMetricIntegration extends AbstractPimCatalogIntegration
+class PimCatalogMetricIntegration extends AbstractPimCatalogTestCase
 {
     public function testLowerThanOperatorWithNumberValue()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/PimCatalogNumberIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/PimCatalogNumberIntegration.php
@@ -12,7 +12,7 @@ namespace Pim\Bundle\CatalogBundle\tests\integration\Elasticsearch\IndexConfigur
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class PimCatalogNumberIntegration extends AbstractPimCatalogIntegration
+class PimCatalogNumberIntegration extends AbstractPimCatalogTestCase
 {
     public function testLowerThanOperatorWithNumberValue()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/PimCatalogOptionIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/PimCatalogOptionIntegration.php
@@ -10,7 +10,7 @@ namespace Pim\Bundle\CatalogBundle\tests\integration\Elasticsearch\IndexConfigur
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
-class PimCatalogOptionIntegration extends AbstractPimCatalogIntegration
+class PimCatalogOptionIntegration extends AbstractPimCatalogTestCase
 {
     public function testInListOperatorWithOptionValue()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/PimCatalogOptionsIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/PimCatalogOptionsIntegration.php
@@ -10,7 +10,7 @@ namespace Pim\Bundle\CatalogBundle\tests\integration\ElasticSearch\IndexConfigur
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
-class PimCatalogOptionsIntegration extends AbstractPimCatalogIntegration
+class PimCatalogOptionsIntegration extends AbstractPimCatalogTestCase
 {
     public function testInListOperatorWithOptionValue()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/PimCatalogPriceCollectionIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/PimCatalogPriceCollectionIntegration.php
@@ -10,7 +10,7 @@ namespace Pim\Bundle\CatalogBundle\tests\integration\Elasticsearch\IndexConfigur
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class PimCatalogPriceCollectionIntegration extends AbstractPimCatalogIntegration
+class PimCatalogPriceCollectionIntegration extends AbstractPimCatalogTestCase
 {
     public function testLowerThanOperator()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/PimCatalogTextAreaIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/PimCatalogTextAreaIntegration.php
@@ -2,7 +2,7 @@
 
 namespace tests\integration\Pim\Bundle\CatalogBundle\Elasticsearch\IndexConfiguration;
 
-use Pim\Bundle\CatalogBundle\tests\integration\Elasticsearch\IndexConfiguration\AbstractPimCatalogIntegration;
+use Pim\Bundle\CatalogBundle\tests\integration\Elasticsearch\IndexConfiguration\AbstractPimCatalogTestCase;
 
 /**
  * This integration tests checks that given an index configuration and some products indexed
@@ -12,7 +12,7 @@ use Pim\Bundle\CatalogBundle\tests\integration\Elasticsearch\IndexConfiguration\
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class PimCatalogTextAreaIntegration extends AbstractPimCatalogIntegration
+class PimCatalogTextAreaIntegration extends AbstractPimCatalogTestCase
 {
     public function testStartWithOperator()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/PimCatalogTextIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/PimCatalogTextIntegration.php
@@ -2,7 +2,7 @@
 
 namespace tests\integration\Pim\Bundle\CatalogBundle\Elasticsearch\IndexConfiguration;
 
-use Pim\Bundle\CatalogBundle\tests\integration\Elasticsearch\IndexConfiguration\AbstractPimCatalogIntegration;
+use Pim\Bundle\CatalogBundle\tests\integration\Elasticsearch\IndexConfiguration\AbstractPimCatalogTestCase;
 
 /**
  * This integration tests checks that given an index configuration and some products indexed
@@ -12,7 +12,7 @@ use Pim\Bundle\CatalogBundle\tests\integration\Elasticsearch\IndexConfiguration\
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class PimCatalogTextIntegration extends AbstractPimCatalogIntegration
+class PimCatalogTextIntegration extends AbstractPimCatalogTestCase
 {
     public function testStartWithOperator()
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/EventSubscriber/LoadProductValuesSubscriberIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/EventSubscriber/LoadProductValuesSubscriberIntegration.php
@@ -26,10 +26,7 @@ class LoadProductValuesSubscriberIntegration extends TestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalSqlCatalogPath()],
-            false
-        );
+        return new Configuration([Configuration::getTechnicalSqlCatalogPath()]);
     }
 
     /**

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/ProductValidation/ProductIdentifierValidationIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/ProductValidation/ProductIdentifierValidationIntegration.php
@@ -28,8 +28,11 @@ class ProductIdentifierValidationIntegration extends TestCase
         $product2 = $this->createProduct('just_an_empty_product');
         $violations = $this->validateProduct($product2);
 
-        $this->assertCount(1, $violations);
+        $this->assertCount(2, $violations);
         $this->assertSame($violations->get(0)->getMessage(), 'The same identifier is already set on another product');
+        $this->assertSame($violations->get(1)->getMessage(), 'The value just_an_empty_product is already set on another product for the unique attribute sku');
+        $this->assertSame($violations->get(0)->getPropertyPath(), 'identifier');
+        $this->assertSame($violations->get(1)->getPropertyPath(), 'values[sku-<all_channels>-<all_locales>]');
     }
 
     public function testForbiddenIdentifierCharactersValidation()
@@ -99,11 +102,11 @@ class ProductIdentifierValidationIntegration extends TestCase
 
         $wrongProduct = $this->createProduct('');
         $violations = $this->validateProduct($wrongProduct);
-        $this->assertCount(1, $violations);
-        $this->assertSame(
-            $violations->get(0)->getMessage(),
-            'This value should not be blank.'
-        );
+        $this->assertCount(2, $violations);
+        $this->assertSame($violations->get(0)->getMessage(), 'This value should not be blank.');
+        $this->assertSame($violations->get(1)->getMessage(), 'This value should not be blank.');
+        $this->assertSame($violations->get(0)->getPropertyPath(), 'identifier');
+        $this->assertSame($violations->get(1)->getPropertyPath(), 'values[sku-<all_channels>-<all_locales>].data');
     }
 
     /**
@@ -111,10 +114,7 @@ class ProductIdentifierValidationIntegration extends TestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()],
-            true
-        );
+        return new Configuration([Configuration::getTechnicalCatalogPath()]);
     }
 
     /**

--- a/src/Pim/Bundle/EnrichBundle/tests/integration/PQB/Sorter/InGroupSorterIntegration.php
+++ b/src/Pim/Bundle/EnrichBundle/tests/integration/PQB/Sorter/InGroupSorterIntegration.php
@@ -40,22 +40,20 @@ class InGroupSorterIntegration extends AbstractProductQueryBuilderTestCase
     {
         parent::setUp();
 
-        if (1 === self::$count || $this->getConfiguration()->isDatabasePurgedForEachTest()) {
-            $group = $this->get('pim_catalog.factory.group')->create();
-            $this->get('pim_catalog.updater.group')->update(
-                $group,
-                [
-                    'code' => 'groupC',
-                    'type' => 'RELATED',
-                ]
-            );
-            $this->get('pim_catalog.saver.group')->save($group);
+        $group = $this->get('pim_catalog.factory.group')->create();
+        $this->get('pim_catalog.updater.group')->update(
+            $group,
+            [
+                'code' => 'groupC',
+                'type' => 'RELATED',
+            ]
+        );
+        $this->get('pim_catalog.saver.group')->save($group);
 
-            $this->createProduct('foo', ['groups' => ['groupA', 'groupB']]);
-            $this->createProduct('bar', ['groups' => ['groupB']]);
-            $this->createProduct('baz', ['groups' => ['groupC']]);
-            $this->createProduct('empty', []);
-        }
+        $this->createProduct('foo', ['groups' => ['groupA', 'groupB']]);
+        $this->createProduct('bar', ['groups' => ['groupB']]);
+        $this->createProduct('baz', ['groups' => ['groupC']]);
+        $this->createProduct('empty', []);
     }
 
 }

--- a/src/Pim/Bundle/VersioningBundle/tests/integration/Manager/VersionManagerIntegration.php
+++ b/src/Pim/Bundle/VersioningBundle/tests/integration/Manager/VersionManagerIntegration.php
@@ -52,10 +52,7 @@ class VersionManagerIntegration extends TestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalSqlCatalogPath()],
-            true
-        );
+        return new Configuration([Configuration::getTechnicalSqlCatalogPath()]);
     }
 
     public function testNoVersionCreatedWhenThereIsNoUpdate()

--- a/src/Pim/Bundle/VersioningBundle/tests/integration/Normalizer/Flat/FamilyIntegration.php
+++ b/src/Pim/Bundle/VersioningBundle/tests/integration/Normalizer/Flat/FamilyIntegration.php
@@ -19,7 +19,9 @@ class FamilyIntegration extends AbstractFlatNormalizerTestCase
             'attribute_as_label'           => 'sku',
             'requirements-ecommerce'       => 'a_date,a_file,a_localizable_image,a_localized_and_scopable_text_area,a_metric,a_multi_select,a_number_float,a_number_float_negative,a_number_integer,a_price,a_ref_data_multi_select,a_ref_data_simple_select,a_scopable_price,a_simple_select,a_text,a_text_area,a_yes_no,an_image,sku',
             'requirements-ecommerce_china' => 'sku',
-            'requirements-tablet'          => 'a_date,a_file,a_localizable_image,a_localized_and_scopable_text_area,a_metric,a_multi_select,a_number_float,a_number_float_negative,a_number_integer,a_price,a_ref_data_multi_select,a_ref_data_simple_select,a_scopable_price,a_simple_select,a_text,a_text_area,a_yes_no,an_image,sku'
+            'requirements-tablet'          => 'a_date,a_file,a_localizable_image,a_localized_and_scopable_text_area,a_metric,a_multi_select,a_number_float,a_number_float_negative,a_number_integer,a_price,a_ref_data_multi_select,a_ref_data_simple_select,a_scopable_price,a_simple_select,a_text,a_text_area,a_yes_no,an_image,sku',
+            'label-fr_FR'                  => 'Une famille A',
+            'label-en_US'                  => 'A family A',
         ];
 
         $family = $this->get('pim_catalog.repository.family')->findOneByIdentifier('familyA');

--- a/src/Pim/Bundle/VersioningBundle/tests/integration/Normalizer/Flat/ProductIntegration.php
+++ b/src/Pim/Bundle/VersioningBundle/tests/integration/Normalizer/Flat/ProductIntegration.php
@@ -15,10 +15,7 @@ class ProductIntegration extends TestCase
 {
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalSqlCatalogPath()],
-            false
-        );
+        return new Configuration([Configuration::getTechnicalSqlCatalogPath()]);
     }
 
     public function testProduct()

--- a/tests/FixturesLoader.php
+++ b/tests/FixturesLoader.php
@@ -2,7 +2,6 @@
 
 namespace Akeneo\Test\Integration;
 
-use Akeneo\Bundle\StorageUtilsBundle\DependencyInjection\AkeneoStorageUtilsExtension;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
@@ -79,6 +78,7 @@ class FixturesLoader
             $this->dropDatabase();
             $this->createDatabase();
             $this->restoreDatabase($dumpFile);
+            $this->clearAclCache();
 
             return;
         }
@@ -344,5 +344,16 @@ class FixturesLoader
         }
 
         return $process->getOutput();
+    }
+
+    /**
+     * Clear Oro cache about Acl.
+     * This cache should be cleared when loading the fixtures with mysql dump.
+     * It avoids inconsistency between the cache and the new data in the database.
+     */
+    protected function clearAclCache()
+    {
+        $aclCache = $this->container->get('security.acl.cache');
+        $aclCache->clearCache();
     }
 }


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

The integrations tests stack has several drawbacks:

- scalable but manually with test suites
- running time very heterogeneous on nodes (not the same number of tests between the test suites)
- some integration were not executed: adding a new directory in the tests should be declared in the phpunit.xml
- integration tests are not executed in EE => MISSION ABORTED

This PR aims to fix all of these problems.

### Scalability

There are about 250 integration files in CE, and about 1740 integration tests. Each test run in approximately 6s.
So, about 3 hours to run all the integration tests.

The first attempt was to execute in each node the same number of files. 
For example, with 10 nodes, 25 files per node.
But the result was that some nodes run with 80 tests and another one 375 tests.
So, some nodes were running in 8 minutes and the longest one in 35min.

Therefore, I choose to execute in each node approximately the same number of tests (not the same number of files).
With 10 nodes, each node run approximately 170 tests. So, approximately in 18 minutes.

### Maintenability

As said above, some integration tests were not executed because the path was not added in the phpunit.xml file.
Declare every tests in phpunit.xml is not maintainable.

It's very difficult to get a list of integration tests with phpunit. Trust me, you can Google it ;)
Moreover, it's very difficult to execute a list of class with phpunit. No command exist.

So, I've choosen to keep it simple:

- get a list of integration file and number of tests in each file, thanks to a shell command
- split it according to the number of nodes, each nodes should run approximately the same number of tests that the other => done in a groovy function

Now, the only thing to do is to add docker nodes if we want to speed up the execution time.
And change the variable `nbAvailableNode ` in the file. 

Pretty simple :)

### EE execution (aborted)

I've tried but it implies more stuff than expected.
For now, when I execute integration tests in EE with all the integration tests from CE, I have an error because the catalog could not be installed.
It could not because the path to the catalog returns the fixtures of the CE, but without the fixtures of the EE.

So, it fails with an exception from here https://github.com/akeneo/pim-community-dev/blob/master/src/Pim/Bundle/InstallerBundle/FixtureLoader/JobInstancesConfigurator.php#L79

`Exception: No replacement path for "asset_categories.csv"`

The job instances (containing job EE + CE) does not match the replace path (only CE path).

### Benchmark

|    Parallelisation strategy    | Time           |
| ------------- |:-------------:|
| Manual test suites (actual behavior) | 1h |
| Same number of files in each node | ~35m      |
| Same number of tests in each node | ~18m      |
| Same number of tests in each node + mysql in ram | ~6m |

Note: I've experienced a lot of instability on the CI's node: sometime some nodes run PHPUnit in 40 minutes (instead of 6m). Not always on the same node, not always on the same bunch of tests.

I think it's an already existing problem on the current stack, I will raise an issue.

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
