### PR TITLE
PIM-6809 - Improve grid perf by using attribute cache for presenters

### DIFF
--- a/src/Akeneo/Component/StorageUtils/Repository/BaseCachedObjectRepository.php
+++ b/src/Akeneo/Component/StorageUtils/Repository/BaseCachedObjectRepository.php
@@ -31,7 +31,7 @@ class BaseCachedObjectRepository implements CachedObjectRepositoryInterface
      */
     public function findOneByIdentifier($identifier)
     {
-        if (!isset($this->objectsCache[$identifier])) {
+        if (!array_key_exists($identifier, $this->objectsCache)) {
             $this->objectsCache[$identifier] = $this->repository->findOneByIdentifier($identifier);
         }
 

--- a/src/Akeneo/Component/StorageUtils/spec/Repository/BaseCachedObjectRepositorySpec.php
+++ b/src/Akeneo/Component/StorageUtils/spec/Repository/BaseCachedObjectRepositorySpec.php
@@ -53,4 +53,12 @@ class BaseCachedObjectRepositorySpec extends ObjectBehavior
         $this->clear();
         $this->findOneByIdentifier('objectidentifier1')->shouldReturn($object1);
     }
+
+    function it_returns_null_on_non_existing_object($repository)
+    {
+        $repository->findOneByIdentifier('objectidentifier1')
+            ->willReturn(null);
+
+        $this->findOneByIdentifier('objectidentifier1')->shouldReturn(null);
+    }
 }

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/localization/presenters.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/localization/presenters.yml
@@ -11,7 +11,7 @@ services:
     pim_catalog.localization.presenter.registry:
         class: '%pim_catalog.localization.presenter.registry.class%'
         arguments:
-            - '@pim_catalog.repository.attribute'
+            - '@pim_catalog.repository.cached_attribute'
 
     # Product values
     pim_catalog.localization.presenter.prices:

--- a/src/Pim/Component/Catalog/Localization/Presenter/PresenterRegistry.php
+++ b/src/Pim/Component/Catalog/Localization/Presenter/PresenterRegistry.php
@@ -3,7 +3,7 @@
 namespace Pim\Component\Catalog\Localization\Presenter;
 
 use Akeneo\Component\Localization\Presenter\PresenterInterface;
-use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
+use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 
 /**
  * The PresenterRegistry registers the presenters to display attribute values readable information. The matching
@@ -21,16 +21,16 @@ class PresenterRegistry implements PresenterRegistryInterface
 
     const TYPE_ATTRIBUTE_OPTION = 'attribute_option';
 
-    /** @var AttributeRepositoryInterface */
+    /** @var IdentifiableObjectRepositoryInterface */
     protected $attributeRepository;
 
     /** @var PresenterInterface[] */
     protected $presenters = [];
 
     /**
-     * @param AttributeRepositoryInterface $attributeRepository
+     * @param IdentifiableObjectRepositoryInterface $attributeRepository
      */
-    public function __construct(AttributeRepositoryInterface $attributeRepository)
+    public function __construct(IdentifiableObjectRepositoryInterface $attributeRepository)
     {
         $this->attributeRepository = $attributeRepository;
     }

--- a/src/Pim/Component/Catalog/spec/Localization/Presenter/PresenterRegistrySpec.php
+++ b/src/Pim/Component/Catalog/spec/Localization/Presenter/PresenterRegistrySpec.php
@@ -5,11 +5,11 @@ namespace spec\Pim\Component\Catalog\Localization\Presenter;
 use Akeneo\Component\Localization\Presenter\PresenterInterface;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Model\AttributeInterface;
-use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
+use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 
 class PresenterRegistrySpec extends ObjectBehavior
 {
-    function let(AttributeRepositoryInterface $attributeRepository)
+    function let(IdentifiableObjectRepositoryInterface $attributeRepository)
     {
         $this->beConstructedWith($attributeRepository);
     }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
Issue PIM-6809.
This PR includes @ahocquard commits, as well as some comment to go further:

 - @ahocquard changes improve by 30%

Two other potential improvements:
 - the grid data is loaded twice, removing one of the load would improve the performances by 50% ;)
 - the normalizer for the grid uses the common serializer, which takes ~10% of the total time to find the right normalizer via the `supportsNormalization` calls to all registered normalizer

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -
