### PR TITLE
API-91: extract product's fields from productFilter

### DIFF
--- a/CHANGELOG-1.8.md
+++ b/CHANGELOG-1.8.md
@@ -218,6 +218,7 @@
 
 ### Constructors
 
+- Change the constructor of `Pim\Component\Catalog\Comparator\Filter\ProductFilter` to add `Pim\Component\Catalog\Comparator\Filter\ProductFilterInterface`
 - Change the constructor of `Oro\Bundle\UserBundle\Form\Handler\AclRoleHandler` to add `Symfony\Component\HttpFoundation\RequestStack`
 - Change the constructor of `Oro\Bundle\DataGridBundle\Datagrid\RequestParameters` to add `Symfony\Component\HttpFoundation\RequestStack`
 - Change the constructor of `Pim\Bundle\DataGridBundle\Datagrid\Configuration\Product\ContextConfigurator` to add `Symfony\Component\HttpFoundation\RequestStack`

--- a/src/Pim/Bundle/ApiBundle/Controller/ProductController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/ProductController.php
@@ -41,8 +41,7 @@ use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
-use Symfony\Component\Routing\Router;
-use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
@@ -90,7 +89,7 @@ class ProductController
     /** @var SaverInterface */
     protected $saver;
 
-    /** @var RouterInterface */
+    /** @var UrlGeneratorInterface */
     protected $router;
 
     /** @var ProductFilterInterface */
@@ -122,7 +121,7 @@ class ProductController
      * @param RemoverInterface                      $remover
      * @param ObjectUpdaterInterface                $updater
      * @param SaverInterface                        $saver
-     * @param RouterInterface                       $router
+     * @param UrlGeneratorInterface                 $router
      * @param ProductFilterInterface                $emptyValuesFilter
      * @param StreamResourceResponse                $partialUpdateStreamResource
      * @param PrimaryKeyEncrypter                   $primaryKeyEncrypter
@@ -142,7 +141,7 @@ class ProductController
         RemoverInterface $remover,
         ObjectUpdaterInterface $updater,
         SaverInterface $saver,
-        RouterInterface $router,
+        UrlGeneratorInterface $router,
         ProductFilterInterface $emptyValuesFilter,
         StreamResourceResponse $partialUpdateStreamResource,
         PrimaryKeyEncrypter $primaryKeyEncrypter,
@@ -465,7 +464,7 @@ class ProductController
         $route = $this->router->generate(
             'pim_api_product_get',
             ['code' => $product->getIdentifier()],
-            Router::ABSOLUTE_URL
+            UrlGeneratorInterface::ABSOLUTE_URL
         );
         $response->headers->set('Location', $route);
 

--- a/src/Pim/Bundle/ApiBundle/Controller/ProductController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/ProductController.php
@@ -36,6 +36,7 @@ use Pim\Component\Catalog\Query\Sorter\Directions;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -392,7 +393,7 @@ class ProductController
                 $exception
             );
         } catch (InvalidArgumentException $exception) {
-            throw new UnprocessableEntityHttpException($exception->getMessage(), $exception);
+            throw new AccessDeniedHttpException($exception->getMessage(), $exception);
         }
     }
 

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/filters.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/filters.yml
@@ -4,6 +4,7 @@ parameters:
     pim_enrich.filter.product_value.channel.class:           Pim\Bundle\CatalogBundle\Filter\ProductValueChannelFilter
     pim_catalog.comparator.filter.product.class:             Pim\Component\Catalog\Comparator\Filter\ProductFilter
     pim_catalog.comparator.filter.product_association.class: Pim\Component\Catalog\Comparator\Filter\ProductAssociationFilter
+    pim_catalog.comparator.filter.product_field.class:       Pim\Component\Catalog\Comparator\Filter\ProductFieldFilter
 
 services:
     pim_catalog.filter.chained:
@@ -29,6 +30,7 @@ services:
             - '@pim_catalog.normalizer.standard.product.properties'
             - '@pim_catalog.comparator.registry'
             - '@pim_catalog.repository.attribute'
+            - '@pim_catalog.comparator.filter.product_field'
             - ['family', 'enabled', 'groups', 'variant_group', 'categories']
 
     pim_catalog.comparator.filter.product_association:
@@ -36,3 +38,10 @@ services:
         arguments:
             - '@pim_catalog.normalizer.standard.product.associations'
             - '@pim_catalog.comparator.registry'
