### PR TITLE
TIP-808: Use version strategy for frontend assets

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -1,3 +1,9 @@
+# 2.0.x
+
+## Tech improvements
+
+- TIP-808: Add version strategy for js and css assets
+
 # 2.0.1 (2017-10-05)
 
 ## Bug Fixes
@@ -31,7 +37,7 @@
 
 - PIM-6343: Classify product models by import and export product models with their categories
 - PIM-6356: Display the image of the 1st variant product created in the grid and on the PEF for product models
-- PIM-6856: List family variants created by import in a new tab "variants" in the family 
+- PIM-6856: List family variants created by import in a new tab "variants" in the family
 - PIM-6797: Automatically add "unique value" and identifier attributes at the last variant product level in family variants
 
 ## Better UI\UX!

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -28,6 +28,10 @@ framework:
     serializer:
         enabled:              true
     http_method_override: true
+    assets:
+        packages:
+            frontend:
+                version_strategy: pim_enrich.version_strategy
 
 # Twig Configuration
 twig:

--- a/src/Oro/Bundle/AsseticBundle/Resources/views/Assets/oro_css.html.twig
+++ b/src/Oro/Bundle/AsseticBundle/Resources/views/Assets/oro_css.html.twig
@@ -6,7 +6,7 @@
     {% set isLess = ('less' in asset_url|split('.')) %}
     {% set hasLess = isLess ? true : hasLess %}
 
-    <link rel="{% if isLess %}stylesheet/less{% else %}stylesheet{% endif %}" media="all" href="{{ asset_url }}" />
+    <link rel="{% if isLess %}stylesheet/less{% else %}stylesheet{% endif %}" media="all" href="{{ asset(asset_url, 'frontend') }}" />
 {% endoro_css %}
 
 {% if hasLess %}

--- a/src/Pim/Bundle/EnrichBundle/DependencyInjection/PimEnrichExtension.php
+++ b/src/Pim/Bundle/EnrichBundle/DependencyInjection/PimEnrichExtension.php
@@ -64,6 +64,7 @@ class PimEnrichExtension extends Extension
         $loader->load('serializers.yml');
         $loader->load('steps.yml');
         $loader->load('twig.yml');
+        $loader->load('version_strategy.yml');
         $loader->load('view_elements.yml');
         $loader->load('view_elements/attribute.yml');
         $loader->load('view_elements/category.yml');

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/version_strategy.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/version_strategy.yml
@@ -1,0 +1,6 @@
+parameters:
+    pim_enrich.version_strategy.class: Pim\Bundle\EnrichBundle\VersionStrategy\CacheBusterVersionStrategy
+
+services:
+    pim_enrich.version_strategy:
+        class: '%pim_enrich.version_strategy.class%'

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/version_strategy.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/version_strategy.yml
@@ -4,3 +4,5 @@ parameters:
 services:
     pim_enrich.version_strategy:
         class: '%pim_enrich.version_strategy.class%'
+        arguments:
+            - '@pim_catalog.version_provider'

--- a/src/Pim/Bundle/EnrichBundle/Resources/views/index.html.twig
+++ b/src/Pim/Bundle/EnrichBundle/Resources/views/index.html.twig
@@ -5,7 +5,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <link rel="shortcut icon" href="favicon.ico" />
 
-        <link rel="stylesheet" href="{{asset('css/pim.css')}}"/>
+        <link rel="stylesheet" href="{{asset('css/pim.css', 'frontend')}}"/>
 
         <script type="text/javascript" src="{{asset('dist/manifest.min.js', 'frontend')}} "></script>
         <script type="text/javascript" src="{{asset('dist/lib.min.js', 'frontend')}} "></script>

--- a/src/Pim/Bundle/EnrichBundle/Resources/views/index.html.twig
+++ b/src/Pim/Bundle/EnrichBundle/Resources/views/index.html.twig
@@ -4,12 +4,13 @@
         <title>Loading...</title>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <link rel="shortcut icon" href="favicon.ico" />
-        <link rel="stylesheet" href="css/pim.css"/>
 
-        <script type="text/javascript" src="{{asset('dist/manifest.min.js')}} "></script>
-        <script type="text/javascript" src="{{asset('dist/lib.min.js')}} "></script>
-        <script type="text/javascript" src="{{asset('dist/vendor.min.js')}} "></script>
-        <script type="text/javascript" src="{{asset('dist/main.min.js')}} "></script>
+        <link rel="stylesheet" href="{{asset('css/pim.css')}}"/>
+
+        <script type="text/javascript" src="{{asset('dist/manifest.min.js', 'frontend')}} "></script>
+        <script type="text/javascript" src="{{asset('dist/lib.min.js', 'frontend')}} "></script>
+        <script type="text/javascript" src="{{asset('dist/vendor.min.js', 'frontend')}} "></script>
+        <script type="text/javascript" src="{{asset('dist/main.min.js', 'frontend')}} "></script>
     </head>
     <body>
         <div class="app">

--- a/src/Pim/Bundle/EnrichBundle/VersionStrategy/CacheBusterVersionStrategy.php
+++ b/src/Pim/Bundle/EnrichBundle/VersionStrategy/CacheBusterVersionStrategy.php
@@ -2,16 +2,32 @@
 
 namespace Pim\Bundle\EnrichBundle\VersionStrategy;
 
