### PR TITLE
TIP-809: Prevents ES from using the scoring system

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -4,6 +4,7 @@
 
 - PIM-6865: Fix ACL on import profile page
 - PIM-6876: Escape u001f character to workaround a mysql bug
+- TIP-809: Prevents ES from using the scoring system and bypass the max_clause_count limit.
 
 # 2.0.1 (2017-10-05)
 

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/SearchQueryBuilder.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/SearchQueryBuilder.php
@@ -142,8 +142,8 @@ class SearchQueryBuilder
             $searchQuery['sort'] = $this->sortClauses;
         }
 
-        if (empty($searchQuery['query'])) {
-            $searchQuery['query'] = new \stdClass();
+        if (empty($searchQuery['query']['constant_score']['filter'])) {
+            $searchQuery['query']['constant_score']['filter'] = new \stdClass();
         }
 
         return $searchQuery;

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/SearchQueryBuilder.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/SearchQueryBuilder.php
@@ -118,20 +118,24 @@ class SearchQueryBuilder
 
         $searchQuery = [
             '_source' => $source,
-            'query'   => [],
+            'query'   => [
+                'constant_score' => [
+                    'filter' => [],
+                ],
+            ],
         ];
 
         if (!empty($this->filterClauses)) {
-            $searchQuery['query']['bool']['filter'] = $this->filterClauses;
+            $searchQuery['query']['constant_score']['filter']['bool']['filter'] = $this->filterClauses;
         }
 
         if (!empty($this->mustNotClauses)) {
-            $searchQuery['query']['bool']['must_not'] = $this->mustNotClauses;
+            $searchQuery['query']['constant_score']['filter']['bool']['must_not'] = $this->mustNotClauses;
         }
 
         if (!empty($this->shouldClauses)) {
-            $searchQuery['query']['bool']['should'] = $this->shouldClauses;
-            $searchQuery['query']['bool']['minimum_should_match'] = 1;
+            $searchQuery['query']['constant_score']['filter']['bool']['should'] = $this->shouldClauses;
+            $searchQuery['query']['constant_score']['filter']['bool']['minimum_should_match'] = 1;
         }
 
         if (!empty($this->sortClauses)) {


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

- Prevents ES from using the scoring system by using "filter" context.
- Also in this "filter" context the max_clause_count search limit does not apply.

We can reach this limit when visiting the product grid in EE => a query with all the category code the current user is allowed to see is issued to ES, potentially filtering in 5K+ category codes making the product grid to break.



**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Ok
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | Ok
| Review and 2 GTM                  | Ok
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
