### PR TITLE
(Re) Active apcu cache for Doctrine in prod

### DIFF
--- a/app/config/config_prod.yml
+++ b/app/config/config_prod.yml
@@ -1,6 +1,16 @@
 imports:
     - { resource: config.yml }
 
+doctrine:
+    orm:
+        entity_managers:
+            default:
+                metadata_cache_driver:
+                    cache_provider: pim
+                result_cache_driver:
+                    cache_provider: pim
+                query_cache_driver:
+                    cache_provider: pim
 monolog:
     handlers:
         main:


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
Re-active the apcu cache (previously deactivated in a PR @jjanvier, who introduces a chain provider).

Activated only in prod because in dev/behat env, it would implies to restart apache as soon as you modify about Doctrine metadata.


Before (check time to get the repository, not normal):
https://blackfire.io/profiles/85442247-1ada-4aad-99fa-f2f94a8fd0fa/graph?settings%5Bdimension%5D=wt&settings%5Bdisplay%5D=landscape&settings%5BtabPane%5D=nodes&selected=Doctrine%5CORM%5CRepository%5CDefaultRepositoryFactory%3A%3AgetRepository&callname=main()

After:
https://blackfire.io/profiles/61af15bb-8ed9-4d39-9eec-51ab1e0e812d/graph?settings%5Bdimension%5D=wt&settings%5Bdisplay%5D=landscape&settings%5BtabPane%5D=nodes&selected=&callname=main()


**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
