### PR TITLE
API-348: reactive "offset" pagination type on the API 

### DIFF
--- a/CHANGELOG-1.8.md
+++ b/CHANGELOG-1.8.md
@@ -233,7 +233,6 @@
 - Change the constructor of `Pim\Component\Connector\Writer\Database\ProductWriter` to replace `Akeneo\Component\StorageUtils\Detacher\BulkObjectDetacherInterface` by `Akeneo\Component\StorageUtils\Cache\CacheClearerInterface`.
 - Change the constructor of `Pim\Component\Catalog\Updater\AttributeGroupUpdater` to add `Akeneo\Component\Localization\TranslatableUpdater`
 - Change the constructor of `Pim\Bundle\EnrichBundle\Controller\JobTrackerController` to add `Oro\Bundle\SecurityBundle\SecurityFacade` and add an associative array
-- Change the constructor of `Pim\Bundle\ApiBundle\Controller\ProductController` to remove `Pim\Component\Api\Pagination\PaginatorInterface`
 - Change the constructor of `Pim\Component\Catalog\Manager\CompletenessManager` to remove the completeness class.
 - Change the constructor of `Pim\Component\Catalog\Updater\FamilyUpdater` to add `Akeneo\Component\Localization\TranslatableUpdater`
 - Change the constructor of `Pim\Component\Catalog\Updater\AttributeUpdater` to add `Akeneo\Component\Localization\TranslatableUpdater`
@@ -298,8 +297,7 @@
 - Change the constructor of `Pim\Bundle\EnrichBundle\Normalizer\AttributeNormalizer` to add `Pim\Bundle\VersioningBundle\Manager\VersionManager`, `Symfony\Component\Serializer\Normalizer\NormalizerInterface`, `Pim\Bundle\EnrichBundle\Provider\StructureVersion\StructureVersionProviderInterface`, `Akeneo\Component\Localization\Localizer\LocalizerInterface`
 - Change the constructor of `Pim\Bundle\EnrichBundle\Normalizer\ProductNormalizer` to add `Pim\Bundle\EnrichBundle\Normalizer\FileNormalizer`
 - Change the constructor of `Pim\Bundle\EnrichBundle\Controller\Rest\JobInstanceController` to add `uploadTmpDir` (string)
-- Change the constructor of `Pim\Bundle\ApiBundle\Controller\ProductController` to remove `Pim\Bundle\EnrichBundle\Doctrine\ORM\Repository`
-- Change the constructor of `Pim\Bundle\ApiBundle\Controller\ProductController` to add `Pim\Bundle\ApiBundle\Checker\QueryParametersCheckerInterface`
+- Change the constructor of `Pim\Bundle\ApiBundle\Controller\ProductController` to remove `Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface` and to add `Pim\Bundle\ApiBundle\Checker\QueryParametersCheckerInterface` and `Pim\Component\Catalog\Query\ProductQueryBuilderFactoryInterface`
 - Change the constructor of `Pim\Component\Catalog\Builder\ProductBuilder` to replace `Pim\Component\Catalog\Manager\AttributeValuesResolver` by `Pim\Component\Catalog\Manager\AttributeValuesResolverInterface`
 - Change the constructor of `Pim\Component\Connector\ArrayConverter\FlatToStandard\Product\AttributeColumnsResolver` to replace `Pim\Component\Catalog\Manager\AttributeValuesResolver` by `Pim\Component\Catalog\Manager\AttributeValuesResolverInterface`
 - Change the constructor of `Pim\Component\Catalog\Builder\EntityWithValuesBuilder` to replace `Pim\Component\Catalog\Manager\AttributeValuesResolver` by `Pim\Component\Catalog\Manager\AttributeValuesResolverInterface`

