### PR TITLE
PIM-6338: display only level attributes of product model

### DIFF
--- a/features/product-model/edit_product_model.feature
+++ b/features/product-model/edit_product_model.feature
@@ -31,3 +31,10 @@ Feature: Edit a product model
     When I press the "Save" button
     Then I should not see the text "There are unsaved changes."
     And the product Name should be "Apollonito blue"
+
+  Scenario: Parent attributes of a sub product model are read only
+    Given I am logged in as "Mary"
+    And I edit the "apollon_blue" product model
+    When I visit the "Marketing" group
+    Then the field Model name should be read only
+    And the field Model description should be read only

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/values_fillers.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/values_fillers.yml
@@ -1,5 +1,6 @@
 parameters:
     pim_catalog.values_filler.product.class: Pim\Component\Catalog\ValuesFiller\ProductValuesFiller
+    pim_catalog.values_filler.entity_with_family_variant.class: Pim\Component\Catalog\ValuesFiller\EntityWithFamilyVariantValuesFiller
 
 services:
     pim_catalog.values_filler.product:
@@ -8,3 +9,11 @@ services:
             - '@pim_catalog.builder.product'
             - '@pim_catalog.resolver.attribute_values'
             - '@pim_catalog.repository.currency'
+
+    pim_catalog.values_filler.entity_with_family_variant:
+        class: '%pim_catalog.values_filler.entity_with_family_variant.class%'
+        arguments:
+            - '@pim_catalog.builder.entity_with_values'
+            - '@pim_catalog.resolver.attribute_values'
+            - '@pim_catalog.repository.currency'
+            - '@pim_catalog.family_variant.provider.entity_with_family_variant_attributes'

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_model/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_model/edit.yml
@@ -186,6 +186,12 @@ extensions:
         targetZone: header
         position: 100
 
+    pim-product-model-edit-form-read-only-parent-attributes:
+        module: pim/product-model-edit-form/attributes/read-only-parent-attributes
+        parent: pim-product-model-edit-form-attributes
+        targetZone: self
+        position: 100
+
     pim-product-model-edit-form-locale-specific:
         module: pim/product-edit-form/attributes/locale-specific
         parent: pim-product-model-edit-form-attributes

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/normalizers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/normalizers.yml
@@ -79,6 +79,8 @@ services:
             - '@pim_enrich.converter.standard_to_enrich.product_value'
             - '@pim_enrich.provider.form.product_model'
             - '@pim_catalog.repository.locale'
+            - '@pim_catalog.values_filler.entity_with_family_variant'
+            - '@pim_catalog.family_variant.provider.entity_with_family_variant_attributes'
         tags:
             - { name: pim_internal_api_serializer.normalizer }
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
@@ -699,6 +699,7 @@ config:
         pim/product-model-edit-form/meta/family-variant: pimenrich/js/product-model/form/meta/family-variant
         pim/product-model-edit-form/product-model-label: pimenrich/js/product-model/form/product-model-label
         pim/product-model-edit-form/save: pimenrich/js/product-model/form/save
+        pim/product-model-edit-form/attributes/read-only-parent-attributes: pimenrich/js/product-model/form/attributes/read-only-parent-attributes
 
         # Attribute group
         pim/attribute-group-form/tab/attribute: pimenrich/js/attribute-group/form/tab/attribute

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product-model/form/attributes/read-only-parent-attributes.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product-model/form/attributes/read-only-parent-attributes.js
@@ -1,0 +1,48 @@
+'use strict';
+/**
+ * This module sets parent attributes as read only
+ *
+ * @author    Adrien Pétremann <adrien.petremann@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+define(
+    [
+        'underscore',
+        'pim/form'
+    ],
+    function (
+        _,
+        BaseForm
+    ) {
+        return BaseForm.extend({
+            /**
+             * {@inheritdoc}
+             */
+            configure: function () {
+                this.listenTo(this.getRoot(), 'pim_enrich:form:field:extension:add', this.addFieldExtension);
+
+                return BaseForm.prototype.configure.apply(this, arguments);
+            },
+
+            /**
+             * {@inheritdoc}
+             */
+            addFieldExtension: function (event) {
+                var productModel = this.getFormData();
+                if (!productModel.meta.attributes_for_this_level) {
+                    return;
+                }
+
+                var levelAttributeCodes = productModel.meta.attributes_for_this_level;
+                var field = event.field;
+
+                if (!_.contains(levelAttributeCodes, field.attribute.code)) {
+                    field.setEditable(false);
+                }
+
+                return this;
+            }
+        });
+    }
+);

--- a/src/Pim/Bundle/EnrichBundle/spec/Normalizer/ProductModelNormalizerSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Normalizer/ProductModelNormalizerSpec.php
@@ -6,12 +6,15 @@ use PhpSpec\ObjectBehavior;
 use Pim\Bundle\EnrichBundle\Normalizer\FileNormalizer;
 use Pim\Bundle\EnrichBundle\Provider\Form\FormProviderInterface;
 use Pim\Bundle\VersioningBundle\Manager\VersionManager;
+use Pim\Component\Catalog\FamilyVariant\EntityWithFamilyVariantAttributesProvider;
 use Pim\Component\Catalog\Localization\Localizer\AttributeConverterInterface;
+use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\FamilyInterface;
 use Pim\Component\Catalog\Model\FamilyVariantInterface;
 use Pim\Component\Catalog\Model\ProductModelInterface;
 use Pim\Component\Catalog\Model\ValueInterface;
 use Pim\Component\Catalog\Repository\LocaleRepositoryInterface;
+use Pim\Component\Catalog\ValuesFiller\EntityWithFamilyValuesFillerInterface;
 use Pim\Component\Enrich\Converter\ConverterInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
@@ -25,7 +28,9 @@ class ProductModelNormalizerSpec extends ObjectBehavior
         AttributeConverterInterface $localizedConverter,
         ConverterInterface $productValueConverter,
         FormProviderInterface $formProvider,
-        LocaleRepositoryInterface $localeRepository
+        LocaleRepositoryInterface $localeRepository,
+        EntityWithFamilyValuesFillerInterface $entityValuesFiller,
+        EntityWithFamilyVariantAttributesProvider $attributesProvider
     ) {
         $this->beConstructedWith(
             $normalizer,
@@ -35,7 +40,9 @@ class ProductModelNormalizerSpec extends ObjectBehavior
             $localizedConverter,
             $productValueConverter,
             $formProvider,
-            $localeRepository
+            $localeRepository,
+            $entityValuesFiller,
+            $attributesProvider
         );
     }
 
@@ -53,6 +60,8 @@ class ProductModelNormalizerSpec extends ObjectBehavior
         $productValueConverter,
         $formProvider,
         $localeRepository,
+        $attributesProvider,
+        AttributeInterface $pictureAttribute,
         ProductModelInterface $productModel,
         FamilyVariantInterface $familyVariant,
         FamilyInterface $family,
@@ -111,6 +120,9 @@ class ProductModelNormalizerSpec extends ObjectBehavior
             ]
         ];
 
+        $attributesProvider->getAttributes($productModel)->willReturn([$pictureAttribute]);
+        $pictureAttribute->getCode()->willReturn('picture');
+
         $localeRepository->getActivatedLocaleCodes()->willReturn(['en_US', 'fr_FR']);
         $productModel->getLabel('en_US')->willReturn('Tshirt blue');
         $productModel->getLabel('fr_FR')->willReturn('Tshirt bleu');
@@ -149,6 +161,7 @@ class ProductModelNormalizerSpec extends ObjectBehavior
                     'created'        => 'normalized_create_version',
                     'updated'        => 'normalized_update_version',
                     'model_type'     => 'product_model',
+                    'attributes_for_this_level' => ['picture'],
                     'image'          => $fileNormalized,
                     'label'          => [
                         'en_US' => 'Tshirt blue',

--- a/src/Pim/Component/Catalog/FamilyVariant/EntityWithFamilyVariantAttributesProvider.php
+++ b/src/Pim/Component/Catalog/FamilyVariant/EntityWithFamilyVariantAttributesProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Pim\Component\Catalog\FamilyVariant;
 
 use Pim\Component\Catalog\Model\AttributeInterface;
@@ -15,6 +17,8 @@ use Pim\Component\Catalog\Model\EntityWithFamilyVariantInterface;
 class EntityWithFamilyVariantAttributesProvider
 {
     /**
+     * This method returns all attributes for the given $entityWithFamilyVariant, including axes.
+     *
      * @param EntityWithFamilyVariantInterface $entityWithFamilyVariant
      *
      * @return AttributeInterface[]

--- a/src/Pim/Component/Catalog/ValuesFiller/AbstractEntityWithFamilyValuesFiller.php
+++ b/src/Pim/Component/Catalog/ValuesFiller/AbstractEntityWithFamilyValuesFiller.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Component\Catalog\ValuesFiller;
+
+use Pim\Component\Catalog\AttributeTypes;
+use Pim\Component\Catalog\Builder\EntityWithValuesBuilderInterface;
+use Pim\Component\Catalog\Manager\AttributeValuesResolverInterface;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\EntityWithFamilyInterface;
+use Pim\Component\Catalog\Model\EntityWithValuesInterface;
+use Pim\Component\Catalog\Repository\CurrencyRepositoryInterface;
+
+/**
+ * Abstract values filler for entities with a family.
+ *
+ * As all entities with a family have ProductValues, there is a lot of common logic to
+ * fill empty Product Values, this class is designed for that.
+ *
+ * @author    Adrien Pétremann <adrien.petremann@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+abstract class AbstractEntityWithFamilyValuesFiller implements EntityWithFamilyValuesFillerInterface
+{
+    /** @var EntityWithValuesBuilderInterface */
+    protected $entityWithValuesBuilder;
+
+    /** @var AttributeValuesResolverInterface */
+    protected $valuesResolver;
+
+    /** @var CurrencyRepositoryInterface */
+    protected $currencyRepository;
+
+    /**
+     * @param EntityWithValuesBuilderInterface          $entityWithValuesBuilder
+     * @param AttributeValuesResolverInterface          $valuesResolver
+     * @param CurrencyRepositoryInterface               $currencyRepository
+     */
+    public function __construct(
+        EntityWithValuesBuilderInterface $entityWithValuesBuilder,
+        AttributeValuesResolverInterface $valuesResolver,
+        CurrencyRepositoryInterface $currencyRepository
+    ) {
+        $this->entityWithValuesBuilder = $entityWithValuesBuilder;
+        $this->valuesResolver = $valuesResolver;
+        $this->currencyRepository = $currencyRepository;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fillMissingValues(EntityWithFamilyInterface $entity): void
+    {
+        $this->checkEntityType($entity);
+
+        $attributes = $this->getExpectedAttributes($entity);
+        $requiredValues = $this->valuesResolver->resolveEligibleValues($attributes);
+        $existingValues = $this->getExistingValues($entity);
+
+        $missingValues = array_filter(
+            $requiredValues,
+            function ($value) use ($existingValues) {
+                return !in_array($value, $existingValues);
+            }
+        );
+
+        foreach ($missingValues as $value) {
+            $this->entityWithValuesBuilder->addOrReplaceValue(
+                $entity,
+                $attributes[$value['attribute']],
+                $value['locale'],
+                $value['scope'],
+                null
+            );
+        }
+
+        $this->addMissingPricesToProduct($entity);
+    }
+
+    /**
+     * Returns an array of product values identifiers
+     *
+     * @param EntityWithValuesInterface $entity
+     *
+     * @return array
+     */
+    protected function getExistingValues(EntityWithValuesInterface $entity): array
+    {
+        $existingValues = [];
+        $values = $entity->getValues();
+        foreach ($values as $value) {
+            $existingValues[] = [
+                'attribute' => $value->getAttribute()->getCode(),
+                'type'      => $value->getAttribute()->getType(),
+                'locale'    => $value->getLocale(),
+                'scope'     => $value->getScope()
+            ];
+        }
+
+        return $existingValues;
+    }
+
+    /**
+     * Add missing prices (a price per currency)
+     *
+     * @param EntityWithValuesInterface $entity
+     */
+    protected function addMissingPricesToProduct(EntityWithValuesInterface $entity): void
+    {
+        $activeCurrencyCodes = $this->currencyRepository->getActivatedCurrencyCodes();
+
+        foreach ($entity->getValues() as $value) {
+            $attribute = $value->getAttribute();
+            if (AttributeTypes::PRICE_COLLECTION === $attribute->getType()) {
+                $prices = [];
+
+                foreach ($value->getData() as $price) {
+                    if (in_array($price->getCurrency(), $activeCurrencyCodes)) {
+                        $prices[] = ['amount' => $price->getData(), 'currency' => $price->getCurrency()];
+                    }
+                }
+
+                foreach ($activeCurrencyCodes as $currencyCode) {
+                    if (null === $value->getPrice($currencyCode)) {
+                        $prices[] = ['amount' => null, 'currency' => $currencyCode];
+                    }
+                }
+
+                $this->entityWithValuesBuilder->addOrReplaceValue($entity, $attribute, $value->getLocale(), $value->getScope(), $prices);
+            }
+        }
+    }
+
+    /**
+     * Check the given $entity type, it can be a Product, a Product Model, a Variant Product...
+     *
+     * @throws \InvalidArgumentException if this Values Filler doesn't handle this kind of entity
+     *
+     * @param EntityWithFamilyInterface $entity
+     */
+    abstract protected function checkEntityType(EntityWithFamilyInterface $entity): void;
+
+    /**
+     * Get expected attributes for the given $entity
+     *
+     * @param EntityWithFamilyInterface $entity
+     *
+     * @return AttributeInterface[]
+     */
+    abstract protected function getExpectedAttributes(EntityWithFamilyInterface $entity): array;
+}

--- a/src/Pim/Component/Catalog/ValuesFiller/EntityWithFamilyVariantValuesFiller.php
+++ b/src/Pim/Component/Catalog/ValuesFiller/EntityWithFamilyVariantValuesFiller.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Component\Catalog\ValuesFiller;
+
+use Pim\Component\Catalog\Builder\EntityWithValuesBuilderInterface;
+use Pim\Component\Catalog\FamilyVariant\EntityWithFamilyVariantAttributesProvider;
+use Pim\Component\Catalog\Manager\AttributeValuesResolverInterface;
+use Pim\Component\Catalog\Model\EntityWithFamilyInterface;
+use Pim\Component\Catalog\Model\EntityWithFamilyVariantInterface;
+use Pim\Component\Catalog\Repository\CurrencyRepositoryInterface;
+
+/**
+ * Values filler for entities with a Family Variant.
+ *
+ * Their attributes come from attribute sets, and values can come from parent product models.
+ *
+ * @author    Adrien Pétremann <adrien.petremann@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class EntityWithFamilyVariantValuesFiller extends AbstractEntityWithFamilyValuesFiller
+{
+    /** @var EntityWithFamilyVariantAttributesProvider */
+    private $attributesProvider;
+
+    /**
+     * @param EntityWithValuesBuilderInterface          $entityWithValuesBuilder
+     * @param AttributeValuesResolverInterface          $valuesResolver
+     * @param CurrencyRepositoryInterface               $currencyRepository
+     * @param EntityWithFamilyVariantAttributesProvider $attributesProvider
+     */
+    public function __construct(
+        EntityWithValuesBuilderInterface $entityWithValuesBuilder,
+        AttributeValuesResolverInterface $valuesResolver,
+        CurrencyRepositoryInterface $currencyRepository,
+        EntityWithFamilyVariantAttributesProvider $attributesProvider
+    ) {
+        parent::__construct($entityWithValuesBuilder, $valuesResolver, $currencyRepository);
+
+        $this->attributesProvider = $attributesProvider;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function checkEntityType(EntityWithFamilyInterface $entity): void
+    {
+        if (!$entity instanceof EntityWithFamilyVariantInterface) {
+            throw new \InvalidArgumentException(
+                sprintf('%s expected, %s given', EntityWithFamilyVariantInterface::class, get_class($entity))
+            );
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getExpectedAttributes(EntityWithFamilyInterface $entity): array
+    {
+        $attributes = [];
+
+        /** @var EntityWithFamilyVariantInterface $entity */
+        foreach ($this->attributesProvider->getAttributes($entity) as $attribute) {
+            $attributes[$attribute->getCode()] = $attribute;
+        }
+
+        if (null !== $entity->getParent()) {
+            $parentAttributes = $this->getExpectedAttributes($entity->getParent());
+            $attributes = array_merge($attributes, $parentAttributes);
+        }
+
+        return $attributes;
+    }
+}

--- a/src/Pim/Component/Catalog/ValuesFiller/ProductValuesFiller.php
+++ b/src/Pim/Component/Catalog/ValuesFiller/ProductValuesFiller.php
@@ -2,98 +2,46 @@
 
 namespace Pim\Component\Catalog\ValuesFiller;
 
-use Pim\Component\Catalog\AttributeTypes;
-use Pim\Component\Catalog\Builder\EntityWithValuesBuilderInterface;
-use Pim\Component\Catalog\Manager\AttributeValuesResolverInterface;
-use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\EntityWithFamilyInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
-use Pim\Component\Catalog\Repository\CurrencyRepositoryInterface;
 
 /**
+ * Values filler for Products.
+ *
+ * Their attributes come directly from the family, and values come directly from the entity.
+ *
  * @author    Adrien Pétremann <adrien.petremann@akeneo.com>
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
-class ProductValuesFiller implements EntityWithFamilyValuesFillerInterface
+class ProductValuesFiller extends AbstractEntityWithFamilyValuesFiller
 {
-    /** @var EntityWithValuesBuilderInterface */
-    private $entityWithValuesBuilder;
-
-    /** @var AttributeValuesResolverInterface */
-    private $valuesResolver;
-
-    /** @var CurrencyRepositoryInterface */
-    private $currencyRepository;
-
     /**
-     * @param EntityWithValuesBuilderInterface $entityWithValuesBuilder
-     * @param AttributeValuesResolverInterface $valuesResolver
-     * @param CurrencyRepositoryInterface      $currencyRepository
+     * {@inheritdoc}
      */
-    public function __construct(
-        EntityWithValuesBuilderInterface $entityWithValuesBuilder,
-        AttributeValuesResolverInterface $valuesResolver,
-        CurrencyRepositoryInterface $currencyRepository
-    ) {
-        $this->entityWithValuesBuilder = $entityWithValuesBuilder;
-        $this->valuesResolver          = $valuesResolver;
-        $this->currencyRepository      = $currencyRepository;
+    protected function checkEntityType(EntityWithFamilyInterface $entity): void
+    {
+        if (!$entity instanceof ProductInterface) {
+            throw new \InvalidArgumentException(
+                sprintf('%s expected, %s given', ProductInterface::class, get_class($entity))
+            );
+        }
     }
 
     /**
      * {@inheritdoc}
      */
-    public function fillMissingValues(EntityWithFamilyInterface $product): void
-    {
-        if (!$product instanceof ProductInterface) {
-            throw new \InvalidArgumentException(
-                sprintf('%s expected, %s given', ProductInterface::class, get_class($product))
-            );
-        }
-
-        $attributes = $this->getExpectedAttributes($product);
-        $requiredValues = $this->valuesResolver->resolveEligibleValues($attributes);
-        $existingValues = $this->getExistingValues($product);
-
-        $missingValues = array_filter(
-            $requiredValues,
-            function ($value) use ($existingValues) {
-                return !in_array($value, $existingValues);
-            }
-        );
-
-        foreach ($missingValues as $value) {
-            $this->entityWithValuesBuilder->addOrReplaceValue(
-                $product,
-                $attributes[$value['attribute']],
-                $value['locale'],
-                $value['scope'],
-                null
-            );
-        }
-
-        $this->addMissingPricesToProduct($product);
-    }
-
-    /**
-     * Get expected attributes for the product
-     *
-     * @param ProductInterface $product
-     *
-     * @return AttributeInterface[]
-     */
-    private function getExpectedAttributes(ProductInterface $product): array
+    protected function getExpectedAttributes(EntityWithFamilyInterface $entity): array
     {
         $attributes = [];
 
         // TODO: remove this when optional attributes are gone
-        $productAttributes = $product->getAttributes();
+        $productAttributes = $entity->getAttributes();
         foreach ($productAttributes as $attribute) {
             $attributes[$attribute->getCode()] = $attribute;
         }
 
-        $family = $product->getFamily();
+        $family = $entity->getFamily();
         if (null !== $family) {
             foreach ($family->getAttributes() as $attribute) {
                 $attributes[$attribute->getCode()] = $attribute;
@@ -101,59 +49,5 @@ class ProductValuesFiller implements EntityWithFamilyValuesFillerInterface
         }
 
         return $attributes;
-    }
-
-    /**
-     * Returns an array of product values identifiers
-     *
-     * @param ProductInterface $product
-     *
-     * @return array
-     */
-    private function getExistingValues(ProductInterface $product): array
-    {
-        $existingValues = [];
-        $values = $product->getValues();
-        foreach ($values as $value) {
-            $existingValues[] = [
-                'attribute' => $value->getAttribute()->getCode(),
-                'type'      => $value->getAttribute()->getType(),
-                'locale'    => $value->getLocale(),
-                'scope'     => $value->getScope()
-            ];
-        }
-
-        return $existingValues;
-    }
-
-    /**
-     * Add missing prices (a price per currency)
-     *
-     * @param ProductInterface $product the product
-     */
-    private function addMissingPricesToProduct(ProductInterface $product): void
-    {
-        $activeCurrencyCodes = $this->currencyRepository->getActivatedCurrencyCodes();
-
-        foreach ($product->getValues() as $value) {
-            $attribute = $value->getAttribute();
-            if (AttributeTypes::PRICE_COLLECTION === $attribute->getType()) {
-                $prices = [];
-
-                foreach ($value->getData() as $price) {
-                    if (in_array($price->getCurrency(), $activeCurrencyCodes)) {
-                        $prices[] = ['amount' => $price->getData(), 'currency' => $price->getCurrency()];
-                    }
-                }
-
-                foreach ($activeCurrencyCodes as $currencyCode) {
-                    if (null === $value->getPrice($currencyCode)) {
-                        $prices[] = ['amount' => null, 'currency' => $currencyCode];
-                    }
-                }
-
-                $this->entityWithValuesBuilder->addOrReplaceValue($product, $attribute, $value->getLocale(), $value->getScope(), $prices);
-            }
-        }
     }
 }

--- a/src/Pim/Component/Catalog/spec/ValuesFiller/EntityWithFamilyVariantValuesFillerSpec.php
+++ b/src/Pim/Component/Catalog/spec/ValuesFiller/EntityWithFamilyVariantValuesFillerSpec.php
@@ -1,0 +1,241 @@
+<?php
+
+namespace spec\Pim\Component\Catalog\ValuesFiller;
+
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Builder\EntityWithValuesBuilderInterface;
+use Pim\Component\Catalog\FamilyVariant\EntityWithFamilyVariantAttributesProvider;
+use Pim\Component\Catalog\Manager\AttributeValuesResolverInterface;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\ProductInterface;
+use Pim\Component\Catalog\Model\ProductModelInterface;
+use Pim\Component\Catalog\Model\ValueInterface;
+use Pim\Component\Catalog\Repository\CurrencyRepositoryInterface;
+use Prophecy\Argument;
+
+class EntityWithFamilyVariantValuesFillerSpec extends ObjectBehavior
+{
+    function let(
+        EntityWithValuesBuilderInterface $entityWithValuesBuilder,
+        AttributeValuesResolverInterface $valuesResolver,
+        CurrencyRepositoryInterface $currencyRepository,
+        EntityWithFamilyVariantAttributesProvider $attributesProvider
+    ) {
+        $this->beConstructedWith($entityWithValuesBuilder, $valuesResolver, $currencyRepository, $attributesProvider);
+    }
+
+    function it_throws_an_exception_if_this_is_not_an_entity_with_a_family_variant(
+        ProductInterface $product
+    ) {
+        $this->shouldThrow(\InvalidArgumentException::class)->during('fillMissingValues', [$product]);
+    }
+
+    function it_fills_missing_product_values_from_attribute_set_on_new_entity_with_family_variant(
+        $attributesProvider,
+        $valuesResolver,
+        $entityWithValuesBuilder,
+        ProductModelInterface $entity,
+        ProductModelInterface $parentEntity,
+        AttributeInterface $name,
+        AttributeInterface $color,
+        AttributeInterface $sku,
+        ValueInterface $skuValue,
+        ValueInterface $colorValue
+    ) {
+        $sku->getCode()->willReturn('sku');
+        $sku->getType()->willReturn('pim_catalog_identifier');
+        $sku->isLocalizable()->willReturn(false);
+        $sku->isScopable()->willReturn(false);
+
+        $name->getCode()->willReturn('name');
+        $name->getType()->willReturn('pim_catalog_text');
+        $name->isLocalizable()->willReturn(true);
+        $name->isScopable()->willReturn(false);
+
+        $color->getCode()->willReturn('color');
+        $color->getType()->willReturn('pim_catalog_simpleselect');
+        $color->isLocalizable()->willReturn(false);
+        $color->isScopable()->willReturn(false);
+
+        $expectedParentAttributes = [$name];
+        $expectedAttributes = [$sku, $color];
+
+        $parentEntity->getParent()->willReturn(null);
+        $entity->getParent()->willReturn($parentEntity);
+
+        $attributesProvider->getAttributes($parentEntity)->willReturn($expectedParentAttributes);
+        $attributesProvider->getAttributes($entity)->willReturn($expectedAttributes);
+
+        $valuesResolver->resolveEligibleValues(['sku' => $sku, 'name' => $name, 'color' => $color])
+            ->willReturn([
+                [
+                    'attribute' => 'sku',
+                    'type' => 'pim_catalog_identifier',
+                    'locale' => null,
+                    'scope' => null
+                ],
+                [
+                    'attribute' => 'name',
+                    'type' => 'pim_catalog_text',
+                    'locale' => 'fr_FR',
+                    'scope' => null
+                ],
+                [
+                    'attribute' => 'name',
+                    'type' => 'pim_catalog_text',
+                    'locale' => 'en_US',
+                    'scope' => null
+                ],
+                [
+                    'attribute' => 'color',
+                    'type' => 'pim_catalog_simpleselect',
+                    'locale' => null,
+                    'scope' => null
+                ]
+            ]);
+
+        // get existing values
+        $skuValue->getAttribute()->willReturn($sku);
+        $skuValue->getLocale()->willReturn(null);
+        $skuValue->getScope()->willReturn(null);
+
+        $colorValue->getAttribute()->willReturn($color);
+        $colorValue->getLocale()->willReturn(null);
+        $colorValue->getScope()->willReturn(null);
+
+        $entity->getValues()->willReturn([$skuValue, $colorValue]);
+
+        $entityWithValuesBuilder->addOrReplaceValue(Argument::cetera())->shouldBeCalledTimes(2);
+
+        $this->fillMissingValues($entity);
+    }
+
+    function it_fills_missing_product_values_from_attribute_set_on_new_entity_with_family_variant_without_parent(
+        $attributesProvider,
+        $valuesResolver,
+        $entityWithValuesBuilder,
+        ProductModelInterface $entity,
+        AttributeInterface $name
+    ) {
+        $name->getCode()->willReturn('name');
+        $name->getType()->willReturn('pim_catalog_text');
+        $name->isLocalizable()->willReturn(true);
+        $name->isScopable()->willReturn(false);
+
+        $expectedAttributes = [$name];
+
+        $entity->getParent()->willReturn(null);
+        $attributesProvider->getAttributes($entity)->willReturn($expectedAttributes);
+
+        $valuesResolver->resolveEligibleValues(['name' => $name])
+            ->willReturn([
+                [
+                    'attribute' => 'name',
+                    'type' => 'pim_catalog_text',
+                    'locale' => 'fr_FR',
+                    'scope' => null
+                ],
+                [
+                    'attribute' => 'name',
+                    'type' => 'pim_catalog_text',
+                    'locale' => 'en_US',
+                    'scope' => null
+                ]
+            ]);
+
+        $entity->getValues()->willReturn([]);
+        $entityWithValuesBuilder->addOrReplaceValue(Argument::cetera())->shouldBeCalledTimes(2);
+
+        $this->fillMissingValues($entity);
+    }
+
+    function it_fills_nothing_if_the_entity_with_family_variant_already_has_all_its_values(
+        $attributesProvider,
+        $valuesResolver,
+        $entityWithValuesBuilder,
+        ProductModelInterface $entity,
+        ProductModelInterface $parentEntity,
+        AttributeInterface $name,
+        AttributeInterface $color,
+        AttributeInterface $sku,
+        ValueInterface $skuValue,
+        ValueInterface $nameFRValue,
+        ValueInterface $nameENValue,
+        ValueInterface $colorValue
+    ) {
+        $sku->getCode()->willReturn('sku');
+        $sku->getType()->willReturn('pim_catalog_identifier');
+        $sku->isLocalizable()->willReturn(false);
+        $sku->isScopable()->willReturn(false);
+
+        $name->getCode()->willReturn('name');
+        $name->getType()->willReturn('pim_catalog_text');
+        $name->isLocalizable()->willReturn(true);
+        $name->isScopable()->willReturn(false);
+
+        $color->getCode()->willReturn('color');
+        $color->getType()->willReturn('pim_catalog_simpleselect');
+        $color->isLocalizable()->willReturn(false);
+        $color->isScopable()->willReturn(false);
+
+        $expectedParentAttributes = [$name];
+        $expectedAttributes = [$sku, $color];
+
+        $parentEntity->getParent()->willReturn(null);
+        $entity->getParent()->willReturn($parentEntity);
+
+        $attributesProvider->getAttributes($parentEntity)->willReturn($expectedParentAttributes);
+        $attributesProvider->getAttributes($entity)->willReturn($expectedAttributes);
+
+        $valuesResolver->resolveEligibleValues(['sku' => $sku, 'name' => $name, 'color' => $color])
+            ->willReturn([
+                [
+                    'attribute' => 'sku',
+                    'type' => 'pim_catalog_identifier',
+                    'locale' => null,
+                    'scope' => null
+                ],
+                [
+                    'attribute' => 'name',
+                    'type' => 'pim_catalog_text',
+                    'locale' => 'fr_FR',
+                    'scope' => null
+                ],
+                [
+                    'attribute' => 'name',
+                    'type' => 'pim_catalog_text',
+                    'locale' => 'en_US',
+                    'scope' => null
+                ],
+                [
+                    'attribute' => 'color',
+                    'type' => 'pim_catalog_simpleselect',
+                    'locale' => null,
+                    'scope' => null
+                ]
+            ]);
+
+        // get existing values
+        $skuValue->getAttribute()->willReturn($sku);
+        $skuValue->getLocale()->willReturn(null);
+        $skuValue->getScope()->willReturn(null);
+
+        $nameFRValue->getAttribute()->willReturn($name);
+        $nameFRValue->getLocale()->willReturn('fr_FR');
+        $nameFRValue->getScope()->willReturn(null);
+
+        $nameENValue->getAttribute()->willReturn($name);
+        $nameENValue->getLocale()->willReturn('en_US');
+        $nameENValue->getScope()->willReturn(null);
+
+        $colorValue->getAttribute()->willReturn($color);
+        $colorValue->getLocale()->willReturn(null);
+        $colorValue->getScope()->willReturn(null);
+
+        $entity->getValues()->willReturn([$skuValue, $nameFRValue, $nameENValue, $colorValue]);
+
+        $entityWithValuesBuilder->addOrReplaceValue(Argument::cetera())->shouldNotBeCalled();
+
+        $this->fillMissingValues($entity);
+    }
+}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This PR fills in missing attributes when normalizing a product model.
On the PEF, it locks (read only) the attributes coming for parents.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Y
| Added Behats                      | Y
| Added integration tests           | N
| Changelog updated                 | N
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo