### PR TITLE
Rename index property product_type to document_type

### DIFF
--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/ErrorListProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/ErrorListProductIntegration.php
@@ -253,7 +253,7 @@ class ErrorListProductIntegration extends AbstractProductTestCase
 
         $this->get('pim_versioning.manager.version')->setRealTimeVersioning(false);
         $this->get('pim_catalog.saver.product')->saveAll($products);
-        $this->get('akeneo_elasticsearch.client')->refreshIndex();
+        $this->get('akeneo_elasticsearch.client.product')->refreshIndex();
 
         $client->request('GET', 'api/rest/v1/products?page=101&limit=100');
 

--- a/src/Pim/Bundle/CatalogBundle/Resources/elasticsearch/index_configuration.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/elasticsearch/index_configuration.yml
@@ -22,7 +22,7 @@ mappings:
             identifier:
                 type: 'keyword'
                 normalizer: 'identifier_normalizer'
-            product_type:
+            document_type:
                 type: 'keyword'
             attributes_for_this_level:
                 type: 'keyword'

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/AbstractPimCatalogProductModelIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/AbstractPimCatalogProductModelIntegration.php
@@ -103,7 +103,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             // simple tshirt
             [
                 'identifier'                => 'model-tshirt',
-                'product_type'              => ProductModelInterface::class,
+                'document_type'             => ProductModelInterface::class,
                 'level'                     => 2,
                 'family_variant'            => 'clothing_color_size',
                 'family'                    => [
@@ -126,7 +126,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             // Tshirt unique color model
             [
                 'identifier'                => 'model-tshirt-unique-color',
-                'product_type'              => ProductModelInterface::class,
+                'document_type'             => ProductModelInterface::class,
                 'level'                     => 1,
                 'family_variant'            => 'clothing_size',
                 'family'                    => [
@@ -164,7 +164,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             // Hats model
             [
                 'identifier'                => 'model-hat',
-                'product_type'              => ProductModelInterface::class,
+                'document_type'             => ProductModelInterface::class,
                 'level'                     => 1,
                 'family_variant'            => 'accessories_size',
                 'family'                    => [
@@ -197,7 +197,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             // Tshirt unique size model
             [
                 'identifier'                => 'model-tshirt-unique-size',
-                'product_type'              => ProductModelInterface::class,
+                'document_type'             => ProductModelInterface::class,
                 'level'                     => 1,
                 'family_variant'            => 'clothing_color',
                 'family'                    => [
@@ -230,7 +230,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             // Running shoes
             [
                 'identifier'                => 'model-running-shoes',
-                'product_type'              => ProductModelInterface::class,
+                'document_type'             => ProductModelInterface::class,
                 'level'                     => 2,
                 'family_variant'            => 'shoes_size_color',
                 'family'                    => [
@@ -258,7 +258,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             // Biker jacket
             [
                 'identifier'                => 'model-biker-jacket',
-                'product_type'              => ProductModelInterface::class,
+                'document_type'             => ProductModelInterface::class,
                 'level'                     => 2,
                 'family_variant'            => 'clothing_material_size',
                 'family'                    => [
@@ -288,7 +288,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             // Tshirt model level-1 (varying on color)
             [
                 'identifier'                => 'model-tshirt-grey',
-                'product_type'              => ProductModelInterface::class,
+                'document_type'             => ProductModelInterface::class,
                 'level'                     => 1,
                 'family_variant'            => 'clothing_color_size',
                 'family'                    => [
@@ -324,7 +324,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             ],
             [
                 'identifier'                => 'model-tshirt-blue',
-                'product_type'              => ProductModelInterface::class,
+                'document_type'             => ProductModelInterface::class,
                 'level'                     => 1,
                 'family_variant'            => 'clothing_color_size',
                 'family'                    => [
@@ -360,7 +360,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             ],
             [
                 'identifier'                => 'model-tshirt-red',
-                'product_type'              => ProductModelInterface::class,
+                'document_type'             => ProductModelInterface::class,
                 'level'                     => 1,
                 'family_variant'            => 'clothing_color_size',
                 'family'                    => [
@@ -396,7 +396,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             ],
             [
                 'identifier'                => 'model-running-shoes-s',
-                'product_type'              => ProductModelInterface::class,
+                'document_type'             => ProductModelInterface::class,
                 'level'                     => 1,
                 'family_variant'            => 'shoes_size_color',
                 'family'                    => [
@@ -423,7 +423,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
 
             [
                 'identifier'                => 'model-running-shoes-m',
-                'product_type'              => ProductModelInterface::class,
+                'document_type'             => ProductModelInterface::class,
                 'level'                     => 1,
                 'family_variant'            => 'shoes_size_color',
                 'family'                    => [
@@ -450,7 +450,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
 
             [
                 'identifier'                => 'model-running-shoes-l',
-                'product_type'              => ProductModelInterface::class,
+                'document_type'             => ProductModelInterface::class,
                 'level'                     => 1,
                 'family_variant'            => 'shoes_size_color',
                 'family'                    => [
@@ -477,7 +477,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
 
             [
                 'identifier'                => 'model-biker-jacket-leather',
-                'product_type'              => ProductModelInterface::class,
+                'document_type'             => ProductModelInterface::class,
                 'level'                     => 1,
                 'family_variant'            => 'clothing_material_size',
                 'family'                    => [
@@ -508,7 +508,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             ],
             [
                 'identifier'                => 'model-biker-jacket-polyester',
-                'product_type'              => ProductModelInterface::class,
+                'document_type'             => ProductModelInterface::class,
                 'level'                     => 1,
                 'family_variant'            => 'clothing_material_size',
                 'family'                    => [
@@ -543,7 +543,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             // tshirt variants (level 2: varying on color and size)
             [
                 'identifier'                => 'tshirt-grey-s',
-                'product_type'              => ProductInterface::class,
+                'document_type'             => ProductInterface::class,
                 'family_variant'            => 'clothing_color_size',
                 'family'                    => [
                     'code'   => 'clothing_size',
@@ -583,7 +583,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             ],
             [
                 'identifier'                => 'tshirt-grey-m',
-                'product_type'              => ProductInterface::class,
+                'document_type'             => ProductInterface::class,
                 'family_variant'            => 'clothing_color_size',
                 'family'                    => [
                     'code'   => 'clothing_size',
@@ -623,7 +623,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             ],
             [
                 'identifier'                => 'tshirt-grey-l',
-                'product_type'              => ProductInterface::class,
+                'document_type'             => ProductInterface::class,
                 'family_variant'            => 'clothing_color_size',
                 'family'                    => [
                     'code'   => 'clothing_size',
@@ -663,7 +663,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             ],
             [
                 'identifier'                => 'tshirt-grey-xl',
-                'product_type'              => ProductInterface::class,
+                'document_type'             => ProductInterface::class,
                 'family_variant'            => 'clothing_color_size',
                 'family'                    => [
                     'code'   => 'clothing_size',
@@ -704,7 +704,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
 
             [
                 'identifier'                => 'tshirt-blue-s',
-                'product_type'              => ProductInterface::class,
+                'document_type'             => ProductInterface::class,
                 'family_variant'            => 'clothing_color_size',
                 'family'                    => [
                     'code'   => 'clothing_size',
@@ -744,7 +744,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             ],
             [
                 'identifier'                => 'tshirt-blue-m',
-                'product_type'              => ProductInterface::class,
+                'document_type'             => ProductInterface::class,
                 'family_variant'            => 'clothing_color_size',
                 'family'                    => [
                     'code'   => 'clothing_size',
@@ -784,7 +784,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             ],
             [
                 'identifier'                => 'tshirt-blue-l',
-                'product_type'              => ProductInterface::class,
+                'document_type'             => ProductInterface::class,
                 'family_variant'            => 'clothing_color_size',
                 'family'                    => [
                     'code'   => 'clothing_size',
@@ -824,7 +824,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             ],
             [
                 'identifier'                => 'tshirt-blue-xl',
-                'product_type'              => ProductInterface::class,
+                'document_type'             => ProductInterface::class,
                 'family_variant'            => 'clothing_color_size',
                 'family'                    => [
                     'code'   => 'clothing_size',
@@ -865,7 +865,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
 
             [
                 'identifier'                => 'tshirt-red-s',
-                'product_type'              => ProductInterface::class,
+                'document_type'             => ProductInterface::class,
                 'family_variant'            => 'clothing_color_size',
                 'family'                    => [
                     'code'   => 'clothing_size',
@@ -905,7 +905,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             ],
             [
                 'identifier'                => 'tshirt-red-m',
-                'product_type'              => ProductInterface::class,
+                'document_type'             => ProductInterface::class,
                 'family_variant'            => 'clothing_color_size',
                 'family'                    => [
                     'code'   => 'clothing_size',
@@ -945,7 +945,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             ],
             [
                 'identifier'                => 'tshirt-red-l',
-                'product_type'              => ProductInterface::class,
+                'document_type'             => ProductInterface::class,
                 'family_variant'            => 'clothing_color_size',
                 'family'                    => [
                     'code'   => 'clothing_size',
@@ -985,7 +985,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             ],
             [
                 'identifier'                => 'tshirt-red-xl',
-                'product_type'              => ProductInterface::class,
+                'document_type'             => ProductInterface::class,
                 'family_variant'            => 'clothing_color_size',
                 'family'                    => [
                     'code'   => 'clothing_size',
@@ -1027,7 +1027,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             // T-shirt: size
             [
                 'identifier'                => 'tshirt-unique-color-s',
-                'product_type'              => ProductInterface::class,
+                'document_type'             => ProductInterface::class,
                 'family_variant'            => 'clothing_size',
                 'family'                    => [
                     'code'   => 'clothing_size',
@@ -1067,7 +1067,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             ],
             [
                 'identifier'                => 'tshirt-unique-color-m',
-                'product_type'              => ProductInterface::class,
+                'document_type'             => ProductInterface::class,
                 'family_variant'            => 'clothing_size',
                 'family'                    => [
                     'code'   => 'clothing_size',
@@ -1107,7 +1107,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             ],
             [
                 'identifier'                => 'tshirt-unique-color-l',
-                'product_type'              => ProductInterface::class,
+                'document_type'             => ProductInterface::class,
                 'family_variant'            => 'clothing_size',
                 'family'                    => [
                     'code'   => 'clothing_size',
@@ -1147,7 +1147,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             ],
             [
                 'identifier'                => 'tshirt-unique-color-xl',
-                'product_type'              => ProductInterface::class,
+                'document_type'             => ProductInterface::class,
                 'family_variant'            => 'clothing_size',
                 'family'                    => [
                     'code'   => 'clothing_size',
@@ -1189,7 +1189,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             // Watch
             [
                 'identifier'                => 'watch',
-                'product_type'              => ProductInterface::class,
+                'document_type'             => ProductInterface::class,
                 'family_variant'            => null,
                 'family'                    => [
                     'code'   => 'watch',
@@ -1216,7 +1216,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             // Hats variants (varying on size)
             [
                 'identifier'                => 'hat-m',
-                'product_type'              => ProductInterface::class,
+                'document_type'             => ProductInterface::class,
                 'family_variant'            => 'accessories_size',
                 'family'                    => [
                     'code'   => 'accessories',
@@ -1251,7 +1251,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             ],
             [
                 'identifier'                => 'hat-l',
-                'product_type'              => ProductInterface::class,
+                'document_type'             => ProductInterface::class,
                 'family_variant'            => 'accessories_size',
                 'family'                    => [
                     'code'   => 'accessories',
@@ -1288,7 +1288,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             // Tshirt unique size model
             [
                 'identifier'                => 'tshirt-unique-size-blue',
-                'product_type'              => ProductInterface::class,
+                'document_type'             => ProductInterface::class,
                 'level'                     => 0,
                 'family_variant'            => 'clothing_color',
                 'family'                    => [
@@ -1330,7 +1330,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
 
             [
                 'identifier'                => 'tshirt-unique-size-red',
-                'product_type'              => ProductInterface::class,
+                'document_type'             => ProductInterface::class,
                 'level'                     => 0,
                 'family_variant'            => 'clothing_color',
                 'family'                    => [
@@ -1372,7 +1372,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
 
             [
                 'identifier'                => 'tshirt-unique-size-yellow',
-                'product_type'              => ProductInterface::class,
+                'document_type'             => ProductInterface::class,
                 'level'                     => 0,
                 'family_variant'            => 'clothing_color',
                 'family'                    => [
@@ -1415,7 +1415,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             // Running shoes
             [
                 'identifier'                => 'running-shoes-s-white',
-                'product_type'              => ProductInterface::class,
+                'document_type'             => ProductInterface::class,
                 'family_variant'            => 'shoes_size_color',
                 'family'                    => [
                     'code'   => 'shoes',
@@ -1451,7 +1451,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
 
             [
                 'identifier'                => 'running-shoes-s-blue',
-                'product_type'              => ProductInterface::class,
+                'document_type'             => ProductInterface::class,
                 'family_variant'            => 'shoes_size_color',
                 'family'                    => [
                     'code'   => 'shoes',
@@ -1487,7 +1487,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
 
             [
                 'identifier'                => 'running-shoes-s-red',
-                'product_type'              => ProductInterface::class,
+                'document_type'             => ProductInterface::class,
                 'family_variant'            => 'shoes_size_color',
                 'family'                    => [
                     'code'   => 'shoes',
@@ -1523,7 +1523,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
 
             [
                 'identifier'                => 'running-shoes-m-white',
-                'product_type'              => ProductInterface::class,
+                'document_type'             => ProductInterface::class,
                 'family_variant'            => 'shoes_size_color',
                 'family'                    => [
                     'code'   => 'shoes',
@@ -1559,7 +1559,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
 
             [
                 'identifier'                => 'running-shoes-m-blue',
-                'product_type'              => ProductInterface::class,
+                'document_type'             => ProductInterface::class,
                 'family_variant'            => 'shoes_size_color',
                 'family'                    => [
                     'code'   => 'shoes',
@@ -1595,7 +1595,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
 
             [
                 'identifier'                => 'running-shoes-m-red',
-                'product_type'              => ProductInterface::class,
+                'document_type'             => ProductInterface::class,
                 'family_variant'            => 'shoes_size_color',
                 'family'                    => [
                     'code'   => 'shoes',
@@ -1631,7 +1631,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
 
             [
                 'identifier'                => 'running-shoes-l-white',
-                'product_type'              => ProductInterface::class,
+                'document_type'             => ProductInterface::class,
                 'family_variant'            => 'shoes_size_color',
                 'family'                    => [
                     'code'   => 'shoes',
@@ -1667,7 +1667,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
 
             [
                 'identifier'                => 'running-shoes-l-blue',
-                'product_type'              => ProductInterface::class,
+                'document_type'             => ProductInterface::class,
                 'family_variant'            => 'shoes_size_color',
                 'family'                    => [
                     'code'   => 'shoes',
@@ -1703,7 +1703,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
 
             [
                 'identifier'                => 'running-shoes-l-red',
-                'product_type'              => ProductInterface::class,
+                'document_type'             => ProductInterface::class,
                 'family_variant'            => 'shoes_size_color',
                 'family'                    => [
                     'code'   => 'shoes',
@@ -1740,7 +1740,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             // Biker
             [
                 'identifier'                => 'biker-jacket-leather-s',
-                'product_type'              => ProductInterface::class,
+                'document_type'             => ProductInterface::class,
                 'family_variant'            => 'clothing_material_size',
                 'family'                    => [
                     'code'   => 'clothing',
@@ -1775,7 +1775,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             ],
             [
                 'identifier'                => 'biker-jacket-leather-m',
-                'product_type'              => ProductInterface::class,
+                'document_type'             => ProductInterface::class,
                 'family_variant'            => 'clothing_material_size',
                 'family'                    => [
                     'code'   => 'clothing',
@@ -1810,7 +1810,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             ],
             [
                 'identifier'                => 'biker-jacket-leather-l',
-                'product_type'              => ProductInterface::class,
+                'document_type'             => ProductInterface::class,
                 'family_variant'            => 'clothing_material_size',
                 'family'                    => [
                     'code'   => 'clothing',
@@ -1846,7 +1846,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
 
             [
                 'identifier'                => 'biker-jacket-polyester-s',
-                'product_type'              => ProductInterface::class,
+                'document_type'             => ProductInterface::class,
                 'family_variant'            => 'clothing_material_size',
                 'family'                    => [
                     'code'   => 'clothing',
@@ -1881,7 +1881,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             ],
             [
                 'identifier'                => 'biker-jacket-polyester-m',
-                'product_type'              => ProductInterface::class,
+                'document_type'             => ProductInterface::class,
                 'family_variant'            => 'clothing_material_size',
                 'family'                    => [
                     'code'   => 'clothing',
@@ -1916,7 +1916,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
             ],
             [
                 'identifier'                => 'biker-jacket-polyester-l',
-                'product_type'              => ProductInterface::class,
+                'document_type'             => ProductInterface::class,
                 'family_variant'            => 'clothing_material_size',
                 'family'                    => [
                     'code'   => 'clothing',

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/SearchProductsAndModelsIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/SearchProductsAndModelsIntegration.php
@@ -19,7 +19,7 @@ use Pim\Component\Catalog\Model\ProductModelInterface;
  * - Each documents has an 'attributes_for_this_level' property which is a list of the attribute codes that belong to the
  *   document (following the family variant settings and levels definition).
  *
- * - Each document has a property 'product_type' which gives an hint about the level in the family variant the document
+ * - Each document has a property 'document_type' which gives an hint about the level in the family variant the document
  *   belongs to.
  *
  * @author    Samir Boulil <samir.boulil@gmail.com>

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/SearchProductsIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/SearchProductsIntegration.php
@@ -15,7 +15,7 @@ use Pim\Component\Catalog\Model\ProductInterface;
  * - Each document (e.g: products, product variants or models) has all the properties of its associated parent model
  *   and grand parent models.
  *
- * - Each document has a property 'product_type' which gives an hint about the level in the family variant the document
+ * - Each document has a property 'document_type' which gives an hint about the level in the family variant the document
  *   belongs to.
  *
  * @author    Samir Boulil <samir.boulil@gmail.com>
@@ -31,7 +31,7 @@ class SearchProductsIntegration extends AbstractPimCatalogProductModelIntegratio
                 'bool' => [
                     'filter' => [
                         [
-                            'terms' => ['product_type' => [ProductInterface::class]],
+                            'terms' => ['document_type' => [ProductInterface::class]],
                         ],
                     ],
                 ],
@@ -108,7 +108,7 @@ class SearchProductsIntegration extends AbstractPimCatalogProductModelIntegratio
                             ],
                         ],
                         [
-                            'terms' => ['product_type' => [ProductInterface::class]],
+                            'terms' => ['document_type' => [ProductInterface::class]],
                         ],
                     ],
                 ],
@@ -157,7 +157,7 @@ class SearchProductsIntegration extends AbstractPimCatalogProductModelIntegratio
                             'terms' => ['values.color-option.<all_channels>.<all_locales>' => ['red']],
                         ],
                         [
-                            'terms' => ['product_type' => [ProductInterface::class]],
+                            'terms' => ['document_type' => [ProductInterface::class]],
                         ],
                     ],
                 ],
@@ -198,7 +198,7 @@ class SearchProductsIntegration extends AbstractPimCatalogProductModelIntegratio
                             'terms' => ['values.color-option.<all_channels>.<all_locales>' => ['grey']],
                         ],
                         [
-                            'terms' => ['product_type' => [ProductInterface::class]],
+                            'terms' => ['document_type' => [ProductInterface::class]],
                         ],
                     ],
                 ],
@@ -230,7 +230,7 @@ class SearchProductsIntegration extends AbstractPimCatalogProductModelIntegratio
                             'terms' => ['values.color-option.<all_channels>.<all_locales>' => ['blue']],
                         ],
                         [
-                            'terms' => ['product_type' => [ProductInterface::class]],
+                            'terms' => ['document_type' => [ProductInterface::class]],
                         ],
                     ],
                 ],
@@ -268,7 +268,7 @@ class SearchProductsIntegration extends AbstractPimCatalogProductModelIntegratio
                             'terms' => ['values.size-option.<all_channels>.<all_locales>' => ['s']],
                         ],
                         [
-                            'terms' => ['product_type' => [ProductInterface::class]],
+                            'terms' => ['document_type' => [ProductInterface::class]],
                         ],
                     ],
                 ],
@@ -306,7 +306,7 @@ class SearchProductsIntegration extends AbstractPimCatalogProductModelIntegratio
                             'terms' => ['values.size-option.<all_channels>.<all_locales>' => ['m']],
                         ],
                         [
-                            'terms' => ['product_type' => [ProductInterface::class]],
+                            'terms' => ['document_type' => [ProductInterface::class]],
                         ],
                     ],
                 ],
@@ -349,7 +349,7 @@ class SearchProductsIntegration extends AbstractPimCatalogProductModelIntegratio
                             'terms' => ['values.size-option.<all_channels>.<all_locales>' => ['s']],
                         ],
                         [
-                            'terms' => ['product_type' => [ProductInterface::class]],
+                            'terms' => ['document_type' => [ProductInterface::class]],
                         ],
                     ],
                 ],
@@ -374,7 +374,7 @@ class SearchProductsIntegration extends AbstractPimCatalogProductModelIntegratio
                             'terms' => ['values.size-option.<all_channels>.<all_locales>' => ['m']],
                         ],
                         [
-                            'terms' => ['product_type' => [ProductInterface::class]],
+                            'terms' => ['document_type' => [ProductInterface::class]],
                         ],
                     ],
                 ],
@@ -402,7 +402,7 @@ class SearchProductsIntegration extends AbstractPimCatalogProductModelIntegratio
                             'terms' => ['values.color-option.<all_channels>.<all_locales>' => ['grey']],
                         ],
                         [
-                            'terms' => ['product_type' => [ProductInterface::class]],
+                            'terms' => ['document_type' => [ProductInterface::class]],
                         ],
                     ],
                 ],
@@ -432,7 +432,7 @@ class SearchProductsIntegration extends AbstractPimCatalogProductModelIntegratio
                             'terms' => ['values.material-option.<all_channels>.<all_locales>' => ['cotton']],
                         ],
                         [
-                            'terms' => ['product_type' => [ProductInterface::class]],
+                            'terms' => ['document_type' => [ProductInterface::class]],
                         ],
                     ],
                 ],
@@ -481,7 +481,7 @@ class SearchProductsIntegration extends AbstractPimCatalogProductModelIntegratio
                             'terms' => ['values.material-option.<all_channels>.<all_locales>' => ['leather']],
                         ],
                         [
-                            'terms' => ['product_type' => [ProductInterface::class]],
+                            'terms' => ['document_type' => [ProductInterface::class]],
                         ],
                     ],
                 ],
@@ -525,7 +525,7 @@ class SearchProductsIntegration extends AbstractPimCatalogProductModelIntegratio
                             'terms' => ['values.color-option.<all_channels>.<all_locales>' => ['white']],
                         ],
                         [
-                            'terms' => ['product_type' => [ProductInterface::class]],
+                            'terms' => ['document_type' => [ProductInterface::class]],
                         ],
                     ],
                 ],
@@ -557,7 +557,7 @@ class SearchProductsIntegration extends AbstractPimCatalogProductModelIntegratio
                             'exists' => ['field' => 'values.color-option.<all_channels>.<all_locales>'],
                         ],
                         [
-                            'terms' => ['product_type' => [ProductInterface::class]],
+                            'terms' => ['document_type' => [ProductInterface::class]],
                         ],
                     ],
                 ],
@@ -626,7 +626,7 @@ class SearchProductsIntegration extends AbstractPimCatalogProductModelIntegratio
                             'terms' => ['values.color-option.<all_channels>.<all_locales>' => ['red']],
                         ],
                         [
-                            'terms' => ['product_type' => [ProductInterface::class]],
+                            'terms' => ['document_type' => [ProductInterface::class]],
                         ],
                     ],
                 ],
@@ -672,7 +672,7 @@ class SearchProductsIntegration extends AbstractPimCatalogProductModelIntegratio
                             'exists' => ['field' => 'values.color-option.<all_channels>.<all_locales>'],
                         ],
                         [
-                            'terms' => ['product_type' => [ProductInterface::class]],
+                            'terms' => ['document_type' => [ProductInterface::class]],
                         ],
                     ],
                 ],
@@ -717,7 +717,7 @@ class SearchProductsIntegration extends AbstractPimCatalogProductModelIntegratio
                             'exists' => ['field' => 'values.size-option.<all_channels>.<all_locales>'],
                         ],
                         [
-                            'terms' => ['product_type' => [ProductInterface::class]],
+                            'terms' => ['document_type' => [ProductInterface::class]],
                         ],
                     ],
                 ],

--- a/src/Pim/Bundle/ConnectorBundle/tests/integration/Command/AuthenticatedBatchCommandIntegration.php
+++ b/src/Pim/Bundle/ConnectorBundle/tests/integration/Command/AuthenticatedBatchCommandIntegration.php
@@ -140,7 +140,7 @@ class AuthenticatedBatchCommandIntegration extends TestCase
         $this->get('pim_catalog.updater.product')->update($product, $data);
         $this->get('pim_catalog.saver.product')->save($product);
 
-        $this->get('akeneo_elasticsearch.client')->refreshIndex();
+        $this->get('akeneo_elasticsearch.client.product')->refreshIndex();
 
         return $product;
     }

--- a/src/Pim/Bundle/EnrichBundle/Elasticsearch/FromSizeCursorFactory.php
+++ b/src/Pim/Bundle/EnrichBundle/Elasticsearch/FromSizeCursorFactory.php
@@ -57,7 +57,7 @@ class FromSizeCursorFactory implements CursorFactoryInterface
     {
         $options = $this->resolveOptions($options);
 
-        $queryBuilder['_source'] = array_merge($queryBuilder['_source'], ['product_type']);
+        $queryBuilder['_source'] = array_merge($queryBuilder['_source'], ['document_type']);
 
         return new FromSizeCursor(
             $this->searchEngine,

--- a/src/Pim/Bundle/EnrichBundle/spec/Elasticsearch/FromSizeCursorSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Elasticsearch/FromSizeCursorSpec.php
@@ -35,11 +35,11 @@ class FromSizeCursorSpec extends ObjectBehavior
                     'total' => 4,
                     'hits' => [
                         [
-                            '_source' => ['identifier' => 'a-variant-product', 'product_type' => ProductInterface::class],
+                            '_source' => ['identifier' => 'a-variant-product', 'document_type' => ProductInterface::class],
                             'sort' => ['pim_catalog_product#a-variant-product']
                         ],
                         [
-                            '_source' => ['identifier' => 'a-sub-product-model', 'product_type' => ProductModelInterface::class],
+                            '_source' => ['identifier' => 'a-sub-product-model', 'document_type' => ProductModelInterface::class],
                             'sort' => ['pim_catalog_product#a-sub-product-model']
                         ],
                     ]
@@ -97,11 +97,11 @@ class FromSizeCursorSpec extends ObjectBehavior
                     'total' => 4,
                     'hits' => [
                         [
-                            '_source' => ['identifier' => 'a-root-product-model', 'product_type' => ProductModelInterface::class],
+                            '_source' => ['identifier' => 'a-root-product-model', 'document_type' => ProductModelInterface::class],
                             'sort' => ['pim_catalog_product#a-root-product-model']
                         ],
                         [
-                            '_source' => ['identifier' => 'a-product', 'product_type' => ProductInterface::class],
+                            '_source' => ['identifier' => 'a-product', 'document_type' => ProductInterface::class],
                             'sort' => ['pim_catalog_product#a-product']
                         ],
                     ]

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/ProductAndProductModel/ProductModelNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/ProductAndProductModel/ProductModelNormalizer.php
@@ -19,7 +19,7 @@ class ProductModelNormalizer implements NormalizerInterface
 {
     public const INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX = 'indexing_product_and_product_model';
     private const FIELD_ATTRIBUTES_IN_LEVEL = 'attributes_for_this_level';
-    private const FIELD_PRODUCT_TYPE = 'product_type';
+    private const FIELD_DOCUMENT_TYPE = 'document_type';
 
     /** @var NormalizerInterface */
     private $propertiesNormalizer;
@@ -41,7 +41,7 @@ class ProductModelNormalizer implements NormalizerInterface
     {
         $data = $this->propertiesNormalizer->normalize($productModel, $format, $context);
 
-        $data[self::FIELD_PRODUCT_TYPE] = ProductModelInterface::class;
+        $data[self::FIELD_DOCUMENT_TYPE] = ProductModelInterface::class;
         $data[self::FIELD_ATTRIBUTES_IN_LEVEL] = array_keys($productModel->getRawValues());
 
         return $data;

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/ProductAndProductModel/ProductNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/ProductAndProductModel/ProductNormalizer.php
@@ -18,7 +18,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 class ProductNormalizer implements NormalizerInterface
 {
     private const FIELD_ATTRIBUTES_IN_LEVEL = 'attributes_for_this_level';
-    private const FIELD_PRODUCT_TYPE = 'product_type';
+    private const FIELD_DOCUMENT_TYPE = 'document_type';
 
     /** @var NormalizerInterface */
     private $propertiesNormalizer;
@@ -38,7 +38,7 @@ class ProductNormalizer implements NormalizerInterface
     {
         $data = $this->propertiesNormalizer->normalize($product, $format, $context);
 
-        $data[self::FIELD_PRODUCT_TYPE] = ProductInterface::class;
+        $data[self::FIELD_DOCUMENT_TYPE] = ProductInterface::class;
         $data[self::FIELD_ATTRIBUTES_IN_LEVEL] = array_keys($product->getRawValues());
 
         return $data;

--- a/src/Pim/Component/Catalog/spec/Normalizer/Indexing/ProductAndProductModel/ProductModelNormalizerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Normalizer/Indexing/ProductAndProductModel/ProductModelNormalizerSpec.php
@@ -55,7 +55,7 @@ class ProductModelNormalizerSpec extends ObjectBehavior
         $this->normalize($productModel, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
             ->shouldReturn([
                 'properties'                => 'properties are normalized here',
-                'product_type'              => ProductModelInterface::class,
+                'document_type'              => ProductModelInterface::class,
                 'attributes_for_this_level' => ['property_1', 'property_2'],
             ]);
     }
@@ -79,7 +79,7 @@ class ProductModelNormalizerSpec extends ObjectBehavior
         $this->normalize($productModel, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
             ->shouldReturn([
                 'properties'                => 'properties are normalized here',
-                'product_type'              => ProductModelInterface::class,
+                'document_type'              => ProductModelInterface::class,
                 'attributes_for_this_level' => ['property_1', 'property_2'],
             ]);
     }

--- a/src/Pim/Component/Catalog/spec/Normalizer/Indexing/ProductAndProductModel/ProductNormalizerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Normalizer/Indexing/ProductAndProductModel/ProductNormalizerSpec.php
@@ -64,7 +64,7 @@ class ProductNormalizerSpec extends ObjectBehavior
         $this->normalize($product, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
             ->shouldReturn([
                 'properties'                => 'properties are normalized here',
-                'product_type'              => ProductInterface::class,
+                'document_type'              => ProductInterface::class,
                 'attributes_for_this_level' => ['property_1', 'property_2'],
             ]);
     }
@@ -88,7 +88,7 @@ class ProductNormalizerSpec extends ObjectBehavior
         $this->normalize($variantProduct, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
             ->shouldReturn([
                 'properties'                => 'properties are normalized here',
-                'product_type'              => ProductInterface::class,
+                'document_type'              => ProductInterface::class,
                 'attributes_for_this_level' => ['property_1', 'property_2'],
             ]);
     }

--- a/src/Pim/Component/Catalog/tests/integration/Normalizer/Indexing/ProductAndProductModelIndexingIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Normalizer/Indexing/ProductAndProductModelIndexingIntegration.php
@@ -55,7 +55,7 @@ class ProductAndProductModelIndexingIntegration extends TestCase
                     ],
                 ],
             ],
-            'product_type' => ProductModelInterface::class,
+            'document_type' => ProductModelInterface::class,
             'attributes_for_this_level' => ['a_text']
         ];
 
@@ -98,7 +98,7 @@ class ProductAndProductModelIndexingIntegration extends TestCase
                     ],
                 ],
             ],
-            'product_type' => ProductModelInterface::class,
+            'document_type' => ProductModelInterface::class,
             'attributes_for_this_level' => ['a_simple_select']
         ];
 
@@ -150,7 +150,7 @@ class ProductAndProductModelIndexingIntegration extends TestCase
                     ],
                 ],
             ],
-            'product_type' => ProductInterface::class,
+            'document_type' => ProductInterface::class,
             'attributes_for_this_level' => ['sku', 'a_yes_no']
         ];
 
@@ -179,7 +179,7 @@ class ProductAndProductModelIndexingIntegration extends TestCase
             'family_variant'            => null,
             'parent'                    => null,
             'values'                    => [],
-            'product_type'              => ProductInterface::class,
+            'document_type'              => ProductInterface::class,
             'attributes_for_this_level' => ['sku'],
         ];
 
@@ -421,7 +421,7 @@ class ProductAndProductModelIndexingIntegration extends TestCase
                     ],
                 ],
             ],
-            'product_type' => ProductInterface::class,
+            'document_type' => ProductInterface::class,
             'attributes_for_this_level' => [
                 123,
                 'sku',


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Rename the property in the index of product and product models: "product_type" into "document_type" which indicates if the document is a product or a model.

Note that "product_type" column also refers in the mysql table "PimCatalogProduct" and tells if a product is a variant_product or a product.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Ok
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Ok
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
