### PR TITLE
PIM-6338: fix feedback from product owner

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/ProductModelController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/ProductModelController.php
@@ -5,6 +5,7 @@ namespace Pim\Bundle\EnrichBundle\Controller\Rest;
 
 use Akeneo\Component\StorageUtils\Saver\SaverInterface;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
+use Oro\Bundle\SecurityBundle\Annotation\AclAncestor;
 use Pim\Bundle\CatalogBundle\Filter\ObjectFilterInterface;
 use Pim\Bundle\UserBundle\Context\UserContext;
 use Pim\Component\Catalog\Comparator\Filter\EntityWithValuesFilter;
@@ -132,6 +133,8 @@ class ProductModelController
     /**
      * @param Request $request
      * @param int     $id
+     *
+     * @AclAncestor("pim_enrich_product_model_edit_attributes")
      *
      * @return JsonResponse
      */

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/acl.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/acl.yml
@@ -73,6 +73,12 @@ pim_enrich_product_history:
     label: pim_enrich.acl.product.history
     group_name: pim_enrich.acl_group.product
 
+# Product Model
+pim_enrich_product_model_edit_attributes:
+    type: action
+    label: pim_enrich.acl.product_model.edit_attributes
+    group_name: pim_enrich.acl_group.product_model
+
 # Mass edit action
 pim_enrich_mass_edit:
     type: action

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/acl_groups.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/acl_groups.yml
@@ -22,3 +22,5 @@ pim_enrich.acl_group.locale:
     order: 100
 pim_enrich.acl_group.product:
     order: 110
+pim_enrich.acl_group.product_model:
+    order: 120

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_model/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_model/edit.yml
@@ -23,7 +23,7 @@ extensions:
         module: pim/product-edit-form/sequential-edit
         parent: pim-product-model-edit-form
         targetZone: sequential
-        aclResourceId: pim_enrich_product_edit_attributes
+        aclResourceId: pim_enrich_product_model_edit_attributes
         position: 100
 
     pim-product-model-edit-form-left-column:
@@ -68,20 +68,6 @@ extensions:
         parent: pim-product-model-edit-form
         targetZone: buttons
         position: 50
-
-    pim-product-model-edit-form-delete:
-        module: pim/product-edit-form/delete
-        parent: pim-product-model-edit-form-secondary-actions
-        targetZone: secondary-actions
-        aclResourceId: pim_enrich_product_remove
-        position: 100
-        config:
-            trans:
-                title: confirmation.remove.product
-                content: pim_enrich.confirmation.delete_item
-                success: pim_enrich.entity.product.info.deletion_successful
-                fail: pim_enrich.entity.product.info.deletion_failed
-            redirect: pim_enrich_product_index
 
     pim-product-model-edit-form-save-buttons:
         module: pim/form/common/save-buttons
@@ -137,20 +123,13 @@ extensions:
         module: pim/product-edit-form/attributes
         parent: pim-product-model-edit-form-column-tabs
         targetZone: container
-        aclResourceId: pim_enrich_product_edit_attributes
+        aclResourceId: pim_enrich_product_model_edit_attributes
         position: 90
         config:
             removeAttributeRoute: pim_enrich_product_remove_attribute_rest
             removeAttributeACL: pim_enrich_product_remove_attribute
             tabTitle: pim_enrich.form.product.tab.attributes.title
             deletionFailed: pim_enrich.form.product.flash.attribute_deletion_error
-
-    pim-product-model-edit-form-categories:
-        module: pim/product-edit-form/categories
-        parent: pim-product-model-edit-form-column-tabs
-        targetZone: container
-        aclResourceId: pim_enrich_product_categories_view
-        position: 100
 
     pim-product-model-edit-form-attribute-group-selector:
         module: pim/form/common/attributes/attribute-group-selector
@@ -209,13 +188,6 @@ extensions:
         parent: pim-product-model-edit-form-attributes
         targetZone: self
         position: 90
-
-    pim-product-model-edit-form-history:
-        module: pim/product-edit-form/history
-        parent: pim-product-model-edit-form-column-tabs
-        targetZone: container
-        aclResourceId: pim_enrich_product_history
-        position: 140
 
     pim-product-model-edit-form-copy-scope-switcher:
         module: pim/product-edit-form/scope-switcher

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/messages.en.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/messages.en.yml
@@ -208,6 +208,8 @@ pim_enrich:
             comment: Comment products
             download: Download the product as PDF
             history: View product history
+        product_model:
+            edit_attributes: Edit attributes of a product model
         category:
             list: List categories
             create: Create a category
@@ -290,6 +292,7 @@ pim_enrich:
         group_type: Group types
         locale: Locales
         product: Products
+        product_model: Product models
     product_value:
         tooltip:
             from_variant:


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This PR fixes some feedbacks from the product owner regarding PIM-6338 and PIM-6669:
- Remove the "delete" button
- Hide the tabs "categories" and "history" managed in other stories
- ACLs

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | N
| Added Behats                      | N
| Added integration tests           | N
| Changelog updated                 | N
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo