### PR TITLE
PIM-6353: index models command

### DIFF
--- a/src/Akeneo/Component/Console/CommandLauncher.php
+++ b/src/Akeneo/Component/Console/CommandLauncher.php
@@ -54,9 +54,10 @@ class CommandLauncher
     protected function buildCommandString($command)
     {
         return sprintf(
-            '%s %s/console --env=%s %s',
+            '%s %s%sconsole --env=%s %s',
             $this->getPhp(),
             sprintf('%s%s..%sbin', $this->rootDir, DIRECTORY_SEPARATOR, DIRECTORY_SEPARATOR),
+            DIRECTORY_SEPARATOR,
             $this->environment,
             $command
         );

--- a/src/Pim/Bundle/CatalogBundle/Command/IndexProductCommand.php
+++ b/src/Pim/Bundle/CatalogBundle/Command/IndexProductCommand.php
@@ -1,8 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Pim\Bundle\CatalogBundle\Command;
 
+use Akeneo\Component\StorageUtils\Detacher\BulkObjectDetacherInterface;
+use Akeneo\Component\StorageUtils\Indexer\BulkIndexerInterface;
+use Pim\Component\Catalog\Repository\ProductRepositoryInterface;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -16,8 +22,16 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class IndexProductCommand extends ContainerAwareCommand
 {
-    /** @var integer */
-    const DEFAULT_PAGE_SIZE = 100;
+    private const BULK_SIZE = 100;
+
+    /** @var ProductRepositoryInterface */
+    private $productRepository;
+
+    /** @var BulkObjectDetacherInterface */
+    private $bulkProductDetacher;
+
+    /** @var BulkIndexerInterface */
+    private $bulkProductIndexer;
 
     /**
      * {@inheritdoc}
@@ -26,14 +40,19 @@ class IndexProductCommand extends ContainerAwareCommand
     {
         $this
             ->setName('pim:product:index')
-            ->addOption(
-                'page-size',
-                false,
-                InputOption::VALUE_OPTIONAL,
-                'Number of products per page',
-                self::DEFAULT_PAGE_SIZE
+            ->addArgument(
+                'identifiers',
+                InputArgument::OPTIONAL | InputArgument::IS_ARRAY,
+                'List of product identifiers to index',
+                []
             )
-            ->setDescription('Index all products into Elasticsearch');
+            ->addOption(
+                'all',
+                true,
+                InputOption::VALUE_NONE,
+                'Index all existing products into Elasticsearch'
+            )
+            ->setDescription('Index all or some products into Elasticsearch');
     }
 
     /**
@@ -41,32 +60,118 @@ class IndexProductCommand extends ContainerAwareCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $productRepository = $this->getContainer()->get('pim_catalog.repository.product');
-        $productIndexer = $this->getContainer()->get('pim_catalog.elasticsearch.indexer.product');
-        $productAndProductModelIndexer = $this->getContainer()->get('pim_catalog.elasticsearch.indexer.product_model');
+        $this->productRepository = $this->getContainer()->get('pim_catalog.repository.product');
+        $this->bulkProductIndexer = $this->getContainer()->get('pim_catalog.elasticsearch.indexer.product');
+        $this->bulkProductDetacher = $this->getContainer()->get('akeneo_storage_utils.doctrine.object_detacher');
 
-        $pageSize = $input->getOption('page-size');
-        $totalElements = $productRepository->countAll();
-        $numberOfPage = ceil($totalElements / $pageSize);
+        $isIndexAll = $input->getOption('all');
+        $productIdentifiers = $input->getArgument('identifiers');
+
+        if ($isIndexAll) {
+            $totalIndexedProducts = $this->indexAll($output);
+        } elseif (0 < count($productIdentifiers)) {
+            $totalIndexedProducts = $this->index($output, $productIdentifiers);
+        } else {
+            $output->writeln('<error>Please specify a list of product identifiers to index or use the flag --all to index all products</error>');
+
+            return;
+        }
+
+        $message = sprintf('<info>%d products indexed</info>', $totalIndexedProducts);
+
+        $output->writeln($message);
+    }
+
+    /**
+     * Indexes all the products in elasticsearch.
+     *
+     * @param OutputInterface $output
+     *
+     * @return int
+     */
+    private function indexAll(OutputInterface $output): int
+    {
+        $totalElements = (int) $this->productRepository->countAll();
+        $numberOfPage = ceil($totalElements / self::BULK_SIZE);
 
         $output->writeln(sprintf('<info>%s products to index</info>', $totalElements));
 
         for ($currentPage = 1; $currentPage <= $numberOfPage; $currentPage++) {
-            $offset = $pageSize * ($currentPage - 1);
-            $output->writeln(
-                sprintf(
-                    'Indexing products %d to %d',
-                    $offset + 1,
-                    ($offset + $pageSize) < $totalElements ? ($offset + $pageSize) : $totalElements
-                )
-            );
+            $offset = self::BULK_SIZE * ($currentPage - 1);
+            $output->writeln(sprintf(
+                'Indexing products %d to %d',
+                $offset + 1,
+                ($offset + self::BULK_SIZE) < $totalElements ? ($offset + self::BULK_SIZE) : $totalElements
+            ));
 
-            $productIndexer->indexAll($productRepository->findAllWithOffsetAndSize($offset, $pageSize));
-            $productAndProductModelIndexer->indexAll($productRepository->findAllWithOffsetAndSize($offset, $pageSize));
+            $products = $this->productRepository->findAllWithOffsetAndSize($offset, self::BULK_SIZE);
+
+            $this->bulkProductIndexer->indexAll($products);
+            $this->bulkProductDetacher->detachAll($products);
         }
 
-        $message = sprintf('<info>%d products indexed</info>', $totalElements);
+        return $totalElements;
+    }
 
-        $output->writeln($message);
+    /**
+     * Indexes the given list of product identifiers in Elasticsearch.
+     *
+     * @param OutputInterface $output
+     * @param array           $identifiers
+     *
+     * @return int
+     */
+    private function index(OutputInterface $output, array $identifiers): int
+    {
+        $products = $this->productRepository->findBy(['identifiers' => $identifiers]);
+        $productsCount = count($products);
+
+        if ($productsCount !== count($identifiers)) {
+            $identifiersFound = [];
+            foreach ($products as $product) {
+                $identifiersFound[] = $product->getIdentifier();
+            }
+
+            $notFoundIdentifiers = array_diff($identifiers, $identifiersFound);
+            $output->writeln(sprintf(
+                '<error>Some products were not found for the given identifiers: %s</error>',
+                implode(', ', $notFoundIdentifiers)
+            ));
+        }
+
+        $output->writeln(sprintf('<info>%d products found for indexing</info>', $productsCount));
+
+        $i = 0;
+        $productBulk = [];
+        $totalProductsIndexed = 0;
+        foreach ($products as $product) {
+            $productBulk[] = $product;
+
+            $i++;
+
+            if (0 === $i % self::BULK_SIZE) {
+                $this->bulkProductIndexer->indexAll($productBulk);
+                $this->bulkProductDetacher->detachAll($productBulk);
+
+                $productBulk = [];
+
+                $totalProductsIndexed += self::BULK_SIZE;
+
+                $output->writeln(sprintf(
+                    '%d on %d products indexed',
+                    $totalProductsIndexed,
+                    $productsCount
+                ));
+            }
+        }
+
+        if (!empty($productBulk)) {
+            $this->bulkProductIndexer->indexAll($productBulk);
+            $this->bulkProductDetacher->detachAll($productBulk);
+
+            $totalProductsIndexed += count($productBulk);
+        }
+
+        return $totalProductsIndexed;
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/Command/IndexProductModelCommand.php
+++ b/src/Pim/Bundle/CatalogBundle/Command/IndexProductModelCommand.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\CatalogBundle\Command;
+
+use Akeneo\Component\StorageUtils\Detacher\BulkObjectDetacherInterface;
+use Akeneo\Component\StorageUtils\Indexer\BulkIndexerInterface;
+use Pim\Component\Catalog\Repository\ProductModelRepositoryInterface;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Index product models into Elasticsearch
+ *
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class IndexProductModelCommand extends ContainerAwareCommand
+{
+    private const BULK_SIZE = 100;
+
+    /** @var ProductModelRepositoryInterface */
+    private $productModelRepository;
+
+    /** @var BulkObjectDetacherInterface */
+    private $bulkProductModelDetacher;
+
+    /** @var BulkIndexerInterface */
+    private $bulkProductModelIndexer;
+
+    /** @var BulkIndexerInterface */
+    private $bulkProductModelDescendantsIndexer;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('pim:product-model:index')
+            ->addArgument(
+                'codes',
+                InputArgument::OPTIONAL | InputArgument::IS_ARRAY,
+                'List of product model codes to index',
+                []
+            )
+            ->addOption(
+                'all',
+                true,
+                InputOption::VALUE_NONE,
+                'Index all existing products into Elasticsearch'
+            )
+            ->setDescription('Index all or some product models into Elasticsearch');
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * TODO: Once the ProductModelQueryBuilder is written, we can use it instead of the productModelRepository.
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->productModelRepository = $this->getContainer()->get('pim_catalog.repository.product_model');
+        $this->bulkProductModelDetacher = $this->getContainer()->get('akeneo_storage_utils.doctrine.object_detacher');
+        $this->bulkProductModelIndexer = $this->getContainer()->get('pim_catalog.elasticsearch.indexer.product_model');
+        $this->bulkProductModelDescendantsIndexer = $this->getContainer()
+            ->get('pim_catalog.elasticsearch.indexer.product_model_descendance');
+
+        $isIndexAll = $input->getOption('all');
+        $productModelCodes = $input->getArgument('codes');
+
+        if ($isIndexAll) {
+            $totalIndexedProductModels = $this->indexAll($output);
+        } elseif (0 < count($productModelCodes)) {
+            $totalIndexedProductModels = $this->index($output, $productModelCodes);
+        } else {
+            $output->writeln('<error>Please specify a list of product model codes to index or use the flag --all to index all product models</error>');
+
+            return;
+        }
+
+        $message = sprintf('<info>%d product models indexed</info>', $totalIndexedProductModels);
+
+        $output->writeln($message);
+    }
+
+    /**
+     * Indexes all the product models in Elasticsearch.
+     *
+     * @param OutputInterface $output
+     *
+     * @return int
+     */
+    private function indexAll(OutputInterface $output): int
+    {
+        $totalElements = $this->productModelRepository->countRootProductModels();
+        $numberOfPage = ceil($totalElements / self::BULK_SIZE);
+
+        $output->writeln(sprintf('<info>%s product models to index</info>', $totalElements));
+
+        for ($currentPage = 1; $currentPage <= $numberOfPage; $currentPage++) {
+            $offset = self::BULK_SIZE * ($currentPage - 1);
+            $output->writeln(sprintf(
+                'Indexing product models %d to %d',
+                $offset + 1,
+                ($offset + self::BULK_SIZE) < $totalElements ? ($offset + self::BULK_SIZE) : $totalElements
+            ));
+
+            $rootProductModels = $this->productModelRepository->findRootProductModelsWithOffsetAndSize(
+                $offset,
+                self::BULK_SIZE
+            );
+
+            $this->bulkProductModelIndexer->indexAll($rootProductModels);
+            $this->bulkProductModelDescendantsIndexer->indexAll($rootProductModels);
+            $this->bulkProductModelDetacher->detachAll($rootProductModels);
+        }
+
+        return $totalElements;
+    }
+
+    /**
+     * Indexes the given list of product model codes in Elasticsearch.
+     *
+     * @param OutputInterface $output
+     * @param array           $codes
+     *
+     * @return int
+     */
+    private function index(OutputInterface $output, array $codes): int
+    {
+        $productModels = $this->productModelRepository->findBy(['code' => $codes]);
+        $productModelsCount = count($productModels);
+
+        if ($productModelsCount !== count($codes)) {
+            $codesFound = [];
+            foreach ($productModels as $productModel) {
+                $codesFound[] = $productModel->getCode();
+            }
+
+            $notFoundCodes = array_diff($codes, $codesFound);
+            $output->writeln(sprintf(
+                '<error>Some product models were not found for the given codes: %s</error>',
+                implode(', ', $notFoundCodes)
+            ));
+        }
+
+        $output->writeln(sprintf('<info>%d product models found for indexing</info>', $productModelsCount));
+
+        $i = 0;
+        $productModelBulk = [];
+        $totalProductModelsIndexed = 0;
+
+        foreach ($productModels as $productModel) {
+            $productModelBulk[] = $productModel;
+
+            $i++;
+
+            if (0 === $i % self::BULK_SIZE) {
+                $this->bulkProductModelIndexer->indexAll($productModelBulk);
+                $this->bulkProductModelDescendantsIndexer->indexAll($productModelBulk);
+                $this->bulkProductModelDetacher->detachAll($productModelBulk);
+
+                $productModelBulk = [];
+
+                $totalProductModelsIndexed += self::BULK_SIZE;
+
+                $output->writeln(sprintf(
+                    '%d on %d product models indexed',
+                    $totalProductModelsIndexed,
+                    $productModelsCount
+                ));
+            }
+        }
+
+        if (!empty($productModelBulk)) {
+            $this->bulkProductModelIndexer->indexAll($productModelBulk);
+            $this->bulkProductModelDescendantsIndexer->indexAll($productModelBulk);
+            $this->bulkProductModelDetacher->detachAll($productModelBulk);
+
+            $totalProductModelsIndexed += count($productModelBulk);
+        }
+
+        return $totalProductModelsIndexed;
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/ProductModelRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/ProductModelRepository.php
@@ -60,4 +60,31 @@ class ProductModelRepository extends EntityRepository implements ProductModelRep
 
         return $qb->getQuery()->execute();
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function countRootProductModels(): int
+    {
+        $count = $this->createQueryBuilder('pm')
+            ->select('COUNT(pm.id)')
+            ->andWhere('pm.parent IS NULL')
+            ->getQuery()
+            ->getSingleScalarResult();
+
+        return $count;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function findRootProductModelsWithOffsetAndSize($offset = 0, $size = 100): array
+    {
+        $queryBuilder = $this->createQueryBuilder('pm')
+            ->andWhere('pm.parent IS NULL')
+            ->setFirstResult($offset)
+            ->setMaxResults($size);
+
+        return $queryBuilder->getQuery()->getResult();
+    }
 }

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/ProductRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/ProductRepository.php
@@ -280,10 +280,7 @@ class ProductRepository extends EntityRepository implements
     }
 
     /**
-     * @param int $offset
-     * @param int $size
-     *
-     * @return array
+     * {@inheritdoc}
      */
     public function findAllWithOffsetAndSize($offset = 0, $size = 100)
     {

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/event_subscribers.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/event_subscribers.yml
@@ -131,8 +131,7 @@ services:
     pim_catalog.event_subscriber.index_product_models_descendants:
         class: '%pim_catalog.event_subscriber.index_product_models_descendants.class%'
         arguments:
-              - '@pim_catalog.elasticsearch.indexer.product_model_descendance'
-              - '@pim_catalog.elasticsearch.indexer.product_model_descendance'
-              - '@pim_catalog.elasticsearch.indexer.product_model_descendance'
+            - '@pim_catalog.elasticsearch.indexer.product_model'
+            - '@pim_catalog.command_launcher'
         tags:
             - { name: kernel.event_subscriber }

--- a/src/Pim/Bundle/CatalogBundle/spec/Command/IndexProductCommandSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Command/IndexProductCommandSpec.php
@@ -2,10 +2,11 @@
 
 namespace spec\Pim\Bundle\CatalogBundle\Command;
 
+use Akeneo\Component\StorageUtils\Detacher\BulkObjectDetacherInterface;
+use Akeneo\Component\StorageUtils\Indexer\BulkIndexerInterface;
 use PhpSpec\ObjectBehavior;
-use Pim\Bundle\CatalogBundle\Doctrine\ORM\Repository\ProductRepository;
-use Pim\Bundle\CatalogBundle\Elasticsearch\Indexer\ProductIndexer;
-use Pim\Bundle\CatalogBundle\Elasticsearch\Indexer\ProductModelIndexer;
+use Pim\Component\Catalog\Model\ProductInterface;
+use Pim\Component\Catalog\Repository\ProductRepositoryInterface;
 use Prophecy\Argument;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Application;
@@ -30,31 +31,34 @@ class IndexProductCommandSpec extends ObjectBehavior
 
     function it_indexes_all_products(
         ContainerInterface $container,
-        ProductRepository $productRepository,
-        ProductIndexer $productIndexer,
-        ProductModelIndexer $productAndProductModelIndexer,
+        ProductRepositoryInterface $productRepository,
+        BulkIndexerInterface $productIndexer,
+        BulkObjectDetacherInterface $productDetacher,
         InputInterface $input,
         OutputInterface $output,
         Application $application,
         HelperSet $helperSet,
-        InputDefinition $definition
+        InputDefinition $definition,
+        ProductInterface $product1,
+        ProductInterface $product2
     ) {
         $container->get('pim_catalog.repository.product')->willReturn($productRepository);
         $container->get('pim_catalog.elasticsearch.indexer.product')->willReturn($productIndexer);
-        $container->get('pim_catalog.elasticsearch.indexer.product_model')->willReturn($productAndProductModelIndexer);
+        $container->get('akeneo_storage_utils.doctrine.object_detacher')->willReturn($productDetacher);
 
-        $productRepository->countAll()->willReturn(6);
-        $productRepository->findAllWithOffsetAndSize(0, 5)->willReturn([]);
-        $productRepository->findAllWithOffsetAndSize(5, 5)->willReturn([]);
+        $productRepository->countAll()->willReturn(2);
+        $productRepository->findAllWithOffsetAndSize(0, 100)->willReturn([$product1, $product2]);
 
-        $output->writeln('<info>6 products to index</info>')->shouldBeCalled();
-        $output->writeln('Indexing products 1 to 5')->shouldBeCalled();
-        $output->writeln('Indexing products 6 to 6')->shouldBeCalled();
-        $output->writeln('<info>6 products indexed</info>')->shouldBeCalled();
+        $productIndexer->indexAll([$product1, $product2])->shouldBeCalled();
+
+        $productDetacher->detachAll([$product1, $product2])->shouldBeCalled();
+
+        $output->writeln('<info>2 products to index</info>')->shouldBeCalled();
+        $output->writeln('Indexing products 1 to 2')->shouldBeCalled();
+        $output->writeln('<info>2 products indexed</info>')->shouldBeCalled();
 
         $commandInput = new ArrayInput([
-            'command' => 'pim:product:index',
-            '--page-size' => 5,
+            'command'    => 'pim:product:index',
             '--no-debug' => true,
         ]);
         $application->run($commandInput, $output)->willReturn(0);
@@ -71,7 +75,199 @@ class IndexProductCommandSpec extends ObjectBehavior
         $input->isInteractive()->shouldBeCalled();
         $input->hasArgument(Argument::any())->shouldBeCalled();
         $input->validate()->shouldBeCalled();
-        $input->getOption('page-size')->willReturn(5);
+        $input->getArgument('identifiers')->willReturn([]);
+        $input->getOption('all')->willReturn(true);
+        $this->run($input, $output);
+    }
+
+    function it_indexes_a_product_with_identifier(
+        ContainerInterface $container,
+        ProductRepositoryInterface $productRepository,
+        BulkIndexerInterface $productIndexer,
+        BulkObjectDetacherInterface $productDetacher,
+        InputInterface $input,
+        OutputInterface $output,
+        Application $application,
+        HelperSet $helperSet,
+        InputDefinition $definition,
+        ProductInterface $productToIndex
+    ) {
+        $container->get('pim_catalog.repository.product')->willReturn($productRepository);
+        $container->get('pim_catalog.elasticsearch.indexer.product')->willReturn($productIndexer);
+        $container->get('akeneo_storage_utils.doctrine.object_detacher')->willReturn($productDetacher);
+
+        $productRepository->findBy(['identifiers' => ['product_identifier_to_index']])->willReturn([$productToIndex]);
+
+        $productIndexer->indexAll([$productToIndex])->shouldBeCalled();
+        $productDetacher->detachAll([$productToIndex])->shouldBeCalled();
+
+        $output->writeln('<info>1 products found for indexing</info>')->shouldBeCalled();
+        $output->writeln('<info>1 products indexed</info>')->shouldBeCalled();
+
+        $commandInput = new ArrayInput([
+            'command'       => 'pim:product:index',
+            '--identifiers' => ['product_identifier_to_index'],
+            '--no-debug'    => true,
+        ]);
+        $application->run($commandInput, $output)->willReturn(0);
+
+        $definition->getOptions()->willReturn([]);
+        $definition->getArguments()->willReturn([]);
+
+        $application->getHelperSet()->willReturn($helperSet);
+        $application->getDefinition()->willReturn($definition);
+
+        $this->setApplication($application);
+        $this->setContainer($container);
+        $input->bind(Argument::any())->shouldBeCalled();
+        $input->isInteractive()->shouldBeCalled();
+        $input->hasArgument(Argument::any())->shouldBeCalled();
+        $input->validate()->shouldBeCalled();
+        $input->getArgument('identifiers')->willReturn(['product_identifier_to_index']);
+        $input->getOption('all')->willReturn(false);
+        $this->run($input, $output);
+    }
+
+    function it_indexes_multiple_products_with_identifiers(
+        ContainerInterface $container,
+        ProductRepositoryInterface $productRepository,
+        BulkIndexerInterface $productIndexer,
+        BulkObjectDetacherInterface $productDetacher,
+        InputInterface $input,
+        OutputInterface $output,
+        Application $application,
+        HelperSet $helperSet,
+        InputDefinition $definition,
+        ProductInterface $product1,
+        ProductInterface $product2
+    ) {
+        $container->get('pim_catalog.repository.product')->willReturn($productRepository);
+        $container->get('pim_catalog.elasticsearch.indexer.product')->willReturn($productIndexer);
+        $container->get('akeneo_storage_utils.doctrine.object_detacher')->willReturn($productDetacher);
+
+        $productRepository->findBy(['identifiers' => ['product_1', 'product_2']])->willReturn([$product1, $product2]);
+
+        $productIndexer->indexAll([$product1, $product2])->shouldBeCalled();
+        $productDetacher->detachAll([$product1, $product2])->shouldBeCalled();
+
+        $output->writeln('<info>2 products found for indexing</info>')->shouldBeCalled();
+        $output->writeln('<info>2 products indexed</info>')->shouldBeCalled();
+
+        $commandInput = new ArrayInput([
+            'command'       => 'pim:product:index',
+            '--identifiers' => ['product_1', 'product_2'],
+            '--no-debug'    => true,
+        ]);
+        $application->run($commandInput, $output)->willReturn(0);
+
+        $definition->getOptions()->willReturn([]);
+        $definition->getArguments()->willReturn([]);
+
+        $application->getHelperSet()->willReturn($helperSet);
+        $application->getDefinition()->willReturn($definition);
+
+        $this->setApplication($application);
+        $this->setContainer($container);
+        $input->bind(Argument::any())->shouldBeCalled();
+        $input->isInteractive()->shouldBeCalled();
+        $input->hasArgument(Argument::any())->shouldBeCalled();
+        $input->validate()->shouldBeCalled();
+        $input->getArgument('identifiers')->willReturn(['product_1', 'product_2']);
+        $input->getOption('all')->willReturn(false);
+        $this->run($input, $output);
+    }
+
+    function it_does_not_index_non_existing_products(
+        ContainerInterface $container,
+        ProductRepositoryInterface $productRepository,
+        BulkIndexerInterface $productIndexer,
+        BulkObjectDetacherInterface $productDetacher,
+        InputInterface $input,
+        OutputInterface $output,
+        Application $application,
+        HelperSet $helperSet,
+        InputDefinition $definition,
+        ProductInterface $productToIndex
+    ) {
+        $container->get('pim_catalog.repository.product')->willReturn($productRepository);
+        $container->get('pim_catalog.elasticsearch.indexer.product')->willReturn($productIndexer);
+        $container->get('akeneo_storage_utils.doctrine.object_detacher')->willReturn($productDetacher);
+
+        $productRepository->findBy(['identifiers' => ['product_1', 'wrong_product']])->willReturn([$productToIndex]);
+
+        $productToIndex->getIdentifier()->willReturn('product_1');
+
+        $productIndexer->indexAll([$productToIndex])->shouldBeCalled();
+        $productDetacher->detachAll([$productToIndex])->shouldBeCalled();
+
+        $output->writeln('<error>Some products were not found for the given identifiers: wrong_product</error>')->shouldBeCalled();
+        $output->writeln('<info>1 products found for indexing</info>')->shouldBeCalled();
+        $output->writeln('<info>1 products indexed</info>')->shouldBeCalled();
+
+        $commandInput = new ArrayInput([
+            'command'       => 'pim:product:index',
+            '--identifiers' => ['product_1', 'wrong_product'],
+            '--no-debug'    => true,
+        ]);
+        $application->run($commandInput, $output)->willReturn(0);
+
+        $definition->getOptions()->willReturn([]);
+        $definition->getArguments()->willReturn([]);
+
+        $application->getHelperSet()->willReturn($helperSet);
+        $application->getDefinition()->willReturn($definition);
+
+        $this->setApplication($application);
+        $this->setContainer($container);
+        $input->bind(Argument::any())->shouldBeCalled();
+        $input->isInteractive()->shouldBeCalled();
+        $input->hasArgument(Argument::any())->shouldBeCalled();
+        $input->validate()->shouldBeCalled();
+        $input->getArgument('identifiers')->willReturn(['product_1', 'wrong_product']);
+        $input->getOption('all')->willReturn(false);
+        $this->run($input, $output);
+    }
+
+    function it_does_not_index_products_if_the_all_flag_is_not_set_and_no_identifier_is_passed(
+        ContainerInterface $container,
+        ProductRepositoryInterface $productRepository,
+        BulkIndexerInterface $productIndexer,
+        BulkObjectDetacherInterface $productDetacher,
+        InputInterface $input,
+        OutputInterface $output,
+        Application $application,
+        HelperSet $helperSet,
+        InputDefinition $definition
+    ) {
+        $container->get('pim_catalog.repository.product')->willReturn($productRepository);
+        $container->get('pim_catalog.elasticsearch.indexer.product')->willReturn($productIndexer);
+        $container->get('akeneo_storage_utils.doctrine.object_detacher')->willReturn($productDetacher);
+
+        $output->writeln('<error>Please specify a list of product identifiers to index or use the flag --all to index all products</error>')
+            ->shouldBeCalled();
+
+        $commandInput = new ArrayInput([
+            'command'       => 'pim:product:index',
+            '--identifiers' => [],
+            '--all'         => false,
+            '--no-debug'    => true,
+        ]);
+        $application->run($commandInput, $output)->willReturn(0);
+
+        $definition->getOptions()->willReturn([]);
+        $definition->getArguments()->willReturn([]);
+
+        $application->getHelperSet()->willReturn($helperSet);
+        $application->getDefinition()->willReturn($definition);
+
+        $this->setApplication($application);
+        $this->setContainer($container);
+        $input->bind(Argument::any())->shouldBeCalled();
+        $input->isInteractive()->shouldBeCalled();
+        $input->hasArgument(Argument::any())->shouldBeCalled();
+        $input->validate()->shouldBeCalled();
+        $input->getArgument('identifiers')->willReturn([]);
+        $input->getOption('all')->willReturn(false);
         $this->run($input, $output);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/spec/Command/IndexProductModelCommandSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Command/IndexProductModelCommandSpec.php
@@ -1,0 +1,301 @@
+<?php
+
+namespace spec\Pim\Bundle\CatalogBundle\Command;
+
+use Akeneo\Component\StorageUtils\Detacher\BulkObjectDetacherInterface;
+use Akeneo\Component\StorageUtils\Indexer\BulkIndexerInterface;
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Model\ProductModelInterface;
+use Pim\Component\Catalog\Repository\ProductModelRepositoryInterface;
+use Prophecy\Argument;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+class IndexProductModelCommandSpec extends ObjectBehavior
+{
+    function it_has_a_name()
+    {
+        $this->getName()->shouldReturn('pim:product-model:index');
+    }
+
+    function it_is_a_command()
+    {
+        $this->shouldBeAnInstanceOf(ContainerAwareCommand::class);
+    }
+
+    function it_indexes_all_product_models(
+        ContainerInterface $container,
+        ProductModelRepositoryInterface $productModelRepository,
+        BulkIndexerInterface $productModelIndexer,
+        BulkIndexerInterface $productModelDescendantsIndexer,
+        BulkObjectDetacherInterface $productModelDetacher,
+        InputInterface $input,
+        OutputInterface $output,
+        Application $application,
+        HelperSet $helperSet,
+        InputDefinition $definition,
+        ProductModelInterface $productModel1,
+        ProductModelInterface $productModel2
+    ) {
+        $container->get('pim_catalog.repository.product_model')->willReturn($productModelRepository);
+        $container->get('akeneo_storage_utils.doctrine.object_detacher')->willReturn($productModelDetacher);
+        $container->get('pim_catalog.elasticsearch.indexer.product_model')->willReturn($productModelIndexer);
+        $container->get('pim_catalog.elasticsearch.indexer.product_model_descendance')
+            ->willReturn($productModelDescendantsIndexer);
+
+        $productModelRepository->countRootProductModels()->willReturn(2);
+        $productModelRepository
+            ->findRootProductModelsWithOffsetAndSize(0, 100)
+            ->willReturn([$productModel1, $productModel2]);
+
+        $productModelIndexer->indexAll([$productModel1, $productModel2])->shouldBeCalled();
+
+        $productModelDetacher->detachAll([$productModel1, $productModel2])->shouldBeCalled();
+
+        $output->writeln('<info>2 product models to index</info>')->shouldBeCalled();
+        $output->writeln('Indexing product models 1 to 2')->shouldBeCalled();
+        $output->writeln('<info>2 product models indexed</info>')->shouldBeCalled();
+
+        $commandInput = new ArrayInput([
+            'command'    => 'pim:product-model:index',
+            '--all' => true,
+            '--no-debug' => true,
+        ]);
+        $application->run($commandInput, $output)->willReturn(0);
+
+        $definition->getOptions()->willReturn([]);
+        $definition->getArguments()->willReturn([]);
+
+        $application->getHelperSet()->willReturn($helperSet);
+        $application->getDefinition()->willReturn($definition);
+
+        $this->setApplication($application);
+        $this->setContainer($container);
+        $input->bind(Argument::any())->shouldBeCalled();
+        $input->isInteractive()->shouldBeCalled();
+        $input->hasArgument(Argument::any())->shouldBeCalled();
+        $input->validate()->shouldBeCalled();
+        $input->getArgument('codes')->willReturn([]);
+        $input->getOption('all')->willReturn(true);
+        $this->run($input, $output);
+    }
+
+    function it_indexes_a_product_with_identifier(
+        ContainerInterface $container,
+        ProductModelRepositoryInterface $productModelRepository,
+        BulkIndexerInterface $productModelIndexer,
+        BulkIndexerInterface $productModelDescendantsIndexer,
+        BulkObjectDetacherInterface $productModelDetacher,
+        InputInterface $input,
+        OutputInterface $output,
+        Application $application,
+        HelperSet $helperSet,
+        InputDefinition $definition,
+        ProductModelInterface $productModelToIndex
+    ) {
+        $container->get('pim_catalog.repository.product_model')->willReturn($productModelRepository);
+        $container->get('akeneo_storage_utils.doctrine.object_detacher')->willReturn($productModelDetacher);
+        $container->get('pim_catalog.elasticsearch.indexer.product_model')->willReturn($productModelIndexer);
+        $container->get('pim_catalog.elasticsearch.indexer.product_model_descendance')
+            ->willReturn($productModelDescendantsIndexer);
+
+        $productModelRepository->findBy(['code' => ['product_model_code_to_index']])->willReturn([$productModelToIndex]);
+
+        $productModelIndexer->indexAll([$productModelToIndex])->shouldBeCalled();
+        $productModelDetacher->detachAll([$productModelToIndex])->shouldBeCalled();
+
+        $output->writeln('<info>1 product models found for indexing</info>')->shouldBeCalled();
+        $output->writeln('<info>1 product models indexed</info>')->shouldBeCalled();
+
+        $commandInput = new ArrayInput([
+            'command'    => 'pim:product-model:index',
+            '--codes'    => ['product_model_code_to_index'],
+            '--all'      => false,
+            '--no-debug' => true,
+        ]);
+        $application->run($commandInput, $output)->willReturn(0);
+
+        $definition->getOptions()->willReturn([]);
+        $definition->getArguments()->willReturn([]);
+
+        $application->getHelperSet()->willReturn($helperSet);
+        $application->getDefinition()->willReturn($definition);
+
+        $this->setApplication($application);
+        $this->setContainer($container);
+        $input->bind(Argument::any())->shouldBeCalled();
+        $input->isInteractive()->shouldBeCalled();
+        $input->hasArgument(Argument::any())->shouldBeCalled();
+        $input->validate()->shouldBeCalled();
+        $input->getArgument('codes')->willReturn(['product_model_code_to_index']);
+        $input->getOption('all')->willReturn(false);
+        $this->run($input, $output);
+    }
+
+    function it_indexes_multiple_product_models_with_identifiers(
+        ContainerInterface $container,
+        ProductModelRepositoryInterface $productModelRepository,
+        BulkIndexerInterface $productModelIndexer,
+        BulkIndexerInterface $productModelDescendantsIndexer,
+        BulkObjectDetacherInterface $productModelDetacher,
+        InputInterface $input,
+        OutputInterface $output,
+        Application $application,
+        HelperSet $helperSet,
+        InputDefinition $definition,
+        ProductModelInterface $productModel1,
+        ProductModelInterface $productModel2
+    ) {
+        $container->get('pim_catalog.repository.product_model')->willReturn($productModelRepository);
+        $container->get('akeneo_storage_utils.doctrine.object_detacher')->willReturn($productModelDetacher);
+        $container->get('pim_catalog.elasticsearch.indexer.product_model')->willReturn($productModelIndexer);
+        $container->get('pim_catalog.elasticsearch.indexer.product_model_descendance')
+            ->willReturn($productModelDescendantsIndexer);
+
+        $productModelRepository->findBy(['code' => ['product_model_1', 'product_model_2']])
+            ->willReturn([$productModel1, $productModel2]);
+
+        $productModel1->getCode()->willReturn('product_model_1');
+        $productModel2->getCode()->willReturn('product_model_2');
+
+        $productModelIndexer->indexAll([$productModel1, $productModel2])->shouldBeCalled();
+        $productModelDetacher->detachAll([$productModel1, $productModel2])->shouldBeCalled();
+
+        $output->writeln('<info>2 product models found for indexing</info>')->shouldBeCalled();
+        $output->writeln('<info>2 product models indexed</info>')->shouldBeCalled();
+
+        $commandInput = new ArrayInput([
+            'command'    => 'pim:product-model:index',
+            '--codes'    => ['product_model_1', 'product_model_2'],
+            '--all'      => false,
+            '--no-debug' => true,
+        ]);
+        $application->run($commandInput, $output)->willReturn(0);
+
+        $definition->getOptions()->willReturn([]);
+        $definition->getArguments()->willReturn([]);
+
+        $application->getHelperSet()->willReturn($helperSet);
+        $application->getDefinition()->willReturn($definition);
+
+        $this->setApplication($application);
+        $this->setContainer($container);
+        $input->bind(Argument::any())->shouldBeCalled();
+        $input->isInteractive()->shouldBeCalled();
+        $input->hasArgument(Argument::any())->shouldBeCalled();
+        $input->validate()->shouldBeCalled();
+        $input->getArgument('codes')->willReturn(['product_model_1', 'product_model_2']);
+        $input->getOption('all')->willReturn(false);
+        $this->run($input, $output);
+    }
+
+    function it_does_not_index_non_existing_product_models(
+        ContainerInterface $container,
+        ProductModelRepositoryInterface $productModelRepository,
+        BulkIndexerInterface $productModelIndexer,
+        BulkIndexerInterface $productModelDescendantsIndexer,
+        BulkObjectDetacherInterface $productModelDetacher,
+        InputInterface $input,
+        OutputInterface $output,
+        Application $application,
+        HelperSet $helperSet,
+        InputDefinition $definition,
+        ProductModelInterface $productModel1,
+        ProductModelInterface $productModel2
+    ) {
+        $container->get('pim_catalog.repository.product_model')->willReturn($productModelRepository);
+        $container->get('akeneo_storage_utils.doctrine.object_detacher')->willReturn($productModelDetacher);
+        $container->get('pim_catalog.elasticsearch.indexer.product_model')->willReturn($productModelIndexer);
+        $container->get('pim_catalog.elasticsearch.indexer.product_model_descendance')
+            ->willReturn($productModelDescendantsIndexer);
+
+        $productModelRepository->findBy(['code' => ['product_model_1', 'product_model_2', 'wrong_product_model']])
+            ->willReturn([$productModel1, $productModel2]);
+
+        $productModel1->getCode()->willReturn('product_model_1');
+        $productModel2->getCode()->willReturn('product_model_2');
+
+        $productModelIndexer->indexAll([$productModel1, $productModel2])->shouldBeCalled();
+        $productModelDetacher->detachAll([$productModel1, $productModel2])->shouldBeCalled();
+
+        $output->writeln('<error>Some product models were not found for the given codes: wrong_product_model</error>')->shouldBeCalled();
+        $output->writeln('<info>2 product models found for indexing</info>')->shouldBeCalled();
+        $output->writeln('<info>2 product models indexed</info>')->shouldBeCalled();
+
+        $commandInput = new ArrayInput([
+            'command'    => 'pim:product-model:index',
+            '--codes'    => ['product_model_1', 'product_model_2', 'wrong_product_model'],
+            '--all'      => false,
+            '--no-debug' => true,
+        ]);
+        $application->run($commandInput, $output)->willReturn(0);
+
+        $definition->getOptions()->willReturn([]);
+        $definition->getArguments()->willReturn([]);
+
+        $application->getHelperSet()->willReturn($helperSet);
+        $application->getDefinition()->willReturn($definition);
+
+        $this->setApplication($application);
+        $this->setContainer($container);
+        $input->bind(Argument::any())->shouldBeCalled();
+        $input->isInteractive()->shouldBeCalled();
+        $input->hasArgument(Argument::any())->shouldBeCalled();
+        $input->validate()->shouldBeCalled();
+        $input->getArgument('codes')->willReturn(['product_model_1', 'product_model_2', 'wrong_product_model']);
+        $input->getOption('all')->willReturn(false);
+        $this->run($input, $output);
+    }
+
+    function it_does_not_index_product_models_if_the_all_flag_is_not_set_and_no_identifier_is_passed(
+        ContainerInterface $container,
+        ProductModelRepositoryInterface $productModelRepository,
+        BulkIndexerInterface $productModelIndexer,
+        BulkIndexerInterface $productModelDescendantsIndexer,
+        BulkObjectDetacherInterface $productModelDetacher,
+        InputInterface $input,
+        OutputInterface $output,
+        Application $application,
+        HelperSet $helperSet,
+        InputDefinition $definition
+    ) {
+        $container->get('pim_catalog.repository.product_model')->willReturn($productModelRepository);
+        $container->get('akeneo_storage_utils.doctrine.object_detacher')->willReturn($productModelDetacher);
+        $container->get('pim_catalog.elasticsearch.indexer.product_model')->willReturn($productModelIndexer);
+        $container->get('pim_catalog.elasticsearch.indexer.product_model_descendance')
+            ->willReturn($productModelDescendantsIndexer);
+
+        $output->writeln('<error>Please specify a list of product model codes to index or use the flag --all to index all product models</error>')
+            ->shouldBeCalled();
+
+        $commandInput = new ArrayInput([
+            'command'       => 'pim:product:index',
+            '--identifiers' => [],
+            '--all'         => false,
+            '--no-debug'    => true,
+        ]);
+        $application->run($commandInput, $output)->willReturn(0);
+
+        $definition->getOptions()->willReturn([]);
+        $definition->getArguments()->willReturn([]);
+
+        $application->getHelperSet()->willReturn($helperSet);
+        $application->getDefinition()->willReturn($definition);
+
+        $this->setApplication($application);
+        $this->setContainer($container);
+        $input->bind(Argument::any())->shouldBeCalled();
+        $input->isInteractive()->shouldBeCalled();
+        $input->hasArgument(Argument::any())->shouldBeCalled();
+        $input->validate()->shouldBeCalled();
+        $input->getArgument('codes')->willReturn([]);
+        $input->getOption('all')->willReturn(false);
+        $this->run($input, $output);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Doctrine/Common/Saver/IndexingProductModelDescendantsIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Doctrine/Common/Saver/IndexingProductModelDescendantsIntegration.php
@@ -34,6 +34,8 @@ class IndexingProductModelDescendantsIntegration extends TestCase
 
         $this->get('pim_catalog.saver.product_model')->save($rootProductModel);
 
+        sleep(10);
+
         $this->assertDocumentIdsForSearch(
             [
                 'seed_root_product_model',
@@ -89,6 +91,8 @@ class IndexingProductModelDescendantsIntegration extends TestCase
 
         $this->get('pim_catalog.saver.product_model')->saveAll([$rootProductModel1, $rootProductModel2]);
 
+        sleep(10);
+
         $this->assertDocumentIdsForSearch(
             [
                 'seed1_root_product_model',
@@ -112,30 +116,6 @@ class IndexingProductModelDescendantsIntegration extends TestCase
                 ],
             ]
         );
-
-        $this->assertDocumentIdsForSearch(
-            [
-                'seed2_root_product_model',
-                'seed2_sub_product_model_1',
-                'seed2_sub_product_model_2',
-                'seed2_product_variant_1',
-                'seed2_product_variant_2',
-                'seed2_product_variant_3',
-                'seed2_product_variant_4',
-            ],
-            [
-                '_source' => 'identifier',
-                'query'   => [
-                    'bool' => [
-                        'filter' => [
-                            'exists' => [
-                                'field' => 'values.a_file-media.<all_channels>.<all_locales>',
-                            ],
-                        ],
-                    ],
-                ],
-            ]
-        );
     }
 
     /**
@@ -151,15 +131,22 @@ class IndexingProductModelDescendantsIntegration extends TestCase
      *
      * @param array $expectedIdentifiers
      * @param array $search
+     *
+     * @return bool
      */
-    private function assertDocumentIdsForSearch(array $expectedIdentifiers, array $search)
+    private function assertDocumentIdsForSearch(array $expectedIdentifiers, array $search): bool
     {
         $documents = $this->esProductAndProductModelClient->search(self::DOCUMENT_TYPE, $search);
         $actualDocumentIdentifiers = array_map(function ($document) {
             return $document['_source']['identifier'];
         }, $documents['hits']['hits']);
 
-        $this->assertSame(sort($expectedIdentifiers), sort($actualDocumentIdentifiers));
+        sort($expectedIdentifiers);
+        sort($actualDocumentIdentifiers);
+
+        $this->assertSame($expectedIdentifiers, $actualDocumentIdentifiers);
+
+        return true;
     }
 
     /**

--- a/src/Pim/Component/Catalog/Repository/ProductModelRepositoryInterface.php
+++ b/src/Pim/Component/Catalog/Repository/ProductModelRepositoryInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Pim\Component\Catalog\Repository;
 
 use Akeneo\Component\StorageUtils\Repository\CursorableRepositoryInterface;
@@ -25,4 +27,19 @@ interface ProductModelRepositoryInterface extends
      * @return ProductModelInterface[]
      */
     public function findSiblingsProductModels(ProductModelInterface $productModel): array;
+
+    /**
+     * Return the number of existing root product models
+     *
+     * @return int
+     */
+    public function countRootProductModels(): int;
+
+    /**
+     * @param int $offset
+     * @param int $size
+     *
+     * @return array
+     */
+    public function findRootProductModelsWithOffsetAndSize($offset = 0, $size = 100): array;
 }

--- a/src/Pim/Component/Catalog/Repository/ProductRepositoryInterface.php
+++ b/src/Pim/Component/Catalog/Repository/ProductRepositoryInterface.php
@@ -108,4 +108,12 @@ interface ProductRepositoryInterface extends ObjectRepository
      * @return array
      */
     public function findProductIdsForVariantGroup(GroupInterface $variantGroup, array $criteria = []);
+
+    /**
+     * @param int $offset
+     * @param int $size
+     *
+     * @return array
+     */
+    public function findAllWithOffsetAndSize($offset = 0, $size = 100);
 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

- Add an argument to the command pim:product:index which let's you specify product identifiers to index
- Add a command pim:product-model:index which let's you index all product models and their descendants. You can pass the product model codes as arguments.
- Changes the ProductModelDescendantSubscriber to run the indexation of product model descendants in a background job using the command above.

**Command usages**:
Indexing products:
```
$ bin/console pim:product:index --env=prod
Please specify a list of product identifiers to index or use the flag --all to index all products

$ bin/console pim:product:index --all --env=prod
66 products to index
66 products indexed

$ bin/console pim:product:index product_1 product_2 --env=prod
Some products were not found for the given identifiers: product_2
1 products found for indexing
1 products indexed
```

Indexing product models:
```
$ bin/console pim:product-model:index --env=prod
Please specify a list of product model codes to index or use the flag --all to index all product models

$ bin/console pim:product-model:index --all --env=prod
55 product models to index
55 product models indexed

$ bin/console pim:product-model:index root_product_model_1 sub_product_model_1 --env=prod
Some product models were not found for the given codes: sub_product_model_1
1 product models found for indexing
1 product models indexed
```


**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Ok
| Added Behats                      | -
| Added integration tests           | Ok
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

