### PR TITLE
PIM-6826: Makes sure the UnitOfWork is in pristine state after re-creating the DB

### DIFF
--- a/src/Pim/Bundle/InstallerBundle/Command/DatabaseCommand.php
+++ b/src/Pim/Bundle/InstallerBundle/Command/DatabaseCommand.php
@@ -98,6 +98,9 @@ class DatabaseCommand extends ContainerAwareCommand
 
         $this->resetElasticsearchIndex($output);
 
+        $entityManager = $this->getContainer()->get('doctrine.orm.default_entity_manager');
+        $entityManager->clear();
+
         $this->getEventDispatcher()->dispatch(InstallerEvents::POST_DB_CREATE);
 
         // TODO: Should be in an event subscriber


### PR DESCRIPTION
The installer fails because job instance access references job instances that should have been created, but have never been inserted in the DB.

Autopsy of the problem:
Here are the steps executed when launching the installer:
 1- a subscriber load all groups and roles and attach them the "system" user. All groups and roles are now loaded in the Unit of Work, with their object hash (spl_object_hash) used as identifiers in the states map
 2- remove the database
 3- create the database
 4- create the schema
 5- install the fixtures

At some point, the new roles and groups coming from the fixtures are loaded. They then replace the ones in the Unit of Work identityMap, because they have the same database id. But when it happens, the states map still contains the old object hash, as well as the new ones.
The old objects are removed from memory.

Latter, during the fixtures installation, new objects (here, job instances) are using the old memory room freed by the old roles and groups objects.
They now have the same object hash as the old objects.
So when they are sent to the Unit of Work to be persisted, they are considered as already managed (not new), so they are not added to the list of new entities to insert.

Latter on, when other object fixtures (job instances access) references the objects that should have been created, but have not, the installation process fails with an error.


**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -
