### PR TITLE
Add a Docker compose file to the PIM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,10 +18,14 @@ app/file_storage/*
 app/bootstrap.php.cache
 app/phpunit.xml
 build/
+/docker/*
+!/docker/akeneo.conf
+!/docker/akeneo-behat.conf
 vendor
 composer.phar
 /cov
-/bin
+/bin/*
+!/bin/merge-coverage
 behat.yml
 web/uploads/*
 web/uploads_test/*
@@ -32,3 +36,4 @@ composer.lock
 .php_cs.cache
 node_modules/
 .grunt/
+docker-compose.yml

--- a/docker-compose.yml.dist
+++ b/docker-compose.yml.dist
@@ -1,0 +1,102 @@
+version: '2'
+
+services:
+  akeneo:
+    image: akeneo/apache-php:php-5.6
+    depends_on:
+      - mysql
+      - mongodb
+    environment:
+      COMPOSER_HOME: '/home/docker/.composer'
+      PHP_IDE_CONFIG: 'serverName=pim-ce'
+      PHP_XDEBUG_ENABLED: 0
+      PHP_XDEBUG_IDE_KEY: XDEBUG_IDE_KEY
+      PHP_XDEBUG_REMOTE_HOST: xxx.xxx.xxx.xxx
+      XDEBUG_CONFIG: 'remote_host=xxx.xxx.xxx.xxx'
+    ports:
+      - '8080:80'
+    user: docker
+    volumes:
+      - ./:/srv/pim
+      - ./docker/akeneo.conf:/etc/apache2/sites-available/000-default.conf:ro
+      - ~/.config/composer:/home/docker/.composer
+    working_dir: /srv/pim
+    networks:
+      - akeneo
+
+  akeneo-behat:
+    image: akeneo/apache-php:php-5.6
+    depends_on:
+      - mysql-behat
+      - mongodb-behat
+      - selenium
+    environment:
+      BEHAT_TMPDIR: '/srv/pim/app/cache/tmp'
+      COMPOSER_HOME: '/home/docker/.composer'
+      PHP_IDE_CONFIG: 'serverName=pim-ce-behat'
+      PHP_XDEBUG_ENABLED: 0
+      PHP_XDEBUG_IDE_KEY: XDEBUG_IDE_KEY
+      PHP_XDEBUG_REMOTE_HOST: xxx.xxx.xxx.xxx
+      XDEBUG_CONFIG: 'remote_host=xxx.xxx.xxx.xxx'
+    ports:
+      - '8081:80'
+    user: docker
+    volumes:
+      - ./:/srv/pim
+      - ./docker/akeneo-behat.conf:/etc/apache2/sites-available/000-default.conf:ro
+      - ~/.config/composer:/home/docker/.composer
+      - /tmp/behat/screenshots:/tmp/behat/screenshots
+    working_dir: /srv/pim
+    networks:
+      - behat
+
+  selenium:
+    image: selenium/standalone-firefox-debug:2.53.1-beryllium
+    ports:
+      - '5900:5900'
+    volumes:
+      - .:/srv/pim
+    networks:
+      - behat
+
+  mysql:
+    image: mysql:5.5
+    environment:
+      - MYSQL_ROOT_PASSWORD=root
+      - MYSQL_USER=akeneo_pim
+      - MYSQL_PASSWORD=akeneo_pim
+      - MYSQL_DATABASE=akeneo_pim
+    ports:
+      - '3306:3306'
+    networks:
+      - akeneo
+
+  mysql-behat:
+    image: mysql:5.5
+    environment:
+      - MYSQL_ROOT_PASSWORD=root
+      - MYSQL_USER=akeneo_pim
+      - MYSQL_PASSWORD=akeneo_pim
+      - MYSQL_DATABASE=akeneo_pim
+    ports:
+      - '3307:3306'
+    networks:
+      - behat
+
+  mongodb:
+    image: mongo:2.4
+    ports:
+      - '21017:21017'
+    networks:
+      - akeneo
+
+  mongodb-behat:
+    image: mongo:2.4
+    ports:
+      - '21018:21017'
+    networks:
+      - behat
+
+networks:
+  akeneo: ~
+  behat: ~

--- a/docker/akeneo-behat.conf
+++ b/docker/akeneo-behat.conf
@@ -1,0 +1,26 @@
+<VirtualHost *:80>
+    ServerName akeneo-behat.dev
+
+    DocumentRoot /srv/pim/web
+    <Directory /srv/pim/web>
+        AllowOverride None
+        Require all granted
+
+        Options -MultiViews
+        RewriteEngine On
+        RewriteCond %{REQUEST_FILENAME} !-f
+        RewriteRule ^(.*)$ app_behat.php [QSA,L]
+    </Directory>
+
+    <Directory /srv/pim>
+        Options FollowSymlinks
+    </Directory>
+
+    <Directory /srv/pim/web/bundles>
+        RewriteEngine Off
+    </Directory>
+
+    ErrorLog /var/log/akeneo-behat_error.log
+    LogLevel warn
+    CustomLog /var/log/akeneo-behat_access.log combined
+</VirtualHost>

--- a/docker/akeneo.conf
+++ b/docker/akeneo.conf
@@ -1,0 +1,26 @@
+<VirtualHost *:80>
+    ServerName akeneo.dev
+
+    DocumentRoot /srv/pim/web
+    <Directory /srv/pim/web>
+        AllowOverride None
+        Require all granted
+
+        Options -MultiViews
+        RewriteEngine On
+        RewriteCond %{REQUEST_FILENAME} !-f
+        RewriteRule ^(.*)$ app.php [QSA,L]
+    </Directory>
+
+    <Directory /srv/pim>
+        Options FollowSymlinks
+    </Directory>
+
+    <Directory /srv/pim/web/bundles>
+        RewriteEngine Off
+    </Directory>
+
+    ErrorLog /var/log/akeneo_error.log
+    LogLevel warn
+    CustomLog /var/log/akeneo_access.log combined
+</VirtualHost>

--- a/src/Pim/Bundle/InstallerBundle/Command/InstallCommand.php
+++ b/src/Pim/Bundle/InstallerBundle/Command/InstallCommand.php
@@ -33,7 +33,9 @@ class InstallCommand extends ContainerAwareCommand
         $this
             ->setName('pim:install')
             ->setDescription(sprintf('%s Application Installer.', static::APP_NAME))
-            ->addOption('force', null, InputOption::VALUE_NONE, 'Force installation');
+            ->addOption('force', null, InputOption::VALUE_NONE, 'Force installation')
+            ->addOption('symlink', null, InputOption::VALUE_NONE, 'Install assets as symlinks')
+            ->addOption('clean', null, InputOption::VALUE_NONE, 'Clean previous install');
     }
 
     /**
@@ -133,7 +135,10 @@ class InstallCommand extends ContainerAwareCommand
      */
     protected function assetsStep(InputInterface $input, OutputInterface $output)
     {
-        $this->commandExecutor->runCommand('pim:installer:assets');
+        $options = null === $input->getOption('symlink') ? [] : ['--symlink' => true];
+        $options = null === $input->getOption('clean') ? $options : array_merge($options, ['--clean' => true]);
+
+        $this->commandExecutor->runCommand('pim:installer:assets', $options);
 
         return $this;
     }
@@ -155,6 +160,8 @@ class InstallCommand extends ContainerAwareCommand
         $params = $dumper->parse();
         $params['system']['installed'] = $installed;
         $dumper->dump($params);
+
+        return $this;
     }
 
     /**

--- a/src/Pim/Bundle/InstallerBundle/Resources/config/services.yml
+++ b/src/Pim/Bundle/InstallerBundle/Resources/config/services.yml
@@ -4,12 +4,12 @@ parameters:
 
 services:
     pim_installer.yaml_persister:
-        class: %pim_installer.yaml_persister.class%
+        class: '%pim_installer.yaml_persister.class%'
         arguments:
-            - %kernel.root_dir%/config
-            - %kernel.environment%
+            - '%kernel.root_dir%/config'
+            - '%kernel.environment%'
 
     pim_installer.directories_registry:
-        class: %pim_installer.directories_registry.class%
+        class: '%pim_installer.directories_registry.class%'
         arguments:
-            - [%catalog_storage_dir%, %tmp_storage_dir%, %archive_dir%]
+            - ['%catalog_storage_dir%', '%tmp_storage_dir%', '%archive_dir%', '%upload_dir%']


### PR DESCRIPTION
## Description

Add a `docker-compose.yml.dist` file, pre-configured. It uses `akeneo/apache-php:php-5.6` image for akeneo containers.

The commands `pim:install` and `pim:installer:assets` have been updated too, to add two new options:
- `symlink`: this will install the assets as relative symlinks instead of hard copy (present in both command as  `pim:install` and `pim:installer:assets`)
- `clean`: this will completely clean the artefacts of the previous pim install, or the previous assets install

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
