### PR TITLE
PIM-6529: allow more than 100 elements to be exported with YAML export

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -1,5 +1,9 @@
 # 1.6.x
 
+## Bug fixes
+
+- PIM-6529: allow more than 100 elements to be exported with YAML export
+
 # 1.6.17 (2017-06-30)
 
 ## Bug fixes

--- a/src/Pim/Component/Connector/Writer/File/Yaml/Writer.php
+++ b/src/Pim/Component/Connector/Writer/File/Yaml/Writer.php
@@ -52,7 +52,7 @@ class Writer extends AbstractFileWriter implements
 
         $yaml = Yaml::dump($data, self::INLINE_ARRAY_LEVEL);
 
-        if (false === file_put_contents($path, $yaml)) {
+        if (false === file_put_contents($path, $yaml, FILE_APPEND)) {
             throw new RuntimeErrorException('Failed to write to file %path%', ['%path%' => $this->getPath()]);
         }
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
This bug has been spotted while trying to export more than 100 rules. Only the last N%100 rules were exported.
This is because batch of elements to be written were overriding previous ones.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | Yes
| Review and 2 GTM                  | Yes
| Micro Demo to the PO (Story only) | -
| Migration script                  | No
| Tech Doc                          | No

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed

CI Not okay, but failed on 2 different unrelated scenarii, random behavior. Merge accepted