### PR TITLE
PIM-6338: Simply display a root product model in the PEF

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Resources/config/serializers_standard.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/serializers_standard.yml
@@ -1,5 +1,6 @@
 parameters:
     pim_catalog.normalizer.standard.product.class: Pim\Component\Catalog\Normalizer\Standard\ProductNormalizer
+    pim_catalog.normalizer.standard.product_model.class: Pim\Component\Catalog\Normalizer\Standard\ProductModelNormalizer
     pim_catalog.normalizer.standard.product.properties.class: Pim\Component\Catalog\Normalizer\Standard\Product\PropertiesNormalizer
     pim_catalog.normalizer.standard.product.associations.class: Pim\Component\Catalog\Normalizer\Standard\Product\AssociationsNormalizer
     pim_catalog.normalizer.standard.product.product_values.class: Pim\Component\Catalog\Normalizer\Standard\Product\ProductValuesNormalizer
@@ -28,6 +29,14 @@ parameters:
 services:
     pim_catalog.normalizer.standard.product:
         class: '%pim_catalog.normalizer.standard.product.class%'
+        arguments:
+            - '@pim_catalog.normalizer.standard.product.properties'
+            - '@pim_catalog.normalizer.standard.product.associations'
+        tags:
+            - { name: pim_serializer.normalizer, priority: 90 }
+
+    pim_catalog.normalizer.standard.product_model:
+        class: '%pim_catalog.normalizer.standard.product_model.class%'
         arguments:
             - '@pim_catalog.normalizer.standard.product.properties'
             - '@pim_catalog.normalizer.standard.product.associations'

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/ProductModelController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/ProductModelController.php
@@ -1,0 +1,82 @@
+<?php
+declare(strict_types=1);
+
+namespace Pim\Bundle\EnrichBundle\Controller\Rest;
+
+use Pim\Bundle\CatalogBundle\Filter\ObjectFilterInterface;
+use Pim\Bundle\UserBundle\Context\UserContext;
+use Pim\Component\Catalog\Model\ProductModelInterface;
+use Pim\Component\Catalog\Repository\ProductModelRepositoryInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * @author    Adrien Pétremann <adrien.petremann@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class ProductModelController
+{
+    /** @var NormalizerInterface */
+    protected $productModelNormalizer;
+
+    /** @var UserContext */
+    protected $userContext;
+
+    /** @var ObjectFilterInterface */
+    protected $objectFilter;
+
+    /** @var ProductModelRepositoryInterface */
+    protected $productModelRepository;
+
+    /**
+     * @param ProductModelRepositoryInterface $productModelRepository
+     * @param NormalizerInterface             $productModelNormalizer
+     * @param UserContext                     $userContext
+     * @param ObjectFilterInterface           $objectFilter
+     */
+    public function __construct(
+        ProductModelRepositoryInterface $productModelRepository,
+        NormalizerInterface $productModelNormalizer,
+        UserContext $userContext,
+        ObjectFilterInterface $objectFilter
+    ) {
+        $this->productModelRepository = $productModelRepository;
+        $this->productModelNormalizer = $productModelNormalizer;
+        $this->userContext            = $userContext;
+        $this->objectFilter           = $objectFilter;
+    }
+
+    /**
+     * @param int $id Product model id
+     *
+     * @throws NotFoundHttpException If product model is not found or the user cannot see it
+     *
+     * @return JsonResponse
+     */
+    public function getAction(int $id): JsonResponse
+    {
+        $productModel = $this->productModelRepository->find($id);
+        $cantView = $this->objectFilter->filterObject($productModel, 'pim.internal_api.product.view');
+
+        if (null === $productModel || true === $cantView) {
+            throw new NotFoundHttpException(
+                sprintf('Product model with id %s could not be found.', $id)
+            );
+        }
+
+        $normalizationContext = $this->userContext->toArray() + [
+            'filter_types'               => ['pim.internal_api.product_value.view'],
+            'disable_grouping_separator' => true
+        ];
+
+        $normalizedProductModel = $this->productModelNormalizer->normalize(
+            $productModel,
+            'internal_api',
+            $normalizationContext
+        );
+
+        return new JsonResponse($normalizedProductModel);
+    }
+}

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/ProductModelNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/ProductModelNormalizer.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Pim\Bundle\EnrichBundle\Normalizer;
+
+use Pim\Bundle\EnrichBundle\Provider\Form\FormProviderInterface;
+use Pim\Bundle\VersioningBundle\Manager\VersionManager;
+use Pim\Component\Catalog\Localization\Localizer\AttributeConverterInterface;
+use Pim\Component\Catalog\Model\ProductModelInterface;
+use Pim\Component\Enrich\Converter\ConverterInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\scalar;
+
+/**
+ * @author    Adrien Pétremann <adrien.petremann@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class ProductModelNormalizer implements NormalizerInterface
+{
+    /** @var string[] */
+    private $supportedFormat = ['internal_api'];
+
+    /** @var NormalizerInterface */
+    private $normalizer;
+
+    /** @var NormalizerInterface */
+    private $versionNormalizer;
+
+    /** @var VersionManager */
+    private $versionManager;
+
+    /** @var AttributeConverterInterface */
+    private $localizedConverter;
+
+    /** @var ConverterInterface */
+    private $productValueConverter;
+
+    /** @var FormProviderInterface */
+    private $formProvider;
+
+    /**
+     * @param NormalizerInterface         $normalizer
+     * @param NormalizerInterface         $versionNormalizer
+     * @param VersionManager              $versionManager
+     * @param AttributeConverterInterface $localizedConverter
+     * @param ConverterInterface          $productValueConverter
+     * @param FormProviderInterface       $formProvider
+     */
+    public function __construct(
+        NormalizerInterface $normalizer,
+        NormalizerInterface $versionNormalizer,
+        VersionManager $versionManager,
+        AttributeConverterInterface $localizedConverter,
+        ConverterInterface $productValueConverter,
+        FormProviderInterface $formProvider
+    ) {
+        $this->normalizer            = $normalizer;
+        $this->versionManager        = $versionManager;
+        $this->localizedConverter    = $localizedConverter;
+        $this->productValueConverter = $productValueConverter;
+        $this->formProvider          = $formProvider;
+        $this->versionNormalizer     = $versionNormalizer;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function normalize($productModel, $format = null, array $context = []): array
+    {
+        $normalizedProductModel = $this->normalizer->normalize($productModel, 'standard', $context);
+        $normalizedProductModel['values'] = $this->localizedConverter->convertToLocalizedFormats(
+            $normalizedProductModel['values'],
+            $context
+        );
+
+        $normalizedProductModel['family'] = $productModel->getFamilyVariant()->getFamily()->getCode();
+        $normalizedProductModel['values'] = $this->productValueConverter->convert($normalizedProductModel['values']);
+
+        $oldestLog = $this->versionManager->getOldestLogEntry($productModel);
+        $newestLog = $this->versionManager->getNewestLogEntry($productModel);
+
+        $created = null !== $oldestLog ? $this->versionNormalizer->normalize($oldestLog, 'internal_api') : null;
+        $updated = null !== $newestLog ? $this->versionNormalizer->normalize($newestLog, 'internal_api') : null;
+
+        $normalizedFamilyVariant = $this->normalizer->normalize($productModel->getFamilyVariant(), 'standard');
+
+        $normalizedProductModel['meta'] = [
+                'family_variant' => $normalizedFamilyVariant,
+                'form'           => $this->formProvider->getForm($productModel),
+                'id'             => $productModel->getId(),
+                'created'        => $created,
+                'updated'        => $updated,
+                'model_type'     => 'product_model'
+            ] + $this->getLabels($productModel);
+
+        return $normalizedProductModel;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsNormalization($data, $format = null)
+    {
+        return $data instanceof ProductModelInterface && in_array($format, $this->supportedFormat);
+    }
+
+    /**
+     * @param ProductModelInterface $productModel
+     *
+     * @return array
+     */
+    private function getLabels(ProductModelInterface $productModel): array
+    {
+        // TODO: in PIM-6669, we'll have to handle labels coming from parent(s)
+
+        return ['label' => ['en_US' => $productModel->getIdentifier()]];
+    }
+}

--- a/src/Pim/Bundle/EnrichBundle/Provider/Form/AttributeFormProvider.php
+++ b/src/Pim/Bundle/EnrichBundle/Provider/Form/AttributeFormProvider.php
@@ -25,7 +25,7 @@ class AttributeFormProvider implements FormProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function getForm($attribute)
+    public function getForm($attribute): string
     {
         return $this->formConfig[$attribute->getType()];
     }
@@ -33,7 +33,7 @@ class AttributeFormProvider implements FormProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function supports($element)
+    public function supports($element): bool
     {
         return $element instanceof AttributeInterface && isset($this->formConfig[$element->getType()]);
     }

--- a/src/Pim/Bundle/EnrichBundle/Provider/Form/FormChainedProvider.php
+++ b/src/Pim/Bundle/EnrichBundle/Provider/Form/FormChainedProvider.php
@@ -17,7 +17,7 @@ class FormChainedProvider implements FormProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function getForm($element)
+    public function getForm($element): string
     {
         foreach ($this->providers as $provider) {
             if ($provider->supports($element)) {
@@ -31,7 +31,7 @@ class FormChainedProvider implements FormProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function supports($element)
+    public function supports($element): bool
     {
         foreach ($this->providers as $provider) {
             if ($provider->supports($element)) {
@@ -47,7 +47,7 @@ class FormChainedProvider implements FormProviderInterface
      *
      * @param FormProviderInterface $provider
      */
-    public function addProvider(FormProviderInterface $provider)
+    public function addProvider(FormProviderInterface $provider): void
     {
         $this->providers[] = $provider;
     }

--- a/src/Pim/Bundle/EnrichBundle/Provider/Form/FormProviderInterface.php
+++ b/src/Pim/Bundle/EnrichBundle/Provider/Form/FormProviderInterface.php
@@ -21,7 +21,7 @@ interface FormProviderInterface
      *
      * @return string
      */
-    public function getForm($element);
+    public function getForm($element): string;
 
     /**
      * Does the Form provider support the element
@@ -30,5 +30,5 @@ interface FormProviderInterface
      *
      * @return bool
      */
-    public function supports($element);
+    public function supports($element): bool;
 }

--- a/src/Pim/Bundle/EnrichBundle/Provider/Form/JobInstanceFormProvider.php
+++ b/src/Pim/Bundle/EnrichBundle/Provider/Form/JobInstanceFormProvider.php
@@ -27,7 +27,7 @@ class JobInstanceFormProvider implements FormProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function getForm($jobInstance)
+    public function getForm($jobInstance): string
     {
         return $this->formConfig[$jobInstance->getJobName()];
     }
@@ -35,7 +35,7 @@ class JobInstanceFormProvider implements FormProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function supports($element)
+    public function supports($element): bool
     {
         return $element instanceof JobInstance && isset($this->formConfig[$element->getJobName()]);
     }

--- a/src/Pim/Bundle/EnrichBundle/Provider/Form/ProductFormProvider.php
+++ b/src/Pim/Bundle/EnrichBundle/Provider/Form/ProductFormProvider.php
@@ -16,7 +16,7 @@ class ProductFormProvider implements FormProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function getForm($product)
+    public function getForm($product): string
     {
         return 'pim-product-edit-form';
     }
@@ -24,7 +24,7 @@ class ProductFormProvider implements FormProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function supports($element)
+    public function supports($element): bool
     {
         return $element instanceof ProductInterface;
     }

--- a/src/Pim/Bundle/EnrichBundle/Provider/Form/ProductModelFormProvider.php
+++ b/src/Pim/Bundle/EnrichBundle/Provider/Form/ProductModelFormProvider.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Pim\Bundle\EnrichBundle\Provider\Form;
+
+use Pim\Component\Catalog\Model\ProductModelInterface;
+
+/**
+ * Form provider for product model
+ *
+ * @author    Adrien Pétremann <adrien.petremann@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class ProductModelFormProvider implements FormProviderInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getForm($productModel): string
+    {
+        return 'pim-product-model-edit-form';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports($element): bool
+    {
+        return $element instanceof ProductModelInterface;
+    }
+}

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/controllers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/controllers.yml
@@ -25,6 +25,7 @@ parameters:
     pim_enrich.controller.rest.measures.class:                Pim\Bundle\EnrichBundle\Controller\Rest\MeasuresController
     pim_enrich.controller.rest.media.class:                   Pim\Bundle\EnrichBundle\Controller\Rest\MediaController
     pim_enrich.controller.rest.product.class:                 Pim\Bundle\EnrichBundle\Controller\Rest\ProductController
+    pim_enrich.controller.rest.product_model.class:           Pim\Bundle\EnrichBundle\Controller\Rest\ProductModelController
     pim_enrich.controller.rest.product_category.class:        Pim\Bundle\EnrichBundle\Controller\Rest\ProductCategoryController
     pim_enrich.controller.rest.product_comment.class:         Pim\Bundle\EnrichBundle\Controller\Rest\ProductCommentController
     pim_enrich.controller.rest.variant_group.class:           Pim\Bundle\EnrichBundle\Controller\Rest\VariantGroupController
@@ -340,6 +341,14 @@ services:
             - '@pim_catalog.comparator.filter.product'
             - '@pim_enrich.converter.enrich_to_standard.product_value'
             - '@pim_enrich.normalizer.product_violation'
+
+    pim_enrich.controller.rest.product_model:
+        class: '%pim_enrich.controller.rest.product_model.class%'
+        arguments:
+            - '@pim_catalog.repository.product_model'
+            - '@pim_internal_api_serializer'
+            - '@pim_user.context.user'
+            - '@pim_catalog.filter.chained'
 
     pim_enrich.controller.rest.product_category:
         class: '%pim_enrich.controller.rest.product_category.class%'

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_model/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_model/edit.yml
@@ -1,0 +1,222 @@
+extensions:
+    pim-product-model-edit-form:
+        module: pim/form/common/edit-form
+
+    pim-product-model-edit-form-breadcrumbs:
+        module: pim/common/breadcrumbs
+        parent: pim-product-model-edit-form
+        targetZone: breadcrumbs
+        config:
+            tab: pim-menu-products
+
+    pim-product-model-edit-form-main-image:
+        module: pim/form/common/main-image
+        parent: pim-product-model-edit-form
+        targetZone: main-image
+
+    pim-product-model-edit-form-cache-invalidator:
+        module: pim/cache-invalidator
+        parent: pim-product-model-edit-form
+        position: 1000
+
+    pim-product-model-edit-form-sequential-edit:
+        module: pim/product-edit-form/sequential-edit
+        parent: pim-product-model-edit-form
+        targetZone: sequential
+        aclResourceId: pim_enrich_product_edit_attributes
+        position: 100
+
+    pim-product-model-edit-form-left-column:
+        module: pim/form/common/column
+        parent: pim-product-model-edit-form
+        position: 5
+        targetZone: column
+        config:
+          stateCode: product_edit_form
+          navigationTitle: pim_enrich.entity.product.navigation
+
+    pim-product-model-edit-form-column-tabs-navigation:
+        module: pim/form/common/column-tabs-navigation
+        parent: pim-product-model-edit-form-left-column
+        targetZone: navigation
+        position: 10
+        config:
+          title: pim_enrich.entity.product.navigation
+
+    pim-product-model-edit-form-meta:
+        module: pim/form/common/meta
+        parent: pim-product-model-edit-form-left-column
+        targetZone: bottom
+        position: 10
+        config:
+            label: pim_enrich.entity.product.infos
+
+    pim-product-model-edit-form-column-tabs:
+        module: pim/form/common/column-tabs
+        parent: pim-product-model-edit-form
+        targetZone: content
+        position: 100
+
+    pim-product-edit-form-product-model-label:
+        module: pim/product-edit-form/product-model-label
+        parent: pim-product-model-edit-form
+        targetZone: title
+        position: 100
+
+    pim-product-model-edit-form-secondary-actions:
+        module: pim/form/common/secondary-actions
+        parent: pim-product-model-edit-form
+        targetZone: buttons
+        position: 50
+
+    pim-product-model-edit-form-delete:
+        module: pim/product-edit-form/delete
+        parent: pim-product-model-edit-form-secondary-actions
+        targetZone: secondary-actions
+        aclResourceId: pim_enrich_product_remove
+        position: 100
+        config:
+            trans:
+                title: confirmation.remove.product
+                content: pim_enrich.confirmation.delete_item
+                success: pim_enrich.entity.product.info.deletion_successful
+                fail: pim_enrich.entity.product.info.deletion_failed
+            redirect: pim_enrich_product_index
+
+    pim-product-model-edit-form-save-buttons:
+        module: pim/form/common/save-buttons
+        parent: pim-product-model-edit-form
+        targetZone: buttons
+        position: 120
+
+    pim-product-model-edit-form-save:
+        module: pim/product-edit-form/save
+        parent: pim-product-model-edit-form
+        targetZone: buttons
+        position: 0
+
+    pim-product-model-edit-form-state:
+        module: pim/form/common/state
+        parent: pim-product-model-edit-form
+        targetZone: state
+        position: 900
+        config:
+            entity: pim_enrich.entity.product.title
+
+    pim-product-model-edit-form-family:
+        module: pim/product-edit-form/meta/family
+        parent: pim-product-model-edit-form-meta
+        targetZone: meta
+        position: 70
+
+    pim-product-model-edit-form-family-variant:
+        module: pim/product-edit-form/meta/family-variant
+        parent: pim-product-model-edit-form-meta
+        targetZone: meta
+        position: 80
+
+    pim-product-model-edit-form-created:
+        module: pim/product-edit-form/meta/created
+        parent: pim-product-model-edit-form-meta
+        targetZone: meta
+        position: 90
+        config:
+            label: pim_enrich.entity.product.meta.created
+            labelBy: pim_enrich.entity.product.meta.created_by
+
+    pim-product-model-edit-form-updated:
+        module: pim/product-edit-form/meta/updated
+        parent: pim-product-model-edit-form-meta
+        targetZone: meta
+        position: 100
+        config:
+            label: pim_enrich.entity.product.meta.updated
+            labelBy: pim_enrich.entity.product.meta.updated_by
+
+    pim-product-model-edit-form-attributes:
+        module: pim/product-edit-form/attributes
+        parent: pim-product-model-edit-form-column-tabs
+        targetZone: container
+        aclResourceId: pim_enrich_product_edit_attributes
+        position: 90
+        config:
+            removeAttributeRoute: pim_enrich_product_remove_attribute_rest
+            removeAttributeACL: pim_enrich_product_remove_attribute
+            tabTitle: pim_enrich.form.product.tab.attributes.title
+            deletionFailed: pim_enrich.form.product.flash.attribute_deletion_error
+
+    pim-product-model-edit-form-categories:
+        module: pim/product-edit-form/categories
+        parent: pim-product-model-edit-form-column-tabs
+        targetZone: container
+        aclResourceId: pim_enrich_product_categories_view
+        position: 100
+
+    pim-product-model-edit-form-attribute-group-selector:
+        module: pim/form/common/attributes/attribute-group-selector
+        parent: pim-product-model-edit-form-attributes
+        targetZone: attribute-group-selector
+        position: 100
+
+    pim-product-model-edit-form-copy:
+        module: pim/form/common/attributes/copy
+        parent: pim-product-model-edit-form-attributes
+        targetZone: header
+        position: 100
+
+    pim-product-model-edit-form-attribute-scope-switcher:
+        module: pim/product-edit-form/scope-switcher
+        parent: pim-product-model-edit-form
+        targetZone: context
+        position: 100
+        config:
+            context: base_product
+
+    pim-product-model-edit-form-attribute-locale-switcher:
+        module: pim/product-edit-form/locale-switcher
+        parent: pim-product-model-edit-form
+        targetZone: context
+        position: 110
+        config:
+            context: base_product
+
+    pim-product-model-edit-form-validation:
+        module: pim/product-edit-form/attributes/validation
+        parent: pim-product-model-edit-form-attributes
+        targetZone: header
+        position: 100
+
+    pim-product-model-edit-form-locale-specific:
+        module: pim/product-edit-form/attributes/locale-specific
+        parent: pim-product-model-edit-form-attributes
+        targetZone: self
+        position: 100
+
+    pim-product-model-edit-form-localizable:
+        module: pim/product-edit-form/attributes/localizable
+        parent: pim-product-model-edit-form-attributes
+        targetZone: self
+        position: 90
+
+    pim-product-model-edit-form-history:
+        module: pim/product-edit-form/history
+        parent: pim-product-model-edit-form-column-tabs
+        targetZone: container
+        aclResourceId: pim_enrich_product_history
+        position: 140
+
+    pim-product-model-edit-form-copy-scope-switcher:
+        module: pim/product-edit-form/scope-switcher
+        parent: pim-product-model-edit-form-copy
+        targetZone: context-selectors
+        position: 100
+        config:
+            context: copy_product
+
+    pim-product-model-edit-form-copy-locale-switcher:
+        module: pim/product-edit-form/locale-switcher
+        parent: pim-product-model-edit-form-copy
+        targetZone: context-selectors
+        position: 110
+        config:
+            context: copy_product

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/normalizers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/normalizers.yml
@@ -3,6 +3,7 @@ parameters:
     pim_enrich.normalizer.attribute_option.class:                  Pim\Bundle\EnrichBundle\Normalizer\AttributeOptionNormalizer
     pim_enrich.normalizer.attribute_option_value.class:            Pim\Bundle\EnrichBundle\Normalizer\AttributeOptionValueNormalizer
     pim_enrich.normalizer.product.class:                           Pim\Bundle\EnrichBundle\Normalizer\ProductNormalizer
+    pim_enrich.normalizer.product_model.class:                     Pim\Bundle\EnrichBundle\Normalizer\ProductModelNormalizer
     pim_enrich.normalizer.completeness.class:                      Pim\Bundle\EnrichBundle\Normalizer\CompletenessNormalizer
     pim_enrich.normalizer.completeness_collection.class:           Pim\Bundle\EnrichBundle\Normalizer\CompletenessCollectionNormalizer
     pim_enrich.normalizer.version.class:                           Pim\Bundle\EnrichBundle\Normalizer\VersionNormalizer
@@ -62,6 +63,18 @@ services:
             - '@pim_user.context.user'
             - '@pim_catalog.completeness.calculator'
             - '@pim_enrich.normalizer.file'
+        tags:
+            - { name: pim_internal_api_serializer.normalizer }
+
+    pim_enrich.normalizer.product_model:
+        class: '%pim_enrich.normalizer.product_model.class%'
+        arguments:
+            - '@pim_serializer'
+            - '@pim_enrich.normalizer.version'
+            - '@pim_versioning.manager.version'
+            - '@pim_catalog.localization.localizer.converter'
+            - '@pim_enrich.converter.standard_to_enrich.product_value'
+            - '@pim_enrich.provider.form.product_model'
         tags:
             - { name: pim_internal_api_serializer.normalizer }
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/providers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/providers.yml
@@ -9,6 +9,7 @@ parameters:
     pim_enrich.provider.empty_value.base.class:    Pim\Bundle\EnrichBundle\Provider\EmptyValue\BaseEmptyValueProvider
     pim_enrich.provider.form.chained.class:        Pim\Bundle\EnrichBundle\Provider\Form\FormChainedProvider
     pim_enrich.provider.form.product.class:        Pim\Bundle\EnrichBundle\Provider\Form\ProductFormProvider
+    pim_enrich.provider.form.product_model.class:  Pim\Bundle\EnrichBundle\Provider\Form\ProductModelFormProvider
     pim_enrich.provider.form.job_instance.class:   Pim\Bundle\EnrichBundle\Provider\Form\JobInstanceFormProvider
     pim_enrich.provider.form.attribute.class:      Pim\Bundle\EnrichBundle\Provider\Form\AttributeFormProvider
     pim_enrich.provider.structure_version.class:   Pim\Bundle\EnrichBundle\Provider\StructureVersion\StructureVersionProvider
@@ -56,6 +57,11 @@ services:
 
     pim_enrich.provider.form.product:
         class: '%pim_enrich.provider.form.product.class%'
+        tags:
+            - { name: pim_enrich.provider.form, priority: 100 }
+
+    pim_enrich.provider.form.product_model:
+        class: '%pim_enrich.provider.form.product_model.class%'
         tags:
             - { name: pim_enrich.provider.form, priority: 100 }
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
@@ -178,6 +178,11 @@ config:
                     options:
                         urls:
                             get: pim_enrich_product_rest_get
+                product_model:
+                    module: pim/product-fetcher
+                    options:
+                        urls:
+                            get: pim_enrich_product_model_rest_get
                 category:
                     module: pim/base-fetcher
                     options:
@@ -263,7 +268,13 @@ config:
                     module: pim/controller/group-type
                     aclResourceId: pim_enrich_grouptype_edit
                 pim_enrich_product_edit:
-                    module: pim/controller/product
+                    module: pim/controller/entity-with-family-variant
+                    config:
+                        entity: product
+                pim_enrich_product_model_edit:
+                    module: pim/controller/entity-with-family-variant
+                    config:
+                        entity: product_model
                 pim_enrich_group_edit:
                     module: pim/controller/group
                     aclResourceId: pim_enrich_group_edit
@@ -499,7 +510,7 @@ config:
         pim/controller/base:                   pimenrich/js/controller/base
         pim/controller/template:               pimenrich/js/controller/template
         pim/controller/form:                   pimenrich/js/controller/form
-        pim/controller/product:                pimenrich/js/controller/product
+        pim/controller/entity-with-family-variant: pimenrich/js/controller/entity-with-family-variant
         pim/controller/family:                 pimenrich/js/controller/family
         pim/controller/channel/edit:           pimenrich/js/controller/channel/edit
         pim/controller/common/index:           pimenrich/js/controller/common/index
@@ -649,6 +660,7 @@ config:
 
         # Product
         pim/product-edit-form/product-label:               pimenrich/js/product/form/product-label
+        pim/product-edit-form/product-model-label:         pimenrich/js/product/form/product-model-label
         pim/product-edit-form/product-completeness:        pimenrich/js/product/form/product-completeness
         pim/product-edit-form/attributes/validation:       pimenrich/js/product/form/attributes/validation
         pim/product-edit-form/attributes/validation-error: pimenrich/js/product/form/attributes/validation-error
@@ -668,6 +680,7 @@ config:
         pim/product-edit-form/sequential-edit:             pimenrich/js/product/form/sequential-edit
         pim/product-edit-form/delete:                      pimenrich/js/product/form/delete
         pim/product-edit-form/meta/family:                 pimenrich/js/product/form/meta/family
+        pim/product-edit-form/meta/family-variant:         pimenrich/js/product/form/meta/family-variant
         pim/product-edit-form/meta/change-family:          pimenrich/js/product/form/meta/change-family
         pim/product-edit-form/meta/created:                pimenrich/js/product/form/meta/created
         pim/product-edit-form/meta/updated:                pimenrich/js/product/form/meta/updated
@@ -971,6 +984,7 @@ config:
         pim/template/product/download-pdf:                   pimenrich/templates/product/download-pdf.html
         pim/template/product/meta/status-switcher:           pimenrich/templates/product/meta/status-switcher.html
         pim/template/product/meta/family:                    pimenrich/templates/product/meta/family.html
+        pim/template/product/meta/family-variant:            pimenrich/templates/product/meta/family-variant.html
         pim/template/product/meta/change-family-modal:       pimenrich/templates/product/meta/change-family-modal.html
         pim/template/product/meta/groups:                    pimenrich/templates/product/meta/groups.html
         pim/template/product/meta/group-modal:               pimenrich/templates/product/meta/group-modal.html

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/routing.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/routing.yml
@@ -58,6 +58,10 @@ product:
     resource: '@PimEnrichBundle/Resources/config/routing/product.yml'
     prefix: /enrich/product
 
+product_model:
+    resource: '@PimEnrichBundle/Resources/config/routing/product_model.yml'
+    prefix: /enrich/product-model
+
 mass_edit_action:
     resource: '@PimEnrichBundle/Resources/config/routing/mass_edit_action.yml'
     prefix: /enrich/mass-edit-action

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/routing/product_model.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/routing/product_model.yml
@@ -1,0 +1,24 @@
+pim_enrich_product_model_edit:
+    path: /{id}
+    methods: [GET, POST]
+
+pim_enrich_product_model_rest_get:
+    path: /rest/{id}
+    defaults: { _controller: pim_enrich.controller.rest.product_model:getAction }
+    requirements:
+        id: '[0-9a-f]+'
+    methods: [GET]
+
+pim_enrich_product_model_category_rest_list:
+    path: /rest/{id}/categories
+    defaults: { _controller: pim_enrich.controller.rest.product_category:listAction }
+    requirements:
+        id: '[0-9a-f]+'
+    methods: [GET]
+
+pim_enrich_product_model_history_rest_get:
+    path: /rest/{entityId}/history
+    defaults: { _controller: pim_enrich.controller.rest.versioning:getAction, entityType: product }
+    requirements:
+        entityId: '[0-9a-f]+'
+    methods: [GET]

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/controller/entity-with-family-variant.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/controller/entity-with-family-variant.js
@@ -18,7 +18,7 @@ define(
              * {@inheritdoc}
              */
             renderRoute: function (route) {
-                return FetcherRegistry.getFetcher('product').fetch(route.params.id, {cached: false})
+                return FetcherRegistry.getFetcher(this.options.config.entity).fetch(route.params.id, {cached: false})
                     .then(function (product) {
                         if (!this.active) {
                             return;

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/meta/family-variant.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/meta/family-variant.js
@@ -1,0 +1,78 @@
+'use strict';
+/**
+ * Meta extension to display family variant label
+ *
+ * @author    Adrien Petremann <adrien.petremann@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+define(
+    [
+        'jquery',
+        'underscore',
+        'oro/translator',
+        'oro/mediator',
+        'pim/form',
+        'pim/template/product/meta/family-variant',
+        'pim/fetcher-registry',
+        'pim/user-context',
+        'pim/i18n'
+    ],
+    function (
+        $,
+        _,
+        __,
+        mediator,
+        BaseForm,
+        template,
+        FetcherRegistry,
+        UserContext,
+        i18n
+    ) {
+        return BaseForm.extend({
+            className: 'AknColumn-block',
+
+            template: _.template(template),
+
+            /**
+             * {@inheritdoc}
+             */
+            configure: function () {
+                UserContext.off('change:catalogLocale change:catalogScope', this.render);
+                this.listenTo(UserContext, 'change:catalogLocale change:catalogScope', this.render);
+
+                return BaseForm.prototype.configure.apply(this, arguments);
+            },
+
+            /**
+             * {@inheritdoc}
+             */
+            render: function () {
+                if (!this.configured) {
+                    return this;
+                }
+
+                var productModel = this.getFormData();
+                var familyVariant = productModel.meta.family_variant;
+                var label = __('pim_enrich.entity.product.meta.family_variant.none');
+
+                if (familyVariant) {
+                    label = i18n.getLabel(
+                        familyVariant.labels,
+                        UserContext.get('catalogLocale'),
+                        productModel.family_variant
+                    );
+                }
+
+                this.$el.html(
+                    this.template({
+                        title: __('pim_enrich.entity.product.meta.family_variant.title'),
+                        familyVariantLabel: label
+                    })
+                );
+
+                BaseForm.prototype.render.apply(this, arguments);
+            }
+        });
+    }
+);

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/product-model-label.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/product-model-label.js
@@ -1,0 +1,28 @@
+'use strict';
+/**
+ * Product model label extension
+ *
+ * @author    Adrien Pétremann <adrien.petremann@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+define(
+    ['pim/form/common/label', 'pim/user-context'],
+    function (Label, UserContext) {
+        return Label.extend({
+            /**
+             * Provide the object label
+             * @return {String}
+             */
+            getLabel: function () {
+                var meta = this.getFormData().meta;
+
+                if (meta && meta.label) {
+                    return meta.label[UserContext.get('catalogLocale')];
+                }
+
+                return this.getFormData().identifier;
+            }
+        });
+    }
+);

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/meta/family-variant.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/meta/family-variant.html
@@ -1,0 +1,2 @@
+<div class="AknColumn-subtitle"><%- title %></div>
+<div class="AknColumn-value product-family"><%- familyVariantLabel %></div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
@@ -196,6 +196,9 @@ pim_enrich:
                 family:
                     title: Family
                     none: None
+                family_variant:
+                    title: Variant
+                    none: None
                 groups:
                     title: Groups
                     modal:

--- a/src/Pim/Bundle/EnrichBundle/spec/Normalizer/ProductModelNormalizerSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Normalizer/ProductModelNormalizerSpec.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace spec\Pim\Bundle\EnrichBundle\Normalizer;
+
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\EnrichBundle\Provider\Form\FormProviderInterface;
+use Pim\Bundle\VersioningBundle\Manager\VersionManager;
+use Pim\Component\Catalog\Localization\Localizer\AttributeConverterInterface;
+use Pim\Component\Catalog\Model\FamilyInterface;
+use Pim\Component\Catalog\Model\FamilyVariantInterface;
+use Pim\Component\Catalog\Model\ProductModelInterface;
+use Pim\Component\Enrich\Converter\ConverterInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+class ProductModelNormalizerSpec extends ObjectBehavior
+{
+    function let(
+        NormalizerInterface $normalizer,
+        NormalizerInterface $versionNormalizer,
+        VersionManager $versionManager,
+        AttributeConverterInterface $localizedConverter,
+        ConverterInterface $productValueConverter,
+        FormProviderInterface $formProvider
+    ) {
+        $this->beConstructedWith(
+            $normalizer,
+            $versionNormalizer,
+            $versionManager,
+            $localizedConverter,
+            $productValueConverter,
+            $formProvider
+        );
+    }
+
+    function it_supports_product_models(ProductModelInterface $productModel)
+    {
+        $this->supportsNormalization($productModel, 'internal_api')->shouldReturn(true);
+    }
+
+    function it_normalize_products(
+        $normalizer,
+        $versionNormalizer,
+        $versionManager,
+        $localizedConverter,
+        $productValueConverter,
+        $formProvider,
+        ProductModelInterface $productModel,
+        FamilyVariantInterface $familyVariant,
+        FamilyInterface $family
+    ) {
+        $options = [
+            'decimal_separator' => ',',
+            'date_format'       => 'dd/MM/yyyy',
+        ];
+
+        $productModelNormalized = [
+            'identifier'     => 'tshirt_blue',
+            'family_variant' => 'tshirts_color',
+            'family'         => 'tshirts',
+            'categories'     => ['summer'],
+            'values'         => [
+                'normalized_property' => [['data' => 'a nice normalized property', 'locale' => null, 'scope' => null]],
+                'number'              => [['data' => 12.5000, 'locale' => null, 'scope' => null]],
+                'metric'              => [['data' => 12.5000, 'locale' => null, 'scope' => null]],
+                'prices'              => [['data' => 12.5, 'locale' => null, 'scope' => null]],
+                'date'                => [['data' => '2015-01-31', 'locale' => null, 'scope' => null]],
+                'picture'             => [['data' => 'a/b/c/my_picture.jpg', 'locale' => null, 'scope' => null]]
+            ]
+        ];
+
+        $familyVariantNormalized = [
+            'code'                   => 'tshirts_color',
+            'labels'                 => ['en_US' => 'Tshirts Color', 'fr_FR' => 'Tshirt Couleur'],
+            'family'                 => 'tshirts',
+            'variant_attribute_sets' => []
+        ];
+
+        $valuesLocalized = [
+            'normalized_property' => [['data' => 'a nice normalized property', 'locale' => null, 'scope' => null]],
+            'number'              => [['data' => '12,5000', 'locale' => null, 'scope' => null]],
+            'metric'              => [['data' => '12,5000', 'locale' => null, 'scope' => null]],
+            'prices'              => [['data' => '12,5', 'locale' => null, 'scope' => null]],
+            'date'                => [['data' => '31/01/2015', 'locale' => null, 'scope' => null]],
+            'picture'             => [['data' => 'a/b/c/my_picture.jpg', 'locale' => null, 'scope' => null]]
+        ];
+
+        $normalizer->normalize($productModel, 'standard', $options)->willReturn($productModelNormalized);
+        $localizedConverter->convertToLocalizedFormats($productModelNormalized['values'], $options)->willReturn($valuesLocalized);
+
+        $valuesConverted = $valuesLocalized;
+        $valuesConverted['picture'] = [
+            [
+                'data' => [
+                    'filePath' => 'a/b/c/my_picture.jpg', 'originalFilename' => 'my_picture.jpg'
+                ],
+                'locale' => null,
+                'scope' => null
+            ]
+        ];
+
+        $productValueConverter->convert($valuesLocalized)->willReturn($valuesConverted);
+
+        $productModel->getId()->willReturn(12);
+        $productModel->getIdentifier()->willReturn('tshirt_blue');
+        $versionManager->getOldestLogEntry($productModel)->willReturn('create_version');
+        $versionNormalizer->normalize('create_version', 'internal_api')->willReturn('normalized_create_version');
+        $versionManager->getNewestLogEntry($productModel)->willReturn('update_version');
+        $versionNormalizer->normalize('update_version', 'internal_api')->willReturn('normalized_update_version');
+
+        $productModel->getFamilyVariant()->willReturn($familyVariant);
+        $familyVariant->getFamily()->willReturn($family);
+        $family->getCode()->willReturn('tshirts');
+        $normalizer->normalize($familyVariant, 'standard')->willReturn($familyVariantNormalized);
+
+        $formProvider->getForm($productModel)->willReturn('pim-product-model-edit-form');
+
+        $this->normalize($productModel, 'internal_api', $options)->shouldReturn(
+            [
+                'identifier'     => 'tshirt_blue',
+                'family_variant' => 'tshirts_color',
+                'family'         => 'tshirts',
+                'categories'     => ['summer'],
+                'values'         => $valuesConverted,
+                'meta'           => [
+                    'family_variant' => $familyVariantNormalized,
+                    'form'           => 'pim-product-model-edit-form',
+                    'id'             => 12,
+                    'created'        => 'normalized_create_version',
+                    'updated'        => 'normalized_update_version',
+                    'model_type'     => 'product_model',
+                    'label'          => [
+                        'en_US' => 'tshirt_blue'
+                    ]
+                ]
+            ]
+        );
+    }
+}


### PR DESCRIPTION
This PR is the first part of PIM-6338, which is about enriching a **root** product model in the PEF.
This PR covers only the **display of a root product model** in the PEF.

-----

What will be done in another PR?
- Display the image of the product model (need common interface for product and models)
- Display only product model attributes (need rework of generateMissing)
- Behats (need to import product models, will be easier)

-----

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Y
| Added Behats                      | N (other PR)
| Added integration tests           | N
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo