### PR TITLE
API-352: add priority on products indexers

### DIFF
--- a/features/update/remove_price.feature
+++ b/features/update/remove_price.feature
@@ -3,6 +3,7 @@ Feature: Remove price fields
   As an internal process or any user
   I need to be able to remove a price field of a product
 
+  @ce
   Scenario: Successfully remove a price field
     Given a "default" catalog configuration
     And the following attributes:

--- a/src/Pim/Bundle/CatalogBundle/EventSubscriber/IndexProductsSubscriber.php
+++ b/src/Pim/Bundle/CatalogBundle/EventSubscriber/IndexProductsSubscriber.php
@@ -55,9 +55,9 @@ class IndexProductsSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents() : array
     {
         return [
-            StorageEvents::POST_SAVE     => 'indexProduct',
-            StorageEvents::POST_SAVE_ALL => 'bulkIndexProducts',
-            StorageEvents::POST_REMOVE   => 'deleteProduct',
+            StorageEvents::POST_SAVE     => ['indexProduct', 300],
+            StorageEvents::POST_SAVE_ALL => ['bulkIndexProducts', 300],
+            StorageEvents::POST_REMOVE   => ['deleteProduct', 300],
         ];
     }
 

--- a/src/Pim/Bundle/CatalogBundle/spec/EventSubscriber/IndexProductsSubscriberSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/EventSubscriber/IndexProductsSubscriberSpec.php
@@ -28,9 +28,9 @@ class IndexProductsSubscriberSpec extends ObjectBehavior
     function it_subscribes_to_events()
     {
         $this->getSubscribedEvents()->shouldReturn([
-            StorageEvents::POST_SAVE     => 'indexProduct',
-            StorageEvents::POST_SAVE_ALL => 'bulkIndexProducts',
-            StorageEvents::POST_REMOVE   => 'deleteProduct',
+            StorageEvents::POST_SAVE     => ['indexProduct', 300],
+            StorageEvents::POST_SAVE_ALL => ['bulkIndexProducts', 300],
+            StorageEvents::POST_REMOVE   => ['deleteProduct', 300],
         ]);
     }
 


### PR DESCRIPTION
[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)

see [sf doc](http://symfony.com/doc/current/event_dispatcher.html) about priority:

> The other optional tag attribute is called  priority, which defaults to 0 and it controls the order in which listeners are executed (the highest the priority, the earlier a listener is executed). This is useful when you need to guarantee that one listener is executed before another. The priorities of the internal Symfony listeners usually range from -255 to 255 but your own listeners can use any positive or negative integer.


[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)

**Description (for Contributor and Core Developer)**

[//]: <> (What does this Pull Request do? reference the related issue?)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
