### PR TITLE
Update jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,7 +40,7 @@ stage("Checkout") {
 
         if (editions.contains('ee') && ('yes' == launchBehatTests || 'yes' == launchIntegrationTests)) {
             checkout([$class: 'GitSCM',
-              branches: [[name: 'master']],
+              branches: [[name: 'catalog-modeling']],
               userRemoteConfigs: [[credentialsId: 'github-credentials', url: 'https://github.com/akeneo/pim-enterprise-dev.git']]
             ])
 


### PR DESCRIPTION
## Description

This PR sets the default EE branch in the Jenkinsfile to `catalog-modeling`, so we can run both CE and EE builds from CE pull requests.

This will be reverted when `catalog-modeling` is ready to be merged.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
