### PR TITLE
API-298: Add username and password argument in stream request executi…

### DIFF
--- a/src/Pim/Bundle/ApiBundle/tests/integration/ApiTestCase.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/ApiTestCase.php
@@ -254,6 +254,8 @@ abstract class ApiTestCase extends WebTestCase
      * @param array  $server
      * @param string $content
      * @param bool   $changeHistory
+     * @param string $username
+     * @param string $password
      *
      * @return array
      */
@@ -264,7 +266,9 @@ abstract class ApiTestCase extends WebTestCase
         array $files = [],
         array $server = [],
         $content = null,
-        $changeHistory = true
+        $changeHistory = true,
+        $username = self::USERNAME,
+        $password = self::PASSWORD
     ) {
         $streamedContent = '';
 
@@ -274,7 +278,7 @@ abstract class ApiTestCase extends WebTestCase
             return '';
         });
 
-        $client = $this->createAuthenticatedClient();
+        $client = $this->createAuthenticatedClient([], [], null, null, $username, $password);
         $client->setServerParameter('CONTENT_TYPE', StreamResourceResponse::CONTENT_TYPE);
         $client->request($method, $uri, $parameters, $files, $server, $content, $changeHistory);
 


### PR DESCRIPTION
…on for unit test

[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
