### PR TITLE
PIM-6333: Fix sub product model import

### DIFF
--- a/features/import/product_model/import_business_rules.feature
+++ b/features/import/product_model/import_business_rules.feature
@@ -89,3 +89,43 @@ Feature: Create product models through CSV import
     And I should see the text "skipped product model with parent 1"
     And I should see the text "skipped product model without parent 1"
     And I should see the text "read lines 2"
+
+  Scenario: Successfully create product models without specifying the family variant of the sub product models
+    Given the following CSV file to import:
+      """
+      code;family_variant;parent;name-en_US;collection;description-en_US-ecommerce;erp_name-en_US;price-EUR;supplier;wash_temperature;color;composition;variation_name-en_US;material;size
+      new_hades;clothing_color_size;;Elegant slim long sleeve shirt;autumn_2016;Elegant slim long sleeve shirt white with button-down collar and breast pocket. 65% polyester, 35% cotton. Machine washable.;Hades;700;zaro;600;;;;;
+      new_hades_blue;;new_hades;;;;;;;;blue;;Hades black;;
+      new_hades_red;;new_hades;;;;;;;;red;;Hades red;;
+      """
+    And the following job "csv_catalog_modeling_product_model_import" configuration:
+      | filePath | %file to import% |
+    When I am on the "csv_catalog_modeling_product_model_import" import job page
+    And I launch the import job
+    And I wait for the "csv_catalog_modeling_product_model_import" job to finish
+    Then I should see the text "Status: Completed"
+    And I should see the text "read lines 3"
+    And I should see the text "created 1"
+    And I should see the text "created 2"
+    And I should see the text "skipped product model with parent 2"
+    And I should see the text "skipped product model without parent 1"
+
+  Scenario: Successfully update product models without specifying the family variant of the sub product models
+    Given the following CSV file to import:
+      """
+      code;family_variant;parent;name-en_US;collection;description-en_US-ecommerce;erp_name-en_US;price-EUR;supplier;wash_temperature;color;composition;variation_name-en_US;material;size
+      hades;clothing_color_size;;Elegant slim long sleeve shirt;autumn_2016;Elegant slim long sleeve shirt white with button-down collar and breast pocket. 65% polyester, 35% cotton. Machine washable.;Hades;700;zaro;600;;;;;
+      hades_blue;;hades;;;;;;;;blue;;Hades black;;
+      hades_red;;hades;;;;;;;;red;;Hades red;;
+      """
+    And the following job "csv_catalog_modeling_product_model_import" configuration:
+      | filePath | %file to import% |
+    When I am on the "csv_catalog_modeling_product_model_import" import job page
+    And I launch the import job
+    And I wait for the "csv_catalog_modeling_product_model_import" job to finish
+    Then I should see the text "Status: Completed"
+    And I should see the text "read lines 3"
+    And I should see the text "processed 1"
+    And I should see the text "processed 2"
+    And I should see the text "skipped product model with parent 2"
+    And I should see the text "skipped product model without parent 1"

--- a/src/Pim/Component/Connector/Processor/Denormalization/AttributeFilter/ProductModelAttributeFilter.php
+++ b/src/Pim/Component/Connector/Processor/Denormalization/AttributeFilter/ProductModelAttributeFilter.php
@@ -46,14 +46,14 @@ class ProductModelAttributeFilter implements AttributeFilterInterface
      */
     public function filter(array $flatProductModel): array
     {
+        $parent = $flatProductModel['parent'] ?? '';
         $familyVariant = $flatProductModel['family_variant'] ?? '';
-        // Skip the attribute filtration if there is no family variant, updater/validation will raise error.
-        if (empty($familyVariant)) {
+        // Skip the attribute filtration if there is no parent nor family variant, updater/validation will raise error.
+        if (empty($parent) && empty($familyVariant)) {
             return $flatProductModel;
         }
 
         $familyVariant = $this->familyVariantRepository->findOneByIdentifier($familyVariant);
-        $parent = $flatProductModel['parent'] ?? '';
         if (empty($parent) && null !== $familyVariant) {
             return $this->keepOnlyAttributes($flatProductModel, $familyVariant->getCommonAttributes());
         }
@@ -62,6 +62,11 @@ class ProductModelAttributeFilter implements AttributeFilterInterface
         // Skip the attribute filtration if the parent does not exist, updater/validation will raise error.
         if (null === $parentProductModel) {
             return $flatProductModel;
+        }
+
+        // Family variant field is not mandatory for sub product models.
+        if (null === $familyVariant) {
+            $familyVariant = $parentProductModel->getFamilyVariant();
         }
 
         $variantAttributeSet = $familyVariant->getVariantAttributeSet($parentProductModel->getVariationLevel() + 1);


### PR DESCRIPTION
## Description

During product model import, we filter the flat data to keep only values that should be here, like for products. It means we keep only values corresponding to attribute declared on the variant attribute set.

Problem was the filter didn't handle the case where sub product models were imported without family variant. This PR fixes the problem by using the family variant of the parent when needed.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | OK
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
