### PR TITLE
Fix family variant integration test

### DIFF
--- a/src/Akeneo/Bundle/ElasticsearchBundle/Client.php
+++ b/src/Akeneo/Bundle/ElasticsearchBundle/Client.php
@@ -37,6 +37,7 @@ class Client
      * To learn more, please see {@link https://www.elastic.co/guide/en/elasticsearch/client/php-api/current/_configuration.html}
      *
      * @param ClientBuilder $builder
+     * @param Loader        $configurationLoader
      * @param array         $hosts
      * @param string        $indexName
      */

--- a/tests/FixturesLoader.php
+++ b/tests/FixturesLoader.php
@@ -65,10 +65,16 @@ class FixturesLoader
     /**
      * Loads test catalog.
      *
+     * The elastic search indexes are reset here, at the same time than the database.
+     * However, the second index is not reset directly after the first one, as it could
+     * prevent the first one to be correctly dilated.
+     *
      * @throws \Exception
      */
     public function load()
     {
+        $this->container->get('akeneo_elasticsearch.client.product')->resetIndex();
+
         $files = $this->getFilesToLoad($this->configuration->getCatalogDirectories());
         $fixturesHash = $this->getHashForFiles($files);
 
@@ -81,10 +87,14 @@ class FixturesLoader
             $this->clearAclCache();
             $this->createUserSystem();
 
+            $this->container->get('akeneo_elasticsearch.client.product_and_product_model')->resetIndex();
+
             return;
         }
 
         $this->databaseSchemaHandler->reset();
+        $this->container->get('akeneo_elasticsearch.client.product_and_product_model')->resetIndex();
+
         $this->loadData();
         $this->dumpDatabase($dumpFile);
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -118,16 +118,12 @@ abstract class TestCase extends KernelTestCase
 
     protected function indexProducts()
     {
-        $this->get('akeneo_elasticsearch.client.product')->resetIndex();
-
         $products = $this->get('pim_catalog.repository.product')->findAll();
         $this->get('pim_catalog.elasticsearch.indexer.product')->indexAll($products);
     }
 
     protected function indexProductModels()
     {
-        $this->get('akeneo_elasticsearch.client.product_and_product_model')->resetIndex();
-
         $productModels = $this->get('pim_catalog.repository.product_model')->findAll();
         $this->get('pim_catalog.elasticsearch.indexer.product_model')->indexAll($productModels);
         $this->get('pim_catalog.elasticsearch.indexer.product_model_descendance')->indexAll($productModels);


### PR DESCRIPTION
## Description

The integration test `Pim\Component\Catalog\tests\integration\Normalizer\Standard\FamilyVariantIntegration` is currently failing on the CI. The problem came from ES index that still exists when it should not, resulting in the following error:

```bash
Elasticsearch\Common\Exceptions\BadRequest400Exception: {"error":{"root_cause":[{"type":"index_already_exists_exception","reason":"index [behat_akeneo_pim_product_and_product_model/qejbJFXvRUaddXfXJyyJ4w] already exists","index_uuid":"qejbJFXvRUaddXfXJyyJ4w","index":"behat_akeneo_pim_product_and_product_model"}],"type":"index_already_exists_exception","reason":"index [behat_akeneo_pim_product_and_product_model/qejbJFXvRUaddXfXJyyJ4w] already exists","index_uuid":"qejbJFXvRUaddXfXJyyJ4w","index":"behat_akeneo_pim_product_and_product_model"},"status":400}
```

Until now, we were resetting the index in the integration tests before reindexing all products and product models, **but after loading the fixtures** into MySQL. In the cases of a new catalog, there is no SLQ dump available, so fixtures are imported CSV using the product saver, and so triggering ES indexation.

Except that index is not reset at this moment, hence the error.

Solution is to reset the ES indexes at the same time we drop the MySQL database, **before** loading any fixtures.

What's more, for an unknown reason, sometime the index is not deleted at first attempt. So this PR add a spin on the index deletion, in `Client::resetIndex()`, to be sure it really is deleted before recreating it.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
