### PR TITLE
PIM-6333: Import product model enhancements

### DIFF
--- a/features/import/product_model/import_business_rules.feature
+++ b/features/import/product_model/import_business_rules.feature
@@ -217,3 +217,17 @@ Feature: Create product models through CSV import
       code;parent;family_variant;categories;collection;description-en_US-ecommerce;erp_name-en_US;price;color;variation_name-en_US;composition;size;ean;sku;weight
       code-003;code-001;clothing_color_size;master_men_blazers;;;;;blue;Blazers;composition;;;;
       """
+
+  Scenario: Skip import with a unexpected field
+    Given the following CSV file to import:
+      """
+      code;parent;family_variant;comment
+      code-001;;clothing_color_size;"my comment"
+      """
+    And the following job "csv_catalog_modeling_product_model_import" configuration:
+      | filePath | %file to import% |
+    When I am on the "csv_catalog_modeling_product_model_import" import job page
+    And I launch the import job
+    And I wait for the "csv_catalog_modeling_product_model_import" job to finish
+    Then I should see the text "Status: FAILED"
+    And I should see the text " The field \"comment\" does not exist"

--- a/features/import/product_model/import_business_rules.feature
+++ b/features/import/product_model/import_business_rules.feature
@@ -137,8 +137,9 @@ Feature: Create product models through CSV import
       | code     | color  | variation_name-en_US | composition |
       | code-002 | [blue] | Blazers              | composition |
     And I should see the text "created 1"
-    And I should see the text "read lines 1"
-    But I should not see the text "read lines 2"
+    And I should see the text "skipped product model with parent 1"
+    And I should see the text "skipped product model without parent 1"
+    And I should see the text "read lines 2"
 
   Scenario: A root product model cannot have a parent
     Given the following root product models:

--- a/src/Akeneo/Component/Batch/Model/StepExecution.php
+++ b/src/Akeneo/Component/Batch/Model/StepExecution.php
@@ -511,21 +511,6 @@ class StepExecution
     }
 
     /**
-     * Decrement counter in summary
-     *
-     * @param string  $key
-     * @param integer $decrement
-     */
-    public function decrementSummaryInfo($key, $decrement = 1)
-    {
-        if (!isset($this->summary[$key])) {
-            $this->summary[$key] = -$decrement;
-        } else {
-            $this->summary[$key] = $this->summary[$key] - $decrement;
-        }
-    }
-
-    /**
      * Get a summary row
      *
      * @param string $key

--- a/src/Akeneo/Component/Batch/spec/Model/StepExecutionSpec.php
+++ b/src/Akeneo/Component/Batch/spec/Model/StepExecutionSpec.php
@@ -74,14 +74,6 @@ class StepExecutionSpec extends ObjectBehavior
         $this->getSummaryInfo('counter')->shouldReturn(4);
     }
 
-    function it_decrements_summary_info()
-    {
-        $this->decrementSummaryInfo('counter');
-        $this->getSummaryInfo('counter')->shouldReturn(-1);
-        $this->decrementSummaryInfo('counter', 3);
-        $this->getSummaryInfo('counter')->shouldReturn(-4);
-    }
-
     function it_is_displayable()
     {
         $this->__toString()->shouldReturn('id=0, name=[myStepName], status=[2], exitCode=[EXECUTING], exitDescription=[]');

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Product/CreateProductModelIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Product/CreateProductModelIntegration.php
@@ -264,9 +264,6 @@ class CreateProductModelIntegration extends TestCase
         );
     }
 
-    /**
-     * Create a product without any errors
-     */
     public function testTheProductModelHaveValidMetricValue()
     {
         $productModel = $this->createProductModel(
@@ -301,6 +298,29 @@ class CreateProductModelIntegration extends TestCase
             'This value should be a valid number.',
             $errors->get(0)->getMessage()
         );
+    }
+
+    public function testFamilyVariantIsOptionalForSubProductModel()
+    {
+        $productModel = $this->createProductModel(
+            [
+                'code' => 'model-running-shoes-l',
+                'parent' => 'model-running-shoes',
+                'values' => [
+                    'size' => [
+                        [
+                            'locale' => null,
+                            'scope' => null,
+                            'data' => 'l',
+                        ],
+                    ],
+                ],
+            ]
+        );
+
+        $errors = $this->get('pim_catalog.validator.product_model')->validate($productModel);
+        $this->assertEquals(0, $errors->count());
+        $this->assertEquals('shoes_size_color', $productModel->getFamilyVariant()->getCode());
     }
 
     /**

--- a/src/Pim/Bundle/ConnectorBundle/Resources/translations/messages.en.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/translations/messages.en.yml
@@ -48,6 +48,8 @@ job_execution.summary:
     product_skipped_no_diff: skipped product (no differences)
     product_skipped_no_associations: skipped product (no associations detected)
     item_position: read lines
+    skipped_in_root_product_model: skipped product model with parent
+    skipped_in_sub_product_model: skipped product model without parent
 
 # Job labels
 batch_jobs:

--- a/src/Pim/Component/Catalog/spec/Updater/ProductModelUpdaterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/ProductModelUpdaterSpec.php
@@ -67,6 +67,7 @@ class ProductModelUpdaterSpec extends ObjectBehavior
         FamilyVariantInterface $familyVariant
     ) {
         $productModel->getId()->willReturn(null);
+        $productModel->getParent()->willReturn(null);
         $productModel->getFamilyVariant()->willReturn(null);
 
         $propertySetter->setData($productModel, 'categories', ['tshirt'])->shouldBeCalled();
@@ -349,6 +350,21 @@ class ProductModelUpdaterSpec extends ObjectBehavior
         FamilyVariantInterface $familyVariant
     ) {
         $productModel->getFamilyVariant()->willReturn($familyVariant);
+        $familyVariant->getCode()->willreturn('family_variant');
+
+        $this->shouldThrow(ImmutablePropertyException::class)->during('update', [$productModel, [
+            'family_variant' => 'new_family_variant'
+        ]]);
+    }
+
+    function it_throws_an_exception_if_the_family_variant_is_different_from_the_parent(
+        ProductModelInterface $productModel,
+        ProductModelInterface $parent,
+        FamilyVariantInterface $familyVariant
+    ) {
+        $productModel->getFamilyVariant()->willReturn(null);
+        $productModel->getParent()->willReturn($parent);
+        $parent->getFamilyVariant()->willReturn($familyVariant);
         $familyVariant->getCode()->willreturn('family_variant');
 
         $this->shouldThrow(ImmutablePropertyException::class)->during('update', [$productModel, [

--- a/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Product.php
+++ b/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Product.php
@@ -183,7 +183,7 @@ class Product implements ArrayConverterInterface
         $this->validateItem($filteredItem);
 
         $mergedItem = $this->columnsMerger->merge($filteredItem);
-        $convertedItem = $this->convertItem($mergedItem, $options);
+        $convertedItem = $this->convertItem($mergedItem);
 
         return $convertedItem;
     }

--- a/src/Pim/Component/Connector/Processor/Denormalization/ProductModelProcessor.php
+++ b/src/Pim/Component/Connector/Processor/Denormalization/ProductModelProcessor.php
@@ -94,7 +94,7 @@ class ProductModelProcessor extends AbstractProcessor implements ItemProcessorIn
         if ($this->importType === self::ROOT_PRODUCT_MODEL && !empty($parent) ||
             $this->importType === self::SUB_PRODUCT_MODEL && empty($parent)
         ) {
-            $this->stepExecution->decrementSummaryInfo('item_position');
+            $this->stepExecution->incrementSummaryInfo(sprintf('skipped_in_%s', $this->importType));
 
             return null;
         }

--- a/src/Pim/Component/Connector/spec/ArrayConverter/FlatToStandard/ProductModelSpec.php
+++ b/src/Pim/Component/Connector/spec/ArrayConverter/FlatToStandard/ProductModelSpec.php
@@ -164,7 +164,7 @@ class ProductModelSpec extends ObjectBehavior
         ]);
     }
 
-    function it_throws(
+    function it_throws_an_exception_if_family_variant_is_different_from_the_parent(
         $columnsMapper,
         $columnsMerger,
         $fieldsRequirementChecker,

--- a/src/Pim/Component/Connector/spec/Processor/Denormalization/ProductModelProcessorSpec.php
+++ b/src/Pim/Component/Connector/spec/Processor/Denormalization/ProductModelProcessorSpec.php
@@ -341,7 +341,7 @@ class ProductModelProcessorSpec extends ObjectBehavior
 
         $this->setStepExecution($stepExecution);
 
-        $stepExecution->decrementSummaryInfo('item_position')->shouldBeCalled();
+        $stepExecution->incrementSummaryInfo('skipped_in_root_product_model')->shouldBeCalled();
 
         $this->process([
             'code' => 'product_model_code',
@@ -373,7 +373,7 @@ class ProductModelProcessorSpec extends ObjectBehavior
 
         $this->setStepExecution($stepExecution);
 
-        $stepExecution->decrementSummaryInfo('item_position')->shouldBeCalled();
+        $stepExecution->incrementSummaryInfo('skipped_in_sub_product_model')->shouldBeCalled();
 
         $this->process([
             'code' => 'product_model_code',


### PR DESCRIPTION
## Description

This PR brings a few enhancements to existing product model creation/update.
- **first commit**: during import, non existing fields are handled the same way than for products, with the same error message
- **second commit**: fix the behavior of the previous PR #6686 after talking with @Delphineray => no more decrement of read product model, but a clear message indicating some have been skipped (product models with parent during the first step, product models without parent during the second)
- **third commit**: add some new business rules to fit with the variant product ones:
    - a sub product model can be imported without variant family, and will in this case inherit the one from its parent
    - if a family variant is specified for a sub product model, it cannot be different from the one of the parent


## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added Behats                      | OK
| Added integration tests           | OK
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
