### PR TITLE
Enable web-server bundle

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -37,6 +37,7 @@ class AppKernel extends Kernel
             $bundles[] = new Sensio\Bundle\GeneratorBundle\SensioGeneratorBundle();
             $bundles[] = new Symfony\Bundle\DebugBundle\DebugBundle();
             $bundles[] = new Symfony\Bundle\WebProfilerBundle\WebProfilerBundle();
+            $bundles[] = new Symfony\Bundle\WebServerBundle\WebServerBundle();
         }
 
         $bundles = array_merge(


### PR DESCRIPTION
From Symfony's [upgrade documentation](https://github.com/symfony/symfony/blob/master/UPGRADE-3.3.md#frameworkbundle):

> The server:run, server:start, server:stop and server:status console commands have been moved to a dedicated bundle. Require symfony/web-server-bundle in your composer.json and register Symfony\Bundle\WebServerBundle\WebServerBundle in your AppKernel to use them.

The bundle is already required by composer via `symfony/symfony`.

I use a lot those commands in dev and test environments. 