### PR TITLE
 PIM-6737: product model index in elasticsearch + product model reader

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -128,6 +128,10 @@ akeneo_elasticsearch:
             index_name: "%product_index_name%"
             configuration_files: "%elasticsearch_index_configuration_files%"
         -
+            service_name: "akeneo_elasticsearch.client.product_model"
+            index_name: "%product_model_index_name%"
+            configuration_files: "%elasticsearch_index_configuration_files%"
+        -
             service_name: "akeneo_elasticsearch.client.product_and_product_model"
             index_name: "%product_and_product_model_index_name%"
             configuration_files: "%elasticsearch_index_configuration_files%"

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -8,5 +8,6 @@ parameters:
     locale:                               en
     secret:                               ThisTokenIsNotSoSecretChangeIt
     product_index_name:                   akeneo_pim_product
+    product_model_index_name:             akeneo_pim_product_model
     product_and_product_model_index_name: akeneo_pim_product_and_product_model
     index_hosts:                          'localhost: 9200'

--- a/app/config/parameters_test.yml.dist
+++ b/app/config/parameters_test.yml.dist
@@ -9,5 +9,6 @@ parameters:
     secret:                                ThisTokenIsNotSoSecretChangeIt
     installer_data:                        PimInstallerBundle:minimal
     product_index_name:                    akeneo_pim_product
+    product_model_index_name:              akeneo_pim_product_model
     product_and_product_model_index_name:  akeneo_pim_product_and_product_model
     index_hosts:                          'localhost: 9200'

