### PR TITLE
PIM-6793

### DIFF
--- a/src/Pim/Bundle/DataGridBundle/Resources/config/requirejs.yml
+++ b/src/Pim/Bundle/DataGridBundle/Resources/config/requirejs.yml
@@ -88,6 +88,9 @@ config:
         oro/loading-mask:                       pimdatagrid/js/loading-mask
         oro/pageable-collection:                pimdatagrid/js/pageable-collection
 
+        oro/datagrid/product-and-product-model-image-cell: pimdatagrid/js/datagrid/cell/product-and-product-model-image-cell
+        oro/datagrid/product-and-product-model-label-cell: pimdatagrid/js/datagrid/cell/product-and-product-model-label-cell
+
         backbone/pageable-collection:           pimdatagrid/lib/backbone-pageable
         backgrid:                               pimdatagrid/lib/backgrid/backgrid
 
@@ -153,3 +156,6 @@ config:
         pim/template/datagrid/filter/scope-filter:       pimdatagrid/templates/filter/scope-filter.html
         pim/template/datagrid/row/version:               pimdatagrid/templates/datagrid/row/version.html
         pim/template/datagrid/row/changes:               pimdatagrid/templates/datagrid/row/changes.html
+        pim/template/datagrid/cell/image-cell:           pimdatagrid/templates/datagrid/cell/image-cell.html
+
+        pim/template/datagrid/cell/product-and-product-model-image-cell: pimdatagrid/templates/datagrid/cell/product-and-product-model-image-cell.html

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/cell/image-cell.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/cell/image-cell.js
@@ -1,24 +1,50 @@
 /* global define */
-define(['oro/datagrid/string-cell', 'pim/media-url-generator'],
-    function(StringCell, MediaUrlGenerator) {
+define(
+    [
+        'underscore',
+        'oro/datagrid/string-cell',
+        'pim/media-url-generator',
+        'pim/template/datagrid/cell/image-cell'
+    ],
+    function (
+        _,
+        StringCell,
+        MediaUrlGenerator,
+        template
+    ) {
         'use strict';
 
         /**
          * Image column cell
          *
+         * @export  oro/datagrid/image-cell
+         * @class   oro.datagrid.ImageCell
          * @extends oro.datagrid.StringCell
          */
         return StringCell.extend({
+            template: _.template(template),
+
             /**
              * Render an image.
              */
             render: function () {
-                var image = this.formatter.fromRaw(this.model.get(this.column.get("name")));
+                const image = this.formatter.fromRaw(this.model.get(this.column.get("name")));
 
-                var src = MediaUrlGenerator.getMediaShowUrl(image.filePath, 'thumbnail_small');
-                this.$el.empty().html('<img src="' + src + '" title="' + image.originalFilename + '" />');
+                const src = MediaUrlGenerator.getMediaShowUrl(image.filePath, 'thumbnail_small');
+                this.$el.empty().html(this.getTemplate({label: image.originalFilename, src}));
 
                 return this;
+            },
+
+            /**
+             * Returns the template used to show the image.
+             *
+             * This function can be overridden to alter the way the image is shown.
+             *
+             * @returns {string}
+             */
+            getTemplate(params) {
+                return this.template(params);
             }
         });
     }

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/cell/product-and-product-model-image-cell.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/cell/product-and-product-model-image-cell.js
@@ -1,0 +1,35 @@
+/* global define */
+define(
+    [
+        'underscore',
+        'oro/datagrid/image-cell',
+        'pim/template/datagrid/cell/product-and-product-model-image-cell'
+    ],
+    function (
+        _,
+        ImageCell,
+        productAndProductModelTemplate
+    ) {
+        'use strict';
+
+        /**
+         * Uses a different template if the model is a product_model.
+         *
+         * @extends oro.datagrid.ImageCell
+         */
+        return ImageCell.extend({
+            productAndProductModelTemplate: _.template(productAndProductModelTemplate),
+
+            /**
+             * {@inheritdoc}
+             */
+            getTemplate(params) {
+                if (this.model.get('document_type') === 'product_model') {
+                    return this.productAndProductModelTemplate(params);
+                }
+
+                return ImageCell.prototype.getTemplate.apply(this, arguments);
+            }
+        });
+    }
+);

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/cell/product-and-product-model-label-cell.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/cell/product-and-product-model-label-cell.js
@@ -1,0 +1,27 @@
+/* global define */
+define(['oro/datagrid/string-cell'],
+    function (StringCell) {
+        'use strict';
+
+        /**
+         * Label column cell for products and product models
+         *
+         * @extends oro.datagrid.StringCell
+         */
+        return StringCell.extend({
+
+            /**
+             * {@inheritdoc}
+             */
+            className() {
+                let className = 'AknGrid-bodyCell AknGrid-bodyCell--highlight';
+
+                if (this.model.get('document_type') === 'product_model') {
+                    className += ' AknGrid-bodyCell--highlightAlternative';
+                }
+
+                return className;
+            }
+        });
+    }
+);

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/templates/datagrid/cell/image-cell.html
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/templates/datagrid/cell/image-cell.html
@@ -1,0 +1,1 @@
+<img class="AknGrid-image" src="<%- src %>" title="<%- label %>" />

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/templates/datagrid/cell/product-and-product-model-image-cell.html
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/templates/datagrid/cell/product-and-product-model-image-cell.html
@@ -1,0 +1,2 @@
+<div class="AknGrid-imageLayer"></div>
+<img class="AknGrid-image" src="<%- src %>" title="<%- label %>" />

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product.yml
@@ -15,12 +15,12 @@ datagrid:
             image:
                 label:         Image
                 data_name:     image
-                frontend_type: image
+                frontend_type: product-and-product-model-image
             label:
                 label:         Label
                 data_name:     label
                 type:          field
-                frontend_type: label
+                frontend_type: product-and-product-model-label
             family:
                 label:         Family
                 data_name:     family

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/grid/Grid.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/grid/Grid.less
@@ -203,4 +203,39 @@
       transform: rotate(90deg);
     }
   }
+
+  &-imageLayer {
+    position: absolute;
+    border: 1px solid @AknBorderColor;
+    background: white;
+    height: 44px;
+    width: 44px;
+    transform: translate(4px, -4px);
+    transition: border-color 0.2s ease-in;
+
+    &:after {
+      content: '';
+      position: absolute;
+      border: 1px solid @AknBorderColor;
+      background: white;
+      height: 42px;
+      width: 42px;
+      transform: translate(-3px, 1px);
+      transition: border-color 0.2s ease-in;
+    }
+  }
+
+  &-bodyRow:hover &-imageLayer,
+  &-bodyRow:hover &-image,
+  &-bodyRow:hover &-imageLayer:after {
+    border-color: darken(@AknBorderColor, 20%);
+  }
+
+  &-image {
+    position: relative;
+    height: 44px;
+    width: 44px;
+    border: 1px solid @AknBorderColor;
+    transition: border-color 0.2s ease-in;
+  }
 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Introduces two new datagrid cell formatters to show product and product models differently in the datagrid.
- product-and-product-model-image (show the image with a stack like frame)
- product-and-product-model-label (show the label with a different color)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
