### PR TITLE
PIM-6352: Make the sequential work for products

### DIFF
--- a/features/product/sequential_edit/sequential_edit_product_and_product_model.feature
+++ b/features/product/sequential_edit/sequential_edit_product_and_product_model.feature
@@ -1,0 +1,29 @@
+@javascript
+Feature: Edit sequentially some products
+  In order to enrich the catalog
+  As a regular user
+  I need to be able to edit sequentially some products
+
+  Background:
+    Given a "catalog_modeling" catalog configuration
+    And I am logged in as "Julia"
+    And I am on the products page
+
+  # PIM-6360: Those tests will be refactored once the sequential edit for product models works.
+  Scenario: Successfully sequentially edit some products but not the product models 1/2
+    Given I show the filter "color"
+    And I filter by "color" with operator "in list" and value "Crimson red"
+    And I sort by "SKU" value ascending
+    And I select rows model-tshirt-divided-crimson-red, running-shoes-xxs-crimson-red
+    When I press "Edit products sequentially" on the "Bulk Actions" dropdown button
+    Then I should see the text "running-shoes-xxs-crimson-red"
+    And I should see the text "Save and finish"
+
+  Scenario: Successfully sequentially edit some products but not the product models 2/2
+    Given I show the filter "color"
+    And I filter by "color" with operator "in list" and value "Crimson red"
+    And I sort by "SKU" value descending
+    And I select rows model-tshirt-divided-crimson-red, running-shoes-xxs-crimson-red
+    When I press "Edit products sequentially" on the "Bulk Actions" dropdown button
+    Then I should see the text "running-shoes-xxs-crimson-red"
+    And I should see the text "Save and finish"

--- a/src/Pim/Bundle/EnrichBundle/Controller/SequentialEditController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/SequentialEditController.php
@@ -91,6 +91,15 @@ class SequentialEditController
 
         $parameters = $this->parameterParser->parse($request);
 
+        # PIM-6360: to refactor for the product models sequential edit to work
+        $filteredIds = [];
+        foreach ($parameters['values'] as $id) {
+            if (1 !== preg_match('/^product_model_/', $id)) {
+                $filteredIds[] = $id;
+            }
+        }
+        $parameters['values'] = $filteredIds;
+
         $sequentialEdit = $this->seqEditManager->createEntity(
             $this->massActionDispatcher->dispatch($parameters),
             $this->userContext->getUser()


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This PR is a small patch that prevents editing products having the same id that product models selected in the datagrid.

It enables this by filtering the ids of the rows selected in the datagrid (removing the product model ids).

This patch will be reworked in an upcoming PR that makes the sequential edit work for product models as well (https://akeneo.atlassian.net/browse/PIM-6360).

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | Ok
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Ok
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
