### PR TITLE
PIM-6338: extract "fill missing attributes" logic

### DIFF
--- a/CHANGELOG-1.8.md
+++ b/CHANGELOG-1.8.md
@@ -315,12 +315,20 @@
 - Change the constructor of `Pim\Component\Connector\ArrayConverter\FlatToStandard\Product\AttributeColumnsResolver` to replace `Pim\Component\Catalog\Manager\AttributeValuesResolver` by `Pim\Component\Catalog\Manager\AttributeValuesResolverInterface` 
 - Change the constructor of `Pim\Component\Catalog\Builder\EntityWithValuesBuilder` to replace `Pim\Component\Catalog\Manager\AttributeValuesResolver` by `Pim\Component\Catalog\Manager\AttributeValuesResolverInterface` 
 - Change the constructor of `Pim\Bundle\ApiBundle\Controller\LocaleController` to add `Pim\Bundle\ApiBundle\Checker\QueryParametersCheckerInterface`
+- Change the constructor of `Pim\Bundle\EnrichBundle\Normalizer\ProductNormalizer` to add `Pim\Component\Catalog\ValuesFiller\EntityWithFamilyValuesFillerInterface`
+- Change the constructor of `Pim\Component\Catalog\Builder\ProductBuilder` to remove `Pim\Component\Catalog\Repository\CurrencyRepositoryInterface` and `Pim\Component\Catalog\Factory\ValueFactory`
+- Change the constructor of `Pim\Component\Catalog\Builder\ProductTemplateBuilder` to add `Pim\Component\Catalog\ValuesFiller\EntityWithFamilyValuesFillerInterface`
+- Change the constructor of `Pim\Component\Connector\Processor\Normalization\ProductProcessor` to remove `Pim\Component\Catalog\Builder\ProductBuilderInterface` and add `Pim\Component\Catalog\ValuesFiller\EntityWithFamilyValuesFillerInterface`
+- Change the constructor of `Pim\Bundle\EnrichBundle\Connector\Processor\QuickExport\ProductProcessor` to replace `Pim\Component\Catalog\Builder\ProductBuilder` by `Pim\Component\Catalog\ValuesFiller\EntityWithFamilyValuesFillerInterface`
+- Change the constructor of `Pim\Bundle\EnrichBundle\Controller\ProductController` to add `Pim\Component\Catalog\ValuesFiller\EntityWithFamilyValuesFillerInterface`
 - Change the constructor of `Akeneo\Bundle\BatchBundle\Launcher\SimpleJobLauncher` to add `Akeneo\Component\Batch\Job\JobParametersValidator`
 - Change the constructor of `Pim\Bundle\ConnectorBundle\Launcher\AuthenticatedJobLauncher` to add `Akeneo\Component\Batch\Job\JobParametersValidator`
 
 ### Methods
 
 - Change `Pim\Component\Catalog\Model\FamilyInterface` to add `setAttributeAsImage` and `getAttributeAsImage`
+- Remove method `addMissingProductValues` of `Pim\Component\Catalog\Builder\ProductBuilderInterface` (this method is now handled by `Pim\Component\Catalog\ValuesFiller\ProductValuesFiller::fillMissingValues`)
+- Remove method `getFamily` of `Pim\Component\Catalog\Model\ProductInterface`
 
 ### Type hint
 

--- a/src/Pim/Bundle/CatalogBundle/DependencyInjection/PimCatalogExtension.php
+++ b/src/Pim/Bundle/CatalogBundle/DependencyInjection/PimCatalogExtension.php
@@ -57,6 +57,7 @@ class PimCatalogExtension extends Extension
         $loader->load('savers.yml');
         $loader->load('updaters.yml');
         $loader->load('validators.yml');
+        $loader->load('values_fillers.yml');
         $loader->load('versions.yml');
         $loader->load('serializers.yml');
         $loader->load('serializers_indexing.yml');

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/builders.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/builders.yml
@@ -10,11 +10,9 @@ services:
         arguments:
             - '@pim_catalog.repository.attribute'
             - '@pim_catalog.repository.family'
-            - '@pim_catalog.repository.currency'
             - '@pim_catalog.repository.association_type'
             - '@event_dispatcher'
             - '@pim_catalog.resolver.attribute_values'
-            - '@pim_catalog.factory.value'
             - '@pim_catalog.builder.entity_with_values'
             - {'product': '%pim_catalog.entity.product.class%', 'association': '%pim_catalog.entity.association.class%'}
 
@@ -23,11 +21,9 @@ services:
         arguments:
             - '@pim_catalog.repository.attribute'
             - '@pim_catalog.repository.family'
-            - '@pim_catalog.repository.currency'
             - '@pim_catalog.repository.association_type'
             - '@event_dispatcher'
             - '@pim_catalog.resolver.attribute_values'
-            - '@pim_catalog.factory.value'
             - '@pim_catalog.builder.entity_with_values'
             - {'product': '%pim_catalog.entity.variant_product.class%', 'association': '%pim_catalog.entity.association.class%'}
 
@@ -41,6 +37,7 @@ services:
         class: '%pim_catalog.builder.product_template.class%'
         arguments:
             - '@pim_catalog.builder.product'
+            - '@pim_catalog.values_filler.product'
             - '%pim_catalog.entity.product_template.class%'
 
     pim_catalog.builder.choices:

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/values_fillers.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/values_fillers.yml
@@ -1,0 +1,10 @@
+parameters:
+    pim_catalog.values_filler.product.class: Pim\Component\Catalog\ValuesFiller\ProductValuesFiller
+
+services:
+    pim_catalog.values_filler.product:
+        class: '%pim_catalog.values_filler.product.class%'
+        arguments:
+            - '@pim_catalog.builder.product'
+            - '@pim_catalog.resolver.attribute_values'
+            - '@pim_catalog.repository.currency'

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/processors.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/processors.yml
@@ -233,9 +233,9 @@ services:
             - '@pim_catalog.normalizer.standard.product'
             - '@pim_catalog.repository.channel'
             - '@pim_catalog.repository.attribute'
-            - '@pim_catalog.builder.product'
             - '@akeneo_storage_utils.doctrine.object_detacher'
             - '@pim_connector.processor.bulk_media_fetcher'
+            - '@pim_catalog.values_filler.product'
 
     pim_connector.processor.normalization.variant_group:
         class: '%pim_connector.processor.normalization.variant_group.class%'

--- a/src/Pim/Bundle/EnrichBundle/Connector/Processor/QuickExport/ProductProcessor.php
+++ b/src/Pim/Bundle/EnrichBundle/Connector/Processor/QuickExport/ProductProcessor.php
@@ -9,10 +9,10 @@ use Akeneo\Component\Batch\Model\StepExecution;
 use Akeneo\Component\StorageUtils\Detacher\ObjectDetacherInterface;
 use Pim\Bundle\EnrichBundle\Connector\Processor\AbstractProcessor;
 use Pim\Component\Catalog\AttributeTypes;
