### PR TITLE
Display js errors in Blue Ocean UI

### DIFF
--- a/features/Context/FeatureContext.php
+++ b/features/Context/FeatureContext.php
@@ -259,6 +259,8 @@ class FeatureContext extends PimContext implements KernelAwareContext
 
         // Check if we reached the timeout unless the condition is false to explicitly wait the specified time
         if ($condition !== false && microtime(true) > $end) {
+            $this->getSubcontext('hook')->collectErrors();
+
             if ($defaultCondition) {
                 foreach ($conditions as $condition) {
                     $result = $this->getSession()->evaluateScript($condition);

--- a/features/Pim/Behat/Context/HookContext.php
+++ b/features/Pim/Behat/Context/HookContext.php
@@ -190,14 +190,12 @@ class HookContext extends PimContext
     public function collectErrors()
     {
         if ($this->getSession()->getDriver() instanceof Selenium2Driver) {
-            try {
-                $script = "return typeof $ != 'undefined' ? $('body').attr('JSerr') || false : false;";
-                $result = $this->getSession()->evaluateScript($script);
-                if ($result) {
-                    $this->getMainContext()->addErrorMessage("WARNING: Encountered a JS error: '{$result}'");
-                }
-            } catch (\Exception $e) {
-                echo "Unable to retrieve js error\n";
+            $script = "return typeof $ != 'undefined' ? $('body').attr('JSerr') || false : false;";
+            $result = $this->getSession()->evaluateScript($script);
+            if ($result) {
+                $this->getMainContext()->addErrorMessage("WARNING: Encountered a JS error: '{$result}'");
+
+                throw new JSErrorEncounteredException("Encountered a JS error: '{$result}'");
             }
         }
     }

--- a/features/Pim/Behat/Context/JSErrorEncounteredException.php
+++ b/features/Pim/Behat/Context/JSErrorEncounteredException.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Pim\Behat\Context;
+
+/**
+ * This exception is meant to be thrown when a javascript error is spotted during a scenario execution.
+ *
+ * @author    Yohan Blain <yohan.blain@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class JSErrorEncounteredException extends \Exception
+{
+}


### PR DESCRIPTION
Throw an exception when a js error is found so it can be retrieved by Behat formatters (and especially the JUnit one for Blue Ocean).

Until now it wasn't possible to see that a js error happened on a scenario by looking in your build result.