### PR TITLE
PIM-6336: Add expected parent key to integration tests

### DIFF
--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateListProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateListProductIntegration.php
@@ -35,7 +35,6 @@ JSON;
 {"line":2,"identifier":"my_identifier","status_code":201}
 JSON;
 
-
         $response = $this->executeStreamRequest('PATCH', 'api/rest/v1/products', [], [], [], $data);
         $httpResponse = $response['http_response'];
 
@@ -48,6 +47,7 @@ JSON;
             'product_family' => [
                 'identifier'    => 'product_family',
                 'family'        => 'familyA1',
+                'parent'        => null,
                 'groups'        => [],
                 'variant_group' => null,
                 'categories'    => [],
@@ -64,6 +64,7 @@ JSON;
             'my_identifier'  => [
                 'identifier'    => 'my_identifier',
                 'family'        => 'familyA2',
+                'parent'        => null,
                 'groups'        => [],
                 'variant_group' => null,
                 'categories'    => [],

--- a/src/Pim/Component/Api/tests/integration/Normalizer/ProductNormalizerIntegration.php
+++ b/src/Pim/Component/Api/tests/integration/Normalizer/ProductNormalizerIntegration.php
@@ -27,6 +27,7 @@ class ProductNormalizerIntegration extends TestCase
         $expected = [
             'identifier'    => 'bar',
             'family'        => null,
+            'parent'        => null,
             'groups'        => [],
             'variant_group' => null,
             'categories'    => [],
@@ -45,6 +46,7 @@ class ProductNormalizerIntegration extends TestCase
         $expected = [
             'identifier'    => 'baz',
             'family'        => null,
+            'parent'        => null,
             'groups'        => [],
             'variant_group' => null,
             'categories'    => [],
@@ -63,6 +65,7 @@ class ProductNormalizerIntegration extends TestCase
         $expected = [
             'identifier'    => 'foo',
             'family'        => 'familyA',
+            'parent'        => null,
             'groups'        => ['groupA', 'groupB'],
             'variant_group' => 'variantA',
             'categories'    => ['categoryA1', 'categoryB'],
@@ -266,6 +269,7 @@ class ProductNormalizerIntegration extends TestCase
         $expected = [
             'identifier'    => 'foo',
             'family'        => 'familyA',
+            'parent'        => null,
             'groups'        => ['groupA', 'groupB'],
             'variant_group' => 'variantA',
             'categories'    => ['categoryA1', 'categoryB'],

--- a/src/Pim/Component/Catalog/tests/integration/Normalizer/Standard/ProductStandardIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Normalizer/Standard/ProductStandardIntegration.php
@@ -27,6 +27,7 @@ class ProductStandardIntegration extends TestCase
         $expected = [
             'identifier'    => 'bar',
             'family'        => null,
+            'parent'        => null,
             'groups'        => [],
             'variant_group' => null,
             'categories'    => [],
@@ -53,6 +54,7 @@ class ProductStandardIntegration extends TestCase
         $expected = [
             'identifier'    => 'baz',
             'family'        => null,
+            'parent'        => null,
             'groups'        => [],
             'variant_group' => null,
             'categories'    => [],
@@ -80,6 +82,7 @@ class ProductStandardIntegration extends TestCase
             [
                 'identifier'    => 'foo',
                 'family'        => 'familyA',
+                'parent'        => null,
                 'groups'        => ['groupA', 'groupB'],
                 'variant_group' => 'variantA',
                 'categories'    => ['categoryA1', 'categoryB'],


### PR DESCRIPTION
## Description

This PR fixes a few integration tests broken by the adding of variant product export.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | OK
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
