### PR TITLE
API-333: make the path of imported files configurable for horizontal scalability

### DIFF
--- a/CHANGELOG-1.8.md
+++ b/CHANGELOG-1.8.md
@@ -292,6 +292,7 @@
 - Change the constructor of `Pim\Bundle\EnrichBundle\Controller\Rest\AttributeController`
 - Change the constructor of `Pim\Bundle\EnrichBundle\Normalizer\AttributeNormalizer` to add `Pim\Bundle\VersioningBundle\Manager\VersionManager`, `Symfony\Component\Serializer\Normalizer\NormalizerInterface`, `Pim\Bundle\EnrichBundle\Provider\StructureVersion\StructureVersionProviderInterface`, `Akeneo\Component\Localization\Localizer\LocalizerInterface`
 - Change the constructor of `Pim\Bundle\EnrichBundle\Normalizer\ProductNormalizer` to add `Pim\Bundle\EnrichBundle\Normalizer\FileNormalizer`
+- Change the constructor of `\Pim\Bundle\EnrichBundle\Controller\Rest\JobInstanceController` to add `uploadTmpDir` (string)
 
 ### Methods
 

--- a/app/config/pim_parameters.yml
+++ b/app/config/pim_parameters.yml
@@ -19,6 +19,7 @@ parameters:
     logs_dir:             '%kernel.logs_dir%'
     catalog_storage_dir:  '%kernel.root_dir%/file_storage/catalog'
     tmp_storage_dir:      '/tmp/pim/file_storage'
+    upload_tmp_dir:       '/tmp/pim/upload_tmp_dir'
 
     installed:            ~
 

--- a/features/attribute/option/import_attribute_options.feature
+++ b/features/attribute/option/import_attribute_options.feature
@@ -6,13 +6,10 @@ Feature: Import attribute options
 
   Background:
     Given the "footwear" catalog configuration
+    And the following attributes:
+      | code  | type                     | localizable | scopable | group |
+      | fruit | pim_catalog_simpleselect | 0           | 0        | other |
     And I am logged in as "Julia"
-    And I am on the attributes page
-    And I create a "Simple select" attribute
-    And I fill in the following information:
-      | Code            | fruit |
-      | Attribute group | Other |
-    And I save the attribute
 
   Scenario: Successfully show default translation when blank text
     Given the following CSV file to import:

--- a/features/import/check_encoding_before_import.feature
+++ b/features/import/check_encoding_before_import.feature
@@ -12,7 +12,7 @@ Feature:
     Given I am on the "csv_footwear_product_import" import job page
     When I upload and import the file "product_export_with_non_utf8_characters.csv"
     And I wait for the "csv_footwear_product_import" job to finish
-    Then I should see the text "The file \"/tmp/product_export_with_non_utf8_characters.csv\" is not correctly encoded in UTF-8. The lines 11, 15 are erroneous."
+    Then I should see the text "The file \"/tmp/pim/upload_tmp_dir/product_export_with_non_utf8_characters.csv\" is not correctly encoded in UTF-8. The lines 11, 15 are erroneous."
 
   Scenario: Import a file that contains only UTF-8 characters
     Given the following CSV file to import:

--- a/features/product-group/create_product_group.feature
+++ b/features/product-group/create_product_group.feature
@@ -9,9 +9,9 @@ Feature: Product group creation
     And I am logged in as "Julia"
     And I am on the product groups page
     And I create a new product group
+    Then I should see the Code and Type fields
 
   Scenario: Successfully create a cross sell
-    Then I should see the Code and Type fields
     And I should not see the Axis field
     When I fill in the following information in the popin:
       | Code | Cross      |
@@ -22,7 +22,9 @@ Feature: Product group creation
     And I should see groups Cross
 
   Scenario: Fail to create a group with an empty or invalid code
-    Given I press the "Save" button
+    Given I fill in the following information in the popin:
+      | Type | Cross sell |
+    And I press the "Save" button
     Then I should see validation error "This value should not be blank."
     When I fill in the following information in the popin:
       | Code | =( |
@@ -35,5 +37,6 @@ Feature: Product group creation
       | TSHIRT | T-Shirt Akeneo | X_SELL |
     When I fill in the following information in the popin:
       | Code | TSHIRT |
+      | Type | Cross sell |
     And I press the "Save" button
     Then I should see validation error "This value is already used."

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/controllers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/controllers.yml
@@ -419,6 +419,7 @@ services:
             - '@pim_catalog.filter.chained'
             - '@pim_enrich.normalizer.violation'
             - '@akeneo_batch.job_instance_factory'
+            - '%upload_tmp_dir%'
 
     pim_enrich.controller.rest.job_execution:
         class: '%pim_enrich.controller.rest.job_execution.class%'

--- a/src/Pim/Bundle/InstallerBundle/Resources/config/services.yml
+++ b/src/Pim/Bundle/InstallerBundle/Resources/config/services.yml
@@ -12,4 +12,4 @@ services:
     pim_installer.directories_registry:
         class: '%pim_installer.directories_registry.class%'
         arguments:
-            - ['%catalog_storage_dir%', '%tmp_storage_dir%', '%archive_dir%', '%upload_dir%', '%logs_dir%']
+            - ['%catalog_storage_dir%', '%tmp_storage_dir%', '%archive_dir%', '%upload_dir%', '%logs_dir%', '%upload_tmp_dir%']


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

Path of the imported files should be configurable in order to be consume by a queue.
This path will be shared across different instances of the PIM in the Saas.

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | Ok
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
