### PR TITLE
PIM-6491: Fix file extension validation on import job upload

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -1,3 +1,9 @@
+# 1.7.x
+
+## Bug Fixes
+
+- PIM-6491: Fix file extension validation on import job upload
+
 # 1.7.8 (2017-08-22)
 
 ## Bug Fixes

--- a/features/import/upload_and_import_products_with_media.feature
+++ b/features/import/upload_and_import_products_with_media.feature
@@ -4,10 +4,12 @@ Feature: Upload and import products with media
   As a product manager
   I need to be able to upload and import products along with media
 
-  Scenario: Successfully upload and import an archive
+  Background:
     Given a "footwear" catalog configuration
     And I am logged in as "Julia"
-    And I am on the "csv_footwear_product_import" import job page
+
+  Scenario: Successfully upload and import an archive
+    Given I am on the "csv_footwear_product_import" import job page
     When I upload and import the file "caterpillar_import.zip"
     And I wait for the "csv_footwear_product_import" job to finish
     Then there should be 3 products
@@ -35,8 +37,17 @@ Feature: Upload and import products with media
 
   @info https://akeneo.atlassian.net/browse/PIM-2090
   Scenario: Fail to launch an import through file upload when no file was selected
-    Given a "footwear" catalog configuration
-    And I am logged in as "Julia"
-    And I am on the "csv_footwear_product_import" import job page
+    Given I am on the "csv_footwear_product_import" import job page
     Then I should see the text "Import now"
-    Then I should not see the text "Import and launch now"
+    But I should not see the text "Import and launch now"
+
+  @info https://akeneo.atlassian.net/browse/PIM-6491
+  Scenario: Fail to launch an import through file upload when the file extension is invalid
+    Given the following CSV file to import:
+      """
+      sku;name-en_US;description-en_US-ecommerce
+      SKU-001;Donec;dictum magna. Ut tincidunt orci quis lectus. Nullam suscipit, est
+      """
+    And I am on the "xlsx_footwear_product_import" import job page
+    When I upload and import the file "%file to import%"
+    Then I should see the flash message "The file extension is not allowed (allowed extensions: xlsx, zip)."

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/JobInstanceController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/JobInstanceController.php
@@ -17,6 +17,7 @@ use Pim\Bundle\EnrichBundle\Provider\Form\FormProviderInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
@@ -318,7 +319,7 @@ class JobInstanceController
         }
 
         $file = $request->files->get('file');
-        if ($file) {
+        if (null !== $file) {
             $violations = $this->validator->validate($file);
 
             if (count($violations) > 0) {
@@ -339,7 +340,8 @@ class JobInstanceController
             $jobInstance->setRawParameters($rawParameters);
         }
 
-        $errors = $this->getValidationErrors($jobInstance);
+        $validationGroups = null !== $file ? ['Default', 'Execution', 'UploadExecution'] : ['Default', 'Execution'];
+        $errors = $this->getValidationErrors($jobInstance, $validationGroups);
         if (count($errors) > 0) {
             return new JsonResponse($errors, 400);
         }
@@ -395,10 +397,11 @@ class JobInstanceController
      * Aggregate validation errors
      *
      * @param JobInstance $jobInstance
+     * @param array|null  $groups
      *
      * @return array
      */
-    protected function getValidationErrors(JobInstance $jobInstance)
+    protected function getValidationErrors(JobInstance $jobInstance, $groups = null)
     {
         $rawParameters = $jobInstance->getRawParameters();
 
@@ -407,7 +410,7 @@ class JobInstanceController
         if (!empty($rawParameters)) {
             $job = $this->jobRegistry->get($jobInstance->getJobName());
             $parameters = $this->jobParamsFactory->create($job, $rawParameters);
-            $parametersViolations = $this->jobParameterValidator->validate($job, $parameters);
+            $parametersViolations = $this->jobParameterValidator->validate($job, $parameters, $groups);
 
             $accessor = PropertyAccess::createPropertyAccessorBuilder()->getPropertyAccessor();
             if ($parametersViolations->count() > 0) {

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/job/common/edit/upload-launch.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/job/common/edit/upload-launch.js
@@ -56,19 +56,30 @@ define(
                     .then(function (response) {
                         Navigation.getInstance().setLocation(response.redirectUrl);
                     }.bind(this))
-                    .fail(function () {
-                        messenger.notificationFlashMessage('error', __('pim_enrich.form.job_instance.fail.launch'));
-                    });
+                    .fail(this.handleErrors);
                 } else {
                     $.post(this.getUrl(), {method: 'POST'}).
                         then(function (response) {
                             Navigation.getInstance().setLocation(response.redirectUrl);
                         })
-                        .fail(function () {
-                            messenger.notificationFlashMessage('error', __('pim_enrich.form.job_instance.fail.launch'));
-                        });
+                        .fail(this.handleErrors);
                 }
+            },
 
+            /**
+             * Displays error messages in case of failed launch.
+             *
+             * @param {Object} response
+             */
+            handleErrors: function (response) {
+                // Warning: this method changed on master
+                messenger.notificationFlashMessage('error', __('pim_enrich.form.job_instance.fail.launch'));
+
+                if (_.has(response.responseJSON, 'configuration')) {
+                    _.each(response.responseJSON.configuration, function (message) {
+                        messenger.notificationFlashMessage('error', message);
+                    });
+                }
             }
         });
     }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This PR fixes a regression between 1.6 and 1.7 : on 1.7 the controller has been replaced and the validation groups were forgotten, so it was possible to upload a file with a unsupported extension and launch the import (which failed with no message in the UI).

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | OK
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
