### PR TITLE
Api 362: use queue job launcher to allow horizontal scalability for the jobs 

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -375,7 +375,7 @@
 - Change the constructor of `Pim\Component\Catalog\Manager\CompletenessManager` to remove the completeness class.
 - Change the constructor of `Pim\Component\Catalog\Updater\FamilyUpdater` to add `Akeneo\Component\Localization\TranslatableUpdater`
 - Change the constructor of `Pim\Component\Catalog\Updater\AttributeUpdater` to add `Akeneo\Component\Localization\TranslatableUpdater`
-- Change the constructor of `Akeneo\Bundle\BatchBundle\Launcher\SimpleJobLauncher` to add `kernel.logs_dir`
+- Change the constructor of `Akeneo\Bundle\BatchBundle\Launcher\SimpleJobLauncher` to add `logDir` (string)
 - Change the constructor of `Pim\Bundle\EnrichBundle\Twig\AttributeExtension` to remove `pim_enrich.attribute_icons`
 - Remove OroNotificationBundle
 - Remove createAction from `Pim\Bundle\EnrichBundle/Controller/AssociationTypeController.php`

--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -108,6 +108,7 @@ class AppKernel extends Kernel
         return [
             new Akeneo\Bundle\ElasticsearchBundle\AkeneoElasticsearchBundle(),
             new Akeneo\Bundle\BatchBundle\AkeneoBatchBundle(),
+            new Akeneo\Bundle\BatchQueueBundle\AkeneoBatchQueueBundle(),
             new Akeneo\Bundle\BufferBundle\AkeneoBufferBundle(),
             new Akeneo\Bundle\FileStorageBundle\AkeneoFileStorageBundle(),
             new Akeneo\Bundle\MeasureBundle\AkeneoMeasureBundle(),

--- a/composer.json
+++ b/composer.json
@@ -58,6 +58,7 @@
         "monolog/monolog": "1.23.0",
         "ocramius/proxy-manager": "2.1.1",
         "oneup/flysystem-bundle": "1.14.0",
+        "ramsey/uuid": "3.7.0",
         "sensio/distribution-bundle": "5.0.20",
         "sensio/framework-extra-bundle": "3.0.26",
         "sensio/generator-bundle": "3.1.6",

--- a/features/Context/WebUser.php
+++ b/features/Context/WebUser.php
@@ -1935,19 +1935,20 @@ class WebUser extends PimContext
      */
     public function iWaitForTheJobToFinish($code)
     {
-        $jobExecution = $this->spin(function () use ($code) {
+        $this->wait();
+
+        $this->spin(function () use ($code) {
             $jobInstance = $this->getFixturesContext()->getJobInstance($code);
             // Force to retrieve its job executions
             $jobInstance->getJobExecutions()->setInitialized(false);
 
             $this->getFixturesContext()->refresh($jobInstance);
+
             $jobExecution = $jobInstance->getJobExecutions()->last();
             $this->getFixturesContext()->refresh($jobExecution);
 
             return $jobExecution && !$jobExecution->isRunning();
         }, sprintf('The job execution of "%s" was too long', $code));
-
-        $this->wait();
 
         $this->getMainContext()->getContainer()->get('pim_connector.doctrine.cache_clearer')->clear();
 

--- a/phpspec.yml.dist
+++ b/phpspec.yml.dist
@@ -14,6 +14,11 @@ suites:
         psr4_prefix: Akeneo\Component\Batch
         spec_path: src/Akeneo/Component/Batch
         src_path: src/Akeneo/Component/Batch
+    BatchQueue:
+        namespace: Akeneo\Component\BatchQueue
+        psr4_prefix: Akeneo\Component\BatchQueue
+        spec_path: src/Akeneo/Component/BatchQueue
+        src_path: src/Akeneo/Component/BatchQueue
     Buffer:
         namespace: Akeneo\Component\Buffer
         psr4_prefix: Akeneo\Component\Buffer
@@ -56,6 +61,11 @@ suites:
         psr4_prefix: Akeneo\Bundle\BatchBundle
         spec_path: src/Akeneo/Bundle/BatchBundle
         src_path: src/Akeneo/Bundle/BatchBundle
+    BatchQueueBundle:
+        namespace: Akeneo\Bundle\BatchQueueBundle
+        psr4_prefix: Akeneo\Bundle\BatchQueueBundle
+        spec_path: src/Akeneo/Bundle/BatchQueueBundle
+        src_path: src/Akeneo/Bundle/BatchQueueBundle
     ClassificationBundle:
         namespace: Akeneo\Bundle\ClassificationBundle
         psr4_prefix: Akeneo\Bundle\ClassificationBundle

--- a/src/Akeneo/Bundle/BatchBundle/EntityManager/PersistedConnectionEntityManager.php
+++ b/src/Akeneo/Bundle/BatchBundle/EntityManager/PersistedConnectionEntityManager.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Bundle\BatchBundle\EntityManager;
+
+use Doctrine\ORM\Decorator\EntityManagerDecorator;
+
+/**
+ * This EntityManager aims to ensure that the connection is always open before doing an operation.
+ *
+ * It is useful in the context of long running processes, when the connection could have been closed
+ * by the database due to a time out.
+ *
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class PersistedConnectionEntityManager extends EntityManagerDecorator
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getConnection()
+    {
+        $this->checkConnection();
+
+        return $this->wrapped->getConnection();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function flush($entity = null)
+    {
+        $this->checkConnection();
+
+        return $this->wrapped->flush($entity);
+    }
+
+    /**
+     * Ping the Server, if the connection is closed, it re-opens it automatically.
+     */
+    private function checkConnection(): void
+    {
+        $connection = $this->wrapped->getConnection();
+
+        if (false === $connection->ping()) {
+            $connection->close();
+            $connection->connect();
+        }
+    }
+}

--- a/src/Akeneo/Bundle/BatchBundle/Job/DoctrineJobRepository.php
+++ b/src/Akeneo/Bundle/BatchBundle/Job/DoctrineJobRepository.php
@@ -2,6 +2,7 @@
 
 namespace Akeneo\Bundle\BatchBundle\Job;
 
+use Akeneo\Bundle\BatchBundle\EntityManager\PersistedConnectionEntityManager;
 use Akeneo\Component\Batch\Job\BatchStatus;
 use Akeneo\Component\Batch\Job\JobParameters;
 use Akeneo\Component\Batch\Job\JobRepositoryInterface;
@@ -9,7 +10,6 @@ use Akeneo\Component\Batch\Model\JobExecution;
 use Akeneo\Component\Batch\Model\JobInstance;
 use Akeneo\Component\Batch\Model\StepExecution;
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\DBALException;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\PersistentCollection;
 
@@ -69,7 +69,7 @@ class DoctrineJobRepository implements JobRepositoryInterface
             $entityManager->getConfiguration()
         );
 
-        $this->jobManager = $jobManager;
+        $this->jobManager = new PersistedConnectionEntityManager($jobManager);
         $this->jobExecutionClass = $jobExecutionClass;
 
         // ... there is an ugly fix related to PIM-5589...
@@ -125,7 +125,6 @@ class DoctrineJobRepository implements JobRepositoryInterface
      */
     public function updateJobExecution(JobExecution $jobExecution)
     {
-        $this->checkConnection();
         $this->jobManager->persist($jobExecution);
         $this->jobManager->flush($jobExecution);
     }
@@ -135,7 +134,6 @@ class DoctrineJobRepository implements JobRepositoryInterface
      */
     public function updateStepExecution(StepExecution $stepExecution)
     {
-        $this->checkConnection();
         $this->jobManager->persist($stepExecution);
         $this->jobManager->flush($stepExecution);
     }
@@ -196,19 +194,6 @@ class DoctrineJobRepository implements JobRepositoryInterface
             $this->jobManager->remove($jobsExecution);
         }
         $this->jobManager->flush();
-    }
-
-    /**
-     * Ping the Server, if not available then reset the connection.
-     * @author Cristian Quiroz <cq@amp.co>
-     */
-    protected function checkConnection(): void
-    {
-        $connection = $this->jobManager->getConnection();
-        if (false === $connection->ping()) {
-            $connection->close();
-            $connection->connect();
-        }
     }
 
     /**

--- a/src/Akeneo/Bundle/BatchBundle/Launcher/SimpleJobLauncher.php
+++ b/src/Akeneo/Bundle/BatchBundle/Launcher/SimpleJobLauncher.php
@@ -12,7 +12,7 @@ use Akeneo\Component\Batch\Model\JobExecution;
 use Akeneo\Component\Batch\Model\JobInstance;
 use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Security\Core\User\UserInterface;
-use Symfony\Component\Validator\ConstraintViolationList;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
 
 /**
  * @author    Marie Bochu <marie.bochu@akeneo.com>
@@ -158,16 +158,16 @@ class SimpleJobLauncher implements JobLauncherInterface
     }
 
     /**
-     * @param ConstraintViolationList $errors
+     * @param ConstraintViolationListInterface $errors
      *
      * @return string
      */
-    private function getErrorMessages(ConstraintViolationList $errors): string
+    private function getErrorMessages(ConstraintViolationListInterface $errors): string
     {
         $errorsStr = '';
 
         foreach ($errors as $error) {
-            $errorsStr .= sprintf("\n  - %s", $error);
+            $errorsStr .= sprintf('%s  - %s', PHP_EOL, $error);
         }
 
         return $errorsStr;

--- a/src/Akeneo/Bundle/BatchBundle/Manager/JobExecutionManager.php
+++ b/src/Akeneo/Bundle/BatchBundle/Manager/JobExecutionManager.php
@@ -38,8 +38,7 @@ class JobExecutionManager
     public function checkRunningStatus(JobExecution $jobExecution)
     {
         if (BatchStatus::STARTING !== $jobExecution->getStatus()->getValue() &&
-            (ExitStatus::UNKNOWN === $jobExecution->getExitStatus()->getExitCode() ||
-            ExitStatus::EXECUTING === $jobExecution->getExitStatus()->getExitCode())
+            $jobExecution->getExitStatus()->isRunning()
         ) {
             return $this->processIsRunning($jobExecution);
         }
@@ -75,7 +74,7 @@ class JobExecutionManager
         $jobExecution->setStatus(new BatchStatus(BatchStatus::FAILED));
         $jobExecution->setExitStatus(new ExitStatus(ExitStatus::FAILED));
         $jobExecution->setEndTime(new \DateTime('now'));
-        $jobExecution->addFailureException(new \Exception('An exception occured during the job execution'));
+        $jobExecution->addFailureException(new \Exception('An exception occurred during the job execution'));
 
         $this->entityManager->persist($jobExecution);
         $this->entityManager->flush();

--- a/src/Akeneo/Bundle/BatchBundle/Resources/config/model/doctrine/JobExecution.orm.yml
+++ b/src/Akeneo/Bundle/BatchBundle/Resources/config/model/doctrine/JobExecution.orm.yml
@@ -38,6 +38,10 @@ Akeneo\Component\Batch\Model\JobExecution:
             type: datetime
             column: updated_time
             nullable: true
+        healthCheckTime:
+            type: datetime
+            column: health_check_time
+            nullable: true
         exitCode:
             type: string
             length: 255

--- a/src/Akeneo/Bundle/BatchBundle/Resources/config/services.yml
+++ b/src/Akeneo/Bundle/BatchBundle/Resources/config/services.yml
@@ -9,6 +9,7 @@ parameters:
     akeneo_batch.set_job_execution_log_file_subscriber.class: Akeneo\Bundle\BatchBundle\EventListener\SetJobExecutionLogFileSubscriber
     akeneo_batch.manager.job_execution.class:                 Akeneo\Bundle\BatchBundle\Manager\JobExecutionManager
     akeneo_batch.launcher.simple_job_launcher.class:          Akeneo\Bundle\BatchBundle\Launcher\SimpleJobLauncher
+    akeneo_batch.entity_manager.persisted_connection_entity_manager.class: Akeneo\Bundle\BatchBundle\EntityManager\PersistedConnectionEntityManager
     akeneo_batch.connectors_config:                           ~
     akeneo_batch.jobs_config:                                 ~
 
@@ -84,3 +85,8 @@ services:
             - '%kernel.root_dir%'
             - '%kernel.environment%'
             - '%logs_dir%'
+
+    akeneo_batch.entity_manager.persisted_connection_entity_manager:
+        class: '%akeneo_batch.entity_manager.persisted_connection_entity_manager.class%'
+        arguments:
+            - '@doctrine.orm.entity_manager'

--- a/src/Akeneo/Bundle/BatchBundle/spec/EntityManager/PersistedConnectionEntityManagerSpec.php
+++ b/src/Akeneo/Bundle/BatchBundle/spec/EntityManager/PersistedConnectionEntityManagerSpec.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace spec\Akeneo\Bundle\BatchBundle\EntityManager;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManagerInterface;
+use PhpSpec\ObjectBehavior;
+
+class PersistedConnectionEntityManagerSpec extends ObjectBehavior
+{
+    function let(EntityManagerInterface $entityManager)
+    {
+        $this->beConstructedWith($entityManager);
+    }
+
+    function it_refreshes_connection_when_getting_connection($entityManager, Connection $connection) {
+        $entityManager->getConnection()->willReturn($connection);
+        $connection->ping()->willReturn(false);
+        $connection->close()->shouldBeCalled();
+        $connection->connect()->shouldBeCalled();
+
+        $this->getConnection()->shouldReturn($connection);
+    }
+
+    function it_refreshes_connection_when_flushing_data($entityManager, Connection $connection) {
+        $entityManager->getConnection()->willReturn($connection);
+        $connection->ping()->willReturn(false);
+        $connection->close()->shouldBeCalled();
+        $connection->connect()->shouldBeCalled();
+        $entityManager->flush(null)->shouldBeCalled();
+
+        $this->flush();
+    }
+}

--- a/src/Akeneo/Bundle/BatchBundle/spec/Launcher/SimpleJobLauncherSpec.php
+++ b/src/Akeneo/Bundle/BatchBundle/spec/Launcher/SimpleJobLauncherSpec.php
@@ -2,11 +2,19 @@
 
 namespace spec\Akeneo\Bundle\BatchBundle\Launcher;
 
+use Akeneo\Bundle\BatchBundle\Launcher\JobLauncherInterface;
+use Akeneo\Component\Batch\Job\Job;
+use Akeneo\Component\Batch\Job\JobParameters;
 use Akeneo\Component\Batch\Job\JobParametersFactory;
 use Akeneo\Component\Batch\Job\JobParametersValidator;
 use Akeneo\Component\Batch\Job\JobRegistry;
 use Akeneo\Component\Batch\Job\JobRepositoryInterface;
+use Akeneo\Component\Batch\Model\JobExecution;
+use Akeneo\Component\Batch\Model\JobInstance;
 use PhpSpec\ObjectBehavior;
+use Pim\Bundle\UserBundle\Entity\UserInterface;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
 
 class SimpleJobLauncherSpec extends ObjectBehavior
 {
@@ -21,6 +29,41 @@ class SimpleJobLauncherSpec extends ObjectBehavior
 
     function it_is_a_job_launcher()
     {
-        $this->shouldHaveType('Akeneo\Bundle\BatchBundle\Launcher\JobLauncherInterface');
+        $this->shouldHaveType(JobLauncherInterface::class);
+    }
+
+    function it_throws_an_exception_if_job_parameters_are_invalid(
+        $jobRegistry,
+        $jobParametersFactory,
+        $jobParametersValidator,
+        JobInstance $jobInstance,
+        UserInterface $user,
+        JobExecution $jobExecution,
+        Job $job,
+        JobParameters $jobParameters,
+        ConstraintViolationListInterface $constraintViolationList,
+        ConstraintViolation $constraintViolation
+    ) {
+        $jobInstance->getJobName()->willReturn('job_instance_name');
+        $jobInstance->getCode()->willReturn('job_instance_code');
+        $jobInstance->getRawParameters()->willReturn(['foo' => 'bar']);
+        $user->getUsername()->willReturn('julia');
+        $jobExecution->getId()->willReturn(1);
+        $constraintViolationList->count()->willReturn(1);
+
+        $constraintViolationList->rewind()->shouldBeCalled();
+        $constraintViolationList->valid()->willReturn(true, false);
+        $constraintViolationList->next()->shouldBeCalled();
+        $constraintViolationList->current()->willReturn($constraintViolation);
+
+        $constraintViolation->__toString()->willReturn('error');
+
+        $jobRegistry->get('job_instance_name')->willReturn($job);
+        $jobParametersFactory->create($job, ['foo' => 'bar'])->willReturn($jobParameters);
+        $jobParametersValidator->validate($job, $jobParameters, ['Default', 'Execution'])->willReturn($constraintViolationList);
+
+        $this
+            ->shouldThrow(new \RuntimeException('Job instance "job_instance_code" running the job "" with parameters "" is invalid because of "' . PHP_EOL .'  - error"'))
+            ->during('launch', [$jobInstance, $user, []]);
     }
 }

--- a/src/Akeneo/Bundle/BatchQueueBundle/AkeneoBatchQueueBundle.php
+++ b/src/Akeneo/Bundle/BatchQueueBundle/AkeneoBatchQueueBundle.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Akeneo\Bundle\BatchQueueBundle;
+
+use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\DoctrineOrmMappingsPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+/**
+ * Batch queue bundle
+ *
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class AkeneoBatchQueueBundle extends Bundle
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function build(ContainerBuilder $container)
+    {
+        $mappings = [
+            realpath(__DIR__ . '/Resources/config/model/doctrine') => 'Akeneo\Component\BatchQueue\Queue'
+        ];
+        $container
+            ->addCompilerPass(
+                DoctrineOrmMappingsPass::createYamlMappingDriver(
+                    $mappings,
+                    ['doctrine.orm.entity_manager'],
+                    false
+                )
+            );
+    }
+}

--- a/src/Akeneo/Bundle/BatchQueueBundle/Command/JobQueueConsumerCommand.php
+++ b/src/Akeneo/Bundle/BatchQueueBundle/Command/JobQueueConsumerCommand.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Bundle\BatchQueueBundle\Command;
+
+use Akeneo\Bundle\BatchQueueBundle\Manager\JobExecutionManager;
+use Akeneo\Bundle\BatchQueueBundle\Queue\JobExecutionMessageRepository;
+use Akeneo\Component\Batch\Job\ExitStatus;
+use Akeneo\Component\BatchQueue\Queue\JobExecutionMessage;
+use Akeneo\Component\BatchQueue\Queue\JobExecutionQueueInterface;
+use Doctrine\DBAL\Connection;
+use Ramsey\Uuid\Provider\NodeProviderInterface;
+use Ramsey\Uuid\Uuid;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Process\PhpExecutableFinder;
+use Symfony\Component\Process\Process;
+use Symfony\Component\Process\ProcessBuilder;
+
+/**
+ * This command is a daemon to consume job execution messages and launch the associated job execution in background.
+ * A command can only execute one single job at a time.
+ * The command will not launch any other jobs until the current job is finished.
+ *
+ * If you want to execute several jobs in parallel, you have to run several daemons.
+ *
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class JobQueueConsumerCommand extends ContainerAwareCommand
+{
+    /** Interval in seconds before checking if the job is still running. */
+    public const HEALTH_CHECK_INTERVAL = 5;
+
+    public const COMMAND_NAME = 'akeneo:batch:job-queue-consumer-daemon';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName(self::COMMAND_NAME)
+            ->setDescription('Launch a daemon that will consume job execution messages and launch the associated job execution in backgrounds')
+            ->addOption('run-once', null, InputOption::VALUE_NONE, 'Launch only one job execution and stop the daemon once the job execution is finished');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $errOutput = $output instanceof ConsoleOutputInterface ? $output->getErrorOutput() : $output;
+
+        $consumerName = Uuid::uuid4();
+        $output->writeln(sprintf('Consumer name: "%s"', $consumerName->toString()));
+
+        $pathFinder = new PhpExecutableFinder();
+        $console = sprintf('%s%sbin%sconsole', $this->getContainer()->getParameter('kernel.project_dir'), DIRECTORY_SEPARATOR, DIRECTORY_SEPARATOR);
+
+        do {
+            try {
+                $jobExecutionMessage = $this->getQueue()->consume($consumerName->toString());
+
+                $arguments = array_merge([$pathFinder->find(), $console, 'akeneo:batch:job' ], $this->getArguments($jobExecutionMessage));
+                $process = new Process($arguments);
+                $process->setTimeout(null);
+
+                $output->writeln(sprintf('Launching job execution "%s".', $jobExecutionMessage->getJobExecutionId()));
+                $output->writeln(sprintf('Command line: "%s"', $process->getCommandLine()));
+
+                $process->start();
+
+                do {
+                    $this->getJobExecutionManager()->updateHealthCheck($jobExecutionMessage);
+                    // TODO: standard and error output in a dedicated file for each job execution
+                    $output->write($process->getIncrementalOutput());
+                    $errOutput->write($process->getIncrementalErrorOutput());
+                    sleep(self::HEALTH_CHECK_INTERVAL);
+                } while ($process->isRunning());
+
+                // update status if the job execution failed due to an uncatchable error as a fatal error
+                $exitStatus = $this->getJobExecutionManager()->getExitStatus($jobExecutionMessage);
+                if ($exitStatus->isRunning()) {
+                    $this->getJobExecutionManager()->markAsFailed($jobExecutionMessage);
+                }
+
+                $output->write($process->getIncrementalOutput());
+                $errOutput->write($process->getIncrementalErrorOutput());
+
+                $output->writeln(sprintf('Job execution "%s" is finished.', $jobExecutionMessage->getJobExecutionId()));
+            } catch (\Throwable $t) {
+                $errOutput->writeln(sprintf('An error occurred: %s', $t->getMessage()));
+                $errOutput->writeln($t->getTraceAsString());
+            }
+        } while (false === $input->getOption('run-once'));
+    }
+
+    /**
+     * Return all the arguments of the command to execute.
+     * Options are considered as arguments.
+     *
+     * @param JobExecutionMessage $jobExecutionMessage
+     *
+     * @return array
+     */
+    protected function getArguments(JobExecutionMessage $jobExecutionMessage): array
+    {
+        $jobInstanceCode = $this->getJobExecutionMessageRepository()->getJobInstanceCode($jobExecutionMessage);
+
+        $arguments = [
+            $jobInstanceCode,
+            $jobExecutionMessage->getJobExecutionId(),
+        ];
+
+        foreach ($jobExecutionMessage->getOptions() as $optionsName => $optionValue) {
+            if (true === $optionValue) {
+                $arguments[] = sprintf('--%s', $optionValue);
+            }
+            if (false !== $optionValue) {
+                $arguments[] = sprintf('--%s=%s', $optionsName, $optionValue);
+            }
+        }
+
+        return $arguments;
+    }
+
+    /**
+     * @return NodeProviderInterface
+     */
+    private function getNodeProvider(): NodeProviderInterface
+    {
+        return $this->getContainer()->get('ramsey.uuid.provider.node.system_node_provider');
+    }
+
+    /**
+     * @return JobExecutionQueueInterface
+     */
+    private function getQueue(): JobExecutionQueueInterface
+    {
+        return $this->getContainer()->get('akeneo_batch_queue.queue.database_job_execution_queue');
+    }
+
+    /**
+     * @return JobExecutionMessageRepository
+     */
+    private function getJobExecutionMessageRepository(): JobExecutionMessageRepository
+    {
+        return $this->getContainer()->get('akeneo_batch_queue.queue.job_execution_message_repository');
+    }
+
+    /**
+     * @return JobExecutionManager
+     */
+    private function getJobExecutionManager(): JobExecutionManager
+    {
+        return $this->getContainer()->get('akeneo_batch_queue.manager.job_execution_manager');
+    }
+}

--- a/src/Akeneo/Bundle/BatchQueueBundle/DependencyInjection/AkeneoBatchQueueExtension.php
+++ b/src/Akeneo/Bundle/BatchQueueBundle/DependencyInjection/AkeneoBatchQueueExtension.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Akeneo\Bundle\BatchQueueBundle\DependencyInjection;
+
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+
+/**
+ * This is the class that loads and manages your bundle configuration
+ *
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class AkeneoBatchQueueExtension extends Extension
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('services.yml');
+
+        if ('test' === $container->getParameter('kernel.environment')) {
+            $loader->load('test/jobs.yml');
+        }
+    }
+}

--- a/src/Akeneo/Bundle/BatchQueueBundle/Hydrator/JobExecutionMessageHydrator.php
+++ b/src/Akeneo/Bundle/BatchQueueBundle/Hydrator/JobExecutionMessageHydrator.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Bundle\BatchQueueBundle\Hydrator;
+
+use Akeneo\Component\BatchQueue\Queue\JobExecutionMessage;
+use Akeneo\Component\StorageUtils\Factory\SimpleFactoryInterface;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Hydrates a JobExecutionMessage from an array.
+ *
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class JobExecutionMessageHydrator
+{
+    /** @var OptionsResolver */
+    protected $resolver;
+
+    /** @var  EntityManagerInterface */
+    protected $entityManager;
+
+    /**
+     * @param EntityManagerInterface $entityManager
+     */
+    public function __construct(EntityManagerInterface $entityManager)
+    {
+        $this->entityManager = $entityManager;
+        $this->resolver = new OptionsResolver();
+        $this->configureOptions($this->resolver);
+    }
+
+    /**
+     * @param array $row
+     *
+     * @throws MissingOptionsException
+     *
+     * @return JobExecutionMessage
+     */
+    public function hydrate(array $row): JobExecutionMessage
+    {
+        $this->resolver->resolve($row);
+
+        $platform = $this->entityManager->getConnection()->getDatabasePlatform();
+
+        $id = Type::getType(Type::INTEGER)->convertToPhpValue($row['id'], $platform);
+        $jobExecutionId = Type::getType(Type::INTEGER)->convertToPhpValue($row['job_execution_id'], $platform);
+        $options = Type::getType(Type::JSON_ARRAY)->convertToPhpValue($row['options'], $platform);
+        $createTime = Type::getType(Type::DATETIME)->convertToPhpValue($row['create_time'], $platform);
+        $updatedTime = Type::getType(Type::DATETIME)->convertToPhpValue($row['updated_time'], $platform);
+        $consumer = Type::getType(Type::STRING)->convertToPhpValue($row['consumer'], $platform);
+
+        $jobExecutionMessage = JobExecutionMessage::createJobExecutionMessageFromDatabase(
+            $id,
+            $jobExecutionId,
+            $consumer,
+            $createTime,
+            $updatedTime,
+            $options
+        );
+
+        return $jobExecutionMessage;
+    }
+
+    /**
+     * @param OptionsResolver $resolver
+     */
+    protected function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setRequired(['id', 'job_execution_id', 'options', 'create_time', 'updated_time', 'consumer']);
+    }
+}

