### PR TITLE
[PIM-6500] Update localizable field design

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/field/date.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/field/date.html
@@ -1,3 +1,7 @@
-<div class="datetimepicker">
-    <input id="<%- fieldId %>" class="AknTextField datepicker-field add-on" type="text" data-locale="<%- value.locale %>" data-scope="<%- value.scope %>" value="<%- value.data %>" <%- editMode === 'view' ? 'disabled' : '' %>/>
+<div class="datetimepicker AknFieldContainer-subContainer">
+    <% if (attribute.localizable) { %>
+        <div class="AknTextField-layer AknTextField-layer--first"></div>
+        <div class="AknTextField-layer AknTextField-layer--second"></div>
+    <% } %>
+    <input id="<%- fieldId %>" class="AknTextField<% if (attribute.localizable) { %> AknTextField--localizable <% } %> datepicker-field add-on" type="text" data-locale="<%- value.locale %>" data-scope="<%- value.scope %>" value="<%- value.data %>" <%- editMode === 'view' ? 'disabled' : '' %>/>
 </div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/field/metric.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/field/metric.html
@@ -1,4 +1,8 @@
-<div class="AknMetricField metric-container">
+<div class="AknMetricField metric-container<% if (attribute.localizable) { %> AknMetricField--localizable<% } %>">
+    <% if (attribute.localizable) { %>
+        <div class="AknTextField-layer AknTextField-layer--first"></div>
+        <div class="AknTextField-layer AknTextField-layer--second"></div>
+    <% } %>
     <input class="AknTextField AknTextField--noRightRadius data" id="<%- fieldId %>" type="text" data-locale="<%- value.locale %>" data-scope="<%- value.scope %>" value="<%- value.data.amount %>" <%- editMode === 'view' ? 'disabled' : '' %>/>
     <select class="AknMetricField-unit unit select-field" data-locale="<%- value.locale %>" data-scope="<%- value.scope %>" <%- editMode === 'view' ? 'disabled' : '' %>>
         <% _.each(_.keys(measures[attribute.metric_family].units), function(unit) { %>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/field/multi-select.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/field/multi-select.html
@@ -1,4 +1,18 @@
-<input id="<%- fieldId %>" type="hidden" class="select-field" value="<%- value.data.join(',') %>" data-locale="<%- value.locale %>" data-scope="<%- value.scope %>" <%- editMode === 'view' ? 'disabled' : '' %>/>
+<div class="AknFieldContainer-subContainer">
+    <% if (attribute.localizable) { %>
+        <div class="AknTextField-layer AknTextField-layer--first"></div>
+        <div class="AknTextField-layer AknTextField-layer--second"></div>
+    <% } %>
+    <input
+        id="<%- fieldId %>"
+        type="hidden"
+        class="select-field<% if (attribute.localizable) { %> AknTextField--localizable<% } %>"
+        value="<%- value.data.join(',') %>"
+        data-locale="<%- value.locale %>"
+        data-scope="<%- value.scope %>"
+        <%- editMode === 'view' ? 'disabled' : '' %>
+    />
+</div>
 <% if (userCanAddOption) { %>
     <div class="AknFieldContainer-iconsContainer">
         <span class="AknIconButton AknIconButton--dark add-attribute-option" data-toggle="tooltip" data-placement="top" data-original-title="<%- _.__('label.attribute_option.add_option') %>">

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/field/number.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/field/number.html
@@ -1,6 +1,6 @@
 <% if (attribute.localizable) { %>
-<div class="AknTextField-layer AknTextField-layer--first"></div>
-<div class="AknTextField-layer AknTextField-layer--second"></div>
+    <div class="AknTextField-layer AknTextField-layer--first"></div>
+    <div class="AknTextField-layer AknTextField-layer--second"></div>
 <% } %>
 <input
     id="<%- fieldId %>"

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/field/number.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/field/number.html
@@ -1,6 +1,6 @@
 <% if (attribute.localizable) { %>
-    <div class="AknTextField-layer AknTextField-layer--first"></div>
-    <div class="AknTextField-layer AknTextField-layer--second"></div>
+<div class="AknTextField-layer AknTextField-layer--first"></div>
+<div class="AknTextField-layer AknTextField-layer--second"></div>
 <% } %>
 <input
     id="<%- fieldId %>"

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/field/number.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/field/number.html
@@ -1,1 +1,13 @@
-<input id="<%- fieldId %>" class="AknTextField" type="text" data-locale="<%- value.locale %>" data-scope="<%- value.scope %>" value="<%- value.data %>" <%- editMode === 'view' ? 'disabled' : '' %>/>
+<% if (attribute.localizable) { %>
+    <div class="AknTextField-layer AknTextField-layer--first"></div>
+    <div class="AknTextField-layer AknTextField-layer--second"></div>
+<% } %>
+<input
+    id="<%- fieldId %>"
+    class="AknTextField<% if (attribute.localizable) { %> AknTextField--localizable <% } %>"
+    type="text"
+    data-locale="<%- value.locale %>"
+    data-scope="<%- value.scope %>"
+    value="<%- value.data %>"
+    <%- editMode === 'view' ? 'disabled' : '' %>
+/>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/field/price-collection.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/field/price-collection.html
@@ -1,7 +1,11 @@
-<div class="AknPriceList">
+<div class="AknPriceList<% if (attribute.localizable) { %> AknPriceList--localizable<% } %>">
     <% if (!value.data) { %>
         <% _.each(currencies, function (currency) { %>
             <div class="AknPriceList-item price-input">
+                <% if (attribute.localizable) { %>
+                    <div class="AknTextField-layer AknTextField-layer--first"></div>
+                    <div class="AknTextField-layer AknTextField-layer--second"></div>
+                <% } %>
                 <input class="AknTextField AknTextField--noRightRadius" type="text" data-locale="<%- value.locale %>" data-scope="<%- value.scope %>" data-currency="<%- currency.code %>" value="" <%- editMode === 'view' ? 'disabled' : '' %> size="1">
                 <span class="AknPriceList-currency"><%- currency.code %></span>
             </div>
@@ -9,6 +13,10 @@
     <% } else { %>
         <% _.each(value.data, function (price) { %>
             <div class="AknPriceList-item price-input">
+                <% if (attribute.localizable) { %>
+                    <div class="AknTextField-layer AknTextField-layer--first"></div>
+                    <div class="AknTextField-layer AknTextField-layer--second"></div>
+                <% } %>
                 <input class="AknTextField AknTextField--noRightRadius" type="text" data-locale="<%- value.locale %>" data-scope="<%- value.scope %>" data-currency="<%- price.currency %>" value="<%- price.amount %>" <%- editMode === 'view' ? 'disabled' : '' %> size="1">
                 <span class="AknPriceList-currency"><%- price.currency %></span>
             </div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/field/simple-select.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/field/simple-select.html
@@ -1,4 +1,19 @@
-<input id="<%- fieldId %>" type="hidden" class="select-field" value="<%- value.data %>" data-min-input-length="0" data-locale="<%- value.locale %>" data-scope="<%- value.scope %>" <%- editMode === 'view' ? 'disabled' : '' %>/>
+<div class="AknFieldContainer-subContainer">
+    <% if (attribute.localizable) { %>
+    <div class="AknTextField-layer AknTextField-layer--first"></div>
+    <div class="AknTextField-layer AknTextField-layer--second"></div>
+    <% } %>
+    <input
+        id="<%- fieldId %>"
+        type="hidden"
+        class="select-field<% if (attribute.localizable) { %> AknTextField--localizable<% } %>"
+        value="<%- value.data %>"
+        data-min-input-length="0"
+        data-locale="<%- value.locale %>"
+        data-scope="<%- value.scope %>"
+        <%- editMode === 'view' ? 'disabled' : '' %>
+    />
+</div>
 <% if (userCanAddOption) { %>
     <div class="AknFieldContainer-iconsContainer">
         <span class="AknIconButton AknIconButton--dark add-attribute-option" data-toggle="tooltip" data-placement="top" data-original-title="<%- _.__('label.attribute_option.add_option') %>">

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/field/simple-select.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/field/simple-select.html
@@ -1,7 +1,7 @@
 <div class="AknFieldContainer-subContainer">
     <% if (attribute.localizable) { %>
-    <div class="AknTextField-layer AknTextField-layer--first"></div>
-    <div class="AknTextField-layer AknTextField-layer--second"></div>
+        <div class="AknTextField-layer AknTextField-layer--first"></div>
+        <div class="AknTextField-layer AknTextField-layer--second"></div>
     <% } %>
     <input
         id="<%- fieldId %>"

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/field/text.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/field/text.html
@@ -1,1 +1,5 @@
-<input id="<%- fieldId %>" class="AknTextField <%- context.isRequired ? 'AknTextField--required' : '' %>" type="text" data-locale="<%- value.locale %>" data-scope="<%- value.scope %>" value="<%- value.data %>" <%- editMode === 'view' ? 'disabled' : '' %>/>
+<% if (attribute.localizable) { %>
+    <div class="AknTextField-layer AknTextField-layer--first"></div>
+    <div class="AknTextField-layer AknTextField-layer--second"></div>
+<% } %>
+<input id="<%- fieldId %>" class="AknTextField<% if (attribute.localizable) { %> AknTextField--localizable <% } %> <%- context.isRequired ? 'AknTextField--required' : '' %>" type="text" data-locale="<%- value.locale %>" data-scope="<%- value.scope %>" value="<%- value.data %>" <%- editMode === 'view' ? 'disabled' : '' %>/>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/field/text.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/field/text.html
@@ -2,4 +2,12 @@
     <div class="AknTextField-layer AknTextField-layer--first"></div>
     <div class="AknTextField-layer AknTextField-layer--second"></div>
 <% } %>
-<input id="<%- fieldId %>" class="AknTextField<% if (attribute.localizable) { %> AknTextField--localizable <% } %> <%- context.isRequired ? 'AknTextField--required' : '' %>" type="text" data-locale="<%- value.locale %>" data-scope="<%- value.scope %>" value="<%- value.data %>" <%- editMode === 'view' ? 'disabled' : '' %>/>
+<input
+    id="<%- fieldId %>"
+    class="AknTextField<% if (attribute.localizable) { %> AknTextField--localizable <% } %> <%- context.isRequired ? 'AknTextField--required' : '' %>"
+    type="text"
+    data-locale="<%- value.locale %>"
+    data-scope="<%- value.scope %>"
+    value="<%- value.data %>"
+    <%- editMode === 'view' ? 'disabled' : '' %>
+/>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/field/textarea.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/field/textarea.html
@@ -1,1 +1,11 @@
-<textarea id="<%- fieldId %>" class="AknTextareaField" data-locale="<%- value.locale %>" data-scope="<%- value.scope %>" <%- editMode === 'view' ? 'disabled' : '' %>><%- value.data %></textarea>
+<% if (attribute.localizable) { %>
+    <div class="AknTextareaField-layer AknTextareaField-layer--first"></div>
+    <div class="AknTextareaField-layer AknTextareaField-layer--second"></div>
+<% } %>
+<textarea
+    id="<%- fieldId %>"
+    class="AknTextareaField<% if (attribute.localizable) { %> AknTextareaField--localizable <% } %>"
+    data-locale="<%- value.locale %>"
+    data-scope="<%- value.scope %>"
+    <%- editMode === 'view' ? 'disabled' : '' %>
+><%- value.data %></textarea>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/field/textarea.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/field/textarea.html
@@ -1,6 +1,6 @@
 <% if (attribute.localizable) { %>
-    <div class="AknTextareaField-layer AknTextareaField-layer--first"></div>
-    <div class="AknTextareaField-layer AknTextareaField-layer--second"></div>
+<div class="AknTextareaField-layer AknTextareaField-layer--first"></div>
+<div class="AknTextareaField-layer AknTextareaField-layer--second"></div>
 <% } %>
 <textarea
     id="<%- fieldId %>"

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/field/textarea.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/field/textarea.html
@@ -1,6 +1,6 @@
 <% if (attribute.localizable) { %>
-<div class="AknTextareaField-layer AknTextareaField-layer--first"></div>
-<div class="AknTextareaField-layer AknTextareaField-layer--second"></div>
+    <div class="AknTextareaField-layer AknTextareaField-layer--first"></div>
+    <div class="AknTextareaField-layer AknTextareaField-layer--second"></div>
 <% } %>
 <textarea
     id="<%- fieldId %>"

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/base/variables.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/base/variables.less
@@ -15,7 +15,6 @@
 @AknLittleIconFontSize: 16px;
 
 // Colors
-
 @AknDarkBlue: #11324D;
 @AknGreen: #67b373;
 @AknOrange: #F8B441;
@@ -49,6 +48,7 @@
 @AknMicroProgressBarHeight: 8px;
 @AknDropdownMenuVerticalPadding: 5px;
 @AknFlashMessagesPadding: 44px;
+@AknLocalizableGap: 2px;
 
 // Various
 @AknButtonsPadding: 12px;

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/product-edit-form/FieldContainer.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/product-edit-form/FieldContainer.less
@@ -31,6 +31,10 @@
     position: relative;
   }
 
+  &-subContainer {
+    position: relative;
+  }
+
   &-iconsContainer {
     margin-left: 5px;
     min-width: @AknIconSize + 4px;

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/product-edit-form/FieldContainer.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/product-edit-form/FieldContainer.less
@@ -33,11 +33,13 @@
 
   &-subContainer {
     position: relative;
+    flex-grow: 1;
   }
 
   &-iconsContainer {
     margin-left: 5px;
     min-width: @AknIconSize + 4px;
+    padding-top: 4px;
   }
 
   &-contextContainer {

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/product-edit-form/FieldContainer.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/product-edit-form/FieldContainer.less
@@ -28,6 +28,7 @@
   &-inputContainer {
     display: flex;
     justify-content: space-between;
+    position: relative;
   }
 
   &-iconsContainer {

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/product-edit-form/MetricField.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/product-edit-form/MetricField.less
@@ -1,8 +1,14 @@
+@import '../../base/variables';
+
 .AknMetricField {
   display: flex;
   width: 100%;
 
   &-unit {
     flex-basis: 50%;
+  }
+
+  &--localizable {
+    margin-right: 2 * @AknLocalizableGap;
   }
 }

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/product-edit-form/PriceList.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/product-edit-form/PriceList.less
@@ -17,10 +17,12 @@
   }
 
   &-currency {
+    background: white;
     height: @AknFormHeight - 2px;
     line-height: @AknFormHeight - 2px;
-    border: 1px solid @AknBorderColor;
-    background: lighten(@AknGrey, 25%);
+    border-top: 1px solid @AknBorderColor;
+    border-right: 1px solid @AknBorderColor;
+    border-bottom: 1px solid @AknBorderColor;
     width: 44px;
     border-top-right-radius: 2px;
     border-bottom-right-radius: 2px;
@@ -28,5 +30,12 @@
     display: block;
     box-sizing: content-box;
     text-align: center;
+    z-index: 1;
+    color: @AknLightFontColor;
+  }
+
+  &--localizable &-item {
+    position: relative;
+    padding-right: 2 * @AknLocalizableGap;
   }
 }

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/product-edit-form/TextField.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/product-edit-form/TextField.less
@@ -9,7 +9,7 @@
   border-radius: 2px;
   padding: 0 8px;
   z-index: 1;
-  
+
   &-layer {
     border: 1px solid @AknBorderColor;
     position: absolute;

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/product-edit-form/TextField.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/product-edit-form/TextField.less
@@ -9,6 +9,25 @@
   border-radius: 2px;
   padding: 0 8px;
 
+  &-layer {
+    border: 1px solid @AknBorderColor;
+    position: absolute;
+    width: ~"calc(100% - 4px)";
+    height: 100%;
+    background: white;
+    border-radius: 2px;
+
+    &--first {
+      top: @AknLocalizableGap * 2;
+      left: @AknLocalizableGap * 2;
+    }
+
+    &--second {
+      top: @AknLocalizableGap;
+      left: @AknLocalizableGap;
+    }
+  }
+
   &--noRightRadius {
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
@@ -60,6 +79,12 @@
     padding-right: @AknFormHeight - 4px;
     color: @AknLightFontColor;
     cursor: not-allowed;
+  }
+
+  &--localizable {
+    width: ~"calc(100% - 4px)";
+    z-index: 1;
+    position: relative;
   }
 }
 

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/product-edit-form/TextField.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/product-edit-form/TextField.less
@@ -8,7 +8,8 @@
   width: 100%;
   border-radius: 2px;
   padding: 0 8px;
-
+  z-index: 1;
+  
   &-layer {
     border: 1px solid @AknBorderColor;
     position: absolute;
@@ -83,7 +84,6 @@
 
   &--localizable {
     width: ~"calc(100% - 4px)";
-    z-index: 1;
     position: relative;
   }
 }

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/product-edit-form/TextareaField.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/product-edit-form/TextareaField.less
@@ -8,6 +8,25 @@
   padding: 12px;
   height: 150px;
 
+  &-layer {
+    border: 1px solid @AknBorderColor;
+    position: absolute;
+    width: ~"calc(100% - 4px)";
+    height: 100%;
+    background: white;
+    border-radius: 2px;
+
+    &--first {
+      top: @AknLocalizableGap * 2;
+      left: @AknLocalizableGap * 2;
+    }
+
+    &--second {
+      top: @AknLocalizableGap;
+      left: @AknLocalizableGap;
+    }
+  }
+
   &[readonly],
   &[disabled] {
     background: @AknDisabledInputColor;
@@ -17,5 +36,10 @@
   &--small {
     height: @AknFormHeight;
     overflow: hidden;
+  }
+
+  &--localizable {
+    margin-right: @AknLocalizableGap * 2;
+    z-index: 1;
   }
 }

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/lib/select2.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/lib/select2.less
@@ -32,6 +32,11 @@
     background-position: ~"calc(100% - 10px)" 10px;
     padding-right: @AknFormHeight - 4px;
   }
+
+  .select2-allowclear .select2-choice abbr {
+    top: 12px;
+    margin-right: 10px;
+  }
 }
 
 .select2-drop-active {
@@ -139,7 +144,7 @@
     .select2-search-choice {
       margin: 1px;
       height: @AknFormHeight - 4px;
-      line-height: @AknFormHeight - 4px;
+      line-height: @AknFormHeight - 6px;
       padding: 0 10px 0 20px;
     }
 
@@ -157,7 +162,7 @@
   }
 
   .select2-search-choice-close {
-    top: 8px;
+    top: (@AknFormHeight / 2) - (12px / 2) - 2 * 2px;
   }
 
   &.select2-container-active .select2-choices {

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/lib/select2.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/lib/select2.less
@@ -33,7 +33,7 @@
     padding-right: @AknFormHeight - 4px;
   }
 
-  .select2-allowclear .select2-choice abbr {
+  &.select2-allowclear .select2-choice abbr {
     top: 12px;
     margin-right: 10px;
   }


### PR DESCRIPTION
This PR updates the field design for all the localizable attributes.
It adds "fake layers" to show there is other locales availables.

only assets, file, image and boolean design does not change, every other attribute type is OK.

![selection_085](https://user-images.githubusercontent.com/1590933/28491346-d3528e7c-6eef-11e7-8cea-73e17408f6e0.png)


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Migration script                  | -
| Tech Doc                          | -
