### PR TITLE
PIM-6863: Hide "Variant" meta in regular products

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/meta/family-variant.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/meta/family-variant.js
@@ -51,13 +51,15 @@ define(
                 const familyVariant = entity.meta.family_variant;
                 let label = __('pim_enrich.entity.product.meta.family_variant.none');
 
-                if (null !== familyVariant) {
-                    label = i18n.getLabel(
-                        familyVariant.labels,
-                        UserContext.get('catalogLocale'),
-                        entity.family_variant
-                    );
+                if (null === familyVariant) {
+                    return this;
                 }
+
+                label = i18n.getLabel(
+                    familyVariant.labels,
+                    UserContext.get('catalogLocale'),
+                    entity.family_variant
+                );
 
                 this.$el.html(
                     this.template({


### PR DESCRIPTION
## Description

The new meta field `VARIANT` displays on which axes the products and product models are based.

![image](https://user-images.githubusercontent.com/5039018/31271160-5361b91c-aa87-11e7-8c3c-23774fef4fcc.png)

However, this meta is useless on non variant products and should just not be displayed.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | OK
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | OK
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
