### PR TITLE
API-70: Fix values

### DIFF
--- a/src/Pim/Bundle/ApiBundle/Checker/QueryParametersChecker.php
+++ b/src/Pim/Bundle/ApiBundle/Checker/QueryParametersChecker.php
@@ -42,15 +42,18 @@ class QueryParametersChecker implements QueryParametersCheckerInterface
      */
     public function checkLocalesParameters(array $localeCodes, ChannelInterface $channel = null)
     {
+        $localeCodes = array_map('trim', $localeCodes);
         $errors = [];
-        foreach ($localeCodes as $locale) {
-            if (null === $this->localeRepository->findOneByIdentifier($locale)) {
-                $errors[] = $locale;
+        foreach ($localeCodes as $localeCode) {
+            $locale = $this->localeRepository->findOneByIdentifier($localeCode);
+            if (null === $locale || !$locale->isActivated()) {
+                $errors[] = $localeCode;
             }
         }
 
         if (!empty($errors)) {
-            $plural = count($errors) > 1 ? 'Locales "%s" do not exist.' : 'Locale "%s" does not exist.';
+            $plural = count($errors) > 1 ?
+                'Locales "%s" do not exist or are not activated.' : 'Locale "%s" does not exist or is not activated.';
             throw new UnprocessableEntityHttpException(sprintf($plural, implode(', ', $errors)));
         }
 
@@ -72,6 +75,7 @@ class QueryParametersChecker implements QueryParametersCheckerInterface
     {
         $errors = [];
         foreach ($attributeCodes as $attributeCode) {
+            $attributeCode = trim($attributeCode);
             if (null === $this->attributeRepository->findOneByIdentifier($attributeCode)) {
                 $errors[] = $attributeCode;
             }
@@ -90,9 +94,10 @@ class QueryParametersChecker implements QueryParametersCheckerInterface
     {
         $errors = [];
         foreach ($categories as $category) {
-            foreach ($category['value'] as $value) {
-                if (null === $this->categoryRepository->findOneByIdentifier($value)) {
-                    $errors[] = $value;
+            foreach ($category['value'] as $categoryCode) {
+                $categoryCode = trim($categoryCode);
+                if (null === $this->categoryRepository->findOneByIdentifier($categoryCode)) {
+                    $errors[] = $categoryCode;
                 }
             }
         }

--- a/src/Pim/Bundle/ApiBundle/spec/Checker/QueryParametersCheckerSpec.php
+++ b/src/Pim/Bundle/ApiBundle/spec/Checker/QueryParametersCheckerSpec.php
@@ -39,11 +39,22 @@ class QueryParametersCheckerSpec extends ObjectBehavior
     function it_raises_an_exception_if_a_locale_does_not_exist($localeRepository, LocaleInterface $enUsLocale)
     {
         $localeCodes = ['de_DE', 'en_US'];
-
+        $enUsLocale->isActivated()->willReturn(true);
         $localeRepository->findOneByIdentifier('de_DE')->willReturn(null);
         $localeRepository->findOneByIdentifier('en_US')->willReturn($enUsLocale);
 
-        $this->shouldThrow(new UnprocessableEntityHttpException('Locale "de_DE" does not exist.'))
+        $this->shouldThrow(new UnprocessableEntityHttpException('Locale "de_DE" does not exist or is not activated.'))
+            ->during('checkLocalesParameters', [$localeCodes, null]);
+    }
+
+    function it_raises_an_exception_if_a_locale_is_not_activated($localeRepository, LocaleInterface $enUsLocale)
+    {
+        $localeCodes = ['de_DE', 'en_US'];
+        $enUsLocale->isActivated()->willReturn(false);
+        $localeRepository->findOneByIdentifier('de_DE')->willReturn(null);
+        $localeRepository->findOneByIdentifier('en_US')->willReturn($enUsLocale);
+
+        $this->shouldThrow(new UnprocessableEntityHttpException('Locales "de_DE, en_US" do not exist or are not activated.'))
             ->during('checkLocalesParameters', [$localeCodes, null]);
     }
 
@@ -53,7 +64,7 @@ class QueryParametersCheckerSpec extends ObjectBehavior
         $localeRepository->findOneByIdentifier('de_DE')->willReturn(null);
         $localeRepository->findOneByIdentifier('en_US')->willReturn(null);
 
-        $this->shouldThrow(new UnprocessableEntityHttpException('Locales "de_DE, en_US" do not exist.'))
+        $this->shouldThrow(new UnprocessableEntityHttpException('Locales "de_DE, en_US" do not exist or are not activated.'))
             ->during('checkLocalesParameters', [$localeCodes, null]);
     }
 

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Category/CreateCategoryIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Category/CreateCategoryIntegration.php
@@ -61,23 +61,23 @@ JSON;
         $data =
 <<<JSON
     {
-        "code": "categoryC",
+        "code": "categoryD",
         "parent": "master",
         "labels": {
-            "en_US": "Category C",
-            "fr_FR": "Catégorie C"
+            "en_US": "Category D",
+            "fr_FR": "Catégorie D"
         }
     }
 JSON;
         $client->request('POST', 'api/rest/v1/categories', [], [], [], $data);
 
-        $category = $this->get('pim_catalog.repository.category')->findOneByIdentifier('categoryC');
+        $category = $this->get('pim_catalog.repository.category')->findOneByIdentifier('categoryD');
         $categoryStandard = [
-            'code'   => 'categoryC',
+            'code'   => 'categoryD',
             'parent' => 'master',
             'labels' => [
-                'en_US' => 'Category C',
-                'fr_FR' => 'Catégorie C',
+                'en_US' => 'Category D',
+                'fr_FR' => 'Catégorie D',
             ],
         ];
         $normalizer = $this->get('pim_catalog.normalizer.standard.category');
@@ -99,7 +99,7 @@ JSON;
         "labels": {
             "en_US": "US label",
             "fr_FR": null,
-            "de_DE": "" 
+            "de_DE": ""
         }
     }
 JSON;

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Category/ListCategoryIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Category/ListCategoryIntegration.php
@@ -83,6 +83,16 @@ class ListCategoryIntegration extends ApiTestCase
             {
                 "_links": {
                     "self": {
+                        "href": "http://localhost/api/rest/v1/categories/categoryC"
+                    }
+                },
+                "code": "categoryC",
+                "parent": "master",
+                "labels": {}
+            },
+            {
+                "_links": {
+                    "self": {
                         "href": "http://localhost/api/rest/v1/categories/master_china"
                     }
                 },
@@ -117,7 +127,7 @@ JSON;
         }
     },
     "current_page": 1,
-    "items_count": 6,
+    "items_count": 7,
     "_embedded": {
         "items": [
             {
@@ -170,6 +180,16 @@ JSON;
                     }
                 },
                 "code": "categoryB",
+                "parent": "master",
+                "labels": {}
+            },
+            {
+                "_links": {
+                    "self": {
+                        "href": "http://localhost/api/rest/v1/categories/categoryC"
+                    }
+                },
+                "code": "categoryC",
                 "parent": "master",
                 "labels": {}
             },

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Category/PartialUpdateCategoryIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Category/PartialUpdateCategoryIntegration.php
@@ -103,23 +103,23 @@ JSON;
         $data =
 <<<JSON
     {
-        "code": "categoryC",
+        "code": "categoryD",
         "parent": "master",
         "labels": {
-            "en_US": "Category C",
-            "fr_FR": "Catégorie C"
+            "en_US": "Category D",
+            "fr_FR": "Catégorie D"
         }
     }
 JSON;
-        $client->request('PATCH', 'api/rest/v1/categories/categoryC', [], [], [], $data);
+        $client->request('PATCH', 'api/rest/v1/categories/categoryD', [], [], [], $data);
 
-        $category = $this->get('pim_catalog.repository.category')->findOneByIdentifier('categoryC');
+        $category = $this->get('pim_catalog.repository.category')->findOneByIdentifier('categoryD');
         $categoryStandard = [
-            'code'   => 'categoryC',
+            'code'   => 'categoryD',
             'parent' => 'master',
             'labels' => [
-                'en_US' => 'Category C',
-                'fr_FR' => 'Catégorie C',
+                'en_US' => 'Category D',
+                'fr_FR' => 'Catégorie D',
             ],
         ];
         $normalizer = $this->get('pim_catalog.normalizer.standard.category');
@@ -257,7 +257,7 @@ JSON;
     {
         "labels": {
             "en_US": null,
-            "fr_FR":"" 
+            "fr_FR":""
         }
     }
 JSON;

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Category/PartialUpdateListCategoryIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Category/PartialUpdateListCategoryIntegration.php
@@ -14,13 +14,13 @@ class PartialUpdateListCategoryIntegration extends ApiTestCase
         $data =
 <<<JSON
     {"code": "categoryA2","labels":{"en_US":"category A2"}}
-    {"code": "categoryC","parent":"master"}
+    {"code": "categoryD","parent":"master"}
 JSON;
 
         $expectedContent =
 <<<JSON
 {"line":1,"code":"categoryA2","status_code":204}
-{"line":2,"code":"categoryC","status_code":201}
+{"line":2,"code":"categoryD","status_code":201}
 JSON;
 
         $response = $this->executeStreamRequest('PATCH', 'api/rest/v1/categories', [], [], [], $data);
@@ -39,29 +39,29 @@ JSON;
                     'en_US' => 'category A2'
                 ]
             ],
-            'categoryC' => [
-                'code'   => 'categoryC',
+            'categoryD' => [
+                'code'   => 'categoryD',
                 'parent' => 'master',
                 'labels' => []
             ]
         ];
 
         $this->assertSameCategories($expectedCategories['categoryA2'], 'categoryA2');
-        $this->assertSameCategories($expectedCategories['categoryC'], 'categoryC');
+        $this->assertSameCategories($expectedCategories['categoryD'], 'categoryD');
     }
 
     public function testCreateAndUpdateSameCategory()
     {
         $data =
 <<<JSON
-    {"code": "categoryC"}
-    {"code": "categoryC"}
+    {"code": "categoryD"}
+    {"code": "categoryD"}
 JSON;
 
         $expectedContent =
 <<<JSON
-{"line":1,"code":"categoryC","status_code":201}
-{"line":2,"code":"categoryC","status_code":204}
+{"line":1,"code":"categoryD","status_code":201}
+{"line":2,"code":"categoryD","status_code":204}
 JSON;
 
         $response = $this->executeStreamRequest('PATCH', 'api/rest/v1/categories', [], [], [], $data);

--- a/src/Pim/Bundle/VersioningBundle/tests/integration/Manager/VersionManagerIntegration.php
+++ b/src/Pim/Bundle/VersioningBundle/tests/integration/Manager/VersionManagerIntegration.php
@@ -77,10 +77,11 @@ class VersionManagerIntegration extends TestCase
         $this->assertEquals($version->getVersion(), 1);
         $this->assertEquals($version->getResourceName(), ClassUtils::getClass($product));
         $this->assertEquals($version->getResourceId(), $product->getId());
+
         $this->assertNotNull($version->getLoggedAt());
         $this->assertFalse($version->isPending());
         $this->assertNull($version->getContext());
-        $this->assertEquals($version->getAuthor(), 'admin');
+        $this->assertEquals($version->getAuthor(), 'system');
         $this->assertEquals($version->getSnapshot(), [
             'sku'        => 'versioned-product',
             'family'     => '',

--- a/src/Pim/Bundle/VersioningBundle/tests/integration/Normalizer/Flat/AttributeIntegration.php
+++ b/src/Pim/Bundle/VersioningBundle/tests/integration/Normalizer/Flat/AttributeIntegration.php
@@ -224,7 +224,7 @@ class AttributeIntegration extends AbstractFlatNormalizerTestCase
         $expected = [
             'code'                   => 'a_metric_without_decimal_negative',
             'type'                   => 'pim_catalog_metric',
-            'group'                  => 'attributeGroupB',
+            'group'                  => 'attributeGroupC',
             'unique'                 => false,
             'useable_as_grid_filter' => false,
             'allowed_extensions'     => '',
@@ -296,7 +296,7 @@ class AttributeIntegration extends AbstractFlatNormalizerTestCase
         $expected = [
             'code'                   => 'a_multi_select',
             'type'                   => 'pim_catalog_multiselect',
-            'group'                  => 'attributeGroupB',
+            'group'                  => 'attributeGroupC',
             'unique'                 => false,
             'useable_as_grid_filter' => false,
             'allowed_extensions'     => '',

--- a/src/Pim/Component/Catalog/Model/AbstractValue.php
+++ b/src/Pim/Component/Catalog/Model/AbstractValue.php
@@ -57,7 +57,7 @@ abstract class AbstractValue implements ValueInterface
      */
     public function isEqual(ValueInterface $value)
     {
-        return $this->getData() === $value->getData() &&
+        return $this->getData() == $value->getData() &&
             $this->scope === $value->getScope() &&
             $this->locale === $value->getLocale();
     }

--- a/src/Pim/Component/Catalog/Value/PriceCollectionValue.php
+++ b/src/Pim/Component/Catalog/Value/PriceCollectionValue.php
@@ -64,6 +64,20 @@ class PriceCollectionValue extends AbstractValue implements PriceCollectionValue
     /**
      * {@inheritdoc}
      */
+    public function hasData()
+    {
+        foreach ($this->data as $price) {
+            if (null !== $price->getData()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function __toString()
     {
         $options = [];

--- a/src/Pim/Component/Catalog/spec/Value/PriceCollectionValueSpec.php
+++ b/src/Pim/Component/Catalog/spec/Value/PriceCollectionValueSpec.php
@@ -80,4 +80,42 @@ class PriceCollectionValueSpec extends ObjectBehavior
 
         $this->__toString()->shouldReturn('34.00 USD');
     }
+
+    function it_returns_true_if_there_is_data(
+        $priceCollection,
+        \ArrayIterator $pricesIterator,
+        ProductPriceInterface $priceUSD,
+        ProductPriceInterface $priceEUR
+    ) {
+        $priceUSD->getData()->willReturn(34);
+        $priceUSD->getCurrency()->willReturn('USD');
+        $priceEUR->getData()->willReturn(null);
+        $priceEUR->getCurrency()->willReturn('EUR');
+
+        $priceCollection->getIterator()->willReturn($pricesIterator);
+        $pricesIterator->rewind()->shouldBeCalled();
+        $pricesIterator->valid()->willReturn(true, true, false);
+        $pricesIterator->current()->willReturn($priceEUR, $priceUSD);
+        $pricesIterator->next()->shouldBeCalled();
+
+        $this->hasData()->shouldReturn(true);
+    }
+
+    function it_returns_false_if_there_is_no_data(
+        $priceCollection,
+        \ArrayIterator $pricesIterator,
+        ProductPriceInterface $priceUSD,
+        ProductPriceInterface $priceEUR
+    ) {
+        $priceUSD->getData()->willReturn(null);
+        $priceEUR->getData()->willReturn(null);
+
+        $priceCollection->getIterator()->willReturn($pricesIterator);
+        $pricesIterator->rewind()->shouldBeCalled();
+        $pricesIterator->valid()->willReturn(true, true, false);
+        $pricesIterator->current()->willReturn($priceEUR, $priceUSD);
+        $pricesIterator->next()->shouldBeCalled();
+
+        $this->hasData()->shouldReturn(false);
+    }
 }


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

Fix `hasData` for PriceCollectionValue.
Remove the strict equality, it does not work when you compare number, etc. A PR will be done after to check if all types in the PIM are correctly compared. 

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
