### PR TITLE
PIM-6220: Fix simple select attribute option sorting in products grid

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -2,8 +2,9 @@
 
 ## Bug Fixes
 
-- PIM-6525: fix issue with select attribute type which never open in PEF
-- PIM-6420: fix simple and multi select auto sorting
+- PIM-6525: Fix issue with select attribute type which never open in PEF.
+- PIM-6420: Fix simple and multi select auto sorting.
+- PIM-6220: Fix simple select attribute option sorting in products grid.
 
 # 1.7.6 (2017-06-30)
 

--- a/features/product/sorting/sort_products_per_attribute.feature
+++ b/features/product/sorting/sort_products_per_attribute.feature
@@ -4,9 +4,9 @@ Feature: Sort products per attributes
   As a regular user
   I need to be able to manually sort products per attributes
 
-  Background:
+  Scenario: Successfully sort products by sku
     Given the "apparel" catalog configuration
-    Given the following products:
+    And the following products:
       | sku          | family  |
       | blue_shirt   | tshirts |
       | red_shirt    | tshirts |
@@ -14,13 +14,20 @@ Feature: Sort products per attributes
       | yellow_shirt | tshirts |
       | orange_shirt | tshirts |
     And I am logged in as "Mary"
-
-  Scenario: Successfully sort products by sku
-    Given I am on the products page
+    And I am on the products page
     And the grid should contain 5 elements
     And I should be able to sort the rows by SKU
 
   Scenario: Successfully sort products by boolean value for boolean attributes
+    Given the "apparel" catalog configuration
+    And the following products:
+      | sku          | family  |
+      | blue_shirt   | tshirts |
+      | red_shirt    | tshirts |
+      | green_shirt  | tshirts |
+      | yellow_shirt | tshirts |
+      | orange_shirt | tshirts |
+    And I am logged in as "Mary"
     And I am on the "blue_shirt" product page
     And I visit the "Additional" group
     When I check the "Handmade" switch
@@ -35,3 +42,17 @@ Feature: Sort products per attributes
     Then the grid should contain 5 elements
     When I display the columns SKU, Label, Family, Status, Complete, Created at, Updated at, Groups and Handmade
     Then I should be able to sort the rows by Handmade
+
+  Scenario: Successfully sort products by simple select attribute options
+    Given the "apparel" catalog configuration
+    And the following products:
+      | sku         | family  | color |
+      | black_shirt | tshirts | black |
+      | white_shirt | tshirts | white |
+      | gray_shirt  | tshirts | gray  |
+      | red_shirt   | tshirts | red   |
+      | blue_shirt  | tshirts | blue  |
+    And I am logged in as "Mary"
+    And I am on the products page
+    And I display the columns SKU, Label, Color, Family, Size, Status, Complete
+    Then I should be able to sort the rows by Color

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Sorter/AttributeOptionSorter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Sorter/AttributeOptionSorter.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Sorter;
+
+use Doctrine\ODM\MongoDB\Query\Builder as QueryBuilder;
+use Pim\Bundle\CatalogBundle\ProductQueryUtility;
+use Pim\Component\Catalog\AttributeTypes;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Query\Sorter\AttributeSorterInterface;
+
+/**
+ * Attribute option sorter
+ *
+ * @author    Willy MESNAGE <willy.mesnage@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class AttributeOptionSorter implements AttributeSorterInterface
+{
+    /** @var QueryBuilder */
+    protected $qb;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setQueryBuilder($queryBuilder)
+    {
+        $this->qb = $queryBuilder;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addAttributeSorter(AttributeInterface $attribute, $direction, $locale = null, $scope = null)
+    {
+        $sortField = ProductQueryUtility::getNormalizedValueFieldFromAttribute($attribute, $locale, $scope);
+        $optionValueField = sprintf(
+            '%s.%s.optionValues.%s.value',
+            ProductQueryUtility::NORMALIZED_FIELD,
+            $sortField,
+            $locale
+        );
+
+        $this->qb->sort($optionValueField, $direction);
+        $this->qb->sort(ProductQueryUtility::NORMALIZED_FIELD.'.'.$sortField.'.code', $direction);
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsAttribute(AttributeInterface $attribute)
+    {
+        return in_array(
+            $attribute->getType(),
+            [
+                AttributeTypes::OPTION_SIMPLE_SELECT
+            ]
+        );
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Sorter/IsAssociatedSorter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Sorter/IsAssociatedSorter.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Sorter;
+
+use Doctrine\ODM\MongoDB\Query\Builder as QueryBuilder;
+use Pim\Bundle\CatalogBundle\ProductQueryUtility;
+use Pim\Component\Catalog\Query\Sorter\FieldSorterInterface;
+
+/**
+ * Is associated sorter
+ *
+ * @author    Willy MESNAGE <willy.mesnage@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class IsAssociatedSorter implements FieldSorterInterface
+{
+    /** @var QueryBuilder */
+    protected $qb;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setQueryBuilder($queryBuilder)
+    {
+        $this->qb = $queryBuilder;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsField($field)
+    {
+        return 'is_associated' === $field;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addFieldSorter($field, $direction, $locale = null, $scope = null)
+    {
+        $this->qb->sort(ProductQueryUtility::NORMALIZED_FIELD.'.'.$field, $direction);
+        $this->qb->sort('_id');
+
+        return $this;
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Sorter/EntitySorter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Sorter/EntitySorter.php
@@ -75,8 +75,9 @@ class EntitySorter implements AttributeSorterInterface
         $condition = $joinAliasOptVal.'.locale = '.$this->qb->expr()->literal($locale);
         $this->qb->leftJoin($joinAliasOpt.'.optionValues', $joinAliasOptVal, 'WITH', $condition);
 
-        $this->qb->addOrderBy($joinAliasOpt.'.code', $direction);
+        $this->qb->addSelect($joinAliasOptVal.'.value AS HIDDEN');
         $this->qb->addOrderBy($joinAliasOptVal.'.value', $direction);
+        $this->qb->addOrderBy($joinAliasOpt.'.code', $direction);
 
         $idField = $this->qb->getRootAlias().'.id';
         $this->qb->addOrderBy($idField);

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/storage_driver/doctrine/mongodb-odm.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/storage_driver/doctrine/mongodb-odm.yml
@@ -69,11 +69,12 @@ parameters:
     pim_catalog.doctrine.query.cursor.class:              Akeneo\Bundle\StorageUtilsBundle\Doctrine\MongoDBODM\Cursor\Cursor
     pim_catalog.doctrine.cursor_factory.product.class:    Akeneo\Bundle\StorageUtilsBundle\Doctrine\MongoDBODM\Cursor\CursorFactory
 
-    pim_catalog.doctrine.query.sorter.base.class:          Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Sorter\BaseSorter
-    pim_catalog.doctrine.query.sorter.completeness.class:  Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Sorter\CompletenessSorter
-    pim_catalog.doctrine.query.sorter.family.class:        Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Sorter\FamilySorter
-    pim_catalog.doctrine.query.sorter.in_group.class:      Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Sorter\InGroupSorter
-    pim_catalog.doctrine.query.sorter.is_associated.class: Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Sorter\BaseSorter
+    pim_catalog.doctrine.query.sorter.base.class:             Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Sorter\BaseSorter
+    pim_catalog.doctrine.query.sorter.completeness.class:     Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Sorter\CompletenessSorter
+    pim_catalog.doctrine.query.sorter.family.class:           Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Sorter\FamilySorter
+    pim_catalog.doctrine.query.sorter.in_group.class:         Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Sorter\InGroupSorter
+    pim_catalog.doctrine.query.sorter.is_associated.class:    Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Sorter\IsAssociatedSorter
+    pim_catalog.doctrine.query.sorter.attribute_option.class: Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Sorter\AttributeOptionSorter
 
     pim_catalog.saver.product.class: Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Saver\ProductSaver
 
@@ -481,3 +482,8 @@ services:
         class: '%pim_catalog.event_subscriber.mongodb.timestampable.class%'
         tags:
             - { name: kernel.event_subscriber, event: akeneo.storage.pre_save }
+
+    pim_catalog.doctrine.query.sorter.attribute_option:
+        class: '%pim_catalog.doctrine.query.sorter.attribute_option.class%'
+        tags:
+            - { name: 'pim_catalog.doctrine.query.sorter', priority: 30 }

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Sorter/AttributeOptionSorterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Sorter/AttributeOptionSorterSpec.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace spec\Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Sorter;
+
+use Doctrine\ODM\MongoDB\Query\Builder;
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Query\Sorter\AttributeSorterInterface;
+
+class AttributeOptionSorterSpec extends ObjectBehavior
+{
+    function let(Builder $queryBuilder)
+    {
+        $this->setQueryBuilder($queryBuilder);
+    }
+
+    function it_is_an_attribute_sorter()
+    {
+        $this->shouldImplement(AttributeSorterInterface::class);
+    }
+
+    function it_supports_only_simple_select_attribute(
+        AttributeInterface $simpleSelectAttribute,
+        AttributeInterface $booleanAttribute
+    ) {
+        $simpleSelectAttribute->getType()->willReturn('pim_catalog_simpleselect');
+        $this->supportsAttribute($simpleSelectAttribute)->shouldReturn(true);
+
+        $booleanAttribute->getType()->willReturn('pim_catalog_boolean');
+        $this->supportsAttribute($booleanAttribute)->shouldReturn(false);
+    }
+
+    function it_adds_a_order_by_on_attribute_option_label_in_the_query(
+        AttributeInterface $simpleSelectAttribute,
+        Builder $queryBuilder
+    ) {
+        $simpleSelectAttribute->isLocalizable()->willReturn(false);
+        $simpleSelectAttribute->isScopable()->willReturn(false);
+        $simpleSelectAttribute->getCode()->willReturn('color');
+        $queryBuilder->sort('normalizedData.color.optionValues.en_US.value', 'desc')->shouldBeCalled();
+        $queryBuilder->sort('normalizedData.color.code', 'desc')->shouldBeCalled();
+
+        $this->addAttributeSorter($simpleSelectAttribute, 'desc', 'en_US', 'print')->shouldReturn($this);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Sorter/IsAssociatedSorterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/MongoDBODM/Sorter/IsAssociatedSorterSpec.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace spec\Pim\Bundle\CatalogBundle\Doctrine\MongoDBODM\Sorter;
+
+use Doctrine\ODM\MongoDB\Query\Builder;
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Query\Sorter\FieldSorterInterface;
+
+class IsAssociatedSorterSpec extends ObjectBehavior
+{
+    function let(Builder $queryBuilder)
+    {
+        $this->setQueryBuilder($queryBuilder);
+    }
+
+    function it_is_a_field_sorter()
+    {
+        $this->shouldImplement(FieldSorterInterface::class);
+    }
+
+    function it_supports_fields()
+    {
+        $this->supportsField('is_associated')->shouldReturn(true);
+        $this->supportsField('not_associated')->shouldReturn(false);
+    }
+
+    function it_adds_a_order_by_on_field_in_the_query(Builder $queryBuilder)
+    {
+        $queryBuilder->sort('normalizedData.my_field', 'desc')->willReturn($queryBuilder);
+        $queryBuilder->sort('_id')->shouldBeCalled();
+
+        $this->addFieldSorter('my_field', 'desc');
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Sorter/EntitySorterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Sorter/EntitySorterSpec.php
@@ -68,8 +68,10 @@ class EntitySorterSpec extends ObjectBehavior
             )
             ->shouldBeCalled()
         ;
-        $qb->addOrderBy('sorterOentity_code.code', 'DESC')->shouldBeCalled();
+
+        $qb->addSelect('sorterOVentity_code.value AS HIDDEN')->shouldBeCalled();
         $qb->addOrderBy('sorterOVentity_code.value', 'DESC')->shouldBeCalled();
+        $qb->addOrderBy('sorterOentity_code.code', 'DESC')->shouldBeCalled();
         $qb->addOrderBy('r.id')->shouldBeCalled();
 
         $this->addAttributeSorter($attribute, 'DESC', 'en_US');


### PR DESCRIPTION
When you add a simple select filter and the associated column in the grid, the sorting of the column was in terms of code first and not in terms of label first. 

In ODM, I added an `AttributeOptionSorter`.
Moreover, for the `pim_catalog.doctrine.query.sorter.is_associated` service, the class was the BaseSorter which has `isAttributeSupported() { return true; }`. The compiler pass `RegisterProductQuerySorterPass` added in the `SorterRegistry` the `is_associated` service with the highest priority (30). So when we were searching for a sorter, the first one was `is_associated` with `isAttributeSupported() { return true; }` and it was not possible to find another sorter.
No pb in ORM because the class for the `is_associated` service was a dedicated one.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | ok
| Added Behats                      | ok
| Added integration tests           | -
| Changelog updated                 | ok
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
