### PR TITLE
PIM-6804: "Manage Assets" Filter not working for products containing "Asset Collection attributes"

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -2,6 +2,10 @@
 
 ## Bug Fixes
 
+- PIM-6804: Fix the positioning (z-index) of the datafilter widgets
+
+## Bug Fixes
+
 - PIM-6491: Fix file extension validation on import job upload
 
 # 1.7.8 (2017-08-22)

--- a/features/attribute/option/sort_attribute_options.feature
+++ b/features/attribute/option/sort_attribute_options.feature
@@ -63,7 +63,7 @@ Feature: Sort attribute options
     And I fill in the following information:
       | Code            | size  |
       | Attribute group | Other |
-    And I visit the "Values" tab
+    When I visit the "Values" tab
     Then I should see the "Options" section
     And I should see "To manage options, please save the attribute first"
     When I save the attribute
@@ -81,9 +81,10 @@ Feature: Sort attribute options
     And I fill in the following information in the popin:
       | SKU | a_product |
     And I press the "Save" button in the popin
+    Then I should be on the product "a_product" edit page
     When I am on the "a_product" product page
     And I switch the locale to "en_US"
     And I add available attributes size
     Then I should see the ordered choices Alarge, Bmedium, Csmall in size
-    And I switch the locale to "fr_FR"
+    When I switch the locale to "fr_FR"
     Then I should see the ordered choices [medium_size], Apetit, Cgrand in size

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filters-manager.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filters-manager.js
@@ -384,7 +384,8 @@ function($, _, Backbone, mediator, MultiselectDecorator) {
 
             this.selectWidget.getWidget().css({
                 top: buttonPosition.top + button.outerHeight(),
-                left: widgetLeftOffset
+                left: widgetLeftOffset,
+                'z-index': 1050
             });
         }
     });


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When you open the "Asset manager" from the PEF, the selection "Manage filter" does not appear. It happens because this element was displayed behind the popin.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | yes
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -