### PR TITLE
PIM-6820: Validate variant axes during imports

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -5,6 +5,7 @@
 - PIM-6804: Fix the positioning (z-index) of the datafilter widgets
 - PIM-6491: Fix file extension validation on import job upload
 - PIM-6798: Fix the simple-select and multi-select copiers
+- PIM-6820: During an import, prevent to add in a variant group two products with same variant axes
 
 # 1.7.8 (2017-08-22)
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -173,6 +173,9 @@ def runPhpUnitTest() {
 def runIntegrationTest(storage, testSuiteName) {
     node('docker') {
         deleteDir()
+        sh "docker stop \$(docker ps -a -q) || true"
+        sh "docker rm \$(docker ps -a -q) || true"
+
         try {
             docker.image("mongo:2.4").withRun("--name mongodb", "--smallfiles") {
                 docker.image("mysql:5.5").withRun("--name mysql -e MYSQL_ROOT_PASSWORD=root -e MYSQL_USER=akeneo_pim -e MYSQL_PASSWORD=akeneo_pim -e MYSQL_DATABASE=akeneo_pim", "--sql_mode=ERROR_FOR_DIVISION_BY_ZERO,NO_ZERO_IN_DATE,NO_ZERO_DATE,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION") {

--- a/features/Context/FixturesContext.php
+++ b/features/Context/FixturesContext.php
@@ -115,8 +115,8 @@ class FixturesContext extends BaseFixturesContext
         $this->getProductSaver()->save($product);
 
         // reset the unique value set to allow to update product values
-        $uniqueValueSet = $this->getContainer()->get('pim_catalog.validator.unique_value_set');
-        $uniqueValueSet->reset();
+        $this->getContainer()->get('pim_catalog.validator.unique_value_set')->reset();
+        $this->getContainer()->get('pim_catalog.validator.unique_axes_combination_set')->reset();
 
         $this->refresh($product);
         $this->buildProductHistory($product);

--- a/features/import/product_variant_group/fail_to_import_products_with_duplicated_axis_values.feature
+++ b/features/import/product_variant_group/fail_to_import_products_with_duplicated_axis_values.feature
@@ -1,0 +1,30 @@
+@javascript
+Feature: Fail to import products with duplicated axis values
+  In order to have consistent catalog data
+  As a product manager
+  I need to prevent importing products with duplicated axis values for a same variant group
+
+  @jira https://akeneo.atlassian.net/browse/PIM-6820
+  Scenario: Fail to import products with duplicated axis values
+    Given an "apparel" catalog configuration
+    And the following CSV file to import:
+      """
+      sku;groups;color;size
+      a_red_tee;tshirts;red;size_M
+      another_red_tee;tshirts;red;size_M
+      """
+    And the following job "product_import" configuration:
+      | filePath | %file to import% |
+    And I am logged in as "Julia"
+    When I am on the "product_import" import job page
+    And I launch the import job
+    And I wait for the "product_import" job to finish
+    Then there should be 1 product
+    And I should see the text "created 1"
+    And I should see the text "skipped 1"
+    And I should see the text "variant_group: Group \"[tshirts]\" already contains another product with values \"size: [size_M], color: [red]\": another_red_tee"
+    And the invalid data file of "product_import" should contain:
+      """
+      sku;groups;color;size
+      another_red_tee;tshirts;red;size_M
+      """

--- a/src/Pim/Bundle/CatalogBundle/EventSubscriber/ResetUniqueValidationSubscriber.php
+++ b/src/Pim/Bundle/CatalogBundle/EventSubscriber/ResetUniqueValidationSubscriber.php
@@ -2,11 +2,12 @@
 
 namespace Pim\Bundle\CatalogBundle\EventSubscriber;
 
+use Pim\Component\Catalog\Validator\UniqueAxesCombinationSet;
 use Pim\Component\Catalog\Validator\UniqueValuesSet;
 
 /**
  * The UniqueValueSet class is stateful, and used when you import several product, to check if in the product batch
- * there is no unique identifier issues.
+ * there is no unique identifier issues or unique axis combination issues.
  * This listener listen the StorageEvents::POST_SAVE_ALL to reset the UniqueValueSet information, to be able to
  * work in another product batch without uniqueness issues.
  *
@@ -19,12 +20,19 @@ class ResetUniqueValidationSubscriber
     /** @var UniqueValuesSet */
     protected $uniqueValueSet;
 
+    /** @var UniqueAxesCombinationSet */
+    protected $uniqueAxesCombinationSet;
+
     /**
-     * @param UniqueValuesSet $uniqueValueSet
+     * @param UniqueValuesSet          $uniqueValueSet
+     * @param UniqueAxesCombinationSet $uniqueAxesCombinationSet
      */
-    public function __construct(UniqueValuesSet $uniqueValueSet)
-    {
+    public function __construct(
+        UniqueValuesSet $uniqueValueSet,
+        UniqueAxesCombinationSet $uniqueAxesCombinationSet = null
+    ) {
         $this->uniqueValueSet = $uniqueValueSet;
+        $this->uniqueAxesCombinationSet = $uniqueAxesCombinationSet;
     }
 
     /**
@@ -34,5 +42,9 @@ class ResetUniqueValidationSubscriber
     public function onAkeneoStoragePostsaveall()
     {
         $this->uniqueValueSet->reset();
+
+        if (null !== $this->uniqueAxesCombinationSet) {
+            $this->uniqueAxesCombinationSet->reset();
+        }
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/event_subscribers.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/event_subscribers.yml
@@ -90,5 +90,6 @@ services:
         class: '%pim_catalog.event_subscriber.reset_unique_validation.class%'
         arguments:
             - '@pim_catalog.validator.unique_value_set'
+            - '@pim_catalog.validator.unique_axes_combination_set'
         tags:
            - { name: kernel.event_listener, event: akeneo.storage.post_save_all }

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/validators.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/validators.yml
@@ -44,6 +44,7 @@ parameters:
     pim_catalog.validator.mapping.delegating_class_metadata_factory.class: Pim\Component\Catalog\Validator\Mapping\DelegatingClassMetadataFactory
     pim_catalog.validator.mapping.product_value_metadata_factory.class:    Pim\Component\Catalog\Validator\Mapping\ProductValueMetadataFactory
     pim_catalog.validator.unique_value_set.class:                          Pim\Component\Catalog\Validator\UniqueValuesSet
+    pim_catalog.validator.unique_axes_combination_set.class:               Pim\Component\Catalog\Validator\UniqueAxesCombinationSet
 
 services:
     # Helpers
@@ -56,6 +57,10 @@ services:
 
     pim_catalog.validator.unique_value_set:
         class: '%pim_catalog.validator.unique_value_set.class%'
+        public: true
+
+    pim_catalog.validator.unique_axes_combination_set:
+        class: '%pim_catalog.validator.unique_axes_combination_set.class%'
         public: true
 
     # Validators
@@ -85,6 +90,7 @@ services:
         class: '%pim_catalog.validator.constraint.unique_variant_axis.class%'
         arguments:
             - '@pim_catalog.repository.product'
+            - '@pim_catalog.validator.unique_axes_combination_set'
         tags:
             - { name: validator.constraint_validator, alias: pim_unique_variant_axis_validator }
 

--- a/src/Pim/Bundle/CatalogBundle/spec/EventSubscriber/ResetUniqueValidationSubscriberSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/EventSubscriber/ResetUniqueValidationSubscriberSpec.php
@@ -3,13 +3,14 @@
 namespace spec\Pim\Bundle\CatalogBundle\EventSubscriber;
 
 use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Validator\UniqueAxesCombinationSet;
 use Pim\Component\Catalog\Validator\UniqueValuesSet;
 
 class ResetUniqueValidationSubscriberSpec extends ObjectBehavior
 {
-    function let(UniqueValuesSet $uniqueValueSet)
+    function let(UniqueValuesSet $uniqueValueSet, UniqueAxesCombinationSet $uniqueAxesCombinationSet)
     {
-        $this->beConstructedWith($uniqueValueSet);
+        $this->beConstructedWith($uniqueValueSet, $uniqueAxesCombinationSet);
     }
 
     function it_is_initializable()
@@ -17,9 +18,11 @@ class ResetUniqueValidationSubscriberSpec extends ObjectBehavior
         $this->shouldHaveType('Pim\Bundle\CatalogBundle\EventSubscriber\ResetUniqueValidationSubscriber');
     }
 
-    function it_should_reset_unique_value_set($uniqueValueSet)
+    function it_should_reset_unique_value_set($uniqueValueSet, $uniqueAxesCombinationSet)
     {
         $uniqueValueSet->reset()->shouldBeCalled();
+        $uniqueAxesCombinationSet->reset()->shouldBeCalled();
+
         $this->onAkeneoStoragePostsaveall();
     }
 }

--- a/src/Pim/Component/Catalog/Validator/Constraints/UniqueValueValidator.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/UniqueValueValidator.php
@@ -111,7 +111,7 @@ class UniqueValueValidator extends ConstraintValidator
     }
 
     /**
-     * @param $mixed $data
+     * @param mixed $data
      *
      * @return string
      */
@@ -129,7 +129,7 @@ class UniqueValueValidator extends ConstraintValidator
     {
         $root = $this->context->getRoot();
         if (!$root instanceof Form) {
-            return;
+            return null;
         }
 
         preg_match(
@@ -138,18 +138,18 @@ class UniqueValueValidator extends ConstraintValidator
             $matches
         );
         if (!isset($matches[1])) {
-            return;
+            return null;
         }
 
         $product = $this->context->getRoot()->getData();
         if (!$product instanceof ProductInterface) {
-            return;
+            return null;
         }
 
         $value = $product->getValue($matches[1]);
 
         if (false === $value) {
-            return;
+            return null;
         }
 
         return $value;

--- a/src/Pim/Component/Catalog/Validator/UniqueAxesCombinationSet.php
+++ b/src/Pim/Component/Catalog/Validator/UniqueAxesCombinationSet.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Pim\Component\Catalog\Validator;
+
+use Pim\Component\Catalog\Model\ProductInterface;
+
+/**
+ * @author    Damien Carcel (damien.carcel@akeneo.com)
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class UniqueAxesCombinationSet
+{
+    /** @var array */
+    protected $uniqueAxesCombination;
+
+    /**
+     * Initializes the set.
+     */
+    public function __construct()
+    {
+        $this->uniqueAxesCombination = [];
+    }
+
+    /**
+     * Resets the set.
+     */
+    public function reset()
+    {
+        $this->uniqueAxesCombination = [];
+    }
+
+    /**
+     * Returns TRUE if axes combination has been added, FALSE if it already
+     * exists inside the set.
+     *
+     * @param ProductInterface $product
+     * @param string           $axesCombination
+     *
+     * @return bool
+     */
+    public function addCombination(ProductInterface $product, $axesCombination)
+    {
+        $groupCode = $product->getVariantGroup()->getCode();
+        $identifier = $product->getIdentifier();
+
+        if (isset($this->uniqueAxesCombination[$groupCode][$axesCombination])) {
+            $cachedIdentifier = $this->uniqueAxesCombination[$groupCode][$axesCombination];
+            if ($cachedIdentifier !== $identifier) {
+                return false;
+            }
+        }
+        if (!isset($this->uniqueAxesCombination[$groupCode])) {
+            $this->uniqueAxesCombination[$groupCode] = [];
+        }
+
+        if (!isset($this->uniqueAxesCombination[$groupCode][$axesCombination])) {
+            $this->uniqueAxesCombination[$groupCode][$axesCombination] = $identifier;
+        }
+
+        return true;
+    }
+}

--- a/src/Pim/Component/Catalog/spec/Validator/UniqueAxesCombinationSetSpec.php
+++ b/src/Pim/Component/Catalog/spec/Validator/UniqueAxesCombinationSetSpec.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace spec\Pim\Component\Catalog\Validator;
+
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Model\GroupInterface;
+use Pim\Component\Catalog\Model\ProductInterface;
+use Pim\Component\Catalog\Validator\UniqueAxesCombinationSet;
+
+class UniqueAxesCombinationSetSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(UniqueAxesCombinationSet::class);
+    }
+
+    function it_adds_new_axis_combinations(
+        GroupInterface $variantGroup1,
+        GroupInterface $variantGroup2,
+        ProductInterface $product1,
+        ProductInterface $product2,
+        ProductInterface $product3
+    ) {
+        $variantGroup1->getCode()->willReturn('variant_group_1');
+        $variantGroup2->getCode()->willReturn('variant_group_2');
+
+        $product1->getIdentifier()->willReturn('product_1');
+        $product1->getVariantGroup()->willReturn($variantGroup1);
+
+        $product2->getIdentifier()->willReturn('product_2');
+        $product2->getVariantGroup()->willReturn($variantGroup1);
+
+        $product3->getIdentifier()->willReturn('product_3');
+        $product3->getVariantGroup()->willReturn($variantGroup2);
+
+        $this->addCombination($product1, 'size-xl,color-red')->shouldReturn(true);
+        $this->addCombination($product2, 'size-xl,color-red')->shouldReturn(false);
+        $this->addCombination($product3, 'size-xl,color-red')->shouldReturn(true);
+    }
+}


### PR DESCRIPTION
## Description

Currently, when creating products and adding them to a variant group, we validate that there is not already a product in this variant group with the same axis values, as each axis values combination are unique for a variant group. For example, you cannot have to red t-shirts in size XL in the same variant group, if color and size are this variant group axes.

However, we did not validate this axis values uniqueness during imports inside one batch. So it was possible to import several products for a same variant group, with the same axis value combination.

This PR introduces a `UniqueAxesCombinationSet` that stores the axis value combinations and is reset after each batch. Its behavior is based on the `UniqueValuesSet`, which does the same for attributes with unique values.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added Behats                      | OK
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
