### PR TITLE
[SLA] PIM-6823: add missing "decimal separator" field on xlsx profil import

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -1,3 +1,9 @@
+# 1.7.x
+
+## Bug Fixes
+
+- PIM-6823: Add missing "decimal separator" field on xlsx profil import
+
 # 1.7.9 (2017-09-27)
 
 ## Bug Fixes

--- a/features/import/edit_an_import.feature
+++ b/features/import/edit_an_import.feature
@@ -58,6 +58,40 @@ Feature: Edit an import
     And I should see the text "Allow file upload"
     And the "Allow file upload" field should contain ""
 
+  Scenario: Successfully update XLSX import job configuration
+    Given I am on the "xlsx_footwear_product_import" import job edit page
+    Then I should see the File, Allow file upload, Enable the product, Categories column, Family column, Groups column, Real time history update, Decimal separator, Date format fields
+    When I fill in the following information:
+      | File              | /tmp/file.csv |
+      | Categories column | cat           |
+      | Family column     | fam           |
+      | Groups column     | grp           |
+      | Decimal separator | dot (.)       |
+      | Date format       | dd/mm/yyyy    |
+    And I uncheck the "Allow file upload" switch
+    And I uncheck the "Enable the product" switch
+    And I uncheck the "Real time history update" switch
+    And I press the "Save" button
+    And I should not see the text "There are unsaved changes."
+    Then I should see the text "File path"
+    And the "File path" field should contain "/tmp/file.csv"
+    And I should see the text "Real time history"
+    And the "Real time history" field should contain ""
+    And I should see the text "Enable the product"
+    And the "Enable the product" field should contain ""
+    And I should see the text "Categories column"
+    And the "Categories column" field should contain "cat"
+    And I should see the text "Family column"
+    And the "Family column" field should contain "fam"
+    And I should see the text "Groups column"
+    And the "Groups column" field should contain "grp"
+    And I should see the text "Decimal separator"
+    And the field Decimal separator should contain "dot (.)"
+    And I should see the text "Date format"
+    And the field Date format should contain "dd/mm/yyyy"
+    And I should see the text "Allow file upload"
+    And the "Allow file upload" field should contain ""
+
   @javascript
   Scenario: Successfully display a dialog when we quit a page with unsaved changes
     Given I am on the "csv_footwear_product_import" import job edit page

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_import_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_import_edit.yml
@@ -76,6 +76,17 @@ extensions:
             label: pim_enrich.form.job_instance.tab.properties.upload_allowed.title
             tooltip: pim_enrich.form.job_instance.tab.properties.upload_allowed.help
 
+    pim-job-instance-xlsx-product-import-edit-properties-decimal-separator:
+        module: pim/job/common/edit/field/decimal-separator
+        parent: pim-job-instance-xlsx-product-import-edit-properties
+        position: 135
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.decimalSeparator
+            readOnly: false
+            label: pim_enrich.form.job_instance.tab.properties.decimal_separator.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.decimal_separator.help
+
     pim-job-instance-xlsx-product-import-edit-properties-date-format:
         module: pim/job/product/edit/field/date-format
         parent: pim-job-instance-xlsx-product-import-edit-properties

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_import_show.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_import_show.yml
@@ -78,16 +78,16 @@ extensions:
             label: pim_enrich.form.job_instance.tab.properties.upload_allowed.title
             tooltip: pim_enrich.form.job_instance.tab.properties.upload_allowed.help
 
-    pim-job-instance-xlsx-product-import-show-properties-categories-column:
-        module: pim/job/common/edit/field/text
+    pim-job-instance-xlsx-product-import-show-properties-decimal-separator:
+        module: pim/job/common/edit/field/decimal-separator
         parent: pim-job-instance-xlsx-product-import-show-properties
         position: 140
         targetZone: global-settings
         config:
-            fieldCode: configuration.categoriesColumn
+            fieldCode: configuration.decimalSeparator
             readOnly: true
-            label: pim_enrich.form.job_instance.tab.properties.categories_column.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.categories_column.help
+            label: pim_enrich.form.job_instance.tab.properties.decimal_separator.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.decimal_separator.help
 
     pim-job-instance-xlsx-product-import-show-properties-date-format:
         module: pim/job/product/edit/field/date-format
@@ -110,6 +110,17 @@ extensions:
             readOnly: true
             label: pim_enrich.form.job_instance.tab.properties.enabled.title
             tooltip: pim_enrich.form.job_instance.tab.properties.enabled.help
+
+    pim-job-instance-xlsx-product-import-show-properties-categories-column:
+        module: pim/job/common/edit/field/text
+        parent: pim-job-instance-xlsx-product-import-show-properties
+        position: 165
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.categoriesColumn
+            readOnly: true
+            label: pim_enrich.form.job_instance.tab.properties.categories_column.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.categories_column.help
 
     pim-job-instance-xlsx-product-import-show-properties-family-column:
         module: pim/job/common/edit/field/text


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
