### PR TITLE
GITHUB-6824: add .web-server-pid to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ npm-debug.log
 !/docker/akeneo-behat.conf
 !/docker/httpd.conf
 docker-compose.yml
+.web-server-pid
 
 yarn.lock
 package-lock.json


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Fix #6824 
Add .web-server-pid to gitignore

_**Must i add this change to CHANGELOG ?**_ 

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | ?
| Review and 2 GTM                  | -
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
