### PR TITLE
Integration tests 1.7

### DIFF
--- a/app/phpunit.xml.dist
+++ b/app/phpunit.xml.dist
@@ -28,47 +28,7 @@
 
         <!-- Complete suite for PIM integration tests -->
         <testsuite name="PIM_Integration_Test">
-            <directory suffix="Integration.php">../src/Pim/Component/*/tests/integration</directory>
-            <directory suffix="Integration.php">../src/Pim/Bundle/*Bundle/tests/integration</directory>
-        </testsuite>
-
-        <!-- Set of small suites for PIM integration tests -->
-        <testsuite name="PIM_Api_Base_Integration_Test">
-            <directory suffix="Integration.php">../src/Pim/Component/Api/tests/integration</directory>
-            <directory suffix="Integration.php">../src/Pim/Bundle/ApiBundle/tests/integration/EventSubscriber</directory>
-            <directory suffix="Integration.php">../src/Pim/Bundle/ApiBundle/tests/integration/Security</directory>
-            <file>../src/Pim/Bundle/ApiBundle/tests/integration/Controller/RootEndpointIntegration.php</file>
-        </testsuite>
-
-        <testsuite name="PIM_Api_Bundle_Controllers_Integration_Test">
-            <directory suffix="Integration.php">../src/Pim/Bundle/ApiBundle/tests/integration/Controller/Channel</directory>
-            <directory suffix="Integration.php">../src/Pim/Bundle/ApiBundle/tests/integration/Controller/Locale</directory>
-            <directory suffix="Integration.php">../src/Pim/Bundle/ApiBundle/tests/integration/Controller/Media</directory>
-            <directory suffix="Integration.php">../src/Pim/Bundle/ApiBundle/tests/integration/Controller/Token</directory>
-        </testsuite>
-
-        <testsuite name="PIM_Api_Bundle_Controllers_Catalog_Integration_Test">
-            <directory suffix="Integration.php">../src/Pim/Bundle/ApiBundle/tests/integration/Controller/Attribute</directory>
-            <directory suffix="Integration.php">../src/Pim/Bundle/ApiBundle/tests/integration/Controller/AttributeOption</directory>
-            <directory suffix="Integration.php">../src/Pim/Bundle/ApiBundle/tests/integration/Controller/Category</directory>
-            <directory suffix="Integration.php">../src/Pim/Bundle/ApiBundle/tests/integration/Controller/Family</directory>
-        </testsuite>
-
-        <testsuite name="PIM_Api_Bundle_Controller_Product_Integration_Test">
-            <directory suffix="Integration.php">../src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product</directory>
-        </testsuite>
-
-        <testsuite name="PIM_Catalog_Integration_Test">
-            <directory suffix="Integration.php">../src/Pim/Bundle/CatalogBundle/tests/integration/Validation</directory>
-            <directory suffix="Integration.php">../src/Pim/Component/Catalog/tests/integration</directory>
-        </testsuite>
-
-        <testsuite name="PIM_Catalog_Completeness_Integration_Test">
-            <directory suffix="Integration.php">../src/Pim/Bundle/CatalogBundle/tests/integration/Completeness</directory>
-        </testsuite>
-
-        <testsuite name="PIM_Catalog_PQB_Integration_Test">
-            <directory suffix="Integration.php">../src/Pim/Bundle/CatalogBundle/tests/integration/PQB</directory>
+            <file></file>
         </testsuite>
 
     </testsuites>

--- a/src/Pim/Bundle/VersioningBundle/tests/integration/Normalizer/Flat/VariantGroupIntegration.php
+++ b/src/Pim/Bundle/VersioningBundle/tests/integration/Normalizer/Flat/VariantGroupIntegration.php
@@ -14,6 +14,8 @@ class VariantGroupIntegration extends AbstractFlatNormalizerTestCase
     public function testVariantGroup()
     {
         $variantGroup = $this->get('pim_catalog.repository.group')->findOneByIdentifier('variantA');
+
+        $this->get('pim_serializer');
         $flatVariantGroup = $this->get('pim_versioning.serializer')->normalize($variantGroup, 'flat');
 
         $this->assertSame($flatVariantGroup, [

--- a/tests/FixturesLoader.php
+++ b/tests/FixturesLoader.php
@@ -79,6 +79,7 @@ class FixturesLoader
             $this->dropDatabase();
             $this->createDatabase();
             $this->restoreDatabase($dumpFile);
+            $this->clearAclCache();
 
             return;
         }
@@ -383,5 +384,16 @@ class FixturesLoader
         }
 
         return $process->getOutput();
+    }
+
+    /**
+     * Clear Oro cache about Acl.
+     * This cache should be cleared when loading the fixtures with mysql dump.
+     * It avoids inconsistency between the cache and the new data in the database.
+     */
+    protected function clearAclCache()
+    {
+        $aclCache = $this->container->get('security.acl.cache');
+        $aclCache->clearCache();
     }
 }


### PR DESCRIPTION
## Description

Currently, integration tests are split manually, into small test suites, to be run in parallel on the CI. This is not ideal, as the suites are not equivalent in size, and so in running time, and we can forgot to add new set of tests in the existing suites.

This PR brings back into 1.7 the work that @ahocquard did on master (2.0), but only for CE and ORM. 
The goal is only to ensure all tests are ran, including new ones, whitout having to do anything else than writing the test.

EE tests ran from CE pull requests could be added later, as well as ODM builds. I also had to deactivate a broken test on variant group normalization (which was not ran before anyway...). It will be fixed later in another PR.

This PR also improves build time by performing a `composer update` only during checkout stage.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | OK
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
