### PR TITLE
Api 332: logs of the import/export should be in a configurable directory for the saas

### DIFF
--- a/app/config/pim_parameters.yml
+++ b/app/config/pim_parameters.yml
@@ -16,8 +16,9 @@ parameters:
 
     upload_dir:           '%kernel.root_dir%/uploads/product'
     archive_dir:          '%kernel.root_dir%/archive'
+    logs_dir:             '%kernel.logs_dir%'
     catalog_storage_dir:  '%kernel.root_dir%/file_storage/catalog'
-    tmp_storage_dir:      /tmp/pim/file_storage
+    tmp_storage_dir:      '/tmp/pim/file_storage'
 
     installed:            ~
 

--- a/src/Akeneo/Bundle/BatchBundle/Resources/config/services.yml
+++ b/src/Akeneo/Bundle/BatchBundle/Resources/config/services.yml
@@ -52,7 +52,7 @@ services:
             - true
             - null
             - false
-            - '%kernel.logs_dir%/batch'
+            - '%logs_dir%/batch'
 
     akeneo_batch.set_job_execution_log_file_subscriber:
         class: '%akeneo_batch.set_job_execution_log_file_subscriber.class%'
@@ -74,4 +74,4 @@ services:
             - '@akeneo_batch.job.job_registry'
             - '%kernel.root_dir%'
             - '%kernel.environment%'
-            - '%kernel.logs_dir%'
+            - '%logs_dir%'

--- a/src/Pim/Bundle/InstallerBundle/Resources/config/services.yml
+++ b/src/Pim/Bundle/InstallerBundle/Resources/config/services.yml
@@ -12,4 +12,4 @@ services:
     pim_installer.directories_registry:
         class: '%pim_installer.directories_registry.class%'
         arguments:
-            - ['%catalog_storage_dir%', '%tmp_storage_dir%', '%archive_dir%']
+            - ['%catalog_storage_dir%', '%tmp_storage_dir%', '%archive_dir%', '%upload_dir%', '%logs_dir%']


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

[//]: <> (What does this Pull Request do? reference the related issue?)

The log files created by the export/import are currently written in a directory that is not configurable in the "pim_parameters". 
It prevents to download a log file across several instances of the PIM.

In order to allow horizontal scalability, the directory should be configurable.
This way, the cloud team can configure the path to a shared directory between all the containers/instances of the PIM.

Note: for now, batch_execute.log is written in the configured repository. It will generate problems as the name is not depending of the job execution id, in case of concurrency access to the file across several instances of the PIM.

This case will be handle in another PR, with a "batch execute" file for each job execution. 

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | -
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
