### PR TITLE
PIM-6867: Fix validation of variant product about parent

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -21,6 +21,10 @@
 - API-377: Get a single product model via API
 - API-379: Get a single family variant via API
 - API-380: Get a list of family variants via API
+- API-369: Get a list of variant products
+- API-370: Get a single variant product
+- API-371: Delete single variant product
+- API-372: Create a variant product
 
 ## Better manage products with variants!
 

--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -12,6 +12,7 @@
 - PIM-6348: Display a red label in the variant navigation if no variant product is complete
 - PIM-6451: Now display variant axes coming from parent as "Variant Axis" on the product edit form
 - PIM-6847: Fix variant product history
+- PIM-6867: Fix validation of variant product, now it's impossible to have a root product model as parent if there are 2 levels of variation
 
 ## Tech improvements
 

--- a/features/Context/catalog/catalog_modeling/products.csv
+++ b/features/Context/catalog/catalog_modeling/products.csv
@@ -151,10 +151,6 @@ sku;color;size;eu_shoes_size;material;family;parent;categories;enabled;name-en_U
 1111111260;red;xxl;;;clothing;juno;master_women_blouses_deals,print_clothing,supplier_zaro;1;;900;GRAM;1234567890272;;
 1111111261;red;xl;;;clothing;juno;master_women_blouses_deals,print_clothing,supplier_zaro;1;;900;GRAM;1234567890273;;
 1111111262;red;m;;;clothing;juno;master_women_blouses_deals,print_clothing,supplier_zaro;1;;800;GRAM;1234567890274;;
-1111111263;yellow;;;;clothing;minerva;master_women_shirts,supplier_mongo;1;;800;GRAM;1234567890275;;
-1111111264;black;;;;clothing;minerva;master_women_shirts,supplier_mongo;1;;800;GRAM;1234567890276;;
-1111111265;red;;;;clothing;minerva;master_women_shirts,supplier_mongo;1;;600;GRAM;1234567890277;;
-1111111266;blue;;;;clothing;minerva;master_women_shirts,supplier_mongo;1;;800;GRAM;1234567890278;;
 1111111267;brown;;410;;shoes;moccasin;master_men_shoes,print_shoes,supplier_abibas;1;;900;GRAM;1234567890279;;
 1111111268;brown;;400;;shoes;moccasin;master_men_shoes,print_shoes,supplier_abibas;1;;900;GRAM;1234567890280;;
 1111111269;brown;;390;;shoes;moccasin;master_men_shoes,print_shoes,supplier_abibas;1;;800;GRAM;1234567890281;;

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/DeleteVariantProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/DeleteVariantProductIntegration.php
@@ -11,7 +11,7 @@ class DeleteVariantProductIntegration extends AbstractProductTestCase
     {
         $client = $this->createAuthenticatedClient();
 
-        $this->assertCount(246, $this->get('pim_catalog.repository.product')->findAll());
+        $this->assertCount(242, $this->get('pim_catalog.repository.product')->findAll());
 
         $bikerJacketLeatherXxs = $this->get('pim_catalog.repository.product')->findOneByIdentifier('biker-jacket-leather-xxs');
         $this->get('pim_catalog.elasticsearch.indexer.product')->index($bikerJacketLeatherXxs);
@@ -20,7 +20,7 @@ class DeleteVariantProductIntegration extends AbstractProductTestCase
         $response = $client->getResponse();
         $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
 
-        $this->assertCount(245, $this->get('pim_catalog.repository.product')->findAll());
+        $this->assertCount(241, $this->get('pim_catalog.repository.product')->findAll());
         $this->assertNull($this->get('pim_catalog.repository.product')->findOneByIdentifier('biker-jacket-leather-xxs'));
     }
 

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Product/CreateVariantProductIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Product/CreateVariantProductIntegration.php
@@ -38,6 +38,30 @@ class CreateVariantProductIntegration extends TestCase
         );
     }
 
+    public function testVariantProductHasValidParent(): void
+    {
+        $variantProduct = $this->get('pim_catalog.builder.variant_product')->createProduct('minerva_blue_m');
+        $this->get('pim_catalog.updater.product')->update($variantProduct, [
+            'parent' => 'minerva',
+            'values' => [
+                'size' => [
+                    [
+                        'locale' => null,
+                        'scope' => null,
+                        'data' => 'm',
+                    ],
+                ],
+            ],
+        ]);
+
+        $errors = $this->get('validator')->validate($variantProduct);
+        $this->assertEquals(2, $errors->count());
+        $this->assertEquals(
+            'The variant product "minerva_blue_m" cannot have product model "minerva" as parent, (this product model can only have other product models as children)',
+            $errors->get(0)->getMessage()
+        );
+    }
+
     public function testVariantAxisValuesAreUnique(): void
     {
         $variantProduct1 = $this->get('pim_catalog.builder.variant_product')->createProduct('apollon_blue_m_1');

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/variant-navigation.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/variant-navigation.js
@@ -151,8 +151,15 @@ define([
                         ratio: localeCompleteness.ratio
                     };
                 } else {
-                    const completeProducts = entity.completeness.completenesses[catalogScope][catalogLocale];
+                    const completenesses = entity.completeness.completenesses;
                     const totalProducts  = entity.completeness.total;
+                    let completeProducts = 0;
+
+                    if (_.has(completenesses, catalogScope) &&
+                        _.has(completenesses[catalogScope], catalogLocale)
+                    ) {
+                        completeProducts = completenesses[catalogScope][catalogLocale];
+                    }
 
                     return {
                         ratio: (completeProducts > 0) ? Math.floor(totalProducts / completeProducts * 100) : 0,

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/common/default-template.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/common/default-template.html
@@ -32,7 +32,7 @@
                     </div>
                 </div>
                 <div class="AknTitleContainer-line">
-                    <div data-drop-zone="navigation"></div>
+                    <div data-drop-zone="navigation" class="AknTitleContainer-navigation"></div>
                 </div>
             </header>
 

--- a/src/Pim/Bundle/InstallerBundle/Resources/fixtures/icecat_demo_dev/products.csv
+++ b/src/Pim/Bundle/InstallerBundle/Resources/fixtures/icecat_demo_dev/products.csv
@@ -1407,62 +1407,6 @@ Handle Type: Sleeveless
 Composition: 100% polyester
 Care instructions: machine wash at 40 ° C, do not put in dryer, washing delicates";;;;;;;;Juno;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;juno;;;;;;;349;;;;;;;;m;;;;zaro;;;;;;;;;;;600;;;;;;;;;;
 10977324;brother,multifunctionals,print_scan_sales;1;multifunctionals;;;;;;;;;;;;;;;;;0;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;297_x_432_mm;;;;;;;;;;;copy,fax,print,scan;Brother MFC-J5910DW multifunctional;;;;;;;;;2011-09-11;;;;;;;;;;;;;;;;;;;;;;;;;;<b>DIN A3 Business 4-in-1 Tinten-Multifunktionscenter mit DIN A3 Duplexdruck-Funktion, LAN-/WLAN-MFC-Server und Touchscreen-Display</b>\n\n<b>DIN A3 Farbdrucker</b>\n- Bis zu 35 Seiten pro Minute in S/W (DIN A4)\n- Bis zu 27 Seiten pro Minute in Farbe (DIN A4)\n- Bis zu 12 ISO-Seiten pro Minute in S/W (DIN A4)\n- Bis zu 10 ISO-Seiten pro Minute in Farbe (DIN A4)\n- Automatischer Duplexdruck bis DIN A3\n- Bis zu 6.000 x 1.200 dpi Druckauflösung\n- 4 separate Tintenpatronen\n- USB 2.0 Hi-Speed, 10/100 BaseTX (LAN) und 802.11 b/g/n (WLAN) Schnittstelle\n- Dokumentenecht drucken nach PTS\n- mit LC-1240BK/LC-1280XLBK\n- AirPrint kompatibel\n- Google Cloud Print™ kompatibel\n\n<b>DIN A4 Farbkopierer</b>\n- 35 Blatt Vorlageneinzug (ADF) und\n- DIN A4 Vorlagenglas\n- 1 Papierkassette für 250 Blatt\n- 4,9 cm Touchscreen LCD-Farbdisplay mit berührungsempfindlichem Bedienfeld\n\n<b>DIN A4 Farbscanner</b>\n- Scan-to-E-Mail, -Bild, -Text, -PDF, -Datei, USB-Stick, -Speicherkarte,\n\n<b>DIN A4 Farbfax</b>\n- Werbefax-Löschfunktion\n\n<b>Fotodirektdruck</b>\n- Randloser Fotodruck bis DIN A3\n- Fotodirektdruck via PictBridge, USB-Stick, Speicherkarte\n\n<b>Integrierter LAN-/WLAN-MFC-Server</b>\n- Drucken, Scannen, Faxen im LAN oder WLAN.;All‐in‐one A3 colour printing just got faster and more affordable. Quickly print, copy, scan or fax using the MFC‐J5910DW, a model that’s compact enough for any office, whether it’s at home or at work.\n\nWith precision colour printing up to A3, your presentations, projects and photographs can be given more punch than previously possible, whilst our XL cartridges help you considerably reduce running costs. Plus, the latest wireless 'N' technology means you can share the benefits of the small printer with big capability with the rest of the team in your office ‐or the family at home.;<b>Imprimante multifonction jet d’encre couleur A3 professionnelle avec Fax, Impression recto-verso et connection réseau et WiFi</b>\nBénéficiez du format A3 grâce à cette imprimante multifonction jet d’encre 4-en-1. En plus d’imprimer, de numériser, de copier et de télécopier jusqu’au format A4, le MFC-J5910DW imprime vos documents et photos jusqu’au format A3. Désormais, donnez davantage d’impact et communiquez en grand pour l’ensemble de vos documents personnels et professionnels. Démarquez-vous et faîtes des économies grâce aux cartouches haute capacité LC1280XL permettant d'imprimer jusqu'à 2400 pages en N&B et 1200 pages en couleur. Economisez jusqu'à 65% sur vos coûts d'impression en noir grâce à l'utilisation des cartouches LC1280XL-BK par rapport aux cartouches standards LC1240BK (calcul basé sur les prix publics HT conseillés par Brother).;;;
-1111111263;master_women_shirts,supplier_mongo;1;clothing;minerva;;;;;;;;;;;;;;spring_2016;yellow;;;;"Relaxed with a classic or dynamic piece with an extravagant accessory: white blouse with it the Mexx brand, your look will be 100% successful!
-
-Length: normal
-Cut: bent
-Back width: 46 cm
-Model: 178 cm
-Occasion: Business
-Pattern / Color: Solid colors
-Total length: 67 cm in size 36
-Col: flared neck
-Sleeve length: 63 cm in size 36
-Sleeve type: Long Sleeve
-Composition: 67% cotton, 28% polyamide, 5% elastane
-Care instructions: machine wash at 30 ° C";;;;;;;;Minerva;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;minerva;;;;;;;799;;;;;;;;;;;;mongo;;;;;;;;;;;600;;;;;;;;;;
-1111111264;master_women_shirts,supplier_mongo;1;clothing;minerva;;;;;;;;;;;;;;spring_2016;black;;;;"Relaxed with a classic or dynamic piece with an extravagant accessory: white blouse with it the Mexx brand, your look will be 100% successful!
-
-Length: normal
-Cut: bent
-Back width: 46 cm
-Model: 178 cm
-Occasion: Business
-Pattern / Color: Solid colors
-Total length: 67 cm in size 36
-Col: flared neck
-Sleeve length: 63 cm in size 36
-Sleeve type: Long Sleeve
-Composition: 67% cotton, 28% polyamide, 5% elastane
-Care instructions: machine wash at 30 ° C";;;;;;;;Minerva;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;minerva;;;;;;;799;;;;;;;;;;;;mongo;;;;;;;;;;;600;;;;;;;;;;
-1111111265;master_women_shirts,supplier_mongo;1;clothing;minerva;;;;;;;;;;;;;;spring_2016;red;;;;"Relaxed with a classic or dynamic piece with an extravagant accessory: white blouse with it the Mexx brand, your look will be 100% successful!
-
-Length: normal
-Cut: bent
-Back width: 46 cm
-Model: 178 cm
-Occasion: Business
-Pattern / Color: Solid colors
-Total length: 67 cm in size 36
-Col: flared neck
-Sleeve length: 63 cm in size 36
-Sleeve type: Long Sleeve
-Composition: 67% cotton, 28% polyamide, 5% elastane
-Care instructions: machine wash at 30 ° C";;;;;;;;Minerva;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;minerva;;;;;;;799;;;;;;;;;;;;mongo;;;;;;;;;;;600;;;;;;;;;;
-1111111266;master_women_shirts,supplier_mongo;1;clothing;minerva;;;;;;;;;;;;;;spring_2016;blue;;;;"Relaxed with a classic or dynamic piece with an extravagant accessory: white blouse with it the Mexx brand, your look will be 100% successful!
-
-Length: normal
-Cut: bent
-Back width: 46 cm
-Model: 178 cm
-Occasion: Business
-Pattern / Color: Solid colors
-Total length: 67 cm in size 36
-Col: flared neck
-Sleeve length: 63 cm in size 36
-Sleeve type: Long Sleeve
-Composition: 67% cotton, 28% polyamide, 5% elastane
-Care instructions: machine wash at 30 ° C";;;;;;;;Minerva;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;minerva;;;;;;;799;;;;;;;;;;;;mongo;;;;;;;;;;;600;;;;;;;;;;
 1111111267;master_men_shoes,print_shoes,supplier_abibas;1;shoes;moccasin;;;;;;;;;;;;;;spring_2015;;;;;;;;;;;;;Moccasin;;410;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;moccasin;;;;;;;322;;;;;;;;;;;;abibas;;;;;;;;;;;;900;GRAM;;;;;;;;
 1111111268;master_men_shoes,print_shoes,supplier_abibas;1;shoes;moccasin;;;;;;;;;;;;;;spring_2015;;;;;;;;;;;;;Moccasin;;400;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;moccasin;;;;;;;322;;;;;;;;;;;;abibas;;;;;;;;;;;;900;GRAM;;;;;;;;
 1111111269;master_men_shoes,print_shoes,supplier_abibas;1;shoes;moccasin;;;;;;;;;;;;;;spring_2015;;;;;;;;;;;;;Moccasin;;390;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;moccasin;;;;;;;322;;;;;;;;;;;;abibas;;;;;;;;;;;;800;GRAM;;;;;;;;

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/Header.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/Header.less
@@ -34,6 +34,7 @@
     cursor: pointer;
     padding-right: 0;
     color: @AknDefaultFontColor;
+    text-align: center;
     transition:
       border-left-width @transitionDelay @transitionKeyframe,
       padding-right @transitionDelay @transitionKeyframe,

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/TitleContainer.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/TitleContainer.less
@@ -111,6 +111,10 @@
     }
   }
 
+  &-navigation {
+    width: 100%;
+  }
+
   &--hidden {
     display: none;
   }

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/lib/select2.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/lib/select2.less
@@ -366,8 +366,9 @@
       }
 
       .select2-arrow {
-        background-position: 4px 2px;
+        background-position: 4px 3px;
         width: @circleSize;
+        background-size: 12px;
 
         b {
           background: url("../../images/jstree/icon-down.svg") no-repeat center center;
@@ -465,6 +466,7 @@
     .select2-arrow {
       width: 25px;
       border-left: none;
+      background-position: 6px 12px;
     }
   }
 }

