### PR TITLE
PIM-6333: Do not update twice a product model in a batch

### DIFF
--- a/features/Context/FixturesContext.php
+++ b/features/Context/FixturesContext.php
@@ -244,6 +244,9 @@ class FixturesContext extends BaseFixturesContext
 
             $this->getContainer()->get('pim_catalog.saver.product_model')->save($productModel);
 
+            $uniqueAxesCombinationSet = $this->getContainer()->get('pim_catalog.validator.unique_axes_combination_set');
+            $uniqueAxesCombinationSet->reset();
+
             $this->refresh($productModel);
             $this->getContainer()->get('akeneo_elasticsearch.client.product_and_product_model')->refreshIndex();
         }
@@ -284,6 +287,9 @@ class FixturesContext extends BaseFixturesContext
             }
 
             $this->getContainer()->get('pim_catalog.saver.product_model')->save($productModel);
+
+            $uniqueAxesCombinationSet = $this->getContainer()->get('pim_catalog.validator.unique_axes_combination_set');
+            $uniqueAxesCombinationSet->reset();
 
             $this->refresh($productModel);
             $this->getContainer()->get('akeneo_elasticsearch.client.product_and_product_model')->refreshIndex();

--- a/features/import/product_model/import_business_rules.feature
+++ b/features/import/product_model/import_business_rules.feature
@@ -188,3 +188,25 @@ Feature: Create product models through CSV import
       code;parent;family_variant;color
       code-002;code-001;clothing_color_size;red
       """
+
+  Scenario: Skip a product model if its combination of axes values exist more than once in an import file
+    Given the following CSV file to import:
+      """
+      code;parent;family_variant;categories;collection;description-en_US-ecommerce;erp_name-en_US;price;color;variation_name-en_US;composition;size;ean;sku;weight
+      code-001;;clothing_color_size;master_men;Spring2017;description;Blazers_1654;100 EUR;;;;;;;
+      code-002;code-001;clothing_color_size;master_men_blazers;;;;;blue;Blazers;composition;;;;
+      code-003;code-001;clothing_color_size;master_men_blazers;;;;;blue;Blazers;composition;;;;
+      """
+    And the following job "csv_catalog_modeling_product_model_import" configuration:
+      | filePath | %file to import% |
+    When I am on the "csv_catalog_modeling_product_model_import" import job page
+    And I launch the import job
+    And I wait for the "csv_catalog_modeling_product_model_import" job to finish
+    Then I should see the text "Status: Completed"
+    And I should see the text "skipped 1"
+    And I should see the text "Cannot set value \"[blue]\" for the attribute axis \"color\", as another sibling entity already has this value"
+    And the invalid data file of "csv_catalog_modeling_product_model_import" should contain:
+      """
+      code;parent;family_variant;categories;collection;description-en_US-ecommerce;erp_name-en_US;price;color;variation_name-en_US;composition;size;ean;sku;weight
+      code-003;code-001;clothing_color_size;master_men_blazers;;;;;blue;Blazers;composition;;;;
+      """

--- a/src/Pim/Bundle/CatalogBundle/EventSubscriber/ResetUniqueValidationSubscriber.php
+++ b/src/Pim/Bundle/CatalogBundle/EventSubscriber/ResetUniqueValidationSubscriber.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Bundle\CatalogBundle\EventSubscriber;
 
+use Pim\Component\Catalog\Validator\UniqueAxesCombinationSet;
 use Pim\Component\Catalog\Validator\UniqueValuesSet;
 
 /**
@@ -19,12 +20,17 @@ class ResetUniqueValidationSubscriber
     /** @var UniqueValuesSet */
     protected $uniqueValueSet;
 
+    /** @var UniqueAxesCombinationSet */
+    protected $uniqueAxesCombinationSet;
+
     /**
-     * @param UniqueValuesSet $uniqueValueSet
+     * @param UniqueValuesSet          $uniqueValueSet
+     * @param UniqueAxesCombinationSet $uniqueAxesCombinationSet
      */
-    public function __construct(UniqueValuesSet $uniqueValueSet)
+    public function __construct(UniqueValuesSet $uniqueValueSet, UniqueAxesCombinationSet $uniqueAxesCombinationSet)
     {
         $this->uniqueValueSet = $uniqueValueSet;
+        $this->uniqueAxesCombinationSet = $uniqueAxesCombinationSet;
     }
 
     /**
@@ -34,5 +40,6 @@ class ResetUniqueValidationSubscriber
     public function onAkeneoStoragePostsaveall()
     {
         $this->uniqueValueSet->reset();
+        $this->uniqueAxesCombinationSet->reset();
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/event_subscribers.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/event_subscribers.yml
@@ -78,6 +78,7 @@ services:
         class: '%pim_catalog.event_subscriber.reset_unique_validation.class%'
         arguments:
             - '@pim_catalog.validator.unique_value_set'
+            - '@pim_catalog.validator.unique_axes_combination_set'
         tags:
            - { name: kernel.event_listener, event: akeneo.storage.post_save_all }
 

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/validators.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/validators.yml
@@ -47,6 +47,7 @@ parameters:
     pim_catalog.validator.mapping.delegating_class_metadata_factory.class: Pim\Component\Catalog\Validator\Mapping\DelegatingClassMetadataFactory
     pim_catalog.validator.mapping.product_value_metadata_factory.class:    Pim\Component\Catalog\Validator\Mapping\ProductValueMetadataFactory
     pim_catalog.validator.unique_value_set.class:                          Pim\Component\Catalog\Validator\UniqueValuesSet
+    pim_catalog.validator.unique_axes_combination_set.class:               Pim\Component\Catalog\Validator\UniqueAxesCombinationSet
     pim_catalog.validator.constraint.family_variant_axes.class:            Pim\Component\Catalog\Validator\Constraints\FamilyVariantValidator
     pim_catalog.validator.constraint.only_expected_attributes.class:       Pim\Component\Catalog\Validator\Constraints\OnlyExpectedAttributesValidator
     pim_catalog.validator.constraint.sibling_unique_variant_axes.class:    Pim\Component\Catalog\Validator\Constraints\SiblingUniqueVariantAxesValidator
@@ -64,6 +65,10 @@ services:
 
     pim_catalog.validator.unique_value_set:
         class: '%pim_catalog.validator.unique_value_set.class%'
+        public: true
+
+    pim_catalog.validator.unique_axes_combination_set:
+        class: '%pim_catalog.validator.unique_axes_combination_set.class%'
         public: true
 
     # Validators
@@ -91,6 +96,7 @@ services:
         arguments:
             - '@pim_catalog.family_variant.provider.entity_with_family_variant_attributes'
             - '@pim_catalog.repository.entity_with_variant_family'
+            - '@pim_catalog.validator.unique_axes_combination_set'
         tags:
             - { name: validator.constraint_validator, alias: pim_sibling_unique_variant_axes_validator }
 

--- a/src/Pim/Bundle/CatalogBundle/spec/EventSubscriber/ResetUniqueValidationSubscriberSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/EventSubscriber/ResetUniqueValidationSubscriberSpec.php
@@ -3,13 +3,14 @@
 namespace spec\Pim\Bundle\CatalogBundle\EventSubscriber;
 
 use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Validator\UniqueAxesCombinationSet;
 use Pim\Component\Catalog\Validator\UniqueValuesSet;
 
 class ResetUniqueValidationSubscriberSpec extends ObjectBehavior
 {
-    function let(UniqueValuesSet $uniqueValueSet)
+    function let(UniqueValuesSet $uniqueValueSet, UniqueAxesCombinationSet $uniqueAxesCombinationSet)
     {
-        $this->beConstructedWith($uniqueValueSet);
+        $this->beConstructedWith($uniqueValueSet, $uniqueAxesCombinationSet);
     }
 
     function it_is_initializable()
@@ -17,9 +18,11 @@ class ResetUniqueValidationSubscriberSpec extends ObjectBehavior
         $this->shouldHaveType('Pim\Bundle\CatalogBundle\EventSubscriber\ResetUniqueValidationSubscriber');
     }
 
-    function it_should_reset_unique_value_set($uniqueValueSet)
+    function it_should_reset_unique_value_set($uniqueValueSet, $uniqueAxesCombinationSet)
     {
         $uniqueValueSet->reset()->shouldBeCalled();
+        $uniqueAxesCombinationSet->reset()->shouldBeCalled();
+
         $this->onAkeneoStoragePostsaveall();
     }
 }

--- a/src/Pim/Component/Catalog/Validator/UniqueAxesCombinationSet.php
+++ b/src/Pim/Component/Catalog/Validator/UniqueAxesCombinationSet.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Component\Catalog\Validator;
+
+use Pim\Component\Catalog\Model\EntityWithFamilyVariantInterface;
+
+/**
+ * Contains the state of the unique axes combination for an entity with family variant.
+ * We use this state to deal with bulk update and validation.
+ *
+ * @author    Damien Carcel <damien.carcel@gmail.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class UniqueAxesCombinationSet
+{
+    /** @var array */
+    private $uniqueAxesCombination;
+
+    /**
+     * Initializes the set.
+     */
+    public function __construct()
+    {
+        $this->uniqueAxesCombination = [];
+    }
+
+    /**
+     * Resets the set.
+     */
+    public function reset(): void
+    {
+        $this->uniqueAxesCombination = [];
+    }
+
+    /**
+     * Returns TRUE if axes combination has been added, FALSE if it already
+     * exists inside the set.
+     *
+     * @param EntityWithFamilyVariantInterface $entity
+     * @param string                           $axesCombination
+     *
+     * @return bool
+     */
+    public function addCombination(EntityWithFamilyVariantInterface $entity, string $axesCombination): bool
+    {
+        $identifier = $this->getEntityId($entity);
+        $familyVariantCode = $entity->getFamilyVariant()->getCode();
+
+        if (isset($this->uniqueAxesCombination[$familyVariantCode][$axesCombination])) {
+            $cachedIdentifier = $this->uniqueAxesCombination[$familyVariantCode][$axesCombination];
+            if ($cachedIdentifier !== $identifier) {
+                return false;
+            }
+        }
+
+        if (!isset($this->uniqueAxesCombination[$familyVariantCode])) {
+            $this->uniqueAxesCombination[$familyVariantCode] = [];
+        }
+
+        if (!isset($this->uniqueAxesCombination[$familyVariantCode][$axesCombination])) {
+            $this->uniqueAxesCombination[$familyVariantCode][$axesCombination] = $identifier;
+        }
+
+        return true;
+    }
+
+    /**
+     * spl_object_hash for new product and id when product exists
+     *
+     * @param EntityWithFamilyVariantInterface $entity
+     *
+     * @return string
+     */
+    private function getEntityId(EntityWithFamilyVariantInterface $entity): string
+    {
+        return $entity->getId() ? (string) $entity->getId() : spl_object_hash($entity);
+    }
+}


### PR DESCRIPTION
## Description

**Only the last commit is relevent, the others come from #6569, which needs to be merged first.**

For each family variant, they can only be one entity with family variant (product model or variant product) for a specific combination of variant axes values.

To ensure that, we check that such a entity does not already exists in database (already done in previous PR), but we also need to ensure there is not one in the current batch of import.

This PR introduces a new `Pim\Component\Catalog\Validator\UniqueAxesCombinationSet`, inspired from the `Pim\Component\Catalog\Validator\UniqueValuesSet` used on the products.

It stores all the MySQL ID (or if it still has none, an object hash) of the encountered entities, associated to their axes combination and family variant code (the same combination is authorized for different family variants). A violation will be raised if the same combination for the same family variant is found on a different product model of variant product.

Storing this in a dedicated object (the "unique axes combination set") allows to reset it between each batch.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added Behats                      | OK
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
