### PR TITLE
API-389: Only view logged user jobs in process tracker

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -18,6 +18,9 @@
 ## Better UI\UX!
 
 - PIM-6584: Update main menu order
+- API-398: As Mary, I want to only see my launched exports/imports
+- API-397: As Mary, I want to only see my launched jobs in the dashboard
+- API-389: As Mary, I want to only see my launched jobs in the process tracker
 
 ## Better manage products with variants!
 

--- a/features/dashboard/display_last_operations_widget.feature
+++ b/features/dashboard/display_last_operations_widget.feature
@@ -4,42 +4,33 @@ Feature: Display last operations widget
   As a regular user
   I need to be able to see a last operations widget on the dashboard
 
-  @unstable
-  Scenario: Display last operations widget
+  Background:
     Given a "footwear" catalog configuration
     And the following job "csv_footwear_category_export" configuration:
       | filePath | %tmp%/category_export/category_export.csv |
     And I am logged in as "Mary"
+
+  Scenario: Display last operations widget
     When I am on the dashboard page
     Then I should see the text "Last operations"
-    When I wait for widgets to load
     Then I should see the text "No operations found"
     When I am on the "csv_footwear_category_export" export job page
     And I launch the export job
     And I wait for the "csv_footwear_category_export" job to finish
     When I am on the dashboard page
     Then I should see the text "Last operations"
-    When I wait for widgets to load
-    Then I should see the text "Export Footwear CSV category export Completed"
+    Then I should see the text "CSV footwear category export"
 
   Scenario: Show last operations list
-    Given a "footwear" catalog configuration
-    And the following job "csv_footwear_category_export" configuration:
-      | filePath | %tmp%/category_export/category_export.csv |
-    And I am logged in as "Mary"
     When I am on the "csv_footwear_category_export" export job page
     And I launch the export job
     And I wait for the "csv_footwear_category_export" job to finish
     When I am on the dashboard page
     Then I should see the text "Last operations"
     When I am on the job tracker page
-    And I should see the columns Job, Type, User, Started at, Status and Warnings
+    And I should see the columns Job, Type, Started at, Status and Warnings
 
   Scenario: Show job tracker
-    Given a "footwear" catalog configuration
-    And the following job "csv_footwear_category_export" configuration:
-      | filePath | %tmp%/category_export/category_export.csv |
-    And I am logged in as "Mary"
     And I am on the "csv_footwear_category_export" export job page
     And I launch the export job
     And I wait for the "csv_footwear_category_export" job to finish

--- a/features/job-execution/last-execution/export.feature
+++ b/features/job-execution/last-execution/export.feature
@@ -1,0 +1,27 @@
+@javascript
+Feature: Display only logged user's jobs execution in last executions job view
+  In order to have an overview of last job executions
+  As a regular user
+  I need to be able to browse the last job executions
+
+  Background:
+    Given a "footwear" catalog configuration
+    And I am logged in as "Julia"
+    And I am on the exports grid
+    And I am on the "csv_footwear_product_export" export job page
+    And I launch the export job
+    And I wait for the "csv_footwear_product_export" job to finish
+    And I am on the "csv_footwear_product_export" export job page
+    And I launch the export job
+    And I wait for the "csv_footwear_product_export" job to finish
+    And I logout
+    And I am logged in as "admin"
+    And I am on the "csv_footwear_product_export" export job page
+    And I launch the export job
+    And I wait for the "csv_footwear_product_export" job to finish
+    And I am on the job tracker page
+
+  Scenario: Only view last executions of user
+    Given I am on the exports grid
+    When I click on the "CSV footwear product export" row
+    Then the grid should contain 1 element

--- a/features/job-execution/last-execution/import.feature
+++ b/features/job-execution/last-execution/import.feature
@@ -1,0 +1,33 @@
+@javascript
+Feature: Display only logged user's jobs execution in last executions job view
+  In order to have an overview of last job executions
+  As a regular user
+  I need to be able to browse the last job executions
+
+  Background:
+    Given the "footwear" catalog configuration
+    And I am logged in as "Julia"
+    And the following CSV file to import:
+      """
+      type;code;label-en_US;group;unique;useable_as_grid_filter;allowed_extensions;metric_family;default_metric_unit;reference_data_name;localizable;scopable;sort_order;label-fr_FR;max_characters;number_min;number_max;decimals_allowed;negative_allowed;max_file_size
+      pim_catalog_identifier;sku;SKU;info;1;1;;;;;0;0;1;;;;;;;
+      """
+    And the following job "csv_footwear_attribute_import" configuration:
+      | filePath | %file to import% |
+    And I am on the "csv_footwear_attribute_import" export job page
+    And I launch the import job
+    And I wait for the "csv_footwear_attribute_import" job to finish
+    And I am on the "csv_footwear_attribute_import" export job page
+    And I launch the import job
+    And I wait for the "csv_footwear_attribute_import" job to finish
+    And I logout
+    And I am logged in as "admin"
+    And I am on the "csv_footwear_attribute_import" export job page
+    And I launch the import job
+    And I wait for the "csv_footwear_attribute_import" job to finish
+    And I am on the job tracker page
+
+  Scenario: Only view last executions of user
+    Given I am on the imports grid
+    When I click on the "CSV footwear attribute import" row
+    Then the grid should contain 1 element

--- a/features/job-tracker/browse_job_executions.feature
+++ b/features/job-tracker/browse_job_executions.feature
@@ -26,12 +26,11 @@ Feature: Display jobs execution in job tracker
     Then I should see entities <result>
 
     Examples:
-      | filter | operator    | value  | result                                                    | count |
-      | user   | is equal to | Julia  | CSV footwear product export                               | 1     |
-      | type   | is equal to | import |                                                           | 0     |
-      | type   | is equal to | export | CSV footwear product export, CSV footwear category export | 2     |
+      | filter | operator    | value  | result                       | count |
+      | type   | is equal to | import |                              | 0     |
+      | type   | is equal to | export | CSV footwear category export | 1     |
 
   Scenario: Successfully search on label
-    When I search "footwear product export"
+    When I search "footwear category export"
     Then the grid should contain 1 element
-    And I should see entity CSV footwear product export
+    And I should see entity CSV footwear category export

--- a/features/job-tracker/display_jobs_execution_in_job_tracker.feature
+++ b/features/job-tracker/display_jobs_execution_in_job_tracker.feature
@@ -15,7 +15,7 @@ Feature: Display jobs execution in job tracker
     And I launch the export job
     And I wait for the "csv_footwear_category_export" job to finish
     When I am on the job tracker page
-    And I should see the columns Job, Type, User, Started at, Status and Warnings
+    And I should see the columns Job, Type, Started at, Status and Warnings
     And the grid should contain 1 element
     And I should see entity CSV footwear category export
 
@@ -36,7 +36,7 @@ Feature: Display jobs execution in job tracker
     And I wait for the "edit_common_attributes" job to finish
     When I am on the dashboard page
     When I am on the job tracker page
-    And I should see the columns Job, Type, User, Started at, Status and Warnings
+    And I should see the columns Job, Type, Started at, Status and Warnings
     And the grid should contain 1 element
     And I should see entity Mass edit common product attributes
 
@@ -57,7 +57,7 @@ Feature: Display jobs execution in job tracker
     And I launch the import job
     And I wait for the "csv_footwear_category_import" job to finish
     And I am on the job tracker page
-    And I should see the columns Job, Type, User, Started at, Status and Warnings
+    And I should see the columns Job, Type, Started at, Status and Warnings
     And the grid should contain 1 element
     And I should see entity CSV footwear category import
 
@@ -74,5 +74,4 @@ Feature: Display jobs execution in job tracker
     And I logout
     And I am logged in as "Julia"
     And I am on the job tracker page
-    When I click on the "CSV footwear product export" row
-    Then I should not see the text "Execution details - CSV footwear product export [csv_footwear_product_export]"
+    And the grid should contain 0 element

--- a/src/Pim/Bundle/DataGridBundle/Datasource/DatasourceInterface.php
+++ b/src/Pim/Bundle/DataGridBundle/Datasource/DatasourceInterface.php
@@ -18,7 +18,7 @@ interface DatasourceInterface extends OroDatasourceInterface
     /**
      * Get the query builder
      *
-     * @return \Doctrine\ORM\QueryBuilder|\Doctrine\ODM\MongoDB\Query\Builder
+     * @return \Doctrine\ORM\QueryBuilder
      *
      * @deprecated you should avoid this method, it's a design flaw, still used by,
      *  `Pim\Bundle\DataGridBundle\Extension\MassAction\MassActionDispatcher`,

--- a/src/Pim/Bundle/DataGridBundle/EventListener/AddUsernameToGridListener.php
+++ b/src/Pim/Bundle/DataGridBundle/EventListener/AddUsernameToGridListener.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Pim\Bundle\DataGridBundle\EventListener;
+
+use Oro\Bundle\DataGridBundle\Event\BuildAfter;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+
+/**
+ * @author    Philippe Mossière <philippe.mossiere@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class AddUsernameToGridListener
+{
+    /**
+     * @var TokenStorageInterface
+     */
+    protected $tokenStorage;
+
+    public function __construct(TokenStorageInterface $tokenStorage)
+    {
+        $this->tokenStorage = $tokenStorage;
+    }
+
+    public function onBuildAfter(BuildAfter $event)
+    {
+        $dataSource = $event->getDatagrid()->getDatasource();
+
+        $token = $this->tokenStorage->getToken();
+        $user = null !== $token ? $token->getUsername() : null;
+
+        $parameters = $dataSource->getParameters();
+        $parameters['user'] = $user;
+        $dataSource->setParameters($parameters);
+
+        $qb = $dataSource->getQueryBuilder();
+        $qb->andWhere($qb->expr()->eq('e.user', ':user'));
+    }
+}

--- a/src/Pim/Bundle/DataGridBundle/Resources/config/event_listeners.yml
+++ b/src/Pim/Bundle/DataGridBundle/Resources/config/event_listeners.yml
@@ -9,6 +9,7 @@ parameters:
     pim_datagrid.event_listener.configure_history_grid_listener.class: Pim\Bundle\DataGridBundle\EventListener\ConfigureHistoryGridListener
 
     pim_datagrid.event_listener.add_job_code_to_grid_listener.class: Pim\Bundle\DataGridBundle\EventListener\AddJobCodeToGridListener
+    pim_datagrid.event_listener.add_username_to_grid_listener.class: Pim\Bundle\DataGridBundle\EventListener\AddUsernameToGridListener
 
 services:
     pim_datagrid.event_listener.configure_sorters_listener:

--- a/src/Pim/Bundle/DataGridBundle/spec/EventListener/AddUsernameToGridListenerSpec.php
+++ b/src/Pim/Bundle/DataGridBundle/spec/EventListener/AddUsernameToGridListenerSpec.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace spec\Pim\Bundle\DataGridBundle\EventListener;
+
+use Doctrine\ORM\Query\Expr;
+use Doctrine\ORM\QueryBuilder;
+use Oro\Bundle\DataGridBundle\Datagrid\DatagridInterface;
+use Oro\Bundle\DataGridBundle\Event\BuildAfter;
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\DataGridBundle\Datasource\RepositoryDatasource;
+use Pim\Bundle\UserBundle\Entity\UserInterface;
+use Prophecy\Argument;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+class AddUsernameToGridListenerSpec extends ObjectBehavior
+{
+    function let(TokenStorageInterface $tokenStorage)
+    {
+        $this->beConstructedWith($tokenStorage);
+    }
+
+    function it_set_user_parameter_to_query_builder(
+        BuildAfter $event,
+        DatagridInterface $datagrid,
+        RepositoryDatasource $datasource,
+        QueryBuilder $queryBuilder,
+        TokenInterface $token,
+        UserInterface $user,
+        Expr $expr,
+        $tokenStorage
+    ) {
+        $event->getDatagrid()->willReturn($datagrid);
+        $datagrid->getDatasource()->willReturn($datasource);
+
+        $datasource->getParameters()->willReturn([]);
+
+        $tokenStorage->getToken()->willReturn($token);
+        $token->getUsername()->willReturn($user);
+
+        $datasource->setParameters(['user' => $user])->willReturn($queryBuilder);
+
+        $datasource->getQueryBuilder()->willReturn($queryBuilder);
+
+        $queryBuilder->expr()->willReturn($expr);
+        $expr->eq(Argument::any(), Argument::any())->willReturn(Argument::any());
+
+        $queryBuilder->andWhere(Argument::any())->shouldBeCalled();
+
+        $this->onBuildAfter($event);
+    }
+
+    function it_set_user_parameter_to_null_if_token_is_null(
+        BuildAfter $event,
+        DatagridInterface $datagrid,
+        RepositoryDatasource $datasource,
+        QueryBuilder $queryBuilder,
+        TokenInterface $token,
+        UserInterface $user,
+        Expr $expr,
+        $tokenStorage
+    ) {
+        $event->getDatagrid()->willReturn($datagrid);
+        $datagrid->getDatasource()->willReturn($datasource);
+
+        $datasource->getParameters()->willReturn([]);
+
+        $tokenStorage->getToken()->willReturn($token);
+        $token->getUsername()->willReturn(null);
+
+        $datasource->setParameters(['user' => null])->willReturn($queryBuilder);
+
+        $datasource->getQueryBuilder()->willReturn($queryBuilder);
+
+        $queryBuilder->expr()->willReturn($expr);
+        $expr->eq(Argument::any(), Argument::any())->willReturn(Argument::any());
+
+        $queryBuilder->andWhere(Argument::any())->shouldBeCalled();
+
+        $this->onBuildAfter($event);
+    }
+}

--- a/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/JobExecutionRepository.php
+++ b/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/JobExecutionRepository.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Pim\Bundle\EnrichBundle\Doctrine\ORM\Repository;
 
 use Doctrine\ORM\EntityManager;
@@ -56,13 +58,14 @@ class JobExecutionRepository extends EntityRepository implements DatagridReposit
     /**
      * Get data for the last operations widget
      *
-     * @param array $types Job types to show
+     * @param array       $types Job types to show
+     * @param string|null $user
      *
      * @return array
      */
-    public function getLastOperationsData(array $types)
+    public function getLastOperationsData(array $types, ?string $user = null)
     {
-        $qb = $this->getLastOperationsQB($types);
+        $qb = $this->getLastOperationsQB($types, $user);
 
         return $qb->getQuery()->getArrayResult();
     }
@@ -70,11 +73,12 @@ class JobExecutionRepository extends EntityRepository implements DatagridReposit
     /**
      * Get last operations query builder
      *
-     * @param array $types
+     * @param array       $types
+     * @param string|null $user
      *
      * @return \Doctrine\ORM\QueryBuilder
      */
-    protected function getLastOperationsQB(array $types)
+    protected function getLastOperationsQB(array $types, ?string $user = null)
     {
         $qb = $this->createQueryBuilder('e');
         $qb
@@ -92,6 +96,10 @@ class JobExecutionRepository extends EntityRepository implements DatagridReposit
 
         if (!empty($types)) {
             $qb->andWhere($qb->expr()->in('j.type', $types));
+        }
+
+        if (null !== $user) {
+            $qb->andWhere($qb->expr()->eq('e.user', $qb->expr()->literal($user)));
         }
 
         return $qb;

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/job_tracker.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/job_tracker.yml
@@ -12,8 +12,6 @@ datagrid:
             type:
                 label: Type
                 type:  job_type
-            user:
-                label: User
             started_at:
                 label: job_tracker.filter.started_at
                 data_name: startTime
@@ -43,8 +41,6 @@ datagrid:
                     data_name: jobLabel
                 type:
                     data_name: type
-                user:
-                    data_name: user
                 started_at:
                     data_name: startTime
                 status:
@@ -63,10 +59,6 @@ datagrid:
                     type:      string
                     label:     Type
                     data_name: j.type
-                user:
-                    type:      string
-                    label:     User
-                    data_name: e.user
                 status:
                     type:             choice
                     data_name:        status

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid_listeners.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid_listeners.yml
@@ -115,3 +115,10 @@ services:
         tags:
           - { name: kernel.event_listener, event: oro_datagrid.datgrid.build.before.history-grid, method: onBuildBefore }
           - { name: kernel.event_listener, event: oro_datagrid.datgrid.build.before.product-history-grid, method: onBuildBefore }
+
+    pim_enrich.event_listener.add_username_to_grid_listener:
+        class: '%pim_datagrid.event_listener.add_username_to_grid_listener.class%'
+        arguments:
+            - '@security.token_storage'
+        tags:
+            - { name: kernel.event_listener, event: oro_datagrid.datgrid.build.after.job-tracker-grid, method: onBuildAfter }

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid_listeners.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid_listeners.yml
@@ -122,3 +122,5 @@ services:
             - '@security.token_storage'
         tags:
             - { name: kernel.event_listener, event: oro_datagrid.datgrid.build.after.job-tracker-grid, method: onBuildAfter }
+            - { name: kernel.event_listener, event: oro_datagrid.datgrid.build.after.last-import-executions-grid, method: onBuildAfter }
+            - { name: kernel.event_listener, event: oro_datagrid.datgrid.build.after.last-export-executions-grid, method: onBuildAfter }

--- a/src/Pim/Bundle/EnrichBundle/tests/integration/Repository/JobExecutionRepositoryIntegration.php
+++ b/src/Pim/Bundle/EnrichBundle/tests/integration/Repository/JobExecutionRepositoryIntegration.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\EnrichBundle\tests\integration\Repository;
+
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Akeneo\Test\IntegrationTestsBundle\Launcher\JobLauncher;
+use Akeneo\Test\IntegrationTestsBundle\Sanitizer\DateSanitizer;
+use Pim\Bundle\EnrichBundle\Doctrine\ORM\Repository\JobExecutionRepository;
+
+class JobExecutionRepositoryIntegration extends TestCase
+{
+    /** @var JobLauncher */
+    protected $jobLauncher;
+
+    public function testGetLastOperationsData()
+    {
+        $this->jobLauncher->launchExport('csv_product_export', 'julia');
+        $this->jobLauncher->launchExport('csv_product_export', 'admin');
+
+        $result = $this->getJobExecutionRepository()->getLastOperationsData([], 'admin');
+        $result[0]['date'] = DateSanitizer::sanitize($result[0]['date']->format('c'));
+
+        $expectedResult = [
+            [
+                'id'           => 20,
+                'date'         => 'this is a date formatted to ISO-8601',
+                'type'         => 'export',
+                'label'        => 'CSV product export',
+                'status'       => 1,
+                'warningCount' => "0",
+            ],
+        ];
+
+        $this->assertCount(1, $result);
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    /**
+     * @return JobExecutionRepository
+     */
+    protected function getJobExecutionRepository(): JobExecutionRepository
+    {
+        return $this->get('pim_enrich.repository.job_execution');
+    }
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->jobLauncher = new JobLauncher(static::$kernel);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration(): Configuration
+    {
+        return new Configuration(
+            [Configuration::getTechnicalCatalogPath()]
+        );
+    }
+}

--- a/src/Pim/Bundle/ImportExportBundle/Manager/JobExecutionManager.php
+++ b/src/Pim/Bundle/ImportExportBundle/Manager/JobExecutionManager.php
@@ -1,9 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Pim\Bundle\ImportExportBundle\Manager;
 
 use Oro\Bundle\SecurityBundle\SecurityFacade;
 use Pim\Bundle\EnrichBundle\Doctrine\ORM\Repository\JobExecutionRepository;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 /**
  * Job execution manager
@@ -20,16 +23,24 @@ class JobExecutionManager
     /** @var SecurityFacade */
     protected $securityFacade;
 
+    /** @var TokenStorageInterface */
+    private $tokenStorage;
+
     /**
      * Constructor
      *
-     * @param JobExecutionRepository $repository
-     * @param SecurityFacade         $securityFacade
+     * @param JobExecutionRepository     $repository
+     * @param SecurityFacade             $securityFacade
+     * @param TokenStorageInterface|null $tokenStorage
      */
-    public function __construct(JobExecutionRepository $repository, SecurityFacade $securityFacade)
-    {
+    public function __construct(
+        JobExecutionRepository $repository,
+        SecurityFacade $securityFacade,
+        TokenStorageInterface $tokenStorage = null
+    ) {
         $this->repository = $repository;
         $this->securityFacade = $securityFacade;
+        $this->tokenStorage = $tokenStorage;
     }
 
     /**
@@ -50,6 +61,9 @@ class JobExecutionManager
             }
         );
 
-        return $this->repository->getLastOperationsData($types);
+        $token = null !== $this->tokenStorage ? $this->tokenStorage->getToken() : null;
+        $username = null !== $token ? $token->getUsername() : null;
+
+        return $this->repository->getLastOperationsData($types, $username);
     }
 }

--- a/src/Pim/Bundle/ImportExportBundle/Resources/config/managers.yml
+++ b/src/Pim/Bundle/ImportExportBundle/Resources/config/managers.yml
@@ -7,3 +7,4 @@ services:
         arguments:
             - '@pim_enrich.repository.job_execution'
             - '@oro_security.security_facade'
+            - '@security.token_storage'


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
[API-389](https://akeneo.atlassian.net/browse/API-389) : As Mary, I want to only see my launched jobs in the process tracker
[API-397](https://akeneo.atlassian.net/browse/API-397): As Mary, I want to only see my launched jobs in the dashboard
[API-398](https://akeneo.atlassian.net/browse/API-398): As Mary, I want to only see my launched exports/imports
<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | Ok
| Review and 2 GTM                  | Ok
| Micro Demo to the PO (Story only) | Ok
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
