### PR TITLE
PIM-6352: link to edit product models & mass actions

### DIFF
--- a/features/Context/CatalogConfigurationContext.php
+++ b/features/Context/CatalogConfigurationContext.php
@@ -61,6 +61,47 @@ class CatalogConfigurationContext extends PimContext
         $this->getMainContext()->getContainer()->get('pim_connector.doctrine.cache_clearer')->clear();
     }
 
+
+    /**
+     * @param string $entity
+     *
+     * @Given /^there is no "([^"]*)" in the catalog$/
+     */
+    public function thereIsNoSuchEntityInTheCatalog($entity)
+    {
+        $db = $this->getMainContext()->getContainer()->get('doctrine.dbal.default_connection');
+        $tablesToPurge = [];
+
+        switch ($entity) {
+            case 'product':
+                $tablesToPurge = [
+                    'pim_catalog_completeness_missing_attribute',
+                    'pim_catalog_completeness',
+                    'pim_catalog_association_product',
+                    'pim_catalog_category_product',
+                    'pim_catalog_group_product',
+                    'pim_catalog_product_unique_data',
+                    'pim_catalog_product',
+                ];
+                $this->getContainer()->get('akeneo_elasticsearch.client.product')->refreshIndex();
+                break;
+            case 'product model':
+                $tablesToPurge = ['pim_catalog_category_product_model', 'pim_catalog_product_model'];
+                $this->getContainer()->get('akeneo_elasticsearch.client.product_and_product_model')->refreshIndex();
+                break;
+            default:
+                throw new \InvalidArgumentException(
+                    sprintf('The purge of "%s" in the catalog has not been implemented yet.')
+                );
+        }
+
+        foreach ($tablesToPurge as $tableToPurge) {
+            $db->exec('SET FOREIGN_KEY_CHECKS = 0;');
+            $db->exec(sprintf('TRUNCATE TABLE %s', $tableToPurge));
+            $db->exec('SET FOREIGN_KEY_CHECKS = 1;');
+        }
+    }
+
     /**
      * @param string[] $files Catalog configuration files to load
      *

--- a/features/mass-action/mass_edit_products_and_product_models.feature
+++ b/features/mass-action/mass_edit_products_and_product_models.feature
@@ -1,0 +1,28 @@
+@javascript
+Feature: Apply a mass action on products and product models
+  In order to modify my catalog
+  As a product manager
+  I need to be able to select products and product models at the same time in the grid and apply mass-edit on them
+
+  Background:
+    Given a "catalog_modeling" catalog configuration
+    And there is no "product" in the catalog
+    And there is no "product model" in the catalog
+    And the following root product models:
+      | code                | parent | family_variant      | categories | price          | color | description-en_US-ecommerce |
+      | tshirt-unique-color |        | clothing_color_size | master_men | 10 USD, 15 EUR | blue  | A unique color t-shirt      |
+    And the following products:
+      | sku                  | family   | name-en_US           | categories | size | description-en_US-ecommerce |
+      | tshirt-kurt-cobain-s | clothing | Tshirt Kurt Cobain S | Tshirts    | S    | A Kurt Cobain t-shirt       |
+    And I am logged in as "Julia"
+
+  Scenario: Apply a mass action on products and product models
+    Given I am on the products page
+    And I select rows tshirt-unique-color and tshirt-kurt-cobain-s
+    And I press "Change product information" on the "Bulk Actions" dropdown button
+    And I choose the "Edit common attributes" operation
+    And I display the Description attribute
+    And I change the "Description" to "a tee"
+    When I move to the confirm page
+    Then I should see the text "You are about to update 2 products with the following information, please confirm."
+

--- a/features/product/filtering/filter_products_and_product_models.feature
+++ b/features/product/filtering/filter_products_and_product_models.feature
@@ -33,3 +33,15 @@ Feature: Filter product and product models
       | groups           |                               |
       | variant products |                               |
 
+  Scenario: View products and product models with the same ID in the grid
+    Given there is no "product" in the catalog
+    And there is no "product model" in the catalog
+    And the following root product models:
+      | code                | parent | family_variant      | categories | price          | color | description-en_US-ecommerce |
+      | tshirt-unique-color |        | clothing_color_size | master_men | 10 USD, 15 EUR | blue  | A unique color t-shirt      |
+    And the following products:
+      | sku                  | family   | name-en_US           | categories | size | description-en_US-ecommerce |
+      | tshirt-kurt-cobain-s | clothing | Tshirt Kurt Cobain S | Tshirts    | S    | A Kurt Cobain t-shirt       |
+    When I am on the products page
+    Then I should see products tshirt-unique-color
+    And I should see the product models tshirt-kurt-cobain-s

--- a/src/Pim/Bundle/DataGridBundle/Normalizer/ProductModelNormalizer.php
+++ b/src/Pim/Bundle/DataGridBundle/Normalizer/ProductModelNormalizer.php
@@ -55,14 +55,14 @@ class ProductModelNormalizer implements NormalizerInterface, NormalizerAwareInte
         $data['label'] = $productModel->getLabel($locale);
         $data['image'] = $this->normalizeImage($productModel->getImage(), $format, $context);
 
-        $data['product_type'] = 'product_model';
-
         // TODO: PIM-6560 - Will show the number of complete products on the number of products (in the subtree)
         $data['variant_products'] = '';
-
         $data['groups'] = null;
         $data['enabled'] = null;
         $data['completeness'] = null;
+        $data['product_type'] = 'product_model';
+        $data['technical_id'] = $productModel->getId();
+        $data['search_id'] = sprintf('%s_%s', $data['product_type'], $data['technical_id']);
 
         return $data;
     }

--- a/src/Pim/Bundle/DataGridBundle/Normalizer/ProductNormalizer.php
+++ b/src/Pim/Bundle/DataGridBundle/Normalizer/ProductNormalizer.php
@@ -55,8 +55,9 @@ class ProductNormalizer implements NormalizerInterface, NormalizerAwareInterface
         $data['label'] = $product->getLabel($locale);
         $data['image'] = $this->normalizeImage($product->getImage(), $format, $context);
         $data['completeness'] = $this->getCompleteness($product, $context);
-
         $data['product_type'] = 'product';
+        $data['technical_id'] = $product->getId();
+        $data['search_id'] = sprintf('%s_%s', $data['product_type'], $data['technical_id']);
 
         return $data;
     }

--- a/src/Pim/Bundle/DataGridBundle/spec/Normalizer/ProductModelNormalizerSpec.php
+++ b/src/Pim/Bundle/DataGridBundle/spec/Normalizer/ProductModelNormalizerSpec.php
@@ -64,6 +64,7 @@ class ProductModelNormalizerSpec extends ObjectBehavior
             'channels'     => ['ecommerce'],
         ];
 
+        $productModel->getId()->willReturn(78);
         $filter->filterCollection($values, 'pim.transform.product_value.structured', $context)
             ->willReturn($values);
 
@@ -126,11 +127,13 @@ class ProductModelNormalizerSpec extends ObjectBehavior
                 'filePath'         => '/p/i/m/4/all.png',
                 'originalFileName' => 'all.png',
             ],
-            'product_type'     => 'product_model',
             'variant_products' => '',
             'groups' => null,
             'enabled'      => null,
             'completeness' => null,
+            'product_type' => 'product_model',
+            'technical_id' => 78,
+            'search_id' => 'product_model_78',
         ];
 
         $this->normalize($productModel, 'datagrid',
@@ -158,6 +161,7 @@ class ProductModelNormalizerSpec extends ObjectBehavior
         $filter->filterCollection($values, 'pim.transform.product_value.structured', $context)
             ->willReturn($values);
 
+        $productModel->getId()->willReturn(78);
         $productModel->getFamilyVariant()->willReturn($familyVariant);
         $familyVariant->getFamily()->willReturn($family);
         $family->getCode()->willReturn('tshirt');
@@ -217,11 +221,13 @@ class ProductModelNormalizerSpec extends ObjectBehavior
                 'filePath'         => '/p/i/m/4/all.png',
                 'originalFileName' => 'all.png',
             ],
-            'product_type'     => 'product_model',
             'variant_products' => '',
             'groups'       => null,
             'enabled'      => null,
             'completeness' => null,
+            'product_type' => 'product_model',
+            'technical_id' => 78,
+            'search_id' => 'product_model_78',
         ];
 
         $this->normalize($productModel, 'datagrid', ['locales' => ['en_US'], 'channels' => ['ecommerce']])

--- a/src/Pim/Bundle/DataGridBundle/spec/Normalizer/ProductNormalizerSpec.php
+++ b/src/Pim/Bundle/DataGridBundle/spec/Normalizer/ProductNormalizerSpec.php
@@ -67,6 +67,7 @@ class ProductNormalizerSpec extends ObjectBehavior
             'locales' => ['en_US'], 'channels' => ['ecommerce']
         ];
 
+        $product->getId()->willReturn(78);
         $filter->filterCollection($values, 'pim.transform.product_value.structured', $context)
             ->willReturn($values);
 
@@ -138,7 +139,9 @@ class ProductNormalizerSpec extends ObjectBehavior
                 'originalFileName' => 'all.png',
             ],
             'completeness' => 76,
-            'product_type' => 'product'
+            'product_type' => 'product',
+            'technical_id' => 78,
+            'search_id' => 'product_78',
         ];
 
         $this->normalize($product, 'datagrid', ['locales' => ['en_US'], 'channels' => ['ecommerce']])->shouldReturn($data);
@@ -163,6 +166,7 @@ class ProductNormalizerSpec extends ObjectBehavior
             'locales' => ['en_US'], 'channels' => ['ecommerce']
         ];
 
+        $product->getId()->willReturn(78);
         $filter->filterCollection($productValues, 'pim.transform.product_value.structured', $context)
             ->willReturn($productValues);
 
@@ -234,7 +238,9 @@ class ProductNormalizerSpec extends ObjectBehavior
                 'originalFileName' => 'all.png',
             ],
             'completeness' => 76,
-            'product_type' => 'product'
+            'product_type' => 'product',
+            'technical_id' => 78,
+            'search_id' => 'product_78',
         ];
 
         $this->normalize($product, 'datagrid', ['locales' => ['en_US'], 'channels' => ['ecommerce']])->shouldReturn($data);

--- a/src/Pim/Bundle/EnrichBundle/DependencyInjection/PimEnrichExtension.php
+++ b/src/Pim/Bundle/EnrichBundle/DependencyInjection/PimEnrichExtension.php
@@ -39,6 +39,7 @@ class PimEnrichExtension extends Extension
         $loader->load('connector/readers.yml');
         $loader->load('controllers.yml');
         $loader->load('converters.yml');
+        $loader->load('datagrid_actions.yml');
         $loader->load('datagrid_listeners.yml');
         $loader->load('entities.yml');
         $loader->load('event_listeners.yml');

--- a/src/Pim/Bundle/EnrichBundle/Extension/Action/Actions/NavigateProductAndProductModelAction.php
+++ b/src/Pim/Bundle/EnrichBundle/Extension/Action/Actions/NavigateProductAndProductModelAction.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Pim\Bundle\EnrichBundle\Extension\Action\Actions;
+
+use Oro\Bundle\DataGridBundle\Extension\Action\Actions\NavigateAction;
+
+/**
+ * Grid action for redirecting product and product models to their enrichment page.
+ *
+ * @author    Julien Janvier <j.janvier@gmail.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class NavigateProductAndProductModelAction extends NavigateAction
+{
+    protected $requiredOptions = [];
+}

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product.yml
@@ -44,13 +44,11 @@ datagrid:
                 data_name:     variant_products
                 type:          field
         properties:
-            id: ~
-            edit_link:
-                type: url
-                route: pim_enrich_product_edit
-                params:
-                    - id
-                    - dataLocale
+            id:
+                type:          field
+                data_name:     search_id
+            product_type: ~
+            technical_id: ~
             delete_link:
                 type: url
                 route: pim_enrich_product_rest_remove
@@ -61,15 +59,11 @@ datagrid:
                 route: pim_enrich_product_toggle_status
                 params:
                     - id
-            product_type:
-                type:          field
-                data_name:     product_type
         actions:
             edit:
-                type:      navigate
+                type:      navigate-product-and-product-model
                 label:
                 icon:
-                link:      edit_link
                 rowAction: true
             edit_attributes:
                 type:      tab-redirect

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid_actions.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid_actions.yml
@@ -1,0 +1,9 @@
+parameters:
+    pim_enrich.extension.action.type.navigate_product_and_product_model.class: 'Pim\Bundle\EnrichBundle\Extension\Action\Actions\NavigateProductAndProductModelAction'
+
+services:
+    pim_enrich.extension.action.type.navigate_product_and_product_model:
+        class: '%pim_enrich.extension.action.type.navigate_product_and_product_model.class%'
+        shared: false
+        tags:
+            - { name: oro_datagrid.extension.action.type, type: navigate-product-and-product-model }

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
@@ -1129,3 +1129,5 @@ config:
         pimcommunity/grid/view-selector/selector: pimenrich/js/grid/view-selector
         pimcommunity/grid/view-selector/line:     pimenrich/js/grid/view-selector-line
         pimcommunity/grid/view-selector/current:  pimenrich/js/grid/view-selector-current
+
+        oro/datagrid/navigate-product-and-product-model-action: pimenrich/js/datagrid/action/navigate-product-and-product-model-action

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/datagrid/action/navigate-product-and-product-model-action.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/datagrid/action/navigate-product-and-product-model-action.js
@@ -1,0 +1,39 @@
+'use strict';
+
+define(
+    [
+        'underscore',
+        'oro/translator',
+        'oro/datagrid/navigate-action',
+        'pim/router'
+    ],
+    function(_, __, NavigateAction, Router) {
+        return NavigateAction.extend({
+            /**
+             * {@inheritdoc}
+             */
+            getLink: function() {
+                return null;
+            },
+            /**
+             * {@inheritdoc}
+             */
+            execute: function() {
+                var route = null;
+                var productType = this.model.get('product_type');
+
+                if ('product' === productType) {
+                    route = 'pim_enrich_product_edit';
+                } else if ('product_model' === productType) {
+                    route = 'pim_enrich_product_model_edit';
+                } else {
+                    Router.displayErrorPage(__('error.common'), 400);
+
+                    return;
+                }
+
+                Router.redirectToRoute(route, {id: this.model.get('technical_id')});
+            }
+        });
+    }
+);


### PR DESCRIPTION
2 commits for 2 different things: 
1. be able to redirect to the product or product model form on the datagrid. The other actions than edit (delete and toggle status) are **NOT** taken into account in this PR. It will be done in another PR. 
2. mass actions on products and product models: it only prepares the datagrid to be able to work with product models. It also allows our current Behats on products to be green. The mass edit actions (like edit common attributes) do **NOT** work on this branch. It will be handled in a dedicated story.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Y
| Added Behats                      | Y
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | 
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -
