### PR TITLE
PIM-6773: Disable toFillFields header for product models only

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes.js
@@ -202,6 +202,12 @@ define(
                             AttributeGroupManager.getAttributeGroupsForObject(data),
                             toFillFieldProvider.getFields(this.getRoot(), data.values)
                         ).then((attributeGroups, fieldsToFill) => {
+
+                            // PIM-6773: Remove to activate fields to fill in product models.
+                            if (this.getFormData().meta.model_type === 'product_model') {
+                                fieldsToFill = [];
+                            }
+
                             const sections = _.values(
                                 fields.reduce(groupFieldsBySection(attributeGroups, fieldsToFill), {})
                             );


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

As the missing required attributes for the product model are not computed yet (see PIM-6773 story).

We need to disable the header for product model edit forms only. 

This *quickfix* allows us to do so.

In short - do not show this for product models only:
![screen shot 2017-09-27 at 17 28 31](https://user-images.githubusercontent.com/1826473/30922404-533eeb24-a3a9-11e7-95f3-0a2054c0f733.png)


**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
