### PR TITLE
PIM-6335: Variant products must have unique variant values

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Resources/config/validation/variantproduct.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/validation/variantproduct.yml
@@ -3,6 +3,7 @@ Pim\Component\Catalog\Model\VariantProduct:
         - Pim\Component\Catalog\Validator\Constraints\VariantProductParent: ~
         - Pim\Component\Catalog\Validator\Constraints\SameFamilyThanParent: ~
         - Pim\Component\Catalog\Validator\Constraints\NotEmptyVariantAxes: ~
+        - Pim\Component\Catalog\Validator\Constraints\SiblingUniqueVariantAxes: ~
         - Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity:
             fields: [identifier]
             message: The same identifier is already set on another product

--- a/src/Pim/Bundle/CatalogBundle/Resources/translations/validators.en.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/translations/validators.en.yml
@@ -39,4 +39,5 @@ pim_catalog:
         has_a_root_product_model_as_parent: 'The sub product model parent must be a root product model'
         attribute_does_not_belong_to_family: 'Attribute "%attribute%" does not belong to the family "%family%"'
         variant_product_invalid_family: 'The variant product family must be the same than its parent'
+        variant_product_has_parent: 'The variant product "%variant_product%" must have a parent'
         invalid_variant_product_parent: 'Parent of the variant product "%variant_product%" cannot have product models as children, only variant products'

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Product/VariantProductIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Product/VariantProductIntegration.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\Product;
+
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+
+/**
+ * @author    Damien Carcel <damien.carcel@gmail.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class VariantProductIntegration extends TestCase
+{
+    public function testVariantProductHasParent(): void
+    {
+        $variantProduct = $this->get('pim_catalog.builder.variant_product')->createProduct('apollon_blue_m');
+        $this->get('pim_catalog.updater.product')->update($variantProduct, [
+            'values' => [
+                'size' => [
+                    [
+                        'locale' => null,
+                        'scope' => null,
+                        'data' => 'm',
+                    ],
+                ],
+            ],
+        ]);
+
+        $errors = $this->get('validator')->validate($variantProduct);
+        $this->assertEquals(1, $errors->count());
+        $this->assertEquals(
+            'The variant product "apollon_blue_m" must have a parent',
+            $errors->get(0)->getMessage()
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration(): Configuration
+    {
+        return new Configuration([Configuration::getFunctionalCatalogPath('catalog_modeling')]);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Product/VariantProductIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Product/VariantProductIntegration.php
@@ -37,6 +37,47 @@ class VariantProductIntegration extends TestCase
         );
     }
 
+    public function testVariantAxisValuesAreUnique(): void
+    {
+        $variantProduct1 = $this->get('pim_catalog.builder.variant_product')->createProduct('apollon_blue_m_1');
+        $this->get('pim_catalog.updater.product')->update($variantProduct1, [
+            'parent' => 'apollon_blue',
+            'values' => [
+                'size' => [
+                    [
+                        'locale' => null,
+                        'scope' => null,
+                        'data' => 'm',
+                    ],
+                ],
+            ],
+        ]);
+        $errors = $this->get('validator')->validate($variantProduct1);
+        $this->assertEquals(0, $errors->count());
+
+        $this->get('pim_catalog.saver.product')->save($variantProduct1);
+
+        $variantProduct2 = $this->get('pim_catalog.builder.variant_product')->createProduct('apollon_blue_m_2');
+        $this->get('pim_catalog.updater.product')->update($variantProduct2, [
+            'parent' => 'apollon_blue',
+            'values' => [
+                'size' => [
+                    [
+                        'locale' => null,
+                        'scope' => null,
+                        'data' => 'm',
+                    ],
+                ],
+            ],
+        ]);
+        $errors = $this->get('validator')->validate($variantProduct2);
+        $this->assertEquals(1, $errors->count());
+        $this->assertEquals(
+            'Cannot set value "[m]" for the attribute axis "size", as another sibling entity already has this value',
+            $errors->get(0)->getMessage()
+        );
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Pim/Component/Catalog/Validator/Constraints/SameFamilyThanParentValidator.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/SameFamilyThanParentValidator.php
@@ -32,9 +32,13 @@ class SameFamilyThanParentValidator extends ConstraintValidator
             throw new UnexpectedTypeException($constraint, SameFamilyThanParent::class);
         }
 
-        $parentFamilyVariant = $variantProduct->getParent()->getFamilyVariant()->getFamily();
+        if (null === $parent = $variantProduct->getParent()) {
+            return;
+        }
 
-        if ($variantProduct->getFamily()->getCode() !== $parentFamilyVariant->getCode()) {
+        $parentFamily = $parent->getFamilyVariant()->getFamily();
+
+        if ($variantProduct->getFamily()->getCode() !== $parentFamily->getCode()) {
             $this->context->buildViolation(SameFamilyThanParent::MESSAGE)->addViolation();
         }
     }

--- a/src/Pim/Component/Catalog/Validator/Constraints/VariantProductParent.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/VariantProductParent.php
@@ -15,6 +15,7 @@ use Symfony\Component\Validator\Constraint;
  */
 class VariantProductParent extends Constraint
 {
+    public const NO_PARENT = 'pim_catalog.constraint.variant_product_has_parent';
     public const INVALID_PARENT = 'pim_catalog.constraint.invalid_variant_product_parent';
 
     /**

--- a/src/Pim/Component/Catalog/Validator/Constraints/VariantProductParentValidator.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/VariantProductParentValidator.php
@@ -10,7 +10,8 @@ use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 /**
- * Validates that the parent of a variant product is not a root product model.
+ * Validates that the variant product has a parent, and that this parent do not
+ * have variant products as children.
  *
  * @author    Damien Carcel (damien.carcel@akeneo.com)
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
@@ -31,10 +32,13 @@ class VariantProductParentValidator extends ConstraintValidator
             throw new UnexpectedTypeException($constraint, VariantProductParent::class);
         }
 
-        $familyVariant = $variantProduct->getFamilyVariant();
         $parent = $variantProduct->getParent();
 
-        if (null === $familyVariant || null === $parent) {
+        if (null === $parent) {
+            $this->context->buildViolation(VariantProductParent::NO_PARENT, [
+                '%variant_product%' => $variantProduct->getIdentifier(),
+            ])->addViolation();
+
             return;
         }
 

--- a/src/Pim/Component/Catalog/spec/Validator/Constraints/VariantProductParentValidatorSpec.php
+++ b/src/Pim/Component/Catalog/spec/Validator/Constraints/VariantProductParentValidatorSpec.php
@@ -56,6 +56,28 @@ class VariantProductParentValidatorSpec extends ObjectBehavior
         ]);
     }
 
+    function it_builds_violation_if_variant_product_has_no_parent(
+        $context,
+        VariantProductInterface $variantProduct,
+        FamilyVariantInterface $familyVariant,
+        ProductModelInterface $productModel,
+        ConstraintViolationBuilderInterface $constraintViolationBuilder,
+        VariantProductParent $constraint
+    ) {
+        $variantProduct->getFamilyVariant()->willReturn($familyVariant);
+        $variantProduct->getParent()->willReturn(null);
+        $variantProduct->getIdentifier()->willReturn('variant_product');
+
+        $productModel->getProductModels()->shouldNotBeCalled();
+
+        $context->buildViolation(VariantProductParent::NO_PARENT, [
+            '%variant_product%' => 'variant_product',
+        ])->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->addViolation()->shouldBeCalled();
+
+        $this->validate($variantProduct, $constraint);
+    }
+
     function it_builds_violation_if_variant_product_parent_is_not_at_the_correct_tree_position(
         $context,
         VariantProductInterface $variantProduct,
@@ -97,30 +119,5 @@ class VariantProductParentValidatorSpec extends ObjectBehavior
         $context->buildViolation(Argument::cetera())->shouldNotBeCalled();
 
         $this->validate($variantProduct, $constraint);
-    }
-
-    function it_does_not_build_violation_if_variant_product_has_no_parent_or_no_variant_family(
-        $context,
-        VariantProductInterface $variantProduct1,
-        VariantProductInterface $variantProduct2,
-        VariantProductInterface $variantProduct3,
-        FamilyVariantInterface $familyVariant,
-        ProductModelInterface $productModel,
-        VariantProductParent $constraint
-    ) {
-        $variantProduct1->getFamilyVariant()->willReturn(null);
-        $variantProduct1->getParent()->willReturn($productModel);
-
-        $variantProduct2->getFamilyVariant()->willReturn($familyVariant);
-        $variantProduct2->getParent()->willReturn(null);
-
-        $variantProduct3->getFamilyVariant()->willReturn(null);
-        $variantProduct3->getParent()->willReturn(null);
-
-        $context->buildViolation(Argument::cetera())->shouldNotBeCalled();
-
-        $this->validate($variantProduct1, $constraint);
-        $this->validate($variantProduct2, $constraint);
-        $this->validate($variantProduct3, $constraint);
     }
 }


### PR DESCRIPTION
## Description

Variant products contain the values corresponding to the variant axes of the last variation level. As for the sub product models, these values must be unique.

To ensure that, this PR adds to the variant products the same `SiblingUniqueVariantAxes` that is already used for product models.

It also adds a missing validation on variant product => ensure that the variant product has a parent!

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added Behats                      | -
| Added integration tests           | OK
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
