### PR TITLE
Apply integration tests from CE in EE

### DIFF
--- a/src/Akeneo/Bundle/BatchQueueBundle/tests/integration/Command/JobQueueConsumerCommandIntegration.php
+++ b/src/Akeneo/Bundle/BatchQueueBundle/tests/integration/Command/JobQueueConsumerCommandIntegration.php
@@ -252,6 +252,6 @@ class JobQueueConsumerCommandIntegration extends TestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Akeneo/Bundle/BatchQueueBundle/tests/integration/Command/PublishJobToQueueCommandIntegration.php
+++ b/src/Akeneo/Bundle/BatchQueueBundle/tests/integration/Command/PublishJobToQueueCommandIntegration.php
@@ -203,8 +203,6 @@ class PublishJobToQueueCommandIntegration extends TestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()]
-        );
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Akeneo/Bundle/BatchQueueBundle/tests/integration/Launcher/QueueJobLauncherIntegration.php
+++ b/src/Akeneo/Bundle/BatchQueueBundle/tests/integration/Launcher/QueueJobLauncherIntegration.php
@@ -96,6 +96,6 @@ class QueueJobLauncherIntegration extends TestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Akeneo/Bundle/BatchQueueBundle/tests/integration/Queue/DatabaseJobExecutionQueueIntegration.php
+++ b/src/Akeneo/Bundle/BatchQueueBundle/tests/integration/Queue/DatabaseJobExecutionQueueIntegration.php
@@ -122,6 +122,6 @@ SQL;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Akeneo/Bundle/ElasticsearchBundle/tests/integration/BulkIndexationIntegration.php
+++ b/src/Akeneo/Bundle/ElasticsearchBundle/tests/integration/BulkIndexationIntegration.php
@@ -45,7 +45,7 @@ class BulkIndexationIntegration extends TestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getMinimalCatalogPath()]);
+        return $this->catalog->useMinimalCatalog();
     }
 
     /**

--- a/src/Pim/Bundle/ApiBundle/tests/integration/ApiTestCase.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/ApiTestCase.php
@@ -3,6 +3,7 @@
 namespace Pim\Bundle\ApiBundle\tests\integration;
 
 use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\IntegrationTestsBundle\Configuration\CatalogInterface;
 use Akeneo\Test\IntegrationTestsBundle\Security\SystemUserAuthenticator;
 use Pim\Bundle\ApiBundle\Stream\StreamResourceResponse;
 use Symfony\Bundle\FrameworkBundle\Client;
@@ -27,6 +28,9 @@ abstract class ApiTestCase extends WebTestCase
     /** @var KernelInterface */
     protected $testKernel;
 
+    /** @var CatalogInterface */
+    protected $catalog;
+
     /**
      * @return Configuration
      */
@@ -44,10 +48,11 @@ abstract class ApiTestCase extends WebTestCase
         $this->testKernel = new \AppKernelTest('test', false);
         $this->testKernel->boot();
 
-        $configuration = $this->getConfiguration();
-        $fixturesLoader = $this->testKernel->getContainer()->get('akeneo_integration_tests.loader.fixtures_loader');
+        $this->catalog = $this->testKernel->getContainer()->get('akeneo_integration_tests.configuration.catalog');
+        $this->testKernel->getContainer()->set('akeneo_integration_tests.catalog.configuration', $this->getConfiguration());
 
-        $fixturesLoader->load($configuration);
+        $fixturesLoader = $this->testKernel->getContainer()->get('akeneo_integration_tests.loader.fixtures_loader');
+        $fixturesLoader->load();
     }
 
     /**
@@ -199,7 +204,7 @@ abstract class ApiTestCase extends WebTestCase
     {
         $configuration = $this->getConfiguration();
         foreach ($configuration->getFixtureDirectories() as $fixtureDirectory) {
-            $path = $fixtureDirectory . $name;
+            $path = $fixtureDirectory . DIRECTORY_SEPARATOR . $name;
             if (is_file($path) && false !== realpath($path)) {
                 return realpath($path);
             }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/ApiTestCase.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/ApiTestCase.php
@@ -174,6 +174,16 @@ abstract class ApiTestCase extends WebTestCase
      *
      * @return mixed
      */
+    protected function getFromTestContainer(string $service)
+    {
+        return $this->testKernel->getContainer()->get($service);
+    }
+
+    /**
+     * @param string $service
+     *
+     * @return mixed
+     */
     protected function getParameter($service)
     {
         return static::$kernel->getContainer()->getParameter($service);

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Client/RevokeTokenIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Client/RevokeTokenIntegration.php
@@ -209,6 +209,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AssociationType/CreateAssociationTypeIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AssociationType/CreateAssociationTypeIntegration.php
@@ -220,8 +220,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()]
-        );
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AssociationType/GetAssociationTypeIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AssociationType/GetAssociationTypeIntegration.php
@@ -53,8 +53,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()]
-        );
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AssociationType/ListAssociationTypeIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AssociationType/ListAssociationTypeIntegration.php
@@ -259,8 +259,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()]
-        );
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AssociationType/PartialUpdateAssociationTypeIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AssociationType/PartialUpdateAssociationTypeIntegration.php
@@ -265,6 +265,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AssociationType/PartialUpdateListAssociationTypeIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AssociationType/PartialUpdateListAssociationTypeIntegration.php
@@ -292,6 +292,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Attribute/CreateAttributeIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Attribute/CreateAttributeIntegration.php
@@ -6,6 +6,9 @@ use Akeneo\Test\Integration\Configuration;
 use Pim\Bundle\ApiBundle\tests\integration\ApiTestCase;
 use Symfony\Component\HttpFoundation\Response;
 
+/**
+ * @group ce
+ */
 class CreateAttributeIntegration extends ApiTestCase
 {
     public function testHttpHeadersInResponseWhenAnAttributeIsCreated()

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Attribute/CreateAttributeIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Attribute/CreateAttributeIntegration.php
@@ -672,6 +672,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Attribute/GetAttributeIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Attribute/GetAttributeIntegration.php
@@ -6,6 +6,9 @@ use Akeneo\Test\Integration\Configuration;
 use Pim\Bundle\ApiBundle\tests\integration\ApiTestCase;
 use Symfony\Component\HttpFoundation\Response;
 
+/**
+ * @group ce
+ */
 class GetAttributeIntegration extends ApiTestCase
 {
     public function testGetAnAttribute()

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Attribute/GetAttributeIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Attribute/GetAttributeIntegration.php
@@ -70,6 +70,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Attribute/ListAttributeIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Attribute/ListAttributeIntegration.php
@@ -6,6 +6,9 @@ use Akeneo\Test\Integration\Configuration;
 use Pim\Bundle\ApiBundle\tests\integration\ApiTestCase;
 use Symfony\Component\HttpFoundation\Response;
 
+/**
+ * @group ce
+ */
 class ListAttributeIntegration extends ApiTestCase
 {
     public function testAttributes()

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Attribute/ListAttributeIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Attribute/ListAttributeIntegration.php
@@ -590,6 +590,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Attribute/PartialUpdateAttributeIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Attribute/PartialUpdateAttributeIntegration.php
@@ -6,6 +6,9 @@ use Akeneo\Test\Integration\Configuration;
 use Pim\Bundle\ApiBundle\tests\integration\ApiTestCase;
 use Symfony\Component\HttpFoundation\Response;
 
+/**
+ * @group ce
+ */
 class PartialUpdateAttributeIntegration extends ApiTestCase
 {
     public function testHttpHeadersInResponseWhenAnAttributeIsUpdated()

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Attribute/PartialUpdateAttributeIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Attribute/PartialUpdateAttributeIntegration.php
@@ -596,6 +596,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Attribute/PartialUpdateListAttributeIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Attribute/PartialUpdateListAttributeIntegration.php
@@ -7,6 +7,9 @@ use Pim\Bundle\ApiBundle\Stream\StreamResourceResponse;
 use Pim\Bundle\ApiBundle\tests\integration\ApiTestCase;
 use Symfony\Component\HttpFoundation\Response;
 
+/**
+ * @group ce
+ */
 class PartialUpdateListAttributeIntegration extends ApiTestCase
 {
     public function testCreateAndUpdateAListOfAttributes()

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Attribute/PartialUpdateListAttributeIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Attribute/PartialUpdateListAttributeIntegration.php
@@ -333,6 +333,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AttributeGroup/CreateAttributeGroupIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AttributeGroup/CreateAttributeGroupIntegration.php
@@ -6,6 +6,9 @@ use Akeneo\Test\Integration\Configuration;
 use Pim\Bundle\ApiBundle\tests\integration\ApiTestCase;
 use Symfony\Component\HttpFoundation\Response;
 
+/**
+ * @group ce
+ */
 class CreateAttributeGroupIntegration extends ApiTestCase
 {
     public function testHttpHeadersInResponseWhenAnAttributeGroupIsCreated()

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AttributeGroup/CreateAttributeGroupIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AttributeGroup/CreateAttributeGroupIntegration.php
@@ -530,6 +530,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AttributeGroup/GetAttributeGroupIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AttributeGroup/GetAttributeGroupIntegration.php
@@ -71,6 +71,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AttributeGroup/ListAttributeGroupIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AttributeGroup/ListAttributeGroupIntegration.php
@@ -264,6 +264,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AttributeGroup/PartialUpdateAttributeGroupIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AttributeGroup/PartialUpdateAttributeGroupIntegration.php
@@ -6,6 +6,9 @@ use Akeneo\Test\Integration\Configuration;
 use Pim\Bundle\ApiBundle\tests\integration\ApiTestCase;
 use Symfony\Component\HttpFoundation\Response;
 
+/**
+ * @group ce
+ */
 class PartialUpdateAttributeGroupIntegration extends ApiTestCase
 {
     public function testHttpHeadersInResponseWhenAnAttributeGroupIsUpdated()

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AttributeGroup/PartialUpdateAttributeGroupIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AttributeGroup/PartialUpdateAttributeGroupIntegration.php
@@ -369,6 +369,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AttributeGroup/PartialUpdateListAttributeGroupIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AttributeGroup/PartialUpdateListAttributeGroupIntegration.php
@@ -312,6 +312,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AttributeOption/CreateAttributeOptionIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AttributeOption/CreateAttributeOptionIntegration.php
@@ -383,6 +383,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AttributeOption/GetAttributeOptionIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AttributeOption/GetAttributeOptionIntegration.php
@@ -93,6 +93,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AttributeOption/ListAttributeOptionIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AttributeOption/ListAttributeOptionIntegration.php
@@ -179,6 +179,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AttributeOption/PartialUpdateAttributeOptionIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AttributeOption/PartialUpdateAttributeOptionIntegration.php
@@ -590,6 +590,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Category/CreateCategoryIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Category/CreateCategoryIntegration.php
@@ -338,6 +338,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Category/GetCategoryIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Category/GetCategoryIntegration.php
@@ -68,6 +68,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Category/ListCategoryIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Category/ListCategoryIntegration.php
@@ -249,6 +249,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Category/PartialUpdateCategoryIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Category/PartialUpdateCategoryIntegration.php
@@ -437,6 +437,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Category/PartialUpdateListCategoryIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Category/PartialUpdateListCategoryIntegration.php
@@ -287,6 +287,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Channel/CreateChannelIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Channel/CreateChannelIntegration.php
@@ -324,8 +324,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()]
-        );
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Channel/GetChannelIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Channel/GetChannelIntegration.php
@@ -55,6 +55,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Channel/ListChannelIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Channel/ListChannelIntegration.php
@@ -218,6 +218,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Channel/PartialUpdateChannelIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Channel/PartialUpdateChannelIntegration.php
@@ -376,6 +376,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Channel/PartialUpdateListChannelIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Channel/PartialUpdateListChannelIntegration.php
@@ -303,6 +303,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Currency/GetCurrencyIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Currency/GetCurrencyIntegration.php
@@ -50,6 +50,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Currency/ListCurrencyIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Currency/ListCurrencyIntegration.php
@@ -340,6 +340,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Family/CreateFamilyIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Family/CreateFamilyIntegration.php
@@ -374,6 +374,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Family/GetFamilyIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Family/GetFamilyIntegration.php
@@ -114,6 +114,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Family/ListFamilyIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Family/ListFamilyIntegration.php
@@ -160,6 +160,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Family/PartialUpdateFamilyIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Family/PartialUpdateFamilyIntegration.php
@@ -537,6 +537,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Family/PartialUpdateListFamilyIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Family/PartialUpdateListFamilyIntegration.php
@@ -303,6 +303,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/FamilyVariant/GetFamilyVariantIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/FamilyVariant/GetFamilyVariantIntegration.php
@@ -163,6 +163,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/FamilyVariant/ListFamilyVariantIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/FamilyVariant/ListFamilyVariantIntegration.php
@@ -263,6 +263,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Locale/FilterLocaleIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Locale/FilterLocaleIntegration.php
@@ -297,6 +297,6 @@ class FilterLocaleIntegration extends ApiTestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Locale/GetLocaleIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Locale/GetLocaleIntegration.php
@@ -59,6 +59,6 @@ class GetLocaleIntegration extends ApiTestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Locale/ListLocaleIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Locale/ListLocaleIntegration.php
@@ -231,6 +231,6 @@ class ListLocaleIntegration extends ApiTestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/MeasureFamily/GetMeasureFamilyIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/MeasureFamily/GetMeasureFamilyIntegration.php
@@ -175,6 +175,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/MeasureFamily/ListMeasureFamilyIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/MeasureFamily/ListMeasureFamilyIntegration.php
@@ -176,7 +176,7 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 
     private function getStandardizedMeasureFamilies()

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Media/AbstractMediaFileTestCase.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Media/AbstractMediaFileTestCase.php
@@ -15,7 +15,7 @@ abstract class AbstractMediaFileTestCase extends ApiTestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 
     /**

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Media/CreateMediaFileIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Media/CreateMediaFileIntegration.php
@@ -300,6 +300,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Media/CreateMediaFileIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Media/CreateMediaFileIntegration.php
@@ -278,12 +278,12 @@ JSON;
     {
         parent::setUp();
 
-        $this->fileRepository = $this->get('pim_api.repository.media_file');
-        $this->productRepository = $this->get('pim_api.repository.product');
+        $this->fileRepository = $this->getFromTestContainer('pim_api.repository.media_file');
+        $this->productRepository = $this->getFromTestContainer('pim_api.repository.product');
 
-        $product = $this->get('pim_catalog.builder.product')->createProduct('foo');
-        $this->get('pim_catalog.saver.product')->save($product);
-        $this->get('akeneo_storage_utils.doctrine.object_detacher')->detach($product);
+        $product = $this->getFromTestContainer('pim_catalog.builder.product')->createProduct('foo');
+        $this->getFromTestContainer('pim_catalog.saver.product')->save($product);
+        $this->getFromTestContainer('akeneo_storage_utils.doctrine.object_detacher')->detach($product);
 
         $this->files['image'] = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'akeneo.jpg';
         copy($this->getFixturePath('akeneo.jpg'), $this->files['image']);
@@ -291,7 +291,7 @@ JSON;
         $this->files['file'] = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'akeneo.txt';
         copy($this->getFixturePath('akeneo.txt'), $this->files['file']);
 
-        $mountManager = $this->get('oneup_flysystem.mount_manager');
+        $mountManager = $this->getFromTestContainer('oneup_flysystem.mount_manager');
         $this->fileSystem = $mountManager->getFilesystem(FileStorage::CATALOG_STORAGE_ALIAS);
     }
 

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/CreateProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/CreateProductIntegration.php
@@ -1002,6 +1002,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/CreateVariantProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/CreateVariantProductIntegration.php
@@ -1182,6 +1182,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/DeleteProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/DeleteProductIntegration.php
@@ -19,17 +19,17 @@ class DeleteProductIntegration extends AbstractProductTestCase
     {
         $client = $this->createAuthenticatedClient();
 
-        $this->assertCount(4, $this->get('pim_catalog.repository.product')->findAll());
+        $this->assertCount(4, $this->getFromTestContainer('pim_catalog.repository.product')->findAll());
 
-        $fooProduct = $this->get('pim_catalog.repository.product')->findOneByIdentifier('foo');
-        $this->get('pim_catalog.elasticsearch.indexer.product')->index($fooProduct);
+        $fooProduct = $this->getFromTestContainer('pim_catalog.repository.product')->findOneByIdentifier('foo');
+        $this->getFromTestContainer('pim_catalog.elasticsearch.indexer.product')->index($fooProduct);
         $client->request('DELETE', 'api/rest/v1/products/foo');
 
         $response = $client->getResponse();
         $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
 
-        $this->assertCount(3, $this->get('pim_catalog.repository.product')->findAll());
-        $this->assertNull($this->get('pim_catalog.repository.product')->findOneByIdentifier('foo'));
+        $this->assertCount(3, $this->getFromTestContainer('pim_catalog.repository.product')->findAll());
+        $this->assertNull($this->getFromTestContainer('pim_catalog.repository.product')->findOneByIdentifier('foo'));
     }
 
     public function testNotFoundAProduct()

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/DeleteProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/DeleteProductIntegration.php
@@ -12,7 +12,7 @@ class DeleteProductIntegration extends AbstractProductTestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalSqlCatalogPath()]);
+        return $this->catalog->useTechnicalSqlCatalog();
     }
 
     public function testDeleteAProduct()

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/DeleteVariantProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/DeleteVariantProductIntegration.php
@@ -29,6 +29,6 @@ class DeleteVariantProductIntegration extends AbstractProductTestCase
      */
     protected function getConfiguration(): Configuration
     {
-        return new Configuration([Configuration::getFunctionalCatalogPath('catalog_modeling')]);
+        return $this->catalog->useFunctionalCatalog('catalog_modeling');
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/DeleteVariantProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/DeleteVariantProductIntegration.php
@@ -11,17 +11,17 @@ class DeleteVariantProductIntegration extends AbstractProductTestCase
     {
         $client = $this->createAuthenticatedClient();
 
-        $this->assertCount(242, $this->get('pim_catalog.repository.product')->findAll());
+        $this->assertCount(242, $this->getFromTestContainer('pim_catalog.repository.product')->findAll());
 
-        $bikerJacketLeatherXxs = $this->get('pim_catalog.repository.product')->findOneByIdentifier('biker-jacket-leather-xxs');
+        $bikerJacketLeatherXxs = $this->getFromTestContainer('pim_catalog.repository.product')->findOneByIdentifier('biker-jacket-leather-xxs');
         $this->get('pim_catalog.elasticsearch.indexer.product')->index($bikerJacketLeatherXxs);
         $client->request('DELETE', 'api/rest/v1/products/biker-jacket-leather-xxs');
 
         $response = $client->getResponse();
         $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
 
-        $this->assertCount(241, $this->get('pim_catalog.repository.product')->findAll());
-        $this->assertNull($this->get('pim_catalog.repository.product')->findOneByIdentifier('biker-jacket-leather-xxs'));
+        $this->assertCount(241, $this->getFromTestContainer('pim_catalog.repository.product')->findAll());
+        $this->assertNull($this->getFromTestContainer('pim_catalog.repository.product')->findOneByIdentifier('biker-jacket-leather-xxs'));
     }
 
     /**

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/ErrorListProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/ErrorListProductIntegration.php
@@ -248,12 +248,12 @@ class ErrorListProductIntegration extends AbstractProductTestCase
 
         $products = [];
         for ($i = 0; $i<=10001; $i++) {
-            $products[] = $this->get('pim_catalog.builder.product')->createProduct('sku' . $i);
+            $products[] = $this->getFromTestContainer('pim_catalog.builder.product')->createProduct('sku' . $i);
         }
 
-        $this->get('pim_versioning.manager.version')->setRealTimeVersioning(false);
-        $this->get('pim_catalog.saver.product')->saveAll($products);
-        $this->get('akeneo_elasticsearch.client.product')->refreshIndex();
+        $this->getFromTestContainer('pim_versioning.manager.version')->setRealTimeVersioning(false);
+        $this->getFromTestContainer('pim_catalog.saver.product')->saveAll($products);
+        $this->getFromTestContainer('akeneo_elasticsearch.client.product')->refreshIndex();
 
         $client->request('GET', 'api/rest/v1/products?page=101&limit=100');
 

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/ErrorListProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/ErrorListProductIntegration.php
@@ -294,6 +294,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/GetProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/GetProductIntegration.php
@@ -239,7 +239,7 @@ class GetProductIntegration extends AbstractProductTestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalSqlCatalogPath()]);
+        return $this->catalog->useTechnicalSqlCatalog();
     }
 
     /**

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/GetProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/GetProductIntegration.php
@@ -6,6 +6,9 @@ use Akeneo\Test\Integration\Configuration;
 use Pim\Component\Catalog\tests\integration\Normalizer\NormalizedProductCleaner;
 use Symfony\Component\HttpFoundation\Response;
 
+/**
+ * @group ce
+ */
 class GetProductIntegration extends AbstractProductTestCase
 {
     public function testGetACompleteProduct()

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/GetVariantProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/GetVariantProductIntegration.php
@@ -109,7 +109,7 @@ class GetVariantProductIntegration extends AbstractProductTestCase
      */
     protected function getConfiguration(): Configuration
     {
-        return new Configuration([Configuration::getFunctionalCatalogPath('catalog_modeling')]);
+        return $this->catalog->useFunctionalCatalog('catalog_modeling');
     }
 
     /**

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/GetVariantProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/GetVariantProductIntegration.php
@@ -6,6 +6,9 @@ use Akeneo\Test\Integration\Configuration;
 use Pim\Component\Catalog\tests\integration\Normalizer\NormalizedProductCleaner;
 use Symfony\Component\HttpFoundation\Response;
 
+/**
+ * @group ce
+ */
 class GetVariantProductIntegration extends AbstractProductTestCase
 {
     public function testGetACompleteVariantProduct()

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/ListProductWithCompletenessIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/ListProductWithCompletenessIntegration.php
@@ -160,7 +160,7 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 
 

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/ListProductWithCompletenessIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/ListProductWithCompletenessIntegration.php
@@ -5,6 +5,9 @@ namespace Pim\Bundle\ApiBundle\tests\integration\Controller\Product;
 use Akeneo\Test\Integration\Configuration;
 use Doctrine\Common\Collections\Collection;
 
+/**
+ * @group ce
+ */
 class ListProductWithCompletenessIntegration extends AbstractProductTestCase
 {
     /** @var Collection */
@@ -169,8 +172,8 @@ JSON;
      */
     private function getEncryptedId($productIdentifier)
     {
-        $encrypter = $this->get('pim_api.security.primary_key_encrypter');
-        $productRepository = $this->get('pim_catalog.repository.product');
+        $encrypter = $this->getFromTestContainer('pim_api.security.primary_key_encrypter');
+        $productRepository = $this->getFromTestContainer('pim_catalog.repository.product');
 
         $product = $productRepository->findOneByIdentifier($productIdentifier);
 

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateListProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateListProductIntegration.php
@@ -323,6 +323,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateListVariantProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateListVariantProductIntegration.php
@@ -303,6 +303,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateProductIntegration.php
@@ -1545,6 +1545,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateProductIntegration.php
@@ -667,6 +667,9 @@ JSON;
     }
      */
 
+    /**
+     * @group ce
+     */
     public function testProductPartialUpdateWithTheAssociationsUpdated()
     {
         $client = $this->createAuthenticatedClient();

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateProductVariantIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateProductVariantIntegration.php
@@ -1801,6 +1801,6 @@ JSON;
      */
     protected function getConfiguration(): Configuration
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessLargeAndOrderedListProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessLargeAndOrderedListProductIntegration.php
@@ -72,7 +72,7 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalSqlCatalogPath()]);
+        return $this->catalog->useTechnicalSqlCatalog();
     }
 
     /**

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessLargeAndOrderedListProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessLargeAndOrderedListProductIntegration.php
@@ -8,6 +8,8 @@ use Pim\Component\Catalog\Model\ProductInterface;
 /**
  * We want to test the API is capable of returning an ordered list of 100 items.
  * ie, twice the size of a cursor page
+ *
+ * @group ce
  */
 class SuccessLargeAndOrderedListProductIntegration extends AbstractProductTestCase
 {

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessListProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessListProductIntegration.php
@@ -6,6 +6,9 @@ use Akeneo\Test\Integration\Configuration;
 use Doctrine\Common\Collections\Collection;
 use Symfony\Component\HttpFoundation\Response;
 
+/**
+ * @group ce
+ */
 class SuccessListProductIntegration extends AbstractProductTestCase
 {
     /** @var Collection */

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessListProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessListProductIntegration.php
@@ -1447,6 +1447,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessListVariantProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessListVariantProductIntegration.php
@@ -1073,6 +1073,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessListVariantProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessListVariantProductIntegration.php
@@ -5,6 +5,9 @@ namespace Pim\Bundle\ApiBundle\tests\integration\Controller\Product;
 use Akeneo\Test\Integration\Configuration;
 use Doctrine\Common\Collections\Collection;
 
+/**
+ * @group ce
+ */
 class SuccessListVariantProductIntegration extends AbstractProductTestCase
 {
     /** @var Collection */

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/ProductModel/AbstractProductModelTestCase.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/ProductModel/AbstractProductModelTestCase.php
@@ -107,6 +107,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/ProductModel/GetProductModelIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/ProductModel/GetProductModelIntegration.php
@@ -99,7 +99,7 @@ class GetProductModelIntegration extends ApiTestCase
      */
     protected function getConfiguration(): Configuration
     {
-        return new Configuration([Configuration::getFunctionalCatalogPath('catalog_modeling')]);
+        return $this->catalog->useFunctionalCatalog('catalog_modeling');
     }
 
     /**

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/ProductModel/LargeAndOrderedListProductModelIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/ProductModel/LargeAndOrderedListProductModelIntegration.php
@@ -73,7 +73,7 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalSqlCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 
     /**

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/ProductModel/ListSearchAfterProductModelIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/ProductModel/ListSearchAfterProductModelIntegration.php
@@ -96,8 +96,8 @@ JSON;
      */
     private function getEncryptedId($productModelIdentifier)
     {
-        $encrypter = $this->get('pim_api.security.primary_key_encrypter');
-        $repository = $this->get('pim_catalog.repository.product_model');
+        $encrypter = $this->getFromTestContainer('pim_api.security.primary_key_encrypter');
+        $repository = $this->getFromTestContainer('pim_catalog.repository.product_model');
 
         $productModel = $repository->findOneByIdentifier($productModelIdentifier);
 

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/RootEndpointIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/RootEndpointIntegration.php
@@ -254,6 +254,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/RootEndpointIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/RootEndpointIntegration.php
@@ -6,6 +6,9 @@ use Akeneo\Test\Integration\Configuration;
 use Pim\Bundle\ApiBundle\tests\integration\ApiTestCase;
 use Symfony\Component\HttpFoundation\Response;
 
+/**
+ * @group ce
+ */
 class RootEndpointIntegration extends ApiTestCase
 {
     public function testGetEndpoint()

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Token/GetAccessTokenIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Token/GetAccessTokenIntegration.php
@@ -280,6 +280,6 @@ class GetAccessTokenIntegration extends ApiTestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Token/RefreshTokenIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Token/RefreshTokenIntegration.php
@@ -103,6 +103,6 @@ class RefreshTokenIntegration extends ApiTestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/EventSubscriber/CheckHeadersRequestSubscriberIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/EventSubscriber/CheckHeadersRequestSubscriberIntegration.php
@@ -129,6 +129,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Security/AssociationTypeAuthorizationIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Security/AssociationTypeAuthorizationIntegration.php
@@ -211,8 +211,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()]
-        );
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Security/AttributeAuthorizationIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Security/AttributeAuthorizationIntegration.php
@@ -204,6 +204,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Security/AttributeGroupAuthorizationIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Security/AttributeGroupAuthorizationIntegration.php
@@ -206,6 +206,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Security/AttributeOptionAuthorizationIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Security/AttributeOptionAuthorizationIntegration.php
@@ -167,6 +167,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Security/CategoryAuthorizationIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Security/CategoryAuthorizationIntegration.php
@@ -200,6 +200,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Security/ChannelAuthorizationIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Security/ChannelAuthorizationIntegration.php
@@ -209,6 +209,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Security/CurrencyAuthorizationIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Security/CurrencyAuthorizationIntegration.php
@@ -87,6 +87,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Security/FamilyAuthorizationIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Security/FamilyAuthorizationIntegration.php
@@ -200,6 +200,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Security/FamilyVariantAuthorizationIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Security/FamilyVariantAuthorizationIntegration.php
@@ -88,6 +88,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Security/LocaleAuthorizationIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Security/LocaleAuthorizationIntegration.php
@@ -87,6 +87,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Classification/ClassifyProductIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Classification/ClassifyProductIntegration.php
@@ -26,6 +26,6 @@ class ClassifyProductIntegration extends TestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getFunctionalCatalogPath('catalog_modeling')]);
+        return $this->catalog->useFunctionalCatalog('catalog_modeling');
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Classification/ClassifyProductModelIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Classification/ClassifyProductModelIntegration.php
@@ -153,6 +153,6 @@ class ClassifyProductModelIntegration extends TestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getFunctionalCatalogPath('catalog_modeling')]);
+        return $this->catalog->useFunctionalCatalog('catalog_modeling');
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AbstractCompletenessTestCase.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AbstractCompletenessTestCase.php
@@ -22,7 +22,7 @@ abstract class AbstractCompletenessTestCase extends TestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getMinimalCatalogPath()]);
+        return $this->catalog->useMinimalCatalog();
     }
 
     /**

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AbstractCompletenessTestCase.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AbstractCompletenessTestCase.php
@@ -79,6 +79,8 @@ abstract class AbstractCompletenessTestCase extends TestCase
         $scopable = false,
         array $localesSpecific = []
     ) {
+        $group = $this->get('pim_api.repository.attribute_group')->findOneByIdentifier('other');
+
         $attributeFactory = $this->get('pim_catalog.factory.attribute');
         $attributeSaver = $this->get('pim_catalog.saver.attribute');
 
@@ -86,6 +88,7 @@ abstract class AbstractCompletenessTestCase extends TestCase
         $attribute->setCode($code);
         $attribute->setLocalizable($localisable);
         $attribute->setScopable($scopable);
+        $attribute->setGroup($group);
         foreach ($localesSpecific as $locale) {
             $attribute->addAvailableLocale($locale);
         }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/ReferenceDataMultiAttributeTypeCompletenessIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/ReferenceDataMultiAttributeTypeCompletenessIntegration.php
@@ -116,9 +116,6 @@ class ReferenceDataMultiAttributeTypeCompletenessIntegration extends AbstractCom
      */
     protected function getConfiguration()
     {
-        return new Configuration([
-            Configuration::getMinimalCatalogPath(),
-            Configuration::getReferenceDataFixtures()
-        ]);
+        return $this->catalog->useMinimalCatalog();
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/ReferenceDataSimpleAttributeTypeCompletenessIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/ReferenceDataSimpleAttributeTypeCompletenessIntegration.php
@@ -97,9 +97,6 @@ class ReferenceDataSimpleAttributeTypeCompletenessIntegration extends AbstractCo
      */
     protected function getConfiguration()
     {
-        return new Configuration([
-            Configuration::getMinimalCatalogPath(),
-            Configuration::getReferenceDataFixtures()
-        ]);
+        return $this->catalog->useMinimalCatalog();
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/CompletenessForLocalisableAttributeIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/CompletenessForLocalisableAttributeIntegration.php
@@ -167,7 +167,7 @@ class CompletenessForLocalisableAttributeIntegration extends AbstractCompletenes
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getMinimalCatalogPath()]);
+        return $this->catalog->useMinimalCatalog();
     }
 
     /**

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/CompletenessForNonRequiredAttributeIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/CompletenessForNonRequiredAttributeIntegration.php
@@ -105,6 +105,6 @@ class CompletenessForNonRequiredAttributeIntegration extends AbstractCompletenes
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getMinimalCatalogPath()]);
+        return $this->catalog->useMinimalCatalog();
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/CompletenessForScopableAndLocalisableAttributeIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/CompletenessForScopableAndLocalisableAttributeIntegration.php
@@ -150,10 +150,7 @@ class CompletenessForScopableAndLocalisableAttributeIntegration extends Abstract
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getFunctionalCatalogPath('footwear')],
-            [Configuration::getFunctionalFixtures()]
-        );
+        return $this->catalog->useFunctionalCatalog('footwear');
     }
 
     /**

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Doctrine/Common/Saver/IndexingProductIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Doctrine/Common/Saver/IndexingProductIntegration.php
@@ -96,6 +96,6 @@ class IndexingProductIntegration extends TestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Doctrine/Common/Saver/IndexingProductModelIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Doctrine/Common/Saver/IndexingProductModelIntegration.php
@@ -83,7 +83,7 @@ class IndexingProductModelIntegration extends TestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 
     /**

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Doctrine/Common/Saver/ProductSaverIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Doctrine/Common/Saver/ProductSaverIntegration.php
@@ -62,7 +62,7 @@ class ProductSaverIntegration extends TestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalSqlCatalogPath()]);
+        return $this->catalog->useTechnicalSqlCatalog();
     }
 
     /**

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Doctrine/Common/Saver/RemovingProductIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Doctrine/Common/Saver/RemovingProductIntegration.php
@@ -80,7 +80,7 @@ class RemovingProductIntegration extends TestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 
     /**

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Doctrine/Common/Saver/SavingProductModelDescendantsIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Doctrine/Common/Saver/SavingProductModelDescendantsIntegration.php
@@ -106,7 +106,7 @@ class SavingProductModelDescendantsIntegration extends TestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 
     /**

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Doctrine/Query/VariantProductRatioIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Doctrine/Query/VariantProductRatioIntegration.php
@@ -105,6 +105,6 @@ class VariantProductRatioIntegration extends TestCase
      */
     protected function getConfiguration(): Configuration
     {
-        return new Configuration([Configuration::getFunctionalCatalogPath('catalog_modeling')]);
+        return $this->catalog->useFunctionalCatalog('catalog_modeling');
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/AbstractPimCatalogTestCase.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/AbstractPimCatalogTestCase.php
@@ -29,7 +29,7 @@ abstract class AbstractPimCatalogTestCase extends TestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getMinimalCatalogPath()]);
+        return $this->catalog->useMinimalCatalog();
     }
 
     /**

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/IndexProductsIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/IndexProductsIntegration.php
@@ -17,8 +17,6 @@ class IndexProductsIntegration extends TestCase
 {
     const DOCUMENT_TYPE = 'pim_catalog_product';
 
-    private const PAGE_SIZE = 100;
-
     /** @var Client */
     protected $esProductClient;
 