-use Pim\Component\Catalog\Builder\ProductBuilderInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
 use Pim\Component\Catalog\Repository\ChannelRepositoryInterface;
+use Pim\Component\Catalog\ValuesFiller\EntityWithFamilyValuesFillerInterface;
 use Pim\Component\Connector\Processor\BulkMediaFetcher;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
@@ -39,8 +39,8 @@ class ProductProcessor extends AbstractProcessor
     /** @var AttributeRepositoryInterface */
     protected $attributeRepository;
 
-    /** @var ProductBuilderInterface */
-    protected $productBuilder;
+    /** @var EntityWithFamilyValuesFillerInterface */
+    protected $valuesFiller;
 
     /** @var ObjectDetacherInterface */
     protected $detacher;
@@ -55,20 +55,20 @@ class ProductProcessor extends AbstractProcessor
     protected $mediaFetcher;
 
     /**
-     * @param NormalizerInterface          $normalizer
-     * @param ChannelRepositoryInterface   $channelRepository
-     * @param AttributeRepositoryInterface $attributeRepository
-     * @param ProductBuilderInterface      $productBuilder
-     * @param ObjectDetacherInterface      $detacher
-     * @param UserProviderInterface        $userProvider
-     * @param TokenStorageInterface        $tokenStorage
-     * @param BulkMediaFetcher             $mediaFetcher
+     * @param NormalizerInterface                   $normalizer
+     * @param ChannelRepositoryInterface            $channelRepository
+     * @param AttributeRepositoryInterface          $attributeRepository
+     * @param EntityWithFamilyValuesFillerInterface $valuesFiller
+     * @param ObjectDetacherInterface               $detacher
+     * @param UserProviderInterface                 $userProvider
+     * @param TokenStorageInterface                 $tokenStorage
+     * @param BulkMediaFetcher                      $mediaFetcher
      */
     public function __construct(
         NormalizerInterface $normalizer,
         ChannelRepositoryInterface $channelRepository,
         AttributeRepositoryInterface $attributeRepository,
-        ProductBuilderInterface $productBuilder,
+        EntityWithFamilyValuesFillerInterface $valuesFiller,
         ObjectDetacherInterface $detacher,
         UserProviderInterface $userProvider,
         TokenStorageInterface $tokenStorage,
@@ -77,7 +77,7 @@ class ProductProcessor extends AbstractProcessor
         $this->normalizer = $normalizer;
         $this->channelRepository = $channelRepository;
         $this->attributeRepository = $attributeRepository;
-        $this->productBuilder = $productBuilder;
+        $this->valuesFiller = $valuesFiller;
         $this->detacher = $detacher;
         $this->userProvider = $userProvider;
         $this->tokenStorage = $tokenStorage;
@@ -91,7 +91,7 @@ class ProductProcessor extends AbstractProcessor
     {
         $this->initSecurityContext($this->stepExecution);
 
-        $this->productBuilder->addMissingProductValues($product);
+        $this->valuesFiller->fillMissingValues($product);
 
         $parameters = $this->stepExecution->getJobParameters();
         $normalizerContext = $this->getNormalizerContext($parameters);

--- a/src/Pim/Bundle/EnrichBundle/Controller/ProductController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/ProductController.php
@@ -14,6 +14,7 @@ use Pim\Component\Catalog\Model\CategoryInterface;
 use Pim\Component\Catalog\Model\LocaleInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Repository\ProductRepositoryInterface;
+use Pim\Component\Catalog\ValuesFiller\EntityWithFamilyValuesFillerInterface;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -77,19 +78,23 @@ class ProductController
     /** @var CategoryRepositoryInterface */
     protected $categoryRepository;
 
+    /** @var EntityWithFamilyValuesFillerInterface */
+    protected $valuesFiller;
+
     /**
-     * @param RouterInterface             $router
-     * @param TokenStorageInterface       $tokenStorage
-     * @param FormFactoryInterface        $formFactory
-     * @param TranslatorInterface         $translator
-     * @param ProductRepositoryInterface  $productRepository
-     * @param CategoryRepositoryInterface $categoryRepository
-     * @param UserContext                 $userContext
-     * @param SecurityFacade              $securityFacade
-     * @param SaverInterface              $productSaver
-     * @param SequentialEditManager       $seqEditManager
-     * @param ProductBuilderInterface     $productBuilder
-     * @param string                      $categoryClass
+     * @param RouterInterface                       $router
+     * @param TokenStorageInterface                 $tokenStorage
+     * @param FormFactoryInterface                  $formFactory
+     * @param TranslatorInterface                   $translator
+     * @param ProductRepositoryInterface            $productRepository
+     * @param CategoryRepositoryInterface           $categoryRepository
+     * @param UserContext                           $userContext
+     * @param SecurityFacade                        $securityFacade
+     * @param SaverInterface                        $productSaver
+     * @param SequentialEditManager                 $seqEditManager
+     * @param ProductBuilderInterface               $productBuilder
+     * @param EntityWithFamilyValuesFillerInterface $valuesFiller
+     * @param string                                $categoryClass
      */
     public function __construct(
         RouterInterface $router,
@@ -103,6 +108,7 @@ class ProductController
         SaverInterface $productSaver,
         SequentialEditManager $seqEditManager,
         ProductBuilderInterface $productBuilder,
+        EntityWithFamilyValuesFillerInterface $valuesFiller,
         $categoryClass
     ) {
         $this->router = $router;
@@ -116,6 +122,7 @@ class ProductController
         $this->seqEditManager = $seqEditManager;
         $this->productBuilder = $productBuilder;
         $this->categoryRepository = $categoryRepository;
+        $this->valuesFiller = $valuesFiller;
         $this->categoryClass = $categoryClass;
     }
 
@@ -289,7 +296,7 @@ class ProductController
             );
         }
         // With this version of the form we need to add missing values from family
-        $this->productBuilder->addMissingProductValues($product);
+        $this->valuesFiller->fillMissingValues($product);
         $this->productBuilder->addMissingAssociations($product);
 
         return $product;

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/ProductNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/ProductNormalizer.php
@@ -16,6 +16,7 @@ use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Model\ValueInterface;
 use Pim\Component\Catalog\Repository\ChannelRepositoryInterface;
 use Pim\Component\Catalog\Repository\LocaleRepositoryInterface;
+use Pim\Component\Catalog\ValuesFiller\EntityWithFamilyValuesFillerInterface;
 use Pim\Component\Enrich\Converter\ConverterInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
@@ -82,24 +83,28 @@ class ProductNormalizer implements NormalizerInterface
     /** @var ProductBuilderInterface */
     protected $productBuilder;
 
+    /** @var EntityWithFamilyValuesFillerInterface */
+    protected $productValuesFiller;
+
     /**
-     * @param NormalizerInterface               $productNormalizer
-     * @param NormalizerInterface               $versionNormalizer
-     * @param VersionManager                    $versionManager
-     * @param LocaleRepositoryInterface         $localeRepository
-     * @param StructureVersionProviderInterface $structureVersionProvider
-     * @param FormProviderInterface             $formProvider
-     * @param AttributeConverterInterface       $localizedConverter
-     * @param ConverterInterface                $productValueConverter
-     * @param ObjectManager                     $productManager
-     * @param CompletenessManager               $completenessManager
-     * @param ChannelRepositoryInterface        $channelRepository
-     * @param CollectionFilterInterface         $collectionFilter
-     * @param NormalizerInterface               $completenessCollectionNormalizer
-     * @param UserContext                       $userContext
-     * @param CompletenessCalculatorInterface   $completenessCalculator
-     * @param FileNormalizer                    $fileNormalizer
-     * @param ProductBuilderInterface           $productBuilder
+     * @param NormalizerInterface                   $productNormalizer
+     * @param NormalizerInterface                   $versionNormalizer
+     * @param VersionManager                        $versionManager
+     * @param LocaleRepositoryInterface             $localeRepository
+     * @param StructureVersionProviderInterface     $structureVersionProvider
+     * @param FormProviderInterface                 $formProvider
+     * @param AttributeConverterInterface           $localizedConverter
+     * @param ConverterInterface                    $productValueConverter
+     * @param ObjectManager                         $productManager
+     * @param CompletenessManager                   $completenessManager
+     * @param ChannelRepositoryInterface            $channelRepository
+     * @param CollectionFilterInterface             $collectionFilter
+     * @param NormalizerInterface                   $completenessCollectionNormalizer
+     * @param UserContext                           $userContext
+     * @param CompletenessCalculatorInterface       $completenessCalculator
+     * @param FileNormalizer                        $fileNormalizer
+     * @param ProductBuilderInterface               $productBuilder
+     * @param EntityWithFamilyValuesFillerInterface $productValuesFiller
      */
     public function __construct(
         NormalizerInterface $productNormalizer,
@@ -118,7 +123,8 @@ class ProductNormalizer implements NormalizerInterface
         UserContext $userContext,
         CompletenessCalculatorInterface $completenessCalculator,
         FileNormalizer $fileNormalizer,
-        ProductBuilderInterface $productBuilder
+        ProductBuilderInterface $productBuilder,
+        EntityWithFamilyValuesFillerInterface $productValuesFiller
     ) {
         $this->productNormalizer                = $productNormalizer;
         $this->versionNormalizer                = $versionNormalizer;
@@ -137,6 +143,7 @@ class ProductNormalizer implements NormalizerInterface
         $this->completenessCalculator           = $completenessCalculator;
         $this->fileNormalizer                   = $fileNormalizer;
         $this->productBuilder                   = $productBuilder;
+        $this->productValuesFiller = $productValuesFiller;
     }
 
     /**
@@ -145,7 +152,7 @@ class ProductNormalizer implements NormalizerInterface
     public function normalize($product, $format = null, array $context = [])
     {
         $this->productBuilder->addMissingAssociations($product);
-        $this->productBuilder->addMissingProductValues($product);
+        $this->productValuesFiller->fillMissingValues($product);
         $normalizedProduct = $this->productNormalizer->normalize($product, 'standard', $context);
         $normalizedProduct['values'] = $this->localizedConverter->convertToLocalizedFormats(
             $normalizedProduct['values'],

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/connector/processors.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/connector/processors.yml
@@ -56,7 +56,7 @@ services:
             - '@pim_catalog.normalizer.standard.product'
             - '@pim_catalog.repository.channel'
             - '@pim_catalog.repository.attribute'
-            - '@pim_catalog.builder.product'
+            - '@pim_catalog.values_filler.product'
             - '@akeneo_storage_utils.doctrine.object_detacher'
             - '@pim_user.provider.user'
             - '@security.token_storage'

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/controllers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/controllers.yml
@@ -97,6 +97,7 @@ services:
             - '@pim_catalog.saver.product'
             - '@pim_enrich.manager.sequential_edit'
             - '@pim_catalog.builder.product'
+            - '@pim_catalog.values_filler.product'
             - '%pim_catalog.entity.category.class%'
 
     pim_enrich.controller.association:

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/normalizers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/normalizers.yml
@@ -64,6 +64,7 @@ services:
             - '@pim_catalog.completeness.calculator'
             - '@pim_enrich.normalizer.file'
             - '@pim_catalog.builder.product'
+            - '@pim_catalog.values_filler.product'
         tags:
             - { name: pim_internal_api_serializer.normalizer }
 

--- a/src/Pim/Bundle/EnrichBundle/spec/Normalizer/ProductNormalizerSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Normalizer/ProductNormalizerSpec.php
@@ -23,6 +23,7 @@ use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Model\ValueInterface;
 use Pim\Component\Catalog\Repository\ChannelRepositoryInterface;
 use Pim\Component\Catalog\Repository\LocaleRepositoryInterface;
+use Pim\Component\Catalog\ValuesFiller\EntityWithFamilyValuesFillerInterface;
 use Pim\Component\Enrich\Converter\ConverterInterface;
 use Prophecy\Argument;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
@@ -46,7 +47,8 @@ class ProductNormalizerSpec extends ObjectBehavior
         UserContext $userContext,
         CompletenessCalculatorInterface $completenessCalculator,
         FileNormalizer $fileNormalizer,
-        ProductBuilderInterface $productBuilder
+        ProductBuilderInterface $productBuilder,
+        EntityWithFamilyValuesFillerInterface $productValuesFiller
     ) {
         $this->beConstructedWith(
             $productNormalizer,
@@ -65,7 +67,8 @@ class ProductNormalizerSpec extends ObjectBehavior
             $userContext,
             $completenessCalculator,
             $fileNormalizer,
-            $productBuilder
+            $productBuilder,
+            $productValuesFiller
         );
     }
 
@@ -88,6 +91,7 @@ class ProductNormalizerSpec extends ObjectBehavior
         $collectionFilter,
         $fileNormalizer,
         $productBuilder,
+        $productValuesFiller,
         ProductInterface $mug,
         AssociationInterface $upsell,
         AssociationTypeInterface $groupType,
@@ -173,7 +177,7 @@ class ProductNormalizerSpec extends ObjectBehavior
         $formProvider->getForm($mug)->willReturn('product-edit-form');
 
         $productBuilder->addMissingAssociations($mug)->shouldBeCalled();
-        $productBuilder->addMissingProductValues($mug)->shouldBeCalled();
+        $productValuesFiller->fillMissingValues($mug)->shouldBeCalled();
 
         $this->normalize($mug, 'internal_api', $options)->shouldReturn(
             [

--- a/src/Pim/Component/Catalog/Builder/ProductBuilder.php
+++ b/src/Pim/Component/Catalog/Builder/ProductBuilder.php
@@ -3,8 +3,6 @@
 namespace Pim\Component\Catalog\Builder;
 
 use Pim\Component\Catalog\AttributeTypes;
-use Pim\Component\Catalog\Factory\ValueFactory;
-use Pim\Component\Catalog\Manager\AttributeValuesResolver;
 use Pim\Component\Catalog\Manager\AttributeValuesResolverInterface;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\EntityWithValuesInterface;
@@ -12,7 +10,6 @@ use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\ProductEvents;
 use Pim\Component\Catalog\Repository\AssociationTypeRepositoryInterface;
 use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
-use Pim\Component\Catalog\Repository\CurrencyRepositoryInterface;
 use Pim\Component\Catalog\Repository\FamilyRepositoryInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
@@ -35,9 +32,6 @@ class ProductBuilder implements ProductBuilderInterface
     /** @var FamilyRepositoryInterface */
     protected $familyRepository;
 
