### PR TITLE
PIM-6343: classify product models

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -1,9 +1,18 @@
 # 2.0.x
 
+## Better manage products with variants!
+
+- PIM-6343: Classify product models via the edit form
+
 ## Bug Fixes
 
 - PIM-6865: Fix ACL on import profile page
 - PIM-6876: Escape u001f character to workaround a mysql bug
+
+## BC breaks
+
+- Change constructor of `Pim\Bundle\EnrichBundle\Controller\ProductController` to add `Oro\Bundle\SecurityBundle\SecurityFacade`, an acl and a template 
+
 
 # 2.0.1 (2017-10-05)
 
@@ -40,10 +49,6 @@
 - PIM-6356: Display the image of the 1st variant product created in the grid and on the PEF for product models
 - PIM-6856: List family variants created by import in a new tab "variants" in the family 
 - PIM-6797: Automatically add "unique value" and identifier attributes at the last variant product level in family variants
-
-## Better manage products with variants!
-
-- PIM-6343: Classify product models via the edit form
 
 ## Better UI\UX!
 

--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -41,6 +41,10 @@
 - PIM-6856: List family variants created by import in a new tab "variants" in the family 
 - PIM-6797: Automatically add "unique value" and identifier attributes at the last variant product level in family variants
 
+## Better manage products with variants!
+
+- PIM-6343: Classify product models via the edit form
+
 ## Better UI\UX!
 
 - TIP-807: Improve menu to pass parameters for routes, cheers @MarieMinasyan!

--- a/features/Context/WebUser.php
+++ b/features/Context/WebUser.php
@@ -1878,23 +1878,48 @@ class WebUser extends PimContext
      * @param string $sku
      * @param string $categoryCode
      *
-     * @Then /^the category of (?:the )?product "([^"]*)" should be "([^"]*)"$/
+     * @Then /^the categor(?:y|ies) of (?:the )?product "([^"]*)" should be "([^"]*)"$/
      */
-    public function theCategoryOfProductShouldBe($sku, $categoryCode)
+    public function theCategoryOfProductShouldBe($sku, $expectedCategoryCodes)
     {
         $product = $this->getFixturesContext()->getProduct($sku);
+        $actualCategoryCodes = $product->getCategoryCodes();
 
-        $categoryCodes = $product->getCategoryCodes();
-        assertEquals(
-            [$categoryCode],
-            $categoryCodes,
-            sprintf(
-                'Expecting the category of "%s" to be "%s", not "%s".',
-                $sku,
-                $categoryCode,
-                implode(', ', $categoryCodes)
-            )
-        );
+        foreach ($this->listToArray($expectedCategoryCodes) as $expectedCategoryCode) {
+            assertContains(
+                $expectedCategoryCode,
+                $actualCategoryCodes,
+                sprintf(
+                    'Product "%s" should contain "%s" as category.',
+                    $sku,
+                    $expectedCategoryCode
+                )
+            );
+        }
+    }
+
+    /**
+     * @param string $code
+     * @param string $expectedCategoryCodes
+     *
+     * @Then /^the categor(?:y|ies) of (?:the )?product model "([^"]*)" should be "([^"]*)"$/
+     */
+    public function theCategoryOfProductModelShouldBe($code, $expectedCategoryCodes)
+    {
+        $productModel = $this->getFixturesContext()->getProductModel($code);
+        $actualCategoryCodes = $productModel->getCategoryCodes();
+
+        foreach ($this->listToArray($expectedCategoryCodes) as $expectedCategoryCode) {
+            assertContains(
+                $expectedCategoryCode,
+                $actualCategoryCodes,
+                sprintf(
+                    'Product model "%s" should contain "%s" as category.',
+                    $code,
+                    $expectedCategoryCode
+                )
+            );
+        }
     }
 
     /**

--- a/features/product-model/classify_product_model.feature
+++ b/features/product-model/classify_product_model.feature
@@ -1,0 +1,38 @@
+@javascript
+Feature: Classify a product model
+  In order to classify product models
+  As a product manager
+  I need to associate a product model to categories
+
+  Background:
+    Given the "catalog_modeling" catalog configuration
+    And the following categories:
+      | code         | label_en_US  | parent  |
+      | long_sleeves | Long sleeves | tshirts |
+      | seasons      | Seasons      | tshirts |
+      | summer       | Summer       | seasons |
+      | spring       | Spring       | seasons |
+    And the following root product models:
+      | code      | family_variant      | categories |
+      | model-nin | clothing_color_size | tshirts    |
+    And the following sub product models:
+      | code            | parent    | family_variant      | categories    | color |
+      | model-nin-black | model-nin | clothing_color_size | summer,spring | black |
+    And the following products:
+      | sku         | parent          | family   | categories   | size |
+      | nin-black-m | model-nin-black | clothing | long_sleeves | m    |
+    And I am logged in as "Julia"
+
+  Scenario: Count root product model categories
+    Given I edit the "model-nin" product model
+    When I visit the "Categories" column tab
+    And I visit the "Master" tab
+    Then I should see 1 category count
+    And the category of the product model "model-nin" should be "tshirts"
+
+  Scenario: Count sub product model categories
+    Given I edit the "model-nin-black" product model
+    When I visit the "Categories" column tab
+    And I visit the "Master" tab
+    Then I should see 3 category count
+    And the category of the product model "model-nin-black" should be "tshirts, summer and spring"

--- a/features/product/classify_variant_product.feature
+++ b/features/product/classify_variant_product.feature
@@ -1,0 +1,31 @@
+@javascript
+Feature: Classify a variant product
+  In order to classify products
+  As a product manager
+  I need to associate a variant product to categories
+
+  Background:
+    Given the "catalog_modeling" catalog configuration
+    And the following categories:
+      | code         | label_en_US  | parent  |
+      | long_sleeves | Long sleeves | tshirts |
+      | seasons      | Seasons      | tshirts |
+      | summer       | Summer       | seasons |
+      | spring       | Spring       | seasons |
+    And the following root product models:
+      | code      | family_variant      | categories |
+      | model-nin | clothing_color_size | tshirts    |
+    And the following sub product models:
+      | code            | parent    | family_variant      | categories    | color |
+      | model-nin-black | model-nin | clothing_color_size | summer,spring | black |
+    And the following products:
+      | sku         | parent          | family   | categories   | size |
+      | nin-black-m | model-nin-black | clothing | long_sleeves | m    |
+    And I am logged in as "Julia"
+
+  Scenario: Count variant product categories
+    Given I edit the "nin-black-m" product
+    When I visit the "Categories" column tab
+    And I visit the "Master" tab
+    Then I should see 4 category count
+    And the category of the product "nin-black-m" should be "tshirts, summer, spring and long_sleeves"

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/ProductModelCategoryRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/ProductModelCategoryRepository.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\Doctrine\ORM\Repository;
+
+use Akeneo\Bundle\ClassificationBundle\Doctrine\ORM\Repository\AbstractItemCategoryRepository;
+use Doctrine\ORM\EntityManager;
+use Pim\Component\Catalog\Repository\ProductModelCategoryRepositoryInterface;
+
+/**
+ * Product model category repository
+ *
+ * @author    Julien Janvier <j.janvier@gmail.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ProductModelCategoryRepository extends AbstractItemCategoryRepository implements ProductModelCategoryRepositoryInterface
+{
+    /** @var string */
+    protected $categoryClass;
+
+    /**
+     * @param EntityManager $em
+     * @param string        $entityName
+     * @param string        $categoryClass
+     */
+    public function __construct(EntityManager $em, $entityName, $categoryClass)
+    {
+        parent::__construct($em, $entityName);
+
+        $this->categoryClass = $categoryClass;
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/repositories.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/repositories.yml
@@ -19,6 +19,7 @@ parameters:
     pim_catalog.repository.completeness.class:          Pim\Bundle\CatalogBundle\Doctrine\ORM\Repository\CompletenessRepository
     pim_catalog.repository.product_mass_action.class:   Pim\Bundle\CatalogBundle\Doctrine\ORM\Repository\ProductMassActionRepository
     pim_catalog.repository.product_category.class:      Pim\Bundle\CatalogBundle\Doctrine\ORM\Repository\ProductCategoryRepository
+    pim_catalog.repository.product_model_category.class: Pim\Bundle\CatalogBundle\Doctrine\ORM\Repository\ProductModelCategoryRepository
     pim_catalog.repository.entity_with_family_variant.class: Pim\Bundle\CatalogBundle\Doctrine\ORM\Repository\EntityWithFamilyVariantRepository
 
 services:
@@ -198,6 +199,14 @@ services:
         arguments:
             - '@pim_catalog.object_manager.product'
             - '%pim_catalog.entity.abstract_product.class%'
+            - '%pim_catalog.entity.category.class%'
+
+    pim_catalog.repository.product_model_category:
+        class:  '%pim_catalog.repository.product_model_category.class%'
+        parent: akeneo_classification.repository.abstract_item_category
+        arguments:
+            - '@pim_catalog.object_manager.product'
+            - '%pim_catalog.entity.product_model.class%'
             - '%pim_catalog.entity.category.class%'
 
     pim_catalog.repository.association:

--- a/src/Pim/Bundle/ConnectorBundle/tests/integration/Export/AbstractExportTestCase.php
+++ b/src/Pim/Bundle/ConnectorBundle/tests/integration/Export/AbstractExportTestCase.php
@@ -7,6 +7,7 @@ use Akeneo\Test\Integration\TestCase;
 use Akeneo\Test\IntegrationTestsBundle\Launcher\JobLauncher;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\AttributeOptionInterface;
+use Pim\Component\Catalog\Model\CategoryInterface;
 use Pim\Component\Catalog\Model\FamilyInterface;
 use Pim\Component\Catalog\Model\FamilyVariantInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
@@ -130,6 +131,21 @@ abstract class AbstractExportTestCase extends TestCase
         $this->get('pim_catalog.saver.attribute')->save($attribute);
 
         return $attribute;
+    }
+
+    /**
+     * @param array $data
+     *
+     * @return CategoryInterface
+     */
+    protected function createCategory(array $data = []) : CategoryInterface
+    {
+        $category = $this->get('pim_catalog.factory.category')->create();
+        $this->get('pim_catalog.updater.category')->update($category, $data);
+        $this->get('validator')->validate($category);
+        $this->get('pim_catalog.saver.category')->save($category);
+
+        return $category;
     }
 
     /**

--- a/src/Pim/Bundle/ConnectorBundle/tests/integration/Export/Product/ExportProductsIntegration.php
+++ b/src/Pim/Bundle/ConnectorBundle/tests/integration/Export/Product/ExportProductsIntegration.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Pim\Bundle\ConnectorBundle\tests\integration\Export\ProductModel;
+namespace Pim\Bundle\ConnectorBundle\tests\integration\Export\Product;
 
 use Pim\Bundle\ConnectorBundle\tests\integration\Export\AbstractExportTestCase;
 
-class ExportProductModelsIntegration extends AbstractExportTestCase
+class ExportProductsIntegration extends AbstractExportTestCase
 {
     /**
      * {@inheritdoc}
@@ -16,20 +16,6 @@ class ExportProductModelsIntegration extends AbstractExportTestCase
             'type'        => 'pim_catalog_textarea',
             'group'       => 'attributeGroupA',
             'localizable' => true,
-            'scopable'    => false,
-        ]);
-        $this->createAttribute([
-            'code'        => 'variation_name',
-            'type'        => 'pim_catalog_text',
-            'group'       => 'attributeGroupA',
-            'localizable' => false,
-            'scopable'    => false,
-        ]);
-        $this->createAttribute([
-            'code'        => 'variation_image',
-            'type'        => 'pim_catalog_image',
-            'group'       => 'attributeGroupA',
-            'localizable' => false,
             'scopable'    => false,
         ]);
         $this->createAttribute([
@@ -62,6 +48,10 @@ class ExportProductModelsIntegration extends AbstractExportTestCase
             'code'        => 'l',
             'attribute'   => 'size',
         ]);
+        $this->createAttributeOption([
+            'code'        => 'xl',
+            'attribute'   => 'size',
+        ]);
         $this->createAttribute([
             'code'        => 'ean',
             'type'        => 'pim_catalog_text',
@@ -69,9 +59,16 @@ class ExportProductModelsIntegration extends AbstractExportTestCase
             'localizable' => false,
             'scopable'    => false,
         ]);
+        $this->createAttribute([
+            'code'        => 'variation_name',
+            'type'        => 'pim_catalog_text',
+            'group'       => 'attributeGroupA',
+            'localizable' => false,
+            'scopable'    => false,
+        ]);
         $this->createFamily([
             'code'        => 'clothing',
-            'attributes'  => ['sku', 'name', 'variation_name', 'variation_image', 'size', 'ean', 'sku', 'color'],
+            'attributes'  => ['sku', 'name', 'color', 'variation_name', 'size', 'ean'],
             'attribute_requirements' => [
                 'tablet' => ['sku', 'name']
             ]
@@ -83,7 +80,7 @@ class ExportProductModelsIntegration extends AbstractExportTestCase
                 [
                     'level' => 1,
                     'axes' => ['color'],
-                    'attributes' => ['color', 'variation_name', 'variation_image'],
+                    'attributes' => ['color', 'variation_name'],
                 ],
                 [
                     'level' => 2,
@@ -131,18 +128,53 @@ class ExportProductModelsIntegration extends AbstractExportTestCase
                 ]
             ]
         );
+        $this->createVariantProduct(
+            'apollon_pink_m',
+            [
+                'family' => 'clothing',
+                'parent' => 'apollon_pink',
+                'categories' => ['spring'],
+                'values'  => [
+                    'size'  => [['data' => 'm', 'locale' => null, 'scope' => null]],
+                    'ean'  => [['data' => '12345678', 'locale' => null, 'scope' => null]],
+                ]
+            ]
+        );
+        $this->createVariantProduct(
+            'apollon_pink_l',
+            [
+                'family' => 'clothing',
+                'parent' => 'apollon_pink',
+                'values'  => [
+                    'size'  => [['data' => 'l', 'locale' => null, 'scope' => null]],
+                    'ean'  => [['data' => '12345679', 'locale' => null, 'scope' => null]],
+                ]
+            ]
+        );
+        $this->createVariantProduct(
+            'apollon_pink_xl',
+            [
+                'family' => 'clothing',
+                'parent' => 'apollon_pink',
+                'categories' => ['tshirt','summer'],
+                'values'  => [
+                    'size'  => [['data' => 'xl', 'locale' => null, 'scope' => null]],
+                    'ean'  => [['data' => '12345465', 'locale' => null, 'scope' => null]],
+                ]
+            ]
+        );
     }
 
-    public function testProductModelsExport()
+    public function testVariantProductExport()
     {
         $expectedCsv = <<<CSV
-code;family_variant;parent;categories;color;name-de_DE;name-en_US;name-fr_FR;name-zh_CN;variation_image;variation_name
-apollon;clothing_color_size;;tshirt;;;;;;;
-apollon_blue;clothing_color_size;apollon;summer,tshirt,v-neck;blue;;;;;;"my blue tshirt"
-apollon_pink;clothing_color_size;apollon;round-neck,tshirt;pink;;;;;;"my pink tshirt"
+sku;categories;enabled;family;parent;groups;color;ean;name-en_US;size;variation_name
+apollon_pink_m;round-neck,spring,tshirt;1;clothing;apollon_pink;;pink;12345678;;m;"my pink tshirt"
+apollon_pink_l;round-neck,tshirt;1;clothing;apollon_pink;;pink;12345679;;l;"my pink tshirt"
+apollon_pink_xl;round-neck,summer,tshirt;1;clothing;apollon_pink;;pink;12345465;;xl;"my pink tshirt"
 
 CSV;
 
-        $this->assertProductModelExport($expectedCsv, []);
+        $this->assertProductExport($expectedCsv, []);
     }
 }

--- a/src/Pim/Bundle/EnrichBundle/Controller/AbstractListCategoryController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/AbstractListCategoryController.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Pim\Bundle\EnrichBundle\Controller;
+
+use Akeneo\Component\Classification\Repository\CategoryRepositoryInterface;
+use Doctrine\Common\Collections\Collection;
+use Oro\Bundle\SecurityBundle\SecurityFacade;
+use Pim\Component\Catalog\Model\CategoryInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+/**
+ * Controller used to render categories of an entity (like products or product models).
+ *
+ * @author    Julien Janvier <j.janvier@gmail.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+abstract class AbstractListCategoryController extends Controller
+{
+    /** @var CategoryRepositoryInterface */
+    protected $categoryRepository;
+
+    /** @var SecurityFacade */
+    protected $securityFacade;
+
+    /** @var string */
+    protected $categoryClass;
+
+    /** @var string */
+    protected $acl;
+
+    /** @var string */
+    protected $template;
+
+    /**
+     * @param CategoryRepositoryInterface $categoryRepository
+     * @param SecurityFacade              $securityFacade
+     * @param string                      $categoryClass
+     * @param string                      $acl
+     * @param string                      $template
+     */
+    public function __construct(
+        CategoryRepositoryInterface $categoryRepository,
+        SecurityFacade $securityFacade,
+        string $categoryClass,
+        string $acl,
+        string $template
+    ) {
+        $this->categoryRepository = $categoryRepository;
+        $this->securityFacade = $securityFacade;
+        $this->categoryClass = $categoryClass;
+        $this->acl = $acl;
+        $this->template = $template;
+    }
+
+    /**
+     * List categories associated with the provided product and descending from the category
+     * defined by the parent parameter.
+     *
+     * @param Request    $request    The request object
+     * @param string     $id         Product id
+     * @param int        $categoryId The parent category id
+     *
+     * httpparam include_category if true, will include the parentCategory in the response
+     *
+     * @return Response
+     */
+    public function listCategoriesAction(Request $request, $id, $categoryId)
+    {
+        if (!$this->securityFacade->isGranted($this->acl)) {
+            throw new AccessDeniedException();
+        }
+
+        $entityWithCategories = $this->findEntityWithCategoriesOr404($id);
+        $category = $this->categoryRepository->find($categoryId);
+
+        if (null === $category) {
+            throw new NotFoundHttpException(sprintf('%s category not found', $this->categoryClass));
+        }
+
+        $categories = null;
+        $selectedCategoryIds = $request->get('selected', null);
+        if (null !== $selectedCategoryIds) {
+            $categories = $this->categoryRepository->getCategoriesByIds($selectedCategoryIds);
+        } elseif (null !== $entityWithCategories) {
+            $categories = $entityWithCategories->getCategories();
+        }
+
+        $trees = $this->getFilledTree($category, $categories);
+
+        return $this->render($this->template, ['trees' => $trees, 'categories' => $categories]);
+    }
+
+    /**
+     * Find an entity by its id or return a 404 response
+     *
+     * @param string $id
+     *
+     * @return mixed
+     *
+     * @throws NotFoundHttpException
+     */
+    abstract protected function findEntityWithCategoriesOr404(string $id);
+
+    /**
+     * Fetch the filled tree
+     *
+     * @param CategoryInterface $parent
+     * @param Collection        $categories
+     *
+     * @return CategoryInterface[]
+     */
+    protected function getFilledTree(CategoryInterface $parent, Collection $categories): array
+    {
+        return $this->categoryRepository->getFilledTree($parent, $categories);
+    }
+}

--- a/src/Pim/Bundle/EnrichBundle/Controller/ProductModelController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/ProductModelController.php
@@ -3,17 +3,10 @@
 namespace Pim\Bundle\EnrichBundle\Controller;
 
 use Akeneo\Component\Classification\Repository\CategoryRepositoryInterface;
-use Doctrine\Common\Collections\Collection;
-use Oro\Bundle\SecurityBundle\Annotation\AclAncestor;
-use Pim\Component\Catalog\Builder\ProductBuilderInterface;
-use Pim\Component\Catalog\Model\CategoryInterface;
+use Oro\Bundle\SecurityBundle\SecurityFacade;
 use Pim\Component\Catalog\Model\ProductModelInterface;
 use Pim\Component\Catalog\Repository\ProductModelRepositoryInterface;
 use Pim\Component\Catalog\ValuesFiller\EntityWithFamilyValuesFillerInterface;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
-use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
@@ -23,109 +16,53 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class ProductModelController
+class ProductModelController extends AbstractListCategoryController
 {
     /** @var ProductModelRepositoryInterface */
-    private $productModelRepository;
-
-    /** @var ProductBuilderInterface */
-    private $productBuilder;
-
-    /** @var string */
-    private $categoryClass;
-
-    /** @var CategoryRepositoryInterface */
-    private $categoryRepository;
+    protected $productModelRepository;
 
     /** @var EntityWithFamilyValuesFillerInterface */
-    private $valuesFiller;
+    protected $valuesFiller;
 
     /**
-     * @param ProductModelRepositoryInterface       $productRepository
-     * @param CategoryRepositoryInterface           $categoryRepository
-     * @param ProductBuilderInterface               $productBuilder
+     * @param ProductModelRepositoryInterface       $productModelRepository
      * @param EntityWithFamilyValuesFillerInterface $valuesFiller
+     * @param CategoryRepositoryInterface           $categoryRepository
+     * @param SecurityFacade                        $securityFacade
      * @param string                                $categoryClass
+     * @param string                                $acl
+     * @param string                                $template
      */
     public function __construct(
-        ProductModelRepositoryInterface $productRepository,
-        CategoryRepositoryInterface $categoryRepository,
-        ProductBuilderInterface $productBuilder,
+        ProductModelRepositoryInterface $productModelRepository,
         EntityWithFamilyValuesFillerInterface $valuesFiller,
-        $categoryClass
+        CategoryRepositoryInterface $categoryRepository,
+        SecurityFacade $securityFacade,
+        string $categoryClass,
+        string $acl,
+        string $template
     ) {
-        $this->productModelRepository  = $productRepository;
-        $this->productBuilder     = $productBuilder;
-        $this->categoryRepository = $categoryRepository;
-        $this->valuesFiller       = $valuesFiller;
-        $this->categoryClass      = $categoryClass;
+        parent::__construct($categoryRepository, $securityFacade, $categoryClass, $acl, $template);
+
+        $this->productModelRepository = $productModelRepository;
+        $this->valuesFiller = $valuesFiller;
     }
 
     /**
-     * List categories associated with the provided product model and descending from the category
-     * defined by the parent parameter.
+     * Find a product model by its id or return a 404 response
      *
-     * @param Request    $request    The request object
-     * @param int|string $id         Product model id
-     * @param int        $categoryId The parent category id
-     *
-     * httpparam include_category if true, will include the parentCategory in the response
-     *
-     * @Template
-     * @AclAncestor("pim_enrich_product_model_categories_view")
-     *
-     * @return array
-     */
-    public function listCategoriesAction(Request $request, $id, $categoryId)
-    {
-        $productModel = $this->findProductModelOr404($id);
-        $parent = $this->categoryRepository->find($categoryId);
-
-        if (null === $parent) {
-            throw new NotFoundHttpException(sprintf('%s entity not found', $this->categoryClass));
-        }
-
-        $categories = null;
-        $selectedCategoryIds = $request->get('selected', null);
-        if (null !== $selectedCategoryIds) {
-            $categories = $this->categoryRepository->getCategoriesByIds($selectedCategoryIds);
-        } elseif (null !== $productModel) {
-            $categories = $productModel->getCategories();
-        }
-
-        $trees = $this->getFilledTree($parent, $categories);
-
-        return ['trees' => $trees, 'categories' => $categories];
-    }
-
-    /**
-     * Fetch the filled tree
-     *
-     * @param CategoryInterface $parent
-     * @param Collection        $categories
-     *
-     * @return CategoryInterface[]
-     */
-    private function getFilledTree(CategoryInterface $parent, Collection $categories)
-    {
-        return $this->categoryRepository->getFilledTree($parent, $categories);
-    }
-
-    /**
-     * Find a product by its id or return a 404 response
-     *
-     * @param int $id the product id
+     * @param string $id the product id
      *
      * @throws NotFoundHttpException
      *
      * @return ProductModelInterface
      */
-    private function findProductModelOr404($id)
+    protected function findEntityWithCategoriesOr404(string $id)
     {
         $productModel = $this->productModelRepository->find($id);
         if (null === $productModel) {
             throw new NotFoundHttpException(
-                sprintf('Product model with id %s could not be found.', (string) $id)
+                sprintf('Product model with ID "%s" could not be found.', $id)
             );
         }
         // With this version of the form we need to add missing values from family

--- a/src/Pim/Bundle/EnrichBundle/Controller/ProductModelController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/ProductModelController.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Pim\Bundle\EnrichBundle\Controller;
+
+use Akeneo\Component\Classification\Repository\CategoryRepositoryInterface;
+use Doctrine\Common\Collections\Collection;
+use Oro\Bundle\SecurityBundle\Annotation\AclAncestor;
+use Pim\Component\Catalog\Builder\ProductBuilderInterface;
+use Pim\Component\Catalog\Model\CategoryInterface;
+use Pim\Component\Catalog\Model\ProductModelInterface;
+use Pim\Component\Catalog\Repository\ProductModelRepositoryInterface;
+use Pim\Component\Catalog\ValuesFiller\EntityWithFamilyValuesFillerInterface;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Product Model Controller
+ *
+ * @author    Julien Janvier <j.janvier@gmail.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ProductModelController
+{
+    /** @var ProductModelRepositoryInterface */
+    private $productModelRepository;
+
+    /** @var ProductBuilderInterface */
+    private $productBuilder;
+
+    /** @var string */
+    private $categoryClass;
+
+    /** @var CategoryRepositoryInterface */
+    private $categoryRepository;
+
+    /** @var EntityWithFamilyValuesFillerInterface */
+    private $valuesFiller;
+
+    /**
+     * @param ProductModelRepositoryInterface       $productRepository
+     * @param CategoryRepositoryInterface           $categoryRepository
+     * @param ProductBuilderInterface               $productBuilder
+     * @param EntityWithFamilyValuesFillerInterface $valuesFiller
+     * @param string                                $categoryClass
+     */
+    public function __construct(
+        ProductModelRepositoryInterface $productRepository,
+        CategoryRepositoryInterface $categoryRepository,
+        ProductBuilderInterface $productBuilder,
+        EntityWithFamilyValuesFillerInterface $valuesFiller,
+        $categoryClass
+    ) {
+        $this->productModelRepository  = $productRepository;
+        $this->productBuilder     = $productBuilder;
+        $this->categoryRepository = $categoryRepository;
+        $this->valuesFiller       = $valuesFiller;
+        $this->categoryClass      = $categoryClass;
+    }
+
+    /**
+     * List categories associated with the provided product model and descending from the category
+     * defined by the parent parameter.
+     *
+     * @param Request    $request    The request object
+     * @param int|string $id         Product model id
+     * @param int        $categoryId The parent category id
+     *
+     * httpparam include_category if true, will include the parentCategory in the response
+     *
+     * @Template
+     * @AclAncestor("pim_enrich_product_model_categories_view")
+     *
+     * @return array
+     */
+    public function listCategoriesAction(Request $request, $id, $categoryId)
+    {
+        $productModel = $this->findProductModelOr404($id);
+        $parent = $this->categoryRepository->find($categoryId);
+
+        if (null === $parent) {
+            throw new NotFoundHttpException(sprintf('%s entity not found', $this->categoryClass));
+        }
+
+        $categories = null;
+        $selectedCategoryIds = $request->get('selected', null);
+        if (null !== $selectedCategoryIds) {
+            $categories = $this->categoryRepository->getCategoriesByIds($selectedCategoryIds);
+        } elseif (null !== $productModel) {
+            $categories = $productModel->getCategories();
+        }
+
+        $trees = $this->getFilledTree($parent, $categories);
+
+        return ['trees' => $trees, 'categories' => $categories];
+    }
+
+    /**
+     * Fetch the filled tree
+     *
+     * @param CategoryInterface $parent
+     * @param Collection        $categories
+     *
+     * @return CategoryInterface[]
+     */
+    private function getFilledTree(CategoryInterface $parent, Collection $categories)
+    {
+        return $this->categoryRepository->getFilledTree($parent, $categories);
+    }
+
+    /**
+     * Find a product by its id or return a 404 response
+     *
+     * @param int $id the product id
+     *
+     * @throws NotFoundHttpException
+     *
+     * @return ProductModelInterface
+     */
+    private function findProductModelOr404($id)
+    {
+        $productModel = $this->productModelRepository->find($id);
+        if (null === $productModel) {
+            throw new NotFoundHttpException(
+                sprintf('Product model with id %s could not be found.', (string) $id)
+            );
+        }
+        // With this version of the form we need to add missing values from family
+        $this->valuesFiller->fillMissingValues($productModel);
+
+        return $productModel;
+    }
+}

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/ProductModelCategoryController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/ProductModelCategoryController.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Pim\Bundle\EnrichBundle\Controller\Rest;
+
+use Akeneo\Component\Classification\Repository\ItemCategoryRepositoryInterface;
+use Oro\Bundle\SecurityBundle\Annotation\AclAncestor;
+use Pim\Bundle\CatalogBundle\Filter\ObjectFilterInterface;
+use Pim\Component\Catalog\Model\ProductModelInterface;
+use Pim\Component\Catalog\Repository\ProductModelRepositoryInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Product model category controller
+ *
+ * @author    Julien Janvier <j.janvier@gmail.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ProductModelCategoryController
+{
+    /** @var ProductModelRepositoryInterface */
+    protected $productModelRepository;
+
+    /** @var ItemCategoryRepositoryInterface */
+    protected $productModelCategoryRepository;
+
+    /** @var ObjectFilterInterface */
+    protected $objectFilter;
+
+    /**
+     * @param ProductModelRepositoryInterface $productModelRepository
+     * @param ItemCategoryRepositoryInterface $productModelCategoryRepository
+     * @param ObjectFilterInterface           $objectFilter
+     */
+    public function __construct(
+        ProductModelRepositoryInterface $productModelRepository,
+        ItemCategoryRepositoryInterface $productModelCategoryRepository,
+        ObjectFilterInterface $objectFilter
+    ) {
+        $this->productModelRepository         = $productModelRepository;
+        $this->productModelCategoryRepository = $productModelCategoryRepository;
+        $this->objectFilter                   = $objectFilter;
+    }
+
+    /**
+     * List categories and trees for a product
+     *
+     * @param string $id
+     *
+     * @AclAncestor("pim_enrich_product_categories_view")
+     *
+     * @return JsonResponse
+     */
+    public function listAction($id)
+    {
+        $productModel = $this->findProductModelOr404($id);
+        $trees = $this->productModelCategoryRepository->getItemCountByTree($productModel);
+
+        $result['trees'] = $this->buildTrees($trees);
+        $result['categories'] = $this->buildCategories($productModel);
+
+        return new JsonResponse($result);
+    }
+
+    /**
+     * Find a product by its id or return a 404 response
+     *
+     * @param string $id the product id
+     *
+     * @throws NotFoundHttpException
+     *
+     * @return ProductModelInterface
+     */
+    protected function findProductModelOr404($id)
+    {
+        $productModel = $this->productModelRepository->find($id);
+
+        if (null === $productModel) {
+            throw new NotFoundHttpException(
+                sprintf('ProductModel with id %s could not be found.', (string) $id)
+            );
+        }
+
+        return $productModel;
+    }
+
+    /**
+     * @param array $trees
+     *
+     * @return array
+     */
+    protected function buildTrees(array $trees)
+    {
+        $result = [];
+
+        foreach ($trees as $tree) {
+            $category = $tree['tree'];
+
+            if (!$this->objectFilter->filterObject($category, 'pim.internal_api.product_category.view')) {
+                $result[] = [
+                    'id'         => $category->getId(),
+                    'code'       => $category->getCode(),
+                    'label'      => $category->getLabel(),
+                    'associated' => $tree['itemCount'] > 0
+                ];
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param ProductModelInterface $productModel
+     *
+     * @return array
+     */
+    protected function buildCategories(ProductModelInterface $productModel)
+    {
+        $result = [];
+
+        foreach ($productModel->getCategories() as $category) {
+            $result[] = [
+                'id'     => $category->getId(),
+                'code'   => $category->getCode(),
+                'rootId' => $category->getRoot(),
+            ];
+        }
+
+        return $result;
+    }
+}

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/ProductModelCategoryController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/ProductModelCategoryController.php
@@ -44,15 +44,15 @@ class ProductModelCategoryController
     }
 
     /**
-     * List categories and trees for a product
+     * List categories and trees for a product model
      *
      * @param string $id
      *
-     * @AclAncestor("pim_enrich_product_categories_view")
+     * @AclAncestor("pim_enrich_product_model_categories_view")
      *
      * @return JsonResponse
      */
-    public function listAction($id)
+    public function listAction($id): JsonResponse
     {
         $productModel = $this->findProductModelOr404($id);
         $trees = $this->productModelCategoryRepository->getItemCountByTree($productModel);
@@ -64,7 +64,7 @@ class ProductModelCategoryController
     }
 
     /**
-     * Find a product by its id or return a 404 response
+     * Find a product model by its id or return a 404 response
      *
      * @param string $id the product id
      *
@@ -72,13 +72,13 @@ class ProductModelCategoryController
      *
      * @return ProductModelInterface
      */
-    protected function findProductModelOr404($id)
+    protected function findProductModelOr404(string $id): ProductModelInterface
     {
         $productModel = $this->productModelRepository->find($id);
 
         if (null === $productModel) {
             throw new NotFoundHttpException(
-                sprintf('ProductModel with id %s could not be found.', (string) $id)
+                sprintf('Product model with ID "%s" could not be found.', $id)
             );
         }
 
@@ -90,7 +90,7 @@ class ProductModelCategoryController
      *
      * @return array
      */
-    protected function buildTrees(array $trees)
+    protected function buildTrees(array $trees): array
     {
         $result = [];
 
@@ -115,7 +115,7 @@ class ProductModelCategoryController
      *
      * @return array
      */
-    protected function buildCategories(ProductModelInterface $productModel)
+    protected function buildCategories(ProductModelInterface $productModel): array
     {
         $result = [];
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/acl.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/acl.yml
@@ -74,6 +74,10 @@ pim_enrich_product_model_edit_attributes:
     type: action
     label: pim_enrich.acl.product_model.edit_attributes
     group_name: pim_enrich.acl_group.product_model
+pim_enrich_product_model_categories_view:
+    type: action
+    label: pim_enrich.acl.product_model.categories_view
+    group_name: pim_enrich.acl_group.product_model
 
 # Mass edit action
 pim_enrich_mass_edit:

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/controllers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/controllers.yml
@@ -4,6 +4,7 @@ parameters:
     pim_enrich.controller.family.class:                       Pim\Bundle\EnrichBundle\Controller\FamilyController
     pim_enrich.controller.attribute_option.class:             Pim\Bundle\EnrichBundle\Controller\AttributeOptionController
     pim_enrich.controller.product.class:                      Pim\Bundle\EnrichBundle\Controller\ProductController
+    pim_enrich.controller.product_model.class:                Pim\Bundle\EnrichBundle\Controller\ProductModelController
     pim_enrich.controller.group.class:                        Pim\Bundle\EnrichBundle\Controller\GroupController
     pim_enrich.controller.association_type.class:             Pim\Bundle\EnrichBundle\Controller\AssociationTypeController
     pim_enrich.controller.file.class:                         Pim\Bundle\EnrichBundle\Controller\FileController
@@ -24,6 +25,7 @@ parameters:
     pim_enrich.controller.rest.product.class:                 Pim\Bundle\EnrichBundle\Controller\Rest\ProductController
     pim_enrich.controller.rest.product_model.class:           Pim\Bundle\EnrichBundle\Controller\Rest\ProductModelController
     pim_enrich.controller.rest.product_category.class:        Pim\Bundle\EnrichBundle\Controller\Rest\ProductCategoryController
+    pim_enrich.controller.rest.product_model_category.class:  Pim\Bundle\EnrichBundle\Controller\Rest\ProductModelCategoryController
     pim_enrich.controller.rest.product_comment.class:         Pim\Bundle\EnrichBundle\Controller\Rest\ProductCommentController
     pim_enrich.controller.rest.versioning.class:              Pim\Bundle\EnrichBundle\Controller\Rest\VersioningController
     pim_enrich.controller.rest.attribute_option.class:        Pim\Bundle\EnrichBundle\Controller\Rest\AttributeOptionController
@@ -88,6 +90,15 @@ services:
             - '@pim_catalog.saver.product'
             - '@pim_catalog.builder.product'
             - '@pim_catalog.values_filler.product'
+            - '%pim_catalog.entity.category.class%'
+
+    pim_enrich.controller.product_model:
+        class: '%pim_enrich.controller.product_model.class%'
+        arguments:
+            - '@pim_catalog.repository.product_model'
+            - '@pim_catalog.repository.category'
+            - '@pim_catalog.builder.product'
+            - '@pim_catalog.values_filler.entity_with_family_variant'
             - '%pim_catalog.entity.category.class%'
 
     pim_enrich.controller.group:
@@ -344,6 +355,13 @@ services:
         arguments:
             - '@pim_catalog.repository.product'
             - '@pim_catalog.repository.product_category'
+            - '@pim_catalog.filter.chained'
+
+    pim_enrich.controller.rest.product_model_category:
+        class: '%pim_enrich.controller.rest.product_model_category.class%'
+        arguments:
+            - '@pim_catalog.repository.product_model'
+            - '@pim_catalog.repository.product_model_category'
             - '@pim_catalog.filter.chained'
 
     pim_enrich.controller.rest.product_comment:

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/controllers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/controllers.yml
@@ -91,15 +91,20 @@ services:
             - '@pim_catalog.builder.product'
             - '@pim_catalog.values_filler.product'
             - '%pim_catalog.entity.category.class%'
+            - '@oro_security.security_facade'
+            - 'pim_enrich_product_categories_view'
+            - '@@PimEnrich/Product/listCategories.json.twig'
 
     pim_enrich.controller.product_model:
         class: '%pim_enrich.controller.product_model.class%'
         arguments:
             - '@pim_catalog.repository.product_model'
-            - '@pim_catalog.repository.category'
-            - '@pim_catalog.builder.product'
             - '@pim_catalog.values_filler.entity_with_family_variant'
+            - '@pim_catalog.repository.category'
+            - '@oro_security.security_facade'
             - '%pim_catalog.entity.category.class%'
+            - 'pim_enrich_product_model_categories_view'
+            - '@@PimEnrich/ProductModel/listCategories.json.twig'
 
     pim_enrich.controller.group:
         class: '%pim_enrich.controller.group.class%'

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product/edit.yml
@@ -203,6 +203,9 @@ extensions:
         targetZone: container
         aclResourceId: pim_enrich_product_categories_view
         position: 100
+        config:
+            itemCategoryListRoute: pim_enrich_product_listcategories
+            itemCategoryTreeRoute: pim_enrich_product_category_rest_list
 
     pim-product-edit-form-associations:
         module: pim/product-edit-form/associations

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_model/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_model/edit.yml
@@ -145,6 +145,16 @@ extensions:
             tabTitle: pim_enrich.form.product.tab.attributes.title
             deletionFailed: pim_enrich.form.product.flash.attribute_deletion_error
 
+    pim-product-model-edit-form-categories:
+        module: pim/product-edit-form/categories
+        parent: pim-product-model-edit-form-column-tabs
+        targetZone: container
+        aclResourceId: pim_enrich_product_categories_view #TODO
+        position: 100
+        config:
+            itemCategoryListRoute: pim_enrich_product_model_listcategories
+            itemCategoryTreeRoute: pim_enrich_product_model_category_rest_list
+
     pim-product-model-edit-form-attribute-group-selector:
         module: pim/form/common/attributes/attribute-group-selector
         parent: pim-product-model-edit-form-attributes

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/routing/product_model.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/routing/product_model.yml
@@ -23,7 +23,7 @@ pim_enrich_product_model_rest_children_list:
 
 pim_enrich_product_model_category_rest_list:
     path: /rest/{id}/categories
-    defaults: { _controller: pim_enrich.controller.rest.product_category:listAction }
+    defaults: { _controller: pim_enrich.controller.rest.product_model_category:listAction }
     requirements:
         id: '[0-9a-f]+'
     methods: [GET]
@@ -34,3 +34,10 @@ pim_enrich_product_model_history_rest_get:
     requirements:
         entityId: '[0-9a-f]+'
     methods: [GET]
+
+pim_enrich_product_model_listcategories:
+    path: /list-categories/product-model/{id}/parent/{categoryId}
+    defaults: { _controller: pim_enrich.controller.product_model:listCategoriesAction, _format: json }
+    requirements:
+        id: '[0-9a-f]+'
+        categoryId: \d+

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/categories.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/categories.js
@@ -58,10 +58,14 @@ define(
             /**
              * {@inheritdoc}
              */
-            initialize: function () {
+            initialize: function (config) {
                 this.state = new Backbone.Model();
 
                 this.state.set('selectedCategories', []);
+
+                if (undefined !== config) {
+                    this.config = config.config;
+                }
 
                 BaseForm.prototype.initialize.apply(this, arguments);
             },
@@ -105,7 +109,7 @@ define(
                     );
 
                     this.treeAssociate = new TreeAssociate('#trees', '#hidden-tree-input', {
-                        list_categories: 'pim_enrich_product_listcategories',
+                        list_categories: this.config.itemCategoryListRoute,
                         children:        'pim_enrich_categorytree_children'
                     });
 
@@ -142,7 +146,7 @@ define(
              */
             loadTrees: function () {
                 return $.getJSON(
-                    Routing.generate('pim_enrich_product_category_rest_list', { id: this.getFormData().meta.id })
+                    Routing.generate(this.config.itemCategoryTreeRoute, { id: this.getFormData().meta.id })
                 ).then(function (data) {
                     _.each(data.categories, function (category) {
                         this.cache[category.id] = category;

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/messages.en.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/messages.en.yml
@@ -184,6 +184,7 @@ pim_enrich:
             history: View product history
         product_model:
             edit_attributes: Edit attributes of a product model
+            categories_view: Consult the categories of a product model
         category:
             list: List categories
             create: Create a category

--- a/src/Pim/Bundle/EnrichBundle/Resources/views/ProductModel/listCategories.json.twig
+++ b/src/Pim/Bundle/EnrichBundle/Resources/views/ProductModel/listCategories.json.twig
@@ -1,0 +1,1 @@
+{{ list_categories_response(trees, categories)|json_encode|raw }}

--- a/src/Pim/Component/Catalog/Repository/ProductModelCategoryRepositoryInterface.php
+++ b/src/Pim/Component/Catalog/Repository/ProductModelCategoryRepositoryInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Pim\Component\Catalog\Repository;
+
+use Akeneo\Component\Classification\Repository\CategoryFilterableRepositoryInterface;
+use Akeneo\Component\Classification\Repository\ItemCategoryRepositoryInterface;
+use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
+
+/**
+ * Product model category repository interface
+ *
+ * @author    Julien Janvier <j.janvier@gmail.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface ProductModelCategoryRepositoryInterface extends
+    ItemCategoryRepositoryInterface,
+    CategoryFilterableRepositoryInterface
+{
+}


### PR DESCRIPTION
This PR is about the product models classification:
- it adds tests on the export
- it adds an ACL
- it adds the categories tab on the product model edit form
- it adds tests on variant products categories (ensuring ancestry categories are taken into account)

The second to last commit tries to mutualize some logic between products and models. It can be removed if you don't like it.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | 
| Added Behats                      | Y
| Added integration tests           | Y
| Changelog updated                 | Y
| Review and 2 GTM                  | 
| Micro Demo to the PO (Story only) | 
| Migration script                  | -
| Tech Doc                          | -

