### PR TITLE
Fix some errors in docker helper scripts

### DIFF
--- a/bin/docker/pim-front.sh
+++ b/bin/docker/pim-front.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-docker-composer exec akeneo --env=prod cache:clear --no-warmup
-docker-composer exec akeneo --env=dev cache:clear --no-warmup
-docker-composer exec akeneo-behat --env=behat cache:clear --no-warmup
-docker-composer exec akeneo-behat --env=test cache:clear --no-warmup
+docker-compose exec akeneo app/console --env=prod cache:clear --no-warmup
+docker-compose exec akeneo app/console --env=dev cache:clear --no-warmup
+docker-compose exec akeneo-behat app/console --env=behat cache:clear --no-warmup
+docker-compose exec akeneo-behat app/console --env=test cache:clear --no-warmup
 
-docker-compose exec akeneo app/console --env=prod pim:installer:assets --symlink
+docker-compose exec akeneo app/console --env=prod pim:installer:assets --symlink --clean

--- a/bin/docker/pim-initialize.sh
+++ b/bin/docker/pim-initialize.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
-docker-composer exec akeneo --env=prod cache:clear --no-warmup
-docker-composer exec akeneo --env=dev cache:clear --no-warmup
-docker-composer exec akeneo-behat --env=behat cache:clear --no-warmup
-docker-composer exec akeneo-behat --env=test cache:clear --no-warmup
+docker-compose exec akeneo app/console --env=prod cache:clear --no-warmup
+docker-compose exec akeneo app/console --env=dev cache:clear --no-warmup
+docker-compose exec akeneo-behat app/console --env=behat cache:clear --no-warmup
+docker-compose exec akeneo-behat app/console --env=test cache:clear --no-warmup
 
-docker-compose exec akeneo app/console --env=prod pim:install --force --symlink
+docker-compose exec akeneo app/console --env=prod pim:install --force --symlink --clean
 docker-compose exec akeneo-behat app/console --env=behat pim:installer:db

--- a/docker-compose.yml.dist
+++ b/docker-compose.yml.dist
@@ -19,7 +19,7 @@ services:
     volumes:
       - ./:/srv/pim
       - ./docker/akeneo.conf:/etc/apache2/sites-available/000-default.conf:ro
-      - ~/.config/composer:/home/docker/.composer
+      - ~/.composer:/home/docker/.composer
     working_dir: /srv/pim
     networks:
       - akeneo
@@ -44,7 +44,7 @@ services:
     volumes:
       - ./:/srv/pim
       - ./docker/akeneo-behat.conf:/etc/apache2/sites-available/000-default.conf:ro
-      - ~/.config/composer:/home/docker/.composer
+      - ~/.composer:/home/docker/.composer
       - /tmp/behat/screenshots:/tmp/behat/screenshots
     working_dir: /srv/pim
     networks:


### PR DESCRIPTION
## Description

There was some error in `bin/docker/*` scripts, making them impossible to run... This PR fixes them.

It updates the compose file too, changing the mapping with the composer folder on the host. This will soon be explained with details in the Dockerfiles documentation.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
