### PR TITLE
PIM-6743: Prevent a regular product to become a variant one

### DIFF
--- a/features/import/variant_product/import_business_rules.feature
+++ b/features/import/variant_product/import_business_rules.feature
@@ -86,3 +86,26 @@ Feature: Import variant products
       apollon_blue;clothing;master_men;12345;apollon_blue_medium;100;GRAM;
       apollon_blue;clothing;master_men;67890;apollon_blue_large;100;GRAM;
       """
+
+  Scenario: Successfully skip a non variant product when we try to set a parent
+    Given the following product:
+      | sku             |
+      | regular_product |
+    And the following CSV file to import:
+      """
+      parent;family;categories;ean;sku;weight;weight-unit;size
+      apollon_blue;clothing;master_men;EAN;regular_product;100;GRAM;m
+      """
+    And the following job "csv_default_product_import" configuration:
+      | filePath | %file to import% |
+    When I am on the "csv_default_product_import" import job page
+    And I launch the import job
+    And I wait for the "csv_default_product_import" job to finish
+    Then I should see the text "Status: Completed"
+    And I should see the text "skipped 1"
+    And I should see the text "Product \"regular_product\" cannot have a parent as it is not a variant product."
+    And the invalid data file of "csv_default_product_import" should contain:
+      """
+      parent;family;categories;ean;sku;weight;weight-unit;size
+      apollon_blue;clothing;master_men;EAN;regular_product;100;GRAM;m
+      """

--- a/features/import/variant_product/import_business_rules.feature
+++ b/features/import/variant_product/import_business_rules.feature
@@ -64,11 +64,12 @@ Feature: Import variant products
       apollon;clothing;master_men;EAN;apollon_blue_medium;100;GRAM;m
       """
 
-  Scenario: Successfully skip a variant product if there is no value for the variant axes defined in the family variant for the last level
+  Scenario: Successfully skip variant products if there are no values for their variant axes as defined in the family variant
     Given the following CSV file to import:
       """
       parent;family;categories;ean;sku;weight;weight-unit;size
-      apollon_blue;clothing;master_men;EAN;apollon_blue_medium;100;GRAM;
+      apollon_blue;clothing;master_men;12345;apollon_blue_medium;100;GRAM;
+      apollon_blue;clothing;master_men;67890;apollon_blue_large;100;GRAM;
       """
     And the following job "csv_default_product_import" configuration:
       | filePath | %file to import% |
@@ -76,10 +77,12 @@ Feature: Import variant products
     And I launch the import job
     And I wait for the "csv_default_product_import" job to finish
     Then I should see the text "Status: Completed"
-    And I should see the text "skipped 1"
-    And I should see the text "Attribute \"size\" cannot be empty, as it is defined as an axis for this entity: apollon_blue_medium"
+    And I should see the text "skipped 2"
+    And I should not see the text "Cannot set value \"\" for the attribute axis \"size\""
+    But I should see the text "Attribute \"size\" cannot be empty, as it is defined as an axis for this entity: apollon_blue_medium"
     And the invalid data file of "csv_default_product_import" should contain:
       """
       parent;family;categories;ean;sku;weight;weight-unit;size
-      apollon_blue;clothing;master_men;EAN;apollon_blue_medium;100;GRAM;
+      apollon_blue;clothing;master_men;12345;apollon_blue_medium;100;GRAM;
+      apollon_blue;clothing;master_men;67890;apollon_blue_large;100;GRAM;
       """

--- a/features/import/variant_product/import_business_rules.feature
+++ b/features/import/variant_product/import_business_rules.feature
@@ -57,7 +57,7 @@ Feature: Import variant products
     And I wait for the "csv_default_product_import" job to finish
     Then I should see the text "Status: Completed"
     And I should see the text "skipped 1"
-    And I should see the text "Parent of the variant product \"apollon_blue_medium\" cannot have product models as children, only variant products"
+    And I should see the text "The variant product \"apollon_blue_medium\" cannot have product model \"apollon\" as parent, (this product model can only have other product models as children)"
     And the invalid data file of "csv_default_product_import" should contain:
       """
       parent;family;categories;ean;sku;weight;weight-unit;size

--- a/products.csv
+++ b/products.csv
@@ -1,3 +1,0 @@
-sku;color;size;eu_shoes_size;material;family;parent;categories;enabled;name-en_US;weight;weight-unit;ean
-1111111111;blue;xxl;;;clothing;amor;master_men_blazers,supplier_zaro;1;;800;GRAM;1234567890123
-1111111112;blue;xl;;;clothing;amor;master_men_blazers,supplier_zaro;1;;800;GRAM;1234567890124

--- a/products.csv
+++ b/products.csv
@@ -1,0 +1,3 @@
+sku;color;size;eu_shoes_size;material;family;parent;categories;enabled;name-en_US;weight;weight-unit;ean
+1111111111;blue;xxl;;;clothing;amor;master_men_blazers,supplier_zaro;1;;800;GRAM;1234567890123
+1111111112;blue;xl;;;clothing;amor;master_men_blazers,supplier_zaro;1;;800;GRAM;1234567890124

--- a/src/Akeneo/Component/StorageUtils/Exception/InvalidPropertyException.php
+++ b/src/Akeneo/Component/StorageUtils/Exception/InvalidPropertyException.php
@@ -52,6 +52,22 @@ class InvalidPropertyException extends PropertyException
     }
 
     /**
+     * @param string $message
+     * @param string $className
+     *
+     * @return InvalidPropertyException
+     */
+    public static function expected($message, $className)
+    {
+        return new static(
+            null,
+            null,
+            $className,
+            $message
+        );
+    }
+
+    /**
      * Build an exception when the data is empty and should not.
      *
      * @param string $propertyName

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/EntityWithFamilyVariantRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/EntityWithFamilyVariantRepository.php
@@ -5,7 +5,7 @@ namespace Pim\Bundle\CatalogBundle\Doctrine\ORM\Repository;
 use Pim\Component\Catalog\Model\EntityWithFamilyVariantInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Model\ProductModelInterface;
-use Pim\Component\Catalog\Repository\EntityWithVariantFamilyRepositoryInterface;
+use Pim\Component\Catalog\Repository\EntityWithFamilyVariantRepositoryInterface;
 use Pim\Component\Catalog\Repository\ProductModelRepositoryInterface;
 
 /**
@@ -13,7 +13,7 @@ use Pim\Component\Catalog\Repository\ProductModelRepositoryInterface;
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
-class EntityWithVariantFamilyRepository implements EntityWithVariantFamilyRepositoryInterface
+class EntityWithFamilyVariantRepository implements EntityWithFamilyVariantRepositoryInterface
 {
     /** @var ProductModelRepositoryInterface */
     protected $productModelRepository;

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/model/doctrine/FamilyVariant.orm.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/model/doctrine/FamilyVariant.orm.yml
@@ -26,7 +26,7 @@ Pim\Component\Catalog\Model\FamilyVariant:
         variantAttributeSets:
             targetEntity: Pim\Component\Catalog\Model\VariantAttributeSetInterface
             joinTable:
-                name: pim_catalog_variant_family_has_variant_attribute_sets
+                name: pim_catalog_family_variant_has_variant_attribute_sets
                 joinColumns:
                     family_variant_id:
                         referencedColumnName: id

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/repositories.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/repositories.yml
@@ -20,7 +20,7 @@ parameters:
     pim_catalog.repository.completeness.class:          Pim\Bundle\CatalogBundle\Doctrine\ORM\Repository\CompletenessRepository
     pim_catalog.repository.product_mass_action.class:   Pim\Bundle\CatalogBundle\Doctrine\ORM\Repository\ProductMassActionRepository
     pim_catalog.repository.product_category.class:      Pim\Bundle\CatalogBundle\Doctrine\ORM\Repository\ProductCategoryRepository
-    pim_catalog.repository.entity_with_variant_family.class: Pim\Bundle\CatalogBundle\Doctrine\ORM\Repository\EntityWithVariantFamilyRepository
+    pim_catalog.repository.entity_with_family_variant.class: Pim\Bundle\CatalogBundle\Doctrine\ORM\Repository\EntityWithFamilyVariantRepository
 
 services:
     # Base repositories
@@ -210,7 +210,7 @@ services:
             - '@doctrine.orm.entity_manager'
             - '%pim_catalog.entity.abstract_product.class%'
 
-    pim_catalog.repository.entity_with_variant_family:
-        class: '%pim_catalog.repository.entity_with_variant_family.class%'
+    pim_catalog.repository.entity_with_family_variant:
+        class: '%pim_catalog.repository.entity_with_family_variant.class%'
         arguments:
             - '@pim_catalog.repository.product_model'

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/validators.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/validators.yml
@@ -98,7 +98,7 @@ services:
         class: '%pim_catalog.validator.constraint.sibling_unique_variant_axes.class%'
         arguments:
             - '@pim_catalog.family_variant.provider.entity_with_family_variant_attributes'
-            - '@pim_catalog.repository.entity_with_variant_family'
+            - '@pim_catalog.repository.entity_with_family_variant'
             - '@pim_catalog.validator.unique_axes_combination_set'
         tags:
             - { name: validator.constraint_validator, alias: pim_sibling_unique_variant_axes_validator }

--- a/src/Pim/Bundle/CatalogBundle/Resources/translations/validators.en.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/translations/validators.en.yml
@@ -41,5 +41,5 @@ pim_catalog:
         attribute_does_not_belong_to_family: 'Attribute "%attribute%" does not belong to the family "%family%"'
         variant_product_invalid_family: 'The variant product family must be the same than its parent'
         variant_product_has_parent: 'The variant product "%variant_product%" must have a parent'
-        invalid_variant_product_parent: 'Parent of the variant product "%variant_product%" cannot have product models as children, only variant products'
+        invalid_variant_product_parent: 'The variant product "%variant_product%" cannot have product model "%product_model%" as parent, (this product model can only have other product models as children)'
         modified_variant_axis_value: 'Variant axis "%variant_axis%" cannot be modified, "%provided_value%" given'

--- a/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Indexer/ProductModelDescendantsIndexerSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Indexer/ProductModelDescendantsIndexerSpec.php
@@ -41,7 +41,7 @@ class ProductModelDescendantsIndexerSpec extends ObjectBehavior
         $this->shouldImplement(BulkRemoverInterface::class);
     }
 
-    function it_indexes_a_product_model_descendants_that_are_product_variants(
+    function it_indexes_a_product_model_descendants_that_are_variant_products(
         $productIndexer,
         $productModelIndexer,
         ProductModelInterface $productModel,
@@ -63,13 +63,13 @@ class ProductModelDescendantsIndexerSpec extends ObjectBehavior
         $this->index($productModel);
     }
 
-    function it_indexes_a_product_model_descendants_that_are_product_models_and_product_variants(
+    function it_indexes_a_product_model_descendants_that_are_product_models_and_variant_products(
         $productIndexer,
         $productModelIndexer,
         ProductModelInterface $rootProductModel,
         ProductModelInterface $childProductModel,
-        VariantProductInterface $childProductVariant1,
-        VariantProductInterface $childProductVariant2,
+        VariantProductInterface $childVariantProduct1,
+        VariantProductInterface $childVariantProduct2,
         ArrayCollection $emptyProductsChildren,
         ArrayCollection $rootProductModelChildren,
         ArrayCollection $emptyChildProductModelChildren,
@@ -110,10 +110,10 @@ class ProductModelDescendantsIndexerSpec extends ObjectBehavior
 
         // Second recursion - second round - index product variants
         $productVariantsChildren->isEmpty()->willReturn(false);
-        $productVariantsChildren->first()->willReturn($childProductVariant1);
-        $productVariantsChildren->toArray()->willReturn([$childProductVariant1, $childProductVariant2]);
+        $productVariantsChildren->first()->willReturn($childVariantProduct1);
+        $productVariantsChildren->toArray()->willReturn([$childVariantProduct1, $childVariantProduct2]);
 
-        $productIndexer->indexAll([$childProductVariant1, $childProductVariant2])->shouldBeCalled();
+        $productIndexer->indexAll([$childVariantProduct1, $childVariantProduct2])->shouldBeCalled();
 
         $this->index($rootProductModel);
     }
@@ -189,7 +189,7 @@ class ProductModelDescendantsIndexerSpec extends ObjectBehavior
         $this->indexAll([]);
     }
 
-    function it_removes_the_descendants_of_a_product_model_that_are_product_variants(
+    function it_removes_the_descendants_of_a_product_model_that_are_variant_products(
         $productRemover,
         $productModelRemover,
         ProductModelInterface $productModel,
@@ -211,13 +211,13 @@ class ProductModelDescendantsIndexerSpec extends ObjectBehavior
         $this->remove($productModel);
     }
 
-    function it_removes_a_product_model_descendants_that_are_product_models_and_product_variants(
+    function it_removes_a_product_model_descendants_that_are_product_models_and_variant_products(
         $productRemover,
         $productModelRemover,
         ProductModelInterface $rootProductModel,
         ProductModelInterface $childProductModel,
-        VariantProductInterface $childProductVariant1,
-        VariantProductInterface $childProductVariant2,
+        VariantProductInterface $childVariantProduct1,
+        VariantProductInterface $childVariantProduct2,
         ArrayCollection $emptyProductsChildren,
         ArrayCollection $rootProductModelChildren,
         ArrayCollection $emptyChildProductModelChildren,
@@ -258,10 +258,10 @@ class ProductModelDescendantsIndexerSpec extends ObjectBehavior
 
         // Second recursion - second round - index product variants
         $productVariantsChildren->isEmpty()->willReturn(false);
-        $productVariantsChildren->first()->willReturn($childProductVariant1);
-        $productVariantsChildren->toArray()->willReturn([$childProductVariant1, $childProductVariant2]);
+        $productVariantsChildren->first()->willReturn($childVariantProduct1);
+        $productVariantsChildren->toArray()->willReturn([$childVariantProduct1, $childVariantProduct2]);
 
-        $productRemover->removeAll([$childProductVariant1, $childProductVariant2])->shouldBeCalled();
+        $productRemover->removeAll([$childVariantProduct1, $childVariantProduct2])->shouldBeCalled();
 
         $this->remove($rootProductModel);
     }

--- a/src/Pim/Bundle/CatalogBundle/tests/helper/EntityBuilder.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/helper/EntityBuilder.php
@@ -8,7 +8,7 @@ use Pim\Component\Catalog\Model\VariantProductInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Helper to create some catalog entities, such as ProductVariant and ProductModel
+ * Helper to create some catalog entities, such as VariantProduct and ProductModel
  *
  * @author    Adrien Pétremann <adrien.petremann@akeneo.com>
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Doctrine/Common/Saver/IndexingProductModelDescendantsIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Doctrine/Common/Saver/IndexingProductModelDescendantsIntegration.php
@@ -57,10 +57,10 @@ class IndexingProductModelDescendantsIntegration extends TestCase
                 'seed_root_product_model',
                 'seed_sub_product_model_1',
                 'seed_sub_product_model_2',
-                'seed_product_variant_1',
-                'seed_product_variant_2',
-                'seed_product_variant_3',
-                'seed_product_variant_4',
+                'seed_variant_product_1',
+                'seed_variant_product_2',
+                'seed_variant_product_3',
+                'seed_variant_product_4',
             ],
             [
                 '_source' => 'identifier',
@@ -114,10 +114,10 @@ class IndexingProductModelDescendantsIntegration extends TestCase
                 'seed1_root_product_model',
                 'seed1_sub_product_model_1',
                 'seed1_sub_product_model_2',
-                'seed1_product_variant_1',
-                'seed1_product_variant_2',
-                'seed1_product_variant_3',
-                'seed1_product_variant_4',
+                'seed1_variant_product_1',
+                'seed1_variant_product_2',
+                'seed1_variant_product_3',
+                'seed1_variant_product_4',
             ],
             [
                 '_source' => 'identifier',
@@ -179,10 +179,10 @@ class IndexingProductModelDescendantsIntegration extends TestCase
         $subProductModel1 = $entityBuilder->createProductModel($seed . '_sub_product_model_1', 'familyVariantA1', $rootProductModel, []);
         $subProductModel2 = $entityBuilder->createProductModel($seed . '_sub_product_model_2', 'familyVariantA1', $rootProductModel, []);
 
-        $variantProduct1 = $entityBuilder->createVariantProduct($seed . '_product_variant_1', 'familyA', 'familyVariantA1', $subProductModel1, []);
-        $variantProduct2 = $entityBuilder->createVariantProduct($seed . '_product_variant_2', 'familyA', 'familyVariantA1', $subProductModel1, []);
-        $variantProduct3 = $entityBuilder->createVariantProduct($seed . '_product_variant_3', 'familyA', 'familyVariantA1', $subProductModel2, []);
-        $variantProduct4 = $entityBuilder->createVariantProduct($seed . '_product_variant_4', 'familyA', 'familyVariantA1', $subProductModel2, []);
+        $variantProduct1 = $entityBuilder->createVariantProduct($seed . '_variant_product_1', 'familyA', 'familyVariantA1', $subProductModel1, []);
+        $variantProduct2 = $entityBuilder->createVariantProduct($seed . '_variant_product_2', 'familyA', 'familyVariantA1', $subProductModel1, []);
+        $variantProduct3 = $entityBuilder->createVariantProduct($seed . '_variant_product_3', 'familyA', 'familyVariantA1', $subProductModel2, []);
+        $variantProduct4 = $entityBuilder->createVariantProduct($seed . '_variant_product_4', 'familyA', 'familyVariantA1', $subProductModel2, []);
 
         $this->get('pim_catalog.saver.product_model')->save($rootProductModel);
         $this->get('pim_catalog.saver.product_model')->saveAll([$subProductModel1, $subProductModel2]);

--- a/src/Pim/Component/Catalog/Repository/EntityWithFamilyVariantRepositoryInterface.php
+++ b/src/Pim/Component/Catalog/Repository/EntityWithFamilyVariantRepositoryInterface.php
@@ -9,7 +9,7 @@ use Pim\Component\Catalog\Model\EntityWithFamilyVariantInterface;
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-interface EntityWithVariantFamilyRepositoryInterface
+interface EntityWithFamilyVariantRepositoryInterface
 {
     /**
      * Find entities with the same parent than the given $entity.

--- a/src/Pim/Component/Catalog/Updater/ProductUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/ProductUpdater.php
@@ -142,7 +142,7 @@ class ProductUpdater implements ObjectUpdaterInterface
                 throw UnknownPropertyException::unknownProperty($code);
             }
         }
-        $this->updateProductVariantValues($product, $data);
+        $this->updateVariantProductValues($product, $data);
 
         return $this;
     }
@@ -166,7 +166,7 @@ class ProductUpdater implements ObjectUpdaterInterface
      * @param ProductInterface $product
      * @param array            $data
      */
-    protected function updateProductVariantValues(ProductInterface $product, array $data)
+    protected function updateVariantProductValues(ProductInterface $product, array $data)
     {
         $variantGroup = $product->getVariantGroup();
         $shouldEraseData = false;

--- a/src/Pim/Component/Catalog/Updater/Setter/ParentFieldSetter.php
+++ b/src/Pim/Component/Catalog/Updater/Setter/ParentFieldSetter.php
@@ -8,6 +8,7 @@ use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Doctrine\Common\Util\ClassUtils;
+use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Model\VariantProductInterface;
 
 /**
@@ -36,16 +37,26 @@ class ParentFieldSetter extends AbstractFieldSetter
      */
     public function setFieldData($product, $field, $data, array $options = []): void
     {
-        if (!$product instanceof VariantProductInterface) {
+
+        // TODO: To test against "VariantProductInterface" instead of "ProductInterface" in PIM-6791.
+        if (!$product instanceof ProductInterface) {
             throw InvalidObjectException::objectExpected(
                 ClassUtils::getClass($product),
                 VariantProductInterface::class
             );
         }
 
+        // TODO: This is to be removed in PIM-6791.
+        if (!$product instanceof VariantProductInterface) {
+            throw InvalidPropertyException::expected(
+                sprintf('Product "%s" cannot have a parent as it is not a variant product.', $product->getIdentifier()),
+                static::class
+            );
+        }
+
         // TODO: This is to be removed in PIM-6350.
         if (null !== $product->getParent() && $data !== $product->getParent()->getCode()) {
-            throw ImmutablePropertyException::immutableProperty('parent', $data, static::class);
+            throw ImmutablePropertyException::immutableProperty($field, $data, static::class);
         }
 
         if (null === $parent = $this->productModelRepository->findOneByIdentifier($data)) {

--- a/src/Pim/Component/Catalog/Validator/Constraints/SiblingUniqueVariantAxesValidator.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/SiblingUniqueVariantAxesValidator.php
@@ -3,9 +3,9 @@
 namespace Pim\Component\Catalog\Validator\Constraints;
 
 use Pim\Component\Catalog\FamilyVariant\EntityWithFamilyVariantAttributesProvider;
+use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\EntityWithFamilyVariantInterface;
-use Pim\Component\Catalog\Model\EntityWithValuesInterface;
-use Pim\Component\Catalog\Repository\EntityWithVariantFamilyRepositoryInterface;
+use Pim\Component\Catalog\Repository\EntityWithFamilyVariantRepositoryInterface;
 use Pim\Component\Catalog\Validator\UniqueAxesCombinationSet;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
@@ -23,7 +23,7 @@ class SiblingUniqueVariantAxesValidator extends ConstraintValidator
     /** @var EntityWithFamilyVariantAttributesProvider */
     private $axesProvider;
 
-    /** @var EntityWithVariantFamilyRepositoryInterface */
+    /** @var EntityWithFamilyVariantRepositoryInterface */
     private $repository;
 
     /** @var UniqueAxesCombinationSet */
@@ -31,12 +31,12 @@ class SiblingUniqueVariantAxesValidator extends ConstraintValidator
 
     /**
      * @param EntityWithFamilyVariantAttributesProvider  $axesProvider
-     * @param EntityWithVariantFamilyRepositoryInterface $repository
+     * @param EntityWithFamilyVariantRepositoryInterface $repository
      * @param UniqueAxesCombinationSet                   $uniqueAxesCombinationSet
      */
     public function __construct(
         EntityWithFamilyVariantAttributesProvider $axesProvider,
-        EntityWithVariantFamilyRepositoryInterface $repository,
+        EntityWithFamilyVariantRepositoryInterface $repository,
         UniqueAxesCombinationSet $uniqueAxesCombinationSet
     ) {
         $this->axesProvider = $axesProvider;
@@ -88,12 +88,12 @@ class SiblingUniqueVariantAxesValidator extends ConstraintValidator
      *
      * This allows use to compare multiple combinations, to look for a potential duplicate.
      *
-     * @param EntityWithValuesInterface $entityWithValues
-     * @param array                     $axes
+     * @param EntityWithFamilyVariantInterface $entityWithValues
+     * @param AttributeInterface[]             $axes
      *
      * @return string
      */
-    private function buildAxesCombination(EntityWithValuesInterface $entityWithValues, array $axes): string
+    private function buildAxesCombination(EntityWithFamilyVariantInterface $entityWithValues, array $axes): string
     {
         $combination = [];
 
@@ -114,7 +114,7 @@ class SiblingUniqueVariantAxesValidator extends ConstraintValidator
     /**
      * This method returns TRUE if there is a duplicate value in siblings of $entity in database, FALSE otherwise
      *
-     * @param $entity
+     * @param EntityWithFamilyVariantInterface $entity
      *
      * @return bool
      */

--- a/src/Pim/Component/Catalog/Validator/Constraints/VariantProductParentValidator.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/VariantProductParentValidator.php
@@ -45,6 +45,7 @@ class VariantProductParentValidator extends ConstraintValidator
         if (!$parent->getProductModels()->isEmpty()) {
             $this->context->buildViolation(VariantProductParent::INVALID_PARENT, [
                 '%variant_product%' => $variantProduct->getIdentifier(),
+                '%product_model%' => $parent->getCode(),
             ])->addViolation();
         }
     }

--- a/src/Pim/Component/Catalog/spec/Model/FamilyVariantSpec.php
+++ b/src/Pim/Component/Catalog/spec/Model/FamilyVariantSpec.php
@@ -21,7 +21,7 @@ class FamilyVariantSpec extends ObjectBehavior
         $this->shouldHaveType(FamilyVariant::class);
     }
 
-    function it_is_a_variant_family()
+    function it_is_a_family_variant()
     {
         $this->shouldImplement(FamilyVariantInterface::class);
     }

--- a/src/Pim/Component/Catalog/spec/Model/VariantAttributeSetSpec.php
+++ b/src/Pim/Component/Catalog/spec/Model/VariantAttributeSetSpec.php
@@ -13,7 +13,7 @@ class VariantAttributeSetSpec extends ObjectBehavior
         $this->shouldHaveType(VariantAttributeSet::class);
     }
 
-    function it_is_a_variant_family()
+    function it_is_a_family_variant()
     {
         $this->shouldImplement(VariantAttributeSetInterface::class);
     }

--- a/src/Pim/Component/Catalog/spec/Updater/Setter/ParentFieldSetterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Setter/ParentFieldSetterSpec.php
@@ -8,6 +8,7 @@ use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Pim\Component\Catalog\Model\FamilyInterface;
 use Pim\Component\Catalog\Model\FamilyVariantInterface;
+use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Model\ProductModelInterface;
 use Pim\Component\Catalog\Model\VariantProductInterface;
 use Pim\Component\Catalog\Updater\Setter\FieldSetterInterface;
@@ -106,6 +107,14 @@ class ParentFieldSetterSpec extends ObjectBehavior
         $this->shouldThrow(ImmutablePropertyException::class)->during(
             'setFieldData',
             [$variantProduct, 'parent', 'new_parent_code']
+        );
+    }
+
+    function it_throws_exception_if_a_parent_is_set_to_a_regular_product(ProductInterface $product)
+    {
+        $this->shouldThrow(InvalidPropertyException::class)->during(
+            'setFieldData',
+            [$product, 'parent', Argument::any()]
         );
     }
 }

--- a/src/Pim/Component/Catalog/spec/Validator/Constraints/SiblingUniqueVariantAxesValidatorSpec.php
+++ b/src/Pim/Component/Catalog/spec/Validator/Constraints/SiblingUniqueVariantAxesValidatorSpec.php
@@ -3,7 +3,7 @@
 namespace spec\Pim\Component\Catalog\Validator\Constraints;
 
 use PhpSpec\ObjectBehavior;
-use Pim\Bundle\CatalogBundle\Doctrine\ORM\Repository\EntityWithVariantFamilyRepository;
+use Pim\Bundle\CatalogBundle\Doctrine\ORM\Repository\EntityWithFamilyVariantRepository;
 use Pim\Component\Catalog\FamilyVariant\EntityWithFamilyVariantAttributesProvider;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\EntityWithFamilyVariantInterface;
@@ -22,7 +22,7 @@ class SiblingUniqueVariantAxesValidatorSpec extends ObjectBehavior
 {
     function let(
         EntityWithFamilyVariantAttributesProvider $axesProvider,
-        EntityWithVariantFamilyRepository $repository,
+        EntityWithFamilyVariantRepository $repository,
         UniqueAxesCombinationSet $uniqueAxesCombinationSet,
         ExecutionContextInterface $context
     ) {

--- a/src/Pim/Component/Catalog/spec/Validator/Constraints/VariantProductParentValidatorSpec.php
+++ b/src/Pim/Component/Catalog/spec/Validator/Constraints/VariantProductParentValidatorSpec.php
@@ -93,9 +93,11 @@ class VariantProductParentValidatorSpec extends ObjectBehavior
 
         $productModel->getProductModels()->willReturn($productModels);
         $productModels->isEmpty()->willReturn(false);
+        $productModel->getCode()->willReturn('product_model');
 
         $context->buildViolation(VariantProductParent::INVALID_PARENT, [
             '%variant_product%' => 'variant_product',
+            '%product_model%' => 'product_model',
         ])->willReturn($constraintViolationBuilder);
         $constraintViolationBuilder->addViolation()->shouldBeCalled();
 

--- a/src/Pim/Component/Connector/spec/Processor/Denormalization/AttributeFilter/ProductModelAttributeFilterSpec.php
+++ b/src/Pim/Component/Connector/spec/Processor/Denormalization/AttributeFilter/ProductModelAttributeFilterSpec.php
@@ -92,7 +92,7 @@ class ProductModelAttributeFilterSpec extends ObjectBehavior
         ]);
     }
 
-    function it_skips_the_filtration_if_the_variant_family_is_invalid()
+    function it_skips_the_filtration_if_the_family_variant_is_invalid()
     {
         $this->filter([
             'code' => 'code',


### PR DESCRIPTION
## Description

Before this PR, it was already not possible to set a parent to a regular product, but an `InvalidObjectException` was thrown, which is not caught by our import/export stack. So such an attempt to transform a regular product into a variant one resulted in the failure of the import.

We now throw an `InvalidPropertyException`, which allows us to skip the product without the import failing. 

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added Behats                      | OK
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
