### PR TITLE
API-php7-fix: Fix array to string conversion exception

### DIFF
--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateProductIntegration.php
@@ -1425,6 +1425,69 @@ JSON;
         $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
     }
 
+    public function testProductPartialUpdateWithInvalidFieldData()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data =
+<<<JSON
+    {
+        "identifier": "product_family",
+        "family": ["familyA"]
+    }
+JSON;
+        $client->request('PATCH', 'api/rest/v1/products/product_family', [], [], [], $data);
+
+        $expectedContent = [
+            'code'    => 422,
+            'message' => 'Property "family" expects a string as data, "array" given. Check the standard format documentation.',
+            '_links'  => [
+                'documentation' => [
+                    'href' => "http://api.akeneo.com/api-reference.html#patch_products__code_"
+                ],
+            ],
+        ];
+
+        $response = $client->getResponse();
+        $this->assertSame($expectedContent, json_decode($response->getContent(), true));
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+    }
+
+    public function testProductPartialUpdateWithInvalidAttributeData()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data =
+<<<JSON
+    {
+        "identifier": "big_boot",
+        "family": "familyA",
+        "values": {
+            "a_text":[{
+                "locale": null,
+                "scope": null,
+                "data": ["an_array"]
+            }]
+        }
+    }
+JSON;
+        $client->request('PATCH', 'api/rest/v1/products/big_boot', [], [], [], $data);
+
+        $expectedContent = [
+            'code'    => 422,
+            'message' => 'Property "a_text" expects a scalar as data, "array" given. Check the standard format documentation.',
+            '_links'  => [
+                'documentation' => [
+                    'href' => "http://api.akeneo.com/api-reference.html#patch_products__code_"
+                ],
+            ],
+        ];
+
+        $response = $client->getResponse();
+        $this->assertSame($expectedContent, json_decode($response->getContent(), true));
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+    }
+
     /**
      * @param array  $expectedProduct normalized data of the product that should be created
      * @param string $identifier identifier of the product that should be created

--- a/src/Pim/Component/Catalog/Comparator/Attribute/ScalarComparator.php
+++ b/src/Pim/Component/Catalog/Comparator/Attribute/ScalarComparator.php
@@ -40,6 +40,10 @@ class ScalarComparator implements ComparatorInterface
         $default = ['locale' => null, 'scope' => null, 'data' => null];
         $originals = array_merge($default, $originals);
 
+        if (is_array($data['data'])) {
+            return $data;
+        }
+
         return (string) $data['data'] !== (string) $originals['data'] ? $data : null;
     }
 }

--- a/src/Pim/Component/Catalog/Comparator/Field/ScalarComparator.php
+++ b/src/Pim/Component/Catalog/Comparator/Field/ScalarComparator.php
@@ -37,6 +37,10 @@ class ScalarComparator implements ComparatorInterface
      */
     public function compare($data, $originals)
     {
+        if (is_array($data)) {
+            return $data;
+        }
+
         if ((string) $originals === (string) $data) {
             return null;
         }

--- a/src/Pim/Component/Catalog/spec/Comparator/Attribute/ScalarComparatorSpec.php
+++ b/src/Pim/Component/Catalog/spec/Comparator/Attribute/ScalarComparatorSpec.php
@@ -53,4 +53,36 @@ class ScalarComparatorSpec extends ObjectBehavior
 
         $this->compare($changes, $originals)->shouldReturn(null);
     }
+
+    function it_returns_value_when_value_is_array()
+    {
+        $changes = ['data' => ['scalar'], 'locale' => 'en_US', 'scope' => 'ecommerce'];
+        $originals = ['data' => 'scalar', 'locale' => 'en_US', 'scope' => 'ecommerce'];
+
+        $this->compare($changes, $originals)->shouldReturn($changes);
+    }
+
+    function it_returns_value_when_value_is_integer()
+    {
+        $changes = ['data' => 2, 'locale' => 'en_US', 'scope' => 'ecommerce'];
+        $originals = ['data' => 'scalar', 'locale' => 'en_US', 'scope' => 'ecommerce'];
+
+        $this->compare($changes, $originals)->shouldReturn($changes);
+    }
+
+    function it_returns_value_when_value_is_float()
+    {
+        $changes = ['data' => 2.44, 'locale' => 'en_US', 'scope' => 'ecommerce'];
+        $originals = ['data' => 'scalar', 'locale' => 'en_US', 'scope' => 'ecommerce'];
+
+        $this->compare($changes, $originals)->shouldReturn($changes);
+    }
+
+    function it_returns_null_value_when_values_are_null()
+    {
+        $changes = null;
+        $originals = ['data' => 'scalar', 'locale' => 'en_US', 'scope' => 'ecommerce'];
+
+        $this->compare($changes, $originals)->shouldReturn(null);
+    }
 }

--- a/src/Pim/Component/Catalog/spec/Comparator/Field/ScalarComparatorSpec.php
+++ b/src/Pim/Component/Catalog/spec/Comparator/Field/ScalarComparatorSpec.php
@@ -43,4 +43,35 @@ class ScalarComparatorSpec extends ObjectBehavior
         $originals = 'tshirt';
         $this->compare($changes, $originals)->shouldReturn(null);
     }
+
+    function it_returns_value_when_value_is_array()
+    {
+        $changes = ['tshirt'];
+        $originals = 'tshirt';
+        $this->compare($changes, $originals)->shouldReturn($changes);
+    }
+
+    function it_returns_value_when_value_is_integer()
+    {
+        $changes = [2];
+        $originals = 'scalar';
+
+        $this->compare($changes, $originals)->shouldReturn($changes);
+    }
+
+    function it_returns_value_when_value_is_float()
+    {
+        $changes = [2.44];
+        $originals = 'scalar';
+
+        $this->compare($changes, $originals)->shouldReturn($changes);
+    }
+
+    function it_returns_null_value_when_values_are_null()
+    {
+        $changes = null;
+        $originals = 'scalar';
+
+        $this->compare($changes, $originals)->shouldReturn(null);
+    }
 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Since PHP 7.0 array to string conversion has been improved and now throw E_RECOVERABLE_ERROR instead of a E_NOTICE. [improve-array-to-string-conversion](https://why-cant-we-have-nice-things.mwl.be/requests/improve-array-to-string-conversion)
With the PIM API we can send invalid data like an array for a `pim_catalog_text` attribute instead string that was not an issue with PHP 5.6, before it thrown a E_NOTICE, and as the next PIM version has to support PHP 7.0, we have to fix it.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added Behats                      | -
| Added integration tests           | OK
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
