### PR TITLE
PIM-6743: Immutable fields on product models and variant products

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Product/CreateProductModelIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Product/CreateProductModelIntegration.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace tests\integration\Pim\Bundle\CatalogBundle\Product;
+namespace Pim\Bundle\CatalogBundle\tests\integration\Product;
 
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Test\Integration\Configuration;
@@ -12,7 +12,7 @@ use Pim\Component\Catalog\Model\ProductModelInterface;
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class ProductModelIntegration extends TestCase
+class CreateProductModelIntegration extends TestCase
 {
     /**
      * Create a product without any errors

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Product/CreateVariantProductIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Product/CreateVariantProductIntegration.php
@@ -12,7 +12,7 @@ use Akeneo\Test\Integration\TestCase;
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class VariantProductIntegration extends TestCase
+class CreateVariantProductIntegration extends TestCase
 {
     public function testVariantProductHasParent(): void
     {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Product/UpdateProductModelIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Product/UpdateProductModelIntegration.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\Product;
+
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+
+/**
+ * @author    Damien Carcel (damien.carcel@akeneo.com)
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class UpdateProductModelIntegration extends TestCase
+{
+    /**
+     * Ensure that the parent of a product model cannot be changed.
+     *
+     * TODO: This will become possible in PIM-6350.
+     *
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\ImmutablePropertyException
+     * @expectedExceptionMessage Property "parent" cannot be modified, "amor" given.
+     */
+    public function testTheParentCannotBeChanged(): void
+    {
+        $productModel = $this->get('pim_catalog.repository.product_model')->findOneByIdentifier('apollon_blue');
+        $this->get('pim_catalog.updater.product_model')->update($productModel, ['parent' => 'amor',]);
+    }
+
+    /**
+     * Ensure that the family variant of a product model cannot be changed.
+     *
+     * TODO: This will become possible in PIM-6344.
+     *
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\ImmutablePropertyException
+     * @expectedExceptionMessage Property "family_variant" cannot be modified, "shoes_size" given.
+     */
+    public function testTheFamilyVariantCannotBeChanged(): void
+    {
+        $productModel = $this->get('pim_catalog.repository.product_model')->findOneByIdentifier('apollon_blue');
+        $this->get('pim_catalog.updater.product_model')->update($productModel, ['family_variant' => 'shoes_size',]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration(): Configuration
+    {
+        return new Configuration([Configuration::getFunctionalCatalogPath('catalog_modeling')]);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Product/UpdateVariantProductIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Product/UpdateVariantProductIntegration.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\Product;
+
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+
+/**
+ * @author    Damien Carcel (damien.carcel@akeneo.com)
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class UpdateVariantProductIntegration extends TestCase
+{
+    /**
+     * Ensure that the parent of a variant product cannot be changed.
+     *
+     * TODO: This will become possible in PIM-6350.
+     *
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\ImmutablePropertyException
+     * @expectedExceptionMessage Property "parent" cannot be modified, "amor" given.
+     */
+    public function testTheParentCannotBeChanged(): void
+    {
+        $product = $this->get('pim_catalog.repository.product')->findOneByIdentifier('apollon_blue_xl');
+        $this->get('pim_catalog.updater.product')->update($product, ['parent' => 'amor',]);
+    }
+
+    /**
+     * Ensure that the family of a variant product cannot be changed.
+     *
+     * TODO: This will become possible in PIM-6460.
+     */
+    public function testTheFamilyCannotBeChanged(): void
+    {
+        $product = $this->get('pim_catalog.repository.product')->findOneByIdentifier('apollon_blue_xl');
+        $this->get('pim_catalog.updater.product')->update($product, ['family' => 'shoes',]);
+
+        $errors = $this->get('validator')->validate($product);
+        $this->assertEquals(1, $errors->count());
+        $this->assertEquals(
+            'The variant product family must be the same than its parent',
+            $errors->get(0)->getMessage()
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration(): Configuration
+    {
+        return new Configuration([Configuration::getFunctionalCatalogPath('catalog_modeling')]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $product = $this->get('pim_catalog.builder.variant_product')->createProduct('apollon_blue_xl', 'clothing');
+        $this->get('pim_catalog.updater.product')->update($product, [
+            'parent' => 'apollon_blue',
+            'values' => [
+                'size' => [
+                    [
+                        'locale' => null,
+                        'scope' => null,
+                        'data' => 'xl',
+                    ],
+                ],
+            ],
+        ]);
+
+        $errors = $this->get('validator')->validate($product);
+        if (0 !== $errors->count()) {
+            throw new \Exception(sprintf(
+                'Impossible to setup test in %s: %s',
+                static::class,
+                $errors->get(0)->getMessage()
+            ));
+        }
+
+        $this->get('pim_catalog.saver.product')->save($product);
+    }
+}

--- a/src/Pim/Component/Catalog/Updater/FamilyVariantUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/FamilyVariantUpdater.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Pim\Component\Catalog\Updater;
 
 use Akeneo\Component\Localization\TranslatableUpdater;

--- a/src/Pim/Component/Catalog/Updater/Setter/ParentFieldSetter.php
+++ b/src/Pim/Component/Catalog/Updater/Setter/ParentFieldSetter.php
@@ -3,11 +3,11 @@ declare(strict_types=1);
 
 namespace Pim\Component\Catalog\Updater\Setter;
 
+use Akeneo\Component\StorageUtils\Exception\ImmutablePropertyException;
 use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Doctrine\Common\Util\ClassUtils;
-use Pim\Component\Catalog\Model\ProductModelInterface;
 use Pim\Component\Catalog\Model\VariantProductInterface;
 
 /**
@@ -43,7 +43,11 @@ class ParentFieldSetter extends AbstractFieldSetter
             );
         }
 
-        /** @var $parent ProductModelInterface */
+        // TODO: This is to be removed in PIM-6350.
+        if (null !== $product->getParent() && $data !== $product->getParent()->getCode()) {
+            throw ImmutablePropertyException::immutableProperty('parent', $data, static::class);
+        }
+
         if (null === $parent = $this->productModelRepository->findOneByIdentifier($data)) {
             throw InvalidPropertyException::validEntityCodeExpected(
                 $field,

--- a/src/Pim/Component/Catalog/Validator/Constraints/NotEmptyVariantAxesValidator.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/NotEmptyVariantAxesValidator.php
@@ -39,7 +39,7 @@ class NotEmptyVariantAxesValidator extends ConstraintValidator
             throw new UnexpectedTypeException($constraint, NotEmptyVariantAxes::class);
         }
 
-        if (null === $familyVariant = $entity->getFamilyVariant()) {
+        if (null === $entity->getFamilyVariant()) {
             return;
         }
 
@@ -49,8 +49,7 @@ class NotEmptyVariantAxesValidator extends ConstraintValidator
             $value = $entity->getValue($axis->getCode());
 
             if (null === $value || empty($value->getData())) {
-                $this->context->buildViolation(
-                    NotEmptyVariantAxes::EMPTY_AXIS_VALUE, [
+                $this->context->buildViolation(NotEmptyVariantAxes::EMPTY_AXIS_VALUE, [
                     '%attribute%' => $axis->getCode()
                 ])->addViolation();
             }

--- a/src/Pim/Component/Catalog/spec/Updater/ProductModelUpdaterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/ProductModelUpdaterSpec.php
@@ -67,6 +67,7 @@ class ProductModelUpdaterSpec extends ObjectBehavior
         FamilyVariantInterface $familyVariant
     ) {
         $productModel->getId()->willReturn(null);
+        $productModel->getFamilyVariant()->willReturn(null);
 
         $propertySetter->setData($productModel, 'categories', ['tshirt'])->shouldBeCalled();
         $productModel->setCode('product_model_code')->shouldBeCalled();
@@ -318,6 +319,20 @@ class ProductModelUpdaterSpec extends ObjectBehavior
         ]]);
     }
 
+    function it_throws_an_exception_if_the_parent_is_updated(
+        ProductModelInterface $productModel,
+        ProductModelInterface $parent
+    ) {
+        $productModel->getId()->willReturn(42);
+        $productModel->isRootProductModel()->willReturn(false);
+        $productModel->getParent()->willReturn($parent);
+        $parent->getCode()->willReturn('parent');
+
+        $this->shouldThrow(ImmutablePropertyException::class)->during('update', [$productModel, [
+            'parent' => 'new_parent'
+        ]]);
+    }
+
     function it_throws_an_exception_if_the_family_variant_code_is_invalid(
         $familyVariantRepository,
         ProductModelInterface $productModel
@@ -326,6 +341,18 @@ class ProductModelUpdaterSpec extends ObjectBehavior
 
         $this->shouldThrow(InvalidPropertyException::class)->during('update', [$productModel, [
             'family_variant' => 'wrong_code'
+        ]]);
+    }
+
+    function it_throws_an_exception_if_the_family_variant_is_updated(
+        ProductModelInterface $productModel,
+        FamilyVariantInterface $familyVariant
+    ) {
+        $productModel->getFamilyVariant()->willReturn($familyVariant);
+        $familyVariant->getCode()->willreturn('family_variant');
+
+        $this->shouldThrow(ImmutablePropertyException::class)->during('update', [$productModel, [
+            'family_variant' => 'new_family_variant'
         ]]);
     }
 

--- a/src/Pim/Component/Catalog/spec/Updater/Setter/ParentFieldSetterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Setter/ParentFieldSetterSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Pim\Component\Catalog\Updater\Setter;
 
+use Akeneo\Component\StorageUtils\Exception\ImmutablePropertyException;
 use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
@@ -47,6 +48,7 @@ class ParentFieldSetterSpec extends ObjectBehavior
         $productModelRepository->findOneByIdentifier('parent_code')->willReturn($productModel);
         $productModel->getFamilyVariant()->willReturn($familyVariant);
 
+        $product->getParent()->willReturn(null);
         $product->setParent($productModel)->shouldBeCalled();
         $product->setFamilyVariant($familyVariant)->shouldBeCalled();
         $product->getFamily()->willReturn($family);
@@ -65,6 +67,7 @@ class ParentFieldSetterSpec extends ObjectBehavior
         $productModel->getFamilyVariant()->willReturn($familyVariant);
         $familyVariant->getFamily()->willReturn($family);
 
+        $product->getParent()->willReturn(null);
         $product->setParent($productModel)->shouldBeCalled();
         $product->setFamilyVariant($familyVariant)->shouldBeCalled();
         $product->getFamily()->willReturn(null);
@@ -90,6 +93,19 @@ class ParentFieldSetterSpec extends ObjectBehavior
         $this->shouldThrow(InvalidPropertyException::class)->during(
             'setFieldData',
             [$variantProduct, 'parent', 'parent_code']
+        );
+    }
+
+    function it_throws_exception_if_the_parent_is_updated(
+        VariantProductInterface $variantProduct,
+        ProductModelInterface $parent
+    ) {
+        $variantProduct->getParent()->willReturn($parent);
+        $parent->getCode()->willReturn('parent_code');
+
+        $this->shouldThrow(ImmutablePropertyException::class)->during(
+            'setFieldData',
+            [$variantProduct, 'parent', 'new_parent_code']
         );
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,7 +2,6 @@
 
 namespace Akeneo\Test\Integration;
 
-use Akeneo\Bundle\ElasticsearchBundle\Client;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**


### PR DESCRIPTION
## Description

This PR ensure the immutability of some fields:
- on product models:
    - family_variant
    - parent
- on variant products:
    - family
    - parent

This will be removed in the future by allowing user to change parent and family/family variant, while managing all the side effects it implies. So meanwhile, we must ensure they really are immutable.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