+
+    pim_catalog.comparator.filter.product_field:
+        class: '%pim_catalog.comparator.filter.product_field.class%'
+        arguments:
+            - '@pim_catalog.normalizer.standard.product.properties'
+            - '@pim_catalog.comparator.registry'
+            - ['family', 'enabled', 'groups', 'variant_group', 'categories', 'associations']

--- a/src/Pim/Component/Catalog/Comparator/Filter/ProductFieldFilter.php
+++ b/src/Pim/Component/Catalog/Comparator/Filter/ProductFieldFilter.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Component\Catalog\Comparator\Filter;
+
+use Akeneo\Component\StorageUtils\Exception\UnknownPropertyException;
+use Pim\Component\Catalog\Comparator\ComparatorRegistry;
+use Pim\Component\Catalog\Model\ProductInterface;
+use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * Filter product's fields to have only updated or new values
+ *
+ * @author    Marie Bochu <marie.bochu@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ProductFieldFilter implements ProductFilterInterface
+{
+    /** @var NormalizerInterface */
+    protected $normalizer;
+
+    /** @var ComparatorRegistry */
+    protected $comparatorRegistry;
+
+    /** @var array */
+    protected $productFields;
+
+    /**
+     * @param NormalizerInterface $normalizer
+     * @param ComparatorRegistry  $comparatorRegistry
+     * @param array               $productFields
+     */
+    public function __construct(
+        NormalizerInterface $normalizer,
+        ComparatorRegistry $comparatorRegistry,
+        array $productFields
+    ) {
+        $this->normalizer = $normalizer;
+        $this->comparatorRegistry = $comparatorRegistry;
+        $this->productFields = $productFields;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function filter(ProductInterface $product, array $newFields)
+    {
+        $originalProduct = $this->normalizer->normalize($product, 'standard');
+        $result = [];
+
+        foreach ($newFields as $field => $value) {
+            if (!in_array($field, $this->productFields)) {
+                throw new \LogicException(sprintf('Cannot filter value of field "%s"', $field));
+            }
+
+            $comparator = $this->comparatorRegistry->getFieldComparator($field);
+            $originalData = !isset($originalProduct[$field]) ? null : $originalProduct[$field];
+            $diff = $comparator->compare($value, $originalData);
+
+            if (null !== $diff) {
+                $result[$field] = $diff;
+            }
+        }
+
+        return $result;
+    }
+}

--- a/src/Pim/Component/Catalog/Comparator/Filter/ProductFilter.php
+++ b/src/Pim/Component/Catalog/Comparator/Filter/ProductFilter.php
@@ -29,6 +29,9 @@ class ProductFilter implements ProductFilterInterface
     /** @var array */
     protected $productFields;
 
+    /** @var ProductFilterInterface */
+    protected $productFieldFilter;
+
     /** @var array[] */
     protected $attributeTypeByCodes;
 
@@ -36,18 +39,21 @@ class ProductFilter implements ProductFilterInterface
      * @param NormalizerInterface          $normalizer
      * @param ComparatorRegistry           $comparatorRegistry
      * @param AttributeRepositoryInterface $attributeRepository
+     * @param ProductFilterInterface       $productFieldFilter
      * @param array                        $productFields
      */
     public function __construct(
         NormalizerInterface $normalizer,
         ComparatorRegistry $comparatorRegistry,
         AttributeRepositoryInterface $attributeRepository,
+        ProductFilterInterface $productFieldFilter,
         array $productFields
     ) {
         $this->normalizer = $normalizer;
         $this->comparatorRegistry = $comparatorRegistry;
         $this->attributeRepository = $attributeRepository;
         $this->productFields = $productFields;
+        $this->productFieldFilter = $productFieldFilter;
         $this->attributeTypeByCodes = [];
     }
 
@@ -58,44 +64,26 @@ class ProductFilter implements ProductFilterInterface
     {
         $originalValues = $this->getOriginalProduct($product);
         $result = [];
+        $fields = [];
+
         foreach ($newProduct as $code => $value) {
             if ('values' === $code) {
                 $data = $this->compareAttribute($originalValues, $value);
+
+                if (null !== $data) {
+                    $result = $this->mergeValueToResult($result, $data);
+                }
             } elseif (in_array($code, $this->productFields)) {
-                $data = $this->compareField($originalValues, $value, $code);
+                $fields[$code] = $value;
             } else {
                 throw new \LogicException(sprintf('Cannot filter value of field "%s"', $code));
             }
-
-            if (null !== $data) {
-                $result = $this->mergeValueToResult($result, $data);
-            }
         }
+
+        $productFieldsFilter = $this->productFieldFilter->filter($product, $fields);
+        $result = $this->mergeValueToResult($result, $productFieldsFilter);
 
         return $result;
-    }
-
-    /**
-     * Compare product's field
-     *
-     * @param array  $originalValues
-     * @param mixed  $field
-     * @param string $code
-     *
-     * @throws \LogicException
-     *
-     * @return array|null
-     */
-    protected function compareField(array $originalValues, $field, $code)
-    {
-        $comparator = $this->comparatorRegistry->getFieldComparator($code);
-        $diff = $comparator->compare($field, $this->getOriginalField($originalValues, $code));
-
-        if (null !== $diff) {
-            return [$code => $diff];
-        }
-
-        return null;
     }
 
     /**
@@ -130,17 +118,6 @@ class ProductFilter implements ProductFilterInterface
         }
 
         return !empty($result) ? ['values' => $result] : null;
-    }
-
-    /**
-     * @param array  $originalValues
-     * @param string $code
-     *
-     * @return array|string|null
-     */
-    protected function getOriginalField(array $originalValues, $code)
-    {
-        return !isset($originalValues[$code]) ? null : $originalValues[$code];
     }
 
     /**

--- a/src/Pim/Component/Catalog/spec/Comparator/Filter/ProductFieldFilterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Comparator/Filter/ProductFieldFilterSpec.php
@@ -1,0 +1,191 @@
+<?php
+
+namespace spec\Pim\Component\Catalog\Comparator\Filter;
+
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Comparator\ComparatorInterface;
+use Pim\Component\Catalog\Comparator\ComparatorRegistry;
+use Pim\Component\Catalog\Comparator\Filter\ProductFilterInterface;
+use Pim\Component\Catalog\Model\ProductInterface;
+use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+class ProductFieldFilterSpec extends ObjectBehavior
+{
+    function let(NormalizerInterface $normalizer, ComparatorRegistry $comparatorRegistry)
+    {
+        $this->beConstructedWith($normalizer, $comparatorRegistry, ['family', 'enabled', 'categories', 'groups', 'associations']);
+    }
+
+    function it_is_a_filter()
+    {
+        $this->shouldBeAnInstanceOf('Pim\Component\Catalog\Comparator\Filter\ProductFilterInterface');
+    }
+
+    function it_returns_all_fields_a_new_product(
+        $normalizer,
+        $comparatorRegistry,
+        ProductInterface $product,
+        ComparatorInterface $scalarComparator,
+        ComparatorInterface $arrayComparator,
+        ComparatorInterface $booleanComparator
+    ) {
+        $originalFields = [];
+        $newFields = [
+            'enabled' => true,
+            'family' => 'tshirt',
+            'categories' => ['categoryA', 'categoryB'],
+            'groups' => ['groupA', 'groupB'],
+            'associations' => [
+                'X_SELL' => [
+                    'products' => ['productA', 'productB']
+                ],
+                'UPSELL' => [
+                    'products' => ['productC', 'productB'],
+                    'groups' => ['groupA', 'groupB']
+                ]
+            ]
+        ];
+
+        $normalizer->normalize($product, 'standard')->willReturn($originalFields);
+
+        $comparatorRegistry->getFieldComparator('enabled')->willReturn($booleanComparator);
+        $booleanComparator->compare($newFields['enabled'], null)->willReturn($newFields['enabled']);
+
+        $comparatorRegistry->getFieldComparator('family')->willReturn($scalarComparator);
+        $scalarComparator->compare($newFields['family'], null)->willReturn($newFields['family']);
+
+        $comparatorRegistry->getFieldComparator('groups')->willReturn($arrayComparator);
+        $arrayComparator->compare($newFields['groups'], null)->willReturn($newFields['groups']);
+
+        $comparatorRegistry->getFieldComparator('categories')->willReturn($arrayComparator);
+        $arrayComparator->compare($newFields['categories'], null)->willReturn($newFields['categories']);
+
+        $comparatorRegistry->getFieldComparator('associations')->willReturn($arrayComparator);
+        $arrayComparator->compare($newFields['associations'], null)->willReturn($newFields['associations']);
+
+        $this->filter($product, $newFields)->shouldReturn($newFields);
+    }
+
+    function it_filters_not_updated_values(
+        $normalizer,
+        $comparatorRegistry,
+        ProductInterface $product,
+        ComparatorInterface $scalarComparator,
+        ComparatorInterface $arrayComparator,
+        ComparatorInterface $booleanComparator
+    ) {
+        $originalFields = [
+            'enabled' => true,
+            'family' => 'tshirt',
+            'groups' => ['groupA', 'groupB'],
+            'associations' => [
+                'X_SELL' => [
+                    'products' => ['productA', 'productB']
+                ],
+                'UPSELL' => [
+                    'products' => ['productC', 'productB'],
+                    'groups' => ['groupA', 'groupB']
+                ]
+            ]
+        ];
+
+        $newFields = [
+            'enabled' => false,
+            'family' => 'cameras',
+            'groups' => ['groupA'],
+            'associations' => [
+                'X_SELL' => [
+                    'products' => ['productA']
+                ],
+                'UPSELL' => [
+                    'products' => ['productB', 'productC'],
+                ]
+            ]
+        ];
+
+        $filteredFields = $newFields;
+        unset($filteredFields['associations']['UPSELL']);
+
+        $normalizer->normalize($product, 'standard')->willReturn($originalFields);
+
+        $comparatorRegistry->getFieldComparator('enabled')->willReturn($booleanComparator);
+        $booleanComparator->compare($newFields['enabled'], $originalFields['enabled'])->willReturn($filteredFields['enabled']);
+
+        $comparatorRegistry->getFieldComparator('family')->willReturn($scalarComparator);
+        $scalarComparator->compare($newFields['family'], $originalFields['family'])->willReturn($filteredFields['family']);
+
+        $comparatorRegistry->getFieldComparator('groups')->willReturn($arrayComparator);
+        $arrayComparator->compare($newFields['groups'], $originalFields['groups'])->willReturn($filteredFields['groups']);
+
+        $comparatorRegistry->getFieldComparator('associations')->willReturn($arrayComparator);
+        $arrayComparator->compare($newFields['associations'], $originalFields['associations'])->willReturn($filteredFields['associations']);
+
+        $this->filter($product, $newFields)->shouldReturn($filteredFields);
+    }
+
+    function it_returns_null_when_new_and_original_products_are_equals(
+        $normalizer,
+        $comparatorRegistry,
+        ProductInterface $product,
+        ComparatorInterface $scalarComparator,
+        ComparatorInterface $arrayComparator,
+        ComparatorInterface $booleanComparator
+    ) {
+        $originalFields = [
+            'enabled' => true,
+            'family' => 'tshirt',
+            'groups' => ['groupA', 'groupB'],
+            'associations' => [
+                'X_SELL' => [
+                    'products' => ['productA', 'productB']
+                ],
+                'UPSELL' => [
+                    'products' => ['productC', 'productB'],
+                    'groups' => ['groupA', 'groupB']
+                ]
+            ]
+        ];
+
+        $newFields = [
+            'enabled' => true,
+            'family' => 'tshirt',
+            'groups' => ['groupB', 'groupA'],
+            'associations' => [
+                'X_SELL' => [
+                    'products' => ['productB', 'productA']
+                ],
+                'UPSELL' => [
+                    'products' => ['productB', 'productC'],
+                ]
+            ]
+        ];
+
+        $normalizer->normalize($product, 'standard')->willReturn($originalFields);
+
+        $comparatorRegistry->getFieldComparator('enabled')->willReturn($booleanComparator);
+        $booleanComparator->compare($newFields['enabled'], $originalFields['enabled'])->willReturn(null);
+
+        $comparatorRegistry->getFieldComparator('family')->willReturn($scalarComparator);
+        $scalarComparator->compare($newFields['family'], $originalFields['family'])->willReturn(null);
+
+        $comparatorRegistry->getFieldComparator('groups')->willReturn($arrayComparator);
+        $arrayComparator->compare($newFields['groups'], $originalFields['groups'])->willReturn(null);
+
+        $comparatorRegistry->getFieldComparator('associations')->willReturn($arrayComparator);
+        $arrayComparator->compare($newFields['associations'], $originalFields['associations'])->willReturn(null);
+
+        $this->filter($product, $newFields)->shouldReturn([]);
+    }
+
+    function it_throws_an_exception_if_code_is_not_found($normalizer, ProductInterface $product)
+    {
+        $originalFields = $newFields = [
+            'other_field' => []
+        ];
+
+        $normalizer->normalize($product, 'standard')->willReturn($originalFields);
+
+        $this->shouldThrow('LogicException')->during('filter', [$product, $newFields]);
+    }
+}

--- a/src/Pim/Component/Catalog/spec/Comparator/Filter/ProductFilterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Comparator/Filter/ProductFilterSpec.php
@@ -5,6 +5,7 @@ namespace spec\Pim\Component\Catalog\Comparator\Filter;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Comparator\ComparatorInterface;
 use Pim\Component\Catalog\Comparator\ComparatorRegistry;
+use Pim\Component\Catalog\Comparator\Filter\ProductFilterInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
@@ -14,9 +15,10 @@ class ProductFilterSpec extends ObjectBehavior
     function let(
         NormalizerInterface $normalizer,
         ComparatorRegistry $comparatorRegistry,
-        AttributeRepositoryInterface $attributeRepository
+        AttributeRepositoryInterface $attributeRepository,
+        ProductFilterInterface $productFieldFilter
     ) {
-        $this->beConstructedWith($normalizer, $comparatorRegistry, $attributeRepository, ['family', 'enabled']);
+        $this->beConstructedWith($normalizer, $comparatorRegistry, $attributeRepository, $productFieldFilter, ['family', 'enabled']);
     }
 
     function it_is_a_filter()
@@ -28,13 +30,12 @@ class ProductFilterSpec extends ObjectBehavior
         $normalizer,
         $comparatorRegistry,
         $attributeRepository,
+        $productFieldFilter,
         ProductInterface $product,
-        ComparatorInterface $familyComparator,
         ComparatorInterface $descriptionComparator
     ) {
         $originalValues = [];
         $newValues = [
-            'family' => 'tshirt',
             'values' => [
                 'description'   => [
                     [
@@ -48,7 +49,8 @@ class ProductFilterSpec extends ObjectBehavior
                         'value'  => 'My description'
                     ]
                 ]
-            ]
+            ],
+            'family' => 'tshirt'
         ];
 
         $attributeRepository->getAttributeTypeByCodes(array_keys($newValues['values']))->willReturn([
@@ -58,8 +60,7 @@ class ProductFilterSpec extends ObjectBehavior
         $normalizer->normalize($product, 'standard')
             ->willReturn($originalValues);
 
-        $comparatorRegistry->getFieldComparator('family')->willReturn($familyComparator);
-        $familyComparator->compare($newValues['family'], null)->willReturn($newValues['family']);
+        $productFieldFilter->filter($product, ['family' => 'tshirt'])->willReturn(['family' => 'tshirt']);
 
         $comparatorRegistry->getAttributeComparator('pim_catalog_textarea')->willReturn($descriptionComparator);
 
@@ -75,8 +76,8 @@ class ProductFilterSpec extends ObjectBehavior
         $normalizer,
         $comparatorRegistry,
         $attributeRepository,
+        $productFieldFilter,
         ProductInterface $product,
-        ComparatorInterface $familyComparator,
         ComparatorInterface $descriptionComparator
     ) {
         $originalValues = [
@@ -122,9 +123,7 @@ class ProductFilterSpec extends ObjectBehavior
         $normalizer->normalize($product, 'standard')
             ->willReturn($originalValues);
 
-        $comparatorRegistry->getFieldComparator('family')->willReturn($familyComparator);
-        $familyComparator->compare($newValues['family'], $originalValues['family'])->willReturn(null);
-
+        $productFieldFilter->filter($product, ['family' => 'tshirt'])->willReturn([]);
         $comparatorRegistry->getAttributeComparator('pim_catalog_textarea')->willReturn($descriptionComparator);
         $descriptionComparator
             ->compare($newValues['values']['description'][0], $originalValues['values']['description'][0])
@@ -150,8 +149,8 @@ class ProductFilterSpec extends ObjectBehavior
         $normalizer,
         $comparatorRegistry,
         $attributeRepository,
+        $productFieldFilter,
         ProductInterface $product,
-        ComparatorInterface $familyComparator,
         ComparatorInterface $descriptionComparator
     ) {
         $originalValues = [
@@ -196,9 +195,7 @@ class ProductFilterSpec extends ObjectBehavior
         $normalizer->normalize($product, 'standard')
             ->willReturn($originalValues);
 
-        $comparatorRegistry->getFieldComparator('family')->willReturn($familyComparator);
-        $familyComparator->compare($newValues['family'], $originalValues['family'])->willReturn(null);
-
+        $productFieldFilter->filter($product, ['family' => 'tshirt'])->willReturn([]);
         $comparatorRegistry->getAttributeComparator('pim_catalog_textarea')->willReturn($descriptionComparator);
         $descriptionComparator
             ->compare($newValues['values']['description'][0], $originalValues['values']['description'][0])


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

Extract product's fields from ProductFilter to be able to use this new Filter on EE

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
