### PR TITLE
Swift_Message instanciation update for SwiftMailer > v6.0.0

### DIFF
--- a/src/Oro/Bundle/UserBundle/Controller/ResetController.php
+++ b/src/Oro/Bundle/UserBundle/Controller/ResetController.php
@@ -48,8 +48,7 @@ class ResetController extends Controller
         /**
          * @todo Move to postUpdate lifecycle event handler as service
          */
-        $message = \Swift_Message::newInstance()
-            ->setSubject('Reset password')
+        $message = (new \Swift_Message('Reset password'))
             ->setFrom($this->container->getParameter('oro_user.email'))
             ->setTo($user->getEmail())
             ->setBody(


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
Fix the `\Swift_Message::newInstance()` error since this method is deprecated by SwiftMailer > 6.0.0
Replaced it with `(new \Swift_Message('My Subject'))`

Changelog depreciation : https://github.com/swiftmailer/swiftmailer/blob/v6.0.0/CHANGES#L14
New implementation : https://swiftmailer.symfony.com/docs/introduction.html#basic-usage

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
