### PR TITLE
[PIM-6670] Optimize attributes normalization

### DIFF
--- a/CHANGELOG-1.8.md
+++ b/CHANGELOG-1.8.md
@@ -371,6 +371,8 @@
 - Remove OroNavigationBundle
 - Remove OroNotificationBundle
 - Remove `Pim\Bundle\EnrichBundle\Controller\FamilyController.php`
+- Split `Pim\Bundle\EnrichBundle\Normalizer\AttributeNormalizer` in two. The original service name (`pim_enrich.normalizer.attribute`) points now to `Pim\Bundle\EnrichBundle\Normalizer\VersionedAttributeNormalizer`
+    The arguments of the old normalizer are now divided between both normalizers, also `Pim\Bundle\EnrichBundle\Normalizer\AttributeNormalizer` is injected into `Pim\Bundle\EnrichBundle\Normalizer\VersionedAttributeNormalizer`.
 
 ### Methods
 

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/AttributeController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/AttributeController.php
@@ -67,6 +67,9 @@ class AttributeController
     /** @var LocalizerInterface */
     protected $numberLocalizer;
 
+    /** @var NormalizerInterface */
+    private $lightAttributeNormalizer;
+
     /**
      * @param AttributeRepositoryInterface  $attributeRepository
      * @param NormalizerInterface           $normalizer
@@ -80,6 +83,7 @@ class AttributeController
      * @param AttributeFactory              $factory
      * @param UserContext                   $userContext
      * @param LocalizerInterface            $numberLocalizer
+     * @param NormalizerInterface           $lightAttributeNormalizer
      */
     public function __construct(
         AttributeRepositoryInterface $attributeRepository,
@@ -93,7 +97,8 @@ class AttributeController
         RemoverInterface $remover,
         AttributeFactory $factory,
         UserContext $userContext,
-        LocalizerInterface $numberLocalizer
+        LocalizerInterface $numberLocalizer,
+        NormalizerInterface $lightAttributeNormalizer
     ) {
         $this->attributeRepository = $attributeRepository;
         $this->normalizer = $normalizer;
@@ -107,6 +112,7 @@ class AttributeController
         $this->factory = $factory;
         $this->userContext = $userContext;
         $this->numberLocalizer = $numberLocalizer;
+        $this->lightAttributeNormalizer = $lightAttributeNormalizer;
     }
 
     /**
@@ -153,11 +159,13 @@ class AttributeController
             $options
         );
 
-        $normalizedAttributes = $this->normalizer->normalize(
-            $attributes,
-            'internal_api',
-            ['locale' => $this->userContext->getUiLocale()->getCode()]
-        );
+        $normalizedAttributes = array_map(function ($attribute) {
+            return $this->lightAttributeNormalizer->normalize(
+                $attribute,
+                'internal_api',
+                ['locale' => $this->userContext->getUiLocale()->getCode()]
+            );
+        }, $attributes);
 
         return new JsonResponse($normalizedAttributes);
     }

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/AttributeNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/AttributeNormalizer.php
@@ -6,8 +6,6 @@ use Akeneo\Component\Localization\Localizer\LocalizerInterface;
 use Pim\Bundle\EnrichBundle\Provider\EmptyValue\EmptyValueProviderInterface;
 use Pim\Bundle\EnrichBundle\Provider\Field\FieldProviderInterface;
 use Pim\Bundle\EnrichBundle\Provider\Filter\FilterProviderInterface;
-use Pim\Bundle\EnrichBundle\Provider\StructureVersion\StructureVersionProviderInterface;
-use Pim\Bundle\VersioningBundle\Manager\VersionManager;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
@@ -35,15 +33,6 @@ class AttributeNormalizer implements NormalizerInterface
     /** @var FilterProviderInterface */
     protected $filterProvider;
 
-    /** @var VersionManager */
-    protected $versionManager;
-
-    /** @var NormalizerInterface */
-    protected $versionNormalizer;
-
-    /** @var StructureVersionProviderInterface */
-    protected $structureVersionProvider;
-
     /** @var LocalizerInterface */
     protected $numberLocalizer;
 
