### PR TITLE
PIM-6568: Fix import items invalid data that were no longer saved

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -1,3 +1,9 @@
+# 1.7.x
+
+## Bug Fixes
+
+- PIM-6568: Fix import items invalid data that were no longer saved
+
 # 1.7.7 (2017-08-03)
 
 ## Bug Fixes

--- a/features/import/view_import_items_invalid_data.feature
+++ b/features/import/view_import_items_invalid_data.feature
@@ -1,0 +1,26 @@
+@javascript
+Feature: Handle import of invalid data
+  In order to correct an import job that failed
+  As a product manager
+  I need to be able to see the content of the items of the import that have invalid data
+
+  Background:
+    Given a "footwear" catalog configuration
+
+  Scenario: Display items of a products import failed
+    Given I am logged in as "Julia"
+    And the following CSV file to import:
+      """
+      sku;family;handmade
+      SKU-001;NO_FAMILY;1
+      SKU-003;sneakers;0
+      """
+    And the following job "csv_footwear_product_import" configuration:
+      | filePath | %file to import% |
+    When I am on the "csv_footwear_product_import" import job page
+    And I launch the import job
+    And I wait for the "csv_footwear_product_import" job to finish
+    And I follow "Display item"
+    Then I should see the text "Warning"
+    And I should see the text "Property \"family\" expects a valid family code. The family does not exist, \"NO_FAMILY\" given."
+    And I should see the text "{\"sku\":[{\"locale\":null,\"scope\":null,\"data\":\"SKU-001\"}],\"handmade\":[{\"locale\":null,\"scope\":null,\"data\":true}]}"

--- a/src/Akeneo/Component/Batch/Step/ItemStep.php
+++ b/src/Akeneo/Component/Batch/Step/ItemStep.php
@@ -206,7 +206,7 @@ class ItemStep extends AbstractStep
             $stepExecution,
             $e->getMessage(),
             $e->getMessageParameters(),
-            $e->getItem()
+            $e->getItem()->getInvalidData()
         );
 
         $this->dispatchInvalidItemEvent(

--- a/src/Akeneo/Component/Batch/spec/Step/ItemStepSpec.php
+++ b/src/Akeneo/Component/Batch/spec/Step/ItemStepSpec.php
@@ -101,7 +101,7 @@ class ItemStepSpec extends ObjectBehavior
         );
 
         $repository
-            ->insertWarning(Argument::cetera())
+            ->insertWarning($execution, 'my msg', [], ['r4'])
             ->shouldBeCalled();
         $dispatcher->dispatch(Argument::any(), Argument::any())->shouldBeCalled();
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When an import fails, the details of the invalid items are no longer displayed on the import job execution details page. (clicking on the link "Display item" does not display anything)

It's because the function `DoctrineJobRepository::insertWarning` expects an array of the invalid data of the item, and not the item itself. No error was raised because the parameter `$item` is not typed. The signature of this method will be fixed on master, because we have to add this method to the interface `JobRepositoryInterface`.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added Behats                      | OK
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
