### PR TITLE
PIM-6876: escape u001f character to workaround a mysql bug

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -3,6 +3,7 @@
 ## Bug Fixes
 
 - PIM-6865: Fix ACL on import profile page
+- PIM-6876: Escape u001f character to workaround a mysql bug
 
 # 2.0.1 (2017-10-05)
 

--- a/src/Akeneo/Bundle/StorageUtilsBundle/Doctrine/DBAL/Types/JsonType.php
+++ b/src/Akeneo/Bundle/StorageUtilsBundle/Doctrine/DBAL/Types/JsonType.php
@@ -29,6 +29,9 @@ class JsonType extends JsonArrayType
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
+        // workaround to fix mysql bug. see https://bugs.mysql.com/bug.php?id=86898
+        $value = preg_replace('/[\x00-\x1F]/', '\\u001f', $value);
+
         return $value === null ? null : parent::convertToPHPValue($value, $platform);
     }
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