-    /** @var CurrencyRepositoryInterface */
-    protected $currencyRepository;
-
     /** @var AssociationTypeRepositoryInterface */
     protected $assocTypeRepository;
 
@@ -53,40 +47,29 @@ class ProductBuilder implements ProductBuilderInterface
     /** @var string */
     protected $associationClass;
 
-    /** @var ValueFactory */
-    protected $productValueFactory;
-
     /**
-     * Constructor
-     *
      * @param AttributeRepositoryInterface       $attributeRepository Attribute repository
      * @param FamilyRepositoryInterface          $familyRepository    Family repository
-     * @param CurrencyRepositoryInterface        $currencyRepository  Currency repository
      * @param AssociationTypeRepositoryInterface $assocTypeRepository Association type repository
      * @param EventDispatcherInterface           $eventDispatcher     Event dispatcher
      * @param AttributeValuesResolverInterface   $valuesResolver      Attributes values resolver
-     * @param ValueFactory                       $productValueFactory Product value factory
      * @param EntityWithValuesBuilderInterface   $entityWithValuesBuilder
      * @param array                              $classes             Model classes
      */
     public function __construct(
         AttributeRepositoryInterface $attributeRepository,
         FamilyRepositoryInterface $familyRepository,
-        CurrencyRepositoryInterface $currencyRepository,
         AssociationTypeRepositoryInterface $assocTypeRepository,
         EventDispatcherInterface $eventDispatcher,
         AttributeValuesResolverInterface $valuesResolver,
-        ValueFactory $productValueFactory,
         EntityWithValuesBuilderInterface $entityWithValuesBuilder,
         array $classes
     ) {
         $this->attributeRepository     = $attributeRepository;
         $this->familyRepository        = $familyRepository;
-        $this->currencyRepository      = $currencyRepository;
         $this->assocTypeRepository     = $assocTypeRepository;
         $this->eventDispatcher         = $eventDispatcher;
         $this->valuesResolver          = $valuesResolver;
-        $this->productValueFactory     = $productValueFactory;
         $this->productClass            = $classes['product'];
         $this->associationClass        = $classes['association'];
         $this->entityWithValuesBuilder = $entityWithValuesBuilder;
@@ -119,37 +102,6 @@ class ProductBuilder implements ProductBuilderInterface
     /**
      * {@inheritdoc}
      */
-    public function addMissingProductValues(ProductInterface $product, array $channels = null, array $locales = null)
-    {
-        $attributes = $this->getExpectedAttributes($product);
-        $requiredValues = $this->valuesResolver->resolveEligibleValues($attributes, $channels, $locales);
-        $existingValues = $this->getExistingValues($product);
-
-        $missingValues = array_filter(
-            $requiredValues,
-            function ($value) use ($existingValues) {
-                return !in_array($value, $existingValues);
-            }
-        );
-
-        foreach ($missingValues as $value) {
-            $this->addOrReplaceValue(
-                $product,
-                $attributes[$value['attribute']],
-                $value['locale'],
-                $value['scope'],
-                null
-            );
-        }
-
-        $this->addMissingPricesToProduct($product);
-
-        return $this;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function addMissingAssociations(ProductInterface $product)
     {
         $missingAssocTypes = $this->assocTypeRepository->findMissingAssociationTypes($product);
@@ -162,53 +114,6 @@ class ProductBuilder implements ProductBuilderInterface
         }
 
         return $this;
-    }
-
-    /**
-     * Get expected attributes for the product
-     *
-     * @param ProductInterface $product
-     *
-     * @return AttributeInterface[]
-     */
-    protected function getExpectedAttributes(ProductInterface $product)
-    {
-        $attributes = [];
-        $productAttributes = $product->getAttributes();
-        foreach ($productAttributes as $attribute) {
-            $attributes[$attribute->getCode()] = $attribute;
-        }
-
-        if ($family = $product->getFamily()) {
-            foreach ($family->getAttributes() as $attribute) {
-                $attributes[$attribute->getCode()] = $attribute;
-            }
-        }
-
-        return $attributes;
-    }
-
-    /**
-     * Returns an array of product values identifiers
-     *
-     * @param ProductInterface $product
-     *
-     * @return array:array
-     */
-    protected function getExistingValues(ProductInterface $product)
-    {
-        $existingValues = [];
-        $values = $product->getValues();
-        foreach ($values as $value) {
-            $existingValues[] = [
-                'attribute' => $value->getAttribute()->getCode(),
-                'type'      => $value->getAttribute()->getType(),
-                'locale'    => $value->getLocale(),
-                'scope'     => $value->getScope()
-            ];
-        }
-
-        return $existingValues;
     }
 
     /**
@@ -233,37 +138,6 @@ class ProductBuilder implements ProductBuilderInterface
     }
 
     /**
-     * Add missing prices (a price per currency)
-     *
-     * @param ProductInterface $product the product
-     */
-    protected function addMissingPricesToProduct(ProductInterface $product)
-    {
-        $activeCurrencyCodes = $this->currencyRepository->getActivatedCurrencyCodes();
-
-        foreach ($product->getValues() as $value) {
-            $attribute = $value->getAttribute();
-            if (AttributeTypes::PRICE_COLLECTION === $attribute->getType()) {
-                $prices = [];
-
-                foreach ($value->getData() as $price) {
-                    if (in_array($price->getCurrency(), $activeCurrencyCodes)) {
-                        $prices[] = ['amount' => $price->getData(), 'currency' => $price->getCurrency()];
-                    }
-                }
-
-                foreach ($activeCurrencyCodes as $currencyCode) {
-                    if (null === $value->getPrice($currencyCode)) {
-                        $prices[] = ['amount' => null, 'currency' => $currencyCode];
-                    }
-                }
-
-                $this->addOrReplaceValue($product, $attribute, $value->getLocale(), $value->getScope(), $prices);
-            }
-        }
-    }
-
-    /**
      * Set product values to "false" by default for every boolean attributes in the product's family.
      *
      * This workaround is due to the UI that does not manage null values for boolean attributes, only false or true.
@@ -274,7 +148,7 @@ class ProductBuilder implements ProductBuilderInterface
      *
      * @param ProductInterface $product
      */
-    protected function addBooleanToProduct(ProductInterface $product)
+    private function addBooleanToProduct(ProductInterface $product)
     {
         $family = $product->getFamily();
 

--- a/src/Pim/Component/Catalog/Builder/ProductBuilderInterface.php
+++ b/src/Pim/Component/Catalog/Builder/ProductBuilderInterface.php
@@ -28,20 +28,6 @@ interface ProductBuilderInterface extends EntityWithValuesBuilderInterface
     public function createProduct($identifier = null, $familyCode = null);
 
     /**
-     * Add empty values for family and product-specific attributes for relevant scopes and locales
-     *
-     * It makes sure that if an attribute is localizable/scopable, then all values in the required locales/channels
-     * exist. If the attribute is not scopable or localizable, makes sure that a single value exists.
-     *
-     * @param ProductInterface   $product
-     * @param ChannelInterface[] $channels
-     * @param LocaleInterface[]  $locales
-     *
-     * @return EntityWithValuesBuilderInterface
-     */
-    public function addMissingProductValues(ProductInterface $product, array $channels = null, array $locales = null);
-
-    /**
      * Add empty associations for each association types when they don't exist yet
      *
      * @param ProductInterface $product

--- a/src/Pim/Component/Catalog/Builder/ProductTemplateBuilder.php
+++ b/src/Pim/Component/Catalog/Builder/ProductTemplateBuilder.php
@@ -5,6 +5,7 @@ namespace Pim\Component\Catalog\Builder;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\ProductTemplateInterface;
 use Pim\Component\Catalog\Model\ValueCollectionInterface;
+use Pim\Component\Catalog\ValuesFiller\EntityWithFamilyValuesFillerInterface;
 
 /**
  * Product template builder, allows to create new product template and update them
@@ -18,16 +19,24 @@ class ProductTemplateBuilder implements ProductTemplateBuilderInterface
     /** @var ProductBuilderInterface */
     protected $productBuilder;
 
+    /** @var EntityWithFamilyValuesFillerInterface */
+    protected $productValuesFiller;
+
     /** @var string */
     protected $productTemplateClass;
 
     /**
-     * @param ProductBuilderInterface $productBuilder
-     * @param string                  $productTemplateClass
+     * @param ProductBuilderInterface               $productBuilder
+     * @param EntityWithFamilyValuesFillerInterface $productValuesFiller
+     * @param string                                $productTemplateClass
      */
-    public function __construct(ProductBuilderInterface $productBuilder, $productTemplateClass)
-    {
+    public function __construct(
+        ProductBuilderInterface $productBuilder,
+        EntityWithFamilyValuesFillerInterface $productValuesFiller,
+        $productTemplateClass
+    ) {
         $this->productBuilder = $productBuilder;
+        $this->productValuesFiller = $productValuesFiller;
         $this->productTemplateClass = $productTemplateClass;
     }
 
@@ -75,7 +84,7 @@ class ProductTemplateBuilder implements ProductTemplateBuilderInterface
             $this->productBuilder->addAttribute($product, $attribute);
         }
 
-        $this->productBuilder->addMissingProductValues($product);
+        $this->productValuesFiller->fillMissingValues($product);
 
         return $product->getValues();
     }

--- a/src/Pim/Component/Catalog/Model/AbstractProduct.php
+++ b/src/Pim/Component/Catalog/Model/AbstractProduct.php
@@ -250,7 +250,7 @@ abstract class AbstractProduct implements ProductInterface
     /**
      * {@inheritdoc}
      */
-    public function getFamily()
+    public function getFamily(): ?FamilyInterface
     {
         return $this->family;
     }

--- a/src/Pim/Component/Catalog/Model/EntityWithFamilyInterface.php
+++ b/src/Pim/Component/Catalog/Model/EntityWithFamilyInterface.php
@@ -3,6 +3,13 @@
 namespace Pim\Component\Catalog\Model;
 
 /**
+ * Entity with a family.
+ *
+ * Having a family means having a structure based on family attributes.
+ * For example, product attributes are all coming from its family.
+ * Product model attributes come from an attribute set, which is a sub-part of family attributes.
+ * The same goes for variant products.
+ *
  * @author    Adrien Pétremann <adrien.petremann@akeneo.com>
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)

--- a/src/Pim/Component/Catalog/Model/EntityWithFamilyInterface.php
+++ b/src/Pim/Component/Catalog/Model/EntityWithFamilyInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Pim\Component\Catalog\Model;
+
+/**
+ * @author    Adrien Pétremann <adrien.petremann@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface EntityWithFamilyInterface extends EntityWithValuesInterface
+{
+    /**
+     * @return null|FamilyInterface
+     */
+    public function getFamily(): ?FamilyInterface;
+}

