### PR TITLE
Api 363 : Add an option in the job parameters to authenticate (or not) the user that launched the job

### DIFF
--- a/CHANGELOG-1.8.md
+++ b/CHANGELOG-1.8.md
@@ -303,7 +303,6 @@
 - Change the constructor of `Pim\Component\Catalog\Builder\EntityWithValuesBuilder` to replace `Pim\Component\Catalog\Manager\AttributeValuesResolver` by `Pim\Component\Catalog\Manager\AttributeValuesResolverInterface`
 - Change the constructor of `Pim\Bundle\ApiBundle\Controller\LocaleController` to add `Pim\Bundle\ApiBundle\Checker\QueryParametersCheckerInterface`
 - Change the constructor of `Akeneo\Bundle\BatchBundle\Launcher\SimpleJobLauncher` to add `Akeneo\Component\Batch\Job\JobParametersValidator`
-- Change the constructor of `Pim\Bundle\ConnectorBundle\Launcher\AuthenticatedJobLauncher` to add `Akeneo\Component\Batch\Job\JobParametersValidator`
 
 ### Methods
 

--- a/src/Akeneo/Bundle/BatchBundle/Launcher/SimpleJobLauncher.php
+++ b/src/Akeneo/Bundle/BatchBundle/Launcher/SimpleJobLauncher.php
@@ -12,6 +12,7 @@ use Akeneo\Component\Batch\Model\JobExecution;
 use Akeneo\Component\Batch\Model\JobInstance;
 use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Validator\ConstraintViolationList;
 
 /**
  * @author    Marie Bochu <marie.bochu@akeneo.com>
@@ -82,7 +83,6 @@ class SimpleJobLauncher implements JobLauncherInterface
         }
 
         $jobExecution = $this->createJobExecution($jobInstance, $user, $configuration);
-        $executionId = $jobExecution->getId();
         $pathFinder = new PhpExecutableFinder();
 
         $cmd = sprintf(
@@ -93,7 +93,7 @@ class SimpleJobLauncher implements JobLauncherInterface
             $this->environment,
             $emailParameter,
             escapeshellarg($jobInstance->getCode()),
-            $executionId,
+            $jobExecution->getId(),
             $this->logDir,
             DIRECTORY_SEPARATOR
         );
@@ -155,5 +155,21 @@ class SimpleJobLauncher implements JobLauncherInterface
         $this->jobRepository->updateJobExecution($jobExecution);
 
         return $jobExecution;
+    }
+
+    /**
+     * @param ConstraintViolationList $errors
+     *
+     * @return string
+     */
+    private function getErrorMessages(ConstraintViolationList $errors): string
+    {
+        $errorsStr = '';
+
+        foreach ($errors as $error) {
+            $errorsStr .= sprintf("\n  - %s", $error);
+        }
+
+        return $errorsStr;
     }
 }

--- a/src/Pim/Bundle/ConnectorBundle/Command/AuthenticatedBatchCommand.php
+++ b/src/Pim/Bundle/ConnectorBundle/Command/AuthenticatedBatchCommand.php
@@ -2,7 +2,7 @@
 
 namespace Pim\Bundle\ConnectorBundle\Command;
 
-use Akeneo\Bundle\BatchBundle\Command\BatchCommand as BaseBatchCommand;
+use Akeneo\Bundle\BatchBundle\Command\BatchCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -15,7 +15,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/MIT MIT
  */
-class BatchCommand extends BaseBatchCommand
+class AuthenticatedBatchCommand extends BatchCommand
 {
     /**
      * {@inheritdoc}

--- a/src/Pim/Bundle/ConnectorBundle/Command/BatchCommand.php
+++ b/src/Pim/Bundle/ConnectorBundle/Command/BatchCommand.php
@@ -3,27 +3,13 @@
 namespace Pim\Bundle\ConnectorBundle\Command;
 
 use Akeneo\Bundle\BatchBundle\Command\BatchCommand as BaseBatchCommand;
-use Akeneo\Bundle\BatchBundle\Monolog\Handler\BatchLogHandler;
-use Akeneo\Bundle\BatchBundle\Notification\MailNotifier;
-use Akeneo\Component\Batch\Job\JobParametersFactory;
-use Akeneo\Component\Batch\Job\JobParametersValidator;
-use Akeneo\Component\Batch\Job\JobRegistry;
-use Akeneo\Component\Batch\Job\JobRepositoryInterface;
-use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
-use Symfony\Bridge\Doctrine\RegistryInterface;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\HttpKernel\Log\DebugLoggerInterface;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
-use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
-use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
-use Symfony\Component\Security\Core\User\UserProviderInterface;
-use Symfony\Component\Validator\Validator\RecursiveValidator;
 
 /**
- * Batch command with user
+ * Batch command to launch an job with an authenticated user.
  *
  * @author    Olivier Soulet <olivier.soulet@akeneo.com>
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
@@ -38,10 +24,9 @@ class BatchCommand extends BaseBatchCommand
     {
         $this
             ->setName('pim:batch:job')
-            ->setDescription('Launch a registered job instance')
+            ->setDescription('Launch a registered job instance with an authenticated user.')
             ->addArgument('code', InputArgument::REQUIRED, 'Job instance code')
-            ->addArgument('username', InputArgument::REQUIRED, 'Username')
-            ->addArgument('execution', InputArgument::OPTIONAL, 'Job execution id')
+            ->addArgument('username', InputArgument::REQUIRED, 'User to use when running the job')
             ->addOption(
                 'config',
                 'c',
@@ -68,16 +53,15 @@ class BatchCommand extends BaseBatchCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $username = $input->getArgument('username');
+        $configuration = null !== $input->getOption('config') ? json_decode($input->getOption('config'), true) : [];
+        $configuration['is_user_authenticated'] = true;
 
-        $user = $this->getContainer()->get('pim_user.provider.user')->loadUserByUsername($username);
+        $encodedConfiguration = json_encode($configuration);
 
-        if (null === $user) {
-            throw new UsernameNotFoundException();
-        }
+        $this->addOption('username', null, InputOption::VALUE_REQUIRED);
 
-        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
-        $this->getContainer()->get('security.token_storage')->setToken($token);
+        $input->setOption('config', $encodedConfiguration);
+        $input->setOption('username', $input->getArgument('username'));
 
         parent::execute($input, $output);
     }

--- a/src/Pim/Bundle/ConnectorBundle/DependencyInjection/PimConnectorExtension.php
+++ b/src/Pim/Bundle/ConnectorBundle/DependencyInjection/PimConnectorExtension.php
@@ -34,6 +34,7 @@ class PimConnectorExtension extends Extension
         $loader->load('job_launchers.yml');
         $loader->load('processors.yml');
         $loader->load('readers.yml');
+        $loader->load('security.yml');
         $loader->load('steps.yml');
         $loader->load('validators.yml');
         $loader->load('writers.yml');

--- a/src/Pim/Bundle/ConnectorBundle/EventListener/JobExecutionAuthenticator.php
+++ b/src/Pim/Bundle/ConnectorBundle/EventListener/JobExecutionAuthenticator.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Pim\Bundle\ConnectorBundle\EventListener;
+
+use Akeneo\Component\Batch\Event\EventInterface;
+use Akeneo\Component\Batch\Event\JobExecutionEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
+
+/**
+ * Authenticate a job execution with the user that launched the job.
+ *
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class JobExecutionAuthenticator implements EventSubscriberInterface
+{
+    /** @var UserProviderInterface */
+    protected $userProvider;
+
+    /** @var TokenStorageInterface */
+    protected $tokenStorage;
+
+    /**
+     * @param UserProviderInterface $userProvider
+     * @param TokenStorageInterface $tokenStorage
+     */
+    public function __construct(UserProviderInterface $userProvider, TokenStorageInterface $tokenStorage)
+    {
+        $this->userProvider = $userProvider;
+        $this->tokenStorage = $tokenStorage;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            EventInterface::BEFORE_JOB_EXECUTION => 'authenticate'
+        ];
+    }
+
+    /**
+     * Authenticate or not the job execution with the user that launched the job,
+     * according to the parameters of the job execution.
+     *
+     * @throws UsernameNotFoundException
+     *
+     * @param JobExecutionEvent $event
+     */
+    public function authenticate(JobExecutionEvent $event): void
+    {
+        $jobExecution = $event->getJobExecution();
+        $jobParameters = $jobExecution->getJobParameters();
+        $username = $jobExecution->getUser();
+
+        if (null === $username || null === $jobParameters || !$jobParameters->has('is_user_authenticated')) {
+            return;
+        }
+
+        if (false === $jobParameters->get('is_user_authenticated')) {
+            return;
+        }
+
+        $user = $this->userProvider->loadUserByUsername($username);
+
+        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
+        $this->tokenStorage->setToken($token);
+    }
+}

