### PR TITLE
PIM-6816: Display product models errors in PEF

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -13,6 +13,7 @@
 - PIM-6451: Now display variant axes coming from parent as "Variant Axis" on the product edit form
 - PIM-6847: Fix variant product history
 - PIM-6867: Fix validation of variant product, now it's impossible to have a root product model as parent if there are 2 levels of variation
+- PIM-6816: Add validation error messages on product model edit form
 
 ## Tech improvements
 

--- a/features/product-model/edit_product_model.feature
+++ b/features/product-model/edit_product_model.feature
@@ -67,3 +67,13 @@ Feature: Edit a product model
     When I edit the "amor" product model
     And I visit the "Marketing" group
     Then the product Model name should be "Heritage jacket navy"
+
+  @jira https://akeneo.atlassian.net/browse/PIM-6816
+  Scenario: Successfully display a validation error message
+    Given I am logged in as "Mary"
+    And I am on the "amor" product model page
+    And I visit the "ERP" group
+    And I change the Price to "foobar USD"
+    When I press the "Save" button
+    Then I should see validation tooltip "This value should be a valid number."
+    And there should be 1 error in the "ERP" tab

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/ProductViolationNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/ProductViolationNormalizer.php
@@ -8,6 +8,9 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Validator\ConstraintViolationInterface;
 
 /**
+ * TODO: This normalizer should be reworked and splitted in smaller normalizers
+ *       with more restrictive support constraints.
+ *
  * @author    Adrien Pétremann <adrien.petremann@akeneo.com>
  * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
@@ -45,8 +48,8 @@ class ProductViolationNormalizer implements NormalizerInterface
         }
 
         if (1 === preg_match('|^values\[(?P<attribute>[a-z0-9-_\<\>]+)|i', $propertyPath, $matches)) {
-            if (!isset($context['product'])) {
-                throw new \InvalidArgumentException('Expects a product context');
+            if (!isset($context['product']) && !isset($context['productModel'])) {
+                throw new \InvalidArgumentException('Expects a product or product model context');
             }
 
             $attribute = explode('-', $matches['attribute']);
@@ -71,8 +74,8 @@ class ProductViolationNormalizer implements NormalizerInterface
         }
 
         if (0 === strpos($propertyPath, 'values[')) {
-            if (!isset($context['product'])) {
-                throw new \InvalidArgumentException('Expects a product context');
+            if (!isset($context['product']) && !isset($context['productModel'])) {
+                throw new \InvalidArgumentException('Expects a product or product model context');
             }
 
             $codeStart = strpos($propertyPath, '[') + 1;

--- a/src/Pim/Bundle/EnrichBundle/spec/Normalizer/ProductViolationNormalizerSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Normalizer/ProductViolationNormalizerSpec.php
@@ -250,7 +250,7 @@ class ProductViolationNormalizerSpec extends ObjectBehavior
         $violation->getPropertyPath()->willReturn('values[price].float');
 
         $this
-            ->shouldThrow(new \InvalidArgumentException('Expects a product context'))
+            ->shouldThrow(new \InvalidArgumentException('Expects a product or product model context'))
             ->duringNormalize($violation, 'internal_api');
     }
 }


### PR DESCRIPTION
## Description

This PR adds the same validation tooltips on product models than we already have on product edit form.

![image](https://user-images.githubusercontent.com/5039018/31229606-91994cfa-a9e1-11e7-8fb6-16655dad248e.png)

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | OK
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
