### PR TITLE
Do not try to notify the user System

### DIFF
--- a/src/Pim/Bundle/NotificationBundle/spec/NotifierSpec.php
+++ b/src/Pim/Bundle/NotificationBundle/spec/NotifierSpec.php
@@ -8,6 +8,7 @@ use PhpSpec\ObjectBehavior;
 use Pim\Bundle\NotificationBundle\Entity\NotificationInterface;
 use Pim\Bundle\NotificationBundle\Entity\UserNotificationInterface;
 use Pim\Bundle\NotificationBundle\Factory\UserNotificationFactory;
+use Prophecy\Argument;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 
@@ -79,5 +80,22 @@ class NotifierSpec extends ObjectBehavior
         $userNotifsSaver->saveAll([$userNotification, $userNotificationAuthor])->shouldBeCalled();
 
         $this->notify($notification, [$user, 'author']);
+    }
+
+    function it_does_not_notify_the_system_user(
+        $notificationSaver,
+        $userNotifsSaver,
+        $userNotifFactory,
+        NotificationInterface $notification,
+        UserInterface $userSystem
+    ) {
+        $userSystem->getUsername()->willReturn('system');
+
+        $userNotifFactory->createUserNotification(Argument::cetera())->shouldNotBeCalled();
+
+        $notificationSaver->save($notification)->shouldBeCalled();
+        $userNotifsSaver->saveAll([])->shouldBeCalled();
+
+        $this->notify($notification, [$userSystem, 'system']);
     }
 }

--- a/src/Pim/Bundle/UserBundle/Entity/UserInterface.php
+++ b/src/Pim/Bundle/UserBundle/Entity/UserInterface.php
@@ -24,6 +24,8 @@ use Symfony\Component\Security\Core\User\AdvancedUserInterface;
  */
 interface UserInterface extends AdvancedUserInterface, \Serializable, EntityUploadedImageInterface
 {
+    public const SYSTEM_USER_NAME = 'system';
+
     /**
      * Get entity class name.
      *

--- a/src/Pim/Bundle/UserBundle/EventSubscriber/CreateUserSystemListener.php
+++ b/src/Pim/Bundle/UserBundle/EventSubscriber/CreateUserSystemListener.php
@@ -5,6 +5,7 @@ namespace Pim\Bundle\UserBundle\EventSubscriber;
 use Akeneo\Component\StorageUtils\Factory\SimpleFactoryInterface;
 use Doctrine\Common\Persistence\ObjectRepository;
 use Doctrine\DBAL\DBALException;
+use Pim\Bundle\UserBundle\Entity\UserInterface;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
@@ -60,7 +61,7 @@ class CreateUserSystemListener
 
         try {
             $user = $this->userFactory->create();
-            $user->setUsername('system');
+            $user->setUsername(UserInterface::SYSTEM_USER_NAME);
             $groups = $this->groupRepository->findAll();
 
             foreach ($groups as $group) {


### PR DESCRIPTION
Without this PR, the execution of rules is totally broken on EE.

```
jjanvier:ped$ sf akeneo:rule:run copy_pt_PT_mobile_description_to_print_description                                                                                                
Running rules...
 1/1 [============================] 100%16:37:14 ERROR     [console] Error thrown while running command "akeneo:rule:run copy_pt_PT_mobile_description_to_print_description". Message: "A new entity was found through the relationship 'Pim\Bundle\NotificationBundle\Entity\UserNotification#user' that was not configured to cascade persist operations for entity: system. To solve this issue: Either explicitly call EntityManager#persist() on this unknown entity or configure cascade persist  this association in the mapping for example @ManyToOne(..,cascade={"persist"})." ["error" => Doctrine\ORM\ORMInvalidArgumentException { …},"command" => "akeneo:rule:run copy_pt_PT_mobile_description_to_print_description","message" => "A new entity was found through the relationship 'Pim\Bundle\NotificationBundle\Entity\UserNotification#user' that was not configured to cascade persist operations for entity: system. To solve this issue: Either explicitly call EntityManager#persist() on this unknown entity or configure cascade persist  this association in the mapping for example @ManyToOne(..,cascade={"persist"})."] []
16:37:14 ERROR     [console] Command "akeneo:rule:run copy_pt_PT_mobile_description_to_print_description" exited with code "1" ["command" => "akeneo:rule:run copy_pt_PT_mobile_description_to_print_description","code" => 1] []

                                                                                                                                                                                              
  [Doctrine\ORM\ORMInvalidArgumentException]                                                                                                                                                  
  A new entity was found through the relationship 'Pim\Bundle\NotificationBundle\Entity\UserNotification#user' that was not configured to cascade persist operations for entity: system. To   
  solve this issue: Either explicitly call EntityManager#persist() on this unknown entity or configure cascade persist  this association in the mapping for example @ManyToOne(..,cascade={"  
  persist"}).    
```

> Hey, but we have Behats for that. Rules work on EE!

Yes, sure dude. CI is green (well..). But the problem is we execute the business code of the rules, not the command `akeneo:rule:run` itself.

Explanations:
- we recently introduced a [CreateUserSystemListener](https://github.com/akeneo/pim-community-dev/blob/master/src/Pim/Bundle/UserBundle/EventSubscriber/CreateUserSystemListener.php#L57)  which role is to create a system user each time we launch a command 
-  some jobs (like the execution of the rules) wait for the end of the job to notify the user who has started the job
- this result in the creation of a UserNotification that is saved in database
- the problem is that the system user was never created in database, and that results in the error shown below

My solution is to prevent the System user from being notified.


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Y
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | 
| Micro Demo to the PO (Story only) | 
| Migration script                  | -
| Tech Doc                          | -
