### PR TITLE
PIM-6348: add new variant navigation component in the PEF

### DIFF
--- a/behat.ci.yml
+++ b/behat.ci.yml
@@ -45,6 +45,8 @@ default:
                     - 'Context\FeatureContext'
                     - '@pim_catalog.repository.product_model'
                     - '@doctrine.orm.entity_manager'
+                - Pim\Behat\Context\Domain\Enrich\VariantNavigationContext:
+                    - 'Context\FeatureContext'
                 - Pim\Behat\Context\Domain\Spread\ExportBuilderContext:
                     - 'Context\FeatureContext'
                 - Pim\Behat\Context\Domain\Spread\ExportProfilesContext:

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -45,6 +45,8 @@ default:
                     - 'Context\FeatureContext'
                     - '@pim_catalog.repository.product_model'
                     - '@doctrine.orm.entity_manager'
+                - Pim\Behat\Context\Domain\Enrich\VariantNavigationContext:
+                    - 'Context\FeatureContext'
                 - Pim\Behat\Context\Domain\Spread\ExportBuilderContext:
                     - 'Context\FeatureContext'
                 - Pim\Behat\Context\Domain\Spread\ExportProfilesContext:

--- a/features/Context/NavigationContext.php
+++ b/features/Context/NavigationContext.php
@@ -10,6 +10,9 @@ use Pim\Component\Catalog\Model\AssociationTypeInterface;
 use Pim\Component\Catalog\Model\AttributeGroupInterface;
 use Pim\Component\Catalog\Model\GroupTypeInterface;
 use Pim\Component\Catalog\Model\Product;
+use Pim\Component\Catalog\Model\ProductInterface;
+use Pim\Component\Catalog\Model\ProductModel;
+use Pim\Component\Catalog\Model\ProductModelInterface;
 
 /**
  * Context for navigating the website
@@ -322,11 +325,11 @@ class NavigationContext extends BaseNavigationContext
     }
 
     /**
-     * @param Product $product
+     * @param ProductInterface $product
      *
      * @Given /^I should be on the (product "([^"]*)") edit page$/
      */
-    public function iShouldBeOnTheProductEditPage(Product $product)
+    public function iShouldBeOnTheProductEditPage(ProductInterface $product)
     {
         $this->spin(function () use ($product) {
             $expectedAddress = $this->getPage('Product edit')->getUrl(['id' => $product->getId()]);
@@ -340,6 +343,27 @@ class NavigationContext extends BaseNavigationContext
         }, 'Can not find any product label');
 
         $this->currentPage = 'Product edit';
+    }
+
+    /**
+     * @param ProductModel $productModel
+     *
+     * @Given /^I should be on the (product model "([^"]*)") edit page$/
+     */
+    public function iShouldBeOnTheProductModelEditPage(ProductModel $productModel)
+    {
+        $this->spin(function () use ($productModel) {
+            $expectedAddress = $this->getPage('ProductModel edit')->getUrl(['id' => $productModel->getId()]);
+            $this->assertAddress($expectedAddress);
+
+            return true;
+        }, sprintf('Cannot find product model "%s"', $productModel->getId()));
+
+        $this->getMainContext()->spin(function () {
+            return $this->getCurrentPage()->find('css', '.AknTitleContainer-title');
+        }, 'Can not find any product model label');
+
+        $this->currentPage = 'ProductModel edit';
     }
 
     /**

--- a/features/Context/Page/Base/ProductEditForm.php
+++ b/features/Context/Page/Base/ProductEditForm.php
@@ -6,6 +6,7 @@ use Behat\Mink\Element\Element;
 use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Exception\ElementNotFoundException;
 use Behat\Mink\Exception\ExpectationException;
+use Pim\Behat\Decorator\VariantNavigationDecorator;
 
 /**
  * Product Edit Form
@@ -34,6 +35,12 @@ class ProductEditForm extends Form
                 'Available attributes list'       => ['css' => '.add-attribute .select2-results'],
                 'Available attributes search'     => ['css' => '.add-attribute .select2-search input[type="text"]'],
                 'Select2 dropmask'                => ['css' => '.select2-drop-mask'],
+                'Variant navigation' => [
+                    'css'        => '.AknVariantNavigation',
+                    'decorators' => [
+                        VariantNavigationDecorator::class
+                    ]
+                ]
             ]
         );
     }
@@ -675,5 +682,14 @@ class ProductEditForm extends Form
                 $field
             ));
         }, sprintf('Spinning to get remove link on product edit form for field "%s"', $field));
+    }
+
+
+    /**
+     * @return NodeElement
+     */
+    public function getVariantNavigation()
+    {
+        return $this->getElement('Variant navigation');
     }
 }

--- a/features/Context/Page/ProductModel/Edit.php
+++ b/features/Context/Page/ProductModel/Edit.php
@@ -3,6 +3,7 @@
 namespace Context\Page\ProductModel;
 
 use Context\Page\Base\ProductEditForm;
+use Pim\Behat\Decorator\ContextSwitcherDecorator;
 
 /**
  * Product model edit page
@@ -13,6 +14,26 @@ use Context\Page\Base\ProductEditForm;
  */
 class Edit extends ProductEditForm
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct($session, $pageFactory, $parameters = [])
+    {
+        parent::__construct($session, $pageFactory, $parameters);
+
+        $this->elements = array_merge(
+            $this->elements,
+            [
+                'Main context selector' => [
+                    'css'        => '.AknTitleContainer-context',
+                    'decorators' => [
+                        ContextSwitcherDecorator::class
+                    ]
+                ]
+            ]
+        );
+    }
+
     /** @var string */
     protected $path = '#/enrich/product-model/{id}';
 }

--- a/features/Context/TransformationContext.php
+++ b/features/Context/TransformationContext.php
@@ -4,6 +4,7 @@ namespace Context;
 
 use Pim\Behat\Context\PimContext;
 use Pim\Component\Catalog\Model\GroupInterface;
+use Pim\Component\Catalog\Model\ProductModel;
 
 /**
  * Context for data transformations
@@ -24,6 +25,18 @@ class TransformationContext extends PimContext
     public function castProductSkuToProduct($sku)
     {
         return $this->getFixturesContext()->getProduct($sku);
+    }
+
+    /**
+     * @param string $code
+     *
+     * @Transform /^product model "([^"]*)"$/
+     *
+     * @return ProductModel
+     */
+    public function castProductModelCodeToProductModel($code)
+    {
+        return $this->getFixturesContext()->getProductModel($code);
     }
 
     /**

--- a/features/Pim/Behat/Context/Domain/Enrich/VariantNavigationContext.php
+++ b/features/Pim/Behat/Context/Domain/Enrich/VariantNavigationContext.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Behat\Context\Domain\Enrich;
+
+use Behat\Mink\Exception\ExpectationException;
+use Pim\Behat\Context\PimContext;
+
+class VariantNavigationContext extends PimContext
+{
+    /**
+     * @Then /^the variant navigation selected axis values for level (\d+) should be "([^"]*)"$/
+     */
+    public function theVariantNavigationSelectedAxisValuesForLevelShouldBe(int $level, string $axisValues): void
+    {
+        $variantNavigation = $this->getCurrentPage()->getVariantNavigation();
+
+        $element = $variantNavigation->getSelectedAxisValuesForLevel($level);
+        $axisValues = strtolower($axisValues);
+        $elementAxisValues = strtolower($element->getText());
+
+        if ($axisValues !== $elementAxisValues) {
+            throw $this->createExpectationException(sprintf(
+                'Selected axis values for level "%s" should be "%s", but "%s" found.',
+                $level,
+                $axisValues,
+                $elementAxisValues
+            ));
+        }
+    }
+
+    /**
+     * @Given /^the variant navigation axis name for level (\d+) should be "([^"]*)"$/
+     */
+    public function theVariantNavigationAxisNameForLevelShouldBe(int $level, string $axisName): void
+    {
+        $variantNavigation = $this->getCurrentPage()->getVariantNavigation();
+
+        $element = $variantNavigation->getAxisNameForLevel($level);
+        $axisName = strtolower($axisName);
+        $elementAxisName = str_replace(':', '', strtolower($element->getText()));
+
+        if ($axisName !== $elementAxisName) {
+            throw $this->createExpectationException(sprintf(
+                'Axis name for level "%s" should be "%s", but "%s" found.',
+                $level,
+                $axisName,
+                $elementAxisName
+            ));
+        }
+    }
+
+    /**
+     * @When /^I open the variant navigation children selector for level (\d+)$/
+     */
+    public function iOpenTheVariantNavigationChildrenSelectorForLevel(int $level): void
+    {
+        $variantNavigation = $this->getCurrentPage()->getVariantNavigation();
+
+        $selector = $variantNavigation->getChildrenSelectorForLevel($level);
+        $selector->open();
+    }
+
+    /**
+     * @Then /^I should( not)? see the "([^"]*)" element in the variant children selector for level (\d+)$/
+     */
+    public function iShouldSeeTheElementInTheVariantChildrenSelectorForLevel($not, string $label, int $level): void
+    {
+        $variantNavigation = $this->getCurrentPage()->getVariantNavigation();
+
+        $selector = $variantNavigation->getChildrenSelectorForLevel($level);
+        $availableValues = $selector->getAvailableValues();
+        $availableLabels = [];
+
+        // We just want the label, not the completeness numbers
+        foreach ($availableValues as $availableValue) {
+            $matches = [];
+            preg_match('#^(.*) ((\d+ \/ \d+)?(\d+\%)?)$#', $availableValue, $matches);
+            $availableLabels[] = $matches[1];
+        }
+
+        if (!in_array($label, $availableLabels) && !$not) {
+            throw $this->createExpectationException(sprintf(
+                'Could not find element "%s" in the variant children selector for level "%s"',
+                $label,
+                $level
+            ));
+        }
+
+        if (in_array($label, $availableLabels) && $not) {
+            throw $this->createExpectationException(sprintf(
+                'Element "%s" in the variant children selector for level "%s" should not be visible',
+                $label,
+                $level
+            ));
+        }
+    }
+
+    /**
+     * @When /^I filter the variant navigation children selector for level (\d+) with text "([^"]*)"$/
+     */
+    public function iFilterTheVariantNavigationChildrenSelectorForLevelWithText(int $level, string $text): void
+    {
+        $variantNavigation = $this->getCurrentPage()->getVariantNavigation();
+
+        $selector = $variantNavigation->getChildrenSelectorForLevel($level);
+        $selector->search($text);
+    }
+
+    /**
+     * @When /^I select the child "([^"]*)" for level (\d+)$/
+     */
+    public function iSelectTheChildForLevel(string $label, int $level): void
+    {
+        $variantNavigation = $this->getCurrentPage()->getVariantNavigation();
+
+        $selector = $variantNavigation->getChildrenSelectorForLevel($level);
+        $selector->setValue($label);
+    }
+
+    /**
+     * @When /^I navigate to the selected element for level (\d+)$/
+     */
+    public function iNavigateToTheSelectedElementForLevel(int $level): void
+    {
+        $variantNavigation = $this->getCurrentPage()->getVariantNavigation();
+
+        $element = $variantNavigation->getSelectedAxisValuesForLevel($level);
+        $element->click();
+    }
+
+    /**
+     * @Then /^completeness for element "([^"]*)" in the variant children selector for level (\d+) should be "([^"]*)"$/
+     */
+    public function completenessForElementInTheVariantChildrenSelectorForLevelShouldBe(
+        string $label,
+        int $level,
+        string $completeness
+    ): void {
+        $variantNavigation = $this->getCurrentPage()->getVariantNavigation();
+
+        $selector = $variantNavigation->getChildrenSelectorForLevel($level);
+        $availableValues = $selector->getAvailableValues();
+
+        foreach ($availableValues as $availableValue) {
+            $matches = [];
+            preg_match('#^(.*) ((\d+ \/ \d+)?(\d+\%)?)$#', $availableValue, $matches);
+            $itemLabel = $matches[1];
+            $itemCompleteness = $matches[2];
+
+            if ($label === $itemLabel && $completeness !== $itemCompleteness) {
+                throw $this->createExpectationException(sprintf(
+                    'Item "%s" for level "%s" should have "%s" for completeness, "%s" found',
+                    $label,
+                    $level,
+                    $completeness,
+                    $itemCompleteness
+                ));
+
+                break;
+            }
+        }
+    }
+
+    /**
+     * Create an expectation exception
+     *
+     * @param string $message
+     *
+     * @return ExpectationException
+     */
+    protected function createExpectationException(string $message): ExpectationException
+    {
+        return $this->getMainContext()->createExpectationException($message);
+    }
+}

--- a/features/Pim/Behat/Decorator/VariantNavigationDecorator.php
+++ b/features/Pim/Behat/Decorator/VariantNavigationDecorator.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Pim\Behat\Decorator;
+
+use Behat\Mink\Element\NodeElement;
+use Context\Spin\SpinCapableTrait;
+
+/**
+ * Decorator for the Variant Navigation bar, displayed on Product Edit Form, which allows user
+ * to navigate among ascendant and descendant elements of the current product / product model.
+ *
+ * @author    Adrien Pétremann <adrien.petremann@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class VariantNavigationDecorator extends ElementDecorator
+{
+    use SpinCapableTrait;
+
+    /**
+     * Get the axis name NodeElement for the given $level.
+     * The axis name, for example "Material", or "Color, Size".
+     *
+     * @param int $level
+     *
+     * @return NodeElement
+     */
+    public function getAxisNameForLevel(int $level): NodeElement
+    {
+        $axisNames = $this->spin(function () {
+            return $this->findAll('css', '.AknVariantNavigation-axisName');
+        }, 'Impossible to find any axis name in the Variant Navigation bar.');
+
+        if (count($axisNames) < $level) {
+            throw new \LogicException(sprintf(
+                'Impossible to get the axis name for level "%s", only "%s" items found.',
+                $level,
+                count($axisNames)
+            ));
+        }
+
+        return $axisNames[$level];
+    }
+
+    /**
+     * Get the selected axis values NodeElement for the given $level.
+     * The selected axis values, for example "Silk", or "Blue, XL".
+     *
+     * @param int $level
+     *
+     * @return NodeElement
+     */
+    public function getSelectedAxisValuesForLevel(int $level): NodeElement
+    {
+        $selectedAxisValues = $this->spin(function () {
+            return $this->findAll('css', '.AknVariantNavigation-axisValue');
+        }, 'Impossible to find any selected axis value in the Variant Navigation bar.');
+
+        if (count($selectedAxisValues) < $level) {
+            throw new \LogicException(sprintf(
+                'Impossible to get the selected axis values for level "%s", only "%s" items found.',
+                $level,
+                count($selectedAxisValues)
+            ));
+        }
+
+        return $selectedAxisValues[$level];
+    }
+
+    /**
+     * Get the Select2 element for the given $level.
+     *
+     * @param int $level
+     *
+     * @return ElementDecorator
+     */
+    public function getChildrenSelectorForLevel(int $level): ElementDecorator
+    {
+        $childrenSelectors = $this->spin(function () {
+            return $this->findAll('css', '.variant-navigation.select2-container');
+        }, 'No children selector found in the Variant Navigation bar.');
+
+        if (count($childrenSelectors) < $level) {
+            throw new \LogicException(sprintf(
+                'Impossible to get the children selector for level "%s", only "%s" items found.',
+                $level,
+                count($childrenSelectors)
+            ));
+        }
+
+        // There is no selector on level 0 of the variant navigation.
+        // So if we want the selector for level 1, it's on index 0, etc.
+        $selectorIndex = $level - 1;
+
+        return $this->decorate($childrenSelectors[$selectorIndex], ['Pim\Behat\Decorator\Field\Select2Decorator']);
+    }
+}

--- a/features/product/navigate_among_variant_entities.feature
+++ b/features/product/navigate_among_variant_entities.feature
@@ -1,0 +1,83 @@
+@javascript
+Feature: Navigate among variant entities
+  In order to be able to add and remove associations
+  As a product manager
+  I need to be able to navigate among variant entities on the product edit form
+
+  Background:
+    Given a "catalog_modeling" catalog configuration
+    And I am logged in as "Julia"
+
+  Scenario: Browse ascendant and descendant entities on 2 levels of variation
+    When I edit the "apollon" product model
+    Then the variant navigation selected axis values for level 0 should be "Common"
+    And the variant navigation axis name for level 1 should be "Color"
+    And the variant navigation axis name for level 2 should be "Size"
+    When I open the variant navigation children selector for level 1
+    Then I should see the "Blue" element in the variant children selector for level 1
+    And I should see the "Red" element in the variant children selector for level 1
+    When I filter the variant navigation children selector for level 1 with text "pi"
+    Then I should see the "Pink" element in the variant children selector for level 1
+    When I filter the variant navigation children selector for level 1 with text "pi"
+    Then I should not see the "Blue" element in the variant children selector for level 1
+    When I select the child "Red" for level 1
+    Then I should be on the product model "apollon_red" edit page
+    And the variant navigation selected axis values for level 0 should be "Common"
+    And the variant navigation axis name for level 1 should be "Color"
+    And the variant navigation axis name for level 2 should be "Size"
+    And the variant navigation selected axis values for level 1 should be "Red"
+    When I open the variant navigation children selector for level 2
+    Then I should see the "XXL" element in the variant children selector for level 2
+    And I should see the "M" element in the variant children selector for level 2
+    When I filter the variant navigation children selector for level 2 with text "xx"
+    Then I should see the "XXL" element in the variant children selector for level 2
+    When I filter the variant navigation children selector for level 2 with text "xx"
+    Then I should not see the "M" element in the variant children selector for level 2
+    When I select the child "XXL" for level 2
+    Then I should be on the product "1111111126" edit page
+    And the variant navigation selected axis values for level 0 should be "Common"
+    And the variant navigation axis name for level 1 should be "Color"
+    And the variant navigation axis name for level 2 should be "Size"
+    And the variant navigation selected axis values for level 1 should be "Red"
+    And the variant navigation selected axis values for level 2 should be "XXL"
+    When I navigate to the selected element for level 1
+    Then I should be on the product model "apollon_red" edit page
+    When I navigate to the selected element for level 0
+    Then I should be on the product model "apollon" edit page
+
+  Scenario: Browse ascendant and descendant entities on 1 level of variation
+    When I edit the "brooksblue" product model
+    Then the variant navigation selected axis values for level 0 should be "Common"
+    And the variant navigation axis name for level 1 should be "EU shoes size"
+    When I open the variant navigation children selector for level 1
+    Then I should see the "41" element in the variant children selector for level 1
+    And I should see the "42" element in the variant children selector for level 1
+    And I should see the "43" element in the variant children selector for level 1
+    When I select the child "42" for level 1
+    Then I should be on the product "1111111287" edit page
+    And the variant navigation selected axis values for level 0 should be "Common"
+    And the variant navigation axis name for level 1 should be "EU shoes size"
+    And the variant navigation selected axis values for level 1 should be "42"
+    And I should see the text "Brooks blue"
+    When I navigate to the selected element for level 0
+    Then I should be on the product model "brooksblue" edit page
+
+
+  Scenario: Variant navigation bar has the context of the product edit form
+    When I edit the "apollon_red" product model
+    Then the variant navigation selected axis values for level 0 should be "Common"
+    And the variant navigation axis name for level 1 should be "Color"
+    And the variant navigation axis name for level 2 should be "Size"
+    And the variant navigation selected axis values for level 1 should be "Red"
+    When I open the variant navigation children selector for level 1
+    Then I should see the "Red" element in the variant children selector for level 1
+    And I should see the "Blue" element in the variant children selector for level 1
+    Then completeness for element "XXL" in the variant children selector for level 1 should be "100%"
+    And I switch the locale to "fr_FR"
+    And the variant navigation axis name for level 1 should be "Couleur"
+    And the variant navigation axis name for level 2 should be "Taille"
+    And the variant navigation selected axis values for level 1 should be "Rouge"
+    When I open the variant navigation children selector for level 1
+    Then I should see the "Rouge" element in the variant children selector for level 1
+    And I should see the "Bleu" element in the variant children selector for level 1
+    And completeness for element "XXL" in the variant children selector for level 1 should be "85%"

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/ProductModelRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/ProductModelRepository.php
@@ -127,4 +127,20 @@ class ProductModelRepository extends EntityRepository implements ProductModelRep
     {
         return $this->findBy(['code' => $codes]);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function findChildrenProducts(ProductModelInterface $productModel): array
+    {
+        $qb = $this
+            ->_em
+            ->createQueryBuilder()
+            ->select('p')
+            ->from(VariantProduct::class, 'p')
+            ->where('p.parent = :parent')
+            ->setParameter('parent', $productModel);
+
+        return $qb->getQuery()->execute();
+    }
 }

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/EntityWithFamilyVariantNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/EntityWithFamilyVariantNormalizer.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\EnrichBundle\Normalizer;
+
+use Pim\Component\Catalog\AttributeTypes;
+use Pim\Component\Catalog\Completeness\CompletenessCalculatorInterface;
+use Pim\Component\Catalog\FamilyVariant\EntityWithFamilyVariantAttributesProvider;
+use Pim\Component\Catalog\Model\EntityWithFamilyVariantInterface;
+use Pim\Component\Catalog\Model\ProductModelInterface;
+use Pim\Component\Catalog\Model\ValueInterface;
+use Pim\Component\Catalog\Model\VariantProductInterface;
+use Pim\Component\Catalog\Repository\LocaleRepositoryInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * Normalizer for entities with family variant, such as VariantProducts and ProductModels.
+ * It only returns some properties of these entities, helpful for some display on the front side.
+ *
+ * To fully normalize a Product or a ProductModel, please use either
+ * {@see \Pim\Bundle\EnrichBundle\Normalizer\ProductNormalizer} or
+ * {@see \Pim\Bundle\EnrichBundle\Normalizer\ProductModelNormalizer}
+ *
+ * @author    Adrien Pétremann <adrien.petremann@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class EntityWithFamilyVariantNormalizer implements NormalizerInterface
+{
+    /** @var string[] */
+    private $supportedFormat = ['internal_api'];
+
+    /** @var FileNormalizer */
+    private $fileNormalizer;
+
+    /** @var LocaleRepositoryInterface */
+    private $localeRepository;
+
+    /** @var EntityWithFamilyVariantAttributesProvider */
+    private $attributesProvider;
+
+    /** @var NormalizerInterface */
+    private $completenessCollectionNormalizer;
+
+    /** @var CompletenessCalculatorInterface */
+    private $completenessCalculator;
+
+    /**
+     * @param FileNormalizer                            $fileNormalizer
+     * @param LocaleRepositoryInterface                 $localeRepository
+     * @param EntityWithFamilyVariantAttributesProvider $attributesProvider
+     * @param NormalizerInterface                       $completenessCollectionNormalizer
+     * @param CompletenessCalculatorInterface           $completenessCalculator
+     */
+    public function __construct(
+        FileNormalizer $fileNormalizer,
+        LocaleRepositoryInterface $localeRepository,
+        EntityWithFamilyVariantAttributesProvider $attributesProvider,
+        NormalizerInterface $completenessCollectionNormalizer,
+        CompletenessCalculatorInterface $completenessCalculator
+    ) {
+        $this->fileNormalizer = $fileNormalizer;
+        $this->localeRepository = $localeRepository;
+        $this->attributesProvider = $attributesProvider;
+        $this->completenessCollectionNormalizer = $completenessCollectionNormalizer;
+        $this->completenessCalculator = $completenessCalculator;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function normalize($entity, $format = null, array $context = []): array
+    {
+        if (!$entity instanceof ProductModelInterface && !$entity instanceof VariantProductInterface) {
+            throw new \InvalidArgumentException(sprintf(
+                '"%s" or "%s" expected, "%s" received',
+                ProductModelInterface::class,
+                VariantProductInterface::class,
+                get_class($entity)
+            ));
+        }
+
+        $localeCodes = $this->localeRepository->getActivatedLocaleCodes();
+
+        $labels = [];
+        foreach ($localeCodes as $localeCode) {
+            $labels[$localeCode] = $entity->getLabel($localeCode);
+        }
+
+        $identifier = $entity instanceof ProductModelInterface ? $entity->getCode() : $entity->getIdentifier();
+
+        return [
+            'id'                 => $entity->getId(),
+            'identifier'         => $identifier,
+            'axes_values_labels' => $this->getAxesValuesLabelsForLocales($entity, $localeCodes),
+            'labels'             => $labels,
+            'image'              => $this->normalizeImage($entity->getImage(), $format, $context),
+            'model_type'         => $entity instanceof ProductModelInterface ? 'product_model' : 'product',
+            'completeness'       => $this->getCompletenessDependingOnEntity($entity)
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsNormalization($data, $format = null): bool
+    {
+        return $data instanceof EntityWithFamilyVariantInterface && in_array($format, $this->supportedFormat);
+    }
+
+    /**
+     * @param ValueInterface $data
+     * @param string         $format
+     * @param array          $context
+     *
+     * @return array|null
+     */
+    private function normalizeImage(?ValueInterface $data, $format, $context = []): ?array
+    {
+        if (null === $data || null === $data->getData()) {
+            return null;
+        }
+
+        return $this->fileNormalizer->normalize($data->getData(), $format, $context);
+    }
+
+    /**
+     * Get axes values labels for the $entity on the given $localeCodes for all axes values.
+     * For example:
+     * [
+     *      'fr_FR' => 'Jaune, XL',
+     *      'en_US' => 'Yellow, XL',
+     * ]
+     *
+     * @param EntityWithFamilyVariantInterface $entity
+     * @param array                            $localeCodes
+     *
+     * @throws \LogicException
+     *
+     * @return array
+     */
+    private function getAxesValuesLabelsForLocales(EntityWithFamilyVariantInterface $entity, array $localeCodes): array
+    {
+        $axesValuesLabels = [];
+
+        foreach ($localeCodes as $localeCode) {
+            $valuesForLocale = [];
+
+            foreach ($this->attributesProvider->getAxes($entity) as $axisAttribute) {
+                $value = $entity->getValue($axisAttribute->getCode());
+
+                if (AttributeTypes::OPTION_SIMPLE_SELECT === $axisAttribute->getType()) {
+                    $option = $value->getData();
+                    $option->setLocale($localeCode);
+                    $valuesForLocale[] = $option->getTranslation()->getLabel();
+                } else {
+                    $valuesForLocale[] = (string) $value;
+                }
+            }
+
+            $axesValuesLabels[$localeCode] = implode(', ', $valuesForLocale);
+        }
+
+        return $axesValuesLabels;
+    }
+
+    /**
+     * Get completeness of the given $entity, whether it's a ProductModel or a VariantProduct.
+     *
+     * @param EntityWithFamilyVariantInterface $entity
+     *
+     * @return array
+     */
+    private function getCompletenessDependingOnEntity(EntityWithFamilyVariantInterface $entity): array
+    {
+        if ($entity instanceof ProductModelInterface) {
+            // TODO: replace this placeholder by the real values, with PIM-6560
+            return [];
+        }
+
+        if ($entity instanceof VariantProductInterface) {
+            $completenessCollection = $entity->getCompletenesses();
+            if ($completenessCollection->isEmpty()) {
+                $newCompletenesses = $this->completenessCalculator->calculate($entity);
+                foreach ($newCompletenesses as $completeness) {
+                    $completenessCollection->add($completeness);
+                }
+            }
+
+            return $this->completenessCollectionNormalizer->normalize($completenessCollection, 'internal_api');
+        }
+    }
+}

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/EntityWithFamilyVariantNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/EntityWithFamilyVariantNormalizer.php
@@ -153,7 +153,8 @@ class EntityWithFamilyVariantNormalizer implements NormalizerInterface
                 if (AttributeTypes::OPTION_SIMPLE_SELECT === $axisAttribute->getType()) {
                     $option = $value->getData();
                     $option->setLocale($localeCode);
-                    $valuesForLocale[] = $option->getTranslation()->getLabel();
+                    $label = $option->getTranslation()->getLabel();
+                    $valuesForLocale[] = empty($label) ? '[' . $option->getCode() . ']' : $label;
                 } else {
                     $valuesForLocale[] = (string) $value;
                 }

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/ProductNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/ProductNormalizer.php
@@ -86,6 +86,9 @@ class ProductNormalizer implements NormalizerInterface
     /** @var EntityWithFamilyValuesFillerInterface */
     protected $productValuesFiller;
 
+    /** @var VariantNavigationNormalizer */
+    protected $navigationNormalizer;
+
     /**
      * @param NormalizerInterface                   $productNormalizer
      * @param NormalizerInterface                   $versionNormalizer
@@ -105,6 +108,7 @@ class ProductNormalizer implements NormalizerInterface
      * @param FileNormalizer                        $fileNormalizer
      * @param ProductBuilderInterface               $productBuilder
      * @param EntityWithFamilyValuesFillerInterface $productValuesFiller
+     * @param VariantNavigationNormalizer           $navigationNormalizer
      */
     public function __construct(
         NormalizerInterface $productNormalizer,
@@ -124,7 +128,8 @@ class ProductNormalizer implements NormalizerInterface
         CompletenessCalculatorInterface $completenessCalculator,
         FileNormalizer $fileNormalizer,
         ProductBuilderInterface $productBuilder,
-        EntityWithFamilyValuesFillerInterface $productValuesFiller
+        EntityWithFamilyValuesFillerInterface $productValuesFiller,
+        VariantNavigationNormalizer $navigationNormalizer
     ) {
         $this->productNormalizer                = $productNormalizer;
         $this->versionNormalizer                = $versionNormalizer;
@@ -143,7 +148,8 @@ class ProductNormalizer implements NormalizerInterface
         $this->completenessCalculator           = $completenessCalculator;
         $this->fileNormalizer                   = $fileNormalizer;
         $this->productBuilder                   = $productBuilder;
-        $this->productValuesFiller = $productValuesFiller;
+        $this->productValuesFiller              = $productValuesFiller;
+        $this->navigationNormalizer = $navigationNormalizer;
     }
 
     /**
@@ -176,6 +182,7 @@ class ProductNormalizer implements NormalizerInterface
             'structure_version' => $this->structureVersionProvider->getStructureVersion(),
             'completenesses'    => $this->getNormalizedCompletenesses($product),
             'image'             => $this->normalizeImage($product->getImage(), $format, $context),
+            'variant_navigation' => $this->navigationNormalizer->normalize($product, $format, $context),
         ] + $this->getLabels($product) + $this->getAssociationMeta($product);
 
         return $normalizedProduct;

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/ProductNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/ProductNormalizer.php
@@ -14,6 +14,7 @@ use Pim\Component\Catalog\Localization\Localizer\AttributeConverterInterface;
 use Pim\Component\Catalog\Manager\CompletenessManager;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Model\ValueInterface;
+use Pim\Component\Catalog\Model\VariantProductInterface;
 use Pim\Component\Catalog\Repository\ChannelRepositoryInterface;
 use Pim\Component\Catalog\Repository\LocaleRepositoryInterface;
 use Pim\Component\Catalog\ValuesFiller\EntityWithFamilyValuesFillerInterface;
@@ -173,6 +174,11 @@ class ProductNormalizer implements NormalizerInterface
         $created = null !== $oldestLog ? $this->versionNormalizer->normalize($oldestLog, 'internal_api') : null;
         $updated = null !== $newestLog ? $this->versionNormalizer->normalize($newestLog, 'internal_api') : null;
 
+        $variantNavigation = [];
+        if ($product instanceof VariantProductInterface) {
+            $variantNavigation = $this->navigationNormalizer->normalize($product, $format, $context);
+        }
+
         $normalizedProduct['meta'] = [
             'form'              => $this->formProvider->getForm($product),
             'id'                => $product->getId(),
@@ -182,7 +188,7 @@ class ProductNormalizer implements NormalizerInterface
             'structure_version' => $this->structureVersionProvider->getStructureVersion(),
             'completenesses'    => $this->getNormalizedCompletenesses($product),
             'image'             => $this->normalizeImage($product->getImage(), $format, $context),
-            'variant_navigation' => $this->navigationNormalizer->normalize($product, $format, $context),
+            'variant_navigation' => $variantNavigation,
         ] + $this->getLabels($product) + $this->getAssociationMeta($product);
 
         return $normalizedProduct;

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/VariantNavigationNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/VariantNavigationNormalizer.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Pim\Bundle\EnrichBundle\Normalizer;
+
+use Pim\Component\Catalog\Model\EntityWithFamilyVariantInterface;
+use Pim\Component\Catalog\Model\ProductModelInterface;
+use Pim\Component\Catalog\Model\VariantProductInterface;
+use Pim\Component\Catalog\Repository\LocaleRepositoryInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * Normalizer for the variant navigation data of the given entity.
+ *
+ * @author    Adrien Pétremann <adrien.petremann@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class VariantNavigationNormalizer implements NormalizerInterface
+{
+    /** @var string[] */
+    private $supportedFormat = ['internal_api'];
+
+    /** @var LocaleRepositoryInterface */
+    private $localeRepository;
+
+    /** @var EntityWithFamilyVariantNormalizer */
+    private $entityWithFamilyVariantNormalizer;
+
+    /**
+     * @param LocaleRepositoryInterface         $localeRepository
+     * @param EntityWithFamilyVariantNormalizer $entityWithFamilyVariantNormalizer
+     */
+    public function __construct(
+        LocaleRepositoryInterface $localeRepository,
+        EntityWithFamilyVariantNormalizer $entityWithFamilyVariantNormalizer
+    ) {
+        $this->localeRepository = $localeRepository;
+        $this->entityWithFamilyVariantNormalizer = $entityWithFamilyVariantNormalizer;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function normalize($entity, $format = null, array $context = [])
+    {
+        if (!$entity instanceof ProductModelInterface && !$entity instanceof VariantProductInterface) {
+            throw new \InvalidArgumentException(sprintf(
+                '"%s" or "%s" expected, "%s" received',
+                ProductModelInterface::class,
+                VariantProductInterface::class,
+                get_class($entity)
+            ));
+        }
+
+        $navigationData = [
+            'root'      => null,
+            'level_one' => [
+                'axes'     => [],
+                'selected' => null,
+            ],
+            'level_two' => [
+                'axes'     => [],
+                'selected' => null,
+            ],
+        ];
+
+        $localeCodes = $this->localeRepository->getActivatedLocaleCodes();
+        foreach ($entity->getFamilyVariant()->getVariantAttributeSets() as $attributeSet) {
+            $level = (1 === $attributeSet->getLevel()) ? 'level_one' : 'level_two';
+            foreach ($attributeSet->getAxes() as $axis) {
+                foreach ($localeCodes as $localeCode) {
+                    $axis->setLocale($localeCode);
+                    $navigationData[$level]['axes'][$localeCode] = $axis->getLabel();
+                }
+            }
+        }
+
+        $parent = $entity->getParent();
+        if (null === $parent) {
+            $navigationData['root'] = $this->entityWithFamilyVariantNormalizer
+                ->normalize($entity, $format, $context);
+
+            return $navigationData;
+        }
+
+        $grandParent = $parent->getParent();
+        if (null === $grandParent) {
+            $navigationData['root'] = $this->entityWithFamilyVariantNormalizer
+                ->normalize($parent, $format, $context);
+            $navigationData['level_one']['selected'] = $this->entityWithFamilyVariantNormalizer
+                ->normalize($entity, $format, $context);
+
+            return $navigationData;
+        }
+
+        $navigationData['root'] = $this->entityWithFamilyVariantNormalizer
+            ->normalize($grandParent, $format, $context);
+        $navigationData['level_one']['selected'] = $this->entityWithFamilyVariantNormalizer
+            ->normalize($parent, $format, $context);
+        $navigationData['level_two']['selected'] = $this->entityWithFamilyVariantNormalizer
+            ->normalize($entity, $format, $context);
+
+        return $navigationData;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsNormalization($data, $format = null)
+    {
+        return $data instanceof EntityWithFamilyVariantInterface && in_array($format, $this->supportedFormat);
+    }
+}

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/controllers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/controllers.yml
@@ -15,7 +15,6 @@ parameters:
     pim_enrich.controller.rest.channel.class:                 Pim\Bundle\EnrichBundle\Controller\Rest\ChannelController
     pim_enrich.controller.rest.currency.class:                Pim\Bundle\EnrichBundle\Controller\Rest\CurrencyController
     pim_enrich.controller.rest.family.class:                  Pim\Bundle\EnrichBundle\Controller\Rest\FamilyController
-    pim_enrich.controller.rest.entity_with_family_variant.class: Pim\Bundle\EnrichBundle\Controller\Rest\EntityWithFamilyVariantController
     pim_enrich.controller.rest.form_extension.class:          Pim\Bundle\EnrichBundle\Controller\Rest\FormExtensionController
     pim_enrich.controller.rest.group.class:                   Pim\Bundle\EnrichBundle\Controller\Rest\GroupController
     pim_enrich.controller.rest.group_type.class:              Pim\Bundle\EnrichBundle\Controller\Rest\GroupTypeController
@@ -251,12 +250,6 @@ services:
             - '@pim_catalog.validator.product'
             - '@pim_catalog.repository.attribute'
             - '@pim_enrich.normalizer.product_violation'
-
-    pim_enrich.controller.rest.entity_with_family_variant:
-        class: '%pim_enrich.controller.rest.entity_with_family_variant.class%'
-        arguments:
-            - '@pim_catalog.repository.product_model'
-            - '@pim_enrich.normalizer.entity_with_family_variant'
 
     pim_enrich.controller.rest.family:
         class: '%pim_enrich.controller.rest.family.class%'

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/controllers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/controllers.yml
@@ -15,6 +15,7 @@ parameters:
     pim_enrich.controller.rest.channel.class:                 Pim\Bundle\EnrichBundle\Controller\Rest\ChannelController
     pim_enrich.controller.rest.currency.class:                Pim\Bundle\EnrichBundle\Controller\Rest\CurrencyController
     pim_enrich.controller.rest.family.class:                  Pim\Bundle\EnrichBundle\Controller\Rest\FamilyController
+    pim_enrich.controller.rest.entity_with_family_variant.class: Pim\Bundle\EnrichBundle\Controller\Rest\EntityWithFamilyVariantController
     pim_enrich.controller.rest.form_extension.class:          Pim\Bundle\EnrichBundle\Controller\Rest\FormExtensionController
     pim_enrich.controller.rest.group.class:                   Pim\Bundle\EnrichBundle\Controller\Rest\GroupController
     pim_enrich.controller.rest.group_type.class:              Pim\Bundle\EnrichBundle\Controller\Rest\GroupTypeController
@@ -251,6 +252,12 @@ services:
             - '@pim_catalog.repository.attribute'
             - '@pim_enrich.normalizer.product_violation'
 
+    pim_enrich.controller.rest.entity_with_family_variant:
+        class: '%pim_enrich.controller.rest.entity_with_family_variant.class%'
+        arguments:
+            - '@pim_catalog.repository.product_model'
+            - '@pim_enrich.normalizer.entity_with_family_variant'
+
     pim_enrich.controller.rest.family:
         class: '%pim_enrich.controller.rest.family.class%'
         arguments:
@@ -337,6 +344,7 @@ services:
             - '@pim_catalog.validator.product'
             - '@pim_catalog.saver.product_model'
             - '@pim_enrich.normalizer.product_violation'
+            - '@pim_enrich.normalizer.entity_with_family_variant'
 
     pim_enrich.controller.rest.product_category:
         class: '%pim_enrich.controller.rest.product_category.class%'

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product/edit.yml
@@ -23,6 +23,11 @@ extensions:
         parent: pim-product-edit-form
         targetZone: main-image
 
+    pim-product-edit-form-variant-navigation:
+        module: pim/product-edit-form/variant-navigation
+        parent: pim-product-edit-form
+        targetZone: navigation
+
     pim-product-edit-form-cache-invalidator:
         module: pim/cache-invalidator
         parent: pim-product-edit-form

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_model/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_model/edit.yml
@@ -9,10 +9,23 @@ extensions:
         config:
             tab: pim-menu-products
 
+    pim-product-model-edit-form-user-navigation:
+        module: pim/menu/user-navigation
+        parent: pim-product-model-edit-form
+        targetZone: user-menu
+        config:
+            userAccount: pim_menu.user.user_account
+            logout: pim_menu.user.logout
+
     pim-product-model-edit-form-main-image:
         module: pim/form/common/main-image
         parent: pim-product-model-edit-form
         targetZone: main-image
+
+    pim-product-model-edit-form-variant-navigation:
+        module: pim/product-edit-form/variant-navigation
+        parent: pim-product-model-edit-form
+        targetZone: navigation
 
     pim-product-model-edit-form-cache-invalidator:
         module: pim/cache-invalidator

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/normalizers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/normalizers.yml
@@ -24,6 +24,8 @@ parameters:
     pim_enrich.normalizer.category.class:                          Pim\Bundle\EnrichBundle\Normalizer\CategoryNormalizer
     pim_enrich.normalizer.attribute_group.class:                   Pim\Bundle\EnrichBundle\Normalizer\AttributeGroupNormalizer
     pim_enrich.normalizer.structured.attribute_option.class:       Pim\Bundle\EnrichBundle\Normalizer\StructuredAttributeOptionNormalizer
+    pim_enrich.normalizer.entity_with_family_variant.class:        Pim\Bundle\EnrichBundle\Normalizer\EntityWithFamilyVariantNormalizer
+    pim_enrich.normalizer.variant_navigation.class:                Pim\Bundle\EnrichBundle\Normalizer\VariantNavigationNormalizer
 
 services:
     pim_enrich.normalizer.attribute_option_value_collection:
@@ -65,6 +67,7 @@ services:
             - '@pim_enrich.normalizer.file'
             - '@pim_catalog.builder.product'
             - '@pim_catalog.values_filler.product'
+            - '@pim_enrich.normalizer.variant_navigation'
         tags:
             - { name: pim_internal_api_serializer.normalizer }
 
@@ -81,6 +84,7 @@ services:
             - '@pim_catalog.repository.locale'
             - '@pim_catalog.values_filler.entity_with_family_variant'
             - '@pim_catalog.family_variant.provider.entity_with_family_variant_attributes'
+            - '@pim_enrich.normalizer.variant_navigation'
         tags:
             - { name: pim_internal_api_serializer.normalizer }
 
@@ -164,6 +168,21 @@ services:
             - '@pim_enrich.provider.empty_value.chained'
             - '@pim_enrich.provider.filter.chained'
             - '@pim_catalog.localization.localizer.number'
+
+    pim_enrich.normalizer.entity_with_family_variant:
+        class: '%pim_enrich.normalizer.entity_with_family_variant.class%'
+        arguments:
+            - '@pim_enrich.normalizer.file'
+            - '@pim_catalog.repository.locale'
+            - '@pim_catalog.family_variant.provider.entity_with_family_variant_attributes'
+            - '@pim_enrich.normalizer.completeness_collection'
+            - '@pim_catalog.completeness.calculator'
+
+    pim_enrich.normalizer.variant_navigation:
+        class: '%pim_enrich.normalizer.variant_navigation.class%'
+        arguments:
+            - '@pim_catalog.repository.locale'
+            - '@pim_enrich.normalizer.entity_with_family_variant'
 
     pim_enrich.normalizer.attribute.versioned:
         class: '%pim_enrich.normalizer.attribute.versioned.class%'

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
@@ -165,11 +165,12 @@ config:
                     options:
                         urls:
                             get: pim_enrich_product_rest_get
-                product_model:
-                    module: pim/product-fetcher
+                product-model:
+                    module: pim/product-model-fetcher
                     options:
                         urls:
                             get: pim_enrich_product_model_rest_get
+                            children: pim_enrich_product_model_rest_children_list
                 category:
                     module: pim/base-fetcher
                     options:
@@ -261,7 +262,7 @@ config:
                 pim_enrich_product_model_edit:
                     module: pim/controller/entity-with-family-variant
                     config:
-                        entity: product_model
+                        entity: product-model
                 pim_enrich_group_edit:
                     module: pim/controller/group
                     aclResourceId: pim_enrich_group_edit
@@ -557,6 +558,7 @@ config:
         pim/attribute-group-fetcher: pimenrich/js/fetcher/attribute-group-fetcher
         pim/locale-fetcher:          pimenrich/js/fetcher/locale-fetcher
         pim/product-fetcher:         pimenrich/js/fetcher/product-fetcher
+        pim/product-model-fetcher:   pimenrich/js/fetcher/product-model-fetcher
 
         # Remover
         pim/remover/base:                pimenrich/js/remover/base-remover
@@ -670,6 +672,7 @@ config:
         pim/product-edit-form/attributes:                        pimenrich/js/product/form/attributes
         pim/product-edit-form/creation/identifier:               pimenrich/js/product/form/creation/identifier
         pim/product-edit-form/start-copy:                        pimenrich/js/product/form/start-copy
+        pim/product-edit-form/variant-navigation:                pimenrich/js/product/form/variant-navigation
 
         # Product model
         pim/product-model-edit-form/meta/family-variant: pimenrich/js/product-model/form/meta/family-variant
@@ -1009,6 +1012,9 @@ config:
         pim/template/product-create-error:                   pimenrich/templates/product/create-error.html
         pim/template/product/add-select/attribute/line:      pimenrich/templates/product/form/add-select/attribute/line.html
         pim/template/product/form/product-completeness:      pimenrich/templates/product/form/product-completeness.html
+        pim/template/product/form/variant-navigation/navigation: pimenrich/templates/product/form/variant-navigation/navigation.html
+        pim/template/product/form/variant-navigation/product-item: pimenrich/templates/product/form/variant-navigation/product-item.html
+        pim/template/product/form/variant-navigation/product-model-item: pimenrich/templates/product/form/variant-navigation/product-model-item.html
         pim/template/attribute-option/form:                  pimenrich/templates/attribute-option/form.html
         pim/template/attribute-option/validation-error:      pimenrich/templates/attribute-option/validation-error.html
         pim/template/attribute-option/index:                 pimenrich/templates/attribute-option/index.html

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/routing/product_model.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/routing/product_model.yml
@@ -16,6 +16,11 @@ pim_enrich_product_model_rest_post:
         id: '[0-9a-f]+'
     methods: [POST]
 
+pim_enrich_product_model_rest_children_list:
+    path: /rest/children
+    defaults: { _controller: pim_enrich.controller.rest.product_model:childrenAction }
+    methods: [GET]
+
 pim_enrich_product_model_category_rest_list:
     path: /rest/{id}/categories
     defaults: { _controller: pim_enrich.controller.rest.product_category:listAction }

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/fetcher/product-model-fetcher.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/fetcher/product-model-fetcher.js
@@ -23,13 +23,10 @@ define(
         Routing
     ) {
         return ProductFetcher.extend({
-            childrenListPromises: {},
-
             /**
              * @param {Object} options
              */
             initialize: function (options) {
-                this.childrenListPromises = {};
                 this.options = options || {};
 
                 ProductFetcher.prototype.initialize.apply(this, [options]);
@@ -41,24 +38,13 @@ define(
              * @return {Promise}
              */
             fetchChildren: function (parentId) {
-                if (!(parentId in this.childrenListPromises)) {
-                    if (!_.has(this.options.urls, 'children')) {
-                        return $.Deferred().reject().promise();
-                    }
-
-                    this.childrenListPromises[parentId] = $.getJSON(
-                        Routing.generate(this.options.urls.children), {id: parentId}
-                    ).then(_.identity).promise();
+                if (!_.has(this.options.urls, 'children')) {
+                    return $.Deferred().reject().promise();
                 }
 
-                return this.childrenListPromises[parentId];
-            },
-
-            /**
-             * Clear promises.
-             */
-            clear: function () {
-                this.childrenListPromises = {};
+                return $.getJSON(
+                    Routing.generate(this.options.urls.children), {id: parentId}
+                ).then(_.identity).promise();
             }
         });
     }

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/fetcher/product-model-fetcher.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/fetcher/product-model-fetcher.js
@@ -1,0 +1,65 @@
+'use strict';
+
+/**
+ * Fetcher for product models
+ *
+ * @author    Adrien Pétremann <adrien.petremann@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+define(
+    [
+        'jquery',
+        'underscore',
+        'pim/product-fetcher',
+        'oro/mediator',
+        'routing'
+    ],
+    function (
+        $,
+        _,
+        ProductFetcher,
+        mediator,
+        Routing
+    ) {
+        return ProductFetcher.extend({
+            childrenListPromises: {},
+
+            /**
+             * @param {Object} options
+             */
+            initialize: function (options) {
+                this.childrenListPromises = {};
+                this.options = options || {};
+
+                ProductFetcher.prototype.initialize.apply(this, [options]);
+            },
+
+            /**
+             * Fetch all children of the given parent.
+             *
+             * @return {Promise}
+             */
+            fetchChildren: function (parentId) {
+                if (!(parentId in this.childrenListPromises)) {
+                    if (!_.has(this.options.urls, 'children')) {
+                        return $.Deferred().reject().promise();
+                    }
+
+                    this.childrenListPromises[parentId] = $.getJSON(
+                        Routing.generate(this.options.urls.children), {id: parentId}
+                    ).then(_.identity).promise();
+                }
+
+                return this.childrenListPromises[parentId];
+            },
+
+            /**
+             * Clear promises.
+             */
+            clear: function () {
+                this.childrenListPromises = {};
+            }
+        });
+    }
+);

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/variant-navigation.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/variant-navigation.js
@@ -41,7 +41,6 @@ define([
             template: _.template(template),
             templateProduct: _.template(templateProduct),
             templateProductModel: _.template(templateProductModel),
-            className: 'AknVariantNavigationBar',
             dropdowns: {},
             queryTimer: null,
             events: {

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/variant-navigation.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/variant-navigation.js
@@ -193,9 +193,10 @@ define([
                         .fetchChildren(parentId)
                         .then((children) => {
                             const childrenResults = this.searchOnResults(options.term, children);
+                            const sortedChildrenResults = _.sortBy(childrenResults, 'order_string');
 
                             options.callback({
-                                results: childrenResults
+                                results: sortedChildrenResults
                             });
                         });
                 }, 400);

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/variant-navigation.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/variant-navigation.js
@@ -41,6 +41,7 @@ define([
             template: _.template(template),
             templateProduct: _.template(templateProduct),
             templateProductModel: _.template(templateProductModel),
+            className: 'AknVariantNavigationBar',
             dropdowns: {},
             queryTimer: null,
             events: {

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/variant-navigation.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/variant-navigation.js
@@ -1,0 +1,277 @@
+'use strict';
+
+/**
+ * Extension to display the variant navigation to browse variant product structure (parents and children)
+ *
+ * @author    Adrien Pétremann <adrien.petremann@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+define([
+        'jquery',
+        'underscore',
+        'oro/translator',
+        'pim/router',
+        'pim/i18n',
+        'pim/user-context',
+        'pim/form',
+        'pim/initselect2',
+        'pim/fetcher-registry',
+        'pim/media-url-generator',
+        'pim/template/product/form/variant-navigation/navigation',
+        'pim/template/product/form/variant-navigation/product-item',
+        'pim/template/product/form/variant-navigation/product-model-item'
+    ],
+    function (
+        $,
+        _,
+        __,
+        router,
+        i18n,
+        UserContext,
+        BaseForm,
+        initSelect2,
+        FetcherRegistry,
+        MediaUrlGenerator,
+        template,
+        templateProduct,
+        templateProductModel
+    ) {
+        return BaseForm.extend({
+            className: 'AknVariantNavigation',
+            template: _.template(template),
+            templateProduct: _.template(templateProduct),
+            templateProductModel: _.template(templateProductModel),
+            levelOneDropdown: null,
+            levelTwoDropdown: null,
+            queryTimer: null,
+            events: {
+                'click [data-action="navigateToRoot"]': 'redirectToRoot',
+                'click [data-action="navigateToModel"]': 'redirectToModel'
+            },
+
+            /**
+             * {@inheritdoc}
+             */
+            configure: function () {
+                UserContext.off('change:catalogLocale change:catalogScope', this.render);
+                this.listenTo(UserContext, 'change:catalogLocale change:catalogScope', this.render);
+
+                return BaseForm.prototype.configure.apply(this, arguments);
+            },
+
+            /**
+             * {@inheritdoc}
+             */
+            render: function () {
+                const entity = this.getFormData();
+                const catalogLocale = UserContext.get('catalogLocale');
+                const nbOfLevels = _.isEmpty(entity.meta.variant_navigation.level_two.axes) ? 1 : 2;
+                let currentLevel = 0;
+
+                if (null !== entity.parent) {
+                    currentLevel = (entity.parent === entity.meta.variant_navigation.root.identifier) ? 1 : 2;
+                }
+
+                this.$el.html(
+                    this.template({
+                        commonLabel: __('pim_enrich.entity.product.common').toUpperCase(),
+                        currentLocale: catalogLocale,
+                        navigation: entity.meta.variant_navigation,
+                        currentLevel: currentLevel,
+                        nbOfLevels: nbOfLevels
+                    })
+                );
+
+                this.initializeSelectWidgets();
+            },
+
+            /**
+             * Initialize the Select2 component and format elements.
+             */
+            initializeSelectWidgets: function () {
+                const entity = this.getFormData();
+
+                const $levelOneSelect = this.$('.select-level-one');
+                const $levelTwoSelect = this.$('.select-level-two');
+
+                const commonOptions = {
+                    dropdownCssClass: 'variant-navigation',
+                    closeOnSelect: false,
+
+                    /**
+                     * Format result (product or product model variations) method of select2.
+                     * This way we can display entities and their info beside them (completeness, image..).
+                     */
+                    formatResult: (item, $container) => {
+                        const catalogLocale = UserContext.get('catalogLocale');
+                        const filePath = (null !== item.image) ? item.image.filePath : null;
+                        const entity = {
+                            label: item.axes_values_labels[catalogLocale],
+                            image: MediaUrlGenerator.getMediaShowUrl(filePath, 'thumbnail_small'),
+                            completeness: this.parseCompleteness(item)
+                        };
+
+                        const html = ('product' === item.model_type)
+                            ? this.templateProduct({ entity: entity })
+                            : this.templateProductModel({ entity: entity })
+                        ;
+
+                        $container.append(html);
+                    },
+                };
+
+                const optionsLevelOne = $.extend(true, {
+                    query: (options) => {
+                        this.queryChildrenEntities(
+                            options,
+                            entity.meta.variant_navigation.root.id
+                        );
+                    }
+                }, commonOptions);
+
+                this.levelOneDropdown = initSelect2.init($levelOneSelect, optionsLevelOne);
+                this.levelOneDropdown.on('select2-selecting', function (event) {
+                    this.redirectToEntity(event.object)
+                }.bind(this));
+
+                if (null !== entity.meta.variant_navigation.level_one.selected) {
+                    const optionsLevelTwo = $.extend(true, {
+                        query: (options) => {
+                            this.queryChildrenEntities(
+                                options,
+                                entity.meta.variant_navigation.level_one.selected.id
+                            )
+                        }
+                    }, commonOptions);
+
+                    this.levelTwoDropdown = initSelect2.init($levelTwoSelect, optionsLevelTwo);
+                    this.levelTwoDropdown.on('select2-selecting', function (event) {
+                        this.redirectToEntity(event.object)
+                    }.bind(this));
+                }
+            },
+
+            /**
+             * Take incoming data and format them to have all required parameters
+             * to be used by the select2 module.
+             *
+             * @param {array} data
+             *
+             * @return {array}
+             */
+            toSelect2Format: function (data) {
+                const catalogLocale = UserContext.get('catalogLocale');
+
+                return _.map(data, function (entity) {
+                    entity.text = entity.axes_values_labels[catalogLocale];
+
+                    return entity;
+                });
+            },
+
+            /**
+             * Return a string of the completeness for the given entity to be displayed.
+             *
+             * @param {Object} entity
+             *
+             * @returns {string}
+             */
+            parseCompleteness: function (entity) {
+                const catalogLocale = UserContext.get('catalogLocale');
+                const catalogScope = UserContext.get('catalogScope');
+
+                if ('product' === entity.model_type) {
+                    const channelCompletenesses = _.findWhere(entity.completeness, {channel: catalogScope});
+                    const localeCompleteness = channelCompletenesses.locales[catalogLocale].completeness;
+
+                    return {
+                        ratio: localeCompleteness.ratio
+                    };
+                } else {
+                    // TODO: replace this placeholder by the real values, with PIM-6560
+                    return {
+                        ratio: 20,
+                        display: '1 / 5'
+                    };
+                }
+            },
+
+            /**
+             * Return all entities that have a label (axes values) that match the given term.
+             *
+             * @param {string} term
+             * @param {array} entities
+             *
+             * @returns {array}
+             */
+            searchOnResults: function (term, entities) {
+                const catalogLocale = UserContext.get('catalogLocale');
+                term = term.toLowerCase();
+
+                return _.filter(entities, (entity) => {
+                    const label = entity.axes_values_labels[catalogLocale].toLowerCase();
+
+                    return -1 !== label.search(term);
+                });
+            },
+
+            /**
+             * Fetch all children of the given parentId and calls the callback of Select2 to
+             * display them in the dropdown.
+             *
+             * @param {Object} options
+             * @param {int} parentId
+             */
+            queryChildrenEntities: function (options, parentId) {
+                clearTimeout(this.queryTimer);
+                this.queryTimer = setTimeout(() => {
+                    FetcherRegistry
+                        .getFetcher('product-model')
+                        .fetchChildren(parentId)
+                        .then((children) => {
+                            const childrenResults = this.searchOnResults(options.term, children);
+
+                            options.callback({
+                                results: childrenResults
+                            });
+                        });
+                }, 400);
+            },
+
+            /**
+             * Redirect to the root product model
+             */
+            redirectToRoot: function () {
+                const entity = this.getFormData();
+                this.redirectToEntity(entity.meta.variant_navigation.root)
+            },
+
+            /**
+             * Redirect to the sub product model
+             */
+            redirectToModel: function () {
+                const entity = this.getFormData();
+                this.redirectToEntity(entity.meta.variant_navigation.level_one.selected)
+            },
+
+            /**
+             * Redirect the user to the given entity edit page
+             *
+             * @param entity
+             */
+            redirectToEntity: function (entity) {
+                const params = {
+                    id: entity.id
+                };
+
+                const route = ('product_model' === entity.model_type)
+                    ? 'pim_enrich_product_model_edit'
+                    : 'pim_enrich_product_edit'
+                ;
+
+                router.redirectToRoute(route, params);
+            },
+        });
+    }
+);

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/form/edit-form.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/form/edit-form.html
@@ -15,9 +15,8 @@
                 <div class="AknTitleContainer-titleButtons AknButtonList" data-drop-zone="title-buttons"></div>
                 <div class="AknTitleContainer-state" data-drop-zone="state"></div>
             </div>
+            <div data-drop-zone="navigation" class="AknVariantNavigationContainer"></div>
         </header>
-
-        <div data-drop-zone="navigation" class="AknVariantNavigationContainer"></div>
 
         <div data-drop-zone="content" class="content"></div>
     </div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/form/edit-form.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/form/edit-form.html
@@ -17,6 +17,8 @@
             </div>
         </header>
 
+        <div data-drop-zone="navigation"></div>
+
         <div data-drop-zone="content" class="content"></div>
     </div>
 </div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/form/edit-form.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/form/edit-form.html
@@ -17,7 +17,7 @@
             </div>
         </header>
 
-        <div data-drop-zone="navigation"></div>
+        <div data-drop-zone="navigation" class="AknVariantNavigationContainer"></div>
 
         <div data-drop-zone="content" class="content"></div>
     </div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/form/variant-navigation/navigation.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/form/variant-navigation/navigation.html
@@ -1,35 +1,27 @@
-<span class="AknVariantNavigation-item <% if (0 == currentLevel) { %>AknVariantNavigation-item--highlight<% } %>">
-    <span class="AknVariantNavigation-axisName AknVariantNavigation-axisValue" data-action="navigateToRoot">
-        <%- commonLabel %>
-    </span>
-</span>
+<div class="AknVariantNavigation">
+    <% for (let level in navigation) { %>
 
-<span class="AknVariantNavigation-item <% if (1 == currentLevel) { %>AknVariantNavigation-item--highlight<% } %>">
-    <span class="AknVariantNavigation-axisName">
-        <%- navigation.level_one.axes[currentLocale] %><% if (navigation.level_one.selected) { %>:<% } %>
+    <span class="AknVariantNavigation-item <% if (navigation[level].selected && navigation[level].selected.id === entity.meta.id) { %>AknVariantNavigation-item--highlight<% } %>">
+        <% if (level > 0) { %>
+            <span class="AknVariantNavigation-axisName <%- navigation[level].selected ? 'AknVariantNavigation-axisName--selected' : '' %>">
+                <%- navigation[level].axes[currentLocale] %>
+            </span>
+
+            <% if (navigation[level].selected) { %>
+                <span class="AknVariantNavigation-axisValue" data-action="navigateToLevel" data-level="<%- level %>">
+                    <%- navigation[level].selected.axes_values_labels[currentLocale] %>
+                </span>
+            <% } %>
+
+            <% if (navigation[level - 1].selected) { %>
+                <input type="hidden" class="variant-navigation select-field" value="0" />
+            <% } %>
+        <% } else { %>
+            <span class="AknVariantNavigation-axisName AknVariantNavigation-axisValue" data-action="navigateToLevel" data-level="<%- level %>">
+                <%- commonLabel %>
+            </span>
+        <% } %>
     </span>
 
-    <% if (navigation.level_one.selected) { %>
-    <span class="AknVariantNavigation-axisValue" data-action="navigateToModel">
-        <%- navigation.level_one.selected.axes_values_labels[currentLocale] %>
-    </span>
     <% } %>
-
-    <input type="hidden" class="variant-navigation select-level-one select-field" value="0"/>
-</span>
-
-<% if (2 == nbOfLevels) { %>
-<span class="AknVariantNavigation-item <% if (2 == currentLevel) { %>AknVariantNavigation-item--highlight<% } %>">
-    <span class="AknVariantNavigation-axisName">
-        <%- navigation.level_two.axes[currentLocale] %><% if (navigation.level_two.selected) { %>:<% } %>
-    </span>
-
-    <% if (navigation.level_two.selected) { %>
-    <span class="AknVariantNavigation-axisValue">
-        <%- navigation.level_two.selected.axes_values_labels[currentLocale] %>
-    </span>
-    <% } %>
-
-    <input type="hidden" class="variant-navigation select-level-two select-field" value="0"/>
-</span>
-<% } %>
+</div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/form/variant-navigation/navigation.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/form/variant-navigation/navigation.html
@@ -1,0 +1,35 @@
+<span class="AknVariantNavigation-item <% if (0 == currentLevel) { %>AknVariantNavigation-item--highlight<% } %>">
+    <span class="AknVariantNavigation-axisName AknVariantNavigation-axisValue" data-action="navigateToRoot">
+        <%- commonLabel %>
+    </span>
+</span>
+
+<span class="AknVariantNavigation-item <% if (1 == currentLevel) { %>AknVariantNavigation-item--highlight<% } %>">
+    <span class="AknVariantNavigation-axisName">
+        <%- navigation.level_one.axes[currentLocale] %><% if (navigation.level_one.selected) { %>:<% } %>
+    </span>
+
+    <% if (navigation.level_one.selected) { %>
+    <span class="AknVariantNavigation-axisValue" data-action="navigateToModel">
+        <%- navigation.level_one.selected.axes_values_labels[currentLocale] %>
+    </span>
+    <% } %>
+
+    <input type="hidden" class="variant-navigation select-level-one select-field" value="0"/>
+</span>
+
+<% if (2 == nbOfLevels) { %>
+<span class="AknVariantNavigation-item <% if (2 == currentLevel) { %>AknVariantNavigation-item--highlight<% } %>">
+    <span class="AknVariantNavigation-axisName">
+        <%- navigation.level_two.axes[currentLocale] %><% if (navigation.level_two.selected) { %>:<% } %>
+    </span>
+
+    <% if (navigation.level_two.selected) { %>
+    <span class="AknVariantNavigation-axisValue">
+        <%- navigation.level_two.selected.axes_values_labels[currentLocale] %>
+    </span>
+    <% } %>
+
+    <input type="hidden" class="variant-navigation select-level-two select-field" value="0"/>
+</span>
+<% } %>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/form/variant-navigation/product-item.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/form/variant-navigation/product-item.html
@@ -1,0 +1,9 @@
+<div class="AknVariantNavigation-listItem">
+    <img class="AknVariantNavigation-listProductImage" src="<%- entity.image %>" alt="">
+    <span class="AknVariantNavigation-listProductLabel">
+        <%- entity.label %>
+    </span>
+    <span class="AknVariantNavigation-listProductCompleteness AknVariantNavigation-listProductCompleteness--<%- (100 == entity.completeness.ratio) ? 'complete' : 'incomplete' %>">
+        <%- entity.completeness.ratio %>%
+    </span>
+</div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/form/variant-navigation/product-item.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/form/variant-navigation/product-item.html
@@ -3,7 +3,7 @@
     <span class="AknVariantNavigation-listProductLabel">
         <%- entity.label %>
     </span>
-    <span class="AknVariantNavigation-listProductCompleteness AknVariantNavigation-listProductCompleteness--<%- (100 == entity.completeness.ratio) ? 'complete' : 'incomplete' %>">
+    <span class="AknVariantNavigation-listProductCompleteness AknVariantNavigation-listProductCompleteness--<%- (100 === parseInt(entity.completeness.ratio)) ? 'complete' : 'incomplete' %>">
         <%- entity.completeness.ratio %>%
     </span>
 </div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/form/variant-navigation/product-model-item.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/form/variant-navigation/product-model-item.html
@@ -1,0 +1,9 @@
+<div class="AknVariantNavigation-listItem">
+    <img class="AknVariantNavigation-listProductModelImage" src="<%- entity.image %>" alt="">
+    <span class="AknVariantNavigation-listProductModelLabel">
+        <%- entity.label %>
+    </span>
+    <span class="AknVariantNavigation-listProductModelCompleteness AknVariantNavigation-listProductCompleteness--<%- (100 == entity.completeness.ratio) ? 'complete' : 'incomplete' %>">
+        <%- entity.completeness.display %>
+    </span>
+</div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/form/variant-navigation/product-model-item.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/form/variant-navigation/product-model-item.html
@@ -3,7 +3,7 @@
     <span class="AknVariantNavigation-listProductModelLabel">
         <%- entity.label %>
     </span>
-    <span class="AknVariantNavigation-listProductModelCompleteness AknVariantNavigation-listProductCompleteness--<%- (100 == entity.completeness.ratio) ? 'complete' : 'incomplete' %>">
+    <span class="AknVariantNavigation-listProductModelCompleteness AknVariantNavigation-listProductCompleteness--<%- (100 === parseInt(entity.completeness.ratio)) ? 'complete' : 'incomplete' %>">
         <%- entity.completeness.display %>
     </span>
 </div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
@@ -169,6 +169,7 @@ pim_enrich:
             create: Create product
             filters: Filters
             selected: selected products
+            common: Common
             btn:
                 enabled: Enabled
                 disabled: Disabled

--- a/src/Pim/Bundle/EnrichBundle/spec/Normalizer/EntityWithFamilyVariantNormalizerSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Normalizer/EntityWithFamilyVariantNormalizerSpec.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace spec\Pim\Bundle\EnrichBundle\Normalizer;
+
+use Doctrine\Common\Collections\Collection;
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\EnrichBundle\Normalizer\FileNormalizer;
+use Pim\Component\Catalog\Completeness\CompletenessCalculatorInterface;
+use Pim\Component\Catalog\FamilyVariant\EntityWithFamilyVariantAttributesProvider;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\AttributeOptionInterface;
+use Pim\Component\Catalog\Model\AttributeOptionValueInterface;
+use Pim\Component\Catalog\Model\CompletenessInterface;
+use Pim\Component\Catalog\Model\ProductModelInterface;
+use Pim\Component\Catalog\Model\ValueInterface;
+use Pim\Component\Catalog\Model\VariantProductInterface;
+use Pim\Component\Catalog\Repository\LocaleRepositoryInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+class EntityWithFamilyVariantNormalizerSpec extends ObjectBehavior
+{
+    function let(
+        FileNormalizer $fileNormalizer,
+        LocaleRepositoryInterface $localeRepository,
+        EntityWithFamilyVariantAttributesProvider $attributesProvider,
+        NormalizerInterface $completenessCollectionNormalizer,
+        CompletenessCalculatorInterface $completenessCalculator
+    ) {
+        $this->beConstructedWith(
+            $fileNormalizer,
+            $localeRepository,
+            $attributesProvider,
+            $completenessCollectionNormalizer,
+            $completenessCalculator
+        );
+    }
+
+    function it_throws_an_exception_if_the_entity_is_not_a_variant_product_nor_a_product_model(
+        \stdClass $entity
+    ) {
+        $this->shouldThrow(\InvalidArgumentException::class)->during(
+            'normalize', [$entity, 'internal_api']
+        );
+    }
+
+    function it_normalizes_a_variant_product(
+        $localeRepository,
+        $attributesProvider,
+        $completenessCollectionNormalizer,
+        $completenessCalculator,
+        VariantProductInterface $variantProduct,
+        AttributeInterface $colorAttribute,
+        AttributeInterface $sizeAttribute,
+        ValueInterface $colorValue,
+        ValueInterface $sizeValue,
+        AttributeOptionInterface $colorAttributeOption,
+        AttributeOptionValueInterface $colorAttributeOptionValue,
+        CompletenessInterface $completeness1,
+        CompletenessInterface $completeness2,
+        Collection $productCompletenesses
+    ) {
+        $localeRepository->getActivatedLocaleCodes()->willReturn(['fr_FR', 'en_US']);
+
+        $variantProduct->getLabel('fr_FR')->willReturn('Tshirt Blanc S');
+        $variantProduct->getLabel('en_US')->willReturn('Tshirt White S');
+        $variantProduct->getId()->willReturn(42);
+
+        $variantProduct->getIdentifier()->willReturn('tshirt_white_s');
+
+        $attributesProvider->getAxes($variantProduct)->willReturn([
+            $colorAttribute,
+            $sizeAttribute
+        ]);
+
+        $colorAttribute->getCode()->willReturn('color');
+        $colorAttribute->getType()->willReturn('pim_catalog_simpleselect');
+        $sizeAttribute->getCode()->willReturn('size');
+        $sizeAttribute->getType()->willReturn('pim_catalog_text');
+        $variantProduct->getValue('color')->willReturn($colorValue);
+        $variantProduct->getValue('size')->willReturn($sizeValue);
+
+        $colorValue->getData()->willReturn($colorAttributeOption);
+        $colorAttributeOption->setLocale('fr_FR')->shouldBeCalled();
+        $colorAttributeOption->setLocale('en_US')->shouldBeCalled();
+        $colorAttributeOption->getTranslation()->willReturn($colorAttributeOptionValue);
+        $colorAttributeOptionValue->getLabel()->willReturn('Blanc', 'White');
+        $sizeValue->__toString()->willReturn('S');
+
+        $variantProduct->getImage()->willReturn(null);
+
+        $variantProduct->getCompletenesses()->willReturn($productCompletenesses);
+
+        $productCompletenesses->isEmpty()->willReturn(true);
+        $completenessCalculator->calculate($variantProduct)->willReturn($completeness1, $completeness2);
+
+        $completenessCollectionNormalizer->normalize($productCompletenesses, 'internal_api')
+            ->willReturn(['NORMALIZED_COMPLETENESS']);
+
+        $this->normalize($variantProduct, 'internal_api')->shouldReturn([
+            'id'                 => 42,
+            'identifier'         => 'tshirt_white_s',
+            'axes_values_labels' => [
+                'fr_FR' => 'Blanc, S',
+                'en_US' => 'White, S',
+            ],
+            'labels'             => [
+                'fr_FR' => 'Tshirt Blanc S',
+                'en_US' => 'Tshirt White S',
+            ],
+            'image'              => null,
+            'model_type'         => 'product',
+            'completeness'       => ['NORMALIZED_COMPLETENESS']
+        ]);
+    }
+
+    function it_normalizes_a_product_model(
+        $localeRepository,
+        $attributesProvider,
+        ProductModelInterface $productModel,
+        AttributeInterface $colorAttribute,
+        ValueInterface $colorValue,
+        AttributeOptionInterface $colorAttributeOption,
+        AttributeOptionValueInterface $colorAttributeOptionValue
+    ) {
+        $localeRepository->getActivatedLocaleCodes()->willReturn(['fr_FR', 'en_US']);
+
+        $productModel->getLabel('fr_FR')->willReturn('Tshirt Blanc');
+        $productModel->getLabel('en_US')->willReturn('Tshirt White');
+        $productModel->getId()->willReturn(5);
+
+        $productModel->getCode()->willReturn('tshirt_white');
+
+        $attributesProvider->getAxes($productModel)->willReturn([$colorAttribute]);
+
+        $colorAttribute->getCode()->willReturn('color');
+        $colorAttribute->getType()->willReturn('pim_catalog_simpleselect');
+        $productModel->getValue('color')->willReturn($colorValue);
+
+        $colorValue->getData()->willReturn($colorAttributeOption);
+        $colorAttributeOption->setLocale('fr_FR')->shouldBeCalled();
+        $colorAttributeOption->setLocale('en_US')->shouldBeCalled();
+        $colorAttributeOption->getTranslation()->willReturn($colorAttributeOptionValue);
+        $colorAttributeOptionValue->getLabel()->willReturn('Blanc', 'White');
+
+        $productModel->getImage()->willReturn(null);
+
+        $this->normalize($productModel, 'internal_api')->shouldReturn([
+            'id'                 => 5,
+            'identifier'         => 'tshirt_white',
+            'axes_values_labels' => [
+                'fr_FR' => 'Blanc',
+                'en_US' => 'White',
+            ],
+            'labels'             => [
+                'fr_FR' => 'Tshirt Blanc',
+                'en_US' => 'Tshirt White',
+            ],
+            'image'              => null,
+            'model_type'         => 'product_model',
+            'completeness'       => []
+        ]);
+    }
+}

--- a/src/Pim/Bundle/EnrichBundle/spec/Normalizer/EntityWithFamilyVariantNormalizerSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Normalizer/EntityWithFamilyVariantNormalizerSpec.php
@@ -82,6 +82,7 @@ class EntityWithFamilyVariantNormalizerSpec extends ObjectBehavior
         $colorValue->getData()->willReturn($colorAttributeOption);
         $colorAttributeOption->setLocale('fr_FR')->shouldBeCalled();
         $colorAttributeOption->setLocale('en_US')->shouldBeCalled();
+        $colorAttributeOption->getSortOrder()->willReturn(2);
         $colorAttributeOption->getTranslation()->willReturn($colorAttributeOptionValue);
         $colorAttributeOptionValue->getLabel()->willReturn('Blanc', 'White');
         $sizeValue->__toString()->willReturn('S');
@@ -107,6 +108,7 @@ class EntityWithFamilyVariantNormalizerSpec extends ObjectBehavior
                 'fr_FR' => 'Tshirt Blanc S',
                 'en_US' => 'Tshirt White S',
             ],
+            'order_string'       => '2, S',
             'image'              => null,
             'model_type'         => 'product',
             'completeness'       => ['NORMALIZED_COMPLETENESS']
@@ -139,6 +141,7 @@ class EntityWithFamilyVariantNormalizerSpec extends ObjectBehavior
         $colorValue->getData()->willReturn($colorAttributeOption);
         $colorAttributeOption->setLocale('fr_FR')->shouldBeCalled();
         $colorAttributeOption->setLocale('en_US')->shouldBeCalled();
+        $colorAttributeOption->getSortOrder()->willReturn(2);
         $colorAttributeOption->getTranslation()->willReturn($colorAttributeOptionValue);
         $colorAttributeOptionValue->getLabel()->willReturn('Blanc', 'White');
 
@@ -155,6 +158,7 @@ class EntityWithFamilyVariantNormalizerSpec extends ObjectBehavior
                 'fr_FR' => 'Tshirt Blanc',
                 'en_US' => 'Tshirt White',
             ],
+            'order_string'       => '2',
             'image'              => null,
             'model_type'         => 'product_model',
             'completeness'       => []

--- a/src/Pim/Bundle/EnrichBundle/spec/Normalizer/ProductModelNormalizerSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Normalizer/ProductModelNormalizerSpec.php
@@ -3,7 +3,7 @@
 namespace spec\Pim\Bundle\EnrichBundle\Normalizer;
 
 use PhpSpec\ObjectBehavior;
-use Pim\Bundle\EnrichBundle\Normalizer\FileNormalizer;
+use Pim\Bundle\EnrichBundle\Normalizer\VariantNavigationNormalizer;
 use Pim\Bundle\EnrichBundle\Provider\Form\FormProviderInterface;
 use Pim\Bundle\VersioningBundle\Manager\VersionManager;
 use Pim\Component\Catalog\FamilyVariant\EntityWithFamilyVariantAttributesProvider;
@@ -31,7 +31,8 @@ class ProductModelNormalizerSpec extends ObjectBehavior
         FormProviderInterface $formProvider,
         LocaleRepositoryInterface $localeRepository,
         EntityWithFamilyValuesFillerInterface $entityValuesFiller,
-        EntityWithFamilyVariantAttributesProvider $attributesProvider
+        EntityWithFamilyVariantAttributesProvider $attributesProvider,
+        VariantNavigationNormalizer $navigationNormalizer
     ) {
         $this->beConstructedWith(
             $normalizer,
@@ -43,7 +44,8 @@ class ProductModelNormalizerSpec extends ObjectBehavior
             $formProvider,
             $localeRepository,
             $entityValuesFiller,
-            $attributesProvider
+            $attributesProvider,
+            $navigationNormalizer
         );
     }
 
@@ -62,6 +64,7 @@ class ProductModelNormalizerSpec extends ObjectBehavior
         $formProvider,
         $localeRepository,
         $attributesProvider,
+        $navigationNormalizer,
         AttributeInterface $pictureAttribute,
         ProductModelInterface $productModel,
         FamilyVariantInterface $familyVariant,
@@ -149,6 +152,9 @@ class ProductModelNormalizerSpec extends ObjectBehavior
 
         $formProvider->getForm($productModel)->willReturn('pim-product-model-edit-form');
 
+        $navigationNormalizer->normalize($productModel, 'internal_api', $options)
+            ->willReturn(['NAVIGATION NORMALIZED']);
+
         $this->normalize($productModel, 'internal_api', $options)->shouldReturn(
             [
                 'code'           => 'tshirt_blue',
@@ -166,6 +172,7 @@ class ProductModelNormalizerSpec extends ObjectBehavior
                     'attributes_for_this_level' => ['picture'],
                     'attributes_axes' => ['picture'],
                     'image'          => $fileNormalized,
+                    'variant_navigation' => ['NAVIGATION NORMALIZED'],
                     'label'          => [
                         'en_US' => 'Tshirt blue',
                         'fr_FR' => 'Tshirt bleu',
@@ -185,6 +192,7 @@ class ProductModelNormalizerSpec extends ObjectBehavior
         $formProvider,
         $localeRepository,
         $attributesProvider,
+        $navigationNormalizer,
         AttributeInterface $pictureAttribute,
         ProductModelInterface $productModel,
         FamilyVariantInterface $familyVariant,
@@ -260,6 +268,9 @@ class ProductModelNormalizerSpec extends ObjectBehavior
 
         $formProvider->getForm($productModel)->willReturn('pim-product-model-edit-form');
 
+        $navigationNormalizer->normalize($productModel, 'internal_api', $options)
+            ->willReturn(['NAVIGATION NORMALIZED']);
+
         $this->normalize($productModel, 'internal_api', $options)->shouldReturn(
             [
                 'code'           => 'tshirt_blue',
@@ -277,6 +288,135 @@ class ProductModelNormalizerSpec extends ObjectBehavior
                     'attributes_for_this_level' => ['picture'],
                     'attributes_axes' => ['picture'],
                     'image'          => null,
+                    'variant_navigation' => ['NAVIGATION NORMALIZED'],
+                    'label'          => [
+                        'en_US' => 'Tshirt blue',
+                        'fr_FR' => 'Tshirt bleu',
+                    ]
+                ]
+            ]
+        );
+    }
+
+    function it_normalizes_product_models_without_multiple_levels(
+        $normalizer,
+        $versionNormalizer,
+        $fileNormalizer,
+        $versionManager,
+        $localizedConverter,
+        $productValueConverter,
+        $formProvider,
+        $localeRepository,
+        $attributesProvider,
+        $navigationNormalizer,
+        AttributeInterface $pictureAttribute,
+        ProductModelInterface $productModel,
+        FamilyVariantInterface $familyVariant,
+        FamilyInterface $family,
+        ValueInterface $picture
+    ) {
+        $options = [
+            'decimal_separator' => ',',
+            'date_format'       => 'dd/MM/yyyy',
+        ];
+
+        $productModelNormalized = [
+            'code'           => 'tshirt_blue',
+            'family_variant' => 'tshirts_color',
+            'family'         => 'tshirts',
+            'categories'     => ['summer'],
+            'values'         => [
+                'normalized_property' => [['data' => 'a nice normalized property', 'locale' => null, 'scope' => null]],
+                'number'              => [['data' => 12.5000, 'locale' => null, 'scope' => null]],
+                'metric'              => [['data' => 12.5000, 'locale' => null, 'scope' => null]],
+                'prices'              => [['data' => 12.5, 'locale' => null, 'scope' => null]],
+                'date'                => [['data' => '2015-01-31', 'locale' => null, 'scope' => null]],
+                'picture'             => [['data' => 'a/b/c/my_picture.jpg', 'locale' => null, 'scope' => null]]
+            ]
+        ];
+
+        $familyVariantNormalized = [
+            'code'                   => 'tshirts_color',
+            'labels'                 => ['en_US' => 'Tshirts Color', 'fr_FR' => 'Tshirt Couleur'],
+            'family'                 => 'tshirts',
+            'variant_attribute_sets' => []
+        ];
+
+        $fileNormalized = [
+            'filePath' => 'a/b/c/my_picture.jpg',
+            'originalFilename' => 'my_picture.jpg'
+        ];
+
+        $valuesLocalized = [
+            'normalized_property' => [['data' => 'a nice normalized property', 'locale' => null, 'scope' => null]],
+            'number'              => [['data' => '12,5000', 'locale' => null, 'scope' => null]],
+            'metric'              => [['data' => '12,5000', 'locale' => null, 'scope' => null]],
+            'prices'              => [['data' => '12,5', 'locale' => null, 'scope' => null]],
+            'date'                => [['data' => '31/01/2015', 'locale' => null, 'scope' => null]],
+            'picture'             => [['data' => 'a/b/c/my_picture.jpg', 'locale' => null, 'scope' => null]]
+        ];
+
+        $normalizer->normalize($productModel, 'standard', $options)->willReturn($productModelNormalized);
+        $localizedConverter->convertToLocalizedFormats($productModelNormalized['values'], $options)->willReturn($valuesLocalized);
+
+        $valuesConverted = $valuesLocalized;
+        $valuesConverted['picture'] = [
+            [
+                'data' => $fileNormalized,
+                'locale' => null,
+                'scope' => null
+            ]
+        ];
+
+        $attributesProvider->getAttributes($productModel)->willReturn([$pictureAttribute]);
+        $attributesProvider->getAxes($productModel)->willReturn([$pictureAttribute]);
+        $pictureAttribute->getCode()->willReturn('picture');
+
+        $localeRepository->getActivatedLocaleCodes()->willReturn(['en_US', 'fr_FR']);
+        $productModel->getLabel('en_US')->willReturn('Tshirt blue');
+        $productModel->getLabel('fr_FR')->willReturn('Tshirt bleu');
+
+        $productModel->getImage()->willReturn($picture);
+        $picture->getData()->willReturn('IMAGE_DATA');
+        $fileNormalizer->normalize('IMAGE_DATA', 'internal_api', $options)->willReturn($fileNormalized);
+
+        $productValueConverter->convert($valuesLocalized)->willReturn($valuesConverted);
+
+        $productModel->getId()->willReturn(12);
+        $productModel->getCode()->willReturn('tshirt_blue');
+        $versionManager->getOldestLogEntry($productModel)->willReturn('create_version');
+        $versionNormalizer->normalize('create_version', 'internal_api')->willReturn('normalized_create_version');
+        $versionManager->getNewestLogEntry($productModel)->willReturn('update_version');
+        $versionNormalizer->normalize('update_version', 'internal_api')->willReturn('normalized_update_version');
+
+        $productModel->getFamilyVariant()->willReturn($familyVariant);
+        $familyVariant->getFamily()->willReturn($family);
+        $family->getCode()->willReturn('tshirts');
+        $normalizer->normalize($familyVariant, 'standard')->willReturn($familyVariantNormalized);
+
+        $formProvider->getForm($productModel)->willReturn('pim-product-model-edit-form');
+
+        $navigationNormalizer->normalize($productModel, 'internal_api', $options)
+            ->willReturn(['NAVIGATION NORMALIZED']);
+
+        $this->normalize($productModel, 'internal_api', $options)->shouldReturn(
+            [
+                'code'           => 'tshirt_blue',
+                'family_variant' => 'tshirts_color',
+                'family'         => 'tshirts',
+                'categories'     => ['summer'],
+                'values'         => $valuesConverted,
+                'meta'           => [
+                    'family_variant' => $familyVariantNormalized,
+                    'form'           => 'pim-product-model-edit-form',
+                    'id'             => 12,
+                    'created'        => 'normalized_create_version',
+                    'updated'        => 'normalized_update_version',
+                    'model_type'     => 'product_model',
+                    'attributes_for_this_level' => ['picture'],
+                    'attributes_axes' => ['picture'],
+                    'image'          => $fileNormalized,
+                    'variant_navigation' => ['NAVIGATION NORMALIZED'],
                     'label'          => [
                         'en_US' => 'Tshirt blue',
                         'fr_FR' => 'Tshirt bleu',

--- a/src/Pim/Bundle/EnrichBundle/spec/Normalizer/ProductNormalizerSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Normalizer/ProductNormalizerSpec.php
@@ -8,6 +8,7 @@ use Doctrine\Common\Persistence\ObjectManager;
 use PhpSpec\ObjectBehavior;
 use Pim\Bundle\CatalogBundle\Filter\CollectionFilterInterface;
 use Pim\Bundle\EnrichBundle\Normalizer\FileNormalizer;
+use Pim\Bundle\EnrichBundle\Normalizer\VariantNavigationNormalizer;
 use Pim\Bundle\EnrichBundle\Provider\Form\FormProviderInterface;
 use Pim\Bundle\EnrichBundle\Provider\StructureVersion\StructureVersionProviderInterface;
 use Pim\Bundle\UserBundle\Context\UserContext;
@@ -21,6 +22,7 @@ use Pim\Component\Catalog\Model\AssociationTypeInterface;
 use Pim\Component\Catalog\Model\GroupInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Model\ValueInterface;
+use Pim\Component\Catalog\Model\VariantProductInterface;
 use Pim\Component\Catalog\Repository\ChannelRepositoryInterface;
 use Pim\Component\Catalog\Repository\LocaleRepositoryInterface;
 use Pim\Component\Catalog\ValuesFiller\EntityWithFamilyValuesFillerInterface;
@@ -48,7 +50,8 @@ class ProductNormalizerSpec extends ObjectBehavior
         CompletenessCalculatorInterface $completenessCalculator,
         FileNormalizer $fileNormalizer,
         ProductBuilderInterface $productBuilder,
-        EntityWithFamilyValuesFillerInterface $productValuesFiller
+        EntityWithFamilyValuesFillerInterface $productValuesFiller,
+        VariantNavigationNormalizer $navigationNormalizer
     ) {
         $this->beConstructedWith(
             $productNormalizer,
@@ -68,7 +71,8 @@ class ProductNormalizerSpec extends ObjectBehavior
             $completenessCalculator,
             $fileNormalizer,
             $productBuilder,
-            $productValuesFiller
+            $productValuesFiller,
+            $navigationNormalizer
         );
     }
 
@@ -77,7 +81,7 @@ class ProductNormalizerSpec extends ObjectBehavior
         $this->supportsNormalization($mug, 'internal_api')->shouldReturn(true);
     }
 
-    function it_normalize_products(
+    function it_normalizes_products(
         $productNormalizer,
         $versionNormalizer,
         $versionManager,
@@ -197,6 +201,144 @@ class ProductNormalizerSpec extends ObjectBehavior
                         'filePath'         => '/p/i/m/4/all.png',
                         'originalFileName' => 'all.png',
                     ],
+                    'variant_navigation' => null,
+                    'label'             => [
+                        'en_US' => 'A nice Mug!',
+                        'fr_FR' => 'Un très beau Mug !'
+                    ],
+                    'associations'      => [
+                        'group' => ['groupIds' => [12]]
+                    ]
+                ]
+            ]
+        );
+    }
+
+    function it_normalizes_variant_products(
+        $productNormalizer,
+        $versionNormalizer,
+        $versionManager,
+        $localeRepository,
+        $structureVersionProvider,
+        $formProvider,
+        $localizedConverter,
+        $productValueConverter,
+        $channelRepository,
+        $userContext,
+        $collectionFilter,
+        $fileNormalizer,
+        $productBuilder,
+        $productValuesFiller,
+        $navigationNormalizer,
+        VariantProductInterface $mug,
+        AssociationInterface $upsell,
+        AssociationTypeInterface $groupType,
+        GroupInterface $group,
+        ArrayCollection $groups,
+        ValueInterface $image,
+        FileInfoInterface $dataImage
+    ) {
+        $options = [
+            'decimal_separator' => ',',
+            'date_format'       => 'dd/MM/yyyy',
+        ];
+
+        $productNormalized = [
+            'enabled'    => true,
+            'categories' => ['kitchen'],
+            'family'     => '',
+            'values' => [
+                'normalized_property' => [['data' => 'a nice normalized property', 'locale' => null, 'scope' => null]],
+                'number'              => [['data' => 12.5000, 'locale' => null, 'scope' => null]],
+                'metric'              => [['data' => 12.5000, 'locale' => null, 'scope' => null]],
+                'prices'              => [['data' => 12.5, 'locale' => null, 'scope' => null]],
+                'date'                => [['data' => '2015-01-31', 'locale' => null, 'scope' => null]],
+                'picture'             => [['data' => 'a/b/c/my_picture.jpg', 'locale' => null, 'scope' => null]]
+            ]
+        ];
+
+        $valuesLocalized = [
+            'normalized_property' => [['data' => 'a nice normalized property', 'locale' => null, 'scope' => null]],
+            'number'              => [['data' => '12,5000', 'locale' => null, 'scope' => null]],
+            'metric'              => [['data' => '12,5000', 'locale' => null, 'scope' => null]],
+            'prices'              => [['data' => '12,5', 'locale' => null, 'scope' => null]],
+            'date'                => [['data' => '31/01/2015', 'locale' => null, 'scope' => null]],
+            'picture'             => [['data' => 'a/b/c/my_picture.jpg', 'locale' => null, 'scope' => null]]
+        ];
+
+        $productNormalizer->normalize($mug, 'standard', $options)->willReturn($productNormalized);
+        $localizedConverter->convertToLocalizedFormats($productNormalized['values'], $options)->willReturn($valuesLocalized);
+
+        $valuesConverted = $valuesLocalized;
+        $valuesConverted['picture'] = [
+            [
+                'data' => [
+                    'filePath' => 'a/b/c/my_picture.jpg', 'originalFilename' => 'my_picture.jpg'
+                ],
+                'locale' => null,
+                'scope' => null
+            ]
+        ];
+
+        $channelRepository->getFullChannels()->willReturn([]);
+        $userContext->getUserLocales()->willReturn([]);
+        $collectionFilter->filterCollection([], 'pim.internal_api.locale.view')->willReturn([]);
+
+        $productValueConverter->convert($valuesLocalized)->willReturn($valuesConverted);
+
+        $mug->getId()->willReturn(12);
+        $versionManager->getOldestLogEntry($mug)->willReturn('create_version');
+        $versionNormalizer->normalize('create_version', 'internal_api')->willReturn('normalized_create_version');
+        $versionManager->getNewestLogEntry($mug)->willReturn('update_version');
+        $versionNormalizer->normalize('update_version', 'internal_api')->willReturn('normalized_update_version');
+
+        $localeRepository->getActivatedLocaleCodes()->willReturn(['en_US', 'fr_FR']);
+        $mug->getLabel('en_US')->willReturn('A nice Mug!');
+        $mug->getLabel('fr_FR')->willReturn('Un très beau Mug !');
+        $mug->getImage()->willReturn($image);
+        $image->getData()->willReturn($dataImage);
+        $fileNormalizer->normalize($dataImage, Argument::any(), Argument::any())->willReturn([
+            'filePath'         => '/p/i/m/4/all.png',
+            'originalFileName' => 'all.png',
+        ]);
+
+        $mug->getAssociations()->willReturn([$upsell]);
+        $upsell->getAssociationType()->willReturn($groupType);
+        $groupType->getCode()->willReturn('group');
+        $upsell->getGroups()->willReturn($groups);
+        $groups->toArray()->willReturn([$group]);
+        $group->getId()->willReturn(12);
+
+        $mug->getCompletenesses()->willReturn(new ArrayCollection(['']));
+
+        $structureVersionProvider->getStructureVersion()->willReturn(12);
+        $formProvider->getForm($mug)->willReturn('product-edit-form');
+
+        $productBuilder->addMissingAssociations($mug)->shouldBeCalled();
+        $productValuesFiller->fillMissingValues($mug)->shouldBeCalled();
+
+        $navigationNormalizer->normalize($mug, 'internal_api', $options)
+            ->willReturn(['NAVIGATION NORMALIZED']);
+
+        $this->normalize($mug, 'internal_api', $options)->shouldReturn(
+            [
+                'enabled'    => true,
+                'categories' => ['kitchen'],
+                'family'     => '',
+                'values'     => $valuesConverted,
+                'meta'       => [
+                    'form'              => 'product-edit-form',
+                    'id'                => 12,
+                    'created'           => 'normalized_create_version',
+                    'updated'           => 'normalized_update_version',
+                    'model_type'        => 'product',
+                    'structure_version' => 12,
+                    'completenesses'    => null,
+                    'image'             => [
+                        'filePath'         => '/p/i/m/4/all.png',
+                        'originalFileName' => 'all.png',
+                    ],
+                    'variant_navigation' => ['NAVIGATION NORMALIZED'],
                     'label'             => [
                         'en_US' => 'A nice Mug!',
                         'fr_FR' => 'Un très beau Mug !'

--- a/src/Pim/Bundle/EnrichBundle/spec/Normalizer/ProductNormalizerSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Normalizer/ProductNormalizerSpec.php
@@ -201,7 +201,7 @@ class ProductNormalizerSpec extends ObjectBehavior
                         'filePath'         => '/p/i/m/4/all.png',
                         'originalFileName' => 'all.png',
                     ],
-                    'variant_navigation' => null,
+                    'variant_navigation' => [],
                     'label'             => [
                         'en_US' => 'A nice Mug!',
                         'fr_FR' => 'Un très beau Mug !'

--- a/src/Pim/Bundle/EnrichBundle/spec/Normalizer/VariantNavigationNormalizerSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Normalizer/VariantNavigationNormalizerSpec.php
@@ -83,21 +83,21 @@ class VariantNavigationNormalizerSpec extends ObjectBehavior
             ->willReturn(['ROOT PRODUCT MODEL NORMALIZED']);
 
         $this->normalize($rootProductModel, 'internal_api')->shouldReturn([
-            'root'      => ['ROOT PRODUCT MODEL NORMALIZED'],
-            'level_one' => [
+            0 => [
+                'selected' => ['ROOT PRODUCT MODEL NORMALIZED']
+            ],
+            1 => [
                 'axes'     => [
                     'en_US' => 'Metric',
                     'fr_FR' => 'Metrique',
-                ],
-                'selected' => null,
+                ]
             ],
-            'level_two' => [
+            2 => [
                 'axes'     => [
                     'en_US' => 'Size',
                     'fr_FR' => 'Taille',
-                ],
-                'selected' => null,
-            ],
+                ]
+            ]
         ]);
     }
 
@@ -165,21 +165,22 @@ class VariantNavigationNormalizerSpec extends ObjectBehavior
             ->willReturn(['PRODUCT MODEL NORMALIZED']);
 
         $this->normalize($productModel, 'internal_api')->shouldReturn([
-            'root'      => ['ROOT PRODUCT MODEL NORMALIZED'],
-            'level_one' => [
+            0 => [
+                'selected' => ['ROOT PRODUCT MODEL NORMALIZED']
+            ],
+            1 => [
                 'axes'     => [
                     'en_US' => 'Metric',
                     'fr_FR' => 'Metrique',
                 ],
                 'selected' => ['PRODUCT MODEL NORMALIZED'],
             ],
-            'level_two' => [
+            2 => [
                 'axes'     => [
                     'en_US' => 'Size',
                     'fr_FR' => 'Taille',
                 ],
-                'selected' => null,
-            ],
+            ]
         ]);
     }
 
@@ -252,21 +253,23 @@ class VariantNavigationNormalizerSpec extends ObjectBehavior
             ->willReturn(['VARIANT PRODUCT NORMALIZED']);
 
         $this->normalize($variantProduct, 'internal_api')->shouldReturn([
-            'root'      => ['ROOT PRODUCT MODEL NORMALIZED'],
-            'level_one' => [
+            0 => [
+                'selected' => ['ROOT PRODUCT MODEL NORMALIZED']
+            ],
+            1 => [
                 'axes'     => [
                     'en_US' => 'Metric',
                     'fr_FR' => 'Metrique',
                 ],
                 'selected' => ['PRODUCT MODEL NORMALIZED'],
             ],
-            'level_two' => [
+            2 => [
                 'axes'     => [
                     'en_US' => 'Size',
                     'fr_FR' => 'Taille',
                 ],
                 'selected' => ['VARIANT PRODUCT NORMALIZED'],
-            ],
+            ]
         ]);
     }
 

--- a/src/Pim/Bundle/EnrichBundle/spec/Normalizer/VariantNavigationNormalizerSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Normalizer/VariantNavigationNormalizerSpec.php
@@ -1,0 +1,280 @@
+<?php
+
+namespace spec\Pim\Bundle\EnrichBundle\Normalizer;
+
+use Doctrine\Common\Collections\Collection;
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\EnrichBundle\Normalizer\EntityWithFamilyVariantNormalizer;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\FamilyVariantInterface;
+use Pim\Component\Catalog\Model\ProductModelInterface;
+use Pim\Component\Catalog\Model\VariantAttributeSetInterface;
+use Pim\Component\Catalog\Model\VariantProductInterface;
+use Pim\Component\Catalog\Repository\LocaleRepositoryInterface;
+
+class VariantNavigationNormalizerSpec extends ObjectBehavior
+{
+    function let(
+        LocaleRepositoryInterface $localeRepository,
+        EntityWithFamilyVariantNormalizer $entityWithFamilyVariantNormalizer
+    ) {
+        $localeRepository->getActivatedLocaleCodes()->willReturn(['en_US', 'fr_FR']);
+
+        $this->beConstructedWith($localeRepository, $entityWithFamilyVariantNormalizer);
+    }
+
+    function it_normalizes_a_root_product_model(
+        $entityWithFamilyVariantNormalizer,
+        FamilyVariantInterface $familyVariant,
+        Collection $attributeSets,
+        \ArrayIterator $attributeSetsIterator,
+        Collection $axesSetsOne,
+        \ArrayIterator $axesSetsOneIterator,
+        Collection $axesSetsTwo,
+        \ArrayIterator $axesSetsTwoIterator,
+        VariantAttributeSetInterface $attributeSetOne,
+        VariantAttributeSetInterface $attributeSetTwo,
+        AttributeInterface $metricAttribute,
+        AttributeInterface $sizeAttribute,
+        ProductModelInterface $rootProductModel
+    ) {
+        // Attribute sets of the family variant
+        $attributeSets->getIterator()->willReturn($attributeSetsIterator);
+        $attributeSetsIterator->rewind()->shouldBeCalled();
+        $attributeSetsIterator->valid()->willReturn(true, true, false);
+        $attributeSetsIterator->current()->willReturn($attributeSetOne, $attributeSetTwo);
+        $attributeSetsIterator->next()->shouldBeCalled();
+
+        // First axes set, with metric as axis
+        $axesSetsOne->getIterator()->willReturn($axesSetsOneIterator);
+        $axesSetsOneIterator->rewind()->shouldBeCalled();
+        $axesSetsOneIterator->valid()->willReturn(true, true, false);
+        $axesSetsOneIterator->current()->willReturn($metricAttribute);
+        $axesSetsOneIterator->next()->shouldBeCalled();
+
+        // Second axes set, with size as axis
+        $axesSetsTwo->getIterator()->willReturn($axesSetsTwoIterator);
+        $axesSetsTwoIterator->rewind()->shouldBeCalled();
+        $axesSetsTwoIterator->valid()->willReturn(true, true, false);
+        $axesSetsTwoIterator->current()->willReturn($sizeAttribute);
+        $axesSetsTwoIterator->next()->shouldBeCalled();
+
+        $familyVariant->getVariantAttributeSets()->willReturn($attributeSets);
+
+        $attributeSetOne->getLevel()->willReturn(1);
+        $attributeSetOne->getAxes()->willReturn($axesSetsOne);
+
+        $attributeSetTwo->getLevel()->willReturn(2);
+        $attributeSetTwo->getAxes()->willReturn($axesSetsTwo);
+
+        $sizeAttribute->setLocale('en_US')->shouldBeCalled();
+        $sizeAttribute->setLocale('fr_FR')->shouldBeCalled();
+        $metricAttribute->setLocale('en_US')->shouldBeCalled();
+        $metricAttribute->setLocale('fr_FR')->shouldBeCalled();
+
+        $sizeAttribute->getLabel()->willReturn('Size', 'Taille', 'Size', 'Taille');
+        $metricAttribute->getLabel()->willReturn('Metric', 'Metrique', 'Metric', 'Metrique');
+
+        // Test start
+        $rootProductModel->getFamilyVariant()->willReturn($familyVariant);
+        $rootProductModel->getParent()->willReturn(null);
+
+        $entityWithFamilyVariantNormalizer->normalize($rootProductModel, 'internal_api', [])
+            ->willReturn(['ROOT PRODUCT MODEL NORMALIZED']);
+
+        $this->normalize($rootProductModel, 'internal_api')->shouldReturn([
+            'root'      => ['ROOT PRODUCT MODEL NORMALIZED'],
+            'level_one' => [
+                'axes'     => [
+                    'en_US' => 'Metric',
+                    'fr_FR' => 'Metrique',
+                ],
+                'selected' => null,
+            ],
+            'level_two' => [
+                'axes'     => [
+                    'en_US' => 'Size',
+                    'fr_FR' => 'Taille',
+                ],
+                'selected' => null,
+            ],
+        ]);
+    }
+
+    function it_normalizes_a_sub_product_model(
+        $entityWithFamilyVariantNormalizer,
+        FamilyVariantInterface $familyVariant,
+        Collection $attributeSets,
+        \ArrayIterator $attributeSetsIterator,
+        Collection $axesSetsOne,
+        \ArrayIterator $axesSetsOneIterator,
+        Collection $axesSetsTwo,
+        \ArrayIterator $axesSetsTwoIterator,
+        VariantAttributeSetInterface $attributeSetOne,
+        VariantAttributeSetInterface $attributeSetTwo,
+        AttributeInterface $metricAttribute,
+        AttributeInterface $sizeAttribute,
+        ProductModelInterface $rootProductModel,
+        ProductModelInterface $productModel
+    ) {
+        // Attribute sets of the family variant
+        $attributeSets->getIterator()->willReturn($attributeSetsIterator);
+        $attributeSetsIterator->rewind()->shouldBeCalled();
+        $attributeSetsIterator->valid()->willReturn(true, true, false);
+        $attributeSetsIterator->current()->willReturn($attributeSetOne, $attributeSetTwo);
+        $attributeSetsIterator->next()->shouldBeCalled();
+
+        // First axes set, with metric as axis
+        $axesSetsOne->getIterator()->willReturn($axesSetsOneIterator);
+        $axesSetsOneIterator->rewind()->shouldBeCalled();
+        $axesSetsOneIterator->valid()->willReturn(true, true, false);
+        $axesSetsOneIterator->current()->willReturn($metricAttribute);
+        $axesSetsOneIterator->next()->shouldBeCalled();
+
+        // Second axes set, with size as axis
+        $axesSetsTwo->getIterator()->willReturn($axesSetsTwoIterator);
+        $axesSetsTwoIterator->rewind()->shouldBeCalled();
+        $axesSetsTwoIterator->valid()->willReturn(true, true, false);
+        $axesSetsTwoIterator->current()->willReturn($sizeAttribute);
+        $axesSetsTwoIterator->next()->shouldBeCalled();
+
+        $familyVariant->getVariantAttributeSets()->willReturn($attributeSets);
+
+        $attributeSetOne->getLevel()->willReturn(1);
+        $attributeSetOne->getAxes()->willReturn($axesSetsOne);
+
+        $attributeSetTwo->getLevel()->willReturn(2);
+        $attributeSetTwo->getAxes()->willReturn($axesSetsTwo);
+
+        $sizeAttribute->setLocale('en_US')->shouldBeCalled();
+        $sizeAttribute->setLocale('fr_FR')->shouldBeCalled();
+        $metricAttribute->setLocale('en_US')->shouldBeCalled();
+        $metricAttribute->setLocale('fr_FR')->shouldBeCalled();
+
+        $sizeAttribute->getLabel()->willReturn('Size', 'Taille', 'Size', 'Taille');
+        $metricAttribute->getLabel()->willReturn('Metric', 'Metrique', 'Metric', 'Metrique');
+
+        // Test start
+        $productModel->getFamilyVariant()->willReturn($familyVariant);
+        $productModel->getParent()->willReturn($rootProductModel);
+
+        $entityWithFamilyVariantNormalizer->normalize($rootProductModel, 'internal_api', [])
+            ->willReturn(['ROOT PRODUCT MODEL NORMALIZED']);
+
+        $entityWithFamilyVariantNormalizer->normalize($productModel, 'internal_api', [])
+            ->willReturn(['PRODUCT MODEL NORMALIZED']);
+
+        $this->normalize($productModel, 'internal_api')->shouldReturn([
+            'root'      => ['ROOT PRODUCT MODEL NORMALIZED'],
+            'level_one' => [
+                'axes'     => [
+                    'en_US' => 'Metric',
+                    'fr_FR' => 'Metrique',
+                ],
+                'selected' => ['PRODUCT MODEL NORMALIZED'],
+            ],
+            'level_two' => [
+                'axes'     => [
+                    'en_US' => 'Size',
+                    'fr_FR' => 'Taille',
+                ],
+                'selected' => null,
+            ],
+        ]);
+    }
+
+    function it_normalizes_a_variant_product(
+        $entityWithFamilyVariantNormalizer,
+        FamilyVariantInterface $familyVariant,
+        Collection $attributeSets,
+        \ArrayIterator $attributeSetsIterator,
+        Collection $axesSetsOne,
+        \ArrayIterator $axesSetsOneIterator,
+        Collection $axesSetsTwo,
+        \ArrayIterator $axesSetsTwoIterator,
+        VariantAttributeSetInterface $attributeSetOne,
+        VariantAttributeSetInterface $attributeSetTwo,
+        AttributeInterface $metricAttribute,
+        AttributeInterface $sizeAttribute,
+        ProductModelInterface $rootProductModel,
+        ProductModelInterface $productModel,
+        VariantProductInterface $variantProduct
+    ) {
+        // Attribute sets of the family variant
+        $attributeSets->getIterator()->willReturn($attributeSetsIterator);
+        $attributeSetsIterator->rewind()->shouldBeCalled();
+        $attributeSetsIterator->valid()->willReturn(true, true, false);
+        $attributeSetsIterator->current()->willReturn($attributeSetOne, $attributeSetTwo);
+        $attributeSetsIterator->next()->shouldBeCalled();
+
+        // First axes set, with metric as axis
+        $axesSetsOne->getIterator()->willReturn($axesSetsOneIterator);
+        $axesSetsOneIterator->rewind()->shouldBeCalled();
+        $axesSetsOneIterator->valid()->willReturn(true, true, false);
+        $axesSetsOneIterator->current()->willReturn($metricAttribute);
+        $axesSetsOneIterator->next()->shouldBeCalled();
+
+        // Second axes set, with size as axis
+        $axesSetsTwo->getIterator()->willReturn($axesSetsTwoIterator);
+        $axesSetsTwoIterator->rewind()->shouldBeCalled();
+        $axesSetsTwoIterator->valid()->willReturn(true, true, false);
+        $axesSetsTwoIterator->current()->willReturn($sizeAttribute);
+        $axesSetsTwoIterator->next()->shouldBeCalled();
+
+        $familyVariant->getVariantAttributeSets()->willReturn($attributeSets);
+
+        $attributeSetOne->getLevel()->willReturn(1);
+        $attributeSetOne->getAxes()->willReturn($axesSetsOne);
+
+        $attributeSetTwo->getLevel()->willReturn(2);
+        $attributeSetTwo->getAxes()->willReturn($axesSetsTwo);
+
+        $sizeAttribute->setLocale('en_US')->shouldBeCalled();
+        $sizeAttribute->setLocale('fr_FR')->shouldBeCalled();
+        $metricAttribute->setLocale('en_US')->shouldBeCalled();
+        $metricAttribute->setLocale('fr_FR')->shouldBeCalled();
+
+        $sizeAttribute->getLabel()->willReturn('Size', 'Taille', 'Size', 'Taille');
+        $metricAttribute->getLabel()->willReturn('Metric', 'Metrique', 'Metric', 'Metrique');
+
+        // Test start
+        $variantProduct->getFamilyVariant()->willReturn($familyVariant);
+        $variantProduct->getParent()->willReturn($productModel);
+        $productModel->getParent()->willReturn($rootProductModel);
+
+        $entityWithFamilyVariantNormalizer->normalize($rootProductModel, 'internal_api', [])
+            ->willReturn(['ROOT PRODUCT MODEL NORMALIZED']);
+
+        $entityWithFamilyVariantNormalizer->normalize($productModel, 'internal_api', [])
+            ->willReturn(['PRODUCT MODEL NORMALIZED']);
+
+        $entityWithFamilyVariantNormalizer->normalize($variantProduct, 'internal_api', [])
+            ->willReturn(['VARIANT PRODUCT NORMALIZED']);
+
+        $this->normalize($variantProduct, 'internal_api')->shouldReturn([
+            'root'      => ['ROOT PRODUCT MODEL NORMALIZED'],
+            'level_one' => [
+                'axes'     => [
+                    'en_US' => 'Metric',
+                    'fr_FR' => 'Metrique',
+                ],
+                'selected' => ['PRODUCT MODEL NORMALIZED'],
+            ],
+            'level_two' => [
+                'axes'     => [
+                    'en_US' => 'Size',
+                    'fr_FR' => 'Taille',
+                ],
+                'selected' => ['VARIANT PRODUCT NORMALIZED'],
+            ],
+        ]);
+    }
+
+    function it_throws_an_exception_if_it_is_not_a_variant_product_nor_a_product_model(
+        \stdClass $entity
+    ) {
+        $this->shouldThrow(\InvalidArgumentException::class)->during(
+            'normalize', [$entity, 'internal_api']
+        );
+    }
+}

--- a/src/Pim/Bundle/UIBundle/Resources/config/assets.yml
+++ b/src/Pim/Bundle/UIBundle/Resources/config/assets.yml
@@ -64,6 +64,7 @@ css:
         - bundles/pimui/less/components/product-edit-form/TabHeader.less
         - bundles/pimui/less/components/product-edit-form/TextareaField.less
         - bundles/pimui/less/components/product-edit-form/TextField.less
+        - bundles/pimui/less/components/product-edit-form/VariantNavigation.less
         - bundles/pimui/less/components/product-edit-form/VerticalNavtab.less
 
         - bundles/pimui/less/components/Acl.less

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/product-edit-form/VariantNavigation.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/product-edit-form/VariantNavigation.less
@@ -54,13 +54,14 @@
 
   &-axisName {
     text-transform: uppercase;
+
+    &--selected:after {
+      content:":";
+    }
   }
 
   &-axisValue {
     cursor: pointer;
-  }
-
-  &-listItem {
   }
 
   &-listProductModelImage,

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/product-edit-form/VariantNavigation.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/product-edit-form/VariantNavigation.less
@@ -1,0 +1,98 @@
+@import '../../base/variables';
+
+.AknVariantNavigation {
+  border: 1px solid @AknBorderColor;
+  border-radius: 3px;
+  height: 34px;
+
+  &-item {
+    display: inline-block;
+    padding: 0 20px;
+    height: 32px;
+    line-height: 32px;
+    position: relative;
+    z-index: 5;
+
+    &:after {
+      content:"";
+      position: absolute;
+      display: block;
+      right:-13px;
+      top:4px;
+      width: 24px;
+      height: 24px;
+      background: #ffffff;
+      transform: rotate(45deg);
+      box-sizing: border-box;
+      border: 1px solid @AknBorderColor;
+      border-width: 1px 1px 0 0;
+      border-radius: 2px;
+    }
+
+    &--highlight {
+      color: @AknLightPurple;
+      background-color: @AknLightGray;
+      z-index: 4;
+
+      &:after {
+        content:"";
+        position: absolute;
+        display: block;
+        right:-13px;
+        top:4px;
+        width: 24px;
+        height: 24px;
+        background: @AknLightGray;
+        transform: rotate(45deg);
+        box-sizing: border-box;
+        border: 1px solid @AknBorderColor;
+        border-width: 1px 1px 0 0;
+        border-radius: 2px;
+      }
+    }
+  }
+
+  &-axisName {
+    text-transform: uppercase;
+  }
+
+  &-axisValue {
+    cursor: pointer;
+  }
+
+  &-listItem {
+  }
+
+  &-listProductModelImage,
+  &-listProductImage {
+    border-radius: 4px;
+    max-width: 25px;
+    max-height: 25px;
+    margin-bottom: -8px;
+  }
+
+  &-listProductModelLabel,
+  &-listProductLabel {
+    margin-left: 5px;
+  }
+
+  &-listProductModelCompleteness,
+  &-listProductCompleteness {
+    border-radius: 50px;
+    float: right;
+    padding: 0 10px;
+    margin-top: 10px;
+    height: 22px;
+    font-size: @AknFontSizeSmall;
+    line-height: 22px;
+    color: #ffffff;
+
+    &--incomplete {
+      background-color: @AknOrange;
+    }
+
+    &--complete {
+      background-color: @AknGreen;
+    }
+  }
+}

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/product-edit-form/VariantNavigation.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/product-edit-form/VariantNavigation.less
@@ -1,5 +1,13 @@
 @import '../../base/variables';
 
+.AknVariantNavigationContainer {
+  top: 194px;
+  position: sticky;
+  background-color: #ffffff;
+  z-index: 5;
+  min-height: 50px;
+}
+
 .AknVariantNavigation {
   border: 1px solid @AknBorderColor;
   border-radius: 3px;

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/product-edit-form/VariantNavigation.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/product-edit-form/VariantNavigation.less
@@ -1,26 +1,15 @@
 @import '../../base/variables';
 
-.AknVariantNavigationContainer {
-  top: 122px;
-  position: sticky;
-  z-index: 5;
-}
-
-.AknVariantNavigationBar {
-  background-color: #ffffff;
-  margin-top: -40px;
-  padding-top: 40px;
-  padding-bottom: 10px;
+.AknVariantNavigationContainer:not(:empty) {
+  order: -10;
+  width: 100%;
 }
 
 .AknVariantNavigation {
   border: 1px solid @AknBorderColor;
   border-radius: 3px;
   height: 34px;
-  background-color: #ffffff;
-  margin-top: -40px;
-  padding-top: 40px;
-  padding-bottom: 10px;
+  margin-top: 20px;
 
   &-item {
     display: inline-block;

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/product-edit-form/VariantNavigation.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/product-edit-form/VariantNavigation.less
@@ -1,17 +1,26 @@
 @import '../../base/variables';
 
 .AknVariantNavigationContainer {
-  top: 194px;
+  top: 122px;
   position: sticky;
-  background-color: #ffffff;
   z-index: 5;
-  min-height: 50px;
+}
+
+.AknVariantNavigationBar {
+  background-color: #ffffff;
+  margin-top: -40px;
+  padding-top: 40px;
+  padding-bottom: 10px;
 }
 
 .AknVariantNavigation {
   border: 1px solid @AknBorderColor;
   border-radius: 3px;
   height: 34px;
+  background-color: #ffffff;
+  margin-top: -40px;
+  padding-top: 40px;
+  padding-bottom: 10px;
 
   &-item {
     display: inline-block;

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/lib/select2.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/lib/select2.less
@@ -327,6 +327,74 @@
   }
 }
 
+/* Variant navigation selector custom */
+.variant-navigation {
+  @circleSize: 18px;
+
+  &.select2-container {
+    display: inline-block;
+    width: auto;
+    line-height: 10px;
+    margin-left: 5px;
+    margin-right: -15px;
+    z-index: 5;
+
+    .select2-choice {
+      line-height: inherit;
+      border-radius: 100px;
+      height: @circleSize;
+      width: @circleSize;
+      display: inline-block;
+      padding: 0;
+
+      & > .select2-chosen {
+        margin-right: 0;
+        height: @circleSize;
+        width: @circleSize;
+      }
+
+      .select2-arrow {
+        width: @circleSize;
+
+        b {
+          background: url("../../images/jstree/icon-down.svg") no-repeat center center;
+          background-size: 12px;
+        }
+      }
+    }
+  }
+
+  &.select2-drop {
+    box-shadow: 1px 2px 8px rgba(0,0,0,0.15);
+    margin-top: -45px;
+    margin-left: -10px;
+    min-width: 340px;
+    border-top: 1px solid @AknBorderColor;
+    border-radius: 2px;
+
+    .select2-results {
+      padding: 0;
+      margin-top: 15px;
+
+      .select2-no-results {
+        padding: 15px;
+      }
+
+      li.select2-result {
+        font-size: @AknFontSizeBig;
+
+        .select2-result-label {
+          padding: 0;
+        }
+
+        &.select2-highlighted {
+          color: @AknLightPurple;
+        }
+      }
+    }
+  }
+}
+
 .select2-drop {
   &.select2--withArrowLeft::before,
   &.select2--withArrowRight::before {
@@ -441,7 +509,7 @@
   .select2-container .select2-choice .select2-arrow b {
     background-size: 90px 48px !important
   }
-  
+
   .select2-search input {
     background: none !important;
   }

--- a/src/Pim/Component/Catalog/Repository/ProductModelRepositoryInterface.php
+++ b/src/Pim/Component/Catalog/Repository/ProductModelRepositoryInterface.php
@@ -69,4 +69,13 @@ interface ProductModelRepositoryInterface extends
      * @return ProductModelInterface[]
      */
     public function findByIdentifiers(array $codes): array;
+
+    /**
+     * Find variant products which are the direct children of the given $productModel
+     *
+     * @param ProductModelInterface $productModel
+     *
+     * @return array
+     */
+    public function findChildrenProducts(ProductModelInterface $productModel): array;
 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This PR adds the new Variant Navigation component, which allows the user to browse a Variant structure of product.

------

![screenshot-1](https://user-images.githubusercontent.com/301169/30697137-38f35612-9ede-11e7-9026-ed1ea1f90512.png)

------

![screenshot](https://user-images.githubusercontent.com/301169/30697138-38f5468e-9ede-11e7-9396-6c78c429fdec.png)


**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Y
| Added Behats                      | Y
| Added integration tests           | N
| Changelog updated                 | N
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo