### PR TITLE
PIM-6352: Fix broken behats regarding grid filtering

### DIFF
--- a/features/product/filtering/filter_products_per_date_fields.feature
+++ b/features/product/filtering/filter_products_per_date_fields.feature
@@ -22,9 +22,9 @@ Feature: Filter products by date field
     Then the grid should contain 3 elements
     And I should see products postit, book and mug
     And I should be able to use the following filters:
-      | filter  | operator     | value | result       |
-      | release | is empty     |       | book and mug |
-      | release | is not empty |       | postit       |
+      | filter  | operator     | value | result |
+      | release | is empty     |       | book   |
+      | release | is not empty |       | postit |
 
   Scenario: Successfully filter products by date attributes
     Given the following products:

--- a/features/product/filtering/filter_products_per_media.feature
+++ b/features/product/filtering/filter_products_per_media.feature
@@ -18,6 +18,7 @@ Feature: Filter products per media
       | shirt-one   | tshirts |
       | shirt-two   | tshirts |
       | shirt-three | tshirts |
+      | shirt-four  | tshirts |
     And the following product values:
       | product     | attribute  | value                              |
       | shirt-one   | image      | %fixtures%/akeneo.jpg              |
@@ -25,15 +26,16 @@ Feature: Filter products per media
       | shirt-three | image      | %fixtures%/fanatic-freewave-76.gif |
       | shirt-one   | attachment | %fixtures%/akeneo.txt              |
       | shirt-two   | attachment | %fixtures%/fanatic-freewave-76.txt |
+    And the "shirt-four" product has the "attachment" attribute
     And I am logged in as "Mary"
     When I am on the products page
-    Then the grid should contain 3 elements
-    And I should see products shirt-one, shirt-two and shirt-three
+    Then the grid should contain 4 elements
+    And I should see products shirt-one, shirt-two, shirt-three and shirt-four
     And I should be able to use the following filters:
       | filter     | operator         | value      | result                    |
       | image      | starts with      | a          | shirt-one                 |
       | image      | contains         | ic         | shirt-two and shirt-three |
       | attachment | does not contain | neo        | shirt-two                 |
       | image      | is equal to      | akeneo.jpg | shirt-one                 |
-      | attachment | is empty         |            | shirt-three               |
-      | attachment | is not empty     |            | shirt-one, shirt-two      |
+      | attachment | is empty         |            | shirt-four                |
+      | attachment | is not empty     |            | shirt-one and shirt-two   |

--- a/features/product/filtering/filter_products_per_number_fields.feature
+++ b/features/product/filtering/filter_products_per_number_fields.feature
@@ -24,21 +24,21 @@ Feature: Filter products by number field
     Then the grid should contain 3 elements
     And I should see products postit, book and mug
     And I should be able to use the following filters:
-      | filter | operator     | value | result         |
-      | count  | is empty     |       | book and mug   |
-      | count  | is not empty |       | postit         |
-      | count  | >            | 200   |                |
-      | count  | <            | 200   |                |
-      | count  | >            | 199   | postit         |
-      | count  | <            | 201   | postit         |
-      | count  | >=           | 200   | postit         |
-      | count  | <=           | 200   | postit         |
-      | count  | =            | 200   | postit         |
-      | count  | =            | 0     |                |
-      | count  | >            | 0     | postit         |
-      | rate   | is empty     |       | mug and postit |
-      | rate   | is not empty |       | book           |
-      | rate   | >            | 9.5   |                |
-      | rate   | <=           | 9.5   | book           |
-      | rate   | =            | 0     |                |
-      | rate   | >            | 0     | book           |
+      | filter | operator     | value | result |
+      | count  | is empty     |       | book   |
+      | count  | is not empty |       | postit |
+      | count  | >            | 200   |        |
+      | count  | <            | 200   |        |
+      | count  | >            | 199   | postit |
+      | count  | <            | 201   | postit |
+      | count  | >=           | 200   | postit |
+      | count  | <=           | 200   | postit |
+      | count  | =            | 200   | postit |
+      | count  | =            | 0     |        |
+      | count  | >            | 0     | postit |
+      | rate   | is empty     |       | mug    |
+      | rate   | is not empty |       | book   |
+      | rate   | >            | 9.5   |        |
+      | rate   | <=           | 9.5   | book   |
+      | rate   | =            | 0     |        |
+      | rate   | >            | 0     | book   |

