### PR TITLE
PIM-6621: fix revert of labels for products

### DIFF
--- a/src/Pim/Component/Catalog/Normalizer/Indexing/ProductAndProductModel/ProductModelPropertiesNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/ProductAndProductModel/ProductModelPropertiesNormalizer.php
@@ -39,7 +39,6 @@ class ProductModelPropertiesNormalizer implements NormalizerInterface, Serialize
 
         $data[self::FIELD_ID] = 'product_model_' . (string) $productModel->getId();
         $data[StandardPropertiesNormalizer::FIELD_IDENTIFIER] = $productModel->getCode();
-        $data[StandardPropertiesNormalizer::FIELD_LABEL] = $productModel->getLabel();
         $data[StandardPropertiesNormalizer::FIELD_CREATED] = $this->serializer->normalize(
             $productModel->getCreated(),
             $format

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/ProductAndProductModel/ProductPropertiesNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/ProductAndProductModel/ProductPropertiesNormalizer.php
@@ -43,7 +43,6 @@ class ProductPropertiesNormalizer implements NormalizerInterface, SerializerAwar
 
         $data[self::FIELD_ID] = 'product_' .(string) $product->getId();
         $data[StandardPropertiesNormalizer::FIELD_IDENTIFIER] = $product->getIdentifier();
-        $data[StandardPropertiesNormalizer::FIELD_LABEL] = $product->getLabel();
         $data[StandardPropertiesNormalizer::FIELD_CREATED] = $this->serializer->normalize(
             $product->getCreated(),
             $format

--- a/src/Pim/Component/Catalog/spec/Normalizer/Indexing/ProductAndProductModel/ProductModelPropertiesNormalizerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Normalizer/Indexing/ProductAndProductModel/ProductModelPropertiesNormalizerSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Pim\Component\Catalog\Normalizer\Indexing\ProductAndProductModel;
 
+use Doctrine\Common\Collections\Collection;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Model\FamilyInterface;
 use Pim\Component\Catalog\Model\FamilyVariantInterface;
@@ -49,8 +50,6 @@ class ProductModelPropertiesNormalizerSpec extends ObjectBehavior
         $productModel->getParent()->willReturn(null);
 
         $productModel->getCode()->willReturn('sku-001');
-        $productModel->getLabel()->willReturn('my sku-001');
-
         $productModel->getCreated()->willReturn($now);
         $serializer
             ->normalize($family, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
@@ -79,7 +78,6 @@ class ProductModelPropertiesNormalizerSpec extends ObjectBehavior
             [
                 'id'             => 'product_model_67',
                 'identifier'     => 'sku-001',
-                'label'          => 'my sku-001',
                 'created'        => $now->format('c'),
                 'updated'        => $now->format('c'),
                 'family'         => 'family_A',
@@ -101,7 +99,6 @@ class ProductModelPropertiesNormalizerSpec extends ObjectBehavior
 
         $productModel->getId()->willReturn(67);
         $productModel->getCode()->willReturn('sku-001');
-        $productModel->getLabel()->willReturn('my sku-001');
 
         $productModel->getParent()->willReturn(null);
 
@@ -149,7 +146,6 @@ class ProductModelPropertiesNormalizerSpec extends ObjectBehavior
             [
                 'id'             => 'product_model_67',
                 'identifier'     => 'sku-001',
-                'label'          => 'my sku-001',
                 'created'        => $now->format('c'),
                 'updated'        => $now->format('c'),
                 'family'         => [
@@ -184,7 +180,6 @@ class ProductModelPropertiesNormalizerSpec extends ObjectBehavior
 
         $productModel->getId()->willReturn(67);
         $productModel->getCode()->willReturn('sku-001');
-        $productModel->getLabel()->willReturn('my sku-001');
 
         $productModel->getParent()->willReturn($parent);
         $parent->getCode()->willReturn('parent_A');
@@ -242,7 +237,6 @@ class ProductModelPropertiesNormalizerSpec extends ObjectBehavior
             [
                 'id'             => 'product_model_67',
                 'identifier'     => 'sku-001',
-                'label'          => 'my sku-001',
                 'created'        => $now->format('c'),
                 'updated'        => $now->format('c'),
                 'family'         => [

--- a/src/Pim/Component/Catalog/spec/Normalizer/Indexing/ProductAndProductModel/ProductPropertiesNormalizerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Normalizer/Indexing/ProductAndProductModel/ProductPropertiesNormalizerSpec.php
@@ -57,7 +57,6 @@ class ProductPropertiesNormalizerSpec extends ObjectBehavior
 
         $product->getIdentifier()->willReturn('sku-001');
         $product->getFamily()->willReturn($family);
-        $product->getLabel()->willReturn('my sku-001');
         $serializer->normalize($family, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
             ->willReturn(null);
 
@@ -89,7 +88,6 @@ class ProductPropertiesNormalizerSpec extends ObjectBehavior
             [
                 'id'             => 'product_67',
                 'identifier'     => 'sku-001',
-                'label'          => 'my sku-001',
                 'created'        => $now->format('c'),
                 'updated'        => $now->format('c'),
                 'family'         => null,
@@ -115,7 +113,6 @@ class ProductPropertiesNormalizerSpec extends ObjectBehavior
 
         $product->getId()->willReturn(67);
         $product->getIdentifier()->willReturn('sku-001');
-        $product->getLabel()->willReturn('my sku-001');
 
         $product->getCreated()->willReturn($now);
         $serializer->normalize(
@@ -180,7 +177,6 @@ class ProductPropertiesNormalizerSpec extends ObjectBehavior
             [
                 'id'            => 'product_67',
                 'identifier'    => 'sku-001',
-                'label'          => 'my sku-001',
                 'created'       => $now->format('c'),
                 'updated'       => $now->format('c'),
                 'family' => [
@@ -234,7 +230,6 @@ class ProductPropertiesNormalizerSpec extends ObjectBehavior
 
         $variantProduct->getId()->willReturn(67);
         $variantProduct->getIdentifier()->willReturn('sku-001');
-        $variantProduct->getLabel()->willReturn('my sku-001');
 
         $variantProduct->getCreated()->willReturn($now);
         $serializer->normalize(
@@ -273,25 +268,24 @@ class ProductPropertiesNormalizerSpec extends ObjectBehavior
             ->willReturn(['the completenesses']);
 
         $this->normalize($variantProduct, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)->shouldReturn([
-                'id'             => 'product_67',
-                'identifier'     => 'sku-001',
-                'label'          => 'my sku-001',
-                'created'        => $now->format('c'),
-                'updated'        => $now->format('c'),
-                'family'         => [
+                'id'            => 'product_67',
+                'identifier'    => 'sku-001',
+                'created'       => $now->format('c'),
+                'updated'       => $now->format('c'),
+                'family' => [
                     'code'   => 'family',
                     'labels' => [
                         'fr_FR' => 'Une famille',
                         'en_US' => 'A family',
                     ],
                 ],
-                'enabled'        => false,
-                'categories'     => [],
-                'groups'         => [],
-                'completeness'   => ['the completenesses'],
+                'enabled'       => false,
+                'categories'    => [],
+                'groups'        => [],
+                'completeness'  => ['the completenesses'],
                 'family_variant' => 'family_variant_A',
-                'parent'         => 'parent_A',
-                'values'         => [],
+                'parent'        => 'parent_A',
+                'values'        => [],
             ]
         );
     }
@@ -312,7 +306,6 @@ class ProductPropertiesNormalizerSpec extends ObjectBehavior
 
         $variantProduct->getId()->willReturn(67);
         $variantProduct->getIdentifier()->willReturn('sku-001');
-        $variantProduct->getLabel()->willReturn('my sku-001');
 
         $variantProduct->getCreated()->willReturn($now);
         $serializer->normalize(
@@ -390,7 +383,6 @@ class ProductPropertiesNormalizerSpec extends ObjectBehavior
             [
                 'id'            => 'product_67',
                 'identifier'    => 'sku-001',
-                'label'          => 'my sku-001',
                 'created'       => $now->format('c'),
                 'updated'       => $now->format('c'),
                 'family' => [


### PR DESCRIPTION
Juju recently reverted the search on labels on master.

During the merge of master into our branch, I forgot to clean the normalization for the grid.
Sorry for that.