### PR TITLE
PIM-6446: fix variant family code uniqueness

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -2,6 +2,7 @@
 
 ## Bug Fixes
 
+- [BC BREAK] PIM-6446: fix variant family code uniqueness. Beware, this changes the MySQL table.
 - GITHUB-6866: Fix the QueryProductCommand, cheers @LeoBenoist!
 - API-393: Add prefix "akeno:batch" to the command "publish-job-to-queue"
 - PIM-6843: Update delete buttons in category, user, role and group pages

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/model/doctrine/FamilyVariant.orm.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/model/doctrine/FamilyVariant.orm.yml
@@ -11,6 +11,8 @@ Pim\Component\Catalog\Model\FamilyVariant:
                 strategy: AUTO
         code:
             type: string
+            length: 100
+            unique: true
 
     oneToMany:
         translations:


### PR DESCRIPTION
Even if it's a change to a MySQL table, it's better imo to fix that very early in the 2.0 life rather getting some really painful bugs in the future.