-use Pim\Bundle\CatalogBundle\Version;
+use Pim\Bundle\CatalogBundle\VersionProviderInterface;
 use Symfony\Component\Asset\VersionStrategy\VersionStrategyInterface;
 
 class CacheBusterVersionStrategy implements VersionStrategyInterface
 {
-    public function getVersion($path)
-    {
-        return Version::VERSION;
+    /** @var VersionProviderInterface */
+    protected $versionProvider;
+
+    /**
+     * @param VersionProviderInterface $versionProvider
+     */
+    public function __construct(VersionProviderInterface $versionProvider) {
+        $this->versionProvider = $versionProvider;
     }
 
+    /**
+     * @param string $path
+     */
+    public function getVersion($path)
+    {
+        return $this->versionProvider->getPatch();
+    }
+
+    /**
+     * @param string $path
+     */
     public function applyVersion($path)
     {
         $version = $this->getVersion($path);

--- a/src/Pim/Bundle/EnrichBundle/VersionStrategy/CacheBusterVersionStrategy.php
+++ b/src/Pim/Bundle/EnrichBundle/VersionStrategy/CacheBusterVersionStrategy.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Pim\Bundle\EnrichBundle\VersionStrategy;
+
+use Pim\Bundle\CatalogBundle\Version;
+use Symfony\Component\Asset\VersionStrategy\VersionStrategyInterface;
+
+class CacheBusterVersionStrategy implements VersionStrategyInterface
+{
+    public function getVersion($path)
+    {
+        return Version::VERSION;
+    }
+
+    public function applyVersion($path)
+    {
+        $version = $this->getVersion($path);
+
+        if ('' === $version) {
+            return $path;
+        }
+
+        $versioned = sprintf('%s?%s', ltrim($path, '/'), $version);
+
+        if ($path && '/' === $path[0]) {
+            return '/'.$versioned;
+        }
+
+        return $versioned;
+    }
+}

--- a/src/Pim/Bundle/EnrichBundle/VersionStrategy/CacheBusterVersionStrategy.php
+++ b/src/Pim/Bundle/EnrichBundle/VersionStrategy/CacheBusterVersionStrategy.php
@@ -13,7 +13,8 @@ class CacheBusterVersionStrategy implements VersionStrategyInterface
     /**
      * @param VersionProviderInterface $versionProvider
      */
-    public function __construct(VersionProviderInterface $versionProvider) {
+    public function __construct(VersionProviderInterface $versionProvider)
+    {
         $this->versionProvider = $versionProvider;
     }
 

--- a/src/Pim/Bundle/EnrichBundle/VersionStrategy/CacheBusterVersionStrategy.php
+++ b/src/Pim/Bundle/EnrichBundle/VersionStrategy/CacheBusterVersionStrategy.php
@@ -31,16 +31,10 @@ class CacheBusterVersionStrategy implements VersionStrategyInterface
      */
     public function applyVersion($path)
     {
-        $version = $this->getVersion($path);
+        $versioned = sprintf('%s?%s', ltrim($path, DIRECTORY_SEPARATOR), $this->getVersion($path));
 
-        if ('' === $version) {
-            return $path;
-        }
-
-        $versioned = sprintf('%s?%s', ltrim($path, '/'), $version);
-
-        if ($path && '/' === $path[0]) {
-            return '/'.$versioned;
+        if ($path && DIRECTORY_SEPARATOR == $path[0]) {
+            return DIRECTORY_SEPARATOR.$versioned;
         }
 
         return $versioned;

--- a/src/Pim/Bundle/EnrichBundle/spec/VersionStrategy/CacheBusterVersionStrategySpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/VersionStrategy/CacheBusterVersionStrategySpec.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace spec\Pim\Bundle\EnrichBundle\VersionStrategy;
+
+use Pim\Bundle\EnrichBundle\VersionStrategy\CacheBusterVersionStrategy;
+use Pim\Bundle\CatalogBundle\VersionProviderInterface;
+use Symfony\Component\Asset\VersionStrategy\VersionStrategyInterface;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class CacheBusterVersionStrategySpec extends ObjectBehavior
+{
+    public function let(VersionProviderInterface $versionProvider) {
+        $this->beConstructedWith($versionProvider);
+    }
+
+    public function it_is_initializable()
+    {
+        $this->shouldHaveType('Pim\Bundle\EnrichBundle\VersionStrategy\CacheBusterVersionStrategy');
+    }
+
+    public function it_returns_the_pim_patch_version($versionProvider)
+    {
+        $versionProvider->getPatch()->willReturn('2.0.1');
+
+        $this->getVersion('')->shouldReturn('2.0.1');
+    }
+
+    public function it_returns_the_versioned_asset_path($versionProvider)
+    {
+        $versionProvider->getPatch()->willReturn('2.0.2');
+
+        $this->applyVersion('css/pim.css')->shouldReturn('css/pim.css?2.0.2');
+    }
+
+    public function it_returns_the_versioned_asset_path_with_leading_slash($versionProvider)
+    {
+        $versionProvider->getPatch()->willReturn('1.7.8');
+
+        $this->applyVersion('/js/main.dist.js')->shouldReturn('/js/main.dist.js?1.7.8');
+    }
+}


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This PR adds a version strategy for our JS and CSS assets so that we can bust the cache when we release a patch version. 

E.g. 
`<script type="text/javascript" src="/dist/manifest.min.js"></script>` becomes
`<script type="text/javascript" src="/dist/manifest.min.js?2.0.1 "></script>`

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
