### PR TITLE
PIM-6737: Export - As Julia, I would like to export products models (csv, xlsx)

### DIFF
--- a/STANDARD_FORMAT.md
+++ b/STANDARD_FORMAT.md
@@ -59,6 +59,7 @@ Let's consider a *bar* product, without any product value, except its identifier
 
 * an identifier
 * a family
+* a parent
 * several groups
 * a variant group
 * several categories
@@ -69,6 +70,7 @@ Its standard format would be the following:
         array:10 [
           "identifier" => "bar"
           "family" => "familyA"
+          "parent" => "parentA"
           "groups" => array:2 [
             0 => "groupA"
             1 => "groupB"
@@ -119,6 +121,7 @@ Its standard format would be the following:
 | ------------- | -------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
 | identifier    | string         | `"bar"`                                                                   | it's the identifier of the product                                                               |
 | family        | string         | `"familyA"`                                                               | it represents the *code* of the *Pim\Component\Catalog\Model\FamilyInterface*                    |
+| parent        | string         | `"parentA"`                                                               | it represents the *code* of the *Pim\Component\Catalog\Model\ProductModelInterface*              |
 | groups        | array          | `[0 => "groupA", 1 => "groupB"]`                                          | it represents the *code* of the *Pim\Component\Catalog\Model\GroupInterface*                     |
 | variant_group | string         | `"variantA"`                                                              | it represents the *code* of the *Pim\Component\Catalog\Model\GroupInterface*                     |
 | categories    | array          | `[0 => "categoryA", 1 => "categoryB"]`                                    | it represents the *code* of the object *Akeneo\Component\Classification\Model\CategoryInterface* |

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/removers.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/removers.yml
@@ -26,7 +26,7 @@ services:
         arguments:
             - '@pim_catalog.object_manager.product'
             - '@event_dispatcher'
-            - 'Pim\Component\Catalog\Model\ProductInterface'
+            - '%pim_catalog.model.product.interface%'
 
     pim_catalog.remover.association_type:
         class: '%pim_catalog.remover.base.class%'

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/array_converters.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/array_converters.yml
@@ -32,6 +32,8 @@ parameters:
     pim_connector.array_converter.standard_to_flat.group_type.class:                              Pim\Component\Connector\ArrayConverter\StandardToFlat\GroupType
     pim_connector.array_converter.standard_to_flat.product.class:                                 Pim\Component\Connector\ArrayConverter\StandardToFlat\Product
     pim_connector.array_converter.standard_to_flat.product_localized.class:                       Pim\Component\Connector\ArrayConverter\StandardToFlat\ProductLocalized
+    pim_connector.array_converter.standard_to_flat.product_model.class:                           Pim\Component\Connector\ArrayConverter\StandardToFlat\ProductModel
+    pim_connector.array_converter.standard_to_flat.product_model_localized.class:                 Pim\Component\Connector\ArrayConverter\StandardToFlat\ProductLocalized
     pim_connector.array_converter.standard_to_flat.user.class:                                    Pim\Component\Connector\ArrayConverter\StandardToFlat\User
 
     pim_connector.array_converter.standard_to_flat.product.product_value_converter.class:         Pim\Component\Connector\ArrayConverter\StandardToFlat\Product\ProductValueConverter
@@ -283,6 +285,17 @@ services:
         class: '%pim_connector.array_converter.standard_to_flat.product_localized.class%'
         arguments:
             - '@pim_connector.array_converter.standard_to_flat.product'
+            - '@pim_catalog.localization.localizer.converter'
+
+    pim_connector.array_converter.standard_to_flat.product_model:
+        class: '%pim_connector.array_converter.standard_to_flat.product_model.class%'
+        arguments:
+            - '@pim_connector.array_converter.standard_to_flat.product.product_value_converter'
+
+    pim_connector.array_converter.standard_to_flat.product_model_localized:
+        class: '%pim_connector.array_converter.standard_to_flat.product_localized.class%'
+        arguments:
+            - '@pim_connector.array_converter.standard_to_flat.product_model'
             - '@pim_catalog.localization.localizer.converter'
 
     pim_connector.array_converter.standard_to_flat.user:

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/job_constraints.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/job_constraints.yml
@@ -31,6 +31,7 @@ services:
                 - 'csv_attribute_group_export'
                 - 'csv_currency_export'
                 - 'csv_group_type_export'
+                - 'csv_product_model_export'
         tags:
             - { name: akeneo_batch.job.job_parameters.constraint_collection_provider }
 

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/job_constraints.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/job_constraints.yml
@@ -4,6 +4,7 @@ parameters:
     pim_connector.job.job_parameters.constraint_collection_provider.simple_yaml_export.class:        Pim\Component\Connector\Job\JobParameters\ConstraintCollectionProvider\SimpleYamlExport
     pim_connector.job.job_parameters.constraint_collection_provider.product_csv_export.class:        Pim\Component\Connector\Job\JobParameters\ConstraintCollectionProvider\ProductCsvExport
     pim_connector.job.job_parameters.constraint_collection_provider.product_xlsx_export.class:       Pim\Component\Connector\Job\JobParameters\ConstraintCollectionProvider\ProductXlsxExport
+    pim_connector.job.job_parameters.constraint_collection_provider.product_model_csv_export.class:  Pim\Component\Connector\Job\JobParameters\ConstraintCollectionProvider\ProductModelCsvExport
 
     pim_connector.job.job_parameters.constraint_collection_provider.simple_csv_import.class:         Pim\Component\Connector\Job\JobParameters\ConstraintCollectionProvider\SimpleCsvImport
     pim_connector.job.job_parameters.constraint_collection_provider.simple_xlsx_import.class:        Pim\Component\Connector\Job\JobParameters\ConstraintCollectionProvider\SimpleXlsxImport
@@ -31,7 +32,6 @@ services:
                 - 'csv_attribute_group_export'
                 - 'csv_currency_export'
                 - 'csv_group_type_export'
-                - 'csv_product_model_export'
         tags:
             - { name: akeneo_batch.job.job_parameters.constraint_collection_provider }
 
@@ -69,6 +69,15 @@ services:
             - '@pim_connector.job.job_parameters.constraint_collection_provider.simple_xlsx_export'
             -
                 - 'xlsx_product_export'
+        tags:
+            - { name: akeneo_batch.job.job_parameters.constraint_collection_provider }
+
+    pim_connector.job.job_parameters.constraint_collection_provider.product_model_csv_export:
+        class: '%pim_connector.job.job_parameters.constraint_collection_provider.product_model_csv_export.class%'
+        arguments:
+            - '@pim_connector.job.job_parameters.constraint_collection_provider.simple_csv_export'
+            -
+                - 'csv_product_model_export'
         tags:
             - { name: akeneo_batch.job.job_parameters.constraint_collection_provider }
 

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/job_constraints.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/job_constraints.yml
@@ -5,6 +5,7 @@ parameters:
     pim_connector.job.job_parameters.constraint_collection_provider.product_csv_export.class:        Pim\Component\Connector\Job\JobParameters\ConstraintCollectionProvider\ProductCsvExport
     pim_connector.job.job_parameters.constraint_collection_provider.product_xlsx_export.class:       Pim\Component\Connector\Job\JobParameters\ConstraintCollectionProvider\ProductXlsxExport
     pim_connector.job.job_parameters.constraint_collection_provider.product_model_csv_export.class:  Pim\Component\Connector\Job\JobParameters\ConstraintCollectionProvider\ProductModelCsvExport
+    pim_connector.job.job_parameters.constraint_collection_provider.product_model_xlsx_export.class: Pim\Component\Connector\Job\JobParameters\ConstraintCollectionProvider\ProductModelCsvExport
 
     pim_connector.job.job_parameters.constraint_collection_provider.simple_csv_import.class:         Pim\Component\Connector\Job\JobParameters\ConstraintCollectionProvider\SimpleCsvImport
     pim_connector.job.job_parameters.constraint_collection_provider.simple_xlsx_import.class:        Pim\Component\Connector\Job\JobParameters\ConstraintCollectionProvider\SimpleXlsxImport
@@ -78,6 +79,15 @@ services:
             - '@pim_connector.job.job_parameters.constraint_collection_provider.simple_csv_export'
             -
                 - 'csv_product_model_export'
+        tags:
+            - { name: akeneo_batch.job.job_parameters.constraint_collection_provider }
+
+    pim_connector.job.job_parameters.constraint_collection_provider.product_model_xlsx_export:
+        class: '%pim_connector.job.job_parameters.constraint_collection_provider.product_model_xlsx_export.class%'
+        arguments:
+            - '@pim_connector.job.job_parameters.constraint_collection_provider.simple_xlsx_export'
+            -
+                - 'xlsx_product_model_export'
         tags:
             - { name: akeneo_batch.job.job_parameters.constraint_collection_provider }
 

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/job_defaults.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/job_defaults.yml
@@ -4,6 +4,7 @@ parameters:
     pim_connector.job.job_parameters.default_values_provider.simple_yaml_export.class:        Pim\Component\Connector\Job\JobParameters\DefaultValuesProvider\SimpleYamlExport
     pim_connector.job.job_parameters.default_values_provider.product_csv_export.class:        Pim\Component\Connector\Job\JobParameters\DefaultValuesProvider\ProductCsvExport
     pim_connector.job.job_parameters.default_values_provider.product_xlsx_export.class:       Pim\Component\Connector\Job\JobParameters\DefaultValuesProvider\ProductXlsxExport
+    pim_connector.job.job_parameters.default_values_provider.product_model_csv_export.class:  Pim\Component\Connector\Job\JobParameters\DefaultValuesProvider\ProductModelCsvExport
 
     pim_connector.job.job_parameters.default_values_provider.simple_csv_import.class:         Pim\Component\Connector\Job\JobParameters\DefaultValuesProvider\SimpleCsvImport
     pim_connector.job.job_parameters.default_values_provider.simple_xlsx_import.class:        Pim\Component\Connector\Job\JobParameters\DefaultValuesProvider\SimpleXlsxImport
@@ -31,7 +32,6 @@ services:
                 - 'csv_attribute_group_export'
                 - 'csv_currency_export'
                 - 'csv_group_type_export'
-                - 'csv_product_model_export'
         tags:
             - { name: akeneo_batch.job.job_parameters.default_values_provider }
 
@@ -73,6 +73,15 @@ services:
             - '@pim_catalog.repository.locale'
             -
                 - 'xlsx_product_export'
+        tags:
+            - { name: akeneo_batch.job.job_parameters.default_values_provider }
+
+    pim_connector.job.job_parameters.default_values_provider.product_model_csv_export:
+        class: '%pim_connector.job.job_parameters.default_values_provider.product_model_csv_export.class%'
+        arguments:
+            - '@pim_connector.job.job_parameters.default_values_provider.simple_csv_export'
+            -
+                - 'csv_product_model_export'
         tags:
             - { name: akeneo_batch.job.job_parameters.default_values_provider }
 

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/job_defaults.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/job_defaults.yml
@@ -5,6 +5,7 @@ parameters:
     pim_connector.job.job_parameters.default_values_provider.product_csv_export.class:        Pim\Component\Connector\Job\JobParameters\DefaultValuesProvider\ProductCsvExport
     pim_connector.job.job_parameters.default_values_provider.product_xlsx_export.class:       Pim\Component\Connector\Job\JobParameters\DefaultValuesProvider\ProductXlsxExport
     pim_connector.job.job_parameters.default_values_provider.product_model_csv_export.class:  Pim\Component\Connector\Job\JobParameters\DefaultValuesProvider\ProductModelCsvExport
+    pim_connector.job.job_parameters.default_values_provider.product_model_xlsx_export.class: Pim\Component\Connector\Job\JobParameters\DefaultValuesProvider\ProductModelCsvExport
 
     pim_connector.job.job_parameters.default_values_provider.simple_csv_import.class:         Pim\Component\Connector\Job\JobParameters\DefaultValuesProvider\SimpleCsvImport
     pim_connector.job.job_parameters.default_values_provider.simple_xlsx_import.class:        Pim\Component\Connector\Job\JobParameters\DefaultValuesProvider\SimpleXlsxImport
@@ -82,6 +83,15 @@ services:
             - '@pim_connector.job.job_parameters.default_values_provider.simple_csv_export'
             -
                 - 'csv_product_model_export'
+        tags:
+            - { name: akeneo_batch.job.job_parameters.default_values_provider }
+
+    pim_connector.job.job_parameters.default_values_provider.product_model_xlsx_export:
+        class: '%pim_connector.job.job_parameters.default_values_provider.product_model_xlsx_export.class%'
+        arguments:
+            - '@pim_connector.job.job_parameters.default_values_provider.simple_xlsx_export'
+            -
+                - 'xlsx_product_model_export'
         tags:
             - { name: akeneo_batch.job.job_parameters.default_values_provider }
 

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/job_defaults.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/job_defaults.yml
@@ -31,6 +31,7 @@ services:
                 - 'csv_attribute_group_export'
                 - 'csv_currency_export'
                 - 'csv_group_type_export'
+                - 'csv_product_model_export'
         tags:
             - { name: akeneo_batch.job.job_parameters.default_values_provider }
 

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/jobs.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/jobs.yml
@@ -44,6 +44,7 @@ parameters:
     pim_connector.job_name.xlsx_product_export: 'xlsx_product_export'
     pim_connector.job_name.xlsx_product_import: 'xlsx_product_import'
     pim_connector.job_name.xlsx_product_model_import: 'xlsx_product_model_import'
+    pim_connector.job_name.xlsx_product_model_export: 'xlsx_product_model_export'
     pim_connector.job_name.xlsx_category_export: 'xlsx_category_export'
     pim_connector.job_name.xlsx_category_import: 'xlsx_category_import'
     pim_connector.job_name.xlsx_channel_export: 'xlsx_channel_export'
@@ -637,6 +638,17 @@ services:
             - '@akeneo_batch.job_repository'
             -
                 - '@pim_connector.step.xlsx_product.export'
+        tags:
+            - { name: akeneo_batch.job, connector: '%pim_connector.connector_name.xlsx%', type: '%pim_connector.job.export_type%' }
+
+    pim_connector.job.xlsx_product_model_export:
+        class: '%pim_connector.job.simple_job.class%'
+        arguments:
+            - '%pim_connector.job_name.xlsx_product_model_export%'
+            - '@event_dispatcher'
+            - '@akeneo_batch.job_repository'
+            -
+                - '@pim_connector.step.xlsx_product_model.export'
         tags:
             - { name: akeneo_batch.job, connector: '%pim_connector.connector_name.xlsx%', type: '%pim_connector.job.export_type%' }
 

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/jobs.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/jobs.yml
@@ -16,6 +16,7 @@ parameters:
     pim_connector.job_name.csv_product_export: 'csv_product_export'
     pim_connector.job_name.csv_product_import: 'csv_product_import'
     pim_connector.job_name.csv_product_model_import: 'csv_product_model_import'
+    pim_connector.job_name.csv_product_model_export: 'csv_product_model_export'
     pim_connector.job_name.csv_category_export: 'csv_category_export'
     pim_connector.job_name.csv_category_import: 'csv_category_import'
     pim_connector.job_name.csv_channel_export: 'csv_channel_export'
@@ -307,6 +308,17 @@ services:
             - '@akeneo_batch.job_repository'
             -
                 - '@pim_connector.step.csv_product.export'
+        tags:
+            - { name: akeneo_batch.job, connector: '%pim_connector.connector_name.csv%', type: '%pim_connector.job.export_type%' }
+
+    pim_connector.job.csv_product_model_export:
+        class: '%pim_connector.job.simple_job.class%'
+        arguments:
+            - '%pim_connector.job_name.csv_product_model_export%'
+            - '@event_dispatcher'
+            - '@akeneo_batch.job_repository'
+            -
+                - '@pim_connector.step.csv_product_model.export'
         tags:
             - { name: akeneo_batch.job, connector: '%pim_connector.connector_name.csv%', type: '%pim_connector.job.export_type%' }
 

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/processors.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/processors.yml
@@ -6,13 +6,13 @@ parameters:
     pim_connector.processor.denormalization.product_association.class: Pim\Component\Connector\Processor\Denormalization\ProductAssociationProcessor
     pim_connector.processor.denormalization.job_instance.class:        Pim\Component\Connector\Processor\Denormalization\JobInstanceProcessor
 
-    pim_connector.processor.normalization.class:               Pim\Component\Connector\Processor\Normalization\Processor
-    pim_connector.processor.normalization.product.class:       Pim\Component\Connector\Processor\Normalization\ProductProcessor
+    pim_connector.processor.normalization.class:                  Pim\Component\Connector\Processor\Normalization\Processor
+    pim_connector.processor.normalization.product.class:          Pim\Component\Connector\Processor\Normalization\ProductProcessor
+    pim_connector.processor.normalization.product_model.class:    Pim\Component\Connector\Processor\Normalization\ProductModelProcessor
 
     pim_connector.processor.bulk_media_fetcher.class: Pim\Component\Connector\Processor\BulkMediaFetcher
     pim_connector.processor.attribute_filter.product_model.class: Pim\Component\Connector\Processor\Denormalization\AttributeFilter\ProductModelAttributeFilter
     pim_connector.processor.attribute_filter.product.class: Pim\Component\Connector\Processor\Denormalization\AttributeFilter\ProductAttributeFilter
-
 
 services:
     # Dummy processor
@@ -227,6 +227,15 @@ services:
             - '@akeneo_storage_utils.doctrine.object_detacher'
             - '@pim_connector.processor.bulk_media_fetcher'
             - '@pim_catalog.values_filler.product'
+
+    pim_connector.processor.normalization.product_model:
+        class: '%pim_connector.processor.normalization.product_model.class%'
+        arguments:
+            - '@pim_catalog.normalizer.standard.product_model'
+            - '@pim_catalog.repository.attribute'
+            - '@akeneo_storage_utils.doctrine.object_detacher'
+            - '@pim_connector.processor.bulk_media_fetcher'
+            - '@pim_catalog.values_filler.entity_with_family_variant'
 
     pim_connector.processor.normalization.family:
         class: '%pim_connector.processor.normalization.class%'

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/readers.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/readers.yml
@@ -3,6 +3,7 @@ parameters:
 
     pim_connector.reader.database.class: Pim\Component\Connector\Reader\Database\Reader
     pim_connector.reader.database.product.class: Pim\Component\Connector\Reader\Database\ProductReader
+    pim_connector.reader.database.product_model.class: Pim\Component\Connector\Reader\Database\ProductModelReader
     pim_connector.reader.database.atribute_option.class: Pim\Component\Connector\Reader\Database\AttributeOptionReader
     pim_connector.reader.database.category.class: Pim\Component\Connector\Reader\Database\CategoryReader
     pim_connector.reader.database.group.class: Pim\Component\Connector\Reader\Database\GroupReader
@@ -69,6 +70,11 @@ services:
         class: '%pim_connector.reader.database.group.class%'
         arguments:
             - '@pim_catalog.repository.group'
+
+    pim_connector.reader.database.product_model:
+        class: '%pim_connector.reader.database.product_model.class%'
+        arguments:
+            - '@pim_catalog.repository.product_model'
 
     pim_connector.reader.database.channel:
         class: '%pim_connector.reader.database.class%'

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/steps.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/steps.yml
@@ -252,6 +252,17 @@ services:
             - '@pim_connector.writer.file.csv_product'
             - 10
 
+    pim_connector.step.csv_product_model.export:
+        class: '%pim_connector.step.item_step.class%'
+        arguments:
+            - 'export'
+            - '@event_dispatcher'
+            - '@akeneo_batch.job_repository'
+            - '@pim_connector.reader.database.product_model'
+            - '@pim_connector.processor.normalization.product_model'
+            - '@pim_connector.writer.file.csv_product_model'
+            - 10
+
     pim_connector.step.csv_category.export:
         class: '%pim_connector.step.item_step.class%'
         arguments:

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/steps.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/steps.yml
@@ -566,6 +566,17 @@ services:
             - '@pim_connector.writer.file.xlsx_product'
             - 10
 
+    pim_connector.step.xlsx_product_model.export:
+        class: '%pim_connector.step.item_step.class%'
+        arguments:
+            - 'export'
+            - '@event_dispatcher'
+            - '@akeneo_batch.job_repository'
+            - '@pim_connector.reader.database.product_model'
+            - '@pim_connector.processor.normalization.product_model'
+            - '@pim_connector.writer.file.xlsx_product_model'
+            - 10
+
     pim_connector.step.xlsx_category.export:
         class: '%pim_connector.step.item_step.class%'
         arguments:

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/writers.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/writers.yml
@@ -171,6 +171,11 @@ services:
         arguments:
              - '@pim_connector.writer.file.product.column_sorter'
 
+    pim_connector.writer.file.product_model.flat_item_buffer_flusher:
+        class: '%pim_connector.writer.file.flat_item_buffer_flusher.class%'
+        arguments:
+             - '@pim_connector.writer.file.product_model.column_sorter'
+
     # CSV
     pim_connector.writer.file.csv:
         class: '%pim_connector.writer.file.csv.class%'
@@ -192,6 +197,16 @@ services:
             - '@pim_connector.array_converter.standard_to_flat.product_localized'
             - '@pim_connector.factory.flat_item_buffer'
             - '@pim_connector.writer.file.product.flat_item_buffer_flusher'
+            - '@pim_catalog.repository.attribute'
+            - '@pim_connector.writer.file.media_exporter_path_generator'
+            - ['pim_catalog_file', 'pim_catalog_image']
+
+    pim_connector.writer.file.csv_product_model:
+        class: '%pim_connector.writer.file.csv_product.class%'
+        arguments:
+            - '@pim_connector.array_converter.standard_to_flat.product_model_localized'
+            - '@pim_connector.factory.flat_item_buffer'
+            - '@pim_connector.writer.file.product_model.flat_item_buffer_flusher'
             - '@pim_catalog.repository.attribute'
             - '@pim_connector.writer.file.media_exporter_path_generator'
             - ['pim_catalog_file', 'pim_catalog_image']
@@ -430,3 +445,9 @@ services:
             - '@pim_catalog.repository.attribute'
             - '@pim_catalog.repository.association_type'
             - ['categories', 'enabled', 'family', 'parent', 'groups']
+
+    pim_connector.writer.file.product_model.column_sorter:
+        class: '%pim_connector.writer.file.default.column_sorter.class%'
+        arguments:
+            - '@pim_connector.array_converter.flat_to_standard.product.field_splitter'
+            - ['code', 'family_variant', 'parent', 'categories']

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/writers.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/writers.yml
@@ -12,6 +12,7 @@ parameters:
     pim_connector.writer.file.yaml.class:                          Pim\Component\Connector\Writer\File\Yaml\Writer
     pim_connector.writer.file.media_exporter_path_generator.class: Pim\Component\Connector\Writer\File\MediaExporterPathGenerator
     pim_connector.writer.file.xlsx_product.class:                  Pim\Component\Connector\Writer\File\Xlsx\ProductWriter
+    pim_connector.writer.file.xlsx_product_model.class:            Pim\Component\Connector\Writer\File\Xlsx\ProductModelWriter
     pim_connector.writer.file.xlsx.class:                          Pim\Component\Connector\Writer\File\Xlsx\Writer
     pim_connector.writer.file.default.column_sorter.class:         Pim\Component\Connector\Writer\File\DefaultColumnSorter
     pim_connector.writer.file.product.column_sorter.class:         Pim\Component\Connector\Writer\File\ProductColumnSorter
@@ -320,6 +321,16 @@ services:
             - '@pim_connector.array_converter.standard_to_flat.product_localized'
             - '@pim_connector.factory.flat_item_buffer'
             - '@pim_connector.writer.file.product.flat_item_buffer_flusher'
+            - '@pim_catalog.repository.attribute'
+            - '@pim_connector.writer.file.media_exporter_path_generator'
+            - ['pim_catalog_file', 'pim_catalog_image']
+
+    pim_connector.writer.file.xlsx_product_model:
+        class: '%pim_connector.writer.file.xlsx_product_model.class%'
+        arguments:
+            - '@pim_connector.array_converter.standard_to_flat.product_model_localized'
+            - '@pim_connector.factory.flat_item_buffer'
+            - '@pim_connector.writer.file.product_model.flat_item_buffer_flusher'
             - '@pim_catalog.repository.attribute'
             - '@pim_connector.writer.file.media_exporter_path_generator'
             - ['pim_catalog_file', 'pim_catalog_image']

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/writers.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/writers.yml
@@ -8,6 +8,7 @@ parameters:
     pim_connector.writer.file.abstract.class:                      Pim\Component\Connector\Writer\File\AbstractFileWriter
     pim_connector.writer.file.csv.class:                           Pim\Component\Connector\Writer\File\Csv\Writer
     pim_connector.writer.file.csv_product.class:                   Pim\Component\Connector\Writer\File\Csv\ProductWriter
+    pim_connector.writer.file.csv_product_model.class:             Pim\Component\Connector\Writer\File\Csv\ProductModelWriter
     pim_connector.writer.file.yaml.class:                          Pim\Component\Connector\Writer\File\Yaml\Writer
     pim_connector.writer.file.media_exporter_path_generator.class: Pim\Component\Connector\Writer\File\MediaExporterPathGenerator
     pim_connector.writer.file.xlsx_product.class:                  Pim\Component\Connector\Writer\File\Xlsx\ProductWriter
@@ -202,7 +203,7 @@ services:
             - ['pim_catalog_file', 'pim_catalog_image']
 
     pim_connector.writer.file.csv_product_model:
-        class: '%pim_connector.writer.file.csv_product.class%'
+        class: '%pim_connector.writer.file.csv_product_model.class%'
         arguments:
             - '@pim_connector.array_converter.standard_to_flat.product_model_localized'
             - '@pim_connector.factory.flat_item_buffer'

--- a/src/Pim/Bundle/ConnectorBundle/Resources/translations/messages.en.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/translations/messages.en.yml
@@ -188,6 +188,9 @@ batch_jobs:
     xlsx_product_export:
         label: Product export in XLSX
         export.label: Product export
+    xlsx_product_model_export:
+        label: Product model export in XLSX
+        export.label: Product model export
     xlsx_product_import:
         label: Product import in XLSX
         validation.label: File validation

--- a/src/Pim/Bundle/ConnectorBundle/Resources/translations/messages.en.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/translations/messages.en.yml
@@ -57,6 +57,9 @@ batch_jobs:
     csv_product_export:
         label: Product export in CSV
         export.label: Product export
+    csv_product_model_export:
+        label: Product model export in CSV
+        export.label: Product model export
     csv_category_export:
         label: Category export in CSV
         export.label: Category export

--- a/src/Pim/Bundle/ConnectorBundle/tests/integration/Export/AbstractExportTestCase.php
+++ b/src/Pim/Bundle/ConnectorBundle/tests/integration/Export/AbstractExportTestCase.php
@@ -6,8 +6,11 @@ use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\JobLauncher;
 use Akeneo\Test\Integration\TestCase;
 use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\AttributeOptionInterface;
 use Pim\Component\Catalog\Model\FamilyInterface;
+use Pim\Component\Catalog\Model\FamilyVariantInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
+use Pim\Component\Catalog\Model\ProductModelInterface;
 
 abstract class AbstractExportTestCase extends TestCase
 {
@@ -63,6 +66,37 @@ abstract class AbstractExportTestCase extends TestCase
      *
      * @return ProductInterface
      */
+    protected function createVariantProduct(string $identifier, array $data = []) : ProductInterface
+    {
+        $product = $this->get('pim_catalog.builder.variant_product')->createProduct($identifier);
+        $this->get('pim_catalog.updater.product')->update($product, $data);
+        $this->get('pim_catalog.saver.product')->save($product);
+
+        $this->get('akeneo_elasticsearch.client.product')->refreshIndex();
+
+        return $product;
+    }
+
+    /**
+     * @param array  $data
+     *
+     * @return ProductModelInterface
+     */
+    protected function createProductModel(array $data = []) : ProductModelInterface
+    {
+        $productModel = $this->get('pim_catalog.factory.product_model')->create();
+        $this->get('pim_catalog.updater.product_model')->update($productModel, $data);
+        $this->get('pim_catalog.saver.product_model')->save($productModel);
+
+        return $productModel;
+    }
+
+    /**
+     * @param string $identifier
+     * @param array  $data
+     *
+     * @return ProductInterface
+     */
     protected function updateProduct(string $identifier, array $data = []) : ProductInterface
     {
         $product = $this->get('pim_catalog.repository.product')->findOneByIdentifier($identifier);
@@ -91,6 +125,20 @@ abstract class AbstractExportTestCase extends TestCase
     /**
      * @param array $data
      *
+     * @return AttributeOptionInterface
+     */
+    protected function createAttributeOption(array $data = []) : AttributeOptionInterface
+    {
+        $attributeOption = $this->get('pim_catalog.factory.attribute_option')->create();
+        $this->get('pim_catalog.updater.attribute_option')->update($attributeOption, $data);
+        $this->get('pim_catalog.saver.attribute_option')->save($attributeOption);
+
+        return $attributeOption;
+    }
+
+    /**
+     * @param array $data
+     *
      * @return FamilyInterface
      */
     protected function createFamily(array $data = []) : FamilyInterface
@@ -103,12 +151,37 @@ abstract class AbstractExportTestCase extends TestCase
     }
 
     /**
+     * @param array $data
+     *
+     * @return FamilyVariantInterface
+     */
+    protected function createFamilyVariant(array $data = []) : FamilyVariantInterface
+    {
+        $family = $this->get('pim_catalog.factory.family_variant')->create();
+        $this->get('pim_catalog.updater.family_variant')->update($family, $data);
+        $this->get('pim_catalog.saver.family_variant')->save($family);
+
+        return $family;
+    }
+
+    /**
      * @param string $expectedCsv
      * @param array  $config
      */
     protected function assertProductExport(string $expectedCsv, array $config) : void
     {
         $csv = $this->jobLauncher->launchExport('akeneo:batch:job', 'csv_product_export', null, $config);
+
+        $this->assertSame($expectedCsv, $csv);
+    }
+
+    /**
+     * @param string $expectedCsv
+     * @param array  $config
+     */
+    protected function assertProductModelExport(string $expectedCsv, array $config) : void
+    {
+        $csv = $this->jobLauncher->launchExport('akeneo:batch:job', 'csv_product_model_export', null, $config);
 
         $this->assertSame($expectedCsv, $csv);
     }

--- a/src/Pim/Bundle/ConnectorBundle/tests/integration/Export/AbstractExportTestCase.php
+++ b/src/Pim/Bundle/ConnectorBundle/tests/integration/Export/AbstractExportTestCase.php
@@ -70,6 +70,7 @@ abstract class AbstractExportTestCase extends TestCase
     {
         $product = $this->get('pim_catalog.builder.variant_product')->createProduct($identifier);
         $this->get('pim_catalog.updater.product')->update($product, $data);
+        $this->get('pim_catalog.validator.product')->validate($product);
         $this->get('pim_catalog.saver.product')->save($product);
 
         $this->get('akeneo_elasticsearch.client.product')->refreshIndex();
@@ -86,6 +87,7 @@ abstract class AbstractExportTestCase extends TestCase
     {
         $productModel = $this->get('pim_catalog.factory.product_model')->create();
         $this->get('pim_catalog.updater.product_model')->update($productModel, $data);
+        $this->get('pim_catalog.validator.product')->validate($productModel);
         $this->get('pim_catalog.saver.product_model')->save($productModel);
 
         return $productModel;
@@ -117,6 +119,7 @@ abstract class AbstractExportTestCase extends TestCase
     {
         $attribute = $this->get('pim_catalog.factory.attribute')->create();
         $this->get('pim_catalog.updater.attribute')->update($attribute, $data);
+        $this->get('validator')->validate($attribute);
         $this->get('pim_catalog.saver.attribute')->save($attribute);
 
         return $attribute;
@@ -131,6 +134,7 @@ abstract class AbstractExportTestCase extends TestCase
     {
         $attributeOption = $this->get('pim_catalog.factory.attribute_option')->create();
         $this->get('pim_catalog.updater.attribute_option')->update($attributeOption, $data);
+        $this->get('validator')->validate($attributeOption);
         $this->get('pim_catalog.saver.attribute_option')->save($attributeOption);
 
         return $attributeOption;
@@ -145,6 +149,7 @@ abstract class AbstractExportTestCase extends TestCase
     {
         $family = $this->get('pim_catalog.factory.family')->create();
         $this->get('pim_catalog.updater.family')->update($family, $data);
+        $this->get('validator')->validate($family);
         $this->get('pim_catalog.saver.family')->save($family);
 
         return $family;
@@ -159,6 +164,7 @@ abstract class AbstractExportTestCase extends TestCase
     {
         $family = $this->get('pim_catalog.factory.family_variant')->create();
         $this->get('pim_catalog.updater.family_variant')->update($family, $data);
+        $this->get('validator')->validate($family);
         $this->get('pim_catalog.saver.family_variant')->save($family);
 
         return $family;

--- a/src/Pim/Bundle/ConnectorBundle/tests/integration/Export/ProductModel/ExportProductModelsIntegration.php
+++ b/src/Pim/Bundle/ConnectorBundle/tests/integration/Export/ProductModel/ExportProductModelsIntegration.php
@@ -148,10 +148,10 @@ class ExportProductModelsIntegration extends AbstractExportTestCase
     public function testProductModelsExport()
     {
         $expectedCsv = <<<CSV
-code;family_variant;parent;categories;color;name-de_DE;name-en_US;name-fr_FR;name-zh_CN;variation_name
-apollon;clothing_color_size;;;;;;;;
-apollon_blue;clothing_color_size;apollon;;blue;;;;;"my blue tshirt"
-apollon_pink;clothing_color_size;apollon;;pink;;;;;"my pink tshirt"
+code;family_variant;parent;categories;color;name-de_DE;name-en_US;name-fr_FR;name-zh_CN;variation_image;variation_name
+apollon;clothing_color_size;;;;;;;;;
+apollon_blue;clothing_color_size;apollon;;blue;;;;;;"my blue tshirt"
+apollon_pink;clothing_color_size;apollon;;pink;;;;;;"my pink tshirt"
 
 CSV;
 

--- a/src/Pim/Bundle/ConnectorBundle/tests/integration/Export/ProductModel/ExportProductModelsIntegration.php
+++ b/src/Pim/Bundle/ConnectorBundle/tests/integration/Export/ProductModel/ExportProductModelsIntegration.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace Pim\Bundle\ConnectorBundle\tests\integration\Export\ProductModel;
+
+use Pim\Bundle\ConnectorBundle\tests\integration\Export\AbstractExportTestCase;
+
+class ExportProductModelsIntegration extends AbstractExportTestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function loadFixtures() : void
+    {
+        $this->createAttribute([
+            'code'        => 'name',
+            'type'        => 'pim_catalog_textarea',
+            'group'       => 'attributeGroupA',
+            'localizable' => true,
+            'scopable'    => false,
+        ]);
+        $this->createFamily([
+            'code'        => 'clothing',
+            'attributes'  => ['sku', 'name'],
+            'attribute_requirements' => [
+                'tablet' => ['sku', 'name']
+            ]
+        ]);
+        $this->createAttribute([
+            'code'        => 'color',
+            'type'        => 'pim_catalog_simpleselect',
+            'group'       => 'attributeGroupA',
+            'localizable' => false,
+            'scopable'    => false,
+        ]);
+        $this->createAttributeOption([
+            'code'        => 'blue',
+            'attribute'   => 'color',
+        ]);
+        $this->createAttributeOption([
+            'code'        => 'pink',
+            'attribute'   => 'color',
+        ]);
+        $this->createAttribute([
+            'code'        => 'size',
+            'type'        => 'pim_catalog_simpleselect',
+            'group'       => 'attributeGroupA',
+            'localizable' => false,
+            'scopable'    => false,
+        ]);
+        $this->createAttributeOption([
+            'code'        => 'm',
+            'attribute'   => 'size',
+        ]);
+        $this->createAttributeOption([
+            'code'        => 'l',
+            'attribute'   => 'size',
+        ]);
+        $this->createAttribute([
+            'code'        => 'ean',
+            'type'        => 'pim_catalog_text',
+            'group'       => 'attributeGroupA',
+            'localizable' => false,
+            'scopable'    => false,
+        ]);
+        $this->createAttribute([
+            'code'        => 'variation_name',
+            'type'        => 'pim_catalog_text',
+            'group'       => 'attributeGroupA',
+            'localizable' => false,
+            'scopable'    => false,
+        ]);
+        $this->createAttribute([
+            'code'        => 'variation_image',
+            'type'        => 'pim_catalog_image',
+            'group'       => 'attributeGroupA',
+            'localizable' => false,
+            'scopable'    => false,
+        ]);
+        $this->createFamilyVariant([
+            'code'        => 'clothing_color_size',
+            'family'      => 'clothing',
+            'variant_attribute_sets' => [
+                [
+                    'level' => 1,
+                    'axes' => ['color'],
+                    'attributes' => ['color', 'variation_name', 'variation_image'],
+                ],
+                [
+                    'level' => 2,
+                    'axes' => ['size'],
+                    'attributes' => ['size', 'ean', 'sku'],
+                ],
+            ]
+        ]);
+
+        $this->createProductModel(
+            [
+                'code' => 'apollon',
+                'family_variant' => 'clothing_color_size',
+            ]
+        );
+        $this->createProductModel(
+            [
+                'code' => 'apollon_blue',
+                'family_variant' => 'clothing_color_size',
+                'parent' => 'apollon',
+                'values'  => [
+                    'color'  => [['data' => 'blue', 'locale' => null, 'scope' => null]],
+                    'variation_name'  => [['data' => 'my blue tshirt', 'locale' => null, 'scope' => null]],
+                ]
+            ]
+        );
+        $this->createProductModel(
+            [
+                'code' => 'apollon_pink',
+                'family_variant' => 'clothing_color_size',
+                'parent' => 'apollon',
+                'values'  => [
+                    'color'  => [['data' => 'pink', 'locale' => null, 'scope' => null]],
+                    'variation_name'  => [['data' => 'my pink tshirt', 'locale' => null, 'scope' => null]],
+                ]
+            ]
+        );
+        $this->createVariantProduct(
+            'apollon_pink_m',
+            [
+                'family' => 'clothing',
+                'parent' => 'apollon_pink',
+                'values'  => [
+                    'size'  => [['data' => 'm', 'locale' => null, 'scope' => null]],
+                    'ean'  => [['data' => '12345678', 'locale' => null, 'scope' => null]],
+                ]
+            ]
+        );
+        $this->createVariantProduct(
+            'apollon_pink_l',
+            [
+                'family' => 'clothing',
+                'parent' => 'apollon_pink',
+                'values'  => [
+                    'size'  => [['data' => 'l', 'locale' => null, 'scope' => null]],
+                    'ean'  => [['data' => '12345679', 'locale' => null, 'scope' => null]],
+                ]
+            ]
+        );
+    }
+
+    public function testProductModelsExport()
+    {
+        $expectedCsv = <<<CSV
+code;family_variant;parent;categories;color;name-de_DE;name-en_US;name-fr_FR;name-zh_CN;variation_name
+apollon;clothing_color_size;;;;;;;;
+apollon_blue;clothing_color_size;apollon;;blue;;;;;"my blue tshirt"
+apollon_pink;clothing_color_size;apollon;;pink;;;;;"my pink tshirt"
+
+CSV;
+
+        $this->assertProductModelExport($expectedCsv, []);
+    }
+}

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/ProductModelNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/ProductModelNormalizer.php
@@ -100,6 +100,9 @@ class ProductModelNormalizer implements NormalizerInterface
         $this->entityValuesFiller->fillMissingValues($productModel);
 
         $normalizedProductModel = $this->normalizer->normalize($productModel, 'standard', $context);
+        // TODO: will be handled by PIM-6741
+        unset($normalizedProductModel['parent']);
+
         $normalizedProductModel['values'] = $this->localizedConverter->convertToLocalizedFormats(
             $normalizedProductModel['values'],
             $context

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_model_export_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_model_export_edit.yml
@@ -1,0 +1,204 @@
+extensions:
+    pim-job-instance-csv-product-model-export-edit:
+        module: pim/form/common/edit-form
+
+    pim-job-instance-csv-product-model-export-edit-main-image:
+        module: pim/form/common/main-image
+        parent: pim-job-instance-csv-product-model-export-edit
+        targetZone: main-image
+        config:
+            path: bundles/pimui/images/illustration-export-csv.svg
+
+    pim-job-instance-csv-product-model-export-edit-breadcrumbs:
+        module: pim/common/breadcrumbs
+        parent: pim-job-instance-csv-product-model-export-edit
+        targetZone: breadcrumbs
+        config:
+            tab: pim-menu-exports
+
+    pim-job-instance-csv-product-model-export-edit-cache-invalidator:
+        module: pim/cache-invalidator
+        parent: pim-job-instance-csv-product-model-export-edit
+        position: 1000
+
+    pim-job-instance-csv-product-model-export-edit-tabs:
+        module: pim/form/common/form-tabs
+        parent: pim-job-instance-csv-product-model-export-edit
+        targetZone: content
+        position: 100
+
+    pim-job-instance-csv-product-model-export-edit-properties:
+        module: pim/job/common/edit/properties
+        parent: pim-job-instance-csv-product-model-export-edit-tabs
+        aclResourceId: pim_importexport_export_profile_property_edit
+        targetZone: container
+        position: 100
+        config:
+            tabTitle: pim_enrich.form.job_instance.tab.properties.title
+            tabCode: pim-job-instance-properties
+
+    pim-job-instance-csv-product-model-export-edit-history:
+        module: pim/common/tab/history
+        parent: pim-job-instance-csv-product-model-export-edit-tabs
+        targetZone: container
+        aclResourceId: pim_importexport_export_profile_history
+        position: 120
+        config:
+            class: Akeneo\Component\Batch\Model\JobInstance
+            title: pim_enrich.form.job_instance.tab.history.title
+            tabCode: pim-job-instance-history
+
+    pim-job-instance-csv-product-model-export-edit-properties-code:
+        module: pim/job/common/edit/field/text
+        parent: pim-job-instance-csv-product-model-export-edit-properties
+        position: 100
+        targetZone: properties
+        config:
+            fieldCode: code
+            label: pim_enrich.form.job_instance.tab.properties.code.title
+            readOnly: true
+
+    pim-job-instance-csv-product-model-export-edit-properties-label:
+        module: pim/job/common/edit/field/text
+        parent: pim-job-instance-csv-product-model-export-edit-properties
+        position: 110
+        targetZone: properties
+        config:
+            fieldCode: label
+            label: pim_enrich.form.job_instance.tab.properties.label.title
+            readOnly: false
+
+    pim-job-instance-csv-product-model-export-edit-properties-file-path:
+        module: pim/job/common/edit/field/text
+        parent: pim-job-instance-csv-product-model-export-edit-properties
+        position: 120
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.filePath
+            readOnly: false
+            label: pim_enrich.form.job_instance.tab.properties.file_path.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.file_path.help
+
+    pim-job-instance-csv-product-model-export-edit-properties-decimal-separator:
+        module: pim/job/common/edit/field/decimal-separator
+        parent: pim-job-instance-csv-product-model-export-edit-properties
+        position: 130
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.decimalSeparator
+            readOnly: false
+            label: pim_enrich.form.job_instance.tab.properties.decimal_separator.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.decimal_separator.help
+
+    pim-job-instance-csv-product-model-export-edit-properties-date-format:
+        module: pim/job/product/edit/field/date-format
+        parent: pim-job-instance-csv-product-model-export-edit-properties
+        position: 140
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.dateFormat
+            readOnly: false
+            label: pim_enrich.form.job_instance.tab.properties.date_format.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.date_format.help
+
+    pim-job-instance-csv-product-model-export-edit-properties-delimiter:
+        module: pim/job/common/edit/field/text
+        parent: pim-job-instance-csv-product-model-export-edit-properties
+        position: 150
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.delimiter
+            readOnly: false
+            label: pim_enrich.form.job_instance.tab.properties.delimiter.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.delimiter.help
+
+    pim-job-instance-csv-product-model-export-edit-properties-enclosure:
+        module: pim/job/common/edit/field/text
+        parent: pim-job-instance-csv-product-model-export-edit-properties
+        position: 160
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.enclosure
+            readOnly: false
+            label: pim_enrich.form.job_instance.tab.properties.enclosure.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.enclosure.help
+
+    pim-job-instance-csv-product-model-export-edit-properties-with-header:
+        module: pim/job/common/edit/field/switch
+        parent: pim-job-instance-csv-product-model-export-edit-properties
+        position: 170
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.withHeader
+            readOnly: false
+            label: pim_enrich.form.job_instance.tab.properties.with_header.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.with_header.help
+
+    pim-job-instance-csv-product-model-export-edit-properties-with-media:
+        module: pim/job/common/edit/field/switch
+        parent: pim-job-instance-csv-product-model-export-edit-properties
+        position: 180
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.with_media
+            readOnly: false
+            label: pim_enrich.form.job_instance.tab.properties.with_media.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.with_media.help
+
+    pim-job-instance-csv-product-model-export-edit-label:
+        module: pim/job/common/edit/label
+        parent: pim-job-instance-csv-product-model-export-edit
+        targetZone: title
+        position: 100
+
+    pim-job-instance-csv-product-model-export-edit-meta:
+        module: pim/job/common/edit/meta
+        parent: pim-job-instance-csv-product-model-export-edit
+        targetZone: meta
+        position: 100
+
+    pim-job-instance-csv-product-model-export-edit-secondary-actions:
+        module: pim/form/common/secondary-actions
+        parent: pim-job-instance-csv-product-model-export-edit
+        targetZone: buttons
+        position: 50
+
+    pim-job-instance-csv-product-model-export-edit-delete:
+        module: pim/job/export/edit/delete
+        parent: pim-job-instance-csv-product-model-export-edit-secondary-actions
+        targetZone: secondary-actions
+        aclResourceId: pim_importexport_export_profile_remove
+        position: 100
+        config:
+            trans:
+                title: confirmation.remove.job_instance
+                content: pim_enrich.confirmation.delete_item
+                success: flash.job_instance.removed
+                failed: error.removing.job_instance
+            redirect: pim_importexport_export_profile_index
+
+    pim-job-instance-csv-product-model-export-edit-save-buttons:
+        module: pim/form/common/save-buttons
+        parent: pim-job-instance-csv-product-model-export-edit
+        targetZone: buttons
+        position: 120
+
+    pim-job-instance-csv-product-model-export-edit-save:
+        module: pim/job-instance-export-edit-form/save
+        parent: pim-job-instance-csv-product-model-export-edit
+        targetZone: buttons
+        position: 0
+        config:
+            redirectPath: pim_importexport_export_profile_show
+
+    pim-job-instance-csv-product-model-export-edit-state:
+        module: pim/form/common/state
+        parent: pim-job-instance-csv-product-model-export-edit
+        targetZone: state
+        position: 900
+        config:
+            entity: pim_enrich.entity.job_instance.title
+
+    pim-job-instance-csv-product-model-export-edit-validation:
+        module: pim/job/common/edit/validation
+        parent: pim-job-instance-csv-product-model-export-edit

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_model_export_show.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_model_export_show.yml
@@ -1,0 +1,65 @@
+extensions:
+    pim-job-instance-csv-product-model-export-show:
+        module: pim/form/common/edit-form
+
+    pim-job-instance-csv-product-model-export-show-main-image:
+        module: pim/form/common/main-image
+        parent: pim-job-instance-csv-product-model-export-show
+        targetZone: main-image
+        config:
+            path: bundles/pimui/images/illustration-export-csv.svg
+
+    pim-job-instance-csv-product-model-export-show-breadcrumbs:
+        module: pim/common/breadcrumbs
+        parent: pim-job-instance-csv-product-model-export-show
+        targetZone: breadcrumbs
+        config:
+            tab: pim-menu-exports
+
+    pim-job-instance-csv-product-model-export-show-launch:
+        module: pim/job/common/edit/launch
+        parent: pim-job-instance-csv-product-model-export-show
+        targetZone: meta
+        position: 110
+        config:
+            label: pim_enrich.form.job_instance.button.export.title
+            route: pim_enrich_job_instance_rest_export_launch
+            identifier:
+                path: code
+                name: code
+
+    pim-job-instance-csv-product-model-export-show-label:
+        module: pim/job/common/edit/label
+        parent: pim-job-instance-csv-product-model-export-show
+        targetZone: title
+        position: 100
+
+    pim-job-instance-csv-product-model-export-show-edit:
+        module: pim/common/redirect
+        parent: pim-job-instance-csv-product-model-export-show
+        targetZone: buttons
+        position: 100
+        config:
+            label: pim_enrich.form.job_instance.button.edit.title
+            route: pim_importexport_export_profile_edit
+            buttonClass: AknButton AknButton--action
+            identifier:
+                path: code
+                name: code
+
+    pim-job-instance-csv-product-model-export-show-subsection:
+        module: pim/form/common/subsection
+        parent: pim-job-instance-csv-product-model-export-show
+        targetZone: content
+        config:
+            title: pim_enrich.form.job_instance.subsection.last_executions
+
+    pim-job-instance-csv-product-model-export-show-grid:
+        module: pim/job/common/grid
+        parent: pim-job-instance-csv-product-model-export-show-subsection
+        position: 1000
+        targetZone: content
+        config:
+            alias: last-export-executions-grid
+            metadata:
+                jobType: export

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_model_export_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_model_export_edit.yml
@@ -1,0 +1,182 @@
+extensions:
+    pim-job-instance-xlsx-product-model-export-edit:
+        module: pim/form/common/edit-form
+
+    pim-job-instance-xlsx-product-model-export-edit-main-image:
+        module: pim/form/common/main-image
+        parent: pim-job-instance-xlsx-product-model-export-edit
+        targetZone: main-image
+        config:
+            path: bundles/pimui/images/illustration-export-xlsx.svg
+
+    pim-job-instance-xlsx-product-model-export-edit-breadcrumbs:
+        module: pim/common/breadcrumbs
+        parent: pim-job-instance-xlsx-product-model-export-edit
+        targetZone: breadcrumbs
+        config:
+            tab: pim-menu-exports
+
+    pim-job-instance-xlsx-product-model-export-edit-cache-invalidator:
+        module: pim/cache-invalidator
+        parent: pim-job-instance-xlsx-product-model-export-edit
+        position: 1000
+
+    pim-job-instance-xlsx-product-model-export-edit-tabs:
+        module: pim/form/common/form-tabs
+        parent: pim-job-instance-xlsx-product-model-export-edit
+        targetZone: content
+        position: 100
+
+    pim-job-instance-xlsx-product-model-export-edit-properties:
+        module: pim/job/common/edit/properties
+        parent: pim-job-instance-xlsx-product-model-export-edit-tabs
+        aclResourceId: pim_importexport_export_profile_property_edit
+        targetZone: container
+        position: 100
+        config:
+            tabTitle: pim_enrich.form.job_instance.tab.properties.title
+            tabCode: pim-job-instance-properties
+
+    pim-job-instance-xlsx-product-model-export-edit-history:
+        module: pim/common/tab/history
+        parent: pim-job-instance-xlsx-product-model-export-edit-tabs
+        targetZone: container
+        aclResourceId: pim_importexport_export_profile_history
+        position: 120
+        config:
+            class: Akeneo\Component\Batch\Model\JobInstance
+            title: pim_enrich.form.job_instance.tab.history.title
+            tabCode: pim-job-instance-history
+
+    pim-job-instance-xlsx-product-model-export-edit-properties-code:
+        module: pim/job/common/edit/field/text
+        parent: pim-job-instance-xlsx-product-model-export-edit-properties
+        position: 100
+        targetZone: properties
+        config:
+            fieldCode: code
+            label: pim_enrich.form.job_instance.tab.properties.code.title
+            readOnly: true
+
+    pim-job-instance-xlsx-product-model-export-edit-properties-label:
+        module: pim/job/common/edit/field/text
+        parent: pim-job-instance-xlsx-product-model-export-edit-properties
+        position: 110
+        targetZone: properties
+        config:
+            fieldCode: label
+            label: pim_enrich.form.job_instance.tab.properties.label.title
+            readOnly: false
+
+    pim-job-instance-xlsx-product-model-export-edit-properties-file-path:
+        module: pim/job/common/edit/field/text
+        parent: pim-job-instance-xlsx-product-model-export-edit-properties
+        position: 120
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.filePath
+            readOnly: false
+            label: pim_enrich.form.job_instance.tab.properties.file_path.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.file_path.help
+
+    pim-job-instance-xlsx-product-model-export-edit-properties-decimal-separator:
+        module: pim/job/common/edit/field/decimal-separator
+        parent: pim-job-instance-xlsx-product-model-export-edit-properties
+        position: 130
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.decimalSeparator
+            readOnly: false
+            label: pim_enrich.form.job_instance.tab.properties.decimal_separator.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.decimal_separator.help
+
+    pim-job-instance-xlsx-product-model-export-edit-properties-date-format:
+        module: pim/job/product/edit/field/date-format
+        parent: pim-job-instance-xlsx-product-model-export-edit-properties
+        position: 140
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.dateFormat
+            readOnly: false
+            label: pim_enrich.form.job_instance.tab.properties.date_format.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.date_format.help
+
+    pim-job-instance-xlsx-product-model-export-edit-properties-with-header:
+        module: pim/job/common/edit/field/switch
+        parent: pim-job-instance-xlsx-product-model-export-edit-properties
+        position: 170
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.withHeader
+            readOnly: false
+            label: pim_enrich.form.job_instance.tab.properties.with_header.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.with_header.help
+
+    pim-job-instance-xlsx-product-model-export-edit-properties-with-media:
+        module: pim/job/common/edit/field/switch
+        parent: pim-job-instance-xlsx-product-model-export-edit-properties
+        position: 180
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.with_media
+            readOnly: false
+            label: pim_enrich.form.job_instance.tab.properties.with_media.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.with_media.help
+
+    pim-job-instance-xlsx-product-model-export-edit-label:
+        module: pim/job/common/edit/label
+        parent: pim-job-instance-xlsx-product-model-export-edit
+        targetZone: title
+        position: 100
+
+    pim-job-instance-xlsx-product-model-export-edit-meta:
+        module: pim/job/common/edit/meta
+        parent: pim-job-instance-xlsx-product-model-export-edit
+        targetZone: meta
+        position: 100
+
+    pim-job-instance-xlsx-product-model-export-edit-secondary-actions:
+        module: pim/form/common/secondary-actions
+        parent: pim-job-instance-xlsx-product-model-export-edit
+        targetZone: buttons
+        position: 50
+
+    pim-job-instance-xlsx-product-model-export-edit-delete:
+        module: pim/job/export/edit/delete
+        parent: pim-job-instance-xlsx-product-model-export-edit-secondary-actions
+        targetZone: secondary-actions
+        aclResourceId: pim_importexport_export_profile_remove
+        position: 100
+        config:
+            trans:
+                title: confirmation.remove.job_instance
+                content: pim_enrich.confirmation.delete_item
+                success: flash.job_instance.removed
+                failed: error.removing.job_instance
+            redirect: pim_importexport_export_profile_index
+
+    pim-job-instance-xlsx-product-model-export-edit-save-buttons:
+        module: pim/form/common/save-buttons
+        parent: pim-job-instance-xlsx-product-model-export-edit
+        targetZone: buttons
+        position: 120
+
+    pim-job-instance-xlsx-product-model-export-edit-save:
+        module: pim/job-instance-export-edit-form/save
+        parent: pim-job-instance-xlsx-product-model-export-edit
+        targetZone: buttons
+        position: 0
+        config:
+            redirectPath: pim_importexport_export_profile_show
+
+    pim-job-instance-xlsx-product-model-export-edit-state:
+        module: pim/form/common/state
+        parent: pim-job-instance-xlsx-product-model-export-edit
+        targetZone: state
+        position: 900
+        config:
+            entity: pim_enrich.entity.job_instance.title
+
+    pim-job-instance-xlsx-product-model-export-edit-validation:
+        module: pim/job/common/edit/validation
+        parent: pim-job-instance-xlsx-product-model-export-edit

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_model_export_show.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_model_export_show.yml
@@ -1,0 +1,65 @@
+extensions:
+    pim-job-instance-xlsx-product-model-export-show:
+        module: pim/form/common/edit-form
+
+    pim-job-instance-xlsx-product-model-export-show-main-image:
+        module: pim/form/common/main-image
+        parent: pim-job-instance-xlsx-product-model-export-show
+        targetZone: main-image
+        config:
+            path: bundles/pimui/images/illustration-export-xlsx.svg
+
+    pim-job-instance-xlsx-product-model-export-show-breadcrumbs:
+        module: pim/common/breadcrumbs
+        parent: pim-job-instance-xlsx-product-model-export-show
+        targetZone: breadcrumbs
+        config:
+            tab: pim-menu-exports
+
+    pim-job-instance-xlsx-product-model-export-show-launch:
+        module: pim/job/common/edit/launch
+        parent: pim-job-instance-xlsx-product-model-export-show
+        targetZone: meta
+        position: 110
+        config:
+            label: pim_enrich.form.job_instance.button.export.title
+            route: pim_enrich_job_instance_rest_export_launch
+            identifier:
+                path: code
+                name: code
+
+    pim-job-instance-xlsx-product-model-export-show-label:
+        module: pim/job/common/edit/label
+        parent: pim-job-instance-xlsx-product-model-export-show
+        targetZone: title
+        position: 100
+
+    pim-job-instance-xlsx-product-model-export-show-edit:
+        module: pim/common/redirect
+        parent: pim-job-instance-xlsx-product-model-export-show
+        targetZone: buttons
+        position: 100
+        config:
+            label: pim_enrich.form.job_instance.button.edit.title
+            route: pim_importexport_export_profile_edit
+            buttonClass: AknButton AknButton--action
+            identifier:
+                path: code
+                name: code
+
+    pim-job-instance-xlsx-product-model-export-show-subsection:
+        module: pim/form/common/subsection
+        parent: pim-job-instance-xlsx-product-model-export-show
+        targetZone: content
+        config:
+            title: pim_enrich.form.job_instance.subsection.last_executions
+
+    pim-job-instance-xlsx-product-model-export-show-grid:
+        module: pim/job/common/grid
+        parent: pim-job-instance-xlsx-product-model-export-show-subsection
+        position: 1000
+        targetZone: content
+        config:
+            alias: last-export-executions-grid
+            metadata:
+                jobType: export

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/providers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/providers.yml
@@ -82,6 +82,7 @@ services:
                 csv_group_type_export: pim-job-instance-csv-base-export
                 csv_locale_export: pim-job-instance-csv-base-export
                 csv_product_export: pim-job-instance-csv-product-export
+                csv_product_model_export: pim-job-instance-csv-base-export
                 xlsx_association_type_export: pim-job-instance-xlsx-base-export
                 xlsx_attribute_export: pim-job-instance-xlsx-base-export
                 xlsx_attribute_group_export: pim-job-instance-xlsx-base-export

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/providers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/providers.yml
@@ -82,7 +82,7 @@ services:
                 csv_group_type_export: pim-job-instance-csv-base-export
                 csv_locale_export: pim-job-instance-csv-base-export
                 csv_product_export: pim-job-instance-csv-product-export
-                csv_product_model_export: pim-job-instance-csv-base-export
+                csv_product_model_export: pim-job-instance-csv-product-model-export
                 xlsx_association_type_export: pim-job-instance-xlsx-base-export
                 xlsx_attribute_export: pim-job-instance-xlsx-base-export
                 xlsx_attribute_group_export: pim-job-instance-xlsx-base-export

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/providers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/providers.yml
@@ -96,6 +96,7 @@ services:
                 xlsx_group_type_export: pim-job-instance-xlsx-base-export
                 xlsx_locale_export: pim-job-instance-xlsx-base-export
                 xlsx_product_export: pim-job-instance-xlsx-product-export
+                xlsx_product_model_export: pim-job-instance-xlsx-product-model-export
                 csv_association_type_import: pim-job-instance-csv-base-import
                 csv_attribute_import: pim-job-instance-csv-base-import
                 csv_attribute_group_import: pim-job-instance-csv-base-import

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
@@ -1211,6 +1211,9 @@ batch_jobs:
     xlsx_product_export:
         label: Product export in XLSX
         export.label: Product export
+    xlsx_product_model_export:
+        label: Product model export in XLSX
+        export.label: Product model export
     xlsx_product_import:
         label: Product import in XLSX
         validation.label: File validation

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
@@ -1090,6 +1090,9 @@ batch_jobs:
     csv_product_export:
         label: Product export in CSV
         export.label: Product export
+    csv_product_model_export:
+        label: Product model export in CSV
+        export.label: Product export
     csv_category_export:
         label: Category export in CSV
         export.label: Category export

--- a/src/Pim/Bundle/InstallerBundle/Resources/fixtures/icecat_demo_dev/jobs.yml
+++ b/src/Pim/Bundle/InstallerBundle/Resources/fixtures/icecat_demo_dev/jobs.yml
@@ -296,6 +296,14 @@ jobs:
                         - fr_FR
                         - en_US
                         - de_DE
+    xlsx_product_model_export:
+        connector: Akeneo XLSX Connector
+        alias:     xlsx_product_model_export
+        label:     Demo XLSX product model export
+        type:      export
+        configuration:
+            withHeader: true
+            with_media: true
     xlsx_group_export:
         connector: Akeneo XLSX Connector
         alias:     xlsx_group_export

--- a/src/Pim/Bundle/InstallerBundle/Resources/fixtures/icecat_demo_dev/jobs.yml
+++ b/src/Pim/Bundle/InstallerBundle/Resources/fixtures/icecat_demo_dev/jobs.yml
@@ -64,6 +64,15 @@ jobs:
                         - fr_FR
                         - en_US
                         - de_DE
+    csv_product_model_export:
+        connector: Akeneo CSV Connector
+        alias:     csv_product_model_export
+        label:     Demo CSV product model export
+        type:      export
+        configuration:
+            delimiter:  ;
+            enclosure:  '"'
+            withHeader: true
     csv_category_import:
         connector: Akeneo CSV Connector
         alias:     csv_category_import

--- a/src/Pim/Bundle/InstallerBundle/Resources/fixtures/icecat_demo_dev/jobs.yml
+++ b/src/Pim/Bundle/InstallerBundle/Resources/fixtures/icecat_demo_dev/jobs.yml
@@ -73,6 +73,7 @@ jobs:
             delimiter:  ;
             enclosure:  '"'
             withHeader: true
+            with_media: true
     csv_category_import:
         connector: Akeneo CSV Connector
         alias:     csv_category_import

--- a/src/Pim/Component/Catalog/Normalizer/Standard/ProductModelNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Standard/ProductModelNormalizer.php
@@ -20,6 +20,7 @@ class ProductModelNormalizer extends SerializerAwareNormalizer implements Normal
     private const FIELD_VALUES = 'values';
     private const FIELD_CREATED = 'created';
     private const FIELD_UPDATED = 'updated';
+    private const FIELD_PARENT = 'parent';
 
     /**
      * {@inheritdoc}
@@ -34,6 +35,7 @@ class ProductModelNormalizer extends SerializerAwareNormalizer implements Normal
 
         $data[self::FIELD_CODE] = $productModel->getCode();
         $data[self::FIELD_FAMILY_VARIANT] = $productModel->getFamilyVariant()->getCode();
+        $data[self::FIELD_PARENT] = null !== $productModel->getParent() ? $productModel->getParent()->getCode() : null;
         $data[self::FIELD_CATEGORIES] = $productModel->getCategoryCodes();
         $data[self::FIELD_VALUES] = $this->serializer->normalize($productModel->getValues(), $format, $context);
         $data[self::FIELD_CREATED] = $this->serializer->normalize($productModel->getCreated(), $format, $context);

--- a/src/Pim/Component/Catalog/spec/Normalizer/Standard/ProductModelNormalizerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Normalizer/Standard/ProductModelNormalizerSpec.php
@@ -29,7 +29,7 @@ class ProductModelNormalizerSpec extends ObjectBehavior
         $this->shouldImplement(SerializerAwareInterface::class);
     }
 
-    function it_normalizes_product_model(
+    function it_normalizes_product_model_without_parent(
         ProductModelInterface $productModel,
         Serializer $normalizer,
         FamilyVariantInterface $familyVariant,
@@ -38,6 +38,7 @@ class ProductModelNormalizerSpec extends ObjectBehavior
         $this->setSerializer($normalizer);
 
         $productModel->getCode()->willReturn('code');
+        $productModel->getParent()->willReturn(null);
         $productModel->getFamilyVariant()->willReturn($familyVariant);
         $familyVariant->getCode()->willReturn('family_variant');
 
@@ -60,6 +61,57 @@ class ProductModelNormalizerSpec extends ObjectBehavior
         $this->normalize($productModel, 'standard')->shouldReturn([
             'code' => 'code',
             'family_variant' => 'family_variant',
+            'parent' => null,
+            'categories' => ['tshirt'],
+            'values' => [
+                'name' => [
+                    [
+                        'locale' => null,
+                        'scope'  => null,
+                        'value'  => 'foo',
+                    ]
+                ]
+            ],
+            'created' => '2010-06-23T00:00:00+01:00',
+            'updated' => '2010-06-23T23:00:00+01:00',
+        ]);
+    }
+
+    function it_normalizes_product_model_with_parent(
+        ProductModelInterface $productModel,
+        Serializer $normalizer,
+        FamilyVariantInterface $familyVariant,
+        ValueCollection $values,
+        ProductModelInterface $parentModel
+    ) {
+        $this->setSerializer($normalizer);
+
+        $productModel->getCode()->willReturn('code');
+        $productModel->getParent()->willReturn($parentModel);
+        $parentModel->getCode()->willReturn('parent_code');
+        $productModel->getFamilyVariant()->willReturn($familyVariant);
+        $familyVariant->getCode()->willReturn('family_variant');
+
+        $productModel->getValues()->willReturn($values);
+
+        $normalizer
+            ->normalize($values, 'standard', [])
+            ->willReturn(['name' => [['locale' => null, 'scope' => null, 'value' => 'foo']]]);
+
+        $productModel->getCategoryCodes()->willReturn(['tshirt']);
+
+        $created = new \DateTime('2010-06-23');
+        $productModel->getCreated()->willReturn($created);
+        $normalizer->normalize($created, 'standard', [])->willReturn('2010-06-23T00:00:00+01:00');
+
+        $updated = new \DateTime('2010-06-23 23:00:00');
+        $productModel->getUpdated()->willReturn($updated);
+        $normalizer->normalize($updated, 'standard', [])->willReturn('2010-06-23T23:00:00+01:00');
+
+        $this->normalize($productModel, 'standard')->shouldReturn([
+            'code' => 'code',
+            'family_variant' => 'family_variant',
+            'parent' => 'parent_code',
             'categories' => ['tshirt'],
             'values' => [
                 'name' => [

--- a/src/Pim/Component/Connector/ArrayConverter/StandardToFlat/ProductModel.php
+++ b/src/Pim/Component/Connector/ArrayConverter/StandardToFlat/ProductModel.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Pim\Component\Connector\ArrayConverter\StandardToFlat;
+
+use Pim\Component\Connector\ArrayConverter\ArrayConverterInterface;
+use Pim\Component\Connector\ArrayConverter\StandardToFlat\Product\ProductValueConverter;
+
+/**
+ * Convert standard format to flat format for product model
+ *
+ * @author    Nicolas Dupont <nicolas@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class ProductModel extends AbstractSimpleArrayConverter implements ArrayConverterInterface
+{
+    /** @var ProductValueConverter */
+    protected $valueConverter;
+
+    /**
+     * @param ProductValueConverter $valueConverter
+     */
+    public function __construct(ProductValueConverter $valueConverter)
+    {
+        $this->valueConverter = $valueConverter;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function convertProperty($property, $data, array $convertedItem, array $options)
+    {
+        switch ($property) {
+            case 'categories':
+                $convertedItem[$property] = implode(',', $data);
+                break;
+            case 'code':
+            case 'family_variant':
+            case 'parent':
+                $convertedItem[$property] = (string) $data;
+                break;
+            case 'values':
+                foreach ($data as $code => $attribute) {
+                    $convertedItem = $convertedItem + $this->valueConverter->convertAttribute($code, $attribute);
+                }
+                break;
+            case 'created':
+            case 'updated':
+                break;
+            default:
+                break;
+        }
+
+        return $convertedItem;
+    }
+}

--- a/src/Pim/Component/Connector/Job/JobParameters/ConstraintCollectionProvider/ProductModelCsvExport.php
+++ b/src/Pim/Component/Connector/Job/JobParameters/ConstraintCollectionProvider/ProductModelCsvExport.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Component\Connector\Job\JobParameters\ConstraintCollectionProvider;
+
+use Akeneo\Component\Batch\Job\JobInterface;
+use Akeneo\Component\Batch\Job\JobParameters\ConstraintCollectionProviderInterface;
+use Pim\Component\Catalog\Validator\Constraints\Channel;
+use Pim\Component\Connector\Validator\Constraints\FilterData;
+use Pim\Component\Connector\Validator\Constraints\FilterStructureAttribute;
+use Pim\Component\Connector\Validator\Constraints\FilterStructureLocale;
+use Symfony\Component\Validator\Constraints\Collection;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Type;
+
+/**
+ * Constraints for product model CSV export
+ *
+ * @author    Nicolas Dupont <nicolas@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ProductModelCsvExport implements ConstraintCollectionProviderInterface
+{
+    /** @var ConstraintCollectionProviderInterface */
+    private $simpleProvider;
+
+    /** @var array */
+    private $supportedJobNames;
+
+    /**
+     * @param ConstraintCollectionProviderInterface $simpleCsv
+     * @param array                                 $supportedJobNames
+     */
+    public function __construct(ConstraintCollectionProviderInterface $simpleCsv, array $supportedJobNames)
+    {
+        $this->simpleProvider = $simpleCsv;
+        $this->supportedJobNames = $supportedJobNames;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getConstraintCollection()
+    {
+        $baseConstraint = $this->simpleProvider->getConstraintCollection();
+        $constraintFields = $baseConstraint->fields;
+        $constraintFields['with_media'] = new Type(
+            [
+                'type'   => 'bool',
+                'groups' => ['Default', 'FileConfiguration'],
+            ]
+        );
+
+        return new Collection(['fields' => $constraintFields]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports(JobInterface $job)
+    {
+        return in_array($job->getName(), $this->supportedJobNames);
+    }
+}

--- a/src/Pim/Component/Connector/Job/JobParameters/DefaultValuesProvider/ProductModelCsvExport.php
+++ b/src/Pim/Component/Connector/Job/JobParameters/DefaultValuesProvider/ProductModelCsvExport.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Component\Connector\Job\JobParameters\DefaultValuesProvider;
+
+use Akeneo\Component\Batch\Job\JobInterface;
+use Akeneo\Component\Batch\Job\JobParameters\DefaultValuesProviderInterface;
+use Akeneo\Component\Localization\Localizer\LocalizerInterface;
+use Pim\Component\Catalog\Query\Filter\Operators;
+use Pim\Component\Catalog\Repository\ChannelRepositoryInterface;
+use Pim\Component\Catalog\Repository\LocaleRepositoryInterface;
+
+/**
+ * DefaultParameters for product model CSV export
+ *
+ * @author    Nicolas Dupont <nicolas@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ProductModelCsvExport implements DefaultValuesProviderInterface
+{
+    /** @var DefaultValuesProviderInterface */
+    private $simpleProvider;
+
+    /** @var array */
+    private $supportedJobNames;
+
+    /**
+     * @param DefaultValuesProviderInterface $simpleProvider
+     * @param array                          $supportedJobNames
+     */
+    public function __construct(
+        DefaultValuesProviderInterface $simpleProvider,
+        array $supportedJobNames
+    ) {
+        $this->simpleProvider = $simpleProvider;
+        $this->supportedJobNames = $supportedJobNames;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultValues()
+    {
+        $parameters = $this->simpleProvider->getDefaultValues();
+        $parameters['with_media'] = true;
+
+        return $parameters;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports(JobInterface $job)
+    {
+        return in_array($job->getName(), $this->supportedJobNames);
+    }
+}

--- a/src/Pim/Component/Connector/Processor/Normalization/ProductModelProcessor.php
+++ b/src/Pim/Component/Connector/Processor/Normalization/ProductModelProcessor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Pim\Component\Connector\Processor\Normalization;
 
 use Akeneo\Component\Batch\Item\DataInvalidItem;
@@ -110,7 +112,7 @@ class ProductModelProcessor implements ItemProcessorInterface, StepExecutionAwar
      * @param ProductModelInterface $productModel
      * @param string                $directory
      */
-    protected function fetchMedia(ProductModelInterface $productModel, $directory)
+    private function fetchMedia(ProductModelInterface $productModel, $directory)
     {
         $identifier = $productModel->getCode();
         $this->mediaFetcher->fetchAll($productModel->getValues(), $directory, $identifier);

--- a/src/Pim/Component/Connector/Processor/Normalization/ProductModelProcessor.php
+++ b/src/Pim/Component/Connector/Processor/Normalization/ProductModelProcessor.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Pim\Component\Connector\Processor\Normalization;
+
+use Akeneo\Component\Batch\Item\DataInvalidItem;
+use Akeneo\Component\Batch\Item\ItemProcessorInterface;
+use Akeneo\Component\Batch\Job\JobInterface;
+use Akeneo\Component\Batch\Job\JobParameters;
+use Akeneo\Component\Batch\Model\StepExecution;
+use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
+use Akeneo\Component\StorageUtils\Detacher\ObjectDetacherInterface;
+use Pim\Component\Catalog\Builder\ProductBuilderInterface;
+use Pim\Component\Catalog\Model\ProductInterface;
+use Pim\Component\Catalog\Model\ProductModelInterface;
+use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
+use Pim\Component\Catalog\Repository\ChannelRepositoryInterface;
+use Pim\Component\Catalog\ValuesFiller\EntityWithFamilyValuesFillerInterface;
+use Pim\Component\Connector\Processor\BulkMediaFetcher;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * Product model processor to process and normalize productModel model to the standard format
+ *
+ * @author    Nicolas Dupont <nicolas@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ProductModelProcessor implements ItemProcessorInterface, StepExecutionAwareInterface
+{
+    /** @var NormalizerInterface */
+    protected $normalizer;
+
+    /** @var AttributeRepositoryInterface */
+    protected $attributeRepository;
+
+    /** @var ObjectDetacherInterface */
+    protected $detacher;
+
+    /** @var StepExecution */
+    protected $stepExecution;
+
+    /** @var BulkMediaFetcher */
+    protected $mediaFetcher;
+
+    /** @var EntityWithFamilyValuesFillerInterface */
+    protected $productModelValuesFiller;
+
+    /**
+     * @param NormalizerInterface                   $normalizer
+     * @param AttributeRepositoryInterface          $attributeRepository
+     * @param ObjectDetacherInterface               $detacher
+     * @param BulkMediaFetcher                      $mediaFetcher
+     * @param EntityWithFamilyValuesFillerInterface $productModelValuesFiller
+     */
+    public function __construct(
+        NormalizerInterface $normalizer,
+        AttributeRepositoryInterface $attributeRepository,
+        ObjectDetacherInterface $detacher,
+        BulkMediaFetcher $mediaFetcher,
+        EntityWithFamilyValuesFillerInterface $productModelValuesFiller
+    ) {
+        $this->normalizer = $normalizer;
+        $this->detacher = $detacher;
+        $this->attributeRepository = $attributeRepository;
+        $this->mediaFetcher = $mediaFetcher;
+        $this->productModelValuesFiller = $productModelValuesFiller;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process($productModel)
+    {
+        $parameters = $this->stepExecution->getJobParameters();
+        $this->productModelValuesFiller->fillMissingValues($productModel);
+        $productModelStandard = $this->normalizer->normalize($productModel, 'standard');
+
+        if ($parameters->has('with_media') && $parameters->get('with_media')) {
+            $directory = $this->stepExecution->getJobExecution()->getExecutionContext()
+                ->get(JobInterface::WORKING_DIRECTORY_PARAMETER);
+
+            $this->fetchMedia($productModel, $directory);
+        } else {
+            $mediaAttributes = $this->attributeRepository->findMediaAttributeCodes();
+            $productModelStandard['values'] = array_filter(
+                $productModelStandard['values'],
+                function ($attributeCode) use ($mediaAttributes) {
+                    return !in_array($attributeCode, $mediaAttributes);
+                },
+                ARRAY_FILTER_USE_KEY
+            );
+        }
+
+        $this->detacher->detach($productModel);
+
+        return $productModelStandard;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setStepExecution(StepExecution $stepExecution)
+    {
+        $this->stepExecution = $stepExecution;
+    }
+
+    /**
+     * Fetch medias on the local filesystem
+     *
+     * @param ProductModelInterface $productModel
+     * @param string                $directory
+     */
+    protected function fetchMedia(ProductModelInterface $productModel, $directory)
+    {
+        $identifier = $productModel->getCode();
+        $this->mediaFetcher->fetchAll($productModel->getValues(), $directory, $identifier);
+
+        foreach ($this->mediaFetcher->getErrors() as $error) {
+            $this->stepExecution->addWarning($error['message'], [], new DataInvalidItem($error['media']));
+        }
+    }
+}

--- a/src/Pim/Component/Connector/Reader/Database/ProductModelReader.php
+++ b/src/Pim/Component/Connector/Reader/Database/ProductModelReader.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Pim\Component\Connector\Reader\Database;
 
 use Akeneo\Component\Batch\Item\InitializableInterface;

--- a/src/Pim/Component/Connector/Reader/Database/ProductModelReader.php
+++ b/src/Pim/Component/Connector/Reader/Database/ProductModelReader.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Pim\Component\Connector\Reader\Database;
+
+use Akeneo\Component\Batch\Item\InitializableInterface;
+use Akeneo\Component\Batch\Item\ItemReaderInterface;
+use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
+use Pim\Component\Catalog\Repository\ProductModelRepositoryInterface;
+
+/**
+ * The product model repository reader
+ *
+ * @author    Nicolas Dupont <nicolas@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ProductModelReader extends AbstractReader implements
+    ItemReaderInterface,
+    InitializableInterface,
+    StepExecutionAwareInterface
+{
+    /** @var ProductModelRepositoryInterface */
+    protected $repository;
+
+    /**
+     * @param ProductModelRepositoryInterface $repository
+     */
+    public function __construct(ProductModelRepositoryInterface $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getResults()
+    {
+        // TODO PIM-6737: temporary until we discuss how to fetch all models, needs a new elastic search index
+        return new \ArrayIterator($this->repository->findAll());
+    }
+}

--- a/src/Pim/Component/Connector/Reader/File/Csv/ProductModelReader.php
+++ b/src/Pim/Component/Connector/Reader/File/Csv/ProductModelReader.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Pim\Component\Connector\Reader\File\Csv;
 
 use Akeneo\Component\Batch\Item\FlushableInterface;

--- a/src/Pim/Component/Connector/Writer/File/Csv/ProductModelWriter.php
+++ b/src/Pim/Component/Connector/Writer/File/Csv/ProductModelWriter.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Pim\Component\Connector\Writer\File\Csv;
+
+use Akeneo\Component\Batch\Item\FlushableInterface;
+use Akeneo\Component\Batch\Item\InitializableInterface;
+use Akeneo\Component\Batch\Item\ItemWriterInterface;
+use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
+use Pim\Component\Connector\Writer\File\AbstractItemMediaWriter;
+use Pim\Component\Connector\Writer\File\ArchivableWriterInterface;
+
+/**
+ * Write product model data into a csv file on the local filesystem
+ *
+ * @author    Nicolas Dupont <nicolas@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ProductModelWriter extends AbstractItemMediaWriter implements
+    ItemWriterInterface,
+    InitializableInterface,
+    FlushableInterface,
+    StepExecutionAwareInterface,
+    ArchivableWriterInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function getWriterConfiguration()
+    {
+        $parameters = $this->stepExecution->getJobParameters();
+
+        return [
+            'type'           => 'csv',
+            'fieldDelimiter' => $parameters->get('delimiter'),
+            'fieldEnclosure' => $parameters->get('enclosure'),
+            'shouldAddBOM'   => false,
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getItemIdentifier(array $productModel)
+    {
+        return $productModel['code'];
+    }
+}

--- a/src/Pim/Component/Connector/Writer/File/Xlsx/ProductModelWriter.php
+++ b/src/Pim/Component/Connector/Writer/File/Xlsx/ProductModelWriter.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Component\Connector\Writer\File\Xlsx;
+
+use Akeneo\Component\Batch\Item\FlushableInterface;
+use Akeneo\Component\Batch\Item\InitializableInterface;
+use Akeneo\Component\Batch\Item\ItemWriterInterface;
+use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
+use Pim\Component\Connector\Writer\File\AbstractItemMediaWriter;
+use Pim\Component\Connector\Writer\File\ArchivableWriterInterface;
+
+/**
+ * Write product model data into a XLSX file on the local filesystem
+ *
+ * @author    Nicolas Dupont <nicolas@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ProductModelWriter extends AbstractItemMediaWriter implements
+    ItemWriterInterface,
+    InitializableInterface,
+    FlushableInterface,
+    StepExecutionAwareInterface,
+    ArchivableWriterInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function getWriterConfiguration()
+    {
+        return ['type' => 'xlsx'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getItemIdentifier(array $productModel)
+    {
+        return $productModel['code'];
+    }
+}

--- a/src/Pim/Component/Connector/spec/ArrayConverter/StandardToFlat/ProductModelSpec.php
+++ b/src/Pim/Component/Connector/spec/ArrayConverter/StandardToFlat/ProductModelSpec.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace spec\Pim\Component\Connector\ArrayConverter\StandardToFlat;
+
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
+use Pim\Component\Connector\ArrayConverter\StandardToFlat\Product\ProductValueConverter;
+
+class ProductModelSpec extends ObjectBehavior
+{
+    function let(
+        ProductValueConverter $valueConverter,
+        AttributeRepositoryInterface $attributeRepository,
+        AttributeInterface $identifierAttribute
+    ) {
+        $attributeRepository->getIdentifier()->willReturn($identifierAttribute);
+        $identifierAttribute->getCode()->willReturn('sku');
+
+        $this->beConstructedWith($valueConverter, $attributeRepository);
+    }
+
+    function it_converts_from_standard_to_flat_format($valueConverter)
+    {
+        $valueConverter->convertAttribute('weight',
+            [
+                [
+                    'locale' => 'de_DE',
+                    'scope'  => 'print',
+                    'data'   => [
+                        'unit'   => 'KILOGRAM',
+                        'amount' => '100'
+                    ]
+                ]
+            ]
+        )->willReturn([
+            'weight-de_DE-print' => '100',
+            'weight-de_DE-print-unit' => 'KILOGRAM',
+        ]);
+
+        $expected = [
+            'code'                    => 'apollon',
+            'categories'              => 'audio_video_sales,loudspeakers,sony',
+            'family_variant'          => 'soundspeaker_color',
+            'parent'                  => 'parent_model_code',
+            'weight-de_DE-print'      => '100',
+            'weight-de_DE-print-unit' => 'KILOGRAM',
+        ];
+
+        $item = [
+            'code'              => 'apollon',
+            'categories'        => ['audio_video_sales', 'loudspeakers', 'sony'],
+            'family_variant'    => 'soundspeaker_color',
+            'parent'            => 'parent_model_code',
+            'values'            => [
+                'weight'            => [
+                    [
+                        'locale' => 'de_DE',
+                        'scope'  => 'print',
+                        'data'   => [
+                            'unit' => 'KILOGRAM',
+                            'amount' => '100'
+                        ]
+                    ]
+                ],
+            ]
+        ];
+
+        $this->convert($item)->shouldReturn($expected);
+    }
+}

--- a/src/Pim/Component/Connector/spec/Job/JobParameters/ConstraintCollectionProvider/ProductModelCsvExportSpec.php
+++ b/src/Pim/Component/Connector/spec/Job/JobParameters/ConstraintCollectionProvider/ProductModelCsvExportSpec.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace spec\Pim\Component\Connector\Job\JobParameters\ConstraintCollectionProvider;
+
+use Akeneo\Component\Batch\Job\JobInterface;
+use Akeneo\Component\Batch\Job\JobParameters\ConstraintCollectionProviderInterface;
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\Validator\Constraints\Collection;
+
+class ProductModelCsvExportSpec extends ObjectBehavior
+{
+    function let(ConstraintCollectionProviderInterface $decoratedProvider)
+    {
+        $this->beConstructedWith($decoratedProvider, ['my_supported_job_name']);
+    }
+
+    function it_is_a_provider()
+    {
+        $this->shouldImplement(ConstraintCollectionProviderInterface::class);
+    }
+
+    function it_provides_constraints_collection(
+        $decoratedProvider,
+        Collection $decoratedCollection
+    ) {
+        $decoratedProvider->getConstraintCollection()->willReturn($decoratedCollection);
+        $collection = $this->getConstraintCollection();
+        $collection->shouldReturnAnInstanceOf('Symfony\Component\Validator\Constraints\Collection');
+        $fields = $collection->fields;
+        $fields->shouldHaveKey('with_media');
+    }
+
+    function it_supports_a_job(JobInterface $job)
+    {
+        $job->getName()->willReturn('my_supported_job_name');
+        $this->supports($job)->shouldReturn(true);
+    }
+}

--- a/src/Pim/Component/Connector/spec/Job/JobParameters/DefaultValuesProvider/ProductModelCsvExportSpec.php
+++ b/src/Pim/Component/Connector/spec/Job/JobParameters/DefaultValuesProvider/ProductModelCsvExportSpec.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace spec\Pim\Component\Connector\Job\JobParameters\DefaultValuesProvider;
+
+use Akeneo\Component\Batch\Job\JobInterface;
+use Akeneo\Component\Batch\Job\JobParameters\DefaultValuesProviderInterface;
+use PhpSpec\ObjectBehavior;
+
+class ProductModelCsvExportSpec extends ObjectBehavior
+{
+    function let(
+        DefaultValuesProviderInterface $decoratedProvider
+    ) {
+        $this->beConstructedWith($decoratedProvider, ['my_supported_job_name']);
+    }
+
+    function it_is_a_provider()
+    {
+        $this->shouldImplement(DefaultValuesProviderInterface::class);
+    }
+
+    function it_provides_default_values(
+        $decoratedProvider
+    ) {
+        $decoratedProvider->getDefaultValues()->willReturn(['decoratedParam' => true]);
+        $this->getDefaultValues()->shouldReturnWellFormedDefaultValues();
+    }
+
+    function it_supports_a_job(JobInterface $job)
+    {
+        $job->getName()->willReturn('my_supported_job_name');
+        $this->supports($job)->shouldReturn(true);
+    }
+
+    public function getMatchers()
+    {
+        return [
+            'returnWellFormedDefaultValues' => function ($parameters) {
+                return true === $parameters['decoratedParam'] &&
+                    true === $parameters['with_media'];
+            }
+        ];
+    }
+}

--- a/src/Pim/Component/Connector/spec/Processor/Normalization/ProductModelProcessorSpec.php
+++ b/src/Pim/Component/Connector/spec/Processor/Normalization/ProductModelProcessorSpec.php
@@ -1,0 +1,233 @@
+<?php
+
+namespace spec\Pim\Component\Connector\Processor\Normalization;
+
+use Akeneo\Component\Batch\Item\DataInvalidItem;
+use Akeneo\Component\Batch\Item\ExecutionContext;
+use Akeneo\Component\Batch\Job\JobInterface;
+use Akeneo\Component\Batch\Job\JobParameters;
+use Akeneo\Component\Batch\Model\JobExecution;
+use Akeneo\Component\Batch\Model\JobInstance;
+use Akeneo\Component\Batch\Model\StepExecution;
+use Akeneo\Component\StorageUtils\Detacher\ObjectDetacherInterface;
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Model\ProductModelInterface;
+use Pim\Component\Catalog\Model\ValueCollectionInterface;
+use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
+use Pim\Component\Catalog\ValuesFiller\EntityWithFamilyValuesFillerInterface;
+use Pim\Component\Connector\Processor\BulkMediaFetcher;
+use Prophecy\Argument;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+class ProductModelProcessorSpec extends ObjectBehavior
+{
+    function let(
+        NormalizerInterface $normalizer,
+        AttributeRepositoryInterface $attributeRepository,
+        ObjectDetacherInterface $detacher,
+        BulkMediaFetcher $mediaFetcher,
+        StepExecution $stepExecution,
+        EntityWithFamilyValuesFillerInterface $valuesFiller
+    ) {
+        $this->beConstructedWith(
+            $normalizer,
+            $attributeRepository,
+            $detacher,
+            $mediaFetcher,
+            $valuesFiller
+        );
+
+        $this->setStepExecution($stepExecution);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('\Pim\Component\Connector\Processor\Normalization\ProductModelProcessor');
+    }
+
+    function it_is_an_item_processor()
+    {
+        $this->shouldImplement('\Akeneo\Component\Batch\Item\ItemProcessorInterface');
+    }
+
+    function it_processes_product_model_without_media(
+        $detacher,
+        $normalizer,
+        $stepExecution,
+        $mediaFetcher,
+        $valuesFiller,
+        $attributeRepository,
+        ProductModelInterface $productModel,
+        JobParameters $jobParameters
+    ) {
+        $attributeRepository->findMediaAttributeCodes()->willReturn(['picture']);
+
+        $stepExecution->getJobParameters()->willReturn($jobParameters);
+        $jobParameters->get('filePath')->willReturn('/my/path/product_model.csv');
+        $jobParameters->has('with_media')->willReturn(true);
+        $jobParameters->get('with_media')->willReturn(false);
+
+        $valuesFiller->fillMissingValues($productModel)->shouldBeCalled();
+
+        $normalizer->normalize($productModel, 'standard')
+            ->willReturn([
+                'code'    => 'janis',
+                'categories' => ['cat1', 'cat2'],
+                'values' => [
+                    'picture' => [
+                        [
+                            'locale' => null,
+                            'scope'  => null,
+                            'data'   => 'a/b/c/d/e/f/little_cat.jpg'
+                        ]
+                    ],
+                    'size' => [
+                        [
+                            'locale' => null,
+                            'scope'  => null,
+                            'data'   => 'M'
+                        ]
+                    ]
+                ]
+            ]);
+
+        $mediaFetcher->fetchAll(Argument::cetera())->shouldNotBeCalled();
+        $mediaFetcher->getErrors()->shouldNotBeCalled();
+
+        $detacher->detach($productModel)->shouldBeCalled();
+
+        $this->process($productModel)->shouldReturn([
+            'code'    => 'janis',
+            'categories' => ['cat1', 'cat2'],
+            'values' => [
+                'size' => [
+                    [
+                        'locale' => null,
+                        'scope'  => null,
+                        'data'   => 'M'
+                    ]
+                ]
+            ]
+        ]);
+    }
+
+    function it_processes_a_product_model_with_several_media(
+        $detacher,
+        $normalizer,
+        $stepExecution,
+        $mediaFetcher,
+        $valuesFiller,
+        ProductModelInterface $productModel,
+        JobParameters $jobParameters,
+        JobExecution $jobExecution,
+        JobInstance $jobInstance,
+        ValueCollectionInterface $valuesCollection,
+        ExecutionContext $executionContext
+    ) {
+        $stepExecution->getJobParameters()->willReturn($jobParameters);
+        $jobParameters->get('filePath')->willReturn('/my/path/product_model.csv');
+        $jobParameters->has('with_media')->willReturn(true);
+        $jobParameters->get('with_media')->willReturn(true);
+
+        $valuesFiller->fillMissingValues($productModel)->shouldBeCalled();
+        $productModel->getCode()->willReturn('janis');
+        $productModel->getValues()->willReturn($valuesCollection);
+
+        $stepExecution->getJobExecution()->willReturn($jobExecution);
+        $jobExecution->getJobInstance()->willReturn($jobInstance);
+        $jobExecution->getId()->willReturn(100);
+        $jobInstance->getCode()->willReturn('csv_product_model_export');
+
+        $jobExecution->getExecutionContext()->willReturn($executionContext);
+        $executionContext->get(JobInterface::WORKING_DIRECTORY_PARAMETER)->willReturn('/working/directory/');
+
+        $productModelStandard = [
+            'values' => [
+                'picture' => [
+                    'locale' => null,
+                    'scope'  => null,
+                    'data'   => ['filePath' => 'a/b/c/d/e/f/little_cat.jpg']
+                ],
+                'pdf_description' => [
+                    'locale' => 'en_US',
+                    'scope'  => null,
+                    'data'   => ['filePath' => 'a/f/c/c/e/f/little_cat.pdf']
+                ]
+            ]
+        ];
+
+        $normalizer->normalize($productModel, 'standard')
+            ->willReturn($productModelStandard);
+
+        $mediaFetcher->fetchAll($valuesCollection, '/working/directory/', 'janis')->shouldBeCalled();
+        $mediaFetcher->getErrors()->willReturn([]);
+
+        $this->process($productModel)->shouldReturn($productModelStandard);
+
+        $detacher->detach($productModel)->shouldBeCalled();
+    }
+
+    function it_throws_an_exception_if_media_of_product_model_is_not_found(
+        $detacher,
+        $normalizer,
+        $stepExecution,
+        $mediaFetcher,
+        $valuesFiller,
+        ProductModelInterface $productModel,
+        JobParameters $jobParameters,
+        JobExecution $jobExecution,
+        JobInstance $jobInstance,
+        ValueCollectionInterface $valuesCollection,
+        ExecutionContext $executionContext
+    ) {
+        $stepExecution->getJobParameters()->willReturn($jobParameters);
+        $jobParameters->get('filePath')->willReturn('/my/path/product_model.csv');
+        $jobParameters->has('with_media')->willReturn(true);
+        $jobParameters->get('with_media')->willReturn(true);
+
+        $valuesFiller->fillMissingValues($productModel)->shouldBeCalled();
+        $productModel->getCode()->willReturn('janis');
+        $productModel->getValues()->willReturn($valuesCollection);
+
+        $stepExecution->getJobExecution()->willReturn($jobExecution);
+        $jobExecution->getJobInstance()->willReturn($jobInstance);
+        $jobExecution->getId()->willReturn(100);
+        $jobInstance->getCode()->willReturn('csv_product_model_export');
+
+        $jobExecution->getExecutionContext()->willReturn($executionContext);
+        $executionContext->get(JobInterface::WORKING_DIRECTORY_PARAMETER)->willReturn('/working/directory/');
+
+        $productModelStandard = [
+            'values' => [
+                'pdf_description' => [
+                    'locale' => 'en_US',
+                    'scope'  => null,
+                    'data'   => ['filePath' => 'path/not_found.jpg']
+                ]
+            ]
+        ];
+
+        $normalizer->normalize($productModel, 'standard')
+            ->willReturn($productModelStandard);
+
+        $mediaFetcher->fetchAll($valuesCollection, '/working/directory/', 'janis')->shouldBeCalled();
+        $mediaFetcher->getErrors()->willReturn(
+            [
+                [
+                    'message' => 'The media has not been found or is not currently available',
+                    'media'   => ['filePath' => 'path/not_found.jpg']
+                ]
+            ]
+        );
+
+        $stepExecution->addWarning(
+            'The media has not been found or is not currently available',
+            [],
+            new DataInvalidItem(['filePath' => 'path/not_found.jpg'])
+        )->shouldBeCalled();
+
+        $this->process($productModel)->shouldReturn($productModelStandard);
+
+        $detacher->detach($productModel)->shouldBeCalled();
+    }
+}

--- a/src/Pim/Component/Connector/spec/Processor/Normalization/ProductModelProcessorSpec.php
+++ b/src/Pim/Component/Connector/spec/Processor/Normalization/ProductModelProcessorSpec.php
@@ -4,6 +4,7 @@ namespace spec\Pim\Component\Connector\Processor\Normalization;
 
 use Akeneo\Component\Batch\Item\DataInvalidItem;
 use Akeneo\Component\Batch\Item\ExecutionContext;
+use Akeneo\Component\Batch\Item\ItemProcessorInterface;
 use Akeneo\Component\Batch\Job\JobInterface;
 use Akeneo\Component\Batch\Job\JobParameters;
 use Akeneo\Component\Batch\Model\JobExecution;
@@ -16,6 +17,7 @@ use Pim\Component\Catalog\Model\ValueCollectionInterface;
 use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
 use Pim\Component\Catalog\ValuesFiller\EntityWithFamilyValuesFillerInterface;
 use Pim\Component\Connector\Processor\BulkMediaFetcher;
+use Pim\Component\Connector\Processor\Normalization\ProductModelProcessor;
 use Prophecy\Argument;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
@@ -42,12 +44,12 @@ class ProductModelProcessorSpec extends ObjectBehavior
 
     function it_is_initializable()
     {
-        $this->shouldHaveType('\Pim\Component\Connector\Processor\Normalization\ProductModelProcessor');
+        $this->shouldHaveType(ProductModelProcessor::class);
     }
 
     function it_is_an_item_processor()
     {
-        $this->shouldImplement('\Akeneo\Component\Batch\Item\ItemProcessorInterface');
+        $this->shouldImplement(ItemProcessorInterface::class);
     }
 
     function it_processes_product_model_without_media(

--- a/src/Pim/Component/Connector/spec/Reader/Database/ProductModelReaderSpec.php
+++ b/src/Pim/Component/Connector/spec/Reader/Database/ProductModelReaderSpec.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace spec\Pim\Component\Connector\Reader\Database;
+
+use Akeneo\Component\Batch\Model\StepExecution;
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Model\ProductModelInterface;
+use Pim\Component\Catalog\Repository\ProductModelRepositoryInterface;
+
+class ProductModelReaderSpec extends ObjectBehavior
+{
+    function let(ProductModelRepositoryInterface $repository)
+    {
+        $this->beConstructedWith($repository);
+    }
+
+    function it_is_a_reader()
+    {
+        $this->shouldImplement('Akeneo\Component\Batch\Item\ItemReaderInterface');
+        $this->shouldImplement('Akeneo\Component\Batch\Step\StepExecutionAwareInterface');
+    }
+
+    function it_returns_a_product_model(
+        $repository,
+        ProductModelInterface $productModel,
+        StepExecution $stepExecution
+    ) {
+        $repository->findAll()->willReturn([$productModel]);
+        $this->setStepExecution($stepExecution);
+        $stepExecution->incrementSummaryInfo('read')->shouldBeCalledTimes(1);
+
+        $this->read()->shouldReturn($productModel);
+        $this->read()->shouldReturn(null);
+    }
+}

--- a/src/Pim/Component/Connector/spec/Reader/Database/ProductModelReaderSpec.php
+++ b/src/Pim/Component/Connector/spec/Reader/Database/ProductModelReaderSpec.php
@@ -2,7 +2,9 @@
 
 namespace spec\Pim\Component\Connector\Reader\Database;
 
+use Akeneo\Component\Batch\Item\ItemReaderInterface;
 use Akeneo\Component\Batch\Model\StepExecution;
+use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Model\ProductModelInterface;
 use Pim\Component\Catalog\Repository\ProductModelRepositoryInterface;
@@ -16,8 +18,8 @@ class ProductModelReaderSpec extends ObjectBehavior
 
     function it_is_a_reader()
     {
-        $this->shouldImplement('Akeneo\Component\Batch\Item\ItemReaderInterface');
-        $this->shouldImplement('Akeneo\Component\Batch\Step\StepExecutionAwareInterface');
+        $this->shouldImplement(ItemReaderInterface::class);
+        $this->shouldImplement(StepExecutionAwareInterface::class);
     }
 
     function it_returns_a_product_model(

--- a/tests/catalog/technical/jobs.yml
+++ b/tests/catalog/technical/jobs.yml
@@ -103,3 +103,13 @@ jobs:
             filePath:     /tmp/products_export_grid_context_%locale%_%scope%_%datetime%.xlsx
             linesPerFile: 10000
             with_media:   true
+    csv_product_model_export:
+        connector: Akeneo CSV Connector
+        alias:     csv_product_model_export
+        label:     CSV product model export
+        type:      export
+        configuration:
+            delimiter:  ;
+            enclosure:  '"'
+            withHeader: true
+            filePath: /tmp/product_models.csv


### PR DESCRIPTION
@jjanvier we need to discuss about the product model reader. Here, I implement it with the repository findAll method as we do for families etc but i'd like use a proper cursor like for products, I don't know yet what are the impacts (needs a dedicated elastic search index for product models?).

As this PR is already pretty fat, I'd prefer pass this change with an upcoming dedicated PR implementing the index, cursor, etc thing + changing the product model reader implementation.

@ahocquard I introduced here the integration tests for product models export, the creation of product model, variant product, family variant, attribute option, etc is now usable in upcoming import/export tests to continue to replace legacy behat scenario by integration tests :wink: 

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Y
| Added Behats                      | N
| Added integration tests           | Y
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
