### PR TITLE
PIM-6331: Add CSV and XLSX family variant exports

### DIFF
--- a/STANDARD_FORMAT.md
+++ b/STANDARD_FORMAT.md
@@ -822,7 +822,7 @@ labels     | string[]       | `["en_US" => "A option"]` | each key of the array 
             ]
           ]
         ]
-  
+
 | type                   | data structure | data example                                                                                               | notes                                                                                                   |
 | ---------------------- | -------------- | ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
 | code                   | string         | `"my_family_variant"`                                                                                      | it's the identifier of the variant group                                                                |

--- a/STANDARD_FORMAT.md
+++ b/STANDARD_FORMAT.md
@@ -800,6 +800,37 @@ labels     | string[]       | `["en_US" => "A option"]` | each key of the array 
 | enabled | boolean         | `false`      |                                   |
 
 
+### Family variant
+
+        array:4 [
+          "code" => "my_family_variant"
+          "family" => "family"
+          "labels" => array:1 [
+            "en_US" => "My family variant"
+            "fr_FR" => "Ma variation de famille"
+          ]
+          "variant_attribute_sets" => array:1 [
+            0 => array:3 [
+              "level" => 1
+              "axes" => array:1 [
+                0 => "a_simple_select"
+              ]
+              "attributes" => array:2 [
+                0 => "an_attribute"
+                1 => "an_other_attribute"
+              ]
+            ]
+          ]
+        ]
+  
+| type                   | data structure | data example                                                                                               | notes                                                                                                   |
+| ---------------------- | -------------- | ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| code                   | string         | `"my_family_variant"`                                                                                      | it's the identifier of the variant group                                                                |
+| family                 | string         | `"family"`                                                                                                 | the code of the family of the family variant                                                            |
+| labels                 | string[]       | `["en_US" => "My family variant", "fr_FR" => "Ma variation de famille"]`                                   | each key of the array represents the *code* of the *Pim\Component\Catalog\Model\LocaleInterface*        |
+| variant_attribute_sets | string[]       | `[["level" => 1, "axes" => ["a_simple_select"], "attributes" => ["an_attribute", "an_other_attribute"]]]`, | each element of the array represents the *code* of the *Pim\Component\Catalog\Model\AttributeInterface* |
+
+
 ### Variant group
 
         array:5 [

--- a/STANDARD_FORMAT.md
+++ b/STANDARD_FORMAT.md
@@ -827,8 +827,8 @@ labels     | string[]       | `["en_US" => "A option"]` | each key of the array 
 | ---------------------- | -------------- | ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
 | code                   | string         | `"my_family_variant"`                                                                                      | it's the identifier of the variant group                                                                |
 | family                 | string         | `"family"`                                                                                                 | the code of the family of the family variant                                                            |
-| labels                 | string[]       | `["en_US" => "My family variant", "fr_FR" => "Ma variation de famille"]`                                   | each key of the array represents the *code* of the *Pim\Component\Catalog\Model\LocaleInterface*        |
-| variant_attribute_sets | string[]       | `[["level" => 1, "axes" => ["a_simple_select"], "attributes" => ["an_attribute", "an_other_attribute"]]]`, | each element of the array represents the *code* of the *Pim\Component\Catalog\Model\AttributeInterface* |
+| labels                 | array          | `["en_US" => "My family variant", "fr_FR" => "Ma variation de famille"]`                                   | each key of the array represents the *code* of the *Pim\Component\Catalog\Model\LocaleInterface*        |
+| variant_attribute_sets | array          | `[["level" => 1, "axes" => ["a_simple_select"], "attributes" => ["an_attribute", "an_other_attribute"]]]`, | each element of the array represents the *code* of the *Pim\Component\Catalog\Model\AttributeInterface* |
 
 
 ### Variant group

--- a/features/Context/catalog/catalog_modeling/jobs.yml
+++ b/features/Context/catalog/catalog_modeling/jobs.yml
@@ -90,3 +90,22 @@ jobs:
         type:      import
         configuration:
             uploadAllowed: true
+
+    csv_catalog_modeling_family_variant_export:
+        connector: Akeneo CSV Connector
+        alias:     csv_family_variant_export
+        label:     CSV catalog modeling family variant export
+        type:      export
+        configuration:
+            delimiter:  ;
+            enclosure:  '"'
+            withHeader: true
+            filePath:   /tmp/family_variant.csv
+    xlsx_catalog_modeling_family_variant_export:
+        connector: Akeneo XLSX Connector
+        alias:     xlsx_family_variant_export
+        label:     XLSX catalog modeling family variant export
+        type:      export
+        configuration:
+            withHeader: true
+            filePath:   /tmp/family_variant.xlsx

--- a/features/export/export_family_variants.feature
+++ b/features/export/export_family_variants.feature
@@ -1,0 +1,46 @@
+@javascript
+Feature: Export family variants in CSV
+  In order to be able to access and modify family variants outside PIM
+  As a product manager
+  I need to be able to export family variants in CSV
+
+  Scenario: Successfully export catalog family variants
+    Given a "catalog_modeling" catalog configuration
+    And the following job "csv_catalog_modeling_family_variant_export" configuration:
+      | filePath | %tmp%/family_variant.csv |
+    And I am logged in as "Julia"
+    And I am on the "csv_catalog_modeling_family_variant_export" export job page
+    When I launch the export job
+    And I wait for the "csv_catalog_modeling_family_variant_export" job to finish
+    Then I should see the text "Read 3"
+    And I should see the text "Written 3"
+    And exported file of "csv_catalog_modeling_family_variant_export" should contain:
+      """
+      code;family;label-de_DE;label-en_US;label-fr_FR;variant-axes_1;variant-axes_2;variant-attributes_1;variant-attributes_2
+      variant_clothing_color_and_size;clothing;"Kleidung nach Farbe und Größe";"Clothing by color and size";"Vêtements par couleur et taille";color;size;name,image_1,variation_image,composition,color;sku,weight,size,EAN
+      variant_shoes_size;shoes;"Schuhe nach Größe";"Shoes by size";"Chaussures par taille";eu_shoes_size;;weight;
+      variant_clothing_color_size;clothing;"Kleidung nach Farbe/Größe";"Clothing by color/size";"Vêtements par couleur/taille";color,size;;name,image_1,variation_image,composition;
+      """
+
+  Scenario: I successfully create and use a family variant export in CSV
+    Given the "catalog_modeling" catalog configuration
+    And I am logged in as "Peter"
+    And I am on the exports page
+    When I create a new export
+    And I fill in the following information in the popin:
+      | Code  | family_variant_export        |
+      | Label | Family variant export in CSV |
+      | Job   | Family variant export in CSV |
+    And I press the "Save" button
+    Then I should not see the text "There are unsaved changes"
+    When I am on the exports page
+    And I click on the "Family variant export in CSV" row
+    And I launch the export job
+    And I wait for the "family_variant_export" job to finish
+    Then exported file of "family_variant_export" should contain:
+      """
+      code;family;label-de_DE;label-en_US;label-fr_FR;variant-axes_1;variant-axes_2;variant-attributes_1;variant-attributes_2
+      variant_clothing_color_and_size;clothing;"Kleidung nach Farbe und Größe";"Clothing by color and size";"Vêtements par couleur et taille";color;size;name,image_1,variation_image,composition,color;sku,weight,size,EAN
+      variant_shoes_size;shoes;"Schuhe nach Größe";"Shoes by size";"Chaussures par taille";eu_shoes_size;;weight;
+      variant_clothing_color_size;clothing;"Kleidung nach Farbe/Größe";"Clothing by color/size";"Vêtements par couleur/taille";color,size;;name,image_1,variation_image,composition;
+      """

--- a/features/export/xlsx/export_family_variants.feature
+++ b/features/export/xlsx/export_family_variants.feature
@@ -1,0 +1,42 @@
+@javascript
+Feature: Export family variants in XLSX
+  In order to be able to access and modify family variants outside PIM
+  As a product manager
+  I need to be able to export family variants in XLSX
+
+  Scenario: Successfully export catalog family variants
+    Given a "catalog_modeling" catalog configuration
+    And the following job "xlsx_catalog_modeling_family_variant_export" configuration:
+      | filePath | %tmp%/family_variant.xlsx |
+    And I am logged in as "Julia"
+    And I am on the "xlsx_catalog_modeling_family_variant_export" export job page
+    When I launch the export job
+    And I wait for the "xlsx_catalog_modeling_family_variant_export" job to finish
+    Then I should see the text "Read 3"
+    And I should see the text "Written 3"
+    And exported xlsx file of "xlsx_catalog_modeling_family_variant_export" should contain:
+      | code                            | family   | label-de_DE                   | label-en_US                | label-fr_FR                     | variant-axes_1 | variant-axes_2 | variant-attributes_1                           | variant-attributes_2 |
+      | variant_clothing_color_and_size | clothing | Kleidung nach Farbe und Größe | Clothing by color and size | Vêtements par couleur et taille | color          | size           | name,image_1,variation_image,composition,color | sku,weight,size,EAN  |
+      | variant_shoes_size              | shoes    | Schuhe nach Größe             | Shoes by size              | Chaussures par taille           | eu_shoes_size  |                | weight                                         |                      |
+      | variant_clothing_color_size     | clothing | Kleidung nach Farbe/Größe     | Clothing by color/size     | Vêtements par couleur/taille    | color,size     |                | name,image_1,variation_image,composition       |                      |
+
+  Scenario: I successfully create and use a family variant export in XLSX
+    Given the "catalog_modeling" catalog configuration
+    And I am logged in as "Peter"
+    And I am on the exports page
+    When I create a new export
+    And I fill in the following information in the popin:
+      | Code  | family_variant_export        |
+      | Label | Family variant export in XLSX |
+      | Job   | Family variant export in XLSX |
+    And I press the "Save" button
+    Then I should not see the text "There are unsaved changes"
+    When I am on the exports page
+    And I click on the "Family variant export in XLSX" row
+    And I launch the export job
+    And I wait for the "family_variant_export" job to finish
+    Then exported xlsx file of "family_variant_export" should contain:
+      | code                            | family   | label-de_DE                   | label-en_US                | label-fr_FR                     | variant-axes_1 | variant-axes_2 | variant-attributes_1                           | variant-attributes_2 |
+      | variant_clothing_color_and_size | clothing | Kleidung nach Farbe und Größe | Clothing by color and size | Vêtements par couleur et taille | color          | size           | name,image_1,variation_image,composition,color | sku,weight,size,EAN  |
+      | variant_shoes_size              | shoes    | Schuhe nach Größe             | Shoes by size              | Chaussures par taille           | eu_shoes_size  |                | weight                                         |                      |
+      | variant_clothing_color_size     | clothing | Kleidung nach Farbe/Größe     | Clothing by color/size     | Vêtements par couleur/taille    | color,size     |                | name,image_1,variation_image,composition       |                      |

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/serializers_standard.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/serializers_standard.yml
@@ -16,6 +16,7 @@ parameters:
     pim_catalog.normalizer.standard.channel.class: Pim\Component\Catalog\Normalizer\Standard\ChannelNormalizer
     pim_catalog.normalizer.standard.currency.class: Pim\Component\Catalog\Normalizer\Standard\CurrencyNormalizer
     pim_catalog.normalizer.standard.family.class: Pim\Component\Catalog\Normalizer\Standard\FamilyNormalizer
+    pim_catalog.normalizer.standard.family_variant.class: Pim\Component\Catalog\Normalizer\Standard\FamilyVariantNormalizer
     pim_catalog.normalizer.standard.proxy_group.class: Pim\Component\Catalog\Normalizer\Standard\ProxyGroupNormalizer
     pim_catalog.normalizer.standard.group.class: Pim\Component\Catalog\Normalizer\Standard\GroupNormalizer
     pim_catalog.normalizer.standard.group_type.class: Pim\Component\Catalog\Normalizer\Standard\GroupTypeNormalizer
@@ -129,6 +130,13 @@ services:
             - '@pim_catalog.filter.chained'
             - '@pim_catalog.repository.attribute'
             - '@pim_catalog.repository.attribute_requirement'
+        tags:
+            - { name: pim_serializer.normalizer, priority: 90 }
+
+    pim_catalog.normalizer.standard.family_variant:
+        class: '%pim_catalog.normalizer.standard.family_variant.class%'
+        arguments:
+            - '@pim_catalog.normalizer.standard.translation'
         tags:
             - { name: pim_serializer.normalizer, priority: 90 }
 

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/array_converters.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/array_converters.yml
@@ -27,7 +27,7 @@ parameters:
     pim_connector.array_converter.standard_to_flat.locale.class:                                  Pim\Component\Connector\ArrayConverter\StandardToFlat\Locale
     pim_connector.array_converter.standard_to_flat.currency.class:                                Pim\Component\Connector\ArrayConverter\StandardToFlat\Currency
     pim_connector.array_converter.standard_to_flat.family.class:                                  Pim\Component\Connector\ArrayConverter\StandardToFlat\Family
-    pim_connector.array_converter.standard_to_flat.family_variant.class:                          Pim\Component\Connector\ArrayConverter\StandardToFlat\FamilyVariant
+    pim_connector.array_converter.standard_to_flat.family_variant.class:                          Pim\Component\Connector\ArrayConverter\StandardToFlat\FamilyVariant\FamilyVariant
     pim_connector.array_converter.standard_to_flat.group.class:                                   Pim\Component\Connector\ArrayConverter\StandardToFlat\Group
     pim_connector.array_converter.standard_to_flat.group_type.class:                              Pim\Component\Connector\ArrayConverter\StandardToFlat\GroupType
     pim_connector.array_converter.standard_to_flat.product.class:                                 Pim\Component\Connector\ArrayConverter\StandardToFlat\Product
@@ -58,6 +58,8 @@ parameters:
     pim_connector.array_converter.standard_to_flat.product.value_converter.text.class:            Pim\Component\Connector\ArrayConverter\StandardToFlat\Product\ValueConverter\TextConverter
     pim_connector.array_converter.standard_to_flat.product.value_converter.boolean.class:         Pim\Component\Connector\ArrayConverter\StandardToFlat\Product\ValueConverter\BooleanConverter
     pim_connector.array_converter.standard_to_flat.product.value_converter.date.class:            Pim\Component\Connector\ArrayConverter\StandardToFlat\Product\ValueConverter\DateConverter
+
+    pim_connector.array_converter.standard_to_flat.family_variant.field_splitter.class:           Pim\Component\Connector\ArrayConverter\StandardToFlat\FamilyVariant\FieldSplitter
 
     pim_connector.array_converter.flat_to_standard.product.field_converter.class:                 Pim\Component\Connector\ArrayConverter\FlatToStandard\Product\FieldConverter
 
@@ -308,7 +310,7 @@ services:
         class: '%pim_connector.array_converter.flat_to_standard.product.value_converter.registry.class%'
 
     pim_connector.array_converter.standard_to_flat.product.value_converter.registry:
-        class: %pim_connector.array_converter.standard_to_flat.product.value_converter.registry.class%
+        class: '%pim_connector.array_converter.standard_to_flat.product.value_converter.registry.class%'
 
     pim_connector.array_converter.flat_to_standard.product.value_converter.abstract:
         class: '%pim_connector.array_converter.flat_to_standard.product.value_converter.abstract.class%'
@@ -324,7 +326,7 @@ services:
             - { name: 'pim_connector.array_converter.flat_to_standard.product.value_converter' }
 
     pim_connector.array_converter.standard_to_flat.product.value_converter.price:
-        class: %pim_connector.array_converter.standard_to_flat.product.value_converter.price.class%
+        class: '%pim_connector.array_converter.standard_to_flat.product.value_converter.price.class%'
         arguments:
             - '@pim_connector.array_converter.flat_to_standard.product.attribute_columns_resolver'
             - ['pim_catalog_price_collection']
@@ -340,7 +342,7 @@ services:
             - { name: 'pim_connector.array_converter.flat_to_standard.product.value_converter' }
 
     pim_connector.array_converter.standard_to_flat.product.value_converter.metric:
-        class: %pim_connector.array_converter.standard_to_flat.product.value_converter.metric.class%
+        class: '%pim_connector.array_converter.standard_to_flat.product.value_converter.metric.class%'
         arguments:
             - '@pim_connector.array_converter.flat_to_standard.product.attribute_columns_resolver'
             - ['pim_catalog_metric']
@@ -356,7 +358,7 @@ services:
             - { name: 'pim_connector.array_converter.flat_to_standard.product.value_converter' }
 
     pim_connector.array_converter.standard_to_flat.product.value_converter.multiselect:
-        class: %pim_connector.array_converter.standard_to_flat.product.value_converter.multiselect.class%
+        class: '%pim_connector.array_converter.standard_to_flat.product.value_converter.multiselect.class%'
         arguments:
             - '@pim_connector.array_converter.flat_to_standard.product.attribute_columns_resolver'
             - ['pim_catalog_multiselect', 'pim_reference_data_multiselect']
@@ -372,7 +374,7 @@ services:
             - { name: 'pim_connector.array_converter.flat_to_standard.product.value_converter' }
 
     pim_connector.array_converter.standard_to_flat.product.value_converter.simpleselect:
-        class: %pim_connector.array_converter.standard_to_flat.product.value_converter.simpleselect.class%
+        class: '%pim_connector.array_converter.standard_to_flat.product.value_converter.simpleselect.class%'
         arguments:
             - '@pim_connector.array_converter.flat_to_standard.product.attribute_columns_resolver'
             - ['pim_catalog_simpleselect', 'pim_reference_data_simpleselect']
@@ -388,7 +390,7 @@ services:
             - { name: 'pim_connector.array_converter.flat_to_standard.product.value_converter' }
 
     pim_connector.array_converter.standard_to_flat.product.value_converter.text:
-        class: %pim_connector.array_converter.standard_to_flat.product.value_converter.text.class%
+        class: '%pim_connector.array_converter.standard_to_flat.product.value_converter.text.class%'
         arguments:
             - '@pim_connector.array_converter.flat_to_standard.product.attribute_columns_resolver'
             - ['pim_catalog_identifier', 'pim_catalog_text', 'pim_catalog_textarea', 'pim_catalog_number']
@@ -420,7 +422,7 @@ services:
             - { name: 'pim_connector.array_converter.flat_to_standard.product.value_converter' }
 
     pim_connector.array_converter.standard_to_flat.product.value_converter.media:
-        class: %pim_connector.array_converter.standard_to_flat.product.value_converter.media.class%
+        class: '%pim_connector.array_converter.standard_to_flat.product.value_converter.media.class%'
         arguments:
             - '@pim_connector.array_converter.flat_to_standard.product.attribute_columns_resolver'
             - ['pim_catalog_image', 'pim_catalog_file']
@@ -444,7 +446,7 @@ services:
             - { name: 'pim_connector.array_converter.flat_to_standard.product.value_converter' }
 
     pim_connector.array_converter.standard_to_flat.product.value_converter.date:
-        class: %pim_connector.array_converter.standard_to_flat.product.value_converter.date.class%
+        class: '%pim_connector.array_converter.standard_to_flat.product.value_converter.date.class%'
         arguments:
             - '@pim_connector.array_converter.flat_to_standard.product.attribute_columns_resolver'
             - ['pim_catalog_date']
@@ -475,6 +477,9 @@ services:
     # splitters
     pim_connector.array_converter.flat_to_standard.product.field_splitter:
         class: '%pim_connector.array_converter.flat_to_standard.product.field_splitter.class%'
+
+    pim_connector.array_converter.standard_to_flat.family_variant.field_splitter:
+        class: '%pim_connector.array_converter.standard_to_flat.family_variant.field_splitter.class%'
 
     # columns mergers
     pim_connector.array_converter.flat_to_standard.product.columns_merger:

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/array_converters.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/array_converters.yml
@@ -72,6 +72,7 @@ parameters:
 
     pim_connector.array_convertor.checker.fields_requirement.class:                               Pim\Component\Connector\ArrayConverter\FieldsRequirementChecker
     pim_connector.array_converter.dummy.class:                                                    Pim\Component\Connector\ArrayConverter\DummyConverter
+    pim_connector.array_converter.field_splitter.class:                                           Pim\Component\Connector\ArrayConverter\FieldSplitter
 
 services:
     # array converters
@@ -475,6 +476,9 @@ services:
             - '@pim_catalog.repository.association_type'
 
     # splitters
+    pim_connector.array_converter.field_splitter:
+        class: '%pim_connector.array_converter.field_splitter.class%'
+
     pim_connector.array_converter.flat_to_standard.product.field_splitter:
         class: '%pim_connector.array_converter.flat_to_standard.product.field_splitter.class%'
 

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/array_converters.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/array_converters.yml
@@ -27,6 +27,7 @@ parameters:
     pim_connector.array_converter.standard_to_flat.locale.class:                                  Pim\Component\Connector\ArrayConverter\StandardToFlat\Locale
     pim_connector.array_converter.standard_to_flat.currency.class:                                Pim\Component\Connector\ArrayConverter\StandardToFlat\Currency
     pim_connector.array_converter.standard_to_flat.family.class:                                  Pim\Component\Connector\ArrayConverter\StandardToFlat\Family
+    pim_connector.array_converter.standard_to_flat.family_variant.class:                          Pim\Component\Connector\ArrayConverter\StandardToFlat\FamilyVariant
     pim_connector.array_converter.standard_to_flat.group.class:                                   Pim\Component\Connector\ArrayConverter\StandardToFlat\Group
     pim_connector.array_converter.standard_to_flat.group_type.class:                              Pim\Component\Connector\ArrayConverter\StandardToFlat\GroupType
     pim_connector.array_converter.standard_to_flat.product.class:                                 Pim\Component\Connector\ArrayConverter\StandardToFlat\Product
@@ -252,6 +253,9 @@ services:
 
     pim_connector.array_converter.standard_to_flat.family:
         class: '%pim_connector.array_converter.standard_to_flat.family.class%'
+
+    pim_connector.array_converter.standard_to_flat.family_variant:
+        class: '%pim_connector.array_converter.standard_to_flat.family_variant.class%'
 
     pim_connector.array_converter.standard_to_flat.group:
         class: '%pim_connector.array_converter.standard_to_flat.group.class%'

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/job_constraints.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/job_constraints.yml
@@ -23,6 +23,7 @@ services:
             -
                 - 'csv_attribute_export'
                 - 'csv_family_export'
+                - 'csv_family_variant_export'
                 - 'csv_group_export'
                 - 'csv_association_type_export'
                 - 'csv_attribute_option_export'
@@ -41,6 +42,7 @@ services:
             -
                 - 'xlsx_attribute_export'
                 - 'xlsx_family_export'
+                - 'xlsx_family_variant_export'
                 - 'xlsx_group_export'
                 - 'xlsx_association_type_export'
                 - 'xlsx_attribute_option_export'

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/job_defaults.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/job_defaults.yml
@@ -23,6 +23,7 @@ services:
             -
                 - 'csv_attribute_export'
                 - 'csv_family_export'
+                - 'csv_family_variant_export'
                 - 'csv_group_export'
                 - 'csv_association_type_export'
                 - 'csv_attribute_option_export'
@@ -41,6 +42,7 @@ services:
             -
                 - 'xlsx_attribute_export'
                 - 'xlsx_family_export'
+                - 'xlsx_family_variant_export'
                 - 'xlsx_group_export'
                 - 'xlsx_association_type_export'
                 - 'xlsx_attribute_option_export'

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/jobs.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/jobs.yml
@@ -9,6 +9,7 @@ parameters:
     pim_connector.job_name.csv_association_type_import: 'csv_association_type_import'
     pim_connector.job_name.csv_family_export: 'csv_family_export'
     pim_connector.job_name.csv_family_import: 'csv_family_import'
+    pim_connector.job_name.csv_family_variant_export: 'csv_family_variant_export'
     pim_connector.job_name.csv_family_variant_import: 'csv_family_variant_import'
     pim_connector.job_name.csv_group_export: 'csv_group_export'
     pim_connector.job_name.csv_group_import: 'csv_group_import'
@@ -36,6 +37,7 @@ parameters:
     pim_connector.job_name.xlsx_association_type_import: 'xlsx_association_type_import'
     pim_connector.job_name.xlsx_family_export: 'xlsx_family_export'
     pim_connector.job_name.xlsx_family_import: 'xlsx_family_import'
+    pim_connector.job_name.xlsx_family_variant_export: 'xlsx_family_variant_export'
     pim_connector.job_name.xlsx_family_variant_import: 'xlsx_family_variant_import'
     pim_connector.job_name.xlsx_group_export: 'xlsx_group_export'
     pim_connector.job_name.xlsx_group_import: 'xlsx_group_import'
@@ -273,6 +275,17 @@ services:
             - '@akeneo_batch.job_repository'
             -
                 - '@pim_connector.step.csv_family.export'
+        tags:
+            - { name: akeneo_batch.job, connector: '%pim_connector.connector_name.csv%', type: '%pim_connector.job.export_type%' }
+
+    pim_connector.job.csv_family_variant_export:
+        class: '%pim_connector.job.simple_job.class%'
+        arguments:
+            - '%pim_connector.job_name.csv_family_variant_export%'
+            - '@event_dispatcher'
+            - '@akeneo_batch.job_repository'
+            -
+                - '@pim_connector.step.csv_family_variant.export'
         tags:
             - { name: akeneo_batch.job, connector: '%pim_connector.connector_name.csv%', type: '%pim_connector.job.export_type%' }
 
@@ -590,6 +603,17 @@ services:
             - '@akeneo_batch.job_repository'
             -
                 - '@pim_connector.step.xlsx_family.export'
+        tags:
+            - { name: akeneo_batch.job, connector: '%pim_connector.connector_name.xlsx%', type: '%pim_connector.job.export_type%' }
+
+    pim_connector.job_name.xlsx_family_variant_export:
+        class: '%pim_connector.job.simple_job.class%'
+        arguments:
+            - '%pim_connector.job_name.xlsx_family_variant_export%'
+            - '@event_dispatcher'
+            - '@akeneo_batch.job_repository'
+            -
+                - '@pim_connector.step.xlsx_family_variant.export'
         tags:
             - { name: akeneo_batch.job, connector: '%pim_connector.connector_name.xlsx%', type: '%pim_connector.job.export_type%' }
 

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/processors.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/processors.yml
@@ -223,6 +223,12 @@ services:
             - '@pim_catalog.normalizer.standard.family'
             - '@akeneo_storage_utils.doctrine.object_detacher'
 
+    pim_connector.processor.normalization.family_variant:
+        class: '%pim_connector.processor.normalization.class%'
+        arguments:
+            - '@pim_catalog.normalizer.standard.family_variant'
+            - '@akeneo_storage_utils.doctrine.object_detacher'
+
     pim_connector.processor.normalization.category:
         class: '%pim_connector.processor.normalization.class%'
         arguments:

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/readers.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/readers.yml
@@ -40,6 +40,11 @@ services:
         arguments:
             - '@pim_catalog.repository.family'
 
+    pim_connector.reader.database.family_variant:
+        class: '%pim_connector.reader.database.class%'
+        arguments:
+            - '@pim_catalog.repository.family_variant'
+
     pim_connector.reader.database.attribute:
         class: '%pim_connector.reader.database.class%'
         arguments:

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/steps.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/steps.yml
@@ -209,6 +209,16 @@ services:
             - '@pim_connector.processor.normalization.family'
             - '@pim_connector.writer.file.csv_family'
 
+    pim_connector.step.csv_family_variant.export:
+        class: '%pim_connector.step.item_step.class%'
+        arguments:
+            - 'export'
+            - '@event_dispatcher'
+            - '@akeneo_batch.job_repository'
+            - '@pim_connector.reader.database.family_variant'
+            - '@pim_connector.processor.normalization.family_variant'
+            - '@pim_connector.writer.file.csv_family_variant'
+
     pim_connector.step.csv_group.export:
         class: '%pim_connector.step.item_step.class%'
         arguments:
@@ -497,6 +507,17 @@ services:
             - '@pim_connector.reader.database.family'
             - '@pim_connector.processor.normalization.family'
             - '@pim_connector.writer.file.xlsx_family'
+            - 10
+
+    pim_connector.step.xlsx_family_variant.export:
+        class: '%pim_connector.step.item_step.class%'
+        arguments:
+            - 'export'
+            - '@event_dispatcher'
+            - '@akeneo_batch.job_repository'
+            - '@pim_connector.reader.database.family_variant'
+            - '@pim_connector.processor.normalization.family_variant'
+            - '@pim_connector.writer.file.xlsx_family_variant'
             - 10
 
     pim_connector.step.xlsx_group.export:

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/writers.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/writers.yml
@@ -155,6 +155,11 @@ services:
         arguments:
              - '@pim_connector.writer.file.default.column_sorter'
 
+    pim_connector.writer.file.family_variant.flat_item_buffer_flusher:
+        class: '%pim_connector.writer.file.flat_item_buffer_flusher.class%'
+        arguments:
+             - '@pim_connector.writer.file.family_variant.column_sorter'
+
     pim_connector.writer.file.flat_invalid_item_buffer_flusher:
         class: '%pim_connector.writer.file.flat_item_buffer_flusher.class%'
 
@@ -255,6 +260,13 @@ services:
             - '@pim_connector.factory.flat_item_buffer'
             - '@pim_connector.writer.file.flat_item_buffer_flusher'
 
+    pim_connector.writer.file.csv_family_variant:
+        class: '%pim_connector.writer.file.csv.class%'
+        arguments:
+            - '@pim_connector.array_converter.standard_to_flat.family_variant'
+            - '@pim_connector.factory.flat_item_buffer'
+            - '@pim_connector.writer.file.family_variant.flat_item_buffer_flusher'
+
     pim_connector.writer.file.csv_channel:
         class: '%pim_connector.writer.file.csv.class%'
         arguments:
@@ -301,109 +313,116 @@ services:
     pim_connector.writer.file.xlsx_product:
         class: '%pim_connector.writer.file.xlsx_product.class%'
         arguments:
-             - '@pim_connector.array_converter.standard_to_flat.product_localized'
-             - '@pim_connector.factory.flat_item_buffer'
-             - '@pim_connector.writer.file.product.flat_item_buffer_flusher'
-             - '@pim_catalog.repository.attribute'
-             - '@pim_connector.writer.file.media_exporter_path_generator'
-             - ['pim_catalog_file', 'pim_catalog_image']
+            - '@pim_connector.array_converter.standard_to_flat.product_localized'
+            - '@pim_connector.factory.flat_item_buffer'
+            - '@pim_connector.writer.file.product.flat_item_buffer_flusher'
+            - '@pim_catalog.repository.attribute'
+            - '@pim_connector.writer.file.media_exporter_path_generator'
+            - ['pim_catalog_file', 'pim_catalog_image']
 
     pim_connector.writer.file.xlsx_product_quick_export:
         class: '%pim_connector.writer.file.xlsx_product.class%'
         arguments:
-             - '@pim_connector.array_converter.standard_to_flat.product_localized'
-             - '@pim_connector.factory.flat_item_buffer'
-             - '@pim_connector.writer.file.product_quick_export.flat_item_buffer_flusher'
-             - '@pim_catalog.repository.attribute'
-             - '@pim_connector.writer.file.media_exporter_path_generator'
-             - ['pim_catalog_file', 'pim_catalog_image']
+            - '@pim_connector.array_converter.standard_to_flat.product_localized'
+            - '@pim_connector.factory.flat_item_buffer'
+            - '@pim_connector.writer.file.product_quick_export.flat_item_buffer_flusher'
+            - '@pim_catalog.repository.attribute'
+            - '@pim_connector.writer.file.media_exporter_path_generator'
+            - ['pim_catalog_file', 'pim_catalog_image']
 
     pim_connector.writer.file.xlsx_variant_group:
         class: '%pim_connector.writer.file.xlsx_variant_group.class%'
         arguments:
-             - '@pim_connector.array_converter.standard_to_flat.variant_group_localized'
-             - '@pim_connector.factory.flat_item_buffer'
-             - '@pim_connector.writer.file.product.flat_item_buffer_flusher'
-             - '@pim_catalog.repository.attribute'
-             - '@pim_connector.writer.file.media_exporter_path_generator'
-             - ['pim_catalog_file', 'pim_catalog_image']
+            - '@pim_connector.array_converter.standard_to_flat.variant_group_localized'
+            - '@pim_connector.factory.flat_item_buffer'
+            - '@pim_connector.writer.file.product.flat_item_buffer_flusher'
+            - '@pim_catalog.repository.attribute'
+            - '@pim_connector.writer.file.media_exporter_path_generator'
+            - ['pim_catalog_file', 'pim_catalog_image']
 
     pim_connector.writer.file.xlsx_group:
         class: '%pim_connector.writer.file.xlsx.class%'
         arguments:
-             - '@pim_connector.array_converter.standard_to_flat.group'
-             - '@pim_connector.factory.flat_item_buffer'
-             - '@pim_connector.writer.file.flat_item_buffer_flusher'
+            - '@pim_connector.array_converter.standard_to_flat.group'
+            - '@pim_connector.factory.flat_item_buffer'
+            - '@pim_connector.writer.file.flat_item_buffer_flusher'
 
     pim_connector.writer.file.xlsx_family:
         class: '%pim_connector.writer.file.xlsx.class%'
         arguments:
-             - '@pim_connector.array_converter.standard_to_flat.family'
-             - '@pim_connector.factory.flat_item_buffer'
-             - '@pim_connector.writer.file.flat_item_buffer_flusher'
+            - '@pim_connector.array_converter.standard_to_flat.family'
+            - '@pim_connector.factory.flat_item_buffer'
+            - '@pim_connector.writer.file.flat_item_buffer_flusher'
+
+    pim_connector.writer.file.xlsx_family_variant:
+        class: '%pim_connector.writer.file.xlsx.class%'
+        arguments:
+            - '@pim_connector.array_converter.standard_to_flat.family_variant'
+            - '@pim_connector.factory.flat_item_buffer'
+            - '@pim_connector.writer.file.family_variant.flat_item_buffer_flusher'
 
     pim_connector.writer.file.xlsx_category:
         class: '%pim_connector.writer.file.xlsx.class%'
         arguments:
-             - '@pim_connector.array_converter.standard_to_flat.category'
-             - '@pim_connector.factory.flat_item_buffer'
-             - '@pim_connector.writer.file.flat_item_buffer_flusher'
+            - '@pim_connector.array_converter.standard_to_flat.category'
+            - '@pim_connector.factory.flat_item_buffer'
+            - '@pim_connector.writer.file.flat_item_buffer_flusher'
 
     pim_connector.writer.file.xlsx_attribute:
         class: '%pim_connector.writer.file.xlsx.class%'
         arguments:
-             - '@pim_connector.array_converter.standard_to_flat.attribute'
-             - '@pim_connector.factory.flat_item_buffer'
-             - '@pim_connector.writer.file.flat_item_buffer_flusher'
+            - '@pim_connector.array_converter.standard_to_flat.attribute'
+            - '@pim_connector.factory.flat_item_buffer'
+            - '@pim_connector.writer.file.flat_item_buffer_flusher'
 
     pim_connector.writer.file.xlsx_attribute_option:
         class: '%pim_connector.writer.file.xlsx.class%'
         arguments:
-             - '@pim_connector.array_converter.standard_to_flat.attribute_option'
-             - '@pim_connector.factory.flat_item_buffer'
-             - '@pim_connector.writer.file.flat_item_buffer_flusher'
+            - '@pim_connector.array_converter.standard_to_flat.attribute_option'
+            - '@pim_connector.factory.flat_item_buffer'
+            - '@pim_connector.writer.file.flat_item_buffer_flusher'
 
     pim_connector.writer.file.xlsx_association_type:
         class: '%pim_connector.writer.file.xlsx.class%'
         arguments:
-             - '@pim_connector.array_converter.standard_to_flat.association_type'
-             - '@pim_connector.factory.flat_item_buffer'
-             - '@pim_connector.writer.file.flat_item_buffer_flusher'
+            - '@pim_connector.array_converter.standard_to_flat.association_type'
+            - '@pim_connector.factory.flat_item_buffer'
+            - '@pim_connector.writer.file.flat_item_buffer_flusher'
 
     pim_connector.writer.file.xlsx_channel:
         class: '%pim_connector.writer.file.xlsx.class%'
         arguments:
-             - '@pim_connector.array_converter.standard_to_flat.channel'
-             - '@pim_connector.factory.flat_item_buffer'
-             - '@pim_connector.writer.file.flat_item_buffer_flusher'
+            - '@pim_connector.array_converter.standard_to_flat.channel'
+            - '@pim_connector.factory.flat_item_buffer'
+            - '@pim_connector.writer.file.flat_item_buffer_flusher'
 
     pim_connector.writer.file.xlsx_locale:
         class: '%pim_connector.writer.file.xlsx.class%'
         arguments:
-             - '@pim_connector.array_converter.standard_to_flat.locale'
-             - '@pim_connector.factory.flat_item_buffer'
-             - '@pim_connector.writer.file.flat_item_buffer_flusher'
+            - '@pim_connector.array_converter.standard_to_flat.locale'
+            - '@pim_connector.factory.flat_item_buffer'
+            - '@pim_connector.writer.file.flat_item_buffer_flusher'
 
     pim_connector.writer.file.xlsx_attribute_group:
         class: '%pim_connector.writer.file.xlsx.class%'
         arguments:
-             - '@pim_connector.array_converter.standard_to_flat.attribute_group'
-             - '@pim_connector.factory.flat_item_buffer'
-             - '@pim_connector.writer.file.flat_item_buffer_flusher'
+            - '@pim_connector.array_converter.standard_to_flat.attribute_group'
+            - '@pim_connector.factory.flat_item_buffer'
+            - '@pim_connector.writer.file.flat_item_buffer_flusher'
 
     pim_connector.writer.file.xlsx_currency:
         class: '%pim_connector.writer.file.xlsx.class%'
         arguments:
-             - '@pim_connector.array_converter.standard_to_flat.currency'
-             - '@pim_connector.factory.flat_item_buffer'
-             - '@pim_connector.writer.file.flat_item_buffer_flusher'
+            - '@pim_connector.array_converter.standard_to_flat.currency'
+            - '@pim_connector.factory.flat_item_buffer'
+            - '@pim_connector.writer.file.flat_item_buffer_flusher'
 
     pim_connector.writer.file.xlsx_group_type:
         class: '%pim_connector.writer.file.xlsx.class%'
         arguments:
-             - '@pim_connector.array_converter.standard_to_flat.group_type'
-             - '@pim_connector.factory.flat_item_buffer'
-             - '@pim_connector.writer.file.flat_item_buffer_flusher'
+            - '@pim_connector.array_converter.standard_to_flat.group_type'
+            - '@pim_connector.factory.flat_item_buffer'
+            - '@pim_connector.writer.file.flat_item_buffer_flusher'
 
     # Column sorter
     pim_connector.writer.file.default.column_sorter:
@@ -411,6 +430,12 @@ services:
         arguments:
             - '@pim_connector.array_converter.flat_to_standard.product.field_splitter'
             - ['code','label']
+
+    pim_connector.writer.file.family_variant.column_sorter:
+        class: '%pim_connector.writer.file.default.column_sorter.class%'
+        arguments:
+            - '@pim_connector.array_converter.standard_to_flat.family_variant.field_splitter'
+            - ['code','family','label','variant-axes','variant-attributes']
 
     pim_connector.writer.file.product_quick_export.column_sorter:
         class: '%pim_connector.writer.file.product.column_sorter.class%'

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/writers.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/writers.yml
@@ -428,7 +428,7 @@ services:
     pim_connector.writer.file.default.column_sorter:
         class: '%pim_connector.writer.file.default.column_sorter.class%'
         arguments:
-            - '@pim_connector.array_converter.flat_to_standard.product.field_splitter'
+            - '@pim_connector.array_converter.field_splitter'
             - ['code','label']
 
     pim_connector.writer.file.family_variant.column_sorter:

--- a/src/Pim/Bundle/ConnectorBundle/Resources/translations/messages.en.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/translations/messages.en.yml
@@ -75,6 +75,9 @@ batch_jobs:
     csv_family_export:
         label: Family export in CSV
         export.label: Family export
+    csv_family_variant_export:
+        label: Family variant export in CSV
+        export.label: Family variant export
     csv_product_import:
         label: Product import in CSV
         validation.label: File validation
@@ -196,6 +199,9 @@ batch_jobs:
     xlsx_family_export:
         label: Family export in XLSX
         export.label: Family export
+    xlsx_family_variant_export:
+        label: Family variant export in XLSX
+        export.label: Family variant export
     xlsx_category_export:
         label: Category export in XLSX
         export.label: Category export

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/providers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/providers.yml
@@ -71,6 +71,7 @@ services:
                 csv_channel_export: pim-job-instance-csv-base-export
                 csv_currency_export: pim-job-instance-csv-base-export
                 csv_family_export: pim-job-instance-csv-base-export
+                csv_family_variant_export: pim-job-instance-csv-base-export
                 csv_group_export: pim-job-instance-csv-base-export
                 csv_group_type_export: pim-job-instance-csv-base-export
                 csv_locale_export: pim-job-instance-csv-base-export
@@ -84,6 +85,7 @@ services:
                 xlsx_channel_export: pim-job-instance-xlsx-base-export
                 xlsx_currency_export: pim-job-instance-xlsx-base-export
                 xlsx_family_export: pim-job-instance-xlsx-base-export
+                xlsx_family_variant_export: pim-job-instance-xlsx-base-export
                 xlsx_group_export: pim-job-instance-xlsx-base-export
                 xlsx_group_type_export: pim-job-instance-xlsx-base-export
                 xlsx_locale_export: pim-job-instance-xlsx-base-export

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
@@ -1055,6 +1055,9 @@ batch_jobs:
     csv_family_export:
         label: Family export in CSV
         export.label: Family export
+    csv_family_variant_export:
+        label: Family variant export in CSV
+        export.label: Family variant export
     csv_product_import:
         label: Product import in CSV
         validation.label: File validation
@@ -1176,6 +1179,9 @@ batch_jobs:
     xlsx_family_export:
         label: Family export in XLSX
         export.label: Family export
+    xlsx_family_variant_export:
+        label: Family variant export in XLSX
+        export.label: Family variant export
     xlsx_category_export:
         label: Category export in XLSX
         export.label: Category export

--- a/src/Pim/Bundle/InstallerBundle/Resources/fixtures/icecat_demo_dev/jobs.yml
+++ b/src/Pim/Bundle/InstallerBundle/Resources/fixtures/icecat_demo_dev/jobs.yml
@@ -175,6 +175,17 @@ jobs:
             delimiter:     ;
             enclosure:     '"'
             escape:        '\'
+    csv_family_variant_import:
+        connector: Akeneo CSV Connector
+        alias:     csv_family_variant_import
+        label:     Demo CSV family variant import
+        type:      import
+        configuration:
+            filePath:      /tmp/family_variant.csv
+            uploadAllowed: true
+            delimiter:     ;
+            enclosure:     '"'
+            escape:        '\'
     csv_attribute_option_export:
         connector: Akeneo CSV Connector
         alias:     csv_attribute_option_export
@@ -247,6 +258,16 @@ jobs:
             enclosure:  '"'
             withHeader: true
             filePath:   /tmp/family.csv
+    csv_family_variant_export:
+        connector: Akeneo CSV Connector
+        alias:     csv_family_variant_export
+        label:     Demo CSV family variant export
+        type:      export
+        configuration:
+            delimiter:  ;
+            enclosure:  '"'
+            withHeader: true
+            filePath:   /tmp/family_variant.csv
     xlsx_product_export:
         connector: Akeneo XLSX Connector
         alias:     xlsx_product_export
@@ -368,6 +389,14 @@ jobs:
         configuration:
             filePath:      /tmp/family.xlsx
             uploadAllowed: true
+    xlsx_family_variant_import:
+        connector: Akeneo XLSX Connector
+        alias:     xlsx_family_variant_import
+        label:     Demo XLSX family variant import
+        type:      import
+        configuration:
+            filePath:      /tmp/family_variant.xlsx
+            uploadAllowed: true
     xlsx_group_import:
         connector: Akeneo XLSX Connector
         alias:     xlsx_group_import
@@ -393,6 +422,15 @@ jobs:
             withHeader: true
             linesPerFile: 10000
             filePath: /tmp/family.xlsx
+    xlsx_family_variant_export:
+        connector: Akeneo XLSX Connector
+        alias:     xlsx_family_variant_export
+        label:     Demo XLSX family variant export
+        type:      export
+        configuration:
+            withHeader: true
+            linesPerFile: 10000
+            filePath: /tmp/family_variant.xlsx
     xlsx_category_export:
         connector: Akeneo XLSX Connector
         alias:     xlsx_category_export

--- a/src/Pim/Component/Catalog/Normalizer/Standard/FamilyVariantNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Standard/FamilyVariantNormalizer.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Pim\Component\Catalog\Normalizer\Standard;
+
+use Doctrine\Common\Collections\Collection;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\FamilyVariantInterface;
+use Pim\Component\Catalog\Model\VariantAttributeSetInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * @author    Damien Carcel (damien.carcel@akeneo.com)
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class FamilyVariantNormalizer implements NormalizerInterface
+{
+    /** @var NormalizerInterface */
+    protected $translationNormalizer;
+
+    /**
+     * @param NormalizerInterface $translationNormalizer
+     */
+    public function __construct(
+        NormalizerInterface $translationNormalizer
+    ) {
+        $this->translationNormalizer = $translationNormalizer;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function normalize($familyVariant, $format = null, array $context = []): array
+    {
+        /** @var FamilyVariantInterface $familyVariant */
+        return [
+            'code' => $familyVariant->getCode(),
+            'labels' => $this->translationNormalizer->normalize($familyVariant, 'standard', $context),
+            'family' => $familyVariant->getFamily()->getCode(),
+            'variant_attribute_sets' => $this->normalizeVariantAttributeSets($familyVariant->getVariantAttributeSets()),
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsNormalization($data, $format = null): bool
+    {
+        return $data instanceof FamilyVariantInterface && 'standard' === $format;
+    }
+
+    /**
+     * Normalizes a collection of variant attribute sets.
+     *
+     * It returns the following:
+     *
+     * [
+     *     [
+     *         "level" => 1,
+     *         "axes" => [
+     *             "a_simple_select"
+     *         ],
+     *         "attributes" => [
+     *             "an_attribute",
+     *             "an_other_attribute"
+     *         ],
+     *     ],
+     * ]
+     *
+     * @param Collection $variantAttributeSets
+     *
+     * @return array
+     */
+    protected function normalizeVariantAttributeSets(Collection $variantAttributeSets): array
+    {
+        return $variantAttributeSets->map(function (VariantAttributeSetInterface $variantAttributeSet) {
+            return [
+                'level' => $variantAttributeSet->getLevel(),
+                'axes' => $this->normalizeAttributes($variantAttributeSet->getAxes()),
+                'attributes' => $this->normalizeAttributes($variantAttributeSet->getAttributes()),
+            ];
+        })->toArray();
+    }
+
+    /**
+     * Normalizes a collection of attributes as an array of attribute codes.
+     *
+     * @param Collection $attributes
+     *
+     * @return array
+     */
+    protected function normalizeAttributes(Collection $attributes): array
+    {
+        return $attributes->map(function (AttributeInterface $attribute) {
+            return $attribute->getCode();
+        })->toArray();
+    }
+}

--- a/src/Pim/Component/Catalog/Normalizer/Standard/FamilyVariantNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Standard/FamilyVariantNormalizer.php
@@ -16,7 +16,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 class FamilyVariantNormalizer implements NormalizerInterface
 {
     /** @var NormalizerInterface */
-    protected $translationNormalizer;
+    private $translationNormalizer;
 
     /**
      * @param NormalizerInterface $translationNormalizer
@@ -32,7 +32,6 @@ class FamilyVariantNormalizer implements NormalizerInterface
      */
     public function normalize($familyVariant, $format = null, array $context = []): array
     {
-        /** @var FamilyVariantInterface $familyVariant */
         return [
             'code' => $familyVariant->getCode(),
             'labels' => $this->translationNormalizer->normalize($familyVariant, 'standard', $context),
@@ -71,7 +70,7 @@ class FamilyVariantNormalizer implements NormalizerInterface
      *
      * @return array
      */
-    protected function normalizeVariantAttributeSets(Collection $variantAttributeSets): array
+    private function normalizeVariantAttributeSets(Collection $variantAttributeSets): array
     {
         return $variantAttributeSets->map(function (VariantAttributeSetInterface $variantAttributeSet) {
             return [
@@ -89,7 +88,7 @@ class FamilyVariantNormalizer implements NormalizerInterface
      *
      * @return array
      */
-    protected function normalizeAttributes(Collection $attributes): array
+    private function normalizeAttributes(Collection $attributes): array
     {
         return $attributes->map(function (AttributeInterface $attribute) {
             return $attribute->getCode();

--- a/src/Pim/Component/Catalog/spec/Normalizer/Standard/FamilyVariantNormalizerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Normalizer/Standard/FamilyVariantNormalizerSpec.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace spec\Pim\Component\Catalog\Normalizer\Standard;
+
+use Doctrine\Common\Collections\Collection;
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Model\FamilyInterface;
+use Pim\Component\Catalog\Model\FamilyVariantInterface;
+use Pim\Component\Catalog\Model\VariantAttributeSetInterface;
+use Pim\Component\Catalog\Normalizer\Standard\FamilyVariantNormalizer;
+use Prophecy\Argument;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+class FamilyVariantNormalizerSpec extends ObjectBehavior
+{
+    function let(NormalizerInterface $transNormalizer)
+    {
+        $this->beConstructedWith($transNormalizer);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(FamilyVariantNormalizer::class);
+    }
+
+    function it_is_a_normalizer()
+    {
+        $this->shouldImplement(NormalizerInterface::class);
+    }
+
+    function it_normalizes_a_family_variant(
+        $transNormalizer,
+        FamilyVariantInterface $familyVariant,
+        FamilyInterface $family,
+        Collection $variantAttributeSets,
+        Collection $normalizedVariantAttributeSets
+    ) {
+        $familyVariant->getCode()->willReturn('family_variant');
+
+        $transNormalizer->normalize(Argument::cetera())->willReturn([]);
+
+        $familyVariant->getFamily()->willReturn($family);
+        $family->getCode()->willReturn('family');
+
+        $familyVariant->getVariantAttributeSets()->willReturn($variantAttributeSets);
+        $variantAttributeSets->map(Argument::cetera())->willReturn($normalizedVariantAttributeSets);
+        $normalizedVariantAttributeSets->toArray()->willReturn([
+            [
+                'level' => 1,
+                'axes' => ['a_simple_select'],
+                'attributes' => ['an_attribute', 'another_attribute'],
+            ],
+            [
+                'level' => 2,
+                'axes' => ['a_simple_reference_data', 'a_boolean'],
+                'attributes' => ['an_identifier'],
+            ],
+        ]);
+
+        $this->normalize($familyVariant, 'standard', [])->shouldReturn([
+            'code' => 'family_variant',
+            'labels' => [],
+            'family' => 'family',
+            'variant_attribute_sets' => [
+                [
+                    'level' => 1,
+                    'axes' => ['a_simple_select'],
+                    'attributes' => ['an_attribute', 'another_attribute'],
+                ],
+                [
+                    'level' => 2,
+                    'axes' => ['a_simple_reference_data', 'a_boolean'],
+                    'attributes' => ['an_identifier'],
+                ],
+            ],
+        ]);
+    }
+}

--- a/src/Pim/Component/Catalog/tests/integration/Normalizer/Standard/FamilyVariantIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Normalizer/Standard/FamilyVariantIntegration.php
@@ -50,7 +50,7 @@ class FamilyVariantIntegration extends TestCase
     /**
      * {@inheritdoc}
      */
-    protected function getConfiguration()
+    protected function getConfiguration(): Configuration
     {
         return new Configuration([Configuration::getFunctionalCatalog('catalog_modeling')]);
     }

--- a/src/Pim/Component/Catalog/tests/integration/Normalizer/Standard/FamilyVariantIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Normalizer/Standard/FamilyVariantIntegration.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Pim\Component\Catalog\tests\integration\Normalizer\Standard;
+
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+
+/**
+ * @author    Damien Carcel (damien.carcel@akeneo.com)
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class FamilyVariantIntegration extends TestCase
+{
+    public function testFamilyVariant()
+    {
+        $expected = [
+            'code' => 'variant_clothing_color_and_size',
+            'labels' => [
+                'de_DE' => 'Kleidung nach Farbe und Größe',
+                'en_US' => 'Clothing by color and size',
+                'fr_FR' => 'Vêtements par couleur et taille',
+            ],
+            'family' => 'clothing',
+            'variant_attribute_sets' => [
+                [
+                    'level' => 1,
+                    'axes' => ['color'],
+                    'attributes' => ['name', 'image_1', 'variation_image', 'composition', 'color'],
+                ],
+                [
+                    'level' => 2,
+                    'axes' => ['size'],
+                    'attributes' => ['sku', 'weight', 'size', 'EAN'],
+                ],
+            ],
+        ];
+
+        $repository = $this->get('pim_catalog.repository.family_variant');
+        $serializer = $this->get('pim_serializer');
+
+        $result = $serializer->normalize(
+            $repository->findOneByIdentifier('variant_clothing_color_and_size'),
+            'standard'
+        );
+
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return new Configuration([Configuration::getFunctionalCatalog('catalog_modeling')]);
+    }
+}

--- a/src/Pim/Component/Connector/ArrayConverter/FieldSplitter.php
+++ b/src/Pim/Component/Connector/ArrayConverter/FieldSplitter.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Pim\Component\Connector\ArrayConverter;
+
+use Pim\Component\Connector\ArrayConverter\FlatToStandard\Product\AttributeColumnInfoExtractor;
+
+/**
+ * @author    Damien Carcel (damien.carcel@akeneo.com)
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class FieldSplitter
+{
+    /**
+     * Split a field name:
+     * 'description-en_US-mobile' => ['description', 'en_US', 'mobile']
+     *
+     * @param string $field Raw field name
+     *
+     * @return string[]
+     */
+    public function splitFieldName($field): array
+    {
+        return '' === $field ? [] : explode(AttributeColumnInfoExtractor::FIELD_SEPARATOR, $field);
+    }
+}

--- a/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Product/FieldSplitter.php
+++ b/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Product/FieldSplitter.php
@@ -2,6 +2,8 @@
 
 namespace Pim\Component\Connector\ArrayConverter\FlatToStandard\Product;
 
+use Pim\Component\Connector\ArrayConverter\FieldSplitter as BaseFieldSplitter;
+
 /**
  * Split fields
  *
@@ -9,7 +11,7 @@ namespace Pim\Component\Connector\ArrayConverter\FlatToStandard\Product;
  * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class FieldSplitter
+class FieldSplitter extends BaseFieldSplitter
 {
     /**
      * Split a value with it's unit/currency:
@@ -82,18 +84,5 @@ class FieldSplitter
         }
 
         return $prices;
-    }
-
-    /**
-     * Split a field name:
-     * 'description-en_US-mobile' => ['description', 'en_US', 'mobile']
-     *
-     * @param string $field Raw field name
-     *
-     * @return array
-     */
-    public function splitFieldName($field)
-    {
-        return '' === $field ? [] : explode(AttributeColumnInfoExtractor::FIELD_SEPARATOR, $field);
     }
 }

--- a/src/Pim/Component/Connector/ArrayConverter/StandardToFlat/FamilyVariant.php
+++ b/src/Pim/Component/Connector/ArrayConverter/StandardToFlat/FamilyVariant.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Pim\Component\Connector\ArrayConverter\StandardToFlat;
+
+use Pim\Component\Connector\ArrayConverter\ArrayConverterInterface;
+
+/**
+ * @author    Damien Carcel (damien.carcel@akeneo.com)
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class FamilyVariant extends AbstractSimpleArrayConverter implements ArrayConverterInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function convertProperty($property, $data, array $convertedItem, array $options)
+    {
+        switch ($property) {
+            case 'labels':
+                foreach ($data as $localeCode => $label) {
+                    $labelKey = sprintf('label-%s', $localeCode);
+                    $convertedItem[$labelKey] = $label;
+                }
+                break;
+            case 'variant_attribute_sets':
+                foreach ($data as $normalizedAttributeSet) {
+                    $axesKey = sprintf('variant-axes_%d', $normalizedAttributeSet['level']);
+                    $attributesKey = sprintf('variant-attributes_%d', $normalizedAttributeSet['level']);
+                    $convertedItem[$axesKey] = implode(',', $normalizedAttributeSet['axes']);
+                    $convertedItem[$attributesKey] = implode(',', $normalizedAttributeSet['attributes']);
+                }
+                break;
+            default:
+                $convertedItem[$property] = (string) $data;
+        }
+
+        return $convertedItem;
+    }
+}

--- a/src/Pim/Component/Connector/ArrayConverter/StandardToFlat/FamilyVariant/FamilyVariant.php
+++ b/src/Pim/Component/Connector/ArrayConverter/StandardToFlat/FamilyVariant/FamilyVariant.php
@@ -15,7 +15,7 @@ class FamilyVariant extends AbstractSimpleArrayConverter implements ArrayConvert
     /**
      * {@inheritdoc}
      */
-    protected function convertProperty($property, $data, array $convertedItem, array $options)
+    protected function convertProperty($property, $data, array $convertedItem, array $options): array
     {
         switch ($property) {
             case 'labels':

--- a/src/Pim/Component/Connector/ArrayConverter/StandardToFlat/FamilyVariant/FamilyVariant.php
+++ b/src/Pim/Component/Connector/ArrayConverter/StandardToFlat/FamilyVariant/FamilyVariant.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Pim\Component\Connector\ArrayConverter\StandardToFlat;
+namespace Pim\Component\Connector\ArrayConverter\StandardToFlat\FamilyVariant;
 
 use Pim\Component\Connector\ArrayConverter\ArrayConverterInterface;
+use Pim\Component\Connector\ArrayConverter\StandardToFlat\AbstractSimpleArrayConverter;
 
 /**
  * @author    Damien Carcel (damien.carcel@akeneo.com)

--- a/src/Pim/Component/Connector/ArrayConverter/StandardToFlat/FamilyVariant/FieldSplitter.php
+++ b/src/Pim/Component/Connector/ArrayConverter/StandardToFlat/FamilyVariant/FieldSplitter.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Pim\Component\Connector\ArrayConverter\StandardToFlat\FamilyVariant;
+
+use Pim\Component\Connector\ArrayConverter\FlatToStandard\Product\FieldSplitter as ProductFieldSplitter;
+
+/**
+ * Field splitter dedicated to the family variant column sorter.
+ *
+ * @author    Damien Carcel (damien.carcel@akeneo.com)
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class FieldSplitter extends ProductFieldSplitter
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function splitFieldName($field): array
+    {
+        if (1 === preg_match('/variant-axes/', $field) || 1 === preg_match('/variant-attributes/', $field)) {
+            return explode('_', $field);
+        }
+
+        return parent::splitFieldName($field);
+    }
+}

--- a/src/Pim/Component/Connector/ArrayConverter/StandardToFlat/FamilyVariant/FieldSplitter.php
+++ b/src/Pim/Component/Connector/ArrayConverter/StandardToFlat/FamilyVariant/FieldSplitter.php
@@ -2,7 +2,7 @@
 
 namespace Pim\Component\Connector\ArrayConverter\StandardToFlat\FamilyVariant;
 
-use Pim\Component\Connector\ArrayConverter\FlatToStandard\Product\FieldSplitter as ProductFieldSplitter;
+use Pim\Component\Connector\ArrayConverter\FieldSplitter as BaseFieldSplitter;
 
 /**
  * Field splitter dedicated to the family variant column sorter.
@@ -11,7 +11,7 @@ use Pim\Component\Connector\ArrayConverter\FlatToStandard\Product\FieldSplitter 
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
-class FieldSplitter extends ProductFieldSplitter
+class FieldSplitter extends BaseFieldSplitter
 {
     /**
      * {@inheritdoc}

--- a/src/Pim/Component/Connector/Writer/File/DefaultColumnSorter.php
+++ b/src/Pim/Component/Connector/Writer/File/DefaultColumnSorter.php
@@ -2,7 +2,7 @@
 
 namespace Pim\Component\Connector\Writer\File;
 
-use Pim\Component\Connector\ArrayConverter\FlatToStandard\Product\FieldSplitter;
+use Pim\Component\Connector\ArrayConverter\FieldSplitter;
 
 /**
  * Reorder columns before export

--- a/src/Pim/Component/Connector/spec/ArrayConverter/FieldSplitterSpec.php
+++ b/src/Pim/Component/Connector/spec/ArrayConverter/FieldSplitterSpec.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace spec\Pim\Component\Connector\ArrayConverter;
+
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Connector\ArrayConverter\FieldSplitter;
+
+class FieldSplitterSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(FieldSplitter::class);
+    }
+
+    function it_split_field_name()
+    {
+        $this->splitFieldName('description-en_US-mobile')->shouldReturn(['description', 'en_US', 'mobile']);
+        $this->splitFieldName('description-en_US')->shouldReturn(['description', 'en_US']);
+        $this->splitFieldName('description')->shouldReturn(['description']);
+        $this->splitFieldName('description--mobile')->shouldReturn(['description', '', 'mobile']);
+        $this->splitFieldName('description--')->shouldReturn(['description', '', '']);
+        $this->splitFieldName('')->shouldReturn([]);
+    }
+}

--- a/src/Pim/Component/Connector/spec/ArrayConverter/StandardToFlat/FamilyVariant/FamilyVariantSpec.php
+++ b/src/Pim/Component/Connector/spec/ArrayConverter/StandardToFlat/FamilyVariant/FamilyVariantSpec.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace spec\Pim\Component\Connector\ArrayConverter\StandardToFlat;
+namespace spec\Pim\Component\Connector\ArrayConverter\StandardToFlat\FamilyVariant;
 
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Connector\ArrayConverter\ArrayConverterInterface;
-use Pim\Component\Connector\ArrayConverter\StandardToFlat\FamilyVariant;
+use Pim\Component\Connector\ArrayConverter\StandardToFlat\FamilyVariant\FamilyVariant;
 
 class FamilyVariantSpec extends ObjectBehavior
 {

--- a/src/Pim/Component/Connector/spec/ArrayConverter/StandardToFlat/FamilyVariant/FieldSplitterSpec.php
+++ b/src/Pim/Component/Connector/spec/ArrayConverter/StandardToFlat/FamilyVariant/FieldSplitterSpec.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace spec\Pim\Component\Connector\ArrayConverter\StandardToFlat\FamilyVariant;
+
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Connector\ArrayConverter\StandardToFlat\FamilyVariant\FieldSplitter;
+
+class FieldSplitterSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(FieldSplitter::class);
+    }
+
+    function it_split_field_name()
+    {
+        $this->splitFieldName('description-en_US-mobile')->shouldReturn(['description', 'en_US', 'mobile']);
+        $this->splitFieldName('description-en_US')->shouldReturn(['description', 'en_US']);
+        $this->splitFieldName('description')->shouldReturn(['description']);
+        $this->splitFieldName('description--mobile')->shouldReturn(['description', '', 'mobile']);
+        $this->splitFieldName('description--')->shouldReturn(['description', '', '']);
+        $this->splitFieldName('variant-attributes_1')->shouldReturn(['variant-attributes', '1']);
+        $this->splitFieldName('variant-attributes_2')->shouldReturn(['variant-attributes', '2']);
+        $this->splitFieldName('variant-axes_1')->shouldReturn(['variant-axes', '1']);
+        $this->splitFieldName('variant-axes_2')->shouldReturn(['variant-axes', '2']);
+        $this->splitFieldName('description-en_US-mobile')->shouldReturn(['description', 'en_US', 'mobile']);
+        $this->splitFieldName('')->shouldReturn([]);
+    }
+}

--- a/src/Pim/Component/Connector/spec/ArrayConverter/StandardToFlat/FamilyVariantSpec.php
+++ b/src/Pim/Component/Connector/spec/ArrayConverter/StandardToFlat/FamilyVariantSpec.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace spec\Pim\Component\Connector\ArrayConverter\StandardToFlat;
+
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Connector\ArrayConverter\ArrayConverterInterface;
+use Pim\Component\Connector\ArrayConverter\StandardToFlat\FamilyVariant;
+
+class FamilyVariantSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(FamilyVariant::class);
+    }
+
+    function it_is_an_array_converter()
+    {
+        $this->shouldImplement(ArrayConverterInterface::class);
+    }
+
+    function it_converts_a_family_variant_from_standard_to_flat_format()
+    {
+        $expected = [
+            'code' => 'family_variant_code',
+            'family' => 'family_code',
+            'label-en_US' => 'My family variant',
+            'label-fr_FR' => 'Ma variante de famille',
+            'variant-axes_1' => 'a_simple_select,a_reference_data',
+            'variant-attributes_1' => 'an_attribute,another_attribute,yet_another_attribute',
+            'variant-axes_2' => 'a_boolean',
+            'variant-attributes_2' => 'an_identifier',
+        ];
+
+        $item = [
+            'code' => 'family_variant_code',
+            'family' => 'family_code',
+            'labels' => [
+                'en_US' => 'My family variant',
+                'fr_FR' => 'Ma variante de famille',
+            ],
+            'variant_attribute_sets' => [
+                [
+                    'level' => 1,
+                    'axes' => ['a_simple_select', 'a_reference_data'],
+                    'attributes' => ['an_attribute', 'another_attribute', 'yet_another_attribute'],
+                ],
+                [
+                    'level' => 2,
+                    'axes' => ['a_boolean'],
+                    'attributes' => ['an_identifier'],
+                ],
+            ],
+        ];
+
+        $this->convert($item)->shouldReturn($expected);
+    }
+}

--- a/src/Pim/Component/Connector/spec/Writer/File/DefaultColumnSorterSpec.php
+++ b/src/Pim/Component/Connector/spec/Writer/File/DefaultColumnSorterSpec.php
@@ -3,7 +3,7 @@
 namespace spec\Pim\Component\Connector\Writer\File;
 
 use PhpSpec\ObjectBehavior;
-use Pim\Component\Connector\ArrayConverter\FlatToStandard\Product\FieldSplitter;
+use Pim\Component\Connector\ArrayConverter\FieldSplitter;
 
 class DefaultColumnSorterSpec extends ObjectBehavior
 {
@@ -22,8 +22,12 @@ class DefaultColumnSorterSpec extends ObjectBehavior
         $this->shouldImplement('Pim\Component\Connector\Writer\File\ColumnSorterInterface');
     }
 
-    function it_sort_headers_columns()
+    function it_sort_headers_columns($fieldSplitter)
     {
+        $fieldSplitter->splitFieldName('code')->willReturn(['code']);
+        $fieldSplitter->splitFieldName('sort_order')->willReturn(['sort_order']);
+        $fieldSplitter->splitFieldName('label')->willReturn(['label']);
+
         $this->sort([
             'code',
             'sort_order',

--- a/src/Pim/Component/Connector/spec/Writer/File/ProductColumnSorterSpec.php
+++ b/src/Pim/Component/Connector/spec/Writer/File/ProductColumnSorterSpec.php
@@ -33,9 +33,13 @@ class ProductColumnSorterSpec extends ObjectBehavior
         $this->shouldImplement('Pim\Component\Connector\Writer\File\ColumnSorterInterface');
     }
 
-    function it_sort_headers_columns($attributeRepository)
+    function it_sort_headers_columns($attributeRepository, $fieldSplitter)
     {
         $attributeRepository->getIdentifierCode()->willReturn('sku');
+
+        $fieldSplitter->splitFieldName('sku')->willReturn(['sku']);
+        $fieldSplitter->splitFieldName('code')->willReturn(['code']);
+        $fieldSplitter->splitFieldName('label')->willReturn(['label']);
 
         $this->sort([
             'sku',


### PR DESCRIPTION
## Description

This PR adds family variant exports in both CSV and XLSX.

I needed to create a new `FamilyVariant\FieldSplitter`, as by default, column order is:
```cvs
code;label;family;variant-attributes;variant-axes
```
but we want
```cvs
code;family;label;variant-axes;variant-attributes
```

As they have no interface, I needed to create a `FieldSplitter` at the root of the `ArrayConverter` namespace so I can use it in the `DefaultColumnSorter` (and so in the basic CSV file writer), and both the  `FamilyVariant\FieldSplitter` and `Product\FieldSplitter` use it.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added Behats                      | OK
| Added integration tests           | OK
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
