### PR TITLE
MIG-23: Check requirements could be launched before an install

### DIFF
--- a/src/Pim/Bundle/InstallerBundle/Command/CheckRequirementsCommand.php
+++ b/src/Pim/Bundle/InstallerBundle/Command/CheckRequirementsCommand.php
@@ -7,6 +7,7 @@ use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * Check requirements command
@@ -34,6 +35,7 @@ class CheckRequirementsCommand extends ContainerAwareCommand
     {
         $output->writeln('<info>Akeneo PIM requirements check:</info>');
 
+        $this->prepareRequirementsDirectories();
         $this->renderRequirements($input, $output, $this->getRequirements());
     }
 
@@ -122,5 +124,20 @@ class CheckRequirementsCommand extends ContainerAwareCommand
     protected function getDirectoriesContainer()
     {
         return $this->getContainer()->get('pim_installer.directories_registry');
+    }
+
+    protected function prepareRequirementsDirectories(): void
+    {
+        foreach ($this->getDirectoriesContainer()->getDirectories() as $directory) {
+            $this->prepareDirectory($directory);
+        }
+    }
+
+    protected function prepareDirectory(string $directory): void
+    {
+        $filesystem = new Filesystem();
+        if (!$filesystem->exists($directory)) {
+            $filesystem->mkdir($directory);
+        }
     }
 }

--- a/src/Pim/Bundle/InstallerBundle/Command/CheckRequirementsCommand.php
+++ b/src/Pim/Bundle/InstallerBundle/Command/CheckRequirementsCommand.php
@@ -35,7 +35,6 @@ class CheckRequirementsCommand extends ContainerAwareCommand
     {
         $output->writeln('<info>Akeneo PIM requirements check:</info>');
 
-        $this->prepareRequirementsDirectories();
         $this->renderRequirements($input, $output, $this->getRequirements());
     }
 
@@ -124,20 +123,5 @@ class CheckRequirementsCommand extends ContainerAwareCommand
     protected function getDirectoriesContainer()
     {
         return $this->getContainer()->get('pim_installer.directories_registry');
-    }
-
-    protected function prepareRequirementsDirectories(): void
-    {
-        foreach ($this->getDirectoriesContainer()->getDirectories() as $directory) {
-            $this->prepareDirectory($directory);
-        }
-    }
-
-    protected function prepareDirectory(string $directory): void
-    {
-        $filesystem = new Filesystem();
-        if (!$filesystem->exists($directory)) {
-            $filesystem->mkdir($directory);
-        }
     }
 }

--- a/src/Pim/Bundle/InstallerBundle/Command/CheckRequirementsCommand.php
+++ b/src/Pim/Bundle/InstallerBundle/Command/CheckRequirementsCommand.php
@@ -7,7 +7,6 @@ use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * Check requirements command

--- a/src/Pim/Bundle/InstallerBundle/Command/InstallCommand.php
+++ b/src/Pim/Bundle/InstallerBundle/Command/InstallCommand.php
@@ -68,11 +68,8 @@ class InstallCommand extends ContainerAwareCommand
         $output->writeln('');
 
         try {
-            foreach ($this->getDirectoriesContainer()->getDirectories() as $directory) {
-                $this->cleanDirectory($directory);
-            }
-
             $this
+                ->prepareRequiredDirectoriesStep()
                 ->checkStep()
                 ->databaseStep()
                 ->assetsStep();
@@ -89,6 +86,20 @@ class InstallCommand extends ContainerAwareCommand
         $output->writeln(sprintf('<info>%s Application has been successfully installed.</info>', static::APP_NAME));
 
         return 0;
+    }
+
+    /**
+     * Step where required directories are created.
+     *
+     * @throws \RuntimeException
+     *
+     * @return InstallCommand
+     */
+    protected function prepareRequiredDirectoriesStep(): InstallCommand
+    {
+        $this->commandExecutor->runCommand('pim:installer:prepare-required-directories');
+
+        return $this;
     }
 
     /**
@@ -147,27 +158,5 @@ class InstallCommand extends ContainerAwareCommand
         $dumper->dump($params);
 
         return $this;
-    }
-
-    /**
-     * Remove directory and all subcontent
-     *
-     * @param string $folder
-     */
-    protected function cleanDirectory($folder)
-    {
-        $filesystem = new Filesystem();
-        if ($filesystem->exists($folder)) {
-            $filesystem->remove($folder);
-        }
-        $filesystem->mkdir($folder);
-    }
-
-    /**
-     * @return PimDirectoriesRegistry
-     */
-    protected function getDirectoriesContainer()
-    {
-        return $this->getContainer()->get('pim_installer.directories_registry');
     }
 }

--- a/src/Pim/Bundle/InstallerBundle/Command/PrepareRequiredDirectoriesCommand.php
+++ b/src/Pim/Bundle/InstallerBundle/Command/PrepareRequiredDirectoriesCommand.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Pim\Bundle\InstallerBundle\Command;
+
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * Prepare required directories
+ *
+ * @author    Anael Chardan <romain@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class PrepareRequiredDirectoriesCommand extends ContainerAwareCommand
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('pim:installer:prepare-required-directories')
+            ->setDescription('Prepare required directories for Akeneo PIM');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $output->writeln('<info>Akeneo PIM required directories creation:</info>');
+
+        $directoriesContainer = $this->getContainer()->get('pim_installer.directories_registry');
+        $filesystem = new Filesystem();
+
+        foreach ($directoriesContainer->getDirectories() as $directory) {
+            if ($filesystem->exists($directory)) {
+                $filesystem->remove($directory);
+                $output->writeln($directory . ' directory, removed.');
+            }
+            $filesystem->mkdir($directory);
+            $output->writeln($directory . ' directory, created.');
+        }
+
+        $output->writeln('<info>Akeneo PIM required directories : creation finished.</info>');
+    }
+}

--- a/src/Pim/Bundle/InstallerBundle/Command/PrepareRequiredDirectoriesCommand.php
+++ b/src/Pim/Bundle/InstallerBundle/Command/PrepareRequiredDirectoriesCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Pim\Bundle\InstallerBundle\Command;
 
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
@@ -19,7 +21,7 @@ class PrepareRequiredDirectoriesCommand extends ContainerAwareCommand
     /**
      * {@inheritdoc}
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('pim:installer:prepare-required-directories')
@@ -29,7 +31,7 @@ class PrepareRequiredDirectoriesCommand extends ContainerAwareCommand
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): void
     {
         $output->writeln('<info>Akeneo PIM required directories creation:</info>');
 


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

The goal of this PR is that we should be able to launch check-requirements before trying to install the PIM. This thing can be done by creating some folder during the check step. Seen with @skeleton and @jjanvier.


[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
