### PR TITLE
[PIM-6498] Move the scope + locale switchers to PEF header

### DIFF
--- a/features/Context/Page/Base/ProductEditForm.php
+++ b/features/Context/Page/Base/ProductEditForm.php
@@ -26,8 +26,8 @@ class ProductEditForm extends Form
         $this->elements = array_merge(
             $this->elements,
             [
-                'Locales dropdown'                => ['css' => '.attribute-edit-actions .locale-switcher'],
-                'Channel dropdown'                => ['css' => '.attribute-edit-actions .scope-switcher'],
+                'Locales dropdown'                => ['css' => '.AknTitleContainer .locale-switcher'],
+                'Channel dropdown'                => ['css' => '.AknTitleContainer .scope-switcher'],
                 // Note: It erases parent add-attributes selector values because of the new JS module,
                 // once refactoring done everywhere, it should be set in parent like before
                 'Available attributes button'     => ['css' => '.add-attribute a.select2-choice'],

--- a/features/Context/Page/Product/Edit.php
+++ b/features/Context/Page/Product/Edit.php
@@ -114,7 +114,9 @@ class Edit extends ProductEditForm
     {
         $dropdown = $this->getElement($copy ? 'Copy locales dropdown' : 'Locales dropdown');
         $link = $this->spin(function () use ($dropdown, $localeCode) {
-            $dropdown->find('css', '.dropdown-toggle, *[data-toggle="dropdown"]')->click();
+            if (!$dropdown->hasClass('open')) {
+                $dropdown->click();
+            }
 
             return $dropdown->find('css', sprintf('a[data-locale="%s"]', $localeCode));
         }, 'Can not click on the locale dropdown button');

--- a/features/Context/Page/Product/Edit.php
+++ b/features/Context/Page/Product/Edit.php
@@ -78,7 +78,7 @@ class Edit extends ProductEditForm
                     ]
                 ],
                 'Main context selector' => [
-                    'css'        => '.tab-container .attribute-edit-actions .context-selectors',
+                    'css'        => '.AknTitleContainer-context',
                     'decorators' => [
                         ContextSwitcherDecorator::class
                     ]

--- a/features/Context/Page/VariantGroup/Edit.php
+++ b/features/Context/Page/VariantGroup/Edit.php
@@ -33,7 +33,7 @@ class Edit extends ProductEditForm
             $this->elements,
             [
                 'Main context selector' => [
-                    'css'        => '.tab-container .object-attributes .attribute-edit-actions .context-selectors',
+                    'css'        => '.AknTitleContainer-context',
                     'decorators' => [
                         ContextSwitcherDecorator::class
                     ]

--- a/src/.htaccess
+++ b/src/.htaccess
@@ -1,1 +1,3 @@
 deny from all
+
+{"code":"csv_product_export","label":"Demo CSV product export","type":"export","configuration":{"filePath":"/tmp/export_%job_label%_%datetime%.csv","delimiter":";","enclosure":"\"","withHeader":true,"decimalSeparator":".","dateFormat":"yyyy-MM-dd","with_media":true,"filters":{"data":[{"field":"enabled","operator":"=","value":true},{"field":"completeness","operator":">=","value":100},{"field":"categories","operator":"IN CHILDREN","value":["master"]},{"field":"description","value":"zzfzfz","operator":"CONTAINS"}],"structure":{"scope":"mobile","locales":["fr_FR","en_US","de_DE"]}}}}

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product/edit.yml
@@ -209,16 +209,16 @@ extensions:
 
     pim-product-edit-form-attribute-scope-switcher:
         module: pim/product-edit-form/scope-switcher
-        parent: pim-product-edit-form-attributes
-        targetZone: context-selectors
+        parent: pim-product-edit-form
+        targetZone: context
         position: 100
         config:
             context: base_product
 
     pim-product-edit-form-attribute-locale-switcher:
         module: pim/product-edit-form/locale-switcher
-        parent: pim-product-edit-form-attributes
-        targetZone: context-selectors
+        parent: pim-product-edit-form
+        targetZone: context
         position: 110
         config:
             context: base_product

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product/edit.yml
@@ -212,12 +212,16 @@ extensions:
         parent: pim-product-edit-form-attributes
         targetZone: context-selectors
         position: 100
+        config:
+            context: base_product
 
     pim-product-edit-form-attribute-locale-switcher:
         module: pim/product-edit-form/locale-switcher
         parent: pim-product-edit-form-attributes
         targetZone: context-selectors
         position: 110
+        config:
+            context: base_product
 
     pim-product-edit-form-validation:
         module: pim/product-edit-form/attributes/validation
@@ -274,12 +278,16 @@ extensions:
         parent: pim-product-edit-form-copy
         targetZone: context-selectors
         position: 100
+        config:
+            context: copy_product
 
     pim-product-edit-form-copy-locale-switcher:
         module: pim/product-edit-form/locale-switcher
         parent: pim-product-edit-form-copy
         targetZone: context-selectors
         position: 110
+        config:
+            context: copy_product
 
 attribute_fields:
     akeneo-switch-field:           pim/boolean-field

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/variant_group/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/variant_group/edit.yml
@@ -108,15 +108,19 @@ extensions:
 
     pim-variant-group-edit-form-attribute-scope-switcher:
         module: pim/product-edit-form/scope-switcher
-        parent: pim-variant-group-edit-form-attributes
-        targetZone: context-selectors
+        parent: pim-variant-group-edit-form
+        targetZone: context
         position: 100
+        config:
+            context: base_product
 
     pim-variant-group-edit-form-attribute-locale-switcher:
         module: pim/product-edit-form/locale-switcher
-        parent: pim-variant-group-edit-form-attributes
-        targetZone: context-selectors
+        parent: pim-variant-group-edit-form
+        targetZone: context
         position: 110
+        config:
+            context: base_product
 
     pim-variant-group-edit-form-no-attribute:
         module: pim/variant-group-edit-form/no-attribute
@@ -147,6 +151,8 @@ extensions:
         parent: pim-variant-group-edit-form-copy
         targetZone: context-selectors
         position: 100
+        config:
+            context: copy_product
 
     pim-variant-group-edit-form-copy-locale-switcher:
         module: pim/product-edit-form/locale-switcher

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/attribute/attribute.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/attribute/attribute.js
@@ -126,11 +126,13 @@ define([
                 this.listenTo(this.getRoot(), 'pim_enrich:form:scope_switcher:pre_render', this.initScope.bind(this));
 
                 this.listenTo(
-                    scopeSwitcher,
+                    this.getRoot(),
                     'pim_enrich:form:scope_switcher:change',
                     function (scopeEvent) {
-                        this.setScope(scopeEvent.scopeCode, {silent: true});
-                        this.trigger('pim_enrich:form:entity:post_update');
+                        if ('base_product' === scopeEvent.context) {
+                            this.setScope(scopeEvent.scopeCode, {silent: true});
+                            this.trigger('pim_enrich:form:entity:post_update');
+                        }
                     }.bind(this)
                 );
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/attribute/attribute.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/attribute/attribute.js
@@ -146,11 +146,13 @@ define([
                 this.listenTo(this.getRoot(), 'pim_enrich:form:locale_switcher:pre_render', this.initLocale.bind(this));
 
                 this.listenTo(
-                    localeSwitcher,
+                    this.getRoot(),
                     'pim_enrich:form:locale_switcher:change',
                     function (localeEvent) {
-                        this.setLocale(localeEvent.localeCode, {silent: true});
-                        this.trigger('pim_enrich:form:entity:post_update');
+                        if ('base_product' === localeEvent.context) {
+                            this.setLocale(localeEvent.localeCode, {silent: true});
+                            this.trigger('pim_enrich:form:entity:post_update');
+                        }
                     }.bind(this)
                 );
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/attribute/attribute.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/attribute/attribute.js
@@ -143,17 +143,7 @@ define([
                 var localeSwitcher = new LocaleSwitcher();
                 localeSwitcher.setDisplayInline(true);
 
-                this.listenTo(
-                    localeSwitcher,
-                    'pim_enrich:form:locale_switcher:pre_render',
-                    function (localeEvent) {
-                        if (this.getLocale()) {
-                            localeEvent.localeCode = this.getLocale();
-                        } else {
-                            this.setLocale(localeEvent.localeCode, {silent: true});
-                        }
-                    }.bind(this)
-                );
+                this.listenTo(this.getRoot(), 'pim_enrich:form:locale_switcher:pre_render', this.initLocale.bind(this));
 
                 this.listenTo(
                     localeSwitcher,
@@ -242,6 +232,23 @@ define([
                     scopeEvent.scopeCode = this.getScope();
                 } else {
                     this.setScope(scopeEvent.scopeCode, {silent: true});
+                }
+            }
+        },
+
+        /**
+         * Initialize the locale
+         *
+         * @param {Object} localeEvent
+         * @param {string} localeEvent.context
+         * @param {string} localeEvent.localeCode
+         */
+        initLocale: function (localeEvent) {
+            if ('base_product' === localeEvent.context) {
+                if (this.getLocale()) {
+                    localeEvent.localeCode = this.getLocale();
+                } else {
+                    this.setLocale(localeEvent.localeCode, {silent: true});
                 }
             }
         }

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/attribute/attribute.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/attribute/attribute.js
@@ -123,17 +123,7 @@ define([
                 var scopeSwitcher = new ScopeSwitcher();
                 scopeSwitcher.setDisplayInline(true);
 
-                this.listenTo(
-                    scopeSwitcher,
-                    'pim_enrich:form:scope_switcher:pre_render',
-                    function (scopeEvent) {
-                        if (this.getScope()) {
-                            scopeEvent.scopeCode = this.getScope();
-                        } else {
-                            this.setScope(scopeEvent.scopeCode, {silent: true});
-                        }
-                    }.bind(this)
-                );
+                this.listenTo(this.getRoot(), 'pim_enrich:form:scope_switcher:pre_render', this.initScope.bind(this));
 
                 this.listenTo(
                     scopeSwitcher,
@@ -235,6 +225,23 @@ define([
                         container
                     );
                 }.bind(this));
+        },
+
+        /**
+         * Initialize the scope
+         *
+         * @param {Object} scopeEvent
+         * @param {string} scopeEvent.context
+         * @param {string} scopeEvent.scopeCode
+         */
+        initScope: function (scopeEvent) {
+            if ('base_product' === scopeEvent.context) {
+                if (this.getScope()) {
+                    scopeEvent.scopeCode = this.getScope();
+                } else {
+                    this.setScope(scopeEvent.scopeCode, {silent: true});
+                }
+            }
         }
     });
 });

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/attribute/attribute.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/attribute/attribute.js
@@ -34,7 +34,7 @@ define([
          * {@inherit}
          */
         initialize: function (config) {
-            if (config.config) {
+            if (undefined !== config) {
                 this.config = config.config;
             }
 
@@ -123,10 +123,10 @@ define([
                 var scopeSwitcher = new ScopeSwitcher();
                 scopeSwitcher.setDisplayInline(true);
 
-                this.listenTo(this.getRoot(), 'pim_enrich:form:scope_switcher:pre_render', this.initScope.bind(this));
+                this.listenTo(scopeSwitcher, 'pim_enrich:form:scope_switcher:pre_render', this.initScope.bind(this));
 
                 this.listenTo(
-                    this.getRoot(),
+                    scopeSwitcher,
                     'pim_enrich:form:scope_switcher:change',
                     function (scopeEvent) {
                         if ('base_product' === scopeEvent.context) {
@@ -143,10 +143,10 @@ define([
                 var localeSwitcher = new LocaleSwitcher();
                 localeSwitcher.setDisplayInline(true);
 
-                this.listenTo(this.getRoot(), 'pim_enrich:form:locale_switcher:pre_render', this.initLocale.bind(this));
+                this.listenTo(localeSwitcher, 'pim_enrich:form:locale_switcher:pre_render', this.initLocale.bind(this));
 
                 this.listenTo(
-                    this.getRoot(),
+                    localeSwitcher,
                     'pim_enrich:form:locale_switcher:change',
                     function (localeEvent) {
                         if ('base_product' === localeEvent.context) {
@@ -229,12 +229,10 @@ define([
          * @param {string} scopeEvent.scopeCode
          */
         initScope: function (scopeEvent) {
-            if ('base_product' === scopeEvent.context) {
-                if (this.getScope()) {
-                    scopeEvent.scopeCode = this.getScope();
-                } else {
-                    this.setScope(scopeEvent.scopeCode, {silent: true});
-                }
+            if (this.getScope()) {
+                scopeEvent.scopeCode = this.getScope();
+            } else {
+                this.setScope(scopeEvent.scopeCode, {silent: true});
             }
         },
 
@@ -246,12 +244,10 @@ define([
          * @param {string} localeEvent.localeCode
          */
         initLocale: function (localeEvent) {
-            if ('base_product' === localeEvent.context) {
-                if (this.getLocale()) {
-                    localeEvent.localeCode = this.getLocale();
-                } else {
-                    this.setLocale(localeEvent.localeCode, {silent: true});
-                }
+            if (this.getLocale()) {
+                localeEvent.localeCode = this.getLocale();
+            } else {
+                this.setLocale(localeEvent.localeCode, {silent: true});
             }
         }
     });

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes.js
@@ -84,6 +84,11 @@ define(
                     }
                 }.bind(this));
                 this.listenTo(this.getRoot(), 'pim_enrich:form:locale_switcher:pre_render', this.initLocale.bind(this));
+                this.listenTo(this.getRoot(), 'pim_enrich:form:locale_switcher:change', function (localeEvent) {
+                    if ('base_product' === localeEvent.context) {
+                        this.setLocale(localeEvent.localeCode);
+                    }
+                }.bind(this));
 
                 FieldManager.clearFields();
 
@@ -93,10 +98,6 @@ define(
                 this.onExtensions('copy:copy-fields:after', this.render.bind(this));
                 this.onExtensions('copy:select:after', this.render.bind(this));
                 this.onExtensions('copy:context:change', this.render.bind(this));
-
-                this.onExtensions('pim_enrich:form:locale_switcher:change', function (event) {
-                    this.setLocale(event.localeCode);
-                }.bind(this));
 
                 return BaseForm.prototype.configure.apply(this, arguments);
             },

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes.js
@@ -77,6 +77,7 @@ define(
                 this.listenTo(this.getRoot(), 'pim_enrich:form:entity:post_fetch', this.render);
                 this.listenTo(this.getRoot(), 'pim_enrich:form:add-attribute:after', this.render);
                 this.listenTo(this.getRoot(), 'pim_enrich:form:show_attribute', this.showAttribute);
+                this.listenTo(this.getRoot(), 'pim_enrich:form:scope_switcher:pre_render', this.initScope.bind(this));
 
                 FieldManager.clearFields();
 
@@ -86,7 +87,6 @@ define(
                 this.onExtensions('copy:copy-fields:after', this.render.bind(this));
                 this.onExtensions('copy:select:after', this.render.bind(this));
                 this.onExtensions('copy:context:change', this.render.bind(this));
-                this.onExtensions('pim_enrich:form:scope_switcher:pre_render', this.initScope.bind(this));
                 this.onExtensions('pim_enrich:form:locale_switcher:pre_render', this.initLocale.bind(this));
                 this.onExtensions('pim_enrich:form:scope_switcher:change', function (event) {
                     this.setScope(event.scopeCode);
@@ -314,13 +314,17 @@ define(
             /**
              * Initialize  the scope if there is none, or modify it by reference if there is already one
              *
-             * @param {Object} event
+             * @param {Object} scopeEvent
+             * @param {string} scopeEvent.context
+             * @param {string} scopeEvent.scopeCode
              */
-            initScope: function (event) {
-                if (undefined === this.getScope()) {
-                    this.setScope(event.scopeCode, {silent: true});
-                } else {
-                    event.scopeCode = this.getScope();
+            initScope: function (scopeEvent) {
+                if ('base_product' === scopeEvent.context) {
+                    if (undefined === this.getScope()) {
+                        this.setScope(scopeEvent.scopeCode, {silent: true});
+                    } else {
+                        scopeEvent.scopeCode = this.getScope();
+                    }
                 }
             },
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes.js
@@ -83,6 +83,8 @@ define(
                         this.setScope(scopeEvent.scopeCode);
                     }
                 }.bind(this));
+                this.listenTo(this.getRoot(), 'pim_enrich:form:locale_switcher:pre_render', this.initLocale.bind(this));
+
                 FieldManager.clearFields();
 
                 this.onExtensions('comparison:change', this.comparisonChange.bind(this));
@@ -91,7 +93,6 @@ define(
                 this.onExtensions('copy:copy-fields:after', this.render.bind(this));
                 this.onExtensions('copy:select:after', this.render.bind(this));
                 this.onExtensions('copy:context:change', this.render.bind(this));
-                this.onExtensions('pim_enrich:form:locale_switcher:pre_render', this.initLocale.bind(this));
 
                 this.onExtensions('pim_enrich:form:locale_switcher:change', function (event) {
                     this.setLocale(event.localeCode);
@@ -350,13 +351,17 @@ define(
             /**
              * Initialize  the locale if there is none, or modify it by reference if there is already one
              *
-             * @param {Object} event
+             * @param {Object} eventLocale
+             * @param {String} eventLocale.context
+             * @param {String} eventLocale.localeCode
              */
-            initLocale: function (event) {
-                if (undefined === this.getLocale()) {
-                    this.setLocale(event.localeCode, {silent: true});
-                } else {
-                    event.localeCode = this.getLocale();
+            initLocale: function (eventLocale) {
+                if ('base_product' === eventLocale.context) {
+                    if (undefined === this.getLocale()) {
+                        this.setLocale(eventLocale.localeCode, {silent: true});
+                    } else {
+                        eventLocale.localeCode = this.getLocale();
+                    }
                 }
             },
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes.js
@@ -78,7 +78,11 @@ define(
                 this.listenTo(this.getRoot(), 'pim_enrich:form:add-attribute:after', this.render);
                 this.listenTo(this.getRoot(), 'pim_enrich:form:show_attribute', this.showAttribute);
                 this.listenTo(this.getRoot(), 'pim_enrich:form:scope_switcher:pre_render', this.initScope.bind(this));
-
+                this.listenTo(this.getRoot(), 'pim_enrich:form:scope_switcher:change', function (scopeEvent) {
+                    if ('base_product' === scopeEvent.context) {
+                        this.setScope(scopeEvent.scopeCode);
+                    }
+                }.bind(this));
                 FieldManager.clearFields();
 
                 this.onExtensions('comparison:change', this.comparisonChange.bind(this));
@@ -88,9 +92,7 @@ define(
                 this.onExtensions('copy:select:after', this.render.bind(this));
                 this.onExtensions('copy:context:change', this.render.bind(this));
                 this.onExtensions('pim_enrich:form:locale_switcher:pre_render', this.initLocale.bind(this));
-                this.onExtensions('pim_enrich:form:scope_switcher:change', function (event) {
-                    this.setScope(event.scopeCode);
-                }.bind(this));
+
                 this.onExtensions('pim_enrich:form:locale_switcher:change', function (event) {
                     this.setLocale(event.localeCode);
                 }.bind(this));

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes/copy.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes/copy.js
@@ -72,9 +72,10 @@ define(
                     }
                 }.bind(this));
                 this.listenTo(this.getRoot(), 'pim_enrich:form:locale_switcher:pre_render', this.initLocale.bind(this));
-
-                this.onExtensions('pim_enrich:form:locale_switcher:change', function (event) {
-                    this.setLocale(event.localeCode);
+                this.listenTo(this.getRoot(), 'pim_enrich:form:locale_switcher:change', function (eventLocale) {
+                    if ('copy_product' === eventLocale.context) {
+                        this.setLocale(eventLocale.localeCode);
+                    }
                 }.bind(this));
 
                 return this.getScopeLabel(this.scope).then(function (scopeLabel) {

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes/copy.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes/copy.js
@@ -66,11 +66,14 @@ define(
 
                 this.listenTo(this.getRoot(), 'pim_enrich:form:field:extension:add', this.addFieldExtension);
                 this.listenTo(this.getRoot(), 'pim_enrich:form:scope_switcher:pre_render', this.initScope.bind(this));
+                this.listenTo(this.getRoot(), 'pim_enrich:form:scope_switcher:change', function (eventScope) {
+                    if ('copy_product' === eventScope.context) {
+                        this.setScope(eventScope.scopeCode);
+                    }
+                }.bind(this));
 
                 this.onExtensions('pim_enrich:form:locale_switcher:pre_render', this.initLocale.bind(this));
-                this.onExtensions('pim_enrich:form:scope_switcher:change', function (event) {
-                    this.setScope(event.scopeCode);
-                }.bind(this));
+
                 this.onExtensions('pim_enrich:form:locale_switcher:change', function (event) {
                     this.setLocale(event.localeCode);
                 }.bind(this));

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes/copy.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes/copy.js
@@ -71,8 +71,7 @@ define(
                         this.setScope(eventScope.scopeCode);
                     }
                 }.bind(this));
-
-                this.onExtensions('pim_enrich:form:locale_switcher:pre_render', this.initLocale.bind(this));
+                this.listenTo(this.getRoot(), 'pim_enrich:form:locale_switcher:pre_render', this.initLocale.bind(this));
 
                 this.onExtensions('pim_enrich:form:locale_switcher:change', function (event) {
                     this.setLocale(event.localeCode);
@@ -203,13 +202,17 @@ define(
             /**
              * Initialize  the locale if there is none, or modify it by reference if there is already one
              *
-             * @param {Object} event
+             * @param {Object} eventLocale
+             * @param {String} eventLocale.context
+             * @param {String} eventLocale.localeCode
              */
-            initLocale: function (event) {
-                if (undefined === this.getLocale()) {
-                    this.setLocale(event.localeCode);
-                } else {
-                    event.localeCode = this.getLocale();
+            initLocale: function (eventLocale) {
+                if ('copy_product' === eventLocale.context) {
+                    if (undefined === this.getLocale()) {
+                        this.setLocale(eventLocale.localeCode);
+                    } else {
+                        eventLocale.localeCode = this.getLocale();
+                    }
                 }
             },
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes/copy.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes/copy.js
@@ -65,8 +65,8 @@ define(
                 }.bind(this));
 
                 this.listenTo(this.getRoot(), 'pim_enrich:form:field:extension:add', this.addFieldExtension);
+                this.listenTo(this.getRoot(), 'pim_enrich:form:scope_switcher:pre_render', this.initScope.bind(this));
 
-                this.onExtensions('pim_enrich:form:scope_switcher:pre_render', this.initScope.bind(this));
                 this.onExtensions('pim_enrich:form:locale_switcher:pre_render', this.initLocale.bind(this));
                 this.onExtensions('pim_enrich:form:scope_switcher:change', function (event) {
                     this.setScope(event.scopeCode);
@@ -232,13 +232,17 @@ define(
             /**
              * Initialize  the scope if there is none, or modify it by reference if there is already one
              *
-             * @param {Object} event
+             * @param {Object} scopeEvent
+             * @param {string} scopeEvent.context
+             * @param {string} scopeEvent.scopeCode
              */
-            initScope: function (event) {
-                if (undefined === this.getScope()) {
-                    this.setScope(event.scopeCode);
-                } else {
-                    event.scopeCode = this.getScope();
+            initScope: function (scopeEvent) {
+                if ('copy_product' === scopeEvent.context) {
+                    if (undefined === this.getScope()) {
+                        this.setScope(scopeEvent.scopeCode);
+                    } else {
+                        scopeEvent.scopeCode = this.getScope();
+                    }
                 }
             },
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/associations.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/associations.js
@@ -123,6 +123,12 @@ define(
 
                 this.listenTo(this.getRoot(), 'pim_enrich:form:entity:post_update', this.postUpdate.bind(this));
 
+                this.listenTo(this.getRoot(), 'pim_enrich:form:locale_switcher:change', function (localeEvent) {
+                    if ('base_product' === localeEvent.context) {
+                        this.render();
+                    }
+                }.bind(this));
+
                 return BaseForm.prototype.configure.apply(this, arguments);
             },
             render: function () {

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/categories.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/categories.js
@@ -76,6 +76,12 @@ define(
                     label: __('pim_enrich.form.product.tab.categories.title')
                 });
 
+                this.listenTo(this.getRoot(), 'pim_enrich:form:locale_switcher:change', function (localeEvent) {
+                    if ('base_product' === localeEvent.context) {
+                        this.render();
+                    }
+                }.bind(this));
+
                 return BaseForm.prototype.configure.apply(this, arguments);
             },
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/locale-switcher.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/locale-switcher.js
@@ -10,12 +10,20 @@
 define(
     [
         'underscore',
+        'oro/translator',
         'pim/form',
         'pim/template/product/locale-switcher',
         'pim/fetcher-registry',
         'pim/i18n'
     ],
-    function (_, BaseForm, template, FetcherRegistry, i18n) {
+    function (
+        _,
+        __,
+        BaseForm,
+        template,
+        FetcherRegistry,
+        i18n
+    ) {
         return BaseForm.extend({
             template: _.template(template),
             className: 'AknDropdown AknButtonList-item locale-switcher',
@@ -53,7 +61,8 @@ define(
                                 locales: locales,
                                 currentLocale: _.findWhere(locales, {code: params.localeCode}),
                                 i18n: i18n,
-                                displayInline: this.displayInline
+                                displayInline: this.displayInline,
+                                label: __('pim_enrich.entity.product.meta.locale')
                             })
                         );
                         this.delegateEvents();

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/locale-switcher.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/locale-switcher.js
@@ -29,7 +29,9 @@ define(
              * {@inheritdoc}
              */
             initialize: function (config) {
-                this.config = config.config;
+                if (undefined !== config) {
+                    this.config = config.config;
+                }
 
                 BaseForm.prototype.initialize.apply(this, arguments);
             },

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/locale-switcher.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/locale-switcher.js
@@ -75,8 +75,9 @@ define(
              * @param {Object} event
              */
             changeLocale: function (event) {
-                this.trigger('pim_enrich:form:locale_switcher:change', {
-                    localeCode: event.currentTarget.dataset.locale
+                this.getRoot().trigger('pim_enrich:form:locale_switcher:change', {
+                    localeCode: event.currentTarget.dataset.locale,
+                    context: this.config.context
                 });
 
                 this.render();

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/locale-switcher.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/locale-switcher.js
@@ -23,6 +23,16 @@ define(
                 'click li a': 'changeLocale'
             },
             displayInline: false,
+            config: {},
+
+            /**
+             * {@inheritdoc}
+             */
+            initialize: function (config) {
+                this.config = config.config;
+
+                BaseForm.prototype.initialize.apply(this, arguments);
+            },
 
             /**
              * {@inheritdoc}

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/locale-switcher.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/locale-switcher.js
@@ -40,8 +40,11 @@ define(
             render: function () {
                 this.getDisplayedLocales()
                     .done(function (locales) {
-                        var params = { localeCode: _.first(locales).code };
-                        this.trigger('pim_enrich:form:locale_switcher:pre_render', params);
+                        var params = {
+                            localeCode: _.first(locales).code,
+                            context: this.config.context
+                        };
+                        this.getRoot().trigger('pim_enrich:form:locale_switcher:pre_render', params);
 
                         this.$el.html(
                             this.template({

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/locale-switcher.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/locale-switcher.js
@@ -40,7 +40,7 @@ define(
             render: function () {
                 this.getDisplayedLocales()
                     .done(function (locales) {
-                        var params = {
+                        const params = {
                             localeCode: _.first(locales).code,
                             context: this.config.context
                         };

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/scope-switcher.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/scope-switcher.js
@@ -38,6 +38,20 @@ define(
             /**
              * {@inheritdoc}
              */
+            configure: function () {
+                this.listenTo(this.getRoot(), 'pim_enrich:form:locale_switcher:change', function (localeEvent) {
+                    if ('base_product' === localeEvent.context) {
+                        UserContext.set('catalogLocale', localeEvent.localeCode);
+                        this.render();
+                    }
+                }.bind(this));
+
+                return BaseForm.prototype.configure.apply(this, arguments);
+            },
+
+            /**
+             * {@inheritdoc}
+             */
             render: function () {
                 FetcherRegistry.getFetcher('channel')
                     .fetchAll()

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/scope-switcher.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/scope-switcher.js
@@ -10,13 +10,22 @@
 define(
     [
         'underscore',
+        'oro/translator',
         'pim/form',
         'pim/template/product/scope-switcher',
         'pim/fetcher-registry',
         'pim/user-context',
         'pim/i18n'
     ],
-    function (_, BaseForm, template, FetcherRegistry, UserContext, i18n) {
+    function (
+        _,
+        __,
+        BaseForm,
+        template,
+        FetcherRegistry,
+        UserContext,
+        i18n
+    ) {
         return BaseForm.extend({
             template: _.template(template),
             className: 'AknDropdown AknButtonList-item scope-switcher',
@@ -76,7 +85,8 @@ define(
                                 ),
                                 catalogLocale: UserContext.get('catalogLocale'),
                                 i18n: i18n,
-                                displayInline: this.displayInline
+                                displayInline: this.displayInline,
+                                label: __('pim_enrich.entity.product.meta.scope')
                             })
                         );
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/scope-switcher.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/scope-switcher.js
@@ -56,7 +56,7 @@ define(
                 FetcherRegistry.getFetcher('channel')
                     .fetchAll()
                     .then(function (channels) {
-                        var params = {
+                        const params = {
                             scopeCode: channels[0].code,
                             context: this.config.context
                         };

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/scope-switcher.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/scope-switcher.js
@@ -30,7 +30,9 @@ define(
              * {@inheritdoc}
              */
             initialize: function (config) {
-                this.config = config.config;
+                if (undefined !== config) {
+                    this.config = config.config;
+                }
 
                 BaseForm.prototype.initialize.apply(this, arguments);
             },

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/scope-switcher.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/scope-switcher.js
@@ -24,6 +24,16 @@ define(
                 'click li a': 'changeScope'
             },
             displayInline: false,
+            config: {},
+
+            /**
+             * {@inheritdoc}
+             */
+            initialize: function (config) {
+                this.config = config.config;
+
+                BaseForm.prototype.initialize.apply(this, arguments);
+            },
 
             /**
              * {@inheritdoc}
@@ -32,8 +42,11 @@ define(
                 FetcherRegistry.getFetcher('channel')
                     .fetchAll()
                     .then(function (channels) {
-                        var params = { scopeCode: channels[0].code };
-                        this.trigger('pim_enrich:form:scope_switcher:pre_render', params);
+                        var params = {
+                            scopeCode: channels[0].code,
+                            context: this.config.context
+                        };
+                        this.getRoot().trigger('pim_enrich:form:scope_switcher:pre_render', params);
 
                         var scope = _.findWhere(channels, { code: params.scopeCode });
 
@@ -64,8 +77,9 @@ define(
              * @param {Event} event
              */
             changeScope: function (event) {
-                this.trigger('pim_enrich:form:scope_switcher:change', {
-                    scopeCode: event.currentTarget.dataset.scope
+                this.getRoot().trigger('pim_enrich:form:scope_switcher:change', {
+                    scopeCode: event.currentTarget.dataset.scope,
+                    context: this.config.context
                 });
 
                 this.render();

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/form/edit-form.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/form/edit-form.html
@@ -6,6 +6,7 @@
             <div class="AknTitleContainer-mainContainer">
                 <div class="AknTitleContainer-breadcrumbs" data-drop-zone="breadcrumbs"></div>
                 <div class="AknTitleContainer-title" data-drop-zone="title"></div>
+                <div class="AknTitleContainer-context AkButtonList" data-drop-zone="context"></div>
                 <div class="AknTitleContainer-meta" data-drop-zone="meta"></div>
             </div>
             <div class="AknTitleContainer-buttonsContainer">

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/form/edit-form.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/form/edit-form.html
@@ -6,7 +6,7 @@
             <div class="AknTitleContainer-mainContainer">
                 <div class="AknTitleContainer-breadcrumbs" data-drop-zone="breadcrumbs"></div>
                 <div class="AknTitleContainer-title" data-drop-zone="title"></div>
-                <div class="AknTitleContainer-context AkButtonList" data-drop-zone="context"></div>
+                <div class="AknTitleContainer-context AknButtonList" data-drop-zone="context"></div>
                 <div class="AknTitleContainer-meta" data-drop-zone="meta"></div>
             </div>
             <div class="AknTitleContainer-buttonsContainer">

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/locale-switcher.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/locale-switcher.html
@@ -1,9 +1,12 @@
-<a class="AknActionButton<% if (displayInline) { %> AknActionButton--big AknActionButton--noLeftBorder<% } %>" data-toggle="dropdown" href="#">
-    <%= i18n.getFlag(currentLocale.code, false) %> <%- currentLocale.language %>
-    <span class="AknActionButton-caret AknCaret"></span>
+<a class="AknActionButton <% if (displayInline) { %> AknActionButton--big AknActionButton--noLeftBorder<% } else { %>AknActionButton--withoutBorder<% } %>" data-toggle="dropdown" href="#">
+    <% if (!displayInline) { %><%- label %>: <% } %><span class="AknActionButton-highlight"><%= i18n.getFlag(currentLocale.code, false) %> <%- currentLocale.language %></span>
+    <span class="AknActionButton-caret"></span>
 </a>
 <ul class="AknDropdown-menu">
+    <div class="AknDropdown-menuTitle"><%- label %></div>
     <% _.each(locales, function (locale) { %>
-        <li><a class="AknDropdown-menuLink<% if (currentLocale.code === locale.code) { %> AknDropdown-menuLink--active<% } %>" data-locale="<%- locale.code %>"><%= i18n.getFlag(locale.code, false) %> <%- locale.language %></a></li>
+        <li>
+            <a class="AknDropdown-menuLink<% if (currentLocale.code === locale.code) { %> AknDropdown-menuLink--active<% } %>" data-locale="<%- locale.code %>"><%= i18n.getFlag(locale.code, false) %> <%- locale.language %></a>
+        </li>
     <% }); %>
 </ul>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/scope-switcher.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/scope-switcher.html
@@ -1,11 +1,12 @@
-<a class="AknActionButton<% if (displayInline) { %> AknActionButton--big AknActionButton--noLeftBorder<% } %>" data-toggle="dropdown" href="#">
-    <%- currentScope %>
-    <span class="AknActionButton-caret AknCaret"></span>
+<a class="AknActionButton <% if (displayInline) { %>AknActionButton--big AknActionButton--noLeftBorder<% } else { %>AknActionButton--withoutBorder<% } %>" data-toggle="dropdown" href="#">
+    <% if (!displayInline) { %><%- label %>: <% } %><span class="AknActionButton-highlight"><%- currentScope %></span>
+    <span class="AknActionButton-caret"></span>
 </a>
 <ul class="AknDropdown-menu">
+    <div class="AknDropdown-menuTitle"><%- label %></div>
     <% _.each(channels, function (scope) { %>
         <li>
-            <a class="AknDropdown-menuLink"
+            <a class="AknDropdown-menuLink <% if (i18n.getLabel(scope.labels, catalogLocale, scope.code) === currentScope) { %> AknDropdown-menuLink--active<% } %>"
                data-scope="<%- scope.code %>"
                data-label="<%- i18n.getLabel(scope.labels, catalogLocale, scope.code) %>">
                 <%- i18n.getLabel(scope.labels, catalogLocale, scope.code) %>

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
@@ -205,6 +205,8 @@ pim_enrich:
                         more_products: '{{ count }} more products...'
                         close: Close
                 status: Status
+                scope: Channel
+                locale: Locale
             copy:
                 select: Select
                 all: All

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/TitleContainer.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/TitleContainer.less
@@ -31,16 +31,11 @@
   }
 
   &-meta {
-    padding-top: 20px;
     display: flex;
 
     &:empty {
       display: none;
     }
-  }
-
-  &-breadcrumbs:not(:empty) {
-    padding-bottom: 10px;
   }
 
   &-title {

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/button/ActionButton.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/button/ActionButton.less
@@ -18,7 +18,12 @@
   outline: none;
 
   &-caret {
-    margin-left: 5px;
+    display: inline-block;
+    width: 12px;
+    height: 6px;
+    background: url("../../../images/jstree/icon-down.svg") no-repeat 0 center;
+    background-size: 12px;
+    margin-left: 3px;
   }
 
   &:hover,
@@ -90,5 +95,14 @@
     padding-left: 0;
     padding-right: 0;
     text-align: center;
+  }
+
+  &--withoutBorder {
+    border: none;
+    padding: 0;
+  }
+
+  &-highlight {
+    color: @AknLightPurple;
   }
 }


### PR DESCRIPTION
This PR only moves the 2 context selectors (scope + locale) in the main title container.

This implies a lot of changes for scope & locale events, because the hierarchy is not the same.
So all the events (pre-scope, update-scope, pre-locale, update-locale) are sent to Root instead of parents.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Migration script                  | -
| Tech Doc                          | -