### PR TITLE
config : adding parameters for switfmailer to add port and encryption…

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -78,6 +78,8 @@ doctrine:
 swiftmailer:
     transport:                "%mailer_transport%"
     host:                     "%mailer_host%"
+    port:                     "%mailer_port%"
+    encryption:               "%mailer_encryption%"
     username:                 "%mailer_user%"
     password:                 "%mailer_password%"
     spool:                    { type: memory }

--- a/app/config/pim_parameters.yml
+++ b/app/config/pim_parameters.yml
@@ -5,6 +5,8 @@ parameters:
 
     mailer_transport:     smtp
     mailer_host:          localhost
+    mailer_port:          25
+    mailer_encryption:    ~
     mailer_user:          ~
     mailer_password:      ~
     mailer_from_address:  no-reply@example.com


### PR DESCRIPTION
Description (for Contributor and Core Developer)

In some case, default smtp parameters must be overloaded like encryption capability and no-standard smtp port.

Default values choose from swiftmailer doc
http://symfony.com/doc/current/reference/configuration/swiftmailer.html#encryption
http://symfony.com/doc/current/reference/configuration/swiftmailer.html#port