### PR TITLE
Fix "symlink" and "clean" options on assets and install command

### DIFF
--- a/src/Pim/Bundle/InstallerBundle/Command/AssetsCommand.php
+++ b/src/Pim/Bundle/InstallerBundle/Command/AssetsCommand.php
@@ -51,7 +51,7 @@ class AssetsCommand extends ContainerAwareCommand
     {
         $output->writeln('<info>Akeneo PIM assets</info>');
 
-        if (null !== $input->getOption('clean')) {
+        if (true === $input->getOption('clean')) {
             try {
                 $webDir = $this->getWebDir();
 
@@ -74,7 +74,7 @@ class AssetsCommand extends ContainerAwareCommand
         $defaultLocales = ['en', 'fr', 'nl', 'de', 'ru', 'ja', 'pt', 'it'];
         $this->commandExecutor->runCommand('oro:translation:dump', ['locale' => $defaultLocales]);
 
-        if (null !== $input->getOption('symlink')) {
+        if (true === $input->getOption('symlink')) {
             $this->commandExecutor->runCommand('assets:install', ['--relative' => true, '--symlink' => true]);
         }
 

--- a/src/Pim/Bundle/InstallerBundle/Command/InstallCommand.php
+++ b/src/Pim/Bundle/InstallerBundle/Command/InstallCommand.php
@@ -135,8 +135,8 @@ class InstallCommand extends ContainerAwareCommand
      */
     protected function assetsStep(InputInterface $input, OutputInterface $output)
     {
-        $options = null === $input->getOption('symlink') ? [] : ['--symlink' => true];
-        $options = null === $input->getOption('clean') ? $options : array_merge($options, ['--clean' => true]);
+        $options = false === $input->getOption('symlink') ? [] : ['--symlink' => true];
+        $options = false === $input->getOption('clean') ? $options : array_merge($options, ['--clean' => true]);
 
         $this->commandExecutor->runCommand('pim:installer:assets', $options);
 


### PR DESCRIPTION
## Description

Two new options were recently added to the "pim:install" and "pim:installer:assets" commands:
- `clean` that ensure the removal of all folders that were not present when cloning the PIM from GitHub
- `symlink` that dump assets as relative symlinks

An error has been made in the option detection: the value returned by `InputInterface::getOption` was tested against `null` when it returns a boolean value.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
