### PR TITLE
PIM-6761: Add attribute filters on the PEF

### DIFF
--- a/CHANGELOG-1.8.md
+++ b/CHANGELOG-1.8.md
@@ -9,6 +9,7 @@
 - GITHUB-4877: Update some tooltips messages of the export builder, Cheers @Milie44!
 - GITHUB-5949: Fix the deletion of a job instance (import\export) from the job edit page, cheers @BatsaxIV !
 - PIM-6531: Have English language as default language for new users
+- PIM-6761: Add filter on required attributes
 
 ## Technical improvements
 
@@ -20,7 +21,7 @@
 - TIP-730: Reworking of the creation popin for basic entities
 - TIP-732: Rework the attribute form using the PEF architecture
 - TIP-747: Migrate to Symfony 3.3
-- PIM-6740: Separe installation state (installed) from config file 
+- PIM-6740: Separe installation state (installed) from config file
 - API-359: Move notified user of a job into the configuration parameters of the job
 
 ## UI\UX Refactoring
@@ -306,7 +307,7 @@
 - Change the constructor of `Pim\Bundle\ApiBundle\Controller\LocaleController` to add `Pim\Bundle\ApiBundle\Checker\QueryParametersCheckerInterface`
 - Change the constructor of `Akeneo\Bundle\BatchBundle\Launcher\SimpleJobLauncher` to add `Akeneo\Component\Batch\Job\JobParametersValidator`
 - Change the constructor of `Pim\Bundle\ConnectorBundle\Launcher\AuthenticatedJobLauncher` to add `Akeneo\Component\Batch\Job\JobParametersValidator`
-- Change the constructor of `Pim\Bundle\AnalyticsBundle\DataCollector\VersionDataCollector` to replace `string` by `Pim\Bundle\InstallerBundle\InstallStatusManager\InstallStatusManager` 
+- Change the constructor of `Pim\Bundle\AnalyticsBundle\DataCollector\VersionDataCollector` to replace `string` by `Pim\Bundle\InstallerBundle\InstallStatusManager\InstallStatusManager`
 
 ### Methods
 

--- a/features/Context/Page/Base/Form.php
+++ b/features/Context/Page/Base/Form.php
@@ -40,6 +40,7 @@ class Form extends Base
                 'Association type selector'       => ['css' => '.association-type-selector'],
                 'Tree selector'                   => ['css' => '.tree-selector'],
                 'Target selector'                 => ['css' => '.target-selector'],
+                'Attribute filter selector'       => ['css' => '.attribute-filter'],
                 'Validation errors'               => ['css' => '.validation-tooltip'],
                 'Available attributes form'       => ['css' => '#pim_available_attributes'],
                 'Available attributes button'     => ['css' => 'button:contains("Add attributes")'],
@@ -142,7 +143,26 @@ class Form extends Base
             $this->getGroup($groupName, $type)->click();
 
             return true;
-        }, sprintf('Can not visit group "%s"', $groupName));
+        }, sprintf('Cannot visit group "%s"', $groupName));
+    }
+
+    /**
+     * @param $filter
+     */
+    public function filterAttributes($filter)
+    {
+        $this->spin(function () use ($filter) {
+            $loadingMasks = $this->findAll('css', '.loading-wrapper');
+            if (0 < count(array_filter($loadingMasks, function ($loadingMask) {
+                    return $loadingMask->isVisible();
+                }))) {
+                return false;
+            }
+
+            $this->getGroup($filter, 'Attribute filter')->click();
+
+            return true;
+        }, sprintf('Cannot filter attributes with "%s"', $filter));
     }
 
     /**
@@ -150,6 +170,8 @@ class Form extends Base
      * @param string $type
      *
      * @return NodeElement
+     *
+     * //TODO: make it more generic, no logic is specific to groups here, it's just naming.
      */
     public function getGroup($groupName, $type = 'Group')
     {

--- a/features/Context/Page/Base/Form.php
+++ b/features/Context/Page/Base/Form.php
@@ -139,7 +139,7 @@ class Form extends Base
             }))) {
                 return false;
             }
-
+            $this->getGroup($groupName, $type)->click();
             $this->getGroup($groupName, $type)->click();
 
             return true;
@@ -154,8 +154,8 @@ class Form extends Base
         $this->spin(function () use ($filter) {
             $loadingMasks = $this->findAll('css', '.loading-wrapper');
             if (0 < count(array_filter($loadingMasks, function ($loadingMask) {
-                    return $loadingMask->isVisible();
-                }))) {
+                return $loadingMask->isVisible();
+            }))) {
                 return false;
             }
 
@@ -864,7 +864,7 @@ class Form extends Base
         $field = $this->findPriceField($label->labelContent, $label->subLabelContent);
         $field->setValue($value);
     }
-    
+
     /**
      * @param string $type
      *

--- a/features/Context/Page/Base/ProductEditForm.php
+++ b/features/Context/Page/Base/ProductEditForm.php
@@ -102,7 +102,15 @@ class ProductEditForm extends Form
         }
 
         $labelNode = $this->spin(function () use ($label) {
-            return $this->find('css', sprintf('.AknComparableFields .AknFieldContainer-label:contains("%s")', $label));
+            $labels = $this->findAll('css', sprintf('.AknComparableFields .AknFieldContainer-label:contains("%s")', $label));
+
+            foreach ($labels as $labelContainer) {
+                if ($labelContainer->getText() === $label) {
+                    return $labelContainer;
+                }
+            }
+
+            return false;
         }, 'Cannot find the field label');
 
         $container = $this->getClosest($labelNode, 'AknComparableFields');

--- a/features/Context/WebUser.php
+++ b/features/Context/WebUser.php
@@ -271,12 +271,10 @@ class WebUser extends PimContext
     }
 
     /**
-     * @Given /^there should be (\d+) errors? in the "([^"]*)" tab$/
+     * @Then /^there should be (\d+) errors? in the "([^"]*)" tab$/
      *
      * @param $expectedErrorsCount
      * @param $tabName
-     *
-     * @throws TimeoutException
      */
     public function thereShouldBeErrorsInTheTab($expectedErrorsCount, $tabName)
     {
@@ -290,6 +288,16 @@ class WebUser extends PimContext
             $tabName,
             $this->getTabErrorsCount($tab)
         ));
+    }
+
+    /**
+     * @When /^I filter attributes with "(.+)"$/
+     *
+     * @param $filter
+     */
+    public function iFilterAttributes($filter)
+    {
+        $this->getCurrentPage()->filterAttributes($filter);
     }
 
     /* -------------------- Other methods -------------------- */

--- a/features/acl/enforce_acl_on_history.feature
+++ b/features/acl/enforce_acl_on_history.feature
@@ -102,6 +102,7 @@ Feature: Enforce ACL on history
     When I am on the "similar_boots" product group page
     Then I should not see "history"
 
+  @skip @info Will be removed in PIM-6444
   Scenario: Successfully hide variant group history when user doesn't have the rights
     Given a "footwear" catalog configuration
     And a "boot" product

--- a/features/localization/variant-group/edit_variant_group_attribute_value.feature
+++ b/features/localization/variant-group/edit_variant_group_attribute_value.feature
@@ -39,7 +39,7 @@ Feature: Editing localized attribute values of a variant group also updates prod
   Scenario: Successfully change a pim_catalog_price_collection attribute of a variant group
     Given I visit the "[marketing]" group
     And I fill in the following information:
-      | price | 89,27 EUR |
+      | [price] | 89,27 EUR |
     And I save the variant group
     Then the product "boot" should have the following values:
       | price | 89.27 EUR |
@@ -68,6 +68,6 @@ Feature: Editing localized attribute values of a variant group also updates prod
   Scenario: Fail to change a pim_catalog_price_collection attribute of a variant group
     Given I visit the "[marketing]" group
     And I fill in the following information:
-      | price | 89.27 EUR |
+      | [price] | 89.27 EUR |
     And I save the variant group
     Then I should see validation error "Ce type de valeur attend une virgule (,) comme séparateur de décimales."

--- a/features/mass-action/edit_common_attributes_per_families.feature
+++ b/features/mass-action/edit_common_attributes_per_families.feature
@@ -44,7 +44,7 @@ Feature: Edit common attributes of many products at once
     And I should see available attribute Size in group "Sizes"
     And I should see available attribute Color in group "Colors"
     And I add available attributes Name and Weather conditions
-    And I change the "Weather condition" to "Cold, Wet"
+    And I change the "Weather conditions" to "Cold, Wet"
     And I change the "Name" to "Product"
     And I should see the text "Product"
     And I confirm mass edit

--- a/features/product/compare_and_copy_localized_fields.feature
+++ b/features/product/compare_and_copy_localized_fields.feature
@@ -36,6 +36,7 @@ Feature: Compare and copy localized fields
 
   Scenario: Successfully copy current tab compared product localized values
     Given I am on the "tshirt" product page
+    And I visit the "General" group
     And I collapse the column
     When I open the comparison panel
     And I switch the comparison locale to "fr_FR"

--- a/features/product/define_product_prices.feature
+++ b/features/product/define_product_prices.feature
@@ -19,13 +19,13 @@ Feature: Define product prices
     Then the product Public price in USD should be "100.00"
     And the product Public price in EUR should be "50.00"
     When I switch the locale to "fr_FR"
-    Then the product publicPrice in USD should be "200.00"
-    And the product publicPrice in EUR should be "150.00"
+    Then the product [publicPrice] in USD should be "200.00"
+    And the product [publicPrice] in EUR should be "150.00"
 
   Scenario: Successfully update the french public prices
     Given I am on the "bike" product page
     And I switch the locale to "fr_FR"
-    When I change the "publicPrice" to "700.00 USD"
+    When I change the "[publicPrice]" to "700.00 USD"
     And I save the product
-    Then the product publicPrice in USD should be "700.00"
-    And the product publicPrice in EUR should be "150.00"
+    Then the product [publicPrice] in USD should be "700.00"
+    And the product [publicPrice] in EUR should be "150.00"

--- a/features/product/edit_and_display_all_attributes.feature
+++ b/features/product/edit_and_display_all_attributes.feature
@@ -6,9 +6,6 @@ Feature: Edit and see all attributes
 
   Background:
     Given the "footwear" catalog configuration
-    And the following family:
-      | code  | attributes                                                       |
-      | shoes | sku,name,description,price,rating,size,color,manufacturer,length |
     And I am logged in as "Julia"
     And I am on the products page
     And I create a new product
@@ -24,7 +21,6 @@ Feature: Edit and see all attributes
     Then I should not see the text "There are unsaved changes."
 
   Scenario: Successfully edit the product and check that all attributes are visible
-    Given I am on the "boots" product page
     Then I should not see the text "Media"
     Then I should not see the text "Colors"
     Then I should not see the text "Marketing"

--- a/features/product/edit_product.feature
+++ b/features/product/edit_product.feature
@@ -30,6 +30,7 @@ Feature: Edit a product
   Scenario: Successfully create, edit and save a product
     Given I am logged in as "Mary"
     And I am on the "sandal" product page
+    And I visit the "All" group
     And I fill in the following information:
       | Name | My Sandal |
     When I press the "Save" button

--- a/features/product/edit_product_and_filter_attributes.feature
+++ b/features/product/edit_product_and_filter_attributes.feature
@@ -17,7 +17,6 @@ Feature: Edit product and filter attributes
 
   Scenario: Edit the product and show only missing required attributes
     When I filter attributes with "All missing required attributes"
-    # Check if it's normal that "all" is not the default value
     And I visit the "All" group
     Then I should not see the text "Manufacturer"
     But I should see the text "Name"

--- a/features/product/edit_product_and_filter_attributes.feature
+++ b/features/product/edit_product_and_filter_attributes.feature
@@ -1,0 +1,39 @@
+@javascript
+Feature: Edit product and filter attributes
+  In order to be efficient when enriching products
+  As a regular user
+  I need to be able to edit a product and choose which attributes are displayed
+
+  Background:
+    Given the "footwear" catalog configuration
+    And I am logged in as "Mary"
+    And I am on the products page
+    And I create a new product
+    And I fill in the following information in the popin:
+      | SKU             | boots |
+      | Choose a family | Boots |
+    And I press the "Save" button in the popin
+    And I wait to be on the "boots" product page
+
+  Scenario: Edit the product and show only missing required attributes
+    When I filter attributes with "All missing required attributes"
+    # Check if it's normal that "all" is not the default value
+    And I visit the "All" group
+    Then I should not see the text "Manufacturer"
+    But I should see the text "Name"
+    And I should see the text "Weather conditions"
+    And I should see the text "Description"
+    And I should see the text "Price"
+    And I should see the text "Rating"
+    And I should see the text "Side view"
+    And I should see the text "Size"
+    And I should see the text "Color"
+    When I filter attributes with "All attributes"
+    Then I should see the text "Manufacturer"
+
+  Scenario: Edit the product and show only missing required attributes from an attribute group
+    When I filter attributes with "All missing required attributes"
+    And I visit the "Media" group
+    Then I should not see the text "Top view"
+    And I should not see the text "Weather conditions"
+    But I should see the text "Side view"

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/fetcher/datagrid-view-fetcher.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/fetcher/datagrid-view-fetcher.js
@@ -18,13 +18,6 @@ define(
     ) {
         return BaseFetcher.extend({
             /**
-             * {@inheritdoc}
-             */
-            initialize: function (options) {
-                BaseFetcher.prototype.initialize.apply(this, arguments);
-            },
-
-            /**
              * Fetch default columns for grid with given alias
              *
              * @param {string} alias

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product/edit.yml
@@ -199,6 +199,22 @@ extensions:
         targetZone: other-actions
         position: 100
 
+    pim-product-edit-form-attribute-filter:
+        module: pim/product-edit-form/attribute-filter
+        parent: pim-product-edit-form-attributes
+        targetZone: other-actions
+        position: 110
+
+    pim-product-edit-form-attribute-filter-all:
+        module: pim/product-edit-form/attribute-filter-all
+        parent: pim-product-edit-form-attribute-filter
+        position: 100
+
+    pim-product-edit-form-attribute-filter-missing-required:
+        module: pim/product-edit-form/attribute-filter-missing-required
+        parent: pim-product-edit-form-attribute-filter
+        position: 110
+
     pim-product-edit-form-copy:
         module: pim/form/common/attributes/copy
         parent: pim-product-edit-form-attributes

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
@@ -655,34 +655,37 @@ config:
         pim/group-edit-form/save: pimenrich/js/group/form/save
 
         # Product
-        pim/product-edit-form/product-label:               pimenrich/js/product/form/product-label
-        pim/product-edit-form/product-completeness:        pimenrich/js/product/form/product-completeness
-        pim/product-edit-form/attributes/validation:       pimenrich/js/product/form/attributes/validation
-        pim/product-edit-form/attributes/validation-error: pimenrich/js/product/form/attributes/validation-error
-        pim/product-edit-form/attributes/variant-group:    pimenrich/js/product/form/attributes/variant-group
-        pim/product-edit-form/attributes/locale-specific:  pimenrich/js/product/form/attributes/locale-specific
-        pim/product-edit-form/attributes/read-only-form:   pimenrich/js/product/form/attributes/read-only-form
-        pim/product-edit-form/attributes/completeness:     pimenrich/js/product/form/attributes/completeness
-        pim/product-edit-form/attributes/localizable:      pimenrich/js/product/form/attributes/localizable
-        pim/product-edit-form/categories:                  pimenrich/js/product/form/categories
-        pim/product-edit-form/associations:                pimenrich/js/product/form/associations
-        pim/product-edit-form/locale-switcher:             pimenrich/js/product/form/locale-switcher
-        pim/product-edit-form/scope-switcher:              pimenrich/js/product/form/scope-switcher
-        pim/product-edit-form/completeness:                pimenrich/js/product/form/completeness
-        pim/product-edit-form/history:                     pimenrich/js/product/form/history
-        pim/product-edit-form/comments:                    pimenrich/js/product/form/comments
-        pim/product-edit-form/save:                        pimenrich/js/product/form/save
-        pim/product-edit-form/sequential-edit:             pimenrich/js/product/form/sequential-edit
-        pim/product-edit-form/delete:                      pimenrich/js/product/form/delete
-        pim/product-edit-form/meta/family:                 pimenrich/js/product/form/meta/family
-        pim/product-edit-form/meta/change-family:          pimenrich/js/product/form/meta/change-family
-        pim/product-edit-form/meta/created:                pimenrich/js/product/form/meta/created
-        pim/product-edit-form/meta/updated:                pimenrich/js/product/form/meta/updated
-        pim/product-edit-form/meta/groups:                 pimenrich/js/product/form/meta/groups
-        pim/product-edit-form/meta/status-switcher:        pimenrich/js/product/form/meta/status-switcher
-        pim/product-edit-form/download-pdf:                pimenrich/js/product/form/download-pdf
-        pim/product-edit-form/attributes:                  pimenrich/js/product/form/attributes
-        pim/product-edit-form/creation/identifier:         pimenrich/js/product/form/creation/identifier
+        pim/product-edit-form/product-label:                     pimenrich/js/product/form/product-label
+        pim/product-edit-form/product-completeness:              pimenrich/js/product/form/product-completeness
+        pim/product-edit-form/attribute-filter:                  pimenrich/js/product/form/attribute-filter
+        pim/product-edit-form/attribute-filter-all:              pimenrich/js/product/form/attribute-filter-all
+        pim/product-edit-form/attribute-filter-missing-required: pimenrich/js/product/form/attribute-filter-missing-required
+        pim/product-edit-form/attributes/validation:             pimenrich/js/product/form/attributes/validation
+        pim/product-edit-form/attributes/validation-error:       pimenrich/js/product/form/attributes/validation-error
+        pim/product-edit-form/attributes/variant-group:          pimenrich/js/product/form/attributes/variant-group
+        pim/product-edit-form/attributes/locale-specific:        pimenrich/js/product/form/attributes/locale-specific
+        pim/product-edit-form/attributes/read-only-form:         pimenrich/js/product/form/attributes/read-only-form
+        pim/product-edit-form/attributes/completeness:           pimenrich/js/product/form/attributes/completeness
+        pim/product-edit-form/attributes/localizable:            pimenrich/js/product/form/attributes/localizable
+        pim/product-edit-form/categories:                        pimenrich/js/product/form/categories
+        pim/product-edit-form/associations:                      pimenrich/js/product/form/associations
+        pim/product-edit-form/locale-switcher:                   pimenrich/js/product/form/locale-switcher
+        pim/product-edit-form/scope-switcher:                    pimenrich/js/product/form/scope-switcher
+        pim/product-edit-form/completeness:                      pimenrich/js/product/form/completeness
+        pim/product-edit-form/history:                           pimenrich/js/product/form/history
+        pim/product-edit-form/comments:                          pimenrich/js/product/form/comments
+        pim/product-edit-form/save:                              pimenrich/js/product/form/save
+        pim/product-edit-form/sequential-edit:                   pimenrich/js/product/form/sequential-edit
+        pim/product-edit-form/delete:                            pimenrich/js/product/form/delete
+        pim/product-edit-form/meta/family:                       pimenrich/js/product/form/meta/family
+        pim/product-edit-form/meta/change-family:                pimenrich/js/product/form/meta/change-family
+        pim/product-edit-form/meta/created:                      pimenrich/js/product/form/meta/created
+        pim/product-edit-form/meta/updated:                      pimenrich/js/product/form/meta/updated
+        pim/product-edit-form/meta/groups:                       pimenrich/js/product/form/meta/groups
+        pim/product-edit-form/meta/status-switcher:              pimenrich/js/product/form/meta/status-switcher
+        pim/product-edit-form/download-pdf:                      pimenrich/js/product/form/download-pdf
+        pim/product-edit-form/attributes:                        pimenrich/js/product/form/attributes
+        pim/product-edit-form/creation/identifier:               pimenrich/js/product/form/creation/identifier
 
         # Attribute group
         pim/attribute-group-form/tab/attribute: pimenrich/js/attribute-group/form/tab/attribute
@@ -933,6 +936,7 @@ config:
         pim/template/form/tab/attributes:                         pimenrich/templates/form/tab/attributes.html
         pim/template/form/save-buttons:                           pimenrich/templates/form/save-buttons.html
         pim/template/form/edit-form:                              pimenrich/templates/form/edit-form.html
+        pim/template/form/tab/attribute/attribute-filter:         pimenrich/templates/form/tab/attributes/attribute-filter.html
         pim/template/form/tab/attribute/attribute-group-selector: pimenrich/templates/form/tab/attributes/attribute-group-selector.html
         pim/template/form/tab/attribute/attribute-group:          pimenrich/templates/form/tab/attributes/attribute-group.html
         pim/template/form/tab/attribute/copy:                     pimenrich/templates/form/tab/attributes/copy.html

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/controller/product/index.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/controller/product/index.js
@@ -2,14 +2,15 @@ define(
     [
         'underscore',
         'jquery',
-        'pim/controller/base',
+        'pim/controller/front',
         'pim/form-builder',
         'pim/user-context',
         'oro/mediator',
         'pim/page-title',
-        'routing'
+        'routing',
+        'pim/fetcher-registry'
     ],
-    function (_, $, BaseController, FormBuilder, UserContext, mediator, PageTitle, Routing) {
+    function (_, $, BaseController, FormBuilder, UserContext, mediator, PageTitle, Routing, fetcherRegistry) {
         return BaseController.extend({
             config: {
                 gridExtension: 'pim-product-index',
@@ -28,16 +29,20 @@ define(
             /**
             * {@inheritdoc}
             */
-            renderRoute() {
+            renderForm() {
                 this.selectMenuTab();
 
                 const { gridName, gridExtension } = this.config;
+                fetcherRegistry.getFetcher('locale').clear();
+                fetcherRegistry.getFetcher('datagrid-view').clear();
 
                 return $.when(this.resetSequentialEdit(),
                     FormBuilder.build(gridExtension).then((form) => {
                         this.setupLocale();
                         this.setupMassEditAttributes();
                         form.setElement(this.$el).render({ gridName });
+
+                        return form;
                     })
                 );
             },

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes.js
@@ -189,6 +189,7 @@ define(
                         this.getExtension('attribute-group-selector').setElements(
                             _.indexBy(attributeGroups, 'code')
                         );
+                        FieldManager.clearVisibleFields();
                     })
                     .then(() => this.filterValues(data.values))
                     .then((values) => this.createFields(data, values))
@@ -255,6 +256,7 @@ define(
                     });
 
                     field.setValues(values);
+                    FieldManager.addVisibleField(field.attribute.code);
 
                     return field;
                 }.bind(this));
@@ -422,8 +424,9 @@ define(
                 var displayedAttributes = FieldManager.getFields();
 
                 if (_.has(displayedAttributes, event.attribute)) {
+                    const field = displayedAttributes[event.attribute];
                     // TODO: the manager shouldn't be stateful, access the field by another way
-                    displayedAttributes[event.attribute].setFocus();
+                    _.defer(field.setFocus.bind(field));
                 }
             },
 
@@ -456,6 +459,10 @@ define(
                         }
                     });
                     values = filteredValues;
+                }
+
+                if (undefined === this.getExtension('attribute-filter')) {
+                    return $.Deferred().resolve(values);
                 }
 
                 return this.getExtension('attribute-filter').filterValues(values);

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes/attribute-group-selector.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes/attribute-group-selector.js
@@ -97,7 +97,7 @@ define(
              */
             render: function () {
                 $.when(
-                    toFillFieldProvider.getFields(this.getRoot(), this.getFormData()),
+                    toFillFieldProvider.getFields(this.getRoot(), this.getFormData().values),
                     AttributeGroupManager.getAttributeGroupsForObject(this.getFormData())
                 ).then(function (attributes, attributeGroups) {
                     var toFillAttributeGroups = _.uniq(_.map(attributes, function (attribute) {

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes/copy.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes/copy.js
@@ -158,7 +158,11 @@ define(
              * @returns {boolean}
              */
             canBeCopied: function (field) {
-                return field.attribute.localizable || field.attribute.scopable;
+                return (field.attribute.localizable || field.attribute.scopable) &&
+                    (
+                        !field.attribute.is_locale_specific ||
+                        _.contains(field.attribute.available_locales, this.getLocale())
+                    );
             },
 
             /**
@@ -311,7 +315,7 @@ define(
              * Mark all visible fields (from active attribute group) as selected
              */
             selectAllVisible: function () {
-                this.selectFields(FieldManager.getFields());
+                this.selectFields(FieldManager.getVisibleFields());
             },
 
             /**

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/group-selector.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/group-selector.js
@@ -174,18 +174,6 @@ define(
             },
 
             /**
-             * Remove badge for the given attribute group
-             *
-             * @param {String} element
-             * @param {String} code
-             */
-            removeBadge: function (element, code) {
-                delete this.badges[element][code];
-
-                this.render();
-            },
-
-            /**
              * Remove badges for all attribute groups
              *
              * @param {String} code

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/group-selector.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/group-selector.js
@@ -132,7 +132,7 @@ define(
                 if (_.isUndefined(this.getCurrent()) ||
                     !this.getElements()[this.getCurrent()]
                 ) {
-                    this.setCurrent(_.first(_.keys(this.getElements())), {silent: true});
+                    this.setCurrent(this.all.code, {silent: true});
                 }
             },
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/mass-edit/form/product/operation.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/mass-edit/form/product/operation.js
@@ -37,7 +37,7 @@ define(
             reset: function () {},
 
             /**
-             * The label diplayed in the operation list
+             * The label displayed in the operation list
              *
              * @return {string}
              */
@@ -57,8 +57,9 @@ define(
             },
 
             /**
-             * [getDescription description]
-             * @return {[type]} [description]
+             * Get the operation description
+             *
+             * @return {string}
              */
             getDescription: function () {
                 return __(this.config.description);

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field-manager.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field-manager.js
@@ -11,7 +11,16 @@ define(
     ['jquery', 'underscore', 'pim/fetcher-registry', 'pim/form-config-provider', 'require-context'],
     function ($, _, FetcherRegistry, ConfigProvider, requireContext) {
         var fields = {};
+        var visibleFields = {};
         var loadedModules = {};
+
+        /**
+         * Create a field view for the given attribute
+         *
+         * @param {Object} attribute
+         *
+         * @return {View}
+         */
         var getFieldForAttribute = function (attribute) {
             var deferred = $.Deferred();
 
@@ -37,6 +46,13 @@ define(
         };
 
         return {
+            /**
+             * Get the field view for the given attribute code
+             *
+             * @param {string} attributeCode
+             *
+             * @return {View}
+             */
             getField: function (attributeCode) {
                 var deferred = $.Deferred();
 
@@ -55,22 +71,56 @@ define(
 
                 return deferred.promise();
             },
+
+            /**
+             * Get all the fields that are not ready (for example media fields that are currently uploading)
+             *
+             * @return {array}
+             */
             getNotReadyFields: function () {
-                var notReadyFields = [];
-
-                _.each(fields, function (field) {
-                    if (!field.isReady()) {
-                        notReadyFields.push(field);
-                    }
-                });
-
-                return notReadyFields;
+                return Object.values(fields).filter(field => !field.isReady());
             },
+
+            /**
+             * Get all the cached fields
+             *
+             * @return {array}
+             */
             getFields: function () {
                 return fields;
             },
+
+            /**
+             * Add a field to the collection of currently displayed fields
+             *
+             * @param {string} attributeCode
+             */
+            addVisibleField: function (attributeCode) {
+                visibleFields[attributeCode] = fields[attributeCode];
+            },
+
+            /**
+             * Get all visible fields
+             *
+             * @return {[type]}
+             */
+            getVisibleFields: function () {
+                return visibleFields;
+            },
+
+            /**
+             * Clear the field collection
+             */
             clearFields: function () {
                 fields = {};
+                this.clearVisibleFields();
+            },
+
+            /**
+             * Clear the displayed field collection
+             */
+            clearVisibleFields: function () {
+                visibleFields = {};
             }
         };
     }

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/field.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/field.js
@@ -219,6 +219,10 @@ define([
             removeElement: function (position, code) {
                 if (this.elements[position] && this.elements[position][code]) {
                     delete this.elements[position][code];
+
+                    if (_.isEmpty(this.elements[position])) {
+                        delete this.elements[position];
+                    }
                 }
             },
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form.js
@@ -46,7 +46,7 @@ define(
                     this.model = new Backbone.Model();
                 }
 
-                var extensionPromises = _.mapObject(this.extensions, function (extension) {
+                var extensionPromises = _.map(this.extensions, function (extension) {
                     return extension.configure();
                 });
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form.js
@@ -46,7 +46,7 @@ define(
                     this.model = new Backbone.Model();
                 }
 
-                var extensionPromises = _.map(this.extensions, function (extension) {
+                var extensionPromises = _.mapObject(this.extensions, function (extension) {
                     return extension.configure();
                 });
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/attribute-filter-all.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/attribute-filter-all.js
@@ -1,0 +1,38 @@
+ 'use strict';
+/**
+ * Idle filter used as default.
+ *
+ * @author    Yohan Blain <yohan.blain@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+
+define(
+    ['jquery', 'oro/translator', 'pim/form'],
+    function ($, __, BaseForm) {
+        return BaseForm.extend({
+            /**
+             * @returns {String}
+             */
+            getCode() {
+                return 'all';
+            },
+
+            /**
+             * @returns {String}
+             */
+            getLabel() {
+                return __('pim_enrich.form.product.tab.attributes.attribute_filter.all');
+            },
+
+            /**
+             * @param {Object} values
+             *
+             * @returns {Promise}
+             */
+            filterValues(values) {
+                return $.Deferred().resolve(values).promise();
+            }
+        });
+    }
+);

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/attribute-filter-missing-required.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/attribute-filter-missing-required.js
@@ -1,0 +1,39 @@
+ 'use strict';
+/**
+ * Filter returning only values missing required values.
+ *
+ * @author    Yohan Blain <yohan.blain@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+
+define(
+    ['underscore', 'oro/translator', 'pim/form', 'pim/provider/to-fill-field-provider'],
+    function (_, __, BaseForm, toFillFieldProvider) {
+        return BaseForm.extend({
+            /**
+             * @returns {String}
+             */
+            getCode() {
+                return 'missing_required';
+            },
+
+            /**
+             * @returns {String}
+             */
+            getLabel() {
+                return __('pim_enrich.form.product.tab.attributes.attribute_filter.missing_required');
+            },
+
+            /**
+             * @param {Object} values
+             *
+             * @returns {Promise}
+             */
+            filterValues(values) {
+                return toFillFieldProvider.getFields(this.getRoot(), values)
+                    .then(fieldCodes => _.pick(values, fieldCodes));
+            }
+        });
+    }
+);

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/attribute-filter.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/attribute-filter.js
@@ -1,0 +1,97 @@
+ 'use strict';
+/**
+ * @author    Yohan Blain <yohan.blain@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+
+define(
+    [
+        'underscore',
+        'oro/translator',
+        'pim/form',
+        'pim/template/form/tab/attribute/attribute-filter'
+    ],
+    function (
+        _,
+        __,
+        BaseForm,
+        template
+    ) {
+        return BaseForm.extend({
+            className: 'AknDropdown AknButtonList-item nav nav-tabs attribute-filter',
+            template: _.template(template),
+            currentFilterCode: null,
+
+            events: {
+                'click li': 'onChange'
+            },
+
+            /**
+             * {@inheritdoc}
+             */
+            render() {
+                const currentFilter = this.getCurrentFilter();
+
+                this.$el.html(this.template({
+                    filters: this.getFilters().map((filter) => {
+                        return { code: filter.getCode(), label: filter.getLabel() }
+                    }),
+                    currentFilter: { code: currentFilter.getCode(), label: currentFilter.getLabel() },
+                    __: __
+                }));
+
+                this.delegateEvents();
+            },
+
+            /**
+             * Facade method delegating the values filtering to the current filter
+             *
+             * @param {Object} values
+             *
+             * @returns {Promise}
+             */
+            filterValues(values) {
+                return this.getCurrentFilter().filterValues(values);
+            },
+
+            /**
+             * Returns all filters extensions registered as children
+             *
+             * @returns {Array}
+             */
+            getFilters() {
+                return _.values(this.extensions);
+            },
+
+            /**
+             * Return the current filter
+             *
+             * @returns {Object}
+             */
+            getCurrentFilter() {
+                if (null === this.currentFilterCode) {
+                    return this.getFilters()[0];
+                }
+
+                return this.getFilters().find((filter) => this.currentFilterCode === filter.getCode());
+            },
+
+            /**
+             * Sets the new current filter and triggers an event.
+             *
+             * @param {Event} event
+             */
+            onChange(event) {
+                const filterCode = event.currentTarget.dataset.code;
+
+                if (filterCode === this.currentFilterCode) {
+                    return;
+                }
+
+                this.currentFilterCode = filterCode;
+                this.trigger('attribute_filter:change');
+            }
+        });
+    }
+);

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/attribute-filter.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/attribute-filter.js
@@ -61,7 +61,7 @@ define(
              * @returns {Array}
              */
             getFilters() {
-                return _.values(this.extensions);
+                return Object.values(this.extensions);
             },
 
             /**

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/attributes/locale-specific.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/attributes/locale-specific.js
@@ -37,6 +37,8 @@ define(
 
                 if (!_.contains(field.attribute.available_locales, field.context.locale)) {
                     this.updateFieldElements(field);
+                } else {
+                    field.removeElement('field-input', 'input_placeholder');
                 }
 
                 return this;

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/product-completeness.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/product-completeness.js
@@ -56,11 +56,11 @@ define(
              * @param options.locale String
              * @param options.scope  String
              */
-            render: function (options) {
-                options = _.extend({
+            render: function () {
+                const options = {
                     locale: UserContext.get('catalogLocale'),
                     scope: UserContext.get('catalogScope')
-                }, options);
+                };
                 this.$el.empty();
 
                 const ratio = this.getCurrentRatio(options);

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/grid/locale-switcher.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/grid/locale-switcher.js
@@ -75,9 +75,8 @@ define([
              */
             fetchLocales() {
                 const localeFetcher = FetcherRegistry.getFetcher('locale');
-                localeFetcher.clear();
 
-                return localeFetcher.search({ activated: true, cached: false });
+                return localeFetcher.fetchActivated();
             },
 
             /**

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/provider/to-fill-field-provider.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/provider/to-fill-field-provider.js
@@ -21,12 +21,12 @@ define(
             /**
              * Get list of fields that need to be filled to complete the product
              *
-             * @param {object} root
-             * @param {object} product
+             * @param {Object} root
+             * @param {Object} values
              *
-             * @return {promise}
+             * @return {Promise}
              */
-            getFields: function (root, product) {
+            getFields: function (root, values) {
 
                 if (null == this.fieldsPromise) {
                     var filterPromises = [];
@@ -38,7 +38,7 @@ define(
                     this.fieldsPromise = $.when.apply($, filterPromises).then(function () {
                         return arguments;
                     }).then(function (filters) {
-                        return fetcherRegistry.getFetcher('attribute').fetchByIdentifiers(_.keys(product.values))
+                        return fetcherRegistry.getFetcher('attribute').fetchByIdentifiers(Object.keys(values))
                             .then(function (attributesToFilter) {
                                 var filteredAttributes = _.reduce(filters, function (attributes, filter) {
                                     return filter(attributes);

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/form/tab/attributes/attribute-filter.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/form/tab/attributes/attribute-filter.html
@@ -7,10 +7,8 @@
 <ul class="AknDropdown-menu AknDropdown-menu--right">
     <li class="AknDropdown-menuTitle"><%- __('pim_enrich.form.product.tab.attributes.attribute_filter.display') %></li>
     <% _.each(filters, function (filter) { %>
-        <li class="<%- currentFilter.code === filter.code ? 'active' : '' %>" data-code="<%- filter.code %>">
-            <div class="AknDropdown-menuLink <%- currentFilter.code === filter.code ? 'AknDropdown-menuLink--active' : '' %>">
-                <span class="label"><%- filter.label %></span>
-            </div>
+        <li class="AknDropdown-menuLink <%- currentFilter.code === filter.code ? 'AknDropdown-menuLink--active active' : '' %>" data-code="<%- filter.code %>">
+            <span class="label"><%- filter.label %></span>
         </li>
     <% }); %>
 </ul>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/form/tab/attributes/attribute-filter.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/form/tab/attributes/attribute-filter.html
@@ -1,0 +1,16 @@
+<div class="AknActionButton AknActionButton--withoutBorder" data-toggle="dropdown">
+    <span class="AknActionButton-highlight">
+        <%- __('pim_enrich.form.product.tab.attributes.attribute_filter.display') %> <%- currentFilter.label %>
+    </span>
+    <span class="AknActionButton-caret"></span>
+</div>
+<ul class="AknDropdown-menu AknDropdown-menu--right">
+    <li class="AknDropdown-menuTitle"><%- __('pim_enrich.form.product.tab.attributes.attribute_filter.display') %></li>
+    <% _.each(filters, function (filter) { %>
+        <li class="<%- currentFilter.code === filter.code ? 'active' : '' %>" data-code="<%- filter.code %>">
+            <div class="AknDropdown-menuLink <%- currentFilter.code === filter.code ? 'AknDropdown-menuLink--active' : '' %>">
+                <span class="label"><%- filter.label %></span>
+            </div>
+        </li>
+    <% }); %>
+</ul>

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
@@ -444,6 +444,10 @@ pim_enrich:
                     attribute_group_selector: Attribute group
                     attribute_group_all: All
                     attribute_group.to_fill_count: "{1}1 empty required attribute|]1, Inf [{{ count }} empty required attributes"
+                    attribute_filter:
+                        display: Display
+                        all: All attributes
+                        missing_required: All missing required attributes
                 categories:
                     title: Categories
             panel:


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This PR adds a dropdown on the PEF that will contain attribute filters. For now only one filter is implemented : "missing required attributes".

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | OK
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
