### PR TITLE
PIM-6847: Fix variant product history

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -9,6 +9,7 @@
 - PIM-6861: Correctly display a product model if it has no product children
 - PIM-6862: Save products on "pim:completeness:calculate" command
 - PIM-6866: Fix PQB sorter when attribute is not localizable and/or not scopable
+- PIM-6847: Fix variant product history
 
 ## Tech improvements
 

--- a/features/product/history/display_variant_product_history.feature
+++ b/features/product/history/display_variant_product_history.feature
@@ -1,0 +1,20 @@
+@javascript
+Feature: Display the variant product history
+  In order to know by who, when and what changes have been made to a variant product
+  As a product manager
+  I need to have access to a variant product history
+
+  Scenario: Display product updates
+    Given a "catalog_modeling" catalog configuration
+    And I am logged in as "Julia"
+    And I am on the "tshirt-unique-color-kurt-l" product page
+    When I visit the "Product" group
+    And I change the "Weight" to "750 Gram"
+    And I press the "Save" button
+    Then I should not see the text "There are unsaved changes."
+    When the history of the product "tshirt-unique-color-kurt-l" has been built
+    And I visit the "History" column tab
+    Then there should be 2 update
+    And I should see history:
+      | version | property | value |
+      | 2       | Weight   | 750   |

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/CreateVariantProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/CreateVariantProductIntegration.php
@@ -74,7 +74,6 @@ JSON;
             'family'        => 'familyA',
             'parent'        => 'amor',
             'groups'        => [],
