### PR TITLE
Logger didn't take into account DateTime objects coming from dates included in Excel files

### DIFF
--- a/src/Akeneo/Bundle/BatchBundle/EventListener/LoggerSubscriber.php
+++ b/src/Akeneo/Bundle/BatchBundle/EventListener/LoggerSubscriber.php
@@ -276,6 +276,10 @@ class LoggerSubscriber implements EventSubscriberInterface
             return $data ? 'true' : 'false';
         }
 
+        if ($data instanceof \DateTime) {
+            return $data->format('Y-m-d');
+        }
+
         return (string) $data;
     }
 }


### PR DESCRIPTION
This PR corrects a problem you experience when importing Excel files. When a product is wrong (for example it has no SKU) but has another field that is a date, Logger gives an error when trying to log the corresponding line.

I discovered that the Logger did not take into account objects of type DateTime that can be found in Excel files and consequently when trying to convert that object into a string crashed and the rest of the import stopped.

Related with issue: #6337

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