--- a/src/Akeneo/Bundle/BatchQueueBundle/Launcher/QueueJobLauncher.php
+++ b/src/Akeneo/Bundle/BatchQueueBundle/Launcher/QueueJobLauncher.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Bundle\BatchQueueBundle\Launcher;
+
+use Akeneo\Bundle\BatchBundle\Launcher\JobLauncherInterface;
+use Akeneo\Component\Batch\Job\JobParametersFactory;
+use Akeneo\Component\Batch\Job\JobParametersValidator;
+use Akeneo\Component\Batch\Job\JobRegistry;
+use Akeneo\Component\Batch\Job\JobRepositoryInterface;
+use Akeneo\Component\Batch\Model\JobExecution;
+use Akeneo\Component\Batch\Model\JobInstance;
+use Akeneo\Component\BatchQueue\Queue\JobExecutionMessage;
+use Akeneo\Component\BatchQueue\Queue\JobExecutionQueueInterface;
+use Akeneo\Component\StorageUtils\Factory\SimpleFactoryInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+
+/**
+ * Publish job execution into a queue in order to be launched asynchronously.
+ *
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class QueueJobLauncher implements JobLauncherInterface
+{
+    /** @var JobRepositoryInterface */
+    private $jobRepository;
+
+    /** @var JobParametersFactory */
+    private $jobParametersFactory;
+
+    /** @var JobRegistry */
+    private $jobRegistry;
+
+    /** @var JobParametersValidator */
+    private $jobParametersValidator;
+
+    /** @var JobExecutionQueueInterface */
+    private $queue;
+
+    /** @var string */
+    private $environment;
+
+    /**
+     * @param JobRepositoryInterface     $jobRepository
+     * @param JobParametersFactory       $jobParametersFactory
+     * @param JobRegistry                $jobRegistry
+     * @param JobParametersValidator     $jobParametersValidator
+     * @param JobExecutionQueueInterface $queue
+     * @param string                     $environment
+     */
+    public function __construct(
+        JobRepositoryInterface $jobRepository,
+        JobParametersFactory $jobParametersFactory,
+        JobRegistry $jobRegistry,
+        JobParametersValidator $jobParametersValidator,
+        JobExecutionQueueInterface $queue,
+        string $environment
+    ) {
+        $this->jobRepository = $jobRepository;
+        $this->jobParametersFactory = $jobParametersFactory;
+        $this->jobRegistry = $jobRegistry;
+        $this->jobParametersValidator = $jobParametersValidator;
+        $this->queue = $queue;
+        $this->environment = $environment;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function launch(JobInstance $jobInstance, UserInterface $user, array $configuration = []) : JobExecution
+    {
+        $options = ['env' => $this->environment];
+        if (isset($configuration['send_email']) && method_exists($user, 'getEmail')) {
+            $options['email'] = $user->getEmail();
+            unset($configuration['send_email']);
+        }
+
+        $jobExecution = $this->createJobExecution($jobInstance, $user, $configuration);
+        $jobExecutionMessage = JobExecutionMessage::createJobExecutionMessage($jobExecution->getId(), $options);
+
+        $this->queue->publish($jobExecutionMessage);
+
+        return $jobExecution;
+    }
+
+    /**
+     * Create a jobExecution
+     *
+     * @param JobInstance   $jobInstance
+     * @param UserInterface $user
+     * @param array         $configuration
+     *
+     * @throws \RuntimeException
+     *
+     * @return JobExecution
+     */
+    private function createJobExecution(JobInstance $jobInstance, UserInterface $user, array $configuration) : JobExecution
+    {
+        $job = $this->jobRegistry->get($jobInstance->getJobName());
+        $configuration = array_merge($jobInstance->getRawParameters(), $configuration);
+
+        $jobParameters = $this->jobParametersFactory->create($job, $configuration);
+
+        $errors = $this->jobParametersValidator->validate($job, $jobParameters, ['Default', 'Execution']);
+
+        if ($errors->count() > 0) {
+            throw new \RuntimeException(
+                sprintf(
+                    'Job instance "%s" running the job "%s" with parameters "%s" is invalid because of "%s"',
+                    $jobInstance->getCode(),
+                    $job->getName(),
+                    print_r($jobParameters->all(), true),
+                    $this->getErrorMessages($errors)
+                )
+            );
+        }
+
+        $jobExecution = $this->jobRepository->createJobExecution($jobInstance, $jobParameters);
+        $jobExecution->setUser($user->getUsername());
+        $this->jobRepository->updateJobExecution($jobExecution);
+
+        return $jobExecution;
+    }
+
+    /**
+     * @param ConstraintViolationListInterface $errors
+     *
+     * @return string
+     */
+    private function getErrorMessages(ConstraintViolationListInterface $errors): string
+    {
+        $errorsStr = '';
+
+        foreach ($errors as $error) {
+            $errorsStr .= sprintf('%s  - %s', PHP_EOL, $error);
+        }
+
+        return $errorsStr;
+    }
+}

--- a/src/Akeneo/Bundle/BatchQueueBundle/Manager/JobExecutionManager.php
+++ b/src/Akeneo/Bundle/BatchQueueBundle/Manager/JobExecutionManager.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Bundle\BatchQueueBundle\Manager;
+
+use Akeneo\Bundle\BatchQueueBundle\Command\JobQueueConsumerCommand;
+use Akeneo\Component\Batch\Job\BatchStatus;
+use Akeneo\Component\Batch\Job\ExitStatus;
+use Akeneo\Component\Batch\Model\JobExecution;
+use Akeneo\Component\BatchQueue\Queue\JobExecutionMessage;
+use Doctrine\DBAL\Driver\Connection;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Repository to manage the status of a job.
+ *
+ * As it used by a daemon, it uses directly the DBAL to avoid any memory leak or connection problem due to the Unit of Work.
+ *
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class JobExecutionManager
+{
+    private const MAX_TIME_TO_UPDATE_HEALTH_CHECK = 5;
+
+    /** @var EntityManagerInterface */
+    private $entityManager;
+
+    /**
+     * @param EntityManagerInterface $entityManager
+     */
+    public function __construct(EntityManagerInterface $entityManager)
+    {
+        $this->entityManager = $entityManager;
+    }
+
+    /**
+     * Resolve the status of the job execution in case of crash of the daemon that launched the job.
+     *
+     * @param JobExecution $jobExecution
+     *
+     * @return JobExecution
+     */
+    public function resolveJobExecutionStatus(JobExecution $jobExecution): JobExecution
+    {
+        if (BatchStatus::STARTING === $jobExecution->getStatus()->getValue() ||
+            !$jobExecution->getExitStatus()->isRunning()) {
+            return $jobExecution;
+        }
+
+        $healthCheck = $jobExecution->getHealthCheckTime();
+
+        if (null === $healthCheck) {
+            $jobExecution->setStatus(new BatchStatus(BatchStatus::FAILED));
+            $jobExecution->setExitStatus(new ExitStatus(ExitStatus::FAILED));
+
+            return $jobExecution;
+        }
+
+        $now = new \DateTime('now', new \DateTimeZone('UTC'));
+        $diffInSeconds = $now->getTimestamp() - $healthCheck->getTimestamp();
+
+        if ($diffInSeconds > JobQueueConsumerCommand::HEALTH_CHECK_INTERVAL + self::MAX_TIME_TO_UPDATE_HEALTH_CHECK) {
+            $jobExecution->setStatus(new BatchStatus(BatchStatus::FAILED));
+            $jobExecution->setExitStatus(new ExitStatus(ExitStatus::FAILED));
+        }
+
+        return $jobExecution;
+    }
+
+    /**
+     * Get the exit status of job execution associated to a job execution message.
+     *
+     * @param JobExecutionMessage $jobExecutionMessage
+     *
+     * @return ExitStatus|null
+     */
+    public function getExitStatus(JobExecutionMessage $jobExecutionMessage): ?ExitStatus
+    {
+        $sql = 'SELECT je.exit_code FROM akeneo_batch_job_execution je WHERE je.id = :id';
+
+        $stmt = $this->entityManager->getConnection()->prepare($sql);
+        $stmt->bindValue('id', $jobExecutionMessage->getJobExecutionId());
+        $stmt->execute();
+        $row = $stmt->fetch();
+
+        return isset($row['exit_code']) ? new ExitStatus($row['exit_code']) : null;
+    }
+
+    /**
+     * Update the status of a job execution associated to a job execution message.
+     *
+     * @param JobExecutionMessage $jobExecutionMessage
+     */
+    public function markAsFailed(JobExecutionMessage $jobExecutionMessage): void
+    {
+        $sql = <<<SQL
+UPDATE 
+    akeneo_batch_job_execution je
+SET 
+    je.status = :status,
+    je.exit_code = :exit_code,
+    je.updated_time = :updated_time
+WHERE
+    je.id = :id;
+SQL;
+
+        $stmt = $this->entityManager->getConnection()->prepare($sql);
+        $stmt->bindValue('id', $jobExecutionMessage->getJobExecutionId());
+        $stmt->bindValue('status', BatchStatus::FAILED);
+        $stmt->bindValue('exit_code', ExitStatus::FAILED);
+        $stmt->bindValue('updated_time', new \DateTime('now', new \DateTimeZone('UTC')), Type::DATETIME);
+        $stmt->execute();
+    }
+
+    /**
+     * Update the health check of the job execution associated to a job execution message.
+     *
+     * @param JobExecutionMessage $jobExecutionMessage
+     */
+    public function updateHealthCheck(JobExecutionMessage $jobExecutionMessage): void
+    {
+        $sql = <<<SQL
+UPDATE 
+    akeneo_batch_job_execution je
+SET 
+    je.health_check_time = :health_check_time,
+    je.updated_time = :updated_time
+WHERE
+    je.id = :id;
+SQL;
+
+        $stmt = $this->entityManager->getConnection()->prepare($sql);
+        $stmt->bindValue('id', $jobExecutionMessage->getJobExecutionId());
+        $stmt->bindValue('health_check_time', new \DateTime('now', new \DateTimeZone('UTC')), Type::DATETIME);
+        $stmt->bindValue('updated_time', new \DateTime('now', new \DateTimeZone('UTC')), Type::DATETIME);
+        $stmt->execute();
+    }
+}

--- a/src/Akeneo/Bundle/BatchQueueBundle/Queue/DatabaseJobExecutionQueue.php
+++ b/src/Akeneo/Bundle/BatchQueueBundle/Queue/DatabaseJobExecutionQueue.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Bundle\BatchQueueBundle\Queue;
+
+use Akeneo\Bundle\BatchQueueBundle\Hydrator\JobExecutionMessageHydrator;
+use Akeneo\Component\BatchQueue\Queue\JobExecutionMessage;
+use Akeneo\Component\BatchQueue\Queue\JobExecutionQueueInterface;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\ORM\EntityManagerInterface;
+use Ramsey\Uuid\Provider\NodeProviderInterface;
+
+/**
+ * Aims to publish and consume job execution messages in a queue stored in database.
+ *
+ * It uses directly the DBAL to avoid any memory leak or connection problem due to the Unit of Work.
+ *
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class DatabaseJobExecutionQueue implements JobExecutionQueueInterface
+{
+    /** Interval in seconds before checking if a new message is in the queue. */
+    const QUEUE_CHECK_INTERVAL = 5;
+
+    /** Prefix to add when locking a job execution message in database. */
+    const LOCK_PREFIX = 'akeneo_job_execution_';
+
+    /** @var EntityManagerInterface */
+    private $entityManager;
+
+    /** @var JobExecutionMessageRepository */
+    private $jobExecutionMessageRepository;
+
+    /**
+     * @param EntityManagerInterface        $entityManager
+     * @param JobExecutionMessageRepository $jobExecutionMessageRepository
+     */
+    public function __construct(
+        EntityManagerInterface $entityManager,
+        JobExecutionMessageRepository $jobExecutionMessageRepository
+    ) {
+        $this->entityManager = $entityManager;
+        $this->jobExecutionMessageRepository = $jobExecutionMessageRepository;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function publish(JobExecutionMessage $jobExecutionMessage): void
+    {
+        $this->jobExecutionMessageRepository->createJobExecutionMessage($jobExecutionMessage);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function consume(string $consumer): JobExecutionMessage
+    {
+        $hasLock = false;
+
+        do {
+            $jobExecutionMessage = $this->jobExecutionMessageRepository->getAvailableJobExecutionMessage();
+            if (null !== $jobExecutionMessage) {
+                $lock = self::LOCK_PREFIX . $jobExecutionMessage->getJobExecutionId();
+                $hasLock = $this->lock($lock);
+            }
+        } while (!$hasLock && 0 === sleep(self::QUEUE_CHECK_INTERVAL));
+
+        $jobExecutionMessage->consumedBy($consumer);
+
+        $this->jobExecutionMessageRepository->updateJobExecutionMessage($jobExecutionMessage);
+        $this->unlock($lock);
+
+        return $jobExecutionMessage;
+    }
+
+    /**
+     * Try to get an application-level lock.
+     *
+     * @param string $lock
+     *
+     * @return bool return true if lock has been acquired, false otherwise
+     */
+    private function lock(string $lock): bool
+    {
+        $stmt = $this->entityManager->getConnection()->prepare('SELECT GET_LOCK(:lock, 0)');
+        $stmt->bindValue('lock', $lock);
+
+        $stmt->execute();
+        $result = $stmt->fetch();
+
+        return '1' === current($result);
+    }
+
+    /**
+     * Release an application-level lock.
+     *
+     * @param string $lock
+     */
+    private function unlock(string $lock): void
+    {
+        $stmt = $this->entityManager->getConnection()->prepare('SELECT RELEASE_LOCK(:lock)');
+        $stmt->bindValue('lock', $lock);
+
+        $stmt->execute();
+    }
+}

--- a/src/Akeneo/Bundle/BatchQueueBundle/Queue/JobExecutionMessageRepository.php
+++ b/src/Akeneo/Bundle/BatchQueueBundle/Queue/JobExecutionMessageRepository.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Bundle\BatchQueueBundle\Queue;
+
+use Akeneo\Bundle\BatchQueueBundle\Hydrator\JobExecutionMessageHydrator;
+use Akeneo\Component\BatchQueue\Queue\JobExecutionMessage;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Repository to persist and get the state of the job execution messages in the queue.
+ *
+ * As it used by a daemon, it uses directly the DBAL to avoid any memory leak or connection problem due to the UOW.
+ *
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class JobExecutionMessageRepository
+{
+    /** @var EntityManagerInterface */
+    private $entityManager;
+
+    /** @var JobExecutionMessageHydrator */
+    private $jobExecutionHydrator;
+
+    /**
+     * @param EntityManagerInterface      $entityManager
+     * @param JobExecutionMessageHydrator $jobExecutionHydrator
+     */
+    public function __construct(
+        EntityManagerInterface $entityManager,
+        JobExecutionMessageHydrator $jobExecutionHydrator
+    ) {
+        $this->entityManager = $entityManager;
+        $this->jobExecutionHydrator = $jobExecutionHydrator;
+    }
+
+    /**
+     * @param JobExecutionMessage $jobExecutionMessage
+     */
+    public function createJobExecutionMessage(JobExecutionMessage $jobExecutionMessage)
+    {
+        $sql = <<<SQL
+INSERT INTO akeneo_batch_job_execution_queue (job_execution_id, options, consumer, create_time, updated_time)
+VALUES (:job_execution_id, :options, :consumer, :create_time, :updated_time)
+SQL;
+
+        $stmt = $this->entityManager->getConnection()->prepare($sql);
+        $stmt->bindValue('job_execution_id', $jobExecutionMessage->getJobExecutionId());
+        $stmt->bindValue('options', $jobExecutionMessage->getOptions(), Type::JSON_ARRAY);
+        $stmt->bindValue('consumer', null);
+        $stmt->bindValue('create_time', new \DateTime('now', new \DateTimeZone('UTC')), Type::DATETIME);
+        $stmt->bindValue('updated_time', null);
+
+        $stmt->execute();
+    }
+
+    /**
+     * @param JobExecutionMessage $jobExecutionMessage
+     */
+    public function updateJobExecutionMessage(JobExecutionMessage $jobExecutionMessage)
+    {
+        $sql = <<<SQL
+UPDATE 
+    akeneo_batch_job_execution_queue q
+SET 
+    q.job_execution_id = :job_execution_id,
+    q.options = :options,
+    q.consumer = :consumer,
+    q.create_time = :create_time,
+    q.updated_time = :updated_time
+WHERE
+    q.id = :id;
+SQL;
+
+        $stmt = $this->entityManager->getConnection()->prepare($sql);
+        $stmt->bindValue('job_execution_id', $jobExecutionMessage->getJobExecutionId());
+        $stmt->bindValue('options', $jobExecutionMessage->getOptions(), Type::JSON_ARRAY);
+        $stmt->bindValue('consumer', $jobExecutionMessage->getConsumer());
+        $stmt->bindValue('create_time', $jobExecutionMessage->getCreateTime(), Type::DATETIME);
+        $stmt->bindValue('updated_time', new \DateTime('now', new \DateTimeZone('UTC')), Type::DATETIME);
+        $stmt->bindValue('id', $jobExecutionMessage->getId());
+        $stmt->execute();
+    }
+
+    /**
+     * Gets a job execution message that has not been consumed yet.
+     * If there is no job execution available, it returns null.
+     *
+     * @return JobExecutionMessage|null
+     */
+    public function getAvailableJobExecutionMessage(): ?JobExecutionMessage
+    {
+        $sql = <<<SQL
+SELECT 
+    q.id, q.job_execution_id, q.create_time, q.updated_time, q.options, q.consumer
+FROM
+    akeneo_batch_job_execution_queue q
+WHERE
+    q.consumer IS NULL
+ORDER BY
+    q.create_time, id
+LIMIT 1;
+SQL;
+
+        $stmt = $this->entityManager->getConnection()->prepare($sql);
+        $stmt->execute();
+        $row = $stmt->fetch();
+
+        return false !== $row ? $this->jobExecutionHydrator->hydrate($row) : null;
+    }
+
+    /**
+     * Gets the job instance code associated to a job execution message.
+     *
+     * @param JobExecutionMessage $jobExecutionMessage
+     *
+     * @return string|null
+     */
+    public function getJobInstanceCode(JobExecutionMessage $jobExecutionMessage): ?string
+    {
+        $sql = <<<SQL
+SELECT 
+    code
+FROM
+    akeneo_batch_job_execution je 
+JOIN akeneo_batch_job_instance ji ON ji.id = je.job_instance_id
+WHERE 
+    je.id = :id
+SQL;
+
+        $stmt = $this->entityManager->getConnection()->prepare($sql);
+        $stmt->bindValue('id', $jobExecutionMessage->getJobExecutionId());
+        $stmt->execute();
+        $data = $stmt->fetch();
+
+        $code = $data['code'] ?? null;
+
+        return $code;
+    }
+}

--- a/src/Akeneo/Bundle/BatchQueueBundle/Resources/config/model/doctrine/JobExecutionMessage.orm.yml
+++ b/src/Akeneo/Bundle/BatchQueueBundle/Resources/config/model/doctrine/JobExecutionMessage.orm.yml
@@ -1,0 +1,30 @@
+Akeneo\Component\BatchQueue\Queue\JobExecutionMessage:
+    type: entity
+    table: akeneo_batch_job_execution_queue
+    changeTrackingPolicy: DEFERRED_EXPLICIT
+    fields:
+        id:
+            type: integer
+            id: true
+            generator:
+                strategy: AUTO
+        jobExecutionId:
+            type: integer
+            column: job_execution_id
+            nullable: true
+        options:
+            type: json_array
+            column: options
+            nullable: true
+        consumer:
+            type: string
+            column: consumer
+            nullable: true
+        createTime:
+            type: datetime
+            column: create_time
+            nullable: true
+        updatedTime:
+            type: datetime
+            column: updated_time
+            nullable: true

--- a/src/Akeneo/Bundle/BatchQueueBundle/Resources/config/services.yml
+++ b/src/Akeneo/Bundle/BatchQueueBundle/Resources/config/services.yml
@@ -1,0 +1,54 @@
+parameters:
+    ramsey.uuid.provider.node.system_node_provider.class: Ramsey\Uuid\Provider\Node\SystemNodeProvider
+    akeneo_batch_queue.hydrator_job_execution_message_hydrator.class: Akeneo\Bundle\BatchQueueBundle\Hydrator\JobExecutionMessageHydrator
+    akeneo_batch_queue.queue.database_job_execution_queue.class: Akeneo\Bundle\BatchQueueBundle\Queue\DatabaseJobExecutionQueue
+    akeneo_batch_queue.queue.job_execution_message.class: Akeneo\Component\BatchQueue\Queue\JobExecutionMessage
+    akeneo_batch_queue.queue.job_execution_message_repository.class: Akeneo\Bundle\BatchQueueBundle\Queue\JobExecutionMessageRepository
+    akeneo_batch_queue.manager.job_execution_manager.class: Akeneo\Bundle\BatchQueueBundle\Manager\JobExecutionManager
+    akeneo_batch_queue.launcher.queue_job_launcher.class: Akeneo\Bundle\BatchQueueBundle\Launcher\QueueJobLauncher
+
+services:
+    ramsey.uuid.provider.node.system_node_provider:
+        class: '%ramsey.uuid.provider.node.system_node_provider.class%'
+
+    akeneo_batch_queue.hydrator_job_execution_message_hydrator:
+        class: '%akeneo_batch_queue.hydrator_job_execution_message_hydrator.class%'
+        arguments:
+            - '@akeneo_batch.entity_manager.persisted_connection_entity_manager'
+
+    akeneo_batch_queue.queue.job_execution_message_repository:
+        class: '%akeneo_batch_queue.queue.job_execution_message_repository.class%'
+        arguments:
+            - '@akeneo_batch.entity_manager.persisted_connection_entity_manager'
+            - '@akeneo_batch_queue.hydrator_job_execution_message_hydrator'
+
+    akeneo_batch_queue.queue.database_job_execution_queue:
+        class: '%akeneo_batch_queue.queue.database_job_execution_queue.class%'
+        arguments:
+            - '@akeneo_batch.entity_manager.persisted_connection_entity_manager'
+            - '@akeneo_batch_queue.queue.job_execution_message_repository'
+
+    akeneo_batch_queue.manager.job_execution_manager:
+        class: '%akeneo_batch_queue.manager.job_execution_manager.class%'
+        arguments:
+            - '@akeneo_batch.entity_manager.persisted_connection_entity_manager'
+
+    akeneo_batch_queue.launcher.queue_job_launcher:
+        class: '%akeneo_batch_queue.launcher.queue_job_launcher.class%'
+        arguments:
+            - '@akeneo_batch.job_repository'
+            - '@akeneo_batch.job_parameters_factory'
+            - '@akeneo_batch.job.job_registry'
+            - '@akeneo_batch.job.job_parameters_validator'
+            - '@akeneo_batch_queue.queue.database_job_execution_queue'
+            - '%kernel.environment%'
+
+    akeneo_batch_queue.launcher.simple_job_launcher:
+        class: '%akeneo_batch_queue.launcher.queue_job_launcher.class%'
+        arguments:
+            - '@akeneo_batch.job_repository'
+            - '@akeneo_batch.job_parameters_factory'
+            - '@akeneo_batch.job.job_registry'
+            - '@akeneo_batch.job.job_parameters_validator'
+            - '@akeneo_batch_queue.queue.database_job_execution_queue'
+            - '%kernel.environment%'

--- a/src/Akeneo/Bundle/BatchQueueBundle/Resources/config/test/jobs.yml
+++ b/src/Akeneo/Bundle/BatchQueueBundle/Resources/config/test/jobs.yml
@@ -1,0 +1,38 @@
+parameters:
+    akeneo_batch_queue.job_parameters.constraints.empty_constraint_collection_provider.class: \Akeneo\Component\Batch\Job\JobParameters\EmptyConstraintCollectionProvider
+    akeneo_batch_queue.job_parameters.provider.empty_default_values_provider.class: \Akeneo\Component\Batch\Job\JobParameters\EmptyDefaultValuesProvider
+    akeneo_batch_queue.step.infinite_loop_step.class: \Akeneo\Bundle\BatchQueueBundle\tests\integration\Command\InfiniteLoopStep
+    akeneo_batch_queue.job_name.infinite_loop_job: 'infinite_loop_job'
+    akeneo_batch_queue.job.test_type: 'integration_test_type'
+    akeneo_batch_queue.job.connector_name: 'Integration Test Connector'
+
+services:
+    akeneo_batch_queue.job_parameters.constraints.empty_constraint_collection_provider:
+        class: '%akeneo_batch_queue.job_parameters.constraints.empty_constraint_collection_provider.class%'
+        arguments:
+            -
+                - '%akeneo_batch_queue.job_name.infinite_loop_job%'
+        tags:
+            - { name: akeneo_batch.job.job_parameters.constraint_collection_provider }
+
+    akeneo_batch_queue.job_parameters.provider.empty_default_values_provider:
+        class: '%akeneo_batch_queue.job_parameters.provider.empty_default_values_provider.class%'
+        arguments:
+            -
+                - '%akeneo_batch_queue.job_name.infinite_loop_job%'
+        tags:
+            - { name: akeneo_batch.job.job_parameters.default_values_provider }
+
+    akeneo_batch_queue.step.infinite_loop_step:
+        class: '%akeneo_batch_queue.step.infinite_loop_step.class%'
+
+    akeneo_batch_queue.job.infinite_loop_job:
+        class: '%pim_connector.job.simple_job.class%'
+        arguments:
+            - '%akeneo_batch_queue.job_name.infinite_loop_job%'
+            - '@event_dispatcher'
+            - '@akeneo_batch.job_repository'
+            -
+                - '@akeneo_batch_queue.step.infinite_loop_step'
+        tags:
+            - { name: akeneo_batch.job, connector: '%akeneo_batch_queue.job.connector_name%', type: '%akeneo_batch_queue.job.test_type%' }

--- a/src/Akeneo/Bundle/BatchQueueBundle/spec/Hydrator/JobExecutionMessageHydratorSpec.php
+++ b/src/Akeneo/Bundle/BatchQueueBundle/spec/Hydrator/JobExecutionMessageHydratorSpec.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace spec\Akeneo\Bundle\BatchQueueBundle\Hydrator;
+
+use Akeneo\Bundle\BatchQueueBundle\Hydrator\JobExecutionMessageHydrator;
+use Akeneo\Component\BatchQueue\Queue\JobExecutionMessage;
+use Akeneo\Component\StorageUtils\Factory\SimpleFactoryInterface;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\ORM\EntityManagerInterface;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
+
+class JobExecutionMessageHydratorSpec extends ObjectBehavior
+{
+    function let(
+        EntityManagerInterface $entityManager,
+        Connection $connection,
+        MySqlPlatform $platform
+    ) {
+        $entityManager->getConnection()->willReturn($connection);
+        $connection->getDatabasePlatform()->willReturn($platform);
+        $this->beConstructedWith($entityManager);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(JobExecutionMessageHydrator::class);
+    }
+
+    function it_hydrates_a_job_execution_message(JobExecutionMessage $jobExecutionMessage) {
+        $row = [
+            'id' => '1',
+            'job_execution_id' => '2',
+            'options' => '{"env": "test"}',
+            'create_time' => '2017-09-19 13:30:00',
+            'updated_time' => '2017-09-19 13:30:15',
+            'consumer' =>  'consumer_name',
+        ];
+        $createdTime = new \DateTime('2017-09-19 13:30:00');
+        $updatedTime = new \DateTime('2017-09-19 13:30:15');
+
+        $jobExecutionMessage = JobExecutionMessage::createJobExecutionMessageFromDatabase(1, 2, 'consumer_name', $createdTime, $updatedTime, ['env' => 'test']);
+
+        $this->hydrate($row)->shouldBeLike($jobExecutionMessage);
+    }
+
+    function it_throws_an_exception_if_a_property_is_missing() {
+        $row = [
+            'id' => '1',
+            'job_execution_id' => '2',
+            'options' => '{"env": "test"}',
+            'create_time' => '2017-09-19 13:30:00',
+            'updated_time' => null,
+        ];
+
+        $this
+            ->shouldThrow(new MissingOptionsException('The required option "consumer" is missing.'))
+            ->during('hydrate', [$row]);
+    }
+}

--- a/src/Akeneo/Bundle/BatchQueueBundle/spec/Launcher/QueueJobLauncherSpec.php
+++ b/src/Akeneo/Bundle/BatchQueueBundle/spec/Launcher/QueueJobLauncherSpec.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace spec\Akeneo\Bundle\BatchQueueBundle\Launcher;
+
+use Akeneo\Bundle\BatchQueueBundle\Launcher\QueueJobLauncher;
+use Akeneo\Component\Batch\Job\Job;
+use Akeneo\Component\Batch\Job\JobParameters;
+use Akeneo\Component\Batch\Job\JobParametersFactory;
+use Akeneo\Component\Batch\Job\JobParametersValidator;
+use Akeneo\Component\Batch\Job\JobRegistry;
+use Akeneo\Component\Batch\Job\JobRepositoryInterface;
+use Akeneo\Component\Batch\Model\JobExecution;
+use Akeneo\Component\Batch\Model\JobInstance;
+use Akeneo\Component\BatchQueue\Queue\JobExecutionMessage;
+use Akeneo\Component\BatchQueue\Queue\JobExecutionQueueInterface;
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\UserBundle\Entity\User;
+use Prophecy\Argument;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+
+class QueueJobLauncherSpec extends ObjectBehavior
+{
+    function let(
+        JobRepositoryInterface $jobRepository,
+        JobParametersFactory $jobParametersFactory,
+        JobRegistry $jobRegistry,
+        JobParametersValidator $jobParametersValidator,
+        JobExecutionQueueInterface $queue
+    ) {
+        $this->beConstructedWith($jobRepository, $jobParametersFactory, $jobRegistry, $jobParametersValidator, $queue, 'test');
+    }
+
+    function it_is_a_job_launcher()
+    {
+        $this->shouldHaveType(QueueJobLauncher::class);
+    }
+
+    function it_launches_a_job_by_pushing_it_to_the_queue(
+        $jobRegistry,
+        $jobParametersFactory,
+        $jobParametersValidator,
+        $jobRepository,
+        $queue,
+        JobInstance $jobInstance,
+        UserInterface $user,
+        JobExecution $jobExecution,
+        Job $job,
+        JobParameters $jobParameters,
+        ConstraintViolationListInterface $constraintViolationList
+    ) {
+        $jobInstance->getJobName()->willReturn('job_instance_name');
+        $jobInstance->getRawParameters()->willReturn(['foo' => 'bar']);
+        $user->getUsername()->willReturn('julia');
+        $jobExecution->getId()->willReturn(1);
+        $constraintViolationList->count()->willReturn(0);
+
+        $jobRegistry->get('job_instance_name')->willReturn($job);
+        $jobParametersFactory->create($job, ['foo' => 'bar', 'baz' => 'foz'])->willReturn($jobParameters);
+        $jobParametersValidator->validate($job, $jobParameters, ['Default', 'Execution'])->willReturn($constraintViolationList);
+        $jobRepository->createJobExecution($jobInstance, $jobParameters)->willReturn($jobExecution);
+        $jobExecution->setUser('julia')->shouldBeCalled();
+        $jobRepository->updateJobExecution($jobExecution)->shouldBeCalled();
+
+        $queue->publish(Argument::type(JobExecutionMessage::class))->shouldBeCalled();
+
+        $this->launch($jobInstance, $user, ['baz' => 'foz'])->shouldReturn($jobExecution);
+    }
+
+    function it_launches_a_job_by_pushing_it_to_the_queue_with_email(
+        $jobRegistry,
+        $jobParametersFactory,
+        $jobParametersValidator,
+        $jobRepository,
+        $queue,
+        JobInstance $jobInstance,
+        User $user,
+        JobExecutionMessage $jobExecutionMessage,
+        JobExecution $jobExecution,
+        Job $job,
+        JobParameters $jobParameters,
+        ConstraintViolationListInterface $constraintViolationList
+    ) {
+        $jobInstance->getJobName()->willReturn('job_instance_name');
+        $jobInstance->getRawParameters()->willReturn(['foo' => 'bar']);
+        $user->getUsername()->willReturn('julia');
+        $jobExecution->getId()->willReturn(1);
+        $constraintViolationList->count()->willReturn(0);
+
+        $user->getEmail()->willReturn('julia@akeneo.com');
+
+        $jobRegistry->get('job_instance_name')->willReturn($job);
+        $jobParametersFactory->create($job, ['foo' => 'bar', 'baz' => 'foz'])->willReturn($jobParameters);
+        $jobParametersValidator->validate($job, $jobParameters, ['Default', 'Execution'])->willReturn($constraintViolationList);
+        $jobRepository->createJobExecution($jobInstance, $jobParameters)->willReturn($jobExecution);
+        $jobExecution->setUser('julia')->shouldBeCalled();
+        $jobRepository->updateJobExecution($jobExecution)->shouldBeCalled();
+
+        $queue->publish(Argument::type(JobExecutionMessage::class))->shouldBeCalled();
+
+        $this->launch($jobInstance, $user, ['baz' => 'foz', 'send_email' => true])->shouldReturn($jobExecution);
+    }
+
+    function it_throws_an_exception_if_job_parameters_are_invalid(
+        $jobRegistry,
+        $jobParametersFactory,
+        $jobParametersValidator,
+        JobInstance $jobInstance,
+        UserInterface $user,
+        JobExecution $jobExecution,
+        Job $job,
+        JobParameters $jobParameters,
+        ConstraintViolationListInterface $constraintViolationList,
+        ConstraintViolation $constraintViolation
+    ) {
+        $jobInstance->getJobName()->willReturn('job_instance_name');
+        $jobInstance->getCode()->willReturn('job_instance_code');
+        $jobInstance->getRawParameters()->willReturn(['foo' => 'bar']);
+        $user->getUsername()->willReturn('julia');
+        $jobExecution->getId()->willReturn(1);
+        $constraintViolationList->count()->willReturn(1);
+
+        $constraintViolationList->rewind()->shouldBeCalled();
+        $constraintViolationList->valid()->willReturn(true, false);
+        $constraintViolationList->next()->shouldBeCalled();
+        $constraintViolationList->current()->willReturn($constraintViolation);
+
+        $constraintViolation->__toString()->willReturn('error');
+
+        $jobRegistry->get('job_instance_name')->willReturn($job);
+        $jobParametersFactory->create($job, ['foo' => 'bar'])->willReturn($jobParameters);
+        $jobParametersValidator->validate($job, $jobParameters, ['Default', 'Execution'])->willReturn($constraintViolationList);
+
+        $this
+            ->shouldThrow(new \RuntimeException('Job instance "job_instance_code" running the job "" with parameters "" is invalid because of "' . PHP_EOL .'  - error"'))
+            ->during('launch', [$jobInstance, $user, []]);
+    }
+}

--- a/src/Akeneo/Bundle/BatchQueueBundle/spec/Manager/JobExecutionManagerSpec.php
+++ b/src/Akeneo/Bundle/BatchQueueBundle/spec/Manager/JobExecutionManagerSpec.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace spec\Akeneo\Bundle\BatchQueueBundle\Manager;
+
+use Akeneo\Component\Batch\Job\BatchStatus;
+use Akeneo\Component\Batch\Job\ExitStatus;
+use Akeneo\Component\Batch\Model\JobExecution;
+use Akeneo\Component\BatchQueue\Queue\JobExecutionMessage;
+use DateInterval;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Statement;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\ORM\EntityManager;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class JobExecutionManagerSpec extends ObjectBehavior
+{
+    function let(EntityManager $entityManager, Connection $connection)
+    {
+        $entityManager->getConnection()->willReturn($connection);
+        $this->beConstructedWith($entityManager);
+    }
+
+    function it_does_not_modify_status_when_a_job_execution_has_not_been_launched(
+        JobExecution $jobExecution,
+        BatchStatus $status,
+        ExitStatus $exitStatus
+    ) {
+        $jobExecution->getStatus()->willReturn($status);
+        $jobExecution->getExitStatus()->willReturn($exitStatus);
+        $status->getValue()->willReturn(BatchStatus::STARTING);
+        $exitStatus->isRunning()->willReturn(false);
+
+        $jobExecution->setStatus(Argument::any())->shouldNotBeCalled();
+        $jobExecution->setExitStatus(Argument::any())->shouldNotBeCalled();
+
+        $this->resolveJobExecutionStatus($jobExecution);
+    }
+
+    function it_does_not_modify_status_when_a_job_execution_is_completed(
+        JobExecution $jobExecution,
+        BatchStatus $status,
+        ExitStatus $exitStatus
+    ) {
+        $jobExecution->getStatus()->willReturn($status);
+        $jobExecution->getExitStatus()->willReturn($exitStatus);
+        $status->getValue()->willReturn(BatchStatus::COMPLETED);
+        $exitStatus->isRunning()->willReturn(false);
+
+        $jobExecution->setStatus(Argument::any())->shouldNotBeCalled();
+        $jobExecution->setExitStatus(Argument::any())->shouldNotBeCalled();
+
+        $this->resolveJobExecutionStatus($jobExecution);
+    }
+
+    function it_resolves_job_execution_status_when_job_execution_failed_but_has_still_a_running_status(
+        JobExecution $jobExecution,
+        BatchStatus $status,
+        ExitStatus $exitStatus
+    ) {
+        $now = new \DateTime('now', new \DateTimeZone('UTC'));
+
+        $healthCheck = new \DateTime('now', new \DateTimeZone('UTC'));
+        $healthCheck->add(DateInterval::createFromDateString('-100 seconds'));
+
+        $jobExecution->getStatus()->willReturn($status);
+        $jobExecution->getExitStatus()->willReturn($exitStatus);
+        $jobExecution->getHealthCheckTime()->willReturn($healthCheck);
+
+        $status->getValue()->willReturn(BatchStatus::STARTED);
+        $exitStatus->isRunning()->willReturn(true);
+
+        $jobExecution->setStatus(new BatchStatus(BatchStatus::FAILED))->shouldBeCalled();
+        $jobExecution->setExitStatus(new ExitStatus(ExitStatus::FAILED))->shouldBeCalled();
+
+        $this->resolveJobExecutionStatus($jobExecution);
+    }
+
+    function it_resolves_job_execution_status_when_job_execution_failed_with_null_health_check(
+        JobExecution $jobExecution,
+        BatchStatus $status,
+        ExitStatus $exitStatus
+    ) {
+        $jobExecution->getStatus()->willReturn($status);
+        $jobExecution->getExitStatus()->willReturn($exitStatus);
+        $jobExecution->getHealthCheckTime()->willReturn(null);
+
+        $status->getValue()->willReturn(BatchStatus::STARTED);
+        $exitStatus->isRunning()->willReturn(true);
+
+        $jobExecution->setStatus(new BatchStatus(BatchStatus::FAILED))->shouldBeCalled();
+        $jobExecution->setExitStatus(new ExitStatus(ExitStatus::FAILED))->shouldBeCalled();
+
+        $this->resolveJobExecutionStatus($jobExecution);
+    }
+
+    function it_gets_exit_status(
+        $connection,
+        JobExecutionMessage $jobExecutionMessage,
+        Statement $stmt
+    ) {
+        $connection
+            ->prepare(Argument::type('string'))
+            ->willReturn($stmt);
+
+        $jobExecutionMessage->getJobExecutionId()->willReturn(1);
+        $stmt->bindValue('id', 1)->shouldBeCalled();
+        $stmt->execute()->shouldBeCalled();
+        $stmt->fetch()->willReturn(['exit_code' => 'COMPLETED']);
+
+        $this->getExitStatus($jobExecutionMessage)->shouldBeLike(new ExitStatus('COMPLETED'));
+    }
+
+    function it_marks_as_failed(
+        $connection,
+        JobExecutionMessage $jobExecutionMessage,
+        Statement $stmt
+    ) {
+        $connection
+            ->prepare(Argument::type('string'))
+            ->willReturn($stmt);
+
+        $jobExecutionMessage->getJobExecutionId()->willReturn(1);
+
+        $stmt->bindValue('id', 1)->shouldBeCalled();
+        $stmt->bindValue('status', BatchStatus::FAILED)->shouldBeCalled();
+        $stmt->bindValue('exit_code', ExitStatus::FAILED)->shouldBeCalled();
+        $stmt->bindValue('updated_time', Argument::type(\DateTime::class), Type::DATETIME)->shouldBeCalled();
+        $stmt->execute()->shouldBeCalled();
+
+        $this->markAsFailed($jobExecutionMessage);
+    }
+
+    function it_updates_healthcheck(
+        $connection,
+        JobExecutionMessage $jobExecutionMessage,
+        Statement $stmt
+    ) {
+        $connection
+            ->prepare(Argument::type('string'))
+            ->willReturn($stmt);
+
+        $jobExecutionMessage->getJobExecutionId()->willReturn(1);
+
+        $stmt->bindValue('id', 1)->shouldBeCalled();
+        $stmt->bindValue('health_check_time', Argument::type(\DateTime::class), Type::DATETIME)->shouldBeCalled();
+        $stmt->bindValue('updated_time', Argument::type(\DateTime::class), Type::DATETIME)->shouldBeCalled();
+        $stmt->execute()->shouldBeCalled();
+
+        $this->updateHealthCheck($jobExecutionMessage);
+    }
+}

--- a/src/Akeneo/Bundle/BatchQueueBundle/spec/Queue/DatabaseJobExecutionQueueSpec.php
+++ b/src/Akeneo/Bundle/BatchQueueBundle/spec/Queue/DatabaseJobExecutionQueueSpec.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace spec\Akeneo\Bundle\BatchQueueBundle\Queue;
+
+use Akeneo\Bundle\BatchQueueBundle\Hydrator\JobExecutionMessageHydrator;
+use Akeneo\Bundle\BatchQueueBundle\Queue\DatabaseJobExecutionQueue;
+use Akeneo\Bundle\BatchQueueBundle\Queue\JobExecutionMessageRepository;
+use Akeneo\Component\BatchQueue\Queue\JobExecutionMessage;
+use Akeneo\Component\StorageUtils\Factory\SimpleFactoryInterface;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Statement;
+use Doctrine\ORM\EntityManagerInterface;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
+
+class DatabaseJobExecutionQueueSpec extends ObjectBehavior
+{
+    function let(
+        EntityManagerInterface $entityManager,
+        Connection $connection,
+        JobExecutionMessageRepository $jobExecutionMessageRepository
+    ) {
+        $entityManager->getConnection()->willReturn($connection);
+        $this->beConstructedWith($entityManager, $jobExecutionMessageRepository);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(DatabaseJobExecutionQueue::class);
+    }
+
+    function it_publishes_a_job_execution_message(
+        $jobExecutionMessageRepository,
+        JobExecutionMessage $jobExecutionMessage
+    ) {
+        $jobExecutionMessageRepository->createJobExecutionMessage($jobExecutionMessage)->shouldBeCalled();
+        $this->publish($jobExecutionMessage);
+    }
+
+    function it_consumes_a_job_execution_message(
+        $jobExecutionMessageRepository,
+        $connection,
+        JobExecutionMessage $jobExecutionMessage,
+        Statement $stmt
+    ) {
+        $jobExecutionMessageRepository->getAvailableJobExecutionMessage()->willReturn($jobExecutionMessage);
+        $jobExecutionMessageRepository->updateJobExecutionMessage($jobExecutionMessage)->shouldBeCalled();
+
+        $jobExecutionMessage->getJobExecutionId()->willReturn(1);
+        $jobExecutionMessage->consumedBy('consumer_name')->shouldBeCalled();
+
+        $connection->prepare(Argument::type('string'))->willReturn($stmt);
+        $stmt->bindValue('lock', DatabaseJobExecutionQueue::LOCK_PREFIX . '1')->shouldBeCalled();
+        $stmt->execute()->shouldBeCalled();
+
+        $stmt->fetch()->willReturn(['1']);
+
+        $this->consume('consumer_name');
+    }
+}

--- a/src/Akeneo/Bundle/BatchQueueBundle/tests/integration/Command/InfiniteLoopStep.php
+++ b/src/Akeneo/Bundle/BatchQueueBundle/tests/integration/Command/InfiniteLoopStep.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Bundle\BatchQueueBundle\tests\integration\Command;
+
+use Akeneo\Component\Batch\Model\StepExecution;
+use Akeneo\Component\Batch\Step\StepInterface;
+
+/**
+ * Step that run infinitely for test purpose.
+ *
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class InfiniteLoopStep implements StepInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function getName()
+    {
+        return 'infinite_loop_step';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function execute(StepExecution $stepExecution)
+    {
+        while (true) {
+            sleep(1000000);
+        }
+    }
+}

--- a/src/Akeneo/Bundle/BatchQueueBundle/tests/integration/Command/JobQueueConsumerCommandIntegration.php
+++ b/src/Akeneo/Bundle/BatchQueueBundle/tests/integration/Command/JobQueueConsumerCommandIntegration.php
@@ -1,0 +1,257 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Bundle\BatchQueueBundle\tests\integration\Command;
+
+use Akeneo\Bundle\BatchQueueBundle\Command\JobQueueConsumerCommand;
+use Akeneo\Bundle\BatchQueueBundle\Manager\JobExecutionManager;
+use Akeneo\Component\Batch\Job\BatchStatus;
+use Akeneo\Component\Batch\Job\ExitStatus;
+use Akeneo\Component\Batch\Model\JobExecution;
+use Akeneo\Component\Batch\Model\JobInstance;
+use Akeneo\Component\BatchQueue\Queue\JobExecutionMessage;
+use Akeneo\Component\BatchQueue\Queue\JobExecutionQueueInterface;
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\JobLauncher;
+use Akeneo\Test\Integration\TestCase;
+use Doctrine\DBAL\Driver\Connection;
+use Symfony\Component\Process\Process;
+
+class JobQueueConsumerCommandIntegration extends TestCase
+{
+    /** @var JobLauncher */
+    protected $jobLauncher;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $jobInstance = new JobInstance('import', 'test', 'infinite_loop_job');
+        $jobInstance->setCode('infinite_loop_job');
+        $jobInstanceSaver = $this->get('akeneo_batch.saver.job_instance');
+        $jobInstanceSaver->save($jobInstance);
+
+        $this->jobLauncher = new JobLauncher(static::$kernel);
+    }
+
+    public function testLaunchAJobExecution()
+    {
+        $jobExecution = $this->createJobExecution('csv_product_export', 'mary');
+
+        $options = ['email' => 'ziggy@akeneo.com', 'env' => $this->getParameter('kernel.environment')];
+        $jobExecutionMessage = JobExecutionMessage::createJobExecutionMessage($jobExecution->getId(), $options);
+
+        $this->getQueue()->publish($jobExecutionMessage);
+
+        $output = $this->jobLauncher->launchConsumerOnce();
+
+        $standardOutput = $output->fetch();
+
+        $this->assertContains(sprintf('Job execution "%s" is finished.', $jobExecution->getId()), $standardOutput);
+
+        $row = $this->getJobExecutionDatabaseRow($jobExecution);
+
+        $this->assertEquals(BatchStatus::COMPLETED, $row['status']);
+        $this->assertEquals(ExitStatus::COMPLETED, $row['exit_code']);
+        $this->assertNotNull($row['health_check_time']);
+
+        $jobExecution = $this->get('pim_enrich.repository.job_execution')->findBy(['id' => $jobExecution->getId()]);
+        $jobExecution = $this->getJobExecutionManager()->resolveJobExecutionStatus($jobExecution[0]);
+
+        $this->assertEquals(BatchStatus::COMPLETED, $jobExecution->getStatus()->getValue());
+        $this->assertEquals(ExitStatus::COMPLETED, $jobExecution->getExitStatus()->getExitCode());
+
+        $stmt = $this->getConnection()->prepare('SELECT consumer from akeneo_batch_job_execution_queue');
+        $stmt->execute();
+        $row = $stmt->fetch();
+
+        $this->assertNotEmpty($row['consumer']);
+    }
+
+    public function testStatusOfACrashedJobExecution()
+    {
+        $jobExecution = $this->createJobExecution('infinite_loop_job', 'mary');
+
+        $options = ['email' => 'ziggy@akeneo.com', 'env' => $this->getParameter('kernel.environment')];
+        $jobExecutionMessage = JobExecutionMessage::createJobExecutionMessage($jobExecution->getId(), $options);
+
+        $this->getQueue()->publish($jobExecutionMessage);
+
+        $daemonProcess = $this->jobLauncher->launchConsumerOnceInBackground();
+
+        $jobExecutionProcessPid = $this->getJobExecutionProcessPid($daemonProcess);
+
+        // wait update of the job execution status in database
+        sleep(5);
+
+        $killJobExecution = new Process(sprintf('kill -9 %s', $jobExecutionProcessPid));
+        $killJobExecution->run();
+        sleep(JobQueueConsumerCommand::HEALTH_CHECK_INTERVAL + 5);
+
+        $row = $this->getJobExecutionDatabaseRow($jobExecution);
+
+        $this->assertEquals(BatchStatus::FAILED, $row['status']);
+        $this->assertEquals(ExitStatus::FAILED, $row['exit_code']);
+        $this->assertNotNull($row['health_check_time']);
+
+        $jobExecution = $this->get('pim_enrich.repository.job_execution')->findBy(['id' => $jobExecution->getId()]);
+        $jobExecution = $this->getJobExecutionManager()->resolveJobExecutionStatus($jobExecution[0]);
+
+        $this->assertEquals(BatchStatus::FAILED, $jobExecution->getStatus()->getValue());
+        $this->assertEquals(ExitStatus::FAILED, $jobExecution->getExitStatus()->getExitCode());
+    }
+
+    public function testJobExecutionStatusResolverWhenDaemonAndJobExecutionCrash()
+    {
+        $jobExecution = $this->createJobExecution('infinite_loop_job', 'mary');
+
+        $options = ['email' => 'ziggy@akeneo.com', 'env' => $this->getParameter('kernel.environment')];
+        $jobExecutionMessage = JobExecutionMessage::createJobExecutionMessage($jobExecution->getId(), $options);
+
+        $this->getQueue()->publish($jobExecutionMessage);
+
+        $daemonProcess = $this->jobLauncher->launchConsumerOnceInBackground();
+
+        $jobExecutionProcessPid = $this->getJobExecutionProcessPid($daemonProcess);
+
+        $killDaemon = new Process(sprintf('kill -9 %s', $daemonProcess->getPid()));
+        $killDaemon->run();
+
+        // wait update of the job execution status in database
+        sleep(5);
+
+        $killJobExecution = new Process(sprintf('kill -9 %s', $jobExecutionProcessPid));
+        $killJobExecution->run();
+
+        // wait healtch check date expiration
+        sleep(JobQueueConsumerCommand::HEALTH_CHECK_INTERVAL + 10);
+
+        $row = $this->getJobExecutionDatabaseRow($jobExecution);
+
+        $this->assertEquals(BatchStatus::STARTED, $row['status']);
+        $this->assertEquals(ExitStatus::UNKNOWN, $row['exit_code']);
+        $this->assertNotNull($row['health_check_time']);
+
+        $jobExecution = $this->get('pim_enrich.repository.job_execution')->findBy(['id' => $jobExecution->getId()]);
+        $jobExecution = $this->getJobExecutionManager()->resolveJobExecutionStatus($jobExecution[0]);
+
+        $this->assertEquals(BatchStatus::FAILED, $jobExecution->getStatus()->getValue());
+        $this->assertEquals(ExitStatus::FAILED, $jobExecution->getExitStatus()->getExitCode());
+    }
+
+    /**
+     * @param string $jobInstanceCode
+     * @param string $user
+     * @param array  $configuration
+     *
+     * @throws \RuntimeException
+     *
+     * @return JobExecution
+     */
+    protected function createJobExecution(string $jobInstanceCode, ?string $user, array $configuration = []) : JobExecution
+    {
+        $jobInstanceClass = $this->getParameter('akeneo_batch.entity.job_instance.class');
+        $jobInstance = $this
+            ->get('doctrine.orm.default_entity_manager')
+            ->getRepository($jobInstanceClass)
+            ->findOneBy(['code' => $jobInstanceCode]);
+
+        $job = $this->get('akeneo_batch.job.job_registry')->get($jobInstanceCode);
+
+        $configuration = array_merge($jobInstance->getRawParameters(), $configuration);
+
+        $jobParameters = $this->get('akeneo_batch.job_parameters_factory')->create($job, $configuration);
+
+        $errors = $this->get('akeneo_batch.job.job_parameters_validator')->validate($job, $jobParameters, ['Default', 'Execution']);
+
+        if (count($errors) > 0) {
+            throw new \RuntimeException('JobExecution could not be created due to invalid job parameters.');
+        }
+
+        $jobExecution = $this->get('akeneo_batch.job_repository')->createJobExecution($jobInstance, $jobParameters);
+        $jobExecution->setUser($user);
+        $this->get('akeneo_batch.job_repository')->updateJobExecution($jobExecution);
+
+        return $jobExecution;
+    }
+
+    /**
+     * Returns the PID of the job execution process launched by the daemon process.
+     *
+     * @param $daemonProcess
+     *
+     * @throws \Exception
+     *
+     * @return string
+     */
+    protected function getJobExecutionProcessPid(Process $daemonProcess): string
+    {
+        $count = 0;
+        do {
+            $pgrep = new Process(sprintf('pgrep -P %s', $daemonProcess->getPid()));
+            $pgrep->run();
+            $output = trim($pgrep->getOutput());
+            $isJobLaunched = '' !== $output;
+
+            $count++;
+            if ($count > 30) {
+                throw new \Exception('Time out to launch the job execution child process.');
+            }
+
+            sleep(1);
+        } while (false === $isJobLaunched);
+
+        return $output;
+    }
+
+    /**
+     * @param JobExecution $jobExecution
+     *
+     * @return array
+     */
+    protected function getJobExecutionDatabaseRow(JobExecution $jobExecution): array
+    {
+        $stmt = $this->getConnection()->prepare('SELECT status, exit_code, health_check_time from akeneo_batch_job_execution where id = :id');
+        $stmt->bindValue('id', $jobExecution->getId());
+        $stmt->execute();
+        $row = $stmt->fetch();
+
+        return $row;
+    }
+
+    /**
+     * @return Connection
+     */
+    protected function getConnection(): Connection
+    {
+        return $this->get('doctrine.orm.entity_manager')->getConnection();
+    }
+
+    /**
+     * @return JobExecutionQueueInterface
+     */
+    protected function getQueue(): JobExecutionQueueInterface
+    {
+        return $this->get('akeneo_batch_queue.queue.database_job_execution_queue');
+    }
+
+    /**
+     * @return JobExecutionManager
+     */
+    protected function getJobExecutionManager(): JobExecutionManager
+    {
+        return $this->get('akeneo_batch_queue.manager.job_execution_manager');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+    }
+}

