### PR TITLE
API-351: Instantly revoke access token on client delete

### DIFF
--- a/src/Pim/Bundle/ApiBundle/Command/ListClientsCommand.php
+++ b/src/Pim/Bundle/ApiBundle/Command/ListClientsCommand.php
@@ -3,6 +3,7 @@
 namespace Pim\Bundle\ApiBundle\Command;
 
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -40,7 +41,7 @@ class ListClientsCommand extends ContainerAwareCommand
             return 0;
         }
 
-        $table = $this->getHelper('table');
+        $table = new Table($output);
         $table->setHeaders(['client id', 'secret', 'label']);
 
         foreach ($clients as $client) {

--- a/src/Pim/Bundle/ApiBundle/Resources/config/doctrine/AccessToken.orm.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/doctrine/AccessToken.orm.yml
@@ -14,3 +14,10 @@ Pim\Bundle\ApiBundle\Entity\AccessToken:
                 user:
                     referencedColumnName: id
                     onDelete: CASCADE
+        client:
+            targetEntity: Pim\Bundle\ApiBundle\Entity\Client
+            joinColumns:
+                client:
+                    referencedColumnName: id
+                    nullable: true
+                    onDelete: CASCADE

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Client/RevokeTokenIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Client/RevokeTokenIntegration.php
@@ -1,0 +1,214 @@
+<?php
+
+namespace Pim\Bundle\ApiBundle\tests\integration\Client;
+
+use Akeneo\Test\Integration\Configuration;
+use Pim\Bundle\ApiBundle\tests\integration\ApiTestCase;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\HttpFoundation\Response;
+
+class RevokeTokenIntegration extends ApiTestCase
+{
+    public function testCascadeDeleteRefreshToken()
+    {
+        $client = static::createClient();
+        list($clientId, $secret) = $this->createOAuthClient();
+
+        $client->request('POST', 'api/oauth/v1/token',
+            [
+                'username'   => static::USERNAME,
+                'password'   => static::PASSWORD,
+                'grant_type' => 'password',
+            ],
+            [],
+            [
+                'PHP_AUTH_USER' => $clientId,
+                'PHP_AUTH_PW'   => $secret,
+                'CONTENT_TYPE'  => 'application/json',
+            ]
+        );
+
+        $arrayClientId = explode('_', $clientId);
+
+        $connection = $this->get('doctrine.orm.default_entity_manager')->getConnection();
+        $stmt = $connection->prepare('SELECT client, user, token from pim_api_refresh_token where client = :client');
+        $stmt->bindParam('client', $arrayClientId[0]);
+        $stmt->execute();
+        $result = $stmt->fetch();
+
+        $this->assertSame(1, $this->count($result));
+
+        $this->revokeOAuthClient($clientId);
+
+        $stmt->bindParam('client', $arrayClientId[0]);
+        $stmt->execute();
+        $result = $stmt->fetch();
+
+        $this->assertSame(false, $result);
+    }
+
+    public function testCascadeDeleteAccessToken()
+    {
+        $client = static::createClient();
+        list($clientId, $secret) = $this->createOAuthClient();
+
+        $client->request('POST', 'api/oauth/v1/token',
+            [
+                'username'   => static::USERNAME,
+                'password'   => static::PASSWORD,
+                'grant_type' => 'password',
+            ],
+            [],
+            [
+                'PHP_AUTH_USER' => $clientId,
+                'PHP_AUTH_PW'   => $secret,
+                'CONTENT_TYPE'  => 'application/json',
+            ]
+        );
+
+        $arrayClientId = explode('_', $clientId);
+
+        $connection = $this->get('doctrine.orm.default_entity_manager')->getConnection();
+        $stmt = $connection->prepare('SELECT client, user, token from pim_api_access_token where client = :client');
+        $stmt->bindParam('client', $arrayClientId[0]);
+        $stmt->execute();
+        $result = $stmt->fetch();
+
+        $this->assertSame(1, $this->count($result));
+
+        $this->revokeOAuthClient($clientId);
+
+        $stmt->bindParam('client', $arrayClientId[0]);
+        $stmt->execute();
+        $result = $stmt->fetch();
+
+        $this->assertSame(false, $result);
+    }
+
+    public function testResponseWhenUseARevokedToken()
+    {
+        list($clientId, $secret) = $this->createOAuthClient();
+        list($accessToken, $refreshToken) = $this->authenticate($clientId, $secret, self::USERNAME, self::PASSWORD);
+
+        $client = $this->createAuthenticatedClient(
+            [],
+            [],
+            $clientId,
+            $secret,
+            self::USERNAME,
+            self::PASSWORD,
+            $accessToken,
+            $refreshToken
+        );
+
+        $client->request('GET', '/api/rest/v1/currencies/eur');
+        $response = $client->getResponse();
+
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+
+        $this->revokeOAuthClient($clientId);
+
+        $client->request('GET', '/api/rest/v1/currencies/eur');
+
+        $expected =
+<<<JSON
+{
+    "code": 401,
+    "message": "The access token provided is invalid."
+}
+JSON;
+
+        $response = $client->getResponse();
+        $this->assertJsonStringEqualsJsonString($expected, $response->getContent());
+    }
+
+    public function testRefreshTokenResponseWithRevokedToken()
+    {
+        list($clientId, $secret) = $this->createOAuthClient();
+        list($accessToken, $refreshToken) = $this->authenticate($clientId, $secret, self::USERNAME, self::PASSWORD);
+
+        $client = $this->createAuthenticatedClient(
+            [],
+            [],
+            $clientId,
+            $secret,
+            self::USERNAME,
+            self::PASSWORD,
+            $accessToken,
+            $refreshToken
+        );
+
+        $client->request('POST', '/api/oauth/v1/token',
+            [
+                'grant_type'    => 'refresh_token',
+                'refresh_token' => $refreshToken,
+            ],
+            [],
+            [
+                'PHP_AUTH_USER' => $clientId,
+                'PHP_AUTH_PW'   => $secret,
+            ]
+        );
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+
+        $this->revokeOAuthClient($clientId);
+
+        $client->request('POST', '/api/oauth/v1/token',
+            [
+                'grant_type'    => 'refresh_token',
+                'refresh_token' => $refreshToken,
+            ],
+            [],
+            [
+                'PHP_AUTH_USER' => $clientId,
+                'PHP_AUTH_PW'   => $secret,
+            ]
+        );
+
+        $expected =
+<<<JSON
+{
+    "code": 422,
+    "message": "Parameter \"client_id\" is missing or does not match any client, or secret is invalid"
+}
+JSON;
+
+        $response = $client->getResponse();
+        $this->assertJsonStringEqualsJsonString($expected, $response->getContent());
+    }
+
+    /**
+     * Revoke a client using command line.
+     *
+     * @param $clientId
+     *
+     * @return string
+     */
+    protected function revokeOAuthClient($clientId)
+    {
+        $consoleApp = new Application(static::$kernel);
+        $consoleApp->setAutoExit(false);
+
+        $input  = new ArrayInput([
+            'command'   => 'pim:oauth-server:revoke-client',
+            'client_id' => $clientId,
+        ]);
+        $output = new BufferedOutput();
+
+        $consoleApp->run($input, $output);
+
+        return $output->fetch();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+    }
+}

--- a/upgrades/schema/Version_1_8_20170821122627_add_client_in_access_token_table.php
+++ b/upgrades/schema/Version_1_8_20170821122627_add_client_in_access_token_table.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Pim\Upgrade\Schema;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+class Version_1_8_20170821122627_add_client_in_access_token_table extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->addSql('ALTER TABLE pim_api_access_token ADD client INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE pim_api_access_token ADD CONSTRAINT FK_BD5E4023C7440455 ' +
+            ' FOREIGN KEY (client) REFERENCES pim_api_client (id) ON DELETE CASCADE');
+        $this->addSql('CREATE INDEX IDX_BD5E4023C7440455 ON pim_api_access_token (client);');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        $this->throwIrreversibleMigrationException();
+    }
+}


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | OK
| Changelog updated                 | -
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | OK
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
