### PR TITLE
Use official Elasticsearch docker image

### DIFF
--- a/bin/docker/pim-front.sh
+++ b/bin/docker/pim-front.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 
-docker-compose exec akeneo app/console --env=prod cache:clear --no-warmup
-docker-compose exec akeneo app/console --env=dev cache:clear --no-warmup
-docker-compose exec akeneo-behat app/console --env=behat cache:clear --no-warmup
-docker-compose exec akeneo-behat app/console --env=test cache:clear --no-warmup
+docker-compose exec fpm bin/console --env=prod cache:clear --no-warmup
+docker-compose exec fpm bin/console --env=dev cache:clear --no-warmup
+docker-compose exec fpm bin/console --env=behat cache:clear --no-warmup
+docker-compose exec fpm bin/console --env=test cache:clear --no-warmup
 
-docker-compose exec akeneo app/console --env=prod pim:installer:assets --symlink --clean
+docker-compose exec fpm bin/console --env=prod pim:installer:assets --symlink --clean
 
 docker-compose run --rm node npm install
 docker-compose run --rm node npm run webpack

--- a/bin/docker/pim-initialize.sh
+++ b/bin/docker/pim-initialize.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
-docker-compose exec akeneo app/console --env=prod cache:clear --no-warmup
-docker-compose exec akeneo app/console --env=dev cache:clear --no-warmup
-docker-compose exec akeneo-behat app/console --env=behat cache:clear --no-warmup
-docker-compose exec akeneo-behat app/console --env=test cache:clear --no-warmup
+docker-compose exec fpm bin/console --env=prod cache:clear --no-warmup
+docker-compose exec fpm bin/console --env=dev cache:clear --no-warmup
+docker-compose exec fpm bin/console --env=behat cache:clear --no-warmup
+docker-compose exec fpm bin/console --env=test cache:clear --no-warmup
 
-docker-compose exec akeneo app/console --env=prod pim:install --force --symlink --clean
-docker-compose exec akeneo-behat app/console --env=behat pim:installer:db
+docker-compose exec fpm bin/console --env=prod pim:install --force --symlink --clean
+docker-compose exec fpm bin/console --env=behat pim:installer:db
 
 docker-compose run --rm node npm install
 docker-compose run --rm node npm run webpack

--- a/docker-compose.yml.dist
+++ b/docker-compose.yml.dist
@@ -79,10 +79,10 @@ services:
   mysql:
     image: mysql:5.7
     environment:
-      - MYSQL_ROOT_PASSWORD=root
-      - MYSQL_USER=akeneo_pim
-      - MYSQL_PASSWORD=akeneo_pim
-      - MYSQL_DATABASE=akeneo_pim
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_USER: akeneo_pim
+      MYSQL_PASSWORD: akeneo_pim
+      MYSQL_DATABASE: akeneo_pim
     ports:
       - '3306:3306'
     networks:
@@ -91,19 +91,19 @@ services:
   mysql-behat:
     image: mysql:5.7
     environment:
-      - MYSQL_ROOT_PASSWORD=root
-      - MYSQL_USER=akeneo_pim
-      - MYSQL_PASSWORD=akeneo_pim
-      - MYSQL_DATABASE=akeneo_pim
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_USER: akeneo_pim
+      MYSQL_PASSWORD: akeneo_pim
+      MYSQL_DATABASE: akeneo_pim
     ports:
       - '3307:3306'
     networks:
       - behat
 
   elasticsearch:
-    image: elasticsearch:5
+    image: docker.elastic.co/elasticsearch/elasticsearch:5.5.2
     environment:
-      ES_JAVA_OPTS: '-Xms256m -Xmx256m'
+      ES_JAVA_OPTS: '-Xms512m -Xmx512m'
     ports:
       - '9200:9200'
     networks:


### PR DESCRIPTION
## Description

[Elasticsearch image](https://hub.docker.com/_/elasticsearch/) from Docker library is deprecated. [Official image](https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html) maintained by Elasticsearch developers.

This official image is to be used with Docker Compose.

It will be used in the CI v2 too.

The PR also fixes an error in the helper script, introduced when merging 1.7 into master.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

Relates to https://github.com/akeneo/Dockerfiles/issues/259

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
