### PR TITLE
PIM-6356: display ascendant or descendant image for product models

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -18,6 +18,7 @@
 - PIM-6841: Add custom pictures for entities creation
 - PIM-6356: Display 1st variant product image in the grid and on the PEF for product models
 - PIM-6348: Display a red label in the variant navigation if no product is complete
+- PIM-6451: Now display variant axes coming from parent as "Variant Axis" on the product edit form
 
 ## BC breaks
 

--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -22,9 +22,9 @@
 
 ## BC breaks
 
-- Change constructor of `Pim\Bundle\DataGridBundle\Normalizer\ProductModelNormalizer` to add `Pim\Component\Catalog\ProductModel\ProductModelImageAsLabel`
-- Change constructor of `Pim\Bundle\EnrichBundle\Normalizer\EntityWithFamilyVariantNormalizer` to add `Pim\Component\Catalog\ProductModel\ProductModelImageAsLabel`
-- Change constructor of `Pim\Bundle\EnrichBundle\Normalizer\ProductModelNormalizer` to add `Pim\Component\Catalog\ProductModel\ProductModelImageAsLabel`
+- Change constructor of `Pim\Bundle\DataGridBundle\Normalizer\ProductModelNormalizer` to add `Pim\Component\Catalog\ProductModel\ImageAsLabel`
+- Change constructor of `Pim\Bundle\EnrichBundle\Normalizer\EntityWithFamilyVariantNormalizer` to add `Pim\Component\Catalog\ProductModel\ImageAsLabel`
+- Change constructor of `Pim\Bundle\EnrichBundle\Normalizer\ProductModelNormalizer` to add `Pim\Component\Catalog\ProductModel\ImageAsLabel`
 
 # 2.0.0 (2017-09-28)
 

--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -16,6 +16,13 @@
 - PIM-6839: Fix the design for large titles
 - PIM-6595: Add missing breadcrumb or user navigation on every page
 - PIM-6841: Add custom pictures for entities creation
+- PIM-6356: Display 1st variant product image in the grid and on the PEF for product models
+
+## BC breaks
+
+- Change constructor of `Pim\Bundle\DataGridBundle\Normalizer\ProductModelNormalizer` to add `Pim\Component\Catalog\ProductModel\ProductModelImageAsLabel`
+- Change constructor of `Pim\Bundle\EnrichBundle\Normalizer\EntityWithFamilyVariantNormalizer` to add `Pim\Component\Catalog\ProductModel\ProductModelImageAsLabel`
+- Change constructor of `Pim\Bundle\EnrichBundle\Normalizer\ProductModelNormalizer` to add `Pim\Component\Catalog\ProductModel\ProductModelImageAsLabel`
 
 # 2.0.0 (2017-09-28)
 

--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -17,6 +17,7 @@
 - PIM-6595: Add missing breadcrumb or user navigation on every page
 - PIM-6841: Add custom pictures for entities creation
 - PIM-6356: Display 1st variant product image in the grid and on the PEF for product models
+- PIM-6348: Display a red label in the variant navigation if no product is complete
 
 ## BC breaks
 

--- a/features/product/choose_and_order_products_grid_columns.feature
+++ b/features/product/choose_and_order_products_grid_columns.feature
@@ -14,7 +14,7 @@ Feature: Choose and order product grids columns
     And I am on the products grid
 
   Scenario: Successfully display default columns
-    Then I should see the columns ID, Image, Label, Family, Status, Complete, Created At, Updated At, Groups, Complete product
+    Then I should see the columns ID, Image, Label, Family, Status, Complete, Created At, Updated At, Groups, Variant products
 
   @skip
   Scenario: Successfully hide some columns

--- a/features/product/edit_variant_product.feature
+++ b/features/product/edit_variant_product.feature
@@ -29,6 +29,8 @@ Feature: Edit a variant product
     Then the field Composition should be read only
     And the field Material should be read only
     And I should see the text "This attribute can be updated on the attributes by Color"
+    And I should see the text "Color (Variant axis)"
+    And I should see the text "Size (Variant axis)"
 
   Scenario: Attributes coming from common attributes are read only
     Given I am logged in as "Mary"

--- a/src/Pim/Bundle/CatalogBundle/DependencyInjection/PimCatalogExtension.php
+++ b/src/Pim/Bundle/CatalogBundle/DependencyInjection/PimCatalogExtension.php
@@ -52,6 +52,7 @@ class PimCatalogExtension extends Extension
         $loader->load('localization/validators.yml');
         $loader->load('managers.yml');
         $loader->load('models.yml');
+        $loader->load('product_models.yml');
         $loader->load('product_values.yml');
         $loader->load('query_builders.yml');
         $loader->load('removers.yml');

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/product_models.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/product_models.yml
@@ -1,5 +1,5 @@
 parameters:
-    pim_catalog.product_models.image_as_label.class: Pim\Component\Catalog\ProductModel\ProductModelImageAsLabel
+    pim_catalog.product_models.image_as_label.class: Pim\Component\Catalog\ProductModel\ImageAsLabel
 
 services:
     pim_catalog.product_models.image_as_label:

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/product_models.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/product_models.yml
@@ -1,0 +1,9 @@
+parameters:
+    pim_catalog.product_models.image_as_label.class: Pim\Component\Catalog\ProductModel\ProductModelImageAsLabel
+
+services:
+    pim_catalog.product_models.image_as_label:
+        class: '%pim_catalog.product_models.image_as_label.class%'
+        arguments:
+            - '@pim_catalog.repository.product_model'
+            - '@pim_catalog.repository.variant_product'

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/repositories.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/repositories.yml
@@ -183,6 +183,17 @@ services:
         tags:
             - { name: 'pim_repository' }
 
+    pim_catalog.repository.variant_product:
+        class: '%pim_catalog.repository.product.class%'
+        factory: 'doctrine.orm.entity_manager:getRepository'
+        arguments: ['%pim_catalog.entity.variant_product.class%']
+        calls:
+            - [setProductQueryBuilderFactory, ['@pim_catalog.query.product_query_builder_factory']]
+            - [setGroupRepository, ['@pim_catalog.repository.group']]
+            - [setReferenceDataRegistry, ['@?pim_reference_data.registry']]
+        tags:
+            - { name: 'pim_repository' }
+
     pim_catalog.repository.product_mass_action:
         class: '%pim_catalog.repository.product_mass_action.class%'
         arguments:

--- a/src/Pim/Bundle/DataGridBundle/Normalizer/ProductModelNormalizer.php
+++ b/src/Pim/Bundle/DataGridBundle/Normalizer/ProductModelNormalizer.php
@@ -8,7 +8,7 @@ use Pim\Bundle\CatalogBundle\Filter\CollectionFilterInterface;
 use Pim\Component\Catalog\Model\ProductModelInterface;
 use Pim\Component\Catalog\Model\ValueCollectionInterface;
 use Pim\Component\Catalog\Model\ValueInterface;
-use Pim\Component\Catalog\ProductModel\ProductModelImageAsLabel;
+use Pim\Component\Catalog\ProductModel\ImageAsLabel;
 use Pim\Component\Catalog\ProductModel\Query\VariantProductRatioInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
@@ -31,22 +31,22 @@ class ProductModelNormalizer implements NormalizerInterface, NormalizerAwareInte
     /** @var VariantProductRatioInterface */
     private $variantProductRatioQuery;
 
-    /** @var ProductModelImageAsLabel */
-    private $productModelImageAsLabel;
+    /** @var ImageAsLabel */
+    private $imageAsLabel;
 
     /**
      * @param CollectionFilterInterface    $filter
      * @param VariantProductRatioInterface $variantProductRatioQuery
-     * @param ProductModelImageAsLabel     $productModelImageAsLabel
+     * @param ImageAsLabel                 $imageAsLabel
      */
     public function __construct(
         CollectionFilterInterface $filter,
         VariantProductRatioInterface $variantProductRatioQuery,
-        ProductModelImageAsLabel $productModelImageAsLabel
+        ImageAsLabel $imageAsLabel
     ) {
-        $this->filter = $filter;
+        $this->filter                   = $filter;
         $this->variantProductRatioQuery = $variantProductRatioQuery;
-        $this->productModelImageAsLabel = $productModelImageAsLabel;
+        $this->imageAsLabel             = $imageAsLabel;
     }
 
     /**
@@ -64,7 +64,7 @@ class ProductModelNormalizer implements NormalizerInterface, NormalizerAwareInte
         $channel = current($context['channels']);
 
         $variantProductCompleteness = $this->variantProductRatioQuery->findComplete($productModel);
-        $closestImage = $this->productModelImageAsLabel->getImage($productModel);
+        $closestImage = $this->imageAsLabel->value($productModel);
 
         $data['identifier'] = $productModel->getCode();
         $data['family'] = $this->getFamilyLabel($productModel, $locale);

--- a/src/Pim/Bundle/DataGridBundle/Normalizer/ProductModelNormalizer.php
+++ b/src/Pim/Bundle/DataGridBundle/Normalizer/ProductModelNormalizer.php
@@ -8,6 +8,7 @@ use Pim\Bundle\CatalogBundle\Filter\CollectionFilterInterface;
 use Pim\Component\Catalog\Model\ProductModelInterface;
 use Pim\Component\Catalog\Model\ValueCollectionInterface;
 use Pim\Component\Catalog\Model\ValueInterface;
+use Pim\Component\Catalog\ProductModel\ProductModelImageAsLabel;
 use Pim\Component\Catalog\ProductModel\Query\VariantProductRatioInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
@@ -30,16 +31,22 @@ class ProductModelNormalizer implements NormalizerInterface, NormalizerAwareInte
     /** @var VariantProductRatioInterface */
     private $variantProductRatioQuery;
 
+    /** @var ProductModelImageAsLabel */
+    private $productModelImageAsLabel;
+
     /**
      * @param CollectionFilterInterface    $filter
      * @param VariantProductRatioInterface $variantProductRatioQuery
+     * @param ProductModelImageAsLabel     $productModelImageAsLabel
      */
     public function __construct(
         CollectionFilterInterface $filter,
-        VariantProductRatioInterface $variantProductRatioQuery
+        VariantProductRatioInterface $variantProductRatioQuery,
+        ProductModelImageAsLabel $productModelImageAsLabel
     ) {
         $this->filter = $filter;
         $this->variantProductRatioQuery = $variantProductRatioQuery;
+        $this->productModelImageAsLabel = $productModelImageAsLabel;
     }
 
     /**
@@ -57,6 +64,7 @@ class ProductModelNormalizer implements NormalizerInterface, NormalizerAwareInte
         $channel = current($context['channels']);
 
         $variantProductCompleteness = $this->variantProductRatioQuery->findComplete($productModel);
+        $closestImage = $this->productModelImageAsLabel->getImage($productModel);
 
         $data['identifier'] = $productModel->getCode();
         $data['family'] = $this->getFamilyLabel($productModel, $locale);
@@ -64,7 +72,7 @@ class ProductModelNormalizer implements NormalizerInterface, NormalizerAwareInte
         $data['created'] = $this->normalizer->normalize($productModel->getCreated(), $format, $context);
         $data['updated'] = $this->normalizer->normalize($productModel->getUpdated(), $format, $context);
         $data['label'] = $productModel->getLabel($locale);
-        $data['image'] = $this->normalizeImage($productModel->getImage(), $format, $context);
+        $data['image'] = $this->normalizeImage($closestImage, $format, $context);
 
         $data['groups'] = null;
         $data['enabled'] = null;

--- a/src/Pim/Bundle/DataGridBundle/Resources/config/normalizers.yml
+++ b/src/Pim/Bundle/DataGridBundle/Resources/config/normalizers.yml
@@ -23,6 +23,7 @@ services:
         arguments:
             - '@pim_catalog.filter.chained'
             - '@pim_catalog.doctrine.query.find_variant_product_completeness'
+            - '@pim_catalog.product_models.image_as_label'
         tags:
             - { name: pim_serializer.normalizer }
 

--- a/src/Pim/Bundle/DataGridBundle/spec/Normalizer/ProductModelNormalizerSpec.php
+++ b/src/Pim/Bundle/DataGridBundle/spec/Normalizer/ProductModelNormalizerSpec.php
@@ -13,6 +13,7 @@ use Pim\Component\Catalog\Model\LocaleInterface;
 use Pim\Component\Catalog\Model\ProductModelInterface;
 use Pim\Component\Catalog\Model\ValueCollectionInterface;
 use Pim\Component\Catalog\Model\ValueInterface;
+use Pim\Component\Catalog\ProductModel\ProductModelImageAsLabel;
 use Pim\Component\Catalog\ProductModel\Query\VariantProductRatioInterface;
 use Pim\Component\Catalog\ProductModel\Query\CompleteVariantProducts;
 use Prophecy\Argument;
@@ -24,9 +25,10 @@ class ProductModelNormalizerSpec extends ObjectBehavior
     function let(
         NormalizerInterface $normalizer,
         CollectionFilterInterface $filter,
-        VariantProductRatioInterface $findVariantProductCompletenessQuery
+        VariantProductRatioInterface $findVariantProductCompletenessQuery,
+        ProductModelImageAsLabel $productModelImageAsLabel
     ) {
-        $this->beConstructedWith($filter, $findVariantProductCompletenessQuery);
+        $this->beConstructedWith($filter, $findVariantProductCompletenessQuery, $productModelImageAsLabel);
 
         $normalizer->implement(NormalizerInterface::class);
         $this->setNormalizer($normalizer);
@@ -55,6 +57,7 @@ class ProductModelNormalizerSpec extends ObjectBehavior
         $normalizer,
         $filter,
         $findVariantProductCompletenessQuery,
+        $productModelImageAsLabel,
         ProductModelInterface $productModel,
         FamilyVariantInterface $familyVariant,
         FamilyInterface $family,
@@ -109,7 +112,7 @@ class ProductModelNormalizerSpec extends ObjectBehavior
 
         $productModel->getLabel('en_US')->willReturn('Purple tshirt');
 
-        $productModel->getImage()->willReturn($image);
+        $productModelImageAsLabel->getImage($productModel)->willReturn($image);
         $normalizer->normalize($image, Argument::any(), Argument::any())->willReturn([
             'data' => [
                 'filePath'         => '/p/i/m/4/all.png',
@@ -160,6 +163,7 @@ class ProductModelNormalizerSpec extends ObjectBehavior
         $normalizer,
         $filter,
         $findVariantProductCompletenessQuery,
+        $productModelImageAsLabel,
         ProductModelInterface $productModel,
         FamilyVariantInterface $familyVariant,
         FamilyInterface $family,
@@ -214,7 +218,7 @@ class ProductModelNormalizerSpec extends ObjectBehavior
 
         $productModel->getLabel('en_US')->willReturn('Purple tshirt');
 
-        $productModel->getImage()->willReturn($image);
+        $productModelImageAsLabel->getImage($productModel)->willReturn($image);
         $normalizer->normalize($image, Argument::any(), Argument::any())->willReturn([
             'data' => [
                 'filePath'         => '/p/i/m/4/all.png',

--- a/src/Pim/Bundle/DataGridBundle/spec/Normalizer/ProductModelNormalizerSpec.php
+++ b/src/Pim/Bundle/DataGridBundle/spec/Normalizer/ProductModelNormalizerSpec.php
@@ -13,7 +13,7 @@ use Pim\Component\Catalog\Model\LocaleInterface;
 use Pim\Component\Catalog\Model\ProductModelInterface;
 use Pim\Component\Catalog\Model\ValueCollectionInterface;
 use Pim\Component\Catalog\Model\ValueInterface;
-use Pim\Component\Catalog\ProductModel\ProductModelImageAsLabel;
+use Pim\Component\Catalog\ProductModel\ImageAsLabel;
 use Pim\Component\Catalog\ProductModel\Query\VariantProductRatioInterface;
 use Pim\Component\Catalog\ProductModel\Query\CompleteVariantProducts;
 use Prophecy\Argument;
@@ -26,9 +26,9 @@ class ProductModelNormalizerSpec extends ObjectBehavior
         NormalizerInterface $normalizer,
         CollectionFilterInterface $filter,
         VariantProductRatioInterface $findVariantProductCompletenessQuery,
-        ProductModelImageAsLabel $productModelImageAsLabel
+        ImageAsLabel $imageAsLabel
     ) {
-        $this->beConstructedWith($filter, $findVariantProductCompletenessQuery, $productModelImageAsLabel);
+        $this->beConstructedWith($filter, $findVariantProductCompletenessQuery, $imageAsLabel);
 
         $normalizer->implement(NormalizerInterface::class);
         $this->setNormalizer($normalizer);
@@ -57,7 +57,7 @@ class ProductModelNormalizerSpec extends ObjectBehavior
         $normalizer,
         $filter,
         $findVariantProductCompletenessQuery,
-        $productModelImageAsLabel,
+        $imageAsLabel,
         ProductModelInterface $productModel,
         FamilyVariantInterface $familyVariant,
         FamilyInterface $family,
@@ -112,7 +112,7 @@ class ProductModelNormalizerSpec extends ObjectBehavior
 
         $productModel->getLabel('en_US')->willReturn('Purple tshirt');
 
-        $productModelImageAsLabel->getImage($productModel)->willReturn($image);
+        $imageAsLabel->value($productModel)->willReturn($image);
         $normalizer->normalize($image, Argument::any(), Argument::any())->willReturn([
             'data' => [
                 'filePath'         => '/p/i/m/4/all.png',
@@ -163,7 +163,7 @@ class ProductModelNormalizerSpec extends ObjectBehavior
         $normalizer,
         $filter,
         $findVariantProductCompletenessQuery,
-        $productModelImageAsLabel,
+        $imageAsLabel,
         ProductModelInterface $productModel,
         FamilyVariantInterface $familyVariant,
         FamilyInterface $family,
@@ -218,7 +218,7 @@ class ProductModelNormalizerSpec extends ObjectBehavior
 
         $productModel->getLabel('en_US')->willReturn('Purple tshirt');
 
-        $productModelImageAsLabel->getImage($productModel)->willReturn($image);
+        $imageAsLabel->value($productModel)->willReturn($image);
         $normalizer->normalize($image, Argument::any(), Argument::any())->willReturn([
             'data' => [
                 'filePath'         => '/p/i/m/4/all.png',

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/EntityWithFamilyVariantNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/EntityWithFamilyVariantNormalizer.php
@@ -11,7 +11,7 @@ use Pim\Component\Catalog\Model\EntityWithFamilyVariantInterface;
 use Pim\Component\Catalog\Model\ProductModelInterface;
 use Pim\Component\Catalog\Model\ValueInterface;
 use Pim\Component\Catalog\Model\VariantProductInterface;
-use Pim\Component\Catalog\ProductModel\ProductModelImageAsLabel;
+use Pim\Component\Catalog\ProductModel\ImageAsLabel;
 use Pim\Component\Catalog\ProductModel\Query\VariantProductRatioInterface;
 use Pim\Component\Catalog\Repository\LocaleRepositoryInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
@@ -51,8 +51,8 @@ class EntityWithFamilyVariantNormalizer implements NormalizerInterface
     /** @var VariantProductRatioInterface */
     private $variantProductRatioQuery;
 
-    /** @var ProductModelImageAsLabel */
-    private $productModelImageAsLabel;
+    /** @var ImageAsLabel */
+    private $imageAsLabel;
 
     /**
      * @param FileNormalizer                            $fileNormalizer
@@ -61,7 +61,7 @@ class EntityWithFamilyVariantNormalizer implements NormalizerInterface
      * @param NormalizerInterface                       $completenessCollectionNormalizer
      * @param CompletenessCalculatorInterface           $completenessCalculator
      * @param VariantProductRatioInterface              $variantProductRatioQuery
-     * @param ProductModelImageAsLabel                  $productModelImageAsLabel
+     * @param ImageAsLabel                              $imageAsLabel
      */
     public function __construct(
         FileNormalizer $fileNormalizer,
@@ -70,15 +70,15 @@ class EntityWithFamilyVariantNormalizer implements NormalizerInterface
         NormalizerInterface $completenessCollectionNormalizer,
         CompletenessCalculatorInterface $completenessCalculator,
         VariantProductRatioInterface $variantProductRatioQuery,
-        ProductModelImageAsLabel $productModelImageAsLabel
+        ImageAsLabel $imageAsLabel
     ) {
-        $this->fileNormalizer = $fileNormalizer;
-        $this->localeRepository = $localeRepository;
-        $this->attributesProvider = $attributesProvider;
+        $this->fileNormalizer                   = $fileNormalizer;
+        $this->localeRepository                 = $localeRepository;
+        $this->attributesProvider               = $attributesProvider;
         $this->completenessCollectionNormalizer = $completenessCollectionNormalizer;
-        $this->completenessCalculator = $completenessCalculator;
-        $this->variantProductRatioQuery = $variantProductRatioQuery;
-        $this->productModelImageAsLabel = $productModelImageAsLabel;
+        $this->completenessCalculator           = $completenessCalculator;
+        $this->variantProductRatioQuery         = $variantProductRatioQuery;
+        $this->imageAsLabel                     = $imageAsLabel;
     }
 
     /**
@@ -105,7 +105,7 @@ class EntityWithFamilyVariantNormalizer implements NormalizerInterface
         $identifier = $entity instanceof ProductModelInterface ? $entity->getCode() : $entity->getIdentifier();
 
         if ($entity instanceof ProductModelInterface) {
-            $image = $this->productModelImageAsLabel->getImage($entity);
+            $image = $this->imageAsLabel->value($entity);
         } else {
             $image = $entity->getImage();
         }

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/ProductModelNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/ProductModelNormalizer.php
@@ -10,6 +10,7 @@ use Pim\Component\Catalog\FamilyVariant\EntityWithFamilyVariantAttributesProvide
 use Pim\Component\Catalog\Localization\Localizer\AttributeConverterInterface;
 use Pim\Component\Catalog\Model\ProductModelInterface;
 use Pim\Component\Catalog\Model\ValueInterface;
+use Pim\Component\Catalog\ProductModel\ProductModelImageAsLabel;
 use Pim\Component\Catalog\ProductModel\Query\VariantProductRatioInterface;
 use Pim\Component\Catalog\Repository\LocaleRepositoryInterface;
 use Pim\Component\Catalog\ValuesFiller\EntityWithFamilyValuesFillerInterface;
@@ -62,6 +63,9 @@ class ProductModelNormalizer implements NormalizerInterface
     /** @var VariantNavigationNormalizer */
     private $navigationNormalizer;
 
+    /** @var ProductModelImageAsLabel */
+    private $productModelImageAsLabel;
+
     /**
      * @param NormalizerInterface                       $normalizer
      * @param NormalizerInterface                       $versionNormalizer
@@ -75,6 +79,7 @@ class ProductModelNormalizer implements NormalizerInterface
      * @param EntityWithFamilyVariantAttributesProvider $attributesProvider
      * @param VariantNavigationNormalizer               $navigationNormalizer
      * @param VariantProductRatioInterface              $variantProductRatioQuery
+     * @param ProductModelImageAsLabel                  $productModelImageAsLabel
      */
     public function __construct(
         NormalizerInterface $normalizer,
@@ -88,7 +93,8 @@ class ProductModelNormalizer implements NormalizerInterface
         EntityWithFamilyValuesFillerInterface $entityValuesFiller,
         EntityWithFamilyVariantAttributesProvider $attributesProvider,
         VariantNavigationNormalizer $navigationNormalizer,
-        VariantProductRatioInterface $variantProductRatioQuery
+        VariantProductRatioInterface $variantProductRatioQuery,
+        ProductModelImageAsLabel $productModelImageAsLabel
     ) {
         $this->normalizer            = $normalizer;
         $this->versionNormalizer     = $versionNormalizer;
@@ -102,6 +108,7 @@ class ProductModelNormalizer implements NormalizerInterface
         $this->attributesProvider    = $attributesProvider;
         $this->navigationNormalizer  = $navigationNormalizer;
         $this->variantProductRatioQuery = $variantProductRatioQuery;
+        $this->productModelImageAsLabel = $productModelImageAsLabel;
     }
 
     /**
@@ -140,6 +147,7 @@ class ProductModelNormalizer implements NormalizerInterface
         $normalizedFamilyVariant = $this->normalizer->normalize($productModel->getFamilyVariant(), 'standard');
 
         $variantProductCompletenesses = $this->variantProductRatioQuery->findComplete($productModel);
+        $closestImage = $this->productModelImageAsLabel->getImage($productModel);
 
         $normalizedProductModel['meta'] = [
                 'variant_product_completenesses' => $variantProductCompletenesses->values(),
@@ -151,7 +159,7 @@ class ProductModelNormalizer implements NormalizerInterface
                 'model_type'                => 'product_model',
                 'attributes_for_this_level' => $levelAttributes,
                 'attributes_axes'           => $axesAttributes,
-                'image'                     => $this->normalizeImage($productModel->getImage(), $format, $context),
+                'image'                     => $this->normalizeImage($closestImage, $format, $context),
                 'variant_navigation'        => $this->navigationNormalizer->normalize($productModel, $format, $context),
             ] + $this->getLabels($productModel);
 

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/ProductModelNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/ProductModelNormalizer.php
@@ -10,7 +10,7 @@ use Pim\Component\Catalog\FamilyVariant\EntityWithFamilyVariantAttributesProvide
 use Pim\Component\Catalog\Localization\Localizer\AttributeConverterInterface;
 use Pim\Component\Catalog\Model\ProductModelInterface;
 use Pim\Component\Catalog\Model\ValueInterface;
-use Pim\Component\Catalog\ProductModel\ProductModelImageAsLabel;
+use Pim\Component\Catalog\ProductModel\ImageAsLabel;
 use Pim\Component\Catalog\ProductModel\Query\VariantProductRatioInterface;
 use Pim\Component\Catalog\Repository\LocaleRepositoryInterface;
 use Pim\Component\Catalog\ValuesFiller\EntityWithFamilyValuesFillerInterface;
@@ -63,8 +63,8 @@ class ProductModelNormalizer implements NormalizerInterface
     /** @var VariantNavigationNormalizer */
     private $navigationNormalizer;
 
-    /** @var ProductModelImageAsLabel */
-    private $productModelImageAsLabel;
+    /** @var ImageAsLabel */
+    private $imageAsLabel;
 
     /**
      * @param NormalizerInterface                       $normalizer
@@ -79,7 +79,7 @@ class ProductModelNormalizer implements NormalizerInterface
      * @param EntityWithFamilyVariantAttributesProvider $attributesProvider
      * @param VariantNavigationNormalizer               $navigationNormalizer
      * @param VariantProductRatioInterface              $variantProductRatioQuery
-     * @param ProductModelImageAsLabel                  $productModelImageAsLabel
+     * @param ImageAsLabel                              $imageAsLabel
      */
     public function __construct(
         NormalizerInterface $normalizer,
@@ -94,7 +94,7 @@ class ProductModelNormalizer implements NormalizerInterface
         EntityWithFamilyVariantAttributesProvider $attributesProvider,
         VariantNavigationNormalizer $navigationNormalizer,
         VariantProductRatioInterface $variantProductRatioQuery,
-        ProductModelImageAsLabel $productModelImageAsLabel
+        ImageAsLabel $imageAsLabel
     ) {
         $this->normalizer            = $normalizer;
         $this->versionNormalizer     = $versionNormalizer;
@@ -108,7 +108,7 @@ class ProductModelNormalizer implements NormalizerInterface
         $this->attributesProvider    = $attributesProvider;
         $this->navigationNormalizer  = $navigationNormalizer;
         $this->variantProductRatioQuery = $variantProductRatioQuery;
-        $this->productModelImageAsLabel = $productModelImageAsLabel;
+        $this->imageAsLabel = $imageAsLabel;
     }
 
     /**
@@ -147,7 +147,7 @@ class ProductModelNormalizer implements NormalizerInterface
         $normalizedFamilyVariant = $this->normalizer->normalize($productModel->getFamilyVariant(), 'standard');
 
         $variantProductCompletenesses = $this->variantProductRatioQuery->findComplete($productModel);
-        $closestImage = $this->productModelImageAsLabel->getImage($productModel);
+        $closestImage = $this->imageAsLabel->value($productModel);
 
         $normalizedProductModel['meta'] = [
                 'variant_product_completenesses' => $variantProductCompletenesses->values(),

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/ProductNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/ProductNormalizer.php
@@ -314,6 +314,10 @@ class ProductNormalizer implements NormalizerInterface
             $meta['attributes_axes'][] = $attribute->getCode();
         }
 
+        foreach ($this->attributesProvider->getAxes($product->getParent()) as $attribute) {
+            $meta['attributes_axes'][] = $attribute->getCode();
+        }
+
         foreach ($this->attributesProvider->getAttributes($product->getParent()) as $attribute) {
             $meta['parent_attributes'][] = $attribute->getCode();
         }

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product.yml
@@ -42,7 +42,7 @@ datagrid:
                 data_name:     groups
                 type:          field
             complete_variant_products:
-                label:         Complete product
+                label:         Variant products
                 data_name:     complete_variant_product
                 frontend_type: complete-variant-product
         properties:

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/normalizers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/normalizers.yml
@@ -87,6 +87,7 @@ services:
             - '@pim_catalog.family_variant.provider.entity_with_family_variant_attributes'
             - '@pim_enrich.normalizer.variant_navigation'
             - '@pim_catalog.doctrine.query.find_variant_product_completeness'
+            - '@pim_catalog.product_models.image_as_label'
         tags:
             - { name: pim_internal_api_serializer.normalizer }
 
@@ -180,6 +181,7 @@ services:
             - '@pim_enrich.normalizer.completeness_collection'
             - '@pim_catalog.completeness.calculator'
             - '@pim_catalog.doctrine.query.find_variant_product_completeness'
+            - '@pim_catalog.product_models.image_as_label'
 
     pim_enrich.normalizer.variant_navigation:
         class: '%pim_enrich.normalizer.variant_navigation.class%'

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/meta/change-family.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/meta/change-family.js
@@ -34,8 +34,9 @@ define(
                 'click': 'showModal'
             },
             render: function () {
-                const entity = this.getFormData();
-                if (null !== entity.meta.family_variant) {
+                if (null !== this.getFormData().meta.family_variant) {
+                    this.$el.remove();
+
                     return;
                 }
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/variant-navigation.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/variant-navigation.js
@@ -108,8 +108,8 @@ define([
                             };
 
                             const html = ('product' === item.model_type)
-                                ? this.templateProduct({ entity: entity })
-                                : this.templateProductModel({ entity: entity })
+                                ? this.templateProduct({ entity: entity, getClass: this.getCompletenessBadgeClass })
+                                : this.templateProductModel({ entity: entity, getClass: this.getCompletenessBadgeClass })
                             ;
 
                             $container.append(html);
@@ -159,6 +159,25 @@ define([
                         display: completeProducts + ' / ' + totalProducts
                     };
                 }
+            },
+
+            /**
+             * Get the CSS class for the completeness badge of the template, depending on the given ratio.
+             *
+             * @param {int} ratio
+             *
+             * @returns {string}
+             */
+            getCompletenessBadgeClass: function (ratio) {
+                if (0 === ratio) {
+                    return 'empty';
+                }
+
+                if (100 === ratio) {
+                    return 'complete';
+                }
+
+                return 'incomplete';
             },
 
             /**

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/variant-navigation.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/variant-navigation.js
@@ -108,8 +108,8 @@ define([
                             };
 
                             const html = ('product' === item.model_type)
-                                ? this.templateProduct({ entity: entity, getClass: this.getCompletenessBadgeClass })
-                                : this.templateProductModel({ entity: entity, getClass: this.getCompletenessBadgeClass })
+                                ? this.templateProduct({entity: entity, getClass: this.getCompletenessBadgeClass})
+                                : this.templateProductModel({entity: entity, getClass: this.getCompletenessBadgeClass})
                             ;
 
                             $container.append(html);

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/form/variant-navigation/product-item.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/form/variant-navigation/product-item.html
@@ -3,7 +3,7 @@
     <span class="AknVariantNavigation-listProductLabel">
         <%- entity.label %>
     </span>
-    <span class="AknVariantNavigation-listProductCompleteness AknVariantNavigation-listProductCompleteness--<%- (100 === parseInt(entity.completeness.ratio)) ? 'complete' : 'incomplete' %>">
+    <span class="AknVariantNavigation-listProductCompleteness AknVariantNavigation-listProductCompleteness--<%- getClass(entity.completeness.ratio) %>">
         <%- entity.completeness.ratio %>%
     </span>
 </div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/form/variant-navigation/product-model-item.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/form/variant-navigation/product-model-item.html
@@ -3,7 +3,7 @@
     <span class="AknVariantNavigation-listProductModelLabel">
         <%- entity.label %>
     </span>
-    <span class="AknVariantNavigation-listProductModelCompleteness AknVariantNavigation-listProductCompleteness--<%- (100 === parseInt(entity.completeness.ratio)) ? 'complete' : 'incomplete' %>">
+    <span class="AknVariantNavigation-listProductModelCompleteness AknVariantNavigation-listProductCompleteness--<%- getClass(entity.completeness.ratio) %>">
         <%- entity.completeness.display %>
     </span>
 </div>

--- a/src/Pim/Bundle/EnrichBundle/spec/Normalizer/EntityWithFamilyVariantNormalizerSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Normalizer/EntityWithFamilyVariantNormalizerSpec.php
@@ -14,7 +14,7 @@ use Pim\Component\Catalog\Model\CompletenessInterface;
 use Pim\Component\Catalog\Model\ProductModelInterface;
 use Pim\Component\Catalog\Model\ValueInterface;
 use Pim\Component\Catalog\Model\VariantProductInterface;
-use Pim\Component\Catalog\ProductModel\ProductModelImageAsLabel;
+use Pim\Component\Catalog\ProductModel\ImageAsLabel;
 use Pim\Component\Catalog\ProductModel\Query\CompleteVariantProducts;
 use Pim\Component\Catalog\ProductModel\Query\VariantProductRatioInterface;
 use Pim\Component\Catalog\Repository\LocaleRepositoryInterface;
@@ -29,7 +29,7 @@ class EntityWithFamilyVariantNormalizerSpec extends ObjectBehavior
         NormalizerInterface $completenessCollectionNormalizer,
         CompletenessCalculatorInterface $completenessCalculator,
         VariantProductRatioInterface $variantProductRatioQuery,
-        ProductModelImageAsLabel $productModelImageAsLabel
+        ImageAsLabel $imageAsLabel
     ) {
         $this->beConstructedWith(
             $fileNormalizer,
@@ -38,7 +38,7 @@ class EntityWithFamilyVariantNormalizerSpec extends ObjectBehavior
             $completenessCollectionNormalizer,
             $completenessCalculator,
             $variantProductRatioQuery,
-            $productModelImageAsLabel
+            $imageAsLabel
         );
     }
 

--- a/src/Pim/Bundle/EnrichBundle/spec/Normalizer/EntityWithFamilyVariantNormalizerSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Normalizer/EntityWithFamilyVariantNormalizerSpec.php
@@ -14,6 +14,7 @@ use Pim\Component\Catalog\Model\CompletenessInterface;
 use Pim\Component\Catalog\Model\ProductModelInterface;
 use Pim\Component\Catalog\Model\ValueInterface;
 use Pim\Component\Catalog\Model\VariantProductInterface;
+use Pim\Component\Catalog\ProductModel\ProductModelImageAsLabel;
 use Pim\Component\Catalog\ProductModel\Query\CompleteVariantProducts;
 use Pim\Component\Catalog\ProductModel\Query\VariantProductRatioInterface;
 use Pim\Component\Catalog\Repository\LocaleRepositoryInterface;
@@ -27,7 +28,8 @@ class EntityWithFamilyVariantNormalizerSpec extends ObjectBehavior
         EntityWithFamilyVariantAttributesProvider $attributesProvider,
         NormalizerInterface $completenessCollectionNormalizer,
         CompletenessCalculatorInterface $completenessCalculator,
-        VariantProductRatioInterface $variantProductRatioQuery
+        VariantProductRatioInterface $variantProductRatioQuery,
+        ProductModelImageAsLabel $productModelImageAsLabel
     ) {
         $this->beConstructedWith(
             $fileNormalizer,
@@ -35,7 +37,8 @@ class EntityWithFamilyVariantNormalizerSpec extends ObjectBehavior
             $attributesProvider,
             $completenessCollectionNormalizer,
             $completenessCalculator,
-            $variantProductRatioQuery
+            $variantProductRatioQuery,
+            $productModelImageAsLabel
         );
     }
 
@@ -150,8 +153,6 @@ class EntityWithFamilyVariantNormalizerSpec extends ObjectBehavior
         $colorAttributeOption->getSortOrder()->willReturn(2);
         $colorAttributeOption->getTranslation()->willReturn($colorAttributeOptionValue);
         $colorAttributeOptionValue->getLabel()->willReturn('Blanc', 'White');
-
-        $productModel->getImage()->willReturn(null);
 
         $variantProductRatioQuery->findComplete($productModel)->willReturn($completeVariantProducts);
         $completeVariantProducts->values()->willReturn(['NORMALIZED COMPLETENESS']);

--- a/src/Pim/Bundle/EnrichBundle/spec/Normalizer/ProductModelNormalizerSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Normalizer/ProductModelNormalizerSpec.php
@@ -13,6 +13,7 @@ use Pim\Component\Catalog\Model\FamilyInterface;
 use Pim\Component\Catalog\Model\FamilyVariantInterface;
 use Pim\Component\Catalog\Model\ProductModelInterface;
 use Pim\Component\Catalog\Model\ValueInterface;
+use Pim\Component\Catalog\ProductModel\ProductModelImageAsLabel;
 use Pim\Component\Catalog\ProductModel\Query\VariantProductRatioInterface;
 use Pim\Component\Catalog\ProductModel\Query\CompleteVariantProducts;
 use Pim\Component\Catalog\Repository\LocaleRepositoryInterface;
@@ -35,7 +36,8 @@ class ProductModelNormalizerSpec extends ObjectBehavior
         EntityWithFamilyValuesFillerInterface $entityValuesFiller,
         EntityWithFamilyVariantAttributesProvider $attributesProvider,
         VariantNavigationNormalizer $navigationNormalizer,
-        VariantProductRatioInterface $findVariantProductCompleteness
+        VariantProductRatioInterface $findVariantProductCompleteness,
+        ProductModelImageAsLabel $productModelImageAsLabel
     ) {
         $this->beConstructedWith(
             $normalizer,
@@ -49,7 +51,8 @@ class ProductModelNormalizerSpec extends ObjectBehavior
             $entityValuesFiller,
             $attributesProvider,
             $navigationNormalizer,
-            $findVariantProductCompleteness
+            $findVariantProductCompleteness,
+            $productModelImageAsLabel
         );
     }
 
@@ -70,6 +73,7 @@ class ProductModelNormalizerSpec extends ObjectBehavior
         $attributesProvider,
         $navigationNormalizer,
         $findVariantProductCompleteness,
+        $productModelImageAsLabel,
         AttributeInterface $pictureAttribute,
         ProductModelInterface $productModel,
         FamilyVariantInterface $familyVariant,
@@ -138,7 +142,7 @@ class ProductModelNormalizerSpec extends ObjectBehavior
         $productModel->getLabel('en_US')->willReturn('Tshirt blue');
         $productModel->getLabel('fr_FR')->willReturn('Tshirt bleu');
 
-        $productModel->getImage()->willReturn($picture);
+        $productModelImageAsLabel->getImage($productModel)->willReturn($picture);
         $picture->getData()->willReturn('IMAGE_DATA');
         $fileNormalizer->normalize('IMAGE_DATA', 'internal_api', $options)->willReturn($fileNormalized);
 
@@ -210,6 +214,7 @@ class ProductModelNormalizerSpec extends ObjectBehavior
         $attributesProvider,
         $navigationNormalizer,
         $findVariantProductCompleteness,
+        $productModelImageAsLabel,
         AttributeInterface $pictureAttribute,
         ProductModelInterface $productModel,
         FamilyVariantInterface $familyVariant,
@@ -266,8 +271,7 @@ class ProductModelNormalizerSpec extends ObjectBehavior
         $productModel->getLabel('en_US')->willReturn('Tshirt blue');
         $productModel->getLabel('fr_FR')->willReturn('Tshirt bleu');
 
-        $productModel->getImage()->willReturn($picture);
-        $picture->getData()->willReturn(null);
+        $productModelImageAsLabel->getImage($productModel)->willReturn(null);
         $fileNormalizer->normalize(Argument::cetera())->shouldNotBeCalled();
 
         $productValueConverter->convert($valuesLocalized)->willReturn($valuesConverted);
@@ -338,6 +342,7 @@ class ProductModelNormalizerSpec extends ObjectBehavior
         $attributesProvider,
         $navigationNormalizer,
         $findVariantProductCompleteness,
+        $productModelImageAsLabel,
         AttributeInterface $pictureAttribute,
         ProductModelInterface $productModel,
         FamilyVariantInterface $familyVariant,
@@ -406,7 +411,7 @@ class ProductModelNormalizerSpec extends ObjectBehavior
         $productModel->getLabel('en_US')->willReturn('Tshirt blue');
         $productModel->getLabel('fr_FR')->willReturn('Tshirt bleu');
 
-        $productModel->getImage()->willReturn($picture);
+        $productModelImageAsLabel->getImage($productModel)->willReturn($picture);
         $picture->getData()->willReturn('IMAGE_DATA');
         $fileNormalizer->normalize('IMAGE_DATA', 'internal_api', $options)->willReturn($fileNormalized);
 

--- a/src/Pim/Bundle/EnrichBundle/spec/Normalizer/ProductModelNormalizerSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Normalizer/ProductModelNormalizerSpec.php
@@ -13,7 +13,7 @@ use Pim\Component\Catalog\Model\FamilyInterface;
 use Pim\Component\Catalog\Model\FamilyVariantInterface;
 use Pim\Component\Catalog\Model\ProductModelInterface;
 use Pim\Component\Catalog\Model\ValueInterface;
-use Pim\Component\Catalog\ProductModel\ProductModelImageAsLabel;
+use Pim\Component\Catalog\ProductModel\ImageAsLabel;
 use Pim\Component\Catalog\ProductModel\Query\VariantProductRatioInterface;
 use Pim\Component\Catalog\ProductModel\Query\CompleteVariantProducts;
 use Pim\Component\Catalog\Repository\LocaleRepositoryInterface;
@@ -37,7 +37,7 @@ class ProductModelNormalizerSpec extends ObjectBehavior
         EntityWithFamilyVariantAttributesProvider $attributesProvider,
         VariantNavigationNormalizer $navigationNormalizer,
         VariantProductRatioInterface $findVariantProductCompleteness,
-        ProductModelImageAsLabel $productModelImageAsLabel
+        ImageAsLabel $imageAsLabel
     ) {
         $this->beConstructedWith(
             $normalizer,
@@ -52,7 +52,7 @@ class ProductModelNormalizerSpec extends ObjectBehavior
             $attributesProvider,
             $navigationNormalizer,
             $findVariantProductCompleteness,
-            $productModelImageAsLabel
+            $imageAsLabel
         );
     }
 
@@ -73,7 +73,7 @@ class ProductModelNormalizerSpec extends ObjectBehavior
         $attributesProvider,
         $navigationNormalizer,
         $findVariantProductCompleteness,
-        $productModelImageAsLabel,
+        $imageAsLabel,
         AttributeInterface $pictureAttribute,
         ProductModelInterface $productModel,
         FamilyVariantInterface $familyVariant,
@@ -142,7 +142,7 @@ class ProductModelNormalizerSpec extends ObjectBehavior
         $productModel->getLabel('en_US')->willReturn('Tshirt blue');
         $productModel->getLabel('fr_FR')->willReturn('Tshirt bleu');
 
-        $productModelImageAsLabel->getImage($productModel)->willReturn($picture);
+        $imageAsLabel->value($productModel)->willReturn($picture);
         $picture->getData()->willReturn('IMAGE_DATA');
         $fileNormalizer->normalize('IMAGE_DATA', 'internal_api', $options)->willReturn($fileNormalized);
 
@@ -214,7 +214,7 @@ class ProductModelNormalizerSpec extends ObjectBehavior
         $attributesProvider,
         $navigationNormalizer,
         $findVariantProductCompleteness,
-        $productModelImageAsLabel,
+        $imageAsLabel,
         AttributeInterface $pictureAttribute,
         ProductModelInterface $productModel,
         FamilyVariantInterface $familyVariant,
@@ -271,7 +271,7 @@ class ProductModelNormalizerSpec extends ObjectBehavior
         $productModel->getLabel('en_US')->willReturn('Tshirt blue');
         $productModel->getLabel('fr_FR')->willReturn('Tshirt bleu');
 
-        $productModelImageAsLabel->getImage($productModel)->willReturn(null);
+        $imageAsLabel->value($productModel)->willReturn(null);
         $fileNormalizer->normalize(Argument::cetera())->shouldNotBeCalled();
 
         $productValueConverter->convert($valuesLocalized)->willReturn($valuesConverted);
@@ -342,7 +342,7 @@ class ProductModelNormalizerSpec extends ObjectBehavior
         $attributesProvider,
         $navigationNormalizer,
         $findVariantProductCompleteness,
-        $productModelImageAsLabel,
+        $imageAsLabel,
         AttributeInterface $pictureAttribute,
         ProductModelInterface $productModel,
         FamilyVariantInterface $familyVariant,
@@ -411,7 +411,7 @@ class ProductModelNormalizerSpec extends ObjectBehavior
         $productModel->getLabel('en_US')->willReturn('Tshirt blue');
         $productModel->getLabel('fr_FR')->willReturn('Tshirt bleu');
 
-        $productModelImageAsLabel->getImage($productModel)->willReturn($picture);
+        $imageAsLabel->value($productModel)->willReturn($picture);
         $picture->getData()->willReturn('IMAGE_DATA');
         $fileNormalizer->normalize('IMAGE_DATA', 'internal_api', $options)->willReturn($fileNormalized);
 

--- a/src/Pim/Bundle/EnrichBundle/spec/Normalizer/ProductNormalizerSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Normalizer/ProductNormalizerSpec.php
@@ -344,6 +344,7 @@ class ProductNormalizerSpec extends ObjectBehavior
         $mug->getParent()->willReturn($productModel);
         $attributesProvider->getAttributes($mug)->willReturn([$size]);
         $attributesProvider->getAxes($mug)->willReturn([$size]);
+        $attributesProvider->getAxes($productModel)->willReturn([]);
         $attributesProvider->getAttributes($productModel)->willReturn([$color, $description]);
 
         $color->getCode()->willReturn('color');

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/product-edit-form/VariantNavigation.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/product-edit-form/VariantNavigation.less
@@ -89,6 +89,10 @@
     line-height: 22px;
     color: #ffffff;
 
+    &--empty {
+      background-color: @AknRed;
+    }
+
     &--incomplete {
       background-color: @AknOrange;
     }

--- a/src/Pim/Component/Catalog/ProductModel/ImageAsLabel.php
+++ b/src/Pim/Component/Catalog/ProductModel/ImageAsLabel.php
@@ -18,7 +18,7 @@ use Pim\Component\Catalog\Repository\ProductRepositoryInterface;
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
-class ProductModelImageAsLabel
+class ImageAsLabel
 {
     /** @var ProductModelRepositoryInterface */
     private $productModelRepository;
@@ -46,7 +46,7 @@ class ProductModelImageAsLabel
      *
      * @return null|ValueInterface
      */
-    public function getImage(ProductModelInterface $productModel): ?ValueInterface
+    public function value(ProductModelInterface $productModel): ?ValueInterface
     {
         $attributeAsImage = $productModel->getFamily()->getAttributeAsImage();
         $attributeSets = $productModel->getFamilyVariant()->getVariantAttributeSets();

--- a/src/Pim/Component/Catalog/ProductModel/ProductModelImageAsLabel.php
+++ b/src/Pim/Component/Catalog/ProductModel/ProductModelImageAsLabel.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Component\Catalog\ProductModel;
+
+use Pim\Component\Catalog\Model\ProductModelInterface;
+use Pim\Component\Catalog\Model\ValueInterface;
+use Pim\Component\Catalog\Repository\ProductModelRepositoryInterface;
+use Pim\Component\Catalog\Repository\ProductRepositoryInterface;
+
+/**
+ * For a given ProductModel, this class retrieves the ValueInterface of its attribute as image,
+ * defined in its family. This value can come from ascendant or descendant entities (from product models above
+ * or variant product below).
+ *
+ * @author    Adrien Pétremann <adrien.petremann@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class ProductModelImageAsLabel
+{
+    /** @var ProductModelRepositoryInterface */
+    private $productModelRepository;
+
+    /** @var ProductRepositoryInterface */
+    private $productRepository;
+
+    /**
+     * @param ProductModelRepositoryInterface $productModelRepository
+     * @param ProductRepositoryInterface      $productRepository
+     */
+    public function __construct(
+        ProductModelRepositoryInterface $productModelRepository,
+        ProductRepositoryInterface $productRepository
+    ) {
+        $this->productModelRepository = $productModelRepository;
+        $this->productRepository = $productRepository;
+    }
+
+    /**
+     * Get the closest attribute as image value for the given $productModel. It can be its own value,
+     * or the value of one of its parent or children.
+     *
+     * @param ProductModelInterface $productModel
+     *
+     * @return null|ValueInterface
+     */
+    public function getImage(ProductModelInterface $productModel): ?ValueInterface
+    {
+        $attributeAsImage = $productModel->getFamily()->getAttributeAsImage();
+        $attributeSets = $productModel->getFamilyVariant()->getVariantAttributeSets();
+        $levelContainingAttribute = 0;
+
+        foreach ($attributeSets as $attributeSet) {
+            if ($attributeSet->getAttributes()->contains($attributeAsImage)) {
+                $levelContainingAttribute = $attributeSet->getLevel();
+            }
+        }
+
+        if ($levelContainingAttribute <= $productModel->getLevel()) {
+            return $productModel->getImage();
+        }
+
+        $currentLevel = $productModel->getLevel();
+        $entity = $productModel;
+
+        do {
+            $modelChild = current($this->productModelRepository->findBy(
+                ['parent' => $entity],
+                ['created' => 'DESC', 'code' => 'ASC'],
+                1
+            ));
+
+            $productChild = current($this->productRepository->findBy(
+                ['parent' => $entity],
+                ['created' => 'DESC', 'identifier' => 'ASC'],
+                1
+            ));
+
+            if (false !== $modelChild) {
+                $entity = $modelChild;
+            }
+
+            if (false !== $productChild) {
+                $entity = $productChild;
+            }
+
+            if (false === $modelChild && false === $productChild) {
+                return null;
+            }
+
+            $currentLevel++;
+        } while ($currentLevel < $levelContainingAttribute);
+
+        return $entity->getImage();
+    }
+}

--- a/src/Pim/Component/Catalog/spec/ProductModel/ImageAsLabelSpec.php
+++ b/src/Pim/Component/Catalog/spec/ProductModel/ImageAsLabelSpec.php
@@ -14,7 +14,7 @@ use Pim\Component\Catalog\Model\VariantProductInterface;
 use Pim\Component\Catalog\Repository\ProductModelRepositoryInterface;
 use Pim\Component\Catalog\Repository\ProductRepositoryInterface;
 
-class ProductModelImageAsLabelSpec extends ObjectBehavior
+class ImageAsLabelSpec extends ObjectBehavior
 {
     function let(
         ProductModelRepositoryInterface $productModelRepository,
@@ -57,7 +57,7 @@ class ProductModelImageAsLabelSpec extends ObjectBehavior
         $productModel->getLevel()->willReturn(1);
         $productModel->getImage()->willReturn($imageValue);
 
-        $this->getImage($productModel)->shouldReturn($imageValue);
+        $this->value($productModel)->shouldReturn($imageValue);
     }
 
     function it_gets_the_attribute_as_image_value_of_a_product_model_coming_from_a_parent(
@@ -97,7 +97,7 @@ class ProductModelImageAsLabelSpec extends ObjectBehavior
         $productModel->getLevel()->willReturn(1);
         $productModel->getImage()->willReturn($imageValue);
 
-        $this->getImage($productModel)->shouldReturn($imageValue);
+        $this->value($productModel)->shouldReturn($imageValue);
     }
 
     function it_gets_the_attribute_as_image_value_of_a_product_model_coming_from_a_product_model_child(
@@ -150,7 +150,7 @@ class ProductModelImageAsLabelSpec extends ObjectBehavior
 
         $subProductModel->getImage()->willReturn($imageValue);
 
-        $this->getImage($productModel)->shouldReturn($imageValue);
+        $this->value($productModel)->shouldReturn($imageValue);
     }
 
     function it_gets_the_attribute_as_image_value_of_a_product_model_coming_from_a_variant_product_child(
@@ -203,7 +203,7 @@ class ProductModelImageAsLabelSpec extends ObjectBehavior
 
         $variantProduct->getImage()->willReturn($imageValue);
 
-        $this->getImage($productModel)->shouldReturn($imageValue);
+        $this->value($productModel)->shouldReturn($imageValue);
     }
 
     function it_returns_null_if_no_image_available_anywhere(
@@ -253,6 +253,6 @@ class ProductModelImageAsLabelSpec extends ObjectBehavior
             1
         )->willReturn([]);
 
-        $this->getImage($productModel)->shouldReturn(null);
+        $this->value($productModel)->shouldReturn(null);
     }
 }

--- a/src/Pim/Component/Catalog/spec/ProductModel/ProductModelImageAsLabelSpec.php
+++ b/src/Pim/Component/Catalog/spec/ProductModel/ProductModelImageAsLabelSpec.php
@@ -1,0 +1,258 @@
+<?php
+
+namespace spec\Pim\Component\Catalog\ProductModel;
+
+use Doctrine\Common\Collections\Collection;
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\FamilyInterface;
+use Pim\Component\Catalog\Model\FamilyVariantInterface;
+use Pim\Component\Catalog\Model\ProductModelInterface;
+use Pim\Component\Catalog\Model\ValueInterface;
+use Pim\Component\Catalog\Model\VariantAttributeSetInterface;
+use Pim\Component\Catalog\Model\VariantProductInterface;
+use Pim\Component\Catalog\Repository\ProductModelRepositoryInterface;
+use Pim\Component\Catalog\Repository\ProductRepositoryInterface;
+
+class ProductModelImageAsLabelSpec extends ObjectBehavior
+{
+    function let(
+        ProductModelRepositoryInterface $productModelRepository,
+        ProductRepositoryInterface $productRepository
+    ) {
+        $this->beConstructedWith($productModelRepository, $productRepository);
+    }
+
+    function it_gets_the_own_attribute_as_image_value_of_a_product_model(
+        ProductModelInterface $productModel,
+        FamilyInterface $family,
+        FamilyVariantInterface $familyVariant,
+        AttributeInterface $attributeAsImage,
+        Collection $attributeSets,
+        \ArrayIterator $attributeSetsIterator,
+        VariantAttributeSetInterface $attributeSetOne,
+        VariantAttributeSetInterface $attributeSetTwo,
+        Collection $attributeCollectionOne,
+        Collection $attributeCollectionTwo,
+        ValueInterface $imageValue
+    ) {
+        $attributeSets->getIterator()->willReturn($attributeSetsIterator);
+        $attributeSetsIterator->rewind()->shouldBeCalled();
+        $attributeSetsIterator->valid()->willReturn(true, true, false);
+        $attributeSetsIterator->current()->willReturn($attributeSetOne, $attributeSetTwo);
+        $attributeSetsIterator->next()->shouldBeCalled();
+
+        $attributeSetOne->getAttributes()->willReturn($attributeCollectionOne);
+        $attributeSetOne->getLevel()->willReturn(1);
+        $attributeSetTwo->getAttributes()->willReturn($attributeCollectionTwo);
+        $attributeSetTwo->getLevel()->willReturn(2);
+
+        $attributeCollectionOne->contains($attributeAsImage)->willReturn(true);
+        $attributeCollectionTwo->contains($attributeAsImage)->willReturn(false);
+
+        $family->getAttributeAsImage()->willReturn($attributeAsImage);
+        $familyVariant->getVariantAttributeSets()->willReturn($attributeSets);
+        $productModel->getFamily()->willReturn($family);
+        $productModel->getFamilyVariant()->willReturn($familyVariant);
+        $productModel->getLevel()->willReturn(1);
+        $productModel->getImage()->willReturn($imageValue);
+
+        $this->getImage($productModel)->shouldReturn($imageValue);
+    }
+
+    function it_gets_the_attribute_as_image_value_of_a_product_model_coming_from_a_parent(
+        $productModelRepository,
+        $productRepository,
+        ProductModelInterface $rootProductModel,
+        ProductModelInterface $productModel,
+        FamilyInterface $family,
+        FamilyVariantInterface $familyVariant,
+        AttributeInterface $attributeAsImage,
+        Collection $attributeSets,
+        \ArrayIterator $attributeSetsIterator,
+        VariantAttributeSetInterface $attributeSetOne,
+        VariantAttributeSetInterface $attributeSetTwo,
+        Collection $attributeCollectionOne,
+        Collection $attributeCollectionTwo,
+        ValueInterface $imageValue
+    ) {
+        $attributeSets->getIterator()->willReturn($attributeSetsIterator);
+        $attributeSetsIterator->rewind()->shouldBeCalled();
+        $attributeSetsIterator->valid()->willReturn(true, true, false);
+        $attributeSetsIterator->current()->willReturn($attributeSetOne, $attributeSetTwo);
+        $attributeSetsIterator->next()->shouldBeCalled();
+
+        $attributeSetOne->getAttributes()->willReturn($attributeCollectionOne);
+        $attributeSetOne->getLevel()->willReturn(1);
+        $attributeSetTwo->getAttributes()->willReturn($attributeCollectionTwo);
+        $attributeSetTwo->getLevel()->willReturn(2);
+
+        $attributeCollectionOne->contains($attributeAsImage)->willReturn(false);
+        $attributeCollectionTwo->contains($attributeAsImage)->willReturn(false);
+
+        $family->getAttributeAsImage()->willReturn($attributeAsImage);
+        $familyVariant->getVariantAttributeSets()->willReturn($attributeSets);
+        $productModel->getFamily()->willReturn($family);
+        $productModel->getFamilyVariant()->willReturn($familyVariant);
+        $productModel->getLevel()->willReturn(1);
+        $productModel->getImage()->willReturn($imageValue);
+
+        $this->getImage($productModel)->shouldReturn($imageValue);
+    }
+
+    function it_gets_the_attribute_as_image_value_of_a_product_model_coming_from_a_product_model_child(
+        $productModelRepository,
+        $productRepository,
+        ProductModelInterface $productModel,
+        ProductModelInterface $subProductModel,
+        FamilyInterface $family,
+        FamilyVariantInterface $familyVariant,
+        AttributeInterface $attributeAsImage,
+        Collection $attributeSets,
+        \ArrayIterator $attributeSetsIterator,
+        VariantAttributeSetInterface $attributeSetOne,
+        VariantAttributeSetInterface $attributeSetTwo,
+        Collection $attributeCollectionOne,
+        Collection $attributeCollectionTwo,
+        ValueInterface $imageValue
+    ) {
+        $attributeSets->getIterator()->willReturn($attributeSetsIterator);
+        $attributeSetsIterator->rewind()->shouldBeCalled();
+        $attributeSetsIterator->valid()->willReturn(true, true, false);
+        $attributeSetsIterator->current()->willReturn($attributeSetOne, $attributeSetTwo);
+        $attributeSetsIterator->next()->shouldBeCalled();
+
+        $attributeSetOne->getAttributes()->willReturn($attributeCollectionOne);
+        $attributeSetOne->getLevel()->willReturn(1);
+        $attributeSetTwo->getAttributes()->willReturn($attributeCollectionTwo);
+        $attributeSetTwo->getLevel()->willReturn(2);
+
+        $attributeCollectionOne->contains($attributeAsImage)->willReturn(false);
+        $attributeCollectionTwo->contains($attributeAsImage)->willReturn(true);
+
+        $family->getAttributeAsImage()->willReturn($attributeAsImage);
+        $familyVariant->getVariantAttributeSets()->willReturn($attributeSets);
+        $productModel->getFamily()->willReturn($family);
+        $productModel->getFamilyVariant()->willReturn($familyVariant);
+        $productModel->getLevel()->willReturn(1);
+
+        $productModelRepository->findBy(
+            ['parent' => $productModel],
+            ['created' => 'DESC', 'code' => 'ASC'],
+            1
+        )->willReturn([$subProductModel]);
+
+        $productRepository->findBy(
+            ['parent' => $productModel],
+            ['created' => 'DESC', 'identifier' => 'ASC'],
+            1
+        )->willReturn([]);
+
+        $subProductModel->getImage()->willReturn($imageValue);
+
+        $this->getImage($productModel)->shouldReturn($imageValue);
+    }
+
+    function it_gets_the_attribute_as_image_value_of_a_product_model_coming_from_a_variant_product_child(
+        $productModelRepository,
+        $productRepository,
+        ProductModelInterface $productModel,
+        VariantProductInterface $variantProduct,
+        FamilyInterface $family,
+        FamilyVariantInterface $familyVariant,
+        AttributeInterface $attributeAsImage,
+        Collection $attributeSets,
+        \ArrayIterator $attributeSetsIterator,
+        VariantAttributeSetInterface $attributeSetOne,
+        VariantAttributeSetInterface $attributeSetTwo,
+        Collection $attributeCollectionOne,
+        Collection $attributeCollectionTwo,
+        ValueInterface $imageValue
+    ) {
+        $attributeSets->getIterator()->willReturn($attributeSetsIterator);
+        $attributeSetsIterator->rewind()->shouldBeCalled();
+        $attributeSetsIterator->valid()->willReturn(true, true, false);
+        $attributeSetsIterator->current()->willReturn($attributeSetOne, $attributeSetTwo);
+        $attributeSetsIterator->next()->shouldBeCalled();
+
+        $attributeSetOne->getAttributes()->willReturn($attributeCollectionOne);
+        $attributeSetOne->getLevel()->willReturn(1);
+        $attributeSetTwo->getAttributes()->willReturn($attributeCollectionTwo);
+        $attributeSetTwo->getLevel()->willReturn(2);
+
+        $attributeCollectionOne->contains($attributeAsImage)->willReturn(false);
+        $attributeCollectionTwo->contains($attributeAsImage)->willReturn(true);
+
+        $family->getAttributeAsImage()->willReturn($attributeAsImage);
+        $familyVariant->getVariantAttributeSets()->willReturn($attributeSets);
+        $productModel->getFamily()->willReturn($family);
+        $productModel->getFamilyVariant()->willReturn($familyVariant);
+        $productModel->getLevel()->willReturn(1);
+
+        $productModelRepository->findBy(
+            ['parent' => $productModel],
+            ['created' => 'DESC', 'code' => 'ASC'],
+            1
+        )->willReturn([]);
+
+        $productRepository->findBy(
+            ['parent' => $productModel],
+            ['created' => 'DESC', 'identifier' => 'ASC'],
+            1
+        )->willReturn([$variantProduct]);
+
+        $variantProduct->getImage()->willReturn($imageValue);
+
+        $this->getImage($productModel)->shouldReturn($imageValue);
+    }
+
+    function it_returns_null_if_no_image_available_anywhere(
+        $productModelRepository,
+        $productRepository,
+        ProductModelInterface $productModel,
+        FamilyInterface $family,
+        FamilyVariantInterface $familyVariant,
+        AttributeInterface $attributeAsImage,
+        Collection $attributeSets,
+        \ArrayIterator $attributeSetsIterator,
+        VariantAttributeSetInterface $attributeSetOne,
+        VariantAttributeSetInterface $attributeSetTwo,
+        Collection $attributeCollectionOne,
+        Collection $attributeCollectionTwo,
+        ValueInterface $imageValue
+    ) {
+        $attributeSets->getIterator()->willReturn($attributeSetsIterator);
+        $attributeSetsIterator->rewind()->shouldBeCalled();
+        $attributeSetsIterator->valid()->willReturn(true, true, false);
+        $attributeSetsIterator->current()->willReturn($attributeSetOne, $attributeSetTwo);
+        $attributeSetsIterator->next()->shouldBeCalled();
+
+        $attributeSetOne->getAttributes()->willReturn($attributeCollectionOne);
+        $attributeSetOne->getLevel()->willReturn(1);
+        $attributeSetTwo->getAttributes()->willReturn($attributeCollectionTwo);
+        $attributeSetTwo->getLevel()->willReturn(2);
+
+        $attributeCollectionOne->contains($attributeAsImage)->willReturn(false);
+        $attributeCollectionTwo->contains($attributeAsImage)->willReturn(true);
+
+        $family->getAttributeAsImage()->willReturn($attributeAsImage);
+        $familyVariant->getVariantAttributeSets()->willReturn($attributeSets);
+        $productModel->getFamily()->willReturn($family);
+        $productModel->getFamilyVariant()->willReturn($familyVariant);
+        $productModel->getLevel()->willReturn(1);
+
+        $productModelRepository->findBy(
+            ['parent' => $productModel],
+            ['created' => 'DESC', 'code' => 'ASC'],
+            1
+        )->willReturn([]);
+
+        $productRepository->findBy(
+            ['parent' => $productModel],
+            ['created' => 'DESC', 'identifier' => 'ASC'],
+            1
+        )->willReturn([]);
+
+        $this->getImage($productModel)->shouldReturn(null);
+    }
+}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Main goal of this PR is to **display image or product models in the grid and in the PEF in a smart way**.
If the attribute as image is on an entity below (product model or variant product), then it returns the first item it finds.

**Bonus fixes from other cards:**
- PIM-6451: Hide the button to edit a family on a variant product edit form
- Change label from "Complete product" to "Variant products"
- PIM-6451: Now display variant axes coming from parent as "Variant Axis" on the product edit form
- PIM-6348: Display a red label in the variant navigation if no product is complete

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Y
| Added Behats                      | Y
| Added integration tests           | N
| Changelog updated                 | Y
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
