### PR TITLE
PIM-6353: filter by default products and product models that don't have a parent

### DIFF
--- a/src/Akeneo/Bundle/ElasticsearchBundle/Cursor/AbstractCursor.php
+++ b/src/Akeneo/Bundle/ElasticsearchBundle/Cursor/AbstractCursor.php
@@ -104,7 +104,8 @@ abstract class AbstractCursor implements CursorInterface
 
         foreach ($identifiers as $identifier) {
             foreach ($hydratedItems as $hydratedItem) {
-                if ($identifier === $hydratedItem->getIdentifier()) {
+                // sometimes $identifier is only numerical whereas getIdentifer() returns a string
+                if ((string) $identifier === $hydratedItem->getIdentifier()) {
                     $orderedItems[] = $hydratedItem;
                     break;
                 }

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/ParentFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/ParentFilter.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Field;
+
+use Pim\Component\Catalog\Exception\InvalidOperatorException;
+use Pim\Component\Catalog\Query\Filter\FieldFilterInterface;
+use Pim\Component\Catalog\Query\Filter\Operators;
+
+/**
+ * Parent filter for an Elasticsearch query
+ *
+ * @author    Julien Janvier <j.janvier@gmail.com>
+ * @copyright 2017  Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class ParentFilter extends AbstractFieldFilter implements FieldFilterInterface
+{
+    /**
+     * @param array $supportedFields
+     * @param array $supportedOperators
+     */
+    public function __construct(
+        array $supportedFields = [],
+        array $supportedOperators = []
+    ) {
+        $this->supportedFields = $supportedFields;
+        $this->supportedOperators = $supportedOperators;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addFieldFilter($field, $operator, $value, $locale = null, $channel = null, $options = [])
+    {
+        if (null === $this->searchQueryBuilder) {
+            throw new \LogicException('The search query builder is not initialized in the filter.');
+        }
+
+        switch ($operator) {
+            case Operators::IS_EMPTY:
+                $clause = [
+                    'exists' => [
+                        'field' => $field,
+                    ],
+                ];
+
+                $this->searchQueryBuilder->addMustNot($clause);
+                break;
+            default:
+                throw InvalidOperatorException::notSupported($operator, static::class);
+        }
+
+        return $this;
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
@@ -24,6 +24,7 @@ parameters:
     pim_catalog.query.elasticsearch.filter.datetime.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Field\DateTimeFilter
     pim_catalog.query.elasticsearch.filter.completeness.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Field\CompletenessFilter
     pim_catalog.query.elasticsearch.filter.with_attributes.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Field\WithAttributesFilter
+    pim_catalog.query.elasticsearch.filter.parent.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Field\ParentFilter
     pim_catalog.query.elasticsearch.filter.date.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute\DateFilter
     pim_catalog.query.elasticsearch.filter.number.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute\NumberFilter
     pim_catalog.query.elasticsearch.filter.text.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute\TextFilter
@@ -244,6 +245,14 @@ services:
             - '@pim_catalog.repository.attribute'
             - ['attributes_for_this_level']
             - ['IN', 'NOT IN']
+        tags:
+            - { name: 'pim_catalog.elasticsearch.query.filter', priority: 30 }
+
+    pim_catalog.query.elasticsearch.filter.parent:
+        class: '%pim_catalog.query.elasticsearch.filter.parent.class%'
+        arguments:
+            - ['parent']
+            - ['EMPTY']
         tags:
             - { name: 'pim_catalog.elasticsearch.query.filter', priority: 30 }
 

--- a/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Filter/Field/ParentFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Filter/Field/ParentFilterSpec.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace spec\Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Field;
+
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Field\AbstractFieldFilter;
+use Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Field\FamilyFilter;
+use Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Field\ParentFilter;
+use Pim\Bundle\CatalogBundle\Elasticsearch\SearchQueryBuilder;
+use Pim\Component\Catalog\Exception\InvalidOperatorException;
+use Pim\Component\Catalog\Exception\ObjectNotFoundException;
+use Pim\Component\Catalog\Model\FamilyInterface;
+use Pim\Component\Catalog\Query\Filter\FieldFilterInterface;
+use Pim\Component\Catalog\Query\Filter\Operators;
+use Pim\Component\Catalog\Repository\FamilyRepositoryInterface;
+
+class ParentFilterSpec extends ObjectBehavior
+{
+    function let()
+    {
+        $this->beConstructedWith(['parent'], ['EMPTY']);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(ParentFilter::class);
+    }
+
+    function it_is_a_filter()
+    {
+        $this->shouldImplement(FieldFilterInterface::class);
+        $this->shouldBeAnInstanceOf(AbstractFieldFilter::class);
+    }
+
+    function it_supports_operators()
+    {
+        $this->getOperators()->shouldReturn(['EMPTY']);
+        $this->supportsOperator('EMPTY')->shouldReturn(true);
+        $this->supportsOperator('DOES NOT CONTAIN')->shouldReturn(false);
+    }
+
+    function it_supports_parent_field()
+    {
+        $this->supportsField('parent')->shouldReturn(true);
+        $this->supportsField('a_not_supported_field')->shouldReturn(false);
+    }
+
+    function it_adds_a_filter_with_operator_is_empty(
+        SearchQueryBuilder $sqb
+    ) {
+        $sqb->addMustNot(
+            [
+                'exists' => ['field' => 'parent'],
+            ]
+        )->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+        $this->addFieldFilter('parent', Operators::IS_EMPTY, null, null, null, []);
+    }
+
+    function it_throws_an_exception_when_the_search_query_builder_is_not_initialized()
+    {
+        $this->shouldThrow(
+            new \LogicException('The search query builder is not initialized in the filter.')
+        )->during('addFieldFilter', ['family', Operators::IN_LIST, ['familyA'], null, null, []]);
+    }
+
+    function it_throws_an_exception_when_it_filters_on_an_unsupported_operator(
+        SearchQueryBuilder $sqb
+    ) {
+        $this->setQueryBuilder($sqb);
+
+        $this->shouldThrow(
+            InvalidOperatorException::notSupported(
+                'IN CHILDREN',
+                ParentFilter::class
+            )
+        )->during('addFieldFilter', ['parent', Operators::IN_CHILDREN_LIST, null, null, null, []]);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/AbstractPimCatalogProductModelIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/AbstractPimCatalogProductModelIntegration.php
@@ -2,6 +2,9 @@
 
 namespace Pim\Bundle\CatalogBundle\tests\integration\Elasticsearch\IndexConfiguration;
 
+use Pim\Component\Catalog\Model\ProductInterface;
+use Pim\Component\Catalog\Model\ProductModelInterface;
+
 /**
  * Dataset used to test the search of:
  * - products only (export builder use case)
@@ -100,7 +103,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             // simple tshirt
             [
                 'identifier'                => 'model-tshirt',
-                'product_type'              => 'PimCatalogRootProductModel',
+                'product_type'              => ProductModelInterface::class,
                 'level'                     => 2,
                 'family_variant'            => 'clothing_color_size',
                 'family'                    => [
@@ -110,6 +113,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     ],
                 ],
                 'attributes_for_this_level' => ['description'],
+                'parent'                    => null,
                 'values'                    => [
                     'description-text' => [
                         '<all_channels>' => [
@@ -122,7 +126,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             // Tshirt unique color model
             [
                 'identifier'                => 'model-tshirt-unique-color',
-                'product_type'              => 'PimCatalogRootProductModel',
+                'product_type'              => ProductModelInterface::class,
                 'level'                     => 1,
                 'family_variant'            => 'clothing_size',
                 'family'                    => [
@@ -132,6 +136,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     ],
                 ],
                 'attributes_for_this_level' => ['description', 'color', 'material'],
+                'parent'                    => null,
                 'values'                    => [
                     'description-text' => [
                         '<all_channels>' => [
@@ -159,7 +164,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             // Hats model
             [
                 'identifier'                => 'model-hat',
-                'product_type'              => 'PimCatalogRootProductModel',
+                'product_type'              => ProductModelInterface::class,
                 'level'                     => 1,
                 'family_variant'            => 'accessories_size',
                 'family'                    => [
@@ -169,6 +174,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     ],
                 ],
                 'attributes_for_this_level' => ['description', 'color', 'material'],
+                'parent'                    => null,
                 'values'                    => [
                     'description-text' => [
                         '<all_channels>' => [
@@ -191,7 +197,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             // Tshirt unique size model
             [
                 'identifier'                => 'model-tshirt-unique-size',
-                'product_type'              => 'PimCatalogRootProductModel',
+                'product_type'              => ProductModelInterface::class,
                 'level'                     => 1,
                 'family_variant'            => 'clothing_color',
                 'family'                    => [
@@ -201,6 +207,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     ],
                 ],
                 'attributes_for_this_level' => ['description', 'size', 'material'],
+                'parent'                    => null,
                 'values'                    => [
                     'description-text' => [
                         '<all_channels>' => [
@@ -223,7 +230,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             // Running shoes
             [
                 'identifier'                => 'model-running-shoes',
-                'product_type'              => 'PimCatalogRootProductModel',
+                'product_type'              => ProductModelInterface::class,
                 'level'                     => 2,
                 'family_variant'            => 'shoes_size_color',
                 'family'                    => [
@@ -233,6 +240,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     ],
                 ],
                 'attributes_for_this_level' => ['description', 'material'],
+                'parent'                    => null,
                 'values'                    => [
                     'description-text' => [
                         '<all_channels>' => [
@@ -250,7 +258,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             // Biker jacket
             [
                 'identifier'                => 'model-biker-jacket',
-                'product_type'              => 'PimCatalogRootProductModel',
+                'product_type'              => ProductModelInterface::class,
                 'level'                     => 2,
                 'family_variant'            => 'clothing_material_size',
                 'family'                    => [
@@ -260,6 +268,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     ],
                 ],
                 'attributes_for_this_level' => ['description', 'color'],
+                'parent'                    => null,
                 'values'                    => [
                     'description-text' => [
                         '<all_channels>' => [
@@ -279,7 +288,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             // Tshirt model level-1 (varying on color)
             [
                 'identifier'                => 'model-tshirt-grey',
-                'product_type'              => 'PimCatalogSubProductModel',
+                'product_type'              => ProductModelInterface::class,
                 'level'                     => 1,
                 'family_variant'            => 'clothing_color_size',
                 'family'                    => [
@@ -289,6 +298,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     ],
                 ],
                 'attributes_for_this_level' => ['color', 'material'],
+                'parent'                    => 'model-tshirt',
                 'values'                    => [
                     'description-text' => [
                         '<all_channels>' => [
@@ -314,7 +324,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             ],
             [
                 'identifier'                => 'model-tshirt-blue',
-                'product_type'              => 'PimCatalogSubProductModel',
+                'product_type'              => ProductModelInterface::class,
                 'level'                     => 1,
                 'family_variant'            => 'clothing_color_size',
                 'family'                    => [
@@ -324,6 +334,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     ],
                 ],
                 'attributes_for_this_level' => ['color', 'material'],
+                'parent'                    => 'model-tshirt',
                 'values'                    => [
                     'description-text' => [
                         '<all_channels>' => [
@@ -349,7 +360,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             ],
             [
                 'identifier'                => 'model-tshirt-red',
-                'product_type'              => 'PimCatalogSubProductModel',
+                'product_type'              => ProductModelInterface::class,
                 'level'                     => 1,
                 'family_variant'            => 'clothing_color_size',
                 'family'                    => [
@@ -359,6 +370,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     ],
                 ],
                 'attributes_for_this_level' => ['color', 'material'],
+                'parent'                    => 'model-tshirt',
                 'values'                    => [
                     'description-text' => [
                         '<all_channels>' => [
@@ -384,7 +396,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             ],
             [
                 'identifier'                => 'model-running-shoes-s',
-                'product_type'              => 'PimCatalogSubProductModel',
+                'product_type'              => ProductModelInterface::class,
                 'level'                     => 1,
                 'family_variant'            => 'shoes_size_color',
                 'family'                    => [
@@ -394,6 +406,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     ],
                 ],
                 'attributes_for_this_level' => ['size'],
+                'parent'                    => 'model-running',
                 'values'                    => [
                     'description-text' => [
                         '<all_channels>' => [
@@ -410,7 +423,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
 
             [
                 'identifier'                => 'model-running-shoes-m',
-                'product_type'              => 'PimCatalogSubProductModel',
+                'product_type'              => ProductModelInterface::class,
                 'level'                     => 1,
                 'family_variant'            => 'shoes_size_color',
                 'family'                    => [
@@ -420,6 +433,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     ],
                 ],
                 'attributes_for_this_level' => ['size'],
+                'parent'                    => 'model-running',
                 'values'                    => [
                     'description-text' => [
                         '<all_channels>' => [
@@ -436,7 +450,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
 
             [
                 'identifier'                => 'model-running-shoes-l',
-                'product_type'              => 'PimCatalogSubProductModel',
+                'product_type'              => ProductModelInterface::class,
                 'level'                     => 1,
                 'family_variant'            => 'shoes_size_color',
                 'family'                    => [
@@ -446,6 +460,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     ],
                 ],
                 'attributes_for_this_level' => ['size'],
+                'parent'                    => 'model-running',
                 'values'                    => [
                     'description-text' => [
                         '<all_channels>' => [
@@ -462,7 +477,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
 
             [
                 'identifier'                => 'model-biker-jacket-leather',
-                'product_type'              => 'PimCatalogSubProductModel',
+                'product_type'              => ProductModelInterface::class,
                 'level'                     => 1,
                 'family_variant'            => 'clothing_material_size',
                 'family'                    => [
@@ -472,6 +487,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     ],
                 ],
                 'attributes_for_this_level' => ['material'],
+                'parent'                    => 'model-biker-jacket',
                 'values'                    => [
                     'description-text' => [
                         '<all_channels>' => [
@@ -492,7 +508,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             ],
             [
                 'identifier'                => 'model-biker-jacket-polyester',
-                'product_type'              => 'PimCatalogSubProductModel',
+                'product_type'              => ProductModelInterface::class,
                 'level'                     => 1,
                 'family_variant'            => 'clothing_material_size',
                 'family'                    => [
@@ -502,6 +518,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     ],
                 ],
                 'attributes_for_this_level' => ['material'],
+                'parent'                    => 'model-biker-jacket',
                 'values'                    => [
                     'description-text' => [
                         '<all_channels>' => [
@@ -526,7 +543,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             // tshirt variants (level 2: varying on color and size)
             [
                 'identifier'                => 'tshirt-grey-s',
-                'product_type'              => 'PimCatalogVariantProduct',
+                'product_type'              => ProductInterface::class,
                 'family_variant'            => 'clothing_color_size',
                 'family'                    => [
                     'code'   => 'clothing_size',
@@ -535,6 +552,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     ],
                 ],
                 'attributes_for_this_level' => ['size'],
+                'parent'                    => 'model-tshirt-grey',
                 'values'                    => [
                     'description-text' => [
                         '<all_channels>' => [
@@ -565,7 +583,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             ],
             [
                 'identifier'                => 'tshirt-grey-m',
-                'product_type'              => 'PimCatalogVariantProduct',
+                'product_type'              => ProductInterface::class,
                 'family_variant'            => 'clothing_color_size',
                 'family'                    => [
                     'code'   => 'clothing_size',
@@ -574,6 +592,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     ],
                 ],
                 'attributes_for_this_level' => ['size'],
+                'parent'                    => 'model-tshirt-grey',
                 'values'                    => [
                     'description-text' => [
                         '<all_channels>' => [
@@ -604,7 +623,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             ],
             [
                 'identifier'                => 'tshirt-grey-l',
-                'product_type'              => 'PimCatalogVariantProduct',
+                'product_type'              => ProductInterface::class,
                 'family_variant'            => 'clothing_color_size',
                 'family'                    => [
                     'code'   => 'clothing_size',
@@ -613,6 +632,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     ],
                 ],
                 'attributes_for_this_level' => ['size'],
+                'parent'                    => 'model-tshirt-grey',
                 'values'                    => [
                     'description-text' => [
                         '<all_channels>' => [
@@ -643,7 +663,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             ],
             [
                 'identifier'                => 'tshirt-grey-xl',
-                'product_type'              => 'PimCatalogVariantProduct',
+                'product_type'              => ProductInterface::class,
                 'family_variant'            => 'clothing_color_size',
                 'family'                    => [
                     'code'   => 'clothing_size',
@@ -652,6 +672,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     ],
                 ],
                 'attributes_for_this_level' => ['size'],
+                'parent'                    => 'model-tshirt-grey',
                 'values'                    => [
                     'description-text' => [
                         '<all_channels>' => [
@@ -683,7 +704,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
 
             [
                 'identifier'                => 'tshirt-blue-s',
-                'product_type'              => 'PimCatalogVariantProduct',
+                'product_type'              => ProductInterface::class,
                 'family_variant'            => 'clothing_color_size',
                 'family'                    => [
                     'code'   => 'clothing_size',
@@ -692,6 +713,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     ],
                 ],
                 'attributes_for_this_level' => ['size'],
+                'parent'                    => 'model-tshirt-blue',
                 'values'                    => [
                     'description-text' => [
                         '<all_channels>' => [
@@ -722,7 +744,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             ],
             [
                 'identifier'                => 'tshirt-blue-m',
-                'product_type'              => 'PimCatalogVariantProduct',
+                'product_type'              => ProductInterface::class,
                 'family_variant'            => 'clothing_color_size',
                 'family'                    => [
                     'code'   => 'clothing_size',
@@ -731,6 +753,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     ],
                 ],
                 'attributes_for_this_level' => ['size'],
+                'parent'                    => 'model-tshirt-blue',
                 'values'                    => [
                     'description-text' => [
                         '<all_channels>' => [
@@ -761,7 +784,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             ],
             [
                 'identifier'                => 'tshirt-blue-l',
-                'product_type'              => 'PimCatalogVariantProduct',
+                'product_type'              => ProductInterface::class,
                 'family_variant'            => 'clothing_color_size',
                 'family'                    => [
                     'code'   => 'clothing_size',
@@ -770,6 +793,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     ],
                 ],
                 'attributes_for_this_level' => ['size'],
+                'parent'                    => 'model-tshirt-blue',
                 'values'                    => [
                     'description-text' => [
                         '<all_channels>' => [
@@ -800,7 +824,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             ],
             [
                 'identifier'                => 'tshirt-blue-xl',
-                'product_type'              => 'PimCatalogVariantProduct',
+                'product_type'              => ProductInterface::class,
                 'family_variant'            => 'clothing_color_size',
                 'family'                    => [
                     'code'   => 'clothing_size',
@@ -809,6 +833,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     ],
                 ],
                 'attributes_for_this_level' => ['size'],
+                'parent'                    => 'model-tshirt-blue',
                 'values'                    => [
                     'description-text' => [
                         '<all_channels>' => [
@@ -840,7 +865,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
 
             [
                 'identifier'                => 'tshirt-red-s',
-                'product_type'              => 'PimCatalogVariantProduct',
+                'product_type'              => ProductInterface::class,
                 'family_variant'            => 'clothing_color_size',
                 'family'                    => [
                     'code'   => 'clothing_size',
@@ -849,6 +874,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     ],
                 ],
                 'attributes_for_this_level' => ['size'],
+                'parent'                    => 'model-tshirt-red',
                 'values'                    => [
                     'description-text' => [
                         '<all_channels>' => [
@@ -879,7 +905,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             ],
             [
                 'identifier'                => 'tshirt-red-m',
-                'product_type'              => 'PimCatalogVariantProduct',
+                'product_type'              => ProductInterface::class,
                 'family_variant'            => 'clothing_color_size',
                 'family'                    => [
                     'code'   => 'clothing_size',
@@ -888,6 +914,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     ],
                 ],
                 'attributes_for_this_level' => ['size'],
+                'parent'                    => 'model-tshirt-red',
                 'values'                    => [
                     'description-text' => [
                         '<all_channels>' => [
@@ -918,7 +945,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             ],
             [
                 'identifier'                => 'tshirt-red-l',
-                'product_type'              => 'PimCatalogVariantProduct',
+                'product_type'              => ProductInterface::class,
                 'family_variant'            => 'clothing_color_size',
                 'family'                    => [
                     'code'   => 'clothing_size',
@@ -927,6 +954,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     ],
                 ],
                 'attributes_for_this_level' => ['size'],
+                'parent'                    => 'model-tshirt-red',
                 'values'                    => [
                     'description-text' => [
                         '<all_channels>' => [
@@ -957,7 +985,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             ],
             [
                 'identifier'                => 'tshirt-red-xl',
-                'product_type'              => 'PimCatalogVariantProduct',
+                'product_type'              => ProductInterface::class,
                 'family_variant'            => 'clothing_color_size',
                 'family'                    => [
                     'code'   => 'clothing_size',
@@ -966,6 +994,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     ],
                 ],
                 'attributes_for_this_level' => ['size'],
+                'parent'                    => 'model-tshirt-red',
                 'values'                    => [
                     'description-text' => [
                         '<all_channels>' => [
@@ -998,7 +1027,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             // T-shirt: size
             [
                 'identifier'                => 'tshirt-unique-color-s',
-                'product_type'              => 'PimCatalogVariantProduct',
+                'product_type'              => ProductInterface::class,
                 'family_variant'            => 'clothing_size',
                 'family'                    => [
                     'code'   => 'clothing_size',
@@ -1007,6 +1036,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     ],
                 ],
                 'attributes_for_this_level' => ['size'],
+                'parent'                    => 'model-tshirt-unique-color',
                 'values'                    => [
                     'description-text' => [
                         '<all_channels>' => [
@@ -1037,7 +1067,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             ],
             [
                 'identifier'                => 'tshirt-unique-color-m',
-                'product_type'              => 'PimCatalogVariantProduct',
+                'product_type'              => ProductInterface::class,
                 'family_variant'            => 'clothing_size',
                 'family'                    => [
                     'code'   => 'clothing_size',
@@ -1046,6 +1076,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     ],
                 ],
                 'attributes_for_this_level' => ['size'],
+                'parent'                    => 'model-tshirt-unique-color',
                 'values'                    => [
                     'description-text' => [
                         '<all_channels>' => [
@@ -1076,7 +1107,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             ],
             [
                 'identifier'                => 'tshirt-unique-color-l',
-                'product_type'              => 'PimCatalogVariantProduct',
+                'product_type'              => ProductInterface::class,
                 'family_variant'            => 'clothing_size',
                 'family'                    => [
                     'code'   => 'clothing_size',
@@ -1085,6 +1116,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     ],
                 ],
                 'attributes_for_this_level' => ['size'],
+                'parent'                    => 'model-tshirt-unique-color',
                 'values'                    => [
                     'description-text' => [
                         '<all_channels>' => [
@@ -1115,7 +1147,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             ],
             [
                 'identifier'                => 'tshirt-unique-color-xl',
-                'product_type'              => 'PimCatalogVariantProduct',
+                'product_type'              => ProductInterface::class,
                 'family_variant'            => 'clothing_size',
                 'family'                    => [
                     'code'   => 'clothing_size',
@@ -1124,6 +1156,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     ],
                 ],
                 'attributes_for_this_level' => ['size'],
+                'parent'                    => 'model-tshirt-unique-color',
                 'values'                    => [
                     'description-text' => [
                         '<all_channels>' => [
@@ -1156,7 +1189,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             // Watch
             [
                 'identifier'                => 'watch',
-                'product_type'              => 'PimCatalogProduct',
+                'product_type'              => ProductInterface::class,
                 'family_variant'            => null,
                 'family'                    => [
                     'code'   => 'watch',
@@ -1165,6 +1198,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     ],
                 ],
                 'attributes_for_this_level' => ['description', 'color'],
+                'parent'                    => null,
                 'values'                    => [
                     'description-text' => [
                         '<all_channels>' => [
@@ -1182,7 +1216,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             // Hats variants (varying on size)
             [
                 'identifier'                => 'hat-m',
-                'product_type'              => 'PimCatalogVariantProduct',
+                'product_type'              => ProductInterface::class,
                 'family_variant'            => 'accessories_size',
                 'family'                    => [
                     'code'   => 'accessories',
@@ -1191,6 +1225,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     ],
                 ],
                 'attributes_for_this_level' => ['size'],
+                'parent'                    => 'model-hat',
                 'values'                    => [
                     'description-text' => [
                         '<all_channels>' => [
@@ -1216,7 +1251,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             ],
             [
                 'identifier'                => 'hat-l',
-                'product_type'              => 'PimCatalogVariantProduct',
+                'product_type'              => ProductInterface::class,
                 'family_variant'            => 'accessories_size',
                 'family'                    => [
                     'code'   => 'accessories',
@@ -1225,6 +1260,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     ],
                 ],
                 'attributes_for_this_level' => ['size'],
+                'parent'                    => 'model-hat',
                 'values'                    => [
                     'description-text' => [
                         '<all_channels>' => [
@@ -1252,7 +1288,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             // Tshirt unique size model
             [
                 'identifier'                => 'tshirt-unique-size-blue',
-                'product_type'              => 'PimCatalogVariantProduct',
+                'product_type'              => ProductInterface::class,
                 'level'                     => 0,
                 'family_variant'            => 'clothing_color',
                 'family'                    => [
@@ -1262,6 +1298,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     ],
                 ],
                 'attributes_for_this_level' => ['color'],
+                'parent'                    => 'model-tshirt-unique-size',
                 'values'                    => [
                     'description-text' => [
                         '<all_channels>' => [
@@ -1293,7 +1330,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
 
             [
                 'identifier'                => 'tshirt-unique-size-red',
-                'product_type'              => 'PimCatalogVariantProduct',
+                'product_type'              => ProductInterface::class,
                 'level'                     => 0,
                 'family_variant'            => 'clothing_color',
                 'family'                    => [
@@ -1303,6 +1340,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     ],
                 ],
                 'attributes_for_this_level' => ['color'],
+                'parent'                    => 'model-tshirt-unique-size',
                 'values'                    => [
                     'description-text' => [
                         '<all_channels>' => [
@@ -1334,7 +1372,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
 
             [
                 'identifier'                => 'tshirt-unique-size-yellow',
-                'product_type'              => 'PimCatalogVariantProduct',
+                'product_type'              => ProductInterface::class,
                 'level'                     => 0,
                 'family_variant'            => 'clothing_color',
                 'family'                    => [
@@ -1344,6 +1382,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     ],
                 ],
                 'attributes_for_this_level' => ['color'],
+                'parent'                    => 'model-tshirt-unique-size',
                 'values'                    => [
                     'description-text' => [
                         '<all_channels>' => [
@@ -1376,7 +1415,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             // Running shoes
             [
                 'identifier'                => 'running-shoes-s-white',
-                'product_type'              => 'PimCatalogVariantProduct',
+                'product_type'              => ProductInterface::class,
                 'family_variant'            => 'shoes_size_color',
                 'family'                    => [
                     'code'   => 'shoes',
@@ -1385,6 +1424,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     ],
                 ],
                 'attributes_for_this_level' => ['color'],
+                'parent'                    => 'model-tshirt-running-shoes-s',
                 'values'                    => [
                     'description-text' => [
                         '<all_channels>' => [
@@ -1411,7 +1451,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
 
             [
                 'identifier'                => 'running-shoes-s-blue',
-                'product_type'              => 'PimCatalogVariantProduct',
+                'product_type'              => ProductInterface::class,
                 'family_variant'            => 'shoes_size_color',
                 'family'                    => [
                     'code'   => 'shoes',
@@ -1420,6 +1460,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     ],
                 ],
                 'attributes_for_this_level' => ['color'],
+                'parent'                    => 'model-tshirt-running-shoes-s',
                 'values'                    => [
                     'description-text' => [
                         '<all_channels>' => [
@@ -1446,7 +1487,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
 
             [
                 'identifier'                => 'running-shoes-s-red',
-                'product_type'              => 'PimCatalogVariantProduct',
+                'product_type'              => ProductInterface::class,
                 'family_variant'            => 'shoes_size_color',
                 'family'                    => [
                     'code'   => 'shoes',
@@ -1455,6 +1496,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     ],
                 ],
                 'attributes_for_this_level' => ['color'],
+                'parent'                    => 'model-tshirt-running-shoes-s',
                 'values'                    => [
                     'description-text' => [
                         '<all_channels>' => [
@@ -1481,7 +1523,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
 
             [
                 'identifier'                => 'running-shoes-m-white',
-                'product_type'              => 'PimCatalogVariantProduct',
+                'product_type'              => ProductInterface::class,
                 'family_variant'            => 'shoes_size_color',
                 'family'                    => [
                     'code'   => 'shoes',
@@ -1490,6 +1532,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     ],
                 ],
                 'attributes_for_this_level' => ['color'],
+                'parent'                    => 'model-tshirt-running-shoes-m',
                 'values'                    => [
                     'description-text' => [
                         '<all_channels>' => [
@@ -1516,7 +1559,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
 
             [
                 'identifier'                => 'running-shoes-m-blue',
-                'product_type'              => 'PimCatalogVariantProduct',
+                'product_type'              => ProductInterface::class,
                 'family_variant'            => 'shoes_size_color',
                 'family'                    => [
                     'code'   => 'shoes',
@@ -1525,6 +1568,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     ],
                 ],
                 'attributes_for_this_level' => ['color'],
+                'parent'                    => 'model-tshirt-running-shoes-m',
                 'values'                    => [
                     'description-text' => [
                         '<all_channels>' => [
@@ -1551,7 +1595,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
 
             [
                 'identifier'                => 'running-shoes-m-red',
-                'product_type'              => 'PimCatalogVariantProduct',
+                'product_type'              => ProductInterface::class,
                 'family_variant'            => 'shoes_size_color',
                 'family'                    => [
                     'code'   => 'shoes',
@@ -1560,6 +1604,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     ],
                 ],
                 'attributes_for_this_level' => ['color'],
+                'parent'                    => 'model-tshirt-running-shoes-m',
                 'values'                    => [
                     'description-text' => [
                         '<all_channels>' => [
@@ -1586,7 +1631,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
 
             [
                 'identifier'                => 'running-shoes-l-white',
-                'product_type'              => 'PimCatalogVariantProduct',
+                'product_type'              => ProductInterface::class,
                 'family_variant'            => 'shoes_size_color',
                 'family'                    => [
                     'code'   => 'shoes',
@@ -1595,6 +1640,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     ],
                 ],
                 'attributes_for_this_level' => ['color'],
+                'parent'                    => 'model-tshirt-running-shoes-l',
                 'values'                    => [
                     'description-text' => [
                         '<all_channels>' => [
@@ -1621,7 +1667,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
 
             [
                 'identifier'                => 'running-shoes-l-blue',
-                'product_type'              => 'PimCatalogVariantProduct',
+                'product_type'              => ProductInterface::class,
                 'family_variant'            => 'shoes_size_color',
                 'family'                    => [
                     'code'   => 'shoes',
@@ -1630,6 +1676,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     ],
                 ],
                 'attributes_for_this_level' => ['color'],
+                'parent'                    => 'model-tshirt-running-shoes-l',
                 'values'                    => [
                     'description-text' => [
                         '<all_channels>' => [
@@ -1656,7 +1703,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
 
             [
                 'identifier'                => 'running-shoes-l-red',
-                'product_type'              => 'PimCatalogVariantProduct',
+                'product_type'              => ProductInterface::class,
                 'family_variant'            => 'shoes_size_color',
                 'family'                    => [
                     'code'   => 'shoes',
@@ -1665,6 +1712,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     ],
                 ],
                 'attributes_for_this_level' => ['color'],
+                'parent'                    => 'model-tshirt-running-shoes-l',
                 'values'                    => [
                     'description-text' => [
                         '<all_channels>' => [
@@ -1692,7 +1740,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             // Biker
             [
                 'identifier'                => 'biker-jacket-leather-s',
-                'product_type'              => 'PimCatalogVariantProduct',
+                'product_type'              => ProductInterface::class,
                 'family_variant'            => 'clothing_material_size',
                 'family'                    => [
                     'code'   => 'clothing',
@@ -1701,6 +1749,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     ],
                 ],
                 'attributes_for_this_level' => ['size'],
+                'parent'                    => 'model-biker-jacket-leather',
                 'values'                    => [
                     'description-text' => [
                         '<all_channels>' => [
@@ -1726,7 +1775,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             ],
             [
                 'identifier'                => 'biker-jacket-leather-m',
-                'product_type'              => 'PimCatalogVariantProduct',
+                'product_type'              => ProductInterface::class,
                 'family_variant'            => 'clothing_material_size',
                 'family'                    => [
                     'code'   => 'clothing',
@@ -1735,6 +1784,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     ],
                 ],
                 'attributes_for_this_level' => ['size'],
+                'parent'                    => 'model-biker-jacket-leather',
                 'values'                    => [
                     'description-text' => [
                         '<all_channels>' => [
@@ -1760,7 +1810,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             ],
             [
                 'identifier'                => 'biker-jacket-leather-l',
-                'product_type'              => 'PimCatalogVariantProduct',
+                'product_type'              => ProductInterface::class,
                 'family_variant'            => 'clothing_material_size',
                 'family'                    => [
                     'code'   => 'clothing',
@@ -1769,6 +1819,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     ],
                 ],
                 'attributes_for_this_level' => ['size'],
+                'parent'                    => 'model-biker-jacket-leather',
                 'values'                    => [
                     'description-text' => [
                         '<all_channels>' => [
@@ -1795,7 +1846,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
 
             [
                 'identifier'                => 'biker-jacket-polyester-s',
-                'product_type'              => 'PimCatalogVariantProduct',
+                'product_type'              => ProductInterface::class,
                 'family_variant'            => 'clothing_material_size',
                 'family'                    => [
                     'code'   => 'clothing',
@@ -1804,6 +1855,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     ],
                 ],
                 'attributes_for_this_level' => ['size'],
+                'parent'                    => 'model-biker-jacket-polyester',
                 'values'                    => [
                     'description-text' => [
                         '<all_channels>' => [
@@ -1829,7 +1881,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             ],
             [
                 'identifier'                => 'biker-jacket-polyester-m',
-                'product_type'              => 'PimCatalogVariantProduct',
+                'product_type'              => ProductInterface::class,
                 'family_variant'            => 'clothing_material_size',
                 'family'                    => [
                     'code'   => 'clothing',
@@ -1838,6 +1890,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     ],
                 ],
                 'attributes_for_this_level' => ['size'],
+                'parent'                    => 'model-biker-jacket-polyester',
                 'values'                    => [
                     'description-text' => [
                         '<all_channels>' => [
@@ -1863,7 +1916,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             ],
             [
                 'identifier'                => 'biker-jacket-polyester-l',
-                'product_type'              => 'PimCatalogVariantProduct',
+                'product_type'              => ProductInterface::class,
                 'family_variant'            => 'clothing_material_size',
                 'family'                    => [
                     'code'   => 'clothing',
@@ -1872,6 +1925,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     ],
                 ],
                 'attributes_for_this_level' => ['size'],
+                'parent'                    => 'model-biker-jacket-polyester',
                 'values'                    => [
                     'description-text' => [
                         '<all_channels>' => [

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/SearchProductsAndModelsIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/SearchProductsAndModelsIntegration.php
@@ -2,6 +2,9 @@
 
 namespace Pim\Bundle\CatalogBundle\tests\integration\Elasticsearch\IndexConfiguration;
 
+use Pim\Component\Catalog\Model\ProductInterface;
+use Pim\Component\Catalog\Model\ProductModelInterface;
+
 /**
  * Search use cases of products and models in a "smart datagrid way".
  * It returns either products or models depending on where the information is stored.
@@ -33,9 +36,9 @@ class SearchProductsAndModelsIntegration extends AbstractPimCatalogProductModelI
         $query = [
             'query' => [
                 'bool' => [
-                   'filter' => [
-                       'terms' => [
-                           'product_type' => ['PimCatalogRootProductModel', 'PimCatalogProduct'],
+                   'must_not' => [
+                       'exists' => [
+                           'field' => 'parent',
                        ],
                    ],
                 ],

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/SearchProductsIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/SearchProductsIntegration.php
@@ -2,6 +2,8 @@
 
 namespace Pim\Bundle\CatalogBundle\tests\integration\Elasticsearch\IndexConfiguration;
 
+use Pim\Component\Catalog\Model\ProductInterface;
+
 /**
  * Search use cases of products only (no product models should be returned).
  *
@@ -29,7 +31,7 @@ class SearchProductsIntegration extends AbstractPimCatalogProductModelIntegratio
                 'bool' => [
                     'filter' => [
                         [
-                            'terms' => ['product_type' => ['PimCatalogProduct', 'PimCatalogVariantProduct']],
+                            'terms' => ['product_type' => [ProductInterface::class]],
                         ],
                     ],
                 ],
@@ -106,7 +108,7 @@ class SearchProductsIntegration extends AbstractPimCatalogProductModelIntegratio
                             ],
                         ],
                         [
-                            'terms' => ['product_type' => ['PimCatalogProduct', 'PimCatalogVariantProduct']],
+                            'terms' => ['product_type' => [ProductInterface::class]],
                         ],
                     ],
                 ],
@@ -155,7 +157,7 @@ class SearchProductsIntegration extends AbstractPimCatalogProductModelIntegratio
                             'terms' => ['values.color-option.<all_channels>.<all_locales>' => ['red']],
                         ],
                         [
-                            'terms' => ['product_type' => ['PimCatalogProduct', 'PimCatalogVariantProduct']],
+                            'terms' => ['product_type' => [ProductInterface::class]],
                         ],
                     ],
                 ],
@@ -196,7 +198,7 @@ class SearchProductsIntegration extends AbstractPimCatalogProductModelIntegratio
                             'terms' => ['values.color-option.<all_channels>.<all_locales>' => ['grey']],
                         ],
                         [
-                            'terms' => ['product_type' => ['PimCatalogProduct', 'PimCatalogVariantProduct']],
+                            'terms' => ['product_type' => [ProductInterface::class]],
                         ],
                     ],
                 ],
@@ -228,7 +230,7 @@ class SearchProductsIntegration extends AbstractPimCatalogProductModelIntegratio
                             'terms' => ['values.color-option.<all_channels>.<all_locales>' => ['blue']],
                         ],
                         [
-                            'terms' => ['product_type' => ['PimCatalogProduct', 'PimCatalogVariantProduct']],
+                            'terms' => ['product_type' => [ProductInterface::class]],
                         ],
                     ],
                 ],
@@ -266,7 +268,7 @@ class SearchProductsIntegration extends AbstractPimCatalogProductModelIntegratio
                             'terms' => ['values.size-option.<all_channels>.<all_locales>' => ['s']],
                         ],
                         [
-                            'terms' => ['product_type' => ['PimCatalogProduct', 'PimCatalogVariantProduct']],
+                            'terms' => ['product_type' => [ProductInterface::class]],
                         ],
                     ],
                 ],
@@ -304,7 +306,7 @@ class SearchProductsIntegration extends AbstractPimCatalogProductModelIntegratio
                             'terms' => ['values.size-option.<all_channels>.<all_locales>' => ['m']],
                         ],
                         [
-                            'terms' => ['product_type' => ['PimCatalogProduct', 'PimCatalogVariantProduct']],
+                            'terms' => ['product_type' => [ProductInterface::class]],
                         ],
                     ],
                 ],
@@ -347,7 +349,7 @@ class SearchProductsIntegration extends AbstractPimCatalogProductModelIntegratio
                             'terms' => ['values.size-option.<all_channels>.<all_locales>' => ['s']],
                         ],
                         [
-                            'terms' => ['product_type' => ['PimCatalogProduct', 'PimCatalogVariantProduct']],
+                            'terms' => ['product_type' => [ProductInterface::class]],
                         ],
                     ],
                 ],
@@ -372,7 +374,7 @@ class SearchProductsIntegration extends AbstractPimCatalogProductModelIntegratio
                             'terms' => ['values.size-option.<all_channels>.<all_locales>' => ['m']],
                         ],
                         [
-                            'terms' => ['product_type' => ['PimCatalogProduct', 'PimCatalogVariantProduct']],
+                            'terms' => ['product_type' => [ProductInterface::class]],
                         ],
                     ],
                 ],
@@ -400,7 +402,7 @@ class SearchProductsIntegration extends AbstractPimCatalogProductModelIntegratio
                             'terms' => ['values.color-option.<all_channels>.<all_locales>' => ['grey']],
                         ],
                         [
-                            'terms' => ['product_type' => ['PimCatalogProduct', 'PimCatalogVariantProduct']],
+                            'terms' => ['product_type' => [ProductInterface::class]],
                         ],
                     ],
                 ],
@@ -430,7 +432,7 @@ class SearchProductsIntegration extends AbstractPimCatalogProductModelIntegratio
                             'terms' => ['values.material-option.<all_channels>.<all_locales>' => ['cotton']],
                         ],
                         [
-                            'terms' => ['product_type' => ['PimCatalogProduct', 'PimCatalogVariantProduct']],
+                            'terms' => ['product_type' => [ProductInterface::class]],
                         ],
                     ],
                 ],
@@ -479,7 +481,7 @@ class SearchProductsIntegration extends AbstractPimCatalogProductModelIntegratio
                             'terms' => ['values.material-option.<all_channels>.<all_locales>' => ['leather']],
                         ],
                         [
-                            'terms' => ['product_type' => ['PimCatalogProduct', 'PimCatalogVariantProduct']],
+                            'terms' => ['product_type' => [ProductInterface::class]],
                         ],
                     ],
                 ],
@@ -523,7 +525,7 @@ class SearchProductsIntegration extends AbstractPimCatalogProductModelIntegratio
                             'terms' => ['values.color-option.<all_channels>.<all_locales>' => ['white']],
                         ],
                         [
-                            'terms' => ['product_type' => ['PimCatalogProduct', 'PimCatalogVariantProduct']],
+                            'terms' => ['product_type' => [ProductInterface::class]],
                         ],
                     ],
                 ],
@@ -555,7 +557,7 @@ class SearchProductsIntegration extends AbstractPimCatalogProductModelIntegratio
                             'exists' => ['field' => 'values.color-option.<all_channels>.<all_locales>'],
                         ],
                         [
-                            'terms' => ['product_type' => ['PimCatalogProduct', 'PimCatalogVariantProduct']],
+                            'terms' => ['product_type' => [ProductInterface::class]],
                         ],
                     ],
                 ],
@@ -624,7 +626,7 @@ class SearchProductsIntegration extends AbstractPimCatalogProductModelIntegratio
                             'terms' => ['values.color-option.<all_channels>.<all_locales>' => ['red']],
                         ],
                         [
-                            'terms' => ['product_type' => ['PimCatalogProduct', 'PimCatalogVariantProduct']],
+                            'terms' => ['product_type' => [ProductInterface::class]],
                         ],
                     ],
                 ],
@@ -670,7 +672,7 @@ class SearchProductsIntegration extends AbstractPimCatalogProductModelIntegratio
                             'exists' => ['field' => 'values.color-option.<all_channels>.<all_locales>'],
                         ],
                         [
-                            'terms' => ['product_type' => ['PimCatalogProduct', 'PimCatalogVariantProduct']],
+                            'terms' => ['product_type' => [ProductInterface::class]],
                         ],
                     ],
                 ],
@@ -715,7 +717,7 @@ class SearchProductsIntegration extends AbstractPimCatalogProductModelIntegratio
                             'exists' => ['field' => 'values.size-option.<all_channels>.<all_locales>'],
                         ],
                         [
-                            'terms' => ['product_type' => ['PimCatalogProduct', 'PimCatalogVariantProduct']],
+                            'terms' => ['product_type' => [ProductInterface::class]],
                         ],
                     ],
                 ],

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/ProductAndProductModelQueryBuilderIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/ProductAndProductModelQueryBuilderIntegration.php
@@ -7,6 +7,7 @@ use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Query\Filter\Operators;
+use Pim\Component\Catalog\Query\Sorter\Directions;
 
 /**
  * Test the ProductAndProductModelQueryBuilder can return both product and product models in a smart way.
@@ -17,18 +18,40 @@ use Pim\Component\Catalog\Query\Filter\Operators;
  */
 class ProductAndProductModelQueryBuilderIntegration extends TestCase
 {
-    public function testDefaultView()
+    public function testNoFilterAndSortIdentifier()
     {
-        $result = $this->executeFilter([]);
+        $pqb = $this->get('pim_enrich.query.product_and_product_model_query_builder_from_size_factory')->create(
+            [
+                'default_locale' => 'en_US',
+                'default_scope'  => 'ecommerce',
+                'limit'          => 19,
+            ]
+        );
+        $pqb->addSorter('identifier', Directions::DESCENDING);
+
+        $result = $pqb->execute();
+
         $this->assertSearch(
             [
-                'model-tshirt-divided',
-                'model-tshirt-unique-color-kurt',
                 'watch',
-                'model-braided-hat',
+                'zeus',
+                'vulcanus',
+                'venus',
+                'terminus',
+                'stock',
+                'stilleto',
+                'securitas',
+                'quirinus',
+                'poseidon',
+                'portunus',
+                'plain',
                 'model-tshirt-unique-size',
+                'model-tshirt-unique-color-kurt',
+                'model-tshirt-divided',
                 'model-running-shoes',
+                'model-braided-hat',
                 'model-biker-jacket',
+                'moccasin',
             ],
             $result
         );

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/ProductAndProductModelQueryBuilderIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/ProductAndProductModelQueryBuilderIntegration.php
@@ -17,8 +17,6 @@ use Pim\Component\Catalog\Query\Filter\Operators;
  */
 class ProductAndProductModelQueryBuilderIntegration extends TestCase
 {
-    // TODO: will be done with the next PR
-    /*
     public function testDefaultView()
     {
         $result = $this->executeFilter([]);
@@ -35,7 +33,6 @@ class ProductAndProductModelQueryBuilderIntegration extends TestCase
             $result
         );
     }
-    */
 
     public function testSearchTshirtInDescription()
     {

--- a/src/Pim/Bundle/EnrichBundle/Elasticsearch/FromSizeCursor.php
+++ b/src/Pim/Bundle/EnrichBundle/Elasticsearch/FromSizeCursor.php
@@ -183,7 +183,7 @@ class FromSizeCursor implements CursorInterface
         $productModelIdentifiers = [];
 
         foreach ($identifiers as $identifier => $type) {
-            if (in_array($type, ['PimCatalogProduct', 'PimCatalogVariantProduct'])) {
+            if ($type === ProductInterface::class) {
                 $productIdentifiers[] = $identifier;
             } else {
                 $productModelIdentifiers[] = $identifier;
@@ -219,7 +219,7 @@ class FromSizeCursor implements CursorInterface
      *
      * For instance
      *      [
-     *          'tshirt-red-s'  => 'variant_product',
+     *          'tshirt-red-s'  => 'product',
      *          'tshirt-red'    => 'product_model',
      *          'watch'         => 'product',
      *      ]

--- a/src/Pim/Bundle/EnrichBundle/Elasticsearch/FromSizeCursor.php
+++ b/src/Pim/Bundle/EnrichBundle/Elasticsearch/FromSizeCursor.php
@@ -197,6 +197,8 @@ class FromSizeCursor implements CursorInterface
         $orderedItems = [];
 
         foreach ($identifiers as $identifier => $type) {
+            // sometimes $identifier is only numerical whereas getIdentifer() returns a string
+            $identifier = (string) $identifier;
             foreach ($hydratedItems as $hydratedItem) {
                 if ($hydratedItem instanceof ProductInterface && $identifier === $hydratedItem->getIdentifier()) {
                     $orderedItems[] = $hydratedItem;

--- a/src/Pim/Bundle/EnrichBundle/ProductQueryBuilder/ProductAndProductModelQueryBuilder.php
+++ b/src/Pim/Bundle/EnrichBundle/ProductQueryBuilder/ProductAndProductModelQueryBuilder.php
@@ -77,7 +77,9 @@ class ProductAndProductModelQueryBuilder implements ProductQueryBuilderInterface
             }
         );
 
-        if (!empty($attributeFilters)) {
+        if (empty($attributeFilters)) {
+            $this->addFilter('parent', Operators::IS_EMPTY, null);
+        } else {
             $attributeFilterKeys = array_column($attributeFilters, 'field');
             $this->addFilter('attributes_for_this_level', Operators::IN_LIST, $attributeFilterKeys);
         }

--- a/src/Pim/Bundle/EnrichBundle/spec/Elasticsearch/FromSizeCursorSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Elasticsearch/FromSizeCursorSpec.php
@@ -35,11 +35,11 @@ class FromSizeCursorSpec extends ObjectBehavior
                     'total' => 4,
                     'hits' => [
                         [
-                            '_source' => ['identifier' => 'a-variant-product', 'product_type' => 'PimCatalogVariantProduct'],
+                            '_source' => ['identifier' => 'a-variant-product', 'product_type' => ProductInterface::class],
                             'sort' => ['pim_catalog_product#a-variant-product']
                         ],
                         [
-                            '_source' => ['identifier' => 'a-sub-product-model', 'product_type' => 'PimCatalogSubProductModel'],
+                            '_source' => ['identifier' => 'a-sub-product-model', 'product_type' => ProductModelInterface::class],
                             'sort' => ['pim_catalog_product#a-sub-product-model']
                         ],
                     ]
@@ -97,11 +97,11 @@ class FromSizeCursorSpec extends ObjectBehavior
                     'total' => 4,
                     'hits' => [
                         [
-                            '_source' => ['identifier' => 'a-root-product-model', 'product_type' => 'PimCatalogRootProductModel'],
+                            '_source' => ['identifier' => 'a-root-product-model', 'product_type' => ProductModelInterface::class],
                             'sort' => ['pim_catalog_product#a-root-product-model']
                         ],
                         [
-                            '_source' => ['identifier' => 'a-product', 'product_type' => 'PimCatalogProduct'],
+                            '_source' => ['identifier' => 'a-product', 'product_type' => ProductInterface::class],
                             'sort' => ['pim_catalog_product#a-product']
                         ],
                     ]

--- a/src/Pim/Bundle/EnrichBundle/spec/ProductQueryBuilder/ProductAndProductModelQueryBuilderSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/ProductQueryBuilder/ProductAndProductModelQueryBuilderSpec.php
@@ -85,7 +85,7 @@ class ProductAndProductModelQueryBuilderSpec extends ObjectBehavior
         $this->execute()->shouldReturn($cursor);
     }
 
-    function it_executes_the_query_by_not_adding_a_filter_on_fields($pqb, CursorInterface $cursor)
+    function it_executes_the_query_by_adding_a_default_filter_on_parents_when_there_is_no_attribute_filter($pqb, CursorInterface $cursor)
     {
         $pqb->getRawFilters()->willReturn(
             [
@@ -99,6 +99,7 @@ class ProductAndProductModelQueryBuilderSpec extends ObjectBehavior
             ]
         );
 
+        $pqb->addFilter('parent', Operators::IS_EMPTY, null, [])->shouldBeCalled();
         $pqb->addFilter('attributes_for_this_level', Argument::cetera())->shouldNotBeCalled();
         $pqb->execute()->willReturn($cursor);
 

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/ProductAndProductModel/ProductModelNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/ProductAndProductModel/ProductModelNormalizer.php
@@ -41,7 +41,7 @@ class ProductModelNormalizer implements NormalizerInterface
     {
         $data = $this->propertiesNormalizer->normalize($productModel, $format, $context);
 
-        $data[self::FIELD_PRODUCT_TYPE] = $this->getVariationLevelCode($productModel);
+        $data[self::FIELD_PRODUCT_TYPE] = ProductModelInterface::class;
         $data[self::FIELD_ATTRIBUTES_IN_LEVEL] = array_keys($productModel->getRawValues());
 
         return $data;
@@ -53,27 +53,5 @@ class ProductModelNormalizer implements NormalizerInterface
     public function supportsNormalization($data, $format = null)
     {
         return $data instanceof ProductModelInterface && self::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX === $format;
-    }
-
-    /**
-     * Returns the product_type of the given product model.
-     *
-     * @param ProductModelInterface $productModel
-     *
-     * @throws \LogicException
-     *
-     * @return string
-     */
-    private function getVariationLevelCode(ProductModelInterface $productModel) : string
-    {
-        $level = $productModel->getVariationLevel();
-        switch ($level) {
-            case 0:
-                return 'PimCatalogRootProductModel';
-            case 1:
-                return 'PimCatalogSubProductModel';
-            default:
-                throw new \LogicException(sprintf('Invalid variant level. %s given', $level));
-        }
     }
 }

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/ProductAndProductModel/ProductModelPropertiesNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/ProductAndProductModel/ProductModelPropertiesNormalizer.php
@@ -24,6 +24,7 @@ class ProductModelPropertiesNormalizer implements NormalizerInterface, Serialize
 
     private const FIELD_FAMILY_VARIANT = 'family_variant';
     private const FIELD_ID = 'id';
+    private const FIELD_PARENT = 'parent';
 
     /**
      * {@inheritdoc}
@@ -58,6 +59,9 @@ class ProductModelPropertiesNormalizer implements NormalizerInterface, Serialize
         }
         $data[StandardPropertiesNormalizer::FIELD_FAMILY] = $family;
         $data[self::FIELD_FAMILY_VARIANT] = $familyVariant;
+
+        $parentCode = null !== $productModel->getParent() ? $productModel->getParent()->getCode() : null;
+        $data[self::FIELD_PARENT] = $parentCode;
 
         $data[StandardPropertiesNormalizer::FIELD_VALUES] = !$productModel->getValues()->isEmpty()
             ? $this->serializer->normalize(

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/ProductAndProductModel/ProductNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/ProductAndProductModel/ProductNormalizer.php
@@ -38,7 +38,7 @@ class ProductNormalizer implements NormalizerInterface
     {
         $data = $this->propertiesNormalizer->normalize($product, $format, $context);
 
-        $data[self::FIELD_PRODUCT_TYPE] = $this->getVariationLevelCode($product);
+        $data[self::FIELD_PRODUCT_TYPE] = ProductInterface::class;
         $data[self::FIELD_ATTRIBUTES_IN_LEVEL] = array_keys($product->getRawValues());
 
         return $data;
@@ -51,19 +51,5 @@ class ProductNormalizer implements NormalizerInterface
     {
         return ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX === $format &&
             $data instanceof ProductInterface;
-    }
-
-    /**
-     * @param ProductInterface $product
-     *
-     * @return string
-     */
-    private function getVariationLevelCode(ProductInterface $product) : string
-    {
-        if ($product instanceof VariantProductInterface) {
-            return 'PimCatalogVariantProduct';
-        }
-
-        return 'PimCatalogProduct';
     }
 }

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/ProductAndProductModel/ProductPropertiesNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/ProductAndProductModel/ProductPropertiesNormalizer.php
@@ -28,6 +28,7 @@ class ProductPropertiesNormalizer implements NormalizerInterface, SerializerAwar
     private const FIELD_FAMILY_VARIANT = 'family_variant';
     private const FIELD_IN_GROUP = 'in_group';
     private const FIELD_ID = 'id';
+    private const FIELD_PARENT = 'parent';
 
     /**
      * {@inheritdoc}
@@ -78,6 +79,12 @@ class ProductPropertiesNormalizer implements NormalizerInterface, SerializerAwar
             $familyVariantCode = null !== $familyVariant ? $familyVariant->getCode() : null;
         }
         $data[self::FIELD_FAMILY_VARIANT] = $familyVariantCode;
+
+        $parentCode = null;
+        if ($product instanceof VariantProductInterface && null !== $product->getParent()) {
+            $parentCode = $product->getParent()->getCode();
+        }
+        $data[self::FIELD_PARENT] = $parentCode;
 
         $data[StandardPropertiesNormalizer::FIELD_VALUES] = !$product->getValues()->isEmpty()
             ? $this->serializer->normalize(

--- a/src/Pim/Component/Catalog/spec/Normalizer/Indexing/ProductAndProductModel/ProductModelNormalizerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Normalizer/Indexing/ProductAndProductModel/ProductModelNormalizerSpec.php
@@ -55,7 +55,7 @@ class ProductModelNormalizerSpec extends ObjectBehavior
         $this->normalize($productModel, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
             ->shouldReturn([
                 'properties'                => 'properties are normalized here',
-                'product_type'              => 'PimCatalogRootProductModel',
+                'product_type'              => ProductModelInterface::class,
                 'attributes_for_this_level' => ['property_1', 'property_2'],
             ]);
     }
@@ -79,27 +79,8 @@ class ProductModelNormalizerSpec extends ObjectBehavior
         $this->normalize($productModel, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
             ->shouldReturn([
                 'properties'                => 'properties are normalized here',
-                'product_type'              => 'PimCatalogSubProductModel',
+                'product_type'              => ProductModelInterface::class,
                 'attributes_for_this_level' => ['property_1', 'property_2'],
             ]);
-    }
-
-    function it_normalizes_throws_if_the_variation_level_is_invalid(
-        $propertiesNormalizer,
-        ProductModelInterface $productModel
-    ) {
-        $productModel->getVariationLevel()->willReturn(-1);
-
-        $propertiesNormalizer->normalize(
-            $productModel,
-            ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX,
-            []
-        )->willReturn(['properties' => 'properties are normalized here']);
-
-        $this->shouldThrow('\LogicException')
-            ->during(
-                'normalize',
-                [$productModel, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX]
-            );
     }
 }

--- a/src/Pim/Component/Catalog/spec/Normalizer/Indexing/ProductAndProductModel/ProductModelPropertiesNormalizerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Normalizer/Indexing/ProductAndProductModel/ProductModelPropertiesNormalizerSpec.php
@@ -47,6 +47,8 @@ class ProductModelPropertiesNormalizerSpec extends ObjectBehavior
         $productModel->getId()->willReturn(67);
         $now = new \DateTime('now', new \DateTimeZone('UTC'));
 
+        $productModel->getParent()->willReturn(null);
+
         $productModel->getCode()->willReturn('sku-001');
         $productModel->getCreated()->willReturn($now);
         $serializer
@@ -80,6 +82,7 @@ class ProductModelPropertiesNormalizerSpec extends ObjectBehavior
                 'updated'        => $now->format('c'),
                 'family'         => 'family_A',
                 'family_variant' => 'family_variant_1',
+                'parent'         => null,
                 'values'         => [],
             ]
         );
@@ -96,6 +99,8 @@ class ProductModelPropertiesNormalizerSpec extends ObjectBehavior
 
         $productModel->getId()->willReturn(67);
         $productModel->getCode()->willReturn('sku-001');
+
+        $productModel->getParent()->willReturn(null);
 
         $productModel->getCreated()->willReturn($now);
         $serializer->normalize(
@@ -151,6 +156,7 @@ class ProductModelPropertiesNormalizerSpec extends ObjectBehavior
                     ],
                 ],
                 'family_variant' => 'family_variant_B',
+                'parent'         => null,
                 'values'         => [
                     'a_size-decimal' => [
                         '<all_channels>' => [
@@ -165,6 +171,7 @@ class ProductModelPropertiesNormalizerSpec extends ObjectBehavior
     function it_normalizes_a_product_model_fields_and_values_with_its_parents_values(
         $serializer,
         ProductModelInterface $productModel,
+        ProductModelInterface $parent,
         ValueCollectionInterface $valueCollection,
         FamilyInterface $family,
         FamilyVariantInterface $familyVariant
@@ -173,6 +180,9 @@ class ProductModelPropertiesNormalizerSpec extends ObjectBehavior
 
         $productModel->getId()->willReturn(67);
         $productModel->getCode()->willReturn('sku-001');
+
+        $productModel->getParent()->willReturn($parent);
+        $parent->getCode()->willReturn('parent_A');
 
         $productModel->getCreated()->willReturn($now);
         $serializer->normalize(
@@ -237,6 +247,7 @@ class ProductModelPropertiesNormalizerSpec extends ObjectBehavior
                     ],
                 ],
                 'family_variant' => 'family_variant_B',
+                'parent'         => 'parent_A',
                 'values'         => [
                     'a_size-decimal'         => [
                         '<all_channels>' => [

--- a/src/Pim/Component/Catalog/spec/Normalizer/Indexing/ProductAndProductModel/ProductNormalizerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Normalizer/Indexing/ProductAndProductModel/ProductNormalizerSpec.php
@@ -64,7 +64,7 @@ class ProductNormalizerSpec extends ObjectBehavior
         $this->normalize($product, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
             ->shouldReturn([
                 'properties'                => 'properties are normalized here',
-                'product_type'              => 'PimCatalogProduct',
+                'product_type'              => ProductInterface::class,
                 'attributes_for_this_level' => ['property_1', 'property_2'],
             ]);
     }
@@ -88,7 +88,7 @@ class ProductNormalizerSpec extends ObjectBehavior
         $this->normalize($variantProduct, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
             ->shouldReturn([
                 'properties'                => 'properties are normalized here',
-                'product_type'              => 'PimCatalogVariantProduct',
+                'product_type'              => ProductInterface::class,
                 'attributes_for_this_level' => ['property_1', 'property_2'],
             ]);
     }

--- a/src/Pim/Component/Catalog/spec/Normalizer/Indexing/ProductAndProductModel/ProductPropertiesNormalizerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Normalizer/Indexing/ProductAndProductModel/ProductPropertiesNormalizerSpec.php
@@ -96,6 +96,7 @@ class ProductPropertiesNormalizerSpec extends ObjectBehavior
                 'groups'         => [],
                 'completeness'   => ['the completenesses'],
                 'family_variant' => null,
+                'parent'         => null,
                 'values'         => [],
             ]
         );
@@ -201,6 +202,7 @@ class ProductPropertiesNormalizerSpec extends ObjectBehavior
                     ],
                 ],
                 'family_variant' => null,
+                'parent'         => null,
                 'values'        => [
                     'a_size-decimal' => [
                         '<all_channels>' => [
@@ -218,9 +220,13 @@ class ProductPropertiesNormalizerSpec extends ObjectBehavior
         ValueCollectionInterface $valueCollection,
         Collection $completenesses,
         FamilyInterface $family,
-        FamilyVariantInterface $familyVariant
+        FamilyVariantInterface $familyVariant,
+        ProductModelInterface $parent
     ) {
         $now = new \DateTime('now', new \DateTimeZone('UTC'));
+
+        $variantProduct->getParent()->willReturn($parent);
+        $parent->getCode()->willReturn('parent_A');
 
         $variantProduct->getId()->willReturn(67);
         $variantProduct->getIdentifier()->willReturn('sku-001');
@@ -278,6 +284,7 @@ class ProductPropertiesNormalizerSpec extends ObjectBehavior
                 'groups'        => [],
                 'completeness'  => ['the completenesses'],
                 'family_variant' => 'family_variant_A',
+                'parent'        => 'parent_A',
                 'values'        => [],
             ]
         );
@@ -289,9 +296,13 @@ class ProductPropertiesNormalizerSpec extends ObjectBehavior
         ValueCollectionInterface $valueCollection,
         Collection $completenesses,
         FamilyInterface $family,
-        FamilyVariantInterface $familyVariant
+        FamilyVariantInterface $familyVariant,
+        ProductModelInterface $parent
     ) {
         $now = new \DateTime('now', new \DateTimeZone('UTC'));
+
+        $variantProduct->getParent()->willReturn($parent);
+        $parent->getCode()->willReturn('parent_A');
 
         $variantProduct->getId()->willReturn(67);
         $variantProduct->getIdentifier()->willReturn('sku-001');
@@ -397,6 +408,7 @@ class ProductPropertiesNormalizerSpec extends ObjectBehavior
                     ],
                 ],
                 'family_variant' => 'family_variant_A',
+                'parent'         => 'parent_A',
                 'values'        => [
                     'a_size-decimal' => [
                         '<all_channels>' => [

--- a/src/Pim/Component/Catalog/tests/integration/Normalizer/Indexing/ProductAndProductModelIndexingIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Normalizer/Indexing/ProductAndProductModelIndexingIntegration.php
@@ -44,6 +44,7 @@ class ProductAndProductModelIndexingIntegration extends TestCase
                 ],
             ],
             'family_variant' => 'familyVariantA1',
+            'parent' => null,
             'values'         => [
                 'a_text-text'            => [
                     '<all_channels>' => [
@@ -80,6 +81,7 @@ class ProductAndProductModelIndexingIntegration extends TestCase
                 ],
             ],
             'family_variant' => 'familyVariantA1',
+            'parent' => 'qux',
             'values'         => [
                 'a_text-text'            => [
                     '<all_channels>' => [
@@ -125,6 +127,7 @@ class ProductAndProductModelIndexingIntegration extends TestCase
             'groups'         => [],
             'completeness'   => [],
             'family_variant' => 'familyVariantA1',
+            'parent'         => 'quux',
             'values'         => [
                 'a_text-text'            => [
                     '<all_channels>' => [
@@ -168,6 +171,7 @@ class ProductAndProductModelIndexingIntegration extends TestCase
             'groups'                    => [],
             'completeness'              => [],
             'family_variant'            => null,
+            'parent'                    => null,
             'values'                    => [],
             'product_type'              => 'PimCatalogProduct',
             'attributes_for_this_level' => ['sku'],
@@ -210,6 +214,7 @@ class ProductAndProductModelIndexingIntegration extends TestCase
                 'tablet'    => ['de_DE' => 89, 'en_US' => 100, 'fr_FR' => 100],
             ],
             'family_variant' => null,
+            'parent'         => null,
             'values'         => [
                 'a_date-date'                                    => [
                     '<all_channels>' => [

--- a/src/Pim/Component/Catalog/tests/integration/Normalizer/Indexing/ProductAndProductModelIndexingIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Normalizer/Indexing/ProductAndProductModelIndexingIntegration.php
@@ -4,6 +4,8 @@ namespace tests\integration\Pim\Component\Catalog\Normalizer\Indexing;
 
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;
+use Pim\Component\Catalog\Model\ProductInterface;
+use Pim\Component\Catalog\Model\ProductModelInterface;
 use Pim\Component\Catalog\Normalizer\Indexing\ProductAndProductModel\ProductModelNormalizer;
 use Pim\Component\Catalog\tests\integration\Normalizer\NormalizedProductCleaner;
 
@@ -52,7 +54,7 @@ class ProductAndProductModelIndexingIntegration extends TestCase
                     ],
                 ],
             ],
-            'product_type' => 'PimCatalogRootProductModel',
+            'product_type' => ProductModelInterface::class,
             'attributes_for_this_level' => ['a_text']
         ];
 
@@ -94,7 +96,7 @@ class ProductAndProductModelIndexingIntegration extends TestCase
                     ],
                 ],
             ],
-            'product_type' => 'PimCatalogSubProductModel',
+            'product_type' => ProductModelInterface::class,
             'attributes_for_this_level' => ['a_simple_select']
         ];
 
@@ -145,7 +147,7 @@ class ProductAndProductModelIndexingIntegration extends TestCase
                     ],
                 ],
             ],
-            'product_type' => 'PimCatalogVariantProduct',
+            'product_type' => ProductInterface::class,
             'attributes_for_this_level' => ['sku', 'a_yes_no']
         ];
 
@@ -173,7 +175,7 @@ class ProductAndProductModelIndexingIntegration extends TestCase
             'family_variant'            => null,
             'parent'                    => null,
             'values'                    => [],
-            'product_type'              => 'PimCatalogProduct',
+            'product_type'              => ProductInterface::class,
             'attributes_for_this_level' => ['sku'],
         ];
 
@@ -414,7 +416,7 @@ class ProductAndProductModelIndexingIntegration extends TestCase
                     ],
                 ],
             ],
-            'product_type' => 'PimCatalogProduct',
+            'product_type' => ProductInterface::class,
             'attributes_for_this_level' => [
                 123,
                 'sku',


### PR DESCRIPTION
*Easier to read commit by commit*

The goal of this is PR is to be able, with the product and product model query builder, to display by default only entities without a parent. Soon, in the product datagrid, we'll see only the root product models and the non variant products.

For that we:
- indexed the parent code of the product models and variant products
- defined a new filter on this parent field

This PR also fixes a few glitches:
- one about numeric identifiers and our Elasticsearch cursors (basically, a product with identifier 12345 was never returned)
- simplify the "product_type" in the product and product model index

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Y
| Added Behats                      | -
| Added integration tests           | Y
| Changelog updated                 | -
| Review and 2 GTM                  | 
| Micro Demo to the PO (Story only) | 
| Migration script                  | -
| Tech Doc                          | -
