### PR TITLE
[WIP] Add metadata length validator

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Resources/config/validation/attribute.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/validation/attribute.yml
@@ -453,8 +453,7 @@ Pim\Bundle\CatalogBundle\Entity\AttributeOption:
 Pim\Bundle\CatalogBundle\Entity\AttributeOptionValue:
     properties:
         value:
-            - Length:
-                max: 100
+            - Pim\Component\Catalog\Validator\Constraints\MetadataLength:
                 payload:
                   standardPropertyName: labels
         locale:

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/validators.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/validators.yml
@@ -23,6 +23,7 @@ parameters:
     pim_catalog.validator.constraint.unique_variant_group_type.class:      Pim\Component\Catalog\Validator\Constraints\UniqueVariantGroupTypeValidator
     pim_catalog.validator.constraints.locale_validator.class:              Pim\Component\Catalog\Validator\Constraints\LocaleValidator
     pim_catalog.validator.constraints.channel_validator.class:             Pim\Component\Catalog\Validator\Constraints\ChannelValidator
+    pim_catalog.validator.constraints.metadata_length_validator.class:     Pim\Component\Catalog\Validator\Constraints\MetadataLengthValidator
     pim_catalog.validator.constraint_guesser.chained.class:                Pim\Component\Catalog\Validator\ChainedAttributeConstraintGuesser
     pim_catalog.validator.constraint_guesser.email.class:                  Pim\Component\Catalog\Validator\ConstraintGuesser\EmailGuesser
     pim_catalog.validator.constraint_guesser.file.class:                   Pim\Component\Catalog\Validator\ConstraintGuesser\FileGuesser
@@ -114,6 +115,13 @@ services:
             - '@pim_catalog.repository.channel'
         tags:
             - { name: validator.constraint_validator, alias: pim_at_least_a_channel }
+
+    pim_catalog.validator.constraints.metadata_length_validator:
+        class: '%pim_catalog.validator.constraints.metadata_length_validator.class%'
+        arguments:
+            - '@doctrine.orm.entity_manager'
+        tags:
+            - { name: validator.constraint_validator, alias: pim_metadata_length_validator }
 
     pim_catalog.validator.constraint.immutable:
         class: '%pim_catalog.validator.constraint.immutable.class%'

--- a/src/Pim/Component/Catalog/Validator/Constraints/MetadataLength.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/MetadataLength.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Pim\Component\Catalog\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Constraint to check if a value is not longer than its database field
+ *
+ * @author    Romain Monceau <romain@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class MetadataLength extends Constraint
+{
+    /** @var string */
+    public $message = 'This value is too long. It should have {{ limit }} characters or less.';
+}

--- a/src/Pim/Component/Catalog/Validator/Constraints/MetadataLengthValidator.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/MetadataLengthValidator.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Pim\Component\Catalog\Validator\Constraints;
+
+use Doctrine\Common\Util\ClassUtils;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ * Validate that the length of a property is not longer that its field in the database
+ *
+ * @author    Romain Monceau <romain@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class MetadataLengthValidator extends ConstraintValidator
+{
+    /** @var EntityManagerInterface $em */
+    private $em;
+
+    /**
+     * @param EntityManagerInterface $em
+     */
+    public function __construct(EntityManagerInterface $em)
+    {
+        $this->em = $em;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validate($value, Constraint $constraint)
+    {
+        if (null === $value || $value === '') {
+            return;
+        }
+
+        $stringValue = (string) $value;
+        $valueLength = strlen($stringValue);
+        $object = $this->context->getObject();
+
+        if (is_object($object)) {
+            $classMetadata = $this->em->getClassMetadata(ClassUtils::getClass($object));
+            $propertyMetadata = $this->context->getMetadata()->getPropertyName();
+
+            $fieldMapping = $classMetadata->getFieldMapping($propertyMetadata);
+            if ($valueLength > $fieldMapping['length']) {
+                $this->context->buildViolation($constraint->message)
+                    ->setParameter('{{ limit }}', $fieldMapping['length'])
+                    ->setInvalidValue($value)
+                    ->addViolation();
+            }
+        }
+    }
+}

--- a/src/Pim/Component/Catalog/spec/Validator/Constraints/MetadataLengthSpec.php
+++ b/src/Pim/Component/Catalog/spec/Validator/Constraints/MetadataLengthSpec.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace spec\Pim\Component\Catalog\Validator\Constraints;
+
+use PhpSpec\ObjectBehavior;
+
+class MetadataLengthSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Pim\Component\Catalog\Validator\Constraints\MetadataLength');
+    }
+
+    function it_has_message()
+    {
+        $this->message->shouldBe('This value is too long. It should have {{ limit }} characters or less.');
+    }
+
+    function it_is_a_validator_constraint()
+    {
+        $this->shouldBeAnInstanceOf('Symfony\Component\Validator\Constraint');
+    }
+}

--- a/src/Pim/Component/Catalog/spec/Validator/Constraints/MetadataLengthValidatorSpec.php
+++ b/src/Pim/Component/Catalog/spec/Validator/Constraints/MetadataLengthValidatorSpec.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace spec\Pim\Component\Catalog\Validator\Constraints;
+
+use Doctrine\Common\Util\ClassUtils;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\CatalogBundle\Entity\AttributeOptionValue;
+use Pim\Component\Catalog\Validator\Constraints\MetadataLength;
+use Prophecy\Argument;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Context\ExecutionContext;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Mapping\PropertyMetadata;
+use Symfony\Component\Validator\MetadataInterface;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilder;
+
+class MetadataLengthValidatorSpec extends ObjectBehavior
+{
+    function let(EntityManagerInterface $em, ExecutionContext $context)
+    {
+        $this->beConstructedWith($em);
+        $this->initialize($context);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Pim\Component\Catalog\Validator\Constraints\MetadataLengthValidator');
+    }
+
+    function it_is_a_validator()
+    {
+        $this->shouldBeAnInstanceOf('Symfony\Component\Validator\ConstraintValidator');
+    }
+
+    function it_is_only_applied_on_non_empty_fields($context, Constraint $constraint)
+    {
+        $context->getObject()->shouldNotBeCalled();
+        $context->buildViolation(Argument::any())->shouldNotBeCalled();
+
+        $this->validate('', $constraint);
+        $this->validate(null, $constraint);
+    }
+
+    function it_is_applied_only_on_objects($context, Constraint $constraint)
+    {
+        $context->getObject()->willReturn('a_string');
+        $context->buildViolation(Argument::any())->shouldNotBeCalled();
+
+        $this->validate('my_translation', $constraint);
+    }
+
+    function it_validates_the_value_is_not_to_long(
+        $context,
+        $em,
+        MetadataLength $constraint,
+        AttributeOptionValue $optionValue,
+        PropertyMetadata $propertyMetadata,
+        ClassMetadata $classMetadata
+    ) {
+        $context->getObject()->willReturn($optionValue);
+        $context->getMetadata()->willReturn($propertyMetadata);
+        $propertyMetadata->getPropertyName()->willReturn('value');
+
+        $em->getClassMetadata(Argument::any())->willReturn($classMetadata);
+        $classMetadata->getFieldMapping('value')->willReturn(['length' => 20]);
+
+        $context->buildViolation(Argument::any())->shouldNotBeCalled();
+
+        $this->validate('my_translation', $constraint);
+    }
+
+    function it_adds_a_violation_when_the_value_is_too_long(
+        $context,
+        $em,
+        MetadataLength $constraint,
+        AttributeOptionValue $optionValue,
+        PropertyMetadata $propertyMetadata,
+        ClassMetadata $classMetadata,
+        ConstraintViolationBuilder $constraintViolationBuilder
+    ) {
+        $context->getObject()->willReturn($optionValue);
+        $context->getMetadata()->willReturn($propertyMetadata);
+        $propertyMetadata->getPropertyName()->willReturn('value');
+
+        $em->getClassMetadata(Argument::any())->willReturn($classMetadata);
+        $classMetadata->getFieldMapping('value')->willReturn(['length' => 10]);
+
+        $context->buildViolation($constraint->message)->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->setParameter('{{ limit }}', 10)->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->setInvalidValue('my_translation')->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->addViolation()->shouldBeCalled();
+
+        $this->validate('my_translation', $constraint);
+    }
+}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Tthe current validation is not overridable and, since 1.7, it breaks the connector with CNET for attribute option labels length.
I did a dedicated validator which is based on the length of the field in the database. So it does not fit to an hard-coded length anymore.

I will do a second PR on next release to make the translations longer. Today a code could be longer than a translation label so it's quite weird.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | -
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
