### PR TITLE
PIM-6837: Fix category tree switching in product grid

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product/index.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product/index.yml
@@ -69,6 +69,7 @@ extensions:
         aclResourceId: pim_enrich_product_category_list
         config:
             gridName: product-grid
+            categoryTreeName: pim_enrich_categorytree
 
     pim-product-index-category-tree-done:
         module: pim/grid/category-tree-done
@@ -131,4 +132,3 @@ extensions:
             gridName: product-grid
             localeParamName: dataLocale
             datagridLoadUrl: pim_datagrid_load
-

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/product-edit-form/CompletenessPanel.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/product-edit-form/CompletenessPanel.less
@@ -19,6 +19,7 @@
     display: flex;
     color: @AknDarkBlue;
     font-size: @AknFontSizeBig;
+    min-width: 300px;
   }
 
   &-headerLocale {

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/lib/select2.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/lib/select2.less
@@ -468,14 +468,6 @@
   }
 }
 
-.select2-searchIcon {
-  font-size: @AknBigIconFontSize;
-  color: @AknBorderColor;
-  line-height: @AknFormHeight - 2px;
-  position: absolute;
-  left: 10px;
-}
-
 // Stylize like AknButton
 .aknButtonLike {
   &.select2-container {


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This PR fixes an issue where the product grid keeps the category tree data from other grids when switching. 

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
