### PR TITLE
PIM-6743: Add variant product business rules for update

### DIFF
--- a/features/import/product_model/import_business_rules.feature
+++ b/features/import/product_model/import_business_rules.feature
@@ -186,7 +186,7 @@ Feature: Create product models through CSV import
     And I wait for the "csv_catalog_modeling_product_model_import" job to finish
     Then I should see the text "Status: Completed"
     And I should see the text "skipped 1"
-    And I should see the text "Property \"color\" cannot be modified, \"red\" given."
+    And I should see the text "Variant axis \"color\" cannot be modified, \"[red]\" given"
     And the invalid data file of "csv_catalog_modeling_product_model_import" should contain:
       """
       code;parent;family_variant;color

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/updaters.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/updaters.yml
@@ -70,9 +70,6 @@ services:
             - '@pim_catalog.updater.entity_with_values'
             - '@pim_catalog.repository.family_variant'
             - '@pim_catalog.repository.product_model'
-            - '@pim_catalog.normalizer.standard.product.product_value'
-            - '@pim_catalog.family_variant.provider.entity_with_family_variant_attributes'
-            - '@pim_catalog.comparator.registry'
             - ['categories']
             - ['identifier', 'created', 'updated']
 

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/validation/productmodel.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/validation/productmodel.yml
@@ -3,6 +3,7 @@ Pim\Component\Catalog\Model\ProductModel:
         - Pim\Component\Catalog\Validator\Constraints\ProductModelPositionInTheVariantTree: ~
         - Pim\Component\Catalog\Validator\Constraints\OnlyExpectedAttributes: ~
         - Pim\Component\Catalog\Validator\Constraints\SiblingUniqueVariantAxes: ~
+        - Pim\Component\Catalog\Validator\Constraints\ImmutableVariantAxesValues: ~
         - Pim\Component\Catalog\Validator\Constraints\NotEmptyVariantAxes: ~
         - Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity:
             fields: ['code']

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/validation/variantproduct.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/validation/variantproduct.yml
@@ -4,6 +4,7 @@ Pim\Component\Catalog\Model\VariantProduct:
         - Pim\Component\Catalog\Validator\Constraints\SameFamilyThanParent: ~
         - Pim\Component\Catalog\Validator\Constraints\NotEmptyVariantAxes: ~
         - Pim\Component\Catalog\Validator\Constraints\SiblingUniqueVariantAxes: ~
+        - Pim\Component\Catalog\Validator\Constraints\ImmutableVariantAxesValues: ~
         - Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity:
             fields: [identifier]
             message: The same identifier is already set on another product

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/validators.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/validators.yml
@@ -55,6 +55,7 @@ parameters:
     pim_catalog.validator.constraint.has_a_root_product_model_as_parent.class: Pim\Component\Catalog\Validator\Constraints\ProductModelPositionInTheVariantTreeValidator
     pim_catalog.validator.constraint.family_same_family_than_parent.class: Pim\Component\Catalog\Validator\Constraints\SameFamilyThanParentValidator
     pim_catalog.validator.constraint.invalid_variant_product_parent.class: Pim\Component\Catalog\Validator\Constraints\VariantProductParentValidator
+    pim_catalog.validator.constraint.immutable_variant_axis_values.class:  Pim\Component\Catalog\Validator\Constraints\ImmutableVariantAxesValuesValidator
 
 services:
     # Helpers
@@ -118,6 +119,15 @@ services:
         class: '%pim_catalog.validator.constraint.invalid_variant_product_parent.class%'
         tags:
             - { name: validator.constraint_validator, alias: pim_invalid_variant_product_parent }
+
+    pim_catalog.validator.constraint.immutable_variant_axis_values:
+        class: '%pim_catalog.validator.constraint.immutable_variant_axis_values.class%'
+        arguments:
+            - '@doctrine.orm.entity_manager'
+            - '@pim_catalog.family_variant.provider.entity_with_family_variant_attributes'
+            - '@pim_catalog.factory.value_collection'
+        tags:
+            - { name: validator.constraint_validator, alias: pim_immutable_variant_axis_values_validator }
 
     pim_catalog.validator.constraint.valid_metric:
         class: '%pim_catalog.validator.constraint.valid_metric.class%'

--- a/src/Pim/Bundle/CatalogBundle/Resources/translations/validators.en.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/translations/validators.en.yml
@@ -42,3 +42,4 @@ pim_catalog:
         variant_product_invalid_family: 'The variant product family must be the same than its parent'
         variant_product_has_parent: 'The variant product "%variant_product%" must have a parent'
         invalid_variant_product_parent: 'Parent of the variant product "%variant_product%" cannot have product models as children, only variant products'
+        modified_variant_axis_value: 'Variant axis "%variant_axis%" cannot be modified, "%provided_value%" given'

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Product/UpdateVariantProductIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Product/UpdateVariantProductIntegration.php
@@ -52,6 +52,29 @@ class UpdateVariantProductIntegration extends TestCase
         );
     }
 
+    public function testTheVariantAxisValuesCannotBeUpdated(): void
+    {
+        $product = $this->get('pim_catalog.repository.product')->findOneByIdentifier('apollon_blue_xl');
+        $this->get('pim_catalog.updater.product')->update($product, [
+            'values' => [
+                'size' => [
+                    [
+                        'locale' => null,
+                        'scope' => null,
+                        'data' => 's',
+                    ],
+                ],
+            ],
+        ]);
+
+        $errors = $this->get('pim_catalog.validator.product')->validate($product);
+        $this->assertEquals(1, $errors->count());
+        $this->assertEquals(
+            'Variant axis "size" cannot be modified, "[s]" given',
+            $errors->get(0)->getMessage()
+        );
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Product/UpdateVariantProductIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Product/UpdateVariantProductIntegration.php
@@ -15,8 +15,6 @@ use Akeneo\Test\Integration\TestCase;
 class UpdateVariantProductIntegration extends TestCase
 {
     /**
-     * Ensure that the parent of a variant product cannot be changed.
-     *
      * TODO: This will become possible in PIM-6350.
      *
      * @expectedException \Akeneo\Component\StorageUtils\Exception\ImmutablePropertyException
@@ -29,8 +27,16 @@ class UpdateVariantProductIntegration extends TestCase
     }
 
     /**
-     * Ensure that the family of a variant product cannot be changed.
-     *
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\ImmutablePropertyException
+     * @expectedExceptionMessage Property "parent" cannot be modified, "" given.
+     */
+    public function testTheParentCannotBeRemoved(): void
+    {
+        $product = $this->get('pim_catalog.repository.product')->findOneByIdentifier('apollon_blue_xl');
+        $this->get('pim_catalog.updater.product')->update($product, ['parent' => '']);
+    }
+
+    /**
      * TODO: This will become possible in PIM-6460.
      */
     public function testTheFamilyCannotBeChanged(): void

--- a/src/Pim/Component/Catalog/Updater/ProductModelUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/ProductModelUpdater.php
@@ -325,6 +325,7 @@ class ProductModelUpdater implements ObjectUpdaterInterface
      * @param ProductModelInterface $productModel
      * @param string                $familyVariantCode
      *
+     * @throws ImmutablePropertyException
      * @throws InvalidPropertyException
      */
     private function updateFamilyVariant(ProductModelInterface $productModel, string $familyVariantCode): void

--- a/src/Pim/Component/Catalog/Updater/ProductModelUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/ProductModelUpdater.php
@@ -12,10 +12,7 @@ use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterfa
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Akeneo\Component\StorageUtils\Updater\PropertySetterInterface;
 use Doctrine\Common\Util\ClassUtils;
-use Pim\Component\Catalog\Comparator\ComparatorRegistryInterface;
-use Pim\Component\Catalog\FamilyVariant\EntityWithFamilyVariantAttributesProvider;
 use Pim\Component\Catalog\Model\ProductModelInterface;
-use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
  * @author    Arnaud Langlade <arnaud.langlade@akeneo.com>
@@ -42,34 +39,19 @@ class ProductModelUpdater implements ObjectUpdaterInterface
     /** @var IdentifiableObjectRepositoryInterface */
     private $productModelRepository;
 
-    /** @var NormalizerInterface */
-    private $valueNormalizer;
-
-    /** @var EntityWithFamilyVariantAttributesProvider */
-    private $attributesProvider;
-
-    /** @var ComparatorRegistryInterface */
-    private $comparatorRegistry;
-
     /**
-     * @param PropertySetterInterface                   $propertySetter
-     * @param ObjectUpdaterInterface                    $valuesUpdater
-     * @param IdentifiableObjectRepositoryInterface     $familyVariantRepository
-     * @param IdentifiableObjectRepositoryInterface     $productModelRepository
-     * @param NormalizerInterface                       $valueNormalizer
-     * @param EntityWithFamilyVariantAttributesProvider $attributesProvider
-     * @param ComparatorRegistryInterface               $comparatorRegistry
-     * @param array                                     $supportedFields
-     * @param array                                     $ignoredFields
+     * @param PropertySetterInterface               $propertySetter
+     * @param ObjectUpdaterInterface                $valuesUpdater
+     * @param IdentifiableObjectRepositoryInterface $familyVariantRepository
+     * @param IdentifiableObjectRepositoryInterface $productModelRepository
+     * @param array                                 $supportedFields
+     * @param array                                 $ignoredFields
      */
     public function __construct(
         PropertySetterInterface $propertySetter,
         ObjectUpdaterInterface $valuesUpdater,
         IdentifiableObjectRepositoryInterface $familyVariantRepository,
         IdentifiableObjectRepositoryInterface $productModelRepository,
-        NormalizerInterface $valueNormalizer,
-        EntityWithFamilyVariantAttributesProvider $attributesProvider,
-        ComparatorRegistryInterface $comparatorRegistry,
         array $supportedFields,
         array $ignoredFields
     ) {
@@ -77,9 +59,6 @@ class ProductModelUpdater implements ObjectUpdaterInterface
         $this->valuesUpdater = $valuesUpdater;
         $this->familyVariantRepository = $familyVariantRepository;
         $this->productModelRepository = $productModelRepository;
-        $this->valueNormalizer = $valueNormalizer;
-        $this->attributesProvider = $attributesProvider;
-        $this->comparatorRegistry = $comparatorRegistry;
         $this->supportedFields = $supportedFields;
         $this->ignoredFields = $ignoredFields;
     }
@@ -103,7 +82,7 @@ class ProductModelUpdater implements ObjectUpdaterInterface
 
         foreach ($data as $code => $value) {
             if ('values' === $code) {
-                $this->updateValues($productModel, $value, $options);
+                $this->valuesUpdater->update($productModel, $value, $options);
             } elseif ('code' === $code) {
                 $productModel->setCode($value);
             } elseif ('family_variant' === $code) {
@@ -136,145 +115,6 @@ class ProductModelUpdater implements ObjectUpdaterInterface
         ) {
             $productModel->setFamilyVariant($productModel->getParent()->getFamilyVariant());
         }
-    }
-
-    /**
-     * Updates the values of the product model.
-     *
-     * If the product model already exists, we ensure we do not update variant
-     * axes values: provided values must be either missing, empty, or identical
-     * to the existing ones, or an exception will be thrown.
-     *
-     * @param ProductModelInterface $productModel
-     * @param array                 $values
-     * @param array                 $options
-     *
-     * @throws ImmutablePropertyException
-     */
-    private function updateValues(ProductModelInterface $productModel, array $values, array $options): void
-    {
-        if (null !== $productModel->getId()) {
-            $axesCodesAndTypes = $this->getProductModelAxesCodesAndTypes($productModel);
-            $newAxesValues = $this->getNewVariantAxesValues($values, array_keys($axesCodesAndTypes));
-
-            if (!empty($newAxesValues)) {
-                $currentAxesValues = $this->getCurrentVariantAxesValues($productModel, array_keys($axesCodesAndTypes));
-                $willBeUpdatedValues = $this->compareVariantAxesValues(
-                    $currentAxesValues,
-                    $newAxesValues,
-                    $axesCodesAndTypes
-                );
-
-                if (!empty($willBeUpdatedValues)) {
-                    throw ImmutablePropertyException::immutableProperty(
-                        implode(', ', array_keys($willBeUpdatedValues)),
-                        implode(', ', $willBeUpdatedValues),
-                        static::class
-                    );
-                }
-            }
-        }
-
-        $this->valuesUpdater->update($productModel, $values, $options);
-    }
-
-    /**
-     * Returns the list of the variant axes codes, associated to their attribute type:
-     *
-     * [
-     *     'attribute_code' => 'attribute_type',
-     * ]
-     *
-     * @param ProductModelInterface $productModel
-     *
-     * @return array
-     */
-    private function getProductModelAxesCodesAndTypes(ProductModelInterface $productModel): array
-    {
-        $productModelAxesCodesAndTypes = [];
-
-        foreach ($this->attributesProvider->getAxes($productModel) as $attribute) {
-            $productModelAxesCodesAndTypes[$attribute->getCode()] = $attribute->getType();
-        }
-
-        return $productModelAxesCodesAndTypes;
-    }
-
-    /**
-     * Removes all values except the ones of the variant axes.
-     *
-     * The provided values (and so the result) are in standard format.
-     *
-     * @param array $values
-     * @param array $axesCodes
-     *
-     * @return array
-     */
-    private function getNewVariantAxesValues(array $values, array $axesCodes): array
-    {
-        $attributeCodes = array_keys($values);
-        foreach ($attributeCodes as $attributeCode) {
-            if (!in_array($attributeCode, $axesCodes)) {
-                unset($values[$attributeCode]);
-            }
-        }
-
-        return $values;
-    }
-
-    /**
-     * Gets the current values of the product model variant axes.
-     *
-     * The returned result is in standard format.
-     *
-     * @param ProductModelInterface $productModel
-     * @param array                 $axesCodes
-     *
-     * @return array
-     */
-    private function getCurrentVariantAxesValues(ProductModelInterface $productModel, array $axesCodes): array
-    {
-        $currentAxesValues = [];
-        foreach ($axesCodes as $axisCode) {
-            $currentAxesValues[$axisCode] = [
-                $this->valueNormalizer->normalize($productModel->getValue($axisCode), 'standard'),
-            ];
-        };
-
-        return $currentAxesValues;
-    }
-
-    /**
-     * Compares the current values of the variant axes against the new ones we
-     * want to update the product model with.
-     *
-     * Returns the new values if they are different, and an empty array if there
-     * is no difference.
-     *
-     * @param array $currentAxesValues
-     * @param array $newAxesValues
-     * @param array $axesCodesAndTypes
-     *
-     * @return array
-     */
-    private function compareVariantAxesValues(
-        array $currentAxesValues,
-        array $newAxesValues,
-        array $axesCodesAndTypes
-    ): array {
-        $updateValues = [];
-
-        foreach (array_keys($axesCodesAndTypes) as $axisCode) {
-            if (array_key_exists($axisCode, $currentAxesValues) && array_key_exists($axisCode, $newAxesValues)) {
-                $comparator = $this->comparatorRegistry->getAttributeComparator($axesCodesAndTypes[$axisCode]);
-                $diff = $comparator->compare($newAxesValues[$axisCode][0], $currentAxesValues[$axisCode][0]);
-                if (null !== $diff) {
-                    $updateValues[$axisCode] = is_array($diff['data']) ? implode(' ', $diff['data']) : $diff['data'];
-                }
-            }
-        }
-
-        return $updateValues;
     }
 
     /**

--- a/src/Pim/Component/Catalog/Validator/Constraints/ImmutableVariantAxesValues.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/ImmutableVariantAxesValues.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Component\Catalog\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Validates that the variant axis values cannot be modified once set.
+ *
+ * @author    Damien Carcel (damien.carcel@akeneo.com)
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class ImmutableVariantAxesValues extends Constraint
+{
+    public const UPDATED_VARIANT_AXIS_VALUE = 'pim_catalog.constraint.modified_variant_axis_value';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validatedBy()
+    {
+        return 'pim_immutable_variant_axis_values_validator';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTargets()
+    {
+        return Constraint::CLASS_CONSTRAINT;
+    }
+}

--- a/src/Pim/Component/Catalog/Validator/Constraints/ImmutableVariantAxesValuesValidator.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/ImmutableVariantAxesValuesValidator.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Component\Catalog\Validator\Constraints;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Pim\Component\Catalog\Factory\ValueCollectionFactoryInterface;
+use Pim\Component\Catalog\FamilyVariant\EntityWithFamilyVariantAttributesProvider;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\EntityWithFamilyVariantInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+/**
+ * Validates that the variant axis values cannot be modified once set.
+ *
+ * @author    Damien Carcel (damien.carcel@akeneo.com)
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class ImmutableVariantAxesValuesValidator extends ConstraintValidator
+{
+    /** @var EntityManagerInterface */
+    private $entityManager;
+
+    /** @var EntityWithFamilyVariantAttributesProvider */
+    private $attributesProvider;
+
+    /** @var ValueCollectionFactoryInterface */
+    private $valueCollectionFactory;
+
+    /**
+     * @param EntityManagerInterface                    $entityManager
+     * @param EntityWithFamilyVariantAttributesProvider $attributesProvider
+     * @param ValueCollectionFactoryInterface           $valueCollectionFactory
+     */
+    public function __construct(
+        EntityManagerInterface $entityManager,
+        EntityWithFamilyVariantAttributesProvider $attributesProvider,
+        ValueCollectionFactoryInterface $valueCollectionFactory
+    ) {
+        $this->entityManager = $entityManager;
+        $this->attributesProvider = $attributesProvider;
+        $this->valueCollectionFactory = $valueCollectionFactory;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validate($entity, Constraint $constraint): void
+    {
+        if (!$entity instanceof EntityWithFamilyVariantInterface) {
+            throw new UnexpectedTypeException($constraint, EntityWithFamilyVariantInterface::class);
+        }
+
+        if (!$constraint instanceof ImmutableVariantAxesValues) {
+            throw new UnexpectedTypeException($constraint, ImmutableVariantAxesValues::class);
+        }
+
+        if (null === $entity->getId() || null === $entity->getFamilyVariant()) {
+            return;
+        }
+
+        $axisCodes = array_map(function (AttributeInterface $axis) {
+            return $axis->getCode();
+        }, $this->attributesProvider->getAxes($entity));
+
+        $originalData = $this->entityManager->getUnitOfWork()->getOriginalEntityData($entity);
+        $originalValues = $this->valueCollectionFactory->createFromStorageFormat($originalData['rawValues']);
+
+        foreach ($axisCodes as $code) {
+            $originalValue = $originalValues->getByCodes($code);
+            $newValue = $entity->getValue($code);
+            if (null !== $originalValue && !$originalValue->isEqual($newValue)) {
+                $this->context->buildViolation(
+                    ImmutableVariantAxesValues::UPDATED_VARIANT_AXIS_VALUE,
+                    [
+                        '%variant_axis%' => $code,
+                        '%provided_value%' => (string) $newValue,
+                    ]
+                )->addViolation();
+            }
+        }
+    }
+}

--- a/src/Pim/Component/Catalog/spec/Updater/ProductModelUpdaterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/ProductModelUpdaterSpec.php
@@ -8,20 +8,15 @@ use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Akeneo\Component\StorageUtils\Updater\PropertySetterInterface;
-use Doctrine\Common\Collections\ArrayCollection;
+use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\AttributeTypes;
 use Pim\Component\Catalog\Comparator\ComparatorInterface;
-use Pim\Component\Catalog\Comparator\ComparatorRegistryInterface;
-use Pim\Component\Catalog\FamilyVariant\EntityWithFamilyVariantAttributesProvider;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\FamilyVariantInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Model\ProductModelInterface;
 use Pim\Component\Catalog\Model\ValueInterface;
 use Pim\Component\Catalog\Updater\ProductModelUpdater;
-use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
-use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class ProductModelUpdaterSpec extends ObjectBehavior
 {
@@ -29,19 +24,13 @@ class ProductModelUpdaterSpec extends ObjectBehavior
         PropertySetterInterface $propertySetter,
         ObjectUpdaterInterface $valuesUpdater,
         IdentifiableObjectRepositoryInterface $familyVariantRepository,
-        IdentifiableObjectRepositoryInterface $productModelRepository,
-        NormalizerInterface $valueNormalizer,
-        EntityWithFamilyVariantAttributesProvider $attributesProvider,
-        ComparatorRegistryInterface $comparatorRegistry
+        IdentifiableObjectRepositoryInterface $productModelRepository
     ) {
         $this->beConstructedWith(
             $propertySetter,
             $valuesUpdater,
             $familyVariantRepository,
             $productModelRepository,
-            $valueNormalizer,
-            $attributesProvider,
-            $comparatorRegistry,
             ['categories'],
             ['code']
         );
@@ -109,193 +98,6 @@ class ProductModelUpdaterSpec extends ObjectBehavior
             'family_variant' => 'clothing_color_size',
             'parent' => 'product_model_parent'
         ])->shouldReturn($this);
-    }
-
-    function it_throws_an_exception_if_an_option_axis_value_is_updated(
-        $valueNormalizer,
-        $attributesProvider,
-        $comparatorRegistry,
-        ProductModelInterface $productModel,
-        ComparatorInterface $comparator,
-        ValueInterface $colorValue,
-        AttributeInterface $color
-    ) {
-        $currentStandardValue = [
-            'locale' => null,
-            'scope' => null,
-            'data' => 'blue',
-        ];
-
-        $newStandardValue = [
-            'locale' => null,
-            'scope' => null,
-            'data' => 'red',
-        ];
-
-        $productModel->getId()->willReturn(42);
-
-        $attributesProvider->getAxes($productModel)->willReturn([$color]);
-        $color->getCode()->willReturn('color');
-        $color->getType()->willReturn(AttributeTypes::OPTION_SIMPLE_SELECT);
-
-        $productModel->getValue('color')->willReturn($colorValue);
-        $valueNormalizer->normalize($colorValue, 'standard')->willReturn($currentStandardValue);
-
-        $comparatorRegistry->getAttributeComparator(AttributeTypes::OPTION_SIMPLE_SELECT)->willReturn($comparator);
-        $comparator->compare($newStandardValue, $currentStandardValue)->willReturn($newStandardValue);
-
-        $this->shouldThrow(ImmutablePropertyException::class)->during('update', [$productModel, [
-            'values' => [
-                'color' => [
-                    $newStandardValue
-                ],
-            ],
-        ]]);
-    }
-
-    function it_throws_an_exception_if_a_simple_reference_data_axis_value_is_updated(
-        $valueNormalizer,
-        $attributesProvider,
-        $comparatorRegistry,
-        ProductModelInterface $productModel,
-        ComparatorInterface $comparator,
-        ValueInterface $colorValue,
-        AttributeInterface $color
-    ) {
-        $currentStandardValue = [
-            'locale' => null,
-            'scope' => null,
-            'data' => 'blue',
-        ];
-
-        $newStandardValue = [
-            'locale' => null,
-            'scope' => null,
-            'data' => 'red',
-        ];
-
-        $productModel->getId()->willReturn(42);
-
-        $attributesProvider->getAxes($productModel)->willReturn([$color]);
-        $color->getCode()->willReturn('color');
-        $color->getType()->willReturn(AttributeTypes::REFERENCE_DATA_SIMPLE_SELECT);
-
-        $productModel->getValue('color')->willReturn($colorValue);
-        $valueNormalizer->normalize($colorValue, 'standard')->willReturn($currentStandardValue);
-
-        $comparatorRegistry
-            ->getAttributeComparator(AttributeTypes::REFERENCE_DATA_SIMPLE_SELECT)
-            ->willReturn($comparator);
-        $comparator->compare($newStandardValue, $currentStandardValue)->willReturn($newStandardValue);
-
-        $this->shouldThrow(ImmutablePropertyException::class)->during('update', [$productModel, [
-            'values' => [
-                'color' => [
-                    $newStandardValue
-                ],
-            ],
-        ]]);
-    }
-
-    function it_throws_an_exception_if_an_boolean_axis_value_is_updated(
-        $valueNormalizer,
-        $attributesProvider,
-        $comparatorRegistry,
-        ProductModelInterface $productModel,
-        ComparatorInterface $comparator,
-        ValueInterface $booleanValue,
-        AttributeInterface $boolean
-    ) {
-        $currentStandardValue = [
-            'locale' => null,
-            'scope' => null,
-            'data' => true,
-        ];
-
-        $newStandardValue = [
-            'locale' => null,
-            'scope' => null,
-            'data' => false,
-        ];
-
-        $productModel->getId()->willReturn(42);
-
-        $attributesProvider->getAxes($productModel)->willReturn([$boolean]);
-        $boolean->getCode()->willReturn('boolean');
-        $boolean->getType()->willReturn(AttributeTypes::BOOLEAN);
-
-        $productModel->getValue('boolean')->willReturn($booleanValue);
-        $valueNormalizer->normalize($booleanValue, 'standard')->willReturn($currentStandardValue);
-
-        $comparatorRegistry
-            ->getAttributeComparator(AttributeTypes::BOOLEAN)
-            ->willReturn($comparator);
-        $comparator->compare($newStandardValue, $currentStandardValue)->willReturn($newStandardValue);
-
-        $this->shouldThrow(ImmutablePropertyException::class)->during('update', [$productModel, [
-            'values' => [
-                'boolean' => [
-                    $newStandardValue,
-                ],
-            ],
-        ]]);
-    }
-
-    function it_throws_an_exception_if_an_metric_axis_value_is_updated(
-        $valueNormalizer,
-        $attributesProvider,
-        $comparatorRegistry,
-        ProductModelInterface $productModel,
-        ComparatorInterface $comparator,
-        ValueInterface $sizeValue,
-        AttributeInterface $size
-    ) {
-        $currentStandardValue = [
-            'locale' => null,
-            'scope' => null,
-            'data' => [
-                'amount' => '420',
-                'unit' => 'GRAM',
-            ],
-        ];
-
-        $newStandardValue = [
-            'locale' => null,
-            'scope' => null,
-            'data' => [
-                'amount' => '42',
-                'unit' => 'GRAM',
-            ],
-        ];
-
-        $productModel->getId()->willReturn(42);
-
-        $attributesProvider->getAxes($productModel)->willReturn([$size]);
-        $size->getCode()->willReturn('size');
-        $size->getType()->willReturn(AttributeTypes::METRIC);
-
-        $productModel->getValue('size')->willReturn($sizeValue);
-        $valueNormalizer->normalize($sizeValue, 'standard')->willReturn($currentStandardValue);
-
-        $comparatorRegistry
-            ->getAttributeComparator(AttributeTypes::METRIC)
-            ->willReturn($comparator);
-        $comparator->compare($newStandardValue, $currentStandardValue)->willReturn($newStandardValue);
-
-        $this->shouldThrow(ImmutablePropertyException::class)->during('update', [$productModel, [
-            'values' => [
-                'size' => [
-                    [
-                        'locale' => null,
-                        'scope' => null,
-                        'data' => [
-                            'amount' => '42',
-                            'unit' => 'GRAM',
-                        ],
-                    ],
-                ],
-            ],
-        ]]);
     }
 
     function it_throws_an_exception_if_a_parent_is_set_to_a_root_product_model(ProductModelInterface $productModel)

--- a/src/Pim/Component/Catalog/spec/Validator/Constraints/ImmutableVariantAxesValuesSpec.php
+++ b/src/Pim/Component/Catalog/spec/Validator/Constraints/ImmutableVariantAxesValuesSpec.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace spec\Pim\Component\Catalog\Validator\Constraints;
+
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Validator\Constraints\ImmutableVariantAxesValues;
+use Symfony\Component\Validator\Constraint;
+
+class ImmutableVariantAxesValuesSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(ImmutableVariantAxesValues::class);
+    }
+
+    function it_is_a_constraint()
+    {
+        $this->shouldBeAnInstanceOf(Constraint::class);
+    }
+
+    function it_is_a_class_constraint()
+    {
+        $this->getTargets()->shouldReturn('class');
+    }
+
+    function it_is_validated_by_the_immutable_variant_axis_values_validator()
+    {
+        $this->validatedBy()->shouldReturn('pim_immutable_variant_axis_values_validator');
+    }
+}

--- a/src/Pim/Component/Catalog/spec/Validator/Constraints/ImmutableVariantAxesValuesValidatorSpec.php
+++ b/src/Pim/Component/Catalog/spec/Validator/Constraints/ImmutableVariantAxesValuesValidatorSpec.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace spec\Pim\Component\Catalog\Validator\Constraints;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\UnitOfWork;
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\UserBundle\Entity\UserInterface;
+use Pim\Component\Catalog\Factory\ValueCollectionFactoryInterface;
+use Pim\Component\Catalog\FamilyVariant\EntityWithFamilyVariantAttributesProvider;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\EntityWithFamilyVariantInterface;
+use Pim\Component\Catalog\Model\FamilyVariantInterface;
+use Pim\Component\Catalog\Model\ValueCollectionInterface;
+use Pim\Component\Catalog\Model\ValueInterface;
+use Pim\Component\Catalog\Model\VariantProductInterface;
+use Pim\Component\Catalog\Validator\Constraints\ImmutableVariantAxesValues;
+use Pim\Component\Catalog\Validator\Constraints\ImmutableVariantAxesValuesValidator;
+use Pim\Component\Catalog\Validator\Constraints\VariantProductParent;
+use Prophecy\Argument;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
+
+class ImmutableVariantAxesValuesValidatorSpec extends ObjectBehavior
+{
+    function let(
+        EntityManagerInterface $entityManager,
+        EntityWithFamilyVariantAttributesProvider $attributesProvider,
+        ValueCollectionFactoryInterface $valueCollectionFactory,
+        ExecutionContextInterface $context
+    ) {
+        $this->beConstructedWith($entityManager, $attributesProvider, $valueCollectionFactory);
+
+        $this->initialize($context);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(ImmutableVariantAxesValuesValidator::class);
+    }
+
+    function it_is_a_constraint_validator()
+    {
+        $this->shouldBeAnInstanceOf(ConstraintValidator::class);
+    }
+
+    function it_throws_an_exception_if_it_does_not_validate_an_entity_with_variant(
+        UserInterface $entity,
+        ImmutableVariantAxesValues $constraint
+    ) {
+        $this->shouldThrow(UnexpectedTypeException::class)->during('validate', [
+            $entity,
+            $constraint
+        ]);
+    }
+
+    function it_throws_an_exception_if_it_does_not_validate_against_the_correct_constraint(
+        EntityWithFamilyVariantInterface $entity,
+        VariantProductParent $constraint
+    ) {
+        $this->shouldThrow(UnexpectedTypeException::class)->during('validate', [
+            $entity,
+            $constraint
+        ]);
+    }
+
+    function it_does_not_build_a_violation_if_the_entity_has_no_id(
+        $context,
+        VariantProductInterface $variantProduct,
+        ImmutableVariantAxesValues $constraint
+    ) {
+        $variantProduct->getId()->willReturn(null);
+        $context->buildViolation(Argument::cetera())->shouldNotBeCalled();
+
+        $this->validate($variantProduct, $constraint);
+    }
+
+    function it_does_not_build_a_violation_if_the_entity_has_no_familyVariant(
+        $context,
+        VariantProductInterface $variantProduct,
+        ImmutableVariantAxesValues $constraint
+    ) {
+        $variantProduct->getId()->willReturn(42);
+        $variantProduct->getFamilyVariant()->willReturn(null);
+        $context->buildViolation(Argument::cetera())->shouldNotBeCalled();
+
+        $this->validate($variantProduct, $constraint);
+    }
+
+    function it_adds_a_violation_if_the_variant_axis_values_are_updated(
+        $context,
+        $entityManager,
+        $attributesProvider,
+        $valueCollectionFactory,
+        VariantProductInterface $variantProduct,
+        ImmutableVariantAxesValues $constraint,
+        FamilyVariantInterface $familyVariant,
+        AttributeInterface $sizeAttribute,
+        AttributeInterface $colorAttribute,
+        UnitOfWork $uow,
+        ValueCollectionInterface $originalValues,
+        ValueInterface $originalSizeValue,
+        ValueInterface $originalColorValue,
+        ValueInterface $newSizeValue,
+        ValueInterface $newColorValue,
+        ConstraintViolationBuilderInterface $constraintViolationBuilder
+    ) {
+        $originalRawData = [
+            'size' => [
+                '<all_channels>' => [
+                    '<all_locales>' => 'xl',
+                ],
+            ],
+            'color' => [
+                '<all_channels>' => [
+                    '<all_locales>' => 'red',
+                ],
+            ],
+        ];
+
+        $variantProduct->getId()->willReturn(42);
+        $variantProduct->getFamilyVariant()->willReturn($familyVariant);
+
+        $attributesProvider->getAxes($variantProduct)->willReturn([$sizeAttribute, $colorAttribute]);
+        $sizeAttribute->getCode()->willReturn('size');
+        $colorAttribute->getCode()->willReturn('color');
+
+        $entityManager->getUnitOfWork()->willReturn($uow);
+        $uow->getOriginalEntityData($variantProduct)->willReturn(['rawValues' => $originalRawData]);
+        $valueCollectionFactory->createFromStorageFormat($originalRawData)->willReturn($originalValues);
+
+        $originalValues->getByCodes('size')->willReturn($originalSizeValue);
+        $originalValues->getByCodes('color')->willReturn($originalColorValue);
+        $variantProduct->getValue('size')->willReturn($newSizeValue);
+        $variantProduct->getValue('color')->willReturn($newColorValue);
+
+        $newSizeValue->__toString()->willReturn('[m]');
+        $newColorValue->__toString()->willReturn('[blue]');
+
+        $originalSizeValue->isEqual($newSizeValue)->willReturn(false);
+        $originalColorValue->isEqual($newColorValue)->willReturn(false);
+
+        $context->buildViolation(ImmutableVariantAxesValues::UPDATED_VARIANT_AXIS_VALUE, [
+            '%variant_axis%' => 'size',
+            '%provided_value%' => '[m]',
+        ])->willReturn($constraintViolationBuilder);
+        $context->buildViolation(ImmutableVariantAxesValues::UPDATED_VARIANT_AXIS_VALUE, [
+            '%variant_axis%' => 'color',
+            '%provided_value%' => '[blue]',
+        ])->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->addViolation()->shouldBeCalledTimes(2);
+
+        $this->validate($variantProduct, $constraint);
+    }
+}


### PR DESCRIPTION
## Description

This PRs adds a new set of business rules specific on variant product update.
- **first commit**: a variant product cannot loose its parent
- **second commit**: the values of the variant axes of a variant products are immutable, like for the product model.

This second commit introduces a dedicated validator that can work both on variant product and product models. To avoid duplication, it is applied on both, and previous validation on product model, that was done in the product model updater, has been removed.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added Behats                      | OK
| Added integration tests           | OK
| Changelog updated                 | -
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
