### PR TITLE
Fix php error messages not catched by the CI in our tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -286,7 +286,7 @@ void runIntegrationTest(String phpVersion, String edition, def testFiles) {
 
                         sh "sed -i \"s#<file></file>#${testSuiteFiles}#\" app/phpunit.xml.dist"
 
-                        sh "./bin/phpunit -c app/phpunit.xml.dist --testsuite PIM_Integration_Test --log-junit app/build/logs/phpunit_integration.xml"
+                        sh "php -d error_reporting='E_ALL' ./bin/phpunit -c app/phpunit.xml.dist --testsuite PIM_Integration_Test --log-junit app/build/logs/phpunit_integration.xml"
                     }
                 }
             }

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/ProductViolationNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/ProductViolationNormalizer.php
@@ -61,10 +61,13 @@ class ProductViolationNormalizer implements NormalizerInterface
                 return [];
             }
 
+            $channel = $attribute[1] ?? null;
+            $locale = $attribute[2] ?? null;
+
             return [
                 'attribute' => $attributeCode,
-                'locale'    => '<all_locales>' === $attribute[2] ? null : $attribute[2],
-                'scope'     => '<all_channels>' === $attribute[1] ? null : $attribute[1],
+                'locale'    => '<all_locales>' === $locale ? null : $locale,
+                'scope'     => '<all_channels>' === $channel ? null : $channel,
                 'message'   => $violation->getMessage(),
             ];
         }

--- a/src/Pim/Bundle/EnrichBundle/spec/Normalizer/ProductViolationNormalizerSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Normalizer/ProductViolationNormalizerSpec.php
@@ -40,7 +40,7 @@ class ProductViolationNormalizerSpec extends ObjectBehavior
         ]);
     }
 
-    function it_normlizes_localization_constraint_violation_with_scope_and_locale(
+    function it_normalizes_localization_constraint_violation_with_scope_and_locale(
         ConstraintViolationInterface $violation,
         ProductInterface $product,
         ValueInterface $value,
@@ -164,6 +164,28 @@ class ProductViolationNormalizerSpec extends ObjectBehavior
         $attribute->getCode()->willReturn('price');
 
         $violation->getPropertyPath()->willReturn('values[price-<all_channels>-<all_locales>].float');
+        $violation->getMessage()->willReturn('The price should be above 10.');
+
+        $this->normalize($violation, 'internal_api', ['product' => $product])->shouldReturn([
+            'attribute' => 'price',
+            'locale'    => null,
+            'scope'     => null,
+            'message'   => 'The price should be above 10.'
+        ]);
+    }
+
+    function it_normalizes_constraint_violation_without_channel_and_locale(
+        ConstraintViolationInterface $violation,
+        ProductInterface $product,
+        ValueInterface $value,
+        AttributeInterface $attribute
+    ) {
+        $value->getLocale()->willReturn(null);
+        $value->getScope()->willReturn(null);
+        $value->getAttribute()->willReturn($attribute);
+        $attribute->getCode()->willReturn('price');
+
+        $violation->getPropertyPath()->willReturn('values[price]');
         $violation->getMessage()->willReturn('The price should be above 10.');
 
         $this->normalize($violation, 'internal_api', ['product' => $product])->shouldReturn([

--- a/web/app_behat.php
+++ b/web/app_behat.php
@@ -3,6 +3,9 @@
 use Symfony\Component\ClassLoader\ApcClassLoader;
 use Symfony\Component\HttpFoundation\Request;
 
+ini_set('display_errors', '1');
+error_reporting(E_ALL);
+
 $loader = require_once __DIR__.'/../app/bootstrap.php.cache';
 // Use APC for autoloading to improve performance.
 // Use the HOST variable if available to define prefix


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

CI is not executed with error mode to ALL, for the integration tests and for the behat.
Moreover, in behat, the display output is Off, so you don't have any error in the output of the Ajax request. Errors are only logged in files (that we don't care at all on the CI).

CI should be strict. 
Our docker images will be changed to be strict. But we have to fix master first (to not have a red CI when we will use the new docker images).

Note: done in EE as well, but 0 error.


[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Ok
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