--- a/src/Akeneo/Bundle/BatchQueueBundle/tests/integration/Launcher/QueueJobLauncherIntegration.php
+++ b/src/Akeneo/Bundle/BatchQueueBundle/tests/integration/Launcher/QueueJobLauncherIntegration.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Bundle\BatchQueueBundle\tests\integration\Launcher;
+
+use Akeneo\Bundle\BatchBundle\Launcher\JobLauncherInterface;
+use Akeneo\Component\Batch\Job\BatchStatus;
+use Akeneo\Component\Batch\Job\ExitStatus;
+use Akeneo\Component\BatchQueue\Queue\JobExecutionMessage;
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\JobLauncher;
+use Akeneo\Test\Integration\TestCase;
+use Doctrine\DBAL\Driver\Connection;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class QueueJobLauncherIntegration extends TestCase
+{
+    /** @var JobLauncher */
+    protected $jobLauncher;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->jobLauncher = new JobLauncher(static::$kernel);
+    }
+
+    public function testPublishAndRunAJobExecutionMessageIntoTheQueue()
+    {
+        $jobInstanceClass = $this->getParameter('akeneo_batch.entity.job_instance.class');
+        $jobInstance = $this
+            ->get('doctrine.orm.default_entity_manager')
+            ->getRepository($jobInstanceClass)
+            ->findOneBy(['code' => 'csv_product_export']);
+
+        $user = $this->get('pim_user.provider.user')->loadUserByUsername('mary');
+
+        $this->getJobLauncher()->launch($jobInstance, $user, ['send_email' => true]);
+
+        $connection = $this->getConnection();
+        $stmt = $connection->prepare('SELECT * from akeneo_batch_job_execution_queue');
+        $stmt->execute();
+        $row = $stmt->fetch();
+
+        $this->assertEquals(1, $row['id']);
+        $this->assertEquals('{"env":"test","email":"mary@example.com"}', $row['options']);
+        $this->assertNotNull($row['create_time']);
+        $this->assertNull($row['updated_time']);
+        $this->assertNull($row['consumer']);
+
+        $stmt = $connection->prepare('SELECT user, status, exit_code, health_check_time from akeneo_batch_job_execution');
+        $stmt->execute();
+        $row = $stmt->fetch();
+
+        $this->assertEquals('mary', $row['user']);
+        $this->assertEquals(BatchStatus::STARTING, $row['status']);
+        $this->assertEquals(ExitStatus::UNKNOWN, $row['exit_code']);
+        $this->assertNull($row['health_check_time']);
+
+        $this->jobLauncher->launchConsumerOnce();
+
+        $stmt = $connection->prepare('SELECT user, status, exit_code, health_check_time from akeneo_batch_job_execution');
+        $stmt->execute();
+        $row = $stmt->fetch();
+
+        $this->assertEquals('mary', $row['user']);
+        $this->assertEquals(BatchStatus::COMPLETED, $row['status']);
+        $this->assertEquals(ExitStatus::COMPLETED, $row['exit_code']);
+        $this->assertNotNull($row['health_check_time']);
+    }
+
+    /**
+     * @return JobLauncherInterface
+     */
+    protected function getJobLauncher(): JobLauncherInterface
+    {
+        return $this->get('akeneo_batch_queue.launcher.queue_job_launcher');
+    }
+
+    /**
+     * @return Connection
+     */
+    protected function getConnection(): Connection
+    {
+        return $this->get('doctrine.orm.entity_manager')->getConnection();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+    }
+}

--- a/src/Akeneo/Bundle/BatchQueueBundle/tests/integration/Queue/DatabaseJobExecutionQueueIntegration.php
+++ b/src/Akeneo/Bundle/BatchQueueBundle/tests/integration/Queue/DatabaseJobExecutionQueueIntegration.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Bundle\BatchQueueBundle\tests\integration\Queue;
+
+use Akeneo\Component\BatchQueue\Queue\JobExecutionMessage;
+use Akeneo\Component\BatchQueue\Queue\JobExecutionQueueInterface;
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Doctrine\DBAL\Driver\Connection;
+
+class DatabaseJobExecutionQueueIntegration extends TestCase
+{
+    public function testPublishAJobExecutionMessage()
+    {
+        $jobExecutionMessage = JobExecutionMessage::createJobExecutionMessage(1, ['email' => 'ziggy@akeneo.com']);
+
+        $this->getQueue()->publish($jobExecutionMessage);
+
+        $connection = $this->getConnection();
+        $stmt = $connection->prepare('SELECT * from akeneo_batch_job_execution_queue');
+        $stmt->execute();
+        $row = $stmt->fetch();
+
+        $this->assertEquals(1, $row['id']);
+        $this->assertEquals(1, $row['job_execution_id']);
+        $this->assertEquals('{"email":"ziggy@akeneo.com"}', $row['options']);
+        $this->assertNotNull($row['create_time']);
+        $this->assertNull($row['updated_time']);
+        $this->assertNull($row['consumer']);
+    }
+
+    public function testConsumeAJobExecutionMessage()
+    {
+        $sql = <<<SQL
+INSERT INTO akeneo_batch_job_execution_queue 
+    (job_execution_id, options, create_time, updated_time, consumer)
+VALUES 
+    (1, "{\"email\":\"ziggy_1@akeneo.com\"}", "2017-08-30 10:15:30", null, null),
+    (2, "{\"email\":\"ziggy_2@akeneo.com\"}", "2017-08-30 10:00:00", null, "consumer_name")
+SQL;
+
+        $connection = $this->getConnection();
+        $stmt = $connection->prepare($sql);
+        $stmt->execute();
+
+        $jobExecutionMessage = $this->getQueue()->consume('consumer_name');
+        $this->assertEquals(1, $jobExecutionMessage->getId());
+        $this->assertEquals(1, $jobExecutionMessage->getJobExecutionId());
+        $this->assertEquals(['email' => 'ziggy_1@akeneo.com'], $jobExecutionMessage->getOptions());
+        $this->assertNull($jobExecutionMessage->getUpdatedTime());
+        $this->assertEquals('consumer_name', $jobExecutionMessage->getConsumer());
+
+        $stmt = $connection->prepare('SELECT * from akeneo_batch_job_execution_queue q where q.job_execution_id = 1');
+        $stmt->execute();
+        $row = $stmt->fetch();
+
+        $this->assertEquals(1, $row['id']);
+        $this->assertEquals(1, $row['job_execution_id']);
+        $this->assertEquals('{"email":"ziggy_1@akeneo.com"}', $row['options']);
+        $this->assertEquals('2017-08-30 10:15:30', $row['create_time']);
+        $this->assertEquals($jobExecutionMessage->getConsumer(), $row['consumer']);
+        $this->assertNotNull($row['updated_time']);
+    }
+
+    public function testConsumeTheOldestJobExecutionMessage()
+    {
+        $sql = <<<SQL
+INSERT INTO akeneo_batch_job_execution_queue 
+    (job_execution_id, options, create_time, updated_time, consumer)
+VALUES 
+    (1, "{\"email\":\"ziggy_1@akeneo.com\"}", "2017-08-30 10:15:30", null, null),
+    (2, "{\"email\":\"ziggy_2@akeneo.com\"}", "2017-08-30 10:10:30", null, null),
+    (3, "{\"email\":\"ziggy_3@akeneo.com\"}", "2017-08-30 10:00:00", "2017-08-30 10:00:05", "consumer_name")
+SQL;
+
+        $connection = $this->getConnection();
+        $stmt = $connection->prepare($sql);
+        $stmt->execute();
+
+        $jobExecutionMessage = $this->getQueue()->consume('consumer_name');
+        $this->assertEquals(2, $jobExecutionMessage->getId());
+        $this->assertEquals(2, $jobExecutionMessage->getJobExecutionId());
+        $this->assertEquals(['email' => 'ziggy_2@akeneo.com'], $jobExecutionMessage->getOptions());
+        $this->assertNull($jobExecutionMessage->getUpdatedTime());
+        $this->assertEquals('consumer_name', $jobExecutionMessage->getConsumer());
+
+        $stmt = $connection->prepare('SELECT * from akeneo_batch_job_execution_queue q where q.job_execution_id = 2');
+        $stmt->execute();
+        $row = $stmt->fetch();
+
+        $this->assertEquals(2, $row['id']);
+        $this->assertEquals(2, $row['job_execution_id']);
+        $this->assertEquals('{"email":"ziggy_2@akeneo.com"}', $row['options']);
+        $this->assertEquals('2017-08-30 10:10:30', $row['create_time']);
+        $this->assertEquals($jobExecutionMessage->getConsumer(), $row['consumer']);
+        $this->assertNotNull($row['updated_time']);
+
+        $jobExecutionMessage = $this->getQueue()->consume('consumer_name');
+        $this->assertEquals(1, $jobExecutionMessage->getId());
+    }
+
+    /**
+     * @return JobExecutionQueueInterface
+     */
+    protected function getQueue(): JobExecutionQueueInterface
+    {
+        return $this->get('akeneo_batch_queue.queue.database_job_execution_queue');
+    }
+
+    /**
+     * @return Connection
+     */
+    protected function getConnection(): Connection
+    {
+        return $this->get('doctrine.orm.entity_manager')->getConnection();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+    }
+}

--- a/src/Akeneo/Component/Batch/Job/ExitStatus.php
+++ b/src/Akeneo/Component/Batch/Job/ExitStatus.php
@@ -196,11 +196,11 @@ class ExitStatus
     /**
      * Check if this status represents a running process.
      *
-     * @return boolean true if the exit code is "RUNNING" or "UNKNOWN"
+     * @return boolean true if the exit code is "EXECUTING" or "UNKNOWN"
      */
     public function isRunning()
     {
-        return (("RUNNING" ==  $this->exitCode) || ("UNKNOWN" == $this->exitCode));
+        return ((self::EXECUTING ===  $this->exitCode) || (self::UNKNOWN === $this->exitCode));
     }
 
     /**

--- a/src/Akeneo/Component/Batch/Model/JobExecution.php
+++ b/src/Akeneo/Component/Batch/Model/JobExecution.php
@@ -50,6 +50,9 @@ class JobExecution
     /** @var \DateTime */
     private $updatedTime;
 
+    /** @var \DateTime */
+    private $healthCheckTime;
+
     /* @var ExecutionContext $executionContext */
     private $executionContext;
 
@@ -228,6 +231,30 @@ class JobExecution
     public function setUpdatedTime(\DateTime $updatedTime)
     {
         $this->updatedTime = $updatedTime;
+
+        return $this;
+    }
+
+    /**
+      * Gets the time this execution has been health checked
+      *
+      * @return \DateTime time this execution has been health checked
+      */
+    public function getHealthCheckTime(): ?\DateTime
+    {
+        return $this->healthCheckTime;
+    }
+
+    /**
+     * Sets the time this execution has been health checked
+     *
+     * @param \DateTime $healthCheckTime the time this execution has been health checked
+     *
+     * @return JobExecution
+     */
+    public function setHealthcheckTime(\DateTime $healthCheckTime): JobExecution
+    {
+        $this->healthCheckTime= $healthCheckTime;
 
         return $this;
     }

--- a/src/Akeneo/Component/Batch/spec/Job/ExitStatusSpec.php
+++ b/src/Akeneo/Component/Batch/spec/Job/ExitStatusSpec.php
@@ -130,6 +130,12 @@ class ExitStatusSpec extends ObjectBehavior
         $this->isRunning()->shouldReturn(true);
     }
 
+    function it_is_running_when_status_is_execution()
+    {
+        $this->beConstructedWith(ExitStatus::EXECUTING);
+        $this->isRunning()->shouldReturn(true);
+    }
+
     function it_is_displayable()
     {
         $this->beConstructedWith(ExitStatus::COMPLETED, 'My test description for completed status');

--- a/src/Akeneo/Component/Batch/spec/Model/JobExecutionSpec.php
+++ b/src/Akeneo/Component/Batch/spec/Model/JobExecutionSpec.php
@@ -25,6 +25,7 @@ class JobExecutionSpec extends ObjectBehavior
         $this->getFailureExceptions()->shouldHaveCount(0);
         $this->getRawParameters()->shouldHaveCount(0);
         $this->getJobParameters()->shouldBeNull();
+        $this->getHealthCheckTime()->shouldBeNull();
     }
 
     function it_is_cloneable(
@@ -127,6 +128,13 @@ class JobExecutionSpec extends ObjectBehavior
         $this->setJobParameters($jobParameters);
         $this->getJobParameters()->shouldReturn($jobParameters);
         $this->getRawParameters()->shouldReturn(['foo' => 'baz']);
+    }
+
+    function it_sets_health_check_time()
+    {
+        $datetime = new \DateTime();
+        $this->setHealthCheckTime($datetime);
+        $this->getHealthCheckTime()->shouldReturn($datetime);
     }
 
     function it_is_displayable()

--- a/src/Akeneo/Component/BatchQueue/Queue/JobExecutionMessage.php
+++ b/src/Akeneo/Component/BatchQueue/Queue/JobExecutionMessage.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Component\BatchQueue\Queue;
+
+/**
+ * Object representing the message pushed into a queue to process a job execution asynchronously.
+ *
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class JobExecutionMessage
+{
+    /** @var int */
+    private $id;
+
+    /** @var int */
+    private $jobExecutionId;
+
+    /** @var string */
+    private $consumer;
+
+    /** @var \DateTime */
+    private $createTime;
+
+    /** @var \DateTime */
+    private $updatedTime;
+
+    /** @var array */
+    private $options = [];
+
+    /**
+     * @param int       $id
+     * @param int       $jobExecutionId
+     * @param string    $consumer
+     * @param \DateTime $createTime
+     * @param \DateTime $updatedTime
+     * @param array     $options
+     */
+    private function __construct(
+        ?int $id,
+        int $jobExecutionId,
+        ?string $consumer,
+        \DateTime $createTime,
+        ?\DateTime $updatedTime,
+        array $options
+    ) {
+        $this->id = $id;
+        $this->jobExecutionId = $jobExecutionId;
+        $this->consumer = $consumer;
+        $this->createTime = $createTime;
+        $this->updatedTime = $updatedTime;
+        $this->options = $options;
+    }
+
+    /**
+     * Create a new JobExecutionMessage that has never been persisted into database.
+     *
+     * @param int   $jobExecutionId
+     * @param array $options
+     *
+     * @return JobExecutionMessage
+     */
+    public static function createJobExecutionMessage(int $jobExecutionId, array $options): JobExecutionMessage
+    {
+        $createTime = new \DateTime('now', new \DateTimeZone('UTC'));
+
+        return new self(null, $jobExecutionId, null, $createTime, null, $options);
+    }
+
+    /**
+     * Create a JobExecutionMessage that has already been persisted in database.
+     *
+     * @param int            $id
+     * @param int            $jobExecutionId
+     * @param null|string    $consumer
+     * @param \DateTime      $createTime
+     * @param \DateTime|null $updatedTime
+     * @param array          $options
+     *
+     * @return JobExecutionMessage
+     */
+    public static function createJobExecutionMessageFromDatabase(
+        int $id,
+        int $jobExecutionId,
+        ?string $consumer,
+        \DateTime $createTime,
+        ?\DateTime $updatedTime,
+        array $options
+    ): JobExecutionMessage {
+        return new self($id, $jobExecutionId, $consumer, $createTime, $updatedTime, $options);
+    }
+
+    /**
+     * @return null|int
+     */
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return int
+     */
+    public function getJobExecutionId(): ?int
+    {
+        return $this->jobExecutionId;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getConsumer(): ?string
+    {
+        return $this->consumer;
+    }
+
+    /**
+     * @param string $consumer
+     *
+     * @return JobExecutionMessage
+     */
+    public function consumedBy(string $consumer): JobExecutionMessage
+    {
+        $this->consumer = $consumer;
+
+        return $this;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getCreateTime(): \DateTime
+    {
+        return $this->createTime;
+    }
+
+    /**
+     * @return null|\DateTime
+     */
+    public function getUpdatedTime(): ?\DateTime
+    {
+        return $this->updatedTime;
+    }
+
+    /**
+     * @return array
+     */
+    public function getOptions(): array
+    {
+        return $this->options;
+    }
+}

--- a/src/Akeneo/Component/BatchQueue/Queue/JobExecutionQueueInterface.php
+++ b/src/Akeneo/Component/BatchQueue/Queue/JobExecutionQueueInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Component\BatchQueue\Queue;
+
+/**
+ * This class aims to publish and consume job execution messages into a queue.
+ *
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface JobExecutionQueueInterface
+{
+    /**
+     * Publishes a message into the queue.
+     *
+     * @param JobExecutionMessage $jobExecutionMessage
+     */
+    public function publish(JobExecutionMessage $jobExecutionMessage): void;
+
+    /**
+     * Gets the last job execution message from the queue, that is not consumed yet.
+     * This method loops until there is a message to consume into the queue.
+     *
+     * @param string $consumer name of the consumer
+     *
+     * @return JobExecutionMessage
+     */
+    public function consume(string $consumer): JobExecutionMessage;
+}

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/job_launchers.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/job_launchers.yml
@@ -5,4 +5,4 @@ services:
     pim_connector.launcher.authenticated_job_launcher:
         class: '%pim_connector.launcher.authenticated_job_launcher.class%'
         arguments:
-            - '@akeneo_batch.launcher.simple_job_launcher'
+            - '@akeneo_batch_queue.launcher.queue_job_launcher'

--- a/src/Pim/Bundle/DataGridBundle/Resources/config/controllers.yml
+++ b/src/Pim/Bundle/DataGridBundle/Resources/config/controllers.yml
@@ -29,7 +29,7 @@ services:
             - '@pim_datagrid.adapter.oro_to_pim_grid_filter'
             - '@akeneo_batch.job.job_instance_repository'
             - '@security.token_storage'
-            - '@akeneo_batch.launcher.simple_job_launcher'
+            - '@akeneo_batch_queue.launcher.queue_job_launcher'
             - '@oro_datagrid.datagrid.manager'
             - '@oro_datagrid.mass_action.parameters_parser'
 

--- a/src/Pim/Bundle/EnrichBundle/Controller/JobTrackerController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/JobTrackerController.php
@@ -2,18 +2,16 @@
 
 namespace Pim\Bundle\EnrichBundle\Controller;
 
-use Akeneo\Bundle\BatchBundle\Manager\JobExecutionManager;
+use Akeneo\Bundle\BatchQueueBundle\Manager\JobExecutionManager;
 use Akeneo\Component\Batch\Model\JobExecution;
 use Akeneo\Component\FileStorage\StreamedFileResponse;
 use Oro\Bundle\SecurityBundle\SecurityFacade;
 use Pim\Bundle\ConnectorBundle\EventListener\JobExecutionArchivist;
 use Pim\Bundle\EnrichBundle\Doctrine\ORM\Repository\JobExecutionRepository;
 use Pim\Bundle\ImportExportBundle\Event\JobExecutionEvents;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -55,7 +53,7 @@ class JobTrackerController extends Controller
     /** @var SerializerInterface */
     protected $serializer;
 
-    /** @var EventSubscriberInterface */
+    /** @var JobExecutionManager */
     protected $jobExecutionManager;
 
     /** @var SecurityFacade */
@@ -132,9 +130,7 @@ class JobTrackerController extends Controller
                 ];
             }
 
-            if (!$this->jobExecutionManager->checkRunningStatus($jobExecution)) {
-                $this->jobExecutionManager->markAsFailed($jobExecution);
-            }
+            $jobExecution = $this->jobExecutionManager->resolveJobExecutionStatus($jobExecution);
 
             // limit the number of step execution returned to avoid memory overflow
             $context = [

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/JobExecutionController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/JobExecutionController.php
@@ -2,7 +2,7 @@
 
 namespace Pim\Bundle\EnrichBundle\Controller\Rest;
 
-use Akeneo\Bundle\BatchBundle\Manager\JobExecutionManager;
+use Akeneo\Bundle\BatchQueueBundle\Manager\JobExecutionManager;
 use Pim\Bundle\ConnectorBundle\EventListener\JobExecutionArchivist;
 use Pim\Bundle\EnrichBundle\Doctrine\ORM\Repository\JobExecutionRepository;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -79,9 +79,7 @@ class JobExecutionController
             ];
         }
 
-        if (!$this->jobExecutionManager->checkRunningStatus($jobExecution)) {
-            $this->jobExecutionManager->markAsFailed($jobExecution);
-        }
+        $jobExecution = $this->jobExecutionManager->resolveJobExecutionStatus($jobExecution);
 
         $context = ['limit_warnings' => 100];
 

--- a/src/Pim/Bundle/EnrichBundle/MassEditAction/OperationJobLauncher.php
+++ b/src/Pim/Bundle/EnrichBundle/MassEditAction/OperationJobLauncher.php
@@ -2,7 +2,7 @@
 
 namespace Pim\Bundle\EnrichBundle\MassEditAction;
 
-use Akeneo\Bundle\BatchBundle\Launcher\SimpleJobLauncher;
+use Akeneo\Bundle\BatchBundle\Launcher\JobLauncherInterface;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Pim\Bundle\EnrichBundle\MassEditAction\Operation\BatchableOperationInterface;
 use Pim\Bundle\EnrichBundle\MassEditAction\Operation\ConfigurableOperationInterface;
@@ -19,7 +19,7 @@ use Symfony\Component\Translation\Exception\NotFoundResourceException;
  */
 class OperationJobLauncher
 {
-    /** @var SimpleJobLauncher */
+    /** @var JobLauncherInterface */
     protected $jobLauncher;
 
     /** @var IdentifiableObjectRepositoryInterface */
@@ -29,12 +29,12 @@ class OperationJobLauncher
     protected $tokenStorage;
 
     /**
-     * @param SimpleJobLauncher                     $jobLauncher
+     * @param JobLauncherInterface                  $jobLauncher
      * @param IdentifiableObjectRepositoryInterface $jobInstanceRepo
      * @param TokenStorageInterface                 $tokenStorage
      */
     public function __construct(
-        SimpleJobLauncher $jobLauncher,
+        JobLauncherInterface $jobLauncher,
         IdentifiableObjectRepositoryInterface $jobInstanceRepo,
         TokenStorageInterface $tokenStorage
     ) {

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/controllers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/controllers.yml
@@ -132,7 +132,7 @@ services:
             - '@pim_enrich.repository.job_execution'
             - '@pim_connector.event_listener.archivist'
             - '@pim_serializer'
-            - '@akeneo_batch.manager.job_execution'
+            - '@akeneo_batch_queue.manager.job_execution_manager'
             - '@oro_security.security_facade'
             - {'import': 'pim_importexport_import_profile_show', 'export': 'pim_importexport_export_profile_show'}
 
@@ -384,7 +384,7 @@ services:
             - '@validator'
             - '@akeneo_batch.job.job_parameters_validator'
             - '@akeneo_batch.job_parameters_factory'
-            - '@akeneo_batch.launcher.simple_job_launcher'
+            - '@akeneo_batch_queue.launcher.queue_job_launcher'
             - '@security.token_storage'
             - '@router'
             - '@pim_enrich.provider.form.chained'
@@ -399,7 +399,7 @@ services:
             - '@translator'
             - '@pim_connector.event_listener.archivist'
             - '@pim_serializer'
-            - '@akeneo_batch.manager.job_execution'
+            - '@akeneo_batch_queue.manager.job_execution_manager'
             - '@pim_enrich.repository.job_execution'
 
     pim_enrich.controller.rest.api_client:

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/mass_actions.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/mass_actions.yml
@@ -7,6 +7,6 @@ services:
     pim_enrich.mass_edit_action.operation_job_launcher:
         class: '%pim_enrich.mass_edit_action.operation_job_launcher.class%'
         arguments:
-            - '@akeneo_batch.launcher.simple_job_launcher'
+            - '@akeneo_batch_queue.launcher.queue_job_launcher'
             - '@akeneo_batch.job.job_instance_repository'
             - '@security.token_storage'


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)
--->

**Description (for Contributor and Core Developer)**

Goal of this PR is push jobs into a queue in order to be run asynchronously. It allows to have several instances of the PIM to execute the jobs.

Previously, the monitoring of a job was done thanks to the PID to know if a job is running or not.
This solution works only when there is one server.

Now, job executions to run are pushed into a queue in Mysql DB.
A daemon will consume one job execution at a time into the queue, and launch the job execution.
Then, it will monitor the status of the process (running/not running) and update a healthcheck date every X seconds, to acknowledge that the process is still running (and the daemon too).

We use only the DBAL to avoid any use of the UOW (memory leak, etc) by the daemon.
That's why we hydrate the data manually.

What is done for now in the PR:
- [x] Create the JobExecutionMessage for the queue
- [x] Create the queue and the algorithm to consume message
- [x] Create the daemon the launch jobs
- [x] Create the job manager to update jobs
- [x] specs
- [x] UI controllers should not used anymore the PID to get the status:
 => create a method `resolveJobExecutionStatus` in the Job manager of the queue bundle, calculating the status from the healthcheck
=> do not modify the status from the controller

Fixed since the mob review:

- [x] Use named construction for JobExecutionMessage instead of setters
- [x] Change `setConsumer`by `consumedBy` in JobExecutionMessage
- [x] Use of a dedicated EntityManager `PersistedConnectionEntityManager` in all the class using the entity manager for the queue to check that the connection is not closed by Mysql (because we use a daemon) => I put this class in BatchBundle, and I've refactored `DoctrineJobRepository` in the BatchBundle to use it as well

It avoids to copy/past always the same function.

- [x] Rename command name `job-queue-consumer` into `job-queue-consumer-daemon`
- [x] Use of `Uuid` to generate the consumer name (displayed on standard output for debugging/monitoring). Validated with Benoît.

What's left in other PR:
- [ ] Command to purge the queue
- [ ] Command to push job execution in database



<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
