### PR TITLE
PIM-6818: SKIP mass delete for product models

### DIFF
--- a/features/mass-action/mass_delete_products_and_product_models.feature
+++ b/features/mass-action/mass_delete_products_and_product_models.feature
@@ -1,0 +1,21 @@
+@javascript
+Feature: Delete many products but not the product models
+  In order to secure integrity of the products catalog
+  As a user
+  I need to be able to mass delete only products within a selection of products and product models
+
+  Background:
+    Given the "catalog_modeling" catalog configuration
+    And I am logged in as "Mary"
+    And I am on the products grid
+
+  Scenario: Successfully mass delete a selection of only products within a selection of products and product models.
+    Given I show the filter "color"
+    And I filter by "color" with operator "in list" and value "Crimson red"
+    And I select rows model-tshirt-divided-crimson-red, tshirt-unique-size-crimson-red and running-shoes-m-crimson-red
+    And I press the "Delete" button
+    Then I should see the text "Are you sure you want to delete selected products?"
+    When I confirm the removal
+    And I refresh current page
+    Then I should not see products tshirt-unique-size-crimson-red and running-shoes-m-crimson-red
+    And I should see the product models model-tshirt-divided-crimson-red


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

It skips the product models when a user selects some products and some product models

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Ok
| Added Behats                      | Ok
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
