### PR TITLE
[PIM-6758] Add dropdown for PEF completeness

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Normalizer/CompletenessCollectionNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/CompletenessCollectionNormalizer.php
@@ -95,16 +95,17 @@ class CompletenessCollectionNormalizer implements NormalizerInterface
             $sortedCompletenesses[$channel->getCode()][$completeness->getLocale()->getCode()] = $completeness;
         }
 
-        foreach ($sortedCompletenesses as $channelCode => $localeCompletenesses) {
+        foreach ($sortedCompletenesses as $channelCode => $channelCompletenesses) {
             $normalizedCompletenesses[] = [
                 'channel'   => $channelCode,
                 'labels'    => $this->getChannelLabels($channels, $locales, $channelCode),
                 'stats'    => [
-                    'total'    => count($localeCompletenesses),
-                    'complete' => $this->countComplete($localeCompletenesses),
+                    'total'    => count($channelCompletenesses),
+                    'complete' => $this->countComplete($channelCompletenesses),
+                    'average'  => $this->average($channelCompletenesses),
                 ],
                 'locales' => $this->normalizeChannelCompletenesses(
-                    $localeCompletenesses,
+                    $channelCompletenesses,
                     $format,
                     $locales,
                     $context
@@ -133,7 +134,6 @@ class CompletenessCollectionNormalizer implements NormalizerInterface
     protected function countComplete(array $completenesses)
     {
         $complete = 0;
-
         foreach ($completenesses as $completeness) {
             if (100 <= $completeness->getRatio()) {
                 $complete++;
@@ -141,6 +141,23 @@ class CompletenessCollectionNormalizer implements NormalizerInterface
         }
 
         return $complete;
+    }
+
+    /**
+     * Returns the average completeness of a specific channel
+     *
+     * @param CompletenessInterface[] $completenesses
+     *
+     * @return int
+     */
+    protected function average(array $completenesses)
+    {
+        $complete = 0;
+        foreach ($completenesses as $completeness) {
+            $complete += $completeness->getRatio();
+        }
+
+        return (int) round($complete / count($completenesses));
     }
 
     /**

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/CompletenessCollectionNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/CompletenessCollectionNormalizer.php
@@ -193,7 +193,7 @@ class CompletenessCollectionNormalizer implements NormalizerInterface
     {
         $result = [];
         foreach ($locales as $locale) {
-            $result[$locale->getCode()] = $attribute->getTranslation($locale)->getLabel();
+            $result[$locale->getCode()] = $attribute->getTranslation($locale->getCode())->getLabel();
         }
 
         return $result;

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/CompletenessCollectionNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/CompletenessCollectionNormalizer.php
@@ -58,7 +58,10 @@ class CompletenessCollectionNormalizer implements NormalizerInterface
      *                 'missing' => [
      *                     [
      *                         'code' = 'description',
-     *                         'label' = 'Description'
+     *                         'labels' = [
+     *                             'en_US' => 'Description',
+     *                             'fr_FR' => 'Description'
+     *                         ]
      *                     ],
      *                     ['...'],
      *                 ],
@@ -103,6 +106,7 @@ class CompletenessCollectionNormalizer implements NormalizerInterface
                 'locales' => $this->normalizeChannelCompletenesses(
                     $localeCompletenesses,
                     $format,
+                    $locales,
                     $context
                 ),
             ];
@@ -144,6 +148,7 @@ class CompletenessCollectionNormalizer implements NormalizerInterface
      *
      * @param CompletenessInterface[] $completenesses
      * @param string                  $format
+     * @param LocaleInterface[]       $locales
      * @param array                   $context
      *
      * @return array
@@ -151,6 +156,7 @@ class CompletenessCollectionNormalizer implements NormalizerInterface
     protected function normalizeChannelCompletenesses(
         array $completenesses,
         $format,
+        array $locales,
         array $context
     ) {
         $normalizedCompletenesses = [];
@@ -166,8 +172,8 @@ class CompletenessCollectionNormalizer implements NormalizerInterface
 
             foreach ($completeness->getMissingAttributes() as $attribute) {
                 $normalizedCompleteness['missing'][] = [
-                    'code'  => $attribute->getCode(),
-                    'label' => $this->normalizeAttributeLabel($attribute),
+                    'code'   => $attribute->getCode(),
+                    'labels' => $this->normalizeAttributeLabels($attribute, $locales),
                 ];
             }
 
@@ -179,12 +185,18 @@ class CompletenessCollectionNormalizer implements NormalizerInterface
 
     /**
      * @param AttributeInterface $attribute
+     * @param LocaleInterface[]  $locales
      *
-     * @return string
+     * @return array
      */
-    protected function normalizeAttributeLabel(AttributeInterface $attribute)
+    protected function normalizeAttributeLabels(AttributeInterface $attribute, $locales): array
     {
-        return $attribute->getTranslation();
+        $result = [];
+        foreach ($locales as $locale) {
+            $result[$locale->getCode()] = $attribute->getTranslation($locale)->getLabel();
+        }
+
+        return $result;
     }
 
     /**

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/completeness.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/completeness.js
@@ -23,9 +23,6 @@ define(
             template: _.template(template),
             className: 'panel-pane completeness-panel AknCompletenessPanel',
             initialFamily: null,
-            events: {
-                'click .missing-attributes a': 'showAttribute'
-            },
 
             /**
              * {@inheritdoc}
@@ -108,19 +105,16 @@ define(
             },
 
             /**
-             * Set focus to the attribute given by the event
-             *
-             * @param Event event
+             * On family change listener
              */
-            showAttribute: function (event) {
-                this.getRoot().trigger(
-                    'pim_enrich:form:show_attribute',
-                    {
-                        attribute: event.currentTarget.dataset.attribute,
-                        locale: event.currentTarget.dataset.locale,
-                        scope: event.currentTarget.dataset.channel
-                    }
-                );
+            onChangeFamily: function () {
+                if (!_.isEmpty(this.getRoot().model._previousAttributes)) {
+                    var data = this.getFormData();
+                    data.meta.completenesses = [];
+                    this.setData(data);
+
+                    this.render();
+                }
             }
         });
     }

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/locale-switcher.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/locale-switcher.js
@@ -47,6 +47,17 @@ define(
             /**
              * {@inheritdoc}
              */
+            configure: function () {
+                this.listenTo(this.getRoot(), 'pim_enrich:form:locale_switcher:change', function (localeEvent) {
+                    if ('base_product' === localeEvent.context) {
+                        this.render();
+                    }
+                }.bind(this));
+            },
+
+            /**
+             * {@inheritdoc}
+             */
             render: function () {
                 this.getDisplayedLocales()
                     .done(function (locales) {

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/product-completeness.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/product-completeness.js
@@ -33,7 +33,6 @@ define(
              * {@inheritdoc}
              */
             configure: function () {
-                this.listenTo(this.getRoot(), 'pim_enrich:form:locale_switcher:change', this.render.bind(this));
                 this.listenTo(this.getRoot(), 'pim_enrich:form:scope_switcher:change', this.render.bind(this));
                 this.listenTo(this.getRoot(), 'pim_enrich:form:locale_switcher:change', function (localeEvent) {
                     if ('base_product' === localeEvent.context) {
@@ -52,7 +51,7 @@ define(
             render: function (localeCode) {
                 this.$el.empty();
 
-                var ratio = this.getCurrentRatio();
+                const ratio = this.getCurrentRatio();
                 if (null !== ratio) {
                     this.$el.append(this.template({
                         __: __,
@@ -84,12 +83,12 @@ define(
              * @returns number|null
              */
             getCurrentRatio: function () {
-                var completenesses = this.getCurrentCompletenesses();
+                const completenesses = this.getCurrentCompletenesses();
                 if (undefined === completenesses) {
                     return null;
                 }
 
-                var completeness = completenesses.locales[UserContext.get('catalogLocale')];
+                const completeness = completenesses.locales[UserContext.get('catalogLocale')];
                 if (undefined === completeness) {
                     return null;
                 }
@@ -103,7 +102,7 @@ define(
              * @returns string
              */
             getBadgeClass: function() {
-                var ratio = this.getCurrentRatio();
+                const ratio = this.getCurrentRatio();
                 if (ratio <= 0) {
                     return 'AknBadge--important';
                 }

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/completeness.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/completeness.html
@@ -4,14 +4,14 @@
     <p><%- noCompletenessLabel %></p>
 <% } else { %>
     <% _.each(completenesses, function(channel) { %>
-        <% var ratio = (channel['stats']['complete'] / channel['stats']['total']) * 100; %>
+        <% var ratio = channel['stats']['average']; %>
         <div class="AknCompletenessPanel-block completeness-block">
             <header class="AknCompletenessPanel-header">
                 <span class="AknCompletenessPanel-headerLocale channel" data-channel="<%- channel.channel %>">
                     <%- (null !== channel.labels[catalogLocale]) ? channel.labels[catalogLocale] : ('[' + channel.channel + ']') %>
                 </span>
                 <span class="AknCompletenessPanel-headerStats stats">
-                    <%- Math.round(ratio) %>%
+                    <%- ratio %>%
                 </span>
             </header>
             <div class="AknCompletenessPanel-content content">

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/form/product-completeness.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/form/product-completeness.html
@@ -1,3 +1,34 @@
-<div class="AknBadge AknBadge--big <%- badgeClass %>">
-    <%- label %>: <%- completeness %>%
+<div class="AknBadge AknBadge--big <%- badgeClass %>" data-toggle="dropdown">
+    <%- label %>: <%- ratio %>%
+</div>
+
+<div class="AknCompletenessPanel-block AknDropdown-menu">
+    <header class="AknCompletenessPanel-header">
+        <span class="AknCompletenessPanel-headerLocale"><%- label %></span>
+        <span class="AknCompletenessPanel-headerStats"><%- ratio %>%</span>
+    </header>
+    <div class="AknCompletenessPanel-content content">
+        <% _.each(completenesses.locales, function(completeness, locale) { %>
+            <div class="AknCompletenessPanel-channel">
+                <div class="AknCompletenessPanel-progressContainer">
+                    <span class="AknCompletenessPanel-channelTitle"><%- completeness.label %></span>
+                    <span class="AknCompletenessPanel-progressRatio literal-progress"><%- completeness.completeness.ratio %>%</span>
+                </div>
+                <div class="AknCompletenessPanel-progress AknProgress AknProgress--micro progress <%- completeness.completeness.ratio === 100 ? 'AknProgress--apply' : 'AknProgress--warning' %>">
+                    <div class="AknProgress-bar bar" style="width: <%- completeness.completeness.ratio %>%;"></div>
+                </div>
+                <% if (0 < completeness.missing.length) { %>
+                    <div class="AknCompletenessPanel-missing">
+                        <%- __(missingValues, {count: completeness.missing.length}, completeness.missing.length) %>:
+                        <% _.each(completeness.missing, function (attribute, i) { %>
+                            <% if (0 !== i) { %> | <% } %>
+                            <span class="AknCompletenessPanel-highlight missing-attribute" data-attribute="<%- attribute.code %>" data-locale="<%- locale %>">
+                                <%- attribute.labels[currentLocale] %>
+                            </span>
+                        <% }) %>
+                    </div>
+                <% } %>
+            </div>
+        <% }) %>
+    </div>
 </div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
@@ -238,6 +238,7 @@ pim_enrich:
             message:
                 created: Product successfully created
             completeness: Complete
+
         association_type:
             info:
                 deletion_successful: Association type successfully deleted.

--- a/src/Pim/Bundle/EnrichBundle/spec/Normalizer/CompletenessCollectionNormalizerSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Normalizer/CompletenessCollectionNormalizerSpec.php
@@ -151,88 +151,89 @@ class CompletenessCollectionNormalizerSpec extends ObjectBehavior
         $normalizer
             ->normalize($completenessPrintFrFR, 'internal_api', ['a_context_key' => 'context_value'])
             ->willReturn([]);
-
+        
         $this
             ->normalize($completenessCollection, 'internal_api', ['a_context_key' => 'context_value'])
             ->shouldReturn([
             [
                 'channel' => "mobile",
-                    'labels'  => [
-                        'en_US' => "mobile",
-                        'fr_FR' => "mobile",
-                    ],
-                    'stats'   => [
-                        'total'    => 2,
-                        'complete' => 0,
-                    ],
-                    'locales' => [
-                        'en_US' => [
-                            'completeness' => [],
-                            'missing'      => [
-                                [
-                                    'code'   => "name",
-                                    'labels' => [
-                                        'en_US' => 'Name',
-                                        'fr_FR' => 'Nom'
-                                    ]
-                                ],
+                'labels'  => [
+                    'en_US' => "mobile",
+                    'fr_FR' => "mobile",
+                ],
+                'stats'   => [
+                    'total'    => 2,
+                    'complete' => 0,
+                    'average'  => 50,
+                ],
+                'locales' => [
+                    'en_US' => [
+                        'completeness' => [],
+                        'missing'      => [
+                            [
+                                'code'   => "name",
+                                'labels' => [
+                                    'en_US' => 'Name',
+                                    'fr_FR' => 'Nom'
+                                ]
                             ],
-                            'label'        => "English",
                         ],
-                        'fr_FR' => [
-                            'completeness' => [],
-                            'missing'      => [
-                                [
-                                    'code'  => "name",
-                                    'labels' => [
-                                        'en_US' => 'Name',
-                                        'fr_FR' => 'Nom'
-                                    ]
-                                ],
-                            ],
-                            'label'        => "French",
-                        ],
+                        'label'        => "English",
                     ],
-                ], [
+                    'fr_FR' => [
+                        'completeness' => [],
+                        'missing'      => [
+                            [
+                                'code'  => "name",
+                                'labels' => [
+                                    'en_US' => 'Name',
+                                    'fr_FR' => 'Nom'
+                                ]
+                            ],
+                        ],
+                        'label'        => "French",
+                    ],
+                ],
+            ], [
                 'channel' => "print",
-                    'labels'  => [
-                        'en_US' => "print",
-                        'fr_FR' => "impression",
-                    ],
-                    'stats'   => [
-                        'total'    => 2,
-                        'complete' => 0,
-                    ],
-                    'locales' => [
-                        'en_US' => [
-                            'completeness' => [],
-                            'missing'      => [
-                                [
-                                    'code'  => "name",
-                                    'labels' => [
-                                        'en_US' => 'Name',
-                                        'fr_FR' => 'Nom'
-                                    ]
-                                ],
+                'labels'  => [
+                    'en_US' => "print",
+                    'fr_FR' => "impression",
+                ],
+                'stats'   => [
+                    'total'    => 2,
+                    'complete' => 0,
+                    'average'  => 50,
+                ],
+                'locales' => [
+                    'en_US' => [
+                        'completeness' => [],
+                        'missing'      => [
+                            [
+                                'code'  => "name",
+                                'labels' => [
+                                    'en_US' => 'Name',
+                                    'fr_FR' => 'Nom'
+                                ]
                             ],
-                            'label'        => "English",
                         ],
-                        'fr_FR' => [
-                            'completeness' => [],
-                            'missing'      => [
-                                [
-                                    'code'  => "name",
-                                    'labels' => [
-                                        'en_US' => 'Name',
-                                        'fr_FR' => 'Nom'
-                                    ]
-                                ],
+                        'label'        => "English",
+                    ],
+                    'fr_FR' => [
+                        'completeness' => [],
+                        'missing'      => [
+                            [
+                                'code'  => "name",
+                                'labels' => [
+                                    'en_US' => 'Name',
+                                    'fr_FR' => 'Nom'
+                                ]
                             ],
-                            'label'        => "French",
-                        ]
+                        ],
+                        'label'        => "French",
                     ]
                 ]
             ]
-        );
+        ]);
     }
 }

--- a/src/Pim/Bundle/EnrichBundle/spec/Normalizer/CompletenessCollectionNormalizerSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Normalizer/CompletenessCollectionNormalizerSpec.php
@@ -6,6 +6,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use PhpSpec\ObjectBehavior;
 use Pim\Bundle\CatalogBundle\Entity\AttributeTranslation;
 use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\AttributeTranslationInterface;
 use Pim\Component\Catalog\Model\ChannelInterface;
 use Pim\Component\Catalog\Model\ChannelTranslationInterface;
 use Pim\Component\Catalog\Model\CompletenessInterface;
@@ -116,8 +117,6 @@ class CompletenessCollectionNormalizerSpec extends ObjectBehavior
         $completenessPrintFrFR->getMissingCount()->willReturn(1);
         $completenessPrintFrFR->getMissingAttributes()->willReturn($attributeCollectionPrintFrFR);
 
-
-
         $mobile->getCode()->willReturn('mobile');
         $print->getCode()->willReturn('print');
         $enUS->getCode()->willReturn('en_US');
@@ -134,7 +133,10 @@ class CompletenessCollectionNormalizerSpec extends ObjectBehavior
         $translationPrintFr->getLabel()->willReturn('impression');
 
         $attribute->getCode()->willReturn('name');
-        $attribute->getTranslation()->willReturn('Name');
+        $attribute->getTranslation('en_US')->willReturn($attributeTranslationEn);
+        $attribute->getTranslation('fr_FR')->willReturn($attributeTranslationFr);
+        $attributeTranslationEn->getLabel()->willReturn('Name');
+        $attributeTranslationFr->getLabel()->willReturn('Nom');
 
         $normalizer->normalize(Argument::cetera())->shouldBeCalledTimes(4);
         $normalizer
@@ -168,8 +170,11 @@ class CompletenessCollectionNormalizerSpec extends ObjectBehavior
                             'completeness' => [],
                             'missing'      => [
                                 [
-                                    'code'  => "name",
-                                    'label' => 'Name'
+                                    'code'   => "name",
+                                    'labels' => [
+                                        'en_US' => 'Name',
+                                        'fr_FR' => 'Nom'
+                                    ]
                                 ],
                             ],
                             'label'        => "English",
@@ -179,7 +184,10 @@ class CompletenessCollectionNormalizerSpec extends ObjectBehavior
                             'missing'      => [
                                 [
                                     'code'  => "name",
-                                    'label' => 'Name'
+                                    'labels' => [
+                                        'en_US' => 'Name',
+                                        'fr_FR' => 'Nom'
+                                    ]
                                 ],
                             ],
                             'label'        => "French",
@@ -201,7 +209,10 @@ class CompletenessCollectionNormalizerSpec extends ObjectBehavior
                             'missing'      => [
                                 [
                                     'code'  => "name",
-                                    'label' => 'Name'
+                                    'labels' => [
+                                        'en_US' => 'Name',
+                                        'fr_FR' => 'Nom'
+                                    ]
                                 ],
                             ],
                             'label'        => "English",
@@ -211,7 +222,10 @@ class CompletenessCollectionNormalizerSpec extends ObjectBehavior
                             'missing'      => [
                                 [
                                     'code'  => "name",
-                                    'label' => 'Name'
+                                    'labels' => [
+                                        'en_US' => 'Name',
+                                        'fr_FR' => 'Nom'
+                                    ]
                                 ],
                             ],
                             'label'        => "French",

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/product-edit-form/CompletenessPanel.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/product-edit-form/CompletenessPanel.less
@@ -10,18 +10,20 @@
 
   &-block {
     width: @width;
-    margin: @margin;
     padding: 8px 20px 20px 20px;
     border: 1px solid @AknBorderColor;
   }
 
+  & &-block {
+    margin: @margin;
+  }
+
   &-header {
-    border-bottom: 1px solid @AknBorderColor;
-    height: @AknTabHeight;
-    line-height: @AknTabHeight;
-    font-size: @AknFontSizeBig;
+    border-bottom: 1px solid @AknPurple;
+    height: @AknBigButtonSize;
+    line-height: @AknBigButtonSize;
     display: flex;
-    color: @AknDarkBlue;
+    color: @AknPurple;
   }
 
   &-headerLocale {
@@ -75,5 +77,10 @@
 
   &[data-closed="true"] &-arrow:before {
     transform: rotate(90deg);
+  }
+
+  &-highlight {
+    cursor: pointer;
+    color: @AknPurple;
   }
 }

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/lib/bootstrap.dropdown.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/lib/bootstrap.dropdown.less
@@ -6,6 +6,7 @@
   animation-name: fadeIn;
   animation-duration: 0.2s;
   transition-timing-function: ease-in;
+  cursor: default;
 }
 
 .AknDropdown.open .AknDropdown-menuTitle,


### PR DESCRIPTION
This PR adds a little dropdown to display the completeness of the current scope, to put back the click to select attributes directly.

![selection_091](https://user-images.githubusercontent.com/1590933/29519967-9fc6d6d8-867f-11e7-8115-bbcafbb81ae8.png)

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Migration script                  | -
| Tech Doc                          | -