### PR TITLE
- Change Product locale-switcher to select2 field with auto completion

### DIFF
--- a/CHANGELOG-1.8.md
+++ b/CHANGELOG-1.8.md
@@ -27,6 +27,7 @@
 - PIM-6290: Update the main navigation design
 - PIM-6397: Enable Search filter on all grids
 - PIM-6406: Update job profile show page to include last executions
+- Change Product Locale-switcher to select2 field with auto completion
 
 ## Remove MongoDB product storage
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/locale-switcher.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/locale-switcher.html
@@ -1,9 +1,9 @@
-<a class="AknActionButton<% if (displayInline) { %> AknActionButton--big AknActionButton--noLeftBorder<% } %>" data-toggle="dropdown" href="#">
-    <%= i18n.getFlag(currentLocale.code, false) %> <%- currentLocale.language %>
-    <span class="AknActionButton-caret AknCaret"></span>
-</a>
-<ul class="AknDropdown-menu">
-    <% _.each(locales, function (locale) { %>
-        <li><a class="AknDropdown-menuLink<% if (currentLocale.code === locale.code) { %> AknDropdown-menuLink--active<% } %>" data-locale="<%- locale.code %>"><%= i18n.getFlag(locale.code, false) %> <%- locale.language %></a></li>
-    <% }); %>
-</ul>
+<div class="AknFieldContainer-inputContainer">
+    <select class="select2 locale-switcher" id="locale-switcher">
+        <% _.each(locales, function (locale) { %>
+        <option value="<%- locale.code %>" <%- (currentLocale.code === locale.code) ? 'selected' : '' %> >
+            <%- locale.label %>
+        </option>
+        <% }); %>
+    </select>
+</div>


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**
Changed product locale switcher to select2 field with auto completion to create the
possibility to filter by typing (suggestion) while selecting locale. It is neccessary if there are many locales available in the channel 

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
