### PR TITLE
PIM-6472: Update product models through imports

### DIFF
--- a/features/import/family_variant/csv/create_family_variant.feature
+++ b/features/import/family_variant/csv/create_family_variant.feature
@@ -20,7 +20,7 @@ Feature: Create variants of family through CSV import
     And I launch the import job
     And I wait for the "csv_catalog_modeling_family_variant_import" job to finish
     Then there should be the following family variants:
-      | code                        | family   | label-de_DE                   | label-en_US                | label-fr_FR                     | variant-axes_1 | variant-axes_2 | variant-attributes_1                           | variant-attributes_2 |
+      | code                        | family   | label-de_DE                   | label-en_US                | label-fr_FR                     | variant-axes_1 | variant-axes_2 | variant-attributes_1                         | variant-attributes_2 |
       | another_clothing_color_size | clothing | Kleidung nach Farbe und Größe | Clothing by color and size | Vêtements par couleur et taille | color          | size           | color,name,image,variation_image,composition | size,ean,sku,weight  |
 
   Scenario: I successfully import a variant by size with one level of variation for the family shoes
@@ -35,7 +35,7 @@ Feature: Create variants of family through CSV import
     And I launch the import job
     And I wait for the "csv_catalog_modeling_family_variant_import" job to finish
     Then there should be the following family variants:
-      | code       | family | label-de_DE       | label-en_US   | label-fr_FR           | variant-axes_1 | variant-attributes_1 |
+      | code               | family | label-de_DE       | label-en_US   | label-fr_FR           | variant-axes_1 | variant-attributes_1 |
       | another_shoes_size | shoes  | Schuhe nach Größe | Shoes by size | Chaussures par taille | eu_shoes_size  | weight               |
 
   Scenario: I successfully import a variant by color and size with one level of variation for the family clothing
@@ -50,7 +50,7 @@ Feature: Create variants of family through CSV import
     And I launch the import job
     And I wait for the "csv_catalog_modeling_family_variant_import" job to finish
     Then there should be the following family variants:
-      | code                        | family   | label-de_DE                   | label-en_US                | label-fr_FR                     | variant-axes_1 | variant-attributes_1                     |
+      | code                        | family   | label-de_DE                   | label-en_US                | label-fr_FR                     | variant-axes_1 | variant-attributes_1                   |
       | another_clothing_color_size | clothing | Kleidung nach Farbe und Größe | Clothing by color and size | Vêtements par couleur et taille | color,size     | name,image,variation_image,composition |
 
   Scenario: I successfully import a variant by color and size with one level of variation for the family clothing with minimal data

--- a/features/import/family_variant/csv/update_family_variant.feature
+++ b/features/import/family_variant/csv/update_family_variant.feature
@@ -7,9 +7,9 @@ Feature: Update variants of family through CSV import
   Background:
     Given the "catalog_modeling" catalog configuration
     And the following family variants:
-      | code                    | family   | label-en_US                | variant-axes_1 | variant-axes_2 | variant-attributes_1                      | variant-attributes_2 |
+      | code                            | family   | label-en_US                | variant-axes_1 | variant-axes_2 | variant-attributes_1                    | variant-attributes_2 |
       | another_clothing_color_and_size | clothing | Clothing by color and size | color          | size           | color,image,variation_image,composition | size,ean,sku         |
-      | another_shoes_size              | shoes    | Shoes by size              | eu_shoes_size  |                |                                           |                      |
+      | another_shoes_size              | shoes    | Shoes by size              | eu_shoes_size  |                |                                         |                      |
       | another_clothing_color_size     | clothing | Clothing by color/size     | color,size     |                | name,image,variation_image              |                      |
     And I am logged in as "Peter"
     And I am on the imports page
@@ -30,7 +30,7 @@ Feature: Update variants of family through CSV import
     Then I should see the text "read lines 3"
     And I should see the text "processed 3"
     And there should be the following family variants:
-      | code                    | family   | label-en_US                        | variant-axes_1 | variant-axes_2 | variant-attributes_1                           | variant-attributes_2 |
+      | code                            | family   | label-en_US                        | variant-axes_1 | variant-axes_2 | variant-attributes_1                         | variant-attributes_2 |
       | another_clothing_color_and_size | clothing | Clothing variant by color and size | color          | size           | color,name,image,variation_image,composition | size,ean,sku,weight  |
-      | another_shoes_size              | shoes    | Shoes variant by size              | eu_shoes_size  |                | weight                                         |                      |
+      | another_shoes_size              | shoes    | Shoes variant by size              | eu_shoes_size  |                | weight                                       |                      |
       | another_clothing_color_size     | clothing | Clothing variant by color/size     | color,size     |                | name,image,variation_image,composition       |                      |

--- a/features/import/family_variant/xlsx/create_family_variant.feature
+++ b/features/import/family_variant/xlsx/create_family_variant.feature
@@ -20,7 +20,7 @@ Feature: Create variants of family through XLSX import
     And I launch the import job
     And I wait for the "xlsx_catalog_modeling_family_variant_import" job to finish
     Then there should be the following family variants:
-      | code                | family   | label-de_DE                   | label-en_US                | label-fr_FR                     | variant-axes_1 | variant-axes_2 | variant-attributes_1                           | variant-attributes_2 |
+      | code                        | family   | label-de_DE                   | label-en_US                | label-fr_FR                     | variant-axes_1 | variant-axes_2 | variant-attributes_1                         | variant-attributes_2 |
       | another_clothing_color_size | clothing | Kleidung nach Farbe und Größe | Clothing by color and size | Vêtements par couleur et taille | color          | size           | color,name,image,variation_image,composition | size,ean,sku,weight  |
 
   Scenario: I successfully import a variant by size with one level of variation for the family shoes
@@ -35,7 +35,7 @@ Feature: Create variants of family through XLSX import
     And I launch the import job
     And I wait for the "xlsx_catalog_modeling_family_variant_import" job to finish
     Then there should be the following family variants:
-      | code       | family | label-de_DE       | label-en_US    | label-fr_FR          | variant-axes_1 | variant-attributes_1 |
+      | code               | family | label-de_DE       | label-en_US   | label-fr_FR           | variant-axes_1 | variant-attributes_1 |
       | another_shoes_size | shoes  | Schuhe nach Größe | Shoes by size | Chaussures par taille | eu_shoes_size  | weight               |
 
   Scenario: I successfully import a variant by color and size with one level of variation for the family clothing
@@ -50,7 +50,7 @@ Feature: Create variants of family through XLSX import
     And I launch the import job
     And I wait for the "xlsx_catalog_modeling_family_variant_import" job to finish
     Then there should be the following family variants:
-      | code                | family   | label-de_DE                   | label-en_US                | label-fr_FR                     | variant-axes_1 | variant-attributes_1                     |
+      | code                        | family   | label-de_DE                   | label-en_US                | label-fr_FR                     | variant-axes_1 | variant-attributes_1                   |
       | another_clothing_color_size | clothing | Kleidung nach Farbe und Größe | Clothing by color and size | Vêtements par couleur et taille | color,size     | name,image,variation_image,composition |
 
   Scenario: I successfully import a variant by color and size with one level of variation for the family clothing with minimal data
@@ -65,5 +65,5 @@ Feature: Create variants of family through XLSX import
     And I launch the import job
     And I wait for the "xlsx_catalog_modeling_family_variant_import" job to finish
     Then there should be the following family variants:
-      | code                | family   | variant-axes_1 |
+      | code                        | family   | variant-axes_1 |
       | another_clothing_color_size | clothing | color,size     |

--- a/features/import/family_variant/xlsx/create_multiple_family_variants.feature
+++ b/features/import/family_variant/xlsx/create_multiple_family_variants.feature
@@ -22,7 +22,7 @@ Feature: Create variants of family through XLSX import
     And I upload and import the file "family_variant.xlsx"
     And I wait for the "family_variant_import" job to finish
     Then there should be the following family variants:
-      | code                    | family   | label-de_DE                   | label-en_US                | label-fr_FR                     | variant-axes_1 | variant-axes_2 | variant-attributes_1                           | variant-attributes_2 |
+      | code                            | family   | label-de_DE                   | label-en_US                | label-fr_FR                     | variant-axes_1 | variant-axes_2 | variant-attributes_1                         | variant-attributes_2 |
       | another_clothing_color_and_size | clothing | Kleidung nach Farbe und Größe | Clothing by color and size | Vêtements par couleur et taille | color          | size           | color,name,image,variation_image,composition | size,ean,sku,weight  |
-      | another_shoes_size              | shoes    | Schuhe nach Größe             | Shoes by size              | Chaussures par taille           | eu_shoes_size  |                | weight                                         |                      |
+      | another_shoes_size              | shoes    | Schuhe nach Größe             | Shoes by size              | Chaussures par taille           | eu_shoes_size  |                | weight                                       |                      |
       | another_clothing_color_size     | clothing | Kleidung nach Farbe/Größe     | Clothing by color/size     | Vêtements par couleur/taille    | color,size     |                | name,image,variation_image,composition       |                      |

--- a/features/import/family_variant/xlsx/update_family_variant.feature
+++ b/features/import/family_variant/xlsx/update_family_variant.feature
@@ -7,9 +7,9 @@ Feature: Update variants of family through XLSX import
   Background:
     Given the "catalog_modeling" catalog configuration
     And the following family variants:
-      | code                    | family   | label-en_US                | variant-axes_1 | variant-axes_2 | variant-attributes_1                      | variant-attributes_2 |
+      | code                            | family   | label-en_US                | variant-axes_1 | variant-axes_2 | variant-attributes_1                    | variant-attributes_2 |
       | another_clothing_color_and_size | clothing | Clothing by color and size | color          | size           | color,image,variation_image,composition | size,ean,sku         |
-      | another_shoes_size              | shoes    | Shoes by size              | eu_shoes_size  |                |                                           |                      |
+      | another_shoes_size              | shoes    | Shoes by size              | eu_shoes_size  |                |                                         |                      |
       | another_clothing_color_size     | clothing | Clothing by color/size     | color,size     |                | name,image,variation_image              |                      |
     And I am logged in as "Peter"
     And I am on the imports page
@@ -30,7 +30,7 @@ Feature: Update variants of family through XLSX import
     Then I should see the text "read lines 3"
     And I should see the text "processed 3"
     And there should be the following family variants:
-      | code                    | family   | label-en_US                        | variant-axes_1 | variant-axes_2 | variant-attributes_1                           | variant-attributes_2 |
+      | code                            | family   | label-en_US                        | variant-axes_1 | variant-axes_2 | variant-attributes_1                         | variant-attributes_2 |
       | another_clothing_color_and_size | clothing | Clothing variant by color and size | color          | size           | color,name,image,variation_image,composition | size,ean,sku,weight  |
-      | another_shoes_size              | shoes    | Shoes variant by size              | eu_shoes_size  |                | weight                                         |                      |
+      | another_shoes_size              | shoes    | Shoes variant by size              | eu_shoes_size  |                | weight                                       |                      |
       | another_clothing_color_size     | clothing | Clothing variant by color/size     | color,size     |                | name,image,variation_image,composition       |                      |

--- a/features/import/product_model/csv/create_product_model.feature
+++ b/features/import/product_model/csv/create_product_model.feature
@@ -1,5 +1,5 @@
 @javascript
-Feature: Create product through CSV import
+Feature: Create product models through CSV import
   In order to setup my application
   As a product manager
   I need to be able to import new product models
@@ -8,7 +8,7 @@ Feature: Create product through CSV import
     Given the "catalog_modeling" catalog configuration
     And I am logged in as "Julia"
 
-  Scenario: Julia imports new root products models
+  Scenario: Julia imports new root products models in CSV
     Given the following CSV file to import:
       """
       code;parent;family_variant;categories;collection;description-en_US-ecommerce;erp_name-en_US;price;color;name-en_US;composition;size;ean;sku;weight
@@ -23,7 +23,7 @@ Feature: Create product through CSV import
       | code     | categories | family_variant     | collection   | description-en_US-ecommerce | erp_name-en_US | price      |
       | code-001 | master_men | clothing_colorsize | [Spring2017] | description                 | Blazers_1654   | 100.00 EUR |
 
-  Scenario: Julia imports new products sub-models
+  Scenario: Julia imports new products sub-models in CSV
     Given the following CSV file to import:
       """
       code;parent;family_variant;categories;collection;description-en_US-ecommerce;erp_name-en_US;price;color;variation_name-en_US;composition;size;ean;sku;weight

--- a/features/import/product_model/csv/create_product_model.feature
+++ b/features/import/product_model/csv/create_product_model.feature
@@ -23,7 +23,7 @@ Feature: Create product models through CSV import
       | code     | categories | family_variant     | collection   | description-en_US-ecommerce | erp_name-en_US | price      |
       | code-001 | master_men | clothing_colorsize | [Spring2017] | description                 | Blazers_1654   | 100.00 EUR |
 
-  Scenario: Julia imports new products sub-models in CSV
+  Scenario: Julia imports new products sub product models in CSV
     Given the following CSV file to import:
       """
       code;parent;family_variant;categories;collection;description-en_US-ecommerce;erp_name-en_US;price;color;variation_name-en_US;composition;size;ean;sku;weight

--- a/features/import/product_model/csv/update_product_model.feature
+++ b/features/import/product_model/csv/update_product_model.feature
@@ -18,7 +18,8 @@ Feature: Update product models through CSV import
       code-001;;clothing_colorsize;master_men;Spring2017;A new description;Blazers_1654;50 EUR;;;;;;;
       """
     And the following job "csv_catalog_modeling_product_model_import" configuration:
-      | filePath | %file to import% |
+      | filePath          | %file to import% |
+      | enabledComparison | no               |
     When I am on the "csv_catalog_modeling_product_model_import" import job page
     And I launch the import job
     And I wait for the "csv_catalog_modeling_product_model_import" job to finish
@@ -26,7 +27,7 @@ Feature: Update product models through CSV import
       | code     | categories | family_variant     | collection   | description-en_US-ecommerce | erp_name-en_US | price     |
       | code-001 | master_men | clothing_colorsize | [Spring2017] | A new description           | Blazers_1654   | 50.00 EUR |
 
-  Scenario: JuliaI successfully updates an exiting product sub-model through CSV import
+  Scenario: Julia successfully updates an exiting product sub product model through CSV import
     Given the following product models:
       | code     | parent   | family_variant      | categories         | collection | description-en_US-ecommerce | erp_name-en_US | price   | color | variation_name-en_US | composition |
       | code-001 |          | clothing_color_size | master_men         | Spring2017 | description                 | Blazers_1654   | 100 EUR |       |                      |             |