@@ -52,9 +41,6 @@ class AttributeNormalizer implements NormalizerInterface
      * @param FieldProviderInterface            $fieldProvider
      * @param EmptyValueProviderInterface       $emptyValueProvider
      * @param FilterProviderInterface           $filterProvider
-     * @param VersionManager                    $versionManager
-     * @param NormalizerInterface               $versionNormalizer
-     * @param StructureVersionProviderInterface $structureVersionProvider
      * @param LocalizerInterface                $numberLocalizer
      */
     public function __construct(
@@ -62,18 +48,12 @@ class AttributeNormalizer implements NormalizerInterface
         FieldProviderInterface $fieldProvider,
         EmptyValueProviderInterface $emptyValueProvider,
         FilterProviderInterface $filterProvider,
-        VersionManager $versionManager,
-        NormalizerInterface $versionNormalizer,
-        StructureVersionProviderInterface $structureVersionProvider,
         LocalizerInterface $numberLocalizer
     ) {
         $this->normalizer = $normalizer;
         $this->fieldProvider = $fieldProvider;
         $this->emptyValueProvider = $emptyValueProvider;
         $this->filterProvider = $filterProvider;
-        $this->versionManager = $versionManager;
-        $this->versionNormalizer = $versionNormalizer;
-        $this->structureVersionProvider = $structureVersionProvider;
         $this->numberLocalizer = $numberLocalizer;
     }
 
@@ -109,23 +89,7 @@ class AttributeNormalizer implements NormalizerInterface
             );
         }
 
-        $firstVersion = $this->versionManager->getOldestLogEntry($attribute);
-        $lastVersion = $this->versionManager->getNewestLogEntry($attribute);
-
-        $firstVersion = null !== $firstVersion ?
-            $this->versionNormalizer->normalize($firstVersion, 'internal_api') :
-            null;
-        $lastVersion = null !== $lastVersion ?
-            $this->versionNormalizer->normalize($lastVersion, 'internal_api') :
-            null;
-
-        $normalizedAttribute['meta'] = [
-            'id'                => $attribute->getId(),
-            'created'           => $firstVersion,
-            'updated'           => $lastVersion,
-            'structure_version' => $this->structureVersionProvider->getStructureVersion(),
-            'model_type'        => 'attribute',
-        ];
+        $normalizedAttribute['meta']['id'] = $attribute->getId();
 
         return $normalizedAttribute;
     }

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/VersionedAttributeNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/VersionedAttributeNormalizer.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Pim\Bundle\EnrichBundle\Normalizer;
+
+use Pim\Bundle\EnrichBundle\Provider\StructureVersion\StructureVersionProviderInterface;
+use Pim\Bundle\VersioningBundle\Manager\VersionManager;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * Normalizing data related to versioning is very costly. As we don't always need it, it's isolated in
+ * this normalizer that decorates the main one.
+ *
+ * @author    Yohan Blain <yohan.blain@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class VersionedAttributeNormalizer implements NormalizerInterface
+{
+    /** @var array $supportedFormats */
+    protected $supportedFormats = ['internal_api'];
+
+    /** @var NormalizerInterface */
+    protected $normalizer;
+
+    /** @var VersionManager */
+    protected $versionManager;
+
+    /** @var NormalizerInterface */
+    protected $versionNormalizer;
+
+    /** @var StructureVersionProviderInterface */
+    protected $structureVersionProvider;
+
+    /**
+     * @param NormalizerInterface               $normalizer
+     * @param VersionManager                    $versionManager
+     * @param NormalizerInterface               $versionNormalizer
+     * @param StructureVersionProviderInterface $structureVersionProvider
+     */
+    public function __construct(
+        NormalizerInterface $normalizer,
+        VersionManager $versionManager,
+        NormalizerInterface $versionNormalizer,
+        StructureVersionProviderInterface $structureVersionProvider
+    ) {
+        $this->normalizer = $normalizer;
+        $this->versionManager = $versionManager;
+        $this->versionNormalizer = $versionNormalizer;
+        $this->structureVersionProvider = $structureVersionProvider;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function normalize($attribute, $format = null, array $context = [])
+    {
+        $normalizedAttribute = $this->normalizer->normalize($attribute, 'internal_api', $context);
+
+        $firstVersion = $this->versionManager->getOldestLogEntry($attribute);
+        $lastVersion = $this->versionManager->getNewestLogEntry($attribute);
+
+        $firstVersion = null !== $firstVersion ?
+            $this->versionNormalizer->normalize($firstVersion, 'internal_api', $context) :
+            null;
+        $lastVersion = null !== $lastVersion ?
+            $this->versionNormalizer->normalize($lastVersion, 'internal_api', $context) :
+            null;
+
+        $normalizedAttribute['meta']['created'] = $firstVersion;
+        $normalizedAttribute['meta']['updated'] = $lastVersion;
+        $normalizedAttribute['meta']['structure_version'] = $this->structureVersionProvider->getStructureVersion();
+        $normalizedAttribute['meta']['model_type'] = 'attribute';
+
+        return $normalizedAttribute;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsNormalization($data, $format = null)
+    {
+        return $data instanceof AttributeInterface && in_array($format, $this->supportedFormats);
+    }
+}

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/controllers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/controllers.yml
@@ -202,6 +202,7 @@ services:
             - '@pim_catalog.factory.attribute'
             - '@pim_user.context.user'
             - '@pim_catalog.localization.localizer.number'
+            - '@pim_enrich.normalizer.attribute'
 
     pim_enrich.controller.rest.attribute_type:
         class: '%pim_enrich.controller.rest.attribute_type.class%'

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/normalizers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/normalizers.yml
@@ -11,6 +11,7 @@ parameters:
     pim_enrich.normalizer.group_type.class:                        Pim\Bundle\EnrichBundle\Normalizer\GroupTypeNormalizer
     pim_enrich.normalizer.family.class:                            Pim\Bundle\EnrichBundle\Normalizer\FamilyNormalizer
     pim_enrich.normalizer.attribute.class:                         Pim\Bundle\EnrichBundle\Normalizer\AttributeNormalizer
+    pim_enrich.normalizer.attribute.versioned.class:               Pim\Bundle\EnrichBundle\Normalizer\VersionedAttributeNormalizer
     pim_enrich.normalizer.locale.class:                            Pim\Bundle\EnrichBundle\Normalizer\LocaleNormalizer
     pim_enrich.normalizer.channel.class:                           Pim\Bundle\EnrichBundle\Normalizer\ChannelNormalizer
     pim_enrich.normalizer.sequential_edit.class:                   Pim\Bundle\EnrichBundle\Normalizer\SequentialEditNormalizer
@@ -144,10 +145,15 @@ services:
             - '@pim_enrich.provider.field.chained'
             - '@pim_enrich.provider.empty_value.chained'
             - '@pim_enrich.provider.filter.chained'
+            - '@pim_catalog.localization.localizer.number'
+
+    pim_enrich.normalizer.attribute.versioned:
+        class: '%pim_enrich.normalizer.attribute.versioned.class%'
+        arguments:
+            - '@pim_enrich.normalizer.attribute'
             - '@pim_versioning.manager.version'
             - '@pim_enrich.normalizer.version'
             - '@pim_enrich.provider.structure_version.attribute'
-            - '@pim_catalog.localization.localizer.number'
         tags:
             - { name: pim_internal_api_serializer.normalizer }
 

--- a/src/Pim/Bundle/EnrichBundle/spec/Normalizer/AttributeNormalizerSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Normalizer/AttributeNormalizerSpec.php
@@ -8,10 +8,7 @@ use PhpSpec\ObjectBehavior;
 use Pim\Bundle\EnrichBundle\Provider\EmptyValue\EmptyValueProviderInterface;
 use Pim\Bundle\EnrichBundle\Provider\Field\FieldProviderInterface;
 use Pim\Bundle\EnrichBundle\Provider\Filter\FilterProviderInterface;
-use Pim\Bundle\EnrichBundle\Provider\StructureVersion\StructureVersionProviderInterface;
-use Pim\Bundle\VersioningBundle\Manager\VersionManager;
 use Pim\Component\Catalog\Model\AttributeInterface;
-use Pim\Component\Catalog\Model\GroupInterface;
 use Prophecy\Argument;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
@@ -22,9 +19,6 @@ class AttributeNormalizerSpec extends ObjectBehavior
         FieldProviderInterface $fieldProvider,
         EmptyValueProviderInterface $emptyValueProvider,
         FilterProviderInterface $filterProvider,
-        VersionManager $versionManager,
-        NormalizerInterface $versionNormalizer,
-        StructureVersionProviderInterface $structureVersionProvider,
         LocalizerInterface $numberLocalizer
     ) {
         $this->beConstructedWith(
@@ -32,9 +26,6 @@ class AttributeNormalizerSpec extends ObjectBehavior
             $fieldProvider,
             $emptyValueProvider,
             $filterProvider,
-            $versionManager,
-            $versionNormalizer,
-            $structureVersionProvider,
             $numberLocalizer
         );
     }
@@ -44,12 +35,7 @@ class AttributeNormalizerSpec extends ObjectBehavior
         $fieldProvider,
         $emptyValueProvider,
         $filterProvider,
-        $versionManager,
-        $versionNormalizer,
-        $structureVersionProvider,
-        AttributeInterface $price,
-        Version $firstVersion,
-        Version $lastVersion
+        AttributeInterface $price
     ) {
         $normalizer->normalize($price, 'standard', Argument::any())->willReturn(
             [
@@ -89,12 +75,7 @@ class AttributeNormalizerSpec extends ObjectBehavior
         $fieldProvider->getField($price)->willReturn('akeneo-text-field');
         $filterProvider->getFilters($price)->willReturn(['product-export-builder' => 'akeneo-attribute-string-filter']);
         $price->isLocaleSpecific()->willReturn(false);
-        $versionManager->getOldestLogEntry($price)->willReturn($firstVersion);
-        $versionManager->getNewestLogEntry($price)->willReturn($lastVersion);
-        $versionNormalizer->normalize($firstVersion, 'internal_api')->willReturn('normalizedFirstVersion');
-        $versionNormalizer->normalize($lastVersion, 'internal_api')->willReturn('normalizedLastVersion');
         $price->getId()->willReturn(12);
-        $structureVersionProvider->getStructureVersion()->willReturn(123789);
 
         $this->normalize($price, 'internal_api', [])->shouldReturn(
             [
@@ -129,13 +110,7 @@ class AttributeNormalizerSpec extends ObjectBehavior
                 'field_type'             => 'akeneo-text-field',
                 'filter_types'           => ['product-export-builder' => 'akeneo-attribute-string-filter'],
                 'is_locale_specific'     => false,
-                'meta'                   => [
-                    'id'                => 12,
-                    'created'           => 'normalizedFirstVersion',
-                    'updated'           => 'normalizedLastVersion',
-                    'structure_version' => 123789,
-                    'model_type'        => 'attribute',
-                ],
+                'meta'                   => ['id' => 12],
             ]
         );
     }
@@ -145,13 +120,8 @@ class AttributeNormalizerSpec extends ObjectBehavior
         $fieldProvider,
         $emptyValueProvider,
         $filterProvider,
-        $versionManager,
-        $versionNormalizer,
-        $structureVersionProvider,
         $numberLocalizer,
-        AttributeInterface $price,
-        Version $firstVersion,
-        Version $lastVersion
+        AttributeInterface $price
     ) {
         $normalizer->normalize($price, 'standard', Argument::any())->willReturn(
             [
@@ -193,12 +163,7 @@ class AttributeNormalizerSpec extends ObjectBehavior
         $price->isLocaleSpecific()->willReturn(false);
         $numberLocalizer->localize('20.5', ['locale' => 'fr_FR'])->willReturn('20,5');
         $numberLocalizer->localize('4000.8', ['locale' => 'fr_FR'])->willReturn('4000,8');
-        $versionManager->getOldestLogEntry($price)->willReturn($firstVersion);
-        $versionManager->getNewestLogEntry($price)->willReturn($lastVersion);
-        $versionNormalizer->normalize($firstVersion, 'internal_api')->willReturn('normalizedFirstVersion');
-        $versionNormalizer->normalize($lastVersion, 'internal_api')->willReturn('normalizedLastVersion');
         $price->getId()->willReturn(12);
-        $structureVersionProvider->getStructureVersion()->willReturn(123789);
 
         $this->normalize($price, 'internal_api', ['locale' => 'fr_FR'])->shouldReturn(
             [
@@ -233,13 +198,7 @@ class AttributeNormalizerSpec extends ObjectBehavior
                 'field_type'             => 'akeneo-text-field',
                 'filter_types'           => ['product-export-builder' => 'akeneo-attribute-string-filter'],
                 'is_locale_specific'     => false,
-                'meta'                   => [
-                    'id'                => 12,
-                    'created'           => 'normalizedFirstVersion',
-                    'updated'           => 'normalizedLastVersion',
-                    'structure_version' => 123789,
-                    'model_type'        => 'attribute',
-                ],
+                'meta'                   => ['id' => 12],
             ]
         );
     }

--- a/src/Pim/Bundle/EnrichBundle/spec/Normalizer/VersionedAttributeNormalizerSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Normalizer/VersionedAttributeNormalizerSpec.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace spec\Pim\Bundle\EnrichBundle\Normalizer;
+
+use Akeneo\Component\Versioning\Model\Version;
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\EnrichBundle\Provider\StructureVersion\StructureVersionProviderInterface;
+use Pim\Bundle\VersioningBundle\Manager\VersionManager;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Prophecy\Argument;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+class VersionedAttributeNormalizerSpec extends ObjectBehavior
+{
+    public function let(
+        NormalizerInterface $normalizer,
+        VersionManager $versionManager,
+        NormalizerInterface $versionNormalizer,
+        StructureVersionProviderInterface $structureVersionProvider
+    ) {
+        $this->beConstructedWith(
+            $normalizer,
+            $versionManager,
+            $versionNormalizer,
+            $structureVersionProvider
+        );
+    }
+
+    function it_normalizes_an_attribute(
+        $normalizer,
+        $versionManager,
+        $versionNormalizer,
+        $structureVersionProvider,
+        AttributeInterface $price,
+        Version $firstVersion,
+        Version $lastVersion
+    ) {
+        $normalizer->normalize($price, 'internal_api', Argument::any())->willReturn([]);
+
+        $versionManager->getOldestLogEntry($price)->willReturn($firstVersion);
+        $versionManager->getNewestLogEntry($price)->willReturn($lastVersion);
+        $versionNormalizer->normalize($firstVersion, 'internal_api')->willReturn('normalizedFirstVersion');
+        $versionNormalizer->normalize($lastVersion, 'internal_api')->willReturn('normalizedLastVersion');
+        $price->getId()->willReturn(12);
+        $structureVersionProvider->getStructureVersion()->willReturn(123789);
+
+        $this->normalize($price, 'internal_api', [])->shouldReturn(
+            [
+                'meta' => [
+                    'created'           => 'normalizedFirstVersion',
+                    'updated'           => 'normalizedLastVersion',
+                    'structure_version' => 123789,
+                    'model_type'        => 'attribute',
+                ],
+            ]
+        );
+    }
+}


### PR DESCRIPTION
**The context**
We need to load the PEF as fast as possible.

**The problem**
Among the most blocking requests : the one getting the list of attributes and the one getting the family. In Enrich, the normalized attributes are embed in the family. It appeared that the normalization of attributes was the common bottleneck.

**The solution**
In the current enrich attribute normalizer we set `created`, `updated`, `structure_version` and `model_type` keys. None of these are used in the PEF, so I split the normalizer in two : `AttributeNormalizer` and `VersionedAttributeNormalizer` (not sure about the naming), the second one decorating the first one. Then use the new one in the family normalizer and in the index route of the attribute rest controller.

For a PEF with 200 attributes :

Request | Before | After
--- | -------- | ------
fetch family | 2,4s | 320ms
fetch attributes | 2,2s | 300ms