### PR TITLE
PIM-6744: Fix field configuration of xlsx product import job edit form

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -3,6 +3,7 @@
 ## Bug Fixes
 
 - PIM-6568: Fix import items invalid data that were no longer saved
+- PIM-6744: Fix field configuration of xlsx product import job edit form
 
 ## Improvements
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_import_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_import_edit.yml
@@ -83,7 +83,7 @@ extensions:
         targetZone: global-settings
         config:
             fieldCode: configuration.dateFormat
-            readOnly: true
+            readOnly: false
             label: pim_enrich.form.job_instance.tab.properties.date_format.title
             tooltip: pim_enrich.form.job_instance.tab.properties.date_format.help
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

On the edit form of the import jobs based on "xlsx_product_import", the field "Date format" is setted as "readonly" whereas it should not.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