--- a/src/Pim/Bundle/ConnectorBundle/Launcher/AuthenticatedJobLauncher.php
+++ b/src/Pim/Bundle/ConnectorBundle/Launcher/AuthenticatedJobLauncher.php
@@ -15,7 +15,7 @@ use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
- * Job launcher authenticated with a username.
+ * Aims to launch job that is authenticated with a username.
  *
  * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
@@ -23,52 +23,12 @@ use Symfony\Component\Security\Core\User\UserInterface;
  */
 class AuthenticatedJobLauncher implements JobLauncherInterface
 {
-    /** @var JobRepositoryInterface */
-    protected $jobRepository;
+    /** @var JobLauncherInterface */
+    protected $jobLauncher;
 
-    /** @var JobParametersFactory */
-    protected $jobParametersFactory;
-
-    /** @var JobRegistry */
-    protected $jobRegistry;
-
-    /** @var JobParametersValidator */
-    protected $jobParametersValidator;
-
-    /** @var string */
-    protected $rootDir;
-
-    /** @var string */
-    protected $environment;
-
-    /** @var string */
-    protected $logDir;
-
-    /**
-     * @param JobRepositoryInterface $jobRepository
-     * @param JobParametersFactory   $jobParametersFactory
-     * @param JobRegistry            $jobRegistry
-     * @param JobParametersValidator $jobParametersValidator
-     * @param string                 $rootDir
-     * @param string                 $environment
-     * @param string                 $logDir
-     */
-    public function __construct(
-        JobRepositoryInterface $jobRepository,
-        JobParametersFactory $jobParametersFactory,
-        JobRegistry $jobRegistry,
-        JobParametersValidator $jobParametersValidator,
-        $rootDir,
-        $environment,
-        $logDir
-    ) {
-        $this->jobRepository = $jobRepository;
-        $this->jobParametersFactory = $jobParametersFactory;
-        $this->jobRegistry = $jobRegistry;
-        $this->jobParametersValidator = $jobParametersValidator;
-        $this->rootDir = $rootDir;
-        $this->environment = $environment;
-        $this->logDir = $logDir;
+    public function __construct(JobLauncherInterface $jobLauncher)
+    {
+        $this->jobLauncher = $jobLauncher;
     }
 
     /**
@@ -76,85 +36,8 @@ class AuthenticatedJobLauncher implements JobLauncherInterface
      */
     public function launch(JobInstance $jobInstance, UserInterface $user, array $configuration = []) : JobExecution
     {
-        $emailParameter = '';
-        if (isset($configuration['send_email']) && method_exists($user, 'getEmail')) {
-            $emailParameter = sprintf('--email=%s', escapeshellarg($user->getEmail()));
-            unset($configuration['send_email']);
-        }
+        $configuration['is_user_authenticated'] = true;
 
-        $jobExecution = $this->createJobExecution($jobInstance, $user, $configuration);
-        $executionId = $jobExecution->getId();
-        $pathFinder = new PhpExecutableFinder();
-
-        $cmd = sprintf(
-            '%s %s%sconsole pim:batch:job --env=%s %s %s %s %s >> %s%sbatch_execute.log 2>&1',
-            $pathFinder->find(),
-            sprintf('%s%s..%sbin', $this->rootDir, DIRECTORY_SEPARATOR, DIRECTORY_SEPARATOR),
-            DIRECTORY_SEPARATOR,
-            $this->environment,
-            $emailParameter,
-            escapeshellarg($jobInstance->getCode()),
-            escapeshellarg($user->getUsername()),
-            $executionId,
-            $this->logDir,
-            DIRECTORY_SEPARATOR
-        );
-
-        $this->launchInBackground($cmd);
-
-        return $jobExecution;
-    }
-
-    /**
-     * Launch command in background
-     *
-     * Please note we do not use Symfony Process as it has some problem
-     * when executed from HTTP request that stop fast (race condition that makes
-     * the process cloning fail when the parent process, i.e. HTTP request, stops
-     * at the same time)
-     *
-     * @param string $cmd
-     */
-    protected function launchInBackground(string $cmd) : void
-    {
-        exec($cmd . ' &');
-    }
-
-    /**
-     * Create a jobExecution
-     *
-     * @param JobInstance   $jobInstance
-     * @param UserInterface $user
-     * @param array         $configuration
-     *
-     * @throws \RuntimeException
-     *
-     * @return JobExecution
-     */
-    protected function createJobExecution(JobInstance $jobInstance, UserInterface $user, array $configuration) : JobExecution
-    {
-        $job = $this->jobRegistry->get($jobInstance->getJobName());
-        $configuration = array_merge($jobInstance->getRawParameters(), $configuration);
-        $jobParameters = $this->jobParametersFactory->create($job, $configuration);
-
-        $errors = $this->jobParametersValidator->validate($job, $jobParameters, ['Default', 'Execution']);
-
-        if (count($errors) > 0) {
-            throw new \RuntimeException(
-                sprintf(
-                    'Job instance "%s" running the job "%s" with parameters "%s" is invalid because of "%s"',
-                    $jobInstance->getCode(),
-                    $job->getName(),
-                    print_r($jobParameters->all(), true),
-                    $this->getErrorMessages($errors)
-                )
-            );
-        }
-
-        $jobExecution = $this->jobRepository->createJobExecution($jobInstance, $jobParameters);
-        $jobExecution->setUser($user->getUsername());
-        $this->jobRepository->updateJobExecution($jobExecution);
-
-        return $jobExecution;
+        return $this->jobLauncher->launch($jobInstance, $user, $configuration);
     }
 }

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/job_launchers.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/job_launchers.yml
@@ -5,10 +5,4 @@ services:
     pim_connector.launcher.authenticated_job_launcher:
         class: '%pim_connector.launcher.authenticated_job_launcher.class%'
         arguments:
-            - '@akeneo_batch.job_repository'
-            - '@akeneo_batch.job_parameters_factory'
-            - '@akeneo_batch.job.job_registry'
-            - '@akeneo_batch.job.job_parameters_validator'
-            - '%kernel.root_dir%'
-            - '%kernel.environment%'
-            - '%kernel.logs_dir%'
+            - '@akeneo_batch.launcher.simple_job_launcher'

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/security.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/security.yml
@@ -1,0 +1,12 @@
+parameters:
+    pim_connector.event_listener.job_execution_authenticator.class: Pim\Bundle\ConnectorBundle\EventListener\JobExecutionAuthenticator
+
+services:
+    pim_connector.event_listener.job_execution_authenticator:
+        class: '%pim_connector.event_listener.job_execution_authenticator.class%'
+        arguments:
+            - '@pim_user.provider.user'
+            - '@security.token_storage'
+        tags:
+            - { name: kernel.event_subscriber }
+

--- a/src/Pim/Bundle/ConnectorBundle/spec/EventListener/JobExecutionAuthenticatorSpec.php
+++ b/src/Pim/Bundle/ConnectorBundle/spec/EventListener/JobExecutionAuthenticatorSpec.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace spec\Pim\Bundle\ConnectorBundle\EventListener;
+
+use Akeneo\Component\Batch\Event\EventInterface;
+use Akeneo\Component\Batch\Event\JobExecutionEvent;
+use Akeneo\Component\Batch\Job\JobParameters;
+use Akeneo\Component\Batch\Model\JobExecution;
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\ConnectorBundle\EventListener\JobExecutionAuthenticator;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
+
+class JobExecutionAuthenticatorSpec extends ObjectBehavior
+{
+    function let(UserProviderInterface $userProvider, TokenStorageInterface $tokenStorage)
+    {
+        $this->beConstructedWith($userProvider, $tokenStorage);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(JobExecutionAuthenticator::class);
+    }
+
+    function it_is_an_event_subscriber()
+    {
+        $this->shouldHaveType(EventSubscriberInterface::class);
+    }
+
+    function it_returns_subscribed_events()
+    {
+        $this->getSubscribedEvents()->shouldReturn([EventInterface::BEFORE_JOB_EXECUTION => 'authenticate']);
+    }
+
+    function it_authenticates_user_with_token(
+        $userProvider,
+        $tokenStorage,
+        JobExecutionEvent $event,
+        JobExecution $jobExecution,
+        JobParameters $jobParameters,
+        UserInterface $user
+    ) {
+        $event->getJobExecution()->willReturn($jobExecution);
+        $jobExecution->getJobParameters()->willReturn($jobParameters);
+        $jobExecution->getUser()->willReturn('julia');
+
+        $jobParameters->has('is_user_authenticated')->willReturn(true);
+        $jobParameters->get('is_user_authenticated')->willReturn(true);
+
+        $userProvider->loadUserByUsername('julia')->willReturn($user);
+
+        $user->getRoles()->willReturn(['role']);
+
+        $token  = new UsernamePasswordToken($user->getWrappedObject(), null, 'main', ['role']);
+        $tokenStorage->setToken($token)->shouldBeCalled();
+
+        $this->authenticate($event);
+    }
+
+    function it_does_not_authenticate_user_when_user_is_null(
+        $tokenStorage,
+        JobExecutionEvent $event,
+        JobExecution $jobExecution,
+        JobParameters $jobParameters,
+        UserInterface $user
+    ) {
+        $event->getJobExecution()->willReturn($jobExecution);
+        $jobExecution->getJobParameters()->willReturn($jobParameters);
+        $jobExecution->getUser()->willReturn(null);
+
+        $token  = new UsernamePasswordToken($user->getWrappedObject(), null, 'main', ['role']);
+        $tokenStorage->setToken($token)->shouldNotBeCalled();
+
+        $this->authenticate($event);
+    }
+
+    function it_does_authenticates_user_when_no_job_parameters(
+        $tokenStorage,
+        JobExecutionEvent $event,
+        JobExecution $jobExecution,
+        UserInterface $user
+    ) {
+        $event->getJobExecution()->willReturn($jobExecution);
+        $jobExecution->getJobParameters()->willReturn(null);
+        $jobExecution->getUser()->willReturn('julia');
+
+        $token  = new UsernamePasswordToken($user->getWrappedObject(), null, 'main', ['role']);
+        $tokenStorage->setToken($token)->shouldNotBeCalled();
+
+        $this->authenticate($event);
+    }
+
+    function it_does_not_authenticates_user_when_it_is_not_configured_in_job_parameters(
+        $tokenStorage,
+        JobExecutionEvent $event,
+        JobExecution $jobExecution,
+        JobParameters $jobParameters,
+        UserInterface $user
+    ) {
+        $event->getJobExecution()->willReturn($jobExecution);
+        $jobExecution->getJobParameters()->willReturn($jobParameters);
+        $jobExecution->getUser()->willReturn('julia');
+
+        $jobParameters->has('is_user_authenticated')->willReturn(false);
+
+        $token  = new UsernamePasswordToken($user->getWrappedObject(), null, 'main', ['role']);
+        $tokenStorage->setToken($token)->shouldNotBeCalled();
+
+        $this->authenticate($event);
+    }
+
+    function it_does_not_authenticates_user_when_it_is_not_activated_in_job_parameters(
+        $tokenStorage,
+        JobExecutionEvent $event,
+        JobExecution $jobExecution,
+        JobParameters $jobParameters,
+        UserInterface $user
+    ) {
+        $event->getJobExecution()->willReturn($jobExecution);
+        $jobExecution->getJobParameters()->willReturn($jobParameters);
+        $jobExecution->getUser()->willReturn('julia');
+
+        $jobParameters->has('is_user_authenticated')->willReturn(false);
+        $jobParameters->get('is_user_authenticated')->willReturn(false);
+
+        $token  = new UsernamePasswordToken($user->getWrappedObject(), null, 'main', ['role']);
+        $tokenStorage->setToken($token)->shouldNotBeCalled();
+
+        $this->authenticate($event);
+    }
+
+    function it_throws_exception_if_username_is_not_found(
+        $userProvider,
+        $tokenStorage,
+        JobExecutionEvent $event,
+        JobExecution $jobExecution,
+        JobParameters $jobParameters,
+        UserInterface $user
+    ) {
+        $event->getJobExecution()->willReturn($jobExecution);
+        $jobExecution->getJobParameters()->willReturn($jobParameters);
+        $jobExecution->getUser()->willReturn('julia');
+
+        $jobParameters->has('is_user_authenticated')->willReturn(true);
+        $jobParameters->get('is_user_authenticated')->willReturn(true);
+
+        $userProvider->loadUserByUsername('julia')->willThrow(UsernameNotFoundException::class);
+
+        $token  = new UsernamePasswordToken($user->getWrappedObject(), null, 'main', ['role']);
+        $tokenStorage->setToken($token)->shouldNotBeCalled();
+
+        $this->shouldThrow(UsernameNotFoundException::class)->during('authenticate', [$event]);
+    }
+}

--- a/src/Pim/Bundle/ConnectorBundle/spec/Launcher/AuthenticatedJobLauncherSpec.php
+++ b/src/Pim/Bundle/ConnectorBundle/spec/Launcher/AuthenticatedJobLauncherSpec.php
@@ -3,25 +3,28 @@
 namespace spec\Pim\Bundle\ConnectorBundle\Launcher;
 
 use Akeneo\Bundle\BatchBundle\Launcher\JobLauncherInterface;
-use Akeneo\Component\Batch\Job\JobParametersFactory;
-use Akeneo\Component\Batch\Job\JobParametersValidator;
-use Akeneo\Component\Batch\Job\JobRegistry;
-use Akeneo\Component\Batch\Job\JobRepositoryInterface;
+use Akeneo\Component\Batch\Model\JobInstance;
 use PhpSpec\ObjectBehavior;
+use Symfony\Component\Security\Core\User\UserInterface;
 
 class AuthenticatedJobLauncherSpec extends ObjectBehavior
 {
-    function let(
-        JobRepositoryInterface $jobRepository,
-        JobParametersFactory $jobParametersFactory,
-        JobRegistry $jobRegistry,
-        JobParametersValidator $jobParametersValidator
-    ) {
-        $this->beConstructedWith($jobRepository, $jobParametersFactory, $jobRegistry, $jobParametersValidator, '/', 'prod', '/logs');
+    function let(JobLauncherInterface $jobLauncher)
+    {
+        $this->beConstructedWith($jobLauncher);
     }
 
     function it_is_a_job_launcher()
     {
         $this->shouldHaveType(JobLauncherInterface::class);
+    }
+
+    function it_should_force_authentication_in_configuration(
+        $jobLauncher,
+        JobInstance $jobInstance,
+        UserInterface $user
+    ) {
+        $jobLauncher->launch($jobInstance, $user, ['filePath' => '/tmp', 'is_user_authenticated' => true]);
+        $this->launch($jobInstance, $user, ['filePath' => '/tmp']);
     }
 }

--- a/src/Pim/Bundle/ConnectorBundle/tests/integration/Command/AuthenticatedBatchCommandIntegration.php
+++ b/src/Pim/Bundle/ConnectorBundle/tests/integration/Command/AuthenticatedBatchCommandIntegration.php
@@ -12,7 +12,7 @@ use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 
-class BatchCommandIntegration extends TestCase
+class AuthenticatedBatchCommandIntegration extends TestCase
 {
     const EXPORT_DIRECTORY = 'pim-integration-tests-export';
 

--- a/src/Pim/Bundle/ConnectorBundle/tests/integration/Command/BatchCommandIntegration.php
+++ b/src/Pim/Bundle/ConnectorBundle/tests/integration/Command/BatchCommandIntegration.php
@@ -35,24 +35,7 @@ class BatchCommandIntegration extends TestCase
         $stmt->execute();
         $result = $stmt->fetch();
 
-        $this->assertEquals(BatchStatus::COMPLETED, $result['status']);
-        $this->assertNotNull($result['start_time']);
-        $this->assertNotNull($result['end_time']);
-        $this->assertNotNull($result['create_time']);
-        $this->assertNotNull($result['pid']);
-        $this->assertNotNull($result['log_file']);
-        $this->assertNotNull(json_decode($result['raw_parameters'], true));
-        $this->assertNull($result['user']);
-        $this->assertEquals('Export csv_product_export has been successfully executed.' . PHP_EOL, $output->fetch());
-    }
-
-    public function testJobExecutionStateWithUsername()
-    {
-        $output = $this->launchJob(['--username' => 'mary']);
-        $connection = $this->get('doctrine.orm.default_entity_manager')->getConnection();
-        $stmt = $connection->prepare('SELECT status, pid, start_time, end_time, create_time, user, log_file, raw_parameters from akeneo_batch_job_execution');
-        $stmt->execute();
-        $result = $stmt->fetch();
+        $rawParameters = json_decode($result['raw_parameters'], true);
 
         $this->assertEquals(BatchStatus::COMPLETED, $result['status']);
         $this->assertNotNull($result['start_time']);
@@ -60,7 +43,9 @@ class BatchCommandIntegration extends TestCase
         $this->assertNotNull($result['create_time']);
         $this->assertNotNull($result['pid']);
         $this->assertNotNull($result['log_file']);
-        $this->assertNotNull(json_decode($result['raw_parameters'], true));
+        $this->assertNotNull($rawParameters);
+        $this->assertArrayHasKey('is_user_authenticated', $rawParameters);
+        $this->assertTrue($rawParameters['is_user_authenticated']);
         $this->assertEquals('mary', $result['user']);
         $this->assertEquals('Export csv_product_export has been successfully executed.' . PHP_EOL, $output->fetch());
     }
@@ -115,38 +100,6 @@ class BatchCommandIntegration extends TestCase
         $this->assertContains('Email "email" is invalid', $output->fetch());
     }
 
-    public function testLaunchJobWithInvalidJobExecutionCode()
-    {
-        $output = $this->launchJob(['execution' => '1']);
-        $this->assertContains('Could not find job execution "1"', $output->fetch());
-    }
-
-    public function testLaunchJobAlreadyStarted()
-    {
-        $this->launchJob();
-        $connection = $this->get('doctrine.orm.default_entity_manager')->getConnection();
-        $stmt = $connection->prepare('SELECT id, status from akeneo_batch_job_execution');
-        $stmt->execute();
-        $result = $stmt->fetch();
-
-        $this->assertEquals(BatchStatus::COMPLETED, $result['status']);
-
-        $output = $this->launchJob(['execution' => $result['id']]);
-        $this->assertContains('Job execution "18" has invalid status: COMPLETED', $output->fetch());
-    }
-
-    public function testLaunchJobExecutionWithConfigOverridden()
-    {
-        $output = $this->launchJob(['execution' => '1', '--config' => ['filePath' => '/tmp/foo']]);
-        $this->assertContains('Configuration option cannot be specified when launching a job execution.', $output->fetch());
-    }
-
-    public function testLaunchJobExecutionWithUsernameOverridden()
-    {
-        $output = $this->launchJob(['execution' => '1', '--username' => 'mary']);
-        $this->assertContains('Username option cannot be specified when launching a job execution', $output->fetch());
-    }
-
     /**
      * @param array $arrayInput
      *
@@ -158,8 +111,9 @@ class BatchCommandIntegration extends TestCase
         $application->setAutoExit(false);
 
         $defaultArrayInput = [
-            'command'  => 'akeneo:batch:job',
+            'command'  => 'pim:batch:job',
             'code'     => 'csv_product_export',
+            'username' => 'mary',
         ];
 
         $arrayInput = array_merge($defaultArrayInput, $arrayInput);

--- a/src/Pim/Bundle/DataGridBundle/Controller/ProductExportController.php
+++ b/src/Pim/Bundle/DataGridBundle/Controller/ProductExportController.php
@@ -121,7 +121,7 @@ class ProductExportController
         }
 
         $configuration = array_merge($rawParameters, $dynamicConfiguration);
-        $configuration['notification_user'] = $this->getUser()->getUsername();
+        $configuration['user_to_notify'] = $this->getUser()->getUsername();
 
         $this->jobLauncher->launch($jobInstance, $this->getUser(), $configuration);
 

--- a/src/Pim/Bundle/EnrichBundle/Connector/Job/JobParameters/ConstraintCollectionProvider/ProductMassEdit.php
+++ b/src/Pim/Bundle/EnrichBundle/Connector/Job/JobParameters/ConstraintCollectionProvider/ProductMassEdit.php
@@ -39,7 +39,8 @@ class ProductMassEdit implements ConstraintCollectionProviderInterface
                     'filters'            => new NotNull(),
                     'actions'            => new NotNull(),
                     'realTimeVersioning' => new Type('bool'),
-                    'user_to_notify'  => new Type('string'),
+                    'user_to_notify'     => new Type('string'),
+                    'is_user_authenticated' => new Type('bool'),
                 ]
             ]
         );

--- a/src/Pim/Bundle/EnrichBundle/Connector/Job/JobParameters/ConstraintCollectionProvider/ProductMassEdit.php
+++ b/src/Pim/Bundle/EnrichBundle/Connector/Job/JobParameters/ConstraintCollectionProvider/ProductMassEdit.php
@@ -39,7 +39,7 @@ class ProductMassEdit implements ConstraintCollectionProviderInterface
                     'filters'            => new NotNull(),
                     'actions'            => new NotNull(),
                     'realTimeVersioning' => new Type('bool'),
-                    'notification_user'  => new Type('string'),
+                    'user_to_notify'  => new Type('string'),
                 ]
             ]
         );

--- a/src/Pim/Bundle/EnrichBundle/Connector/Job/JobParameters/ConstraintCollectionProvider/SimpleMassEdit.php
+++ b/src/Pim/Bundle/EnrichBundle/Connector/Job/JobParameters/ConstraintCollectionProvider/SimpleMassEdit.php
@@ -39,6 +39,7 @@ class SimpleMassEdit implements ConstraintCollectionProviderInterface
                     'filters' => new NotNull(),
                     'actions' => new NotNull(),
                     'user_to_notify' => new Type('string'),
+                    'is_user_authenticated' => new Type('bool'),
                 ]
             ]
         );

--- a/src/Pim/Bundle/EnrichBundle/Connector/Job/JobParameters/ConstraintCollectionProvider/SimpleMassEdit.php
+++ b/src/Pim/Bundle/EnrichBundle/Connector/Job/JobParameters/ConstraintCollectionProvider/SimpleMassEdit.php
@@ -38,7 +38,7 @@ class SimpleMassEdit implements ConstraintCollectionProviderInterface
                 'fields' => [
                     'filters' => new NotNull(),
                     'actions' => new NotNull(),
-                    'notification_user' => new Type('string'),
+                    'user_to_notify' => new Type('string'),
                 ]
             ]
         );

--- a/src/Pim/Bundle/EnrichBundle/Connector/Job/JobParameters/DefaultValuesProvider/ProductMassEdit.php
+++ b/src/Pim/Bundle/EnrichBundle/Connector/Job/JobParameters/DefaultValuesProvider/ProductMassEdit.php
@@ -34,7 +34,8 @@ class ProductMassEdit implements DefaultValuesProviderInterface
             'filters'            => [],
             'actions'            => [],
             'realTimeVersioning' => true,
-            'user_to_notify'  => null,
+            'user_to_notify'     => null,
+            'is_user_authenticated' => false,
         ];
     }
 

--- a/src/Pim/Bundle/EnrichBundle/Connector/Job/JobParameters/DefaultValuesProvider/ProductMassEdit.php
+++ b/src/Pim/Bundle/EnrichBundle/Connector/Job/JobParameters/DefaultValuesProvider/ProductMassEdit.php
@@ -34,7 +34,7 @@ class ProductMassEdit implements DefaultValuesProviderInterface
             'filters'            => [],
             'actions'            => [],
             'realTimeVersioning' => true,
-            'notification_user'  => null,
+            'user_to_notify'  => null,
         ];
     }
 

--- a/src/Pim/Bundle/EnrichBundle/Connector/Job/JobParameters/DefaultValuesProvider/SimpleMassEdit.php
+++ b/src/Pim/Bundle/EnrichBundle/Connector/Job/JobParameters/DefaultValuesProvider/SimpleMassEdit.php
@@ -34,6 +34,7 @@ class SimpleMassEdit implements DefaultValuesProviderInterface
             'filters' => [],
             'actions' => [],
             'user_to_notify' => null,
+            'is_user_authenticated' => false,
         ];
     }
 

--- a/src/Pim/Bundle/EnrichBundle/Connector/Job/JobParameters/DefaultValuesProvider/SimpleMassEdit.php
+++ b/src/Pim/Bundle/EnrichBundle/Connector/Job/JobParameters/DefaultValuesProvider/SimpleMassEdit.php
@@ -33,7 +33,7 @@ class SimpleMassEdit implements DefaultValuesProviderInterface
         return [
             'filters' => [],
             'actions' => [],
-            'notification_user' => null,
+            'user_to_notify' => null,
         ];
     }
 

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/JobInstanceController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/JobInstanceController.php
@@ -500,7 +500,7 @@ class JobInstanceController
 
         $configuration = $jobInstance->getRawParameters();
         $configuration['send_email'] = true;
-        $configuration['notification_user'] = $user->getUsername();
+        $configuration['user_to_notify'] = $user->getUsername();
 
         return $this->jobLauncher->launch($jobInstance, $user, $configuration);
     }

--- a/src/Pim/Bundle/EnrichBundle/MassEditAction/OperationJobLauncher.php
+++ b/src/Pim/Bundle/EnrichBundle/MassEditAction/OperationJobLauncher.php
@@ -62,7 +62,7 @@ class OperationJobLauncher
         $user = $this->tokenStorage->getToken()->getUser();
 
         $configuration = $operation->getBatchConfig();
-        $configuration['notification_user'] = $user->getUsername();
+        $configuration['user_to_notify'] = $user->getUsername();
 
         $this->jobLauncher->launch($jobInstance, $user, $configuration);
     }

--- a/src/Pim/Bundle/EnrichBundle/spec/MassEditAction/OperationJobLauncherSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/MassEditAction/OperationJobLauncherSpec.php
@@ -49,7 +49,7 @@ class OperationJobLauncherSpec extends ObjectBehavior
             [
                 'foo'  => 'bar',
                 'pomf' => 'thud',
-                'notification_user' => 'julia'
+                'user_to_notify' => 'julia'
             ]
         );
 

--- a/src/Pim/Bundle/NotificationBundle/EventSubscriber/JobExecutionNotifier.php
+++ b/src/Pim/Bundle/NotificationBundle/EventSubscriber/JobExecutionNotifier.php
@@ -57,11 +57,11 @@ class JobExecutionNotifier implements EventSubscriberInterface
         $jobExecution = $event->getJobExecution();
         $jobParameters = $jobExecution->getJobParameters();
 
-        if (null === $jobParameters || !$jobParameters->has('notification_user')) {
+        if (null === $jobParameters || !$jobParameters->has('user_to_notify')) {
             return;
         }
 
-        $user = $jobParameters->get('notification_user');
+        $user = $jobParameters->get('user_to_notify');
         if (null === $user) {
             return;
         }

--- a/src/Pim/Bundle/NotificationBundle/spec/EventSubscriber/JobExecutionNotifierSpec.php
+++ b/src/Pim/Bundle/NotificationBundle/spec/EventSubscriber/JobExecutionNotifierSpec.php
@@ -36,8 +36,8 @@ class JobExecutionNotifierSpec extends ObjectBehavior
         $jobExecution->getStatus()->willReturn($status);
         $jobExecution->getJobInstance()->willReturn($jobInstance);
 
-        $jobParameters->has('notification_user')->willReturn(true);
-        $jobParameters->get('notification_user')->willReturn('julia');
+        $jobParameters->has('user_to_notify')->willReturn(true);
+        $jobParameters->get('user_to_notify')->willReturn('julia');
 
         $stepExecution->getWarnings()->willReturn($warnings);
         $jobExecution->getId()->willReturn(5);
@@ -69,14 +69,14 @@ class JobExecutionNotifierSpec extends ObjectBehavior
         $this->afterJobExecution($event);
     }
 
-    function it_does_not_notify_if_job_execution_parameters_has_no_notification_user(
+    function it_does_not_notify_if_job_execution_parameters_has_no_user_to_notify(
         $event,
         $jobExecution,
         $notifier,
         JobParameters $jobParameters
     ) {
         $jobExecution->getJobParameters()->willReturn($jobParameters);
-        $jobParameters->has('notification_user')->willReturn(false);
+        $jobParameters->has('user_to_notify')->willReturn(false);
 
         $notifier->notify(Argument::cetera())->shouldNotBeCalled();
 

--- a/src/Pim/Component/Connector/Job/JobParameters/ConstraintCollectionProvider/SimpleCsvExport.php
+++ b/src/Pim/Component/Connector/Job/JobParameters/ConstraintCollectionProvider/SimpleCsvExport.php
@@ -75,7 +75,7 @@ class SimpleCsvExport implements ConstraintCollectionProviderInterface
                             'groups' => ['Default', 'FileConfiguration'],
                         ]
                     ),
-                    'notification_user' => new Type('string'),
+                    'user_to_notify' => new Type('string'),
                 ],
             ]
         );

--- a/src/Pim/Component/Connector/Job/JobParameters/ConstraintCollectionProvider/SimpleCsvExport.php
+++ b/src/Pim/Component/Connector/Job/JobParameters/ConstraintCollectionProvider/SimpleCsvExport.php
@@ -76,6 +76,7 @@ class SimpleCsvExport implements ConstraintCollectionProviderInterface
                         ]
                     ),
                     'user_to_notify' => new Type('string'),
+                    'is_user_authenticated' => new Type('bool'),
                 ],
             ]
         );

--- a/src/Pim/Component/Connector/Job/JobParameters/ConstraintCollectionProvider/SimpleCsvImport.php
+++ b/src/Pim/Component/Connector/Job/JobParameters/ConstraintCollectionProvider/SimpleCsvImport.php
@@ -75,7 +75,7 @@ class SimpleCsvImport implements ConstraintCollectionProviderInterface
                         new IsTrue(['groups' => 'UploadExecution']),
                     ],
                     'invalid_items_file_format' => new NotBlank(),
-                    'notification_user' => new Type('string'),
+                    'user_to_notify' => new Type('string'),
                 ]
             ]
         );

--- a/src/Pim/Component/Connector/Job/JobParameters/ConstraintCollectionProvider/SimpleCsvImport.php
+++ b/src/Pim/Component/Connector/Job/JobParameters/ConstraintCollectionProvider/SimpleCsvImport.php
@@ -76,6 +76,7 @@ class SimpleCsvImport implements ConstraintCollectionProviderInterface
                     ],
                     'invalid_items_file_format' => new NotBlank(),
                     'user_to_notify' => new Type('string'),
+                    'is_user_authenticated' => new Type('bool'),
                 ]
             ]
         );

--- a/src/Pim/Component/Connector/Job/JobParameters/ConstraintCollectionProvider/SimpleXlsxExport.php
+++ b/src/Pim/Component/Connector/Job/JobParameters/ConstraintCollectionProvider/SimpleXlsxExport.php
@@ -63,6 +63,7 @@ class SimpleXlsxExport implements ConstraintCollectionProviderInterface
                         ),
                     ],
                     'user_to_notify' => new Type('string'),
+                    'is_user_authenticated' => new Type('bool'),
                 ],
             ]
         );

--- a/src/Pim/Component/Connector/Job/JobParameters/ConstraintCollectionProvider/SimpleXlsxExport.php
+++ b/src/Pim/Component/Connector/Job/JobParameters/ConstraintCollectionProvider/SimpleXlsxExport.php
@@ -62,7 +62,7 @@ class SimpleXlsxExport implements ConstraintCollectionProviderInterface
                             ]
                         ),
                     ],
-                    'notification_user' => new Type('string'),
+                    'user_to_notify' => new Type('string'),
                 ],
             ]
         );

--- a/src/Pim/Component/Connector/Job/JobParameters/ConstraintCollectionProvider/SimpleXlsxImport.php
+++ b/src/Pim/Component/Connector/Job/JobParameters/ConstraintCollectionProvider/SimpleXlsxImport.php
@@ -54,6 +54,7 @@ class SimpleXlsxImport implements ConstraintCollectionProviderInterface
                     ],
                     'invalid_items_file_format' => new NotBlank(),
                     'user_to_notify' => new Type('string'),
+                    'is_user_authenticated' => new Type('bool'),
                 ]
             ]
         );

--- a/src/Pim/Component/Connector/Job/JobParameters/ConstraintCollectionProvider/SimpleXlsxImport.php
+++ b/src/Pim/Component/Connector/Job/JobParameters/ConstraintCollectionProvider/SimpleXlsxImport.php
@@ -53,7 +53,7 @@ class SimpleXlsxImport implements ConstraintCollectionProviderInterface
                         new IsTrue(['groups' => 'UploadExecution']),
                     ],
                     'invalid_items_file_format' => new NotBlank(),
-                    'notification_user' => new Type('string'),
+                    'user_to_notify' => new Type('string'),
                 ]
             ]
         );

--- a/src/Pim/Component/Connector/Job/JobParameters/ConstraintCollectionProvider/SimpleYamlExport.php
+++ b/src/Pim/Component/Connector/Job/JobParameters/ConstraintCollectionProvider/SimpleYamlExport.php
@@ -46,7 +46,7 @@ class SimpleYamlExport implements ConstraintCollectionProviderInterface
                             ]
                         )
                     ],
-                    'notification_user' => new Type('string'),
+                    'user_to_notify' => new Type('string'),
                 ]
             ]
         );

--- a/src/Pim/Component/Connector/Job/JobParameters/ConstraintCollectionProvider/SimpleYamlExport.php
+++ b/src/Pim/Component/Connector/Job/JobParameters/ConstraintCollectionProvider/SimpleYamlExport.php
@@ -47,6 +47,7 @@ class SimpleYamlExport implements ConstraintCollectionProviderInterface
                         )
                     ],
                     'user_to_notify' => new Type('string'),
+                    'is_user_authenticated' => new Type('bool'),
                 ]
             ]
         );

--- a/src/Pim/Component/Connector/Job/JobParameters/ConstraintCollectionProvider/SimpleYamlImport.php
+++ b/src/Pim/Component/Connector/Job/JobParameters/ConstraintCollectionProvider/SimpleYamlImport.php
@@ -52,7 +52,7 @@ class SimpleYamlImport implements ConstraintCollectionProviderInterface
                         new IsTrue(['groups' => 'UploadExecution']),
                     ],
                     'invalid_items_file_format' => new NotBlank(),
-                    'notification_user' => new Type('string'),
+                    'user_to_notify' => new Type('string'),
                 ]
             ]
         );

--- a/src/Pim/Component/Connector/Job/JobParameters/ConstraintCollectionProvider/SimpleYamlImport.php
+++ b/src/Pim/Component/Connector/Job/JobParameters/ConstraintCollectionProvider/SimpleYamlImport.php
@@ -53,6 +53,7 @@ class SimpleYamlImport implements ConstraintCollectionProviderInterface
                     ],
                     'invalid_items_file_format' => new NotBlank(),
                     'user_to_notify' => new Type('string'),
+                    'is_user_authenticated' => new Type('bool'),
                 ]
             ]
         );

--- a/src/Pim/Component/Connector/Job/JobParameters/DefaultValuesProvider/SimpleCsvExport.php
+++ b/src/Pim/Component/Connector/Job/JobParameters/DefaultValuesProvider/SimpleCsvExport.php
@@ -35,7 +35,7 @@ class SimpleCsvExport implements DefaultValuesProviderInterface
             'delimiter'         => ';',
             'enclosure'         => '"',
             'withHeader'        => true,
-            'notification_user' => null,
+            'user_to_notify' => null,
         ];
     }
 

--- a/src/Pim/Component/Connector/Job/JobParameters/DefaultValuesProvider/SimpleCsvExport.php
+++ b/src/Pim/Component/Connector/Job/JobParameters/DefaultValuesProvider/SimpleCsvExport.php
@@ -35,7 +35,8 @@ class SimpleCsvExport implements DefaultValuesProviderInterface
             'delimiter'         => ';',
             'enclosure'         => '"',
             'withHeader'        => true,
-            'user_to_notify' => null,
+            'user_to_notify'    => null,
+            'is_user_authenticated' => false,
         ];
     }
 

--- a/src/Pim/Component/Connector/Job/JobParameters/DefaultValuesProvider/SimpleCsvImport.php
+++ b/src/Pim/Component/Connector/Job/JobParameters/DefaultValuesProvider/SimpleCsvImport.php
@@ -38,7 +38,8 @@ class SimpleCsvImport implements DefaultValuesProviderInterface
             'withHeader'                => true,
             'uploadAllowed'             => true,
             'invalid_items_file_format' => 'csv',
-            'user_to_notify'         => null,
+            'user_to_notify'            => null,
+            'is_user_authenticated'     => false,
         ];
     }
 

--- a/src/Pim/Component/Connector/Job/JobParameters/DefaultValuesProvider/SimpleCsvImport.php
+++ b/src/Pim/Component/Connector/Job/JobParameters/DefaultValuesProvider/SimpleCsvImport.php
@@ -38,7 +38,7 @@ class SimpleCsvImport implements DefaultValuesProviderInterface
             'withHeader'                => true,
             'uploadAllowed'             => true,
             'invalid_items_file_format' => 'csv',
-            'notification_user'         => null,
+            'user_to_notify'         => null,
         ];
     }
 

--- a/src/Pim/Component/Connector/Job/JobParameters/DefaultValuesProvider/SimpleXlsxExport.php
+++ b/src/Pim/Component/Connector/Job/JobParameters/DefaultValuesProvider/SimpleXlsxExport.php
@@ -34,7 +34,8 @@ class SimpleXlsxExport implements DefaultValuesProviderInterface
             'filePath'          => sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'export_%job_label%_%datetime%.xlsx',
             'withHeader'        => true,
             'linesPerFile'      => 10000,
-            'user_to_notify' => null,
+            'user_to_notify'    => null,
+            'is_user_authenticated' => false,
         ];
     }
 

--- a/src/Pim/Component/Connector/Job/JobParameters/DefaultValuesProvider/SimpleXlsxExport.php
+++ b/src/Pim/Component/Connector/Job/JobParameters/DefaultValuesProvider/SimpleXlsxExport.php
@@ -34,7 +34,7 @@ class SimpleXlsxExport implements DefaultValuesProviderInterface
             'filePath'          => sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'export_%job_label%_%datetime%.xlsx',
             'withHeader'        => true,
             'linesPerFile'      => 10000,
-            'notification_user' => null,
+            'user_to_notify' => null,
         ];
     }
 

--- a/src/Pim/Component/Connector/Job/JobParameters/DefaultValuesProvider/SimpleXlsxImport.php
+++ b/src/Pim/Component/Connector/Job/JobParameters/DefaultValuesProvider/SimpleXlsxImport.php
@@ -35,7 +35,7 @@ class SimpleXlsxImport implements DefaultValuesProviderInterface
             'withHeader'                => true,
             'uploadAllowed'             => true,
             'invalid_items_file_format' => 'xlsx',
-            'notification_user'         => null,
+            'user_to_notify'         => null,
         ];
     }
 

--- a/src/Pim/Component/Connector/Job/JobParameters/DefaultValuesProvider/SimpleXlsxImport.php
+++ b/src/Pim/Component/Connector/Job/JobParameters/DefaultValuesProvider/SimpleXlsxImport.php
@@ -35,7 +35,8 @@ class SimpleXlsxImport implements DefaultValuesProviderInterface
             'withHeader'                => true,
             'uploadAllowed'             => true,
             'invalid_items_file_format' => 'xlsx',
-            'user_to_notify'         => null,
+            'user_to_notify'            => null,
+            'is_user_authenticated'     => false,
         ];
     }
 

--- a/src/Pim/Component/Connector/Job/JobParameters/DefaultValuesProvider/SimpleYamlExport.php
+++ b/src/Pim/Component/Connector/Job/JobParameters/DefaultValuesProvider/SimpleYamlExport.php
@@ -31,8 +31,9 @@ class SimpleYamlExport implements DefaultValuesProviderInterface
     public function getDefaultValues()
     {
         return [
-            'filePath'          => sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'export_%job_label%_%datetime%.yml',
-            'user_to_notify' => null,
+            'filePath'              => sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'export_%job_label%_%datetime%.yml',
+            'user_to_notify'        => null,
+            'is_user_authenticated' => false,
         ];
     }
 

--- a/src/Pim/Component/Connector/Job/JobParameters/DefaultValuesProvider/SimpleYamlExport.php
+++ b/src/Pim/Component/Connector/Job/JobParameters/DefaultValuesProvider/SimpleYamlExport.php
@@ -32,7 +32,7 @@ class SimpleYamlExport implements DefaultValuesProviderInterface
     {
         return [
             'filePath'          => sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'export_%job_label%_%datetime%.yml',
-            'notification_user' => null,
+            'user_to_notify' => null,
         ];
     }
 

--- a/src/Pim/Component/Connector/Job/JobParameters/DefaultValuesProvider/SimpleYamlImport.php
+++ b/src/Pim/Component/Connector/Job/JobParameters/DefaultValuesProvider/SimpleYamlImport.php
@@ -34,7 +34,8 @@ class SimpleYamlImport implements DefaultValuesProviderInterface
             'filePath'                  => null,
             'uploadAllowed'             => true,
             'invalid_items_file_format' => 'yaml',
-            'user_to_notify'         => null,
+            'user_to_notify'            => null,
+            'is_user_authenticated'     => false,
         ];
     }
 

--- a/src/Pim/Component/Connector/Job/JobParameters/DefaultValuesProvider/SimpleYamlImport.php
+++ b/src/Pim/Component/Connector/Job/JobParameters/DefaultValuesProvider/SimpleYamlImport.php
@@ -34,7 +34,7 @@ class SimpleYamlImport implements DefaultValuesProviderInterface
             'filePath'                  => null,
             'uploadAllowed'             => true,
             'invalid_items_file_format' => 'yaml',
-            'notification_user'         => null,
+            'user_to_notify'         => null,
         ];
     }
 

--- a/src/Pim/Component/Connector/spec/Job/JobParameters/ConstraintCollectionProvider/SimpleCsvExportSpec.php
+++ b/src/Pim/Component/Connector/spec/Job/JobParameters/ConstraintCollectionProvider/SimpleCsvExportSpec.php
@@ -27,7 +27,7 @@ class SimpleCsvExportSpec extends ObjectBehavior
         $fields->shouldHaveKey('delimiter');
         $fields->shouldHaveKey('enclosure');
         $fields->shouldHaveKey('withHeader');
-        $fields->shouldHaveKey('notification_user');
+        $fields->shouldHaveKey('user_to_notify');
     }
 
     function it_supports_a_job(JobInterface $job)

--- a/src/Pim/Component/Connector/spec/Job/JobParameters/ConstraintCollectionProvider/SimpleCsvExportSpec.php
+++ b/src/Pim/Component/Connector/spec/Job/JobParameters/ConstraintCollectionProvider/SimpleCsvExportSpec.php
@@ -22,12 +22,13 @@ class SimpleCsvExportSpec extends ObjectBehavior
         $collection = $this->getConstraintCollection();
         $collection->shouldReturnAnInstanceOf('Symfony\Component\Validator\Constraints\Collection');
         $fields = $collection->fields;
-        $fields->shouldHaveCount(5);
+        $fields->shouldHaveCount(6);
         $fields->shouldHaveKey('filePath');
         $fields->shouldHaveKey('delimiter');
         $fields->shouldHaveKey('enclosure');
         $fields->shouldHaveKey('withHeader');
         $fields->shouldHaveKey('user_to_notify');
+        $fields->shouldHaveKey('is_user_authenticated');
     }
 
     function it_supports_a_job(JobInterface $job)

--- a/src/Pim/Component/Connector/spec/Job/JobParameters/ConstraintCollectionProvider/SimpleCsvImportSpec.php
+++ b/src/Pim/Component/Connector/spec/Job/JobParameters/ConstraintCollectionProvider/SimpleCsvImportSpec.php
@@ -22,7 +22,7 @@ class SimpleCsvImportSpec extends ObjectBehavior
         $collection = $this->getConstraintCollection();
         $collection->shouldReturnAnInstanceOf('Symfony\Component\Validator\Constraints\Collection');
         $fields = $collection->fields;
-        $fields->shouldHaveCount(8);
+        $fields->shouldHaveCount(9);
         $fields->shouldHaveKey('filePath');
         $fields->shouldHaveKey('delimiter');
         $fields->shouldHaveKey('enclosure');
@@ -31,6 +31,7 @@ class SimpleCsvImportSpec extends ObjectBehavior
         $fields->shouldHaveKey('uploadAllowed');
         $fields->shouldHaveKey('invalid_items_file_format');
         $fields->shouldHaveKey('user_to_notify');
+        $fields->shouldHaveKey('is_user_authenticated');
     }
 
     function it_supports_a_job(JobInterface $job)

--- a/src/Pim/Component/Connector/spec/Job/JobParameters/ConstraintCollectionProvider/SimpleCsvImportSpec.php
+++ b/src/Pim/Component/Connector/spec/Job/JobParameters/ConstraintCollectionProvider/SimpleCsvImportSpec.php
@@ -30,7 +30,7 @@ class SimpleCsvImportSpec extends ObjectBehavior
         $fields->shouldHaveKey('escape');
         $fields->shouldHaveKey('uploadAllowed');
         $fields->shouldHaveKey('invalid_items_file_format');
-        $fields->shouldHaveKey('notification_user');
+        $fields->shouldHaveKey('user_to_notify');
     }
 
     function it_supports_a_job(JobInterface $job)

--- a/src/Pim/Component/Connector/spec/Job/JobParameters/ConstraintCollectionProvider/SimpleXlsxExportSpec.php
+++ b/src/Pim/Component/Connector/spec/Job/JobParameters/ConstraintCollectionProvider/SimpleXlsxExportSpec.php
@@ -22,11 +22,12 @@ class SimpleXlsxExportSpec extends ObjectBehavior
         $collection = $this->getConstraintCollection();
         $collection->shouldReturnAnInstanceOf('Symfony\Component\Validator\Constraints\Collection');
         $fields = $collection->fields;
-        $fields->shouldHaveCount(4);
+        $fields->shouldHaveCount(5);
         $fields->shouldHaveKey('filePath');
         $fields->shouldHaveKey('withHeader');
         $fields->shouldHaveKey('linesPerFile');
         $fields->shouldHaveKey('user_to_notify');
+        $fields->shouldHaveKey('is_user_authenticated');
     }
 
     function it_supports_a_job(JobInterface $job)

--- a/src/Pim/Component/Connector/spec/Job/JobParameters/ConstraintCollectionProvider/SimpleXlsxExportSpec.php
+++ b/src/Pim/Component/Connector/spec/Job/JobParameters/ConstraintCollectionProvider/SimpleXlsxExportSpec.php
@@ -26,7 +26,7 @@ class SimpleXlsxExportSpec extends ObjectBehavior
         $fields->shouldHaveKey('filePath');
         $fields->shouldHaveKey('withHeader');
         $fields->shouldHaveKey('linesPerFile');
-        $fields->shouldHaveKey('notification_user');
+        $fields->shouldHaveKey('user_to_notify');
     }
 
     function it_supports_a_job(JobInterface $job)

--- a/src/Pim/Component/Connector/spec/Job/JobParameters/ConstraintCollectionProvider/SimpleXlsxImportSpec.php
+++ b/src/Pim/Component/Connector/spec/Job/JobParameters/ConstraintCollectionProvider/SimpleXlsxImportSpec.php
@@ -27,7 +27,7 @@ class SimpleXlsxImportSpec extends ObjectBehavior
         $fields->shouldHaveKey('withHeader');
         $fields->shouldHaveKey('uploadAllowed');
         $fields->shouldHaveKey('invalid_items_file_format');
-        $fields->shouldHaveKey('notification_user');
+        $fields->shouldHaveKey('user_to_notify');
     }
 
     function it_supports_a_job(JobInterface $job)

--- a/src/Pim/Component/Connector/spec/Job/JobParameters/ConstraintCollectionProvider/SimpleXlsxImportSpec.php
+++ b/src/Pim/Component/Connector/spec/Job/JobParameters/ConstraintCollectionProvider/SimpleXlsxImportSpec.php
@@ -22,12 +22,13 @@ class SimpleXlsxImportSpec extends ObjectBehavior
         $collection = $this->getConstraintCollection();
         $collection->shouldReturnAnInstanceOf('Symfony\Component\Validator\Constraints\Collection');
         $fields = $collection->fields;
-        $fields->shouldHaveCount(5);
+        $fields->shouldHaveCount(6);
         $fields->shouldHaveKey('filePath');
         $fields->shouldHaveKey('withHeader');
         $fields->shouldHaveKey('uploadAllowed');
         $fields->shouldHaveKey('invalid_items_file_format');
         $fields->shouldHaveKey('user_to_notify');
+        $fields->shouldHaveKey('is_user_authenticated');
     }
 
     function it_supports_a_job(JobInterface $job)

--- a/src/Pim/Component/Connector/spec/Job/JobParameters/ConstraintCollectionProvider/SimpleYamlExportSpec.php
+++ b/src/Pim/Component/Connector/spec/Job/JobParameters/ConstraintCollectionProvider/SimpleYamlExportSpec.php
@@ -22,8 +22,10 @@ class SimpleYamlExportSpec extends ObjectBehavior
         $collection = $this->getConstraintCollection();
         $collection->shouldReturnAnInstanceOf('Symfony\Component\Validator\Constraints\Collection');
         $fields = $collection->fields;
-        $fields->shouldHaveCount(2);
+        $fields->shouldHaveCount(3);
         $fields->shouldHaveKey('filePath');
+        $fields->shouldHaveKey('user_to_notify');
+        $fields->shouldHaveKey('is_user_authenticated');
     }
 
     function it_supports_a_job(JobInterface $job)

--- a/src/Pim/Component/Connector/spec/Job/JobParameters/ConstraintCollectionProvider/SimpleYamlImportSpec.php
+++ b/src/Pim/Component/Connector/spec/Job/JobParameters/ConstraintCollectionProvider/SimpleYamlImportSpec.php
@@ -26,7 +26,7 @@ class SimpleYamlImportSpec extends ObjectBehavior
         $fields->shouldHaveKey('filePath');
         $fields->shouldHaveKey('uploadAllowed');
         $fields->shouldHaveKey('invalid_items_file_format');
-        $fields->shouldHaveKey('notification_user');
+        $fields->shouldHaveKey('user_to_notify');
     }
 
     function it_supports_a_job(JobInterface $job)

--- a/src/Pim/Component/Connector/spec/Job/JobParameters/ConstraintCollectionProvider/SimpleYamlImportSpec.php
+++ b/src/Pim/Component/Connector/spec/Job/JobParameters/ConstraintCollectionProvider/SimpleYamlImportSpec.php
@@ -22,11 +22,12 @@ class SimpleYamlImportSpec extends ObjectBehavior
         $collection = $this->getConstraintCollection();
         $collection->shouldReturnAnInstanceOf('Symfony\Component\Validator\Constraints\Collection');
         $fields = $collection->fields;
-        $fields->shouldHaveCount(4);
+        $fields->shouldHaveCount(5);
         $fields->shouldHaveKey('filePath');
         $fields->shouldHaveKey('uploadAllowed');
         $fields->shouldHaveKey('invalid_items_file_format');
         $fields->shouldHaveKey('user_to_notify');
+        $fields->shouldHaveKey('is_user_authenticated');
     }
 
     function it_supports_a_job(JobInterface $job)

--- a/src/Pim/Component/Connector/spec/Job/JobParameters/DefaultValuesProvider/SimpleCsvExportSpec.php
+++ b/src/Pim/Component/Connector/spec/Job/JobParameters/DefaultValuesProvider/SimpleCsvExportSpec.php
@@ -25,7 +25,8 @@ class SimpleCsvExportSpec extends ObjectBehavior
                 'delimiter'  => ";",
                 'enclosure'  => '"',
                 'withHeader' => true,
-                'user_to_notify' => null
+                'user_to_notify' => null,
+                'is_user_authenticated' => false,
             ]
         );
     }

--- a/src/Pim/Component/Connector/spec/Job/JobParameters/DefaultValuesProvider/SimpleCsvExportSpec.php
+++ b/src/Pim/Component/Connector/spec/Job/JobParameters/DefaultValuesProvider/SimpleCsvExportSpec.php
@@ -25,7 +25,7 @@ class SimpleCsvExportSpec extends ObjectBehavior
                 'delimiter'  => ";",
                 'enclosure'  => '"',
                 'withHeader' => true,
-                'notification_user' => null
+                'user_to_notify' => null
             ]
         );
     }

--- a/src/Pim/Component/Connector/spec/Job/JobParameters/DefaultValuesProvider/SimpleCsvImportSpec.php
+++ b/src/Pim/Component/Connector/spec/Job/JobParameters/DefaultValuesProvider/SimpleCsvImportSpec.php
@@ -28,7 +28,8 @@ class SimpleCsvImportSpec extends ObjectBehavior
                 'withHeader'                => true,
                 'uploadAllowed'             => true,
                 'invalid_items_file_format' => 'csv',
-                'user_to_notify'         => null,
+                'user_to_notify'            => null,
+                'is_user_authenticated'     => false,
             ]
         );
     }

--- a/src/Pim/Component/Connector/spec/Job/JobParameters/DefaultValuesProvider/SimpleCsvImportSpec.php
+++ b/src/Pim/Component/Connector/spec/Job/JobParameters/DefaultValuesProvider/SimpleCsvImportSpec.php
@@ -28,7 +28,7 @@ class SimpleCsvImportSpec extends ObjectBehavior
                 'withHeader'                => true,
                 'uploadAllowed'             => true,
                 'invalid_items_file_format' => 'csv',
-                'notification_user'         => null,
+                'user_to_notify'         => null,
             ]
         );
     }

--- a/src/Pim/Component/Connector/spec/Job/JobParameters/DefaultValuesProvider/SimpleXlsxExportSpec.php
+++ b/src/Pim/Component/Connector/spec/Job/JobParameters/DefaultValuesProvider/SimpleXlsxExportSpec.php
@@ -24,7 +24,7 @@ class SimpleXlsxExportSpec extends ObjectBehavior
                 'filePath'     => sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'export_%job_label%_%datetime%.xlsx',
                 'withHeader'   => true,
                 'linesPerFile' => 10000,
-                'notification_user' => null
+                'user_to_notify' => null
             ]
         );
     }

--- a/src/Pim/Component/Connector/spec/Job/JobParameters/DefaultValuesProvider/SimpleXlsxExportSpec.php
+++ b/src/Pim/Component/Connector/spec/Job/JobParameters/DefaultValuesProvider/SimpleXlsxExportSpec.php
@@ -24,7 +24,8 @@ class SimpleXlsxExportSpec extends ObjectBehavior
                 'filePath'     => sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'export_%job_label%_%datetime%.xlsx',
                 'withHeader'   => true,
                 'linesPerFile' => 10000,
-                'user_to_notify' => null
+                'user_to_notify' => null,
+                'is_user_authenticated' => false,
             ]
         );
     }

--- a/src/Pim/Component/Connector/spec/Job/JobParameters/DefaultValuesProvider/SimpleYamlExportSpec.php
+++ b/src/Pim/Component/Connector/spec/Job/JobParameters/DefaultValuesProvider/SimpleYamlExportSpec.php
@@ -22,7 +22,8 @@ class SimpleYamlExportSpec extends ObjectBehavior
         $this->getDefaultValues()->shouldReturn(
             [
                 'filePath' => sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'export_%job_label%_%datetime%.yml',
-                'user_to_notify' => null
+                'user_to_notify' => null,
+                'is_user_authenticated' => false,
             ]
         );
     }

--- a/src/Pim/Component/Connector/spec/Job/JobParameters/DefaultValuesProvider/SimpleYamlExportSpec.php
+++ b/src/Pim/Component/Connector/spec/Job/JobParameters/DefaultValuesProvider/SimpleYamlExportSpec.php
@@ -22,7 +22,7 @@ class SimpleYamlExportSpec extends ObjectBehavior
         $this->getDefaultValues()->shouldReturn(
             [
                 'filePath' => sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'export_%job_label%_%datetime%.yml',
-                'notification_user' => null
+                'user_to_notify' => null
             ]
         );
     }

--- a/src/Pim/Component/Connector/spec/Job/JobParameters/DefaultValuesProvider/SimpleYamlImportSpec.php
+++ b/src/Pim/Component/Connector/spec/Job/JobParameters/DefaultValuesProvider/SimpleYamlImportSpec.php
@@ -24,7 +24,8 @@ class SimpleYamlImportSpec extends ObjectBehavior
                 'filePath'                  => null,
                 'uploadAllowed'             => true,
                 'invalid_items_file_format' => 'yaml',
-                'user_to_notify'         => null,
+                'user_to_notify'            => null,
+                'is_user_authenticated'     => false,
             ]
         );
     }

--- a/src/Pim/Component/Connector/spec/Job/JobParameters/DefaultValuesProvider/SimpleYamlImportSpec.php
+++ b/src/Pim/Component/Connector/spec/Job/JobParameters/DefaultValuesProvider/SimpleYamlImportSpec.php
@@ -24,7 +24,7 @@ class SimpleYamlImportSpec extends ObjectBehavior
                 'filePath'                  => null,
                 'uploadAllowed'             => true,
                 'invalid_items_file_format' => 'yaml',
-                'notification_user'         => null,
+                'user_to_notify'         => null,
             ]
         );
     }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
I've updated my accordingly to the discussion with @BitOne, and here a sum-up of the architecture:

We will have a queue to execute a job in CE/EE/Saas (no mode queue/no queue):
- launched from the UI
- launched from the CLI, with a new command (not implemented in this PR) 

The command "akeneo:batch:job" will not be modified (at least, for now):
- it executes a job synchronously (not pushed into the queue)
- or it executes a job execution synchronously

In the last case, "username" and "config" option are forbidden, because a job execution should be immutable.

- [x] Add an optional "username" in the command "akeneo:batch:job" (to be like the SimpleJobLauncher, except that the SimpleJobLauncher force the use of a user)
- [x] Add an option in the job parameters to authenticate (or not) the user that launched the job.
- [x] Rename key "notification_user" into "user_to_notify" ( @jjanvier comment on already merged PR)

What's left ?
- [ ] Add a table for the queue
- [ ] Push Job Execution messages into the queue with a "QueueJobLauncher"
- [ ] Create a daemon to consume job execution messages into the queue, execute them, and monitor them
- [ ] Create a command to create a job execution and push it into database => should be used by the cron in the future

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Ok
| Added Behats                      | -
| Added integration tests           | Ok
| Changelog updated                 | Ok
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
