### PR TITLE
PIM-6330: Import new family variants

### DIFF
--- a/features/Context/catalog/catalog_modeling/jobs.yml
+++ b/features/Context/catalog/catalog_modeling/jobs.yml
@@ -72,3 +72,21 @@ jobs:
         alias:     csv_product_import
         label:     CSV default product import
         type:      import
+
+    csv_catalog_modeling_family_variant_import:
+        connector: Akeneo CSV Connector
+        alias:     csv_family_variant_import
+        label:     CSV catalog modeling family variant import
+        type:      import
+        configuration:
+            uploadAllowed: true
+            delimiter:     ;
+            enclosure:     '"'
+            escape:        '\'
+    xlsx_catalog_modeling_family_variant_import:
+        connector: Akeneo XLSX Connector
+        alias:     xlsx_family_variant_import
+        label:     XLSX catalog modeling family variant import
+        type:      import
+        configuration:
+            uploadAllowed: true

--- a/features/Pim/Behat/Context/FixturesContext.php
+++ b/features/Pim/Behat/Context/FixturesContext.php
@@ -7,6 +7,7 @@ use Context\Spin\TimeoutException;
 use Doctrine\Common\Util\ClassUtils;
 use Doctrine\Common\Util\Debug;
 use Doctrine\Common\Util\Inflector;
+use Pim\Component\Catalog\Model\FamilyVariant;
 use Pim\Component\Catalog\Model\ProductInterface;
 
 /**
@@ -27,6 +28,7 @@ class FixturesContext extends PimContext
         'Channel'          => 'PimCatalogBundle:Channel',
         'Currency'         => 'PimCatalogBundle:Currency',
         'Family'           => 'PimCatalogBundle:Family',
+        'FamilyVariant'    => FamilyVariant::class,
         'Category'         => 'PimCatalogBundle:Category', // TODO: To remove
         'ProductCategory'  => 'PimCatalogBundle:Category',
         'AssociationType'  => 'PimCatalogBundle:AssociationType',

--- a/features/import/family_variant/csv/create_family_variant.feature
+++ b/features/import/family_variant/csv/create_family_variant.feature
@@ -1,0 +1,54 @@
+@javascript
+Feature: Create variants of family through CSV import
+  In order to setup my application
+  As a product manager
+  I need to be able to import new family variants
+
+  Background:
+    Given the "catalog_modeling" catalog configuration
+    And I am logged in as "Julia"
+
+  Scenario: I successfully import a variant by color and size with two levels of variation for the family clothing
+    Given the following CSV file to import:
+      """
+      code;family;label-de_DE;label-en_US;label-fr_FR;variant-axes_1;variant-axes_2;variant-attributes_1;variant-attributes_2
+      clothing_color_size;clothing;Kleidung nach Farbe und Größe;Clothing by color and size;Vêtements par couleur et taille;color;size;color,name,image_1,variation_image,composition;size,EAN,sku,weight
+      """
+    And the following job "csv_catalog_modeling_family_variant_import" configuration:
+      | filePath | %file to import% |
+    When I am on the "csv_catalog_modeling_family_variant_import" import job page
+    And I launch the import job
+    And I wait for the "csv_catalog_modeling_family_variant_import" job to finish
+    Then there should be the following family variants:
+      | code                | family   | label-de_DE                   | label-en_US                | label-fr_FR                     | variant-axes_1 | variant-axes_2 | variant-attributes_1                           | variant-attributes_2 |
+      | clothing_color_size | clothing | Kleidung nach Farbe und Größe | Clothing by color and size | Vêtements par couleur et taille | color          | size           | color,name,image_1,variation_image,composition | size,EAN,sku,weight  |
+
+  Scenario: I successfully import a variant by size with one level of variation for the family shoes
+    Given the following CSV file to import:
+      """
+      code;family;label-de_DE;label-en_US;label-fr_FR;variant-axes_1;variant-attributes_1
+      shoes_size;shoes;Schuhe nach Größe;Shoes by size;Chaussures par taille;eu_shoes_size;weight
+      """
+    And the following job "csv_catalog_modeling_family_variant_import" configuration:
+      | filePath | %file to import% |
+    When I am on the "csv_catalog_modeling_family_variant_import" import job page
+    And I launch the import job
+    And I wait for the "csv_catalog_modeling_family_variant_import" job to finish
+    Then there should be the following family variants:
+      | code       | family | label-de_DE       | label-en_US    | label-fr_FR          | variant-axes_1 | variant-attributes_1 |
+      | shoes_size | shoes  | Schuhe nach Größe | Shoes by size | Chaussures par taille | eu_shoes_size  | weight               |
+
+  Scenario: I successfully import a variant by color and size with one level of variation for the family clothing
+    Given the following CSV file to import:
+      """
+      code;family;label-de_DE;label-en_US;label-fr_FR;variant-axes_1;variant-attributes_1
+      clothing_color_size;clothing;Kleidung nach Farbe und Größe;Clothing by color and size;Vêtements par couleur et taille;color,size;name,image_1,variation_image,composition
+      """
+    And the following job "csv_catalog_modeling_family_variant_import" configuration:
+      | filePath | %file to import% |
+    When I am on the "csv_catalog_modeling_family_variant_import" import job page
+    And I launch the import job
+    And I wait for the "csv_catalog_modeling_family_variant_import" job to finish
+    Then there should be the following family variants:
+      | code                | family   | label-de_DE                   | label-en_US                | label-fr_FR                     | variant-axes_1 | variant-attributes_1                     |
+      | clothing_color_size | clothing | Kleidung nach Farbe und Größe | Clothing by color and size | Vêtements par couleur et taille | color,size     | name,image_1,variation_image,composition |

--- a/features/import/family_variant/xlsx/create_family_variant.feature
+++ b/features/import/family_variant/xlsx/create_family_variant.feature
@@ -1,0 +1,54 @@
+@javascript
+Feature: Create variants of family through XLSX import
+  In order to setup my application
+  As a product manager
+  I need to be able to import new family variants
+
+  Background:
+    Given the "catalog_modeling" catalog configuration
+    And I am logged in as "Julia"
+
+  Scenario: I successfully import a variant by color and size with two levels of variation for the family clothing
+    Given the following XLSX file to import:
+      """
+      code;family;label-de_DE;label-en_US;label-fr_FR;variant-axes_1;variant-axes_2;variant-attributes_1;variant-attributes_2
+      clothing_color_size;clothing;Kleidung nach Farbe und Größe;Clothing by color and size;Vêtements par couleur et taille;color;size;color,name,image_1,variation_image,composition;size,EAN,sku,weight
+      """
+    And the following job "xlsx_catalog_modeling_family_variant_import" configuration:
+      | filePath | %file to import% |
+    When I am on the "xlsx_catalog_modeling_family_variant_import" import job page
+    And I launch the import job
+    And I wait for the "xlsx_catalog_modeling_family_variant_import" job to finish
+    Then there should be the following family variants:
+      | code                | family   | label-de_DE                   | label-en_US                | label-fr_FR                     | variant-axes_1 | variant-axes_2 | variant-attributes_1                           | variant-attributes_2 |
+      | clothing_color_size | clothing | Kleidung nach Farbe und Größe | Clothing by color and size | Vêtements par couleur et taille | color          | size           | color,name,image_1,variation_image,composition | size,EAN,sku,weight  |
+
+  Scenario: I successfully import a variant by size with one level of variation for the family shoes
+    Given the following XLSX file to import:
+      """
+      code;family;label-de_DE;label-en_US;label-fr_FR;variant-axes_1;variant-attributes_1
+      shoes_size;shoes;Schuhe nach Größe;Shoes by size;Chaussures par taille;eu_shoes_size;weight
+      """
+    And the following job "xlsx_catalog_modeling_family_variant_import" configuration:
+      | filePath | %file to import% |
+    When I am on the "xlsx_catalog_modeling_family_variant_import" import job page
+    And I launch the import job
+    And I wait for the "xlsx_catalog_modeling_family_variant_import" job to finish
+    Then there should be the following family variants:
+      | code       | family | label-de_DE       | label-en_US    | label-fr_FR          | variant-axes_1 | variant-attributes_1 |
+      | shoes_size | shoes  | Schuhe nach Größe | Shoes by size | Chaussures par taille | eu_shoes_size  | weight               |
+
+  Scenario: I successfully import a variant by color and size with one level of variation for the family clothing
+    Given the following XLSX file to import:
+      """
+      code;family;label-de_DE;label-en_US;label-fr_FR;variant-axes_1;variant-attributes_1
+      clothing_color_size;clothing;Kleidung nach Farbe und Größe;Clothing by color and size;Vêtements par couleur et taille;color,size;name,image_1,variation_image,composition
+      """
+    And the following job "xlsx_catalog_modeling_family_variant_import" configuration:
+      | filePath | %file to import% |
+    When I am on the "xlsx_catalog_modeling_family_variant_import" import job page
+    And I launch the import job
+    And I wait for the "xlsx_catalog_modeling_family_variant_import" job to finish
+    Then there should be the following family variants:
+      | code                | family   | label-de_DE                   | label-en_US                | label-fr_FR                     | variant-axes_1 | variant-attributes_1                     |
+      | clothing_color_size | clothing | Kleidung nach Farbe und Größe | Clothing by color and size | Vêtements par couleur et taille | color,size     | name,image_1,variation_image,composition |

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/model/doctrine/VariantAttributeSet.orm.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/model/doctrine/VariantAttributeSet.orm.yml
@@ -9,6 +9,9 @@ Pim\Component\Catalog\Model\VariantAttributeSet:
             id: true
             generator:
                 strategy: AUTO
+        level:
+            type: integer
+            column: level
 
     manyToMany:
         attributes:

--- a/src/Pim/Bundle/CatalogBundle/Resources/translations/messages.en.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/translations/messages.en.yml
@@ -8,6 +8,7 @@ pim_catalog:
         family_variant_axes_attribute_type: Variant axes "%axis%" must be a boolean, a simple select, a simple reference data or a metric
         family_variant_axes_wrong_type: Variant axes "%axis%" cannot be localizable, not scopable and not locale specific
         family_variant_axes_number_of_axes: A variant attribute set cannot have more than 5 attributes
+        family_variant_level_do_not_exist: There is no variant attribute set for level "%level%"
         family_variant_attributes_unique: Attributes must be unique, "%attributes%" are used several times in variant attributes sets
         product_identifier: These identifiers "%s" don't exist.
         0: An unexpected error occurred.

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Family/FamilyVariantIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Family/FamilyVariantIntegration.php
@@ -245,15 +245,6 @@ class FamilyVariantIntegration extends TestCase
     }
 
     /**
-     * un attribute ne peut pas être un arbre et vise versa
-     * da
-     */
-    public function testTODO()
-    {
-
-    }
-
-    /**
      * {@inheritdoc}
      */
     protected function getConfiguration()

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Family/FamilyVariantIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Family/FamilyVariantIntegration.php
@@ -15,9 +15,9 @@ class FamilyVariantIntegration extends TestCase
      */
     public function testTheFamilyVariantCreation()
     {
-        $variantFamily = $this->get('pim_catalog.factory.family_variant')->create();
+        $familyVariant = $this->get('pim_catalog.factory.family_variant')->create();
 
-        $this->get('pim_catalog.updater.family_variant')->update($variantFamily, [
+        $this->get('pim_catalog.updater.family_variant')->update($familyVariant, [
             'code' => 'family_variant',
             'family' => 'boots',
             'label' => [
@@ -26,32 +26,33 @@ class FamilyVariantIntegration extends TestCase
             'variant_attribute_sets' => [
                 [
                     'axes' => ['color'],
-                    'attributes' => ['weather_conditions', 'rating', 'side_view', 'top_view', 'lace_color']
+                    'attributes' => ['weather_conditions', 'rating', 'side_view', 'top_view', 'lace_color'],
+                    'level'=> 1,
                 ],
                 [
                     'axes' => ['size'],
-                    'attributes' => ['sku', 'price']
+                    'attributes' => ['sku', 'price'],
+                    'level'=> 2,
                 ]
             ],
         ]);
 
-        $errors = $this->get('validator')->validate($variantFamily);
+        $errors = $this->get('validator')->validate($familyVariant);
         $this->assertEquals(0, $errors->count());
 
-        $this->get('pim_catalog.saver.family_variant')->save($variantFamily);
+        $this->get('pim_catalog.saver.family_variant')->save($familyVariant);
 
-        /** @var FamilyVariantInterface $variantFamily */
-        $variantFamily = $this->get('pim_catalog.repository.family_variant')->findOneByIdentifier('family_variant');
-        $this->assertNotNull($variantFamily, 'The family variant with the code "family_variant" does not exist');
+        $this->get('doctrine.orm.entity_manager')->refresh($familyVariant);
+        $this->assertNotNull($familyVariant, 'The family variant with the code "family_variant" does not exist');
 
-        $this->assertEquals('boots', $variantFamily->getFamily()->getCode(), 'The family code does not match boots');
+        $this->assertEquals('boots', $familyVariant->getFamily()->getCode(), 'The family code does not match boots');
         $this->assertEquals(
             ['name', 'manufacturer', 'description'],
-            $this->extractAttributeCode($variantFamily->getCommonAttributes()),
+            $this->extractAttributeCode($familyVariant->getCommonAttributes()),
             'Common attributes are invalid'
         );
 
-        $variantAttributeSet = $variantFamily->getVariantAttributeSet(1);
+        $variantAttributeSet = $familyVariant->getVariantAttributeSet(1);
         $this->assertEquals(
             ['color'],
             $this->extractAttributeCode($variantAttributeSet->getAxes()),
@@ -63,7 +64,7 @@ class FamilyVariantIntegration extends TestCase
             'Variant attribute are invalid (level 1)'
         );
 
-        $variantAttributeSet = $variantFamily->getVariantAttributeSet(2);
+        $variantAttributeSet = $familyVariant->getVariantAttributeSet(2);
         $this->assertEquals(
             ['size'],
             $this->extractAttributeCode($variantAttributeSet->getAxes()),
@@ -83,9 +84,9 @@ class FamilyVariantIntegration extends TestCase
     {
         $this->createDefaultFamilyVariant();
 
-        $variantFamily = $this->get('pim_catalog.factory.family_variant')->create();
+        $familyVariant = $this->get('pim_catalog.factory.family_variant')->create();
 
-        $this->get('pim_catalog.updater.family_variant')->update($variantFamily, [
+        $this->get('pim_catalog.updater.family_variant')->update($familyVariant, [
             'code' => 'family_variant',
             'family' => 'boots',
             'label' => [
@@ -94,16 +95,18 @@ class FamilyVariantIntegration extends TestCase
             'variant_attribute_sets' => [
                 [
                     'axes' => ['color'],
-                    'attributes' => ['weather_conditions', 'rating', 'side_view', 'top_view', 'lace_color']
+                    'attributes' => ['weather_conditions', 'rating', 'side_view', 'top_view', 'lace_color'],
+                    'level'=> 1,
                 ],
                 [
                     'axes' => ['size'],
-                    'attributes' => ['sku', 'price']
+                    'attributes' => ['sku', 'price'],
+                    'level'=> 2,
                 ]
             ],
         ]);
 
-        $errors = $this->get('validator')->validate($variantFamily);
+        $errors = $this->get('validator')->validate($familyVariant);
         $this->assertEquals(1, $errors->count());
         $this->assertEquals('This value is already used.', $errors->get(0)->getMessage());
     }
@@ -115,9 +118,9 @@ class FamilyVariantIntegration extends TestCase
     {
         $this->createDefaultFamilyVariant();
 
-        $variantFamily = $this->get('pim_catalog.factory.family_variant')->create();
+        $familyVariant = $this->get('pim_catalog.factory.family_variant')->create();
 
-        $this->get('pim_catalog.updater.family_variant')->update($variantFamily, [
+        $this->get('pim_catalog.updater.family_variant')->update($familyVariant, [
             'code' => 'invalid_axis',
             'family' => 'boots',
             'label' => [
@@ -126,16 +129,18 @@ class FamilyVariantIntegration extends TestCase
             'variant_attribute_sets' => [
                 [
                     'axes' => ['color'],
-                    'attributes' => ['weather_conditions', 'rating', 'side_view', 'top_view', 'lace_color']
+                    'attributes' => ['weather_conditions', 'rating', 'side_view', 'top_view', 'lace_color'],
+                    'level'=> 1,
                 ],
                 [
                     'axes' => ['size', 'color'],
-                    'attributes' => ['sku', 'price']
+                    'attributes' => ['sku', 'price'],
+                    'level'=> 2,
                 ]
             ],
         ]);
 
-        $errors = $this->get('validator')->validate($variantFamily);
+        $errors = $this->get('validator')->validate($familyVariant);
         $this->assertEquals(1, $errors->count());
         $this->assertEquals(
             'Variant axes must be unique, "color" are used several times in variant attributes sets',
@@ -150,9 +155,9 @@ class FamilyVariantIntegration extends TestCase
     {
         $this->createDefaultFamilyVariant();
 
-        $variantFamily = $this->get('pim_catalog.factory.family_variant')->create();
+        $familyVariant = $this->get('pim_catalog.factory.family_variant')->create();
 
-        $this->get('pim_catalog.updater.family_variant')->update($variantFamily, [
+        $this->get('pim_catalog.updater.family_variant')->update($familyVariant, [
             'code' => 'invalid_attribute',
             'family' => 'boots',
             'label' => [
@@ -161,16 +166,18 @@ class FamilyVariantIntegration extends TestCase
             'variant_attribute_sets' => [
                 [
                     'axes' => ['color'],
-                    'attributes' => ['weather_conditions', 'rating', 'side_view', 'top_view', 'lace_color']
+                    'attributes' => ['weather_conditions', 'rating', 'side_view', 'top_view', 'lace_color'],
+                    'level'=> 1,
                 ],
                 [
                     'axes' => ['size'],
-                    'attributes' => ['sku', 'rating', 'price']
+                    'attributes' => ['sku', 'rating', 'price'],
+                    'level'=> 2,
                 ]
             ],
         ]);
 
-        $errors = $this->get('validator')->validate($variantFamily);
+        $errors = $this->get('validator')->validate($familyVariant);
         $this->assertEquals(1, $errors->count());
         $this->assertEquals(
             'Attributes must be unique, "rating" are used several times in variant attributes sets',
@@ -186,9 +193,9 @@ class FamilyVariantIntegration extends TestCase
     {
         $this->createDefaultFamilyVariant();
 
-        $variantFamily = $this->get('pim_catalog.factory.family_variant')->create();
+        $familyVariant = $this->get('pim_catalog.factory.family_variant')->create();
 
-        $this->get('pim_catalog.updater.family_variant')->update($variantFamily, [
+        $this->get('pim_catalog.updater.family_variant')->update($familyVariant, [
             'code' => 'invalid_axis_type',
             'family' => 'boots',
             'label' => [
@@ -197,16 +204,18 @@ class FamilyVariantIntegration extends TestCase
             'variant_attribute_sets' => [
                 [
                     'axes' => ['name'],
-                    'attributes' => ['side_view', 'rating', 'color', 'top_view', 'lace_color']
+                    'attributes' => ['side_view', 'rating', 'color', 'top_view', 'lace_color'],
+                    'level'=> 1,
                 ],
                 [
                     'axes' => ['size'],
-                    'attributes' => ['sku', 'weather_conditions']
+                    'attributes' => ['sku', 'weather_conditions'],
+                    'level'=> 2,
                 ]
             ],
         ]);
 
-        $errors = $this->get('validator')->validate($variantFamily);
+        $errors = $this->get('validator')->validate($familyVariant);
         $this->assertEquals(2, $errors->count());
         $this->assertEquals(
             'Variant axes "name" must be a boolean, a simple select, a simple reference data or a metric',
@@ -225,9 +234,9 @@ class FamilyVariantIntegration extends TestCase
      */
     public function testTheNumberOfAttributeSetType()
     {
-        $variantFamily = $this->get('pim_catalog.factory.family_variant')->create();
+        $familyVariant = $this->get('pim_catalog.factory.family_variant')->create();
 
-        $this->get('pim_catalog.updater.family_variant')->update($variantFamily, [
+        $this->get('pim_catalog.updater.family_variant')->update($familyVariant, [
             'code' => 'family_variant',
             'family' => 'boots',
             'label' => [
@@ -236,16 +245,55 @@ class FamilyVariantIntegration extends TestCase
             'variant_attribute_sets' => [
                 [
                     'axes' => ['color', 'size', 'rating', 'lace_color', 'side_view', 'top_view'],
-                    'attributes' => ['weather_conditions', 'side_view', 'top_view']
+                    'attributes' => ['weather_conditions', 'side_view', 'top_view'],
+                    'level'=> 1,
                 ],
 
             ],
         ]);
 
-        $errors = $this->get('validator')->validate($variantFamily);
+        $errors = $this->get('validator')->validate($familyVariant);
         $this->assertEquals(
             'A variant attribute set cannot have more than 5 attributes',
             $errors->get(2)->getMessage()
+        );
+    }
+
+    /**
+     * Validation: Available attributes for axis are metric, simple select and reference data simple select
+     */
+    public function testTheNumberOfAttributeSetLevel()
+    {
+        $familyVariant = $this->get('pim_catalog.factory.family_variant')->create();
+
+        $this->get('pim_catalog.updater.family_variant')->update($familyVariant, [
+            'code' => 'family_variant',
+            'family' => 'boots',
+            'label' => [
+                'en_US' => 'My family variant'
+            ],
+            'variant_attribute_sets' => [
+                [
+                    'axes' => ['color', 'size'],
+                    'attributes' => [
+                        'weather_conditions',
+                        'rating',
+                        'side_view',
+                        'top_view',
+                        'lace_color',
+                        'sku',
+                        'price',
+                    ],
+                    'level'=> 2,
+                ],
+            ],
+        ]);
+
+        $errors = $this->get('validator')->validate($familyVariant);
+        $this->assertEquals(1, $errors->count());
+        $this->assertEquals(
+            'There is no variant attribute set for level "1"',
+            $errors->get(0)->getMessage()
         );
     }
 
@@ -264,9 +312,9 @@ class FamilyVariantIntegration extends TestCase
      */
     private function createDefaultFamilyVariant(): FamilyVariantInterface
     {
-        $variantFamily = $this->get('pim_catalog.factory.family_variant')->create();
+        $familyVariant = $this->get('pim_catalog.factory.family_variant')->create();
 
-        $this->get('pim_catalog.updater.family_variant')->update($variantFamily, [
+        $this->get('pim_catalog.updater.family_variant')->update($familyVariant, [
             'code' => 'family_variant',
             'family' => 'boots',
             'label' => [
@@ -275,18 +323,20 @@ class FamilyVariantIntegration extends TestCase
             'variant_attribute_sets' => [
                 [
                     'axes' => ['color'],
-                    'attributes' => ['weather_conditions', 'rating', 'side_view', 'top_view', 'lace_color']
+                    'attributes' => ['weather_conditions', 'rating', 'side_view', 'top_view', 'lace_color'],
+                    'level'=> 1,
                 ],
                 [
                     'axes' => ['size'],
-                    'attributes' => ['sku', 'price']
+                    'attributes' => ['sku', 'price'],
+                    'level'=> 2,
                 ]
             ],
         ]);
 
-        $this->get('pim_catalog.saver.family_variant')->save($variantFamily);
+        $this->get('pim_catalog.saver.family_variant')->save($familyVariant);
 
-        return $variantFamily;
+        return $familyVariant;
     }
 
     /**

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Family/FamilyVariantIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Family/FamilyVariantIntegration.php
@@ -7,7 +7,6 @@ use Akeneo\Test\Integration\TestCase;
 use Doctrine\Common\Collections\Collection;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\FamilyVariantInterface;
-use Webmozart\Assert\Assert;
 
 class FamilyVariantIntegration extends TestCase
 {
@@ -80,7 +79,7 @@ class FamilyVariantIntegration extends TestCase
     /**
      * Validation: Family variant code is unique
      */
-    function testTheFamilyVariantCodeUniqueness()
+    public function testTheFamilyVariantCodeUniqueness()
     {
         $this->createDefaultFamilyVariant();
 
@@ -112,7 +111,7 @@ class FamilyVariantIntegration extends TestCase
     /**
      * Validation: An attribute can only be used one time as an axis
      */
-    function testTheAttributeSetAxisUniqueness()
+    public function testTheAttributeSetAxisUniqueness()
     {
         $this->createDefaultFamilyVariant();
 
@@ -138,13 +137,16 @@ class FamilyVariantIntegration extends TestCase
 
         $errors = $this->get('validator')->validate($variantFamily);
         $this->assertEquals(1, $errors->count());
-        $this->assertEquals('Variant axes must be unique, "color" are used several times in variant attributes sets', $errors->get(0)->getMessage());
+        $this->assertEquals(
+            'Variant axes must be unique, "color" are used several times in variant attributes sets',
+            $errors->get(0)->getMessage()
+        );
     }
 
     /**
      * Validation: An attribute can only be used for one attribute set
      */
-    function testTheAttributeSetAttributeUniqueness()
+    public function testTheAttributeSetAttributeUniqueness()
     {
         $this->createDefaultFamilyVariant();
 
@@ -170,14 +172,17 @@ class FamilyVariantIntegration extends TestCase
 
         $errors = $this->get('validator')->validate($variantFamily);
         $this->assertEquals(1, $errors->count());
-        $this->assertEquals('Attributes must be unique, "rating" are used several times in variant attributes sets', $errors->get(0)->getMessage());
+        $this->assertEquals(
+            'Attributes must be unique, "rating" are used several times in variant attributes sets',
+            $errors->get(0)->getMessage()
+        );
     }
 
     /**
      * Validation: Available attributes for axis are metric, simple select and reference data simple select
      * Validation: Variant axes "%axis%" cannot be localizable, not scopable and not locale specific
      */
-    function testTheAttributeSetAxesType()
+    public function testTheAttributeSetAxesType()
     {
         $this->createDefaultFamilyVariant();
 
@@ -218,7 +223,7 @@ class FamilyVariantIntegration extends TestCase
      * Validation: Available attributes for axis are metric, simple select and reference data simple select
      * Validation: Variant axes "%axis%" cannot be localizable, not scopable and not locale specific
      */
-    function testTheNumberOfAttributeSetType()
+    public function testTheNumberOfAttributeSetType()
     {
         $variantFamily = $this->get('pim_catalog.factory.family_variant')->create();
 
@@ -293,7 +298,7 @@ class FamilyVariantIntegration extends TestCase
      */
     private function extractAttributeCode(Collection $collection): array
     {
-        $codes = $collection->map(function(AttributeInterface $attribute) {
+        $codes = $collection->map(function (AttributeInterface $attribute) {
             return $attribute->getCode();
         })->toArray();
 

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/archiving.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/archiving.yml
@@ -66,7 +66,7 @@ services:
             - '@pim_connector.writer.file.invalid_items_xlsx'
             - '@pim_connector.reader.file.xlsx_iterator_factory'
             - '@oneup_flysystem.archivist_filesystem'
-            - '@pim_connector.job.job_parameters.default_values_provider.product_xslx_export'
+            - '@pim_connector.job.job_parameters.default_values_provider.product_xlsx_export'
             - 'xlsx'
         tags:
             - { name: pim_connector.archiver }

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/array_converters.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/array_converters.yml
@@ -10,6 +10,7 @@ parameters:
     pim_connector.array_converter.flat_to_standard.category.class:                                Pim\Component\Connector\ArrayConverter\FlatToStandard\Category
     pim_connector.array_converter.flat_to_standard.association_type.class:                        Pim\Component\Connector\ArrayConverter\FlatToStandard\AssociationType
     pim_connector.array_converter.flat_to_standard.family.class:                                  Pim\Component\Connector\ArrayConverter\FlatToStandard\Family
+    pim_connector.array_converter.flat_to_standard.family_variant.class:                          Pim\Component\Connector\ArrayConverter\FlatToStandard\FamilyVariant
     pim_connector.array_converter.flat_to_standard.channel.class:                                 Pim\Component\Connector\ArrayConverter\FlatToStandard\Channel
     pim_connector.array_converter.flat_to_standard.attribute_group.class:                         Pim\Component\Connector\ArrayConverter\FlatToStandard\AttributeGroup
     pim_connector.array_converter.flat_to_standard.group_type.class:                              Pim\Component\Connector\ArrayConverter\FlatToStandard\GroupType
@@ -105,6 +106,11 @@ services:
 
     pim_connector.array_converter.flat_to_standard.family:
         class: '%pim_connector.array_converter.flat_to_standard.family.class%'
+        arguments:
+            - '@pim_connector.array_convertor.checker.fields_requirement'
+
+    pim_connector.array_converter.flat_to_standard.family_variant:
+        class: '%pim_connector.array_converter.flat_to_standard.family_variant.class%'
         arguments:
             - '@pim_connector.array_convertor.checker.fields_requirement'
 

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/job_constraints.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/job_constraints.yml
@@ -96,6 +96,7 @@ services:
             -
                 - 'csv_attribute_import'
                 - 'csv_family_import'
+                - 'csv_family_variant_import'
                 - 'csv_group_import'
                 - 'csv_association_type_import'
                 - 'csv_attribute_option_import'
@@ -114,6 +115,7 @@ services:
             -
                 - 'xlsx_attribute_import'
                 - 'xlsx_family_import'
+                - 'xlsx_family_variant_import'
                 - 'xlsx_group_import'
                 - 'xlsx_association_type_import'
                 - 'xlsx_attribute_option_import'

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/job_defaults.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/job_defaults.yml
@@ -64,7 +64,7 @@ services:
         tags:
             - { name: akeneo_batch.job.job_parameters.default_values_provider }
 
-    pim_connector.job.job_parameters.default_values_provider.product_xslx_export:
+    pim_connector.job.job_parameters.default_values_provider.product_xlsx_export:
         class: '%pim_connector.job.job_parameters.default_values_provider.product_xlsx_export.class%'
         arguments:
             - '@pim_connector.job.job_parameters.default_values_provider.simple_xlsx_export'
@@ -100,6 +100,7 @@ services:
             -
                 - 'csv_attribute_import'
                 - 'csv_family_import'
+                - 'csv_family_variant_import'
                 - 'csv_group_import'
                 - 'csv_association_type_import'
                 - 'csv_attribute_option_import'
@@ -118,6 +119,7 @@ services:
             -
                 - 'xlsx_attribute_import'
                 - 'xlsx_family_import'
+                - 'xlsx_family_variant_import'
                 - 'xlsx_group_import'
                 - 'xlsx_association_type_import'
                 - 'xlsx_attribute_option_import'

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/jobs.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/jobs.yml
@@ -9,6 +9,7 @@ parameters:
     pim_connector.job_name.csv_association_type_import: 'csv_association_type_import'
     pim_connector.job_name.csv_family_export: 'csv_family_export'
     pim_connector.job_name.csv_family_import: 'csv_family_import'
+    pim_connector.job_name.csv_family_variant_import: 'csv_family_variant_import'
     pim_connector.job_name.csv_group_export: 'csv_group_export'
     pim_connector.job_name.csv_group_import: 'csv_group_import'
     pim_connector.job_name.csv_product_export: 'csv_product_export'
@@ -35,6 +36,7 @@ parameters:
     pim_connector.job_name.xlsx_association_type_import: 'xlsx_association_type_import'
     pim_connector.job_name.xlsx_family_export: 'xlsx_family_export'
     pim_connector.job_name.xlsx_family_import: 'xlsx_family_import'
+    pim_connector.job_name.xlsx_family_variant_import: 'xlsx_family_variant_import'
     pim_connector.job_name.xlsx_group_export: 'xlsx_group_export'
     pim_connector.job_name.xlsx_group_import: 'xlsx_group_import'
     pim_connector.job_name.xlsx_product_export: 'xlsx_product_export'
@@ -105,6 +107,18 @@ services:
             -
                 - '@pim_connector.step.charset_validator'
                 - '@pim_connector.step.csv_family.import'
+        tags:
+            - { name: akeneo_batch.job, connector: '%pim_connector.connector_name.csv%', type: '%pim_connector.job.import_type%' }
+
+    pim_connector.job.csv_family_variant_import:
+        class: '%pim_connector.job.simple_job.class%'
+        arguments:
+            - '%pim_connector.job_name.csv_family_variant_import%'
+            - '@event_dispatcher'
+            - '@akeneo_batch.job_repository'
+            -
+                - '@pim_connector.step.charset_validator'
+                - '@pim_connector.step.csv_family_variant.import'
         tags:
             - { name: akeneo_batch.job, connector: '%pim_connector.connector_name.csv%', type: '%pim_connector.job.import_type%' }
 
@@ -407,6 +421,18 @@ services:
             -
                 - '@pim_connector.step.charset_validator'
                 - '@pim_connector.step.xlsx_family.import'
+        tags:
+            - { name: akeneo_batch.job, connector: '%pim_connector.connector_name.xlsx%', type: '%pim_connector.job.import_type%' }
+
+    pim_connector.job.xlsx_family_variant_import:
+        class: '%pim_connector.job.simple_job.class%'
+        arguments:
+            - '%pim_connector.job_name.xlsx_family_variant_import%'
+            - '@event_dispatcher'
+            - '@akeneo_batch.job_repository'
+            -
+                - '@pim_connector.step.charset_validator'
+                - '@pim_connector.step.xlsx_family_variant.import'
         tags:
             - { name: akeneo_batch.job, connector: '%pim_connector.connector_name.xlsx%', type: '%pim_connector.job.import_type%' }
 

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/processors.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/processors.yml
@@ -101,6 +101,15 @@ services:
             - '@validator'
             - '@akeneo_storage_utils.doctrine.object_detacher'
 
+    pim_connector.processor.denormalization.family_variant:
+        class: '%pim_connector.processor.denormalization.class%'
+        arguments:
+            - '@pim_catalog.repository.family_variant'
+            - '@pim_catalog.factory.family_variant'
+            - '@pim_catalog.updater.family_variant'
+            - '@validator'
+            - '@akeneo_storage_utils.doctrine.object_detacher'
+
     pim_connector.processor.denormalization.channel:
         class: '%pim_connector.processor.denormalization.class%'
         arguments:

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/readers.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/readers.yml
@@ -129,6 +129,12 @@ services:
             - '@pim_connector.reader.file.csv_iterator_factory'
             - '@pim_connector.array_converter.flat_to_standard.family'
 
+    pim_connector.reader.file.csv_family_variant:
+        class: '%pim_connector.reader.file.csv.class%'
+        arguments:
+            - '@pim_connector.reader.file.csv_iterator_factory'
+            - '@pim_connector.array_converter.flat_to_standard.family_variant'
+
     pim_connector.reader.file.csv_association:
         class: '%pim_connector.reader.file.csv_association.class%'
         arguments:
@@ -278,6 +284,12 @@ services:
         arguments:
             - '@pim_connector.reader.file.xlsx_iterator_factory'
             - '@pim_connector.array_converter.flat_to_standard.family'
+
+    pim_connector.reader.file.xlsx_family_variant:
+        class: '%pim_connector.reader.file.xlsx.class%'
+        arguments:
+            - '@pim_connector.reader.file.xlsx_iterator_factory'
+            - '@pim_connector.array_converter.flat_to_standard.family_variant'
 
     pim_connector.reader.file.xlsx_category:
         class: '%pim_connector.reader.file.xlsx.class%'

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/steps.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/steps.yml
@@ -54,6 +54,16 @@ services:
             - '@pim_connector.processor.denormalization.family'
             - '@pim_connector.writer.database.family'
 
+    pim_connector.step.csv_family_variant.import:
+        class: '%pim_connector.step.item_step.class%'
+        arguments:
+            - 'import'
+            - '@event_dispatcher'
+            - '@akeneo_batch.job_repository'
+            - '@pim_connector.reader.file.csv_family_variant'
+            - '@pim_connector.processor.denormalization.family_variant'
+            - '@pim_connector.writer.database.family_variant'
+
     pim_connector.step.csv_group.import:
         class: '%pim_connector.step.item_step.class%'
         arguments:
@@ -330,6 +340,16 @@ services:
             - '@pim_connector.reader.file.xlsx_family'
             - '@pim_connector.processor.denormalization.family'
             - '@pim_connector.writer.database.family'
+
+    pim_connector.step.xlsx_family_variant.import:
+        class: '%pim_connector.step.item_step.class%'
+        arguments:
+            - 'import'
+            - '@event_dispatcher'
+            - '@akeneo_batch.job_repository'
+            - '@pim_connector.reader.file.xlsx_family_variant'
+            - '@pim_connector.processor.denormalization.family_variant'
+            - '@pim_connector.writer.database.family_variant'
 
     pim_connector.step.xlsx_group.import:
         class: '%pim_connector.step.item_step.class%'

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/writers.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/writers.yml
@@ -42,6 +42,12 @@ services:
             - '@pim_catalog.saver.family'
             - '@akeneo_storage_utils.doctrine.object_detacher'
 
+    pim_connector.writer.database.family_variant:
+        class: '%pim_connector.writer.database.class%'
+        arguments:
+            - '@pim_catalog.saver.family_variant'
+            - '@akeneo_storage_utils.doctrine.object_detacher'
+
     pim_connector.writer.database.product:
         class: '%pim_connector.writer.database.product.class%'
         arguments:

--- a/src/Pim/Bundle/ConnectorBundle/Resources/translations/messages.en.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/translations/messages.en.yml
@@ -43,7 +43,7 @@ job_execution.summary:
     skip_products: skipped products
     displayed: first warnings displayed
     charset_validator:
-        title: File encoding:
+        title: 'File encoding:'
         skipped: skipped, extension in white list
     product_skipped_no_diff: skipped product (no differences)
     product_skipped_no_associations: skipped product (no associations detected)
@@ -100,6 +100,10 @@ batch_jobs:
         label: Family import in CSV
         validation.label: File validation
         import.label: Family import
+    csv_family_variant_import:
+        label: Family variant import in CSV
+        validation.label: File validation
+        import.label: Family variant import
     csv_group_import:
         label: Group import in CSV
         validation.label: File validation
@@ -163,6 +167,10 @@ batch_jobs:
         label: Family import in XLSX
         validation.label: File validation
         import.label: Family import
+    xlsx_family_variant_import:
+        label: Family variant import in XLSX
+        validation.label: File validation
+        import.label: Family variant import
     xlsx_product_export:
         label: Product export in XLSX
         export.label: Product export

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/providers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/providers.yml
@@ -96,6 +96,7 @@ services:
                 csv_channel_import: pim-job-instance-csv-base-import
                 csv_currency_import: pim-job-instance-csv-base-import
                 csv_family_import: pim-job-instance-csv-base-import
+                csv_family_variant_import: pim-job-instance-csv-base-import
                 csv_group_import: pim-job-instance-csv-base-import
                 csv_group_type_import: pim-job-instance-csv-base-import
                 csv_locale_import: pim-job-instance-csv-base-import
@@ -109,6 +110,7 @@ services:
                 xlsx_channel_import: pim-job-instance-xlsx-base-import
                 xlsx_currency_import: pim-job-instance-xlsx-base-import
                 xlsx_family_import: pim-job-instance-xlsx-base-import
+                xlsx_family_variant_import: pim-job-instance-xlsx-base-import
                 xlsx_group_import: pim-job-instance-xlsx-base-import
                 xlsx_group_type_import: pim-job-instance-xlsx-base-import
                 xlsx_locale_import: pim-job-instance-xlsx-base-import

--- a/src/Pim/Component/Catalog/Model/FamilyVariant.php
+++ b/src/Pim/Component/Catalog/Model/FamilyVariant.php
@@ -87,13 +87,19 @@ class FamilyVariant implements FamilyVariantInterface
     /**
      * {@inheritdoc}
      */
-    public function getVariantAttributeSet(int $level): VariantAttributeSetInterface
+    public function getVariantAttributeSet(int $level): ?VariantAttributeSetInterface
     {
         if ($level <= 0) {
             throw new \InvalidArgumentException('The level must be greater than 0');
         }
 
-        return $this->variantAttributeSets->get($level);
+        foreach ($this->variantAttributeSets as $variantAttributeSet) {
+            if ($level === $variantAttributeSet->getLevel()) {
+                return $variantAttributeSet;
+            }
+        }
+
+        return null;
     }
 
     /**
@@ -127,13 +133,9 @@ class FamilyVariant implements FamilyVariantInterface
     /**
      * {@inheritdoc}
      */
-    public function addVariantAttributeSet(int $level, VariantAttributeSetInterface $variantAttributeSet): void
+    public function addVariantAttributeSet(VariantAttributeSetInterface $variantAttributeSet): void
     {
-        if ($level <= 0) {
-            throw new \InvalidArgumentException('The level must be greater than 0');
-        }
-
-        $this->variantAttributeSets->set($level, $variantAttributeSet);
+        $this->variantAttributeSets->add($variantAttributeSet);
     }
 
     /**

--- a/src/Pim/Component/Catalog/Model/FamilyVariant.php
+++ b/src/Pim/Component/Catalog/Model/FamilyVariant.php
@@ -43,7 +43,7 @@ class FamilyVariant implements FamilyVariantInterface
     /**
      * {@inheritdoc}
      */
-    public function getId(): int
+    public function getId(): ?int
     {
         return $this->id;
     }

--- a/src/Pim/Component/Catalog/Model/FamilyVariant.php
+++ b/src/Pim/Component/Catalog/Model/FamilyVariant.php
@@ -7,8 +7,8 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 
 /**
- * A variant in a family defines the structure for the products with variants: Common attributes, Specific or variant attributes
- * Variant axes
+ * A variant in a family defines the structure for the products with variants:
+ * Common attributes, Specific or variant attributes, Variant axes.
  *
  * @author    Arnaud Langlade <arnaud.langlade@akeneo.com>
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)

--- a/src/Pim/Component/Catalog/Model/FamilyVariantInterface.php
+++ b/src/Pim/Component/Catalog/Model/FamilyVariantInterface.php
@@ -16,7 +16,7 @@ interface FamilyVariantInterface extends TranslatableInterface
     /**
      * @return int
      */
-    public function getId(): int;
+    public function getId(): ?int;
 
     /**
      * @return string

--- a/src/Pim/Component/Catalog/Model/FamilyVariantInterface.php
+++ b/src/Pim/Component/Catalog/Model/FamilyVariantInterface.php
@@ -3,7 +3,6 @@
 namespace Pim\Component\Catalog\Model;
 
 use Akeneo\Component\Localization\Model\TranslatableInterface;
-use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 
 /**
@@ -36,11 +35,11 @@ interface FamilyVariantInterface extends TranslatableInterface
     /**
      * @param int $level
      *
-     * @return VariantAttributeSetInterface
+     * @return null|VariantAttributeSetInterface
      *
      * @throws \InvalidArgumentException
      */
-    public function getVariantAttributeSet(int $level): VariantAttributeSetInterface;
+    public function getVariantAttributeSet(int $level): ?VariantAttributeSetInterface;
 
     /**
      * @return Collection
@@ -53,12 +52,9 @@ interface FamilyVariantInterface extends TranslatableInterface
     public function getAxes(): Collection;
 
     /**
-     * @param int                          $level
      * @param VariantAttributeSetInterface $variantAttributeSet
-     *
-     * @throws \InvalidArgumentException
      */
-    public function addVariantAttributeSet(int $level, VariantAttributeSetInterface $variantAttributeSet): void;
+    public function addVariantAttributeSet(VariantAttributeSetInterface $variantAttributeSet): void;
 
     /**
      * @param FamilyInterface $family

--- a/src/Pim/Component/Catalog/Model/VariantAttributeSet.php
+++ b/src/Pim/Component/Catalog/Model/VariantAttributeSet.php
@@ -21,6 +21,9 @@ class VariantAttributeSet implements VariantAttributeSetInterface
     /** @var Collection */
     private $axes;
 
+    /** @var int */
+    private $level;
+
     public function __construct()
     {
         $this->attributes = new ArrayCollection();
@@ -65,5 +68,21 @@ class VariantAttributeSet implements VariantAttributeSetInterface
     public function setAxes(array $axes): void
     {
         $this->axes = new ArrayCollection($axes);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLevel(): int
+    {
+        return $this->level;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setLevel(int $level): void
+    {
+        $this->level = $level;
     }
 }

--- a/src/Pim/Component/Catalog/Model/VariantAttributeSetInterface.php
+++ b/src/Pim/Component/Catalog/Model/VariantAttributeSetInterface.php
@@ -35,4 +35,14 @@ interface VariantAttributeSetInterface
      * @param array $axes
      */
     public function setAxes(array $axes): void;
+
+    /**
+     * @return int
+     */
+    public function getLevel(): int;
+
+    /**
+     * @param int $level
+     */
+    public function setLevel(int $level): void;
 }

--- a/src/Pim/Component/Catalog/Updater/FamilyVariantUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/FamilyVariantUpdater.php
@@ -112,7 +112,6 @@ class FamilyVariantUpdater implements ObjectUpdaterInterface
                 }
 
                 foreach ($value as $key => $attributeSetData) {
-                    /** @var VariantAttributeSetInterface $attributeSet */
                     if (!isset($attributeSetData['axes']) || !isset($attributeSetData['attributes'])) {
                         continue;
                     }

--- a/src/Pim/Component/Catalog/Updater/FamilyVariantUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/FamilyVariantUpdater.php
@@ -11,7 +11,6 @@ use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterfa
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Doctrine\Common\Util\ClassUtils;
 use Pim\Component\Catalog\Model\FamilyVariantInterface;
-use Pim\Component\Catalog\Model\VariantAttributeSetInterface;
 
 /**
  * Update the family variant properties
@@ -111,8 +110,11 @@ class FamilyVariantUpdater implements ObjectUpdaterInterface
                     throw InvalidPropertyTypeException::arrayExpected($field, static::class, $value);
                 }
 
-                foreach ($value as $key => $attributeSetData) {
-                    if (!isset($attributeSetData['axes']) || !isset($attributeSetData['attributes'])) {
+                foreach ($value as $attributeSetData) {
+                    if (!isset($attributeSetData['axes']) ||
+                        !isset($attributeSetData['attributes']) ||
+                        !isset($attributeSetData['level'])
+                    ) {
                         continue;
                     }
 
@@ -124,11 +126,16 @@ class FamilyVariantUpdater implements ObjectUpdaterInterface
                         throw InvalidPropertyTypeException::arrayExpected($field, static::class, $value);
                     }
 
+                    if (!is_numeric($attributeSetData['level'])) {
+                        throw InvalidPropertyTypeException::numericExpected($field, static::class, $value);
+                    }
+
                     $attributeSet = $this->attributeSetFactory->create();
                     $attributeSet->setAxes($this->getAttributes($attributeSetData['axes']));
                     $attributeSet->setAttributes($this->getAttributes($attributeSetData['attributes']));
+                    $attributeSet->setLevel($attributeSetData['level']);
 
-                    $familyVariant->addVariantAttributeSet($key + 1, $attributeSet);
+                    $familyVariant->addVariantAttributeSet($attributeSet);
                 }
                 break;
         }

--- a/src/Pim/Component/Catalog/Validator/Constraints/FamilyVariantValidator.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/FamilyVariantValidator.php
@@ -19,6 +19,8 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
  */
 class FamilyVariantValidator extends ConstraintValidator
 {
+    const MAXIMUM_AXES_NUMBER = 5;
+
     /** @var TranslatorInterface */
     private $translator;
 
@@ -83,7 +85,6 @@ class FamilyVariantValidator extends ConstraintValidator
     {
         $axisCodes = [];
         foreach ($axes as $axis) {
-            /** @var $axis AttributeInterface */
             $axisCodes[] = $axis->getCode();
             if ($axis->isLocalizable() || $axis->isScopable() || $axis->isLocaleSpecific()) {
                 $message = $this->translator->trans('pim_catalog.constraint.family_variant_axes_wrong_type');
@@ -116,7 +117,14 @@ class FamilyVariantValidator extends ConstraintValidator
         $numberOfLevel = $familyVariant->getLevel();
         $i = 0;
         while ($i !== $numberOfLevel) {
-            if (5 < $familyVariant->getVariantAttributeSet($i + 1)->getAxes()->count()) {
+            $attributeSet = $familyVariant->getVariantAttributeSet($i + 1);
+
+            if (null === $attributeSet) {
+                $message = $this->translator->trans('pim_catalog.constraint.family_variant_level_do_not_exist');
+                $this->context->buildViolation($message, [
+                    '%level%' => $i + 1,
+                ])->addViolation();
+            } elseif (static::MAXIMUM_AXES_NUMBER < $attributeSet->getAxes()->count()) {
                 $message = $this->translator->trans('pim_catalog.constraint.family_variant_axes_number_of_axes');
                 $this->context->buildViolation($message)->addViolation();
             }

--- a/src/Pim/Component/Catalog/spec/Model/FamilyVariantSpec.php
+++ b/src/Pim/Component/Catalog/spec/Model/FamilyVariantSpec.php
@@ -45,8 +45,8 @@ class FamilyVariantSpec extends ObjectBehavior
         Collection $attribute2,
         \Iterator $iterator
     ) {
-        $this->addVariantAttributeSet(1, $variantAttributeSet1);
-        $this->addVariantAttributeSet(2, $variantAttributeSet2);
+        $this->addVariantAttributeSet($variantAttributeSet1);
+        $this->addVariantAttributeSet($variantAttributeSet2);
         $this->setFamily($family);
 
         $family->getAttributes()->willReturn($familyAttributes);
@@ -56,12 +56,14 @@ class FamilyVariantSpec extends ObjectBehavior
         $variantAttributeSet1->getAxes()->willReturn($axes1);
         $attribute1->getIterator()->willReturn($iterator);
         $variantAttributeSet1->getAttributes()->willReturn($attribute1);
+        $variantAttributeSet1->getLevel()->willReturn(1);
 
         $axes2->getIterator()->willReturn($iterator);
         $variantAttributeSet2->getAxes()->willReturn($axes2);
 
         $attribute2->getIterator()->willReturn($iterator);
         $variantAttributeSet2->getAttributes()->willReturn($attribute2);
+        $variantAttributeSet2->getLevel()->willReturn(2);
 
         $this->getCommonAttributes()->shouldHaveType(CommonAttributeCollection::class);
     }
@@ -70,8 +72,11 @@ class FamilyVariantSpec extends ObjectBehavior
         VariantAttributeSetInterface $variantAttributeSet1,
         VariantAttributeSetInterface $variantAttributeSet2
     ) {
-        $this->addVariantAttributeSet(1, $variantAttributeSet1)->shouldReturn(null);
-        $this->addVariantAttributeSet(2, $variantAttributeSet2)->shouldReturn(null);
+        $variantAttributeSet1->getLevel()->willReturn(1);
+        $variantAttributeSet2->getLevel()->willReturn(2);
+
+        $this->addVariantAttributeSet($variantAttributeSet1)->shouldReturn(null);
+        $this->addVariantAttributeSet($variantAttributeSet2)->shouldReturn(null);
 
         $this->getVariantAttributeSet(1)->shouldReturn($variantAttributeSet1);
         $this->getVariantAttributeSet(2)->shouldReturn($variantAttributeSet2);
@@ -85,8 +90,8 @@ class FamilyVariantSpec extends ObjectBehavior
         AttributeInterface $color,
         AttributeInterface $size
     ) {
-        $this->addVariantAttributeSet(1, $variantAttributeSet1);
-        $this->addVariantAttributeSet(2, $variantAttributeSet2);
+        $this->addVariantAttributeSet($variantAttributeSet1);
+        $this->addVariantAttributeSet($variantAttributeSet2);
 
         $variantAttributeSet1->getAxes()->willReturn($axes1);
         $variantAttributeSet2->getAxes()->willReturn($axes2);
@@ -110,8 +115,8 @@ class FamilyVariantSpec extends ObjectBehavior
         AttributeInterface $color,
         AttributeInterface $size
     ) {
-        $this->addVariantAttributeSet(1, $variantAttributeSet1);
-        $this->addVariantAttributeSet(2, $variantAttributeSet2);
+        $this->addVariantAttributeSet($variantAttributeSet1);
+        $this->addVariantAttributeSet($variantAttributeSet2);
 
         $commonAttributeSet->getAttributes()->willReturn($commonAttributes);
         $variantAttributeSet1->getAttributes()->willReturn($attributes1);
@@ -126,14 +131,8 @@ class FamilyVariantSpec extends ObjectBehavior
         $axes->toArray([$color, $size]);
     }
 
-    function it_throws_an_exception_if_variant_attribute_set_index_is_invalid(
-        VariantAttributeSetInterface $variantAttributeSets
-    ) {
-        $this->shouldThrow(\InvalidArgumentException::class)->during('addVariantAttributeSet', [
-            0,
-            $variantAttributeSets
-        ]);
-
+    function it_throws_an_exception_if_variant_attribute_set_index_is_invalid()
+    {
         $this->shouldThrow(\InvalidArgumentException::class)->during('getVariantAttributeSet', [
             0,
         ]);

--- a/src/Pim/Component/Catalog/spec/Updater/FamilyVariantUpdaterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/FamilyVariantUpdaterSpec.php
@@ -9,14 +9,13 @@ use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Akeneo\Component\StorageUtils\Factory\SimpleFactoryInterface;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
+use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\VariantAttributeSetInterface;
 use Pim\Component\Catalog\Model\ChannelInterface;
 use Pim\Component\Catalog\Model\FamilyInterface;
 use Pim\Component\Catalog\Model\FamilyVariantInterface;
 use Pim\Component\Catalog\Updater\FamilyVariantUpdater;
-use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 class FamilyVariantUpdaterSpec extends ObjectBehavior
 {
@@ -76,13 +75,15 @@ class FamilyVariantUpdaterSpec extends ObjectBehavior
 
         $attributeSetFactory->create()->willReturn($attributeSet1, $attributeSet2, $commonAttributeSet);
 
-        $familyVariant->addVariantAttributeSet(1, $attributeSet1)->shouldBeCalled();
+        $familyVariant->addVariantAttributeSet($attributeSet1)->shouldBeCalled();
         $attributeSet1->setAxes([$color])->shouldBeCalled();
         $attributeSet1->setAttributes([$description])->shouldBeCalled();
+        $attributeSet1->setLevel(1)->shouldBeCalled();
 
-        $familyVariant->addVariantAttributeSet(2, $attributeSet2)->shouldBeCalled();
+        $familyVariant->addVariantAttributeSet($attributeSet2)->shouldBeCalled();
         $attributeSet2->setAxes([$size, $other])->shouldBeCalled();
         $attributeSet2->setAttributes([$size, $sku])->shouldBeCalled();
+        $attributeSet2->setLevel(2)->shouldBeCalled();
 
         $this->update($familyVariant, [
             'code' => 'my-tshirt',
@@ -93,11 +94,13 @@ class FamilyVariantUpdaterSpec extends ObjectBehavior
             'variant_attribute_sets' => [
                 [
                     'axes' => ['color'],
-                    'attributes' => ['description']
+                    'attributes' => ['description'],
+                    'level' => 1,
                 ],
                 [
                     'axes' => ['size', 'other'],
-                    'attributes' => ['size', 'sku']
+                    'attributes' => ['size', 'sku'],
+                    'level' => 2,
                 ]
             ],
         ], []);
@@ -117,7 +120,7 @@ class FamilyVariantUpdaterSpec extends ObjectBehavior
         ]);
     }
 
-    function it_throw_an_exception_if_code_is_not_string(FamilyVariantInterface $familyVariant)
+    function it_throws_an_exception_if_code_is_not_string(FamilyVariantInterface $familyVariant)
     {
         $this->shouldThrow(InvalidPropertyTypeException::class)->during('update', [
             $familyVariant,
@@ -127,7 +130,7 @@ class FamilyVariantUpdaterSpec extends ObjectBehavior
         ]);
     }
 
-    function it_throw_an_exception_if_labels_are_not_an_array(FamilyVariantInterface $familyVariant)
+    function it_throws_an_exception_if_labels_are_not_an_array(FamilyVariantInterface $familyVariant)
     {
         $this->shouldThrow(InvalidPropertyTypeException::class)->during('update', [
             $familyVariant,
@@ -137,7 +140,7 @@ class FamilyVariantUpdaterSpec extends ObjectBehavior
         ]);
     }
 
-    function it_throw_an_exception_if_variant_attributes_are_not_an_array(FamilyVariantInterface $familyVariant)
+    function it_throws_an_exception_if_variant_attribute_sets_are_not_an_array(FamilyVariantInterface $familyVariant)
     {
         $this->shouldThrow(InvalidPropertyTypeException::class)->during('update', [
             $familyVariant,

--- a/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/FamilyVariant.php
+++ b/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/FamilyVariant.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Pim\Component\Connector\ArrayConverter\FlatToStandard;
+
+use Pim\Component\Connector\ArrayConverter\ArrayConverterInterface;
+use Pim\Component\Connector\ArrayConverter\FieldsRequirementChecker;
+
+/**
+ * @author    Damien Carcel <damien.carcel@gmail.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class FamilyVariant implements ArrayConverterInterface
+{
+    /** @var FieldsRequirementChecker */
+    protected $fieldChecker;
+
+    /**
+     * @param FieldsRequirementChecker $fieldChecker
+     */
+    public function __construct(FieldsRequirementChecker $fieldChecker)
+    {
+        $this->fieldChecker = $fieldChecker;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * Converts flat csv array to standard structured array:
+     *
+     * Before:
+     * [
+     *      'code'                => 'pc_monitors',
+     *      'label-en_US'         => 'PC Monitors',
+     *      'label-fr_FR'         => 'Moniteurs',
+     *      'attributes'          => 'sku,name,description,price',
+     *      'attribute_as_label'  => 'name',
+     *      'requirements-print'  => 'sku,name,description',
+     *      'requirements-mobile' => 'sku,name',
+     * ]
+     *
+     * After:
+     * [
+     *      'code'                   => 'pc_monitors',
+     *      'attributes'             => ['sku', 'name', 'description', 'price'],
+     *      'attribute_as_label'     => 'name',
+     *      'attribute_requirements' => [
+     *          'mobile' => ['sku', 'name'],
+     *          'print'  => ['sku', 'name', 'description'],
+     *      ],
+     *      'labels'                 => [
+     *          'fr_FR' => 'Moniteurs',
+     *          'en_US' => 'PC Monitors',
+     *      ],
+     * ]
+     */
+    public function convert(array $item, array $options = []): array
+    {
+        $this->fieldChecker->checkFieldsPresence($item, ['code']);
+        $this->fieldChecker->checkFieldsPresence($item, ['family']);
+        $this->fieldChecker->checkFieldsPresence($item, ['variant-axes_1']);
+        $this->fieldChecker->checkFieldsPresence($item, ['variant-attributes_1']);
+        $this->fieldChecker->checkFieldsFilling($item, ['code']);
+        $this->fieldChecker->checkFieldsFilling($item, ['family']);
+        $this->fieldChecker->checkFieldsFilling($item, ['variant-axes_1']);
+        $this->fieldChecker->checkFieldsFilling($item, ['variant-attributes_1']);
+
+        $convertedItem = ['labels' => [], 'variant_attribute_sets' => []];
+        foreach ($item as $field => $data) {
+            $convertedItem = $this->convertField($convertedItem, $field, $data);
+        }
+
+        return $convertedItem;
+    }
+
+    /**
+     * @param array  $convertedItem
+     * @param string $field
+     * @param mixed  $data
+     *
+     * @return array
+     */
+    protected function convertField(array $convertedItem, string $field, $data): array
+    {
+        if (false !== strpos($field, 'label-', 0)) {
+            $labelTokens = explode('-', $field);
+            $labelLocale = $labelTokens[1];
+            $convertedItem['labels'][$labelLocale] = $data;
+        } elseif ('' !== $data) {
+            switch ($field) {
+                case 'code':
+                case 'family':
+                    $convertedItem[$field] = (string) $data;
+                    break;
+                case (false !== strpos($field, 'variant-axes_')):
+                    $matches = null;
+                    preg_match('/^variant-axes_(?P<level>.*)$/', $field, $matches);
+                    $convertedItem['variant_attribute_sets'][$matches['level'] - 1]['axes'] = explode(',', $data);
+                    break;
+                case (false !== strpos($field, 'variant-attributes_')):
+                    $matches = null;
+                    preg_match('/^variant-attributes_(?P<level>.*)$/', $field, $matches);
+                    $convertedItem['variant_attribute_sets'][$matches['level'] - 1]['attributes'] = explode(
+                        ',',
+                        $data
+                    );
+                    break;
+            }
+        }
+
+        return $convertedItem;
+    }
+}

--- a/src/Pim/Component/Connector/spec/ArrayConverter/FlatToStandard/FamilyVariantSpec.php
+++ b/src/Pim/Component/Connector/spec/ArrayConverter/FlatToStandard/FamilyVariantSpec.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace spec\Pim\Component\Connector\ArrayConverter\FlatToStandard;
+
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Connector\ArrayConverter\ArrayConverterInterface;
+use Pim\Component\Connector\ArrayConverter\FieldsRequirementChecker;
+use Pim\Component\Connector\ArrayConverter\FlatToStandard\FamilyVariant;
+
+class FamilyVariantSpec extends ObjectBehavior
+{
+    function let(FieldsRequirementChecker $fieldsChecker)
+    {
+        $this->beConstructedWith($fieldsChecker);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(FamilyVariant::class);
+    }
+
+    function it_is_an_array_converter()
+    {
+        $this->shouldImplement(ArrayConverterInterface::class);
+    }
+
+    function it_converts_from_flat_to_standard_format()
+    {
+        $item = [
+            'code' => 'my-tshirt',
+            'family' => 't-shirt',
+            'label-fr_FR' => 'Mon tshirt',
+            'label-en_US' => 'My tshirt',
+            'variant-axes_1' => 'color',
+            'variant-attributes_1' => 'description',
+            'variant-axes_2' => 'size,other',
+            'variant-attributes_2' => 'size,other,sku',
+        ];
+
+        $expected = [
+            'labels' => [
+                'fr_FR' => 'Mon tshirt',
+                'en_US' => 'My tshirt',
+            ],
+            'variant_attribute_sets' => [
+                [
+                    'level' => 1,
+                    'axes' => ['color'],
+                    'attributes' => ['description'],
+                ],
+                [
+                    'level' => 2,
+                    'axes' => ['size', 'other'],
+                    'attributes' => ['size', 'other', 'sku'],
+                ]
+            ],
+            'code' => 'my-tshirt',
+            'family' => 't-shirt',
+        ];
+
+        $this->convert($item)->shouldReturn($expected);
+    }
+}


### PR DESCRIPTION
## Description

### What's in this PR?

This PR is the first step to add import of family variants, both in CSV and XLSX. It adds the following (each point correspond to a commit of the PR):
- basic acceptance tests: 3 simple import scenarios, all of them in CSV and XLSX
- the imports themselves: basically a lot of YAML configuration, and the flat to standard FamilyVariant array converter
- a change in the way the levels are stored: it was directly set as the indexes of the array collection that contains the family variant attribute sets. However, the information seems to be lost when the family variant is loaded from database. **So instead, the last commit proposes to store this level information in database, as an attribute set field**.

### What's next?

I still have to implement the business rules specific to those imports, and the behat tests that will come along. But I prefer to do it in a separate PR, so reviews can be easier.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added Behats                      | OK
| Added integration tests           | OK
| Changelog updated                 | -
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
