### PR TITLE
Fix normalization of a product model with null data for image

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Normalizer/ProductModelNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/ProductModelNormalizer.php
@@ -174,7 +174,7 @@ class ProductModelNormalizer implements NormalizerInterface
      */
     private function normalizeImage(?ValueInterface $data, string $format, array $context = []): ?array
     {
-        if (null === $data) {
+        if (null === $data || null === $data->getData()) {
             return null;
         }
 

--- a/src/Pim/Bundle/EnrichBundle/spec/Normalizer/ProductModelNormalizerSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Normalizer/ProductModelNormalizerSpec.php
@@ -16,6 +16,7 @@ use Pim\Component\Catalog\Model\ValueInterface;
 use Pim\Component\Catalog\Repository\LocaleRepositoryInterface;
 use Pim\Component\Catalog\ValuesFiller\EntityWithFamilyValuesFillerInterface;
 use Pim\Component\Enrich\Converter\ConverterInterface;
+use Prophecy\Argument;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class ProductModelNormalizerSpec extends ObjectBehavior
@@ -51,7 +52,7 @@ class ProductModelNormalizerSpec extends ObjectBehavior
         $this->supportsNormalization($productModel, 'internal_api')->shouldReturn(true);
     }
 
-    function it_normalize_product_models(
+    function it_normalizes_product_models(
         $normalizer,
         $versionNormalizer,
         $fileNormalizer,
@@ -165,6 +166,117 @@ class ProductModelNormalizerSpec extends ObjectBehavior
                     'attributes_for_this_level' => ['picture'],
                     'attributes_axes' => ['picture'],
                     'image'          => $fileNormalized,
+                    'label'          => [
+                        'en_US' => 'Tshirt blue',
+                        'fr_FR' => 'Tshirt bleu',
+                    ]
+                ]
+            ]
+        );
+    }
+
+    function it_normalizes_product_models_without_image(
+        $normalizer,
+        $versionNormalizer,
+        $fileNormalizer,
+        $versionManager,
+        $localizedConverter,
+        $productValueConverter,
+        $formProvider,
+        $localeRepository,
+        $attributesProvider,
+        AttributeInterface $pictureAttribute,
+        ProductModelInterface $productModel,
+        FamilyVariantInterface $familyVariant,
+        FamilyInterface $family,
+        ValueInterface $picture
+    ) {
+        $options = [
+            'decimal_separator' => ',',
+            'date_format'       => 'dd/MM/yyyy',
+        ];
+
+        $productModelNormalized = [
+            'code'           => 'tshirt_blue',
+            'family_variant' => 'tshirts_color',
+            'family'         => 'tshirts',
+            'categories'     => ['summer'],
+            'values'         => [
+                'normalized_property' => [['data' => 'a nice normalized property', 'locale' => null, 'scope' => null]],
+                'number'              => [['data' => 12.5000, 'locale' => null, 'scope' => null]],
+                'metric'              => [['data' => 12.5000, 'locale' => null, 'scope' => null]],
+                'prices'              => [['data' => 12.5, 'locale' => null, 'scope' => null]],
+                'date'                => [['data' => '2015-01-31', 'locale' => null, 'scope' => null]],
+                'picture'             => [['data' => null, 'locale' => null, 'scope' => null]]
+            ]
+        ];
+
+        $familyVariantNormalized = [
+            'code'                   => 'tshirts_color',
+            'labels'                 => ['en_US' => 'Tshirts Color', 'fr_FR' => 'Tshirt Couleur'],
+            'family'                 => 'tshirts',
+            'variant_attribute_sets' => []
+        ];
+
+        $valuesLocalized = [
+            'normalized_property' => [['data' => 'a nice normalized property', 'locale' => null, 'scope' => null]],
+            'number'              => [['data' => '12,5000', 'locale' => null, 'scope' => null]],
+            'metric'              => [['data' => '12,5000', 'locale' => null, 'scope' => null]],
+            'prices'              => [['data' => '12,5', 'locale' => null, 'scope' => null]],
+            'date'                => [['data' => '31/01/2015', 'locale' => null, 'scope' => null]],
+            'picture'             => [['data' => null, 'locale' => null, 'scope' => null]]
+        ];
+
+        $normalizer->normalize($productModel, 'standard', $options)->willReturn($productModelNormalized);
+        $localizedConverter->convertToLocalizedFormats($productModelNormalized['values'], $options)->willReturn($valuesLocalized);
+
+        $valuesConverted = $valuesLocalized;
+
+        $attributesProvider->getAttributes($productModel)->willReturn([$pictureAttribute]);
+        $attributesProvider->getAxes($productModel)->willReturn([$pictureAttribute]);
+        $pictureAttribute->getCode()->willReturn('picture');
+
+        $localeRepository->getActivatedLocaleCodes()->willReturn(['en_US', 'fr_FR']);
+        $productModel->getLabel('en_US')->willReturn('Tshirt blue');
+        $productModel->getLabel('fr_FR')->willReturn('Tshirt bleu');
+
+        $productModel->getImage()->willReturn($picture);
+        $picture->getData()->willReturn(null);
+        $fileNormalizer->normalize(Argument::cetera())->shouldNotBeCalled();
+
+        $productValueConverter->convert($valuesLocalized)->willReturn($valuesConverted);
+
+        $productModel->getId()->willReturn(12);
+        $productModel->getCode()->willReturn('tshirt_blue');
+        $versionManager->getOldestLogEntry($productModel)->willReturn('create_version');
+        $versionNormalizer->normalize('create_version', 'internal_api')->willReturn('normalized_create_version');
+        $versionManager->getNewestLogEntry($productModel)->willReturn('update_version');
+        $versionNormalizer->normalize('update_version', 'internal_api')->willReturn('normalized_update_version');
+
+        $productModel->getFamilyVariant()->willReturn($familyVariant);
+        $familyVariant->getFamily()->willReturn($family);
+        $family->getCode()->willReturn('tshirts');
+        $normalizer->normalize($familyVariant, 'standard')->willReturn($familyVariantNormalized);
+
+        $formProvider->getForm($productModel)->willReturn('pim-product-model-edit-form');
+
+        $this->normalize($productModel, 'internal_api', $options)->shouldReturn(
+            [
+                'code'           => 'tshirt_blue',
+                'family_variant' => 'tshirts_color',
+                'family'         => 'tshirts',
+                'categories'     => ['summer'],
+                'values'         => $valuesConverted,
+                'meta'           => [
+                    'family_variant' => $familyVariantNormalized,
+                    'form'           => 'pim-product-model-edit-form',
+                    'id'             => 12,
+                    'created'        => 'normalized_create_version',
+                    'updated'        => 'normalized_update_version',
+                    'model_type'     => 'product_model',
+                    'attributes_for_this_level' => ['picture'],
+                    'attributes_axes' => ['picture'],
+                    'image'          => null,
                     'label'          => [
                         'en_US' => 'Tshirt blue',
                         'fr_FR' => 'Tshirt bleu',


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

I don't know why I did work before, but if there is null as data for image, the normalization of product model was failing.. now it's fixed, we check for null data too.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Y
| Added Behats                      | N
| Added integration tests           | N
| Changelog updated                 | N