### PR TITLE
PIM-6773: Add missing required attributes for product models

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Resources/config/completeness.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/completeness.yml
@@ -2,18 +2,35 @@ parameters:
     pim_catalog.completeness.calculator.class: Pim\Component\Catalog\Completeness\CompletenessCalculator
     pim_catalog.completeness.generator.class: Pim\Component\Catalog\Completeness\CompletenessGenerator
 
-services:
-    pim_catalog.completeness.calculator:
-        class: '%pim_catalog.completeness.calculator.class%'
-        arguments:
-            - '@pim_catalog.factory.value'
-            - '@pim_catalog.repository.cached_channel'
-            - '@pim_catalog.repository.cached_locale'
-            - '@pim_catalog.completeness.checker'
-            - '%pim_catalog.entity.completeness.class%'
+#    To move in dedicated files
+    pim_catalog.family.required_values.class: Pim\Component\Catalog\Family\RequiredValues
+    pim_catalog.missing_required_attributes.calculator.class: Pim\Component\Catalog\MissingRequiredAttributes\MissingRequiredValuesCalculator
 
+services:
     pim_catalog.completeness.generator:
         class: '%pim_catalog.completeness.generator.class%'
         arguments:
             - '@pim_catalog.query.product_query_builder_factory'
             - '@pim_catalog.completeness.calculator'
+
+    pim_catalog.generator.required_values:
+        class: '%pim_catalog.family.required_values.class%'
+        arguments:
+            - '@pim_catalog.factory.value'
+
+    pim_catalog.completeness.calculator:
+        class: '%pim_catalog.completeness.calculator.class%'
+        arguments:
+            - '@pim_catalog.repository.cached_channel'
+            - '@pim_catalog.repository.cached_locale'
+            - '@pim_catalog.calculator.missing_required_attributes'
+            - '@pim_catalog.generator.required_values'
+            - '%pim_catalog.entity.completeness.class%'
+
+    pim_catalog.calculator.missing_required_attributes:
+        class: '%pim_catalog.missing_required_attributes.calculator.class%'
+        arguments:
+            - '@pim_catalog.factory.value'
+            - '@pim_catalog.completeness.checker'
+            - '@pim_catalog.repository.cached_channel'
+            - '@pim_catalog.repository.cached_locale'

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/MissingRequiredAttributesNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/MissingRequiredAttributesNormalizer.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\EnrichBundle\Normalizer;
+
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\LocaleInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\scalar;
+
+/**
+ * {description}
+ *
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class MissingRequiredAttributesNormalizer implements NormalizerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function normalize($requiredMissingAttributes, $format = null, array $context = []): array
+    {
+        $locales = $context['locales'] ?? [];
+
+        $normalizedMissingRequiredAttributes = [];
+        foreach ($requiredMissingAttributes as $attribute) {
+            $attribute = $attribute;
+            $normalizedMissingRequiredAttributes[] = [
+                'code'   => $attribute->getCode(),
+                'labels' => $this->normalizeAttributeLabels($attribute, $locales),
+            ];
+        }
+
+        return $normalizedMissingRequiredAttributes;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsNormalization($data, $format = null): bool
+    {
+        return false;
+    }
+
+    /**
+     * Normalizes the label of the missing required attributes.
+     *
+     * @param AttributeInterface $attribute
+     * @param LocaleInterface[]  $localeCodes
+     *
+     * @return array
+     */
+    private function normalizeAttributeLabels(AttributeInterface $attribute, array $localeCodes): array
+    {
+        $result = [];
+        foreach ($localeCodes as $localeCode) {
+            $result[$localeCode] = $attribute->getTranslation($localeCode)->getLabel();
+        }
+
+        return $result;
+    }
+}

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_model/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_model/edit.yml
@@ -215,6 +215,12 @@ extensions:
         targetZone: self
         position: 100
 
+    pim-product-model-edit-form-completeness-filter:
+        module: pim/product-edit-form/attributes/completeness
+        parent: pim-product-model-edit-form-attributes
+        targetZone: self
+        position: 100
+
     pim-product-model-edit-form-localizable:
         module: pim/product-edit-form/attributes/localizable
         parent: pim-product-model-edit-form-attributes
@@ -236,3 +242,19 @@ extensions:
         position: 110
         config:
             context: copy_product
+
+    pim-product-model-edit-form-attribute-filter:
+        module: pim/product-edit-form/attribute-filter
+        parent: pim-product-model-edit-form-attributes
+        targetZone: other-actions
+        position: 110
+
+    pim-product-model-edit-form-attribute-filter-all:
+        module: pim/product-edit-form/attribute-filter-all
+        parent: pim-product-model-edit-form-attribute-filter
+        position: 100
+
+    pim-product-model-edit-form-attribute-filter-missing-required:
+        module: pim/product-edit-form/attribute-filter-missing-required
+        parent: pim-product-model-edit-form-attribute-filter
+        position: 110

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/normalizers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/normalizers.yml
@@ -26,6 +26,7 @@ parameters:
     pim_enrich.normalizer.structured.attribute_option.class:       Pim\Bundle\EnrichBundle\Normalizer\StructuredAttributeOptionNormalizer
     pim_enrich.normalizer.entity_with_family_variant.class:        Pim\Bundle\EnrichBundle\Normalizer\EntityWithFamilyVariantNormalizer
     pim_enrich.normalizer.variant_navigation.class:                Pim\Bundle\EnrichBundle\Normalizer\VariantNavigationNormalizer
+    pim_enrich.normalizer.missing_required_attributes.class:       Pim\Bundle\EnrichBundle\Normalizer\MissingRequiredAttributesNormalizer
 
 services:
     pim_enrich.normalizer.attribute_option_value_collection:
@@ -88,6 +89,9 @@ services:
             - '@pim_enrich.normalizer.variant_navigation'
             - '@pim_catalog.doctrine.query.find_variant_product_completeness'
             - '@pim_catalog.product_models.image_as_label'
+            - '@pim_catalog.generator.required_values'
+            - '@pim_catalog.calculator.missing_required_attributes'
+            - '@pim_enrich.normalizer.missing_required_attributes'
         tags:
             - { name: pim_internal_api_serializer.normalizer }
 
@@ -100,6 +104,10 @@ services:
         class: '%pim_enrich.normalizer.completeness_collection.class%'
         arguments:
             - '@pim_enrich.normalizer.completeness'
+            - '@pim_enrich.normalizer.missing_required_attributes'
+
+    pim_enrich.normalizer.missing_required_attributes:
+        class: '%pim_enrich.normalizer.missing_required_attributes.class%'
 
     pim_enrich.normalizer.version:
         class: '%pim_enrich.normalizer.version.class%'

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes.js
@@ -203,11 +203,6 @@ define(
                             toFillFieldProvider.getFields(this.getRoot(), data.values)
                         ).then((attributeGroups, fieldsToFill) => {
 
-                            // PIM-6773: Remove to activate fields to fill in product models.
-                            if (this.getFormData().meta.model_type === 'product_model') {
-                                fieldsToFill = [];
-                            }
-
                             const sections = _.values(
                                 fields.reduce(groupFieldsBySection(attributeGroups, fieldsToFill), {})
                             );

--- a/src/Pim/Component/Catalog/Family/RequiredValue.php
+++ b/src/Pim/Component/Catalog/Family/RequiredValue.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Component\Catalog\Family;
+
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\ChannelInterface;
+use Pim\Component\Catalog\Model\LocaleInterface;
+
+/**
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class RequiredValue
+{
+    private $channel;
+
+    private $locale;
+
+    private $attribute;
+
+    /**
+     * @param ChannelInterface   $channel
+     * @param LocaleInterface    $locale
+     * @param AttributeInterface $attribute
+     */
+    public function __construct(ChannelInterface $channel, LocaleInterface $locale, AttributeInterface $attribute)
+    {
+        $this->channel = $channel;
+        $this->locale = $locale;
+        $this->attribute = $attribute;
+    }
+
+    /**
+     * @return AttributeInterface
+     */
+    public function getAttribute(): AttributeInterface
+    {
+        return $this->attribute;
+    }
+
+    /**
+     * @return LocaleInterface
+     */
+    public function getLocale(): LocaleInterface
+    {
+        return $this->locale;
+    }
+
+    /**
+     * @return ChannelInterface
+     */
+    public function getChannel(): ChannelInterface
+    {
+        return $this->channel;
+    }
+}

--- a/src/Pim/Component/Catalog/Family/RequiredValues.php
+++ b/src/Pim/Component/Catalog/Family/RequiredValues.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Component\Catalog\Family;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Pim\Component\Catalog\Factory\ValueFactory;
+use Pim\Component\Catalog\Model\FamilyInterface;
+use Pim\Component\Catalog\Model\ValueCollection;
+use Pim\Component\Catalog\Model\ValueCollectionInterface;
+
+/**
+ *
+ *
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class RequiredValues
+{
+    /** @var ValueFactory */
+    private $valueFactory;
+
+    /**
+     * @param ValueFactory $valueFactory
+     */
+    public function __construct(ValueFactory $valueFactory)
+    {
+        $this->valueFactory = $valueFactory;
+    }
+
+    /**
+     * @param FamilyInterface $family
+     *
+     * @return RequiredValuesCollection[]
+     */
+    public function fromFamily(FamilyInterface $family): ArrayCollection
+    {
+        $requiredValues = new ArrayCollection();
+
+        foreach ($family->getAttributeRequirements() as $attributeRequirement) {
+            foreach ($attributeRequirement->getChannel()->getLocales() as $locale) {
+                if ($attributeRequirement->isRequired()) {
+                    $channel = $attributeRequirement->getChannel();
+
+                    $attribute = $attributeRequirement->getAttribute();
+                    if ($attribute->isLocaleSpecific() && !$attribute->hasLocaleSpecific($locale)) {
+                        continue;
+                    }
+
+                    $requiredValue = new RequiredValue($channel, $locale, $attribute);
+                    $requiredValues->add($requiredValue);
+                }
+            }
+        }
+
+        return $requiredValues;
+    }
+}

