### PR TITLE
PIM-6526

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-6529: allow more than 100 elements to be exported with YAML export
+- PIM-6526: Prevent MySQL exclusive locks on completeness calculation requests
 
 # 1.6.17 (2017-06-30)
 

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/CompletenessGenerator.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/CompletenessGenerator.php
@@ -121,16 +121,16 @@ class CompletenessGenerator implements CompletenessGeneratorInterface
         $cleanupStmt = $this->connection->prepare($cleanupSql);
         $cleanupStmt->execute();
 
-        // Create temporary table
-        $createSQL = 'CREATE TEMPORARY TABLE ' .
-            self::COMPLETE_PRICES_TABLE .
-            ' (locale_id int, channel_id int, value_id int, primary key(locale_id, channel_id, value_id)) ';
-        $createSQL = $this->applyTableNames($createSQL);
+        $tempTableName = self::COMPLETE_PRICES_TABLE;
+        $createSQL = <<<SQL
+    CREATE TEMPORARY TABLE {$tempTableName}
+    (locale_id int, channel_id int, value_id int, primary key(locale_id, channel_id, value_id))
+SQL;
 
+        $createSQL = $this->applyTableNames($createSQL);
         $tempTableStmt = $this->connection->prepare($createSQL);
         $tempTableStmt->execute();
 
-        // Execute the SELECT
         $sql = $this->getCompletePricesSQL();
         $sql = $this->applyCriteria($sql, $criteria);
         $sql = $this->applyTableNames($sql);
@@ -141,23 +141,21 @@ class CompletenessGenerator implements CompletenessGeneratorInterface
         }
         $fetchStmt->execute();
 
-        // Fill in temporary table
         $this->connection->beginTransaction();
-        $insertPattern = 'INSERT INTO %s (locale_id, channel_id, value_id) VALUES (%s, %s, %s)';
+        $insertSql = <<<SQL
+    INSERT INTO {$tempTableName} (locale_id, channel_id, value_id) 
+    VALUES (?, ?, ?)
+SQL;
+        $insertStmt = $this->connection->prepare($insertSql);
 
         try {
             while ($completeness = $fetchStmt->fetch()) {
-                $insertSQL = sprintf(
-                    $insertPattern,
-                    self::COMPLETE_PRICES_TABLE,
-                    $completeness['locale_id'],
-                    $completeness['channel_id'],
-                    $completeness['value_id']
-                );
-
-                $insertStmt = $this->connection->prepare($insertSQL);
+                $insertStmt->bindValue(1, $completeness['locale_id']);
+                $insertStmt->bindValue(2, $completeness['channel_id']);
+                $insertStmt->bindValue(3, $completeness['value_id']);
                 $insertStmt->execute();
             }
+
             $this->connection->commit();
         } catch (\Exception $e) {
             $this->connection->rollBack();
@@ -177,16 +175,15 @@ class CompletenessGenerator implements CompletenessGeneratorInterface
         $cleanupStmt = $this->connection->prepare($cleanupSql);
         $cleanupStmt->execute();
 
-        // Create temporary table
         $tempTableName = self::MISSING_TABLE;
-        $createPattern = 'CREATE TEMPORARY TABLE %s (locale_id int, channel_id int, product_id int)';
-        $createSql = sprintf($createPattern, $tempTableName);
-        $createSql = $this->applyTableNames($createSql);
+        $createSql = <<<SQL
+    CREATE TEMPORARY TABLE {$tempTableName} (locale_id int, channel_id int, product_id int)
+SQL;
 
+        $createSql = $this->applyTableNames($createSql);
         $tempTableStmt = $this->connection->prepare($createSql);
         $tempTableStmt->execute();
 
-        // Execute the SELECT
         $sql = $this->getMissingCompletenessesSQL();
         $sql = $this->applyCriteria($sql, $criteria);
         $sql = $this->applyTableNames($sql);
@@ -197,23 +194,20 @@ class CompletenessGenerator implements CompletenessGeneratorInterface
         }
         $fetchStmt->execute();
 
-        // Fill in temporary table
         $this->connection->beginTransaction();
-        $insertPattern = 'INSERT INTO %s (locale_id, channel_id, product_id) VALUES (%s, %s, %s)';
+        $insertSql = <<<SQL
+    INSERT INTO {$tempTableName} (locale_id, channel_id, product_id) VALUES (?, ?, ?)
+SQL;
+        $insertStmt = $this->connection->prepare($insertSql);
 
         try {
             while ($completeness = $fetchStmt->fetch()) {
-                $insertSQL = sprintf(
-                    $insertPattern,
-                    $tempTableName,
-                    $completeness['locale_id'],
-                    $completeness['channel_id'],
-                    $completeness['product_id']
-                );
-
-                $insertStmt = $this->connection->prepare($insertSQL);
+                $insertStmt->bindValue(1, $completeness['locale_id']);
+                $insertStmt->bindValue(2, $completeness['channel_id']);
+                $insertStmt->bindValue(3, $completeness['product_id']);
                 $insertStmt->execute();
             }
+
             $this->connection->commit();
         } catch (\Exception $e) {
             $this->connection->rollBack();
@@ -334,24 +328,23 @@ MISSING_SQL;
         $fetchStmt->execute();
 
         $this->connection->beginTransaction();
-        $insertPattern = 'INSERT INTO pim_catalog_completeness ' .
-            '(locale_id, channel_id, product_id, ratio, missing_count, required_count) VALUES (%s, %s, %s, %s, %s, %s)';
+        $insertSql = <<<SQL
+    INSERT INTO pim_catalog_completeness
+    (locale_id, channel_id, product_id, ratio, missing_count, required_count) VALUES (?, ?, ?, ?, ?, ?)
+SQL;
+        $insertStmt = $this->connection->prepare($insertSql);
 
         try {
             while ($completeness = $fetchStmt->fetch()) {
-                $insertSQL = sprintf(
-                    $insertPattern,
-                    $completeness['locale_id'],
-                    $completeness['channel_id'],
-                    $completeness['product_id'],
-                    $completeness['ratio'],
-                    $completeness['missing_count'],
-                    $completeness['required_count']
-                );
-
-                $insertStmt = $this->connection->prepare($insertSQL);
+                $insertStmt->bindValue(1, $completeness['locale_id']);
+                $insertStmt->bindValue(2, $completeness['channel_id']);
+                $insertStmt->bindValue(3, $completeness['product_id']);
+                $insertStmt->bindValue(4, $completeness['ratio']);
+                $insertStmt->bindValue(5, $completeness['missing_count']);
+                $insertStmt->bindValue(6, $completeness['required_count']);
                 $insertStmt->execute();
             }
+
             $this->connection->commit();
         } catch (\Exception $e) {
             $this->connection->rollBack();

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/CompletenessGenerator.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/CompletenessGenerator.php
@@ -153,7 +153,7 @@ SQL;
 
         $insertSql = <<<SQL
     INSERT INTO {$tempTableName} (locale_id, channel_id, value_id) 
-    VALUES (?, ?, ?)
+    VALUES (:locale_id, :channel_id, :value_id)
 SQL;
         $insertStmt = $this->connection->prepare($insertSql);
         $count = 0;
@@ -164,9 +164,9 @@ SQL;
                     $this->connection->beginTransaction();
                 }
 
-                $insertStmt->bindValue(1, $completeness['locale_id']);
-                $insertStmt->bindValue(2, $completeness['channel_id']);
-                $insertStmt->bindValue(3, $completeness['value_id']);
+                $insertStmt->bindValue('locale_id', $completeness['locale_id']);
+                $insertStmt->bindValue('channel_id', $completeness['channel_id']);
+                $insertStmt->bindValue('value_id', $completeness['value_id']);
                 $insertStmt->execute();
                 $count++;
 
@@ -217,7 +217,8 @@ SQL;
         $fetchStmt->execute();
 
         $insertSql = <<<SQL
-    INSERT INTO {$tempTableName} (locale_id, channel_id, product_id) VALUES (?, ?, ?)
+    INSERT INTO {$tempTableName} (locale_id, channel_id, product_id) 
+    VALUES (:locale_id, :channel_id, :product_id)
 SQL;
         $insertStmt = $this->connection->prepare($insertSql);
         $count = 0;
@@ -228,9 +229,9 @@ SQL;
                     $this->connection->beginTransaction();
                 }
 
-                $insertStmt->bindValue(1, $completeness['locale_id']);
-                $insertStmt->bindValue(2, $completeness['channel_id']);
-                $insertStmt->bindValue(3, $completeness['product_id']);
+                $insertStmt->bindValue('locale_id', $completeness['locale_id']);
+                $insertStmt->bindValue('channel_id', $completeness['channel_id']);
+                $insertStmt->bindValue('product_id', $completeness['product_id']);
                 $insertStmt->execute();
                 $count++;
 
@@ -362,8 +363,8 @@ MISSING_SQL;
         $fetchStmt->execute();
 
         $insertSql = <<<SQL
-    INSERT INTO pim_catalog_completeness
-    (locale_id, channel_id, product_id, ratio, missing_count, required_count) VALUES (?, ?, ?, ?, ?, ?)
+    INSERT INTO pim_catalog_completeness (locale_id, channel_id, product_id, ratio, missing_count, required_count) 
+    VALUES (:locale_id, :channel_id, :product_id, :ratio, :missing_count, :required_count)
 SQL;
         $insertStmt = $this->connection->prepare($insertSql);
         $count = 0;
@@ -374,12 +375,12 @@ SQL;
                     $this->connection->beginTransaction();
                 }
 
-                $insertStmt->bindValue(1, $completeness['locale_id']);
-                $insertStmt->bindValue(2, $completeness['channel_id']);
-                $insertStmt->bindValue(3, $completeness['product_id']);
-                $insertStmt->bindValue(4, $completeness['ratio']);
-                $insertStmt->bindValue(5, $completeness['missing_count']);
-                $insertStmt->bindValue(6, $completeness['required_count']);
+                $insertStmt->bindValue('locale_id', $completeness['locale_id']);
+                $insertStmt->bindValue('channel_id', $completeness['channel_id']);
+                $insertStmt->bindValue('product_id', $completeness['product_id']);
+                $insertStmt->bindValue('ratio', $completeness['ratio']);
+                $insertStmt->bindValue('missing_count', $completeness['missing_count']);
+                $insertStmt->bindValue('required_count', $completeness['required_count']);
                 $insertStmt->execute();
                 $count++;
 

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/storage_driver/doctrine/orm.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/storage_driver/doctrine/orm.yml
@@ -49,6 +49,7 @@ services:
             - '%pim_catalog.entity.product.class%'
             - '%pim_catalog.entity.product_value.class%'
             - '%pim_catalog.entity.attribute.class%'
+            - '1000'
 
     pim_catalog.event_subscriber.orm.inject_product_reference:
         class: '%pim_catalog.event_subscriber.orm.inject_product_reference.class%'


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This PR is to avoid a deadlock on completeness requests.
When we do a `INSERT INTO (...) SELECT FROM`, the `SELECT` is linked to a writing statement, so it does a  "hard" (exclusive) lock of the table. The same goes for `CREATE TEMPORARY TABLE (...) SELECT FROM`, as it's a writing operation too.

This PRs avoids this by executing the `SELECT` statement **before** doing the writing operation, this way, tables touched by the `SELECT` are not "hard locked" (soft lock).

-----
**Before:**
Duration (in milliseconds): 53366
Memory usage (in bytes): 36175872

**With this patch:**
Duration (in milliseconds): 67761 (**x1.2**)
Memory usage (in bytes): 36438016 (**x1.007**)

_Benchmark done with catalog medium, 10k products_.

-------


**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | N
| Added Behats                      | N
| Added integration tests           | N
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Migration script                  | -
| Tech Doc                          | -