### PR TITLE
PIM-6822: Fix standard to flat product conversion

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -2,10 +2,11 @@
 
 ## Bug Fixes
 
-- PIM-6804: Fix the positioning (z-index) of the datafilter widgets
 - PIM-6491: Fix file extension validation on import job upload
 - PIM-6798: Fix the simple-select and multi-select copiers
+- PIM-6804: Fix the positioning (z-index) of the datafilter widgets
 - PIM-6820: During an import, prevent to add in a variant group two products with same variant axes
+- PIM-6822: Fix the product conversion from standard to flat format when the product is in one or several groups, but no variant group
 
 # 1.7.8 (2017-08-22)
 

--- a/src/Pim/Component/Connector/ArrayConverter/StandardToFlat/Product.php
+++ b/src/Pim/Component/Connector/ArrayConverter/StandardToFlat/Product.php
@@ -73,12 +73,17 @@ class Product extends AbstractSimpleArrayConverter implements ArrayConverterInte
      */
     protected function convertGroups($data, array $convertedItem)
     {
-        $groups = is_array($data) ? implode(',', $data) : (string) $data;
+        if (!array_key_exists('groups', $convertedItem)) {
+            $convertedItem['groups'] = '';
+        }
 
-        if (isset($convertedItem['groups']) && '' !== $convertedItem['groups']) {
-            $convertedItem['groups'] .= sprintf(',%s', $groups);
-        } else {
-            $convertedItem['groups'] = $groups;
+        $groups = is_array($data) ? implode(',', $data) : (string) $data;
+        if ('' !== $groups) {
+            if ('' !== $convertedItem['groups']) {
+                $convertedItem['groups'] .= sprintf(',%s', $groups);
+            } else {
+                $convertedItem['groups'] = $groups;
+            }
         }
 
         return $convertedItem;

--- a/src/Pim/Component/Connector/spec/ArrayConverter/StandardToFlat/ProductSpec.php
+++ b/src/Pim/Component/Connector/spec/ArrayConverter/StandardToFlat/ProductSpec.php
@@ -99,4 +99,244 @@ class ProductSpec extends ObjectBehavior
 
         $this->convert($item)->shouldReturn($expected);
     }
+
+    function it_converts_a_product_without_variant_group_from_standard_to_flat_format($valueConverter)
+    {
+        $valueConverter->convertAttribute('sku',
+            [
+                [
+                    'locale' => null,
+                    'scope'  => null,
+                    'data'   => '10699783'
+                ]
+            ]
+        )->willReturn(['sku' => '10699783']);
+
+        $valueConverter->convertAttribute('weight',
+            [
+                [
+                    'locale' => 'de_DE',
+                    'scope'  => 'print',
+                    'data'   => [
+                        'unit'   => 'KILOGRAM',
+                        'amount' => '100'
+                    ]
+                ]
+            ]
+        )->willReturn([
+            'weight-de_DE-print' => '100',
+            'weight-de_DE-print-unit' => 'KILOGRAM',
+        ]);
+
+        $expected = [
+            'categories'              => 'audio_video_sales,loudspeakers,sony',
+            'enabled'                 => '1',
+            'family'                  => 'loudspeakers',
+            'groups'                  => 'sound,audio,mp3',
+            'UPSELL-groups'           => '',
+            'UPSELL-products'         => '',
+            'X_SELL-groups'           => 'akeneo_tshirt,oro_tshirt',
+            'X_SELL-products'         => 'AKN_TS,ORO_TSH',
+            'sku'                     => '10699783',
+            'weight-de_DE-print'      => '100',
+            'weight-de_DE-print-unit' => 'KILOGRAM',
+        ];
+
+        $item = [
+            'categories'        => ['audio_video_sales', 'loudspeakers', 'sony'],
+            'enabled'           => true,
+            'family'            => 'loudspeakers',
+            'groups'            => ['sound', 'audio', 'mp3'],
+            'variant_group'     => null,
+            'associations'      => [
+                'UPSELL' => [
+                    'groups'   => [],
+                    'products' => []
+                ],
+                'X_SELL' => [
+                    'groups'   => ['akeneo_tshirt', 'oro_tshirt'],
+                    'products' => ['AKN_TS', 'ORO_TSH']
+                ]
+            ],
+            'sku'               => [
+                [
+                    'locale' => null,
+                    'scope'  => null,
+                    'data'   => '10699783'
+                ]
+            ],
+            'weight'            => [
+                [
+                    'locale' => 'de_DE',
+                    'scope'  => 'print',
+                    'data'   => [
+                        'unit' => 'KILOGRAM',
+                        'amount' => '100'
+                    ]
+                ]
+            ],
+        ];
+
+        $this->convert($item)->shouldReturn($expected);
+    }
+
+    function it_converts_a_product_with_only_a_variant_group_from_standard_to_flat_format($valueConverter)
+    {
+        $valueConverter->convertAttribute('sku',
+            [
+                [
+                    'locale' => null,
+                    'scope'  => null,
+                    'data'   => '10699783'
+                ]
+            ]
+        )->willReturn(['sku' => '10699783']);
+
+        $valueConverter->convertAttribute('weight',
+            [
+                [
+                    'locale' => 'de_DE',
+                    'scope'  => 'print',
+                    'data'   => [
+                        'unit'   => 'KILOGRAM',
+                        'amount' => '100'
+                    ]
+                ]
+            ]
+        )->willReturn([
+            'weight-de_DE-print' => '100',
+            'weight-de_DE-print-unit' => 'KILOGRAM',
+        ]);
+
+        $expected = [
+            'categories'              => 'audio_video_sales,loudspeakers,sony',
+            'enabled'                 => '1',
+            'family'                  => 'loudspeakers',
+            'groups'                  => 'speakers',
+            'UPSELL-groups'           => '',
+            'UPSELL-products'         => '',
+            'X_SELL-groups'           => 'akeneo_tshirt,oro_tshirt',
+            'X_SELL-products'         => 'AKN_TS,ORO_TSH',
+            'sku'                     => '10699783',
+            'weight-de_DE-print'      => '100',
+            'weight-de_DE-print-unit' => 'KILOGRAM',
+        ];
+
+        $item = [
+            'categories'        => ['audio_video_sales', 'loudspeakers', 'sony'],
+            'enabled'           => true,
+            'family'            => 'loudspeakers',
+            'groups'            => [],
+            'variant_group'     => 'speakers',
+            'associations'      => [
+                'UPSELL' => [
+                    'groups'   => [],
+                    'products' => []
+                ],
+                'X_SELL' => [
+                    'groups'   => ['akeneo_tshirt', 'oro_tshirt'],
+                    'products' => ['AKN_TS', 'ORO_TSH']
+                ]
+            ],
+            'sku'               => [
+                [
+                    'locale' => null,
+                    'scope'  => null,
+                    'data'   => '10699783'
+                ]
+            ],
+            'weight'            => [
+                [
+                    'locale' => 'de_DE',
+                    'scope'  => 'print',
+                    'data'   => [
+                        'unit' => 'KILOGRAM',
+                        'amount' => '100'
+                    ]
+                ]
+            ],
+        ];
+
+        $this->convert($item)->shouldReturn($expected);
+    }
+
+    function it_converts_a_product_without_any_group_from_standard_to_flat_format($valueConverter)
+    {
+        $valueConverter->convertAttribute('sku',
+            [
+                [
+                    'locale' => null,
+                    'scope'  => null,
+                    'data'   => '10699783'
+                ]
+            ]
+        )->willReturn(['sku' => '10699783']);
+
+        $valueConverter->convertAttribute('weight',
+            [
+                [
+                    'locale' => 'de_DE',
+                    'scope'  => 'print',
+                    'data'   => [
+                        'unit'   => 'KILOGRAM',
+                        'amount' => '100'
+                    ]
+                ]
+            ]
+        )->willReturn([
+            'weight-de_DE-print' => '100',
+            'weight-de_DE-print-unit' => 'KILOGRAM',
+        ]);
+
+        $expected = [
+            'categories'              => 'audio_video_sales,loudspeakers,sony',
+            'enabled'                 => '1',
+            'family'                  => 'loudspeakers',
+            'groups'                  => '',
+            'UPSELL-groups'           => '',
+            'UPSELL-products'         => '',
+            'X_SELL-groups'           => 'akeneo_tshirt,oro_tshirt',
+            'X_SELL-products'         => 'AKN_TS,ORO_TSH',
+            'sku'                     => '10699783',
+            'weight-de_DE-print'      => '100',
+            'weight-de_DE-print-unit' => 'KILOGRAM',
+        ];
+
+        $item = [
+            'categories'        => ['audio_video_sales', 'loudspeakers', 'sony'],
+            'enabled'           => true,
+            'family'            => 'loudspeakers',
+            'groups'            => [],
+            'variant_group'     => '',
+            'associations'      => [
+                'UPSELL' => [
+                    'groups'   => [],
+                    'products' => []
+                ],
+                'X_SELL' => [
+                    'groups'   => ['akeneo_tshirt', 'oro_tshirt'],
+                    'products' => ['AKN_TS', 'ORO_TSH']
+                ]
+            ],
+            'sku'               => [
+                [
+                    'locale' => null,
+                    'scope'  => null,
+                    'data'   => '10699783'
+                ]
+            ],
+            'weight'            => [
+                [
+                    'locale' => 'de_DE',
+                    'scope'  => 'print',
+                    'data'   => [
+                        'unit' => 'KILOGRAM',
+                        'amount' => '100'
+                    ]
+                ]
+            ],
+        ];
+
+        $this->convert($item)->shouldReturn($expected);
+    }
 }


### PR DESCRIPTION
## Description

### Some context

In the product standard format, codes of the product groups and product variant group are in different fields: `groups` which contains an array of code, coma separated, and `variant_group` which contains the code as a string, as a product can only have one variant group, respectively.

When converted into the flat format for the export, those codes are concatenated into a single `groups` field (the corresponding column of the exported file), the variant group being added after the other groups.

### The problem

If the product is in one or several groups, but in no variant group, we end up with an additional coma at the end of the group list, this being the result of the concatenation of the groups with an empty string as variant group… This leads to invalid CSV or XLSX file that cannot be reimported.

This PR fixes the problem by ensuring we only concatenate non empty group codes.

### A side note on tests

Only unit tests were added, as they are enough to ensure the problem won't come back. We tested the standard to flat converter only with a product having both groups and variant group. This PR adds two more tests: one converting a product with only groups, the other with only a variant group.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