-            'variant_group' => null,
             'categories'    => [],
             'enabled'       => true,
             'values'        => [
@@ -158,7 +157,6 @@ JSON;
             'family'        => 'familyA',
             'parent'        => 'amor',
             'groups'        => [],
-            'variant_group' => null,
             'categories'    => [],
             'enabled'       => true,
             'values'        => [
@@ -433,7 +431,6 @@ JSON;
             'family'        => "familyA",
             'parent'        => 'amor',
             'groups'        => ["groupA", "groupB"],
-            'variant_group' => null,
             'categories'    => [],
             'enabled'       => true,
             'values'        => [
@@ -518,7 +515,6 @@ JSON;
             'family'        => "familyA",
             'parent'        => "amor",
             'groups'        => [],
-            'variant_group' => null,
             'categories'    => ["categoryA", "master"],
             'enabled'       => true,
             'values'        => [
@@ -608,7 +604,6 @@ JSON;
             'family'        => "familyA",
             'parent'        => "amor",
             'groups'        => [],
-            'variant_group' => null,
             'categories'    => [],
             'enabled'       => true,
             'values'        => [
@@ -697,7 +692,6 @@ JSON;
         "identifier": "product_variant_creation_product_values",
         "groups": ["groupA", "groupB"],
         "parent": "amor",
-        "variant_group": null,
         "family": "familyA",
         "categories": ["master", "categoryA"],
         "values": {
@@ -881,7 +875,6 @@ JSON;
             'family'        => 'familyA',
             'parent'        => "amor",
             'groups'        => ['groupA', 'groupB'],
-            'variant_group' => null,
             'categories'    => ['categoryA', 'master'],
             'enabled'       => true,
             'values'        => [
@@ -964,7 +957,6 @@ JSON;
             'family'        => "familyA",
             'parent'        => "amor",
             'groups'        => [],
-            'variant_group' => null,
             'categories'    => [],
             'enabled'       => true,
             'values'        => [

--- a/src/Pim/Bundle/CatalogBundle/EventSubscriber/AddUniqueAttributesToVariantProductAttributeSetSubscriber.php
+++ b/src/Pim/Bundle/CatalogBundle/EventSubscriber/AddUniqueAttributesToVariantProductAttributeSetSubscriber.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Pim\Bundle\CatalogBundle\EventSubscriber;
 
 use Akeneo\Component\StorageUtils\StorageEvents;
-use Pim\Component\Catalog\FamilyVariant\AddUniqueAttributesToVariantProductAttributeSet;
+use Pim\Component\Catalog\FamilyVariant\AddUniqueAttributes;
 use Pim\Component\Catalog\Model\FamilyInterface;
 use Pim\Component\Catalog\Model\FamilyVariantInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -24,13 +24,13 @@ use Symfony\Component\EventDispatcher\GenericEvent;
  */
 class AddUniqueAttributesToVariantProductAttributeSetSubscriber implements EventSubscriberInterface
 {
-    /** @var AddUniqueAttributesToVariantProductAttributeSet */
+    /** @var AddUniqueAttributes */
     private $addUniqueAttributes;
 
     /**
-     * @param AddUniqueAttributesToVariantProductAttributeSet $addUniqueAttributes
+     * @param AddUniqueAttributes $addUniqueAttributes
      */
-    public function __construct(AddUniqueAttributesToVariantProductAttributeSet $addUniqueAttributes)
+    public function __construct(AddUniqueAttributes $addUniqueAttributes)
     {
         $this->addUniqueAttributes = $addUniqueAttributes;
     }
@@ -51,7 +51,7 @@ class AddUniqueAttributesToVariantProductAttributeSetSubscriber implements Event
         $subject = $event->getSubject();
 
         if ($subject instanceof FamilyVariantInterface) {
-            $this->addUniqueAttributes->addUniqueAttributesToFamilyVariant($subject);
+            $this->addUniqueAttributes->addToFamilyVariant($subject);
         }
 
         if ($subject instanceof FamilyInterface) {
@@ -61,7 +61,7 @@ class AddUniqueAttributesToVariantProductAttributeSetSubscriber implements Event
             }
 
             foreach ($familyVariants as $familyVariant) {
-                $this->addUniqueAttributes->addUniqueAttributesToFamilyVariant($familyVariant);
+                $this->addUniqueAttributes->addToFamilyVariant($familyVariant);
             }
         }
     }

--- a/src/Pim/Bundle/CatalogBundle/Resolver/FQCNResolver.php
+++ b/src/Pim/Bundle/CatalogBundle/Resolver/FQCNResolver.php
@@ -17,6 +17,9 @@ class FQCNResolver
     /** @var array */
     protected $classNames = [];
 
+    /** @var ContainerInterface */
+    protected $container;
+
     /**
      * @param ContainerInterface $container
      */
@@ -36,8 +39,7 @@ class FQCNResolver
     {
         try {
             $className = $this->container->getParameter(
-                sprintf('pim_catalog.entity.%s.class', $entityType),
-                ContainerInterface::NULL_ON_INVALID_REFERENCE
+                sprintf('pim_catalog.entity.%s.class', $entityType)
             );
         } catch (InvalidArgumentException $e) {
             $className = null;

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/event_subscribers.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/event_subscribers.yml
@@ -110,6 +110,6 @@ services:
     pim_catalog.event_subscriber.add_unique_attributes_to_variant_product_attribute_set:
         class: '%pim_catalog.event_subscriber.add_unique_attributes_to_variant_product_attribute_set.class%'
         arguments:
-            - '@pim_catalog.family_variant.add_unique_attributes_to_variant_product_attribute_set'
+            - '@pim_catalog.family_variant.add_unique_attributes'
         tags:
             - { name: kernel.event_subscriber }

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/family_variant.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/family_variant.yml
@@ -1,10 +1,10 @@
 parameters:
     pim_catalog.family_variant.provider.entity_with_family_variant_attributes.class: Pim\Component\Catalog\FamilyVariant\EntityWithFamilyVariantAttributesProvider
-    pim_catalog.family_variant.add_unique_attributes_to_variant_product_attribute_set.class: Pim\Component\Catalog\FamilyVariant\AddUniqueAttributesToVariantProductAttributeSet
+    pim_catalog.family_variant.add_unique_attributes.class: Pim\Component\Catalog\FamilyVariant\AddUniqueAttributes
 
 services:
     pim_catalog.family_variant.provider.entity_with_family_variant_attributes:
         class: '%pim_catalog.family_variant.provider.entity_with_family_variant_attributes.class%'
 
-    pim_catalog.family_variant.add_unique_attributes_to_variant_product_attribute_set:
-        class: '%pim_catalog.family_variant.add_unique_attributes_to_variant_product_attribute_set.class%'
+    pim_catalog.family_variant.add_unique_attributes:
+        class: '%pim_catalog.family_variant.add_unique_attributes.class%'

--- a/src/Pim/Bundle/CatalogBundle/spec/EventSubscriber/AddUniqueAttributesToVariantProductAttributeSetSubscriberSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/EventSubscriber/AddUniqueAttributesToVariantProductAttributeSetSubscriberSpec.php
@@ -6,7 +6,7 @@ use Akeneo\Component\StorageUtils\StorageEvents;
 use Doctrine\Common\Collections\ArrayCollection;
 use PhpSpec\ObjectBehavior;
 use Pim\Bundle\CatalogBundle\EventSubscriber\AddUniqueAttributesToVariantProductAttributeSetSubscriber;
-use Pim\Component\Catalog\FamilyVariant\AddUniqueAttributesToVariantProductAttributeSet;
+use Pim\Component\Catalog\FamilyVariant\AddUniqueAttributes;
 use Pim\Component\Catalog\Model\CategoryInterface;
 use Pim\Component\Catalog\Model\FamilyInterface;
 use Pim\Component\Catalog\Model\FamilyVariantInterface;
@@ -16,7 +16,7 @@ use Symfony\Component\EventDispatcher\GenericEvent;
 
 class AddUniqueAttributesToVariantProductAttributeSetSubscriberSpec extends ObjectBehavior
 {
-    function let(AddUniqueAttributesToVariantProductAttributeSet $addUniqueAttributes)
+    function let(AddUniqueAttributes $addUniqueAttributes)
     {
         $this->beConstructedWith($addUniqueAttributes);
     }
@@ -45,7 +45,7 @@ class AddUniqueAttributesToVariantProductAttributeSetSubscriberSpec extends Obje
     ) {
         $event->getSubject()->willReturn($category);
 
-        $addUniqueAttributes->addUniqueAttributesToFamilyVariant(Argument::any())->shouldNotBeCalled();
+        $addUniqueAttributes->addToFamilyVariant(Argument::any())->shouldNotBeCalled();
 
         $this->addUniqueAttributes($event);
     }
@@ -57,7 +57,7 @@ class AddUniqueAttributesToVariantProductAttributeSetSubscriberSpec extends Obje
     ) {
         $event->getSubject()->willReturn($familyVariant);
 
-        $addUniqueAttributes->addUniqueAttributesToFamilyVariant($familyVariant)->shouldBeCalled();
+        $addUniqueAttributes->addToFamilyVariant($familyVariant)->shouldBeCalled();
 
         $this->addUniqueAttributes($event);
     }
@@ -80,7 +80,7 @@ class AddUniqueAttributesToVariantProductAttributeSetSubscriberSpec extends Obje
         $familyVariantsIterator->current()->willReturn($familyVariant);
         $familyVariantsIterator->next()->shouldBeCalled();
 
-        $addUniqueAttributes->addUniqueAttributesToFamilyVariant($familyVariant)->shouldBeCalled();
+        $addUniqueAttributes->addToFamilyVariant($familyVariant)->shouldBeCalled();
 
         $this->addUniqueAttributes($event);
     }
@@ -95,7 +95,7 @@ class AddUniqueAttributesToVariantProductAttributeSetSubscriberSpec extends Obje
         $family->getFamilyVariants()->willReturn($familyVariants);
         $familyVariants->isEmpty()->willReturn(true);
 
-        $addUniqueAttributes->addUniqueAttributesToFamilyVariant(Argument::any())->shouldNotBeCalled();
+        $addUniqueAttributes->addToFamilyVariant(Argument::any())->shouldNotBeCalled();
 
         $this->addUniqueAttributes($event);
     }

--- a/src/Pim/Bundle/VersioningBundle/Builder/VersionBuilder.php
+++ b/src/Pim/Bundle/VersioningBundle/Builder/VersionBuilder.php
@@ -5,6 +5,8 @@ namespace Pim\Bundle\VersioningBundle\Builder;
 use Akeneo\Component\Versioning\Model\Version;
 use Doctrine\Common\Util\ClassUtils;
 use Pim\Bundle\VersioningBundle\Factory\VersionFactory;
+use Pim\Component\Catalog\Model\Product;
+use Pim\Component\Catalog\Model\ProductInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
@@ -33,7 +35,10 @@ class VersionBuilder
     }
 
     /**
-     * Build a version for a versionable entity
+     * Builds a version for a versionable entity.
+     *
+     * Products and variant products will both have `Pim\Component\Catalog\Model\Product`
+     * as resource name.
      *
      * @param object       $versionable
      * @param string       $author
@@ -44,7 +49,8 @@ class VersionBuilder
      */
     public function buildVersion($versionable, $author, Version $previousVersion = null, $context = null)
     {
-        $resourceName = ClassUtils::getClass($versionable);
+        $resourceName = $this->getResourceName($versionable);
+
         $resourceId = $versionable->getId();
 
         $versionNumber = $previousVersion ? $previousVersion->getVersion() + 1 : 1;
@@ -64,7 +70,10 @@ class VersionBuilder
     }
 
     /**
-     * Create a pending version for a versionable entity
+     * Creates a pending version for a versionable entity.
+     *
+     * Products and variant products will both have `Pim\Component\Catalog\Model\Product`
+     * as resource name.
      *
      * @param object      $versionable
      * @param string      $author
@@ -75,8 +84,10 @@ class VersionBuilder
      */
     public function createPendingVersion($versionable, $author, array $changeset, $context = null)
     {
+        $resourceName = $this->getResourceName($versionable);
+
         $version = $this->versionFactory->create(
-            ClassUtils::getClass($versionable),
+            $resourceName,
             $versionable->getId(),
             $author,
             $context
@@ -175,5 +186,19 @@ class VersionBuilder
                 return $item['old'] != $item['new'];
             }
         );
+    }
+
+    /**
+     * @param object $versionable
+     *
+     * @return string
+     */
+    protected function getResourceName($versionable)
+    {
+        if ($versionable instanceof ProductInterface) {
+            return Product::class;
+        }
+
+        return ClassUtils::getClass($versionable);
     }
 }

--- a/src/Pim/Bundle/VersioningBundle/EventSubscriber/AddRemoveVersionSubscriber.php
+++ b/src/Pim/Bundle/VersioningBundle/EventSubscriber/AddRemoveVersionSubscriber.php
@@ -9,6 +9,8 @@ use Akeneo\Component\Versioning\Model\VersionableInterface;
 use Doctrine\Common\Util\ClassUtils;
 use Pim\Bundle\VersioningBundle\Factory\VersionFactory;
 use Pim\Bundle\VersioningBundle\Repository\VersionRepositoryInterface;
+use Pim\Component\Catalog\Model\Product;
+use Pim\Component\Catalog\Model\ProductInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
@@ -87,12 +89,12 @@ class AddRemoveVersionSubscriber implements EventSubscriberInterface
         }
 
         $previousVersion = $this->versionRepository->getNewestLogEntry(
-            ClassUtils::getClass($subject),
+            $this->getRessourceName($subject),
             $event->getSubjectId()
         );
 
         $version = $this->versionFactory->create(
-            ClassUtils::getClass($subject),
+            $this->getRessourceName($subject),
             $event->getSubjectId(),
             $author,
             'Deleted'
@@ -104,5 +106,19 @@ class AddRemoveVersionSubscriber implements EventSubscriberInterface
 
         $options = $event->getArguments();
         $this->versionSaver->save($version, $options);
+    }
+
+    /**
+     * @param object $versionable
+     *
+     * @return string
+     */
+    private function getRessourceName($versionable)
+    {
+        if ($versionable instanceof ProductInterface) {
+            return Product::class;
+        }
+
+        return ClassUtils::getClass($versionable);
     }
 }

--- a/src/Pim/Component/Catalog/FamilyVariant/AddUniqueAttributes.php
+++ b/src/Pim/Component/Catalog/FamilyVariant/AddUniqueAttributes.php
@@ -17,12 +17,12 @@ use Pim\Component\Catalog\Model\FamilyVariantInterface;
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class AddUniqueAttributesToVariantProductAttributeSet
+class AddUniqueAttributes
 {
     /**
      * @param FamilyVariantInterface $familyVariant
      */
-    public function addUniqueAttributesToFamilyVariant(FamilyVariantInterface $familyVariant)
+    public function addToFamilyVariant(FamilyVariantInterface $familyVariant)
     {
         $familyUniqueAttributes = $this->getFamilyUniqueAttributes($familyVariant->getFamily());
 

--- a/src/Pim/Component/Catalog/spec/FamilyVariant/AddUniqueAttributesSpec.php
+++ b/src/Pim/Component/Catalog/spec/FamilyVariant/AddUniqueAttributesSpec.php
@@ -4,7 +4,7 @@ namespace spec\Pim\Component\Catalog\FamilyVariant;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Pim\Component\Catalog\AttributeTypes;
-use Pim\Component\Catalog\FamilyVariant\AddUniqueAttributesToVariantProductAttributeSet;
+use Pim\Component\Catalog\FamilyVariant\AddUniqueAttributes;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\FamilyInterface;
@@ -12,11 +12,11 @@ use Pim\Component\Catalog\Model\FamilyVariantInterface;
 use Pim\Component\Catalog\Model\VariantAttributeSetInterface;
 use Prophecy\Argument;
 
-class AddUniqueAttributesToVariantProductAttributeSetSpec extends ObjectBehavior
+class AddUniqueAttributesSpec extends ObjectBehavior
 {
     function it_is_initializable()
     {
-        $this->shouldHaveType(AddUniqueAttributesToVariantProductAttributeSet::class);
+        $this->shouldHaveType(AddUniqueAttributes::class);
     }
 
     function it_adds_unique_attributes_for_family_variant(
@@ -65,6 +65,6 @@ class AddUniqueAttributesToVariantProductAttributeSetSpec extends ObjectBehavior
 
         $variantAttributeSet->addAttribute($ean)->shouldBeCalled();
 
-        $this->addUniqueAttributesToFamilyVariant($familyVariant);
+        $this->addToFamilyVariant($familyVariant);
     }
 }


### PR DESCRIPTION
## Description

### The problem

Currently, there is no version visible in the variant products history panel.

This is because of the way our versioning work: every entity versions are in the same table `pim_versioning_version`. To know to what entity a version belong, there is a field `resource_name` in that table that contains the namespace of the versioned entity.

Problem is, the variant product and regular product share the same interface, but are different entities, with different namespaces. But on the front side, they are both treated as products. So versions are fetched using the "product-history-fetcher", which looks only for the regular product namespace in the `resource_name` field.

### Solving on the front part

A way to solve that would be to create two product forms, with two different routings: one for `product` and one for `variant_product`. JS code would be shared for both except for the history fetcher: there would still be one `product-history-fetcher` for regular products, and a `variant-product-history-fetcher` for variant products.

Problem of this solution is that we create kind of a big BC break in the PEF, introducing new routings, new forms.

### Solution proposed in this PR

The solution is clearly a hack, but allows no BC break at all. The idea is to always use the product namespace, for the regular products and for variant products (whenever the versionable entity implements a `ProductInterface`).

This way, the product versions are still working without any changes, and the new variant product versions are visible too. Only the previous versions (for an already in production system) will remain not visible in PEF.

### Bonus

There is also a renaming of `AddUniqueAttributesToVariantProductAttributeSet::addUniqueAttributesToFamilyVariant` into `AddUniqueAttributes::addToFamilyVariant` (and also the renaming of the corresponding service) as requested by @aRn0D in #6903 (didn't do it in the original PR because the CI was green, sorry for that :trollface: ).

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added Behats                      | OK
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
