### PR TITLE
Use Elasticsearch 5.6.1 with Docker Compose

### DIFF
--- a/docker-compose.yml.dist
+++ b/docker-compose.yml.dist
@@ -103,7 +103,7 @@ services:
       - behat
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:5.5.2
+    image: docker.elastic.co/elasticsearch/elasticsearch:5.6.1
     environment:
       ES_JAVA_OPTS: '-Xms512m -Xmx512m'
     ports:


### PR DESCRIPTION
## Description

Update the file `docker-compose.yml.dist` to use the latest Elasticsearch version.

Jenkinsfile cannot be updated for the moment as the current CI cannot handle the official Elasticsearch images. It still uses the Docker library image, which is deprecated and will never be updated to this version (last version available is 5.5). This problem will be solved with our next CI, which will use the official image, in version 5.6.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
