### PR TITLE
Optimize AbstractProduct::getIdentifier

### DIFF
--- a/src/Pim/Component/Catalog/Model/AbstractProduct.php
+++ b/src/Pim/Component/Catalog/Model/AbstractProduct.php
@@ -79,7 +79,7 @@ abstract class AbstractProduct implements ProductInterface
     protected $normalizedData;
 
     /** @var string */
-    private $identifierAttributeCode;
+    protected $identifierAttributeCode;
 
     /**
      * Constructor

--- a/src/Pim/Component/Catalog/Model/AbstractProduct.php
+++ b/src/Pim/Component/Catalog/Model/AbstractProduct.php
@@ -39,7 +39,7 @@ abstract class AbstractProduct implements ProductInterface
      */
     protected $scope;
 
-    /** @var ArrayCollection */
+    /** @var ArrayCollection|ProductValueInterface[] */
     protected $values;
 
     /** @var array */
@@ -63,7 +63,7 @@ abstract class AbstractProduct implements ProductInterface
     /** @var bool $enabled */
     protected $enabled = true;
 
-    /** @var ArrayCollection $groups */
+    /** @var ArrayCollection|GroupInterface[] */
     protected $groups;
 
     /** @var array */
@@ -77,6 +77,9 @@ abstract class AbstractProduct implements ProductInterface
 
     /** @var array */
     protected $normalizedData;
+
+    /** @var string */
+    private $identifierAttributeCode;
 
     /**
      * Constructor
@@ -187,7 +190,7 @@ abstract class AbstractProduct implements ProductInterface
     {
         $this->values[] = $value;
         $this->indexedValues[$value->getAttribute()->getCode()][] = $value;
-        $value->setEntity($this);
+        $value->setProduct($this);
 
         return $this;
     }
@@ -394,13 +397,22 @@ abstract class AbstractProduct implements ProductInterface
      */
     public function getIdentifier()
     {
-        foreach ($this->values as $value) {
-            if (AttributeTypes::IDENTIFIER === $value->getAttribute()->getAttributeType()) {
-                return $value;
+        if (null === $this->identifierAttributeCode) {
+            foreach ($this->values as $value) {
+                $attribute = $value->getAttribute();
+                if (AttributeTypes::IDENTIFIER === $attribute->getAttributeType()) {
+                    $this->identifierAttributeCode = $attribute->getCode();
+                }
             }
         }
 
-        throw new MissingIdentifierException($this);
+        $identifier = $this->getValue($this->identifierAttributeCode);
+
+        if (null === $identifier) {
+            throw new MissingIdentifierException($this);
+        }
+
+        return $identifier;
     }
 
     /**

--- a/src/Pim/Component/Catalog/Model/FamilyInterface.php
+++ b/src/Pim/Component/Catalog/Model/FamilyInterface.php
@@ -4,6 +4,7 @@ namespace Pim\Component\Catalog\Model;
 
 use Akeneo\Component\Localization\Model\TranslatableInterface;
 use Akeneo\Component\Versioning\Model\VersionableInterface;
+use Doctrine\Common\Collections\ArrayCollection;
 
 /**
  * Family interface

--- a/src/Pim/Component/Catalog/spec/Builder/ProductTemplateBuilderSpec.php
+++ b/src/Pim/Component/Catalog/spec/Builder/ProductTemplateBuilderSpec.php
@@ -50,7 +50,7 @@ class ProductTemplateBuilderSpec extends ObjectBehavior
         $color->isLocalizable()->willReturn(false);
         $color->isScopable()->willReturn(false);
         $colorValue->getAttribute()->willReturn($color);
-        $colorValue->setEntity(Argument::type('Pim\Component\Catalog\Model\Product'))->willReturn($colorValue);
+        $colorValue->setProduct(Argument::type('Pim\Component\Catalog\Model\Product'))->willReturn($colorValue);
 
         $options = ['locale' => 'en_US', 'disable_grouping_separator' => true];
         $template->getValuesData()->willReturn(['color' => 'bar']);


### PR DESCRIPTION
Optimize AbstractProduct::getIdentifier to not iterate on all values each time we get the identifier.
Noticed after digging for an export memory leak where i seen we were iterating on values thousand times.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | Todo
