### PR TITLE
PIM-6525: Fix attribute options auto-sorting

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -1,3 +1,10 @@
+# 1.7.x
+
+## Bug Fixes
+
+- PIM-6525: fix issue with select attribute type which never open in PEF
+- PIM-6420: fix simple and multi select auto sorting
+
 # 1.7.6 (2017-06-30)
 
 ## Bug Fixes

--- a/features/Context/Page/Base/Form.php
+++ b/features/Context/Page/Base/Form.php
@@ -507,7 +507,7 @@ class Form extends Base
                 return false;
             }
 
-            return $container->find('css', '.select2, .select2-default');
+            return $container->find('css', '.select2-container');
         }, 'Impossible to find the select');
         $select2 = $this->decorate($select2, [Select2Decorator::class]);
         $selectChoices = $select2->getAvailableValues();

--- a/features/attribute/option/sort_attribute_options.feature
+++ b/features/attribute/option/sort_attribute_options.feature
@@ -8,19 +8,19 @@ Feature: Sort attribute options
     Given the "default" catalog configuration
     And I am logged in as "Julia"
     And I am on the attributes page
-    And I create a "Simple select" attribute
+
+  Scenario: Auto sorting disable reorder
+    Given I create a "Simple select" attribute
     And I fill in the following information:
       | Code            | size  |
       | Attribute group | Other |
     And I visit the "Values" tab
-    And I should see the "Options" section
+    Then I should see the "Options" section
     And I should see "To manage options, please save the attribute first"
-    And I save the attribute
-    And I should see the flash message "Attribute successfully created"
-
-  Scenario: Auto sorting disable reorder
-    Given I check the "Automatic option sorting" switch
-    When I create the following attribute options:
+    When I save the attribute
+    Then I should see the flash message "Attribute successfully created"
+    When I check the "Automatic option sorting" switch
+    And I create the following attribute options:
       | Code        |
       | small_size  |
       | medium_size |
@@ -31,20 +31,59 @@ Feature: Sort attribute options
     Then I should see reorder handles
     And I should see "small_size medium_size large_size"
 
-  Scenario: Display attribute options ordered in PEF
-    Given I check the "Automatic option sorting" switch
-    When I create the following attribute options:
+  Scenario: Display attribute options ordered by code in PEF when no label on options
+    Given I create a "Simple select" attribute
+    And I fill in the following information:
+      | Code            | size  |
+      | Attribute group | Other |
+    And I visit the "Values" tab
+    Then I should see the "Options" section
+    And I should see "To manage options, please save the attribute first"
+    When I save the attribute
+    Then I should see the flash message "Attribute successfully created"
+    When I check the "Automatic option sorting" switch
+    And I create the following attribute options:
       | Code        |
       | small_size  |
       | medium_size |
       | large_size  |
     And I save the attribute
-    And I should not see the text "There are unsaved changes"
-    And I am on the products page
+    Then I should not see the text "There are unsaved changes"
+    When I am on the products page
     And I create a new product
     And I fill in the following information in the popin:
       | SKU | a_product |
     And I press the "Save" button in the popin
-    And I should be on the product "a_product" edit page
-    And I add available attributes size
+    Then I should be on the product "a_product" edit page
+    When I add available attributes size
     Then I should see the ordered choices [large_size], [medium_size], [small_size] in size
+
+  Scenario: Display attribute options ordered by label in PEF
+    Given I create a "Simple select" attribute
+    And I fill in the following information:
+      | Code            | size  |
+      | Attribute group | Other |
+    And I visit the "Values" tab
+    Then I should see the "Options" section
+    And I should see "To manage options, please save the attribute first"
+    When I save the attribute
+    Then I should see the flash message "Attribute successfully created"
+    When I check the "Automatic option sorting" switch
+    And I create the following attribute options:
+      | Code        | en_US  | fr_FR  |
+      | small_size  | Csmall | Apetit |
+      | medium_size | Bmedium|        |
+      | large_size  | Alarge | Cgrand |
+    And I save the attribute
+    Then I should not see the text "There are unsaved changes"
+    When I am on the products page
+    And I create a new product
+    And I fill in the following information in the popin:
+      | SKU | a_product |
+    And I press the "Save" button in the popin
+    When I am on the "a_product" product page
+    And I switch the locale to "en_US"
+    And I add available attributes size
+    Then I should see the ordered choices Alarge, Bmedium, Csmall in size
+    And I switch the locale to "fr_FR"
+    Then I should see the ordered choices [medium_size], Apetit, Cgrand in size

--- a/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/AttributeOptionSearchableRepository.php
+++ b/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/AttributeOptionSearchableRepository.php
@@ -57,13 +57,17 @@ class AttributeOptionSearchableRepository implements SearchableRepositoryInterfa
         $qb->select('o')
             ->distinct()
             ->from($this->entityName, 'o')
-            ->leftJoin('o.optionValues', 'v')
             ->leftJoin('o.attribute', 'a')
+            ->leftJoin('o.optionValues', 'v')
             ->andWhere('a.code = :attributeCode')
             ->setParameter('attributeCode', $options['identifier']);
 
-        if ($this->isAttributeAutoSorted($options['identifier'])) {
-            $qb->orderBy('v.value, o.code');
+        if ($this->isAttributeAutoSorted($options['identifier']) && isset($options['catalogLocale'])) {
+            $qb
+                ->addSelect('v.value AS HIDDEN')
+                ->andWhere('v.locale = :localeCode')
+                ->setParameter('localeCode', $options['catalogLocale'])
+                ->orderBy('v.value, o.code');
         } else {
             $qb->orderBy('o.sortOrder');
         }
@@ -118,6 +122,6 @@ class AttributeOptionSearchableRepository implements SearchableRepositoryInterfa
         }
         $attribute = $this->attributeRepository->findOneByIdentifier($attributeIdentifier);
 
-        return $attribute->getProperties()['autoOptionSorting'];
+        return true === $attribute->getProperty('autoOptionSorting');
     }
 }

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/multi-select-field.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/multi-select-field.js
@@ -96,7 +96,8 @@ define(
                                     search: term,
                                     options: {
                                         limit: 20,
-                                        page: page
+                                        page: page,
+                                        catalogLocale: UserContext.get('catalogLocale')
                                     }
                                 };
                             }.bind(this),

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/simple-select-field.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/simple-select-field.js
@@ -81,7 +81,8 @@ define(
                                     search: term,
                                     options: {
                                         limit: 20,
-                                        page: page
+                                        page: page,
+                                        catalogLocale: UserContext.get('catalogLocale')
                                     }
                                 };
                             },


### PR DESCRIPTION
When the `autoOptionSorting` properties of the select attribute is not set, the select type failed.
Options in select type have to be sort in terms of the current locale.
    -> I added an option `locale` in the `findBySearch()` to avoid BC break.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | OK
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
