### PR TITLE
PIM-6792: Issue on Filter when using Underscore

### DIFF
--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -1,3 +1,9 @@
+# 1.5.x
+
+## Bug fixes
+
+- PIM-6792: Issue on Filter when using Underscore
+
 # 1.5.26 (2017-08-03)
 
 # 1.5.25 (2017-06-30)

--- a/features/filter/identifier.feature
+++ b/features/filter/identifier.feature
@@ -13,12 +13,25 @@ Feature: Filter on identifier
       | BOOTBL  |
       | MUGRXS  |
     Then I should get the following results for the given filters:
-      | filter                                                                                   | result                                    |
-      | [{"field":"sku", "operator":"STARTS WITH",      "value": "BOOT"   }] | ["BOOTBXS", "BOOTWXS", "BOOTBS", "BOOTBL"] |
-      | [{"field":"sku", "operator":"STARTS WITH",      "value": "boot"   }] | ["BOOTBXS", "BOOTWXS", "BOOTBS", "BOOTBL"] |
-      | [{"field":"sku", "operator":"ENDS WITH",        "value": "xs"     }] | ["BOOTBXS", "BOOTWXS", "MUGRXS"]                     |
-      | [{"field":"sku", "operator":"CONTAINS",         "value": "TB"     }] | ["BOOTBXS", "BOOTBS", "BOOTBL"]            |
-      | [{"field":"sku", "operator":"DOES NOT CONTAIN", "value": "Boot"   }] | ["MUGRXS"]                                 |
-      | [{"field":"sku", "operator":"=",                "value": "BOOTWXS"}] | ["BOOTWXS"]                                |
-      | [{"field":"sku", "operator":"=",                "value": "MUGRXS "}] | []                                         |
-      | [{"field":"sku", "operator":"IN", "value": ["BOOTBL", "MUGRXS"]}, {"field":"sku", "operator":"DOES NOT CONTAIN", "value": "BOOT"}] | ["MUGRXS"] |
+      | filter                                                                                                                             | result                                     |
+      | [{"field":"sku", "operator":"STARTS WITH",      "value": "BOOT"   }]                                                               | ["BOOTBXS", "BOOTWXS", "BOOTBS", "BOOTBL"] |
+      | [{"field":"sku", "operator":"STARTS WITH",      "value": "boot"   }]                                                               | ["BOOTBXS", "BOOTWXS", "BOOTBS", "BOOTBL"] |
+      | [{"field":"sku", "operator":"ENDS WITH",        "value": "xs"     }]                                                               | ["BOOTBXS", "BOOTWXS", "MUGRXS"]           |
+      | [{"field":"sku", "operator":"CONTAINS",         "value": "TB"     }]                                                               | ["BOOTBXS", "BOOTBS", "BOOTBL"]            |
+      | [{"field":"sku", "operator":"DOES NOT CONTAIN", "value": "Boot"   }]                                                               | ["MUGRXS"]                                 |
+      | [{"field":"sku", "operator":"=",                "value": "BOOTWXS"}]                                                               | ["BOOTWXS"]                                |
+      | [{"field":"sku", "operator":"=",                "value": "MUGRXS "}]                                                               | []                                         |
+      | [{"field":"sku", "operator":"IN", "value": ["BOOTBL", "MUGRXS"]}, {"field":"sku", "operator":"DOES NOT CONTAIN", "value": "BOOT"}] | ["MUGRXS"]                                 |
+
+  Scenario: Filter indentifier with special character
+    Given a "footwear" catalog configuration
+    And the following products:
+      | sku        |
+      | BOOT_BOOT1 |
+      | BOOT%BOOT2 |
+    Then I should get the following results for the given filters:
+      | filter                                                                            | result         |
+      | [{"field":"sku", "operator":"DOES NOT CONTAIN", "value": "_", "locale": "en_US"}] | ["BOOT%BOOT2"] |
+      | [{"field":"sku", "operator":"DOES NOT CONTAIN", "value": "%", "locale": "en_US"}] | ["BOOT_BOOT1"] |
+      | [{"field":"sku", "operator":"CONTAINS", "value": "_",         "locale": "en_US"}] | ["BOOT_BOOT1"] |
+      | [{"field":"sku", "operator":"CONTAINS", "value": "%",         "locale": "en_US"}] | ["BOOT%BOOT2"] |

--- a/features/filter/string.feature
+++ b/features/filter/string.feature
@@ -20,5 +20,18 @@ Feature: Filter on string
       | [{"field":"name", "operator":"CONTAINS",         "value": "black",        "locale": "en_US"}] | ["BOOTBXS", "BOOTBS"]            |
       | [{"field":"name", "operator":"DOES NOT CONTAIN", "value": "Boot",         "locale": "en_US"}] | ["BOOTBL"]                       |
       | [{"field":"name", "operator":"=",                "value": "Boot black s", "locale": "en_US"}] | ["BOOTBS"]                       |
-      | [{"field":"name", "operator":"=",                "value": "Mug ",         "locale": "en_US"}] | []                       |
+      | [{"field":"name", "operator":"=",                "value": "Mug ",         "locale": "en_US"}] | []                               |
       | [{"field":"name", "operator":"EMPTY",            "value": null,           "locale": "en_US"}] | ["BOOTRXS"]                      |
+
+  Scenario: Filter string with special character
+    Given a "footwear" catalog configuration
+    And the following products:
+      | sku       | name-en_US |
+      | BOOTBOOT1 | _          |
+      | BOOTBOOT2 | %          |
+    Then I should get the following results for the given filters:
+      | filter                                                                                        | result        |
+      | [{"field":"name", "operator":"DOES NOT CONTAIN", "value": "_", "locale": "en_US"}] | ["BOOTBOOT2"] |
+      | [{"field":"name", "operator":"DOES NOT CONTAIN", "value": "%", "locale": "en_US"}] | ["BOOTBOOT1"] |
+      | [{"field":"name", "operator":"CONTAINS", "value": "_",         "locale": "en_US"}] | ["BOOTBOOT1"] |
+      | [{"field":"name", "operator":"CONTAINS", "value": "%",         "locale": "en_US"}] | ["BOOTBOOT2"] |

--- a/src/Oro/Bundle/FilterBundle/Filter/StringFilter.php
+++ b/src/Oro/Bundle/FilterBundle/Filter/StringFilter.php
@@ -51,6 +51,11 @@ class StringFilter extends AbstractFilter
         }
 
         $data['type']  = isset($data['type']) ? $data['type'] : null;
+
+        if (null !== $data['type'] && $data['type'] !== TextFilterType::TYPE_EQUAL) {
+            $data['value'] = str_replace(['%', '_'], ['\\%', '\\_'], $data['value']);
+        }
+
         $data['value'] = sprintf($this->getFormatByComparisonType($data['type']), $data['value']);
 
         return $data;

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/StringFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Filter/StringFilter.php
@@ -120,26 +120,27 @@ class StringFilter extends AbstractAttributeFilter implements AttributeFilterInt
             $value = '';
         }
 
+        $likeValue = str_replace(['%', '_'], ['\\%', '\\_'], $value);
+
         switch ($operator) {
             case Operators::STARTS_WITH:
                 $operator = 'LIKE';
-                $value    = $value . '%';
+                $value    = $likeValue . '%';
                 break;
             case Operators::ENDS_WITH:
                 $operator = 'LIKE';
-                $value    = '%' . $value;
+                $value    = '%' . $likeValue;
                 break;
             case Operators::CONTAINS:
                 $operator = 'LIKE';
-                $value    = '%' . $value . '%';
+                $value    = '%' . $likeValue . '%';
                 break;
             case Operators::DOES_NOT_CONTAIN:
                 $operator = 'NOT LIKE';
-                $value    = '%' . $value . '%';
+                $value    = '%' . $likeValue . '%';
                 break;
             case Operators::EQUALS:
                 $operator = 'LIKE';
-                $value    = $value;
                 break;
             default:
                 break;


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Using a filter with special char like % or _ does not work because it uses the SQL operator LIKE. To avoid this problem, we need to escape the value gave to the filter.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | yes
| Added integration tests           | no
| Changelog updated                 | yes
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -
