### PR TITLE
Make attribute option field longer

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -4,6 +4,10 @@
 
 - PIM-6568: Fix import items invalid data that were no longer saved
 
+## Improvements
+
+- Make Attribute option labels longer
+
 # 1.7.7 (2017-08-03)
 
 ## Bug Fixes

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/doctrine/AttributeOptionValue.orm.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/doctrine/AttributeOptionValue.orm.yml
@@ -20,7 +20,7 @@ Pim\Bundle\CatalogBundle\Entity\AttributeOptionValue:
         value:
             type: string
             nullable: true
-            length: 100
+            length: 255
     manyToOne:
         option:
             targetEntity: Pim\Component\Catalog\Model\AttributeOptionInterface

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/validation/attribute.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/validation/attribute.yml
@@ -454,7 +454,7 @@ Pim\Bundle\CatalogBundle\Entity\AttributeOptionValue:
     properties:
         value:
             - Length:
-                max: 100
+                max: 255
                 payload:
                   standardPropertyName: labels
         locale:


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

**Description (for Contributor and Core Developer)**

The current validation is not overridable and, since 1.7, it breaks the connector with CNET for attribute option labels length.
Discussing with @jjanvier , I propose this PR to make attribute option translations longer.

I will do a second PR on next release to homogeneize translations fields and fix validation issues.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | -
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