--- a/src/Pim/Component/Catalog/Validator/Constraints/VariantProductParentValidator.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/VariantProductParentValidator.php
@@ -42,7 +42,10 @@ class VariantProductParentValidator extends ConstraintValidator
             return;
         }
 
-        if (!$parent->getProductModels()->isEmpty()) {
+        $numberOfLevels = $variantProduct->getFamilyVariant()->getNumberOfLevel();
+        $parentLevelAllowed = $numberOfLevels - 1;
+
+        if ($parent->getVariationLevel() !== $parentLevelAllowed) {
             $this->context->buildViolation(VariantProductParent::INVALID_PARENT, [
                 '%variant_product%' => $variantProduct->getIdentifier(),
                 '%product_model%' => $parent->getCode(),

--- a/src/Pim/Component/Catalog/spec/Validator/Constraints/VariantProductParentValidatorSpec.php
+++ b/src/Pim/Component/Catalog/spec/Validator/Constraints/VariantProductParentValidatorSpec.php
@@ -68,7 +68,7 @@ class VariantProductParentValidatorSpec extends ObjectBehavior
         $variantProduct->getParent()->willReturn(null);
         $variantProduct->getIdentifier()->willReturn('variant_product');
 
-        $productModel->getProductModels()->shouldNotBeCalled();
+        $productModel->getVariationLevel()->shouldNotBeCalled();
 
 
         $context->buildViolation(VariantProductParent::NO_PARENT, [
@@ -93,7 +93,8 @@ class VariantProductParentValidatorSpec extends ObjectBehavior
         $variantProduct->getParent()->willReturn($productModel);
         $variantProduct->getIdentifier()->willReturn('variant_product');
 
-        $productModel->getProductModels()->willReturn($productModels);
+        $familyVariant->getNumberOfLevel()->willReturn(2);
+        $productModel->getVariationLevel()->willReturn(0);
         $productModels->isEmpty()->willReturn(false);
         $productModel->getCode()->willReturn('product_model');
 
@@ -118,7 +119,8 @@ class VariantProductParentValidatorSpec extends ObjectBehavior
         $variantProduct->getFamilyVariant()->willReturn($familyVariant);
         $variantProduct->getParent()->willReturn($productModel);
 
-        $productModel->getProductModels()->willReturn($productModels);
+        $familyVariant->getNumberOfLevel()->willReturn(2);
+        $productModel->getVariationLevel()->willReturn(1);
         $productModels->isEmpty()->willReturn(true);
 
         $context->buildViolation(Argument::cetera())->shouldNotBeCalled();


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Currently, you can set the root product model as parent of a variant product. This shouldn't be possible.

I removed 4 products from the fixtures, because they were not valid anymore now that the validation is correct.

This PR also fixes Variant Navigation bar & dropdown (thanks @pierallard <3)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Y
| Added Behats                      | N
| Added integration tests           | Y
| Changelog updated                 | Y
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo