### PR TITLE
PIM-6798: Fix select attribute copiers

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -3,10 +3,8 @@
 ## Bug Fixes
 
 - PIM-6804: Fix the positioning (z-index) of the datafilter widgets
-
-## Bug Fixes
-
 - PIM-6491: Fix file extension validation on import job upload
+- PIM-6798: Fix the simple-select and multi-select copiers
 
 # 1.7.8 (2017-08-22)
 

--- a/features/update/copy_multiselect.feature
+++ b/features/update/copy_multiselect.feature
@@ -10,6 +10,7 @@ Feature: Update multi select fields
       | body_color    | pim_catalog_multiselect | other |
       | sleeves_color | pim_catalog_multiselect | other |
     And the following "body_color" attribute options: Red, Yellow, Black and White
+    And the following "sleeves_color" attribute options: Red, Yellow, Black and White
     And the following products:
       | sku             | body_color   |
       | STRIPED_T_SHIRT | Black, White |

--- a/features/update/copy_simpleselect.feature
+++ b/features/update/copy_simpleselect.feature
@@ -10,6 +10,7 @@ Feature: Update simple select fields
       | front_color | pim_catalog_simpleselect | other |
       | back_color  | pim_catalog_simpleselect | other |
     And the following "front_color" attribute options: Red and Yellow
+    And the following "back_color" attribute options: Red and Yellow
     And the following products:
       | sku                 | front_color |
       | MONOCHROMATIC_PAPER | Red         |

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/updaters.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/updaters.yml
@@ -45,7 +45,7 @@ parameters:
     pim_catalog.updater.copier.image_value.class:             Pim\Component\Catalog\Updater\Copier\MediaAttributeCopier
     pim_catalog.updater.copier.file_value.class:              Pim\Component\Catalog\Updater\Copier\MediaAttributeCopier
     pim_catalog.updater.copier.metric_value.class:            Pim\Component\Catalog\Updater\Copier\MetricAttributeCopier
-    pim_catalog.updater.copier.simpleselect_value.class:      Pim\Component\Catalog\Updater\Copier\BaseAttributeCopier
+    pim_catalog.updater.copier.simpleselect_value.class:      Pim\Component\Catalog\Updater\Copier\SimpleSelectAttributeCopier
     pim_catalog.updater.copier.multiselect_value.class:       Pim\Component\Catalog\Updater\Copier\MultiSelectAttributeCopier
     pim_catalog.updater.copier.price_collection_value.class:  Pim\Component\Catalog\Updater\Copier\PriceCollectionAttributeCopier
 
@@ -422,6 +422,7 @@ services:
         arguments:
             - ['pim_catalog_simpleselect']
             - ['pim_catalog_simpleselect']
+            - '@pim_catalog.repository.attribute_option'
         tags:
             - { name: 'pim_catalog.updater.copier' }
 
@@ -431,6 +432,7 @@ services:
         arguments:
             - ['pim_catalog_multiselect']
             - ['pim_catalog_multiselect']
+            - '@pim_catalog.repository.attribute_option'
         tags:
             - { name: 'pim_catalog.updater.copier' }
 

--- a/src/Pim/Component/Catalog/Updater/Copier/AbstractAttributeCopier.php
+++ b/src/Pim/Component/Catalog/Updater/Copier/AbstractAttributeCopier.php
@@ -33,7 +33,7 @@ abstract class AbstractAttributeCopier implements AttributeCopierInterface
     protected $resolver;
 
     /**
-     * @param \Pim\Component\Catalog\Builder\ProductBuilderInterface  $productBuilder
+     * @param ProductBuilderInterface  $productBuilder
      * @param AttributeValidatorHelper $attrValidatorHelper
      */
     public function __construct(

--- a/src/Pim/Component/Catalog/Updater/Copier/MultiSelectAttributeCopier.php
+++ b/src/Pim/Component/Catalog/Updater/Copier/MultiSelectAttributeCopier.php
@@ -4,8 +4,10 @@ namespace Pim\Component\Catalog\Updater\Copier;
 
 use Pim\Component\Catalog\Builder\ProductBuilderInterface;
 use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\AttributeOptionInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Model\ProductValueInterface;
+use Pim\Component\Catalog\Repository\AttributeOptionRepositoryInterface;
 use Pim\Component\Catalog\Validator\AttributeValidatorHelper;
 
 /**
@@ -17,19 +19,26 @@ use Pim\Component\Catalog\Validator\AttributeValidatorHelper;
  */
 class MultiSelectAttributeCopier extends AbstractAttributeCopier
 {
+    /** @var AttributeOptionRepositoryInterface */
+    protected $attributeOptionRepository;
+
     /**
-     * @param \Pim\Component\Catalog\Builder\ProductBuilderInterface  $productBuilder
-     * @param AttributeValidatorHelper $attrValidatorHelper
-     * @param array                    $supportedFromTypes
-     * @param array                    $supportedToTypes
+     * @param ProductBuilderInterface                 $productBuilder
+     * @param AttributeValidatorHelper                $attrValidatorHelper
+     * @param array                                   $supportedFromTypes
+     * @param array                                   $supportedToTypes
+     * @param AttributeOptionRepositoryInterface|null $attributeOptionRepository
      */
     public function __construct(
         ProductBuilderInterface $productBuilder,
         AttributeValidatorHelper $attrValidatorHelper,
         array $supportedFromTypes,
-        array $supportedToTypes
+        array $supportedToTypes,
+        AttributeOptionRepositoryInterface $attributeOptionRepository = null
     ) {
         parent::__construct($productBuilder, $attrValidatorHelper);
+
+        $this->attributeOptionRepository = $attributeOptionRepository;
         $this->supportedFromTypes = $supportedFromTypes;
         $this->supportedToTypes = $supportedToTypes;
     }
@@ -91,11 +100,16 @@ class MultiSelectAttributeCopier extends AbstractAttributeCopier
         if (null !== $fromValue) {
             $toValue = $toProduct->getValue($toAttribute->getCode(), $toLocale, $toScope);
             if (null === $toValue) {
-                $toValue = $this->productBuilder->addOrReplaceProductValue($toProduct, $toAttribute, $toLocale, $toScope);
+                $toValue = $this->productBuilder->addOrReplaceProductValue(
+                    $toProduct,
+                    $toAttribute,
+                    $toLocale,
+                    $toScope
+                );
             }
 
             $this->removeOptions($toValue);
-            $this->copyOptions($fromValue, $toValue);
+            $this->copyOptions($fromValue, $toValue, $toAttribute);
         }
     }
 
@@ -116,11 +130,57 @@ class MultiSelectAttributeCopier extends AbstractAttributeCopier
      *
      * @param ProductValueInterface $fromValue
      * @param ProductValueInterface $toValue
+     * @param AttributeInterface    $toAttribute
      */
-    protected function copyOptions(ProductValueInterface $fromValue, ProductValueInterface $toValue)
-    {
-        foreach ($fromValue->getOptions() as $attributeOption) {
-            $toValue->addOption($attributeOption);
+    protected function copyOptions(
+        ProductValueInterface $fromValue,
+        ProductValueInterface $toValue,
+        AttributeInterface $toAttribute
+    ) {
+        foreach ($fromValue->getOptions() as $fromAttributeOption) {
+            $toValue->addOption($this->getMatchingOptionForAttribute($fromAttributeOption, $toAttribute));
         }
+    }
+
+    /**
+     * Returns the option of the destination attribute corresponding to the one
+     * of the original value.
+     *
+     * @param AttributeOptionInterface $fromAttributeOption ,
+     * @param AttributeInterface       $toAttribute
+     *
+     * @throws \InvalidArgumentException
+     * @return AttributeOptionInterface
+     */
+    protected function getMatchingOptionForAttribute(
+        AttributeOptionInterface $fromAttributeOption,
+        AttributeInterface $toAttribute
+    ) {
+        // TODO: This is the previous, buggy behavior. To remove on master, along with the "= null" of the constructor.
+        if (null === $this->attributeOptionRepository) {
+            return $fromAttributeOption;
+        }
+
+        $optionCode = $fromAttributeOption->getCode();
+        $toAttributeCode = $toAttribute->getCode();
+        $toOption = $this->attributeOptionRepository->findOneByIdentifier(
+            sprintf(
+                '%s.%s',
+                $toAttributeCode,
+                $optionCode
+            )
+        );
+
+        if (null === $toOption) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'There is no valid option "%s" for attribute "%s".',
+                    $optionCode,
+                    $toAttributeCode
+                )
+            );
+        }
+
+        return $toOption;
     }
 }

--- a/src/Pim/Component/Catalog/tests/integration/Updater/Copier/AbstractCopierTestCase.php
+++ b/src/Pim/Component/Catalog/tests/integration/Updater/Copier/AbstractCopierTestCase.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Pim\Component\Catalog\tests\integration\Updater\Copier;
+
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Pim\Component\Catalog\Model\ProductInterface;
+use Symfony\Component\Validator\ConstraintViolationList;
+
+/**
+ * @author    Damien Carcel (damien.carcel@akeneo.com)
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class AbstractCopierTestCase extends TestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+    }
+
+    /**
+     * Creates a product.
+     *
+     * @param string $sku
+     * @param array  $data
+     *
+     * @throws \Exception
+     *
+     * @return ProductInterface
+     */
+    protected function createProduct($sku, array $data)
+    {
+        $productUpdater = $this->get('pim_catalog.updater.product');
+
+        $product = $this->get('pim_catalog.builder.product')->createProduct($sku);
+        $productUpdater->update($product, $data);
+
+        $errors = $this->get('pim_catalog.validator.product')->validate($product);
+        if (0 !== $errors->count()) {
+            throw new \Exception(sprintf(
+                'Impossible to setup test in %s: %s',
+                static::class,
+                $errors->get(0)->getMessage()
+            ));
+        }
+
+        $this->get('pim_catalog.saver.product')->save($product);
+        $this->get('pim_catalog.validator.unique_value_set')->reset();
+
+        return $product;
+    }
+}

--- a/src/Pim/Component/Catalog/tests/integration/Updater/Copier/MediaAttributeCopierIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Updater/Copier/MediaAttributeCopierIntegration.php
@@ -1,10 +1,8 @@
 <?php
 
-namespace tests\integration\Pim\Component\Catalog\Updater\Copier;
+namespace Pim\Component\Catalog\tests\integration\Updater\Copier;
 
-use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\MediaSanitizer;
-use Akeneo\Test\Integration\TestCase;
 use Pim\Component\Catalog\Model\ProductInterface;
 
 /**
@@ -12,16 +10,8 @@ use Pim\Component\Catalog\Model\ProductInterface;
  * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class MediaAttributeCopierIntegration extends TestCase
+class MediaAttributeCopierIntegration extends AbstractCopierTestCase
 {
-    /**
-     * {@inheritdoc}
-     */
-    protected function getConfiguration()
-    {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
-    }
-
     public function testCopyToMediaWithLocale()
     {
         $sku = 'test_localizable_media';
@@ -180,25 +170,6 @@ class MediaAttributeCopierIntegration extends TestCase
         $standardValues = $this->sanitizeMediaAttributeData($standardProduct['values'][$fields['to']]);
 
         $this->assertEquals($result, $standardValues);
-    }
-
-    /**
-     * Create a product.
-     *
-     * @param $sku
-     * @param $parameters
-     * @return ProductInterface
-     */
-    protected function createProduct($sku, $parameters)
-    {
-        $productUpdater = $this->get('pim_catalog.updater.product');
-
-        $product = $this->get('pim_catalog.builder.product')->createProduct($sku);
-        $productUpdater->update($product, $parameters);
-
-        $this->get('pim_catalog.saver.product')->save($product);
-
-        return $product;
     }
 
     /**

--- a/src/Pim/Component/Catalog/tests/integration/Updater/Copier/MultiSelectAttributeCopierIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Updater/Copier/MultiSelectAttributeCopierIntegration.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Pim\Component\Catalog\tests\integration\Updater\Copier;
+
+use Pim\Component\Catalog\AttributeTypes;
+
+/**
+ * @author    Damien Carcel (damien.carcel@akeneo.com)
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class MultiSelectAttributeCopierIntegration extends AbstractCopierTestCase
+{
+    public function testCopyMultiSelectAttributeValue()
+    {
+        $product = $this->createProduct('test-copy-multi-select', [
+            'values' => [
+                'a_multi_select' => [
+                    [
+                        'data' => ['optionA', 'optionB'],
+                        'locale' => null,
+                        'scope' => null,
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->get('pim_catalog.updater.product_property_copier')->copyData(
+            $product,
+            $product,
+            'a_multi_select',
+            'another_multi_select'
+        );
+
+        $errors = $this->get('pim_catalog.validator.product')->validate($product);
+        $this->assertEquals(0, $errors->count());
+
+        $newValue = $product->getValue('another_multi_select');
+
+        $this->assertSame(
+            'another_multi_select',
+            $newValue->getAttribute()->getCode()
+        );
+        $this->assertSame(
+            '[optionA], [optionB]',
+            (string)$newValue
+        );
+
+        foreach ($newValue->getData() as $actualOption) {
+            $expectedOption = $this
+                ->get('pim_catalog.repository.attribute_option')
+                ->findOneByIdentifier(sprintf('another_multi_select.%s', $actualOption->getCode()));
+
+            $this->assertSame($expectedOption, $actualOption);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $optionA = $this->get('pim_catalog.factory.attribute_option')->create();
+        $optionA->setCode('optionA');
+
+        $optionB = $this->get('pim_catalog.factory.attribute_option')->create();
+        $optionB->setCode('optionB');
+
+        $simpleSelectAttribute = $this->get('pim_catalog.factory.attribute')->createAttribute(
+            AttributeTypes::OPTION_MULTI_SELECT
+        );
+        $simpleSelectAttribute->setCode('another_multi_select');
+        $simpleSelectAttribute->addOption($optionA);
+        $simpleSelectAttribute->addOption($optionB);
+
+        $this->get('pim_catalog.saver.attribute')->save($simpleSelectAttribute);
+    }
+}

--- a/src/Pim/Component/Catalog/tests/integration/Updater/Copier/SimpleSelectAttributeCopierIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Updater/Copier/SimpleSelectAttributeCopierIntegration.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Pim\Component\Catalog\tests\integration\Updater\Copier;
+
+use Pim\Component\Catalog\AttributeTypes;
+
+/**
+ * @author    Damien Carcel (damien.carcel@akeneo.com)
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class SimpleSelectAttributeCopierIntegration extends AbstractCopierTestCase
+{
+    public function testCopySimpleSelectAttributeValue()
+    {
+        $product = $this->createProduct('test-copy-simple-select', [
+            'values' => [
+                'a_simple_select' => [
+                    [
+                        'data' => 'optionA',
+                        'locale' => null,
+                        'scope' => null,
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->get('pim_catalog.updater.product_property_copier')->copyData(
+            $product,
+            $product,
+            'a_simple_select',
+            'another_simple_select'
+        );
+
+        $errors = $this->get('pim_catalog.validator.product')->validate($product);
+        $this->assertEquals(0, $errors->count());
+
+        $newValue = $product->getValue('another_simple_select');
+
+        $this->assertSame(
+            'another_simple_select',
+            $newValue->getAttribute()->getCode()
+        );
+        $this->assertSame(
+            '[optionA]',
+            (string)$newValue
+        );
+        $this->assertSame(
+            $this->get('pim_catalog.repository.attribute_option')->findOneByIdentifier('another_simple_select.optionA'),
+            $newValue->getData()
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $optionA = $this->get('pim_catalog.factory.attribute_option')->create();
+        $optionA->setCode('optionA');
+
+        $simpleSelectAttribute = $this->get('pim_catalog.factory.attribute')->createAttribute(
+            AttributeTypes::OPTION_SIMPLE_SELECT
+        );
+        $simpleSelectAttribute->setCode('another_simple_select');
+        $simpleSelectAttribute->addOption($optionA);
+
+        $this->get('pim_catalog.saver.attribute')->save($simpleSelectAttribute);
+    }
+}

--- a/src/Pim/Component/Catalog/tests/integration/Updater/Setter/MediaAttributeSetterIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Updater/Setter/MediaAttributeSetterIntegration.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace tests\integration\Pim\Component\Catalog\Updater\Setter;
+namespace Pim\Component\Catalog\tests\integration\Updater\Setter;
 
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\MediaSanitizer;


### PR DESCRIPTION
## Description

There is a bug into the simple and multi select attribute copiers. We were directly copying the options from the source value into the destination value.

Problem is, when we copy, inside one product, the value from an attribute to the one of another attribute (where option codes are identical between the two attributes, of course), we end up with the destination attribute containing an option (the relation on the ID in database) from the source attribute, which should never happen!

This PR fixes this behavior by ensuring the copy is made through the option code, not the entire object, validating in the process that this option really exists for the destination attribute.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added Behats                      | -
| Added integration tests           | OK
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
