### PR TITLE
API-324: Convert label option to mandatory argument in  command

### DIFF
--- a/CHANGELOG-1.8.md
+++ b/CHANGELOG-1.8.md
@@ -2,6 +2,7 @@
 
 ## Functional improvements
 
+- API-324: Convert label option to mandatory argument in command `pim:oauth-server:create-client`
 - API-312: Add UI to manage (create/revoke) API connections
 - TIP-718: Update group types form
 - PIM-6291: Adds attribute used as the main picture in the UI for each family (attribute_as_image)

--- a/features/Context/Page/Product/Index.php
+++ b/features/Context/Page/Product/Index.php
@@ -147,4 +147,28 @@ class Index extends Grid
             return $this->findAll('css', $this->elements['Manage filters options']['css']);
         }, 'Filters list was not found.');
     }
+
+    /**
+     * {@inheritdoc}
+     *
+     * This method is overridden in this class because we have to wait modal to be display before continue
+     */
+    public function clickCreationLink()
+    {
+        $this->spin(function () {
+            $modal = $this->find('css', '.modal-backdrop');
+
+            if (null !== $modal && $modal->isVisible()) {
+                return true;
+            }
+
+            $button = $this->find('css', $this->elements['Creation link']['css']);
+
+            if (null !== $button && $button->isVisible()) {
+                $button->click();
+            }
+
+            return null;
+        }, 'Cannot create product');
+    }
 }

--- a/src/Pim/Bundle/ApiBundle/Command/CreateClientCommand.php
+++ b/src/Pim/Bundle/ApiBundle/Command/CreateClientCommand.php
@@ -4,6 +4,7 @@ namespace Pim\Bundle\ApiBundle\Command;
 
 use OAuth2\OAuth2;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -40,10 +41,9 @@ class CreateClientCommand extends ContainerAwareCommand
                 'Sets allowed grant type for client.',
                 [OAuth2::GRANT_TYPE_USER_CREDENTIALS, OAuth2::GRANT_TYPE_REFRESH_TOKEN]
             )
-            ->addOption(
+            ->addArgument(
                 'label',
-                null,
-                InputOption::VALUE_REQUIRED,
+                InputArgument::REQUIRED,
                 'Sets a label to ease the administration of client ids.'
             )
         ;
@@ -60,8 +60,8 @@ class CreateClientCommand extends ContainerAwareCommand
         $client->setRedirectUris($input->getOption('redirect_uri'));
         $client->setAllowedGrantTypes($input->getOption('grant_type'));
 
-        if ($input->hasOption('label')) {
-            $client->setLabel($input->getOption('label'));
+        if ($input->hasArgument('label')) {
+            $client->setLabel($input->getArgument('label'));
         }
 
         $clientManager->updateClient($client);

--- a/src/Pim/Bundle/ApiBundle/Command/CreateClientCommand.php
+++ b/src/Pim/Bundle/ApiBundle/Command/CreateClientCommand.php
@@ -59,10 +59,7 @@ class CreateClientCommand extends ContainerAwareCommand
 
         $client->setRedirectUris($input->getOption('redirect_uri'));
         $client->setAllowedGrantTypes($input->getOption('grant_type'));
-
-        if ($input->hasArgument('label')) {
-            $client->setLabel($input->getArgument('label'));
-        }
+        $client->setLabel($input->getArgument('label'));
 
         $clientManager->updateClient($client);
 

--- a/src/Pim/Bundle/ApiBundle/tests/integration/ApiTestCase.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/ApiTestCase.php
@@ -91,20 +91,25 @@ abstract class ApiTestCase extends WebTestCase
     /**
      * Creates a new OAuth client and returns its client id and secret.
      *
+     * @param string|null $label
+     *
      * @return string[]
      */
-    protected function createOAuthClient()
+    protected function createOAuthClient(?string $label = null): array
     {
         $consoleApp = new Application(static::$kernel);
         $consoleApp->setAutoExit(false);
 
-        $input  = new ArrayInput(['command' => 'pim:oauth-server:create-client']);
+        $input  = new ArrayInput([
+            'command' => 'pim:oauth-server:create-client',
+            'label'   => null !== $label ? $label : 'Api test case client',
+        ]);
         $output = new BufferedOutput();
 
         $consoleApp->run($input, $output);
 
         $content = $output->fetch();
-        preg_match('/client_id: (.+)\nsecret: (.+)$/', $content, $matches);
+        preg_match('/client_id: (.+)\nsecret: (.+)\nlabel: (.+)$/', $content, $matches);
 
         return [$matches[1], $matches[2]];
     }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Command/CreateClientIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Command/CreateClientIntegration.php
@@ -30,7 +30,7 @@ class CreateClientIntegration extends KernelTestCase
         $this->assertContains('secret:', $output);
         $this->assertContains('label: Magento connector', $output);
 
-        $this->assertSame( 0, $commandTester->getStatusCode());
+        $this->assertSame(0, $commandTester->getStatusCode());
     }
 
     /**

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Command/CreateClientIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Command/CreateClientIntegration.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Pim\Bundle\ApiBundle\tests\integration\Command;
+
+use Pim\Bundle\ApiBundle\Command\CreateClientCommand;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Exception\RuntimeException;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class CreateClientIntegration extends KernelTestCase
+{
+    public function testResponseWhenCreateClient()
+    {
+        self::bootKernel();
+        $application = new Application(self::$kernel);
+        $application->add(new CreateClientCommand());
+
+        $command = $application->find('pim:oauth-server:create-client');
+        $commandTester = new CommandTester($command);
+
+        $commandTester->execute([
+            'command'  => $command->getName(),
+            'label' => 'Magento connector',
+        ]);
+        $output = $commandTester->getDisplay();
+
+        $this->assertContains('A new client has been added.', $output);
+        $this->assertContains('client_id:', $output);
+        $this->assertContains('secret:', $output);
+        $this->assertContains('label: Magento connector', $output);
+
+        $this->assertSame( 0, $commandTester->getStatusCode());
+    }
+
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage Not enough arguments (missing: "label").
+     */
+    public function testResponseWhenMissingLabel()
+    {
+        self::bootKernel();
+        $application = new Application(self::$kernel);
+        $application->add(new CreateClientCommand());
+
+        $command = $application->find('pim:oauth-server:create-client');
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(['command' => $command->getName()]);
+    }
+}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Label is now a required argument (before it was an option) by the command and mandatory when you create a client with the command line

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
