### PR TITLE
PIM-6862: save products on "pim:completeness:calculate" command

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -7,6 +7,7 @@
 - API-393: Add prefix "akeno:batch" to the command "publish-job-to-queue"
 - PIM-6843: Update delete buttons in category, user, role and group pages
 - PIM-6861: Correctly display a product model if it has no product children
+- PIM-6862: Save products on "pim:completeness:calculate" command
 
 ## Tech improvements
 

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/CalculateCompletenessCommandIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/CalculateCompletenessCommandIntegration.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\Completeness;
+
+use Akeneo\Test\IntegrationTestsBundle\Launcher\CommandLauncher;
+use Pim\Component\Catalog\AttributeTypes;
+
+class CalculateCompletenessCommandIntegration extends AbstractCompletenessTestCase
+{
+    public function testToCalculeCompletenessAfterPurge()
+    {
+        $family = $this->createFamilyWithRequirement(
+            'another_family',
+            'ecommerce',
+            'a_text',
+            AttributeTypes::TEXT,
+            false,
+            false
+        );
+
+        $this->createProductWithStandardValues(
+            $family,
+            'product_complete',
+            [
+                'values' => [
+                    'a_text' => [
+                        [
+                            'locale' => null,
+                            'scope'  => null,
+                            'data'   => 'juste un texte'
+                        ],
+                    ]
+                ]
+            ]
+        );
+
+        $this->get('akeneo_elasticsearch.client.product')->refreshIndex();
+
+        $commandLauncher = new CommandLauncher(static::$kernel);
+
+        $exitCode = $commandLauncher->execute('pim:completeness:purge');
+        $this->assertSame(0, $exitCode);
+        $this->assertSame(0, $this->getCountRowCompleteness());
+
+        $exitCode = $commandLauncher->execute('pim:completeness:calculate');
+        $this->assertSame(0, $exitCode);
+        $this->assertSame(1, $this->getCountRowCompleteness());
+    }
+
+    private function getCountRowCompleteness()
+    {
+        $sql = 'SELECT count(*) AS count FROM pim_catalog_completeness';
+        $stmt = $this->get('doctrine.orm.entity_manager')->getConnection()->prepare($sql);
+        $stmt->execute();
+
+        return (int) $stmt->fetch()['count'];
+    }
+}

--- a/tests/IntegrationTestsBundle/Launcher/CommandLauncher.php
+++ b/tests/IntegrationTestsBundle/Launcher/CommandLauncher.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Test\IntegrationTestsBundle\Launcher;
+
+use Akeneo\Bundle\BatchBundle\Command\BatchCommand;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+/**
+ * Launch commands for the integration tests.
+ */
+class CommandLauncher
+{
+    /** @var KernelInterface */
+    protected $kernel;
+
+    /**
+     * @param KernelInterface $kernel
+     */
+    public function __construct(KernelInterface $kernel)
+    {
+        $this->kernel = $kernel;
+    }
+
+    /**
+     * @param string      $commandName
+     * @param string|null $username
+     * @param array       $config
+     *
+     * @throws \Exception
+     *
+     * @return int
+     */
+    public function execute(string $commandName, string $username = null, array $config = []) : int
+    {
+        $application = new Application($this->kernel);
+        $application->setAutoExit(false);
+
+        $arrayInput = [
+            'command'  => $commandName,
+            '-v'       => true,
+        ];
+
+        if (null !== $username) {
+            $arrayInput['--username'] = $username;
+        }
+
+        $input = new ArrayInput($arrayInput);
+
+        $output = new BufferedOutput();
+        $exitCode = $application->run($input, $output);
+
+        if (BatchCommand::EXIT_SUCCESS_CODE !== $exitCode) {
+            throw new \Exception(sprintf('Command "%s" failed, "%s".', $commandName, $output->fetch()));
+        }
+
+        return $exitCode;
+    }
+}


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

With the rework on the completeness, products are not saved anymore when we call the `generateMissing` method.
Now to be sure ES is synchro with the db, we refresh the product index, get all products without completeness and save products in the db & ES (when we save a product, the completeness is automatically calculated) 

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
