### PR TITLE
API-393: add prefix akeno:batch to the command to push a job into the queue

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,10 @@
-[//]: <> (<3 Thanks for taking the time to contribute! You're awesome! <3)
+<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->
 
-[//]: <> (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md)
+<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->
 
 **Description (for Contributor and Core Developer)**
 
-[//]: <> (What does this Pull Request do? reference the related issue?)
+<!--- (What does this Pull Request do? reference the related issue?) --->
 
 **Definition Of Done (for Core Developer only)**
 

--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -4,6 +4,7 @@
 
 - GITHUB-6824: Update gitignore for web-server-bundle, cheers @xElysioN!
 - GITHUB-6866: fix the QueryProductCommand, cheers @LeoBenoist!
+- API-393: add prefix "akeno:batch" to the command "publish-job-to-queue"
 
 ## Better UI\UX!
 

--- a/src/Akeneo/Bundle/BatchQueueBundle/Command/JobQueueConsumerCommand.php
+++ b/src/Akeneo/Bundle/BatchQueueBundle/Command/JobQueueConsumerCommand.php
@@ -132,14 +132,6 @@ class JobQueueConsumerCommand extends ContainerAwareCommand
     }
 
     /**
-     * @return NodeProviderInterface
-     */
-    private function getNodeProvider(): NodeProviderInterface
-    {
-        return $this->getContainer()->get('ramsey.uuid.provider.node.system_node_provider');
-    }
-
-    /**
      * @return JobExecutionQueueInterface
      */
     private function getQueue(): JobExecutionQueueInterface

--- a/src/Akeneo/Bundle/BatchQueueBundle/Command/PublishJobToQueueCommand.php
+++ b/src/Akeneo/Bundle/BatchQueueBundle/Command/PublishJobToQueueCommand.php
@@ -33,7 +33,7 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
  */
 class PublishJobToQueueCommand extends ContainerAwareCommand
 {
-    public const COMMAND_NAME = 'publish-job-to-queue';
+    public const COMMAND_NAME = 'akeneo:batch:publish-job-to-queue';
     public const EXIT_SUCCESS_CODE = 0;
 
     /**


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
 
My bad: the command is "akeneo:batch:publish-job-to-queue" and not "publish-job-to-queue".


<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | Ok
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
