### PR TITLE
TIP-613: take ES errors into accound during indexation

### DIFF
--- a/src/Akeneo/Bundle/ElasticsearchBundle/Exception/IndexationException.php
+++ b/src/Akeneo/Bundle/ElasticsearchBundle/Exception/IndexationException.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Akeneo\Bundle\ElasticsearchBundle\Exception;
+
+/**
+ * Exception thrown when indexation has failed.
+ *
+ * @author    Julien Janvier <j.janvier@gmail.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class IndexationException extends \LogicException
+{
+}

--- a/src/Pim/Bundle/InstallerBundle/Command/DatabaseCommand.php
+++ b/src/Pim/Bundle/InstallerBundle/Command/DatabaseCommand.php
@@ -127,6 +127,7 @@ class DatabaseCommand extends ContainerAwareCommand
         $output->writeln('<info>Reset elasticsearch indexes</info>');
 
         $this->getContainer()->get('akeneo_elasticsearch.client.product')->resetIndex();
+        $this->getContainer()->get('akeneo_elasticsearch.client.product_model')->resetIndex();
         $this->getContainer()->get('akeneo_elasticsearch.client.product_and_product_model')->resetIndex();
     }
 


### PR DESCRIPTION
During indexation, we didn't take into account ES errors that can occur.
There are 2 types of errors:
- sometimes an exception is thrown by the official ES PHP client 
- sometimes there is just a field `error` set in the response

Errors can occur for instance when we have reach the `index.mapping.total_fields.limit` parameter of Elasticsearch.

Before this PR, the indexation would silently fail. That means, you think that everything's working, but actually, your products or product models are not indexed (and thus are not available in the datagrid)

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Y
| Added Behats                      | 
| Added integration tests           | 
| Changelog updated                 | 
| Review and 2 GTM                  | 
| Micro Demo to the PO (Story only) | 
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
