### PR TITLE
API-369-370-371: add tests for variant product API

### DIFF
--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Attribute/ListAttributeIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Attribute/ListAttributeIntegration.php
@@ -121,7 +121,7 @@ JSON;
 		}
 	},
 	"current_page": 2,
-	"items_count": 27,
+	"items_count": 29,
     "_embedded" : {
         "items" : [
             {$standardizedAttributes['a_metric']},

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AttributeGroup/ListAttributeGroupIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AttributeGroup/ListAttributeGroupIntegration.php
@@ -208,7 +208,9 @@ JSON;
        "a_simple_select",
        "a_localizable_image",
        "a_scopable_image",
-       "a_localizable_scopable_image"
+       "a_localizable_scopable_image",
+       "a_simple_select_color",
+       "a_simple_select_size"
     ],
     "labels":{
        "en_US":"Attribute group B",

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/AbstractProductTestCase.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/AbstractProductTestCase.php
@@ -4,6 +4,7 @@ namespace Pim\Bundle\ApiBundle\tests\integration\Controller\Product;
 
 use Pim\Bundle\ApiBundle\tests\integration\ApiTestCase;
 use Pim\Component\Catalog\Model\ProductInterface;
+use Pim\Component\Catalog\Model\ProductModelInterface;
 use Pim\Component\Catalog\tests\integration\Normalizer\NormalizedProductCleaner;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -37,7 +38,7 @@ abstract class AbstractProductTestCase extends ApiTestCase
      *
      * @return ProductInterface
      */
-    protected function createVariantProduct($identifier, array $data = [])
+    protected function createVariantProduct($identifier, array $data = []) : ProductInterface
     {
         $product = $this->get('pim_catalog.builder.variant_product')->createProduct($identifier);
         $this->get('pim_catalog.updater.product')->update($product, $data);
@@ -46,6 +47,23 @@ abstract class AbstractProductTestCase extends ApiTestCase
         $this->get('akeneo_elasticsearch.client.product')->refreshIndex();
 
         return $product;
+    }
+
+    /**
+     * @param array  $data
+     *
+     * @return ProductModelInterface
+     */
+    protected function createProductModel(array $data = []) : ProductModelInterface
+    {
+        $productModel = $this->get('pim_catalog.factory.product_model')->create();
+        $this->get('pim_catalog.updater.product_model')->update($productModel, $data);
+        $this->get('pim_catalog.validator.product')->validate($productModel);
+        $this->get('pim_catalog.saver.product_model')->save($productModel);
+
+        $this->get('akeneo_elasticsearch.client.product_model')->refreshIndex();
+
+        return $productModel;
     }
 
     /**

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/AbstractProductTestCase.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/AbstractProductTestCase.php
@@ -32,6 +32,23 @@ abstract class AbstractProductTestCase extends ApiTestCase
     }
 
     /**
+     * @param string $identifier
+     * @param array  $data
+     *
+     * @return ProductInterface
+     */
+    protected function createVariantProduct($identifier, array $data = [])
+    {
+        $product = $this->get('pim_catalog.builder.variant_product')->createProduct($identifier);
+        $this->get('pim_catalog.updater.product')->update($product, $data);
+        $this->get('pim_catalog.saver.product')->save($product);
+
+        $this->get('akeneo_elasticsearch.client.product')->refreshIndex();
+
+        return $product;
+    }
+
+    /**
      * @param Response $response
      * @param string   $expected
      */

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/DeleteVariantProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/DeleteVariantProductIntegration.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Pim\Bundle\ApiBundle\tests\integration\Controller\Product;
+
+use Akeneo\Test\Integration\Configuration;
+use Symfony\Component\HttpFoundation\Response;
+
+class DeleteVariantProductIntegration extends AbstractProductTestCase
+{
+    public function testDeleteAVariantProduct()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $this->assertCount(247, $this->get('pim_catalog.repository.product')->findAll());
+
+        $fooProduct = $this->get('pim_catalog.repository.product')->findOneByIdentifier('apollon_blue_xl');
+        $this->get('pim_catalog.elasticsearch.indexer.product')->index($fooProduct);
+        $client->request('DELETE', 'api/rest/v1/products/apollon_blue_xl');
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+
+        $this->assertCount(246, $this->get('pim_catalog.repository.product')->findAll());
+        $this->assertNull($this->get('pim_catalog.repository.product')->findOneByIdentifier('apollon_blue_xl'));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration(): Configuration
+    {
+        return new Configuration([Configuration::getFunctionalCatalogPath('catalog_modeling')]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $product = $this->get('pim_catalog.builder.variant_product')->createProduct('apollon_blue_xl', 'clothing');
+        $this->get('pim_catalog.updater.product')->update($product, [
+            'parent' => 'apollon_blue',
+            'values' => [
+                'size' => [
+                    [
+                        'locale' => null,
+                        'scope' => null,
+                        'data' => 'xl',
+                    ],
+                ],
+            ],
+        ]);
+
+        $errors = $this->get('pim_catalog.validator.product')->validate($product);
+        if (0 !== $errors->count()) {
+            throw new \Exception(sprintf(
+                                     'Impossible to setup test in %s: %s',
+                                     static::class,
+                                     $errors->get(0)->getMessage()
+                                 ));
+        }
+
+        $this->get('pim_catalog.saver.product')->save($product);
+        $this->get('pim_catalog.validator.unique_value_set')->reset();
+    }
+
+}

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/DeleteVariantProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/DeleteVariantProductIntegration.php
@@ -11,17 +11,17 @@ class DeleteVariantProductIntegration extends AbstractProductTestCase
     {
         $client = $this->createAuthenticatedClient();
 
-        $this->assertCount(247, $this->get('pim_catalog.repository.product')->findAll());
+        $this->assertCount(246, $this->get('pim_catalog.repository.product')->findAll());
 
-        $fooProduct = $this->get('pim_catalog.repository.product')->findOneByIdentifier('apollon_blue_xl');
-        $this->get('pim_catalog.elasticsearch.indexer.product')->index($fooProduct);
-        $client->request('DELETE', 'api/rest/v1/products/apollon_blue_xl');
+        $bikerJacketLeatherXxs = $this->get('pim_catalog.repository.product')->findOneByIdentifier('biker-jacket-leather-xxs');
+        $this->get('pim_catalog.elasticsearch.indexer.product')->index($bikerJacketLeatherXxs);
+        $client->request('DELETE', 'api/rest/v1/products/biker-jacket-leather-xxs');
 
         $response = $client->getResponse();
         $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
 
-        $this->assertCount(246, $this->get('pim_catalog.repository.product')->findAll());
-        $this->assertNull($this->get('pim_catalog.repository.product')->findOneByIdentifier('apollon_blue_xl'));
+        $this->assertCount(245, $this->get('pim_catalog.repository.product')->findAll());
+        $this->assertNull($this->get('pim_catalog.repository.product')->findOneByIdentifier('biker-jacket-leather-xxs'));
     }
 
     /**
@@ -31,39 +31,4 @@ class DeleteVariantProductIntegration extends AbstractProductTestCase
     {
         return new Configuration([Configuration::getFunctionalCatalogPath('catalog_modeling')]);
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $product = $this->get('pim_catalog.builder.variant_product')->createProduct('apollon_blue_xl', 'clothing');
-        $this->get('pim_catalog.updater.product')->update($product, [
-            'parent' => 'apollon_blue',
-            'values' => [
-                'size' => [
-                    [
-                        'locale' => null,
-                        'scope' => null,
-                        'data' => 'xl',
-                    ],
-                ],
-            ],
-        ]);
-
-        $errors = $this->get('pim_catalog.validator.product')->validate($product);
-        if (0 !== $errors->count()) {
-            throw new \Exception(sprintf(
-                                     'Impossible to setup test in %s: %s',
-                                     static::class,
-                                     $errors->get(0)->getMessage()
-                                 ));
-        }
-
-        $this->get('pim_catalog.saver.product')->save($product);
-        $this->get('pim_catalog.validator.unique_value_set')->reset();
-    }
-
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/GetVariantProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/GetVariantProductIntegration.php
@@ -12,43 +12,57 @@ class GetVariantProductIntegration extends AbstractProductTestCase
     {
         $client = $this->createAuthenticatedClient();
 
-        $client->request('GET', 'api/rest/v1/products/apollon_blue_xl');
+        $client->request('GET', 'api/rest/v1/products/biker-jacket-leather-xxs');
 
         $standardVariantProduct = [
-            "identifier"    => "apollon_blue_xl",
+            "identifier"    => "biker-jacket-leather-xxs",
             "family"        => "clothing",
-            "parent"        => "apollon_blue",
+            "parent"        => "model-biker-jacket-leather",
             "groups"        => [],
             "variant_group" => null,
-            "categories"    => [],
+            "categories"    => ["master_men_blazers"],
             "enabled"       => true,
             "values"        => [
-                "size"             => [
+                "ean"             => [
                     [
                         "locale" => null,
                         "scope"  => null,
-                        "data"   => "xl",
+                        "data"   => "1234567890362",
+                    ],
+                ],
+                "size" => [
+                    [
+                        "locale" => null,
+                        "scope"  => null,
+                        "data"   => "xxs",
                     ],
                 ],
                 "color"            => [
                     [
                         "locale" => null,
                         "scope"  => null,
-                        "data"   => "blue",
+                        "data"   => "antique_white",
+                    ],
+                ],
+                "material"   => [
+                    [
+                        "locale" => null,
+                        "scope"  => null,
+                        "data"   => "leather",
                     ],
                 ],
                 "variation_name"   => [
                     [
                         "locale" => "en_US",
                         "scope"  => null,
-                        "data"   => "Apollon blue",
+                        "data"   => "Biker jacket leather",
                     ],
                 ],
                 "name"             => [
                     [
                         "locale" => "en_US",
                         "scope"  => null,
-                        "data"   => "Long gray suit jacket and matching pants unstructured",
+                        "data"   => "Biker jacket",
                     ],
                 ],
                 "price"            => [
@@ -57,24 +71,10 @@ class GetVariantProductIntegration extends AbstractProductTestCase
                         "scope"  => null,
                         "data"   => [
                             [
-                                "amount"   => "899.00",
+                                "amount"   => null,
                                 "currency" => "EUR",
                             ],
                         ],
-                    ],
-                ],
-                "erp_name"         => [
-                    [
-                        "locale" => "en_US",
-                        "scope"  => null,
-                        "data"   => "Apollon",
-                    ],
-                ],
-                "supplier"         => [
-                    [
-                        "locale" => null,
-                        "scope"  => null,
-                        "data"   => "zaro",
                     ],
                 ],
                 "collection"       => [
@@ -82,7 +82,7 @@ class GetVariantProductIntegration extends AbstractProductTestCase
                         "locale" => null,
                         "scope"  => null,
                         "data"   => [
-                            "winter_2016",
+                            "summer_2017",
                         ],
                     ],
                 ],
@@ -90,14 +90,7 @@ class GetVariantProductIntegration extends AbstractProductTestCase
                     [
                         "locale" => "en_US",
                         "scope"  => "ecommerce",
-                        "data"   => "Long gray suit jacket and matching pants unstructured. 61% wool, 30% polyester, 9% ramie. Dry clean only.",
-                    ],
-                ],
-                "wash_temperature" => [
-                    [
-                        "locale" => null,
-                        "scope"  => null,
-                        "data"   => "600",
+                        "data"   => "Biker jacket",
                     ],
                 ],
             ],
@@ -118,40 +111,6 @@ class GetVariantProductIntegration extends AbstractProductTestCase
     protected function getConfiguration(): Configuration
     {
         return new Configuration([Configuration::getFunctionalCatalogPath('catalog_modeling')]);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $product = $this->get('pim_catalog.builder.variant_product')->createProduct('apollon_blue_xl', 'clothing');
-        $this->get('pim_catalog.updater.product')->update($product, [
-            'parent' => 'apollon_blue',
-            'values' => [
-                'size' => [
-                    [
-                        'locale' => null,
-                        'scope' => null,
-                        'data' => 'xl',
-                    ],
-                ],
-            ],
-        ]);
-
-        $errors = $this->get('pim_catalog.validator.product')->validate($product);
-        if (0 !== $errors->count()) {
-            throw new \Exception(sprintf(
-                                     'Impossible to setup test in %s: %s',
-                                     static::class,
-                                     $errors->get(0)->getMessage()
-                                 ));
-        }
-
-        $this->get('pim_catalog.saver.product')->save($product);
-        $this->get('pim_catalog.validator.unique_value_set')->reset();
     }
 
     /**

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/GetVariantProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/GetVariantProductIntegration.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace Pim\Bundle\ApiBundle\tests\integration\Controller\Product;
+
+use Akeneo\Test\Integration\Configuration;
+use Pim\Component\Catalog\tests\integration\Normalizer\NormalizedProductCleaner;
+use Symfony\Component\HttpFoundation\Response;
+
+class GetVariantProductIntegration extends AbstractProductTestCase
+{
+    public function testGetACompleteVariantProduct()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $client->request('GET', 'api/rest/v1/products/apollon_blue_xl');
+
+        $standardVariantProduct = [
+            "identifier"    => "apollon_blue_xl",
+            "family"        => "clothing",
+            "parent"        => "apollon_blue",
+            "groups"        => [],
+            "variant_group" => null,
+            "categories"    => [],
+            "enabled"       => true,
+            "values"        => [
+                "size"             => [
+                    [
+                        "locale" => null,
+                        "scope"  => null,
+                        "data"   => "xl",
+                    ],
+                ],
+                "color"            => [
+                    [
+                        "locale" => null,
+                        "scope"  => null,
+                        "data"   => "blue",
+                    ],
+                ],
+                "variation_name"   => [
+                    [
+                        "locale" => "en_US",
+                        "scope"  => null,
+                        "data"   => "Apollon blue",
+                    ],
+                ],
+                "name"             => [
+                    [
+                        "locale" => "en_US",
+                        "scope"  => null,
+                        "data"   => "Long gray suit jacket and matching pants unstructured",
+                    ],
+                ],
+                "price"            => [
+                    [
+                        "locale" => null,
+                        "scope"  => null,
+                        "data"   => [
+                            [
+                                "amount"   => "899.00",
+                                "currency" => "EUR",
+                            ],
+                        ],
+                    ],
+                ],
+                "erp_name"         => [
+                    [
+                        "locale" => "en_US",
+                        "scope"  => null,
+                        "data"   => "Apollon",
+                    ],
+                ],
+                "supplier"         => [
+                    [
+                        "locale" => null,
+                        "scope"  => null,
+                        "data"   => "zaro",
+                    ],
+                ],
+                "collection"       => [
+                    [
+                        "locale" => null,
+                        "scope"  => null,
+                        "data"   => [
+                            "winter_2016",
+                        ],
+                    ],
+                ],
+                "description"      => [
+                    [
+                        "locale" => "en_US",
+                        "scope"  => "ecommerce",
+                        "data"   => "Long gray suit jacket and matching pants unstructured. 61% wool, 30% polyester, 9% ramie. Dry clean only.",
+                    ],
+                ],
+                "wash_temperature" => [
+                    [
+                        "locale" => null,
+                        "scope"  => null,
+                        "data"   => "600",
+                    ],
+                ],
+            ],
+            "created"       => "2017-09-19T15:58:19+02:00",
+            "updated"       => "2017-09-19T15:58:19+02:00",
+            "associations"  => [],
+        ];
+
+        $response = $client->getResponse();
+
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertResponse($response, $standardVariantProduct);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration(): Configuration
+    {
+        return new Configuration([Configuration::getFunctionalCatalogPath('catalog_modeling')]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $product = $this->get('pim_catalog.builder.variant_product')->createProduct('apollon_blue_xl', 'clothing');
+        $this->get('pim_catalog.updater.product')->update($product, [
+            'parent' => 'apollon_blue',
+            'values' => [
+                'size' => [
+                    [
+                        'locale' => null,
+                        'scope' => null,
+                        'data' => 'xl',
+                    ],
+                ],
+            ],
+        ]);
+
+        $errors = $this->get('pim_catalog.validator.product')->validate($product);
+        if (0 !== $errors->count()) {
+            throw new \Exception(sprintf(
+                                     'Impossible to setup test in %s: %s',
+                                     static::class,
+                                     $errors->get(0)->getMessage()
+                                 ));
+        }
+
+        $this->get('pim_catalog.saver.product')->save($product);
+        $this->get('pim_catalog.validator.unique_value_set')->reset();
+    }
+
+    /**
+     * @param Response $response
+     * @param array    $expected
+     */
+    private function assertResponse(Response $response, array $expected)
+    {
+        $result = json_decode($response->getContent(), true);
+
+        NormalizedProductCleaner::clean($expected);
+        NormalizedProductCleaner::clean($result);
+
+        $this->assertSame($expected, $result);
+    }
+}

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessListVariantProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessListVariantProductIntegration.php
@@ -1,0 +1,1475 @@
+<?php
+
+namespace Pim\Bundle\ApiBundle\tests\integration\Controller\Product;
+
+use Akeneo\Test\Integration\Configuration;
+use Doctrine\Common\Collections\Collection;
+
+class SuccessListVariantProductIntegration extends AbstractProductTestCase
+{
+    /** @var Collection */
+    private $products;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        // no locale, no scope, 1 category
+        $this->createVariantProduct('apollon_blue_s', [
+            'categories' => ['master'],
+            'parent' => 'amor',
+            'values' => [
+                'size' => [
+                    [
+                        'locale' => null,
+                        'scope' => null,
+                        'data' => 's',
+                    ],
+                ],
+            ],
+        ]);
+
+        // apollon_blue_m, categorized in 1 tree (master)
+        $this->createVariantProduct('apollon_blue_m', [
+            'categories' => ['master_accessories'],
+            'parent' => 'amor',
+            'values' => [
+                'color' => [
+                    [
+                        'locale' => null,
+                        'scope' => null,
+                        'data' => 'blue',
+                    ],
+                ],
+            ],
+        ]);
+
+        // apollon_blue_l, categorized in 1 tree (master)
+        $this->createVariantProduct('apollon_blue_l', [
+            'categories' => ['master_men_blazers_deals', 'master_accessories_hats'],
+            'parent' => 'amor',
+            'values' => [
+                'size' => [
+                    [
+                        'locale' => null,
+                        'scope' => null,
+                        'data' => 'l',
+                    ],
+                ],
+            ],
+        ]);
+
+        // apollon_blue_m & apollon_blue_l, categorized in 2 trees (master and master_women_blouses_deals)
+        $this->createVariantProduct('apollon_blue_xl', [
+            'categories' => ['suppliers', 'master_women_blouses_deals'],
+            'parent' => 'amor',
+            'values' => [
+                'size' => [
+                    [
+                        'locale' => null,
+                        'scope' => null,
+                        'data' => 'xl',
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->createVariantProduct('apollon_blue_xxl', [
+            'categories' => ['master_women_blouses_deals'],
+            'parent' => 'amor',
+        ]);
+
+        $this->createVariantProduct('apollon_blue_xs', [
+            'parent' => 'amor',
+            'values' => [
+                'size' => [
+                    [
+                        'locale' => null,
+                        'scope' => null,
+                        'data' => 'xs',
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->products = $this->get('pim_catalog.repository.product')->findAll();
+    }
+
+    /**
+     * Get all products, whatever locale, scope, category with the default pagination type that is with an offset.
+     */
+    public function testDefaultPaginationListProductsWithoutParameter()
+    {
+        $standardizedProducts = $this->getStandardizedProducts();
+        $client = $this->createAuthenticatedClient();
+
+        $client->request('GET', 'api/rest/v1/products');
+        $expected = <<<JSON
+{
+    "_links": {
+        "self"  : {"href": "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10"},
+        "first" : {"href": "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10"}
+    },
+    "current_page" : 1,
+    "_embedded"    : {
+		"items": [
+            {$standardizedProducts['apollon_blue_s']},
+            {$standardizedProducts['apollon_blue_m']},
+            {$standardizedProducts['apollon_blue_l']},
+            {$standardizedProducts['apollon_blue_xl']},
+            {$standardizedProducts['apollon_blue_xxl']},
+            {$standardizedProducts['apollon_blue_xs']}
+		]
+    }
+}
+JSON;
+
+        $this->assertListResponse($client->getResponse(), $expected);
+    }
+
+    public function testDefaultPaginationFirstPageListProductsWithCount()
+    {
+        $standardizedProducts = $this->getStandardizedProducts();
+        $client = $this->createAuthenticatedClient();
+
+        $client->request('GET', 'api/rest/v1/products?with_count=true&limit=3');
+        $expected = <<<JSON
+{
+    "_links": {
+        "self"  : {"href": "http://localhost/api/rest/v1/products?page=1&with_count=true&pagination_type=page&limit=3"},
+        "first" : {"href": "http://localhost/api/rest/v1/products?page=1&with_count=true&pagination_type=page&limit=3"},
+        "next"  : {"href": "http://localhost/api/rest/v1/products?page=2&with_count=true&pagination_type=page&limit=3"}
+    },
+    "current_page" : 1,
+    "items_count"  : 6,
+    "_embedded"    : {
+		"items": [
+            {$standardizedProducts['apollon_blue_s']},
+            {$standardizedProducts['apollon_blue_m']},
+            {$standardizedProducts['apollon_blue_l']}
+		]
+    }
+}
+JSON;
+
+        $this->assertListResponse($client->getResponse(), $expected);
+    }
+
+    public function testDefaultPaginationLastPageListProductsWithCount()
+    {
+        $standardizedProducts = $this->getStandardizedProducts();
+        $client = $this->createAuthenticatedClient();
+
+        $client->request('GET', 'api/rest/v1/products?with_count=true&limit=3&page=2');
+        $expected = <<<JSON
+{
+    "_links": {
+        "self"     : {"href": "http://localhost/api/rest/v1/products?page=2&with_count=true&pagination_type=page&limit=3"},
+        "first"    : {"href": "http://localhost/api/rest/v1/products?page=1&with_count=true&pagination_type=page&limit=3"},
+        "previous" : {"href": "http://localhost/api/rest/v1/products?page=1&with_count=true&pagination_type=page&limit=3"},
+        "next"     : {"href": "http://localhost/api/rest/v1/products?page=3&with_count=true&pagination_type=page&limit=3"}
+    },
+    "current_page" : 2,
+    "items_count"  : 6,
+    "_embedded"    : {
+		"items": [
+            {$standardizedProducts['apollon_blue_xl']},
+            {$standardizedProducts['apollon_blue_xxl']},
+            {$standardizedProducts['apollon_blue_xs']}
+		]
+    }
+}
+JSON;
+
+        $this->assertListResponse($client->getResponse(), $expected);
+    }
+
+    /**
+     * Scope "ecommerce" has only "en_US" activated locale and it category tree linked is "master"
+     * So PV are returned only if:
+     *    - scope = "ecommerce"
+     *    - locale = "en_US" or null
+     * Then only products in "master" tree are returned
+     */
+    public function testOffsetPaginationListProductsWithEcommerceChannel()
+    {
+        $standardizedProducts = $this->getStandardizedProducts();
+        $client = $this->createAuthenticatedClient();
+
+        $client->request('GET', 'api/rest/v1/products?scope=ecommerce&pagination_type=page');
+        $expected = <<<JSON
+{
+    "_links"       : {
+        "self"  : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&scope=ecommerce"},
+        "first" : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&scope=ecommerce"}
+    },
+    "current_page" : 1,
+    "_embedded"    : {
+        "items" : [
+            {$standardizedProducts['apollon_blue_s']},
+            {$standardizedProducts['apollon_blue_m']},
+            {$standardizedProducts['apollon_blue_l']},
+            {$standardizedProducts['apollon_blue_xl']},
+            {$standardizedProducts['apollon_blue_xxl']}
+		]
+    }
+}
+JSON;
+
+        $this->assertListResponse($client->getResponse(), $expected);
+    }
+
+    public function testOffsetPaginationListProductsWithFilteredAttributes()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $client->request('GET', 'api/rest/v1/products?attributes=color&pagination_type=page');
+        $expected = <<<JSON
+{
+    "_links": {
+        "self"  : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&attributes=color"},
+        "first" : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&attributes=color"}
+    },
+    "current_page" : 1,
+    "_embedded"    : {
+        "items" : [
+            {
+                "_links" : {
+                    "self" : {"href" : "http://localhost/api/rest/v1/products/apollon_blue_s"}
+                },
+                "identifier"    : "apollon_blue_s",
+                "family"        : "clothing",
+                "parent"        : "amor",
+                "groups"        : [],
+                "variant_group" : null,
+                "categories"    : ["master"],
+                "enabled"       : true,
+                "values"        : {},
+                "created"       : "2017-01-23T11:44:25+01:00",
+                "updated"       : "2017-01-23T11:44:25+01:00",
+                "associations"  : {}
+            },
+            {
+                "_links" : {
+                    "self" : {"href" : "http://localhost/api/rest/v1/products/apollon_blue_m"}
+                },
+                "identifier"    : "apollon_blue_m",
+                "family"        : "clothing",
+                "parent"        : "amor",
+                "groups"        : [],
+                "variant_group" : null,
+                "categories"    : ["master_accessories"],
+                "enabled"       : true,
+                "values": {
+                    "color": [{
+                        "locale": null,
+                        "scope": null,
+                        "data": "blue"
+                    }]
+                },
+                "created"       : "2017-01-23T11:44:25+01:00",
+                "updated"       : "2017-01-23T11:44:25+01:00",
+                "associations"  : {}
+            },
+            {
+                "_links" : {
+                    "self" : {"href" : "http://localhost/api/rest/v1/products/apollon_blue_l"}
+                },
+                "identifier"    : "apollon_blue_l",
+                "family"        : "clothing",
+                "parent"        : "amor",
+                "groups"        : [],
+                "variant_group" : null,
+                "categories"    : ["master_accessories_hats", "master_men_blazers_deals"],
+                "enabled"       : true,
+                "values"        : {},
+                "created"       : "2017-01-23T11:44:25+01:00",
+                "updated"       : "2017-01-23T11:44:25+01:00",
+                "associations"  : {}
+            },
+            {
+                "_links" : {
+                    "self" : {"href" : "http://localhost/api/rest/v1/products/apollon_blue_xl"}
+                },
+                "identifier"    : "apollon_blue_xl",
+                "family"        : "clothing",
+                "parent"        : "amor",
+                "groups"        : [],
+                "variant_group" : null,
+                "categories"    : ["master_women_blouses_deals", "suppliers"],
+                "enabled"       : true,
+                "values"        : {},
+                "created"       : "2017-01-23T11:44:25+01:00",
+                "updated"       : "2017-01-23T11:44:25+01:00",
+                "associations"  : {}
+            },
+            {
+                "_links" : {
+                    "self" : {"href" : "http://localhost/api/rest/v1/products/apollon_blue_xxl"}
+                },
+                "identifier"    : "apollon_blue_xxl",
+                "family"        : "clothing",
+                "parent"        : "amor",
+                "groups"        : [],
+                "variant_group" : null,
+                "categories"    : ["master_women_blouses_deals"],
+                "enabled"       : true,
+                "values"        : {},
+                "created"       : "2017-01-23T11:44:25+01:00",
+                "updated"       : "2017-01-23T11:44:25+01:00",
+                "associations"  : {}
+            },
+            {
+                "_links" : {
+                    "self" : {"href" : "http://localhost/api/rest/v1/products/apollon_blue_xs"}
+                },
+                "identifier"    : "apollon_blue_xs",
+                "family"        : "clothing",
+                "parent"        : "amor",
+                "groups"        : [],
+                "variant_group" : null,
+                "categories"    : [],
+                "enabled"       : true,
+                "values"        : [],
+                "created"       : "2017-01-23T11:44:25+01:00",
+                "updated"       : "2017-01-23T11:44:25+01:00",
+                "associations"  : {}
+            }
+        ]
+    }
+}
+JSON;
+
+        $this->assertListResponse($client->getResponse(), $expected);
+    }
+
+    public function testOffsetPaginationListProductsWithChannelLocalesAndAttributesParams()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $client->request('GET', 'api/rest/v1/products?scope=ecommerce&locales=fr_FR&attributes=size,erp_name,supplier&pagination_type=page');
+        $expected = <<<JSON
+{
+  "_links": {
+    "self": {
+      "href": "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&scope=ecommerce&locales=fr_FR&attributes=size%2Cerp_name%2Csupplier"
+    },
+    "first": {
+      "href": "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&scope=ecommerce&locales=fr_FR&attributes=size%2Cerp_name%2Csupplier"
+    }
+  },
+  "current_page": 1,
+  "_embedded": {
+    "items": [
+      {
+        "_links": {
+          "self": {
+            "href": "http://localhost/api/rest/v1/products/apollon_blue_s"
+          }
+        },
+        "identifier": "apollon_blue_s",
+        "family": "clothing",
+        "parent": "amor",
+        "groups": [
+          
+        ],
+        "variant_group": null,
+        "categories": [
+          "master"
+        ],
+        "enabled": true,
+        "values": {
+          "size": [
+            {
+              "locale": null,
+              "scope": null,
+              "data": "s"
+            }
+          ],
+          "supplier": [
+            {
+              "locale": null,
+              "scope": null,
+              "data": "zaro"
+            }
+          ]
+        },
+        "created": "2017-09-20T17:46:20+02:00",
+        "updated": "2017-09-20T17:46:20+02:00",
+        "associations": {
+          
+        }
+      },
+      {
+        "_links": {
+          "self": {
+            "href": "http://localhost/api/rest/v1/products/apollon_blue_m"
+          }
+        },
+        "identifier": "apollon_blue_m",
+        "family": "clothing",
+        "parent": "amor",
+        "groups": [
+          
+        ],
+        "variant_group": null,
+        "categories": [
+          "master_accessories"
+        ],
+        "enabled": true,
+        "values": {
+          "supplier": [
+            {
+              "locale": null,
+              "scope": null,
+              "data": "zaro"
+            }
+          ]
+        },
+        "created": "2017-09-20T17:46:21+02:00",
+        "updated": "2017-09-20T17:46:21+02:00",
+        "associations": {
+          
+        }
+      },
+      {
+        "_links": {
+          "self": {
+            "href": "http://localhost/api/rest/v1/products/apollon_blue_l"
+          }
+        },
+        "identifier": "apollon_blue_l",
+        "family": "clothing",
+        "parent": "amor",
+        "groups": [
+          
+        ],
+        "variant_group": null,
+        "categories": [
+          "master_accessories_hats",
+          "master_men_blazers_deals"
+        ],
+        "enabled": true,
+        "values": {
+          "size": [
+            {
+              "locale": null,
+              "scope": null,
+              "data": "l"
+            }
+          ],
+          "supplier": [
+            {
+              "locale": null,
+              "scope": null,
+              "data": "zaro"
+            }
+          ]
+        },
+        "created": "2017-09-20T17:46:21+02:00",
+        "updated": "2017-09-20T17:46:21+02:00",
+        "associations": {
+          
+        }
+      },
+      {
+        "_links": {
+          "self": {
+            "href": "http://localhost/api/rest/v1/products/apollon_blue_xl"
+          }
+        },
+        "identifier": "apollon_blue_xl",
+        "family": "clothing",
+        "parent": "amor",
+        "groups": [
+          
+        ],
+        "variant_group": null,
+        "categories": [
+          "master_women_blouses_deals",
+          "suppliers"
+        ],
+        "enabled": true,
+        "values": {
+          "size": [
+            {
+              "locale": null,
+              "scope": null,
+              "data": "xl"
+            }
+          ],
+          "supplier": [
+            {
+              "locale": null,
+              "scope": null,
+              "data": "zaro"
+            }
+          ]
+        },
+        "created": "2017-09-20T17:46:21+02:00",
+        "updated": "2017-09-20T17:46:21+02:00",
+        "associations": {
+          
+        }
+      },
+      {
+        "_links": {
+          "self": {
+            "href": "http://localhost/api/rest/v1/products/apollon_blue_xxl"
+          }
+        },
+        "identifier": "apollon_blue_xxl",
+        "family": "clothing",
+        "parent": "amor",
+        "groups": [
+          
+        ],
+        "variant_group": null,
+        "categories": [
+          "master_women_blouses_deals"
+        ],
+        "enabled": true,
+        "values": {
+          "supplier": [
+            {
+              "locale": null,
+              "scope": null,
+              "data": "zaro"
+            }
+          ]
+        },
+        "created": "2017-09-20T17:46:21+02:00",
+        "updated": "2017-09-20T17:46:21+02:00",
+        "associations": {
+          
+        }
+      }
+    ]
+  }
+}
+JSON;
+
+        $this->assertListResponse($client->getResponse(), $expected);
+    }
+
+    public function testTheSecondPageOfTheListOfProductsWithOffsetPaginationWithoutCount()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $client->request('GET', 'api/rest/v1/products?attributes=size&page=2&limit=2&pagination_type=page&with_count=false');
+        $expected = <<<JSON
+{
+  "_links": {
+    "self": {
+      "href": "http://localhost/api/rest/v1/products?page=2&with_count=false&pagination_type=page&limit=2&attributes=size"
+    },
+    "first": {
+      "href": "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=2&attributes=size"
+    },
+    "previous": {
+      "href": "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=2&attributes=size"
+    },
+    "next": {
+      "href": "http://localhost/api/rest/v1/products?page=3&with_count=false&pagination_type=page&limit=2&attributes=size"
+    }
+  },
+  "current_page": 2,
+  "_embedded": {
+    "items": [
+      {
+        "_links": {
+          "self": {
+            "href": "http://localhost/api/rest/v1/products/apollon_blue_l"
+          }
+        },
+        "identifier": "apollon_blue_l",
+        "family": "clothing",
+        "parent": "amor",
+        "groups": [
+          
+        ],
+        "variant_group": null,
+        "categories": [
+          "master_accessories_hats",
+          "master_men_blazers_deals"
+        ],
+        "enabled": true,
+        "values": {
+          "size": [
+            {
+              "locale": null,
+              "scope": null,
+              "data": "l"
+            }
+          ]
+        },
+        "created": "2017-09-20T17:50:44+02:00",
+        "updated": "2017-09-20T17:50:44+02:00",
+        "associations": {
+          
+        }
+      },
+      {
+        "_links": {
+          "self": {
+            "href": "http://localhost/api/rest/v1/products/apollon_blue_xl"
+          }
+        },
+        "identifier": "apollon_blue_xl",
+        "family": "clothing",
+        "parent": "amor",
+        "groups": [
+          
+        ],
+        "variant_group": null,
+        "categories": [
+          "master_women_blouses_deals",
+          "suppliers"
+        ],
+        "enabled": true,
+        "values": {
+          "size": [
+            {
+              "locale": null,
+              "scope": null,
+              "data": "xl"
+            }
+          ]
+        },
+        "created": "2017-09-20T17:50:44+02:00",
+        "updated": "2017-09-20T17:50:44+02:00",
+        "associations": {
+          
+        }
+      }
+    ]
+  }
+}
+JSON;
+
+        $this->assertListResponse($client->getResponse(), $expected);
+    }
+
+    public function testOutOfRangeProductsList()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $client->request('GET', 'api/rest/v1/products?page=2&pagination_type=page&with_count=true');
+        $expected = <<<JSON
+{
+    "_links"       : {
+        "self"        : {"href" : "http://localhost/api/rest/v1/products?page=2&with_count=true&pagination_type=page&limit=10"},
+        "first"       : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=true&pagination_type=page&limit=10"},
+        "previous"    : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=true&pagination_type=page&limit=10"}
+    },
+    "current_page" : 2,
+    "items_count"  : 6,
+    "_embedded"    : {
+        "items" : []
+    }
+}
+JSON;
+
+        $this->assertListResponse($client->getResponse(), $expected);
+    }
+
+    public function testOffsetPaginationListProductsWithSearch()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $search = '{"size":[{"operator":"IN","value":["s"]}]}';
+        $client->request('GET', 'api/rest/v1/products?pagination_type=page&search=' . $search);
+        $searchEncoded = rawurlencode($search);
+        $expected = <<<JSON
+{
+    "_links"       : {
+        "self"  : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&search=${searchEncoded}"},
+        "first" : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&search=${searchEncoded}"}
+    },
+    "current_page" : 1,
+    "_embedded"    : {
+        "items" : [
+            {
+                "_links" : {
+                    "self" : {"href" : "http://localhost/api/rest/v1/products/apollon_blue_s"}
+                },
+                "identifier"    : "apollon_blue_s",
+                "family"        : "clothing",
+                "parent"        : "amor",
+                "groups"        : [],
+                "variant_group" : null,
+                "categories"    : ["master"],
+                "enabled"       : true,
+                "values": {
+                "size": [
+                  {
+                    "locale": null,
+                    "scope": null,
+                    "data": "s"
+                  }
+                ],
+                "name": [
+                  {
+                    "locale": "en_US",
+                    "scope": null,
+                    "data": "Heritage jacket navy"
+                  }
+                ],
+                "price": [
+                  {
+                    "locale": null,
+                    "scope": null,
+                    "data": [
+                      {
+                        "amount": "999.00",
+                        "currency": "EUR"
+                      }
+                    ]
+                  }
+                ],
+                "erp_name": [
+                  {
+                    "locale": "en_US",
+                    "scope": null,
+                    "data": "Amor"
+                  }
+                ],
+                "supplier": [
+                  {
+                    "locale": null,
+                    "scope": null,
+                    "data": "zaro"
+                  }
+                ],
+                "collection": [
+                  {
+                    "locale": null,
+                    "scope": null,
+                    "data": [
+                      "summer_2016"
+                    ]
+                  }
+                ],
+                "description": [
+                  {
+                    "locale": "en_US",
+                    "scope": "ecommerce",
+                    "data": "Heritage jacket navy blue tweed suit with single breasted 2 button. 53% wool, 22% polyester, 18% acrylic, 5% nylon, 1% cotton, 1% viscose. Dry Cleaning uniquement.Le mannequin measuring 1m85 and wears UK size 40, size 50 FR"
+                  }
+                ],
+                "wash_temperature": [
+                  {
+                    "locale": null,
+                    "scope": null,
+                    "data": "800"
+                  }
+                ]
+                },
+                "created"       : "2017-01-23T11:44:25+01:00",
+                "updated"       : "2017-01-23T11:44:25+01:00",
+                "associations"  : {}
+            }
+        ]
+    }
+}
+JSON;
+
+        $this->assertListResponse($client->getResponse(), $expected);
+    }
+
+    public function testOffsetPaginationListProductsWithMultiplePQBFilters()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $search = '{"categories":[{"operator":"IN", "value":["master_accessories"]}], "color":[{"operator":"IN","value":["black"]}]}';
+        $client->request('GET', 'api/rest/v1/products?pagination_type=page&search=' . $search);
+        $searchEncoded = rawurlencode($search);
+        $expected = <<<JSON
+{
+    "_links": {
+        "self"  : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&search=${searchEncoded}"},
+        "first" : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&search=${searchEncoded}"}
+    },
+    "current_page" : 1,
+    "_embedded"    : {
+        "items" : []
+    }
+}
+JSON;
+
+        $this->assertListResponse($client->getResponse(), $expected);
+    }
+
+    public function testListProductsWithCompletenessPQBFilters()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $search = '{"completeness":[{"operator":"GREATER THAN ON ALL LOCALES","value":50,"locales":["fr_FR"],"scope":"ecommerce"}],"categories":[{"operator":"IN", "value":["master_accessories"]}], "size":[{"operator":"IN","value":["xl"]}]}';
+        $client->request('GET', 'api/rest/v1/products?search=' . $search);
+        $searchEncoded = rawurlencode($search);
+        $expected = <<<JSON
+{
+    "_links": {
+        "self"  : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&search=${searchEncoded}"},
+        "first" : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&search=${searchEncoded}"}
+    },
+    "current_page" : 1,
+    "_embedded"    : {
+        "items" : []
+    }
+}
+JSON;
+
+        $this->assertListResponse($client->getResponse(), $expected);
+    }
+
+    /**
+     * Get all products, whatever locale, scope, category with a search after pagination
+     */
+    public function testSearchAfterPaginationListProductsWithoutParameter()
+    {
+        $standardizedProducts = $this->getStandardizedProducts();
+        $client = $this->createAuthenticatedClient();
+
+        $client->request('GET', 'api/rest/v1/products?pagination_type=search_after');
+        $expected = <<<JSON
+{
+    "_links": {
+        "self"  : {"href": "http://localhost/api/rest/v1/products?pagination_type=search_after&limit=10"},
+        "first" : {"href": "http://localhost/api/rest/v1/products?pagination_type=search_after&limit=10"}
+    },
+    "_embedded" : {
+        "items" : [
+            {$standardizedProducts['apollon_blue_s']},
+            {$standardizedProducts['apollon_blue_m']},
+            {$standardizedProducts['apollon_blue_l']},
+            {$standardizedProducts['apollon_blue_xl']},
+            {$standardizedProducts['apollon_blue_xxl']},
+            {$standardizedProducts['apollon_blue_xs']}
+        ]
+    }
+}
+JSON;
+
+        $this->assertListResponse($client->getResponse(), $expected);
+    }
+
+    public function testSearchAfterPaginationListProductsWithNextLink()
+    {
+        $standardizedProducts = $this->getStandardizedProducts();
+        $client = $this->createAuthenticatedClient();
+
+        $id = [
+            'apollon_blue_s'  => rawurlencode($this->getEncryptedId('apollon_blue_s')),
+            'apollon_blue_m'  => rawurlencode($this->getEncryptedId('apollon_blue_m')),
+            'apollon_blue_xl' => rawurlencode($this->getEncryptedId('apollon_blue_xl')),
+        ];
+
+        $client->request('GET', sprintf('api/rest/v1/products?pagination_type=search_after&limit=3&search_after=%s', $id['apollon_blue_s']));
+        $expected = <<<JSON
+{
+    "_links": {
+        "self"  : {"href": "http://localhost/api/rest/v1/products?pagination_type=search_after&limit=3&search_after={$id['apollon_blue_s']}"},
+        "first" : {"href": "http://localhost/api/rest/v1/products?pagination_type=search_after&limit=3"},
+        "next"  : {"href": "http://localhost/api/rest/v1/products?pagination_type=search_after&limit=3&search_after={$id['apollon_blue_xl']}"}
+    },
+    "_embedded"    : {
+        "items" : [
+            {$standardizedProducts['apollon_blue_m']},
+            {$standardizedProducts['apollon_blue_l']},
+            {$standardizedProducts['apollon_blue_xl']}
+        ]
+    }
+}
+JSON;
+
+        $this->assertListResponse($client->getResponse(), $expected);
+    }
+
+    public function testSearchAfterPaginationLastPageOfTheListOfProducts()
+    {
+        $standardizedProducts = $this->getStandardizedProducts();
+        $client = $this->createAuthenticatedClient();
+
+        $encryptedId = rawurlencode($this->getEncryptedId('apollon_blue_l'));
+
+        $client->request('GET', sprintf('api/rest/v1/products?pagination_type=search_after&limit=4&search_after=%s' , $encryptedId));
+        $expected = <<<JSON
+{
+    "_links": {
+        "self"  : {"href": "http://localhost/api/rest/v1/products?pagination_type=search_after&limit=4&search_after={$encryptedId}"},
+        "first" : {"href": "http://localhost/api/rest/v1/products?pagination_type=search_after&limit=4"}
+    },
+    "_embedded"    : {
+        "items" : [
+            {$standardizedProducts['apollon_blue_xl']},
+            {$standardizedProducts['apollon_blue_xxl']},
+            {$standardizedProducts['apollon_blue_xs']}
+        ]
+    }
+}
+JSON;
+
+        $this->assertListResponse($client->getResponse(), $expected);
+    }
+
+    /**
+     * @param string $productIdentifier
+     */
+    private function getEncryptedId($productIdentifier)
+    {
+        $encrypter = $this->get('pim_api.security.primary_key_encrypter');
+        $productRepository = $this->get('pim_catalog.repository.product');
+
+        $product = $productRepository->findOneByIdentifier($productIdentifier);
+
+        return $encrypter->encrypt($product->getId());
+    }
+
+    /**
+     * @return array
+     */
+    private function getStandardizedProducts() {
+        $standardizedProducts['apollon_blue_s'] = <<<JSON
+{
+    "_links": {
+        "self": {
+            "href": "http://localhost/api/rest/v1/products/apollon_blue_s"
+        }
+    },
+  "identifier": "apollon_blue_s",
+  "family": "clothing",
+  "parent": "amor",
+  "groups": [],
+  "variant_group": null,
+  "categories": [
+    "master"
+  ],
+  "enabled": true,
+  "values": {
+    "size": [
+      {
+        "locale": null,
+        "scope": null,
+        "data": "s"
+      }
+    ],
+    "name": [
+      {
+        "locale": "en_US",
+        "scope": null,
+        "data": "Heritage jacket navy"
+      }
+    ],
+    "price": [
+      {
+        "locale": null,
+        "scope": null,
+        "data": [
+          {
+            "amount": "999.00",
+            "currency": "EUR"
+          }
+        ]
+      }
+    ],
+    "erp_name": [
+      {
+        "locale": "en_US",
+        "scope": null,
+        "data": "Amor"
+      }
+    ],
+    "supplier": [
+      {
+        "locale": null,
+        "scope": null,
+        "data": "zaro"
+      }
+    ],
+    "collection": [
+      {
+        "locale": null,
+        "scope": null,
+        "data": [
+          "summer_2016"
+        ]
+      }
+    ],
+    "description": [
+      {
+        "locale": "en_US",
+        "scope": "ecommerce",
+        "data": "Heritage jacket navy blue tweed suit with single breasted 2 button. 53% wool, 22% polyester, 18% acrylic, 5% nylon, 1% cotton, 1% viscose. Dry Cleaning uniquement.Le mannequin measuring 1m85 and wears UK size 40, size 50 FR"
+      }
+    ],
+    "wash_temperature": [
+      {
+        "locale": null,
+        "scope": null,
+        "data": "800"
+      }
+    ]
+  },
+  "created": "2017-09-20T15:37:40+02:00",
+  "updated": "2017-09-20T15:37:40+02:00",
+  "associations": {}
+}
+JSON;
+
+        $standardizedProducts['apollon_blue_m'] = <<<JSON
+{
+    "_links": {
+        "self": {
+            "href": "http://localhost/api/rest/v1/products/apollon_blue_m"
+        }
+    },
+  "identifier": "apollon_blue_m",
+  "family": "clothing",
+  "parent": "amor",
+  "groups": [],
+  "variant_group": null,
+  "categories": [
+    "master_accessories"
+  ],
+  "enabled": true,
+  "values": {
+    "color": [
+      {
+        "locale": null,
+        "scope": null,
+        "data": "blue"
+      }
+    ],
+    "name": [
+      {
+        "locale": "en_US",
+        "scope": null,
+        "data": "Heritage jacket navy"
+      }
+    ],
+    "price": [
+      {
+        "locale": null,
+        "scope": null,
+        "data": [
+          {
+            "amount": "999.00",
+            "currency": "EUR"
+          }
+        ]
+      }
+    ],
+    "erp_name": [
+      {
+        "locale": "en_US",
+        "scope": null,
+        "data": "Amor"
+      }
+    ],
+    "supplier": [
+      {
+        "locale": null,
+        "scope": null,
+        "data": "zaro"
+      }
+    ],
+    "collection": [
+      {
+        "locale": null,
+        "scope": null,
+        "data": [
+          "summer_2016"
+        ]
+      }
+    ],
+    "description": [
+      {
+        "locale": "en_US",
+        "scope": "ecommerce",
+        "data": "Heritage jacket navy blue tweed suit with single breasted 2 button. 53% wool, 22% polyester, 18% acrylic, 5% nylon, 1% cotton, 1% viscose. Dry Cleaning uniquement.Le mannequin measuring 1m85 and wears UK size 40, size 50 FR"
+      }
+    ],
+    "wash_temperature": [
+      {
+        "locale": null,
+        "scope": null,
+        "data": "800"
+      }
+    ]
+  },
+  "created": "2017-09-20T15:37:40+02:00",
+  "updated": "2017-09-20T15:37:40+02:00",
+  "associations": {}
+}
+JSON;
+
+        $standardizedProducts['apollon_blue_l'] = <<<JSON
+{
+    "_links": {
+        "self": {
+            "href": "http://localhost/api/rest/v1/products/apollon_blue_l"
+        }
+    },
+  "identifier": "apollon_blue_l",
+  "family": "clothing",
+  "parent": "amor",
+  "groups": [],
+  "variant_group": null,
+  "categories": [
+    "master_accessories_hats",
+    "master_men_blazers_deals"
+  ],
+  "enabled": true,
+  "values": {
+    "size": [
+      {
+        "locale": null,
+        "scope": null,
+        "data": "l"
+      }
+    ],
+    "name": [
+      {
+        "locale": "en_US",
+        "scope": null,
+        "data": "Heritage jacket navy"
+      }
+    ],
+    "price": [
+      {
+        "locale": null,
+        "scope": null,
+        "data": [
+          {
+            "amount": "999.00",
+            "currency": "EUR"
+          }
+        ]
+      }
+    ],
+    "erp_name": [
+      {
+        "locale": "en_US",
+        "scope": null,
+        "data": "Amor"
+      }
+    ],
+    "supplier": [
+      {
+        "locale": null,
+        "scope": null,
+        "data": "zaro"
+      }
+    ],
+    "collection": [
+      {
+        "locale": null,
+        "scope": null,
+        "data": [
+          "summer_2016"
+        ]
+      }
+    ],
+    "description": [
+      {
+        "locale": "en_US",
+        "scope": "ecommerce",
+        "data": "Heritage jacket navy blue tweed suit with single breasted 2 button. 53% wool, 22% polyester, 18% acrylic, 5% nylon, 1% cotton, 1% viscose. Dry Cleaning uniquement.Le mannequin measuring 1m85 and wears UK size 40, size 50 FR"
+      }
+    ],
+    "wash_temperature": [
+      {
+        "locale": null,
+        "scope": null,
+        "data": "800"
+      }
+    ]
+  },
+  "created": "2017-09-20T15:37:40+02:00",
+  "updated": "2017-09-20T15:37:40+02:00",
+  "associations": {}
+}
+JSON;
+
+        $standardizedProducts['apollon_blue_xl'] = <<<JSON
+{
+    "_links": {
+        "self": {
+            "href": "http://localhost/api/rest/v1/products/apollon_blue_xl"
+        }
+    },
+  "identifier": "apollon_blue_xl",
+  "family": "clothing",
+  "parent": "amor",
+  "groups": [
+    
+  ],
+  "variant_group": null,
+  "categories": [
+    "master_women_blouses_deals",
+    "suppliers"
+  ],
+  "enabled": true,
+  "values": {
+    "size": [
+      {
+        "locale": null,
+        "scope": null,
+        "data": "xl"
+      }
+    ],
+    "name": [
+      {
+        "locale": "en_US",
+        "scope": null,
+        "data": "Heritage jacket navy"
+      }
+    ],
+    "price": [
+      {
+        "locale": null,
+        "scope": null,
+        "data": [
+          {
+            "amount": "999.00",
+            "currency": "EUR"
+          }
+        ]
+      }
+    ],
+    "erp_name": [
+      {
+        "locale": "en_US",
+        "scope": null,
+        "data": "Amor"
+      }
+    ],
+    "supplier": [
+      {
+        "locale": null,
+        "scope": null,
+        "data": "zaro"
+      }
+    ],
+    "collection": [
+      {
+        "locale": null,
+        "scope": null,
+        "data": [
+          "summer_2016"
+        ]
+      }
+    ],
+    "description": [
+      {
+        "locale": "en_US",
+        "scope": "ecommerce",
+        "data": "Heritage jacket navy blue tweed suit with single breasted 2 button. 53% wool, 22% polyester, 18% acrylic, 5% nylon, 1% cotton, 1% viscose. Dry Cleaning uniquement.Le mannequin measuring 1m85 and wears UK size 40, size 50 FR"
+      }
+    ],
+    "wash_temperature": [
+      {
+        "locale": null,
+        "scope": null,
+        "data": "800"
+      }
+    ]
+  },
+  "created": "2017-09-20T15:37:40+02:00",
+  "updated": "2017-09-20T15:37:40+02:00",
+  "associations": {
+    
+  }
+}
+JSON;
+
+        $standardizedProducts['apollon_blue_xxl'] = <<<JSON
+{
+   "_links": {
+       "self": {
+           "href": "http://localhost/api/rest/v1/products/apollon_blue_xxl"
+       }
+   },
+  "identifier": "apollon_blue_xxl",
+  "family": "clothing",
+  "parent": "amor",
+  "groups": [
+    
+  ],
+  "variant_group": null,
+  "categories": [
+    "master_women_blouses_deals"
+  ],
+  "enabled": true,
+  "values": {
+    "name": [
+      {
+        "locale": "en_US",
+        "scope": null,
+        "data": "Heritage jacket navy"
+      }
+    ],
+    "price": [
+      {
+        "locale": null,
+        "scope": null,
+        "data": [
+          {
+            "amount": "999.00",
+            "currency": "EUR"
+          }
+        ]
+      }
+    ],
+    "erp_name": [
+      {
+        "locale": "en_US",
+        "scope": null,
+        "data": "Amor"
+      }
+    ],
+    "supplier": [
+      {
+        "locale": null,
+        "scope": null,
+        "data": "zaro"
+      }
+    ],
+    "collection": [
+      {
+        "locale": null,
+        "scope": null,
+        "data": [
+          "summer_2016"
+        ]
+      }
+    ],
+    "description": [
+      {
+        "locale": "en_US",
+        "scope": "ecommerce",
+        "data": "Heritage jacket navy blue tweed suit with single breasted 2 button. 53% wool, 22% polyester, 18% acrylic, 5% nylon, 1% cotton, 1% viscose. Dry Cleaning uniquement.Le mannequin measuring 1m85 and wears UK size 40, size 50 FR"
+      }
+    ],
+    "wash_temperature": [
+      {
+        "locale": null,
+        "scope": null,
+        "data": "800"
+      }
+    ]
+  },
+  "created": "2017-09-20T15:37:40+02:00",
+  "updated": "2017-09-20T15:37:40+02:00",
+  "associations": {
+    
+  }
+}
+JSON;
+
+        $standardizedProducts['apollon_blue_xs'] = <<<JSON
+{
+    "_links": {
+        "self": {
+            "href": "http://localhost/api/rest/v1/products/apollon_blue_xs"
+        }
+    },
+    "identifier": "apollon_blue_xs",
+      "family": "clothing",
+      "parent": "amor",
+      "groups": [
+        
+      ],
+      "variant_group": null,
+      "categories": [
+        
+      ],
+      "enabled": true,
+      "values": {
+        "size": [
+          {
+            "locale": null,
+            "scope": null,
+            "data": "xs"
+          }
+        ],
+        "name": [
+          {
+            "locale": "en_US",
+            "scope": null,
+            "data": "Heritage jacket navy"
+          }
+        ],
+        "price": [
+          {
+            "locale": null,
+            "scope": null,
+            "data": [
+              {
+                "amount": "999.00",
+                "currency": "EUR"
+              }
+            ]
+          }
+        ],
+        "erp_name": [
+          {
+            "locale": "en_US",
+            "scope": null,
+            "data": "Amor"
+          }
+        ],
+        "supplier": [
+          {
+            "locale": null,
+            "scope": null,
+            "data": "zaro"
+          }
+        ],
+        "collection": [
+          {
+            "locale": null,
+            "scope": null,
+            "data": [
+              "summer_2016"
+            ]
+          }
+        ],
+        "description": [
+          {
+            "locale": "en_US",
+            "scope": "ecommerce",
+            "data": "Heritage jacket navy blue tweed suit with single breasted 2 button. 53% wool, 22% polyester, 18% acrylic, 5% nylon, 1% cotton, 1% viscose. Dry Cleaning uniquement.Le mannequin measuring 1m85 and wears UK size 40, size 50 FR"
+          }
+        ],
+        "wash_temperature": [
+          {
+            "locale": null,
+            "scope": null,
+            "data": "800"
+          }
+        ]
+      },
+      "created": "2017-09-20T15:37:40+02:00",
+      "updated": "2017-09-20T15:37:40+02:00",
+      "associations": {
+        
+      }
+    }
+JSON;
+
+        return $standardizedProducts;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration(): Configuration
+    {
+        return new Configuration([Configuration::getFunctionalCatalogPath('catalog_modeling')]);
+    }
+}

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessListVariantProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessListVariantProductIntegration.php
@@ -17,6 +17,20 @@ class SuccessListVariantProductIntegration extends AbstractProductTestCase
     {
         parent::setUp();
 
+        $this->createProductModel(
+            [
+                'code' => 'amor',
+                'family_variant' => 'familyVariantA1',
+                'values'  => [
+                    'a_price'  => [
+                        'data' => ['data' => [['amount' => '50', 'currency' => 'EUR']], 'locale' => null, 'scope' => null],
+                    ],
+                    'a_number_float'  => [['data' => '12.5', 'locale' => null, 'scope' => null]],
+                    'a_localized_and_scopable_text_area'  => [['data' => 'my pink tshirt', 'locale' => 'en_US', 'scope' => 'ecommerce']],
+                ]
+            ]
+        );
+
         // no locale, no scope, 1 category
         $this->createVariantProduct('apollon_blue_s', [
             'categories' => ['master'],
@@ -397,24 +411,10 @@ JSON;
               "scope": null,
               "data": "s"
             }
-          ],
-        "a_text_area": [
-        {
-          "locale": null,
-          "scope": null,
-          "data": "a super text area"
-        }
-        ],
-        "a_number_integer": [
-        {
-          "locale": null,
-          "scope": null,
-          "data": 12
-        }
-        ]
+          ]
         },
-        "created": "2017-09-20T17:46:20+02:00",
-        "updated": "2017-09-20T17:46:20+02:00",
+        "created": "2017-09-25T14:02:10+02:00",
+        "updated": "2017-09-25T14:02:11+02:00",
         "associations": {
           
         }
@@ -437,23 +437,10 @@ JSON;
         ],
         "enabled": true,
         "values": {
-        "a_text_area": [
-        {
-          "locale": null,
-          "scope": null,
-          "data": "a super text area"
-        }
-        ],
-        "a_number_integer": [
-        {
-          "locale": null,
-          "scope": null,
-          "data": 12
-        }
-        ]
+          
         },
-        "created": "2017-09-20T17:46:21+02:00",
-        "updated": "2017-09-20T17:46:21+02:00",
+        "created": "2017-09-25T14:02:11+02:00",
+        "updated": "2017-09-25T14:02:11+02:00",
         "associations": {
           
         }
@@ -483,24 +470,10 @@ JSON;
               "scope": null,
               "data": "l"
             }
-          ],
-        "a_text_area": [
-        {
-          "locale": null,
-          "scope": null,
-          "data": "a super text area"
-        }
-        ],
-        "a_number_integer": [
-        {
-          "locale": null,
-          "scope": null,
-          "data": 12
-        }
-        ]
+          ]
         },
-        "created": "2017-09-20T17:46:21+02:00",
-        "updated": "2017-09-20T17:46:21+02:00",
+        "created": "2017-09-25T14:02:11+02:00",
+        "updated": "2017-09-25T14:02:11+02:00",
         "associations": {
           
         }
@@ -530,24 +503,10 @@ JSON;
               "scope": null,
               "data": "xl"
             }
-          ],
-        "a_text_area": [
-        {
-          "locale": null,
-          "scope": null,
-          "data": "a super text area"
-        }
-        ],
-        "a_number_integer": [
-        {
-          "locale": null,
-          "scope": null,
-          "data": 12
-        }
-        ]
+          ]
         },
-        "created": "2017-09-20T17:46:21+02:00",
-        "updated": "2017-09-20T17:46:21+02:00",
+        "created": "2017-09-25T14:02:11+02:00",
+        "updated": "2017-09-25T14:02:11+02:00",
         "associations": {
           
         }
@@ -576,24 +535,10 @@ JSON;
               "scope": null,
               "data": "xxl"
             }
-          ],
-        "a_text_area": [
-        {
-          "locale": null,
-          "scope": null,
-          "data": "a super text area"
-        }
-        ],
-        "a_number_integer": [
-        {
-          "locale": null,
-          "scope": null,
-          "data": 12
-        }
-        ]
+          ]
         },
-        "created": "2017-09-20T17:46:21+02:00",
-        "updated": "2017-09-20T17:46:21+02:00",
+        "created": "2017-09-25T14:02:11+02:00",
+        "updated": "2017-09-25T14:02:11+02:00",
         "associations": {
           
         }
@@ -774,18 +719,18 @@ JSON;
                   ]
                 }
                 ],
-                "a_text_area": [
+                "a_number_float": [
                 {
                   "locale": null,
                   "scope": null,
-                  "data": "a super text area"
+                  "data": "12.5000"
                 }
                 ],
-                "a_number_integer": [
+                "a_localized_and_scopable_text_area": [
                 {
-                  "locale": null,
-                  "scope": null,
-                  "data": 12
+                  "locale": "en_US",
+                  "scope": "ecommerce",
+                  "data": "my pink tshirt"
                 }
                 ]
                 },
@@ -990,21 +935,21 @@ JSON;
       ]
     }
     ],
-    "a_text_area": [
-    {
-      "locale": null,
-      "scope": null,
-      "data": "a super text area"
-    }
-    ],
-    "a_number_integer": [
-    {
-      "locale": null,
-      "scope": null,
-      "data": 12
-    }
-    ]
-    },
+          "a_number_float": [
+            {
+              "locale": null,
+              "scope": null,
+              "data": "12.5000"
+            }
+          ],
+          "a_localized_and_scopable_text_area": [
+            {
+              "locale": "en_US",
+              "scope": "ecommerce",
+              "data": "my pink tshirt"
+            }
+          ]
+        },
   "created": "2017-09-20T15:37:40+02:00",
   "updated": "2017-09-20T15:37:40+02:00",
   "associations": {}
@@ -1047,21 +992,21 @@ JSON;
       ]
     }
     ],
-    "a_text_area": [
-    {
-      "locale": null,
-      "scope": null,
-      "data": "a super text area"
-    }
-    ],
-    "a_number_integer": [
-    {
-      "locale": null,
-      "scope": null,
-      "data": 12
-    }
-    ]
-    },
+          "a_number_float": [
+            {
+              "locale": null,
+              "scope": null,
+              "data": "12.5000"
+            }
+          ],
+          "a_localized_and_scopable_text_area": [
+            {
+              "locale": "en_US",
+              "scope": "ecommerce",
+              "data": "my pink tshirt"
+            }
+          ]
+        },
   "created": "2017-09-20T15:37:40+02:00",
   "updated": "2017-09-20T15:37:40+02:00",
   "associations": {}
@@ -1105,21 +1050,21 @@ JSON;
       ]
     }
     ],
-    "a_text_area": [
-    {
-      "locale": null,
-      "scope": null,
-      "data": "a super text area"
-    }
-    ],
-    "a_number_integer": [
-    {
-      "locale": null,
-      "scope": null,
-      "data": 12
-    }
-    ]
-    },
+          "a_number_float": [
+            {
+              "locale": null,
+              "scope": null,
+              "data": "12.5000"
+            }
+          ],
+          "a_localized_and_scopable_text_area": [
+            {
+              "locale": "en_US",
+              "scope": "ecommerce",
+              "data": "my pink tshirt"
+            }
+          ]
+        },
   "created": "2017-09-20T15:37:40+02:00",
   "updated": "2017-09-20T15:37:40+02:00",
   "associations": {}
@@ -1165,21 +1110,21 @@ JSON;
       ]
     }
     ],
-    "a_text_area": [
-    {
-      "locale": null,
-      "scope": null,
-      "data": "a super text area"
-    }
-    ],
-    "a_number_integer": [
-    {
-      "locale": null,
-      "scope": null,
-      "data": 12
-    }
-    ]
-    },
+          "a_number_float": [
+            {
+              "locale": null,
+              "scope": null,
+              "data": "12.5000"
+            }
+          ],
+          "a_localized_and_scopable_text_area": [
+            {
+              "locale": "en_US",
+              "scope": "ecommerce",
+              "data": "my pink tshirt"
+            }
+          ]
+        },
   "created": "2017-09-20T15:37:40+02:00",
   "updated": "2017-09-20T15:37:40+02:00",
   "associations": {
@@ -1226,21 +1171,21 @@ JSON;
       ]
     }
     ],
-    "a_text_area": [
-    {
-      "locale": null,
-      "scope": null,
-      "data": "a super text area"
-    }
-    ],
-    "a_number_integer": [
-    {
-      "locale": null,
-      "scope": null,
-      "data": 12
-    }
-    ]
-    },
+          "a_number_float": [
+            {
+              "locale": null,
+              "scope": null,
+              "data": "12.5000"
+            }
+          ],
+          "a_localized_and_scopable_text_area": [
+            {
+              "locale": "en_US",
+              "scope": "ecommerce",
+              "data": "my pink tshirt"
+            }
+          ]
+        },
   "created": "2017-09-20T15:37:40+02:00",
   "updated": "2017-09-20T15:37:40+02:00",
   "associations": {
@@ -1287,21 +1232,21 @@ JSON;
           ]
         }
         ],
