### PR TITLE
Fix behat datagrid scroll

### DIFF
--- a/features/product-model/navigate_product_and_product_model_edit_page.feature
+++ b/features/product-model/navigate_product_and_product_model_edit_page.feature
@@ -4,6 +4,7 @@ Feature: Navigate to product model and product edit pages
   As a regular user
   I need to be able to navigate to the product model and product edit pages
 
+  @ce
   Scenario: Successfully navigate to a product model and a product edit page
     Given a "catalog_modeling" catalog configuration
     And I am logged in as "Julia"

--- a/features/product/filtering/filter_products_and_product_models.feature
+++ b/features/product/filtering/filter_products_and_product_models.feature
@@ -8,6 +8,7 @@ Feature: Filter product and product models
     Given the "catalog_modeling" catalog configuration
     And I am logged in as "Mary"
 
+  @ce
   Scenario: Successfully filter and display both products and product models
     Given I am on the products page
     When I show the filter "color"

--- a/features/product/sequential_edit/sequential_edit_product_and_product_model.feature
+++ b/features/product/sequential_edit/sequential_edit_product_and_product_model.feature
@@ -10,6 +10,7 @@ Feature: Edit sequentially some products
     And I am on the products page
 
   # PIM-6360: Those tests will be refactored once the sequential edit for product models works.
+  @ce
   Scenario: Successfully sequentially edit some products but not the product models 1/2
     Given I show the filter "color"
     And I filter by "color" with operator "in list" and value "Crimson red"
@@ -19,6 +20,7 @@ Feature: Edit sequentially some products
     Then I should see the text "running-shoes-xxs-crimson-red"
     And I should see the text "Save and finish"
 
+  @ce
   Scenario: Successfully sequentially edit some products but not the product models 2/2
     Given I show the filter "color"
     And I filter by "color" with operator "in list" and value "Crimson red"


### PR DESCRIPTION
## Description

This PR adds a dirty fix (that will removed PIM-6574) to prevent some behat because a datagrid filter is not accessible without scrolling.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | -
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