--- a/features/product/filtering/filter_products_per_option_fields.feature
+++ b/features/product/filtering/filter_products_per_option_fields.feature
@@ -24,19 +24,19 @@ Feature: Filter products per option
     Given I am on the products page
     And the grid should contain 3 elements
     Then I should be able to use the following filters:
-      | filter | operator     | value | result          |
-      | size   | in list      | M     | Sweat           |
-      | size   | is empty     |       | Shirt and Shoes |
-      | size   | is not empty |       | Sweat           |
+      | filter | operator     | value | result |
+      | size   | in list      | M     | Sweat  |
+      | size   | is empty     |       | Shirt  |
+      | size   | is not empty |       | Sweat  |
 
   Scenario: Successfully filter products by a multi option
     Given I am on the products page
     And the grid should contain 3 elements
     Then I should be able to use the following filters:
-      | filter | operator     | value | result          |
-      | color  | in list      | Black | Shoes           |
-      | color  | is empty     |       | Shirt and Sweat |
-      | color  | is not empty |       | Shoes           |
+      | filter | operator     | value | result |
+      | color  | in list      | Black | Shoes  |
+      | color  | is empty     |       | Shirt  |
+      | color  | is not empty |       | Shoes  |
 
   @jira https://akeneo.atlassian.net/browse/PIM-5802
   Scenario: Successfully keep data previously filled on a simple option

--- a/features/product/filtering/filter_products_per_text_fields.feature
+++ b/features/product/filtering/filter_products_per_text_fields.feature
@@ -51,11 +51,11 @@ Feature: Filter products by text field
     Then the grid should contain 3 elements
     And I should see products postit, book and mug
     And I should be able to use the following filters:
-      | filter      | operator     | value | result          |
-      | name        | is empty     |       | book and mug    |
-      | name        | is not empty |       | postit          |
-      | description | is empty     |       | postit and book |
-      | description | is not empty |       | mug             |
+      | filter      | operator     | value | result |
+      | name        | is empty     |       | book   |
+      | name        | is not empty |       | postit |
+      | description | is empty     |       | postit |
+      | description | is not empty |       | mug    |
 
   Scenario: Successfully filter products by empty value for localizable text attribute
     Given the following attributes:
@@ -70,9 +70,9 @@ Feature: Filter products by text field
     Then the grid should contain 3 elements
     And I should see products postit, book and mug
     And I should be able to use the following filters:
-      | filter | operator     | value | result       |
-      | name   | is empty     |       | book and mug |
-      | name   | is not empty |       | postit       |
+      | filter | operator     | value | result |
+      | name   | is empty     |       | book   |
+      | name   | is not empty |       | postit |
 
   Scenario: Successfully filter products by empty value for scopable text attribute
     Given the following attributes:
@@ -87,9 +87,9 @@ Feature: Filter products by text field
     Then the grid should contain 3 elements
     And I should see products postit, book and mug
     And I should be able to use the following filters:
-      | filter | operator     | value | result       |
-      | name   | is empty     |       | book and mug |
-      | name   | is not empty |       | postit       |
+      | filter | operator     | value | result |
+      | name   | is empty     |       | book   |
+      | name   | is not empty |       | postit |
 
   Scenario: Successfully filter products by empty value for scopable and localizable text attribute
     Given I add the "english" locale to the "mobile" channel
@@ -105,6 +105,6 @@ Feature: Filter products by text field
     Then the grid should contain 3 elements
     And I should see products postit, book and mug
     And I should be able to use the following filters:
-      | filter | operator     | value | result       |
-      | name   | is empty     |       | book and mug |
-      | name   | is not empty |       | postit       |
+      | filter | operator     | value | result |
+      | name   | is empty     |       | book   |
+      | name   | is not empty |       | postit |

--- a/features/reference-data/product/filtering/filtering_by_multi_reference_data.feature
+++ b/features/reference-data/product/filtering/filtering_by_multi_reference_data.feature
@@ -9,13 +9,15 @@ Feature: Filter products by reference data
     And the following "sole_color" attribute reference data: Red, Blue and Green
     And the following "sole_fabric" attribute reference data: Cashmerewool, Neoprene and Silk
     And the following products:
-      | sku    |
-      | postit |
-      | mug    |
+      | sku    | family |
+      | postit | heels  |
+      | mug    | heels  |
+      | book   | heels  |
     And the following product values:
       | product | attribute   | value             |
       | postit  | sole_color  | Red               |
       | postit  | sole_fabric | Cashmerewool,Silk |
+    And the "mug" product has the "sole_fabric" attributes
     And I am logged in as "Mary"
     And I am on the products page
 

--- a/features/reference-data/product/filtering/filtering_by_reference_data.feature
+++ b/features/reference-data/product/filtering/filtering_by_reference_data.feature
@@ -26,12 +26,12 @@ Feature: Filter products by reference data
       | filter      | operator     | value                 | result |
       | sole_color  | in list      | Red                   | postit |
       | sole_color  | in list      | Red,Blue              | postit |
-      | sole_color  | is empty     |                       | mug    |
+      | sole_color  | is empty     |                       |        |
       | sole_color  | is not empty |                       | postit |
       | sole_color  | in list      | Green                 |        |
       | sole_fabric | in list      | Cashmerewool          | postit |
       | sole_fabric | in list      | Cashmerewool,Neoprene | postit |
       | sole_fabric | in list      | Silk                  | postit |
       | sole_fabric | in list      | Neoprene              |        |
-      | sole_fabric | is empty     |                       | mug    |
+      | sole_fabric | is empty     |                       |        |
       | sole_fabric | is not empty |                       | postit |

--- a/features/reference-data/product/filtering/filtering_by_reference_data_with_locale_and_scope.feature
+++ b/features/reference-data/product/filtering/filtering_by_reference_data_with_locale_and_scope.feature
@@ -28,28 +28,28 @@ Feature: Filter products by reference data with locale and scope
       | filter      | operator     | value        | result |
       | cap_color   | in list      | Black        | postit |
       | cap_color   | in list      | Black,Orange | postit |
-      | cap_color   | is empty     |              | mug    |
+      | cap_color   | is empty     |              |        |
       | cap_color   | is not empty |              | postit |
       | cap_color   | in list      | Orange       |        |
       | lace_fabric | in list      | Cotton       | postit |
       | lace_fabric | in list      | Cotton,Straw | postit |
       | lace_fabric | in list      | Flax         | postit |
       | lace_fabric | in list      | Straw        |        |
-      | lace_fabric | is empty     |              | mug    |
+      | lace_fabric | is empty     |              |        |
       | lace_fabric | is not empty |              | postit |
     When I filter by "scope" with operator "" and value "Mobile"
     Then I should be able to use the following filters:
       | filter      | operator     | value         | result |
       | cap_color   | in list      | Purple        | postit |
       | cap_color   | in list      | Purple,Orange | postit |
-      | cap_color   | is empty     |               | mug    |
+      | cap_color   | is empty     |               |        |
       | cap_color   | is not empty |               | postit |
       | cap_color   | in list      | Orange        |        |
       | lace_fabric | in list      | Straw         | postit |
       | lace_fabric | in list      | Cotton,Straw  | postit |
       | lace_fabric | in list      | Flax          |        |
       | lace_fabric | in list      | Cotton        |        |
-      | lace_fabric | is empty     |               | mug    |
+      | lace_fabric | is empty     |               |        |
       | lace_fabric | is not empty |               | postit |
 
   Scenario: Successfully filter product with multi reference data filters

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/LabelOrIdentifierFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/LabelOrIdentifierFilter.php
@@ -2,7 +2,6 @@
 
 namespace Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Field;
 
-use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Pim\Component\Catalog\Exception\InvalidOperatorException;
 use Pim\Component\Catalog\Query\Filter\FieldFilterHelper;
 use Pim\Component\Catalog\Query\Filter\Operators;

--- a/src/Pim/Component/Catalog/Model/ProductModel.php
+++ b/src/Pim/Component/Catalog/Model/ProductModel.php
@@ -490,7 +490,7 @@ class ProductModel implements ProductModelInterface
     /**
      * {@inheritdoc}
      */
-    public function getLabel(?string $localeCode): string
+    public function getLabel(string $localeCode = null): string
     {
         $code = (string) $this->getCode();
         $attributeAsLabel = $this->familyVariant->getFamily()->getAttributeAsLabel();

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/ProductAndProductModel/ProductModelPropertiesNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/ProductAndProductModel/ProductModelPropertiesNormalizer.php
@@ -39,6 +39,7 @@ class ProductModelPropertiesNormalizer implements NormalizerInterface, Serialize
 
         $data[self::FIELD_ID] = 'product_model_' . (string) $productModel->getId();
         $data[StandardPropertiesNormalizer::FIELD_IDENTIFIER] = $productModel->getCode();
+        $data[StandardPropertiesNormalizer::FIELD_LABEL] = $productModel->getLabel();
         $data[StandardPropertiesNormalizer::FIELD_CREATED] = $this->serializer->normalize(
             $productModel->getCreated(),
             $format

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/ProductAndProductModel/ProductPropertiesNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/ProductAndProductModel/ProductPropertiesNormalizer.php
@@ -43,6 +43,7 @@ class ProductPropertiesNormalizer implements NormalizerInterface, SerializerAwar
 
         $data[self::FIELD_ID] = 'product_' .(string) $product->getId();
         $data[StandardPropertiesNormalizer::FIELD_IDENTIFIER] = $product->getIdentifier();
+        $data[StandardPropertiesNormalizer::FIELD_LABEL] = $product->getLabel();
         $data[StandardPropertiesNormalizer::FIELD_CREATED] = $this->serializer->normalize(
             $product->getCreated(),
             $format

--- a/src/Pim/Component/Catalog/spec/Model/ProductModelSpec.php
+++ b/src/Pim/Component/Catalog/spec/Model/ProductModelSpec.php
@@ -179,6 +179,33 @@ class ProductModelSpec extends ObjectBehavior
         $this->getLabel('fr_FR')->shouldReturn('shovel');
     }
 
+    function it_gets_the_label_if_no_locale_is_specified(
+        FamilyVariantInterface $familyVariant,
+        FamilyInterface $family,
+        AttributeInterface $attributeAsLabel,
+        ValueCollectionInterface $values,
+        ValueInterface $nameValue
+    ) {
+        $familyVariant->getFamily()->willReturn($family);
+        $family->getAttributeAsLabel()->willReturn($attributeAsLabel);
+        $attributeAsLabel->getCode()->willReturn('name');
+        $attributeAsLabel->isLocalizable()->willReturn(false);
+        $attributeAsLabel->isUnique()->willReturn(false);
+
+        $values->toArray()->willreturn(['name-<all_channels>-fr_FR' => $nameValue]);
+
+        $nameValue->getAttribute()->willReturn($attributeAsLabel);
+        $nameValue->getScope()->willReturn(null);
+        $nameValue->getLocale()->willReturn('fr_FR');
+        $nameValue->getData()->willReturn(null);
+
+        $this->setFamilyVariant($familyVariant);
+        $this->setValues($values);
+        $this->setCode('shovel');
+
+        $this->getLabel()->shouldReturn('shovel');
+    }
+
     function it_gets_the_image_of_the_product_model(
         FamilyVariantInterface $familyVariant,
         FamilyInterface $family,

--- a/src/Pim/Component/Catalog/spec/Normalizer/Indexing/ProductAndProductModel/ProductModelPropertiesNormalizerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Normalizer/Indexing/ProductAndProductModel/ProductModelPropertiesNormalizerSpec.php
@@ -2,7 +2,6 @@
 
 namespace spec\Pim\Component\Catalog\Normalizer\Indexing\ProductAndProductModel;
 
-use Doctrine\Common\Collections\Collection;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Model\FamilyInterface;
 use Pim\Component\Catalog\Model\FamilyVariantInterface;
@@ -50,6 +49,8 @@ class ProductModelPropertiesNormalizerSpec extends ObjectBehavior
         $productModel->getParent()->willReturn(null);
 
         $productModel->getCode()->willReturn('sku-001');
+        $productModel->getLabel()->willReturn('my sku-001');
+
         $productModel->getCreated()->willReturn($now);
         $serializer
             ->normalize($family, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
@@ -78,6 +79,7 @@ class ProductModelPropertiesNormalizerSpec extends ObjectBehavior
             [
                 'id'             => 'product_model_67',
                 'identifier'     => 'sku-001',
+                'label'          => 'my sku-001',
                 'created'        => $now->format('c'),
                 'updated'        => $now->format('c'),
                 'family'         => 'family_A',
@@ -99,6 +101,7 @@ class ProductModelPropertiesNormalizerSpec extends ObjectBehavior
 
         $productModel->getId()->willReturn(67);
         $productModel->getCode()->willReturn('sku-001');
+        $productModel->getLabel()->willReturn('my sku-001');
 
         $productModel->getParent()->willReturn(null);
 
@@ -146,6 +149,7 @@ class ProductModelPropertiesNormalizerSpec extends ObjectBehavior
             [
                 'id'             => 'product_model_67',
                 'identifier'     => 'sku-001',
+                'label'          => 'my sku-001',
                 'created'        => $now->format('c'),
                 'updated'        => $now->format('c'),
                 'family'         => [
@@ -180,6 +184,7 @@ class ProductModelPropertiesNormalizerSpec extends ObjectBehavior
 
         $productModel->getId()->willReturn(67);
         $productModel->getCode()->willReturn('sku-001');
+        $productModel->getLabel()->willReturn('my sku-001');
 
         $productModel->getParent()->willReturn($parent);
         $parent->getCode()->willReturn('parent_A');
@@ -237,6 +242,7 @@ class ProductModelPropertiesNormalizerSpec extends ObjectBehavior
             [
                 'id'             => 'product_model_67',
                 'identifier'     => 'sku-001',
+                'label'          => 'my sku-001',
                 'created'        => $now->format('c'),
                 'updated'        => $now->format('c'),
                 'family'         => [

--- a/src/Pim/Component/Catalog/spec/Normalizer/Indexing/ProductAndProductModel/ProductPropertiesNormalizerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Normalizer/Indexing/ProductAndProductModel/ProductPropertiesNormalizerSpec.php
@@ -57,6 +57,7 @@ class ProductPropertiesNormalizerSpec extends ObjectBehavior
 
         $product->getIdentifier()->willReturn('sku-001');
         $product->getFamily()->willReturn($family);
+        $product->getLabel()->willReturn('my sku-001');
         $serializer->normalize($family, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
             ->willReturn(null);
 
@@ -88,6 +89,7 @@ class ProductPropertiesNormalizerSpec extends ObjectBehavior
             [
                 'id'             => 'product_67',
                 'identifier'     => 'sku-001',
+                'label'          => 'my sku-001',
                 'created'        => $now->format('c'),
                 'updated'        => $now->format('c'),
                 'family'         => null,
@@ -113,6 +115,7 @@ class ProductPropertiesNormalizerSpec extends ObjectBehavior
 
         $product->getId()->willReturn(67);
         $product->getIdentifier()->willReturn('sku-001');
+        $product->getLabel()->willReturn('my sku-001');
 
         $product->getCreated()->willReturn($now);
         $serializer->normalize(
@@ -177,6 +180,7 @@ class ProductPropertiesNormalizerSpec extends ObjectBehavior
             [
                 'id'            => 'product_67',
                 'identifier'    => 'sku-001',
+                'label'          => 'my sku-001',
                 'created'       => $now->format('c'),
                 'updated'       => $now->format('c'),
                 'family' => [
@@ -230,6 +234,7 @@ class ProductPropertiesNormalizerSpec extends ObjectBehavior
 
         $variantProduct->getId()->willReturn(67);
         $variantProduct->getIdentifier()->willReturn('sku-001');
+        $variantProduct->getLabel()->willReturn('my sku-001');
 
         $variantProduct->getCreated()->willReturn($now);
         $serializer->normalize(
@@ -268,24 +273,25 @@ class ProductPropertiesNormalizerSpec extends ObjectBehavior
             ->willReturn(['the completenesses']);
 
         $this->normalize($variantProduct, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)->shouldReturn([
-                'id'            => 'product_67',
-                'identifier'    => 'sku-001',
-                'created'       => $now->format('c'),
-                'updated'       => $now->format('c'),
-                'family' => [
+                'id'             => 'product_67',
+                'identifier'     => 'sku-001',
+                'label'          => 'my sku-001',
+                'created'        => $now->format('c'),
+                'updated'        => $now->format('c'),
+                'family'         => [
                     'code'   => 'family',
                     'labels' => [
                         'fr_FR' => 'Une famille',
                         'en_US' => 'A family',
                     ],
                 ],
-                'enabled'       => false,
-                'categories'    => [],
-                'groups'        => [],
-                'completeness'  => ['the completenesses'],
+                'enabled'        => false,
+                'categories'     => [],
+                'groups'         => [],
+                'completeness'   => ['the completenesses'],
                 'family_variant' => 'family_variant_A',
-                'parent'        => 'parent_A',
-                'values'        => [],
+                'parent'         => 'parent_A',
+                'values'         => [],
             ]
         );
     }
@@ -306,6 +312,7 @@ class ProductPropertiesNormalizerSpec extends ObjectBehavior
 
         $variantProduct->getId()->willReturn(67);
         $variantProduct->getIdentifier()->willReturn('sku-001');
+        $variantProduct->getLabel()->willReturn('my sku-001');
 
         $variantProduct->getCreated()->willReturn($now);
         $serializer->normalize(
@@ -383,6 +390,7 @@ class ProductPropertiesNormalizerSpec extends ObjectBehavior
             [
                 'id'            => 'product_67',
                 'identifier'    => 'sku-001',
+                'label'          => 'my sku-001',
                 'created'       => $now->format('c'),
                 'updated'       => $now->format('c'),
                 'family' => [


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

- Not empty in the datagrid does not show products that don't have the attribute.
- Add Label property in the Product and product model index

**Fixes behats:**
features/product/filtering/filter_products_per_date_fields.feature
features/product/filtering/filter_products_per_media.feature
features/product/filtering/filter_products_per_number_fields.feature
features/product/filtering/filter_products_per_option_fields.feature
features/product/filtering/filter_products_per_text_fields.feature
features/reference-data/product/filtering/filtering_by_multi_reference_data.feature
features/reference-data/product/filtering/filtering_by_reference_data.feature
features/reference-data/product/filtering/filtering_by_reference_data_with_locale_and_scope.feature

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Ok
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
