### PR TITLE
[PIM-6832] Fix the column category display when category node is expanded

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -20,6 +20,7 @@
 - PIM-6356: Display 1st variant product image in the grid and on the PEF for product models
 - PIM-6348: Display a red label in the variant navigation if no product is complete
 - PIM-6451: Now display variant axes coming from parent as "Variant Axis" on the product edit form
+- PIM-6832: Fix the column category display when category node is expanded
 
 ## BC breaks
 

--- a/features/Context/Page/Product/Index.php
+++ b/features/Context/Page/Product/Index.php
@@ -41,6 +41,10 @@ class Index extends Grid
                 'Sidebar collapse button' => ['css' => '.sidebar .sidebar-controls i.icon-double-angle-left'],
                 'Sidebar expand button'   => ['css' => '.separator.collapsed i.icon-double-angle-right'],
                 'Manage filters options'  => ['css' => '.filter-list.select-filter-widget .ui-multiselect-checkboxes li label span'],
+                'Category tree'           => [
+                    'css'        => '#tree',
+                    'decorators' => [ 'Pim\Behat\Decorator\Tree\JsTreeDecorator' ]
+                ]
             ]
         );
     }

--- a/features/product/filtering/filter_products_per_category.feature
+++ b/features/product/filtering/filter_products_per_category.feature
@@ -30,3 +30,15 @@ Feature: Filter products by category
     Then I should be able to use the following filters:
       | filter   | operator | value    | result     |
       | category |          | men_2015 | blue-jeans |
+
+  @jira https://akeneo.atlassian.net/browse/PIM-6832
+  Scenario: Successfully display category on column but don't display the subcategories
+    Given the following category:
+      | code | label-en_US | parent     |
+      | shoe | Shoe        | women_2013 |
+    And I am on the products grid
+    When I open the category tree
+    And I expand the "women_2013" category
+    And I click on the "women_2013" category
+    Then I should not see the text "2013 women's collection (0)  Shoe"
+    But I should see the text "2013 collection - 2013 women's collection"

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/grid/category-switcher.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/grid/category-switcher.js
@@ -62,7 +62,7 @@ define(
                 this.getRoot().trigger('grid:third_column:toggle');
 
                 if (!this.isOpen) {
-                    this.outsideEventListener = this.outsideClickListener.bind(this)
+                    this.outsideEventListener = this.outsideClickListener.bind(this);
                     document.addEventListener('mousedown', this.outsideEventListener);
                 }
                 this.isOpen = !this.isOpen;

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/grid/category-tree.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/grid/category-tree.js
@@ -101,7 +101,7 @@ define(
              * @returns {String}
              */
             getCategoryLabel(id) {
-                return this.trimCount($('#node_' + id).text().trim());
+                return this.trimCount($('#node_' + id + ' > a:first').text().trim());
             },
 
             /**


### PR DESCRIPTION
There was a bug when
- you expand a node
- you select this node
-> the column displayed this node and all its children.

This fix prevent it.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | y
| Added integration tests           | -
| Changelog updated                 | y
| Review and 2 GTM                  | Todo
| Migration script                  | -
| Tech Doc                          | -
