### PR TITLE
[POC] PIM-6352: display product models in the datagrid

### DIFF
--- a/src/Pim/Bundle/DataGridBundle/Datasource/ProductDatasource.php
+++ b/src/Pim/Bundle/DataGridBundle/Datasource/ProductDatasource.php
@@ -2,11 +2,14 @@
 
 namespace Pim\Bundle\DataGridBundle\Datasource;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Persistence\ObjectManager;
 use Oro\Bundle\DataGridBundle\Datasource\ResultRecord;
 use Pim\Bundle\DataGridBundle\Extension\Pager\PagerExtension;
 use Pim\Component\Catalog\Query\ProductQueryBuilderFactoryInterface;
 use Pim\Component\Catalog\Query\ProductQueryBuilderInterface;
+use Pim\Component\Catalog\Repository\ProductModelRepositoryInterface;
+use Pim\Component\Catalog\Repository\ProductRepositoryInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
@@ -27,19 +30,31 @@ class ProductDatasource extends Datasource
     /** @var NormalizerInterface */
     protected $normalizer;
 
+    /** @var ProductRepositoryInterface */
+    private $productRepository;
+
+    /** @var ProductModelRepositoryInterface */
+    private $productModelRepository;
+
     /**
      * @param ObjectManager                       $om
      * @param ProductQueryBuilderFactoryInterface $factory
      * @param NormalizerInterface                 $normalizer
+     * @param ProductRepositoryInterface          $productRepository
+     * @param ProductModelRepositoryInterface     $productModelRepository
      */
     public function __construct(
         ObjectManager $om,
         ProductQueryBuilderFactoryInterface $factory,
-        NormalizerInterface $normalizer
+        NormalizerInterface $normalizer,
+        ProductRepositoryInterface $productRepository,
+        ProductModelRepositoryInterface $productModelRepository
     ) {
         $this->om = $om;
         $this->factory = $factory;
         $this->normalizer = $normalizer;
+        $this->productRepository = $productRepository;
+        $this->productModelRepository = $productModelRepository;
     }
 
     /**
@@ -47,7 +62,13 @@ class ProductDatasource extends Datasource
      */
     public function getResults()
     {
-        $productCursor = $this->pqb->execute();
+        // let's mock the PQB with a search (MAIN_COLOR=orange AND TSHIRT_MATERIAL=cotton)
+        // that should return one root model, one sub model and and variant product
+        $productCursor = new ArrayCollection();
+        $productCursor->add($this->productModelRepository->findOneByIdentifier('Cotton t-shirt with a round neck Divided orange'));
+        $productCursor->add($this->productModelRepository->findOneByIdentifier('T-shirt with a Kurt Cobain print motif'));
+        $productCursor->add($this->productRepository->findOneByIdentifier('T-shirt unique size orange'));
+
         $context = [
             'locales'             => [$this->getConfiguration('locale_code')],
             'channels'            => [$this->getConfiguration('scope_code')],

--- a/src/Pim/Bundle/DataGridBundle/Datasource/VariantGroupProductDatasource.php
+++ b/src/Pim/Bundle/DataGridBundle/Datasource/VariantGroupProductDatasource.php
@@ -8,6 +8,8 @@ use Pim\Component\Catalog\Model\GroupInterface;
 use Pim\Component\Catalog\Query\Filter\Operators;
 use Pim\Component\Catalog\Query\ProductQueryBuilderFactoryInterface;
 use Pim\Component\Catalog\Repository\GroupRepositoryInterface;
+use Pim\Component\Catalog\Repository\ProductModelRepositoryInterface;
+use Pim\Component\Catalog\Repository\ProductRepositoryInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
@@ -25,14 +27,18 @@ class VariantGroupProductDatasource extends ProductDatasource
      * @param ProductQueryBuilderFactoryInterface $factory
      * @param NormalizerInterface                 $normalizer
      * @param GroupRepositoryInterface            $groupRepository
+     * @param ProductRepositoryInterface          $productRepository
+     * @param ProductModelRepositoryInterface     $productModelRepository
      */
     public function __construct(
         ObjectManager $om,
         ProductQueryBuilderFactoryInterface $factory,
         NormalizerInterface $normalizer,
-        GroupRepositoryInterface $groupRepository
+        GroupRepositoryInterface $groupRepository,
+        ProductRepositoryInterface $productRepository,
+        ProductModelRepositoryInterface $productModelRepository
     ) {
-        parent::__construct($om, $factory, $normalizer);
+        parent::__construct($om, $factory, $normalizer, $productRepository, $productModelRepository);
 
         $this->groupRepository = $groupRepository;
     }

--- a/src/Pim/Bundle/DataGridBundle/Normalizer/ProductNormalizer.php
+++ b/src/Pim/Bundle/DataGridBundle/Normalizer/ProductNormalizer.php
@@ -4,6 +4,7 @@ namespace Pim\Bundle\DataGridBundle\Normalizer;
 
 use Pim\Bundle\CatalogBundle\Filter\CollectionFilterInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
+use Pim\Component\Catalog\Model\ProductModelInterface;
 use Pim\Component\Catalog\Model\ValueCollectionInterface;
 use Pim\Component\Catalog\Model\ValueInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
@@ -43,15 +44,15 @@ class ProductNormalizer extends SerializerAwareNormalizer implements NormalizerI
         $locale = current($context['locales']);
 
         $data['identifier'] = $product->getIdentifier();
-        $data['family'] = $this->getFamilyLabel($product, $locale);
-        $data['groups'] = $this->getGroupsLabels($product, $locale);
-        $data['enabled'] = (bool) $product->isEnabled();
+        $data['family'] = $product instanceof ProductInterface ? $this->getFamilyLabel($product, $locale) : '';
+        $data['groups'] = $product instanceof ProductInterface ? $this->getGroupsLabels($product, $locale) : '';
+        $data['enabled'] = $product instanceof ProductInterface ? (bool) $product->isEnabled() : false;
         $data['values'] = $this->normalizeValues($product->getValues(), $format, $context);
         $data['created'] = $this->serializer->normalize($product->getCreated(), $format, $context);
         $data['updated'] = $this->serializer->normalize($product->getUpdated(), $format, $context);
-        $data['label'] = $product->getLabel($locale);
+        $data['label'] = $product instanceof ProductInterface ? $product->getLabel($locale) : $product->getIdentifier();
         $data['image'] = $this->normalizeImage($product->getImage(), $format, $context);
-        $data['completeness'] = $this->getCompleteness($product, $context);
+        $data['completeness'] = $product instanceof ProductInterface ? $this->getCompleteness($product, $context) : '';
 
         return $data;
     }
@@ -61,7 +62,7 @@ class ProductNormalizer extends SerializerAwareNormalizer implements NormalizerI
      */
     public function supportsNormalization($data, $format = null)
     {
-        return $data instanceof ProductInterface && 'datagrid' === $format;
+        return ($data instanceof ProductInterface || $data instanceof ProductModelInterface) && 'datagrid' === $format;
     }
 
     /**

--- a/src/Pim/Bundle/DataGridBundle/Resources/config/data_sources.yml
+++ b/src/Pim/Bundle/DataGridBundle/Resources/config/data_sources.yml
@@ -119,6 +119,8 @@ services:
             - '@pim_catalog.object_manager.product'
             - '@pim_catalog.query.product_query_builder_from_size_factory'
             - '@pim_datagrid.normalizer.product'
+            - '@pim_catalog.repository.product'
+            - '@pim_catalog.repository.product_model'
         calls:
             - [ setMassActionRepository, ['@pim_catalog.repository.product_mass_action'] ]
         tags:
@@ -130,6 +132,8 @@ services:
             - '@pim_catalog.object_manager.product'
             - '@pim_catalog.query.product_query_builder_from_size_factory'
             - '@pim_datagrid.normalizer.product_association'
+            - '@pim_catalog.repository.product'
+            - '@pim_catalog.repository.product_model'
         tags:
             - { name: oro_datagrid.datasource, type: pim_datasource_associated_product }
 
@@ -139,6 +143,8 @@ services:
             - '@pim_catalog.object_manager.product'
             - '@pim_catalog.query.product_query_builder_from_size_factory'
             - '@pim_datagrid.normalizer.group_product'
+            - '@pim_catalog.repository.product'
+            - '@pim_catalog.repository.product_model'
         tags:
             - { name: oro_datagrid.datasource, type: pim_datasource_group_product }
 
@@ -149,6 +155,8 @@ services:
             - '@pim_catalog.query.product_query_builder_from_size_factory'
             - '@pim_datagrid.normalizer.group_product'
             - '@pim_catalog.repository.group'
+            - '@pim_catalog.repository.product'
+            - '@pim_catalog.repository.product_model'
         tags:
             - { name: oro_datagrid.datasource, type: pim_datasource_variant_group_product }
 

--- a/src/product_and_models.php
+++ b/src/product_and_models.php
@@ -1,0 +1,142 @@
+<?php
+
+use Pim\Component\Catalog\Model\Product;
+use Pim\Component\Catalog\Model\ProductModel;
+use Symfony\Component\HttpFoundation\Request;
+
+$loader = require_once __DIR__ . '/../app/bootstrap.php.cache';
+
+require_once __DIR__ . '/../app/AppKernel.php';
+
+$kernel = new AppKernel('prod', true);
+$kernel->boot();
+$c = $kernel->getContainer();
+
+$doctrine = $c->get('doctrine.dbal.default_connection');
+$doctrine->exec('DELETE FROM pim_catalog_product');
+$doctrine->exec('DELETE FROM pim_catalog_product_model');
+
+
+$productSaver = $c->get('pim_catalog.saver.product');
+$productUpdater = $c->get('pim_catalog.updater.product');
+$productBuilder = $c->get('pim_catalog.builder.product');
+$modelSaver = $c->get('pim_catalog.saver.product_model');
+$modelUpdater = $c->get('pim_catalog.updater.product_model');
+
+$modelDivided = new ProductModel();
+$modelDivided->setIdentifier('Cotton t-shirt with a round neck Divided');
+$modelUpdater->update(
+    $modelDivided,
+    [
+        'values' => [
+            'description' => [
+                [
+                    'locale' => 'en_US',
+                    'scope'  => 'ecommerce',
+                    'data'   => 'such a magnificient tshirt'
+                ]
+            ],
+        ]
+    ]
+);
+$modelSaver->save($modelDivided);
+
+
+$subModelDividedOrange = new ProductModel();
+$subModelDividedOrange->setIdentifier('Cotton t-shirt with a round neck Divided orange');
+$subModelDividedOrange->setParent($modelDivided);
+$modelUpdater->update(
+    $subModelDividedOrange,
+    [
+        'values' => [
+            'main_color'       => [
+                [
+                    'locale' => null,
+                    'scope'  => null,
+                    'data'   => 'orange'
+                ]
+            ],
+            'tshirt_materials' => [
+                [
+                    'locale' => null,
+                    'scope'  => null,
+                    'data'   => 'cotton'
+                ]
+            ],
+        ]
+    ]
+);
+$modelSaver->save($subModelDividedOrange);
+
+
+$modelKurt = new ProductModel();
+$modelKurt->setIdentifier('T-shirt with a Kurt Cobain print motif');
+$modelUpdater->update(
+    $modelKurt,
+    [
+        'values' => [
+            'main_color'       => [
+                [
+                    'locale' => null,
+                    'scope'  => null,
+                    'data'   => 'orange'
+                ]
+            ],
+            'tshirt_materials' => [
+                [
+                    'locale' => null,
+                    'scope'  => null,
+                    'data'   => 'cotton'
+                ]
+            ],
+        ]
+    ]
+);
+$modelSaver->save($modelKurt);
+
+
+$modelUniqueSize = new ProductModel();
+$modelUniqueSize->setIdentifier('T-shirt unique size');
+$modelUpdater->update(
+    $modelUniqueSize,
+    [
+        'values' => [
+            'clothing_size'    => [
+                [
+                    'locale' => null,
+                    'scope'  => null,
+                    'data'   => 'm'
+                ]
+            ],
+            'tshirt_materials' => [
+                [
+                    'locale' => null,
+                    'scope'  => null,
+                    'data'   => 'cotton'
+                ]
+            ],
+        ]
+    ]
+);
+$modelSaver->save($modelUniqueSize);
+
+
+$productUniqueSizeOrange = $productBuilder->createProduct('T-shirt unique size orange');
+$productUniqueSizeOrange->setProductModel($modelUniqueSize);
+$productUpdater->update(
+    $productUniqueSizeOrange,
+    [
+        'values' => [
+            'main_color' => [
+                [
+                    'locale' => null,
+                    'scope'  => null,
+                    'data'   => 'orange'
+                ]
+            ],
+        ]
+    ]
+);
+$productSaver->save($productUniqueSizeOrange);
+
+echo "DONE!!!!!!";


### PR DESCRIPTION
Install the PIM with `icecat_demo_dev` catalog.

Then launch `php src/product_and_models.php` to have the fixtures. The search that is mocked in the datagrid is related to the tab `Cotton Red` of https://docs.google.com/spreadsheets/d/1KY0CrlYKMxPvhxj-pQAU8awmkBlV9IW2M4AOnYYgK5o/edit#gid=1683059866. 

Instead of `Red`, the color `Orange` used is (red is not present in icecat) #