### PR TITLE
PIM-6520: Remove filtering from channel locale normalizer

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Normalizer/ChannelNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/ChannelNormalizer.php
@@ -103,7 +103,7 @@ class ChannelNormalizer implements NormalizerInterface
     {
         $normalizedLocales = [];
 
-        foreach ($this->collectionFilter->filterCollection($locales, 'pim.internal_api.locale.view') as $locale) {
+        foreach ($locales as $locale) {
             $normalizedLocales[] = $this->localeNormalizer->normalize($locale, 'standard');
         }
 

--- a/src/Pim/Bundle/EnrichBundle/spec/Normalizer/ChannelNormalizerSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Normalizer/ChannelNormalizerSpec.php
@@ -43,11 +43,15 @@ class ChannelNormalizerSpec extends ObjectBehavior
     ) {
         $channel->getLocales()->willReturn([$locale1, $locale2]);
         $channel->getId()->willReturn(10);
-        $collectionFilter->filterCollection([$locale1, $locale2], 'pim.internal_api.locale.view')
-            ->willReturn([$locale1]);
+
         $localeNormalizer->normalize($locale1, 'standard')->willReturn([
             'code' => 'fr_FR',
             'label' => 'French'
+        ]);
+
+        $localeNormalizer->normalize($locale2, 'standard')->willReturn([
+            'code' => 'de_DE',
+            'label' => 'German'
         ]);
 
         $channelNormalizer->normalize($channel, 'standard', [])->willReturn([
@@ -58,7 +62,8 @@ class ChannelNormalizerSpec extends ObjectBehavior
             [
                 'keyFromNormalizer' => 'dataFromNormalizer',
                 'locales' => [
-                    ['code' => 'fr_FR', 'label' => 'French']
+                    ['code' => 'fr_FR', 'label' => 'French'],
+                    ['code' => 'de_DE', 'label' => 'German']
                 ],
 
                 'meta' => [


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

This PR updates the `normalizeLocales` method in `ChannelNormalizer` to allow locales to be returned regardless of whether they have permissions/are activated. It fixes a bug in the channel edit form where a user saves a locale, removes permissions from it, and then can no longer see it when editing the channel. 

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | Todo
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
