### PR TITLE
API-213: Add missing case for many locales

### DIFF
--- a/src/Pim/Bundle/ApiBundle/Controller/ProductController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/ProductController.php
@@ -200,7 +200,7 @@ class ProductController
         $queryParameters = array_merge([
             'limit' => $this->apiConfiguration['pagination']['limit_by_default']
         ], $request->query->all());
-        $pqbOptions = ['limit' => (int)$queryParameters['limit']];
+        $pqbOptions = ['limit' => (int) $queryParameters['limit']];
 
         $searchParameter = null;
         if (isset($queryParameters['search_after'])) {
@@ -538,8 +538,12 @@ class ProductController
 
                 $context['scope'] = isset($filter['scope']) ? $filter['scope'] : $request->query->get('search_scope');
 
-                if (isset($filter['locales'])) {
+                if (isset($filter['locales']) && '' !== $filter['locales']) {
                     $context['locales'] = $filter['locales'];
+
+                    $this->queryParametersChecker->checkLocalesParameters(
+                        !is_array($context['locales']) ? [$context['locales']] : $context['locales']
+                    );
                 }
 
                 $value = isset($filter['value']) ? $filter['value'] : null;

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/ErrorListProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/ErrorListProductIntegration.php
@@ -142,6 +142,14 @@ class ErrorListProductIntegration extends AbstractProductTestCase
         $this->assert($client, 'Property "completeness" expects an array of arrays as data.');
     }
 
+    public function testSearchWithEmptyLocales()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $client->request('GET', '/api/rest/v1/products?search={"completeness":[{"operator":"GREATER THAN ON ALL LOCALES", "scope":"ecommerce", "value":100, "locales":""}]}');
+        $this->assert($client, 'Property "completeness" expects an array with the key "locales" as data.');
+    }
+
     public function testSearchWithMissingScope()
     {
         $client = $this->createAuthenticatedClient();
@@ -222,9 +230,12 @@ class ErrorListProductIntegration extends AbstractProductTestCase
      */
     private function assert(Client $client, $message)
     {
-        $expected = sprintf('{"code":%s,"message":"%s"}', Response::HTTP_UNPROCESSABLE_ENTITY, addslashes($message));
+        $response = $client->getResponse();
 
-        $this->assertSame($expected, $client->getResponse()->getContent());
+        $expected = sprintf('{"code":%d,"message":"%s"}', Response::HTTP_UNPROCESSABLE_ENTITY, addslashes($message));
+
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertSame($expected, $response->getContent());
     }
 
     /**


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

Workaround to check the permissions on the locales even if it's not an array, as the check if it's an array is in the pqb so far deeper in the code ....

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
