### PR TITLE
PIM-6333: rework getValue method

### DIFF
--- a/features/Pim/Behat/Context/Storage/ProductModelStorage.php
+++ b/features/Pim/Behat/Context/Storage/ProductModelStorage.php
@@ -72,6 +72,7 @@ class ProductModelStorage extends RawMinkContext
         $attributesCodes = explode(',', $attributesCodes);
         $attributesCodes = array_map('trim', $attributesCodes);
 
+        /** @var ProductModelInterface $productModel */
         $productModel = $this->productModelRepository->findOneByIdentifier($code);
 
         if (null === $productModel) {
@@ -83,7 +84,11 @@ class ProductModelStorage extends RawMinkContext
             $infos = $this->attributeColumnInfoExtractor->extractColumnInfo($propertyName);
             /** @var AttributeInterface $attribute */
             $attribute = $infos['attribute'];
-            $productValue = $productModel->getValue($attribute->getCode(), $infos['locale_code'], $infos['scope_code']);
+            $productValue = $productModel->getValuesForVariation()->getByCodes(
+                $attribute->getCode(),
+                $infos['locale_code'],
+                $infos['scope_code']
+            );
 
             if (null !== $productValue) {
                 throw new \Exception(

--- a/features/import/product_model/import_business_rules.feature
+++ b/features/import/product_model/import_business_rules.feature
@@ -106,13 +106,12 @@ Feature: Create product through CSV import
     And I wait for the "csv_catalog_modeling_product_model_import" job to finish
     Then the product model "code-001" should not have the following values "composition, name-en_US, color"
 
-  @skip
   Scenario: Only the attributes with values defined as variant attributes level 1 in the family variant are updated.
     Given the following CSV file to import:
       """
-      code;parent;family_variant;categories;collection;description-en_US-ecommerce;erp_name-en_US;price;color;variation_name-en_US;composition;size;EAN;sku;weight
-      code-001;;clothing_color_size;master_men;Spring2017;description;Blazers_1654;100 EUR;blue;Blazers;composition;;;;
-      code-002;code-001;clothing_color_size;master_men;Spring2017;description;Blazers_1654;100 EUR;blue;Blazers;composition;;;;
+      code;parent;family_variant;categories;collection;description-en_US-ecommerce;erp_name-en_US;price;color;variation_name-en_US;composition;size;ean;sku;weight
+      code-001;;clothing_color_size;master_men;Spring2017;description;Blazers_1654;100 EUR;;;;;;;
+      code-002;code-001;clothing_color_size;master_men_blazers;Spring2017;description;Blazers_1654;100 EUR;blue;Blazers;composition;;;;
       """
     And the following job "csv_catalog_modeling_product_model_import" configuration:
       | filePath | %file to import% |

--- a/src/Pim/Bundle/CatalogBundle/EventSubscriber/LoadEntityWithValuesSubscriber.php
+++ b/src/Pim/Bundle/CatalogBundle/EventSubscriber/LoadEntityWithValuesSubscriber.php
@@ -6,7 +6,6 @@ use Doctrine\Common\EventSubscriber;
 use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
 use Doctrine\ORM\Events;
 use Pim\Component\Catalog\Factory\ValueCollectionFactory;
-use Pim\Component\Catalog\Model\EntityWithFamilyVariantInterface;
 use Pim\Component\Catalog\Model\EntityWithValuesInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -70,12 +69,6 @@ class LoadEntityWithValuesSubscriber implements EventSubscriber
         }
 
         $rawValues = $entity->getRawValues();
-        if ($entity instanceof EntityWithFamilyVariantInterface) {
-            $ancestryRawValues = $this->getAncestryRawValues($entity);
-            foreach ($ancestryRawValues as $attributeCode => $value) {
-                $rawValues[$attributeCode] = $value;
-            }
-        }
 
         $values = $this->getProductValueCollectionFactory()->createFromStorageFormat($rawValues);
         $entity->setValues($values);
@@ -91,24 +84,5 @@ class LoadEntityWithValuesSubscriber implements EventSubscriber
         }
 
         return $this->valueCollectionFactory;
-    }
-
-    /**
-     * Recursively get the raw values of all the parents of an entity.
-     *
-     * @param EntityWithFamilyVariantInterface $entity
-     * @param array                            $ancestryRawValues
-     *
-     * @return array
-     */
-    private function getAncestryRawValues(EntityWithFamilyVariantInterface $entity, array $ancestryRawValues = []): array
-    {
-        $parent = $entity->getParent();
-
-        if (null === $parent) {
-            return $ancestryRawValues;
-        }
-
-        return $this->getAncestryRawValues($parent, array_merge($ancestryRawValues, $parent->getRawValues()));
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/spec/EventSubscriber/ComputeEntityRawValuesSubscriberSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/EventSubscriber/ComputeEntityRawValuesSubscriberSpec.php
@@ -59,11 +59,9 @@ class ComputeEntityRawValuesSubscriberSpec extends ObjectBehavior
         $this->computeRawValues($event);
     }
 
-    function it_computes_raw_values_of_a_variant_product(
+    function it_computes_raw_values_of_an_entity_with_family_variant(
         $serializer,
         ProductModelInterface $rootProductModel,
-        ProductModelInterface $subProductModel,
-        VariantProductInterface $product,
         ValueCollectionInterface $values,
         ValueInterface $descriptionValue,
         ValueInterface $colorValue,
@@ -76,8 +74,8 @@ class ComputeEntityRawValuesSubscriberSpec extends ObjectBehavior
         AttributeInterface $attribute,
         GenericEvent $event
     ) {
-        $event->getSubject()->willReturn($product);
-        $product->getValues()->willReturn($values);
+        $event->getSubject()->willReturn($rootProductModel);
+        $rootProductModel->getValuesForVariation()->willReturn($values);
         $values->toArray()->willReturn([$descriptionValue, $colorValue, $imageValue, $value1, $value2]);
 
         $attribute->getCode()->willReturn('an_attribute');
@@ -104,16 +102,11 @@ class ComputeEntityRawValuesSubscriberSpec extends ObjectBehavior
         $imageValue->getScope()->willReturn(null);
         $imageValue->getLocale()->willReturn(null);
 
-        $rootProductModel->getParent()->willReturn(null);
-        $rootProductModel->getRawValues()->willReturn(['description' => 'a desc']);
-        $subProductModel->getParent()->willReturn($rootProductModel);
-        $subProductModel->getRawValues()->willReturn(['color' => 'red', 'image' => 'red.png']);
-        $product->getParent()->willReturn($subProductModel);
 
         $serializer->normalize(Argument::type(ValueCollectionInterface::class), 'storage')->willReturn(
             ['storage_value1' => 'data1', 'storage_value2' => 'data2']
         );
-        $product->setRawValues(['storage_value1' => 'data1', 'storage_value2' => 'data2'])->shouldBeCalled();
+        $rootProductModel->setRawValues(['storage_value1' => 'data1', 'storage_value2' => 'data2'])->shouldBeCalled();
 
         $this->computeRawValues($event);
     }

--- a/src/Pim/Bundle/CatalogBundle/spec/EventSubscriber/LoadEntityWithValuesSubscriberSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/EventSubscriber/LoadEntityWithValuesSubscriberSpec.php
@@ -7,9 +7,7 @@ use PhpSpec\ObjectBehavior;
 use Pim\Bundle\CatalogBundle\EventSubscriber\LoadEntityWithValuesSubscriber;
 use Pim\Component\Catalog\Factory\ValueCollectionFactory;
 use Pim\Component\Catalog\Model\ProductInterface;
-use Pim\Component\Catalog\Model\ProductModelInterface;
 use Pim\Component\Catalog\Model\ValueCollectionInterface;
-use Pim\Component\Catalog\Model\VariantProductInterface;
 use Prophecy\Argument;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -47,41 +45,6 @@ class LoadEntityWithValuesSubscriberSpec extends ObjectBehavior
 
         $valueCollectionFactory
             ->createFromStorageFormat(['an attribute' => 'a value', 'another attribute' => 'another value'])
-            ->willReturn($values);
-
-        $product->setValues($values)->shouldBeCalled();
-
-        $this->postLoad($event);
-    }
-
-    function it_loads_values_of_a_variant_product(
-        $valueCollectionFactory,
-        LifecycleEventArgs $event,
-        ProductModelInterface $rootProductModel,
-        ProductModelInterface $subProductModel,
-        VariantProductInterface $product,
-        ValueCollectionInterface $values
-    ) {
-        $event->getObject()->willReturn($product);
-        $product->getIdentifier()->willReturn('foo');
-        $product->getRawValues()->willReturn(['an attribute' => 'a value', 'another attribute' => 'another value']);
-
-        $rootProductModel->getParent()->willReturn(null);
-        $rootProductModel->getRawValues()->willReturn(['description' => 'a desc']);
-        $subProductModel->getParent()->willReturn($rootProductModel);
-        $subProductModel->getRawValues()->willReturn(['color' => 'red', 'image' => 'red.png']);
-        $product->getParent()->willReturn($subProductModel);
-
-        $valueCollectionFactory
-            ->createFromStorageFormat(
-                [
-                    'description'       => 'a desc',
-                    'color'             => 'red',
-                    'image'             => 'red.png',
-                    'an attribute'      => 'a value',
-                    'another attribute' => 'another value'
-                ]
-            )
             ->willReturn($values);
 
         $product->setValues($values)->shouldBeCalled();

--- a/src/Pim/Component/Catalog/Model/AbstractProduct.php
+++ b/src/Pim/Component/Catalog/Model/AbstractProduct.php
@@ -218,7 +218,7 @@ abstract class AbstractProduct implements ProductInterface
      */
     public function getValue($attributeCode, $localeCode = null, $scopeCode = null)
     {
-        return $this->values->getByCodes($attributeCode, $scopeCode, $localeCode);
+        return $this->getValues()->getByCodes($attributeCode, $scopeCode, $localeCode);
     }
 
     /**
@@ -244,7 +244,7 @@ abstract class AbstractProduct implements ProductInterface
      */
     public function hasAttribute(AttributeInterface $attribute)
     {
-        return in_array($attribute, $this->values->getAttributes(), true);
+        return in_array($attribute, $this->getValues()->getAttributes(), true);
     }
 
     /**
@@ -312,7 +312,7 @@ abstract class AbstractProduct implements ProductInterface
      */
     public function getAttributes()
     {
-        return $this->values->getAttributes();
+        return $this->getValues()->getAttributes();
     }
 
     /**

--- a/src/Pim/Component/Catalog/Model/EntityWithFamilyVariantInterface.php
+++ b/src/Pim/Component/Catalog/Model/EntityWithFamilyVariantInterface.php
@@ -37,4 +37,9 @@ interface EntityWithFamilyVariantInterface extends EntityWithValuesInterface
      * @return ProductModelInterface|null
      */
     public function getParent(): ?ProductModelInterface;
+
+    /**
+     * @return ValueCollectionInterface
+     */
+    public function getValuesForVariation(): ValueCollectionInterface;
 }

--- a/src/Pim/Component/Catalog/Model/VariantProduct.php
+++ b/src/Pim/Component/Catalog/Model/VariantProduct.php
@@ -57,4 +57,45 @@ class VariantProduct extends AbstractProduct implements VariantProductInterface
     {
         return $this->getParent()->getVariationLevel() + 1;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getValuesForVariation(): ValueCollectionInterface
+    {
+        return $this->values;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getValues(): ValueCollectionInterface
+    {
+        $values = ValueCollection::fromCollection($this->values);
+
+        return $this->getAllValues($this, $values);
+    }
+
+    /**
+     * @param EntityWithFamilyVariantInterface $entity
+     * @param ValueCollectionInterface         $valueCollection
+     *
+     * @return ValueCollectionInterface
+     */
+    private function getAllValues(
+        EntityWithFamilyVariantInterface $entity,
+        ValueCollectionInterface $valueCollection
+    ) {
+        $parent = $entity->getParent();
+
+        if (null === $parent) {
+            return $valueCollection;
+        }
+
+        foreach ($parent->getValuesForVariation() as $value) {
+            $valueCollection->add($value);
+        }
+
+        return $this->getAllValues($parent, $valueCollection);
+    }
 }

--- a/src/Pim/Component/Catalog/Validator/Constraints/OnlyExpectedAttributesValidator.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/OnlyExpectedAttributesValidator.php
@@ -46,7 +46,7 @@ class OnlyExpectedAttributesValidator extends ConstraintValidator
         $familyAttributes = $family->getAttributes();
         $levelAttributes = $this->attributesProvider->getAttributes($entity);
 
-        foreach ($entity->getAttributes() as $modelAttribute) {
+        foreach ($entity->getValuesForVariation()->getAttributes() as $modelAttribute) {
             if (!$familyAttributes->contains($modelAttribute)) {
                 $this->context->buildViolation(
                     OnlyExpectedAttributes::ATTRIBUTE_DOES_NOT_BELONG_TO_FAMILY, [

--- a/src/Pim/Component/Catalog/spec/Validator/Constraints/OnlyExpectedAttributesValidatorSpec.php
+++ b/src/Pim/Component/Catalog/spec/Validator/Constraints/OnlyExpectedAttributesValidatorSpec.php
@@ -9,6 +9,7 @@ use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\EntityWithFamilyVariantInterface;
 use Pim\Component\Catalog\Model\FamilyInterface;
 use Pim\Component\Catalog\Model\FamilyVariantInterface;
+use Pim\Component\Catalog\Model\ValueCollection;
 use Pim\Component\Catalog\Validator\Constraints\OnlyExpectedAttributes;
 use Prophecy\Argument;
 use Symfony\Component\Validator\Constraint;
@@ -65,10 +66,12 @@ class OnlyExpectedAttributesValidatorSpec extends ObjectBehavior
         OnlyExpectedAttributes $constraint,
         AttributeInterface $color,
         FamilyInterface $family,
-        Collection $attributes
+        Collection $attributes,
+        ValueCollection $valuesForVariation
     ) {
         $entity->getFamilyVariant()->willReturn($familyVariant);
-        $entity->getAttributes()->willReturn([]);
+        $entity->getValuesForVariation()->willReturn($valuesForVariation);
+        $valuesForVariation->getAttributes()->willReturn([]);
         $attributesProvider->getAttributes($entity)->willReturn([$color]);
 
         $familyVariant->getFamily()->willReturn($family);
@@ -91,10 +94,12 @@ class OnlyExpectedAttributesValidatorSpec extends ObjectBehavior
         AttributeInterface $price,
         ConstraintViolationBuilderInterface $violation,
         FamilyInterface $family,
-        Collection $attributes
+        Collection $attributes,
+        ValueCollection $valuesForVariation
     ) {
         $entity->getFamilyVariant()->willReturn($familyVariant);
-        $entity->getAttributes()->willReturn([$color, $sku, $price]);
+        $entity->getValuesForVariation()->willReturn($valuesForVariation);
+        $valuesForVariation->getAttributes()->willReturn([$color, $sku, $price]);
 
         $familyVariant->getFamily()->willReturn($family);
         $family->getAttributes()->willReturn($attributes);


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

For product models and variant products, the method `getValues` will return its values and the parent ones. To only get the values at the current level, you need to call `getValuesForVariation` method.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | yes
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

