### PR TITLE
Add a dirty sleep as workaround to wait the availability of elastic search container

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -286,6 +286,8 @@ void runIntegrationTest(String phpVersion, String edition, def testFiles) {
 
                         sh "sed -i \"s#<file></file>#${testSuiteFiles}#\" app/phpunit.xml.dist"
 
+                        sh "sleep 20"
+
                         sh "php -d error_reporting='E_ALL' ./bin/phpunit -c app/phpunit.xml.dist --testsuite PIM_Integration_Test --log-junit app/build/logs/phpunit_integration.xml"
                     }
                 }


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**
![screen shot 2017-08-01 at 10 31 38](https://user-images.githubusercontent.com/1942439/28816291-a0ff3490-76a4-11e7-99eb-4f056caa8aec.png)

Dirty fix to avoid the error in the CI.
Should be properly fix with healthcheck.

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | -
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
