### PR TITLE
Fix QueryProductCommand table deprecation

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Command/QueryProductCommand.php
+++ b/src/Pim/Bundle/CatalogBundle/Command/QueryProductCommand.php
@@ -6,6 +6,7 @@ use Akeneo\Component\StorageUtils\Cursor\CursorInterface;
 use Pim\Component\Catalog\Query\ProductQueryBuilderInterface;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Helper\HelperInterface;
+use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -80,7 +81,7 @@ class QueryProductCommand extends ContainerAwareCommand
         $products = $productQueryBuilder->execute();
 
         if (!$input->getOption('json-output')) {
-            $table = $this->buildTable($products, $pageSize);
+            $table = $this->buildTable($products, $pageSize, $output);
             $table->render($output);
 
             $nbProducts = count($products);
@@ -113,12 +114,12 @@ class QueryProductCommand extends ContainerAwareCommand
     /**
      * @param CursorInterface $products
      * @param int             $maxRows
+     * @param OutputInterface $output
      *
      * @return HelperInterface
      */
-    protected function buildTable(CursorInterface $products, $maxRows)
+    protected function buildTable(CursorInterface $products, $maxRows, OutputInterface $output)
     {
-        $helperSet = $this->getHelperSet();
         $rows = [];
         $ind = 0;
         foreach ($products as $product) {
@@ -130,7 +131,7 @@ class QueryProductCommand extends ContainerAwareCommand
             }
         }
         $headers = ['id', 'identifier'];
-        $table = $helperSet->get('table');
+        $table = new Table($output);
         $table->setHeaders($headers)->setRows($rows);
 
         return $table;


### PR DESCRIPTION
Due to a Sf3 deprecation https://symfony.com/doc/current/components/console/helpers/tablehelper.html

Before:
```
➜  pim-demos2.0 git:(dev2.0.0.0) ✗ bin/console pim:product:query {}     
12:17:55 ERROR     [console] Error thrown while running command "pim:product:query '{}'". Message: "The helper "table" is not defined." ["error" => Symfony\Component\Console\Exception\InvalidArgumentException { …},"command" => "pim:product:query '{}'","message" => "The helper "table" is not defined."] []
12:17:55 ERROR     [console] Command "pim:product:query '{}'" exited with code "1" ["command" => "pim:product:query '{}'","code" => 1] []

                                                                  
  [Symfony\Component\Console\Exception\InvalidArgumentException]  
  The helper "table" is not defined.                              
```

After:

```
➜  pim-demos2.0 git:(dev2.0.0.0) ✗ bin/console pim:product:query {}
+------+-----------------+
| id   | identifier      |
+------+-----------------+
| 1    | belt            |
| 10   | 23116299        |
| 100  | aphrodite_8     |
| 1000 | climbingshoe_11 |
| 1001 | brogueshoe_0    |
| 1002 | brogueshoe_1    |
| 1003 | brogueshoe_2    |
| 1004 | brogueshoe_3    |
| 1005 | 31040101        |
| 1006 | 31040247        |
| ...  | ...             |
+------+-----------------+
10 first products on 1098 matching these criterias
```

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
