### PR TITLE
TIP-749: upgrade total fields limit in ES

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Resources/elasticsearch/index_configuration.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/elasticsearch/index_configuration.yml
@@ -212,4 +212,4 @@ settings:
         # ES default value is 1000. This value can be too low for big catalogs.
         # For more information see https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping.html#mapping-limit-settings
         total_fields:
-            limit: 3000
+            limit: 10000


### PR DESCRIPTION
With Leo we imported a catalog they use at presales.
This catalog contains 1000 attributes.

We already reach the limit of 3000 fields in ES with this catalog.
We decided with Benoit to upgrade this limit to 10000 fields. 