### PR TITLE
GITHUB-6657: Fix mapping for Product and ProductUniqueData

### DIFF
--- a/CHANGELOG-1.8.md
+++ b/CHANGELOG-1.8.md
@@ -481,3 +481,4 @@
 
 - GITHUB-6101: Fix Summernote (WYSIWYG) style
 - GITHUB-6337: Write invalid items process fails when it encounters a Date field in xlsx files thanks to @pablollorens!
+- GITHUB-6657: Fix mapping for Product and ProductUniqueData

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/model/doctrine/Product.orm.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/model/doctrine/Product.orm.yml
@@ -34,6 +34,7 @@ Pim\Component\Catalog\Model\Product:
     manyToMany:
         groups:
             targetEntity: Pim\Component\Catalog\Model\GroupInterface
+            inversedBy: products
             joinTable:
                 name: pim_catalog_group_product
                 joinColumns:
@@ -46,6 +47,7 @@ Pim\Component\Catalog\Model\Product:
                         onDelete: CASCADE
         categories:
             targetEntity: Pim\Component\Catalog\Model\CategoryInterface
+            inversedBy: products
             joinTable:
                 name: pim_catalog_category_product
                 joinColumns:

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/model/doctrine/ProductUniqueData.orm.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/model/doctrine/ProductUniqueData.orm.yml
@@ -19,6 +19,7 @@ Pim\Component\Catalog\Model\ProductUniqueData:
     manyToOne:
         product:
             targetEntity: Pim\Component\Catalog\Model\ProductInterface
+            inversedBy: uniqueData
             joinColumns:
                 product_id:
                     referencedColumnName: id


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
Fix issue #6657 

In ProductUniqueData, add inversedBy for the _Product Relation_
In Product, add inversedBy for the _categories_ relation and _groups_
Update CHANGELOG

```
[Mapping]  OK - The mapping files are correct.
[Database] OK - The database schema is in sync with the mapping files.
```

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | -
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
