### PR TITLE
API: Fix NormalizedProductCleaner static function

### DIFF
--- a/src/Pim/Component/Catalog/tests/integration/Normalizer/NormalizedProductCleaner.php
+++ b/src/Pim/Component/Catalog/tests/integration/Normalizer/NormalizedProductCleaner.php
@@ -152,7 +152,7 @@ class NormalizedProductCleaner
      *
      * @return array
      */
-    private function sanitizeMediaAttributeData(array &$data)
+    private static function sanitizeMediaAttributeData(array &$data)
     {
         if (!isset($data['values'])) {
             return $data;


### PR DESCRIPTION
This resulted to errors on CI:

1) PimEnterprise\Bundle\ApiBundle\tests\integration\Controller\ProductDraft\GetProductDraftIntegration::testGetProductDraftSuccessful
Non-static method Pim\Component\Catalog\tests\integration\Normalizer\NormalizedProductCleaner::sanitizeMediaAttributeData() should not be called statically

/home/akeneo/jenkins-workspace/workspace/_pim-enterprise-dev_PR-2982-56AOGLAMMLGCQRC2MWNFGKSA3JAER44QA7NXPN3Z4YPPXLYSFUDA/vendor/akeneo/pim-community-dev/src/Pim/Component/Catalog/tests/integration/Normalizer/NormalizedProductCleaner.php:26
/home/akeneo/jenkins-workspace/workspace/_pim-enterprise-dev_PR-2982-56AOGLAMMLGCQRC2MWNFGKSA3JAER44QA7NXPN3Z4YPPXLYSFUDA/src/PimEnterprise/Bundle/ApiBundle/tests/integration/Controller/ProductDraft/GetProductDraftIntegration.php:69


**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
