### PR TITLE
Extract dependencies install into a new Docker script helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,8 +30,9 @@ composer.phar
 /bin/*
 !/bin/docker
 /bin/docker/*
-!/bin/docker/pim-initialize.sh
+!/bin/docker/pim-dependencies.sh
 !/bin/docker/pim-front.sh
+!/bin/docker/pim-initialize.sh
 !/bin/merge-coverage
 !/bin/console
 behat.yml

--- a/bin/docker/pim-dependencies.sh
+++ b/bin/docker/pim-dependencies.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+docker-compose exec fpm composer update
+docker-compose run --rm node npm install

--- a/bin/docker/pim-front.sh
+++ b/bin/docker/pim-front.sh
@@ -7,5 +7,4 @@ docker-compose exec fpm bin/console --env=test cache:clear --no-warmup
 
 docker-compose exec fpm bin/console --env=prod pim:installer:assets --symlink --clean
 
-docker-compose run --rm node npm install
 docker-compose run --rm node npm run webpack

--- a/bin/docker/pim-initialize.sh
+++ b/bin/docker/pim-initialize.sh
@@ -8,5 +8,4 @@ docker-compose exec fpm bin/console --env=test cache:clear --no-warmup
 docker-compose exec fpm bin/console --env=prod pim:install --force --symlink --clean
 docker-compose exec fpm bin/console --env=behat pim:installer:db
 
-docker-compose run --rm node npm install
 docker-compose run --rm node npm run webpack


### PR DESCRIPTION
## Description

This PR removes the execution of `npm install` from the script `bin/docker/pim-initialize.sh`, and put it in a new script `bin/docker/pim-dependencies.sh` with `composer update`.
This way, a developer can choose to install the PIM dependencies or not, before launching an install.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
