### PR TITLE
TIP-425: group by only on needed column to fix regression about performance for the jobs

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/JobExecutionRepository.php
+++ b/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/JobExecutionRepository.php
@@ -48,15 +48,7 @@ class JobExecutionRepository extends EntityRepository implements DatagridReposit
         $qb->leftJoin('s.warnings', 'w');
         $qb->andWhere('j.type = :jobType');
 
-        $qb
-            ->groupBy('e')
-            ->addGroupBy('e.id')
-            ->addGroupBy('status')
-            ->addGroupBy('statusLabel')
-            ->addGroupBy('date')
-            ->addGroupBy('jobCode')
-            ->addGroupBy('jobLabel')
-            ->addGroupBy('jobName');
+        $qb->groupBy('e.id');
 
         return $qb;
     }

--- a/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/JobTrackerRepository.php
+++ b/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/JobTrackerRepository.php
@@ -44,14 +44,7 @@ class JobTrackerRepository extends EntityRepository implements DatagridRepositor
             ->innerJoin('e.jobInstance', 'j')
             ->leftJoin('e.stepExecutions', 's')
             ->leftJoin('s.warnings', 'w')
-            ->groupBy('e')
-            ->addGroupBy('e.id')
-            ->addGroupBy('type')
-            ->addGroupBy('status')
-            ->addGroupBy('statusLabel')
-            ->addGroupBy('startTime')
-            ->addGroupBy('jobLabel')
-            ->addGroupBy('user');
+            ->groupBy('e.id');
 
         return $qb;
     }


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

When testing exports through UI, @NolwennP had some issues: the PIM was unavailable.
The reason is that I introduced a regression with https://github.com/akeneo/pim-community-dev/pull/6306 . 

The performance was very bad by adding every column in the group by for the job repositories. The request take 18 seconds in local for an export with 50000 warning (warnings were created just for testing, in reality it does not export with warnings).
And the, the session block all the other requests of the UI (looking forward to finish this one to resolve it: https://github.com/akeneo/pim-community-dev/pull/6211).

It's not necessary to to put every column in the group by, as Mysql is clever enough to determine if a column depends of another one.

Unfortunately, Mysql is not clever enough to do it when you add every columns in the group by (not normal imho as it can detect the needed columns). 
So, internally, I suppose it sorts on every columns, even not the indexed one.


Now, it takes 20ms (yes, it was not a tiny regression).

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