--- a/src/Pim/Component/Catalog/Family/RequiredValuesCollection.php
+++ b/src/Pim/Component/Catalog/Family/RequiredValuesCollection.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Component\Catalog\Family;
+
+use Pim\Component\Catalog\Model\ChannelInterface;
+use Pim\Component\Catalog\Model\LocaleInterface;
+use Pim\Component\Catalog\Model\ValueCollection;
+use Pim\Component\Catalog\Model\ValueCollectionInterface;
+use Pim\Component\Catalog\Model\ValueInterface;
+
+/**
+ * Matrix of required attributes for a channel and a scope.
+ *
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class RequiredValuesCollection
+{
+    /** @var ValueCollectionInterface */
+    private $requiredValues;
+
+    /**
+     * @param ValueInterface $value
+     */
+    public function add(ValueInterface $value): void
+    {
+        $this->requiredValues->add($value);
+    }
+}

--- a/src/Pim/Component/Catalog/MissingRequiredAttributes/MissingRequiredValues.php
+++ b/src/Pim/Component/Catalog/MissingRequiredAttributes/MissingRequiredValues.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Component\Catalog\MissingRequiredAttributes;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\ChannelInterface;
+use Pim\Component\Catalog\Model\LocaleInterface;
+
+/**
+ * Object that holds the list of missing required attributes for a channel and locale.
+ *
+ * The CompletenessCalculator uses it to generate the completeness for a product, channel and scope.
+ *
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *            // missing required value
+ */
+class MissingRequiredValues
+{
+    private $channel;
+
+    private $locale;
+
+    /** @var array */
+    private $missingRequiredAttributes = [];
+
+    public function add(AttributeInterface $attribute, LocaleInterface $locale, ChannelInterface $channel)
+    {
+        $channelCode = $channel->getCode();
+        $localeCode = $locale->getCode();
+        if (!isset($this->missingRequiredAttributes[$channelCode][$localeCode])) {
+            $this->missingRequiredAttributes[$channelCode][$localeCode] = new ArrayCollection();
+        }
+
+        $this->missingRequiredAttributes[$channelCode][$localeCode]->add($attribute);
+    }
+
+    public function getChannels()
+    {
+        return array_keys($this->missingRequiredAttributes);
+    }
+
+    public function getLocales()
+    {
+        $locales = [];
+        foreach ($this->missingRequiredAttributes as $channel => $missingRequiredForChannel) {
+            $locales = array_merge($locales, array_keys($missingRequiredForChannel));
+        }
+
+        return $locales;
+    }
+}