@@ -37,13 +38,38 @@ Feature: Update product models through CSV import
       code-002;code-001;clothing_color_size;master_men_blazers;;A new description for a sub model;;;blue;Beautiful blazers;composition;;;;
       """
     And the following job "csv_catalog_modeling_product_model_import" configuration:
-      | filePath | %file to import% |
+      | filePath          | %file to import% |
+      | enabledComparison | no               |
     When I am on the "csv_catalog_modeling_product_model_import" import job page
     And I launch the import job
     And I wait for the "csv_catalog_modeling_product_model_import" job to finish
     Then there should be the following root product model:
       | code     | categories | family_variant      | collection   | description-en_US-ecommerce | erp_name-en_US | price      |
       | code-001 | master_men | clothing_color_size | [Spring2017] | description                 | Blazers_1654   | 100.00 EUR |
+    And there should be the following product model:
+      | code     | color  | variation_name-en_US | composition |
+      | code-002 | [blue] | Beautiful blazers    | composition |
+
+  Scenario: Julia successfully updates exiting product models through CSV import with comparison enabled
+    Given the following product models:
+      | code     | parent   | family_variant      | categories         | collection | description-en_US-ecommerce | erp_name-en_US | price   | color | variation_name-en_US | composition |
+      | code-001 |          | clothing_color_size | master_men         | Spring2017 | description                 | Blazers_1654   | 100 EUR |       |                      |             |
+      | code-002 | code-001 | clothing_color_size | master_men_blazers |            |                             |                |         | blue  | Blazers              | composition |
+    And the following CSV file to import:
+      """
+      code;parent;family_variant;categories;collection;description-en_US-ecommerce;erp_name-en_US;price;color;variation_name-en_US;composition
+      code-001;;clothing_color_size;master_men;Spring2017;a new description;Blazers_1654;50 EUR;;;
+      code-002;code-001;clothing_color_size;master_men_blazers;;;;;blue;Beautiful blazers;composition
+      """
+    And the following job "csv_catalog_modeling_product_model_import" configuration:
+      | filePath          | %file to import% |
+      | enabledComparison | yes              |
+    When I am on the "csv_catalog_modeling_product_model_import" import job page
+    And I launch the import job
+    And I wait for the "csv_catalog_modeling_product_model_import" job to finish
+    Then there should be the following root product model:
+      | code     | categories | family_variant      | collection   | description-en_US-ecommerce | erp_name-en_US | price     |
+      | code-001 | master_men | clothing_color_size | [Spring2017] | a new description           | Blazers_1654   | 50.00 EUR |
     And there should be the following product model:
       | code     | color  | variation_name-en_US | composition |
       | code-002 | [blue] | Beautiful blazers    | composition |

--- a/features/import/product_model/csv/update_product_model.feature
+++ b/features/import/product_model/csv/update_product_model.feature
@@ -1,0 +1,49 @@
+@javascript
+Feature: Update product models through CSV import
+  In order to setup my application
+  As a product manager
+  I need to be able to update existing product models
+
+  Background:
+    Given the "catalog_modeling" catalog configuration
+    And I am logged in as "Julia"
+
+  Scenario: Julia successfully updates an exiting root product model through CSV import
+    Given the following product model:
+      | code     | parent | family_variant      | categories | collection | description-en_US-ecommerce | erp_name-en_US | price   | color | variation_name-en_US | composition |
+      | code-001 |        | clothing_color_size | master_men | Spring2017 | description                 | Blazers_1654   | 100 EUR |       |                      |             |
+    And the following CSV file to import:
+      """
+      code;parent;family_variant;categories;collection;description-en_US-ecommerce;erp_name-en_US;price;color;name-en_US;composition;size;ean;sku;weight
+      code-001;;clothing_colorsize;master_men;Spring2017;A new description;Blazers_1654;50 EUR;;;;;;;
+      """
+    And the following job "csv_catalog_modeling_product_model_import" configuration:
+      | filePath | %file to import% |
+    When I am on the "csv_catalog_modeling_product_model_import" import job page
+    And I launch the import job
+    And I wait for the "csv_catalog_modeling_product_model_import" job to finish
+    Then there should be the following root product model:
+      | code     | categories | family_variant     | collection   | description-en_US-ecommerce | erp_name-en_US | price     |
+      | code-001 | master_men | clothing_colorsize | [Spring2017] | A new description           | Blazers_1654   | 50.00 EUR |
+
+  Scenario: JuliaI successfully updates an exiting product sub-model through CSV import
+    Given the following product models:
+      | code     | parent   | family_variant      | categories         | collection | description-en_US-ecommerce | erp_name-en_US | price   | color | variation_name-en_US | composition |
+      | code-001 |          | clothing_color_size | master_men         | Spring2017 | description                 | Blazers_1654   | 100 EUR |       |                      |             |
+      | code-002 | code-001 | clothing_color_size | master_men_blazers |            |                             |                |         | blue  | Blazers              | composition |
+    And the following CSV file to import:
+      """
+      code;parent;family_variant;categories;collection;description-en_US-ecommerce;erp_name-en_US;price;color;variation_name-en_US;composition;size;ean;sku;weight
+      code-002;code-001;clothing_color_size;master_men_blazers;;A new description for a sub model;;;blue;Beautiful blazers;composition;;;;
+      """
+    And the following job "csv_catalog_modeling_product_model_import" configuration:
+      | filePath | %file to import% |
+    When I am on the "csv_catalog_modeling_product_model_import" import job page
+    And I launch the import job
+    And I wait for the "csv_catalog_modeling_product_model_import" job to finish
+    Then there should be the following root product model:
+      | code     | categories | family_variant      | collection   | description-en_US-ecommerce | erp_name-en_US | price      |
+      | code-001 | master_men | clothing_color_size | [Spring2017] | description                 | Blazers_1654   | 100.00 EUR |
+    And there should be the following product model:
+      | code     | color  | variation_name-en_US | composition |
+      | code-002 | [blue] | Beautiful blazers    | composition |

--- a/features/import/product_model/csv/update_product_model.feature
+++ b/features/import/product_model/csv/update_product_model.feature
@@ -9,7 +9,7 @@ Feature: Update product models through CSV import
     And I am logged in as "Julia"
 
   Scenario: Julia successfully updates an exiting root product model through CSV import
-    Given the following product model:
+    Given the following root product model:
       | code     | parent | family_variant      | categories | collection | description-en_US-ecommerce | erp_name-en_US | price   | color | variation_name-en_US | composition |
       | code-001 |        | clothing_color_size | master_men | Spring2017 | description                 | Blazers_1654   | 100 EUR |       |                      |             |
     And the following CSV file to import:
@@ -28,10 +28,12 @@ Feature: Update product models through CSV import
       | code-001 | master_men | clothing_colorsize | [Spring2017] | A new description           | Blazers_1654   | 50.00 EUR |
 
   Scenario: Julia successfully updates an exiting product sub product model through CSV import
-    Given the following product models:
-      | code     | parent   | family_variant      | categories         | collection | description-en_US-ecommerce | erp_name-en_US | price   | color | variation_name-en_US | composition |
-      | code-001 |          | clothing_color_size | master_men         | Spring2017 | description                 | Blazers_1654   | 100 EUR |       |                      |             |
-      | code-002 | code-001 | clothing_color_size | master_men_blazers |            |                             |                |         | blue  | Blazers              | composition |
+    Given the following root product model:
+      | code     | parent   | family_variant      | categories         | collection | description-en_US-ecommerce | erp_name-en_US | price   |
+      | code-001 |          | clothing_color_size | master_men         | Spring2017 | description                 | Blazers_1654   | 100 EUR |
+    And the following sub product model:
+      | code     | parent   | family_variant      | categories         | color | variation_name-en_US | composition |
+      | code-002 | code-001 | clothing_color_size | master_men_blazers | blue  | Blazers              | composition |
     And the following CSV file to import:
       """
       code;parent;family_variant;categories;collection;description-en_US-ecommerce;erp_name-en_US;price;color;variation_name-en_US;composition;size;ean;sku;weight
@@ -51,10 +53,12 @@ Feature: Update product models through CSV import
       | code-002 | [blue] | Beautiful blazers    | composition |
 
   Scenario: Julia successfully updates exiting product models through CSV import with comparison enabled
-    Given the following product models:
-      | code     | parent   | family_variant      | categories         | collection | description-en_US-ecommerce | erp_name-en_US | price   | color | variation_name-en_US | composition |
-      | code-001 |          | clothing_color_size | master_men         | Spring2017 | description                 | Blazers_1654   | 100 EUR |       |                      |             |
-      | code-002 | code-001 | clothing_color_size | master_men_blazers |            |                             |                |         | blue  | Blazers              | composition |
+    Given the following root product model:
+      | code     | parent   | family_variant      | categories         | collection | description-en_US-ecommerce | erp_name-en_US | price   |
+      | code-001 |          | clothing_color_size | master_men         | Spring2017 | description                 | Blazers_1654   | 100 EUR |
+    And the following sub product model:
+      | code     | parent   | family_variant      | categories         | color | variation_name-en_US | composition |
+      | code-002 | code-001 | clothing_color_size | master_men_blazers | blue  | Blazers              | composition |
     And the following CSV file to import:
       """
       code;parent;family_variant;categories;collection;description-en_US-ecommerce;erp_name-en_US;price;color;variation_name-en_US;composition

--- a/features/import/product_model/import_business_rules.feature
+++ b/features/import/product_model/import_business_rules.feature
@@ -138,7 +138,7 @@ Feature: Create product models through CSV import
       | code-002 | [blue] | Blazers              | composition |
 
   Scenario: A root product model cannot have a parent
-    Given the following product model:
+    Given the following root product models:
       | code     | parent | family_variant      | categories | collection | description-en_US-ecommerce | erp_name-en_US | price   |
       | code-001 |        | clothing_color_size | master_men | Spring2017 | A description for 001       | Blazers_1654   | 100 EUR |
       | code-002 |        | clothing_color_size | master_men | Spring2017 | A description for 002       | Blazers_1654   | 50 EUR  |
@@ -163,10 +163,12 @@ Feature: Create product models through CSV import
       """
 
   Scenario: The variant axis values of a product model are immutable
-    Given the following product model:
-      | code     | parent   | family_variant      | categories         | collection | description-en_US-ecommerce | erp_name-en_US | price   | color | variation_name-en_US | composition |
-      | code-001 |          | clothing_color_size | master_men         | Spring2017 | description                 | Blazers_1654   | 100 EUR |       |                      |             |
-      | code-002 | code-001 | clothing_color_size | master_men_blazers |            |                             |                |         | blue  | Blazers              | composition |
+    Given the following root product model:
+      | code     | parent   | family_variant      | categories         | collection | description-en_US-ecommerce | erp_name-en_US | price   |
+      | code-001 |          | clothing_color_size | master_men         | Spring2017 | description                 | Blazers_1654   | 100 EUR |
+    And the following sub product model:
+      | code     | parent   | family_variant      | categories         | color | variation_name-en_US | composition |
+      | code-002 | code-001 | clothing_color_size | master_men_blazers | blue  | Blazers              | composition |
     And the following CSV file to import:
       """
       code;parent;family_variant;color

--- a/features/import/product_model/import_business_rules.feature
+++ b/features/import/product_model/import_business_rules.feature
@@ -1,5 +1,5 @@
 @javascript
-Feature: Create product through CSV import
+Feature: Create product models through CSV import
   In order to import product model
   As a catalog manager
   I need to be able to import product models with valid data
@@ -136,3 +136,27 @@ Feature: Create product through CSV import
     And there should be the following product model:
       | code     | color  | variation_name-en_US | composition |
       | code-002 | [blue] | Blazers              | composition |
+
+  Scenario: Skip the root product model if a parent is added
+    Given the following product model:
+      | code     | parent | family_variant      | categories | collection | description-en_US-ecommerce | erp_name-en_US | price   |
+      | code-001 |        | clothing_color_size | master_men | Spring2017 | A description for 001       | Blazers_1654   | 100 EUR |
+      | code-002 |        | clothing_color_size | master_men | Spring2017 | A description for 002       | Blazers_1654   | 50 EUR  |
+    And the following CSV file to import:
+      """
+      code;parent;family_variant;categories;collection;description-en_US-ecommerce;erp_name-en_US;price;color;name-en_US;composition;size;ean;sku;weight
+      code-002;code-001;clothing_colorsize;master_men;Spring2017;A description for 002;Blazers_1654;50 EUR;;;;;;;
+      """
+    And the following job "csv_catalog_modeling_product_model_import" configuration:
+      | filePath | %file to import% |
+    When I am on the "csv_catalog_modeling_product_model_import" import job page
+    And I launch the import job
+    And I wait for the "csv_catalog_modeling_product_model_import" job to finish
+    Then I should see the text "Status: Completed"
+    And I should see the text "skipped 1"
+    And I should see the text "parent: Property \"parent\" cannot be modified, \"code-001\" given."
+    And the invalid data file of "csv_catalog_modeling_product_model_import" should contain:
+      """
+      code;parent;family_variant;categories;collection;description-en_US-ecommerce;erp_name-en_US;price;color;name-en_US;composition;size;ean;sku;weight
+      code-002;code-001;clothing_colorsize;master_men;Spring2017;A description for 002;Blazers_1654;50 EUR;;;;;;;
+      """

--- a/features/import/product_model/xslx/create_product_model.feature
+++ b/features/import/product_model/xslx/create_product_model.feature
@@ -1,5 +1,5 @@
 @javascript
-Feature: Create product through XLSX import
+Feature: Create product models through XLSX import
   In order to setup my application
   As a product manager
   I need to be able to import new product model
@@ -8,7 +8,7 @@ Feature: Create product through XLSX import
     Given the "catalog_modeling" catalog configuration
     And I am logged in as "Julia"
 
-  Scenario: Julia imports new root products models
+  Scenario: Julia imports new root products models in XLSX
     Given the following XLSX file to import:
       """
       code;parent;family_variant;categories;collection;description-en_US-ecommerce;erp_name-en_US;price;color;name-en_US;composition;size;ean;sku;weight
@@ -23,7 +23,7 @@ Feature: Create product through XLSX import
       | code     | categories | family_variant     | collection   | description-en_US-ecommerce | erp_name-en_US | price      |
       | code-001 | master_men | clothing_colorsize | [Spring2017] | description                 | Blazers_1654   | 100.00 EUR |
 
-  Scenario: Julia imports new products sub-models
+  Scenario: Julia imports new products sub-models in XLSX
     Given the following XLSX file to import:
       """
       code;parent;family_variant;categories;collection;description-en_US-ecommerce;erp_name-en_US;price;color;variation_name-en_US;composition;size;ean;sku;weight

--- a/features/import/product_model/xslx/create_product_model.feature
+++ b/features/import/product_model/xslx/create_product_model.feature
@@ -20,7 +20,7 @@ Feature: Create product through XLSX import
     And I launch the import job
     And I wait for the "xlsx_catalog_modeling_product_model_import" job to finish
     Then there should be the following root product model:
-      | code     | categories | family_variant                  | collection   | description-en_US-ecommerce | erp_name-en_US | price      |
+      | code     | categories | family_variant     | collection   | description-en_US-ecommerce | erp_name-en_US | price      |
       | code-001 | master_men | clothing_colorsize | [Spring2017] | description                 | Blazers_1654   | 100.00 EUR |
 
   Scenario: Julia imports new products sub-models
@@ -36,8 +36,8 @@ Feature: Create product through XLSX import
     And I launch the import job
     And I wait for the "xlsx_catalog_modeling_product_model_import" job to finish
     Then there should be the following root product model:
-      | code     | categories | family_variant                  | collection   | description-en_US-ecommerce | erp_name-en_US | price      |
+      | code     | categories | family_variant      | collection   | description-en_US-ecommerce | erp_name-en_US | price      |
       | code-001 | master_men | clothing_color_size | [Spring2017] | description                 | Blazers_1654   | 100.00 EUR |
     And there should be the following product model:
       | code     | color  | variation_name-en_US | composition |
-      | code-002 | [blue] | Blazers    | composition |
+      | code-002 | [blue] | Blazers              | composition |

--- a/features/import/product_model/xslx/create_product_model.feature
+++ b/features/import/product_model/xslx/create_product_model.feature
@@ -23,7 +23,7 @@ Feature: Create product models through XLSX import
       | code     | categories | family_variant     | collection   | description-en_US-ecommerce | erp_name-en_US | price      |
       | code-001 | master_men | clothing_colorsize | [Spring2017] | description                 | Blazers_1654   | 100.00 EUR |
 
-  Scenario: Julia imports new products sub-models in XLSX
+  Scenario: Julia imports new products sub product models in XLSX
     Given the following XLSX file to import:
       """
       code;parent;family_variant;categories;collection;description-en_US-ecommerce;erp_name-en_US;price;color;variation_name-en_US;composition;size;ean;sku;weight

--- a/features/import/product_model/xslx/update_product_model.feature
+++ b/features/import/product_model/xslx/update_product_model.feature
@@ -18,7 +18,8 @@ Feature: Update product models through XLSX import
       code-001;;clothing_colorsize;master_men;Spring2017;A new description;Blazers_1654;50 EUR;;;;;;;
       """
     And the following job "xlsx_catalog_modeling_product_model_import" configuration:
-      | filePath | %file to import% |
+      | filePath          | %file to import% |
+      | enabledComparison | no               |
     When I am on the "xlsx_catalog_modeling_product_model_import" import job page
     And I launch the import job
     And I wait for the "xlsx_catalog_modeling_product_model_import" job to finish
@@ -26,7 +27,7 @@ Feature: Update product models through XLSX import
       | code     | categories | family_variant     | collection   | description-en_US-ecommerce | erp_name-en_US | price     |
       | code-001 | master_men | clothing_colorsize | [Spring2017] | A new description           | Blazers_1654   | 50.00 EUR |
 
-  Scenario: JuliaI successfully updates an exiting product sub-model through XLSX import
+  Scenario: Julia successfully updates an exiting product sub product model through XLSX import
     Given the following product models:
       | code     | parent   | family_variant      | categories         | collection | description-en_US-ecommerce | erp_name-en_US | price   | color | variation_name-en_US | composition |
       | code-001 |          | clothing_color_size | master_men         | Spring2017 | description                 | Blazers_1654   | 100 EUR |       |                      |             |
@@ -37,13 +38,38 @@ Feature: Update product models through XLSX import
       code-002;code-001;clothing_color_size;master_men_blazers;;A new description for a sub model;;;blue;Beautiful blazers;composition;;;;
       """
     And the following job "xlsx_catalog_modeling_product_model_import" configuration:
-      | filePath | %file to import% |
+      | filePath          | %file to import% |
+      | enabledComparison | no               |
     When I am on the "xlsx_catalog_modeling_product_model_import" import job page
     And I launch the import job
     And I wait for the "xlsx_catalog_modeling_product_model_import" job to finish
     Then there should be the following root product model:
       | code     | categories | family_variant      | collection   | description-en_US-ecommerce | erp_name-en_US | price      |
       | code-001 | master_men | clothing_color_size | [Spring2017] | description                 | Blazers_1654   | 100.00 EUR |
+    And there should be the following product model:
+      | code     | color  | variation_name-en_US | composition |
+      | code-002 | [blue] | Beautiful blazers    | composition |
+
+  Scenario: Julia successfully updates exiting product models through XLSX import with comparison enabled
+    Given the following product models:
+      | code     | parent   | family_variant      | categories         | collection | description-en_US-ecommerce | erp_name-en_US | price   | color | variation_name-en_US | composition |
+      | code-001 |          | clothing_color_size | master_men         | Spring2017 | description                 | Blazers_1654   | 100 EUR |       |                      |             |
+      | code-002 | code-001 | clothing_color_size | master_men_blazers |            |                             |                |         | blue  | Blazers              | composition |
+    And the following XLSX file to import:
+      """
+      code;parent;family_variant;categories;collection;description-en_US-ecommerce;erp_name-en_US;price;color;variation_name-en_US;composition
+      code-001;;clothing_color_size;master_men;Spring2017;a new description;Blazers_1654;50 EUR;;;
+      code-002;code-001;clothing_color_size;master_men_blazers;;;;;blue;Beautiful blazers;composition
+      """
+    And the following job "xlsx_catalog_modeling_product_model_import" configuration:
+      | filePath          | %file to import% |
+      | enabledComparison | no               |
+    When I am on the "xlsx_catalog_modeling_product_model_import" import job page
+    And I launch the import job
+    And I wait for the "xlsx_catalog_modeling_product_model_import" job to finish
+    Then there should be the following root product model:
+      | code     | categories | family_variant      | collection   | description-en_US-ecommerce | erp_name-en_US | price     |
+      | code-001 | master_men | clothing_color_size | [Spring2017] | a new description           | Blazers_1654   | 50.00 EUR |
     And there should be the following product model:
       | code     | color  | variation_name-en_US | composition |
       | code-002 | [blue] | Beautiful blazers    | composition |

--- a/features/import/product_model/xslx/update_product_model.feature
+++ b/features/import/product_model/xslx/update_product_model.feature
@@ -1,0 +1,49 @@
+@javascript
+Feature: Update product models through XLSX import
+  In order to setup my application
+  As a product manager
+  I need to be able to update existing product models
+
+  Background:
+    Given the "catalog_modeling" catalog configuration
+    And I am logged in as "Julia"
+
+  Scenario: Julia successfully updates an exiting root product model through XLSX import
+    Given the following product model:
+      | code     | parent | family_variant      | categories | collection | description-en_US-ecommerce | erp_name-en_US | price   | color | variation_name-en_US | composition |
+      | code-001 |        | clothing_color_size | master_men | Spring2017 | description                 | Blazers_1654   | 100 EUR |       |                      |             |
+    And the following XLSX file to import:
+      """
+      code;parent;family_variant;categories;collection;description-en_US-ecommerce;erp_name-en_US;price;color;name-en_US;composition;size;ean;sku;weight
+      code-001;;clothing_colorsize;master_men;Spring2017;A new description;Blazers_1654;50 EUR;;;;;;;
+      """
+    And the following job "xlsx_catalog_modeling_product_model_import" configuration:
+      | filePath | %file to import% |
+    When I am on the "xlsx_catalog_modeling_product_model_import" import job page
+    And I launch the import job
+    And I wait for the "xlsx_catalog_modeling_product_model_import" job to finish
+    Then there should be the following root product model:
+      | code     | categories | family_variant     | collection   | description-en_US-ecommerce | erp_name-en_US | price     |
+      | code-001 | master_men | clothing_colorsize | [Spring2017] | A new description           | Blazers_1654   | 50.00 EUR |
+
+  Scenario: JuliaI successfully updates an exiting product sub-model through XLSX import
+    Given the following product models:
+      | code     | parent   | family_variant      | categories         | collection | description-en_US-ecommerce | erp_name-en_US | price   | color | variation_name-en_US | composition |
+      | code-001 |          | clothing_color_size | master_men         | Spring2017 | description                 | Blazers_1654   | 100 EUR |       |                      |             |
+      | code-002 | code-001 | clothing_color_size | master_men_blazers |            |                             |                |         | blue  | Blazers              | composition |
+    And the following XLSX file to import:
+      """
+      code;parent;family_variant;categories;collection;description-en_US-ecommerce;erp_name-en_US;price;color;variation_name-en_US;composition;size;ean;sku;weight
+      code-002;code-001;clothing_color_size;master_men_blazers;;A new description for a sub model;;;blue;Beautiful blazers;composition;;;;
+      """
+    And the following job "xlsx_catalog_modeling_product_model_import" configuration:
+      | filePath | %file to import% |
+    When I am on the "xlsx_catalog_modeling_product_model_import" import job page
+    And I launch the import job
+    And I wait for the "xlsx_catalog_modeling_product_model_import" job to finish
+    Then there should be the following root product model:
+      | code     | categories | family_variant      | collection   | description-en_US-ecommerce | erp_name-en_US | price      |
+      | code-001 | master_men | clothing_color_size | [Spring2017] | description                 | Blazers_1654   | 100.00 EUR |
+    And there should be the following product model:
+      | code     | color  | variation_name-en_US | composition |
+      | code-002 | [blue] | Beautiful blazers    | composition |

--- a/features/import/product_model/xslx/update_product_model.feature
+++ b/features/import/product_model/xslx/update_product_model.feature
@@ -9,7 +9,7 @@ Feature: Update product models through XLSX import
     And I am logged in as "Julia"
 
   Scenario: Julia successfully updates an exiting root product model through XLSX import
-    Given the following product model:
+    Given the following root product model:
       | code     | parent | family_variant      | categories | collection | description-en_US-ecommerce | erp_name-en_US | price   | color | variation_name-en_US | composition |
       | code-001 |        | clothing_color_size | master_men | Spring2017 | description                 | Blazers_1654   | 100 EUR |       |                      |             |
     And the following XLSX file to import:
@@ -28,10 +28,12 @@ Feature: Update product models through XLSX import
       | code-001 | master_men | clothing_colorsize | [Spring2017] | A new description           | Blazers_1654   | 50.00 EUR |
 
   Scenario: Julia successfully updates an exiting product sub product model through XLSX import
-    Given the following product models:
-      | code     | parent   | family_variant      | categories         | collection | description-en_US-ecommerce | erp_name-en_US | price   | color | variation_name-en_US | composition |
-      | code-001 |          | clothing_color_size | master_men         | Spring2017 | description                 | Blazers_1654   | 100 EUR |       |                      |             |
-      | code-002 | code-001 | clothing_color_size | master_men_blazers |            |                             |                |         | blue  | Blazers              | composition |
+    Given the following root product model:
+      | code     | parent   | family_variant      | categories         | collection | description-en_US-ecommerce | erp_name-en_US | price   |
+      | code-001 |          | clothing_color_size | master_men         | Spring2017 | description                 | Blazers_1654   | 100 EUR |
+    And the following sub product model:
+      | code     | parent   | family_variant      | categories         | color | variation_name-en_US | composition |
+      | code-002 | code-001 | clothing_color_size | master_men_blazers | blue  | Blazers              | composition |
     And the following XLSX file to import:
       """
       code;parent;family_variant;categories;collection;description-en_US-ecommerce;erp_name-en_US;price;color;variation_name-en_US;composition;size;ean;sku;weight
@@ -51,10 +53,12 @@ Feature: Update product models through XLSX import
       | code-002 | [blue] | Beautiful blazers    | composition |
 
   Scenario: Julia successfully updates exiting product models through XLSX import with comparison enabled
-    Given the following product models:
-      | code     | parent   | family_variant      | categories         | collection | description-en_US-ecommerce | erp_name-en_US | price   | color | variation_name-en_US | composition |
-      | code-001 |          | clothing_color_size | master_men         | Spring2017 | description                 | Blazers_1654   | 100 EUR |       |                      |             |
-      | code-002 | code-001 | clothing_color_size | master_men_blazers |            |                             |                |         | blue  | Blazers              | composition |
+    Given the following root product model:
+      | code     | parent   | family_variant      | categories         | collection | description-en_US-ecommerce | erp_name-en_US | price   |
+      | code-001 |          | clothing_color_size | master_men         | Spring2017 | description                 | Blazers_1654   | 100 EUR |
+    And the following sub product model:
+      | code     | parent   | family_variant      | categories         | color | variation_name-en_US | composition |
+      | code-002 | code-001 | clothing_color_size | master_men_blazers | blue  | Blazers              | composition |
     And the following XLSX file to import:
       """
       code;parent;family_variant;categories;collection;description-en_US-ecommerce;erp_name-en_US;price;color;variation_name-en_US;composition

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/comparators.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/comparators.yml
@@ -97,6 +97,6 @@ services:
     pim_catalog.comparator.field.scalar:
         class: '%pim_catalog.comparator.field.scalar.class%'
         arguments:
-            - ['family', 'family_variant', 'variant_group']
+            - ['family', 'family_variant', 'variant_group', 'parent']
         tags:
             - { name: pim_catalog.field.comparator, priority: -128 }

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/filters.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/filters.yml
@@ -37,7 +37,7 @@ services:
             - '@pim_catalog.normalizer.standard.product_model'
             - '@pim_catalog.comparator.registry'
             - '@pim_catalog.repository.attribute'
-            - ['family_variant', 'categories']
+            - ['family_variant', 'categories', 'parent']
 
     pim_catalog.comparator.filter.product_association:
         class: '%pim_catalog.comparator.filter.product_association.class%'

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/updaters.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/updaters.yml
@@ -69,6 +69,9 @@ services:
             - '@pim_catalog.updater.entity_with_values'
             - '@pim_catalog.repository.family_variant'
             - '@pim_catalog.repository.product_model'
+            - '@pim_catalog.normalizer.standard.product.product_value'
+            - '@pim_catalog.family_variant.provider.entity_with_family_variant_attributes'
+            - '@pim_catalog.comparator.registry'
             - ['categories']
             - ['identifier', 'created', 'updated']
 

--- a/src/Pim/Component/Catalog/Model/ProductModel.php
+++ b/src/Pim/Component/Catalog/Model/ProductModel.php
@@ -410,7 +410,7 @@ class ProductModel implements ProductModelInterface
     public function addProductModel(ProductModelInterface $child): ProductModelInterface
     {
         $child->setParent($this);
-        if (!$this->productModelss->contains($child)) {
+        if (!$this->productModels->contains($child)) {
             $this->productModels->add($child);
         }
 
@@ -475,6 +475,8 @@ class ProductModel implements ProductModelInterface
 
             $level++;
         }
+
+        return $level;
     }
 
     /**

--- a/src/Pim/Component/Catalog/Updater/ProductModelUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/ProductModelUpdater.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Component\Catalog\Updater;
 
+use Akeneo\Component\StorageUtils\Exception\ImmutablePropertyException;
 use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Exception\UnknownPropertyException;
@@ -79,6 +80,14 @@ class ProductModelUpdater implements ObjectUpdaterInterface
                 $productModel->setCode($value);
             } elseif ('parent' === $code) {
                 if (!empty($value)) {
+                    if (null !== $productModel->getId() && $productModel->isRootProductModel()) {
+                        throw ImmutablePropertyException::immutableProperty(
+                            'parent',
+                            $value,
+                            static::class
+                        );
+                    }
+
                     if (null === $parentProductModel = $this->productModelRepository->findOneByIdentifier($value)) {
                         throw InvalidPropertyException::validEntityCodeExpected(
                             'parent',

--- a/src/Pim/Component/Catalog/Updater/ProductModelUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/ProductModelUpdater.php
@@ -10,7 +10,10 @@ use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterfa
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Akeneo\Component\StorageUtils\Updater\PropertySetterInterface;
 use Doctrine\Common\Util\ClassUtils;
+use Pim\Component\Catalog\Comparator\ComparatorRegistryInterface;
+use Pim\Component\Catalog\FamilyVariant\EntityWithFamilyVariantAttributesProvider;
 use Pim\Component\Catalog\Model\ProductModelInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
  * @author    Arnaud Langlade <arnaud.langlade@akeneo.com>
@@ -37,19 +40,34 @@ class ProductModelUpdater implements ObjectUpdaterInterface
     /** @var IdentifiableObjectRepositoryInterface */
     private $productModelRepository;
 
+    /** @var NormalizerInterface */
+    private $valueNormalizer;
+
+    /** @var EntityWithFamilyVariantAttributesProvider */
+    private $attributesProvider;
+
+    /** @var ComparatorRegistryInterface */
+    private $comparatorRegistry;
+
     /**
-     * @param PropertySetterInterface               $propertySetter
-     * @param ObjectUpdaterInterface                $valuesUpdater
-     * @param IdentifiableObjectRepositoryInterface $familyVariantRepository
-     * @param IdentifiableObjectRepositoryInterface $productModelRepository
-     * @param array                                 $supportedFields
-     * @param array                                 $ignoredFields
+     * @param PropertySetterInterface                   $propertySetter
+     * @param ObjectUpdaterInterface                    $valuesUpdater
+     * @param IdentifiableObjectRepositoryInterface     $familyVariantRepository
+     * @param IdentifiableObjectRepositoryInterface     $productModelRepository
+     * @param NormalizerInterface                       $valueNormalizer
+     * @param EntityWithFamilyVariantAttributesProvider $attributesProvider
+     * @param ComparatorRegistryInterface               $comparatorRegistry
+     * @param array                                     $supportedFields
+     * @param array                                     $ignoredFields
      */
     public function __construct(
         PropertySetterInterface $propertySetter,
         ObjectUpdaterInterface $valuesUpdater,
         IdentifiableObjectRepositoryInterface $familyVariantRepository,
         IdentifiableObjectRepositoryInterface $productModelRepository,
+        NormalizerInterface $valueNormalizer,
+        EntityWithFamilyVariantAttributesProvider $attributesProvider,
+        ComparatorRegistryInterface $comparatorRegistry,
         array $supportedFields,
         array $ignoredFields
     ) {
@@ -57,6 +75,9 @@ class ProductModelUpdater implements ObjectUpdaterInterface
         $this->valuesUpdater = $valuesUpdater;
         $this->familyVariantRepository = $familyVariantRepository;
         $this->productModelRepository = $productModelRepository;
+        $this->valueNormalizer = $valueNormalizer;
+        $this->attributesProvider = $attributesProvider;
+        $this->comparatorRegistry = $comparatorRegistry;
         $this->supportedFields = $supportedFields;
         $this->ignoredFields = $ignoredFields;
     }
@@ -75,43 +96,13 @@ class ProductModelUpdater implements ObjectUpdaterInterface
 
         foreach ($data as $code => $value) {
             if ('values' === $code) {
-                $this->valuesUpdater->update($productModel, $value, $options);
+                $this->updateValues($productModel, $value, $options);
             } elseif ('code' === $code) {
                 $productModel->setCode($value);
             } elseif ('parent' === $code) {
-                if (!empty($value)) {
-                    if (null !== $productModel->getId() && $productModel->isRootProductModel()) {
-                        throw ImmutablePropertyException::immutableProperty(
-                            'parent',
-                            $value,
-                            static::class
-                        );
-                    }
-
-                    if (null === $parentProductModel = $this->productModelRepository->findOneByIdentifier($value)) {
-                        throw InvalidPropertyException::validEntityCodeExpected(
-                            'parent',
-                            'parent code',
-                            'The product model does not exist',
-                            static::class,
-                            $value
-                        );
-                    }
-
-                    $productModel->setParent($parentProductModel);
-                }
+                $this->updateParent($productModel, $value);
             } elseif ('family_variant' === $code) {
-                if (null === $familyVariant = $this->familyVariantRepository->findOneByIdentifier($value)) {
-                    throw InvalidPropertyException::validEntityCodeExpected(
-                        'family_variant',
-                        'family variant code',
-                        'The family variant does not exist',
-                        static::class,
-                        $value
-                    );
-                }
-
-                $productModel->setFamilyVariant($familyVariant);
+                $this->updateFamilyVariant($productModel, $value);
             } elseif (in_array($code, $this->supportedFields)) {
                 $this->propertySetter->setData($productModel, $code, $value);
             } elseif (!in_array($code, $this->ignoredFields)) {
@@ -120,5 +111,205 @@ class ProductModelUpdater implements ObjectUpdaterInterface
         }
 
         return $this;
+    }
+
+    /**
+     * Updates the values of the product model.
+     *
+     * If the product model already exists, we ensure we do not update variant
+     * axes values: provided values must be either missing, empty, or identical
+     * to the existing ones, or an exception will be thrown.
+     *
+     * @param ProductModelInterface $productModel
+     * @param array                 $values
+     * @param array                 $options
+     *
+     * @throws ImmutablePropertyException
+     */
+    private function updateValues(ProductModelInterface $productModel, array $values, array $options): void
+    {
+        if (null !== $productModel->getId()) {
+            $axesCodesAndTypes = $this->getProductModelAxesCodesAndTypes($productModel);
+            $newAxesValues = $this->getNewVariantAxesValues($values, array_keys($axesCodesAndTypes));
+
+            if (!empty($newAxesValues)) {
+                $currentAxesValues = $this->getCurrentVariantAxesValues($productModel, array_keys($axesCodesAndTypes));
+                $willBeUpdatedValues = $this->compareVariantAxesValues(
+                    $currentAxesValues,
+                    $newAxesValues,
+                    $axesCodesAndTypes
+                );
+
+                if (!empty($willBeUpdatedValues)) {
+                    throw ImmutablePropertyException::immutableProperty(
+                        implode(', ', array_keys($willBeUpdatedValues)),
+                        implode(', ', $willBeUpdatedValues),
+                        static::class
+                    );
+                }
+            }
+        }
+
+        $this->valuesUpdater->update($productModel, $values, $options);
+    }
+
+    /**
+     * Returns the list of the variant axes codes, associated to their attribute type:
+     *
+     * [
+     *     'attribute_code' => 'attribute_type',
+     * ]
+     *
+     * @param ProductModelInterface $productModel
+     *
+     * @return array
+     */
+    private function getProductModelAxesCodesAndTypes(ProductModelInterface $productModel): array
+    {
+        $productModelAxesCodesAndTypes = [];
+
+        foreach ($this->attributesProvider->getAxes($productModel) as $attribute) {
+            $productModelAxesCodesAndTypes[$attribute->getCode()] = $attribute->getType();
+        }
+
+        return $productModelAxesCodesAndTypes;
+    }
+
+    /**
+     * Removes all values except the ones of the variant axes.
+     *
+     * The provided values (and so the result) are in standard format.
+     *
+     * @param array $values
+     * @param array $axesCodes
+     *
+     * @return array
+     */
+    private function getNewVariantAxesValues(array $values, array $axesCodes): array
+    {
+        $attributeCodes = array_keys($values);
+        foreach ($attributeCodes as $attributeCode) {
+            if (!in_array($attributeCode, $axesCodes)) {
+                unset($values[$attributeCode]);
+            }
+        }
+
+        return $values;
+    }
+
+    /**
+     * Gets the current values of the product model variant axes.
+     *
+     * The returned result is in standard format.
+     *
+     * @param ProductModelInterface $productModel
+     * @param array                 $axesCodes
+     *
+     * @return array
+     */
+    private function getCurrentVariantAxesValues(ProductModelInterface $productModel, array $axesCodes): array
+    {
+        $currentAxesValues = [];
+        foreach ($axesCodes as $axisCode) {
+            $currentAxesValues[$axisCode] = [
+                $this->valueNormalizer->normalize($productModel->getValue($axisCode), 'standard'),
+            ];
+        };
+
+        return $currentAxesValues;
+    }
+
+    /**
+     * Compares the current values of the variant axes against the new ones we
+     * want to update the product model with.
+     *
+     * Returns the new values if they are different, and an empty array if there
+     * is no difference.
+     *
+     * @param array $currentAxesValues
+     * @param array $newAxesValues
+     * @param array $axesCodesAndTypes
+     *
+     * @return array
+     */
+    private function compareVariantAxesValues(
+        array $currentAxesValues,
+        array $newAxesValues,
+        array $axesCodesAndTypes
+    ): array {
+        $updateValues = [];
+
+        foreach (array_keys($axesCodesAndTypes) as $axisCode) {
+            if (array_key_exists($axisCode, $currentAxesValues) && array_key_exists($axisCode, $newAxesValues)) {
+                $comparator = $this->comparatorRegistry->getAttributeComparator($axesCodesAndTypes[$axisCode]);
+                $diff = $comparator->compare($newAxesValues[$axisCode][0], $currentAxesValues[$axisCode][0]);
+                if (null !== $diff) {
+                    $updateValues[$axisCode] = is_array($diff['data']) ? implode(' ', $diff['data']) : $diff['data'];
+                }
+            }
+        }
+
+        return $updateValues;
+    }
+
+    /**
+     * Updates the parent of the product model.
+     * If the product model is a root one, it cannot have a parent, so an
+     * exception will be thrown.
+     *
+     * @param ProductModelInterface $productModel
+     * @param mixed                 $value
+     *
+     * @throws ImmutablePropertyException
+     * @throws InvalidPropertyException
+     */
+    private function updateParent(ProductModelInterface $productModel, $value): void
+    {
+        if (empty($value)) {
+            return;
+        }
+
+        if (null !== $productModel->getId() && $productModel->isRootProductModel()) {
+            throw ImmutablePropertyException::immutableProperty(
+                'parent',
+                $value,
+                static::class
+            );
+        }
+
+        if (null === $parentProductModel = $this->productModelRepository->findOneByIdentifier($value)) {
+            throw InvalidPropertyException::validEntityCodeExpected(
+                'parent',
+                'parent code',
+                'The product model does not exist',
+                static::class,
+                $value
+            );
+        }
+
+        $productModel->setParent($parentProductModel);
+    }
+
+    /**
+     * Updates the family variant of the family variant of the product model.
+     *
+     * @param ProductModelInterface $productModel
+     * @param mixed                 $value
+     *
+     * @throws InvalidPropertyException
+     */
+    private function updateFamilyVariant(ProductModelInterface $productModel, $value): void
+    {
+        if (null === $familyVariant = $this->familyVariantRepository->findOneByIdentifier($value)) {
+            throw InvalidPropertyException::validEntityCodeExpected(
+                'family_variant',
+                'family variant code',
+                'The family variant does not exist',
+                static::class,
+                $value
+            );
+        }
+
+        $productModel->setFamilyVariant($familyVariant);
     }
 }

--- a/src/Pim/Component/Catalog/Validator/Constraints/UniqueValueValidator.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/UniqueValueValidator.php
@@ -49,7 +49,7 @@ class UniqueValueValidator extends ConstraintValidator
      * @param ValueInterface $value
      * @param Constraint     $constraint
      *
-     * @see Pim\Bundle\CatalogBundle\Validator\ConstraintGuesser\UniqueValueGuesser
+     * @see \Pim\Component\Catalog\Validator\ConstraintGuesser\UniqueValueGuesser
      */
     public function validate($value, Constraint $constraint)
     {

--- a/src/Pim/Component/Catalog/spec/Updater/ProductModelUpdaterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/ProductModelUpdaterSpec.php
@@ -8,12 +8,20 @@ use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Akeneo\Component\StorageUtils\Updater\PropertySetterInterface;
+use Doctrine\Common\Collections\ArrayCollection;
+use Pim\Component\Catalog\AttributeTypes;
+use Pim\Component\Catalog\Comparator\ComparatorInterface;
+use Pim\Component\Catalog\Comparator\ComparatorRegistryInterface;
+use Pim\Component\Catalog\FamilyVariant\EntityWithFamilyVariantAttributesProvider;
+use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\FamilyVariantInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Model\ProductModelInterface;
+use Pim\Component\Catalog\Model\ValueInterface;
 use Pim\Component\Catalog\Updater\ProductModelUpdater;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class ProductModelUpdaterSpec extends ObjectBehavior
 {
@@ -21,13 +29,19 @@ class ProductModelUpdaterSpec extends ObjectBehavior
         PropertySetterInterface $propertySetter,
         ObjectUpdaterInterface $valuesUpdater,
         IdentifiableObjectRepositoryInterface $familyVariantRepository,
-        IdentifiableObjectRepositoryInterface $productModelRepository
+        IdentifiableObjectRepositoryInterface $productModelRepository,
+        NormalizerInterface $valueNormalizer,
+        EntityWithFamilyVariantAttributesProvider $attributesProvider,
+        ComparatorRegistryInterface $comparatorRegistry
     ) {
         $this->beConstructedWith(
             $propertySetter,
             $valuesUpdater,
             $familyVariantRepository,
             $productModelRepository,
+            $valueNormalizer,
+            $attributesProvider,
+            $comparatorRegistry,
             ['categories'],
             ['code']
         );
@@ -93,6 +107,193 @@ class ProductModelUpdaterSpec extends ObjectBehavior
             'family_variant' => 'clothing_color_size',
             'parent' => 'product_model_parent'
         ])->shouldReturn($this);
+    }
+
+    function it_throws_an_exception_if_an_option_axis_value_is_updated(
+        $valueNormalizer,
+        $attributesProvider,
+        $comparatorRegistry,
+        ProductModelInterface $productModel,
+        ComparatorInterface $comparator,
+        ValueInterface $colorValue,
+        AttributeInterface $color
+    ) {
+        $currentStandardValue = [
+            'locale' => null,
+            'scope' => null,
+            'data' => 'blue',
+        ];
+
+        $newStandardValue = [
+            'locale' => null,
+            'scope' => null,
+            'data' => 'red',
+        ];
+
+        $productModel->getId()->willReturn(42);
+
+        $attributesProvider->getAxes($productModel)->willReturn([$color]);
+        $color->getCode()->willReturn('color');
+        $color->getType()->willReturn(AttributeTypes::OPTION_SIMPLE_SELECT);
+
+        $productModel->getValue('color')->willReturn($colorValue);
+        $valueNormalizer->normalize($colorValue, 'standard')->willReturn($currentStandardValue);
+
+        $comparatorRegistry->getAttributeComparator(AttributeTypes::OPTION_SIMPLE_SELECT)->willReturn($comparator);
+        $comparator->compare($newStandardValue, $currentStandardValue)->willReturn($newStandardValue);
+
+        $this->shouldThrow(ImmutablePropertyException::class)->during('update', [$productModel, [
+            'values' => [
+                'color' => [
+                    $newStandardValue
+                ],
+            ],
+        ]]);
+    }
+
+    function it_throws_an_exception_if_a_simple_reference_data_axis_value_is_updated(
+        $valueNormalizer,
+        $attributesProvider,
+        $comparatorRegistry,
+        ProductModelInterface $productModel,
+        ComparatorInterface $comparator,
+        ValueInterface $colorValue,
+        AttributeInterface $color
+    ) {
+        $currentStandardValue = [
+            'locale' => null,
+            'scope' => null,
+            'data' => 'blue',
+        ];
+
+        $newStandardValue = [
+            'locale' => null,
+            'scope' => null,
+            'data' => 'red',
+        ];
+
+        $productModel->getId()->willReturn(42);
+
+        $attributesProvider->getAxes($productModel)->willReturn([$color]);
+        $color->getCode()->willReturn('color');
+        $color->getType()->willReturn(AttributeTypes::REFERENCE_DATA_SIMPLE_SELECT);
+
+        $productModel->getValue('color')->willReturn($colorValue);
+        $valueNormalizer->normalize($colorValue, 'standard')->willReturn($currentStandardValue);
+
+        $comparatorRegistry
+            ->getAttributeComparator(AttributeTypes::REFERENCE_DATA_SIMPLE_SELECT)
+            ->willReturn($comparator);
+        $comparator->compare($newStandardValue, $currentStandardValue)->willReturn($newStandardValue);
+
+        $this->shouldThrow(ImmutablePropertyException::class)->during('update', [$productModel, [
+            'values' => [
+                'color' => [
+                    $newStandardValue
+                ],
+            ],
+        ]]);
+    }
+
+    function it_throws_an_exception_if_an_boolean_axis_value_is_updated(
+        $valueNormalizer,
+        $attributesProvider,
+        $comparatorRegistry,
+        ProductModelInterface $productModel,
+        ComparatorInterface $comparator,
+        ValueInterface $booleanValue,
+        AttributeInterface $boolean
+    ) {
+        $currentStandardValue = [
+            'locale' => null,
+            'scope' => null,
+            'data' => true,
+        ];
+
+        $newStandardValue = [
+            'locale' => null,
+            'scope' => null,
+            'data' => false,
+        ];
+
+        $productModel->getId()->willReturn(42);
+
+        $attributesProvider->getAxes($productModel)->willReturn([$boolean]);
+        $boolean->getCode()->willReturn('boolean');
+        $boolean->getType()->willReturn(AttributeTypes::BOOLEAN);
+
+        $productModel->getValue('boolean')->willReturn($booleanValue);
+        $valueNormalizer->normalize($booleanValue, 'standard')->willReturn($currentStandardValue);
+
+        $comparatorRegistry
+            ->getAttributeComparator(AttributeTypes::BOOLEAN)
+            ->willReturn($comparator);
+        $comparator->compare($newStandardValue, $currentStandardValue)->willReturn($newStandardValue);
+
+        $this->shouldThrow(ImmutablePropertyException::class)->during('update', [$productModel, [
+            'values' => [
+                'boolean' => [
+                    $newStandardValue,
+                ],
+            ],
+        ]]);
+    }
+
+    function it_throws_an_exception_if_an_metric_axis_value_is_updated(
+        $valueNormalizer,
+        $attributesProvider,
+        $comparatorRegistry,
+        ProductModelInterface $productModel,
+        ComparatorInterface $comparator,
+        ValueInterface $sizeValue,
+        AttributeInterface $size
+    ) {
+        $currentStandardValue = [
+            'locale' => null,
+            'scope' => null,
+            'data' => [
+                'amount' => '420',
+                'unit' => 'GRAM',
+            ],
+        ];
+
+        $newStandardValue = [
+            'locale' => null,
+            'scope' => null,
+            'data' => [
+                'amount' => '42',
+                'unit' => 'GRAM',
+            ],
+        ];
+
+        $productModel->getId()->willReturn(42);
+
+        $attributesProvider->getAxes($productModel)->willReturn([$size]);
+        $size->getCode()->willReturn('size');
+        $size->getType()->willReturn(AttributeTypes::METRIC);
+
+        $productModel->getValue('size')->willReturn($sizeValue);
+        $valueNormalizer->normalize($sizeValue, 'standard')->willReturn($currentStandardValue);
+
+        $comparatorRegistry
+            ->getAttributeComparator(AttributeTypes::METRIC)
+            ->willReturn($comparator);
+        $comparator->compare($newStandardValue, $currentStandardValue)->willReturn($newStandardValue);
+
+        $this->shouldThrow(ImmutablePropertyException::class)->during('update', [$productModel, [
+            'values' => [
+                'size' => [
+                    [
+                        'locale' => null,
+                        'scope' => null,
+                        'data' => [
+                            'amount' => '42',
+                            'unit' => 'GRAM',
+                        ],
+                    ],
+                ],
+            ],
+        ]]);
     }
 
     function it_throws_an_exception_if_a_parent_is_set_to_a_root_product_model(ProductModelInterface $productModel)

--- a/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/ProductModel.php
+++ b/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/ProductModel.php
@@ -68,8 +68,7 @@ class ProductModel implements ArrayConverterInterface
         $flatProductModel = $this->columnsMapper->map($flatProductModel, $options['mapping']);
         $flatProductModel = $this->columnsMerger->merge($flatProductModel);
 
-        $requiredField = $this->attributeColumnsResolver->resolveIdentifierField();
-        $this->fieldsRequirementChecker->checkFieldsPresence($flatProductModel, [$requiredField]);
+        $this->fieldsRequirementChecker->checkFieldsPresence($flatProductModel, ['code']);
 
         foreach ($flatProductModel as $column => $value) {
             if ($this->fieldConverter->supportsColumn($column)) {

--- a/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/ProductModel.php
+++ b/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/ProductModel.php
@@ -65,7 +65,9 @@ class ProductModel implements ArrayConverterInterface
     public function convert(array $flatProductModel, array $options = []): array
     {
         $convertedValues = $convertedFlatProductModel = [];
-        $flatProductModel = $this->columnsMapper->map($flatProductModel, $options['mapping']);
+        if (isset($options['mapping'])) {
+            $flatProductModel = $this->columnsMapper->map($flatProductModel, $options['mapping']);
+        }
         $flatProductModel = $this->columnsMerger->merge($flatProductModel);
 
         $this->fieldsRequirementChecker->checkFieldsPresence($flatProductModel, ['code']);

--- a/src/Pim/Component/Connector/Processor/Denormalization/ProductModelProcessor.php
+++ b/src/Pim/Component/Connector/Processor/Denormalization/ProductModelProcessor.php
@@ -109,7 +109,6 @@ class ProductModelProcessor extends AbstractProcessor implements ItemProcessorIn
             // We don't compare immutable fields
             $flatProductModelToCompare = $flatProductModel;
             unset($flatProductModelToCompare['code']);
-            unset($flatProductModelToCompare['parent']);
 
             $flatProductModel = $this->productModelFilter->filter($productModel, $flatProductModelToCompare);
 


### PR DESCRIPTION
## Description

This PR ensures the update of the product models through imports.
`First commit` is a cherry pick for this PR #6511, `second commit` is only some alignments automatically performed by PHPStorm, so no real interest here.

The `third commit` adds the basic behat scenarios for update through import.

The PR adds two new business rules (with according tests):
- ensure that a parent cannot be added to a root product model (`fourth commit`),
- ensure that the variant axes values set on a product model cannot be changed once defined (`fifth commit`).

I also add a scenario to ensure that update works with `comparison` parameter enabled (included in `fifth` commit).

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added Behats                      | OK
| Added integration tests           | OK
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
