### PR TITLE
Add docker install scripts for 1.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,10 @@ vendor
 composer.phar
 /cov
 bin/*
+!/bin/docker
+/bin/docker/*
+!/bin/docker/pim-initialize.sh
+!/bin/docker/pim-front.sh
 !/bin/merge-coverage
 behat.yml
 /phpspec.yml

--- a/bin/docker/pim-front.sh
+++ b/bin/docker/pim-front.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+currentDir=$(dirname "$0")
+
+echo "Clean previous assets"
+
+rm -rf ${currentDir}/../../app/cache/*
+
+echo "Install the assets"
+
+docker-compose exec akeneo app/console --env=prod pim:installer:assets --symlink

--- a/bin/docker/pim-initialize.sh
+++ b/bin/docker/pim-initialize.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+currentDir=$(dirname "$0")
+
+echo "Clean previous install"
+
+rm -rf ${currentDir}/../../app/cache/*
+rm -rf ${currentDir}/../../app/logs/*
+
+echo "Install the PIM database"
+
+docker-compose exec akeneo app/console --env=prod pim:install --force --symlink
+docker-compose exec akeneo-behat app/console --env=behat pim:installer:db


### PR DESCRIPTION
Add simple scripts to install the PIM with docker in 1.7

These scripts are simpler than those on master but at least, makes the doc simpler, as a developer using docker, on any Akeneo version, i run the same scripts (even if they internally run different things, like npm on master). If i want to move to a more advanced use, i can look at the script and manually run internal commands.

In other words, as a dev using docker, I don't want to remind subtilities between 1.7 and 1.8 installations, I'm lazy, I run the same script ;)

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