--- a/src/Pim/Component/Catalog/MissingRequiredAttributes/MissingRequiredValuesCalculator.php
+++ b/src/Pim/Component/Catalog/MissingRequiredAttributes/MissingRequiredValuesCalculator.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Component\Catalog\MissingRequiredAttributes;
+
+use Akeneo\Component\StorageUtils\Repository\CachedObjectRepositoryInterface;
+use Pim\Component\Catalog\Completeness\Checker\ValueCompleteCheckerInterface;
+use Pim\Component\Catalog\Factory\ValueFactory;
+use Pim\Component\Catalog\Model\FamilyInterface;
+use Pim\Component\Catalog\Model\ValueCollection;
+use Pim\Component\Catalog\Model\ValueCollectionInterface;
+
+/**
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class MissingRequiredValuesCalculator
+{
+    /** @var CachedObjectRepositoryInterface */
+    private $channelRepository;
+
+    /** @var CachedObjectRepositoryInterface */
+    private $localeRepository;
+
+    /** @var ValueCompleteCheckerInterface */
+    private $valueCompleteChecker;
+
+    /**
+     * @param ValueCompleteCheckerInterface   $valueCompleteChecker
+     * @param CachedObjectRepositoryInterface $channelRepository
+     * @param CachedObjectRepositoryInterface $localeRepository
+     */
+    public function __construct(
+        ValueFactory $valueFactory,
+        ValueCompleteCheckerInterface $valueCompleteChecker,
+        CachedObjectRepositoryInterface $channelRepository,
+        CachedObjectRepositoryInterface $localeRepository
+    ) {
+        $this->valueFactory = $valueFactory;
+        $this->valueCompleteChecker = $valueCompleteChecker;
+        $this->channelRepository = $channelRepository;
+        $this->localeRepository = $localeRepository;
+    }
+
+    public function generate(
+        FamilyInterface $family,
+        ValueCollectionInterface $values
+    ): ValueCollectionInterface {
+        $missingRequiredValues = new ValueCollection();
+
+        foreach ($family->getAttributeRequirements() as $attributeRequirement) {
+            $channel = $attributeRequirement->getChannel();
+            foreach ($channel->getLocales() as $locale) {
+                if ($attributeRequirement->isRequired()) {
+                    $attribute = $attributeRequirement->getAttribute();
+                    if ($attribute->isLocaleSpecific() && !$attribute->hasLocaleSpecific($locale)) {
+                        continue;
+                    }
+
+                    $value = $values->getByCodes(
+                        $attributeRequirement->getAttribute()->getCode(),
+                        $attribute->isScopable() ? $channel->getCode() : null,
+                        $attribute->isLocalizable() ? $locale->getCode() : null
+                    );
+
+                    if (null === $value) {
+                        $value = $this->valueFactory->create(
+                            $attribute,
+                            $attribute->isScopable() ? $channel->getCode() : null,
+                            $attribute->isLocalizable() ? $locale->getCode() : null,
+                            null
+                        );
+
+                        $missingRequiredValues->add($value);
+                    }
+
+                    if (!$this->valueCompleteChecker->isComplete($value, $channel, $locale)) {
+                        $missingRequiredValues->add($value);
+                    }
+                }
+            }
+        }
+
+        return $missingRequiredValues; // pvm1, pvm2, pvm3
+    }
+}
+

--- a/src/Pim/Component/Catalog/spec/Completeness/MissingRequiredAttributesSpec.php
+++ b/src/Pim/Component/Catalog/spec/Completeness/MissingRequiredAttributesSpec.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace spec\Pim\Component\Catalog\Completeness;
+
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\MissingRequiredAttributes\MissingRequiredValues;
+use Pim\Component\Catalog\Model\AttributeInterface;
+
+class MissingRequiredAttributesSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(MissingRequiredValues::class);
+    }
+
+    function it_returns_an_empty_list_of_attributes()
+    {
+        $this->getAttributes()->shouldReturn([]);
+    }
+
+    function it_adds_an_attribute(AttributeInterface $attribute)
+    {
+        $this->add($attribute);
+
+        $this->getAttributes()->shouldReturn([$attribute]);
+    }
+
+    function it_adds_multiple_attributes(AttributeInterface $attribute1, AttributeInterface $attribute2)
+    {
+        $attribute1->getCode()->willReturn('attribute_1');
+        $attribute2->getCode()->willReturn('attribute_2');
+
+        $this->add($attribute1);
+        $this->add($attribute2);
+
+        $this->getAttributes()->shouldReturn([$attribute1, $attribute2]);
+    }
+
+    function it_does_not_add_multiple_time_the_same_attribute(AttributeInterface $sameAttribute)
+    {
+        $sameAttribute->getCode()->willReturn('sameAttributeCode');
+
+        $this->add($sameAttribute);
+        $this->add($sameAttribute);
+
+        $this->getAttributes()->shouldReturn([$sameAttribute]);
+    }
+
+    function it_returns_the_list_of_missing_required_attribute_codes(
+        AttributeInterface $attribute1,
+        AttributeInterface $attribute2
+    ) {
+        $attribute1->getCode()->willReturn('attribute_1');
+        $attribute2->getCode()->willReturn('attribute_2');
+
+        $this->add($attribute1);
+        $this->add($attribute2);
+
+        $this->getAttributeCodes()->shouldReturn(['attribute_1', 'attribute_2']);
+    }
+}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Adds the completeness navigation tools available in the in the product edit form for the product model edit form.

- [x] Extract missingAttributes concept from the completenessCalculator
- [x] Extract the getRequiredValues from the completenessCalculator
- [x] Adapt the computation of the completeness
- [x] Adapts the productNormalizer and normalize the completeness for the ProductModels
- [x] Add configuration for the front
- [ ] Rename "RequiredMissing" => "MissingRequired"
- [ ] normalize the label key
- [ ] Cleanup & BCs
- [ ] Add BCs

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