--- a/src/Pim/Component/Catalog/Model/EntityWithFamilyVariantInterface.php
+++ b/src/Pim/Component/Catalog/Model/EntityWithFamilyVariantInterface.php
@@ -10,7 +10,7 @@ namespace Pim\Component\Catalog\Model;
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-interface EntityWithFamilyVariantInterface extends EntityWithValuesInterface
+interface EntityWithFamilyVariantInterface extends EntityWithFamilyInterface
 {
     public const ROOT_VARIATION_LEVEL = 0;
 

--- a/src/Pim/Component/Catalog/Model/ProductInterface.php
+++ b/src/Pim/Component/Catalog/Model/ProductInterface.php
@@ -25,7 +25,7 @@ interface ProductInterface extends
     CommentSubjectInterface,
     ReferableInterface,
     CategoryAwareInterface,
-    EntityWithValuesInterface
+    EntityWithFamilyInterface
 {
     /**
      * Get the ID of the product
@@ -246,13 +246,6 @@ interface ProductInterface extends
      * @return ProductInterface
      */
     public function setFamily(FamilyInterface $family = null);
-
-    /**
-     * Get family
-     *
-     * @return FamilyInterface
-     */
-    public function getFamily();
 
     /**
      * Get family id

--- a/src/Pim/Component/Catalog/Model/ProductModel.php
+++ b/src/Pim/Component/Catalog/Model/ProductModel.php
@@ -551,4 +551,12 @@ class ProductModel implements ProductModelInterface
 
         return $this->getAllValues($parent, $valueCollection);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFamily(): ?FamilyInterface
+    {
+        return null !== $this->getFamilyVariant() ? $this->getFamilyVariant()->getFamily() : null;
+    }
 }

--- a/src/Pim/Component/Catalog/ValuesFiller/EntityWithFamilyValuesFillerInterface.php
+++ b/src/Pim/Component/Catalog/ValuesFiller/EntityWithFamilyValuesFillerInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Pim\Component\Catalog\ValuesFiller;
+
+use Pim\Component\Catalog\Model\EntityWithFamilyInterface;
+
+/**
+ * @author    Adrien Pétremann <adrien.petremann@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+interface EntityWithFamilyValuesFillerInterface
+{
+    /**
+     * Add empty values for family for relevant scopes and locales
+     *
+     * It makes sure that if an attribute is localizable/scopable, then all values in the required locales/channels
+     * exist. If the attribute is not scopable or localizable, makes sure that a single value exists.
+     *
+     * @param EntityWithFamilyInterface $entity
+     */
+    public function fillMissingValues(EntityWithFamilyInterface $entity): void;
+}

--- a/src/Pim/Component/Catalog/ValuesFiller/EntityWithFamilyValuesFillerInterface.php
+++ b/src/Pim/Component/Catalog/ValuesFiller/EntityWithFamilyValuesFillerInterface.php
@@ -5,6 +5,9 @@ namespace Pim\Component\Catalog\ValuesFiller;
 use Pim\Component\Catalog\Model\EntityWithFamilyInterface;
 
 /**
+ * This service takes an EntityWithFamilyInterface, guesses the attributes it should have (depending on its family),
+ * and fills all missing values of this entity (the ones it doesn't have yet), but putting empty values for them.
+ *
  * @author    Adrien Pétremann <adrien.petremann@akeneo.com>
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)

--- a/src/Pim/Component/Catalog/ValuesFiller/ProductValuesFiller.php
+++ b/src/Pim/Component/Catalog/ValuesFiller/ProductValuesFiller.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace Pim\Component\Catalog\ValuesFiller;
+
+use Pim\Component\Catalog\AttributeTypes;
+use Pim\Component\Catalog\Builder\EntityWithValuesBuilderInterface;
+use Pim\Component\Catalog\Manager\AttributeValuesResolverInterface;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\EntityWithFamilyInterface;
+use Pim\Component\Catalog\Model\ProductInterface;
+use Pim\Component\Catalog\Repository\CurrencyRepositoryInterface;
+
+/**
+ * @author    Adrien Pétremann <adrien.petremann@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class ProductValuesFiller implements EntityWithFamilyValuesFillerInterface
+{
+    /** @var EntityWithValuesBuilderInterface */
+    private $entityWithValuesBuilder;
+
+    /** @var AttributeValuesResolverInterface */
+    private $valuesResolver;
+
+    /** @var CurrencyRepositoryInterface */
+    private $currencyRepository;
+
+    /**
+     * @param EntityWithValuesBuilderInterface $entityWithValuesBuilder
+     * @param AttributeValuesResolverInterface $valuesResolver
+     * @param CurrencyRepositoryInterface      $currencyRepository
+     */
+    public function __construct(
+        EntityWithValuesBuilderInterface $entityWithValuesBuilder,
+        AttributeValuesResolverInterface $valuesResolver,
+        CurrencyRepositoryInterface $currencyRepository
+    ) {
+        $this->entityWithValuesBuilder = $entityWithValuesBuilder;
+        $this->valuesResolver          = $valuesResolver;
+        $this->currencyRepository      = $currencyRepository;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fillMissingValues(EntityWithFamilyInterface $product): void
+    {
+        if (!$product instanceof ProductInterface) {
+            throw new \InvalidArgumentException(
+                sprintf('%s expected, %s given', ProductInterface::class, get_class($product))
+            );
+        }
+
+        $attributes = $this->getExpectedAttributes($product);
+        $requiredValues = $this->valuesResolver->resolveEligibleValues($attributes);
+        $existingValues = $this->getExistingValues($product);
+
+        $missingValues = array_filter(
+            $requiredValues,
+            function ($value) use ($existingValues) {
+                return !in_array($value, $existingValues);
+            }
+        );
+
+        foreach ($missingValues as $value) {
+            $this->entityWithValuesBuilder->addOrReplaceValue(
+                $product,
+                $attributes[$value['attribute']],
+                $value['locale'],
+                $value['scope'],
+                null
+            );
+        }
+
+        $this->addMissingPricesToProduct($product);
+    }
+
+    /**
+     * Get expected attributes for the product
+     *
+     * @param ProductInterface $product
+     *
+     * @return AttributeInterface[]
+     */
+    private function getExpectedAttributes(ProductInterface $product): array
+    {
+        $attributes = [];
+
+        // TODO: remove this when optional attributes are gone
+        $productAttributes = $product->getAttributes();
+        foreach ($productAttributes as $attribute) {
+            $attributes[$attribute->getCode()] = $attribute;
+        }
+
+        $family = $product->getFamily();
+        if (null !== $family) {
+            foreach ($family->getAttributes() as $attribute) {
+                $attributes[$attribute->getCode()] = $attribute;
+            }
+        }
+
+        return $attributes;
+    }
+
+    /**
+     * Returns an array of product values identifiers
+     *
+     * @param ProductInterface $product
+     *
+     * @return array
+     */
+    private function getExistingValues(ProductInterface $product): array
+    {
+        $existingValues = [];
+        $values = $product->getValues();
+        foreach ($values as $value) {
+            $existingValues[] = [
+                'attribute' => $value->getAttribute()->getCode(),
+                'type'      => $value->getAttribute()->getType(),
+                'locale'    => $value->getLocale(),
+                'scope'     => $value->getScope()
+            ];
+        }
+
+        return $existingValues;
+    }
+
+    /**
+     * Add missing prices (a price per currency)
+     *
+     * @param ProductInterface $product the product
+     */
+    private function addMissingPricesToProduct(ProductInterface $product): void
+    {
+        $activeCurrencyCodes = $this->currencyRepository->getActivatedCurrencyCodes();
+
+        foreach ($product->getValues() as $value) {
+            $attribute = $value->getAttribute();
+            if (AttributeTypes::PRICE_COLLECTION === $attribute->getType()) {
+                $prices = [];
+
+                foreach ($value->getData() as $price) {
+                    if (in_array($price->getCurrency(), $activeCurrencyCodes)) {
+                        $prices[] = ['amount' => $price->getData(), 'currency' => $price->getCurrency()];
+                    }
+                }
+
+                foreach ($activeCurrencyCodes as $currencyCode) {
+                    if (null === $value->getPrice($currencyCode)) {
+                        $prices[] = ['amount' => null, 'currency' => $currencyCode];
+                    }
+                }
+
+                $this->entityWithValuesBuilder->addOrReplaceValue($product, $attribute, $value->getLocale(), $value->getScope(), $prices);
+            }
+        }
+    }
+}

--- a/src/Pim/Component/Catalog/spec/Builder/EntityWithValuesBuilderSpec.php
+++ b/src/Pim/Component/Catalog/spec/Builder/EntityWithValuesBuilderSpec.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace spec\Pim\Component\Catalog\Builder;
+
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\AttributeTypes;
+use Pim\Component\Catalog\Factory\ValueFactory;
+use Pim\Component\Catalog\Manager\AttributeValuesResolverInterface;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\ProductInterface;
+use Pim\Component\Catalog\Model\ValueInterface;
+use Prophecy\Argument;
+
+class EntityWithValuesBuilderSpec extends ObjectBehavior
+{
+    public function let(
+        AttributeValuesResolverInterface $valuesResolver,
+        ValueFactory $productValueFactory
+    ) {
+        $this->beConstructedWith($valuesResolver, $productValueFactory);
+    }
+
+    function it_adds_an_empty_product_value(
+        $productValueFactory,
+        ProductInterface $product,
+        AttributeInterface $size,
+        AttributeInterface $color,
+        ValueInterface $sizeValue,
+        ValueInterface $colorValue
+    ) {
+        $size->getCode()->willReturn('size');
+        $size->getType()->willReturn(AttributeTypes::OPTION_SIMPLE_SELECT);
+        $size->isLocalizable()->willReturn(false);
+        $size->isScopable()->willReturn(false);
+
+        $color->getCode()->willReturn('color');
+        $color->getType()->willReturn(AttributeTypes::OPTION_SIMPLE_SELECT);
+        $color->isLocalizable()->willReturn(true);
+        $color->isScopable()->willReturn(true);
+
+        $product->getValue('size', null, null)->willReturn($sizeValue);
+        $product->getValue('color', 'en_US', 'ecommerce')->willReturn($colorValue);
+
+        $product->removeValue($sizeValue)->willReturn($product);
+        $product->removeValue($colorValue)->willReturn($product);
+
+        $productValueFactory->create($size, null, null, null)->willReturn($sizeValue);
+        $productValueFactory->create($color, 'ecommerce', 'en_US', null)->willReturn($colorValue);
+
+        $product->addValue($sizeValue)->willReturn($product);
+        $product->addValue($colorValue)->willReturn($product);
+
+        $this->addOrReplaceValue($product, $size, null, null, null);
+        $this->addOrReplaceValue($product, $color, 'en_US', 'ecommerce', null);
+    }
+
+    function it_adds_a_non_empty_product_value(
+        $productValueFactory,
+        ProductInterface $product,
+        AttributeInterface $size,
+        AttributeInterface $color,
+        ValueInterface $sizeValue,
+        ValueInterface $colorValue
+    ) {
+        $size->getCode()->willReturn('size');
+        $size->getType()->willReturn(AttributeTypes::OPTION_SIMPLE_SELECT);
+        $size->isLocalizable()->willReturn(false);
+        $size->isScopable()->willReturn(false);
+
+        $color->getCode()->willReturn('color');
+        $color->getType()->willReturn(AttributeTypes::OPTION_SIMPLE_SELECT);
+        $color->isLocalizable()->willReturn(true);
+        $color->isScopable()->willReturn(true);
+
+        $product->getValue('size', null, null)->willReturn($sizeValue);
+        $product->getValue('color', 'en_US', 'ecommerce')->willReturn($colorValue);
+
+        $product->removeValue($sizeValue)->willReturn($product);
+        $product->removeValue($colorValue)->willReturn($product);
+
+        $productValueFactory->create($size, null, null, null)->willReturn($sizeValue);
+        $productValueFactory->create($color, 'ecommerce', 'en_US', 'red')->willReturn($colorValue);
+
+        $product->addValue($sizeValue)->willReturn($product);
+        $product->addValue($colorValue)->willReturn($product);
+
+        $this->addOrReplaceValue($product, $size, null, null, null);
+        $this->addOrReplaceValue($product, $color, 'en_US', 'ecommerce', 'red');
+    }
+
+    function it_adds_a_product_value_if_there_was_not_a_previous_one(
+        $productValueFactory,
+        ProductInterface $product,
+        AttributeInterface $label,
+        ValueInterface $value
+    ) {
+        $label->getCode()->willReturn('label');
+        $label->getType()->willReturn(AttributeTypes::TEXT);
+        $label->isLocalizable()->willReturn(false);
+        $label->isScopable()->willReturn(false);
+
+        $product->getValue('label', null, null)->willReturn(null);
+
+        $product->removeValue(Argument::any())->shouldNotBeCalled();
+
+        $productValueFactory->create($label, null, null, 'foobar')->willReturn($value);
+
+        $product->addValue($value)->willReturn($product);
+
+        $this->addOrReplaceValue($product, $label, null, null, 'foobar');
+    }
+}

--- a/src/Pim/Component/Catalog/spec/Builder/ProductTemplateBuilderSpec.php
+++ b/src/Pim/Component/Catalog/spec/Builder/ProductTemplateBuilderSpec.php
@@ -9,13 +9,15 @@ use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Model\ProductTemplateInterface;
 use Pim\Component\Catalog\Model\ValueCollectionInterface;
 use Pim\Component\Catalog\Model\ValueInterface;
+use Pim\Component\Catalog\ValuesFiller\EntityWithFamilyValuesFillerInterface;
 
 class ProductTemplateBuilderSpec extends ObjectBehavior
 {
-    function let(ProductBuilderInterface $productBuilder)
+    function let(ProductBuilderInterface $productBuilder, EntityWithFamilyValuesFillerInterface $productValuesFiller)
     {
         $this->beConstructedWith(
             $productBuilder,
+            $productValuesFiller,
             'Pim\Bundle\CatalogBundle\Entity\ProductTemplate'
         );
     }
@@ -32,6 +34,7 @@ class ProductTemplateBuilderSpec extends ObjectBehavior
 
     function it_adds_attributes_to_a_product_template(
         $productBuilder,
+        $productValuesFiller,
         ProductTemplateInterface $template,
         AttributeInterface $name,
         ValueCollectionInterface $originalValues,
@@ -44,7 +47,7 @@ class ProductTemplateBuilderSpec extends ObjectBehavior
         $product->setValues($originalValues)->shouldBeCalled();
 
         $productBuilder->addAttribute($product, $name)->shouldBeCalled();
-        $productBuilder->addMissingProductValues($product)->shouldBeCalled();
+        $productValuesFiller->fillMissingValues($product)->shouldBeCalled();
 
         $product->getValues()->willReturn($newValues);
 

--- a/src/Pim/Component/Catalog/spec/ValuesFiller/ProductValuesFillerSpec.php
+++ b/src/Pim/Component/Catalog/spec/ValuesFiller/ProductValuesFillerSpec.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace spec\Pim\Component\Catalog\ValuesFiller;
+
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Builder\EntityWithValuesBuilderInterface;
+use Pim\Component\Catalog\Builder\ProductBuilderInterface;
+use Pim\Component\Catalog\Manager\AttributeValuesResolverInterface;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\FamilyInterface;
+use Pim\Component\Catalog\Model\ProductInterface;
+use Pim\Component\Catalog\Model\ValueInterface;
+use Pim\Component\Catalog\Repository\CurrencyRepositoryInterface;
+use Prophecy\Argument;
+
+class ProductValuesFillerSpec extends ObjectBehavior
+{
+    function let(
+        EntityWithValuesBuilderInterface $entityWithValuesBuilder,
+        AttributeValuesResolverInterface $valuesResolver,
+        CurrencyRepositoryInterface $currencyRepository
+    ) {
+        $this->beConstructedWith($entityWithValuesBuilder, $valuesResolver, $currencyRepository);
+    }
+
+    function it_fills_missing_product_values_from_family_on_new_product(
+        $valuesResolver,
+        $entityWithValuesBuilder,
+        FamilyInterface $family,
+        ProductInterface $product,
+        AttributeInterface $sku,
+        AttributeInterface $name,
+        AttributeInterface $desc,
+        ValueInterface $skuValue
+    ) {
+        $sku->getCode()->willReturn('sku');
+        $sku->getType()->willReturn('pim_catalog_identifier');
+        $sku->isLocalizable()->willReturn(false);
+        $sku->isScopable()->willReturn(false);
+
+        $name->getCode()->willReturn('name');
+        $name->getType()->willReturn('pim_catalog_text');
+        $name->isLocalizable()->willReturn(true);
+        $name->isScopable()->willReturn(false);
+
+        $desc->getCode()->willReturn('description');
+        $desc->getType()->willReturn('pim_catalog_text');
+        $desc->isLocalizable()->willReturn(true);
+        $desc->isScopable()->willReturn(true);
+
+        // get expected attributes
+        $product->getAttributes()->willReturn([$sku]);
+        $family->getAttributes()->willReturn([$sku, $name, $desc]);
+        $product->getFamily()->willReturn($family);
+
+        // get eligible values
+        $valuesResolver->resolveEligibleValues(['sku' => $sku, 'name' => $name, 'description' => $desc], null, null)
+            ->willReturn([
+                [
+                    'attribute' => 'sku',
+                    'type' => 'pim_catalog_identifier',
+                    'locale' => null,
+                    'scope' => null
+                ],
+                [
+                    'attribute' => 'name',
+                    'type' => 'pim_catalog_text',
+                    'locale' => 'fr_FR',
+                    'scope' => null
+                ],
+                [
+                    'attribute' => 'name',
+                    'type' => 'pim_catalog_text',
+                    'locale' => 'en_US',
+                    'scope' => null
+                ],
+                [
+                    'attribute' => 'description',
+                    'type' => 'pim_catalog_text',
+                    'locale' => 'en_US',
+                    'scope' => 'ecommerce'
+                ],
+                [
+                    'attribute' => 'description',
+                    'type' => 'pim_catalog_text',
+                    'locale' => 'fr_FR',
+                    'scope' => 'ecommerce'
+                ],
+                [
+                    'attribute' => 'description',
+                    'type' => 'pim_catalog_text',
+                    'locale' => 'en_US',
+                    'scope' => 'print'
+                ],
+                [
+                    'attribute' => 'description',
+                    'type' => 'pim_catalog_text',
+                    'locale' => 'fr_FR',
+                    'scope' => 'print'
+                ]
+            ]);
+
+        // get existing values
+        $skuValue->getAttribute()->willReturn($sku);
+        $skuValue->getLocale()->willReturn(null);
+        $skuValue->getScope()->willReturn(null);
+        $product->getValues()->willReturn([$skuValue]);
+
+        $entityWithValuesBuilder->addOrReplaceValue(Argument::cetera())->shouldBeCalledTimes(6);
+
+        $this->fillMissingValues($product);
+    }
+}

--- a/src/Pim/Component/Connector/spec/Processor/Normalization/ProductProcessorSpec.php
+++ b/src/Pim/Component/Connector/spec/Processor/Normalization/ProductProcessorSpec.php
@@ -19,6 +19,7 @@ use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Model\ValueCollectionInterface;
 use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
 use Pim\Component\Catalog\Repository\ChannelRepositoryInterface;
+use Pim\Component\Catalog\ValuesFiller\EntityWithFamilyValuesFillerInterface;
 use Pim\Component\Connector\Processor\BulkMediaFetcher;
 use Prophecy\Argument;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
@@ -29,18 +30,18 @@ class ProductProcessorSpec extends ObjectBehavior
         NormalizerInterface $normalizer,
         ChannelRepositoryInterface $channelRepository,
         AttributeRepositoryInterface $attributeRepository,
-        ProductBuilderInterface $productBuilder,
         ObjectDetacherInterface $detacher,
         BulkMediaFetcher $mediaFetcher,
-        StepExecution $stepExecution
+        StepExecution $stepExecution,
+        EntityWithFamilyValuesFillerInterface $productValuesFiller
     ) {
         $this->beConstructedWith(
             $normalizer,
             $channelRepository,
             $attributeRepository,
-            $productBuilder,
             $detacher,
-            $mediaFetcher
+            $mediaFetcher,
+            $productValuesFiller
         );
 
         $this->setStepExecution($stepExecution);
@@ -62,7 +63,7 @@ class ProductProcessorSpec extends ObjectBehavior
         $channelRepository,
         $stepExecution,
         $mediaFetcher,
-        $productBuilder,
+        $productValuesFiller,
         $attributeRepository,
         ChannelInterface $channel,
         LocaleInterface $locale,
@@ -86,7 +87,7 @@ class ProductProcessorSpec extends ObjectBehavior
         $channel->getCode()->willReturn('foobar');
         $channel->getLocaleCodes()->willReturn(['en_US', 'de_DE']);
 
-        $productBuilder->addMissingProductValues($product, [$channel], [$locale])->shouldBeCalled();
+        $productValuesFiller->fillMissingValues($product)->shouldBeCalled();
 
         $normalizer->normalize($product, 'standard', ['channels' => ['foobar'], 'locales' => ['en_US']])
             ->willReturn([
@@ -136,7 +137,7 @@ class ProductProcessorSpec extends ObjectBehavior
         $channelRepository,
         $stepExecution,
         $mediaFetcher,
-        $productBuilder,
+        $productValuesFiller,
         ChannelInterface $channel,
         LocaleInterface $locale,
         ProductInterface $product,
@@ -161,7 +162,7 @@ class ProductProcessorSpec extends ObjectBehavior
         $channel->getCode()->willReturn('foobar');
         $channel->getLocaleCodes()->willReturn(['en_US', 'de_DE']);
 
-        $productBuilder->addMissingProductValues($product, [$channel], [$locale])->shouldBeCalled();
+        $productValuesFiller->fillMissingValues($product)->shouldBeCalled();
         $product->getIdentifier()->willReturn('AKIS_XS');
         $product->getValues()->willReturn($valuesCollection);
 
@@ -205,7 +206,7 @@ class ProductProcessorSpec extends ObjectBehavior
         $channelRepository,
         $stepExecution,
         $mediaFetcher,
-        $productBuilder,
+        $productValuesFiller,
         ChannelInterface $channel,
         LocaleInterface $locale,
         ProductInterface $product,
@@ -230,7 +231,7 @@ class ProductProcessorSpec extends ObjectBehavior
         $channel->getCode()->willReturn('foobar');
         $channel->getLocaleCodes()->willReturn(['en_US', 'de_DE']);
 
-        $productBuilder->addMissingProductValues($product, [$channel], [$locale])->shouldBeCalled();
+        $productValuesFiller->fillMissingValues($product)->shouldBeCalled();
         $product->getIdentifier()->willReturn('AKIS_XS');
         $product->getValues()->willReturn($valuesCollection);
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This PR does 2 things:
- Create a new interface `EntityWithFamilyInterface`. It's now the common interface between **products**, **variant products** and **product models**.
- Extract the logic of filling missing attributes on a product (currently in the product builder) in a dedicated service.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Y
| Added Behats                      | N
| Added integration tests           | N
| Changelog updated                 | Y
| Review and 2 GTM                  | Todo
| Migration script                  | -
| Tech Doc                          | -