### PR TITLE
PIM-6338: Display image and label on product model pef

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Resources/config/normalizers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/normalizers.yml
@@ -71,10 +71,12 @@ services:
         arguments:
             - '@pim_serializer'
             - '@pim_enrich.normalizer.version'
+            - '@pim_enrich.normalizer.file'
             - '@pim_versioning.manager.version'
             - '@pim_catalog.localization.localizer.converter'
             - '@pim_enrich.converter.standard_to_enrich.product_value'
             - '@pim_enrich.provider.form.product_model'
+            - '@pim_catalog.repository.locale'
         tags:
             - { name: pim_internal_api_serializer.normalizer }
 

--- a/src/Pim/Component/Catalog/Model/AbstractProduct.php
+++ b/src/Pim/Component/Catalog/Model/AbstractProduct.php
@@ -359,17 +359,17 @@ abstract class AbstractProduct implements ProductInterface
      */
     public function getImage()
     {
-        if ($this->family) {
-            $attributeAsImage = $this->family->getAttributeAsImage();
-            if (null !== $attributeAsImage) {
-                $value = $this->getValue($attributeAsImage->getCode());
-                if (null !== $value) {
-                    return $value;
-                }
-            }
+        if (null === $this->family) {
+            return null;
         }
 
-        return null;
+        $attributeAsImage = $this->family->getAttributeAsImage();
+
+        if (null === $attributeAsImage) {
+            return null;
+        }
+
+        return $this->getValue($attributeAsImage->getCode());
     }
 
     /**
@@ -377,21 +377,32 @@ abstract class AbstractProduct implements ProductInterface
      */
     public function getLabel($locale = null)
     {
-        if ($this->family) {
-            if ($attributeAsLabel = $this->family->getAttributeAsLabel()) {
-                if (!$attributeAsLabel->isLocalizable()) {
-                    $locale = null;
-                }
-                if ($value = $this->getValue($attributeAsLabel->getCode(), $locale)) {
-                    $data = $value->getData();
-                    if (!empty($data)) {
-                        return (string) $data;
-                    }
-                }
-            }
+        $identifier = (string) $this->getIdentifier();
+
+        if (null === $this->family) {
+            return $identifier;
         }
 
-        return (string) $this->getIdentifier();
+        $attributeAsLabel = $this->family->getAttributeAsLabel();
+
+        if (null === $attributeAsLabel) {
+            return $identifier;
+        }
+
+        $locale = $attributeAsLabel->isLocalizable() ? $locale : null;
+        $value = $this->getValue($attributeAsLabel->getCode(), $locale);
+
+        if (null === $value) {
+            return $identifier;
+        }
+
+        $data = $value->getData();
+
+        if (empty($data)) {
+            return $identifier;
+        }
+
+        return (string) $data;
     }
 
     /**

--- a/src/Pim/Component/Catalog/Model/ProductModel.php
+++ b/src/Pim/Component/Catalog/Model/ProductModel.php
@@ -470,4 +470,46 @@ class ProductModel implements ProductModelInterface
     {
         return null === $this->parent;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLabel(?string $localeCode): string
+    {
+        $identifier = (string) $this->getIdentifier();
+        $attributeAsLabel = $this->familyVariant->getFamily()->getAttributeAsLabel();
+
+        if (null === $attributeAsLabel) {
+            return $identifier;
+        }
+
+        $localeCode = $attributeAsLabel->isLocalizable() ? $localeCode : null;
+        $value = $this->getValue($attributeAsLabel->getCode(), $localeCode);
+
+        if (null === $value) {
+            return $identifier;
+        }
+
+        $data = $value->getData();
+
+        if (empty($data)) {
+            return $identifier;
+        }
+
+        return (string) $data;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getImage(): ?ValueInterface
+    {
+        $attributeAsImage = $this->familyVariant->getFamily()->getAttributeAsImage();
+
+        if (null === $attributeAsImage) {
+            return null;
+        }
+
+        return $this->getValue($attributeAsImage->getCode());
+    }
 }

--- a/src/Pim/Component/Catalog/Model/ProductModelInterface.php
+++ b/src/Pim/Component/Catalog/Model/ProductModelInterface.php
@@ -169,4 +169,20 @@ interface ProductModelInterface extends
      * @return bool
      */
     public function isRootProductModel(): bool;
+
+    /**
+     * Get product model label
+     *
+     * @param string|null $localeCode
+     *
+     * @return string
+     */
+    public function getLabel(?string $localeCode): string;
+
+    /**
+     * Get product model image
+     *
+     * @return ValueInterface|null
+     */
+    public function getImage(): ?ValueInterface;
 }

--- a/src/Pim/Component/Catalog/spec/Model/ProductModelSpec.php
+++ b/src/Pim/Component/Catalog/spec/Model/ProductModelSpec.php
@@ -9,12 +9,15 @@ use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\CategoryInterface;
 use Pim\Component\Catalog\Model\EntityWithValuesInterface;
+use Pim\Component\Catalog\Model\FamilyInterface;
+use Pim\Component\Catalog\Model\FamilyVariantInterface;
 use Pim\Component\Catalog\Model\ProductModel;
 use Pim\Component\Catalog\Model\ProductModelInterface;
 use Pim\Component\Catalog\Model\TimestampableInterface;
 use Pim\Component\Catalog\Model\ValueCollection;
 use Pim\Component\Catalog\Model\ValueCollectionInterface;
 use Pim\Component\Catalog\Model\ValueInterface;
+use Pim\Component\Connector\ArrayConverter\FlatToStandard\Value;
 
 class ProductModelSpec extends ObjectBehavior
 {
@@ -85,5 +88,135 @@ class ProductModelSpec extends ObjectBehavior
         $categorie->getCode()->willReturn('foobar');
 
         $this->getCategoryCodes()->shouldReturn(['foobar']);
+    }
+
+    function it_gets_the_label_of_the_product_model(
+        FamilyVariantInterface $familyVariant,
+        FamilyInterface $family,
+        AttributeInterface $attributeAsLabel,
+        ValueCollectionInterface $values,
+        ValueInterface $nameValue
+    ) {
+        $familyVariant->getFamily()->willReturn($family);
+        $family->getAttributeAsLabel()->willReturn($attributeAsLabel);
+        $attributeAsLabel->getCode()->willReturn('name');
+        $attributeAsLabel->isLocalizable()->willReturn(true);
+
+        $values->getByCodes('name', null, 'fr_FR')->willReturn($nameValue);
+        $nameValue->getData()->willReturn('Petit outil agricole authentique');
+
+        $this->setFamilyVariant($familyVariant);
+        $this->setValues($values);
+        $this->setIdentifier('shovel');
+
+        $this->getLabel('fr_FR')->shouldReturn('Petit outil agricole authentique');
+    }
+
+    function it_gets_the_identifier_as_label_if_there_is_no_attribute_as_label(
+        FamilyVariantInterface $familyVariant,
+        FamilyInterface $family,
+        ValueCollectionInterface $values
+    ) {
+        $familyVariant->getFamily()->willReturn($family);
+        $family->getAttributeAsLabel()->willReturn(null);
+
+        $this->setFamilyVariant($familyVariant);
+        $this->setValues($values);
+        $this->setIdentifier('shovel');
+
+        $this->getLabel('fr_FR')->shouldReturn('shovel');
+    }
+
+    function it_gets_the_identifier_as_label_if_the_label_value_is_null(
+        FamilyVariantInterface $familyVariant,
+        FamilyInterface $family,
+        AttributeInterface $attributeAsLabel,
+        ValueCollectionInterface $values
+    ) {
+        $familyVariant->getFamily()->willReturn($family);
+        $family->getAttributeAsLabel()->willReturn($attributeAsLabel);
+        $attributeAsLabel->getCode()->willReturn('name');
+        $attributeAsLabel->isLocalizable()->willReturn(true);
+
+        $values->getByCodes('name', null, 'fr_FR')->willReturn(null);
+
+        $this->setFamilyVariant($familyVariant);
+        $this->setValues($values);
+        $this->setIdentifier('shovel');
+
+        $this->getLabel('fr_FR')->shouldReturn('shovel');
+    }
+
+    function it_gets_the_identifier_as_label_if_the_label_value_data_is_empty(
+        FamilyVariantInterface $familyVariant,
+        FamilyInterface $family,
+        AttributeInterface $attributeAsLabel,
+        ValueCollectionInterface $values,
+        ValueInterface $nameValue
+    ) {
+        $familyVariant->getFamily()->willReturn($family);
+        $family->getAttributeAsLabel()->willReturn($attributeAsLabel);
+        $attributeAsLabel->getCode()->willReturn('name');
+        $attributeAsLabel->isLocalizable()->willReturn(true);
+
+        $values->getByCodes('name', null, 'fr_FR')->willReturn($nameValue);
+        $nameValue->getData()->willReturn(null);
+
+        $this->setFamilyVariant($familyVariant);
+        $this->setValues($values);
+        $this->setIdentifier('shovel');
+
+        $this->getLabel('fr_FR')->shouldReturn('shovel');
+    }
+
+    function it_gets_the_image_of_the_product_model(
+        FamilyVariantInterface $familyVariant,
+        FamilyInterface $family,
+        AttributeInterface $attributeAsImage,
+        ValueCollectionInterface $values,
+        ValueInterface $pictureValue
+    ) {
+        $familyVariant->getFamily()->willReturn($family);
+        $family->getAttributeAsImage()->willReturn($attributeAsImage);
+        $attributeAsImage->getCode()->willReturn('picture');
+
+        $values->getByCodes('picture', null, null)->willReturn($pictureValue);
+
+        $this->setFamilyVariant($familyVariant);
+        $this->setValues($values);
+
+        $this->getImage()->shouldReturn($pictureValue);
+    }
+
+    function it_gets_no_image_if_there_is_no_attribute_as_image(
+        FamilyVariantInterface $familyVariant,
+        FamilyInterface $family,
+        ValueCollectionInterface $values
+    ) {
+        $familyVariant->getFamily()->willReturn($family);
+        $family->getAttributeAsImage()->willReturn(null);
+
+        $this->setFamilyVariant($familyVariant);
+        $this->setValues($values);
+
+        $this->getImage()->shouldReturn(null);
+    }
+
+    function it_gets_no_image_if_the_value_of_image_is_empty(
+        FamilyVariantInterface $familyVariant,
+        FamilyInterface $family,
+        AttributeInterface $attributeAsImage,
+        ValueCollectionInterface $values
+    ) {
+        $familyVariant->getFamily()->willReturn($family);
+        $family->getAttributeAsImage()->willReturn($attributeAsImage);
+        $attributeAsImage->getCode()->willReturn('picture');
+
+        $values->getByCodes('picture', null, null)->willReturn(null);
+
+        $this->setFamilyVariant($familyVariant);
+        $this->setValues($values);
+
+        $this->getImage()->shouldReturn(null);
     }
 }

--- a/src/Pim/Component/Catalog/spec/Model/ProductSpec.php
+++ b/src/Pim/Component/Catalog/spec/Model/ProductSpec.php
@@ -14,6 +14,8 @@ use Pim\Component\Catalog\Model\GroupInterface;
 use Pim\Component\Catalog\Model\GroupTypeInterface;
 use Pim\Component\Catalog\Model\ProductModelInterface;
 use Pim\Component\Catalog\Model\ProductTemplateInterface;
+use Pim\Component\Catalog\Model\ValueCollectionInterface;
+use Pim\Component\Catalog\Model\ValueInterface;
 
 class ProductSpec extends ObjectBehavior
 {
@@ -191,5 +193,181 @@ class ProductSpec extends ObjectBehavior
     function it_is_attribute_removable(AttributeInterface $attribute)
     {
         $this->isAttributeRemovable($attribute)->shouldReturn(true);
+    }
+
+    function it_gets_the_label_of_the_product(
+        FamilyInterface $family,
+        AttributeInterface $attributeAsLabel,
+        ValueCollectionInterface $values,
+        ValueInterface $nameValue,
+        ValueInterface $identifier
+    ) {
+        $identifier->getData()->willReturn('shovel');
+        $identifier->getAttribute()->willReturn($attributeAsLabel);
+
+        $family->getAttributeAsLabel()->willReturn($attributeAsLabel);
+        $family->getId()->willReturn(42);
+        $attributeAsLabel->getCode()->willReturn('name');
+        $attributeAsLabel->isLocalizable()->willReturn(true);
+
+        $values->getByCodes('name', null, 'fr_FR')->willReturn($nameValue);
+        $values->removeByAttribute($attributeAsLabel)->shouldBeCalled();
+        $values->add($identifier)->shouldBeCalled();
+
+        $nameValue->getData()->willReturn('Petit outil agricole authentique');
+
+        $this->setFamily($family);
+        $this->setValues($values);
+        $this->setIdentifier($identifier);
+
+        $this->getLabel('fr_FR')->shouldReturn('Petit outil agricole authentique');
+    }
+
+    function it_gets_the_identifier_as_label_if_there_is_no_family(
+        AttributeInterface $attributeAsLabel,
+        ValueCollectionInterface $values,
+        ValueInterface $identifier
+    ) {
+        $identifier->getData()->willReturn('shovel');
+        $identifier->getAttribute()->willReturn($attributeAsLabel);
+
+        $values->removeByAttribute($attributeAsLabel)->shouldBeCalled();
+        $values->add($identifier)->shouldBeCalled();
+
+        $this->setFamily(null);
+        $this->setValues($values);
+        $this->setIdentifier($identifier);
+
+        $this->getLabel('fr_FR')->shouldReturn('shovel');
+    }
+
+    function it_gets_the_identifier_as_label_if_there_is_no_attribute_as_label(
+        FamilyInterface $family,
+        AttributeInterface $attributeAsLabel,
+        ValueCollectionInterface $values,
+        ValueInterface $identifier
+    ) {
+        $family->getAttributeAsLabel()->willReturn(null);
+        $family->getId()->willReturn(42);
+
+        $identifier->getData()->willReturn('shovel');
+        $identifier->getAttribute()->willReturn($attributeAsLabel);
+
+        $values->removeByAttribute($attributeAsLabel)->shouldBeCalled();
+        $values->add($identifier)->shouldBeCalled();
+
+        $this->setFamily($family);
+        $this->setValues($values);
+        $this->setIdentifier($identifier);
+
+        $this->getLabel('fr_FR')->shouldReturn('shovel');
+    }
+
+    function it_gets_the_identifier_as_label_if_the_label_value_is_null(
+        FamilyInterface $family,
+        AttributeInterface $attributeAsLabel,
+        ValueCollectionInterface $values,
+        ValueInterface $nameValue,
+        ValueInterface $identifier
+    ) {
+        $identifier->getData()->willReturn('shovel');
+        $identifier->getAttribute()->willReturn($attributeAsLabel);
+
+        $family->getAttributeAsLabel()->willReturn($attributeAsLabel);
+        $family->getId()->willReturn(42);
+        $attributeAsLabel->getCode()->willReturn('name');
+        $attributeAsLabel->isLocalizable()->willReturn(true);
+
+        $values->removeByAttribute($attributeAsLabel)->shouldBeCalled();
+        $values->add($identifier)->shouldBeCalled();
+        $values->getByCodes('name', null, 'fr_FR')->willReturn(null);
+
+        $this->setFamily($family);
+        $this->setValues($values);
+        $this->setIdentifier($identifier);
+
+        $this->getLabel('fr_FR')->shouldReturn('shovel');
+    }
+
+    function it_gets_the_identifier_as_label_if_the_label_value_data_is_empty(
+        FamilyInterface $family,
+        AttributeInterface $attributeAsLabel,
+        ValueCollectionInterface $values,
+        ValueInterface $nameValue,
+        ValueInterface $identifier
+    ) {
+        $identifier->getData()->willReturn('shovel');
+        $identifier->getAttribute()->willReturn($attributeAsLabel);
+
+        $family->getAttributeAsLabel()->willReturn($attributeAsLabel);
+        $family->getId()->willReturn(42);
+        $attributeAsLabel->getCode()->willReturn('name');
+        $attributeAsLabel->isLocalizable()->willReturn(true);
+
+        $values->getByCodes('name', null, 'fr_FR')->willReturn($nameValue);
+        $values->removeByAttribute($attributeAsLabel)->shouldBeCalled();
+        $values->add($identifier)->shouldBeCalled();
+
+        $nameValue->getData()->willReturn(null);
+
+        $this->setFamily($family);
+        $this->setValues($values);
+        $this->setIdentifier($identifier);
+
+        $this->getLabel('fr_FR')->shouldReturn('shovel');
+    }
+
+    function it_gets_the_image_of_the_product(
+        FamilyInterface $family,
+        AttributeInterface $attributeAsImage,
+        ValueCollectionInterface $values,
+        ValueInterface $pictureValue
+    ) {
+        $attributeAsImage->getCode()->willReturn('picture');
+
+        $family->getAttributeAsImage()->willReturn($attributeAsImage);
+        $family->getId()->willReturn(42);
+
+        $values->getByCodes('picture', null, null)->willReturn($pictureValue);
+
+        $this->setFamily($family);
+        $this->setValues($values);
+
+        $this->getImage()->shouldReturn($pictureValue);
+    }
+
+    function it_gets_no_image_if_there_is_no_family()
+    {
+        $this->setFamily(null);
+        $this->getImage()->shouldReturn(null);
+    }
+
+    function it_gets_no_image_if_there_is_no_attribute_as_image(
+        FamilyInterface $family
+    ) {
+        $family->getAttributeAsImage()->willReturn(null);
+        $family->getId()->willReturn(42);
+
+        $this->setFamily($family);
+
+        $this->getImage()->shouldReturn(null);
+    }
+
+    function it_gets_no_image_if_the_value_of_image_is_empty(
+        FamilyInterface $family,
+        AttributeInterface $attributeAsImage,
+        ValueCollectionInterface $values
+    ) {
+        $attributeAsImage->getCode()->willReturn('picture');
+
+        $family->getAttributeAsImage()->willReturn($attributeAsImage);
+        $family->getId()->willReturn(42);
+
+        $values->getByCodes('picture', null, null)->willReturn(null);
+
+        $this->setFamily($family);
+        $this->setValues($values);
+
+        $this->getImage()->shouldReturn(null);
     }
 }


### PR DESCRIPTION
This PR adds "Attribute as image" and "Attribute as label" on product model, which then can be displayed on the PEF.

![screenshot from 2017-08-03 15-57-55](https://user-images.githubusercontent.com/301169/28925234-8a1da402-7864-11e7-9500-78bec6b9c331.png)

-----

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Y
| Added Behats                      | N
| Added integration tests           | N
| Changelog updated                 | N
| Review and 2 GTM                  | Todo
