### PR TITLE
API-334: store job parameters into database

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -75,7 +75,7 @@ stage("Checkout") {
 
             def output = sh (
                 returnStdout: true,
-                script: 'find src -name "*Integration.php" -exec sh -c "grep -Ho \'function test\' {} | uniq -c"  \\; | sed "s/:function test//"'
+                script: 'find src tests -name "*Integration.php" -exec sh -c "grep -Ho \'function test\' {} | uniq -c"  \\; | sed "s/:function test//"'
             )
             def files = output.tokenize('\n')
             for (file in files) {

--- a/src/Akeneo/Bundle/BatchBundle/CHANGELOG.md
+++ b/src/Akeneo/Bundle/BatchBundle/CHANGELOG.md
@@ -1,6 +1,15 @@
 CHANGELOG
 =========
 
+0.5.x (2017-xx-xx)
+------------------
+
+- Upgrade minimal version to PHP 7.1
+
+### Bug fixes
+
+- PIM-5120: Do not hydrate all JobExecution of a JobInstance during a the creation of a JobExecution
+
 0.4.5 (2015-11-04)
 ------------------
 

--- a/src/Akeneo/Bundle/BatchBundle/Command/BatchCommand.php
+++ b/src/Akeneo/Bundle/BatchBundle/Command/BatchCommand.php
@@ -1,17 +1,23 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Akeneo\Bundle\BatchBundle\Command;
 
+use Akeneo\Bundle\BatchBundle\Notification\MailNotifier;
 use Akeneo\Component\Batch\Event\BatchCommandEvent;
 use Akeneo\Component\Batch\Event\EventInterface;
 use Akeneo\Component\Batch\Item\ExecutionContext;
 use Akeneo\Component\Batch\Job\ExitStatus;
+use Akeneo\Component\Batch\Job\JobParameters;
 use Akeneo\Component\Batch\Job\JobParametersFactory;
 use Akeneo\Component\Batch\Job\JobParametersValidator;
 use Akeneo\Component\Batch\Job\JobRegistry;
+use Akeneo\Component\Batch\Model\JobInstance;
 use Akeneo\Component\Batch\Model\StepExecution;
-use Doctrine\ORM\EntityManager;
-use Monolog\Handler\StreamHandler;
+use Doctrine\Common\Util\ClassUtils;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bridge\Monolog\Handler\ConsoleHandler;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -19,7 +25,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\ConstraintViolationList;
-use Symfony\Component\Validator\Validator;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 /**
  * Batch command
@@ -80,16 +86,16 @@ class BatchCommand extends ContainerAwareCommand
 
         if (!$noLog) {
             $logger = $this->getContainer()->get('monolog.logger.batch');
-            // Fixme: Use ConsoleHandler available on next Symfony version (2.4 ?)
-            $logger->pushHandler(new StreamHandler('php://stdout'));
+            $logger->pushHandler(new ConsoleHandler($output));
         }
 
         $code = $input->getArgument('code');
         $jobInstanceClass = $this->getContainer()->getParameter('akeneo_batch.entity.job_instance.class');
-        $jobInstance = $this
-            ->getJobManager()
-            ->getRepository($jobInstanceClass)
-            ->findOneByCode($code);
+        $jobInstance = $this->getJobManager()->getRepository($jobInstanceClass)->findOneBy(['code' => $code]);
+
+        if (null === $jobInstance) {
+            throw new \InvalidArgumentException(sprintf('Could not find job instance "%s".', $code));
+        }
 
         $event = new BatchCommandEvent($this, $input, $output, $jobInstance);
         $this->getContainer()->get('event_dispatcher')->dispatch(EventInterface::BATCH_COMMAND_START, $event);
@@ -97,19 +103,7 @@ class BatchCommand extends ContainerAwareCommand
             return self::EXIT_ERROR_CODE;
         }
 
-        if (!$jobInstance) {
-            throw new \InvalidArgumentException(sprintf('Could not find job instance "%s".', $code));
-        }
-
-        $job = $this->getJobRegistry()->get($jobInstance->getJobName());
-        $jobParamsFactory = $this->getJobParametersFactory();
-        $rawParameters = $jobInstance->getRawParameters();
-        if ($config = $input->getOption('config')) {
-            $rawParameters = array_merge($rawParameters, $this->decodeConfiguration($config));
-        }
-        $jobParameters = $jobParamsFactory->create($job, $rawParameters);
         $validator = $this->getValidator();
-
         // Override mail notifier recipient email
         if ($email = $input->getOption('email')) {
             $errors = $validator->validate($email, new Assert\Email());
@@ -118,35 +112,23 @@ class BatchCommand extends ContainerAwareCommand
                     sprintf('Email "%s" is invalid: %s', $email, $this->getErrorMessages($errors))
                 );
             }
-            $this
-                ->getMailNotifier()
-                ->setRecipientEmail($email);
+            $this->getMailNotifier()->setRecipientEmail($email);
         }
 
-        // We merge the JobInstance from the JobManager EntityManager to the DefaultEntityManager
-        // in order to be able to have a working UniqueEntity validation
-        $defaultJobInstance = $this->getDefaultEntityManager()->merge($jobInstance);
-        $paramsValidator = $this->getJobParametersValidator();
-        $errors = $paramsValidator->validate($job, $jobParameters, ['Default', 'Execution']);
-        if (count($errors) > 0) {
-            throw new \RuntimeException(
-                sprintf(
-                    'Job instance "%s" running the job "%s" with parameters "%s" is invalid because of "%s"',
-                    $code,
-                    $job->getName(),
-                    print_r($jobParameters->all(), true),
-                    $this->getErrorMessages($errors)
-                )
-            );
-        }
-
-        $this->getDefaultEntityManager()->clear(get_class($jobInstance));
-
+        $job = $this->getJobRegistry()->get($jobInstance->getJobName());
         $executionId = $input->getArgument('execution');
-        if ($executionId) {
-            $jobExecution = $this->getJobManager()->getRepository('Akeneo\Component\Batch\Model\JobExecution')
-                ->find($executionId);
-            $jobExecution->setJobParameters($jobParameters);
+
+        if (null !== $executionId && null !== $input->getOption('config')) {
+            throw new \InvalidArgumentException('Configuration option cannot be specified when launching a job execution.');
+        }
+
+        if (null === $executionId) {
+            $jobParameters = $this->createJobParameters($jobInstance, $input);
+            $this->validateJobParameters($jobInstance, $jobParameters, $code);
+            $jobExecution = $job->getJobRepository()->createJobExecution($jobInstance, $jobParameters);
+        } else {
+            $jobExecutionClass = $this->getContainer()->getParameter('akeneo_batch.entity.job_execution.class');
+            $jobExecution = $this->getJobManager()->getRepository($jobExecutionClass)->find($executionId);
             if (!$jobExecution) {
                 throw new \InvalidArgumentException(sprintf('Could not find job execution "%s".', $executionId));
             }
@@ -158,12 +140,10 @@ class BatchCommand extends ContainerAwareCommand
             if (null === $jobExecution->getExecutionContext()) {
                 $jobExecution->setExecutionContext(new ExecutionContext());
             }
-        } else {
-            $jobExecution = $job->getJobRepository()->createJobExecution($jobInstance, $jobParameters);
         }
-        $jobExecution->setJobInstance($jobInstance);
 
         $jobExecution->setPid(getmypid());
+        $job->getJobRepository()->updateJobExecution($jobExecution);
 
         $this
             ->getContainer()
@@ -256,33 +236,33 @@ class BatchCommand extends ContainerAwareCommand
     }
 
     /**
-     * @return EntityManager
+     * @return EntityManagerInterface
      */
-    protected function getJobManager()
+    protected function getJobManager(): EntityManagerInterface
     {
         return $this->getContainer()->get('akeneo_batch.job_repository')->getJobManager();
     }
 
     /**
-     * @return EntityManager
+     * @return EntityManagerInterface
      */
-    protected function getDefaultEntityManager()
+    protected function getDefaultEntityManager(): EntityManagerInterface
     {
         return $this->getContainer()->get('doctrine')->getManager();
     }
 
     /**
-     * @return Validator
+     * @return ValidatorInterface
      */
-    protected function getValidator()
+    protected function getValidator(): ValidatorInterface
     {
         return $this->getContainer()->get('validator');
     }
 
     /**
-     * @return Validator
+     * @return MailNotifier
      */
-    protected function getMailNotifier()
+    protected function getMailNotifier(): MailNotifier
     {
         return $this->getContainer()->get('akeneo_batch.mail_notifier');
     }
@@ -290,7 +270,7 @@ class BatchCommand extends ContainerAwareCommand
     /**
      * @return JobRegistry
      */
-    protected function getJobRegistry()
+    protected function getJobRegistry(): JobRegistry
     {
         return $this->getContainer()->get('akeneo_batch.job.job_registry');
     }
@@ -298,7 +278,7 @@ class BatchCommand extends ContainerAwareCommand
     /**
      * @return JobParametersFactory
      */
-    protected function getJobParametersFactory()
+    protected function getJobParametersFactory(): JobParametersFactory
     {
         return $this->getContainer()->get('akeneo_batch.job_parameters_factory');
     }
@@ -306,9 +286,60 @@ class BatchCommand extends ContainerAwareCommand
     /**
      * @return JobParametersValidator
      */
-    protected function getJobParametersValidator()
+    protected function getJobParametersValidator(): JobParametersValidator
     {
         return $this->getContainer()->get('akeneo_batch.job.job_parameters_validator');
+    }
+
+    /**
+     * @param JobInstance    $jobInstance
+     * @param InputInterface $input
+     *
+     * @return JobParameters
+     */
+    protected function createJobParameters(JobInstance $jobInstance, InputInterface $input): JobParameters
+    {
+        $job = $this->getJobRegistry()->get($jobInstance->getJobName());
+        $jobParamsFactory = $this->getJobParametersFactory();
+        $rawParameters = $jobInstance->getRawParameters();
+
+        $config = $input->getOption('config') ? $this->decodeConfiguration($input->getOption('config')) : [];
+
+        $rawParameters = array_merge($rawParameters, $config);
+        $jobParameters = $jobParamsFactory->create($job, $rawParameters);
+
+        return $jobParameters;
+    }
+
+    /**
+     * @param JobInstance   $jobInstance
+     * @param JobParameters $jobParameters
+     * @param string        $code
+     *
+     * @throws \RuntimeException
+     */
+    protected function validateJobParameters(JobInstance $jobInstance, JobParameters $jobParameters, string $code) : void
+    {
+        // We merge the JobInstance from the JobManager EntityManager to the DefaultEntityManager
+        // in order to be able to have a working UniqueEntity validation
+        $defaultJobInstance = $this->getDefaultEntityManager()->merge($jobInstance);
+        $job = $this->getJobRegistry()->get($jobInstance->getJobName());
+        $paramsValidator = $this->getJobParametersValidator();
+        $errors = $paramsValidator->validate($job, $jobParameters, ['Default', 'Execution']);
+
+        if (count($errors) > 0) {
+            throw new \RuntimeException(
+                sprintf(
+                    'Job instance "%s" running the job "%s" with parameters "%s" is invalid because of "%s"',
+                    $code,
+                    $job->getName(),
+                    print_r($jobParameters->all(), true),
+                    $this->getErrorMessages($errors)
+                )
+            );
+        }
+
+        $this->getDefaultEntityManager()->clear(ClassUtils::getClass($jobInstance));
     }
 
     /**
@@ -316,7 +347,7 @@ class BatchCommand extends ContainerAwareCommand
      *
      * @return string
      */
-    private function getErrorMessages(ConstraintViolationList $errors)
+    private function getErrorMessages(ConstraintViolationList $errors): string
     {
         $errorsStr = '';
 
@@ -330,9 +361,11 @@ class BatchCommand extends ContainerAwareCommand
     /**
      * @param string $data
      *
+     * @throws \InvalidArgumentException
+     *
      * @return array
      */
-    private function decodeConfiguration($data)
+    private function decodeConfiguration($data): array
     {
         $config = json_decode($data, true);
 

--- a/src/Akeneo/Bundle/BatchBundle/EventListener/LoadJobParametersListener.php
+++ b/src/Akeneo/Bundle/BatchBundle/EventListener/LoadJobParametersListener.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Bundle\BatchBundle\EventListener;
+
+use Akeneo\Component\Batch\Job\JobParametersFactory;
+use Akeneo\Component\Batch\Model\JobExecution;
+use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
+
+/**
+ * Load raw parameters of a job execution in order to inject it as a value object JobParameters,
+ * when loading the object with Doctrine.
+ *
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class LoadJobParametersListener
+{
+    /** @var JobParametersFactory */
+    protected $jobParametersFactory;
+
+    /**
+     * @param JobParametersFactory $jobParametersFactory
+     */
+    public function __construct(JobParametersFactory $jobParametersFactory)
+    {
+        $this->jobParametersFactory = $jobParametersFactory;
+    }
+
+    /**
+     * Load the raw parameters of the job into the value object JobParameters.
+     *
+     * @param JobExecution       $jobExecution
+     * @param LifecycleEventArgs $event
+     */
+    public function postLoad(JobExecution $jobExecution, LifecycleEventArgs $event): void
+    {
+        $jobParameters = $this->jobParametersFactory->createFromRawParameters($jobExecution);
+        $jobExecution->setJobParameters($jobParameters);
+    }
+}

--- a/src/Akeneo/Bundle/BatchBundle/Job/DoctrineJobRepository.php
+++ b/src/Akeneo/Bundle/BatchBundle/Job/DoctrineJobRepository.php
@@ -202,32 +202,12 @@ class DoctrineJobRepository implements JobRepositoryInterface
      * Ping the Server, if not available then reset the connection.
      * @author Cristian Quiroz <cq@amp.co>
      */
-    protected function checkConnection()
+    protected function checkConnection(): void
     {
         $connection = $this->jobManager->getConnection();
-        if ($this->pingConnection() === false) {
+        if (false === $connection->ping()) {
             $connection->close();
             $connection->connect();
-        }
-    }
-
-    /**
-     * Pings the server, returns false if it's not available.
-     * There is a ping() method in Doctrine\DBAL\Connection in the doctrine/dbal package
-     * as of 2.5.0, but  we are currently on 2.4.x
-     * @author Cristian Quiroz <cq@amp.co>
-     *
-     * @return bool
-     */
-    protected function pingConnection()
-    {
-        $connection = $this->jobManager->getConnection();
-        $connection->connect();
-        try {
-            $connection->query($connection->getDatabasePlatform()->getDummySelectSQL());
-            return true;
-        } catch (DBALException $e) {
-            return false;
         }
     }
 

--- a/src/Akeneo/Bundle/BatchBundle/Resources/config/model/doctrine/JobExecution.orm.yml
+++ b/src/Akeneo/Bundle/BatchBundle/Resources/config/model/doctrine/JobExecution.orm.yml
@@ -3,6 +3,8 @@ Akeneo\Component\Batch\Model\JobExecution:
     table: akeneo_batch_job_execution
     # TODO: should be like other entities
     #changeTrackingPolicy: DEFERRED_EXPLICIT
+    entityListeners:
+        \Akeneo\Bundle\BatchBundle\EventListener\LoadJobParametersListener: ~
     fields:
         id:
             type: integer
@@ -54,6 +56,9 @@ Akeneo\Component\Batch\Model\JobExecution:
             length: 255
             column: log_file
             nullable: true
+        rawParameters:
+            type: json_array
+            column: raw_parameters
     oneToMany:
         stepExecutions:
             targetEntity: Akeneo\Component\Batch\Model\StepExecution

--- a/src/Akeneo/Bundle/BatchBundle/Resources/config/services.yml
+++ b/src/Akeneo/Bundle/BatchBundle/Resources/config/services.yml
@@ -3,6 +3,7 @@ parameters:
     akeneo_batch.logger_subscriber.class:                     Akeneo\Bundle\BatchBundle\EventListener\LoggerSubscriber
     akeneo_batch.notification_subscriber.class:               Akeneo\Bundle\BatchBundle\EventListener\NotificationSubscriber
     akeneo_batch.lock_subscriber.class:                       Akeneo\Bundle\BatchBundle\EventListener\LockSubscriber
+    akeneo_batch.load_job_parameters_listener.class:          Akeneo\Bundle\BatchBundle\EventListener\LoadJobParametersListener
     akeneo_batch.logger.batch_log_handler.class:              Akeneo\Bundle\BatchBundle\Monolog\Handler\BatchLogHandler
     akeneo_batch.mail_notifier.class:                         Akeneo\Bundle\BatchBundle\Notification\MailNotifier
     akeneo_batch.set_job_execution_log_file_subscriber.class: Akeneo\Bundle\BatchBundle\EventListener\SetJobExecutionLogFileSubscriber
@@ -35,6 +36,13 @@ services:
         class: '%akeneo_batch.notification_subscriber.class%'
         tags:
             - { name: kernel.event_subscriber }
+
+    akeneo_batch.load_job_parameters_listener:
+        class: '%akeneo_batch.load_job_parameters_listener.class%'
+        arguments:
+            - '@akeneo_batch.job_parameters_factory'
+        tags:
+            - { name: doctrine.orm.entity_listener, lazy: true }
 
     akeneo_batch.mail_notifier:
         class: '%akeneo_batch.mail_notifier.class%'

--- a/src/Akeneo/Bundle/BatchBundle/spec/EventListener/LoadJobParametersListenerSpec.php
+++ b/src/Akeneo/Bundle/BatchBundle/spec/EventListener/LoadJobParametersListenerSpec.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace spec\Akeneo\Bundle\BatchBundle\EventListener;
+
+use Akeneo\Component\Batch\Event\JobExecutionEvent;
+use Akeneo\Component\Batch\Job\JobParameters;
+use Akeneo\Component\Batch\Job\JobParametersFactory;
+use Akeneo\Component\Batch\Model\JobExecution;
+use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
+use PhpSpec\ObjectBehavior;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Translation\TranslatorInterface;
+
+class LoadJobParametersListenerSpec extends ObjectBehavior
+{
+    function let(JobParametersFactory $jobParametersFactory)
+    {
+        $this->beConstructedWith($jobParametersFactory);
+    }
+
+    function it_sets_job_parameters_into_job_execution(
+        $jobParametersFactory,
+        JobExecution $jobExecution,
+        LifecycleEventArgs $event,
+        JobParameters $jobParameters
+    ) {
+        $jobParametersFactory->createFromRawParameters($jobExecution)->willReturn($jobParameters);
+        $jobExecution->setJobParameters($jobParameters)->shouldBeCalled();
+        $this->postLoad($jobExecution, $event);
+    }
+}

--- a/src/Akeneo/Component/Batch/Job/JobParametersFactory.php
+++ b/src/Akeneo/Component/Batch/Job/JobParametersFactory.php
@@ -3,6 +3,7 @@
 namespace Akeneo\Component\Batch\Job;
 
 use Akeneo\Component\Batch\Job\JobParameters\DefaultValuesProviderRegistry;
+use Akeneo\Component\Batch\Model\JobExecution;
 
 /**
  * Allow to create immutable JobParameters with passed parameters completed by default values
@@ -41,5 +42,17 @@ class JobParametersFactory
         $parameters = array_merge($provider->getDefaultValues(), $parameters);
 
         return new $this->jobParametersClass($parameters);
+    }
+
+    /**
+     * Create a JobParameters from the raw parameters of a job execution.
+     *
+     * @param JobExecution $jobExecution the job execution to create the job parameters from
+     *
+     * @return JobParameters
+     */
+    public function createFromRawParameters(JobExecution $jobExecution) : JobParameters
+    {
+        return new $this->jobParametersClass($jobExecution->getRawParameters());
     }
 }

--- a/src/Akeneo/Component/Batch/Model/JobExecution.php
+++ b/src/Akeneo/Component/Batch/Model/JobExecution.php
@@ -71,6 +71,9 @@ class JobExecution
     /** @var JobParameters */
     private $jobParameters;
 
+    /** @var array */
+    private $rawParameters;
+
     /**
      * Constructor
      */
@@ -82,6 +85,7 @@ class JobExecution
         $this->stepExecutions = new ArrayCollection();
         $this->createTime = new \DateTime();
         $this->failureExceptions = [];
+        $this->rawParameters = [];
     }
 
     /**
@@ -572,17 +576,30 @@ class JobExecution
 
     /**
      * @param JobParameters $jobParameters
+     *
+     * @return JobExecution
      */
-    public function setJobParameters(JobParameters $jobParameters)
+    public function setJobParameters(JobParameters $jobParameters): JobExecution
     {
         $this->jobParameters = $jobParameters;
+        $this->rawParameters = $jobParameters->all();
+
+        return $this;
     }
 
     /**
      * @return JobParameters
      */
-    public function getJobParameters()
+    public function getJobParameters(): ?JobParameters
     {
         return $this->jobParameters;
+    }
+
+    /**
+     * @return array|null
+     */
+    public function getRawParameters(): array
+    {
+        return $this->rawParameters;
     }
 }

--- a/src/Akeneo/Component/Batch/spec/Job/JobParametersFactorySpec.php
+++ b/src/Akeneo/Component/Batch/spec/Job/JobParametersFactorySpec.php
@@ -3,13 +3,15 @@
 namespace spec\Akeneo\Component\Batch\Job;
 
 use Akeneo\Component\Batch\Job\JobInterface;
+use Akeneo\Component\Batch\Job\JobParameters;
 use Akeneo\Component\Batch\Job\JobParameters\DefaultValuesProviderInterface;
 use Akeneo\Component\Batch\Job\JobParameters\DefaultValuesProviderRegistry;
+use Akeneo\Component\Batch\Model\JobExecution;
 use PhpSpec\ObjectBehavior;
 
 class JobParametersFactorySpec extends ObjectBehavior
 {
-    const INSTANCE_CLASS = 'Akeneo\Component\Batch\Job\JobParameters';
+    const INSTANCE_CLASS = JobParameters::class;
 
     function let(DefaultValuesProviderRegistry $registry)
     {
@@ -27,12 +29,21 @@ class JobParametersFactorySpec extends ObjectBehavior
 
         $jobParameters = $this->create($job, ['my_defined_field' => 'my defined value']);
 
-        $jobParameters->shouldReturnAnInstanceOf('Akeneo\Component\Batch\Job\JobParameters');
+        $jobParameters->shouldReturnAnInstanceOf(JobParameters::class);
         $jobParameters->all()->shouldBe(
             [
                 'my_default_field' => 'my default value',
                 'my_defined_field' => 'my defined value',
             ]
         );
+    }
+
+    function it_creates_a_job_parameters_from_raw_parameters_of_a_job_execution(JobExecution $jobExecution)
+    {
+        $jobExecution->getRawParameters()->willreturn(['foo' => 'baz']);
+        $jobParameters = $this->createFromRawParameters($jobExecution);
+
+        $jobParameters->shouldReturnAnInstanceOf(JobParameters::class);
+        $jobParameters->all()->shouldBe(['foo' => 'baz']);
     }
 }

--- a/src/Akeneo/Component/Batch/spec/Model/JobExecutionSpec.php
+++ b/src/Akeneo/Component/Batch/spec/Model/JobExecutionSpec.php
@@ -5,6 +5,7 @@ namespace spec\Akeneo\Component\Batch\Model;
 use Akeneo\Component\Batch\Item\ExecutionContext;
 use Akeneo\Component\Batch\Job\BatchStatus;
 use Akeneo\Component\Batch\Job\ExitStatus;
+use Akeneo\Component\Batch\Job\JobParameters;
 use Akeneo\Component\Batch\Model\JobInstance;
 use Akeneo\Component\Batch\Model\StepExecution;
 use PhpSpec\ObjectBehavior;
@@ -22,6 +23,8 @@ class JobExecutionSpec extends ObjectBehavior
         $this->getStepExecutions()->shouldBeEmpty();
         $this->getCreateTime()->shouldBeAnInstanceOf('\Datetime');
         $this->getFailureExceptions()->shouldHaveCount(0);
+        $this->getRawParameters()->shouldHaveCount(0);
+        $this->getJobParameters()->shouldBeNull();
     }
 
     function it_is_cloneable(
@@ -116,6 +119,14 @@ class JobExecutionSpec extends ObjectBehavior
         $this->setJobInstance($jobInstance);
         $jobInstance->getLabel()->willReturn('my label');
         $this->getLabel()->shouldReturn('my label');
+    }
+
+    function it_sets_raw_parameters_when_setting_job_parameters(JobParameters $jobParameters)
+    {
+        $jobParameters->all()->willReturn(['foo' => 'baz']);
+        $this->setJobParameters($jobParameters);
+        $this->getJobParameters()->shouldReturn($jobParameters);
+        $this->getRawParameters()->shouldReturn(['foo' => 'baz']);
     }
 
     function it_is_displayable()