-        "a_text_area": [
+        "a_number_float": [
         {
           "locale": null,
           "scope": null,
-          "data": "a super text area"
+          "data": "12.5000"
         }
         ],
-        "a_number_integer": [
+        "a_localized_and_scopable_text_area": [
         {
-          "locale": null,
-          "scope": null,
-          "data": 12
+          "locale": "en_US",
+          "scope": "ecommerce",
+          "data": "my pink tshirt"
         }
         ]
-        },
+      },
       "created": "2017-09-20T15:37:40+02:00",
       "updated": "2017-09-20T15:37:40+02:00",
       "associations": {

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessListVariantProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessListVariantProductIntegration.php
@@ -36,7 +36,7 @@ class SuccessListVariantProductIntegration extends AbstractProductTestCase
             'categories' => ['master'],
             'parent' => 'amor',
             'values' => [
-                'size' => [
+                'a_simple_select_size' => [
                     [
                         'locale' => null,
                         'scope' => null,
@@ -51,7 +51,7 @@ class SuccessListVariantProductIntegration extends AbstractProductTestCase
             'categories' => ['categoryA'],
             'parent' => 'amor',
             'values' => [
-                'color' => [
+                'a_simple_select_color' => [
                     [
                         'locale' => null,
                         'scope' => null,
@@ -66,7 +66,7 @@ class SuccessListVariantProductIntegration extends AbstractProductTestCase
             'categories' => ['categoryB', 'categoryC'],
             'parent' => 'amor',
             'values' => [
-                'size' => [
+                'a_simple_select_size' => [
                     [
                         'locale' => null,
                         'scope' => null,
@@ -81,7 +81,7 @@ class SuccessListVariantProductIntegration extends AbstractProductTestCase
             'categories' => ['categoryA2', 'categoryA1'],
             'parent' => 'amor',
             'values' => [
-                'size' => [
+                'a_simple_select_size' => [
                     [
                         'locale' => null,
                         'scope' => null,
@@ -95,7 +95,7 @@ class SuccessListVariantProductIntegration extends AbstractProductTestCase
             'categories' => ['categoryA1'],
             'parent' => 'amor',
             'values' => [
-                'size' => [
+                'a_simple_select_size' => [
                     [
                         'locale' => null,
                         'scope' => null,
@@ -108,7 +108,7 @@ class SuccessListVariantProductIntegration extends AbstractProductTestCase
         $this->createVariantProduct('apollon_blue_xs', [
             'parent' => 'amor',
             'values' => [
-                'size' => [
+                'a_simple_select_size' => [
                     [
                         'locale' => null,
                         'scope' => null,
@@ -249,12 +249,12 @@ JSON;
     {
         $client = $this->createAuthenticatedClient();
 
-        $client->request('GET', 'api/rest/v1/products?attributes=color&pagination_type=page');
+        $client->request('GET', 'api/rest/v1/products?attributes=a_simple_select_color&pagination_type=page');
         $expected = <<<JSON
 {
     "_links": {
-        "self"  : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&attributes=color"},
-        "first" : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&attributes=color"}
+        "self"  : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&attributes=a_simple_select_color"},
+        "first" : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&attributes=a_simple_select_color"}
     },
     "current_page" : 1,
     "_embedded"    : {
@@ -287,7 +287,7 @@ JSON;
                 "categories"    : ["categoryA"],
                 "enabled"       : true,
                 "values": {
-                    "color": [{
+                    "a_simple_select_color": [{
                         "locale": null,
                         "scope": null,
                         "data": "blue"
@@ -373,15 +373,15 @@ JSON;
     {
         $client = $this->createAuthenticatedClient();
 
-        $client->request('GET', 'api/rest/v1/products?scope=ecommerce&locales=en_US&attributes=size,a_text_area,a_number_integer&pagination_type=page');
+        $client->request('GET', 'api/rest/v1/products?scope=ecommerce&locales=en_US&attributes=a_simple_select_size,a_text_area,a_number_integer&pagination_type=page');
         $expected = <<<JSON
 {
   "_links": {
     "self": {
-      "href": "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&scope=ecommerce&locales=en_US&attributes=size%2Ca_text_area%2Ca_number_integer"
+      "href": "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&scope=ecommerce&locales=en_US&attributes=a_simple_select_size%2Ca_text_area%2Ca_number_integer"
     },
     "first": {
-      "href": "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&scope=ecommerce&locales=en_US&attributes=size%2Ca_text_area%2Ca_number_integer"
+      "href": "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&scope=ecommerce&locales=en_US&attributes=a_simple_select_size%2Ca_text_area%2Ca_number_integer"
     }
   },
   "current_page": 1,
@@ -405,7 +405,7 @@ JSON;
         ],
         "enabled": true,
         "values": {
-          "size": [
+          "a_simple_select_size": [
             {
               "locale": null,
               "scope": null,
@@ -464,7 +464,7 @@ JSON;
         ],
         "enabled": true,
         "values": {
-          "size": [
+          "a_simple_select_size": [
             {
               "locale": null,
               "scope": null,
@@ -497,7 +497,7 @@ JSON;
         ],
         "enabled": true,
         "values": {
-          "size": [
+          "a_simple_select_size": [
             {
               "locale": null,
               "scope": null,
@@ -529,7 +529,7 @@ JSON;
         ],
         "enabled": true,
         "values": {
-          "size": [
+          "a_simple_select_size": [
             {
               "locale": null,
               "scope": null,
@@ -555,21 +555,21 @@ JSON;
     {
         $client = $this->createAuthenticatedClient();
 
-        $client->request('GET', 'api/rest/v1/products?attributes=size&page=2&limit=2&pagination_type=page&with_count=false');
+        $client->request('GET', 'api/rest/v1/products?attributes=a_simple_select_size&page=2&limit=2&pagination_type=page&with_count=false');
         $expected = <<<JSON
 {
   "_links": {
     "self": {
-      "href": "http://localhost/api/rest/v1/products?page=2&with_count=false&pagination_type=page&limit=2&attributes=size"
+      "href": "http://localhost/api/rest/v1/products?page=2&with_count=false&pagination_type=page&limit=2&attributes=a_simple_select_size"
     },
     "first": {
-      "href": "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=2&attributes=size"
+      "href": "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=2&attributes=a_simple_select_size"
     },
     "previous": {
-      "href": "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=2&attributes=size"
+      "href": "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=2&attributes=a_simple_select_size"
     },
     "next": {
-      "href": "http://localhost/api/rest/v1/products?page=3&with_count=false&pagination_type=page&limit=2&attributes=size"
+      "href": "http://localhost/api/rest/v1/products?page=3&with_count=false&pagination_type=page&limit=2&attributes=a_simple_select_size"
     }
   },
   "current_page": 2,
@@ -594,7 +594,7 @@ JSON;
         ],
         "enabled": true,
         "values": {
-          "size": [
+          "a_simple_select_size": [
             {
               "locale": null,
               "scope": null,
@@ -627,7 +627,7 @@ JSON;
         ],
         "enabled": true,
         "values": {
-          "size": [
+          "a_simple_select_size": [
             {
               "locale": null,
               "scope": null,
@@ -676,7 +676,7 @@ JSON;
     {
         $client = $this->createAuthenticatedClient();
 
-        $search = '{"size":[{"operator":"IN","value":["s"]}]}';
+        $search = '{"a_simple_select_size":[{"operator":"IN","value":["s"]}]}';
         $client->request('GET', 'api/rest/v1/products?pagination_type=page&search=' . $search);
         $searchEncoded = rawurlencode($search);
         $expected = <<<JSON
@@ -700,7 +700,7 @@ JSON;
                 "categories"    : ["master"],
                 "enabled"       : true,
                 "values": {
-                "size": [
+                "a_simple_select_size": [
                   {
                     "locale": null,
                     "scope": null,
@@ -750,7 +750,7 @@ JSON;
     {
         $client = $this->createAuthenticatedClient();
 
-        $search = '{"categories":[{"operator":"IN", "value":["categoryA"]}], "color":[{"operator":"IN","value":["black"]}]}';
+        $search = '{"categories":[{"operator":"IN", "value":["categoryA"]}], "a_simple_select_color":[{"operator":"IN","value":["black"]}]}';
         $client->request('GET', 'api/rest/v1/products?pagination_type=page&search=' . $search);
         $searchEncoded = rawurlencode($search);
         $expected = <<<JSON
@@ -773,7 +773,7 @@ JSON;
     {
         $client = $this->createAuthenticatedClient();
 
-        $search = '{"completeness":[{"operator":"GREATER THAN ON ALL LOCALES","value":50,"locales":["en_US"],"scope":"ecommerce"}],"categories":[{"operator":"IN", "value":["categoryA"]}], "size":[{"operator":"IN","value":["xl"]}]}';
+        $search = '{"completeness":[{"operator":"GREATER THAN ON ALL LOCALES","value":50,"locales":["en_US"],"scope":"ecommerce"}],"categories":[{"operator":"IN", "value":["categoryA"]}], "a_simple_select_size":[{"operator":"IN","value":["xl"]}]}';
         $client->request('GET', 'api/rest/v1/products?search=' . $search);
         $searchEncoded = rawurlencode($search);
         $expected = <<<JSON
@@ -916,7 +916,7 @@ JSON;
   ],
   "enabled": true,
   "values": {
-    "size": [
+    "a_simple_select_size": [
       {
         "locale": null,
         "scope": null,
@@ -973,7 +973,7 @@ JSON;
   ],
   "enabled": true,
   "values": {
-    "color": [
+    "a_simple_select_color": [
       {
         "locale": null,
         "scope": null,
@@ -1031,7 +1031,7 @@ JSON;
   ],
   "enabled": true,
   "values": {
-    "size": [
+    "a_simple_select_size": [
       {
         "locale": null,
         "scope": null,
@@ -1091,7 +1091,7 @@ JSON;
   ],
   "enabled": true,
   "values": {
-    "size": [
+    "a_simple_select_size": [
       {
         "locale": null,
         "scope": null,
@@ -1152,7 +1152,7 @@ JSON;
   ],
   "enabled": true,
   "values": {
-    "size": [
+    "a_simple_select_size": [
       {
         "locale": null,
         "scope": null,
@@ -1213,7 +1213,7 @@ JSON;
       ],
       "enabled": true,
       "values": {
-        "size": [
+        "a_simple_select_size": [
           {
             "locale": null,
             "scope": null,

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessListVariantProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessListVariantProductIntegration.php
@@ -34,7 +34,7 @@ class SuccessListVariantProductIntegration extends AbstractProductTestCase
 
         // apollon_blue_m, categorized in 1 tree (master)
         $this->createVariantProduct('apollon_blue_m', [
-            'categories' => ['master_accessories'],
+            'categories' => ['categoryA'],
             'parent' => 'amor',
             'values' => [
                 'color' => [
@@ -49,7 +49,7 @@ class SuccessListVariantProductIntegration extends AbstractProductTestCase
 
         // apollon_blue_l, categorized in 1 tree (master)
         $this->createVariantProduct('apollon_blue_l', [
-            'categories' => ['master_men_blazers_deals', 'master_accessories_hats'],
+            'categories' => ['categoryB', 'categoryC'],
             'parent' => 'amor',
             'values' => [
                 'size' => [
@@ -62,9 +62,9 @@ class SuccessListVariantProductIntegration extends AbstractProductTestCase
             ],
         ]);
 
-        // apollon_blue_m & apollon_blue_l, categorized in 2 trees (master and master_women_blouses_deals)
+        // apollon_blue_m & apollon_blue_l, categorized in 2 trees (master and categoryA1)
         $this->createVariantProduct('apollon_blue_xl', [
-            'categories' => ['suppliers', 'master_women_blouses_deals'],
+            'categories' => ['categoryA2', 'categoryA1'],
             'parent' => 'amor',
             'values' => [
                 'size' => [
@@ -78,8 +78,17 @@ class SuccessListVariantProductIntegration extends AbstractProductTestCase
         ]);
 
         $this->createVariantProduct('apollon_blue_xxl', [
-            'categories' => ['master_women_blouses_deals'],
+            'categories' => ['categoryA1'],
             'parent' => 'amor',
+            'values' => [
+                'size' => [
+                    [
+                        'locale' => null,
+                        'scope' => null,
+                        'data' => 'xxl',
+                    ],
+                ],
+            ],
         ]);
 
         $this->createVariantProduct('apollon_blue_xs', [
@@ -241,7 +250,7 @@ JSON;
                     "self" : {"href" : "http://localhost/api/rest/v1/products/apollon_blue_s"}
                 },
                 "identifier"    : "apollon_blue_s",
-                "family"        : "clothing",
+                "family"        : "familyA",
                 "parent"        : "amor",
                 "groups"        : [],
                 "variant_group" : null,
@@ -257,11 +266,11 @@ JSON;
                     "self" : {"href" : "http://localhost/api/rest/v1/products/apollon_blue_m"}
                 },
                 "identifier"    : "apollon_blue_m",
-                "family"        : "clothing",
+                "family"        : "familyA",
                 "parent"        : "amor",
                 "groups"        : [],
                 "variant_group" : null,
-                "categories"    : ["master_accessories"],
+                "categories"    : ["categoryA"],
                 "enabled"       : true,
                 "values": {
                     "color": [{
@@ -279,11 +288,11 @@ JSON;
                     "self" : {"href" : "http://localhost/api/rest/v1/products/apollon_blue_l"}
                 },
                 "identifier"    : "apollon_blue_l",
-                "family"        : "clothing",
+                "family"        : "familyA",
                 "parent"        : "amor",
                 "groups"        : [],
                 "variant_group" : null,
-                "categories"    : ["master_accessories_hats", "master_men_blazers_deals"],
+                "categories"    : ["categoryB", "categoryC"],
                 "enabled"       : true,
                 "values"        : {},
                 "created"       : "2017-01-23T11:44:25+01:00",
@@ -295,11 +304,11 @@ JSON;
                     "self" : {"href" : "http://localhost/api/rest/v1/products/apollon_blue_xl"}
                 },
                 "identifier"    : "apollon_blue_xl",
-                "family"        : "clothing",
+                "family"        : "familyA",
                 "parent"        : "amor",
                 "groups"        : [],
                 "variant_group" : null,
-                "categories"    : ["master_women_blouses_deals", "suppliers"],
+                "categories"    : ["categoryA1", "categoryA2"],
                 "enabled"       : true,
                 "values"        : {},
                 "created"       : "2017-01-23T11:44:25+01:00",
@@ -311,11 +320,11 @@ JSON;
                     "self" : {"href" : "http://localhost/api/rest/v1/products/apollon_blue_xxl"}
                 },
                 "identifier"    : "apollon_blue_xxl",
-                "family"        : "clothing",
+                "family"        : "familyA",
                 "parent"        : "amor",
                 "groups"        : [],
                 "variant_group" : null,
-                "categories"    : ["master_women_blouses_deals"],
+                "categories"    : ["categoryA1"],
                 "enabled"       : true,
                 "values"        : {},
                 "created"       : "2017-01-23T11:44:25+01:00",
@@ -327,7 +336,7 @@ JSON;
                     "self" : {"href" : "http://localhost/api/rest/v1/products/apollon_blue_xs"}
                 },
                 "identifier"    : "apollon_blue_xs",
-                "family"        : "clothing",
+                "family"        : "familyA",
                 "parent"        : "amor",
                 "groups"        : [],
                 "variant_group" : null,
@@ -350,15 +359,15 @@ JSON;
     {
         $client = $this->createAuthenticatedClient();
 
-        $client->request('GET', 'api/rest/v1/products?scope=ecommerce&locales=fr_FR&attributes=size,erp_name,supplier&pagination_type=page');
+        $client->request('GET', 'api/rest/v1/products?scope=ecommerce&locales=en_US&attributes=size,a_text_area,a_number_integer&pagination_type=page');
         $expected = <<<JSON
 {
   "_links": {
     "self": {
-      "href": "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&scope=ecommerce&locales=fr_FR&attributes=size%2Cerp_name%2Csupplier"
+      "href": "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&scope=ecommerce&locales=en_US&attributes=size%2Ca_text_area%2Ca_number_integer"
     },
     "first": {
-      "href": "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&scope=ecommerce&locales=fr_FR&attributes=size%2Cerp_name%2Csupplier"
+      "href": "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&scope=ecommerce&locales=en_US&attributes=size%2Ca_text_area%2Ca_number_integer"
     }
   },
   "current_page": 1,
@@ -371,7 +380,7 @@ JSON;
           }
         },
         "identifier": "apollon_blue_s",
-        "family": "clothing",
+        "family": "familyA",
         "parent": "amor",
         "groups": [
           
@@ -389,13 +398,20 @@ JSON;
               "data": "s"
             }
           ],
-          "supplier": [
-            {
-              "locale": null,
-              "scope": null,
-              "data": "zaro"
-            }
-          ]
+        "a_text_area": [
+        {
+          "locale": null,
+          "scope": null,
+          "data": "a super text area"
+        }
+        ],
+        "a_number_integer": [
+        {
+          "locale": null,
+          "scope": null,
+          "data": 12
+        }
+        ]
         },
         "created": "2017-09-20T17:46:20+02:00",
         "updated": "2017-09-20T17:46:20+02:00",
@@ -410,24 +426,31 @@ JSON;
           }
         },
         "identifier": "apollon_blue_m",
-        "family": "clothing",
+        "family": "familyA",
         "parent": "amor",
         "groups": [
           
         ],
         "variant_group": null,
         "categories": [
-          "master_accessories"
+          "categoryA"
         ],
         "enabled": true,
         "values": {
-          "supplier": [
-            {
-              "locale": null,
-              "scope": null,
-              "data": "zaro"
-            }
-          ]
+        "a_text_area": [
+        {
+          "locale": null,
+          "scope": null,
+          "data": "a super text area"
+        }
+        ],
+        "a_number_integer": [
+        {
+          "locale": null,
+          "scope": null,
+          "data": 12
+        }
+        ]
         },
         "created": "2017-09-20T17:46:21+02:00",
         "updated": "2017-09-20T17:46:21+02:00",
@@ -442,15 +465,15 @@ JSON;
           }
         },
         "identifier": "apollon_blue_l",
-        "family": "clothing",
+        "family": "familyA",
         "parent": "amor",
         "groups": [
           
         ],
         "variant_group": null,
         "categories": [
-          "master_accessories_hats",
-          "master_men_blazers_deals"
+          "categoryB",
+          "categoryC"
         ],
         "enabled": true,
         "values": {
@@ -461,13 +484,20 @@ JSON;
               "data": "l"
             }
           ],
-          "supplier": [
-            {
-              "locale": null,
-              "scope": null,
-              "data": "zaro"
-            }
-          ]
+        "a_text_area": [
+        {
+          "locale": null,
+          "scope": null,
+          "data": "a super text area"
+        }
+        ],
+        "a_number_integer": [
+        {
+          "locale": null,
+          "scope": null,
+          "data": 12
+        }
+        ]
         },
         "created": "2017-09-20T17:46:21+02:00",
         "updated": "2017-09-20T17:46:21+02:00",
@@ -482,15 +512,15 @@ JSON;
           }
         },
         "identifier": "apollon_blue_xl",
-        "family": "clothing",
+        "family": "familyA",
         "parent": "amor",
         "groups": [
           
         ],
         "variant_group": null,
         "categories": [
-          "master_women_blouses_deals",
-          "suppliers"
+          "categoryA1",
+          "categoryA2"
         ],
         "enabled": true,
         "values": {
@@ -501,13 +531,20 @@ JSON;
               "data": "xl"
             }
           ],
-          "supplier": [
-            {
-              "locale": null,
-              "scope": null,
-              "data": "zaro"
-            }
-          ]
+        "a_text_area": [
+        {
+          "locale": null,
+          "scope": null,
+          "data": "a super text area"
+        }
+        ],
+        "a_number_integer": [
+        {
+          "locale": null,
+          "scope": null,
+          "data": 12
+        }
+        ]
         },
         "created": "2017-09-20T17:46:21+02:00",
         "updated": "2017-09-20T17:46:21+02:00",
@@ -522,24 +559,38 @@ JSON;
           }
         },
         "identifier": "apollon_blue_xxl",
-        "family": "clothing",
+        "family": "familyA",
         "parent": "amor",
         "groups": [
           
         ],
         "variant_group": null,
         "categories": [
-          "master_women_blouses_deals"
+          "categoryA1"
         ],
         "enabled": true,
         "values": {
-          "supplier": [
+          "size": [
             {
               "locale": null,
               "scope": null,
-              "data": "zaro"
+              "data": "xxl"
             }
-          ]
+          ],
+        "a_text_area": [
+        {
+          "locale": null,
+          "scope": null,
+          "data": "a super text area"
+        }
+        ],
+        "a_number_integer": [
+        {
+          "locale": null,
+          "scope": null,
+          "data": 12
+        }
+        ]
         },
         "created": "2017-09-20T17:46:21+02:00",
         "updated": "2017-09-20T17:46:21+02:00",
@@ -586,15 +637,15 @@ JSON;
           }
         },
         "identifier": "apollon_blue_l",
-        "family": "clothing",
+        "family": "familyA",
         "parent": "amor",
         "groups": [
           
         ],
         "variant_group": null,
         "categories": [
-          "master_accessories_hats",
-          "master_men_blazers_deals"
+          "categoryB",
+          "categoryC"
         ],
         "enabled": true,
         "values": {
@@ -619,15 +670,15 @@ JSON;
           }
         },
         "identifier": "apollon_blue_xl",
-        "family": "clothing",
+        "family": "familyA",
         "parent": "amor",
         "groups": [
           
         ],
         "variant_group": null,
         "categories": [
-          "master_women_blouses_deals",
-          "suppliers"
+          "categoryA1",
+          "categoryA2"
         ],
         "enabled": true,
         "values": {
@@ -697,7 +748,7 @@ JSON;
                     "self" : {"href" : "http://localhost/api/rest/v1/products/apollon_blue_s"}
                 },
                 "identifier"    : "apollon_blue_s",
-                "family"        : "clothing",
+                "family"        : "familyA",
                 "parent"        : "amor",
                 "groups"        : [],
                 "variant_group" : null,
@@ -711,61 +762,31 @@ JSON;
                     "data": "s"
                   }
                 ],
-                "name": [
-                  {
-                    "locale": "en_US",
-                    "scope": null,
-                    "data": "Heritage jacket navy"
-                  }
+                "a_price": [
+                {
+                  "locale": null,
+                  "scope": null,
+                  "data": [
+                    {
+                      "amount": "50.00",
+                      "currency": "EUR"
+                    }
+                  ]
+                }
                 ],
-                "price": [
-                  {
-                    "locale": null,
-                    "scope": null,
-                    "data": [
-                      {
-                        "amount": "999.00",
-                        "currency": "EUR"
-                      }
-                    ]
-                  }
+                "a_text_area": [
+                {
+                  "locale": null,
+                  "scope": null,
+                  "data": "a super text area"
+                }
                 ],
-                "erp_name": [
-                  {
-                    "locale": "en_US",
-                    "scope": null,
-                    "data": "Amor"
-                  }
-                ],
-                "supplier": [
-                  {
-                    "locale": null,
-                    "scope": null,
-                    "data": "zaro"
-                  }
-                ],
-                "collection": [
-                  {
-                    "locale": null,
-                    "scope": null,
-                    "data": [
-                      "summer_2016"
-                    ]
-                  }
-                ],
-                "description": [
-                  {
-                    "locale": "en_US",
-                    "scope": "ecommerce",
-                    "data": "Heritage jacket navy blue tweed suit with single breasted 2 button. 53% wool, 22% polyester, 18% acrylic, 5% nylon, 1% cotton, 1% viscose. Dry Cleaning uniquement.Le mannequin measuring 1m85 and wears UK size 40, size 50 FR"
-                  }
-                ],
-                "wash_temperature": [
-                  {
-                    "locale": null,
-                    "scope": null,
-                    "data": "800"
-                  }
+                "a_number_integer": [
+                {
+                  "locale": null,
+                  "scope": null,
+                  "data": 12
+                }
                 ]
                 },
                 "created"       : "2017-01-23T11:44:25+01:00",
@@ -784,7 +805,7 @@ JSON;
     {
         $client = $this->createAuthenticatedClient();
 
-        $search = '{"categories":[{"operator":"IN", "value":["master_accessories"]}], "color":[{"operator":"IN","value":["black"]}]}';
+        $search = '{"categories":[{"operator":"IN", "value":["categoryA"]}], "color":[{"operator":"IN","value":["black"]}]}';
         $client->request('GET', 'api/rest/v1/products?pagination_type=page&search=' . $search);
         $searchEncoded = rawurlencode($search);
         $expected = <<<JSON
@@ -807,7 +828,7 @@ JSON;
     {
         $client = $this->createAuthenticatedClient();
 
-        $search = '{"completeness":[{"operator":"GREATER THAN ON ALL LOCALES","value":50,"locales":["fr_FR"],"scope":"ecommerce"}],"categories":[{"operator":"IN", "value":["master_accessories"]}], "size":[{"operator":"IN","value":["xl"]}]}';
+        $search = '{"completeness":[{"operator":"GREATER THAN ON ALL LOCALES","value":50,"locales":["en_US"],"scope":"ecommerce"}],"categories":[{"operator":"IN", "value":["categoryA"]}], "size":[{"operator":"IN","value":["xl"]}]}';
         $client->request('GET', 'api/rest/v1/products?search=' . $search);
         $searchEncoded = rawurlencode($search);
         $expected = <<<JSON
@@ -941,7 +962,7 @@ JSON;
         }
     },
   "identifier": "apollon_blue_s",
-  "family": "clothing",
+  "family": "familyA",
   "parent": "amor",
   "groups": [],
   "variant_group": null,
@@ -957,63 +978,33 @@ JSON;
         "data": "s"
       }
     ],
-    "name": [
-      {
-        "locale": "en_US",
-        "scope": null,
-        "data": "Heritage jacket navy"
-      }
+    "a_price": [
+    {
+      "locale": null,
+      "scope": null,
+      "data": [
+        {
+          "amount": "50.00",
+          "currency": "EUR"
+        }
+      ]
+    }
     ],
-    "price": [
-      {
-        "locale": null,
-        "scope": null,
-        "data": [
-          {
-            "amount": "999.00",
-            "currency": "EUR"
-          }
-        ]
-      }
+    "a_text_area": [
+    {
+      "locale": null,
+      "scope": null,
+      "data": "a super text area"
+    }
     ],
-    "erp_name": [
-      {
-        "locale": "en_US",
-        "scope": null,
-        "data": "Amor"
-      }
-    ],
-    "supplier": [
-      {
-        "locale": null,
-        "scope": null,
-        "data": "zaro"
-      }
-    ],
-    "collection": [
-      {
-        "locale": null,
-        "scope": null,
-        "data": [
-          "summer_2016"
-        ]
-      }
-    ],
-    "description": [
-      {
-        "locale": "en_US",
-        "scope": "ecommerce",
-        "data": "Heritage jacket navy blue tweed suit with single breasted 2 button. 53% wool, 22% polyester, 18% acrylic, 5% nylon, 1% cotton, 1% viscose. Dry Cleaning uniquement.Le mannequin measuring 1m85 and wears UK size 40, size 50 FR"
-      }
-    ],
-    "wash_temperature": [
-      {
-        "locale": null,
-        "scope": null,
-        "data": "800"
-      }
+    "a_number_integer": [
+    {
+      "locale": null,
+      "scope": null,
+      "data": 12
+    }
     ]
-  },
+    },
   "created": "2017-09-20T15:37:40+02:00",
   "updated": "2017-09-20T15:37:40+02:00",
   "associations": {}
@@ -1028,12 +1019,12 @@ JSON;
         }
     },
   "identifier": "apollon_blue_m",
-  "family": "clothing",
+  "family": "familyA",
   "parent": "amor",
   "groups": [],
   "variant_group": null,
   "categories": [
-    "master_accessories"
+    "categoryA"
   ],
   "enabled": true,
   "values": {
@@ -1044,63 +1035,33 @@ JSON;
         "data": "blue"
       }
     ],
-    "name": [
-      {
-        "locale": "en_US",
-        "scope": null,
-        "data": "Heritage jacket navy"
-      }
+    "a_price": [
+    {
+      "locale": null,
+      "scope": null,
+      "data": [
+        {
+          "amount": "50.00",
+          "currency": "EUR"
+        }
+      ]
+    }
     ],
-    "price": [
-      {
-        "locale": null,
-        "scope": null,
-        "data": [
-          {
-            "amount": "999.00",
-            "currency": "EUR"
-          }
-        ]
-      }
+    "a_text_area": [
+    {
+      "locale": null,
+      "scope": null,
+      "data": "a super text area"
+    }
     ],
-    "erp_name": [
-      {
-        "locale": "en_US",
-        "scope": null,
-        "data": "Amor"
-      }
-    ],
-    "supplier": [
-      {
-        "locale": null,
-        "scope": null,
-        "data": "zaro"
-      }
-    ],
-    "collection": [
-      {
-        "locale": null,
-        "scope": null,
-        "data": [
-          "summer_2016"
-        ]
-      }
-    ],
-    "description": [
-      {
-        "locale": "en_US",
-        "scope": "ecommerce",
-        "data": "Heritage jacket navy blue tweed suit with single breasted 2 button. 53% wool, 22% polyester, 18% acrylic, 5% nylon, 1% cotton, 1% viscose. Dry Cleaning uniquement.Le mannequin measuring 1m85 and wears UK size 40, size 50 FR"
-      }
-    ],
-    "wash_temperature": [
-      {
-        "locale": null,
-        "scope": null,
-        "data": "800"
-      }
+    "a_number_integer": [
+    {
+      "locale": null,
+      "scope": null,
+      "data": 12
+    }
     ]
-  },
+    },
   "created": "2017-09-20T15:37:40+02:00",
   "updated": "2017-09-20T15:37:40+02:00",
   "associations": {}
@@ -1115,13 +1076,13 @@ JSON;
         }
     },
   "identifier": "apollon_blue_l",
-  "family": "clothing",
+  "family": "familyA",
   "parent": "amor",
   "groups": [],
   "variant_group": null,
   "categories": [
-    "master_accessories_hats",
-    "master_men_blazers_deals"
+    "categoryB",
+    "categoryC"
   ],
   "enabled": true,
   "values": {
@@ -1132,63 +1093,33 @@ JSON;
         "data": "l"
       }
     ],
-    "name": [
-      {
-        "locale": "en_US",
-        "scope": null,
-        "data": "Heritage jacket navy"
-      }
+    "a_price": [
+    {
+      "locale": null,
+      "scope": null,
+      "data": [
+        {
+          "amount": "50.00",
+          "currency": "EUR"
+        }
+      ]
+    }
     ],
-    "price": [
-      {
-        "locale": null,
-        "scope": null,
-        "data": [
-          {
-            "amount": "999.00",
-            "currency": "EUR"
-          }
-        ]
-      }
+    "a_text_area": [
+    {
+      "locale": null,
+      "scope": null,
+      "data": "a super text area"
+    }
     ],
-    "erp_name": [
-      {
-        "locale": "en_US",
-        "scope": null,
-        "data": "Amor"
-      }
-    ],
-    "supplier": [
-      {
-        "locale": null,
-        "scope": null,
-        "data": "zaro"
-      }
-    ],
-    "collection": [
-      {
-        "locale": null,
-        "scope": null,
-        "data": [
-          "summer_2016"
-        ]
-      }
-    ],
-    "description": [
-      {
-        "locale": "en_US",
-        "scope": "ecommerce",
-        "data": "Heritage jacket navy blue tweed suit with single breasted 2 button. 53% wool, 22% polyester, 18% acrylic, 5% nylon, 1% cotton, 1% viscose. Dry Cleaning uniquement.Le mannequin measuring 1m85 and wears UK size 40, size 50 FR"
-      }
-    ],
-    "wash_temperature": [
-      {
-        "locale": null,
-        "scope": null,
-        "data": "800"
-      }
+    "a_number_integer": [
+    {
+      "locale": null,
+      "scope": null,
+      "data": 12
+    }
     ]
-  },
+    },
   "created": "2017-09-20T15:37:40+02:00",
   "updated": "2017-09-20T15:37:40+02:00",
   "associations": {}
@@ -1203,15 +1134,15 @@ JSON;
         }
     },
   "identifier": "apollon_blue_xl",
-  "family": "clothing",
+  "family": "familyA",
   "parent": "amor",
   "groups": [
     
   ],
   "variant_group": null,
   "categories": [
-    "master_women_blouses_deals",
-    "suppliers"
+    "categoryA1",
+    "categoryA2"
   ],
   "enabled": true,
   "values": {
@@ -1222,63 +1153,33 @@ JSON;
         "data": "xl"
       }
     ],
-    "name": [
-      {
-        "locale": "en_US",
-        "scope": null,
-        "data": "Heritage jacket navy"
-      }
+    "a_price": [
+    {
+      "locale": null,
+      "scope": null,
+      "data": [
+        {
+          "amount": "50.00",
+          "currency": "EUR"
+        }
+      ]
+    }
     ],
-    "price": [
-      {
-        "locale": null,
-        "scope": null,
-        "data": [
-          {
-            "amount": "999.00",
-            "currency": "EUR"
-          }
-        ]
-      }
+    "a_text_area": [
+    {
+      "locale": null,
+      "scope": null,
+      "data": "a super text area"
+    }
     ],
-    "erp_name": [
-      {
-        "locale": "en_US",
-        "scope": null,
-        "data": "Amor"
-      }
-    ],
-    "supplier": [
-      {
-        "locale": null,
-        "scope": null,
-        "data": "zaro"
-      }
-    ],
-    "collection": [
-      {
-        "locale": null,
-        "scope": null,
-        "data": [
-          "summer_2016"
-        ]
-      }
-    ],
-    "description": [
-      {
-        "locale": "en_US",
-        "scope": "ecommerce",
-        "data": "Heritage jacket navy blue tweed suit with single breasted 2 button. 53% wool, 22% polyester, 18% acrylic, 5% nylon, 1% cotton, 1% viscose. Dry Cleaning uniquement.Le mannequin measuring 1m85 and wears UK size 40, size 50 FR"
-      }
-    ],
-    "wash_temperature": [
-      {
-        "locale": null,
-        "scope": null,
-        "data": "800"
-      }
+    "a_number_integer": [
+    {
+      "locale": null,
+      "scope": null,
+      "data": 12
+    }
     ]
-  },
+    },
   "created": "2017-09-20T15:37:40+02:00",
   "updated": "2017-09-20T15:37:40+02:00",
   "associations": {
@@ -1295,74 +1196,51 @@ JSON;
        }
    },
   "identifier": "apollon_blue_xxl",
-  "family": "clothing",
+  "family": "familyA",
   "parent": "amor",
   "groups": [
     
   ],
   "variant_group": null,
   "categories": [
-    "master_women_blouses_deals"
+    "categoryA1"
   ],
   "enabled": true,
   "values": {
-    "name": [
-      {
-        "locale": "en_US",
-        "scope": null,
-        "data": "Heritage jacket navy"
-      }
-    ],
-    "price": [
+    "size": [
       {
         "locale": null,
         "scope": null,
-        "data": [
-          {
-            "amount": "999.00",
-            "currency": "EUR"
-          }
-        ]
+        "data": "xxl"
       }
     ],
-    "erp_name": [
-      {
-        "locale": "en_US",
-        "scope": null,
-        "data": "Amor"
-      }
+    "a_price": [
+    {
+      "locale": null,
+      "scope": null,
+      "data": [
+        {
+          "amount": "50.00",
+          "currency": "EUR"
+        }
+      ]
+    }
     ],
-    "supplier": [
-      {
-        "locale": null,
-        "scope": null,
-        "data": "zaro"
-      }
+    "a_text_area": [
+    {
+      "locale": null,
+      "scope": null,
+      "data": "a super text area"
+    }
     ],
-    "collection": [
-      {
-        "locale": null,
-        "scope": null,
-        "data": [
-          "summer_2016"
-        ]
-      }
-    ],
-    "description": [
-      {
-        "locale": "en_US",
-        "scope": "ecommerce",
-        "data": "Heritage jacket navy blue tweed suit with single breasted 2 button. 53% wool, 22% polyester, 18% acrylic, 5% nylon, 1% cotton, 1% viscose. Dry Cleaning uniquement.Le mannequin measuring 1m85 and wears UK size 40, size 50 FR"
-      }
-    ],
-    "wash_temperature": [
-      {
-        "locale": null,
-        "scope": null,
-        "data": "800"
-      }
+    "a_number_integer": [
+    {
+      "locale": null,
+      "scope": null,
+      "data": 12
+    }
     ]
-  },
+    },
   "created": "2017-09-20T15:37:40+02:00",
   "updated": "2017-09-20T15:37:40+02:00",
   "associations": {
@@ -1379,7 +1257,7 @@ JSON;
         }
     },
     "identifier": "apollon_blue_xs",
-      "family": "clothing",
+      "family": "familyA",
       "parent": "amor",
       "groups": [
         
@@ -1397,63 +1275,33 @@ JSON;
             "data": "xs"
           }
         ],
-        "name": [
-          {
-            "locale": "en_US",
-            "scope": null,
-            "data": "Heritage jacket navy"
-          }
+        "a_price": [
+        {
+          "locale": null,
+          "scope": null,
+          "data": [
+            {
+              "amount": "50.00",
+              "currency": "EUR"
+            }
+          ]
+        }
         ],
-        "price": [
-          {
-            "locale": null,
-            "scope": null,
-            "data": [
-              {
-                "amount": "999.00",
-                "currency": "EUR"
-              }
-            ]
-          }
+        "a_text_area": [
+        {
+          "locale": null,
+          "scope": null,
+          "data": "a super text area"
+        }
         ],
-        "erp_name": [
-          {
-            "locale": "en_US",
-            "scope": null,
-            "data": "Amor"
-          }
-        ],
-        "supplier": [
-          {
-            "locale": null,
-            "scope": null,
-            "data": "zaro"
-          }
-        ],
-        "collection": [
-          {
-            "locale": null,
-            "scope": null,
-            "data": [
-              "summer_2016"
-            ]
-          }
-        ],
-        "description": [
-          {
-            "locale": "en_US",
-            "scope": "ecommerce",
-            "data": "Heritage jacket navy blue tweed suit with single breasted 2 button. 53% wool, 22% polyester, 18% acrylic, 5% nylon, 1% cotton, 1% viscose. Dry Cleaning uniquement.Le mannequin measuring 1m85 and wears UK size 40, size 50 FR"
-          }
-        ],
-        "wash_temperature": [
-          {
-            "locale": null,
-            "scope": null,
-            "data": "800"
-          }
+        "a_number_integer": [
+        {
+          "locale": null,
+          "scope": null,
+          "data": 12
+        }
         ]
-      },
+        },
       "created": "2017-09-20T15:37:40+02:00",
       "updated": "2017-09-20T15:37:40+02:00",
       "associations": {
@@ -1466,10 +1314,10 @@ JSON;
     }
 
     /**
-     * {@inheritdoc}
+     * @return Configuration
      */
-    protected function getConfiguration(): Configuration
+    protected function getConfiguration()
     {
-        return new Configuration([Configuration::getFunctionalCatalogPath('catalog_modeling')]);
+        return new Configuration([Configuration::getTechnicalCatalogPath()]);
     }
 }

--- a/src/Pim/Component/Catalog/tests/integration/Normalizer/Standard/AttributeGroupIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Normalizer/Standard/AttributeGroupIntegration.php
@@ -44,7 +44,9 @@ class AttributeGroupIntegration extends AbstractStandardNormalizerTestCase
                 'a_simple_select',
                 'a_localizable_image',
                 'a_scopable_image',
-                'a_localizable_scopable_image'
+                'a_localizable_scopable_image',
+                'a_simple_select_color',
+                'a_simple_select_size'
             ],
             'labels'     => [
                 'en_US' => 'Attribute group B',

--- a/tests/catalog/technical/attribute_options.csv
+++ b/tests/catalog/technical/attribute_options.csv
@@ -3,3 +3,22 @@ optionA;a_multi_select;10;Option A
 optionB;a_multi_select;20;Option B
 optionA;a_simple_select;10;Option A
 optionB;a_simple_select;20;Option B
+orange;color;1;Orange
+green;color;1;Green
+white;color;1;White
+blue;color;1;Blue
+red;color;1;Red
+pink;color;1;Pink
+yellow;color;1;Yellow
+brown;color;1;Brown
+black;color;1;Black
+grey;color;1;Grey
+l;size;1;L
+xxl;size;1;XXL
+xs;size;1;XS
+m;size;1;M
+xl;size;1;XL
+s;size;1;S
+xxs;size;1;XXS
+xxxl;size;1;XXXL
+u;size;1;U

--- a/tests/catalog/technical/attribute_options.csv
+++ b/tests/catalog/technical/attribute_options.csv
@@ -3,22 +3,22 @@ optionA;a_multi_select;10;Option A
 optionB;a_multi_select;20;Option B
 optionA;a_simple_select;10;Option A
 optionB;a_simple_select;20;Option B
-orange;color;1;Orange
-green;color;1;Green
-white;color;1;White
-blue;color;1;Blue
-red;color;1;Red
-pink;color;1;Pink
-yellow;color;1;Yellow
-brown;color;1;Brown
-black;color;1;Black
-grey;color;1;Grey
-l;size;1;L
-xxl;size;1;XXL
-xs;size;1;XS
-m;size;1;M
-xl;size;1;XL
-s;size;1;S
-xxs;size;1;XXS
-xxxl;size;1;XXXL
-u;size;1;U
+orange;a_simple_select_color;1;Orange
+green;a_simple_select_color;1;Green
+white;a_simple_select_color;1;White
+blue;a_simple_select_color;1;Blue
+red;a_simple_select_color;1;Red
+pink;a_simple_select_color;1;Pink
+yellow;a_simple_select_color;1;Yellow
+brown;a_simple_select_color;1;Brown
+black;a_simple_select_color;1;Black
+grey;a_simple_select_color;1;Grey
+l;a_simple_select_size;1;L
+xxl;a_simple_select_size;1;XXL
+xs;a_simple_select_size;1;XS
+m;a_simple_select_size;1;M
+xl;a_simple_select_size;1;XL
+s;a_simple_select_size;1;S
+xxs;a_simple_select_size;1;XXS
+xxxl;a_simple_select_size;1;XXXL
+u;a_simple_select_size;1;U

--- a/tests/catalog/technical/attributes.csv
+++ b/tests/catalog/technical/attributes.csv
@@ -26,5 +26,5 @@ a_scopable_image;;;;;;;;attributeGroupB;0;;;;;;;;;1;0;pim_catalog_image;0;0;;;
 a_localizable_scopable_image;;;;;;;;attributeGroupB;1;;;;;;;;;1;0;pim_catalog_image;0;0;;;
 a_scopable_price;;;;;;1;;attributeGroupA;0;;;;;;;;;1;9;pim_catalog_price_collection;0;0;;;
 a_localized_and_scopable_text_area;;;;;;;;attributeGroupA;1;;;;;;;;;1;10;pim_catalog_textarea;0;0;;;0
-color;;1;;;;;;attributeGroupB;0;;;;;;;;;0;0;pim_catalog_simpleselect;0;0;;;
-size;;1;;;;;;attributeGroupB;0;;;;;;;;;0;0;pim_catalog_simpleselect;0;0;;;
+a_simple_select_color;;1;;;;;;attributeGroupB;0;;;;;;;;;0;0;pim_catalog_simpleselect;0;0;;;
+a_simple_select_size;;1;;;;;;attributeGroupB;0;;;;;;;;;0;0;pim_catalog_simpleselect;0;0;;;

--- a/tests/catalog/technical/attributes.csv
+++ b/tests/catalog/technical/attributes.csv
@@ -26,3 +26,5 @@ a_scopable_image;;;;;;;;attributeGroupB;0;;;;;;;;;1;0;pim_catalog_image;0;0;;;
 a_localizable_scopable_image;;;;;;;;attributeGroupB;1;;;;;;;;;1;0;pim_catalog_image;0;0;;;
 a_scopable_price;;;;;;1;;attributeGroupA;0;;;;;;;;;1;9;pim_catalog_price_collection;0;0;;;
 a_localized_and_scopable_text_area;;;;;;;;attributeGroupA;1;;;;;;;;;1;10;pim_catalog_textarea;0;0;;;0
+color;;1;;;;;;attributeGroupB;0;;;;;;;;;0;0;pim_catalog_simpleselect;0;0;;;
+size;;1;;;;;;attributeGroupB;0;;;;;;;;;0;0;pim_catalog_simpleselect;0;0;;;

--- a/tests/catalog/technical/product_models.csv
+++ b/tests/catalog/technical/product_models.csv
@@ -1,0 +1,2 @@
+code;family_variant;parent;a_price-EUR;a_number_integer;a_yes_no;a_text;a_text_area
+amor;familyVariantA1;;50;12;0;a super text;a super text area

--- a/tests/catalog/technical/product_models.csv
+++ b/tests/catalog/technical/product_models.csv
@@ -1,2 +1,0 @@
-code;family_variant;parent;a_price-EUR;a_number_integer;a_yes_no;a_text;a_text_area
-amor;familyVariantA1;;50;12;0;a super text;a super text area


### PR DESCRIPTION
Add a test for variant product (on the API) it checks the parent field is well set.