--- a/src/Akeneo/Bundle/ElasticsearchBundle/Cursor/AbstractCursor.php
+++ b/src/Akeneo/Bundle/ElasticsearchBundle/Cursor/AbstractCursor.php
@@ -103,10 +103,16 @@ abstract class AbstractCursor implements CursorInterface
         foreach ($identifiers as $identifier) {
             foreach ($hydratedItems as $hydratedItem) {
                 // sometimes $identifier is only numerical whereas getIdentifier() / getCode() returns a string
-                if (method_exists($hydratedItem, 'getIdentifier') && (string) $identifier === $hydratedItem->getIdentifier()) {
+                if (
+                    method_exists($hydratedItem, 'getIdentifier')
+                    && (string) $identifier === $hydratedItem->getIdentifier()
+                ) {
                     $orderedItems[] = $hydratedItem;
                     break;
-                } else if (method_exists($hydratedItem, 'getCode') && (string) $identifier === $hydratedItem->getCode()) {
+                } elseif (
+                    method_exists($hydratedItem, 'getCode')
+                    && (string) $identifier === $hydratedItem->getCode()
+                ) {
                     $orderedItems[] = $hydratedItem;
                     break;
                 }

--- a/src/Akeneo/Bundle/ElasticsearchBundle/Cursor/AbstractCursor.php
+++ b/src/Akeneo/Bundle/ElasticsearchBundle/Cursor/AbstractCursor.php
@@ -99,13 +99,14 @@ abstract class AbstractCursor implements CursorInterface
         }
 
         $hydratedItems = $this->repository->getItemsFromIdentifiers($identifiers);
-
         $orderedItems = [];
-
         foreach ($identifiers as $identifier) {
             foreach ($hydratedItems as $hydratedItem) {
-                // sometimes $identifier is only numerical whereas getIdentifer() returns a string
-                if ((string) $identifier === $hydratedItem->getIdentifier()) {
+                // sometimes $identifier is only numerical whereas getIdentifier() / getCode() returns a string
+                if (method_exists($hydratedItem, 'getIdentifier') && (string) $identifier === $hydratedItem->getIdentifier()) {
+                    $orderedItems[] = $hydratedItem;
+                    break;
+                } else if (method_exists($hydratedItem, 'getCode') && (string) $identifier === $hydratedItem->getCode()) {
                     $orderedItems[] = $hydratedItem;
                     break;
                 }

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Indexer/ProductModelIndexer.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Indexer/ProductModelIndexer.php
@@ -10,8 +10,8 @@ use Akeneo\Component\StorageUtils\Indexer\BulkIndexerInterface;
 use Akeneo\Component\StorageUtils\Indexer\IndexerInterface;
 use Akeneo\Component\StorageUtils\Remover\BulkRemoverInterface;
 use Akeneo\Component\StorageUtils\Remover\RemoverInterface;
-use Pim\Component\Catalog\Normalizer\Indexing\ProductModel;
 use Pim\Component\Catalog\Normalizer\Indexing\ProductAndProductModel;
+use Pim\Component\Catalog\Normalizer\Indexing\ProductModel;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Indexer/ProductModelIndexer.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Indexer/ProductModelIndexer.php
@@ -10,7 +10,8 @@ use Akeneo\Component\StorageUtils\Indexer\BulkIndexerInterface;
 use Akeneo\Component\StorageUtils\Indexer\IndexerInterface;
 use Akeneo\Component\StorageUtils\Remover\BulkRemoverInterface;
 use Akeneo\Component\StorageUtils\Remover\RemoverInterface;
-use Pim\Component\Catalog\Normalizer\Indexing\ProductAndProductModel\ProductModelNormalizer;
+use Pim\Component\Catalog\Normalizer\Indexing\ProductModel;
+use Pim\Component\Catalog\Normalizer\Indexing\ProductAndProductModel;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
@@ -24,31 +25,37 @@ class ProductModelIndexer implements IndexerInterface, BulkIndexerInterface, Rem
 {
     private const PRODUCT_MODEL_IDENTIFIER_PREFIX = 'product_model_';
     /** @var NormalizerInterface */
-    protected $normalizer;
+    private $normalizer;
 
     /** @var Client */
-    protected $productAndProductModelClient;
+    private $productModelClient;
+
+    /** @var Client */
+    private $productAndProductModelClient;
 
     /** @var string */
-    protected $indexType;
+    private $indexType;
 
     /**
      * @param NormalizerInterface $normalizer
+     * @param Client              $productModelClient
      * @param Client              $productAndProductModelClient
      * @param string              $indexType
      */
     public function __construct(
         NormalizerInterface $normalizer,
+        Client $productModelClient,
         Client $productAndProductModelClient,
         string $indexType
     ) {
         $this->normalizer = $normalizer;
+        $this->productModelClient = $productModelClient;
         $this->productAndProductModelClient = $productAndProductModelClient;
         $this->indexType = $indexType;
     }
 
     /**
-     * Indexes a product in both the product index and the product and product model index.
+     * Indexes a product in both the product model index and the product and product model index.
      *
      * {@inheritdoc}
      */
@@ -56,14 +63,21 @@ class ProductModelIndexer implements IndexerInterface, BulkIndexerInterface, Rem
     {
         $normalizedObject = $this->normalizer->normalize(
             $object,
-            ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX
+            ProductModel\ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX
+        );
+        $this->validateObjectNormalization($normalizedObject);
+        $this->productModelClient->index($this->indexType, $normalizedObject['id'], $normalizedObject);
+
+        $normalizedObject = $this->normalizer->normalize(
+            $object,
+            ProductAndProductModel\ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX
         );
         $this->validateObjectNormalization($normalizedObject);
         $this->productAndProductModelClient->index($this->indexType, $normalizedObject['id'], $normalizedObject);
     }
 
     /**
-     * Indexes a product in both the product index and the product and product model index.
+     * Indexes a product in both the product model index and the product and product model index.
      *
      * {@inheritdoc}
      */
@@ -74,11 +88,27 @@ class ProductModelIndexer implements IndexerInterface, BulkIndexerInterface, Rem
         }
 
         $normalizedObjects = [];
-
         foreach ($objects as $object) {
             $normalizedObject = $this->normalizer->normalize(
                 $object,
-                ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX
+                ProductModel\ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX
+            );
+            $this->validateObjectNormalization($normalizedObject);
+            $normalizedObjects[] = $normalizedObject;
+        }
+
+        $this->productModelClient->bulkIndexes(
+            $this->indexType,
+            $normalizedObjects,
+            'id',
+            Refresh::waitFor()
+        );
+
+        $normalizedObjects = [];
+        foreach ($objects as $object) {
+            $normalizedObject = $this->normalizer->normalize(
+                $object,
+                ProductAndProductModel\ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX
             );
             $this->validateObjectNormalization($normalizedObject);
             $normalizedObjects[] = $normalizedObject;
@@ -93,12 +123,17 @@ class ProductModelIndexer implements IndexerInterface, BulkIndexerInterface, Rem
     }
 
     /**
-     * Removes the product from both the product index and the product and product model index.
+     * Removes the product from both the product model index and the product and product model index.
      *
      * {@inheritdoc}
      */
     public function remove($objectId, array $options = []) : void
     {
+        $this->productModelClient->delete(
+            $this->indexType,
+            (string) $objectId
+        );
+
         $this->productAndProductModelClient->delete(
             $this->indexType,
             self::PRODUCT_MODEL_IDENTIFIER_PREFIX . (string) $objectId
@@ -106,12 +141,18 @@ class ProductModelIndexer implements IndexerInterface, BulkIndexerInterface, Rem
     }
 
     /**
-     * Removes the products from both the product index and the product and product model index.
+     * Removes the products from both the product model index and the product and product model index.
      *
      * {@inheritdoc}
      */
     public function removeAll(array $objects, array $options = []) : void
     {
+        $objectIds = [];
+        foreach ($objects as $objectId) {
+            $objectIds[] = (string) $objectId;
+        }
+        $this->productModelClient->bulkDelete($this->indexType, $objectIds);
+
         $objectIds = [];
         foreach ($objects as $objectId) {
             $objectIds[]  = self::PRODUCT_MODEL_IDENTIFIER_PREFIX . (string) $objectId;

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/cursors.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/cursors.yml
@@ -37,3 +37,13 @@ services:
             - '%akeneo_elasticsearch.cursor.from_size_cursor.class%'
             - '%pim_catalog.factory.product_cursor.page_size%'
             - 'pim_catalog_product'
+
+    pim_catalog.factory.product_model_cursor:
+        class: '%akeneo_elasticsearch.cursor.cursor_factory.class%'
+        arguments:
+            - '@akeneo_elasticsearch.client.product_model'
+            - '@pim_catalog.object_manager.product'
+            - '%pim_catalog.entity.product_model.class%'
+            - '%akeneo_elasticsearch.cursor.cursor.class%'
+            - '%pim_catalog.factory.product_cursor.page_size%'
+            - 'pim_catalog_product'

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/elasticsearch.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/elasticsearch.yml
@@ -16,6 +16,7 @@ services:
         class: '%pim_catalog.elasticsearch.indexer.product_model_indexer.class%'
         arguments:
             - '@pim_serializer'
+            - '@akeneo_elasticsearch.client.product_model'
             - '@akeneo_elasticsearch.client.product_and_product_model'
             - 'pim_catalog_product'
 

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
@@ -73,6 +73,16 @@ services:
             - '@pim_catalog.factory.product_from_size_cursor'
             - '@pim_catalog.elasticsearch.product_query_builder_from_size_resolver'
 
+    pim_catalog.query.product_model_query_builder_factory:
+        class: '%pim_catalog.query.elasticsearch.product_query_builder_factory.class%'
+        arguments:
+            - '%pim_catalog.query.product_query_builder.class%'
+            - '@pim_catalog.repository.attribute'
+            - '@pim_catalog.query.filter.registry'
+            - '@pim_catalog.query.sorter.registry'
+            - '@pim_catalog.factory.product_model_cursor'
+            - '@pim_catalog.query.product_query_builder_resolver'
+
     pim_catalog.query.product_query_builder_resolver:
         class: '%pim_catalog.query.product_query_builder_resolver.class%'
 

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/serializers_indexing.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/serializers_indexing.yml
@@ -17,6 +17,9 @@ parameters:
     pim_catalog.normalizer.indexing_product.product.media.class: Pim\Component\Catalog\Normalizer\Indexing\Value\MediaNormalizer
     pim_catalog.normalizer.indexing_product.product.boolean.class: Pim\Component\Catalog\Normalizer\Indexing\Value\BooleanNormalizer
 
+    pim_catalog.normalizer.indexing_product_model.product_model.class: Pim\Component\Catalog\Normalizer\Indexing\ProductModel\ProductModelNormalizer
+    pim_catalog.normalizer.indexing_product_model.product_model.properties.class: Pim\Component\Catalog\Normalizer\Indexing\ProductModel\ProductModelPropertiesNormalizer
+
     pim_catalog.normalizer.indexing_product_and_product_model.product.class: Pim\Component\Catalog\Normalizer\Indexing\ProductAndProductModel\ProductNormalizer
     pim_catalog.normalizer.indexing_product_and_product_model.product.properties.class: Pim\Component\Catalog\Normalizer\Indexing\ProductAndProductModel\ProductPropertiesNormalizer
     pim_catalog.normalizer.indexing_product_and_product_model.product_model.class: Pim\Component\Catalog\Normalizer\Indexing\ProductAndProductModel\ProductModelNormalizer
@@ -116,6 +119,18 @@ services:
         class: '%pim_catalog.normalizer.indexing_product.product.boolean.class%'
         tags:
             - { name: pim_serializer.normalizer, priority: 90 }
+
+    pim_catalog.normalizer.indexing_product_model.product_model:
+        class: '%pim_catalog.normalizer.indexing_product_model.product_model.class%'
+        arguments:
+            - '@pim_catalog.normalizer.indexing_product_model.product_model.properties'
+        tags:
+            - { name: pim_serializer.normalizer, priority: 90 }
+
+    pim_catalog.normalizer.indexing_product_model.product_model.properties:
+        class: '%pim_catalog.normalizer.indexing_product_model.product_model.properties.class%'
+        tags:
+            - { name: pim_serializer.normalizer, priority: 40 }
 
     pim_catalog.normalizer.indexing_product_and_product_model.product_model:
         class: '%pim_catalog.normalizer.indexing_product_and_product_model.product_model.class%'

--- a/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Indexer/ProductModelIndexerSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Indexer/ProductModelIndexerSpec.php
@@ -11,15 +11,21 @@ use Akeneo\Component\StorageUtils\Remover\RemoverInterface;
 use PhpSpec\ObjectBehavior;
 use Pim\Bundle\CatalogBundle\Elasticsearch\Indexer\ProductModelIndexer;
 use Pim\Component\Catalog\Model\ProductModelInterface;
-use Pim\Component\Catalog\Normalizer\Indexing\ProductAndProductModel\ProductModelNormalizer;
+use Pim\Component\Catalog\Normalizer\Indexing\ProductModel;
+use Pim\Component\Catalog\Normalizer\Indexing\ProductAndProductModel;
 use Prophecy\Argument;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class ProductModelIndexerSpec extends ObjectBehavior
 {
-    function let(NormalizerInterface $normalizer, Client $productModelIndexer)
+    function let(NormalizerInterface $normalizer, Client $productModelClient, Client $productAndProductModelClient)
     {
-        $this->beConstructedWith($normalizer, $productModelIndexer, 'an_index_type_for_test_purpose');
+        $this->beConstructedWith(
+            $normalizer,
+            $productModelClient,
+            $productAndProductModelClient,
+            'an_index_type_for_test_purpose'
+        );
     }
 
     function it_is_initializable()
@@ -41,37 +47,46 @@ class ProductModelIndexerSpec extends ObjectBehavior
 
     function it_throws_an_exception_when_attempting_to_index_a_product_model_without_id(
         $normalizer,
-        $productModelIndexer,
+        $productModelClient,
         \stdClass $aWrongProductModel
     ) {
-        $normalizer->normalize($aWrongProductModel, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
+        $normalizer->normalize($aWrongProductModel, ProductModel\ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX)
             ->willReturn([]);
-        $productModelIndexer->index(Argument::cetera())->shouldNotBeCalled();
+        $productModelClient->index(Argument::cetera())->shouldNotBeCalled();
 
         $this->shouldThrow(\InvalidArgumentException::class)->during('index', [$aWrongProductModel]);
     }
 
     function it_throws_an_exception_when_attempting_to_bulk_index_a_product_model_without_an_id(
         $normalizer,
-        $productModelIndexer,
+        $productModelClient,
         ProductModelInterface $productModel,
         \stdClass $aWrongProductModel
     ) {
-        $normalizer->normalize($productModel, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
+        $normalizer->normalize($productModel, ProductModel\ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX)
             ->willReturn(['id' => 'baz']);
-        $normalizer->normalize($aWrongProductModel, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
+        $normalizer->normalize($aWrongProductModel, ProductModel\ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX)
             ->willReturn([]);
 
-        $productModelIndexer->bulkIndexes(Argument::cetera())->shouldNotBeCalled();
+        $productModelClient->bulkIndexes(Argument::cetera())->shouldNotBeCalled();
 
         $this->shouldThrow(\InvalidArgumentException::class)->during('indexAll', [[$productModel, $aWrongProductModel]]);
     }
 
-    function it_indexes_a_single_product_model($normalizer, $productModelIndexer, ProductModelInterface $productModel)
-    {
-        $normalizer->normalize($productModel, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
+    function it_indexes_a_single_product_model(
+        $normalizer,
+        $productModelClient,
+        $productAndProductModelClient,
+        ProductModelInterface $productModel
+    ) {
+        $normalizer->normalize($productModel, ProductModel\ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX)
             ->willReturn(['id' => 'foobar', 'a key' => 'a value']);
-        $productModelIndexer->index('an_index_type_for_test_purpose', 'foobar', ['id' => 'foobar', 'a key' => 'a value'])
+        $productModelClient->index('an_index_type_for_test_purpose', 'foobar', ['id' => 'foobar', 'a key' => 'a value'])
+            ->shouldBeCalled();
+
+        $normalizer->normalize($productModel, ProductAndProductModel\ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
+            ->willReturn(['id' => 'foobar', 'a key' => 'a value']);
+        $productAndProductModelClient->index('an_index_type_for_test_purpose', 'foobar', ['id' => 'foobar', 'a key' => 'a value'])
             ->shouldBeCalled();
 
         $this->index($productModel);
@@ -79,16 +94,27 @@ class ProductModelIndexerSpec extends ObjectBehavior
 
     function it_bulk_indexes_product_models(
         $normalizer,
-        $productModelIndexer,
+        $productModelClient,
+        $productAndProductModelClient,
         ProductModelInterface $productModel1,
         ProductModelInterface $productModel2
     ) {
-        $normalizer->normalize($productModel1, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
+        $normalizer->normalize($productModel1, ProductModel\ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX)
             ->willReturn(['id' => 'foo', 'a key' => 'a value']);
-        $normalizer->normalize($productModel2, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
+        $normalizer->normalize($productModel2, ProductModel\ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX)
             ->willReturn(['id' => 'bar', 'a key' => 'another value']);
 
-        $productModelIndexer->bulkIndexes('an_index_type_for_test_purpose', [
+        $productModelClient->bulkIndexes('an_index_type_for_test_purpose', [
+            ['id' => 'foo', 'a key' => 'a value'],
+            ['id' => 'bar', 'a key' => 'another value'],
+        ], 'id', Refresh::waitFor())->shouldBeCalled();
+
+        $normalizer->normalize($productModel1, ProductAndProductModel\ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
+            ->willReturn(['id' => 'foo', 'a key' => 'a value']);
+        $normalizer->normalize($productModel2, ProductAndProductModel\ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
+            ->willReturn(['id' => 'bar', 'a key' => 'another value']);
+
+        $productAndProductModelClient->bulkIndexes('an_index_type_for_test_purpose', [
             ['id' => 'foo', 'a key' => 'a value'],
             ['id' => 'bar', 'a key' => 'another value'],
         ], 'id', Refresh::waitFor())->shouldBeCalled();
@@ -96,24 +122,28 @@ class ProductModelIndexerSpec extends ObjectBehavior
         $this->indexAll([$productModel1, $productModel2]);
     }
 
-    function it_does_not_bulk_index_empty_arrays_of_product_models($normalizer, $productModelIndexer)
+    function it_does_not_bulk_index_empty_arrays_of_product_models($normalizer, $productModelClient, $productAndProductModelClient)
     {
         $normalizer->normalize(Argument::cetera())->shouldNotBeCalled();
-        $productModelIndexer->bulkIndexes(Argument::cetera())->shouldNotBeCalled();
+        $productModelClient->bulkIndexes(Argument::cetera())->shouldNotBeCalled();
+        $productAndProductModelClient->bulkIndexes(Argument::cetera())->shouldNotBeCalled();
 
         $this->indexAll([]);
     }
 
-    function it_deletes_product_models_from_elasticsearch_index($productModelIndexer)
+    function it_deletes_product_models_from_elasticsearch_index($productModelClient, $productAndProductModelClient)
     {
-        $productModelIndexer->delete('an_index_type_for_test_purpose', 'product_model_40')->shouldBeCalled();
+        $productModelClient->delete('an_index_type_for_test_purpose', '40')->shouldBeCalled();
+        $productAndProductModelClient->delete('an_index_type_for_test_purpose', 'product_model_40')->shouldBeCalled();
 
         $this->remove(40)->shouldReturn(null);
     }
 
-    function it_bulk_deletes_product_models_from_elasticsearch_index($productModelIndexer)
+    function it_bulk_deletes_product_models_from_elasticsearch_index($productModelClient, $productAndProductModelClient)
     {
-        $productModelIndexer->bulkDelete('an_index_type_for_test_purpose', ['product_model_40', 'product_model_33'])
+        $productModelClient->bulkDelete('an_index_type_for_test_purpose', ['40', '33'])
+            ->shouldBeCalled();
+        $productAndProductModelClient->bulkDelete('an_index_type_for_test_purpose', ['product_model_40', 'product_model_33'])
             ->shouldBeCalled();
 
         $this->removeAll([40, 33])->shouldReturn(null);

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Doctrine/Common/Saver/IndexingProductModelIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Doctrine/Common/Saver/IndexingProductModelIntegration.php
@@ -17,6 +17,9 @@ class IndexingProductModelIntegration extends TestCase
     /** @var Client */
     private $esProductAndProductModelClient;
 
+    /** @var Client */
+    private $esProductModelClient;
+
     /**
      * {@inheritdoc}
      */
@@ -25,6 +28,7 @@ class IndexingProductModelIntegration extends TestCase
         parent::setUp();
 
         $this->esProductAndProductModelClient = $this->get('akeneo_elasticsearch.client.product_and_product_model');
+        $this->esProductModelClient = $this->get('akeneo_elasticsearch.client.product_model');
     }
 
     public function testIndexingProductModelsOnBulkSave()
@@ -37,17 +41,26 @@ class IndexingProductModelIntegration extends TestCase
         $this->get('pim_catalog.saver.product_model')->saveAll($productModels);
 
         $productModelRepository = $this->get('pim_catalog.repository.product_model');
-        $productModelFooESId = 'product_model_' . $productModelRepository->findOneByIdentifier('foo')->getId();
-        $productModelBarESId = 'product_model_' . $productModelRepository->findOneByIdentifier('bar')->getId();
-        $productModelBazESId = 'product_model_' . $productModelRepository->findOneByIdentifier('baz')->getId();
+        $productModelFooESId = $productModelRepository->findOneByIdentifier('foo')->getId();
+        $productModelBarESId = $productModelRepository->findOneByIdentifier('bar')->getId();
+        $productModelBazESId = $productModelRepository->findOneByIdentifier('baz')->getId();
 
-        $indexedProductModelFoo = $this->esProductAndProductModelClient->get(self::DOCUMENT_TYPE, $productModelFooESId);
+        $indexedProductModelFoo = $this->esProductModelClient->get(self::DOCUMENT_TYPE, $productModelFooESId);
         $this->assertTrue($indexedProductModelFoo['found']);
 
-        $indexedProductModelBar = $this->esProductAndProductModelClient->get(self::DOCUMENT_TYPE, $productModelBarESId);
+        $indexedProductModelBar = $this->esProductModelClient->get(self::DOCUMENT_TYPE, $productModelBarESId);
         $this->assertTrue($indexedProductModelBar['found']);
 
-        $indexedProductModelBaz = $this->esProductAndProductModelClient->get(self::DOCUMENT_TYPE, $productModelBazESId);
+        $indexedProductModelBaz = $this->esProductModelClient->get(self::DOCUMENT_TYPE, $productModelBazESId);
+        $this->assertTrue($indexedProductModelBaz['found']);
+
+        $indexedProductModelFoo = $this->esProductAndProductModelClient->get(self::DOCUMENT_TYPE, 'product_model_' . $productModelFooESId);
+        $this->assertTrue($indexedProductModelFoo['found']);
+
+        $indexedProductModelBar = $this->esProductAndProductModelClient->get(self::DOCUMENT_TYPE, 'product_model_' . $productModelBarESId);
+        $this->assertTrue($indexedProductModelBar['found']);
+
+        $indexedProductModelBaz = $this->esProductAndProductModelClient->get(self::DOCUMENT_TYPE, 'product_model_' . $productModelBazESId);
         $this->assertTrue($indexedProductModelBaz['found']);
     }
 
@@ -56,9 +69,12 @@ class IndexingProductModelIntegration extends TestCase
         $productModel = $this->createProductModel('bat');
         $this->get('pim_catalog.saver.product_model')->save($productModel);
 
-        $productBatESId = 'product_model_' . $this->get('pim_catalog.repository.product_model')->findOneByIdentifier('bat')->getId();
+        $productBatESId = $this->get('pim_catalog.repository.product_model')->findOneByIdentifier('bat')->getId();
 
-        $indexedProduct = $this->esProductAndProductModelClient->get(self::DOCUMENT_TYPE, $productBatESId);
+        $indexedProductModelFoo = $this->esProductModelClient->get(self::DOCUMENT_TYPE, $productBatESId);
+        $this->assertTrue($indexedProductModelFoo['found']);
+
+        $indexedProduct = $this->esProductAndProductModelClient->get(self::DOCUMENT_TYPE, 'product_model_' . $productBatESId);
         $this->assertTrue($indexedProduct['found']);
     }
 

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/readers.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/readers.yml
@@ -74,7 +74,7 @@ services:
     pim_connector.reader.database.product_model:
         class: '%pim_connector.reader.database.product_model.class%'
         arguments:
-            - '@pim_catalog.repository.product_model'
+            - '@pim_catalog.query.product_model_query_builder_factory'
 
     pim_connector.reader.database.channel:
         class: '%pim_connector.reader.database.class%'

--- a/src/Pim/Bundle/ConnectorBundle/tests/integration/Export/AbstractExportTestCase.php
+++ b/src/Pim/Bundle/ConnectorBundle/tests/integration/Export/AbstractExportTestCase.php
@@ -90,6 +90,8 @@ abstract class AbstractExportTestCase extends TestCase
         $this->get('pim_catalog.validator.product')->validate($productModel);
         $this->get('pim_catalog.saver.product_model')->save($productModel);
 
+        $this->get('akeneo_elasticsearch.client.product_model')->refreshIndex();
+
         return $productModel;
     }
 

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/CompletenessCollectionNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/CompletenessCollectionNormalizer.php
@@ -5,7 +5,8 @@ namespace Pim\Component\Catalog\Normalizer\Indexing;
 use Doctrine\Common\Collections\Collection;
 use Pim\Component\Catalog\Model\CompletenessInterface;
 use Pim\Component\Catalog\Normalizer\Indexing\Product\ProductNormalizer;
-use Pim\Component\Catalog\Normalizer\Indexing\ProductAndProductModel\ProductModelNormalizer;
+use Pim\Component\Catalog\Normalizer\Indexing\ProductAndProductModel;
+use Pim\Component\Catalog\Normalizer\Indexing\ProductModel;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
@@ -41,7 +42,8 @@ class CompletenessCollectionNormalizer implements NormalizerInterface
         return
             (
                 ProductNormalizer::INDEXING_FORMAT_PRODUCT_INDEX === $format ||
-                ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX === $format
+                ProductModel\ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX === $format ||
+                ProductAndProductModel\ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX === $format
             ) &&
             $data instanceof Collection &&
             !$data->isEmpty() &&

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/DateTimeNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/DateTimeNormalizer.php
@@ -3,7 +3,8 @@
 namespace Pim\Component\Catalog\Normalizer\Indexing;
 
 use Pim\Component\Catalog\Normalizer\Indexing\Product\ProductNormalizer;
-use Pim\Component\Catalog\Normalizer\Indexing\ProductAndProductModel\ProductModelNormalizer;
+use Pim\Component\Catalog\Normalizer\Indexing\ProductAndProductModel;
+use Pim\Component\Catalog\Normalizer\Indexing\ProductModel;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
@@ -46,7 +47,8 @@ class DateTimeNormalizer implements NormalizerInterface
     {
         return $data instanceof \DateTime && (
                 $format === ProductNormalizer::INDEXING_FORMAT_PRODUCT_INDEX ||
-                $format === ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX
+                ProductModel\ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX === $format ||
+                ProductAndProductModel\ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX === $format
             );
     }
 }

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/FamilyNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/FamilyNormalizer.php
@@ -4,7 +4,8 @@ namespace Pim\Component\Catalog\Normalizer\Indexing;
 
 use Pim\Component\Catalog\Model\FamilyInterface;
 use Pim\Component\Catalog\Normalizer\Indexing\Product\ProductNormalizer;
-use Pim\Component\Catalog\Normalizer\Indexing\ProductAndProductModel\ProductModelNormalizer;
+use Pim\Component\Catalog\Normalizer\Indexing\ProductAndProductModel;
+use Pim\Component\Catalog\Normalizer\Indexing\ProductModel;
 use Pim\Component\Catalog\Repository\LocaleRepositoryInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
@@ -57,7 +58,8 @@ class FamilyNormalizer implements NormalizerInterface
     {
         return (
                 ProductNormalizer::INDEXING_FORMAT_PRODUCT_INDEX === $format ||
-                ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX === $format
+                ProductModel\ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX === $format ||
+                ProductAndProductModel\ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX === $format
             ) && $data instanceof FamilyInterface;
     }
 }

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/ProductModel/ProductModelNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/ProductModel/ProductModelNormalizer.php
@@ -2,21 +2,22 @@
 
 declare(strict_types=1);
 
-namespace Pim\Component\Catalog\Normalizer\Indexing\ProductAndProductModel;
+namespace Pim\Component\Catalog\Normalizer\Indexing\ProductModel;
 
+use Pim\Component\Catalog\Model\EntityWithFamilyVariantInterface;
 use Pim\Component\Catalog\Model\ProductModelInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
- * Normalize a product model to the "indexing_product_and_product_model" format.
+ * Normalize a product model to the "indexing_product_model" format.
  *
- * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @author    Nicolas Dupont <nicolas@akeneo.com>
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 class ProductModelNormalizer implements NormalizerInterface
 {
-    public const INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX = 'indexing_product_and_product_model';
+    public const INDEXING_FORMAT_PRODUCT_MODEL_INDEX = 'indexing_product_model';
     private const FIELD_ATTRIBUTES_IN_LEVEL = 'attributes_for_this_level';
     private const FIELD_DOCUMENT_TYPE = 'document_type';
 
@@ -51,6 +52,6 @@ class ProductModelNormalizer implements NormalizerInterface
      */
     public function supportsNormalization($data, $format = null)
     {
-        return $data instanceof ProductModelInterface && self::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX === $format;
+        return $data instanceof ProductModelInterface && self::INDEXING_FORMAT_PRODUCT_MODEL_INDEX === $format;
     }
 }

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/ProductModel/ProductModelPropertiesNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/ProductModel/ProductModelPropertiesNormalizer.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Component\Catalog\Normalizer\Indexing\ProductModel;
+
+use Pim\Component\Catalog\Model\ProductModelInterface;
+use Pim\Component\Catalog\Normalizer\Standard\Product\PropertiesNormalizer as StandardPropertiesNormalizer;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Serializer\SerializerAwareInterface;
+use Symfony\Component\Serializer\SerializerAwareTrait;
+
+/**
+ * Transform the properties of a product model object (fields and product values)
+ * to the indexing_product_model format.
+ *
+ * @author    Nicolas Dupont <nicolas@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ProductModelPropertiesNormalizer implements NormalizerInterface, SerializerAwareInterface
+{
+    use SerializerAwareTrait;
+
+    private const FIELD_FAMILY_VARIANT = 'family_variant';
+    private const FIELD_ID = 'id';
+    private const FIELD_PARENT = 'parent';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function normalize($productModel, $format = null, array $context = [])
+    {
+        if (!$this->serializer instanceof NormalizerInterface) {
+            throw new \LogicException('Serializer must be a normalizer');
+        }
+
+        $data = [];
+
+        $data[self::FIELD_ID] = (string) $productModel->getId();
+        $data[StandardPropertiesNormalizer::FIELD_IDENTIFIER] = $productModel->getCode();
+        $data[StandardPropertiesNormalizer::FIELD_CREATED] = $this->serializer->normalize(
+            $productModel->getCreated(),
+            $format
+        );
+        $data[StandardPropertiesNormalizer::FIELD_UPDATED] = $this->serializer->normalize(
+            $productModel->getUpdated(),
+            $format
+        );
+
+        $family = null;
+        $familyVariant = null;
+        if (null !== $productModel->getFamilyVariant()) {
+            $family = $this->serializer->normalize(
+                $productModel->getFamilyVariant()->getFamily(),
+                $format
+            );
+            $familyVariant = $productModel->getFamilyVariant()->getCode();
+        }
+        $data[StandardPropertiesNormalizer::FIELD_FAMILY] = $family;
+        $data[self::FIELD_FAMILY_VARIANT] = $familyVariant;
+
+        $parentCode = null !== $productModel->getParent() ? $productModel->getParent()->getCode() : null;
+        $data[self::FIELD_PARENT] = $parentCode;
+
+        $data[StandardPropertiesNormalizer::FIELD_VALUES] = !$productModel->getValues()->isEmpty()
+            ? $this->serializer->normalize(
+                $productModel->getValues(),
+                ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX,
+                $context
+            ) : [];
+
+        return $data;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsNormalization($data, $format = null)
+    {
+        return $data instanceof ProductModelInterface
+            && ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX === $format;
+    }
+}

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/Value/BooleanNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/Value/BooleanNormalizer.php
@@ -5,7 +5,8 @@ namespace Pim\Component\Catalog\Normalizer\Indexing\Value;
 use Pim\Component\Catalog\AttributeTypes;
 use Pim\Component\Catalog\Model\ValueInterface;
 use Pim\Component\Catalog\Normalizer\Indexing\Product\ProductNormalizer;
-use Pim\Component\Catalog\Normalizer\Indexing\ProductAndProductModel\ProductModelNormalizer;
+use Pim\Component\Catalog\Normalizer\Indexing\ProductAndProductModel;
+use Pim\Component\Catalog\Normalizer\Indexing\ProductModel;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
@@ -23,7 +24,8 @@ class BooleanNormalizer extends AbstractProductValueNormalizer implements Normal
         return $data instanceof ValueInterface &&
             AttributeTypes::BACKEND_TYPE_BOOLEAN === $data->getAttribute()->getBackendType() && (
                 $format === ProductNormalizer::INDEXING_FORMAT_PRODUCT_INDEX ||
-                $format === ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX
+                $format === ProductModel\ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX ||
+                $format === ProductAndProductModel\ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX
             );
     }
 

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/Value/DateNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/Value/DateNormalizer.php
@@ -5,7 +5,8 @@ namespace Pim\Component\Catalog\Normalizer\Indexing\Value;
 use Pim\Component\Catalog\AttributeTypes;
 use Pim\Component\Catalog\Model\ValueInterface;
 use Pim\Component\Catalog\Normalizer\Indexing\Product\ProductNormalizer;
-use Pim\Component\Catalog\Normalizer\Indexing\ProductAndProductModel\ProductModelNormalizer;
+use Pim\Component\Catalog\Normalizer\Indexing\ProductAndProductModel;
+use Pim\Component\Catalog\Normalizer\Indexing\ProductModel;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
@@ -25,7 +26,8 @@ class DateNormalizer extends AbstractProductValueNormalizer implements Normalize
         return $data instanceof ValueInterface &&
             AttributeTypes::BACKEND_TYPE_DATE === $data->getAttribute()->getBackendType() && (
                 $format === ProductNormalizer::INDEXING_FORMAT_PRODUCT_INDEX ||
-                $format === ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX
+                $format === ProductModel\ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX ||
+                $format === ProductAndProductModel\ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX
             );
     }
 

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/Value/DummyNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/Value/DummyNormalizer.php
@@ -4,7 +4,8 @@ namespace Pim\Component\Catalog\Normalizer\Indexing\Value;
 
 use Pim\Component\Catalog\Model\ValueInterface;
 use Pim\Component\Catalog\Normalizer\Indexing\Product\ProductNormalizer;
-use Pim\Component\Catalog\Normalizer\Indexing\ProductAndProductModel\ProductModelNormalizer;
+use Pim\Component\Catalog\Normalizer\Indexing\ProductAndProductModel;
+use Pim\Component\Catalog\Normalizer\Indexing\ProductModel;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
@@ -24,7 +25,8 @@ class DummyNormalizer extends AbstractProductValueNormalizer implements Normaliz
     {
         return $data instanceof ValueInterface && (
                 $format === ProductNormalizer::INDEXING_FORMAT_PRODUCT_INDEX ||
-                $format === ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX
+                $format === ProductModel\ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX ||
+                $format === ProductAndProductModel\ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX
             );
     }
 

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/Value/MediaNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/Value/MediaNormalizer.php
@@ -4,7 +4,8 @@ namespace Pim\Component\Catalog\Normalizer\Indexing\Value;
 
 use Pim\Component\Catalog\Model\ValueInterface;
 use Pim\Component\Catalog\Normalizer\Indexing\Product\ProductNormalizer;
-use Pim\Component\Catalog\Normalizer\Indexing\ProductAndProductModel\ProductModelNormalizer;
+use Pim\Component\Catalog\Normalizer\Indexing\ProductAndProductModel;
+use Pim\Component\Catalog\Normalizer\Indexing\ProductModel;
 use Pim\Component\Catalog\Value\MediaValueInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
@@ -24,7 +25,8 @@ class MediaNormalizer extends AbstractProductValueNormalizer implements Normaliz
     {
         return $data instanceof MediaValueInterface && (
                 $format === ProductNormalizer::INDEXING_FORMAT_PRODUCT_INDEX ||
-                $format === ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX
+                $format === ProductModel\ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX ||
+                $format === ProductAndProductModel\ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX
             );
     }
 

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/Value/MetricNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/Value/MetricNormalizer.php
@@ -4,7 +4,8 @@ namespace Pim\Component\Catalog\Normalizer\Indexing\Value;
 
 use Pim\Component\Catalog\Model\ValueInterface;
 use Pim\Component\Catalog\Normalizer\Indexing\Product\ProductNormalizer;
-use Pim\Component\Catalog\Normalizer\Indexing\ProductAndProductModel\ProductModelNormalizer;
+use Pim\Component\Catalog\Normalizer\Indexing\ProductAndProductModel;
+use Pim\Component\Catalog\Normalizer\Indexing\ProductModel;
 use Pim\Component\Catalog\Value\MetricValueInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
@@ -24,7 +25,8 @@ class MetricNormalizer extends AbstractProductValueNormalizer implements Normali
     {
         return $data instanceof MetricValueInterface && (
                 $format === ProductNormalizer::INDEXING_FORMAT_PRODUCT_INDEX ||
-                $format === ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX
+                $format === ProductModel\ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX ||
+                $format === ProductAndProductModel\ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX
             );
     }
 

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/Value/NumberNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/Value/NumberNormalizer.php
@@ -5,7 +5,8 @@ namespace Pim\Component\Catalog\Normalizer\Indexing\Value;
 use Pim\Component\Catalog\AttributeTypes;
 use Pim\Component\Catalog\Model\ValueInterface;
 use Pim\Component\Catalog\Normalizer\Indexing\Product\ProductNormalizer;
-use Pim\Component\Catalog\Normalizer\Indexing\ProductAndProductModel\ProductModelNormalizer;
+use Pim\Component\Catalog\Normalizer\Indexing\ProductAndProductModel;
+use Pim\Component\Catalog\Normalizer\Indexing\ProductModel;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
@@ -27,7 +28,8 @@ class NumberNormalizer extends AbstractProductValueNormalizer implements Normali
         return $data instanceof ValueInterface &&
             AttributeTypes::BACKEND_TYPE_DECIMAL === $data->getAttribute()->getBackendType() && (
                 $format === ProductNormalizer::INDEXING_FORMAT_PRODUCT_INDEX ||
-                $format === ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX
+                $format === ProductModel\ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX ||
+                $format === ProductAndProductModel\ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX
             );
     }
 

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/Value/OptionNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/Value/OptionNormalizer.php
@@ -4,7 +4,8 @@ namespace Pim\Component\Catalog\Normalizer\Indexing\Value;
 
 use Pim\Component\Catalog\Model\ValueInterface;
 use Pim\Component\Catalog\Normalizer\Indexing\Product\ProductNormalizer;
-use Pim\Component\Catalog\Normalizer\Indexing\ProductAndProductModel\ProductModelNormalizer;
+use Pim\Component\Catalog\Normalizer\Indexing\ProductAndProductModel;
+use Pim\Component\Catalog\Normalizer\Indexing\ProductModel;
 use Pim\Component\Catalog\Value\OptionValueInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
@@ -24,7 +25,8 @@ class OptionNormalizer extends AbstractProductValueNormalizer implements Normali
     {
         return $data instanceof OptionValueInterface && (
                 $format === ProductNormalizer::INDEXING_FORMAT_PRODUCT_INDEX ||
-                $format === ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX
+                $format === ProductModel\ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX ||
+                $format === ProductAndProductModel\ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX
             );
     }
 

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/Value/OptionsNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/Value/OptionsNormalizer.php
@@ -4,7 +4,8 @@ namespace Pim\Component\Catalog\Normalizer\Indexing\Value;
 
 use Pim\Component\Catalog\Model\ValueInterface;
 use Pim\Component\Catalog\Normalizer\Indexing\Product\ProductNormalizer;
-use Pim\Component\Catalog\Normalizer\Indexing\ProductAndProductModel\ProductModelNormalizer;
+use Pim\Component\Catalog\Normalizer\Indexing\ProductAndProductModel;
+use Pim\Component\Catalog\Normalizer\Indexing\ProductModel;
 use Pim\Component\Catalog\Value\OptionsValueInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
@@ -24,7 +25,8 @@ class OptionsNormalizer extends AbstractProductValueNormalizer implements Normal
     {
         return $data instanceof OptionsValueInterface && (
                 $format === ProductNormalizer::INDEXING_FORMAT_PRODUCT_INDEX ||
-                $format === ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX
+                $format === ProductModel\ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX ||
+                $format === ProductAndProductModel\ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX
             );
     }
 

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/Value/PriceCollectionNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/Value/PriceCollectionNormalizer.php
@@ -5,7 +5,8 @@ namespace Pim\Component\Catalog\Normalizer\Indexing\Value;
 use Pim\Component\Catalog\AttributeTypes;
 use Pim\Component\Catalog\Model\ValueInterface;
 use Pim\Component\Catalog\Normalizer\Indexing\Product\ProductNormalizer;
-use Pim\Component\Catalog\Normalizer\Indexing\ProductAndProductModel\ProductModelNormalizer;
+use Pim\Component\Catalog\Normalizer\Indexing\ProductAndProductModel;
+use Pim\Component\Catalog\Normalizer\Indexing\ProductModel;
 use Pim\Component\Catalog\Value\PriceCollectionValue;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
@@ -26,7 +27,8 @@ class PriceCollectionNormalizer extends AbstractProductValueNormalizer implement
         return $data instanceof PriceCollectionValue &&
             AttributeTypes::BACKEND_TYPE_PRICE === $data->getAttribute()->getBackendType() && (
                 $format === ProductNormalizer::INDEXING_FORMAT_PRODUCT_INDEX ||
-                $format === ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX
+                $format === ProductModel\ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX ||
+                $format === ProductAndProductModel\ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX
             );
     }
 

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/Value/TextAreaNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/Value/TextAreaNormalizer.php
@@ -5,7 +5,8 @@ namespace Pim\Component\Catalog\Normalizer\Indexing\Value;
 use Pim\Component\Catalog\AttributeTypes;
 use Pim\Component\Catalog\Model\ValueInterface;
 use Pim\Component\Catalog\Normalizer\Indexing\Product\ProductNormalizer;
-use Pim\Component\Catalog\Normalizer\Indexing\ProductAndProductModel\ProductModelNormalizer;
+use Pim\Component\Catalog\Normalizer\Indexing\ProductAndProductModel;
+use Pim\Component\Catalog\Normalizer\Indexing\ProductModel;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
@@ -25,7 +26,8 @@ class TextAreaNormalizer extends AbstractProductValueNormalizer implements Norma
         return $data instanceof ValueInterface &&
             AttributeTypes::BACKEND_TYPE_TEXTAREA === $data->getAttribute()->getBackendType() && (
                 $format === ProductNormalizer::INDEXING_FORMAT_PRODUCT_INDEX ||
-                $format === ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX
+                $format === ProductModel\ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX ||
+                $format === ProductAndProductModel\ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX
             );
     }
 

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/Value/TextNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/Value/TextNormalizer.php
@@ -5,7 +5,8 @@ namespace Pim\Component\Catalog\Normalizer\Indexing\Value;
 use Pim\Component\Catalog\AttributeTypes;
 use Pim\Component\Catalog\Model\ValueInterface;
 use Pim\Component\Catalog\Normalizer\Indexing\Product\ProductNormalizer;
-use Pim\Component\Catalog\Normalizer\Indexing\ProductAndProductModel\ProductModelNormalizer;
+use Pim\Component\Catalog\Normalizer\Indexing\ProductAndProductModel;
+use Pim\Component\Catalog\Normalizer\Indexing\ProductModel;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
@@ -25,7 +26,8 @@ class TextNormalizer extends AbstractProductValueNormalizer implements Normalize
         return $data instanceof ValueInterface &&
             AttributeTypes::BACKEND_TYPE_TEXT === $data->getAttribute()->getBackendType() && (
                 $format === ProductNormalizer::INDEXING_FORMAT_PRODUCT_INDEX ||
-                $format === ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX
+                $format === ProductModel\ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX ||
+                $format === ProductAndProductModel\ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX
             );
     }
 

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/Value/ValueCollectionNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/Value/ValueCollectionNormalizer.php
@@ -5,7 +5,8 @@ namespace Pim\Component\Catalog\Normalizer\Indexing\Value;
 use Pim\Component\Catalog\AttributeTypes;
 use Pim\Component\Catalog\Model\ValueCollectionInterface;
 use Pim\Component\Catalog\Normalizer\Indexing\Product\ProductNormalizer;
-use Pim\Component\Catalog\Normalizer\Indexing\ProductAndProductModel\ProductModelNormalizer;
+use Pim\Component\Catalog\Normalizer\Indexing\ProductAndProductModel;
+use Pim\Component\Catalog\Normalizer\Indexing\ProductModel;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\SerializerAwareInterface;
 use Symfony\Component\Serializer\SerializerAwareTrait;
@@ -46,7 +47,8 @@ class ValueCollectionNormalizer implements NormalizerInterface, SerializerAwareI
     {
         return $data instanceof ValueCollectionInterface && (
                 $format === ProductNormalizer::INDEXING_FORMAT_PRODUCT_INDEX ||
-                $format === ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX
+                $format === ProductModel\ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX ||
+                $format === ProductAndProductModel\ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX
             );
     }
 }

--- a/src/Pim/Component/Catalog/spec/Normalizer/Indexing/ProductModel/ProductModelNormalizerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Normalizer/Indexing/ProductModel/ProductModelNormalizerSpec.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace spec\Pim\Component\Catalog\Normalizer\Indexing\ProductModel;
+
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Model\ProductModelInterface;
+use Pim\Component\Catalog\Normalizer\Indexing\ProductModel\ProductModelNormalizer;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+class ProductModelNormalizerSpec extends ObjectBehavior
+{
+    function let(NormalizerInterface $propertiesNormalizer)
+    {
+        $this->beConstructedWith($propertiesNormalizer);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(ProductModelNormalizer::class);
+    }
+
+    function it_is_a_normalizer()
+    {
+        $this->shouldImplement(NormalizerInterface::class);
+    }
+
+    function it_supports_indexing_normalization_only(ProductModelInterface $productModel)
+    {
+        $this->supportsNormalization($productModel, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX)
+            ->shouldReturn(true);
+        $this->supportsNormalization($productModel, 'other_format')
+            ->shouldReturn(false);
+        $this->supportsNormalization(new \stdClass(), ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX)
+            ->shouldReturn(false);
+        $this->supportsNormalization(new \stdClass(), 'other_format')
+            ->shouldReturn(false);
+    }
+
+    function it_normalizes_a_root_product_model_in_indexing_format(
+        $propertiesNormalizer,
+        ProductModelInterface $productModel
+    ) {
+        $productModel->getVariationLevel()->willReturn(0);
+        $productModel->getRawValues()
+            ->willReturn([
+                'property_1' => ['value_1'],
+                'property_2' => ['value_2'],
+            ]);
+        $propertiesNormalizer->normalize(
+            $productModel,
+            ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX,
+            []
+        )->willReturn(['properties' => 'properties are normalized here']);
+
+        $this->normalize($productModel, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX)
+            ->shouldReturn([
+                'properties'                => 'properties are normalized here',
+                'document_type'              => ProductModelInterface::class,
+                'attributes_for_this_level' => ['property_1', 'property_2'],
+            ]);
+    }
+
+    function it_normalizes_a_sub_product_model_in_indexing_format(
+        $propertiesNormalizer,
+        ProductModelInterface $productModel
+    ) {
+        $productModel->getVariationLevel()->willReturn(1);
+        $productModel->getRawValues()
+            ->willReturn([
+                'property_1' => ['value_1'],
+                'property_2' => ['value_2'],
+            ]);
+        $propertiesNormalizer->normalize(
+            $productModel,
+            ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX,
+            []
+        )->willReturn(['properties' => 'properties are normalized here']);
+
+        $this->normalize($productModel, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX)
+            ->shouldReturn([
+                'properties'                => 'properties are normalized here',
+                'document_type'              => ProductModelInterface::class,
+                'attributes_for_this_level' => ['property_1', 'property_2'],
+            ]);
+    }
+}

--- a/src/Pim/Component/Catalog/spec/Normalizer/Indexing/ProductModel/ProductModelPropertiesNormalizerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Normalizer/Indexing/ProductModel/ProductModelPropertiesNormalizerSpec.php
@@ -1,0 +1,270 @@
+<?php
+
+namespace spec\Pim\Component\Catalog\Normalizer\Indexing\ProductModel;
+
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Model\FamilyInterface;
+use Pim\Component\Catalog\Model\FamilyVariantInterface;
+use Pim\Component\Catalog\Model\ProductModelInterface;
+use Pim\Component\Catalog\Model\ValueCollectionInterface;
+use Pim\Component\Catalog\Normalizer\Indexing\ProductModel\ProductModelNormalizer;
+use Pim\Component\Catalog\Normalizer\Indexing\ProductModel\ProductModelPropertiesNormalizer;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+
+class ProductModelPropertiesNormalizerSpec extends ObjectBehavior
+{
+    function let(SerializerInterface $serializer)
+    {
+        $serializer->implement(NormalizerInterface::class);
+        $this->setSerializer($serializer);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(ProductModelPropertiesNormalizer::class);
+    }
+
+    function it_support_product_models(
+        ProductModelInterface $productModel
+    ) {
+        $this->supportsNormalization(new \stdClass(), 'whatever')->shouldReturn(false);
+        $this->supportsNormalization(new \stdClass(), ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX)
+            ->shouldReturn(false);
+        $this->supportsNormalization($productModel, 'whatever')->shouldReturn(false);
+        $this->supportsNormalization($productModel, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX)
+            ->shouldReturn(true);
+    }
+
+    function it_normalizes_a_root_product_model_properties_with_minimum_filled_fields_and_values(
+        $serializer,
+        ProductModelInterface $productModel,
+        ValueCollectionInterface $productValueCollection,
+        FamilyInterface $family,
+        FamilyVariantInterface $familyVariant
+    ) {
+        $productModel->getId()->willReturn(67);
+        $now = new \DateTime('now', new \DateTimeZone('UTC'));
+
+        $productModel->getParent()->willReturn(null);
+
+        $productModel->getCode()->willReturn('sku-001');
+        $productModel->getCreated()->willReturn($now);
+        $serializer
+            ->normalize($family, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX)
+            ->willReturn(null);
+        $serializer
+            ->normalize($productModel->getWrappedObject()->getCreated(),
+                ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX)
+            ->willReturn($now->format('c'));
+        $productModel->getUpdated()->willReturn($now);
+        $serializer
+            ->normalize($productModel->getWrappedObject()->getUpdated(),
+                ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX)
+            ->willReturn($now->format('c'));
+        $productModel->getValues()->willReturn($productValueCollection);
+
+        $familyVariant->getCode()->willReturn('family_variant_1');
+        $familyVariant->getFamily()->willReturn($family);
+        $productModel->getFamilyVariant()->willReturn($familyVariant);
+        $serializer
+            ->normalize($family, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX)
+            ->willReturn('family_A');
+
+        $productValueCollection->isEmpty()->willReturn(true);
+
+        $this->normalize($productModel, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX)->shouldReturn(
+            [
+                'id'             => '67',
+                'identifier'     => 'sku-001',
+                'created'        => $now->format('c'),
+                'updated'        => $now->format('c'),
+                'family'         => 'family_A',
+                'family_variant' => 'family_variant_1',
+                'parent'         => null,
+                'values'         => [],
+            ]
+        );
+    }
+
+    function it_normalizes_a_root_product_model_fields_and_values(
+        $serializer,
+        ProductModelInterface $productModel,
+        ValueCollectionInterface $productValueCollection,
+        FamilyInterface $family,
+        FamilyVariantInterface $familyVariant
+    ) {
+        $now = new \DateTime('now', new \DateTimeZone('UTC'));
+
+        $productModel->getId()->willReturn(67);
+        $productModel->getCode()->willReturn('sku-001');
+
+        $productModel->getParent()->willReturn(null);
+
+        $productModel->getCreated()->willReturn($now);
+        $serializer->normalize(
+            $productModel->getWrappedObject()->getCreated(),
+            ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX
+        )->willReturn($now->format('c'));
+
+        $productModel->getUpdated()->willReturn($now);
+        $serializer->normalize(
+            $productModel->getWrappedObject()->getUpdated(),
+            ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX
+        )->willReturn($now->format('c'));
+
+        $familyVariant->getCode()->willReturn('family_variant_B');
+        $familyVariant->getFamily()->willReturn($family);
+        $productModel->getFamilyVariant()->willReturn($familyVariant);
+        $serializer
+            ->normalize($family, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX)
+            ->willReturn([
+                'code'   => 'family',
+                'labels' => [
+                    'fr_FR' => 'Une famille',
+                    'en_US' => 'A family',
+                ],
+            ]);
+
+        $productModel->getValues()->shouldBeCalledTimes(2)->willReturn($productValueCollection);
+        $productValueCollection->isEmpty()->willReturn(false);
+
+        $serializer->normalize($productValueCollection, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX,
+            [])
+            ->willReturn(
+                [
+                    'a_size-decimal' => [
+                        '<all_channels>' => [
+                            '<all_locales>' => '10.51',
+                        ],
+                    ],
+                ]
+            );
+
+        $this->normalize($productModel, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX)->shouldReturn(
+            [
+                'id'             => '67',
+                'identifier'     => 'sku-001',
+                'created'        => $now->format('c'),
+                'updated'        => $now->format('c'),
+                'family'         => [
+                    'code'   => 'family',
+                    'labels' => [
+                        'fr_FR' => 'Une famille',
+                        'en_US' => 'A family',
+                    ],
+                ],
+                'family_variant' => 'family_variant_B',
+                'parent'         => null,
+                'values'         => [
+                    'a_size-decimal' => [
+                        '<all_channels>' => [
+                            '<all_locales>' => '10.51',
+                        ],
+                    ],
+                ],
+            ]
+        );
+    }
+
+    function it_normalizes_a_product_model_fields_and_values_with_its_parents_values(
+        $serializer,
+        ProductModelInterface $productModel,
+        ProductModelInterface $parent,
+        ValueCollectionInterface $valueCollection,
+        FamilyInterface $family,
+        FamilyVariantInterface $familyVariant
+    ) {
+        $now = new \DateTime('now', new \DateTimeZone('UTC'));
+
+        $productModel->getId()->willReturn(67);
+        $productModel->getCode()->willReturn('sku-001');
+
+        $productModel->getParent()->willReturn($parent);
+        $parent->getCode()->willReturn('parent_A');
+
+        $productModel->getCreated()->willReturn($now);
+        $serializer->normalize(
+            $productModel->getWrappedObject()->getCreated(),
+            ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX
+        )->willReturn($now->format('c'));
+
+        $productModel->getUpdated()->willReturn($now);
+        $serializer->normalize(
+            $productModel->getWrappedObject()->getUpdated(),
+            ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX
+        )->willReturn($now->format('c'));
+
+        $familyVariant->getCode()->willReturn('family_variant_B');
+        $familyVariant->getFamily()->willReturn($family);
+        $productModel->getFamilyVariant()->willReturn($familyVariant);
+        $serializer
+            ->normalize($family, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX)
+            ->willReturn([
+                'code'   => 'family',
+                'labels' => [
+                    'fr_FR' => 'Une famille',
+                    'en_US' => 'A family',
+                ],
+            ]);
+
+        $productModel->getValues()->shouldBeCalledTimes(2)->willReturn($valueCollection);
+        $valueCollection->isEmpty()->willReturn(false);
+
+        $serializer->normalize($valueCollection, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX, [])
+            ->willReturn(
+                [
+                    'a_size-decimal'         => [
+                        '<all_channels>' => [
+                            '<all_locales>' => '10.51',
+                        ],
+                    ],
+                    'a_date-date'            => [
+                        '<all_channels>' => [
+                            '<all_locales>' => '2017-05-05',
+                        ],
+                    ],
+                    'a_simple_select-option' => [
+                        '<all_channels>' => [
+                            '<all_locales>' => 'OPTION_A',
+                        ],
+                    ],
+                ]
+            );
+
+        $this->normalize($productModel, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX)->shouldReturn(
+            [
+                'id'             => '67',
+                'identifier'     => 'sku-001',
+                'created'        => $now->format('c'),
+                'updated'        => $now->format('c'),
+                'family'         => [
+                    'code'   => 'family',
+                    'labels' => [
+                        'fr_FR' => 'Une famille',
+                        'en_US' => 'A family',
+                    ],
+                ],
+                'family_variant' => 'family_variant_B',
+                'parent'         => 'parent_A',
+                'values'         => [
+                    'a_size-decimal'         => [
+                        '<all_channels>' => [
+                            '<all_locales>' => '10.51',
+                        ],
+                    ],
+                    'a_date-date'            => [
+                        '<all_channels>' => [
+                            '<all_locales>' => '2017-05-05',
+                        ],
+                    ],
+                    'a_simple_select-option' => [
+                        '<all_channels>' => [
+                            '<all_locales>' => 'OPTION_A',
+                        ],
+                    ],
+                ],
+            ]
+        );
+    }
+}

--- a/src/Pim/Component/Connector/spec/Reader/Database/ProductModelReaderSpec.php
+++ b/src/Pim/Component/Connector/spec/Reader/Database/ProductModelReaderSpec.php
@@ -45,14 +45,8 @@ class ProductModelReaderSpec extends ObjectBehavior
             ->shouldBeCalled()
             ->willReturn($cursor);
 
-        $productModels = [$productModel1, $productModel2, $productModel3];
-        $productModelsCount = count($productModels);
-        $cursor->valid()->will(
-            function () use (&$productModelsCount) {
-                return $productModelsCount-- > 0;
-            }
-        );
-        $cursor->current()->will(new ReturnPromise($productModels));
+        $cursor->valid()->willReturn(true, true, true, false);
+        $cursor->current()->willReturn($productModel1, $productModel2, $productModel3);
         $cursor->next()->shouldBeCalled();
 
         $stepExecution->incrementSummaryInfo('read')->shouldBeCalledTimes(3);

--- a/src/Pim/Component/Connector/spec/Reader/Database/ProductModelReaderSpec.php
+++ b/src/Pim/Component/Connector/spec/Reader/Database/ProductModelReaderSpec.php
@@ -5,15 +5,22 @@ namespace spec\Pim\Component\Connector\Reader\Database;
 use Akeneo\Component\Batch\Item\ItemReaderInterface;
 use Akeneo\Component\Batch\Model\StepExecution;
 use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
+use Akeneo\Component\StorageUtils\Cursor\CursorInterface;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Model\ProductModelInterface;
-use Pim\Component\Catalog\Repository\ProductModelRepositoryInterface;
+use Pim\Component\Catalog\Query\ProductQueryBuilderFactoryInterface;
+use Pim\Component\Catalog\Query\ProductQueryBuilderInterface;
+use Prophecy\Promise\ReturnPromise;
 
 class ProductModelReaderSpec extends ObjectBehavior
 {
-    function let(ProductModelRepositoryInterface $repository)
-    {
-        $this->beConstructedWith($repository);
+    function let(
+        ProductQueryBuilderFactoryInterface $pqbFactory,
+        StepExecution $stepExecution
+    ) {
+        $this->beConstructedWith($pqbFactory);
+
+        $this->setStepExecution($stepExecution);
     }
 
     function it_is_a_reader()
@@ -22,16 +29,38 @@ class ProductModelReaderSpec extends ObjectBehavior
         $this->shouldImplement(StepExecutionAwareInterface::class);
     }
 
-    function it_returns_a_product_model(
-        $repository,
-        ProductModelInterface $productModel,
-        StepExecution $stepExecution
+    function it_reads_product_models(
+        $pqbFactory,
+        $stepExecution,
+        ProductQueryBuilderInterface $pqb,
+        CursorInterface $cursor,
+        ProductModelInterface $productModel1,
+        ProductModelInterface $productModel2,
+        ProductModelInterface $productModel3
     ) {
-        $repository->findAll()->willReturn([$productModel]);
-        $this->setStepExecution($stepExecution);
-        $stepExecution->incrementSummaryInfo('read')->shouldBeCalledTimes(1);
+        $pqbFactory->create([])
+            ->shouldBeCalled()
+            ->willReturn($pqb);
+        $pqb->execute()
+            ->shouldBeCalled()
+            ->willReturn($cursor);
 
-        $this->read()->shouldReturn($productModel);
+        $productModels = [$productModel1, $productModel2, $productModel3];
+        $productModelsCount = count($productModels);
+        $cursor->valid()->will(
+            function () use (&$productModelsCount) {
+                return $productModelsCount-- > 0;
+            }
+        );
+        $cursor->current()->will(new ReturnPromise($productModels));
+        $cursor->next()->shouldBeCalled();
+
+        $stepExecution->incrementSummaryInfo('read')->shouldBeCalledTimes(3);
+
+        $this->initialize();
+        $this->read()->shouldReturn($productModel1);
+        $this->read()->shouldReturn($productModel2);
+        $this->read()->shouldReturn($productModel3);
         $this->read()->shouldReturn(null);
     }
 }


### PR DESCRIPTION
Make queries on product model scalable by introducing a dedicated product model index and query builder (use cases: product model export & product model web api)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Y
| Added Behats                      | N
| Added integration tests           | Y
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
