### PR TITLE
Display filepath instead of namespace of the failing scenarios of the CI

### DIFF
--- a/behat.ci.yml
+++ b/behat.ci.yml
@@ -89,7 +89,8 @@ default:
             factory:
                 page_parameters:
                     base_url: 'http://akeneo/'
+        Pim\Behat\Extension\PimFormatter\PimFormatterExtension: ~
 
     formatters:
-        junit:
+        pim:
             output_path: app/build/logs/behat/

--- a/features/Pim/Behat/Extension/PimFormatter/Output/Node/EventListener/PimFeatureElementListener.php
+++ b/features/Pim/Behat/Extension/PimFormatter/Output/Node/EventListener/PimFeatureElementListener.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Behat\Extension\PimFormatter\Output\Node\EventListener;
+
+use Behat\Behat\EventDispatcher\Event\AfterFeatureTested;
+use Behat\Behat\EventDispatcher\Event\AfterScenarioTested;
+use Behat\Behat\EventDispatcher\Event\AfterStepTested;
+use Behat\Behat\EventDispatcher\Event\BeforeFeatureTested;
+use Behat\Behat\EventDispatcher\Event\ScenarioTested;
+use Behat\Behat\EventDispatcher\Event\StepTested;
+use Behat\Behat\Output\Node\Printer\FeaturePrinter;
+use Behat\Behat\Output\Node\Printer\JUnit\JUnitScenarioPrinter;
+use Behat\Behat\Output\Node\Printer\StepPrinter;
+use Behat\Gherkin\Node\FeatureNode;
+use Behat\Testwork\Output\Formatter;
+use Behat\Testwork\Output\Node\EventListener\EventListener;
+use Pim\Behat\Extension\PimFormatter\Output\Node\Printer\PimScenarioPrinter;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Listens to feature, scenario and step events and calls appropriate printers.
+ *
+ * This class is unfortunately a copy past of the class Behat\Behat\Output\Node\EventListener\JUnit\JUnitFeatureElementListener
+ * because the class is not open to the modification (scenario printer is not an interface).
+ * So, this implementation allows to inject our own scenario printer `PimScenarioPrinter`.
+ *
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *
+ * @see Behat\Behat\Output\Node\EventListener\JUnit\JUnitFeatureElementListener
+ */
+final class PimFeatureElementListener implements EventListener
+{
+    /** @var FeaturePrinter */
+    private $featurePrinter;
+
+    /** @var JUnitScenarioPrinter */
+    private $scenarioPrinter;
+
+    /** @var StepPrinter */
+    private $stepPrinter;
+
+    /** @var FeatureNode */
+    private $beforeFeatureTestedEvent;
+
+    /** @var AfterScenarioTested[] */
+    private $afterScenarioTestedEvents = [];
+
+    /** @var AfterStepTested[] */
+    private $afterStepTestedEvents = [];
+
+    /**
+     * @param FeaturePrinter     $featurePrinter
+     * @param PimScenarioPrinter $scenarioPrinter
+     * @param StepPrinter        $stepPrinter
+     */
+    public function __construct(FeaturePrinter $featurePrinter, PimScenarioPrinter $scenarioPrinter, StepPrinter $stepPrinter)
+    {
+        $this->featurePrinter = $featurePrinter;
+        $this->scenarioPrinter = $scenarioPrinter;
+        $this->stepPrinter = $stepPrinter;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function listenEvent(Formatter $formatter, Event $event, $eventName)
+    {
+        if ($event instanceof ScenarioTested) {
+            $this->captureScenarioEvent($event);
+        }
+
+        if ($event instanceof StepTested) {
+            $this->captureStepEvent($event);
+        }
+
+        $this->captureFeatureOnBeforeEvent($event);
+        $this->printFeatureOnAfterEvent($formatter, $event);
+    }
+
+    /**
+     * Prints the feature on AFTER event.
+     *
+     * @param Formatter $formatter
+     * @param Event     $event
+     */
+    public function printFeatureOnAfterEvent(Formatter $formatter, Event $event) : void
+    {
+        if (!$event instanceof AfterFeatureTested) {
+            return;
+        }
+
+        $this->featurePrinter->printHeader($formatter, $this->beforeFeatureTestedEvent);
+
+        foreach ($this->afterScenarioTestedEvents as $afterScenario) {
+            $afterScenarioTested = $afterScenario['event'];
+            $this->scenarioPrinter->printOpenTag($formatter, $afterScenarioTested->getFeature(), $afterScenarioTested->getScenario(), $afterScenarioTested->getTestResult());
+
+            foreach ($afterScenario['step_events'] as $afterStepTested) {
+                $this->stepPrinter->printStep($formatter, $afterScenarioTested->getScenario(), $afterStepTested->getStep(), $afterStepTested->getTestResult());
+            }
+        }
+
+        $this->featurePrinter->printFooter($formatter, $event->getTestResult());
+        $this->afterScenarioTestedEvents = [];
+    }
+
+    /**
+     * Captures scenario tested event.
+     *
+     * @param ScenarioTested $event
+     */
+    private function captureScenarioEvent(ScenarioTested $event) : void
+    {
+        if ($event instanceof AfterScenarioTested) {
+            $this->afterScenarioTestedEvents[$event->getScenario()->getLine()] = [
+                'event' => $event,
+                'step_events' => $this->afterStepTestedEvents,
+            ];
+
+            $this->afterStepTestedEvents = [];
+        }
+    }
+
+    /**
+     * Captures feature on BEFORE event.
+     *
+     * @param Event $event
+     */
+    private function captureFeatureOnBeforeEvent(Event $event) : void
+    {
+        if (!$event instanceof BeforeFeatureTested) {
+            return;
+        }
+
+        $this->beforeFeatureTestedEvent = $event->getFeature();
+    }
+
+    /**
+     * Captures step tested event.
+     *
+     * @param StepTested $event
+     */
+    private function captureStepEvent(StepTested $event) : void
+    {
+        if ($event instanceof AfterStepTested) {
+            $this->afterStepTestedEvents[$event->getStep()->getLine()] = $event;
+        }
+    }
+}

--- a/features/Pim/Behat/Extension/PimFormatter/Output/Node/Printer/PimScenarioPrinter.php
+++ b/features/Pim/Behat/Extension/PimFormatter/Output/Node/Printer/PimScenarioPrinter.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Behat\Extension\PimFormatter\Output\Node\Printer;
+
+use Behat\Behat\Output\Node\EventListener\JUnit\JUnitOutlineStoreListener;
+use Behat\Behat\Output\Node\Printer\Helper\ResultToStringConverter;
+use Behat\Gherkin\Node\FeatureNode;
+use Behat\Gherkin\Node\ScenarioLikeInterface;
+use Behat\Testwork\Output\Formatter;
+use Behat\Testwork\Tester\Result\TestResult;
+
+/**
+ * Scenario printer of the PIM, for the CI. Instead of displaying the namespace of the scenario,
+ * it displays the filepath of the scenario.
+ *
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *
+ * @see Behat\Behat\Output\Node\Printer\JUnit\JUnitScenarioPrinter
+ */
+final class PimScenarioPrinter
+{
+    /** @var string */
+    private $basePath;
+
+    /** @var ResultToStringConverter */
+    private $resultConverter;
+
+    /** @var JUnitOutlineStoreListener */
+    private $outlineStoreListener;
+
+    /**
+     * @param string                    $basePath
+     * @param ResultToStringConverter   $resultConverter
+     * @param JUnitOutlineStoreListener $outlineListener
+     */
+    public function __construct(string $basePath, ResultToStringConverter $resultConverter, JUnitOutlineStoreListener $outlineListener)
+    {
+        $this->basePath = $basePath;
+        $this->resultConverter = $resultConverter;
+        $this->outlineStoreListener = $outlineListener;
+    }
+
+    /**
+     * @param Formatter             $formatter
+     * @param FeatureNode           $feature
+     * @param ScenarioLikeInterface $scenario
+     * @param TestResult            $result
+     */
+    public function printOpenTag(Formatter $formatter, FeatureNode $feature, ScenarioLikeInterface $scenario, TestResult $result) : void
+    {
+        $fileAndLine = sprintf('%s:%s', $this->relativizePaths($feature->getFile()), $scenario->getLine());
+
+        $outputPrinter = $formatter->getOutputPrinter();
+
+        $outputPrinter->addTestcase([
+            'name'   => $fileAndLine,
+            'status' => $this->resultConverter->convertResultToString($result),
+        ]);
+    }
+
+    /**
+     * Transforms path to relative.
+     *
+     * @param string $path
+     *
+     * @return string
+     */
+    private function relativizePaths($path)
+    {
+        if (!$this->basePath) {
+            return $path;
+        }
+
+        return str_replace($this->basePath . DIRECTORY_SEPARATOR, '', $path);
+    }
+}

--- a/features/Pim/Behat/Extension/PimFormatter/PimFormatterExtension.php
+++ b/features/Pim/Behat/Extension/PimFormatter/PimFormatterExtension.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Behat\Extension\PimFormatter;
+
+use Behat\Testwork\ServiceContainer\Extension as ExtensionInterface;
+use Behat\Testwork\ServiceContainer\ExtensionManager;
+use Pim\Behat\Extension\PimFormatter\ServiceContainer\Formatter\PimFormatterFactory;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class PimFormatterExtension implements ExtensionInterface {
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container) {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getConfigKey() {
+        return "pim_formatter";
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function initialize(ExtensionManager $extensionManager) {
+        $outputExtension = $extensionManager->getExtension('formatters');
+        $outputExtension->registerFormatterFactory(new PimFormatterFactory());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configure(ArrayNodeDefinition $builder) {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function load(ContainerBuilder $container, array $config) {
+    }
+}

--- a/features/Pim/Behat/Extension/PimFormatter/ServiceContainer/Formatter/PimFormatterFactory.php
+++ b/features/Pim/Behat/Extension/PimFormatter/ServiceContainer/Formatter/PimFormatterFactory.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Behat\Extension\PimFormatter\ServiceContainer\Formatter;
+
+use Behat\Behat\Output\Node\EventListener\JUnit\JUnitOutlineStoreListener;
+use Behat\Behat\Output\Node\EventListener\Statistics\HookStatsListener;
+use Behat\Behat\Output\Node\EventListener\Statistics\ScenarioStatsListener;
+use Behat\Behat\Output\Node\EventListener\Statistics\StepStatsListener;
+use Behat\Behat\Output\Node\Printer\Helper\ResultToStringConverter;
+use Behat\Behat\Output\Node\Printer\JUnit\JUnitFeaturePrinter;
+use Behat\Behat\Output\Node\Printer\JUnit\JUnitStepPrinter;
+use Behat\Behat\Output\Node\Printer\JUnit\JUnitSuitePrinter;
+use Behat\Behat\Output\Statistics\PhaseStatistics;
+use Behat\Testwork\Exception\ServiceContainer\ExceptionExtension;
+use Behat\Testwork\Output\Node\EventListener\ChainEventListener;
+use Behat\Testwork\Output\NodeEventListeningFormatter;
+use Behat\Testwork\Output\Printer\Factory\FilesystemOutputFactory;
+use Behat\Testwork\Output\Printer\JUnitOutputPrinter;
+use Behat\Testwork\Output\ServiceContainer\Formatter\FormatterFactory;
+use Behat\Testwork\Output\ServiceContainer\OutputExtension;
+use Pim\Behat\Extension\PimFormatter\Output\Node\EventListener\PimFeatureElementListener;
+use Pim\Behat\Extension\PimFormatter\Output\Node\Printer\PimScenarioPrinter;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * PIM formatter factory, based on junit factory.
+ *
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *
+ * @see \Behat\Behat\Output\ServiceContainer\Formatter\JUnitFormatterFactory
+ */
+final class PimFormatterFactory implements FormatterFactory
+{
+    /*
+     * Available services
+     */
+    const ROOT_LISTENER_ID = 'pim.output.node.listener.junit';
+    const RESULT_TO_STRING_CONVERTER_ID = 'pim.output.node.printer.result_to_string';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildFormatter(ContainerBuilder $container)
+    {
+        $this->loadRootNodeListener($container);
+        $this->loadPrinterHelpers($container);
+        $this->loadCorePrinters($container);
+        $this->loadFormatter($container);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function processFormatter(ContainerBuilder $container)
+    {
+    }
+
+    /**
+     * Loads printer helpers.
+     *
+     * @param ContainerBuilder $container
+     */
+    private function loadPrinterHelpers(ContainerBuilder $container) : void
+    {
+        $definition = new Definition(ResultToStringConverter::class);
+        $container->setDefinition(self::RESULT_TO_STRING_CONVERTER_ID, $definition);
+    }
+
+    /**
+     * Loads the specific printers for Akeneo PIM.
+     *
+     * @param ContainerBuilder $container
+     */
+    private function loadCorePrinters(ContainerBuilder $container) : void
+    {
+        $definition = new Definition(JUnitSuitePrinter::class, [
+            new Reference('pim.output.junit.statistics'),
+        ]);
+        $container->setDefinition('pim.output.node.printer.junit.suite', $definition);
+
+        $definition = new Definition(JUnitFeaturePrinter::class, [
+            new Reference('pim.output.junit.statistics'),
+        ]);
+        $container->setDefinition('pim.output.node.printer.junit.feature', $definition);
+
+        $definition = new Definition(PimScenarioPrinter::class, [
+            '%paths.base%',
+            new Reference(self::RESULT_TO_STRING_CONVERTER_ID),
+            new Reference('pim.output.node.listener.junit.outline'),
+        ]);
+        $container->setDefinition('pim.output.node.printer.pim.scenario', $definition);
+
+        $definition = new Definition(JUnitStepPrinter::class, [
+            new Reference(ExceptionExtension::PRESENTER_ID),
+        ]);
+        $container->setDefinition('pim.output.node.printer.junit.step', $definition);
+    }
+
+    /**
+     * Loads the node listeners required for JUnit printers to work.
+     *
+     * @param ContainerBuilder $container
+     */
+    private function loadRootNodeListener(ContainerBuilder $container) : void
+    {
+        $definition = new Definition(JUnitOutlineStoreListener::class, [
+                new Reference('pim.output.node.printer.junit.suite')
+            ]
+        );
+        $container->setDefinition('pim.output.node.listener.junit.outline', $definition);
+
+        $definition = new Definition(ChainEventListener::class, [
+            [
+                new Reference('pim.output.node.listener.junit.outline'),
+                new Definition(PimFeatureElementListener::class, [
+                    new Reference('pim.output.node.printer.junit.feature'),
+                    new Reference('pim.output.node.printer.pim.scenario'),
+                    new Reference('pim.output.node.printer.junit.step'),
+                ]),
+            ],
+        ]);
+        $container->setDefinition(self::ROOT_LISTENER_ID, $definition);
+    }
+
+    /**
+     * Loads formatter itself.
+     *
+     * @param ContainerBuilder $container
+     */
+    private function loadFormatter(ContainerBuilder $container) : void
+    {
+        $definition = new Definition(PhaseStatistics::class);
+        $container->setDefinition('pim.output.junit.statistics', $definition);
+
+        $definition = new Definition(NodeEventListeningFormatter::class, [
+            'pim',
+            'Outputs the failures in JUnit compatible files, with path to the failing scenario instead of namespace.',
+            ['timer' => true],
+            $this->createOutputPrinterDefinition(),
+            new Definition(ChainEventListener::class, [
+                [
+                    new Reference(self::ROOT_LISTENER_ID),
+                    new Definition(ScenarioStatsListener::class, [
+                        new Reference('pim.output.junit.statistics')
+                    ]),
+                    new Definition(StepStatsListener::class, [
+                        new Reference('pim.output.junit.statistics'),
+                        new Reference(ExceptionExtension::PRESENTER_ID)
+                    ]),
+                    new Definition(HookStatsListener::class, [
+                        new Reference('pim.output.junit.statistics'),
+                        new Reference(ExceptionExtension::PRESENTER_ID)
+                    ]),
+                ],
+            ]),
+        ]);
+        $definition->addTag(OutputExtension::FORMATTER_TAG, ['priority' => 110]);
+        $container->setDefinition(OutputExtension::FORMATTER_TAG . '.pim', $definition);
+    }
+
+    /**
+     * Creates output printer definition.
+     *
+     * @return Definition
+     */
+    private function createOutputPrinterDefinition() : Definition
+    {
+        return new Definition(JUnitOutputPrinter::class, [
+            new Definition(FilesystemOutputFactory::class),
+        ]);
+    }
+}


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

Before the upgrade Behat 2 -> Behat 3, a custom formatter was doing the job to display filepath instead of namespace of the failing behat tests in the CI.

During the migration, we realized with @anaelChardan that is was not so easy to perform the same thing with Behat 3.
After investigation, it has to be done with an extension, and here it is.

![screen shot 2017-07-30 at 23 52 55](https://user-images.githubusercontent.com/1942439/28757382-47f9e336-7582-11e7-8f96-5328d9345048.png)


This PR is heavily inspired from the Junit Formatter. There are some copy/past of classes, because most of the classes are final (not possible to extend), and they don't use interfaces (no DI, no decoration).

Note: what a pain to develop a Behat 3 extension. It is very poorly documented.

Note 2: last commit will not be merged, only for test.

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
