### PR TITLE
PIM-6333: Split the import product model step

### DIFF
--- a/behat.ci.yml
+++ b/behat.ci.yml
@@ -69,6 +69,10 @@ default:
                     - '@pim_connector.array_converter.flat_to_standard.product.attribute_column_info_extractor'
                     - '@pim_catalog.repository.product_model'
                     - '@pim_catalog.repository.family_variant'
+                    - '@pim_catalog.factory.product_model'
+                    - '@pim_catalog.updater.product_model'
+                    - '@validator'
+                    - '@pim_catalog.saver.product_model'
     extensions:
         Behat\ChainedStepsExtension: ~
         Behat\MinkExtension:

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -69,6 +69,9 @@ default:
                     - '@pim_connector.array_converter.flat_to_standard.product.attribute_column_info_extractor'
                     - '@pim_catalog.repository.product_model'
                     - '@pim_catalog.repository.family_variant'
+                    - '@pim_catalog.factory.product_model'
+                    - '@pim_catalog.updater.product_model'
+                    - '@pim_catalog.saver.product_model'
     extensions:
         Behat\ChainedStepsExtension: ~
         Behat\MinkExtension:

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -71,6 +71,7 @@ default:
                     - '@pim_catalog.repository.family_variant'
                     - '@pim_catalog.factory.product_model'
                     - '@pim_catalog.updater.product_model'
+                    - '@validator'
                     - '@pim_catalog.saver.product_model'
     extensions:
         Behat\ChainedStepsExtension: ~

--- a/features/Pim/Behat/Context/Storage/ProductModelStorage.php
+++ b/features/Pim/Behat/Context/Storage/ProductModelStorage.php
@@ -13,6 +13,7 @@ use Pim\Component\Catalog\Model\ProductModelInterface;
 use Pim\Component\Catalog\Repository\FamilyVariantRepositoryInterface;
 use Pim\Component\Catalog\Repository\ProductModelRepositoryInterface;
 use Pim\Component\Connector\ArrayConverter\FlatToStandard\Product\AttributeColumnInfoExtractor;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class ProductModelStorage extends RawMinkContext
 {
@@ -34,6 +35,9 @@ class ProductModelStorage extends RawMinkContext
     /** @var ObjectUpdaterInterface */
     private $productModelUpdater;
 
+    /** @var ValidatorInterface */
+    private $validator;
+
     /** @var SaverInterface */
     private $productModelSaver;
 
@@ -43,6 +47,7 @@ class ProductModelStorage extends RawMinkContext
      * @param FamilyVariantRepositoryInterface $familyVariantRepository
      * @param SimpleFactoryInterface           $productModelFactory
      * @param ObjectUpdaterInterface           $productModelUpdater
+     * @param ValidatorInterface               $validator
      * @param SaverInterface                   $productModelSaver
      */
     public function __construct(
@@ -51,6 +56,7 @@ class ProductModelStorage extends RawMinkContext
         FamilyVariantRepositoryInterface $familyVariantRepository,
         SimpleFactoryInterface $productModelFactory,
         ObjectUpdaterInterface $productModelUpdater,
+        ValidatorInterface $validator,
         SaverInterface $productModelSaver
     ) {
         $this->attributeColumnInfoExtractor = $attributeColumnInfoExtractor;
@@ -58,6 +64,7 @@ class ProductModelStorage extends RawMinkContext
         $this->familyVariantRepository = $familyVariantRepository;
         $this->productModelFactory = $productModelFactory;
         $this->productModelUpdater = $productModelUpdater;
+        $this->validator = $validator;
         $this->productModelSaver = $productModelSaver;
     }
 
@@ -130,6 +137,8 @@ class ProductModelStorage extends RawMinkContext
             'parent' => '',
             'family_variant' => $variantFamilyCode,
         ]);
+
+        $this->validator->validate($productModel);
         $this->productModelSaver->save($productModel);
     }
 
@@ -146,6 +155,8 @@ class ProductModelStorage extends RawMinkContext
             'parent' => $parentCode,
             'family_variant' => $parentProductModel->getFamilyVariant()->getCode(),
         ]);
+
+        $this->validator->validate($productModel);
         $this->productModelSaver->save($productModel);
     }
 

--- a/features/import/product_model/csv/create_product_model.feature
+++ b/features/import/product_model/csv/create_product_model.feature
@@ -20,7 +20,7 @@ Feature: Create product through CSV import
     And I launch the import job
     And I wait for the "csv_catalog_modeling_product_model_import" job to finish
     Then there should be the following root product model:
-      | code     | categories | family_variant                  | collection   | description-en_US-ecommerce | erp_name-en_US | price      |
+      | code     | categories | family_variant     | collection   | description-en_US-ecommerce | erp_name-en_US | price      |
       | code-001 | master_men | clothing_colorsize | [Spring2017] | description                 | Blazers_1654   | 100.00 EUR |
 
   Scenario: Julia imports new products sub-models
@@ -36,8 +36,8 @@ Feature: Create product through CSV import
     And I launch the import job
     And I wait for the "csv_catalog_modeling_product_model_import" job to finish
     Then there should be the following root product model:
-      | code     | categories | family_variant                  | collection   | description-en_US-ecommerce | erp_name-en_US | price      |
+      | code     | categories | family_variant      | collection   | description-en_US-ecommerce | erp_name-en_US | price      |
       | code-001 | master_men | clothing_color_size | [Spring2017] | description                 | Blazers_1654   | 100.00 EUR |
     And there should be the following product model:
-      | code     | color   | variation_name-en_US | composition |
-      | code-002 | [blue]  | Blazers               | composition |
+      | code     | color  | variation_name-en_US | composition |
+      | code-002 | [blue] | Blazers              | composition |

--- a/features/import/product_model/import_business_rules.feature
+++ b/features/import/product_model/import_business_rules.feature
@@ -117,3 +117,22 @@ Feature: Create product through CSV import
     And I launch the import job
     And I wait for the "csv_catalog_modeling_product_model_import" job to finish
     Then the product model "code-002" should not have the following values "collection, description-en_US-ecommerce, erp_name-en_US, price"
+
+  Scenario: Import a file regardless of the product model order, first the root product model are imported then the sub product model
+    Given the following CSV file to import:
+      """
+      code;parent;family_variant;categories;collection;description-en_US-ecommerce;erp_name-en_US;price;color;variation_name-en_US;composition;size;ean;sku;weight
+      code-002;code-001;clothing_color_size;master_men_blazers;;;;;blue;Blazers;composition;;;;
+      code-001;;clothing_color_size;master_men;Spring2017;description;Blazers_1654;100 EUR;;;;;;;
+      """
+    And the following job "csv_catalog_modeling_product_model_import" configuration:
+      | filePath | %file to import% |
+    When I am on the "csv_catalog_modeling_product_model_import" import job page
+    And I launch the import job
+    And I wait for the "csv_catalog_modeling_product_model_import" job to finish
+    Then there should be the following root product model:
+      | code     | categories | family_variant      | collection   | description-en_US-ecommerce | erp_name-en_US | price      |
+      | code-001 | master_men | clothing_color_size | [Spring2017] | description                 | Blazers_1654   | 100.00 EUR |
+    And there should be the following product model:
+      | code     | color  | variation_name-en_US | composition |
+      | code-002 | [blue] | Blazers              | composition |

--- a/features/import/product_model/import_business_rules.feature
+++ b/features/import/product_model/import_business_rules.feature
@@ -43,11 +43,11 @@ Feature: Create product through CSV import
     And I should see the text "Property \"family_variant\" expects a valid family variant code. The family variant does not exist, \"\" given"
 
   Scenario: Skip a product model if the parent does not exist or is not a root product model
-    Given the following CSV file to import:
+    Given the following root product model "code-001" with the variant family clothing_color_size
+    And the following sub product model "code-002" with "code-001" as parent
+    And the following CSV file to import:
       """
       code;parent;family_variant;categories;collection;description-en_US-ecommerce;erp_name-en_US;price;color;variation_name-en_US;composition;size;EAN;sku;weight
-      code-001;;clothing_color_size;master_men;Spring2017;description;Blazers_1654;100 EUR;;;;;;;
-      code-002;code-001;clothing_color_size;master_men_blazers;;;;;blue;Blazers;composition;;;;
       code-003;code-002;clothing_color_size;master_men_blazers;;;;;blue;Blazers;composition;;;;
       code-004;code-005;clothing_color_size;master_men_blazers;;;;;blue;Blazers;composition;;;;
       """
@@ -56,8 +56,6 @@ Feature: Create product through CSV import
     When I am on the "csv_catalog_modeling_product_model_import" import job page
     And I launch the import job
     And I wait for the "csv_catalog_modeling_product_model_import" job to finish
-    Then I should see the text "created 2"
-    Then I should see the text "skipped 2"
     And I should see the text "Property \"parent\" expects a valid parent code. The product model does not exist, \"code-005\" given"
     And I should see the text "The sub product model parent must be a root product model"
 

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/jobs.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/jobs.yml
@@ -159,7 +159,8 @@ services:
             - '@akeneo_batch.job_repository'
             -
                 - '@pim_connector.step.charset_validator'
-                - '@pim_connector.step.csv_product_model.import'
+                - '@pim_connector.step.csv_root_product_model.import'
+                - '@pim_connector.step.csv_sub_product_model.import'
         tags:
             - { name: akeneo_batch.job, connector: '%pim_connector.connector_name.csv%', type: '%pim_connector.job.import_type%' }
 
@@ -496,7 +497,8 @@ services:
             - '@akeneo_batch.job_repository'
             -
                 - '@pim_connector.step.charset_validator'
-                - '@pim_connector.step.xlsx_product_model.import'
+                - '@pim_connector.step.xlsx_root_product_model.import'
+                - '@pim_connector.step.xlsx_sub_product_model.import'
         tags:
             - { name: akeneo_batch.job, connector: '%pim_connector.connector_name.xlsx%', type: '%pim_connector.job.import_type%' }
 

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/processors.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/processors.yml
@@ -59,7 +59,7 @@ services:
             - '@pim_catalog.comparator.filter.product'
             - '@pim_catalog.localization.localizer.converter'
 
-    pim_connector.processor.denormalization.product_model:
+    pim_connector.processor.denormalization.root_product_model:
         class: '%pim_connector.processor.denormalization.product_model.class%'
         arguments:
             - '@pim_catalog.factory.product_model'
@@ -69,6 +69,19 @@ services:
             - '@pim_catalog.comparator.filter.product_model'
             - '@akeneo_storage_utils.doctrine.object_detacher'
             - '@pim_connector.processor.product_model.attribute_filter'
+            - 'root_product_model'
+
+    pim_connector.processor.denormalization.sub_product_model:
+        class: '%pim_connector.processor.denormalization.product_model.class%'
+        arguments:
+            - '@pim_catalog.factory.product_model'
+            - '@pim_catalog.updater.product_model'
+            - '@pim_catalog.repository.product_model'
+            - '@validator'
+            - '@pim_catalog.comparator.filter.product_model'
+            - '@akeneo_storage_utils.doctrine.object_detacher'
+            - '@pim_connector.processor.product_model.attribute_filter'
+            - 'sub_product_model'
 
     pim_connector.processor.denormalization.product_association:
         class: '%pim_connector.processor.denormalization.product_association.class%'

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/steps.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/steps.yml
@@ -2,7 +2,7 @@ parameters:
     pim_connector.step.validator.class: Pim\Component\Connector\Step\ValidatorStep
     pim_connector.step.tasklet.class:   Pim\Component\Connector\Step\TaskletStep
     pim_connector.step.product.import.bulk_size: 1000
-    pim_connector.step.product_model.import.bulk_size: 1
+    pim_connector.step.product_model.import.bulk_size: 100
 
 services:
     # Validator steps -------------------------------------------------------------------------------------------------
@@ -86,14 +86,25 @@ services:
             - '@pim_connector.writer.database.product'
             - '%pim_connector.step.product.import.bulk_size%'
 
-    pim_connector.step.csv_product_model.import:
+    pim_connector.step.csv_root_product_model.import:
         class: '%pim_connector.step.item_step.class%'
         arguments:
-            - 'import'
+            - 'import_root_product_model'
             - '@event_dispatcher'
             - '@akeneo_batch.job_repository'
             - '@pim_connector.reader.file.csv_product_model'
-            - '@pim_connector.processor.denormalization.product_model'
+            - '@pim_connector.processor.denormalization.root_product_model'
+            - '@pim_connector.writer.database.product_model'
+            - '%pim_connector.step.product_model.import.bulk_size%'
+
+    pim_connector.step.csv_sub_product_model.import:
+        class: '%pim_connector.step.item_step.class%'
+        arguments:
+            - 'import_sub_product_model'
+            - '@event_dispatcher'
+            - '@akeneo_batch.job_repository'
+            - '@pim_connector.reader.file.csv_product_model'
+            - '@pim_connector.processor.denormalization.sub_product_model'
             - '@pim_connector.writer.database.product_model'
             - '%pim_connector.step.product_model.import.bulk_size%'
 
@@ -394,14 +405,25 @@ services:
             - '@pim_connector.writer.database.product'
             - '%pim_connector.step.product.import.bulk_size%'
 
-    pim_connector.step.xlsx_product_model.import:
+    pim_connector.step.xlsx_root_product_model.import:
         class: '%pim_connector.step.item_step.class%'
         arguments:
-            - 'import'
+            - 'import_root_product_model'
             - '@event_dispatcher'
             - '@akeneo_batch.job_repository'
             - '@pim_connector.reader.file.xlsx_product_model'
-            - '@pim_connector.processor.denormalization.product_model'
+            - '@pim_connector.processor.denormalization.root_product_model'
+            - '@pim_connector.writer.database.product_model'
+            - '%pim_connector.step.product_model.import.bulk_size%'
+
+    pim_connector.step.xlsx_sub_product_model.import:
+        class: '%pim_connector.step.item_step.class%'
+        arguments:
+            - 'import_sub_product_model'
+            - '@event_dispatcher'
+            - '@akeneo_batch.job_repository'
+            - '@pim_connector.reader.file.xlsx_product_model'
+            - '@pim_connector.processor.denormalization.sub_product_model'
             - '@pim_connector.writer.database.product_model'
             - '%pim_connector.step.product_model.import.bulk_size%'
 

--- a/src/Pim/Bundle/ConnectorBundle/Resources/translations/messages.en.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/translations/messages.en.yml
@@ -86,7 +86,8 @@ batch_jobs:
     csv_product_model_import:
         label: Product model import in CSV
         validation.label: File validation
-        import.label: Product model import
+        import_root_product_model.label: Root product model import
+        import_sub_product_model.label: Sub product model import
     csv_category_import:
         label: Category import in CSV
         validation.label: File validation
@@ -189,7 +190,8 @@ batch_jobs:
     xlsx_product_model_import:
         label: Product model import in XSLX
         validation.label: File validation
-        import.label: Product model import
+        import_root_product_model.label: Root product model import
+        import_sub_product_model.label: Sub product model import
     xlsx_group_export:
         label: Group export in XLSX
         export.label: Group export

--- a/src/Pim/Component/Connector/Processor/Denormalization/ProductModelProcessor.php
+++ b/src/Pim/Component/Connector/Processor/Denormalization/ProductModelProcessor.php
@@ -28,6 +28,9 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
  */
 class ProductModelProcessor extends AbstractProcessor implements ItemProcessorInterface, StepExecutionAwareInterface
 {
+    private const SUB_PRODUCT_MODEL = 'sub_product_model';
+    private const ROOT_PRODUCT_MODEL = 'root_product_model';
+
     /** @var SimpleFactoryInterface */
     private $productModelFactory;
 
@@ -49,6 +52,9 @@ class ProductModelProcessor extends AbstractProcessor implements ItemProcessorIn
     /** @var AttributeFilter */
     private $attributeFilter;
 
+    /** @var string */
+    private $importType;
+
     /**
      * @param SimpleFactoryInterface                $productModelFactory
      * @param ObjectUpdaterInterface                $productModelUpdater
@@ -57,6 +63,7 @@ class ProductModelProcessor extends AbstractProcessor implements ItemProcessorIn
      * @param FilterInterface                       $productModelFilter
      * @param ObjectDetacherInterface               $objectDetacher
      * @param AttributeFilter                       $attributeFilter
+     * @param string                                $importType
      */
     public function __construct(
         SimpleFactoryInterface $productModelFactory,
@@ -65,7 +72,8 @@ class ProductModelProcessor extends AbstractProcessor implements ItemProcessorIn
         ValidatorInterface $validator,
         FilterInterface $productModelFilter,
         ObjectDetacherInterface $objectDetacher,
-        AttributeFilter $attributeFilter
+        AttributeFilter $attributeFilter,
+        string $importType
     ) {
         $this->productModelFactory = $productModelFactory;
         $this->productModelUpdater = $productModelUpdater;
@@ -74,6 +82,7 @@ class ProductModelProcessor extends AbstractProcessor implements ItemProcessorIn
         $this->productModelFilter = $productModelFilter;
         $this->objectDetacher = $objectDetacher;
         $this->attributeFilter = $attributeFilter;
+        $this->importType = $importType;
     }
 
     /**
@@ -81,6 +90,13 @@ class ProductModelProcessor extends AbstractProcessor implements ItemProcessorIn
      */
     public function process($flatProductModel): ?ProductModelInterface
     {
+        $parent = $flatProductModel['parent'] ?? '';
+        if ($this->importType === self::ROOT_PRODUCT_MODEL && !empty($parent) ||
+            $this->importType === self::SUB_PRODUCT_MODEL && empty($parent)
+        ) {
+            return null;
+        }
+
         if (!isset($flatProductModel['code'])) {
             $this->skipItemWithMessage($flatProductModel, 'The code must be filled');
         }

--- a/src/Pim/Component/Connector/spec/Processor/Denormalization/ProductModelProcessorSpec.php
+++ b/src/Pim/Component/Connector/spec/Processor/Denormalization/ProductModelProcessorSpec.php
@@ -38,7 +38,8 @@ class ProductModelProcessorSpec extends ObjectBehavior
             $validator,
             $productModelFilter,
             $objectDetacher,
-            $attributeFilter
+            $attributeFilter,
+            'root_product_model'
         );
     }
 
@@ -315,5 +316,59 @@ class ProductModelProcessorSpec extends ObjectBehavior
         $this->shouldThrow(InvalidItemException::class)->during('process', [[
             'family_variant' => 'tshirt',
         ]]);
+    }
+
+    function it_only_processes_the_root_product_model(
+        $productModelFactory,
+        $productModelUpdater,
+        $productModelRepository,
+        $validator,
+        $productModelFilter,
+        $objectDetacher,
+        $attributeFilter
+    ) {
+        $this->beConstructedWith(
+            $productModelFactory,
+            $productModelUpdater,
+            $productModelRepository,
+            $validator,
+            $productModelFilter,
+            $objectDetacher,
+            $attributeFilter,
+            'root_product_model'
+        );
+
+        $this->process([
+            'code' => 'product_model_code',
+            'family_variant' => 'tshirt',
+            'parent' => 'parent'
+        ])->shouldReturn(null);
+    }
+
+    function it_only_processes_the_product_model(
+        $productModelFactory,
+        $productModelUpdater,
+        $productModelRepository,
+        $validator,
+        $productModelFilter,
+        $objectDetacher,
+        $attributeFilter
+    ) {
+        $this->beConstructedWith(
+            $productModelFactory,
+            $productModelUpdater,
+            $productModelRepository,
+            $validator,
+            $productModelFilter,
+            $objectDetacher,
+            $attributeFilter,
+            'sub_product_model'
+        );
+
+        $this->process([
+            'code' => 'product_model_code',
+            'family_variant' => 'tshirt',
+            'parent' => ''
+        ])->shouldReturn(null);
     }
 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Product models are like categories, a tree. We decided to create 2 steps to avoid to:
* use batch size equals to 1 
* some errors related CSV file order. For instance, it avoids error when you try to link a sub product a root product model which is in memory but not flushed.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | yes
| Added Behats                      | yes
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
