### PR TITLE
PIM-6649: Create 2 SearchQueryBuilders to iterate over products or product and product models.

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -7,5 +7,6 @@ parameters:
     database_password: akeneo_pim
     locale:            en
     secret:            ThisTokenIsNotSoSecretChangeIt
-    index_name:        akeneo_pim
+    default_index_name: akeneo_pim
+    product_and_model_index_name: akeneo_pim_models
     index_hosts:       'localhost: 9200'

--- a/src/Akeneo/Bundle/ElasticsearchBundle/Client.php
+++ b/src/Akeneo/Bundle/ElasticsearchBundle/Client.php
@@ -22,9 +22,6 @@ class Client
     /** @var array */
     private $hosts;
 
-    /** @var string */
-    private $indexName;
-
     /** @var NativeClient */
     private $client;
 
@@ -36,28 +33,28 @@ class Client
      * @param array         $hosts
      * @param string        $indexName
      */
-    public function __construct(ClientBuilder $builder, array $hosts, $indexName)
+    public function __construct(ClientBuilder $builder, array $hosts)
     {
         $this->builder = $builder;
         $this->hosts = $hosts;
-        $this->indexName = $indexName;
 
         $builder->setHosts($hosts);
         $this->client = $builder->build();
     }
 
     /**
+     * @param string       $indexName
      * @param string       $indexType
      * @param string       $id
      * @param array        $body
      * @param Refresh|null $refresh
      *
-     * @return array see {@link https://www.elastic.co/guide/en/elasticsearch/client/php-api/current/_quickstart.html#_index_a_document}
+     * @return array see <a href='psi_element://https://www.elastic.co/guide/en/elasticsearch/client/php-api/current/_quickstart.html#_index_a_document}'>https://www.elastic.co/guide/en/elasticsearch/client/php-api/current/_quickstart.html#_index_a_document}</a>
      */
-    public function index($indexType, $id, array $body, Refresh $refresh = null)
+    public function index($indexName, $indexType, $id, array $body, Refresh $refresh = null)
     {
         $params = [
-            'index' => $this->indexName,
+            'index' => $indexName,
             'type' => $indexType,
             'id' => $id,
             'body' => $body,
@@ -80,7 +77,7 @@ class Client
      *
      * @return array see {@link https://www.elastic.co/guide/en/elasticsearch/client/php-api/current/_indexing_documents.html#_bulk_indexing}
      */
-    public function bulkIndexes($indexType, $documents, $keyAsId, Refresh $refresh = null)
+    public function bulkIndexes($indexName, $indexType, $documents, $keyAsId, Refresh $refresh = null)
     {
         $params = [];
 
@@ -91,7 +88,7 @@ class Client
 
             $params['body'][] = [
                 'index' => [
-                    '_index' => $this->indexName,
+                    '_index' => $indexName,
                     '_type' => $indexType,
                     '_id' => $document[$keyAsId],
                 ],
@@ -113,10 +110,10 @@ class Client
      *
      * @return array see {@link https://www.elastic.co/guide/en/elasticsearch/client/php-api/current/_quickstart.html#_get_a_document}
      */
-    public function get($indexType, $id)
+    public function get($indexName, $indexType, $id)
     {
         $params = [
-            'index' => $this->indexName,
+            'index' => $indexName,
             'type' => $indexType,
             'id' => $id,
         ];
@@ -130,10 +127,10 @@ class Client
      *
      * @return array see {@link https://www.elastic.co/guide/en/elasticsearch/client/php-api/current/_quickstart.html#_search_for_a_document}
      */
-    public function search($indexType, array $body)
+    public function search($indexName, $indexType, array $body)
     {
         $params = [
-            'index' => $this->indexName,
+            'index' => $indexName,
             'type' => $indexType,
             'body' => $body,
         ];
@@ -147,10 +144,10 @@ class Client
      *
      * @return array see {@link https://www.elastic.co/guide/en/elasticsearch/client/php-api/current/_quickstart.html#_delete_a_document}
      */
-    public function delete($indexType, $id)
+    public function delete($indexName, $indexType, $id)
     {
         $params = [
-            'index' => $this->indexName,
+            'index' => $indexName,
             'type' => $indexType,
             'id' => $id,
         ];
@@ -164,14 +161,14 @@ class Client
      *
      * @return array
      */
-    public function bulkDelete($indexType, $documentIds)
+    public function bulkDelete($indexName, $indexType, $documentIds)
     {
         $params = [];
 
         foreach ($documentIds as $identifier) {
             $params['body'][] = [
                 'delete' => [
-                    '_index' => $this->indexName,
+                    '_index' => $indexName,
                     '_type' => $indexType,
                     '_id' => $identifier,
                 ],
@@ -184,9 +181,9 @@ class Client
     /**
      * @return array see {@link https://www.elastic.co/guide/en/elasticsearch/client/php-api/current/_quickstart.html#_delete_an_index}
      */
-    public function deleteIndex()
+    public function deleteIndex($indexName)
     {
-        return $this->client->indices()->delete(['index' => $this->indexName]);
+        return $this->client->indices()->delete(['index' => $indexName]);
     }
 
     /**
@@ -194,10 +191,10 @@ class Client
      *
      * @return array see {@link https://www.elastic.co/guide/en/elasticsearch/client/php-api/current/_quickstart.html#_create_an_index}
      */
-    public function createIndex(array $body)
+    public function createIndex($indexName, array $body)
     {
         $params = [
-            'index' => $this->indexName,
+            'index' => $indexName,
             'body' => $body,
         ];
 
@@ -209,16 +206,16 @@ class Client
      *
      * @return bool
      */
-    public function hasIndex()
+    public function hasIndex($indexName)
     {
-        return $this->client->indices()->exists(['index' => $this->indexName]);
+        return $this->client->indices()->exists(['index' => $indexName]);
     }
 
     /**
      * @return array see {@link https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-refresh.html}
      */
-    public function refreshIndex()
+    public function refreshIndex($indexName)
     {
-        return $this->client->indices()->refresh(['index' => $this->indexName]);
+        return $this->client->indices()->refresh(['index' => $indexName]);
     }
 }

--- a/src/Akeneo/Bundle/ElasticsearchBundle/Cursor/AbstractCursor.php
+++ b/src/Akeneo/Bundle/ElasticsearchBundle/Cursor/AbstractCursor.php
@@ -27,6 +27,9 @@ abstract class AbstractCursor implements CursorInterface
     /** @var string */
     protected $indexType;
 
+    /** @var string */
+    protected $indexName;
+
     /** @var array */
     protected $items;
 

--- a/src/Akeneo/Bundle/ElasticsearchBundle/Cursor/Cursor.php
+++ b/src/Akeneo/Bundle/ElasticsearchBundle/Cursor/Cursor.php
@@ -32,12 +32,14 @@ class Cursor extends AbstractCursor implements CursorInterface
         Client $esClient,
         CursorableRepositoryInterface $repository,
         array $esQuery,
+        $indexName,
         $indexType,
         $pageSize
     ) {
         $this->esClient = $esClient;
         $this->repository = $repository;
         $this->esQuery = $esQuery;
+        $this->indexName = $indexName;
         $this->indexType = $indexType;
         $this->pageSize = $pageSize;
         $this->searchAfter = [];
@@ -89,7 +91,7 @@ class Cursor extends AbstractCursor implements CursorInterface
             $esQuery['search_after'] = $this->searchAfter;
         }
 
-        $response = $this->esClient->search($this->indexType, $esQuery);
+        $response = $this->esClient->search($this->indexName, $this->indexType, $esQuery);
         $this->count = $response['hits']['total'];
 
         $identifiers = [];

--- a/src/Akeneo/Bundle/ElasticsearchBundle/Cursor/CursorFactory.php
+++ b/src/Akeneo/Bundle/ElasticsearchBundle/Cursor/CursorFactory.php
@@ -33,6 +33,9 @@ class CursorFactory implements CursorFactoryInterface
     protected $pageSize;
 
     /** @var string */
+    protected $indexName;
+
+    /** @var string */
     protected $indexType;
 
     /**
@@ -49,6 +52,7 @@ class CursorFactory implements CursorFactoryInterface
         $entityClassName,
         $cursorClassName,
         $pageSize,
+        $indexName,
         $indexType
     ) {
         $this->searchEngine = $searchEngine;
@@ -56,6 +60,7 @@ class CursorFactory implements CursorFactoryInterface
         $this->entityClassName = $entityClassName;
         $this->cursorClassName = $cursorClassName;
         $this->pageSize = $pageSize;
+        $this->indexName = $indexType;
         $this->indexType = $indexType;
     }
 
@@ -71,6 +76,6 @@ class CursorFactory implements CursorFactoryInterface
 
         $pageSize = !isset($options['page_size']) ? $this->pageSize : $options['page_size'];
 
-        return new $this->cursorClassName($this->searchEngine, $repository, $queryBuilder, $this->indexType, $pageSize);
+        return new $this->cursorClassName($this->searchEngine, $repository, $queryBuilder, $this->indexName, $this->indexType, $pageSize);
     }
 }

--- a/src/Akeneo/Bundle/ElasticsearchBundle/Cursor/FromSizeCursor.php
+++ b/src/Akeneo/Bundle/ElasticsearchBundle/Cursor/FromSizeCursor.php
@@ -46,6 +46,7 @@ class FromSizeCursor extends AbstractCursor implements CursorInterface
         Client $esClient,
         CursorableRepositoryInterface $repository,
         array $esQuery,
+        $indexName,
         $indexType,
         $pageSize,
         $limit,
@@ -54,6 +55,7 @@ class FromSizeCursor extends AbstractCursor implements CursorInterface
         $this->esClient = $esClient;
         $this->repository = $repository;
         $this->esQuery = $esQuery;
+        $this->indexName = $indexName;
         $this->indexType = $indexType;
         $this->pageSize = $pageSize;
         $this->limit = $limit;
@@ -97,7 +99,7 @@ class FromSizeCursor extends AbstractCursor implements CursorInterface
         $esQuery['sort'] = $sort;
         $esQuery['from'] = $this->from;
 
-        $response = $this->esClient->search($this->indexType, $esQuery);
+        $response = $this->esClient->search($this->indexName, $this->indexType, $esQuery);
         $this->count = $response['hits']['total'];
 
         $identifiers = [];

--- a/src/Akeneo/Bundle/ElasticsearchBundle/Cursor/FromSizeCursorFactory.php
+++ b/src/Akeneo/Bundle/ElasticsearchBundle/Cursor/FromSizeCursorFactory.php
@@ -32,6 +32,9 @@ class FromSizeCursorFactory implements CursorFactoryInterface
     protected $pageSize;
 
     /** @var string */
+    protected $indexName;
+
+    /** @var string */
     protected $indexType;
 
     /**
@@ -48,6 +51,7 @@ class FromSizeCursorFactory implements CursorFactoryInterface
         $entityClassName,
         $cursorClassName,
         $pageSize,
+        $indexName,
         $indexType
     ) {
         $this->searchEngine = $searchEngine;
@@ -55,6 +59,7 @@ class FromSizeCursorFactory implements CursorFactoryInterface
         $this->entityClassName = $entityClassName;
         $this->cursorClassName = $cursorClassName;
         $this->pageSize = $pageSize;
+        $this->indexName = $indexName;
         $this->indexType = $indexType;
     }
 
@@ -74,6 +79,7 @@ class FromSizeCursorFactory implements CursorFactoryInterface
             $this->searchEngine,
             $repository,
             $queryBuilder,
+            $this->indexName,
             $this->indexType,
             $options['page_size'],
             $options['limit'],

--- a/src/Akeneo/Bundle/ElasticsearchBundle/Cursor/SearchAfterSizeCursor.php
+++ b/src/Akeneo/Bundle/ElasticsearchBundle/Cursor/SearchAfterSizeCursor.php
@@ -48,6 +48,7 @@ class SearchAfterSizeCursor extends AbstractCursor implements CursorInterface
         CursorableRepositoryInterface $repository,
         array $esQuery,
         array $searchAfter = [],
+        $indexName,
         $indexType,
         $pageSize,
         $limit,
@@ -56,6 +57,7 @@ class SearchAfterSizeCursor extends AbstractCursor implements CursorInterface
         $this->repository = $repository;
         $this->esClient = $esClient;
         $this->esQuery = $esQuery;
+        $this->indexName = $indexName;
         $this->indexType = $indexType;
         $this->pageSize = $pageSize;
         $this->limit = $limit;
@@ -106,7 +108,7 @@ class SearchAfterSizeCursor extends AbstractCursor implements CursorInterface
             $esQuery['search_after'] = $this->searchAfter;
         }
 
-        $response = $this->esClient->search($this->indexType, $esQuery);
+        $response = $this->esClient->search($this->indexName, $this->indexType, $esQuery);
         $this->count = $response['hits']['total'];
 
         $identifiers = [];

--- a/src/Akeneo/Bundle/ElasticsearchBundle/Cursor/SearchAfterSizeCursorFactory.php
+++ b/src/Akeneo/Bundle/ElasticsearchBundle/Cursor/SearchAfterSizeCursorFactory.php
@@ -34,6 +34,9 @@ class SearchAfterSizeCursorFactory implements CursorFactoryInterface
     protected $pageSize;
 
     /** @var string */
+    protected $indexName;
+
+    /** @var string */
     protected $indexType;
 
     /**
@@ -50,6 +53,7 @@ class SearchAfterSizeCursorFactory implements CursorFactoryInterface
         $entityClassName,
         $cursorClassName,
         $pageSize,
+        $indexName,
         $indexType
     ) {
         $this->searchEngine = $searchEngine;
@@ -57,6 +61,7 @@ class SearchAfterSizeCursorFactory implements CursorFactoryInterface
         $this->entityClassName = $entityClassName;
         $this->cursorClassName = $cursorClassName;
         $this->pageSize = $pageSize;
+        $this->indexName = $indexName;
         $this->indexType = $indexType;
     }
 
@@ -77,6 +82,7 @@ class SearchAfterSizeCursorFactory implements CursorFactoryInterface
             $repository,
             $queryBuilder,
             $options['search_after'],
+            $this->indexName,
             $this->indexType,
             $options['page_size'],
             $options['limit'],

--- a/src/Akeneo/Bundle/ElasticsearchBundle/DependencyInjection/AkeneoElasticsearchExtension.php
+++ b/src/Akeneo/Bundle/ElasticsearchBundle/DependencyInjection/AkeneoElasticsearchExtension.php
@@ -25,7 +25,11 @@ class AkeneoElasticsearchExtension extends Extension
         $config = $this->processConfiguration($configuration, $configs);
 
         $container->setParameter('akeneo_elasticsearch.index_configuration.files', $config['configuration_files']);
-        $container->setParameter('akeneo_elasticsearch.index_name', $config['index_name']);
+
+        // TODO: Check that $config['default_index_name'] and $config['product_and_model_index_name'] are different!
+        $container->setParameter('akeneo_elasticsearch.product_index_name', $config['default_index_name']);
+        $container->setParameter('akeneo_elasticsearch.product_and_model_index_name', $config['product_and_model_index_name']);
+
         $container->setParameter('akeneo_elasticsearch.hosts', $config['hosts']);
 
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));

--- a/src/Akeneo/Bundle/ElasticsearchBundle/Resources/config/services.yml
+++ b/src/Akeneo/Bundle/ElasticsearchBundle/Resources/config/services.yml
@@ -17,4 +17,3 @@ services:
         arguments:
             - '@akeneo_elasticsearch.client_builder'
             - '%akeneo_elasticsearch.hosts%'
-            - '%akeneo_elasticsearch.index_name%'

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/ProductAndModelSearchQueryBuilder.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/ProductAndModelSearchQueryBuilder.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\Elasticsearch;
+
+class ProductAndModelSearchQueryBuilder extends SearchQueryBuilder
+{
+    protected $attributeCodes = [];
+
+    /**
+     * Returns an Elastic search Query
+     *
+     * @param array $source
+     *
+     * @return array
+     */
+    public function getQuery(array $source = [])
+    {
+        if (empty($source)) {
+            $source = ['identifier'];
+        }
+
+        $searchQuery = [
+            '_source' => $source,
+            'query'   => [],
+        ];
+
+        if (!empty($this->filterClauses)) {
+            $searchQuery['query']['bool']['filter'] = $this->filterClauses;
+        }
+
+        if (!empty($this->mustNotClauses)) {
+            $searchQuery['query']['bool']['must_not'] = $this->mustNotClauses;
+        }
+
+        if (!empty($this->shouldClauses)) {
+            $searchQuery['query']['bool']['should'] = $this->shouldClauses;
+            $searchQuery['query']['bool']['minimum_should_match'] = 1;
+        }
+
+        if (!empty($this->sortClauses)) {
+            $searchQuery['sort'] = $this->sortClauses;
+        }
+
+        if (empty($searchQuery['query'])) {
+            $searchQuery['query'] = new \stdClass();
+        }
+
+        if (empty($searchQuery['query']['bool']['filter'])) {
+            $searchQuery['query']['bool']['filter'] = [];
+        }
+        $searchQuery['query']['bool']['filter'][] = [
+            'terms' => ['owned_attributes' => $this->attributeCodes],
+        ];
+
+        return $searchQuery;
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/ProductAndModelSearchQueryBuilder.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/ProductAndModelSearchQueryBuilder.php
@@ -18,7 +18,6 @@ class ProductAndModelSearchQueryBuilder extends SearchQueryBuilder
         if (empty($source)) {
             $source = ['identifier'];
         }
-
         $searchQuery = [
             '_source' => $source,
             'query'   => [],
@@ -45,6 +44,7 @@ class ProductAndModelSearchQueryBuilder extends SearchQueryBuilder
             $searchQuery['query'] = new \stdClass();
         }
 
+        // Add extra clause to do smart search (p&pm)
         if (empty($searchQuery['query']['bool']['filter'])) {
             $searchQuery['query']['bool']['filter'] = [];
         }

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/ProductQueryBuilderFactory.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/ProductQueryBuilderFactory.php
@@ -48,6 +48,7 @@ class ProductQueryBuilderFactory implements ProductQueryBuilderFactoryInterface
      */
     public function __construct(
         $pqbClass,
+        $searchQueryBuilderClass,
         AttributeRepositoryInterface $attributeRepository,
         FilterRegistryInterface $filterRegistry,
         SorterRegistryInterface $sorterRegistry,
@@ -60,6 +61,7 @@ class ProductQueryBuilderFactory implements ProductQueryBuilderFactoryInterface
         $this->sorterRegistry = $sorterRegistry;
         $this->cursorFactory = $cursorFactory;
         $this->optionsResolver = $optionsResolver;
+        $this->searchQueryBuilderClass = $searchQueryBuilderClass;
     }
 
     /**
@@ -91,7 +93,7 @@ class ProductQueryBuilderFactory implements ProductQueryBuilderFactoryInterface
         }
 
         $pqb = $this->createProductQueryBuilder($pqbOptions);
-        $pqb->setQueryBuilder(new SearchQueryBuilder());
+        $pqb->setQueryBuilder(new $this->searchQueryBuilderClass());
 
         foreach ($options['filters'] as $filter) {
             $pqb->addFilter($filter['field'], $filter['operator'], $filter['value'], $filter['context']);

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/ProductSearchQueryBuilder.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/ProductSearchQueryBuilder.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\Elasticsearch;
+
+class ProductSearchQueryBuilder extends SearchQueryBuilder
+{
+    // TODO: Inject this from constructor and DI
+    const PRODUCT_TYPES = ['PimCatalogProduct', 'PimCatalogProductVariant'];
+
+    /**
+     * Returns an Elastic search Query
+     *
+     * @param array $source
+     *
+     * @return array
+     */
+    public function getQuery(array $source = [])
+    {
+        if (empty($source)) {
+            $source = ['identifier'];
+        }
+
+        $searchQuery = [
+            '_source' => $source,
+            'query'   => [],
+        ];
+
+        if (!empty($this->filterClauses)) {
+            $searchQuery['query']['bool']['filter'] = $this->filterClauses;
+        }
+
+        if (!empty($this->mustNotClauses)) {
+            $searchQuery['query']['bool']['must_not'] = $this->mustNotClauses;
+        }
+
+        if (!empty($this->shouldClauses)) {
+            $searchQuery['query']['bool']['should'] = $this->shouldClauses;
+            $searchQuery['query']['bool']['minimum_should_match'] = 1;
+        }
+
+        if (!empty($this->sortClauses)) {
+            $searchQuery['sort'] = $this->sortClauses;
+        }
+
+        if (empty($searchQuery['query'])) {
+            $searchQuery['query'] = new \stdClass();
+        }
+
+        if (empty($searchQuery['query']['bool']['filter'])) {
+            $searchQuery['query']['bool']['filter'] = [];
+        }
+        $searchQuery['query']['bool']['filter'][] = [
+            'terms' => ['product_type' => self::PRODUCT_TYPES],
+        ];
+
+        return $searchQuery;
+    }
+}
+

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/ProductSearchQueryBuilder.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/ProductSearchQueryBuilder.php
@@ -46,6 +46,7 @@ class ProductSearchQueryBuilder extends SearchQueryBuilder
             $searchQuery['query'] = new \stdClass();
         }
 
+        // Add extra clause to search for products only
         if (empty($searchQuery['query']['bool']['filter'])) {
             $searchQuery['query']['bool']['filter'] = [];
         }

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/SearchQueryBuilder.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/SearchQueryBuilder.php
@@ -110,38 +110,5 @@ abstract class SearchQueryBuilder
      *
      * @return array
      */
-    public function getQuery(array $source = [])
-    {
-        if (empty($source)) {
-            $source = ['identifier'];
-        }
-
-        $searchQuery = [
-            '_source' => $source,
-            'query'   => [],
-        ];
-
-        if (!empty($this->filterClauses)) {
-            $searchQuery['query']['bool']['filter'] = $this->filterClauses;
-        }
-
-        if (!empty($this->mustNotClauses)) {
-            $searchQuery['query']['bool']['must_not'] = $this->mustNotClauses;
-        }
-
-        if (!empty($this->shouldClauses)) {
-            $searchQuery['query']['bool']['should'] = $this->shouldClauses;
-            $searchQuery['query']['bool']['minimum_should_match'] = 1;
-        }
-
-        if (!empty($this->sortClauses)) {
-            $searchQuery['sort'] = $this->sortClauses;
-        }
-
-        if (empty($searchQuery['query'])) {
-            $searchQuery['query'] = new \stdClass();
-        }
-
-        return $searchQuery;
-    }
+    public abstract function getQuery(array $source = []);
 }

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/SearchQueryBuilder.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/SearchQueryBuilder.php
@@ -33,19 +33,19 @@ namespace Pim\Bundle\CatalogBundle\Elasticsearch;
  *
  * @internal This class is used by the ProductQueryBuilder to create an ES search query.
  */
-class SearchQueryBuilder
+abstract class SearchQueryBuilder
 {
     /** @var array */
-    private $mustNotClauses = [];
+    protected $mustNotClauses = [];
 
     /** @var array */
-    private $filterClauses = [];
+    protected $filterClauses = [];
 
     /** @var array */
-    private $shouldClauses = [];
+    protected $shouldClauses = [];
 
     /** @var array */
-    private $sortClauses = [];
+    protected $sortClauses = [];
 
     /**
      * Adds a must_not clause to the query

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/cursors.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/cursors.yml
@@ -16,6 +16,18 @@ services:
             - '%pim_catalog.entity.product.class%'
             - '%akeneo_elasticsearch.cursor.cursor.class%'
             - '%pim_catalog.factory.product_cursor.page_size%'
+            - '%akeneo_elasticsearch.product_index_name'
+            - 'pim_catalog_product'
+
+    pim_catalog.factory.product_and_model_cursor:
+        class: '%akeneo_elasticsearch.cursor.cursor_factory.class%'
+        arguments:
+            - '@akeneo_elasticsearch.client'
+            - '@pim_catalog.object_manager.product'
+            - '%pim_catalog.entity.product.class%'
+            - '%akeneo_elasticsearch.cursor.cursor.class%'
+            - '%pim_catalog.factory.product_cursor.page_size%'
+            - '%akeneo_elasticsearch.product_and_model_index_name%'
             - 'pim_catalog_product'
 
     pim_catalog.factory.product_search_after_size_cursor:
@@ -26,6 +38,18 @@ services:
             - '%pim_catalog.entity.product.class%'
             - '%akeneo_elasticsearch.cursor.search_after_size_cursor.class%'
             - '%pim_catalog.factory.product_cursor.page_size%'
+            - '%akeneo_elasticsearch.product_index_name'
+            - 'pim_catalog_product'
+
+    pim_catalog.factory.product_and_model_search_after_size_cursor:
+        class: '%akeneo_elasticsearch.cursor.search_after_size_cursor_factory.class%'
+        arguments:
+            - '@akeneo_elasticsearch.client'
+            - '@pim_catalog.object_manager.product'
+            - '%pim_catalog.entity.product.class%'
+            - '%akeneo_elasticsearch.cursor.search_after_size_cursor.class%'
+            - '%pim_catalog.factory.product_cursor.page_size%'
+            - '%akeneo_elasticsearch.product_and_model_index_name%'
             - 'pim_catalog_product'
 
     pim_catalog.factory.product_from_size_cursor:
@@ -36,4 +60,16 @@ services:
             - '%pim_catalog.entity.product.class%'
             - '%akeneo_elasticsearch.cursor.from_size_cursor.class%'
             - '%pim_catalog.factory.product_cursor.page_size%'
+            - '%akeneo_elasticsearch.product_index_name'
+            - 'pim_catalog_product'
+
+    pim_catalog.factory.product_and_model_from_size_cursor:
+        class: '%akeneo_elasticsearch.cursor.from_size_cursor_factory.class%'
+        arguments:
+            - '@akeneo_elasticsearch.client'
+            - '@pim_catalog.object_manager.product'
+            - '%pim_catalog.entity.product.class%'
+            - '%akeneo_elasticsearch.cursor.from_size_cursor.class%'
+            - '%pim_catalog.factory.product_cursor.page_size%'
+            - '%akeneo_elasticsearch.product_and_model_index_name%'
             - 'pim_catalog_product'

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/elasticsearch.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/elasticsearch.yml
@@ -1,7 +1,11 @@
 parameters:
     pim_catalog.elasticsearch.product_indexer.class: 'Pim\Bundle\CatalogBundle\Elasticsearch\ProductIndexer'
 
+    pim_catalog.elasticsearch.search_query_builder.product.class: 'Pim\Bundle\CatalogBundle\Elasticsearch\ProductSearchQueryBuilder'
+    pim_catalog.elasticsearch.search_query_builder.product_and_product_models.class: 'Pim\Bundle\CatalogBundle\Elasticsearch\ProductAndModelSearchQueryBuilder'
+
 services:
+
     pim_catalog.elasticsearch.product_indexer:
         class: '%pim_catalog.elasticsearch.product_indexer.class%'
         arguments:

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
@@ -45,30 +45,66 @@ services:
         class: '%pim_catalog.query.elasticsearch.product_query_builder_factory.class%'
         arguments:
             - '%pim_catalog.query.product_query_builder.class%'
+            - '%pim_catalog.elasticsearch.search_query_builder.product.class%'
             - '@pim_catalog.repository.attribute'
             - '@pim_catalog.query.filter.registry'
             - '@pim_catalog.query.sorter.registry'
             - '@pim_catalog.factory.product_cursor'
             - '@pim_catalog.query.product_query_builder_resolver'
 
+    pim_catalog.query.product_and_product_model_query_builder_factory:
+        class: '%pim_catalog.query.elasticsearch.product_query_builder_factory.class%'
+        arguments:
+            - '%pim_catalog.query.product_query_builder.class%'
+            - '%pim_catalog.elasticsearch.search_query_builder.product_and_product_models.class%'
+            - '@pim_catalog.repository.attribute'
+            - '@pim_catalog.query.filter.registry'
+            - '@pim_catalog.query.sorter.registry'
+            - '@pim_catalog.factory.product_and_model_cursor'
+            - '@pim_catalog.query.product_query_builder_resolver'
+
     pim_catalog.query.product_query_builder_search_after_size_factory:
         class: '%pim_catalog.query.elasticsearch.product_query_builder_factory.class%'
         arguments:
             - '%pim_catalog.query.product_query_builder.class%'
+            - '%pim_catalog.elasticsearch.search_query_builder.product.class%'
             - '@pim_catalog.repository.attribute'
             - '@pim_catalog.query.filter.registry'
             - '@pim_catalog.query.sorter.registry'
             - '@pim_catalog.factory.product_search_after_size_cursor'
             - '@pim_catalog.elasticsearch.product_query_builder_search_after_resolver'
 
+    pim_catalog.query.product_and_product_model_query_builder_search_after_size_factory:
+        class: '%pim_catalog.query.elasticsearch.product_query_builder_factory.class%'
+        arguments:
+            - '%pim_catalog.query.product_query_builder.class%'
+            - '%pim_catalog.elasticsearch.search_query_builder.product_and_product_models.class%'
+            - '@pim_catalog.repository.attribute'
+            - '@pim_catalog.query.filter.registry'
+            - '@pim_catalog.query.sorter.registry'
+            - '@pim_catalog.factory.product_and_model_search_after_size_cursor'
+            - '@pim_catalog.elasticsearch.product_query_builder_search_after_resolver'
+
     pim_catalog.query.product_query_builder_from_size_factory:
         class: '%pim_catalog.query.elasticsearch.product_query_builder_factory.class%'
         arguments:
             - '%pim_catalog.query.product_query_builder.class%'
+            - '%pim_catalog.elasticsearch.search_query_builder.product.class%'
             - '@pim_catalog.repository.attribute'
             - '@pim_catalog.query.filter.registry'
             - '@pim_catalog.query.sorter.registry'
             - '@pim_catalog.factory.product_from_size_cursor'
+            - '@pim_catalog.elasticsearch.product_query_builder_from_size_resolver'
+
+    pim_catalog.query.product_and_model_query_builder_from_size_factory:
+        class: '%pim_catalog.query.elasticsearch.product_query_builder_factory.class%'
+        arguments:
+            - '%pim_catalog.query.product_query_builder.class%'
+            - '%pim_catalog.elasticsearch.search_query_builder.product_and_product_models.class%'
+            - '@pim_catalog.repository.attribute'
+            - '@pim_catalog.query.filter.registry'
+            - '@pim_catalog.query.sorter.registry'
+            - '@pim_catalog.factory.product_and_model_from_size_cursor'
             - '@pim_catalog.elasticsearch.product_query_builder_from_size_resolver'
 
     pim_catalog.query.product_query_builder_resolver:


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
- SQB is now injected into the query builder via the factory
- Add new PQB factory to take into account the instanciation of PQB
supporting:
  * Search of products and models via page_size cursor
  * Search of products and models via search after cursor
  * Search of products and models via from size cursor

Using this technique :
- The cursors are correctly iterating over the right
index_name/index_type they were instanciated with via their cursor
Factory.

- There is one PQB class and one PQBFactory class but you can iterate
using any ES technique wanted, on products only or products and models
by using the right service definition.

- The ES Client wrapper is not glued to one index in particular, but can
now be configured to iterate over whatever index we want.

- The ES SQBs are the only one having the capability to generate the
right query for their entity (products or models).

One problem:
- How do we fill the owned_attributes for products_and_models SQB
because the raw_filters are stored in the PQB not in the SQB.


**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
