### PR TITLE
Improve the upgrade file when setting the security about API

### DIFF
--- a/UPGRADE-1.7.md
+++ b/UPGRADE-1.7.md
@@ -74,7 +74,7 @@ fos_oauth_server:
 
 4. Update the security configuration `$PIM_DIR/app/config/security.yml`:
 
-    Add these new lines under `security.firewalls`:
+    Add these new lines under `security.firewalls`, before `security.firewalls.main`:
    
 ```YAML
 oauth_token:
@@ -89,6 +89,8 @@ api:
     stateless:                      true
     access_denied_handler:          pim_api.security.access_denied_handler
 ```
+
+Do note that if you don't add these lines __before__ `security.firewalls.main`, you will not be able to access to the API.
 
   Add these new lines under `security.access_control`:
     


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

Some customers add the security lines about the API after the key "security.firewalls.main".
Consequently, it's not possible to access to the API.

https://github.com/akeneo/pim-api-docs/issues/70

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | -
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
