### PR TITLE
PIM-6674: Mass actions only process ProductInterface.

### DIFF
--- a/features/Context/FixturesContext.php
+++ b/features/Context/FixturesContext.php
@@ -34,6 +34,7 @@ use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\AttributeOptionInterface;
 use Pim\Component\Catalog\Model\LocaleInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
+use Pim\Component\Catalog\Model\ProductModelInterface;
 use Pim\Component\Catalog\Model\ValueInterface;
 use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
 use Pim\Component\Catalog\Repository\FamilyVariantRepositoryInterface;
@@ -1502,6 +1503,24 @@ class FixturesContext extends BaseFixturesContext
     }
 
     /**
+     * @param string $code
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @return ProductModelInterface
+     */
+    public function getProductModel($code)
+    {
+        $productModel = $this->spin(function () use ($code) {
+            return $this->getProductModelRepository()->findOneByIdentifier($code);
+        }, sprintf('Could not find a product model with code "%s"', $code));
+
+        $this->refresh($productModel);
+
+        return $productModel;
+    }
+
+    /**
      * @param string $username
      *
      * @return User
@@ -2138,6 +2157,14 @@ class FixturesContext extends BaseFixturesContext
     protected function getProductRepository()
     {
         return $this->getContainer()->get('pim_catalog.repository.product');
+    }
+
+    /**
+     * @return \Pim\Component\Catalog\Repository\ProductModelRepositoryInterface
+     */
+    protected function getProductModelRepository()
+    {
+        return $this->getContainer()->get('pim_catalog.repository.product_model');
     }
 
     /**

--- a/features/Context/WebUser.php
+++ b/features/Context/WebUser.php
@@ -1843,6 +1843,23 @@ class WebUser extends PimContext
     }
 
     /**
+     * @param string      $code
+     * @param string|null $expectedFamily
+     *
+     * @Then /^the product model "([^"]*)" should have no family$/
+     * @Then /^the family of (?:the )?product model "([^"]*)" should be "([^"]*)"$/
+     */
+    public function theFamilyOfProductModelShouldBe($code, $expectedFamily = '')
+    {
+        $this->spin(function () use ($code, $expectedFamily) {
+            $productModel = $this->getFixturesContext()->getProductModel($code);
+            $actualFamily = $productModel->getFamily() ? $productModel->getFamily()->getCode() : '';
+
+            return $expectedFamily === $actualFamily;
+        }, sprintf('Expecting the family of "%s" to be "%s".', $code, $expectedFamily));
+    }
+
+    /**
      * @param string $sku
      * @param string $categoryCode
      *
@@ -1863,6 +1880,17 @@ class WebUser extends PimContext
                 implode(', ', $categoryCodes)
             )
         );
+    }
+
+    /**
+     * @param string $sku
+     *
+     * @Then /^the product "([^"]*)" should not have any category$/
+     */
+    public function theProductShouldNotHaveAnyCategory($sku)
+    {
+        $product = $this->getFixturesContext()->getProduct($sku);
+        assertEmpty($product->getCategoryCodes());
     }
 
     /**

--- a/features/Context/catalog/catalog_modeling/groups.csv
+++ b/features/Context/catalog/catalog_modeling/groups.csv
@@ -1,0 +1,2 @@
+code;type;label-en_US;label-fr_FR;label-de_DE
+related;related;Related;Connexe;Verbunden

--- a/features/mass-action/mass_edit_products_and_product_models.feature
+++ b/features/mass-action/mass_edit_products_and_product_models.feature
@@ -1,28 +1,165 @@
+# TODO: PIM-6357 - Scenario should be removed once mass edits work for product models.
 @javascript
-Feature: Apply a mass action on products and product models
+Feature: Apply a mass action on products only (and not product models)
   In order to modify my catalog
   As a product manager
   I need to be able to select products and product models at the same time in the grid and apply mass-edit on them
 
   Background:
     Given a "catalog_modeling" catalog configuration
-    And there is no "product" in the catalog
-    And there is no "product model" in the catalog
-    And the following root product models:
-      | code                | parent | family_variant      | categories | price          | color | description-en_US-ecommerce |
-      | tshirt-unique-color |        | clothing_color_size | master_men | 10 USD, 15 EUR | blue  | A unique color t-shirt      |
-    And the following products:
-      | sku                  | family   | name-en_US           | categories | size | description-en_US-ecommerce |
-      | tshirt-kurt-cobain-s | clothing | Tshirt Kurt Cobain S | Tshirts    | S    | A Kurt Cobain t-shirt       |
     And I am logged in as "Julia"
+    And I am on the products page
 
   Scenario: Apply a mass action on products and product models
-    Given I am on the products page
-    And I select rows tshirt-unique-color and tshirt-kurt-cobain-s
+    Given I show the filter "color"
+    And I filter by "color" with operator "in list" and value "Crimson red"
+    And I select rows tshirt-unique-size-crimson-red, running-shoes-m-crimson-red and model-tshirt-divided-crimson-red
     And I press the "Bulk actions" button
     And I choose the "Edit common attributes" operation
-    And I display the Model description attribute
-    And I change the "Model description" to "a tee"
+    And I display the Composition attribute
+    And I change the "Composition" to "my composition"
     When I move to the confirm page
-    Then I should see the text "You are about to update 2 products with the following information, please confirm."
+    Then I should see the text "You are about to update 3 products with the following information, please confirm."
 
+  Scenario: Mass edits common attributes of only products within a selection of products and product models
+    Given I show the filter "color"
+    And I filter by "color" with operator "in list" and value "Crimson red"
+    Given I select rows tshirt-unique-size-crimson-red, running-shoes-m-crimson-red and model-tshirt-divided-crimson-red
+    And I press "Change product information" on the "Bulk Actions" dropdown button
+    And I choose the "Edit common attributes" operation
+    And I display the Composition attribute
+    And I change the "Composition" to "My composition"
+    When I confirm mass edit
+    And I wait for the "edit_common_attributes" job to finish
+    When I go on the last executed job resume of "edit_common_attributes"
+    Then I should see the text "COMPLETED"
+    And I should see the text "processed 2"
+    And I should see the text "skipped 1"
+    And I should see the text "Bulk actions do not support Product models entities yet."
+    And attribute composition of "tshirt-unique-size-crimson-red" should be "My composition"
+    And attribute composition of "running-shoes-m-crimson-red" should be "My composition"
+
+  Scenario: Mass edits family of only products within a selection of products and product models
+    Given I show the filter "color"
+    And I filter by "color" with operator "in list" and value "Navy blue"
+    And I select rows watch, tshirt-unique-size-navy-blue and model-tshirt-divided-navy-blue
+    And I press "Change product information" on the "Bulk Actions" dropdown button
+    And I choose the "Change family" operation
+    And I change the Family to "Shoes"
+    And I confirm mass edit
+    And I wait for the "update_product_value" job to finish
+    When I go on the last executed job resume of "update_product_value"
+    Then I should see the text "COMPLETED"
+    And I should see the text "processed 1"
+    And I should see the text "skipped 1"
+    And I should see the text "Skipped products 1"
+    And I should see the text "The variant product family must be the same than its parent: tshirt-unique-size-navy-blue"
+    And I should see the text "Bulk actions do not support Product models entities yet."
+    And the family of product "watch" should be "shoes"
+    And the family of product "tshirt-unique-size-crimson-red" should be "clothing"
+    And the family of product model "model-tshirt-divided-crimson-red" should be "clothing"
+
+  Scenario: Mass edits status of only products within a selection of products and product models
+    Given I show the filter "color"
+    And I filter by "color" with operator "in list" and value "Navy blue"
+    And I select rows watch, tshirt-unique-size-navy-blue and model-tshirt-divided-navy-blue
+    And I press "Change product information" on the "Bulk Actions" dropdown button
+    And I choose the "Change status" operation
+    And I disable the products
+    And I wait for the "update_product_value" job to finish
+    When I go on the last executed job resume of "update_product_value"
+    Then I should see the text "COMPLETED"
+    And I should see the text "processed 2"
+    And I should see the text "skipped 1"
+    And I should see the text "Bulk actions do not support Product models entities yet."
+    And product "watch" should be disabled
+    And product "tshirt-unique-size-navy-blue" should be disabled
+
+  Scenario: Mass edits groups of only products within a selection of products and product models
+    Given I show the filter "color"
+    And I filter by "color" with operator "in list" and value "Navy blue"
+    And I select rows watch, tshirt-unique-size-navy-blue and model-tshirt-divided-navy-blue
+    And I press "Change product information" on the "Bulk Actions" dropdown button
+    And I choose the "Add to groups" operation
+    And I check "Related"
+    When I confirm mass edit
+    And I wait for the "add_product_value" job to finish
+    When I go on the last executed job resume of "add_product_value"
+    Then I should see the text "COMPLETED"
+    And I should see the text "processed 2"
+    And I should see the text "skipped 1"
+    And I should see the text "Bulk actions do not support Product models entities yet."
+    Then "related" group should contain "watch, tshirt-unique-size-navy-blue"
+
+  Scenario: Mass edits add categories of only products within a selection of products and product models
+    Given I show the filter "color"
+    And I filter by "color" with operator "in list" and value "Navy blue"
+    And I select rows watch, tshirt-unique-size-navy-blue and model-tshirt-divided-navy-blue
+    And I press "Change product information" on the "Bulk Actions" dropdown button
+    And I choose the "Add to categories" operation
+    And I move on to the choose step
+    And I choose the "Add to categories" operation
+    And I select the "Master" tree
+    And I expand the "master" category
+    And I press the "Women" button
+    And I confirm mass edit
+    And I wait for the "add_product_value" job to finish
+    When I go on the last executed job resume of "add_product_value"
+    Then I should see the text "COMPLETED"
+    And I should see the text "processed 2"
+    And I should see the text "skipped 1"
+    And I should see the text "Bulk actions do not support Product models entities yet."
+    When I am on the products grid
+    And I open the category tree
+    Then I should be able to use the following filters:
+      | filter   | operator | value        | result                              |
+      | category |          | master_women | watch, tshirt-unique-size-navy-blue |
+
+  Scenario: Mass edits move categories of only products within a selection of products and product models
+    Given I show the filter "color"
+    And I filter by "color" with operator "in list" and value "Navy blue"
+    And I select rows watch, tshirt-unique-size-navy-blue and model-tshirt-divided-navy-blue
+    And I press "Change product information" on the "Bulk Actions" dropdown button
+    And I choose the "Move between categories" operation
+    And I move on to the choose step
+    And I choose the "Move between categories" operation
+    And I select the "Master" tree
+    And I expand the "master" category
+    And I press the "Women" button
+    And I confirm mass edit
+    And I wait for the "update_product_value" job to finish
+    When I go on the last executed job resume of "update_product_value"
+    Then I should see the text "COMPLETED"
+    And I should see the text "processed 2"
+    And I should see the text "skipped 1"
+    And I should see the text "Bulk actions do not support Product models entities yet."
+    When I am on the products grid
+    And I open the category tree
+    Then I should be able to use the following filters:
+      | filter   | operator | value        | result                              |
+      | category |          | master_women | watch, tshirt-unique-size-navy-blue |
+
+  Scenario: Mass edits remove categories of only products within a selection of products and product models
+    Given I show the filter "color"
+    And I filter by "color" with operator "in list" and value "Navy blue"
+    And I select rows watch, tshirt-unique-size-navy-blue and model-tshirt-divided-navy-blue
+    And I press "Change product information" on the "Bulk Actions" dropdown button
+    And I choose the "Remove from categories" operation
+    And I move on to the choose step
+    And I choose the "Remove from categories" operation
+    And I select the "Master" tree
+    And I expand the "master" category
+    And I expand the "master_men" category
+    And I press the "T-shirts" button
+    And I select the "Suppliers" tree
+    And I expand the "suppliers" category
+    And I press the "Zaro" button
+    And I confirm mass edit
+    And I wait for the "remove_product_value" job to finish
+    When I go on the last executed job resume of "remove_product_value"
+    Then I should see the text "COMPLETED"
+    And I should see the text "processed 2"
+    And I should see the text "skipped 1"
+    And I should see the text "Bulk actions do not support Product models entities yet."
+    And the product "watch" should not have any category
+    And the product "tshirt-unique-size-navy-blue" should not have any category

--- a/features/mass-action/mass_edit_products_and_product_models.feature
+++ b/features/mass-action/mass_edit_products_and_product_models.feature
@@ -13,7 +13,7 @@ Feature: Apply a mass action on products only (and not product models)
   Scenario: Apply a mass action on products and product models
     Given I show the filter "color"
     And I filter by "color" with operator "in list" and value "Crimson red"
-    And I select rows tshirt-unique-size-crimson-red, running-shoes-m-crimson-red and model-tshirt-divided-crimson-red
+    And I select rows model-tshirt-divided-crimson-red, running-shoes-m-crimson-red and tshirt-unique-size-crimson-red
     And I press the "Bulk actions" button
     And I choose the "Edit common attributes" operation
     And I display the Composition attribute
@@ -24,7 +24,7 @@ Feature: Apply a mass action on products only (and not product models)
   Scenario: Mass edits common attributes of only products within a selection of products and product models
     Given I show the filter "color"
     And I filter by "color" with operator "in list" and value "Crimson red"
-    And I select rows tshirt-unique-size-crimson-red, running-shoes-m-crimson-red and model-tshirt-divided-crimson-red
+    And I select rows model-tshirt-divided-crimson-red, running-shoes-m-crimson-red and tshirt-unique-size-crimson-red
     And I press the "Bulk actions" button
     And I choose the "Edit common attributes" operation
     And I display the Composition attribute

--- a/features/mass-action/mass_edit_products_and_product_models.feature
+++ b/features/mass-action/mass_edit_products_and_product_models.feature
@@ -24,8 +24,8 @@ Feature: Apply a mass action on products only (and not product models)
   Scenario: Mass edits common attributes of only products within a selection of products and product models
     Given I show the filter "color"
     And I filter by "color" with operator "in list" and value "Crimson red"
-    Given I select rows tshirt-unique-size-crimson-red, running-shoes-m-crimson-red and model-tshirt-divided-crimson-red
-    And I press "Change product information" on the "Bulk Actions" dropdown button
+    And I select rows tshirt-unique-size-crimson-red, running-shoes-m-crimson-red and model-tshirt-divided-crimson-red
+    And I press the "Bulk actions" button
     And I choose the "Edit common attributes" operation
     And I display the Composition attribute
     And I change the "Composition" to "My composition"
@@ -43,7 +43,7 @@ Feature: Apply a mass action on products only (and not product models)
     Given I show the filter "color"
     And I filter by "color" with operator "in list" and value "Navy blue"
     And I select rows watch, tshirt-unique-size-navy-blue and model-tshirt-divided-navy-blue
-    And I press "Change product information" on the "Bulk Actions" dropdown button
+    And I press the "Bulk actions" button
     And I choose the "Change family" operation
     And I change the Family to "Shoes"
     And I confirm mass edit
@@ -63,7 +63,7 @@ Feature: Apply a mass action on products only (and not product models)
     Given I show the filter "color"
     And I filter by "color" with operator "in list" and value "Navy blue"
     And I select rows watch, tshirt-unique-size-navy-blue and model-tshirt-divided-navy-blue
-    And I press "Change product information" on the "Bulk Actions" dropdown button
+    And I press the "Bulk actions" button
     And I choose the "Change status" operation
     And I disable the products
     And I wait for the "update_product_value" job to finish
@@ -79,7 +79,7 @@ Feature: Apply a mass action on products only (and not product models)
     Given I show the filter "color"
     And I filter by "color" with operator "in list" and value "Navy blue"
     And I select rows watch, tshirt-unique-size-navy-blue and model-tshirt-divided-navy-blue
-    And I press "Change product information" on the "Bulk Actions" dropdown button
+    And I press the "Bulk actions" button
     And I choose the "Add to groups" operation
     And I check "Related"
     When I confirm mass edit
@@ -95,7 +95,7 @@ Feature: Apply a mass action on products only (and not product models)
     Given I show the filter "color"
     And I filter by "color" with operator "in list" and value "Navy blue"
     And I select rows watch, tshirt-unique-size-navy-blue and model-tshirt-divided-navy-blue
-    And I press "Change product information" on the "Bulk Actions" dropdown button
+    And I press the "Bulk actions" button
     And I choose the "Add to categories" operation
     And I move on to the choose step
     And I choose the "Add to categories" operation
@@ -119,7 +119,7 @@ Feature: Apply a mass action on products only (and not product models)
     Given I show the filter "color"
     And I filter by "color" with operator "in list" and value "Navy blue"
     And I select rows watch, tshirt-unique-size-navy-blue and model-tshirt-divided-navy-blue
-    And I press "Change product information" on the "Bulk Actions" dropdown button
+    And I press the "Bulk actions" button
     And I choose the "Move between categories" operation
     And I move on to the choose step
     And I choose the "Move between categories" operation
@@ -143,7 +143,7 @@ Feature: Apply a mass action on products only (and not product models)
     Given I show the filter "color"
     And I filter by "color" with operator "in list" and value "Navy blue"
     And I select rows watch, tshirt-unique-size-navy-blue and model-tshirt-divided-navy-blue
-    And I press "Change product information" on the "Bulk Actions" dropdown button
+    And I press the "Bulk actions" button
     And I choose the "Remove from categories" operation
     And I move on to the choose step
     And I choose the "Remove from categories" operation

--- a/features/mass-action/quick_export_products_and_product_models.feature
+++ b/features/mass-action/quick_export_products_and_product_models.feature
@@ -12,7 +12,7 @@ Feature: Export products and product models
     And I filter by "color" with operator "in list" and value "Crimson red"
 
   Scenario: Successfully export only products to multiple channels
-    Given I select rows tshirt-unique-size-crimson-red, running-shoes-m-crimson-red and model-tshirt-divided-crimson-red
+    And I select rows model-tshirt-divided-crimson-red, running-shoes-m-crimson-red and tshirt-unique-size-crimson-red
     And I press "CSV (Grid context)" on the "Quick Export" dropdown button
     And I wait for the "csv_product_grid_context_quick_export" quick export to finish
     And I am on the dashboard page

--- a/features/mass-action/quick_export_products_and_product_models.feature
+++ b/features/mass-action/quick_export_products_and_product_models.feature
@@ -1,0 +1,28 @@
+@javascript
+Feature: Export products and product models
+  In order to use the enriched product data
+  As a product manager
+  I need to be able to export the products and product models to several channels
+
+  Background:
+    Given a "catalog_modeling" catalog configuration
+    And I am logged in as "Julia"
+    And I am on the products page
+    And I show the filter "color"
+    And I filter by "color" with operator "in list" and value "Crimson red"
+
+  Scenario: Successfully export only products to multiple channels
+    Given I select rows tshirt-unique-size-crimson-red, running-shoes-m-crimson-red and model-tshirt-divided-crimson-red
+    And I press "CSV (Grid context)" on the "Quick Export" dropdown button
+    And I wait for the "csv_product_grid_context_quick_export" quick export to finish
+    And I am on the dashboard page
+    When I go on the last executed job resume of "csv_product_grid_context_quick_export"
+    Then I should see the text "COMPLETED"
+    And I should see the text "skipped 1"
+    And the name of the exported file of "csv_product_grid_context_quick_export" should be "products_export_grid_context_en_US_ecommerce.csv"
+    And exported file of "csv_product_grid_context_quick_export" should contain:
+      """
+      sku;enabled;family;groups;image
+      tshirt-unique-size-crimson-red;1;clothing;;
+      running-shoes-m-crimson-red;1;shoes;;
+      """

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/ProductAndProductModelQueryBuilderIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/ProductAndProductModelQueryBuilderIntegration.php
@@ -2,10 +2,7 @@
 
 namespace Pim\Bundle\CatalogBundle\tests\integration\PQB;
 
-use Akeneo\Component\StorageUtils\Cursor\CursorInterface;
-use Akeneo\Test\Integration\Configuration;
-use Akeneo\Test\Integration\TestCase;
-use Pim\Component\Catalog\Model\ProductInterface;
+use Pim\Bundle\DataGridBundle\Normalizer\IdEncoder;
 use Pim\Component\Catalog\Query\Filter\Operators;
 use Pim\Component\Catalog\Query\Sorter\Directions;
 
@@ -53,6 +50,71 @@ class ProductAndProductModelQueryBuilderIntegration extends AbstractProductAndPr
                 'model-braided-hat',
                 'model-biker-jacket',
                 'moccasin',
+            ]
+        );
+    }
+
+    public function testIdentifierFilter()
+    {
+        $pqb = $this->get('pim_enrich.query.product_and_product_model_query_builder_from_size_factory')->create(
+            [
+                'limit' => 19,
+            ]
+        );
+
+        $pqb->addFilter(
+            'identifier',
+            Operators::IN_LIST,
+            ['watch', 'model-tshirt-unique-size', 'tshirt-unique-size-crimson-red']
+        );
+
+        $result = $pqb->execute();
+
+        $this->assert(
+            $result,
+            [
+                'watch',
+                'model-tshirt-unique-size',
+                'tshirt-unique-size-crimson-red',
+            ]
+        );
+    }
+
+    public function testIdFilter()
+    {
+        $productId = IdEncoder::encode(
+            IdEncoder::PRODUCT_TYPE,
+            $this->get('pim_catalog.repository.product')->findOneByIdentifier('watch')->getId()
+        );
+        $variantProductId = IdEncoder::encode(
+            IdEncoder::PRODUCT_TYPE,
+            $this->get('pim_catalog.repository.product')->findOneByIdentifier('tshirt-unique-size-crimson-red')->getId()
+        );
+        $productModelId = IdEncoder::encode(
+            IdEncoder::PRODUCT_MODEL_TYPE,
+            $this->get('pim_catalog.repository.product_model')->findOneByIdentifier('model-tshirt-unique-size')->getId()
+        );
+
+        $pqb = $this->get('pim_enrich.query.product_and_product_model_query_builder_from_size_factory')->create(
+            [
+                'limit' => 19,
+            ]
+        );
+
+        $pqb->addFilter(
+            'id',
+            Operators::IN_LIST,
+            [$productId, $variantProductId, $productModelId]
+        );
+
+        $result = $pqb->execute();
+
+        $this->assert(
+            $result,
+            [
+                'watch',
+                'model-tshirt-unique-size',
+                'tshirt-unique-size-crimson-red',
             ]
         );
     }

--- a/src/Pim/Bundle/EnrichBundle/Connector/Reader/MassEdit/FilteredProductAndProductModelReader.php
+++ b/src/Pim/Bundle/EnrichBundle/Connector/Reader/MassEdit/FilteredProductAndProductModelReader.php
@@ -78,7 +78,7 @@ class FilteredProductAndProductModelReader implements
     /**
      * {@inheritdoc}
      */
-    public function initialize() : void
+    public function initialize(): void
     {
         $channel = $this->getConfiguredChannel();
         if (null !== $channel && $this->generateCompleteness) {
@@ -92,7 +92,7 @@ class FilteredProductAndProductModelReader implements
     /**
      * {@inheritdoc}
      */
-    public function read() : ?ProductInterface
+    public function read(): ?ProductInterface
     {
         $product = null;
         $product = $this->getNextProduct();

--- a/src/Pim/Bundle/EnrichBundle/Connector/Reader/MassEdit/FilteredProductAndProductModelReader.php
+++ b/src/Pim/Bundle/EnrichBundle/Connector/Reader/MassEdit/FilteredProductAndProductModelReader.php
@@ -123,7 +123,7 @@ class FilteredProductAndProductModelReader implements
      *
      * @return ChannelInterface|null
      */
-    protected function getConfiguredChannel(): ?ChannelInterface
+    private function getConfiguredChannel(): ?ChannelInterface
     {
         $parameters = $this->stepExecution->getJobParameters();
         if (!isset($parameters->get('filters')['structure']['scope'])) {
@@ -145,7 +145,7 @@ class FilteredProductAndProductModelReader implements
      *
      * @return array
      */
-    protected function getConfiguredFilters(): array
+    private function getConfiguredFilters(): array
     {
         $filters = $this->stepExecution->getJobParameters()->get('filters');
 
@@ -164,7 +164,7 @@ class FilteredProductAndProductModelReader implements
      *
      * @return CursorInterface
      */
-    protected function getProductsCursor(array $filters, ChannelInterface $channel = null): CursorInterface
+    private function getProductsCursor(array $filters, ChannelInterface $channel = null): CursorInterface
     {
         $options = ['filters' => $filters];
 

--- a/src/Pim/Bundle/EnrichBundle/Connector/Reader/MassEdit/FilteredProductAndProductModelReader.php
+++ b/src/Pim/Bundle/EnrichBundle/Connector/Reader/MassEdit/FilteredProductAndProductModelReader.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\EnrichBundle\Connector\Reader\MassEdit;
+
+use Akeneo\Component\Batch\Item\DataInvalidItem;
+use Akeneo\Component\Batch\Item\InitializableInterface;
+use Akeneo\Component\Batch\Item\ItemReaderInterface;
+use Akeneo\Component\Batch\Model\StepExecution;
+use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
+use Akeneo\Component\StorageUtils\Cursor\CursorInterface;
+use Pim\Component\Catalog\Converter\MetricConverter;
+use Pim\Component\Catalog\Exception\ObjectNotFoundException;
+use Pim\Component\Catalog\Manager\CompletenessManager;
+use Pim\Component\Catalog\Model\ChannelInterface;
+use Pim\Component\Catalog\Model\ProductInterface;
+use Pim\Component\Catalog\Model\ProductModelInterface;
+use Pim\Component\Catalog\Query\ProductQueryBuilderFactoryInterface;
+use Pim\Component\Catalog\Repository\ChannelRepositoryInterface;
+
+/**
+ * Product reader that only returns product entities and skips product models.
+ *
+ * TODO: To remove with PIM-6357 (mass actions on product models)
+ *
+ * @author Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class FilteredProductAndProductModelReader implements
+    ItemReaderInterface,
+    InitializableInterface,
+    StepExecutionAwareInterface
+{
+    /** @var ProductQueryBuilderFactoryInterface */
+    private $pqbFactory;
+
+    /** @var ChannelRepositoryInterface */
+    private $channelRepository;
+
+    /** @var CompletenessManager */
+    private $completenessManager;
+
+    /** @var MetricConverter */
+    private $metricConverter;
+
+    /** @var bool */
+    private $generateCompleteness;
+
+    /** @var StepExecution */
+    private $stepExecution;
+
+    /** @var CursorInterface */
+    private $productsAndProductModels;
+
+    /**
+     * @param ProductQueryBuilderFactoryInterface $pqbFactory
+     * @param ChannelRepositoryInterface          $channelRepository
+     * @param CompletenessManager                 $completenessManager
+     * @param MetricConverter                     $metricConverter
+     * @param bool                                $generateCompleteness
+     */
+    public function __construct(
+        ProductQueryBuilderFactoryInterface $pqbFactory,
+        ChannelRepositoryInterface $channelRepository,
+        CompletenessManager $completenessManager,
+        MetricConverter $metricConverter,
+        $generateCompleteness
+    ) {
+        $this->pqbFactory = $pqbFactory;
+        $this->channelRepository = $channelRepository;
+        $this->completenessManager = $completenessManager;
+        $this->metricConverter = $metricConverter;
+        $this->generateCompleteness = (bool) $generateCompleteness;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function initialize() : void
+    {
+        $channel = $this->getConfiguredChannel();
+        if (null !== $channel && $this->generateCompleteness) {
+            $this->completenessManager->generateMissingForChannel($channel);
+        }
+
+        $filters = $this->getConfiguredFilters();
+        $this->productsAndProductModels = $this->getProductsCursor($filters, $channel);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function read() : ?ProductInterface
+    {
+        $product = null;
+        $product = $this->getNextProduct();
+
+        if (null !== $product) {
+            $channel = $this->getConfiguredChannel();
+            if (null !== $channel) {
+                $this->metricConverter->convert($product, $channel);
+            }
+        }
+
+        return $product;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setStepExecution(StepExecution $stepExecution): void
+    {
+        $this->stepExecution = $stepExecution;
+    }
+
+    /**
+     * Returns the configured channel from the parameters.
+     * If no channel is specified, returns null.
+     *
+     * @throws ObjectNotFoundException
+     *
+     * @return ChannelInterface|null
+     */
+    protected function getConfiguredChannel(): ?ChannelInterface
+    {
+        $parameters = $this->stepExecution->getJobParameters();
+        if (!isset($parameters->get('filters')['structure']['scope'])) {
+            return null;
+        }
+
+        $channelCode = $parameters->get('filters')['structure']['scope'];
+        $channel = $this->channelRepository->findOneByIdentifier($channelCode);
+        if (null === $channel) {
+            throw new ObjectNotFoundException(sprintf('Channel with "%s" code does not exist', $channelCode));
+        }
+
+        return $channel;
+    }
+
+    /**
+     * Returns the filters from the configuration.
+     * The parameters can be in the 'filters' root node, or in filters data node (e.g. for export).
+     *
+     * @return array
+     */
+    protected function getConfiguredFilters(): array
+    {
+        $filters = $this->stepExecution->getJobParameters()->get('filters');
+
+        if (array_key_exists('data', $filters)) {
+            $filters = $filters['data'];
+        }
+
+        return array_filter($filters, function ($filter) {
+            return count($filter) > 0;
+        });
+    }
+
+    /**
+     * @param array            $filters
+     * @param ChannelInterface $channel
+     *
+     * @return CursorInterface
+     */
+    protected function getProductsCursor(array $filters, ChannelInterface $channel = null): CursorInterface
+    {
+        $options = ['filters' => $filters];
+
+        if (null !== $channel) {
+            $options['default_scope'] = $channel->getCode();
+        }
+
+        $productQueryBuilder = $this->pqbFactory->create($options);
+
+        return $productQueryBuilder->execute();
+    }
+
+    /**
+     * This reader makes sure we return only product entities.
+     *
+     * @return null|ProductInterface
+     */
+    private function getNextProduct(): ?ProductInterface
+    {
+        $entity = null;
+
+        while ($this->productsAndProductModels->valid()) {
+            $entity = $this->productsAndProductModels->current();
+
+            $this->productsAndProductModels->next();
+
+            if ($entity instanceof ProductModelInterface) {
+                if ($this->stepExecution) {
+                    $this->stepExecution->incrementSummaryInfo('skip');
+                    $warning = 'Bulk actions do not support Product models entities yet.';
+                    $this->stepExecution->addWarning(
+                        $warning,
+                        [],
+                        new DataInvalidItem(['code' => $entity->getCode()])
+                    );
+                }
+
+                $entity = null;
+                continue;
+            }
+
+            $this->stepExecution->incrementSummaryInfo('read');
+
+            break;
+        }
+
+        return $entity;
+    }
+}

--- a/src/Pim/Bundle/EnrichBundle/ProductQueryBuilder/ProductAndProductModelQueryBuilder.php
+++ b/src/Pim/Bundle/EnrichBundle/ProductQueryBuilder/ProductAndProductModelQueryBuilder.php
@@ -84,7 +84,14 @@ class ProductAndProductModelQueryBuilder implements ProductQueryBuilderInterface
             }
         );
 
-        if (empty($attributeFilters) && empty($parentFilter)) {
+        $idFilter = array_filter(
+            $this->getRawFilters(),
+            function ($filter) {
+                return 'id' === $filter['field'];
+            }
+        );
+
+        if (empty($attributeFilters) && empty($parentFilter) && empty($idFilter)) {
             $this->addFilter('parent', Operators::IS_EMPTY, null);
         }
 

--- a/src/Pim/Bundle/EnrichBundle/ProductQueryBuilder/ProductAndProductModelQueryBuilder.php
+++ b/src/Pim/Bundle/EnrichBundle/ProductQueryBuilder/ProductAndProductModelQueryBuilder.php
@@ -70,12 +70,30 @@ class ProductAndProductModelQueryBuilder implements ProductQueryBuilderInterface
      */
     public function execute()
     {
-        $attributeFilters = array_filter(
-            $this->getRawFilters(),
-            function ($filter) {
-                return 'attribute' === $filter['type'];
-            }
-        );
+        if ($this->isSearchGroupedByProductModels()) {
+            $this->addFilter('parent', Operators::IS_EMPTY, null);
+        }
+
+        $attributeFilters = $this->getAttributeFilters();
+        if (!empty($attributeFilters)) {
+            $attributeFilterKeys = array_column($attributeFilters, 'field');
+            $this->addFilter('attributes_for_this_level', Operators::IN_LIST, $attributeFilterKeys);
+        }
+
+        return $this->pqb->execute();
+    }
+
+    /**
+     * If there are no filter on the following fields, the request should not try to group the result by product models.
+     * - field Id or identifier
+     * - on any attributes
+     * - on the parent field
+     *
+     * @return bool
+     */
+    private function isSearchGroupedByProductModels(): bool
+    {
+        $attributeFilters = $this->getAttributeFilters();
 
         $parentFilter = array_filter(
             $this->getRawFilters(),
@@ -91,15 +109,30 @@ class ProductAndProductModelQueryBuilder implements ProductQueryBuilderInterface
             }
         );
 
-        if (empty($attributeFilters) && empty($parentFilter) && empty($idFilter)) {
-            $this->addFilter('parent', Operators::IS_EMPTY, null);
-        }
+        $identifierFilter = array_filter(
+            $this->getRawFilters(),
+            function ($filter) {
+                return 'identifier' === $filter['field'];
+            }
+        );
 
-        if (!empty($attributeFilters)) {
-            $attributeFilterKeys = array_column($attributeFilters, 'field');
-            $this->addFilter('attributes_for_this_level', Operators::IN_LIST, $attributeFilterKeys);
-        }
+        return empty($attributeFilters) && empty($parentFilter) && empty($idFilter) && empty($identifierFilter);
+    }
 
-        return $this->pqb->execute();
+    /**
+     * Returns the filters on the attributes
+     *
+     * @return array
+     */
+    private function getAttributeFilters(): array
+    {
+        $attributeFilters = array_filter(
+            $this->getRawFilters(),
+            function ($filter) {
+                return 'attribute' === $filter['type'];
+            }
+        );
+
+        return $attributeFilters;
     }
 }

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/readers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/readers.yml
@@ -1,6 +1,9 @@
+parameters:
+    pim_enrich.reader.database.filtered_product_and_product_model_reader.class: Pim\Bundle\EnrichBundle\Connector\Reader\MassEdit\FilteredProductAndProductModelReader
+
 services:
     pim_enrich.reader.database.product_and_product_model:
-        class: '%pim_connector.reader.database.product.class%'
+        class: '%pim_enrich.reader.database.filtered_product_and_product_model_reader.class%'
         arguments:
             - '@pim_enrich.query.product_and_product_model_query_builder_factory'
             - '@pim_catalog.repository.channel'

--- a/src/Pim/Bundle/EnrichBundle/spec/Connector/Reader/MassEdit/FilteredProductAndProductModelReaderSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Connector/Reader/MassEdit/FilteredProductAndProductModelReaderSpec.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace spec\Pim\Bundle\EnrichBundle\Connector\Reader\MassEdit;
+
+use Akeneo\Component\Batch\Job\JobParameters;
+use Akeneo\Component\Batch\Model\StepExecution;
+use Akeneo\Component\StorageUtils\Cursor\CursorInterface;
+use Akeneo\Component\StorageUtils\Detacher\ObjectDetacherInterface;
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\EnrichBundle\Connector\Reader\MassEdit\FilteredProductAndProductModelReader;
+use Pim\Component\Catalog\Manager\CompletenessManager;
+use Pim\Component\Catalog\Model\ChannelInterface;
+use Pim\Component\Catalog\Model\ProductInterface;
+use Pim\Component\Catalog\Model\ProductModelInterface;
+use Pim\Component\Catalog\Query\ProductQueryBuilderFactoryInterface;
+use Pim\Component\Catalog\Query\ProductQueryBuilderInterface;
+use Pim\Component\Catalog\Repository\ChannelRepositoryInterface;
+use Pim\Component\Catalog\Converter\MetricConverter;
+use Prophecy\Argument;
+use Prophecy\Promise\ReturnPromise;
+
+class FilteredProductAndProductModelReaderSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(FilteredProductAndProductModelReader::class);
+    }
+
+    function let(
+        ProductQueryBuilderFactoryInterface $pqbFactory,
+        ChannelRepositoryInterface $channelRepository,
+        CompletenessManager $completenessManager,
+        MetricConverter $metricConverter,
+        ObjectDetacherInterface $objectDetacher,
+        StepExecution $stepExecution
+    ) {
+        $this->beConstructedWith(
+            $pqbFactory,
+            $channelRepository,
+            $completenessManager,
+            $metricConverter,
+            $objectDetacher,
+            true
+        );
+
+        $this->setStepExecution($stepExecution);
+    }
+
+    function it_reads_products_only_and_not_product_models(
+        $pqbFactory,
+        $channelRepository,
+        $metricConverter,
+        $stepExecution,
+        $completenessManager,
+        ChannelInterface $channel,
+        ProductQueryBuilderInterface $pqb,
+        CursorInterface $cursor,
+        ProductModelInterface $productModel1,
+        ProductModelInterface $productModel2,
+        ProductModelInterface $productModel3,
+        ProductInterface $product1,
+        ProductInterface $product2,
+        ProductInterface $product3,
+        JobParameters $jobParameters
+    ) {
+        $filters = [
+            'data'      => [
+                [
+                    'field'    => 'enabled',
+                    'operator' => '=',
+                    'value'    => true,
+                ],
+                [
+                    'field'    => 'family',
+                    'operator' => 'IN',
+                    'value'    => [
+                        'camcorder',
+                    ],
+                ],
+            ],
+            'structure' => [
+                'scope'   => 'mobile',
+                'locales' => ['fr_FR', 'en_US'],
+            ],
+        ];
+        $stepExecution->getJobParameters()->willReturn($jobParameters);
+        $jobParameters->get('filters')->willReturn($filters);
+
+        $channelRepository->findOneByIdentifier('mobile')->willReturn($channel);
+        $channel->getCode()->willReturn('mobile');
+
+        $pqbFactory->create(['filters' => $filters['data'], 'default_scope' => 'mobile'])
+            ->shouldBeCalled()
+            ->willReturn($pqb);
+        $pqb->execute()
+            ->shouldBeCalled()
+            ->willReturn($cursor);
+
+        $completenessManager->generateMissingForChannel($channel)->shouldBeCalled();
+        $products = [$productModel1, $product1, $productModel2, $product2, $product3, $productModel3];
+        $productsCount = count($products);
+        $cursor->valid()->will(
+            function () use (&$productsCount) {
+                return $productsCount-- > 0;
+            }
+        );
+        $cursor->current()->will(new ReturnPromise($products));
+        $cursor->next()->shouldBeCalled();
+
+        $stepExecution->incrementSummaryInfo('read')->shouldBeCalledTimes(3);
+        $metricConverter->convert(Argument::any(), $channel)->shouldBeCalledTimes(3);
+
+        $productModel1->getCode()->willReturn('product_model_1');
+        $productModel2->getCode()->willReturn('product_model_2');
+        $productModel3->getCode()->willReturn('product_model_3');
+        $stepExecution->incrementSummaryInfo('skip')->shouldBeCalledTimes(3);
+        $stepExecution->addWarning('Bulk actions do not support Product models entities yet.', Argument::cetera())
+            ->shouldBeCalledTimes(3);
+
+        $this->initialize();
+        $this->read()->shouldReturn($product1);
+        $this->read()->shouldReturn($product2);
+        $this->read()->shouldReturn($product3);
+        $this->read()->shouldReturn(null);
+    }
+}

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/pages/Default.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/pages/Default.less
@@ -43,7 +43,7 @@
   }
 
   &-mainContent {
-    padding: @mainContentPadding;
+    padding: @mainContentPadding @mainContentPadding 100px @mainContentPadding;
     overflow-x: auto;
     flex-grow: 1;
     height: 100%;


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Modifying the current `pim_enrich.reader.database.product_and_product_model ` reader service to use a dedicated class `\Pim\Bundle\EnrichBundle\Connector\Reader\MassEdit\FilteredProductAndProductModelReader`
Which is only used for now in order to make the existing mass_edits/quick exports actions pass to only process ProductInterface entities.

Todo:
- [X] Quick export
- [X] Mass action change common attribute
- [x] Mass action change family
- [x] Change status
- [x] Add to group
- [x] Add categories + move + remove

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Ok
| Added Behats                      | Ok
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