--- a/src/Pim/Bundle/ConnectorBundle/Launcher/AuthenticatedJobLauncher.php
+++ b/src/Pim/Bundle/ConnectorBundle/Launcher/AuthenticatedJobLauncher.php
@@ -69,19 +69,18 @@ class AuthenticatedJobLauncher implements JobLauncherInterface
      */
     public function launch(JobInstance $jobInstance, UserInterface $user, array $configuration = []) : JobExecution
     {
-        $jobExecution = $this->createJobExecution($jobInstance, $user);
-        $executionId = $jobExecution->getId();
-        $pathFinder = new PhpExecutableFinder();
-
         $emailParameter = '';
         if (isset($configuration['send_email']) && method_exists($user, 'getEmail')) {
             $emailParameter = sprintf('--email=%s', escapeshellarg($user->getEmail()));
             unset($configuration['send_email']);
         }
 
-        $encodedConfiguration = json_encode($configuration, JSON_HEX_APOS);
+        $jobExecution = $this->createJobExecution($jobInstance, $user, $configuration);
+        $executionId = $jobExecution->getId();
+        $pathFinder = new PhpExecutableFinder();
+
         $cmd = sprintf(
-            '%s %s%sconsole pim:batch:job --env=%s %s %s %s %s %s >> %s%sbatch_execute.log 2>&1',
+            '%s %s%sconsole pim:batch:job --env=%s %s %s %s %s >> %s%sbatch_execute.log 2>&1',
             $pathFinder->find(),
             sprintf('%s%s..%sbin', $this->rootDir, DIRECTORY_SEPARATOR, DIRECTORY_SEPARATOR),
             DIRECTORY_SEPARATOR,
@@ -90,7 +89,6 @@ class AuthenticatedJobLauncher implements JobLauncherInterface
             escapeshellarg($jobInstance->getCode()),
             escapeshellarg($user->getUsername()),
             $executionId,
-            !empty($configuration) ? sprintf('--config=%s', escapeshellarg($encodedConfiguration)) : '',
             $this->logDir,
             DIRECTORY_SEPARATOR
         );
@@ -120,13 +118,15 @@ class AuthenticatedJobLauncher implements JobLauncherInterface
      *
      * @param JobInstance   $jobInstance
      * @param UserInterface $user
+     * @param array         $configuration
      *
      * @return JobExecution
      */
-    protected function createJobExecution(JobInstance $jobInstance, UserInterface $user) : JobExecution
+    protected function createJobExecution(JobInstance $jobInstance, UserInterface $user, array $configuration) : JobExecution
     {
         $job = $this->jobRegistry->get($jobInstance->getJobName());
-        $jobParameters = $this->jobParametersFactory->create($job, $jobInstance->getRawParameters());
+        $configuration = array_merge($jobInstance->getRawParameters(), $configuration);
+        $jobParameters = $this->jobParametersFactory->create($job, $configuration);
         $jobExecution = $this->jobRepository->createJobExecution($jobInstance, $jobParameters);
         $jobExecution->setUser($user->getUsername());
         $this->jobRepository->updateJobExecution($jobExecution);

--- a/tests/integration/BatchBundle/Command/BatchCommandIntegration.php
+++ b/tests/integration/BatchBundle/Command/BatchCommandIntegration.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Test\Integration\integration\BatchBundle\Command;
+
+use Akeneo\Component\Batch\Job\BatchStatus;
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Pim\Component\Catalog\Model\ProductInterface;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class BatchCommandIntegration extends TestCase
+{
+    const EXPORT_DIRECTORY = 'pim-integration-tests-export';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->createProduct('product_1');
+        $this->createProduct('product_2');
+    }
+
+    public function testJobExecutionStateWhenJobIsCompleted()
+    {
+        $output = $this->launchJob();
+        $connection = $this->get('doctrine.orm.default_entity_manager')->getConnection();
+        $stmt = $connection->prepare('SELECT status, pid, start_time, end_time, create_time, user, log_file, raw_parameters from akeneo_batch_job_execution');
+        $stmt->execute();
+        $result = $stmt->fetch();
+
+        $this->assertEquals(BatchStatus::COMPLETED, $result['status']);
+        $this->assertNotNull($result['start_time']);
+        $this->assertNotNull($result['end_time']);
+        $this->assertNotNull($result['create_time']);
+        $this->assertNotNull($result['pid']);
+        $this->assertNotNull($result['log_file']);
+        $this->assertNotNull(json_decode($result['raw_parameters'], true));
+        $this->assertNull($result['user']);
+        $this->assertEquals('Export csv_product_export has been successfully executed.' . PHP_EOL, $output->fetch());
+    }
+
+    public function testLaunchJobWithConfigOverridden()
+    {
+        $filePath= sys_get_temp_dir() . DIRECTORY_SEPARATOR . self::EXPORT_DIRECTORY . DIRECTORY_SEPARATOR . 'new_export.csv';
+        if (file_exists($filePath)) {
+            unlink($filePath);
+        }
+
+        $output = $this->launchJob(['--config' => ['filePath' => $filePath]]);
+        $this->assertEquals('Export csv_product_export has been successfully executed.' . PHP_EOL, $output->fetch());
+        $this->assertTrue(file_exists($filePath));
+    }
+
+    public function testLaunchJobWithNoLog()
+    {
+        $output = $this->launchJob(['--no-log' => true]);
+        $this->assertEquals('Export csv_product_export has been successfully executed.' . PHP_EOL, $output->fetch());
+    }
+
+    public function testLaunchJobWithNormalVerbosity()
+    {
+        $output = $this->launchJob(['--no-log' => false]);
+        $this->assertEquals('Export csv_product_export has been successfully executed.' . PHP_EOL, $output->fetch());
+    }
+
+    public function testLaunchJobWithDebugVerbosity()
+    {
+        $output = $this->launchJob(['-vvv' => true]);
+        $outputContent = $output->fetch();
+        $this->assertContains('DEBUG', $outputContent);
+        $this->assertContains('Export csv_product_export has been successfully executed.', $outputContent);
+    }
+
+    public function testLaunchJobWithValidEmail()
+    {
+        $output = $this->launchJob(['--email' => 'ziggy@akeneo.com']);
+        $this->assertEquals('Export csv_product_export has been successfully executed.' . PHP_EOL, $output->fetch());
+    }
+
+    public function testLaunchJobWithInvalidJobInstance()
+    {
+        $output = $this->launchJob(['code' => 'unknown_command']);
+        $this->assertContains('Could not find job instance "unknown_command".', $output->fetch());
+    }
+
+    public function testLaunchJobWithInvalidEmail()
+    {
+        $output = $this->launchJob(['--email' => 'email']);
+        $this->assertContains('Email "email" is invalid', $output->fetch());
+    }
+
+    public function testLaunchJobWithInvalidJobExecutionCode()
+    {
+        $output = $this->launchJob(['execution' => '1']);
+        $this->assertContains('Could not find job execution "1"', $output->fetch());
+    }
+
+    public function testLaunchJobAlreadyStarted()
+    {
+        $this->launchJob();
+        $connection = $this->get('doctrine.orm.default_entity_manager')->getConnection();
+        $stmt = $connection->prepare('SELECT id, status from akeneo_batch_job_execution');
+        $stmt->execute();
+        $result = $stmt->fetch();
+
+        $this->assertEquals(BatchStatus::COMPLETED, $result['status']);
+
+        $output = $this->launchJob(['execution' => $result['id']]);
+        $this->assertContains('Job execution "18" has invalid status: COMPLETED', $output->fetch());
+    }
+
+    public function testLaunchJobExecutionWithConfigOverridden()
+    {
+        $output = $this->launchJob(['execution' => '1', '--config' => ['filePath' => '/tmp/foo']]);
+        $this->assertContains('Configuration option cannot be specified when launching a job execution.', $output->fetch());
+    }
+
+    /**
+     * @param array $arrayInput
+     *
+     * @throws \Exception
+     *
+     * @return BufferedOutput
+     */
+    protected function launchJob(array $arrayInput = [])
+    {
+        $application = new Application(static::$kernel);
+        $application->setAutoExit(false);
+
+        $defaultArrayInput = [
+            'command'  => 'akeneo:batch:job',
+            'code'     => 'csv_product_export',
+        ];
+
+        $arrayInput = array_merge($defaultArrayInput, $arrayInput);
+        if (isset($arrayInput['--config'])) {
+            $arrayInput['--config'] = json_encode($arrayInput['--config']);
+        }
+
+        $input = new ArrayInput($arrayInput);
+        $output = new BufferedOutput();
+        $application->run($input, $output);
+
+        return $output;
+    }
+
+    /**
+     * @param string $identifier
+     * @param array  $data
+     *
+     * @return ProductInterface
+     */
+    protected function createProduct(string $identifier, array $data = []): ProductInterface
+    {
+        $product = $this->get('pim_catalog.builder.product')->createProduct($identifier);
+        $this->get('pim_catalog.updater.product')->update($product, $data);
+        $this->get('pim_catalog.saver.product')->save($product);
+
+        $this->get('akeneo_elasticsearch.client')->refreshIndex();
+
+        return $product;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return new Configuration(
+            [Configuration::getTechnicalCatalogPath()]
+        );
+    }
+}

--- a/tests/integration/BatchBundle/Job/DoctrineJobRepositoryIntegration.php
+++ b/tests/integration/BatchBundle/Job/DoctrineJobRepositoryIntegration.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Test\Integration\integration\BatchBundle\Job;
+
+use Akeneo\Bundle\BatchBundle\Job\DoctrineJobRepository;
+use Akeneo\Bundle\BatchBundle\Job\JobInstanceRepository;
+use Akeneo\Component\Batch\Job\BatchStatus;
+use Akeneo\Component\Batch\Job\ExitStatus;
+use Akeneo\Component\Batch\Job\JobParameters;
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+
+class DoctrineJobRepositoryIntegration extends TestCase
+{
+    public function testCreateJobExecutionWithJobParameters()
+    {
+        $connection = $this->get('doctrine.orm.default_entity_manager')->getConnection();
+
+        $jobInstance = $this->getJobInstanceRepository()->findOneByIdentifier('csv_product_quick_export');
+
+        $jobParameters =  new JobParameters(['foo' => 'bar']);
+        $jobExecution = $this->getDoctrineJobRepository()->createJobExecution($jobInstance, $jobParameters);
+
+        $jobExecutionId = $jobExecution->getId();
+        $stmt = $connection->prepare('SELECT status, exit_code, raw_parameters from akeneo_batch_job_execution where id = :id');
+        $stmt->bindParam('id', $jobExecutionId);
+        $stmt->execute();
+        $result = $stmt->fetch();
+
+        $expectedResult = [
+            'status' => 2,
+            'exit_code' => 'UNKNOWN',
+            'raw_parameters' => '{"foo":"bar"}',
+        ];
+
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    public function testGetLastJobExecutionWithJobParameters()
+    {
+        $jobInstance = $this->getJobInstanceRepository()->findOneByIdentifier('csv_product_quick_export');
+
+        $jobParameters =  new JobParameters(['foo' => 'bar']);
+        $jobExecution = $this->getDoctrineJobRepository()->createJobExecution($jobInstance, $jobParameters);
+        $this->getDoctrineJobRepository()->getJobManager()->clear();
+
+        $lastJobExecution = $this->getDoctrineJobRepository()->getLastJobExecution($jobInstance, BatchStatus::STARTING);
+
+        $this->assertEquals($jobExecution->getId(), $lastJobExecution->getId());
+        $this->assertEquals($jobInstance->getId(), $lastJobExecution->getJobInstance()->getId());
+        $this->assertEquals(BatchStatus::STARTING, $lastJobExecution->getStatus()->getValue());
+        $this->assertEquals(ExitStatus::UNKNOWN, $lastJobExecution->getExitStatus()->getExitCode());
+        $this->assertEquals(['foo' => 'bar'], $lastJobExecution->getRawParameters());
+        $this->assertEquals(['foo' => 'bar'], $lastJobExecution->getJobParameters()->all());
+    }
+
+    /**
+     * @return DoctrineJobRepository
+     */
+    protected function getDoctrineJobRepository(): DoctrineJobRepository
+    {
+        return $this->get('akeneo_batch.job_repository');
+    }
+
+    /**
+     * @return JobInstanceRepository
+     */
+    protected function getJobInstanceRepository(): JobInstanceRepository
+    {
+        return $this->get('akeneo_batch.job.job_instance_repository');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return new Configuration(
+            [Configuration::getTechnicalCatalogPath()]
+        );
+    }
+}


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**
When you launch a job instance, a job execution is created.

The configuration  of this job execution  can be overridden on the fly, and there is no way to find the configuration in database because it's not stored in DB.

To be able to launch job executions in background, we have to:
- make a job execution immutable: not possible to specify a config when launching a job execution, only when we launch a job instance

- store the job parameters in database

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Ok
| Added Behats                      | -
| Added integration tests           | Ok
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
