### PR TITLE
PIM-6669: enrich a sub product model

### DIFF
--- a/features/product-model/edit_product_model.feature
+++ b/features/product-model/edit_product_model.feature
@@ -38,3 +38,13 @@ Feature: Edit a product model
     When I visit the "Marketing" group
     Then the field Model name should be read only
     And the field Model description should be read only
+    When I visit the "Medias" group
+    Then the field Notice should be read only
+    And I should see the text "This attribute can be updated on the common attributes."
+
+  Scenario: Variant axes attributes are read only
+    Given I am logged in as "Mary"
+    And I edit the "apollon_blue" product model
+    And I visit the "Product" group
+    Then the field Color should be read only
+    And I should see the text "Color (Variant axis)"

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/ProductModelNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/ProductModelNormalizer.php
@@ -119,6 +119,11 @@ class ProductModelNormalizer implements NormalizerInterface
             $levelAttributes[] = $attribute->getCode();
         }
 
+        $axesAttributes = [];
+        foreach ($this->attributesProvider->getAxes($productModel) as $attribute) {
+            $axesAttributes[] = $attribute->getCode();
+        }
+
         $normalizedFamilyVariant = $this->normalizer->normalize($productModel->getFamilyVariant(), 'standard');
 
         $normalizedProductModel['meta'] = [
@@ -129,6 +134,7 @@ class ProductModelNormalizer implements NormalizerInterface
                 'updated'                   => $updated,
                 'model_type'                => 'product_model',
                 'attributes_for_this_level' => $levelAttributes,
+                'attributes_axes'           => $axesAttributes,
                 'image'                     => $this->normalizeImage($productModel->getImage(), $format, $context),
             ] + $this->getLabels($productModel);
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_model/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_model/edit.yml
@@ -192,6 +192,12 @@ extensions:
         targetZone: self
         position: 100
 
+    pim-product-model-edit-form-read-only-variant-axes:
+        module: pim/product-model-edit-form/attributes/variant-axes
+        parent: pim-product-model-edit-form-attributes
+        targetZone: self
+        position: 110
+
     pim-product-model-edit-form-locale-specific:
         module: pim/product-edit-form/attributes/locale-specific
         parent: pim-product-model-edit-form-attributes

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
@@ -700,6 +700,7 @@ config:
         pim/product-model-edit-form/product-model-label: pimenrich/js/product-model/form/product-model-label
         pim/product-model-edit-form/save: pimenrich/js/product-model/form/save
         pim/product-model-edit-form/attributes/read-only-parent-attributes: pimenrich/js/product-model/form/attributes/read-only-parent-attributes
+        pim/product-model-edit-form/attributes/variant-axes: pimenrich/js/product-model/form/attributes/variant-axes
 
         # Attribute group
         pim/attribute-group-form/tab/attribute: pimenrich/js/attribute-group/form/tab/attribute

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product-model/form/attributes/variant-axes.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product-model/form/attributes/variant-axes.js
@@ -1,6 +1,6 @@
 'use strict';
 /**
- * This module sets parent attributes as read only and add a message in the footer of the field
+ * This module sets variant axes as read only and add a message in the label of the field
  *
  * @author    Adrien Pétremann <adrien.petremann@akeneo.com>
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
@@ -32,14 +32,14 @@ define(
              */
             addFieldExtension: function (event) {
                 var productModel = this.getFormData();
-                if (!productModel.meta.attributes_for_this_level) {
+                if (!productModel.meta.attributes_axes) {
                     return;
                 }
 
-                var levelAttributeCodes = productModel.meta.attributes_for_this_level;
+                var axesAttributeCodes = productModel.meta.attributes_axes;
                 var field = event.field;
 
-                if (!_.contains(levelAttributeCodes, field.attribute.code)) {
+                if (_.contains(axesAttributeCodes, field.attribute.code)) {
                     field.setEditable(false);
                     this.updateFieldElements(field);
                 }
@@ -53,18 +53,10 @@ define(
              * @param {Object} field
              */
             updateFieldElements: function (field) {
-                var productModel = this.getFormData();
-                var message = '';
+                var message = '(' + __('pim_enrich.entity.product_model.variant_axis') + ')';
+                var element = '<span class="">' + message + '</span>';
 
-                if ('product_model' === productModel.meta.model_type) {
-                    message = __('pim_enrich.entity.product_model.read_only_parent_attribute_from_common');
-                } else {
-                    // TODO: PIM-6451, specific message for variant products
-                }
-
-                var element = '<span class="AknFieldContainer-unavailable">' + message + '</span>';
-
-                field.addElement('footer', 'read_only_parent_attribute', element);
+                field.addElement('label', 'variant_axis', element);
             }
         });
     }

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
@@ -245,6 +245,8 @@ pim_enrich:
                 update_successful: Product model successfully updated.
                 update_failed: The product model could not be updated.
                 field_not_ready: "The product model cannot be saved right now. The following fields are not ready: {{ fields }}"
+            read_only_parent_attribute_from_common: This attribute can be updated on the common attributes.
+            variant_axis: Variant axis
         association_type:
             info:
                 deletion_successful: Association type successfully deleted.
@@ -1062,6 +1064,7 @@ page_title:
     pim_enrich_attribute_edit:             Attributes {{ attribute.label }} | Edit
     pim_enrich_product_index:              Products
     pim_enrich_product_edit:               Products {{ product.sku }} | Edit
+    pim_enrich_product_model_edit:         Product models {{ product.sku }} | Edit
     pim_enrich_family_index:               Families
     pim_enrich_family_edit:                Families {{ family.label }} | Edit
     pim_enrich_channel_index:              Channels

--- a/src/Pim/Bundle/EnrichBundle/spec/Normalizer/ProductModelNormalizerSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Normalizer/ProductModelNormalizerSpec.php
@@ -51,7 +51,7 @@ class ProductModelNormalizerSpec extends ObjectBehavior
         $this->supportsNormalization($productModel, 'internal_api')->shouldReturn(true);
     }
 
-    function it_normalize_products(
+    function it_normalize_product_models(
         $normalizer,
         $versionNormalizer,
         $fileNormalizer,
@@ -121,6 +121,7 @@ class ProductModelNormalizerSpec extends ObjectBehavior
         ];
 
         $attributesProvider->getAttributes($productModel)->willReturn([$pictureAttribute]);
+        $attributesProvider->getAxes($productModel)->willReturn([$pictureAttribute]);
         $pictureAttribute->getCode()->willReturn('picture');
 
         $localeRepository->getActivatedLocaleCodes()->willReturn(['en_US', 'fr_FR']);
@@ -162,6 +163,7 @@ class ProductModelNormalizerSpec extends ObjectBehavior
                     'updated'        => 'normalized_update_version',
                     'model_type'     => 'product_model',
                     'attributes_for_this_level' => ['picture'],
+                    'attributes_axes' => ['picture'],
                     'image'          => $fileNormalized,
                     'label'          => [
                         'en_US' => 'Tshirt blue',


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This PR adds more business to the enrich of sub product models, such as:
- Adding a message under attributes coming from parent in the PEF
- Locking variant axis (and add message)
- Fix title of the PEF when editing a product model

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Y
| Added Behats                      | Y
| Added integration tests           | N
| Changelog updated                 | N
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo