### PR TITLE
Fix list jobs command

### DIFF
--- a/src/Akeneo/Bundle/BatchBundle/Command/ListJobsCommand.php
+++ b/src/Akeneo/Bundle/BatchBundle/Command/ListJobsCommand.php
@@ -3,6 +3,7 @@
 namespace Akeneo\Bundle\BatchBundle\Command;
 
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -50,25 +51,24 @@ class ListJobsCommand extends ContainerAwareCommand
         }
         $jobs = $this->getJobManager()->getRepository('Akeneo\Component\Batch\Model\JobInstance')
             ->findBy($criteria, ['type' => 'asc', 'code' => 'asc']);
-        $table = $this->buildTable($jobs);
+        $table = $this->buildTable($jobs, $output);
         $table->render($output);
     }
 
     /**
-     * @param array $jobs
+     * @param array           $jobs
+     * @param OutputInterface $output
      *
      * @return \Symfony\Component\Console\Helper\HelperInterface
      */
-    protected function buildTable(array $jobs)
+    protected function buildTable(array $jobs, OutputInterface $output)
     {
-        $helperSet = $this->getHelperSet();
         $rows = [];
-        $ind = 0;
         foreach ($jobs as $job) {
             $rows[] = [$job->getType(), $job->getCode()];
         }
         $headers = ['type', 'code'];
-        $table = $helperSet->get('table');
+        $table = new Table($output);
         $table->setHeaders($headers)->setRows($rows);
 
         return $table;


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

The command "akeneo:batch:list-jobs" is broken because it uses the Symfony table helper which is deprecated since Symfony 2.5 and has been removed since 3.0

We have to use directly the class `Table` instead. cf : http://symfony.com/doc/current/components/console/helpers/tablehelper.html

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