--- a/src/Pim/Bundle/ApiBundle/Controller/ProductController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/ProductController.php
@@ -54,7 +54,7 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 class ProductController
 {
     /** @var ProductQueryBuilderFactoryInterface */
-    protected $pqbFactory;
+    protected $searchAfterPqbFactory;
 
     /** @var NormalizerInterface */
     protected $normalizer;
@@ -67,6 +67,9 @@ class ProductController
 
     /** @var ProductRepositoryInterface */
     protected $productRepository;
+
+    /** @var PaginatorInterface */
+    protected $offsetPaginator;
 
     /** @var PaginatorInterface */
     protected $searchAfterPaginator;
@@ -98,7 +101,7 @@ class ProductController
     /** @var StreamResourceResponse */
     protected $partialUpdateStreamResource;
 
-    /** @var  PrimaryKeyEncrypter */
+    /** @var PrimaryKeyEncrypter */
     protected $primaryKeyEncrypter;
 
     /** @var array */
@@ -107,13 +110,17 @@ class ProductController
     /** @var QueryParametersCheckerInterface */
     protected $queryParametersChecker;
 
+    /** @var ProductQueryBuilderFactoryInterface */
+    protected $fromSizePqbFactory;
+
     /**
-     * @param ProductQueryBuilderFactoryInterface   $pqbFactory
+     * @param ProductQueryBuilderFactoryInterface   $searchAfterPqbFactory
      * @param NormalizerInterface                   $normalizer
      * @param IdentifiableObjectRepositoryInterface $channelRepository
      * @param QueryParametersCheckerInterface       $queryParametersChecker
      * @param AttributeRepositoryInterface          $attributeRepository
      * @param ProductRepositoryInterface            $productRepository
+     * @param PaginatorInterface                    $offsetPaginator
      * @param PaginatorInterface                    $searchAfterPaginator
      * @param ParameterValidatorInterface           $parameterValidator
      * @param ValidatorInterface                    $productValidator
@@ -125,15 +132,17 @@ class ProductController
      * @param ProductFilterInterface                $emptyValuesFilter
      * @param StreamResourceResponse                $partialUpdateStreamResource
      * @param PrimaryKeyEncrypter                   $primaryKeyEncrypter
+     * @param ProductQueryBuilderFactoryInterface   $fromSizePqbFactory
      * @param array                                 $apiConfiguration
      */
     public function __construct(
-        ProductQueryBuilderFactoryInterface $pqbFactory,
+        ProductQueryBuilderFactoryInterface $searchAfterPqbFactory,
         NormalizerInterface $normalizer,
         IdentifiableObjectRepositoryInterface $channelRepository,
         QueryParametersCheckerInterface $queryParametersChecker,
         AttributeRepositoryInterface $attributeRepository,
         ProductRepositoryInterface $productRepository,
+        PaginatorInterface $offsetPaginator,
         PaginatorInterface $searchAfterPaginator,
         ParameterValidatorInterface $parameterValidator,
         ValidatorInterface $productValidator,
@@ -145,14 +154,16 @@ class ProductController
         ProductFilterInterface $emptyValuesFilter,
         StreamResourceResponse $partialUpdateStreamResource,
         PrimaryKeyEncrypter $primaryKeyEncrypter,
+        ProductQueryBuilderFactoryInterface $fromSizePqbFactory,
         array $apiConfiguration
     ) {
-        $this->pqbFactory = $pqbFactory;
+        $this->searchAfterPqbFactory = $searchAfterPqbFactory;
         $this->normalizer = $normalizer;
         $this->channelRepository = $channelRepository;
         $this->queryParametersChecker = $queryParametersChecker;
         $this->attributeRepository = $attributeRepository;
         $this->productRepository = $productRepository;
+        $this->offsetPaginator = $offsetPaginator;
         $this->searchAfterPaginator = $searchAfterPaginator;
         $this->parameterValidator = $parameterValidator;
         $this->productValidator = $productValidator;
@@ -164,6 +175,7 @@ class ProductController
         $this->emptyValuesFilter = $emptyValuesFilter;
         $this->partialUpdateStreamResource = $partialUpdateStreamResource;
         $this->primaryKeyEncrypter = $primaryKeyEncrypter;
+        $this->fromSizePqbFactory = $fromSizePqbFactory;
         $this->apiConfiguration = $apiConfiguration;
     }
 
@@ -177,14 +189,7 @@ class ProductController
     public function listAction(Request $request): JsonResponse
     {
         try {
-            $pagination = $request->query->has('pagination_type') &&
-                PaginationTypes::OFFSET === $request->query->get('pagination_type') ?
-                PaginationTypes::SEARCH_AFTER : $request->query->get('pagination_type');
-
-            $this->parameterValidator->validate(
-                array_merge($request->query->all(), [$pagination]),
-                ['support_search_after' => true]
-            );
+            $this->parameterValidator->validate($request->query->all(), ['support_search_after' => true]);
         } catch (PaginationParametersException $e) {
             throw new UnprocessableEntityHttpException($e->getMessage(), $e);
         }
@@ -200,40 +205,16 @@ class ProductController
         }
 
         $normalizerOptions = $this->getNormalizerOptions($request, $channel);
+        $defaultParameters = [
+            'pagination_type' => PaginationTypes::OFFSET,
+            'limit'           => $this->apiConfiguration['pagination']['limit_by_default'],
+        ];
 
-        $queryParameters = array_merge([
-            'limit' => $this->apiConfiguration['pagination']['limit_by_default']
-        ], $request->query->all());
-        $pqbOptions = ['limit' => (int) $queryParameters['limit']];
+        $queryParameters = array_merge($defaultParameters, $request->query->all());
 
-        $searchParameter = '';
-        if (isset($queryParameters['search_after'])) {
-            $searchParameter = $queryParameters['search_after'];
-        } elseif (isset($queryParameters['search_before']) && '' !== $queryParameters['search_before']) {
-            $searchParameter = $queryParameters['search_before'];
-        }
-
-        if ('' !== $searchParameter) {
-            $searchParameterDecrypted = $this->primaryKeyEncrypter->decrypt($searchParameter);
-            $pqbOptions['search_after_unique_key'] = $searchParameterDecrypted;
-            $pqbOptions['search_after'] = [$searchParameterDecrypted];
-        }
-
-        $pqb = $this->pqbFactory->create($pqbOptions);
-
-        try {
-            $this->setPQBFilters($pqb, $request, $channel);
-        } catch (
-            UnsupportedFilterException
-            | PropertyException
-            | InvalidOperatorException
-            | ObjectNotFoundException
-            $e
-        ) {
-            throw new UnprocessableEntityHttpException($e->getMessage(), $e);
-        }
-
-        $paginatedProducts = $this->searchAfterIdentifier($pqb, $queryParameters, $normalizerOptions, $searchParameter);
+        $paginatedProducts = PaginationTypes::OFFSET === $queryParameters['pagination_type'] ?
+            $this->searchAfterOffset($request, $channel, $queryParameters, $normalizerOptions) :
+            $this->searchAfterIdentifier($request, $channel, $queryParameters, $normalizerOptions);
 
         return new JsonResponse($paginatedProducts);
     }
@@ -616,61 +597,123 @@ class ProductController
     }
 
     /**
-     * Explanation of how links are generated. Take this example with this list of identifiers:
-     * A - B - C - D - E - F - G - H
+     * @param Request               $request
+     * @param null|ChannelInterface $channel
+     * @param array                 $queryParameters
+     * @param array                 $normalizerOptions
      *
-     * With request "&search_after=E&limit=2":
-     *  - identifiers returned: F and G
-     *  - "next" link to generate: &search_after=G&limit=2 (so the last item returned)
-     *  - "previous" link to generate: &search_before=F&limit=2 (so the first item returned)
-     *
-     * To be able to find items with a "search_before" in request, we reverse the sort of the search:
-     * H - G - F - E - D - C - B - A
-     *
-     * So with a "search_after=F", identifiers returned will be: D and E
-     *
-     * @param ProductQueryBuilderInterface $pqb
-     * @param array                        $queryParameters
-     * @param array                        $normalizerOptions
-     * @param string                       $searchParameter
+     * @throws UnprocessableEntityHttpException
      *
      * @return array
      */
-    protected function searchAfterIdentifier(
-        ProductQueryBuilderInterface $pqb,
+    protected function searchAfterOffset(
+        Request $request,
+        ?ChannelInterface $channel,
         array $queryParameters,
-        array $normalizerOptions,
-        string $searchParameter
+        array $normalizerOptions
     ): array {
-        $direction = isset($queryParameters['search_before']) ? Directions::DESCENDING : Directions::ASCENDING;
-        $pqb->addSorter('id', $direction);
+        $from = isset($queryParameters['page']) ? ($queryParameters['page'] - 1) * $queryParameters['limit'] : 0;
+        $pqb = $this->fromSizePqbFactory->create(['limit' => (int) $queryParameters['limit'], 'from' => (int) $from]);
 
-        $productCursor = $pqb->execute();
-        $products = [];
-        foreach ($productCursor as $product) {
-            $products[] = $product;
+        try {
+            $this->setPQBFilters($pqb, $request, $channel);
+        } catch (
+            UnsupportedFilterException
+            | PropertyException
+            | InvalidOperatorException
+            | ObjectNotFoundException
+            $e
+        ) {
+            throw new UnprocessableEntityHttpException($e->getMessage(), $e);
         }
 
-        if (isset($queryParameters['search_before'])) {
-            $products = array_reverse($products);
-        }
+        $queryParameters = array_merge(['page' => 1, 'with_count' => 'false'], $queryParameters);
+        $pqb->addSorter('id', Directions::ASCENDING);
+        $products = $pqb->execute();
 
-        $parameters = [
+        $count = 'true' === $queryParameters['with_count'] ? $products->count() : null;
+
+        $paginationParameters = [
             'query_parameters'    => $queryParameters,
             'list_route_name'     => 'pim_api_product_list',
             'item_route_name'     => 'pim_api_product_get',
             'item_identifier_key' => 'identifier',
         ];
 
-        $parameters['search_after']['self'] = $searchParameter;
-        $parameters['search_after']['next'] = !empty($products) ? $this->primaryKeyEncrypter->encrypt(end($products)->getId()) : '';
-        $parameters['search_after']['previous'] = !empty($products) ? $this->primaryKeyEncrypter->encrypt(reset($products)->getId()) : '';
+        $paginatedProducts = $this->offsetPaginator->paginate(
+            $this->normalizer->normalize($products, 'external_api', $normalizerOptions),
+            $paginationParameters,
+            $count
+        );
 
-        $count = isset($queryParameters['with_count']) && 'true' === $queryParameters['with_count'] ?
-            $productCursor->count() : null;
-        $products = $this->normalizer->normalize($products, 'external_api', $normalizerOptions);
+        return $paginatedProducts;
+    }
 
-        $paginatedProducts = $this->searchAfterPaginator->paginate($products, $parameters, $count);
+    /**
+     * @param Request               $request
+     * @param null|ChannelInterface $channel
+     * @param array                 $queryParameters
+     * @param array                 $normalizerOptions
+     *
+     * @throws UnprocessableEntityHttpException
+     *
+     * @return array
+     */
+    protected function searchAfterIdentifier(
+        Request $request,
+        ?ChannelInterface $channel,
+        array $queryParameters,
+        array $normalizerOptions
+    ): array {
+        $pqbOptions = ['limit' => (int) $queryParameters['limit']];
+        $searchParameterCrypted = null;
+        if (isset($queryParameters['search_after'])) {
+            $searchParameterCrypted = $queryParameters['search_after'];
+            $searchParameterDecrypted = $this->primaryKeyEncrypter->decrypt($queryParameters['search_after']);
+            $pqbOptions['search_after_unique_key'] = $searchParameterDecrypted;
+            $pqbOptions['search_after'] = [$searchParameterDecrypted];
+        }
+        $pqb = $this->searchAfterPqbFactory->create($pqbOptions);
+
+        try {
+            $this->setPQBFilters($pqb, $request, $channel);
+        } catch (
+            UnsupportedFilterException
+            | PropertyException
+            | InvalidOperatorException
+            | ObjectNotFoundException
+            $e
+        ) {
+            throw new UnprocessableEntityHttpException($e->getMessage(), $e);
+        }
+
+        $pqb->addSorter('id', Directions::ASCENDING);
+        $productCursor = $pqb->execute();
+
+        $products = [];
+        foreach ($productCursor as $product) {
+            $products[] = $product;
+        }
+
+        $lastProduct = end($products);
+        reset($products);
+
+        $parameters = [
+            'query_parameters'    => $queryParameters,
+            'search_after'        => [
+                'next' => false !== $lastProduct ? $this->primaryKeyEncrypter->encrypt($lastProduct->getId()) : null,
+                'self' => $searchParameterCrypted,
+            ],
+            'list_route_name'     => 'pim_api_product_list',
+            'item_route_name'     => 'pim_api_product_get',
+            'item_identifier_key' => 'identifier'
+        ];
+
+        $paginatedProducts = $this->searchAfterPaginator->paginate(
+            $this->normalizer->normalize($products, 'external_api', $normalizerOptions),
+            $parameters,
+            null
+        );
 
         return $paginatedProducts;
     }

--- a/src/Pim/Bundle/ApiBundle/Documentation.php
+++ b/src/Pim/Bundle/ApiBundle/Documentation.php
@@ -12,4 +12,5 @@ namespace Pim\Bundle\ApiBundle;
 class Documentation
 {
     const URL = 'http://api.akeneo.com/api-reference.html#';
+    const URL_DOCUMENTATION = 'http://api.akeneo.com/documentation/';
 }

--- a/src/Pim/Bundle/ApiBundle/Resources/config/controllers.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/controllers.yml
@@ -130,6 +130,7 @@ services:
             - '@pim_api.checker.query_parameters'
             - '@pim_api.repository.attribute'
             - '@pim_api.repository.product'
+            - '@pim_api.pagination.offset_hal_paginator'
             - '@pim_api.pagination.search_after_hal_paginator'
             - '@pim_api.pagination.parameter_validator'
             - '@pim_catalog.validator.product'
@@ -141,6 +142,7 @@ services:
             - '@pim_catalog.comparator.filter.product'
             - '@pim_api.stream.product_partial_update_stream'
             - '@pim_api.security.primary_key_encrypter'
+            - '@pim_catalog.query.product_query_builder_from_size_factory'
             - '%pim_api.configuration%'
 
     pim_api.controller.root_endpoint:

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/ListProductWithCompletenessIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/ListProductWithCompletenessIntegration.php
@@ -73,11 +73,11 @@ class ListProductWithCompletenessIntegration extends AbstractProductTestCase
         $expected = <<<JSON
 {
     "_links": {
-        "self": {"href": "http://localhost/api/rest/v1/products?limit=2&scope=ecommerce&locales=en_US&search=${searchEncoded}"},
-        "first": {"href": "http://localhost/api/rest/v1/products?limit=2&scope=ecommerce&locales=en_US&search=${searchEncoded}"},
-        "next": {"href": "http://localhost/api/rest/v1/products?limit=2&scope=ecommerce&locales=en_US&search=${searchEncoded}&search_after=${encryptedId}"}
+        "self": {"href": "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=2&scope=ecommerce&locales=en_US&search=${searchEncoded}"},
+        "first": {"href": "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=2&scope=ecommerce&locales=en_US&search=${searchEncoded}"},
+        "next": {"href": "http://localhost/api/rest/v1/products?page=2&with_count=false&pagination_type=page&limit=2&scope=ecommerce&locales=en_US&search=${searchEncoded}"}
     },
-    "current_page" : null,
+    "current_page" : 1,
     "_embedded"    : {
 		"items": [
 		    {

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessLargeAndOrderedListProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessLargeAndOrderedListProductIntegration.php
@@ -47,15 +47,14 @@ class SuccessLargeAndOrderedListProductIntegration extends AbstractProductTestCa
         $lastEncryptedId = rawurlencode($this->getEncryptedId(end($this->products)));
 
         $client = $this->createAuthenticatedClient();
-        $client->request('GET', 'api/rest/v1/products?limit=100');
+        $client->request('GET', 'api/rest/v1/products?limit=100&pagination_type=search_after');
         $expected = <<<JSON
 {
     "_links": {
-        "self"  : {"href": "http://localhost/api/rest/v1/products?limit=100"},
-        "first" : {"href": "http://localhost/api/rest/v1/products?limit=100"},
-        "next" : {"href": "http://localhost/api/rest/v1/products?limit=100&search_after={$lastEncryptedId}"}
+        "self"  : {"href": "http://localhost/api/rest/v1/products?pagination_type=search_after&limit=100"},
+        "first" : {"href": "http://localhost/api/rest/v1/products?pagination_type=search_after&limit=100"},
+        "next" : {"href": "http://localhost/api/rest/v1/products?pagination_type=search_after&limit=100&search_after={$lastEncryptedId}"}
     },
-    "current_page" : null,
     "_embedded"    : {
 		"items": [
             {$standardizedProducts}

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessListProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessListProductIntegration.php
@@ -100,9 +100,9 @@ class SuccessListProductIntegration extends AbstractProductTestCase
     }
 
     /**
-     * Get all products, whatever locale, scope, category
+     * Get all products, whatever locale, scope, category with the default pagination type that is with an offset.
      */
-    public function testListProductsWithoutParameter()
+    public function testDefaultPaginationListProductsWithoutParameter()
     {
         $standardizedProducts = $this->getStandardizedProducts();
         $client = $this->createAuthenticatedClient();
@@ -111,10 +111,10 @@ class SuccessListProductIntegration extends AbstractProductTestCase
         $expected = <<<JSON
 {
     "_links": {
-        "self"  : {"href": "http://localhost/api/rest/v1/products?limit=10"},
-        "first" : {"href": "http://localhost/api/rest/v1/products?limit=10"}
+        "self"  : {"href": "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10"},
+        "first" : {"href": "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10"}
     },
-    "current_page" : null,
+    "current_page" : 1,
     "_embedded"    : {
 		"items": [
             {$standardizedProducts['simple']},
@@ -131,22 +131,20 @@ JSON;
         $this->assertListResponse($client->getResponse(), $expected);
     }
 
-    public function testFirstPageListProductsWithCount()
+    public function testDefaultPaginationFirstPageListProductsWithCount()
     {
         $standardizedProducts = $this->getStandardizedProducts();
         $client = $this->createAuthenticatedClient();
-
-        $nextId = rawurlencode($this->getEncryptedId('scopable'));
 
         $client->request('GET', 'api/rest/v1/products?with_count=true&limit=3');
         $expected = <<<JSON
 {
     "_links": {
-        "self"  : {"href": "http://localhost/api/rest/v1/products?limit=3&with_count=true"},
-        "first" : {"href": "http://localhost/api/rest/v1/products?limit=3&with_count=true"},
-        "next"  : {"href": "http://localhost/api/rest/v1/products?limit=3&with_count=true&search_after={$nextId}"}
+        "self"  : {"href": "http://localhost/api/rest/v1/products?page=1&with_count=true&pagination_type=page&limit=3"},
+        "first" : {"href": "http://localhost/api/rest/v1/products?page=1&with_count=true&pagination_type=page&limit=3"},
+        "next"  : {"href": "http://localhost/api/rest/v1/products?page=2&with_count=true&pagination_type=page&limit=3"}
     },
-    "current_page" : null,
+    "current_page" : 1,
     "items_count"  : 6,
     "_embedded"    : {
 		"items": [
@@ -161,67 +159,25 @@ JSON;
         $this->assertListResponse($client->getResponse(), $expected);
     }
 
-    /**
-     * Get products with "search_before" parameter.
-     */
-    public function testListProductsWithSearchBeforeParameter()
+    public function testDefaultPaginationLastPageListProductsWithCount()
     {
         $standardizedProducts = $this->getStandardizedProducts();
         $client = $this->createAuthenticatedClient();
 
-        $ids = [
-            'localizable'              => rawurlencode($this->getEncryptedId('localizable')),
-            'localizable_and_scopable' => rawurlencode($this->getEncryptedId('localizable_and_scopable')),
-            'scopable'                 => rawurlencode($this->getEncryptedId('scopable')),
-        ];
-
-        $client->request('GET', sprintf('api/rest/v1/products?search_before=%s&limit=2', $ids['localizable_and_scopable']));
+        $client->request('GET', 'api/rest/v1/products?with_count=true&limit=3&page=2');
         $expected = <<<JSON
 {
     "_links": {
-        "self" : {"href": "http://localhost/api/rest/v1/products?limit=2&search_before={$ids['localizable_and_scopable']}"},
-        "first" : {"href": "http://localhost/api/rest/v1/products?limit=2"},
-        "next": {"href": "http://localhost/api/rest/v1/products?limit=2&search_after={$ids['scopable']}"},
-        "previous": {"href": "http://localhost/api/rest/v1/products?limit=2&search_before={$ids['localizable']}"}
+        "self"     : {"href": "http://localhost/api/rest/v1/products?page=2&with_count=true&pagination_type=page&limit=3"},
+        "first"    : {"href": "http://localhost/api/rest/v1/products?page=1&with_count=true&pagination_type=page&limit=3"},
+        "previous" : {"href": "http://localhost/api/rest/v1/products?page=1&with_count=true&pagination_type=page&limit=3"},
+        "next"     : {"href": "http://localhost/api/rest/v1/products?page=3&with_count=true&pagination_type=page&limit=3"}
     },
-    "current_page" : null,
+    "current_page" : 2,
+    "items_count"  : 6,
     "_embedded"    : {
 		"items": [
-            {$standardizedProducts['localizable']},
-            {$standardizedProducts['scopable']}
-		]
-    }
-}
-JSON;
-
-        $this->assertListResponse($client->getResponse(), $expected);
-    }
-
-    /**
-     * Get the 3 latest products with "search_before" parameter.
-     */
-    public function testLatestProductsWithSearchBeforeParameter()
-    {
-        $standardizedProducts = $this->getStandardizedProducts();
-        $client = $this->createAuthenticatedClient();
-
-        $ids = [
-            'product_china'            => rawurlencode($this->getEncryptedId('product_china')),
-            'product_without_category' => rawurlencode($this->getEncryptedId('product_without_category'))
-        ];
-
-        $client->request('GET', 'api/rest/v1/products?search_before=&limit=2');
-        $expected = <<<JSON
-{
-    "_links": {
-        "self" : {"href": "http://localhost/api/rest/v1/products?limit=2&search_before="},
-        "first" : {"href": "http://localhost/api/rest/v1/products?limit=2"},
-        "next": {"href": "http://localhost/api/rest/v1/products?limit=2&search_after={$ids['product_without_category']}"},
-        "previous": {"href": "http://localhost/api/rest/v1/products?limit=2&search_before={$ids['product_china']}"}
-    },
-    "current_page" : null,
-    "_embedded"    : {
-		"items": [
+            {$standardizedProducts['localizable_and_scopable']},
             {$standardizedProducts['product_china']},
             {$standardizedProducts['product_without_category']}
 		]
@@ -239,19 +195,19 @@ JSON;
      *    - locale = "en_US" or null
      * Then only products in "master" tree are returned
      */
-    public function testListProductsWithEcommerceChannel()
+    public function testOffsetPaginationListProductsWithEcommerceChannel()
     {
         $standardizedProducts = $this->getStandardizedProducts();
         $client = $this->createAuthenticatedClient();
 
-        $client->request('GET', 'api/rest/v1/products?scope=ecommerce');
+        $client->request('GET', 'api/rest/v1/products?scope=ecommerce&pagination_type=page');
         $expected = <<<JSON
 {
     "_links"       : {
-        "self"  : {"href" : "http://localhost/api/rest/v1/products?limit=10&scope=ecommerce"},
-        "first" : {"href" : "http://localhost/api/rest/v1/products?limit=10&scope=ecommerce"}
+        "self"  : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&scope=ecommerce"},
+        "first" : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&scope=ecommerce"}
     },
-    "current_page" : null,
+    "current_page" : 1,
     "_embedded"    : {
         "items" : [
             {$standardizedProducts['simple']},
@@ -344,19 +300,19 @@ JSON;
      *     - locale = "en_US", "fr_FR" or null
      * Then only products in "master" tree are returned
      */
-    public function testListProductsWithTabletChannel()
+    public function testOffsetPaginationListProductsWithTabletChannel()
     {
         $standardizedProducts = $this->getStandardizedProducts();
         $client = $this->createAuthenticatedClient();
 
-        $client->request('GET', 'api/rest/v1/products?scope=tablet');
+        $client->request('GET', 'api/rest/v1/products?scope=tablet&pagination_type=page');
         $expected = <<<JSON
 {
     "_links"       : {
-        "self"  : {"href" : "http://localhost/api/rest/v1/products?limit=10&scope=tablet"},
-        "first" : {"href" : "http://localhost/api/rest/v1/products?limit=10&scope=tablet"}
+        "self"  : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&scope=tablet"},
+        "first" : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&scope=tablet"}
     },
-    "current_page" : null,
+    "current_page" : 1,
     "_embedded"    : {
         "items" : [
             {$standardizedProducts['simple']},
@@ -460,19 +416,19 @@ JSON;
      *     - locale = "fr_FR" or null
      * Then only products in "master" tree are returned
      */
-    public function testListProductsWithTabletChannelAndFRLocale()
+    public function testOffsetPaginationListProductsWithTabletChannelAndFRLocale()
     {
         $standardizedProducts = $this->getStandardizedProducts();
         $client = $this->createAuthenticatedClient();
 
-        $client->request('GET', 'api/rest/v1/products?scope=tablet&locales=fr_FR');
+        $client->request('GET', 'api/rest/v1/products?scope=tablet&locales=fr_FR&pagination_type=page');
         $expected = <<<JSON
 {
     "_links": {
-        "self"  : {"href" : "http://localhost/api/rest/v1/products?limit=10&scope=tablet&locales=fr_FR"},
-        "first" : {"href" : "http://localhost/api/rest/v1/products?limit=10&scope=tablet&locales=fr_FR"}
+        "self"  : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&scope=tablet&locales=fr_FR"},
+        "first" : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&scope=tablet&locales=fr_FR"}
     },
-    "current_page" : null,
+    "current_page" : 1,
     "_embedded"    : {
         "items" : [
             {$standardizedProducts['simple']},
@@ -565,18 +521,18 @@ JSON;
      *     - locale = "en_US", "zh_CN" or null
      * Then only products in "master_china" tree are returned
      */
-    public function testListProductsWithEcommerceChinaChannel()
+    public function testOffsetPaginationListProductsWithEcommerceChinaChannel()
     {
         $client = $this->createAuthenticatedClient();
 
-        $client->request('GET', 'api/rest/v1/products?scope=ecommerce_china');
+        $client->request('GET', 'api/rest/v1/products?scope=ecommerce_china&pagination_type=page');
         $expected = <<<JSON
 {
     "_links"       : {
-        "self"  : {"href" : "http://localhost/api/rest/v1/products?limit=10&scope=ecommerce_china"},
-        "first" : {"href" : "http://localhost/api/rest/v1/products?limit=10&scope=ecommerce_china"}
+        "self"  : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&scope=ecommerce_china"},
+        "first" : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&scope=ecommerce_china"}
     },
-    "current_page" : null,
+    "current_page" : 1,
     "_embedded"    : {
         "items" : [
             {
@@ -627,19 +583,19 @@ JSON;
      *     - locale = "en_US", "zh_CN" or null
      * Then we return all products (whatever the categories)
      */
-    public function testListProductsWithENAndCNLocales()
+    public function testOffsetPaginationListProductsWithENAndCNLocales()
     {
         $standardizedProducts = $this->getStandardizedProducts();
         $client = $this->createAuthenticatedClient();
 
-        $client->request('GET', 'api/rest/v1/products?locales=en_US,zh_CN');
+        $client->request('GET', 'api/rest/v1/products?locales=en_US,zh_CN&pagination_type=page');
         $expected = <<<JSON
 {
     "_links": {
-        "self"  : {"href" : "http://localhost/api/rest/v1/products?limit=10&locales=en_US%2Czh_CN"},
-        "first" : {"href" : "http://localhost/api/rest/v1/products?limit=10&locales=en_US%2Czh_CN"}
+        "self"  : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&locales=en_US%2Czh_CN"},
+        "first" : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&locales=en_US%2Czh_CN"}
     },
-    "current_page" : null,
+    "current_page" : 1,
     "_embedded"    : {
         "items" : [
             {$standardizedProducts['simple']},
@@ -748,18 +704,18 @@ JSON;
         $this->assertListResponse($client->getResponse(), $expected);
     }
 
-    public function testListProductsWithFilteredAttributes()
+    public function testOffsetPaginationListProductsWithFilteredAttributes()
     {
         $client = $this->createAuthenticatedClient();
 
-        $client->request('GET', 'api/rest/v1/products?attributes=a_text');
+        $client->request('GET', 'api/rest/v1/products?attributes=a_text&pagination_type=page');
         $expected = <<<JSON
 {
     "_links": {
-        "self"  : {"href" : "http://localhost/api/rest/v1/products?limit=10&attributes=a_text"},
-        "first" : {"href" : "http://localhost/api/rest/v1/products?limit=10&attributes=a_text"}
+        "self"  : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&attributes=a_text"},
+        "first" : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&attributes=a_text"}
     },
-    "current_page" : null,
+    "current_page" : 1,
     "_embedded"    : {
         "items" : [
             {
@@ -868,18 +824,18 @@ JSON;
         $this->assertListResponse($client->getResponse(), $expected);
     }
 
-    public function testListProductsWithChannelLocalesAndAttributesParams()
+    public function testOffsetPaginationListProductsWithChannelLocalesAndAttributesParams()
     {
         $client = $this->createAuthenticatedClient();
 
-        $client->request('GET', 'api/rest/v1/products?scope=tablet&locales=fr_FR&attributes=a_scopable_price,a_metric,a_localized_and_scopable_text_area');
+        $client->request('GET', 'api/rest/v1/products?scope=tablet&locales=fr_FR&attributes=a_scopable_price,a_metric,a_localized_and_scopable_text_area&pagination_type=page');
         $expected = <<<JSON
 {
     "_links"       : {
-        "self"  : {"href" : "http://localhost/api/rest/v1/products?limit=10&scope=tablet&locales=fr_FR&attributes=a_scopable_price%2Ca_metric%2Ca_localized_and_scopable_text_area"},
-        "first" : {"href" : "http://localhost/api/rest/v1/products?limit=10&scope=tablet&locales=fr_FR&attributes=a_scopable_price%2Ca_metric%2Ca_localized_and_scopable_text_area"}
+        "self"  : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&scope=tablet&locales=fr_FR&attributes=a_scopable_price%2Ca_metric%2Ca_localized_and_scopable_text_area"},
+        "first" : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&scope=tablet&locales=fr_FR&attributes=a_scopable_price%2Ca_metric%2Ca_localized_and_scopable_text_area"}
     },
-    "current_page" : null,
+    "current_page" : 1,
     "_embedded"    : {
         "items" : [
             {
@@ -977,37 +933,31 @@ JSON;
         $this->assertListResponse($client->getResponse(), $expected);
     }
 
-    public function testTheSecondPageOfTheListOfProductsWithoutCount()
+    public function testTheSecondPageOfTheListOfProductsWithOffsetPaginationWithoutCount()
     {
         $client = $this->createAuthenticatedClient();
 
-        $ids = [
-            'localizable_and_scopable' => rawurlencode($this->getEncryptedId('localizable_and_scopable')),
-            'product_china'            => rawurlencode($this->getEncryptedId('product_china')),
-            'product_without_category' => rawurlencode($this->getEncryptedId('product_without_category')),
-        ];
-
-        $client->request('GET', sprintf('api/rest/v1/products?attributes=a_text&search_after=%s&limit=2&with_count=false', $ids['localizable_and_scopable']));
+        $client->request('GET', 'api/rest/v1/products?attributes=a_text&page=2&limit=2&pagination_type=page&with_count=false');
         $expected = <<<JSON
 {
     "_links"       : {
-        "self"     : {"href" : "http://localhost/api/rest/v1/products?limit=2&attributes=a_text&search_after={$ids['localizable_and_scopable']}&with_count=false"},
-        "first"    : {"href" : "http://localhost/api/rest/v1/products?limit=2&attributes=a_text&with_count=false"},
-        "previous" : {"href" : "http://localhost/api/rest/v1/products?limit=2&attributes=a_text&with_count=false&search_before={$ids['product_china']}"},
-        "next"     : {"href" : "http://localhost/api/rest/v1/products?limit=2&attributes=a_text&search_after={$ids['product_without_category']}&with_count=false"}
+        "self"     : {"href" : "http://localhost/api/rest/v1/products?page=2&with_count=false&pagination_type=page&limit=2&attributes=a_text"},
+        "first"    : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=2&attributes=a_text"},
+        "previous" : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=2&attributes=a_text"},
+        "next"     : {"href" : "http://localhost/api/rest/v1/products?page=3&with_count=false&pagination_type=page&limit=2&attributes=a_text"}
     },
-    "current_page" : null,
+    "current_page" : 2,
     "_embedded"    : {
         "items" : [
             {
                 "_links" : {
-                    "self" : {"href" : "http://localhost/api/rest/v1/products/product_china"}
+                    "self" : {"href" : "http://localhost/api/rest/v1/products/scopable"}
                 },
-                "identifier"    : "product_china",
+                "identifier"    : "scopable",
                 "family"        : null,
                 "groups"        : [],
                 "variant_group" : null,
-                "categories"    : ["master_china"],
+                "categories"    : ["categoryA1", "categoryA2"],
                 "enabled"       : true,
                 "values"        : {},
                 "created"       : "2017-01-23T11:44:25+01:00",
@@ -1016,13 +966,13 @@ JSON;
             },
             {
                 "_links" : {
-                    "self" : {"href" : "http://localhost/api/rest/v1/products/product_without_category"}
+                    "self" : {"href" : "http://localhost/api/rest/v1/products/localizable_and_scopable"}
                 },
-                "identifier"    : "product_without_category",
+                "identifier"    : "localizable_and_scopable",
                 "family"        : null,
                 "groups"        : [],
                 "variant_group" : null,
-                "categories"    : [],
+                "categories"    : ["categoryA", "master_china"],
                 "enabled"       : true,
                 "values"        : {},
                 "created"       : "2017-01-23T11:44:25+01:00",
@@ -1041,17 +991,15 @@ JSON;
     {
         $client = $this->createAuthenticatedClient();
 
-        $id = rawurlencode($this->getEncryptedId('product_without_category'));
-
-        $client->request('GET', sprintf('api/rest/v1/products?search_after=%s&with_count=true', $id));
+        $client->request('GET', 'api/rest/v1/products?page=2&pagination_type=page&with_count=true');
         $expected = <<<JSON
 {
-    "_links" : {
-        "self": {"href" : "http://localhost/api/rest/v1/products?limit=10&search_after={$id}&with_count=true"},
-        "first" : {"href" : "http://localhost/api/rest/v1/products?limit=10&with_count=true"},
-        "previous": {"href" : "http://localhost/api/rest/v1/products?limit=10&with_count=true&search_before="}
+    "_links"       : {
+        "self"        : {"href" : "http://localhost/api/rest/v1/products?page=2&with_count=true&pagination_type=page&limit=10"},
+        "first"       : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=true&pagination_type=page&limit=10"},
+        "previous"    : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=true&pagination_type=page&limit=10"}
     },
-    "current_page" : null,
+    "current_page" : 2,
     "items_count"  : 6,
     "_embedded"    : {
         "items" : []
@@ -1062,20 +1010,20 @@ JSON;
         $this->assertListResponse($client->getResponse(), $expected);
     }
 
-    public function testListProductsWithSearch()
+    public function testOffsetPaginationListProductsWithSearch()
     {
         $client = $this->createAuthenticatedClient();
 
         $search = '{"a_metric":[{"operator":">","value":{"amount":"9","unit":"KILOWATT"}}]}';
-        $client->request('GET', 'api/rest/v1/products?search=' . $search);
+        $client->request('GET', 'api/rest/v1/products?pagination_type=page&search=' . $search);
         $searchEncoded = rawurlencode($search);
         $expected = <<<JSON
 {
     "_links"       : {
-        "self"  : {"href" : "http://localhost/api/rest/v1/products?limit=10&search=${searchEncoded}"},
-        "first" : {"href" : "http://localhost/api/rest/v1/products?limit=10&search=${searchEncoded}"}
+        "self"  : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&search=${searchEncoded}"},
+        "first" : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&search=${searchEncoded}"}
     },
-    "current_page" : null,
+    "current_page" : 1,
     "_embedded"    : {
         "items" : [
             {
@@ -1119,20 +1067,20 @@ JSON;
         $this->assertListResponse($client->getResponse(), $expected);
     }
 
-    public function testListProductsWithMultiplePQBFilters()
+    public function testOffsetPaginationListProductsWithMultiplePQBFilters()
     {
         $client = $this->createAuthenticatedClient();
 
         $search = '{"categories":[{"operator":"IN", "value":["categoryB"]}], "a_yes_no":[{"operator":"=","value":true}]}';
-        $client->request('GET', 'api/rest/v1/products?search=' . $search);
+        $client->request('GET', 'api/rest/v1/products?pagination_type=page&search=' . $search);
         $searchEncoded = rawurlencode($search);
         $expected = <<<JSON
 {
     "_links": {
-        "self"  : {"href" : "http://localhost/api/rest/v1/products?limit=10&search=${searchEncoded}"},
-        "first" : {"href" : "http://localhost/api/rest/v1/products?limit=10&search=${searchEncoded}"}
+        "self"  : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&search=${searchEncoded}"},
+        "first" : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&search=${searchEncoded}"}
     },
-    "current_page" : null,
+    "current_page" : 1,
     "_embedded"    : {
         "items" : []
     }
@@ -1152,10 +1100,10 @@ JSON;
         $expected = <<<JSON
 {
     "_links": {
-        "self"  : {"href" : "http://localhost/api/rest/v1/products?limit=10&search=${searchEncoded}"},
-        "first" : {"href" : "http://localhost/api/rest/v1/products?limit=10&search=${searchEncoded}"}
+        "self"  : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&search=${searchEncoded}"},
+        "first" : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&search=${searchEncoded}"}
     },
-    "current_page" : null,
+    "current_page" : 1,
     "_embedded"    : {
         "items" : []
     }
@@ -1165,27 +1113,27 @@ JSON;
         $this->assertListResponse($client->getResponse(), $expected);
     }
 
-    public function testPaginationLastPageOfTheListOfProducts()
+    /**
+     * Get all products, whatever locale, scope, category with a search after pagination
+     */
+    public function testSearchAfterPaginationListProductsWithoutParameter()
     {
         $standardizedProducts = $this->getStandardizedProducts();
         $client = $this->createAuthenticatedClient();
 
-        $ids = [
-            'localizable_and_scopable' => rawurlencode($this->getEncryptedId('localizable_and_scopable')),
-            'product_china'            => rawurlencode($this->getEncryptedId('product_china')),
-        ];
-
-        $client->request('GET', sprintf('api/rest/v1/products?limit=4&search_after=%s', $ids['localizable_and_scopable']));
+        $client->request('GET', 'api/rest/v1/products?pagination_type=search_after');
         $expected = <<<JSON
 {
     "_links": {
-        "self"  : {"href": "http://localhost/api/rest/v1/products?limit=4&search_after={$ids['localizable_and_scopable']}"},
-        "first" : {"href": "http://localhost/api/rest/v1/products?limit=4"},
-        "previous": {"href": "http://localhost/api/rest/v1/products?limit=4&search_before={$ids['product_china']}"}
+        "self"  : {"href": "http://localhost/api/rest/v1/products?pagination_type=search_after&limit=10"},
+        "first" : {"href": "http://localhost/api/rest/v1/products?pagination_type=search_after&limit=10"}
     },
-    "current_page" : null,
-    "_embedded"    : {
+    "_embedded" : {
         "items" : [
+            {$standardizedProducts['simple']},
+            {$standardizedProducts['localizable']},
+            {$standardizedProducts['scopable']},
+            {$standardizedProducts['localizable_and_scopable']},
             {$standardizedProducts['product_china']},
             {$standardizedProducts['product_without_category']}
         ]
@@ -1196,9 +1144,6 @@ JSON;
         $this->assertListResponse($client->getResponse(), $expected);
     }
 
-    /**
-     * @group todo
-     */
     public function testSearchAfterPaginationListProductsWithNextLink()
     {
         $standardizedProducts = $this->getStandardizedProducts();
@@ -1214,10 +1159,9 @@ JSON;
         $expected = <<<JSON
 {
     "_links": {
-        "self"  : {"href": "http://localhost/api/rest/v1/products?limit=3&pagination_type=search_after&search_after={$id['simple']}"},
-        "first" : {"href": "http://localhost/api/rest/v1/products?limit=3&pagination_type=search_after"},
-        "next"  : {"href": "http://localhost/api/rest/v1/products?limit=3&pagination_type=search_after&search_after={$id['localizable_and_scopable']}"},
-        "previous" : {"href": "http://localhost/api/rest/v1/products?limit=3&pagination_type=search_after&search_before={$id['localizable']}"}
+        "self"  : {"href": "http://localhost/api/rest/v1/products?pagination_type=search_after&limit=3&search_after={$id['simple']}"},
+        "first" : {"href": "http://localhost/api/rest/v1/products?pagination_type=search_after&limit=3"},
+        "next"  : {"href": "http://localhost/api/rest/v1/products?pagination_type=search_after&limit=3&search_after={$id['localizable_and_scopable']}"}
     },
     "_embedded"    : {
         "items" : [
@@ -1225,8 +1169,7 @@ JSON;
             {$standardizedProducts['scopable']},
             {$standardizedProducts['localizable_and_scopable']}
         ]
-    },
-    "current_page": null
+    }
 }
 JSON;
 
@@ -1239,15 +1182,13 @@ JSON;
         $client = $this->createAuthenticatedClient();
 
         $scopableEncryptedId = rawurlencode($this->getEncryptedId('scopable'));
-        $localizableAndScopableEncryptedId = rawurlencode($this->getEncryptedId('localizable_and_scopable'));
 
         $client->request('GET', sprintf('api/rest/v1/products?pagination_type=search_after&limit=4&search_after=%s' , $scopableEncryptedId));
         $expected = <<<JSON
 {
     "_links": {
-        "self"  : {"href": "http://localhost/api/rest/v1/products?limit=4&pagination_type=search_after&search_after={$scopableEncryptedId}"},
-        "first" : {"href": "http://localhost/api/rest/v1/products?limit=4&pagination_type=search_after"},
-        "previous"  : {"href": "http://localhost/api/rest/v1/products?limit=4&pagination_type=search_after&search_before={$localizableAndScopableEncryptedId}"}
+        "self"  : {"href": "http://localhost/api/rest/v1/products?pagination_type=search_after&limit=4&search_after={$scopableEncryptedId}"},
+        "first" : {"href": "http://localhost/api/rest/v1/products?pagination_type=search_after&limit=4"}
     },
     "_embedded"    : {
         "items" : [
@@ -1255,8 +1196,7 @@ JSON;
             {$standardizedProducts['product_china']},
             {$standardizedProducts['product_without_category']}
         ]
-    },
-    "current_page": null
+    }
 }
 JSON;
 
@@ -1279,8 +1219,7 @@ JSON;
     /**
      * @return array
      */
-    private function getStandardizedProducts()
-    {
+    private function getStandardizedProducts() {
         $standardizedProducts['simple'] = <<<JSON
 {
     "_links": {
@@ -1502,8 +1441,9 @@ JSON;
 
         return $standardizedProducts;
     }
+
     /**
-     * {@inheritdoc}
+     * @return Configuration
      */
     protected function getConfiguration()
     {


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

At the beginning of the 1.8 when elasticsearch was used to get products, we removed the pagination_type `offset` (or `page`), because elasticsearch forbidden to process more than 10000 items, it sends this exception: 
`Result window is too large, from + size must be less than or equal to: [10000] but was [10050]. See the scroll api for a more efficient way to request large data sets. This limit can be set by changing the [index.max_result_window] index level setting.`

To be able to continue to browse the pages (to be able to access on the next page and the **previous** page), we twisted (a lot) the `search_after` pagination type. 
The code was horrible to code and even more to understand.

After a discussion with PO, it's acceptable to use the [from/size pagination type](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-from-size.html) of elasticsearch and to have an exception. It's not normal to use this type of pagination and want to access to the 10000th products. If we want to access to these products, we have to use the search_after type


[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
