### PR TITLE
PIM-6757: Fix scalability issue on product deletion

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Repository/ProductRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Repository/ProductRepository.php
@@ -637,11 +637,7 @@ class ProductRepository extends DocumentRepository implements
 
         $collection = $this->dm->getDocumentCollection($this->documentName);
 
-        $findQuery = [
-            'associations.products' => [
-                '$elemMatch' => $mongoRef
-            ]
-        ];
+        $findQuery = ['associations.products' => $mongoRef];
 
         $updateQuery = [
             '$pull' => [

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/model/doctrine/Product.mongodb.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/model/doctrine/Product.mongodb.yml
@@ -34,6 +34,11 @@ Pim\Component\Catalog\Model\Product:
                 background: true
             keys:
                 normalizedData.updated: 1
+        associations_products:
+            options:
+                background: true
+            keys:
+                associations.products: 1
     fields:
         id:
             id: true


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

**Context**
On a project with Mongo storage, when you delete a product, a subscriber is used to clean all associations using the deleted product.

**Problem**
The query is super long with large catalogs and can even lead to timeouts.

**Solution**
- add an index on `product.associations`
- remove the `$elemMatch` clause from the query : since we know the complete DBRef object it's overkill and it prevents the index from being used

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