@@ -27,7 +25,7 @@ class IndexProductsIntegration extends TestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getMinimalCatalogPath()]);
+        return $this->catalog->useMinimalCatalog();
     }
 
     /**

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/EventSubscriber/LoadEntityWithValuesSubscriberIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/EventSubscriber/LoadEntityWithValuesSubscriberIntegration.php
@@ -50,7 +50,7 @@ class LoadEntityWithValuesSubscriberIntegration extends TestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalSqlCatalogPath()]);
+        return $this->catalog->useTechnicalSqlCatalog();
     }
 
     /**

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Family/CreateFamilyVariantIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Family/CreateFamilyVariantIntegration.php
@@ -581,7 +581,7 @@ class CreateFamilyVariantIntegration extends TestCase
      */
     protected function getConfiguration(): Configuration
     {
-        return new Configuration([Configuration::getFunctionalCatalogPath('footwear')]);
+        return $this->catalog->useFunctionalCatalog('footwear');
     }
 
     /**

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Family/UpdateFamilyVariantIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Family/UpdateFamilyVariantIntegration.php
@@ -295,7 +295,7 @@ class UpdateFamilyVariantIntegration extends TestCase
      */
     protected function getConfiguration(): Configuration
     {
-        return new Configuration([Configuration::getFunctionalCatalogPath('catalog_modeling')]);
+        return $this->catalog->useFunctionalCatalog('catalog_modeling');
     }
 
     /**

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/AbstractProductAndProductModelQueryBuilderTestCase.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/AbstractProductAndProductModelQueryBuilderTestCase.php
@@ -34,7 +34,7 @@ class AbstractProductAndProductModelQueryBuilderTestCase extends TestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getFunctionalCatalogPath('catalog_modeling')]);
+        return $this->catalog->useFunctionalCatalog('catalog_modeling');
     }
 
     /**

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/AbstractProductQueryBuilderTestCase.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/AbstractProductQueryBuilderTestCase.php
@@ -69,8 +69,12 @@ abstract class AbstractProductQueryBuilderTestCase extends TestCase
      */
     protected function createAttribute(array $data)
     {
+        $data['group'] = $data['group'] ?? 'other';
+
         $attribute = $this->get('pim_catalog.factory.attribute')->create();
         $this->get('pim_catalog.updater.attribute')->update($attribute, $data);
+        $constraints = $this->get('validator')->validate($attribute);
+        $this->assertCount(0, $constraints);
         $this->get('pim_catalog.saver.attribute')->save($attribute);
     }
 

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/AbstractProductQueryBuilderTestCase.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/AbstractProductQueryBuilderTestCase.php
@@ -33,7 +33,7 @@ abstract class AbstractProductQueryBuilderTestCase extends TestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 
     /**

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Metric/LocalizableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Metric/LocalizableFilterIntegration.php
@@ -24,6 +24,7 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
             'code'                => 'a_localizable_metric',
             'type'                => AttributeTypes::METRIC,
             'localizable'         => true,
+            'negative_allowed'    => true,
             'decimals_allowed'    => false,
             'metric_family'       => 'Length',
             'default_metric_unit' => 'METER',

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Metric/LocalizableScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Metric/LocalizableScopableFilterIntegration.php
@@ -25,6 +25,7 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
             'type'                => AttributeTypes::METRIC,
             'localizable'         => true,
             'scopable'            => true,
+            'negative_allowed'    => true,
             'decimals_allowed'    => true,
             'metric_family'       => 'Power',
             'default_metric_unit' => 'KILOWATT'

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Metric/ScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Metric/ScopableFilterIntegration.php
@@ -26,6 +26,7 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
             'localizable'         => false,
             'scopable'            => true,
             'decimals_allowed'    => true,
+            'negative_allowed'    => true,
             'metric_family'       => 'Length',
             'default_metric_unit' => 'METER'
         ]);

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Number/LocalizableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Number/LocalizableFilterIntegration.php
@@ -25,7 +25,8 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
             'type'                => AttributeTypes::NUMBER,
             'localizable'         => true,
             'scopable'            => false,
-            'negative_allowed'    => true
+            'negative_allowed'    => true,
+            'decimals_allowed'    => true,
         ]);
 
         $this->createProduct('product_one', [

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Number/LocalizableScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Number/LocalizableScopableFilterIntegration.php
@@ -25,7 +25,8 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
             'type'                => AttributeTypes::NUMBER,
             'localizable'         => true,
             'scopable'            => true,
-            'negative_allowed'    => true
+            'negative_allowed'    => true,
+            'decimals_allowed'    => true,
         ]);
 
         $this->createProduct('product_one', [

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Number/ScopableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Number/ScopableFilterIntegration.php
@@ -25,7 +25,8 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
             'type'                => AttributeTypes::NUMBER,
             'localizable'         => false,
             'scopable'            => true,
-            'negative_allowed'    => true
+            'negative_allowed'    => true,
+            'decimals_allowed'    => true,
         ]);
 
         $this->createProduct('product_one', [

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Price/LocalizableFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Price/LocalizableFilterIntegration.php
@@ -25,6 +25,7 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
             'type' => AttributeTypes::PRICE_COLLECTION,
             'localizable' => true,
             'scopable' => false,
+            'decimals_allowed' => false,
         ]);
 
         $this->createProduct('product_one', [

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/ProductQueryBuilderIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/ProductQueryBuilderIntegration.php
@@ -84,7 +84,7 @@ class ProductQueryBuilderIntegration extends AbstractProductQueryBuilderTestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 
     /**

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Metric/LocalizableScopableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Metric/LocalizableScopableSorterIntegration.php
@@ -27,6 +27,7 @@ class LocalizableScopableSorterIntegration extends AbstractProductQueryBuilderTe
             'type'                => AttributeTypes::METRIC,
             'localizable'         => true,
             'scopable'            => true,
+            'negative_allowed'    => true,
             'decimals_allowed'    => true,
             'metric_family'       => 'Power',
             'default_metric_unit' => 'WATT'

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Metric/LocalizableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Metric/LocalizableSorterIntegration.php
@@ -27,6 +27,7 @@ class LocalizableSorterIntegration extends AbstractProductQueryBuilderTestCase
             'type'                => AttributeTypes::METRIC,
             'localizable'         => true,
             'scopable'            => false,
+            'negative_allowed'    => true,
             'decimals_allowed'    => true,
             'metric_family'       => 'Power',
             'default_metric_unit' => 'WATT'

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Metric/ScopableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Metric/ScopableSorterIntegration.php
@@ -27,6 +27,7 @@ class ScopableSorterIntegration extends AbstractProductQueryBuilderTestCase
             'type'                => AttributeTypes::METRIC,
             'localizable'         => false,
             'scopable'            => true,
+            'negative_allowed'    => true,
             'decimals_allowed'    => true,
             'metric_family'       => 'Power',
             'default_metric_unit' => 'WATT'

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Number/LocalizableScopableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Number/LocalizableScopableSorterIntegration.php
@@ -27,7 +27,8 @@ class LocalizableScopableSorterIntegration extends AbstractProductQueryBuilderTe
             'type'                => AttributeTypes::NUMBER,
             'localizable'         => true,
             'scopable'            => true,
-            'negative_allowed'    => true
+            'negative_allowed'    => true,
+            'decimals_allowed'    => true,
         ]);
 
         $this->createProduct('product_one', [

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Number/LocalizableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Number/LocalizableSorterIntegration.php
@@ -28,6 +28,7 @@ class LocalizableSorterIntegration extends AbstractProductQueryBuilderTestCase
             'localizable'      => true,
             'scopable'         => false,
             'negative_allowed' => true,
+            'decimals_allowed' => true,
         ]);
 
         $this->createProduct('product_one', [

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Number/ScopableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Number/ScopableSorterIntegration.php
@@ -28,6 +28,7 @@ class ScopableSorterIntegration extends AbstractProductQueryBuilderTestCase
             'localizable'      => false,
             'scopable'         => true,
             'negative_allowed' => true,
+            'decimals_allowed' => true,
         ]);
 
         $this->createProduct('product_one', [

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Product/CreateProductModelIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Product/CreateProductModelIntegration.php
@@ -387,7 +387,7 @@ class CreateProductModelIntegration extends TestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getFunctionalCatalogPath('catalog_modeling')]);
+        return $this->catalog->useFunctionalCatalog('catalog_modeling');
     }
 
     /**

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Product/CreateVariantProductIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Product/CreateVariantProductIntegration.php
@@ -131,6 +131,6 @@ class CreateVariantProductIntegration extends TestCase
      */
     protected function getConfiguration(): Configuration
     {
-        return new Configuration([Configuration::getFunctionalCatalogPath('catalog_modeling')]);
+        return $this->catalog->useFunctionalCatalog('catalog_modeling');
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Product/UpdateProductModelIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Product/UpdateProductModelIntegration.php
@@ -94,6 +94,6 @@ class UpdateProductModelIntegration extends TestCase
      */
     protected function getConfiguration(): Configuration
     {
-        return new Configuration([Configuration::getFunctionalCatalogPath('catalog_modeling')]);
+        return $this->catalog->useFunctionalCatalog('catalog_modeling');
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Product/UpdateVariantProductIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Product/UpdateVariantProductIntegration.php
@@ -80,7 +80,7 @@ class UpdateVariantProductIntegration extends TestCase
      */
     protected function getConfiguration(): Configuration
     {
-        return new Configuration([Configuration::getFunctionalCatalogPath('catalog_modeling')]);
+        return $this->catalog->useFunctionalCatalog('catalog_modeling');
     }
 
     /**

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Validation/AssociationTypeValidationIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Validation/AssociationTypeValidationIntegration.php
@@ -179,8 +179,6 @@ class AssociationTypeValidationIntegration extends TestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()]
-        );
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Validation/Attribute/AbstractAttributeTestCase.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Validation/Attribute/AbstractAttributeTestCase.php
@@ -455,6 +455,6 @@ abstract class AbstractAttributeTestCase extends TestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Validation/Attribute/GlobalConstraintsIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Validation/Attribute/GlobalConstraintsIntegration.php
@@ -6,6 +6,8 @@ namespace Pim\Bundle\CatalogBundle\tests\integration\Validation\Attribute;
  * @author    Yohan Blain <yohan.blain@akeneo.com>
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ *
+ * @group ce
  */
 class GlobalConstraintsIntegration extends AbstractAttributeTestCase
 {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Validation/Attribute/ReferenceDataMultiSelectIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Validation/Attribute/ReferenceDataMultiSelectIntegration.php
@@ -6,6 +6,8 @@ namespace Pim\Bundle\CatalogBundle\tests\integration\Validation\Attribute;
  * @author    Yohan Blain <yohan.blain@akeneo.com>
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ *
+ * @group ce
  */
 class ReferenceDataMultiSelectIntegration extends AbstractAttributeTestCase
 {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Validation/Attribute/ReferenceDataSimpleSelectIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Validation/Attribute/ReferenceDataSimpleSelectIntegration.php
@@ -6,6 +6,8 @@ namespace Pim\Bundle\CatalogBundle\tests\integration\Validation\Attribute;
  * @author    Yohan Blain <yohan.blain@akeneo.com>
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ *
+ * @group ce
  */
 class ReferenceDataSimpleSelectIntegration extends AbstractAttributeTestCase
 {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Validation/AttributeGroupValidationIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Validation/AttributeGroupValidationIntegration.php
@@ -267,7 +267,7 @@ class AttributeGroupValidationIntegration extends TestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Validation/ChannelValidationIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Validation/ChannelValidationIntegration.php
@@ -384,8 +384,6 @@ class ChannelValidationIntegration extends TestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()]
-        );
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Validation/ProductIdentifierValidationIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Validation/ProductIdentifierValidationIntegration.php
@@ -114,7 +114,7 @@ class ProductIdentifierValidationIntegration extends TestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 
     /**

--- a/src/Pim/Bundle/ConnectorBundle/tests/integration/Export/AbstractExportTestCase.php
+++ b/src/Pim/Bundle/ConnectorBundle/tests/integration/Export/AbstractExportTestCase.php
@@ -41,7 +41,7 @@ abstract class AbstractExportTestCase extends TestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 
     /**

--- a/src/Pim/Bundle/ConnectorBundle/tests/integration/Export/Product/ExportProductsIntegration.php
+++ b/src/Pim/Bundle/ConnectorBundle/tests/integration/Export/Product/ExportProductsIntegration.php
@@ -4,6 +4,9 @@ namespace Pim\Bundle\ConnectorBundle\tests\integration\Export\Product;
 
 use Pim\Bundle\ConnectorBundle\tests\integration\Export\AbstractExportTestCase;
 
+/**
+ * @group ce
+ */
 class ExportProductsIntegration extends AbstractExportTestCase
 {
     /**

--- a/src/Pim/Bundle/ConnectorBundle/tests/integration/Export/ProductModel/ExportProductModelsIntegration.php
+++ b/src/Pim/Bundle/ConnectorBundle/tests/integration/Export/ProductModel/ExportProductModelsIntegration.php
@@ -4,6 +4,9 @@ namespace Pim\Bundle\ConnectorBundle\tests\integration\Export\ProductModel;
 
 use Pim\Bundle\ConnectorBundle\tests\integration\Export\AbstractExportTestCase;
 
+/**
+ * @group ce
+ */
 class ExportProductModelsIntegration extends AbstractExportTestCase
 {
     /**

--- a/src/Pim/Bundle/EnrichBundle/tests/integration/Repository/JobExecutionRepositoryIntegration.php
+++ b/src/Pim/Bundle/EnrichBundle/tests/integration/Repository/JobExecutionRepositoryIntegration.php
@@ -21,16 +21,18 @@ class JobExecutionRepositoryIntegration extends TestCase
         $this->jobLauncher->launchExport('csv_product_export', 'admin');
 
         $result = $this->getJobExecutionRepository()->getLastOperationsData([], 'admin');
+        $this->assertNotNull($result[0]['id']);
+
         $result[0]['date'] = DateSanitizer::sanitize($result[0]['date']->format('c'));
+        unset($result[0]['id']);
 
         $expectedResult = [
             [
-                'id'           => 20,
                 'date'         => 'this is a date formatted to ISO-8601',
                 'type'         => 'export',
                 'label'        => 'CSV product export',
                 'status'       => 1,
-                'warningCount' => "0",
+                'warningCount' => '0',
             ],
         ];
 
@@ -58,8 +60,6 @@ class JobExecutionRepositoryIntegration extends TestCase
      */
     protected function getConfiguration(): Configuration
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()]
-        );
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/InstallerBundle/tests/integration/InstallStatusManagerIntegration.php
+++ b/src/Pim/Bundle/InstallerBundle/tests/integration/InstallStatusManagerIntegration.php
@@ -20,6 +20,6 @@ class InstallStatusManagerIntegration extends TestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ReferenceDataBundle/tests/integration/PQB/Filter/ReferenceData/ReferenceDataMultiSelectFilterIntegration.php
+++ b/src/Pim/Bundle/ReferenceDataBundle/tests/integration/PQB/Filter/ReferenceData/ReferenceDataMultiSelectFilterIntegration.php
@@ -139,8 +139,6 @@ class ReferenceDataMultiSelectFilterIntegration extends AbstractProductQueryBuil
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath(), Configuration::getReferenceDataFixtures()]
-        );
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ReferenceDataBundle/tests/integration/PQB/Filter/ReferenceData/ReferenceDataSimpleSelectFilterIntegration.php
+++ b/src/Pim/Bundle/ReferenceDataBundle/tests/integration/PQB/Filter/ReferenceData/ReferenceDataSimpleSelectFilterIntegration.php
@@ -107,8 +107,6 @@ class ReferenceDataSimpleSelectFilterIntegration extends AbstractProductQueryBui
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath(), Configuration::getReferenceDataFixtures()]
-        );
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ReferenceDataBundle/tests/integration/PQB/Sorter/ReferenceData/ReferenceDataSimpleSelectSorterIntegration.php
+++ b/src/Pim/Bundle/ReferenceDataBundle/tests/integration/PQB/Sorter/ReferenceData/ReferenceDataSimpleSelectSorterIntegration.php
@@ -73,8 +73,6 @@ class ReferenceDataSimpleSelectSorterIntegration extends AbstractProductQueryBui
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath(), Configuration::getReferenceDataFixtures()]
-        );
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/VersioningBundle/tests/integration/Manager/EntityWithVariantVersionIntegration.php
+++ b/src/Pim/Bundle/VersioningBundle/tests/integration/Manager/EntityWithVariantVersionIntegration.php
@@ -85,7 +85,7 @@ class EntityWithVariantVersionIntegration extends TestCase
      */
     protected function getConfiguration(): Configuration
     {
-        return new Configuration([Configuration::getFunctionalCatalogPath('catalog_modeling')]);
+        return $this->catalog->useFunctionalCatalog('catalog_modeling');
     }
 
     /**

--- a/src/Pim/Bundle/VersioningBundle/tests/integration/Manager/VersionManagerIntegration.php
+++ b/src/Pim/Bundle/VersioningBundle/tests/integration/Manager/VersionManagerIntegration.php
@@ -52,7 +52,7 @@ class VersionManagerIntegration extends TestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalSqlCatalogPath()]);
+        return $this->catalog->useTechnicalSqlCatalog();
     }
 
     public function testNoVersionCreatedWhenThereIsNoUpdate()

--- a/src/Pim/Bundle/VersioningBundle/tests/integration/Normalizer/Flat/AbstractFlatNormalizerTestCase.php
+++ b/src/Pim/Bundle/VersioningBundle/tests/integration/Normalizer/Flat/AbstractFlatNormalizerTestCase.php
@@ -17,6 +17,6 @@ abstract class AbstractFlatNormalizerTestCase extends TestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/VersioningBundle/tests/integration/Normalizer/Flat/AttributeGroupIntegration.php
+++ b/src/Pim/Bundle/VersioningBundle/tests/integration/Normalizer/Flat/AttributeGroupIntegration.php
@@ -8,6 +8,8 @@ use Pim\Bundle\VersioningBundle\tests\integration\Normalizer\Flat\AbstractFlatNo
  * @author    Marie Bochu <marie.bochu@akeneo.com>
  * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *
+ * @group ce
  */
 class AttributeGroupIntegration extends AbstractFlatNormalizerTestCase
 {

--- a/src/Pim/Bundle/VersioningBundle/tests/integration/Normalizer/Flat/AttributeIntegration.php
+++ b/src/Pim/Bundle/VersioningBundle/tests/integration/Normalizer/Flat/AttributeIntegration.php
@@ -8,6 +8,8 @@ use Pim\Bundle\VersioningBundle\tests\integration\Normalizer\Flat\AbstractFlatNo
  * @author    Marie Bochu <marie.bochu@akeneo.com>
  * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *
+ * @group ce
  */
 class AttributeIntegration extends AbstractFlatNormalizerTestCase
 {

--- a/src/Pim/Bundle/VersioningBundle/tests/integration/Normalizer/Flat/CategoryIntegration.php
+++ b/src/Pim/Bundle/VersioningBundle/tests/integration/Normalizer/Flat/CategoryIntegration.php
@@ -8,6 +8,8 @@ use Pim\Bundle\VersioningBundle\tests\integration\Normalizer\Flat\AbstractFlatNo
  * @author    Marie Bochu <marie.bochu@akeneo.com>
  * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *
+ * @group ce
  */
 class CategoryIntegration extends AbstractFlatNormalizerTestCase
 {

--- a/src/Pim/Bundle/VersioningBundle/tests/integration/Normalizer/Flat/LocaleIntegration.php
+++ b/src/Pim/Bundle/VersioningBundle/tests/integration/Normalizer/Flat/LocaleIntegration.php
@@ -8,6 +8,8 @@ use Pim\Bundle\VersioningBundle\tests\integration\Normalizer\Flat\AbstractFlatNo
  * @author    Marie Bochu <marie.bochu@akeneo.com>
  * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *
+ * @group ce
  */
 class LocaleIntegration extends AbstractFlatNormalizerTestCase
 {

--- a/src/Pim/Bundle/VersioningBundle/tests/integration/Normalizer/Flat/ProductIntegration.php
+++ b/src/Pim/Bundle/VersioningBundle/tests/integration/Normalizer/Flat/ProductIntegration.php
@@ -15,7 +15,7 @@ class ProductIntegration extends TestCase
 {
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalSqlCatalogPath()]);
+        return $this->catalog->useTechnicalSqlCatalog();
     }
 
     public function testProduct()

--- a/src/Pim/Component/Api/tests/integration/Normalizer/AbstractNormalizerTestCase.php
+++ b/src/Pim/Component/Api/tests/integration/Normalizer/AbstractNormalizerTestCase.php
@@ -17,6 +17,6 @@ abstract class AbstractNormalizerTestCase extends TestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Component/Api/tests/integration/Normalizer/AttributeIntegration.php
+++ b/src/Pim/Component/Api/tests/integration/Normalizer/AttributeIntegration.php
@@ -6,6 +6,8 @@ namespace Pim\Component\Api\tests\integration\Normalizer;
  * @author    Marie Bochu <marie.bochu@akeneo.com>
  * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *
+ * @group ce
  */
 class AttributeIntegration extends AbstractNormalizerTestCase
 {

--- a/src/Pim/Component/Api/tests/integration/Normalizer/ProductNormalizerIntegration.php
+++ b/src/Pim/Component/Api/tests/integration/Normalizer/ProductNormalizerIntegration.php
@@ -18,7 +18,7 @@ class ProductNormalizerIntegration extends TestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalSqlCatalogPath()]);
+        return $this->catalog->useTechnicalSqlCatalog();
     }
 
     public function testEmptyDisabledProduct()

--- a/src/Pim/Component/Api/tests/integration/Normalizer/ProductNormalizerIntegration.php
+++ b/src/Pim/Component/Api/tests/integration/Normalizer/ProductNormalizerIntegration.php
@@ -2,7 +2,6 @@
 
 namespace Pim\Component\Api\tests\integration\Normalizer;
 
-use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\IntegrationTestsBundle\Sanitizer\MediaSanitizer;
 use Akeneo\Test\Integration\TestCase;
 use Pim\Component\Catalog\Model\ProductInterface;
@@ -10,6 +9,8 @@ use Pim\Component\Catalog\tests\integration\Normalizer\NormalizedProductCleaner;
 
 /**
  * Integration tests to verify data from database are well formatted in the external api format
+ *
+ * @group ce
  */
 class ProductNormalizerIntegration extends TestCase
 {

--- a/src/Pim/Component/Catalog/tests/integration/Normalizer/Indexing/ProductAndProductModelIndexingIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Normalizer/Indexing/ProductAndProductModelIndexingIntegration.php
@@ -19,9 +19,7 @@ class ProductAndProductModelIndexingIntegration extends TestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalSqlCatalogPath()]
-        );
+        return $this->catalog->useTechnicalSqlCatalog();
     }
 
     public function testRootProductModel()

--- a/src/Pim/Component/Catalog/tests/integration/Normalizer/Indexing/ProductIndexingIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Normalizer/Indexing/ProductIndexingIntegration.php
@@ -17,9 +17,7 @@ class ProductIndexingIntegration extends TestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalSqlCatalogPath()]
-        );
+        return $this->catalog->useTechnicalSqlCatalog();
     }
 
     public function testEmptyDisabledProduct()

--- a/src/Pim/Component/Catalog/tests/integration/Normalizer/Standard/AbstractStandardNormalizerTestCase.php
+++ b/src/Pim/Component/Catalog/tests/integration/Normalizer/Standard/AbstractStandardNormalizerTestCase.php
@@ -17,6 +17,6 @@ abstract class AbstractStandardNormalizerTestCase extends TestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Component/Catalog/tests/integration/Normalizer/Standard/AttributeGroupIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Normalizer/Standard/AttributeGroupIntegration.php
@@ -8,6 +8,8 @@ use Pim\Component\Catalog\tests\integration\Normalizer\Standard\AbstractStandard
  * @author    Marie Bochu <marie.bochu@akeneo.com>
  * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *
+ * @group ce
  */
 class AttributeGroupIntegration extends AbstractStandardNormalizerTestCase
 {

--- a/src/Pim/Component/Catalog/tests/integration/Normalizer/Standard/AttributeIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Normalizer/Standard/AttributeIntegration.php
@@ -8,6 +8,8 @@ use Pim\Component\Catalog\tests\integration\Normalizer\Standard\AbstractStandard
  * @author    Marie Bochu <marie.bochu@akeneo.com>
  * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *
+ * @group ce
  */
 class AttributeIntegration extends AbstractStandardNormalizerTestCase
 {

--- a/src/Pim/Component/Catalog/tests/integration/Normalizer/Standard/FamilyVariantIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Normalizer/Standard/FamilyVariantIntegration.php
@@ -52,6 +52,6 @@ class FamilyVariantIntegration extends TestCase
      */
     protected function getConfiguration(): Configuration
     {
-        return new Configuration([Configuration::getFunctionalCatalogPath('catalog_modeling')]);
+        return $this->catalog->useFunctionalCatalog('catalog_modeling');
     }
 }

--- a/src/Pim/Component/Catalog/tests/integration/Normalizer/Standard/ProductStandardIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Normalizer/Standard/ProductStandardIntegration.php
@@ -19,7 +19,7 @@ class ProductStandardIntegration extends TestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalSqlCatalogPath()]);
+        return $this->catalog->useTechnicalSqlCatalog();
     }
 
     public function testEmptyDisabledProduct()

--- a/src/Pim/Component/Catalog/tests/integration/Normalizer/Storage/EntityWithValuesStorageIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Normalizer/Storage/EntityWithValuesStorageIntegration.php
@@ -17,9 +17,7 @@ class EntityWithValuesStorageIntegration extends TestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalSqlCatalogPath()]
-        );
+        return $this->catalog->useTechnicalSqlCatalog();
     }
 
     public function testProductWithAllAttributes()

--- a/src/Pim/Component/Catalog/tests/integration/Updater/AssociationTypeUpdaterIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Updater/AssociationTypeUpdaterIntegration.php
@@ -100,8 +100,6 @@ class AssociationTypeUpdaterIntegration extends TestCase
 
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()]
-        );
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Component/Catalog/tests/integration/Updater/AttributeGroupUpdaterIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Updater/AttributeGroupUpdaterIntegration.php
@@ -149,6 +149,6 @@ class AttributeGroupUpdaterIntegration extends TestCase
 
     protected function getConfiguration()
     {
-        return new Configuration( [Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Component/Catalog/tests/integration/Updater/ChannelUpdaterIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Updater/ChannelUpdaterIntegration.php
@@ -228,6 +228,6 @@ class ChannelUpdaterIntegration extends TestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Component/Catalog/tests/integration/Updater/Copier/AbstractCopierTestCase.php
+++ b/src/Pim/Component/Catalog/tests/integration/Updater/Copier/AbstractCopierTestCase.php
@@ -19,7 +19,7 @@ class AbstractCopierTestCase extends TestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 
     /**

--- a/src/Pim/Component/Catalog/tests/integration/Updater/Setter/MediaAttributeSetterIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Updater/Setter/MediaAttributeSetterIntegration.php
@@ -18,7 +18,7 @@ class MediaAttributeSetterIntegration extends TestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 
     public function testLocalizableMedia()

--- a/tests/Configuration.php
+++ b/tests/Configuration.php
@@ -19,12 +19,13 @@ class Configuration
     protected $fixtureDirectories;
 
     /**
-     * @param array      $catalogDirectories       The catalog directories to load
-     * @param array|null $fixtureDirectories       The fixtures directories. Will look at least in "test/fixtures/".
+     * @param array $catalogDirectories The catalog directories to load
+     * @param array $fixtureDirectories The fixtures directories. Will look at least in "test/fixtures/".
      *
      * @throws \Exception
      */
-    public function __construct(array $catalogDirectories, array $fixtureDirectories = null) {
+    public function __construct(array $catalogDirectories, array $fixtureDirectories = [])
+    {
         $this->catalogDirectories = $catalogDirectories;
         foreach ($this->catalogDirectories as $catalogDirectory) {
             if (!is_dir($catalogDirectory)) {
@@ -32,15 +33,7 @@ class Configuration
             }
         }
 
-        $this->fixtureDirectories = [];
-        if (null !== $fixtureDirectories) {
-            $this->fixtureDirectories = array_merge($this->fixtureDirectories, $fixtureDirectories);
-        }
-
-        $defaultFixturePath = self::getRootDirectory() . DIRECTORY_SEPARATOR . 'tests' .
-            DIRECTORY_SEPARATOR . 'fixtures' . DIRECTORY_SEPARATOR;
-        $this->fixtureDirectories[] = $defaultFixturePath;
-
+        $this->fixtureDirectories = $fixtureDirectories;
         foreach ($this->fixtureDirectories as $fixtureDirectory) {
             if (!is_dir($fixtureDirectory)) {
                 throw new \Exception(sprintf('The fixture directory "%s" does not exist.', $fixtureDirectory));
@@ -62,75 +55,5 @@ class Configuration
     public function getFixtureDirectories()
     {
         return $this->fixtureDirectories;
-    }
-
-    /**
-     * @return string
-     */
-    public static function getTechnicalSqlCatalogPath()
-    {
-        return realpath(self::getRootDirectory() . DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR . 'catalog' .
-            DIRECTORY_SEPARATOR . 'technical_sql');
-    }
-
-    /**
-     * @return string
-     */
-    public static function getTechnicalCatalogPath()
-    {
-        return realpath(self::getRootDirectory() . DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR . 'catalog' .
-            DIRECTORY_SEPARATOR . 'technical');
-    }
-
-    /**
-     * @return string
-     */
-    public static function getMinimalCatalogPath()
-    {
-        return realpath(self::getRootDirectory() . DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR . 'Pim' .
-            DIRECTORY_SEPARATOR . 'Bundle' . DIRECTORY_SEPARATOR . 'InstallerBundle' . DIRECTORY_SEPARATOR .
-            'Resources' . DIRECTORY_SEPARATOR . 'fixtures' . DIRECTORY_SEPARATOR . 'minimal');
-    }
-
-    /**
-     * @return string
-     */
-    public static function getReferenceDataFixtures()
-    {
-        return realpath(self::getRootDirectory() . DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR . 'Acme' .
-            DIRECTORY_SEPARATOR . 'Bundle' . DIRECTORY_SEPARATOR . 'AppBundle' . DIRECTORY_SEPARATOR . 'Resources' .
-            DIRECTORY_SEPARATOR . 'fixtures');
-    }
-
-    /**
-     * Returns the path to a given functional (aka behat) catalog.
-     *
-     * @param $catalog
-     *
-     * @return string
-     */
-    public static function getFunctionalCatalogPath($catalog)
-    {
-        return realpath(self::getRootDirectory(). DIRECTORY_SEPARATOR . 'features'. DIRECTORY_SEPARATOR . 'Context' .
-            DIRECTORY_SEPARATOR .'catalog'. DIRECTORY_SEPARATOR . $catalog);
-    }
-
-    /**
-     * Returns the path to a functional (aka behat) fixture folder.
-     *
-     * @return string
-     */
-    public static function getFunctionalFixtures()
-    {
-        return realpath(self::getRootDirectory(). DIRECTORY_SEPARATOR . 'features'. DIRECTORY_SEPARATOR . 'Context' .
-            DIRECTORY_SEPARATOR .'fixtures');
-    }
-
-    /**
-     * @return string
-     */
-    private static function getRootDirectory()
-    {
-        return realpath(__DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR);
     }
 }

--- a/tests/IntegrationTestsBundle/Configuration/Catalog.php
+++ b/tests/IntegrationTestsBundle/Configuration/Catalog.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Test\IntegrationTestsBundle\Configuration;
+
+use Akeneo\Test\Integration\Configuration;
+
+/**
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class Catalog implements CatalogInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function useTechnicalSqlCatalog(): Configuration
+    {
+        $catalogDirectories = [realpath($this->getRootDirectory() . 'tests' . DIRECTORY_SEPARATOR . 'catalog' .
+            DIRECTORY_SEPARATOR . 'technical_sql')];
+
+        $fixtureDirectories = [
+            $this->getTechnicalFixtures(),
+            $this->getReferenceDataFixtures()
+        ];
+
+        return new Configuration($catalogDirectories, $fixtureDirectories);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function useTechnicalCatalog(): Configuration
+    {
+        $catalogDirectories = [realpath($this->getRootDirectory() . 'tests' . DIRECTORY_SEPARATOR . 'catalog' .
+            DIRECTORY_SEPARATOR . 'technical')];
+
+        $fixtureDirectories = [
+            $this->getTechnicalFixtures(),
+            $this->getReferenceDataFixtures()
+        ];
+
+        return new Configuration($catalogDirectories, $fixtureDirectories);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function useMinimalCatalog(): Configuration
+    {
+        $catalogDirectories = [realpath($this->getRootDirectory() . 'src' . DIRECTORY_SEPARATOR . 'Pim' .
+            DIRECTORY_SEPARATOR . 'Bundle' . DIRECTORY_SEPARATOR . 'InstallerBundle' . DIRECTORY_SEPARATOR .
+            'Resources' . DIRECTORY_SEPARATOR . 'fixtures' . DIRECTORY_SEPARATOR . 'minimal')];
+
+        $fixtureDirectories = [
+            $this->getReferenceDataFixtures(),
+            $this->getTechnicalFixtures(),
+        ];
+
+        return new Configuration($catalogDirectories, $fixtureDirectories);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function useFunctionalCatalog(string $catalog): Configuration
+    {
+        $catalogDirectories = [realpath($this->getRootDirectory() . 'features'. DIRECTORY_SEPARATOR . 'Context' .
+            DIRECTORY_SEPARATOR .'catalog'. DIRECTORY_SEPARATOR . $catalog)];
+
+        $fixtureDirectories = [
+            realpath($this->getRootDirectory(). DIRECTORY_SEPARATOR . 'features'. DIRECTORY_SEPARATOR . 'Context' .
+            DIRECTORY_SEPARATOR .'fixtures'),
+            $this->getReferenceDataFixtures()
+        ];
+
+        return new Configuration($catalogDirectories, $fixtureDirectories);
+    }
+
+
+    /**
+     * {@inheritdoc}
+     */
+    private function getReferenceDataFixtures(): string
+    {
+        $path = $this->getRootDirectory() . 'src' . DIRECTORY_SEPARATOR . 'Acme' .
+            DIRECTORY_SEPARATOR . 'Bundle' . DIRECTORY_SEPARATOR . 'AppBundle' . DIRECTORY_SEPARATOR . 'Resources' .
+            DIRECTORY_SEPARATOR . 'fixtures' . DIRECTORY_SEPARATOR;
+        $test = realpath($path);
+
+        return $test;
+    }
+
+    private function getTechnicalFixtures(): string
+    {
+        return realpath($this->getRootDirectory() . 'tests' . DIRECTORY_SEPARATOR . 'fixtures');
+    }
+
+    /**
+     * @return string
+     */
+    private function getRootDirectory()
+    {
+        return __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR;
+    }
+}

--- a/tests/IntegrationTestsBundle/Configuration/CatalogInterface.php
+++ b/tests/IntegrationTestsBundle/Configuration/CatalogInterface.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Test\IntegrationTestsBundle\Configuration;
+
+use Akeneo\Test\Integration\Configuration;
+
+/**
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface CatalogInterface
+{
+    /**
+     * @return Configuration
+     */
+    public function useTechnicalSqlCatalog(): Configuration;
+
+    /**
+     * @return Configuration
+     */
+    public function useTechnicalCatalog(): Configuration;
+
+    /**
+     * @return Configuration
+     */
+    public function useMinimalCatalog(): Configuration;
+
+    /**
+     * Returns the path to a given functional (aka behat) catalog.
+     *
+     * @param string $catalog
+     *
+     * @return Configuration
+     */
+    public function useFunctionalCatalog(string $catalog): Configuration;
+}

--- a/tests/IntegrationTestsBundle/Loader/FixturesLoaderInterface.php
+++ b/tests/IntegrationTestsBundle/Loader/FixturesLoaderInterface.php
@@ -18,9 +18,7 @@ interface FixturesLoaderInterface
     /**
      * Loads test catalog accordingly to the given configuration.
      *
-     * @param Configuration $configuration
-     *
      * @throws \Exception
      */
-    public function load(Configuration $configuration): void;
+    public function load(): void;
 }

--- a/tests/IntegrationTestsBundle/Resources/config/services.yml
+++ b/tests/IntegrationTestsBundle/Resources/config/services.yml
@@ -5,6 +5,7 @@ parameters:
     akeneo_integration_tests.doctrine.connection.connection_closer.class: Akeneo\Test\IntegrationTestsBundle\Doctrine\Connection\ConnectionCloser
     akeneo_integration_tests.doctrine.job_execution.class: Akeneo\Test\IntegrationTestsBundle\Doctrine\JobExecution
     akeneo_integration_tests.security.system_user_authenticator.class: Akeneo\Test\IntegrationTestsBundle\Security\SystemUserAuthenticator
+    akeneo_integration_tests.configuration.catalog.class: Akeneo\Test\IntegrationTestsBundle\Configuration\Catalog
 
 services:
     akeneo_integration_tests.loader.reference_data_loader:
@@ -22,6 +23,7 @@ services:
             - '@kernel'
             - '@akeneo_integration_tests.loader.database_schema_handler'
             - '@akeneo_integration_tests.security.system_user_authenticator'
+            - '@akeneo_integration_tests.catalog.configuration'
 
     akeneo_integration_tests.loader.database_schema_handler:
         class: '%akeneo_integration_tests.loader.database_schema_handler.class%'
@@ -42,3 +44,9 @@ services:
         class: '%akeneo_integration_tests.security.system_user_authenticator.class%'
         arguments:
             - '@service_container'
+
+    akeneo_integration_tests.configuration.catalog:
+        class: '%akeneo_integration_tests.configuration.catalog.class%'
+
+    akeneo_integration_tests.catalog.configuration:
+        synthetic: true

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,13 +4,10 @@ declare(strict_types=1);
 
 namespace Akeneo\Test\Integration;
 
-use Akeneo\Test\IntegrationTestsBundle\Doctrine\Connection\ConnectionCloser;
-use Akeneo\Test\IntegrationTestsBundle\Loader\FixturesLoader;
-use Akeneo\Test\IntegrationTestsBundle\Loader\FixturesLoaderInterface;
+use Akeneo\Test\IntegrationTestsBundle\Configuration\CatalogInterface;
 use Akeneo\Test\IntegrationTestsBundle\Security\SystemUserAuthenticator;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\HttpKernel\KernelInterface;
-use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 /**
  * @author    Marie Bochu <marie.bochu@akeneo.com>
@@ -21,6 +18,9 @@ abstract class TestCase extends KernelTestCase
 {
     /** @var KernelInterface */
     protected $testKernel;
+
+    /** @var CatalogInterface */
+    protected $catalog;
 
     /**
      * @return Configuration
@@ -39,10 +39,11 @@ abstract class TestCase extends KernelTestCase
         $this->testKernel = new \AppKernelTest('test', false);
         $this->testKernel->boot();
 
-        $configuration = $this->getConfiguration();
-        $fixturesLoader = $this->testKernel->getContainer()->get('akeneo_integration_tests.loader.fixtures_loader');
+        $this->catalog = $this->testKernel->getContainer()->get('akeneo_integration_tests.configuration.catalog');
+        $this->testKernel->getContainer()->set('akeneo_integration_tests.catalog.configuration', $this->getConfiguration());
 
-        $fixturesLoader->load($configuration);
+        $fixturesLoader = $this->testKernel->getContainer()->get('akeneo_integration_tests.loader.fixtures_loader');
+        $fixturesLoader->load();
     }
 
     /**
@@ -100,7 +101,7 @@ abstract class TestCase extends KernelTestCase
     {
         $configuration = $this->getConfiguration();
         foreach ($configuration->getFixtureDirectories() as $fixtureDirectory) {
-            $path = $fixtureDirectory . $name;
+            $path = $fixtureDirectory . DIRECTORY_SEPARATOR . $name;
             if (is_file($path) && false !== realpath($path)) {
                 return realpath($path);
             }

--- a/tests/integration/BatchBundle/Command/BatchCommandIntegration.php
+++ b/tests/integration/BatchBundle/Command/BatchCommandIntegration.php
@@ -207,8 +207,6 @@ class BatchCommandIntegration extends TestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()]
-        );
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/tests/integration/BatchBundle/Job/DoctrineJobRepositoryIntegration.php
+++ b/tests/integration/BatchBundle/Job/DoctrineJobRepositoryIntegration.php
@@ -77,8 +77,6 @@ class DoctrineJobRepositoryIntegration extends TestCase
      */
     protected function getConfiguration()
     {
-        return new Configuration(
-            [Configuration::getTechnicalCatalogPath()]
-        );
+        return $this->catalog->useTechnicalSqlCatalog();
     }
 }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This PR aims to execute integrations tests from CE in EE.
The catalog from CE was not installable in EE (due to missing files in CE that were mandatory in EE). 
The configuration of the files to load was done in static function in CE.
Therefore, it was not possible to override in EE.

To achieve that, I use the DI for the tests that I implemented in a previous PR: https://github.com/akeneo/pim-community-dev/pull/6875

To inject the Configuration object into the DI of the container, I use synthetic services. https://symfony.com/doc/current/service_container/synthetic_services.html
It allows to inject a service after having booting the kernel.

Before doing any fix, there were 575 fails in EE.
After fix, 140 tests failing test in EE left, due to additional data in EE (permissions, metadata, is_read_only property).
I added a group "ce" for these tests, in order to not be executed in EE.

I've some ideas about the technical strategy to use for these tests to be both executed in CE and EE, but we need to discuss about it together.

**Problems detected**

- API

   - Test on products are failing, due the field `metadata` in EE: not executed in EE

   - No user associated to the the token when using services in the container in EE(resulting in fatal error).
This is due to the function `$client = $this->createAuthenticatedClient();` executed before a test. 

      When creating a client, the `tokenStorage` does not have the system user. In EE, a user has to be authenticated to use some services, for example to create a product before executing a test.

      Solution: use the container created for the tests `$this->getFromTestContainer(..)` to use services (a system user is loaded in the token storage in this container). 

    - Missing a `return` in EE for the ACL on the API: does not work correctly in EE (it fixes 90 tests)

- PQB

A lot of tests don't create properly fixtures in integration tests, because we save the entity without validating it.
So, we create a lot of attributes without the property `group`. Therefore, in EE, the attribute is considered as not existing (even with system user having all roles).

The solution is just to add a group when creating an attribute.
I've fixed a lot of attributes with missing data in the standard format as well. 

And a bug in the category filter fixed in this PR: https://github.com/akeneo/pim-community-dev/pull/6942

- Property "is_read_only"

In EE, on some entities, you have an additional property "is_read_only". So, the data is not the same between EE an CE. I added the group "ce" on these tests to not being executed in EE.

    
<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
