### PR TITLE
PIM-6333: Fix "UniqueAxesCombinationSet"

### DIFF
--- a/src/Pim/Component/Catalog/Validator/Constraints/SiblingUniqueVariantAxesValidator.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/SiblingUniqueVariantAxesValidator.php
@@ -152,7 +152,9 @@ class SiblingUniqueVariantAxesValidator extends ConstraintValidator
      */
     private function hasAlreadyValidatedTheSameValue(EntityWithFamilyVariantInterface $entity): bool
     {
-        return false;
+        if (null === $entity->getParent()) {
+            return false;
+        }
 
         $axes = $this->axesProvider->getAxes($entity);
 

--- a/src/Pim/Component/Catalog/Validator/UniqueAxesCombinationSet.php
+++ b/src/Pim/Component/Catalog/Validator/UniqueAxesCombinationSet.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Pim\Component\Catalog\Validator;
 
 use Pim\Component\Catalog\Model\EntityWithFamilyVariantInterface;
+use Pim\Component\Catalog\Model\VariantProductInterface;
 
 /**
  * Contains the state of the unique axes combination for an entity with family variant.
@@ -46,11 +47,12 @@ class UniqueAxesCombinationSet
      */
     public function addCombination(EntityWithFamilyVariantInterface $entity, string $axesCombination): bool
     {
-        $identifier = $this->getEntityId($entity);
         $familyVariantCode = $entity->getFamilyVariant()->getCode();
+        $parentCode = $entity->getParent()->getCode();
+        $identifier = $this->getEntityCode($entity);
 
-        if (isset($this->uniqueAxesCombination[$familyVariantCode][$axesCombination])) {
-            $cachedIdentifier = $this->uniqueAxesCombination[$familyVariantCode][$axesCombination];
+        if (isset($this->uniqueAxesCombination[$familyVariantCode][$parentCode][$axesCombination])) {
+            $cachedIdentifier = $this->uniqueAxesCombination[$familyVariantCode][$parentCode][$axesCombination];
             if ($cachedIdentifier !== $identifier) {
                 return false;
             }
@@ -60,8 +62,12 @@ class UniqueAxesCombinationSet
             $this->uniqueAxesCombination[$familyVariantCode] = [];
         }
 
-        if (!isset($this->uniqueAxesCombination[$familyVariantCode][$axesCombination])) {
-            $this->uniqueAxesCombination[$familyVariantCode][$axesCombination] = $identifier;
+        if (!isset($this->uniqueAxesCombination[$familyVariantCode][$parentCode])) {
+            $this->uniqueAxesCombination[$familyVariantCode][$parentCode] = [];
+        }
+
+        if (!isset($this->uniqueAxesCombination[$familyVariantCode][$parentCode][$axesCombination])) {
+            $this->uniqueAxesCombination[$familyVariantCode][$parentCode][$axesCombination] = $identifier;
         }
 
         return true;
@@ -74,8 +80,12 @@ class UniqueAxesCombinationSet
      *
      * @return string
      */
-    private function getEntityId(EntityWithFamilyVariantInterface $entity): string
+    private function getEntityCode(EntityWithFamilyVariantInterface $entity): string
     {
-        return $entity->getId() ? (string) $entity->getId() : spl_object_hash($entity);
+        if ($entity instanceof VariantProductInterface) {
+            return $entity->getIdentifier();
+        }
+
+        return $entity->getCode();
     }
 }

--- a/src/Pim/Component/Catalog/spec/Validator/UniqueAxesCombinationSetSpec.php
+++ b/src/Pim/Component/Catalog/spec/Validator/UniqueAxesCombinationSetSpec.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace spec\Pim\Component\Catalog\Validator;
+
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Model\FamilyVariantInterface;
+use Pim\Component\Catalog\Model\ProductModelInterface;
+use Pim\Component\Catalog\Model\VariantProductInterface;
+use Pim\Component\Catalog\Validator\UniqueAxesCombinationSet;
+use Prophecy\Argument;
+
+class UniqueAxesCombinationSetSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(UniqueAxesCombinationSet::class);
+    }
+
+    function it_adds_axes_combinations(
+        FamilyVariantInterface $familyVariant,
+        ProductModelInterface $rootProductModel,
+        ProductModelInterface $productModel,
+        VariantProductInterface $variantProduct
+    ) {
+        $familyVariant->getCode()->willReturn('family_variant');
+
+        $rootProductModel->getCode()->willReturn('root_product_model');
+        $rootProductModel->getFamilyVariant()->willReturn($familyVariant);
+
+        $productModel->getCode()->willReturn('product_model');
+        $productModel->getParent()->willReturn($rootProductModel);
+        $productModel->getFamilyVariant()->willReturn($familyVariant);
+
+        $variantProduct->getIdentifier()->willReturn('variant_product');
+        $variantProduct->getParent()->willReturn($productModel);
+        $variantProduct->getFamilyVariant()->willReturn($familyVariant);
+
+        $this->addCombination($productModel, '[a_color]')->shouldReturn(true);
+        $this->addCombination($variantProduct, '[a_size]')->shouldReturn(true);
+    }
+
+    function it_does_not_add_axes_combinations_twice(
+        FamilyVariantInterface $familyVariant,
+        ProductModelInterface $rootProductModel,
+        ProductModelInterface $productModel,
+        ProductModelInterface $invalidProductModel
+    ) {
+        $familyVariant->getCode()->willReturn('family_variant');
+
+        $rootProductModel->getCode()->willReturn('root_product_model');
+        $rootProductModel->getFamilyVariant()->willReturn($familyVariant);
+
+        $productModel->getCode()->willReturn('product_model');
+        $productModel->getParent()->willReturn($rootProductModel);
+        $productModel->getFamilyVariant()->willReturn($familyVariant);
+
+        $invalidProductModel->getCode()->willReturn('invalid_product_model');
+        $invalidProductModel->getParent()->willReturn($rootProductModel);
+        $invalidProductModel->getFamilyVariant()->willReturn($familyVariant);
+
+        $this->addCombination($productModel, '[a_color]')->shouldReturn(true);
+        $this->addCombination($invalidProductModel, '[a_color]')->shouldReturn(false);
+    }
+}


### PR DESCRIPTION
## Description

The newly introduced `UniqueAxesCombinationSet` was wrong as it stored axes combinations only according to family variants. However, there can be several root product models for the same family variant, so several time the same axes combination for a family variant.

This PR updates the `UniqueAxesCombinationSet` so axes combination are now stored according to family variant and parent.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
