### PR TITLE
API-395: Get list of product models through API

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -3,10 +3,8 @@
 ## Tech improvements
 
 - TIP-808: Add version strategy for js and css assets
-
-## Better manage products with variants!
-
-- PIM-6343: Classify product models via the edit form
+- PRE_SAVE and POST_SAVE events dispatched by instances of BaseSaver now include an "is_new" argument indicating if entities are being inserted or updated.
+- API-395: Get list of product models via API
 
 ## Bug Fixes
 
@@ -24,21 +22,15 @@
 
 ## Better manage products with variants!
 
+- PIM-6343: Classify product models via the edit form
 - PIM-6346: Add history on product model edit page
 - PIM-6863: Hide "Variant" meta in non variant products
 
 ## BC breaks
 
-- Change constructor of `Pim\Bundle\EnrichBundle\Controller\ProductController` to add `Oro\Bundle\SecurityBundle\SecurityFacade`, an acl and a template 
-
-## Tech improvements
-
-- PRE_SAVE and POST_SAVE events dispatched by instances of BaseSaver now include an "is_new" argument indicating if entities are being inserted or updated.
-
-## BC breaks
-
 - Change the constructor of `Pim\Bundle\EnrichBundle\Controller\Rest\AttributeGroupController` to add dependencies to `Symfony\Component\EventDispatcher\EventDispatcherInterface` and `Pim\Bundle\CatalogBundle\Filter\CollectionFilterInterface`
 - Change the constructor of `Pim\Bundle\EnrichBundle\Controller\Rest\JobInstanceController` to add dependencies to `Symfony\Component\EventDispatcher\EventDispatcherInterface` and `Pim\Bundle\CatalogBundle\Filter\CollectionFilterInterface`
+- Change constructor of `Pim\Bundle\EnrichBundle\Controller\ProductController` to add `Oro\Bundle\SecurityBundle\SecurityFacade`, an acl and a template 
 
 # 2.0.1 (2017-10-05)
 

--- a/src/Pim/Bundle/ApiBundle/Controller/ProductController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/ProductController.php
@@ -687,6 +687,8 @@ class ProductController
      * @param array                 $normalizerOptions
      *
      * @throws UnprocessableEntityHttpException
+     * @throws DocumentedHttpException
+     * @throws ServerErrorResponseException
      *
      * @return array
      */

--- a/src/Pim/Bundle/ApiBundle/Controller/ProductModelController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/ProductModelController.php
@@ -4,10 +4,21 @@ declare(strict_types=1);
 
 namespace Pim\Bundle\ApiBundle\Controller;
 
+use Elasticsearch\Common\Exceptions\ServerErrorResponseException;
+use Pim\Bundle\ApiBundle\Documentation;
+use Pim\Component\Api\Exception\DocumentedHttpException;
+use Pim\Component\Api\Exception\PaginationParametersException;
+use Pim\Component\Api\Pagination\PaginationTypes;
+use Pim\Component\Api\Pagination\PaginatorInterface;
+use Pim\Component\Api\Pagination\ParameterValidatorInterface;
+use Pim\Component\Api\Security\PrimaryKeyEncrypter;
 use Pim\Component\Catalog\Query\Filter\Operators;
 use Pim\Component\Catalog\Query\ProductQueryBuilderFactoryInterface;
+use Pim\Component\Catalog\Query\Sorter\Directions;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
@@ -20,19 +31,61 @@ class ProductModelController
     /** @var ProductQueryBuilderFactoryInterface */
     protected $pqbFactory;
 
+    /** @var ProductQueryBuilderFactoryInterface */
+    protected $pqbFromSizeFactory;
+
+    /** @var ProductQueryBuilderFactoryInterface */
+    protected $pqbSearchAfterFactory;
+
     /** @var NormalizerInterface */
     protected $normalizer;
 
+    /** @var ParameterValidatorInterface */
+    protected $parameterValidator;
+
+    /** @var PaginatorInterface */
+    protected $offsetPaginator;
+
+    /** @var PaginatorInterface */
+    protected $searchAfterPaginator;
+
+    /** @var PrimaryKeyEncrypter */
+    protected $primaryKeyEncrypter;
+
+    /** @var array */
+    protected $apiConfiguration;
+
     /**
      * @param ProductQueryBuilderFactoryInterface $pqbFactory
+     * @param ProductQueryBuilderFactoryInterface $pqbFromSizeFactory
+     * @param ProductQueryBuilderFactoryInterface $pqbSearchAfterFactory
      * @param NormalizerInterface                 $normalizer
+     * @param ParameterValidatorInterface         $parameterValidator
+     * @param PaginatorInterface                  $offsetPaginator
+     * @param PaginatorInterface                  $searchAfterPaginator
+     * @param PrimaryKeyEncrypter                 $primaryKeyEncrypter
+     * @param array                               $apiConfiguration
      */
     public function __construct(
         ProductQueryBuilderFactoryInterface $pqbFactory,
-        NormalizerInterface $normalizer
+        ProductQueryBuilderFactoryInterface $pqbFromSizeFactory,
+        ProductQueryBuilderFactoryInterface $pqbSearchAfterFactory,
+        NormalizerInterface $normalizer,
+        ParameterValidatorInterface $parameterValidator,
+        PaginatorInterface $offsetPaginator,
+        PaginatorInterface $searchAfterPaginator,
+        PrimaryKeyEncrypter $primaryKeyEncrypter,
+        array $apiConfiguration
     ) {
-        $this->pqbFactory = $pqbFactory;
-        $this->normalizer = $normalizer;
+        $this->pqbFactory            = $pqbFactory;
+        $this->pqbFromSizeFactory    = $pqbFromSizeFactory;
+        $this->pqbSearchAfterFactory = $pqbSearchAfterFactory;
+        $this->normalizer            = $normalizer;
+        $this->parameterValidator    = $parameterValidator;
+        $this->offsetPaginator       = $offsetPaginator;
+        $this->searchAfterPaginator  = $searchAfterPaginator;
+        $this->primaryKeyEncrypter   = $primaryKeyEncrypter;
+        $this->apiConfiguration      = $apiConfiguration;
     }
 
     /**
@@ -55,5 +108,139 @@ class ProductModelController
         $productModelApi = $this->normalizer->normalize($productModels->current(), 'standard');
 
         return new JsonResponse($productModelApi);
+    }
+
+    /**
+     * @param Request $request
+     *
+     * @throws UnprocessableEntityHttpException
+     *
+     * @return JsonResponse
+     */
+    public function listAction(Request $request): JsonResponse
+    {
+        try {
+            $this->parameterValidator->validate($request->query->all(), ['support_search_after' => true]);
+        } catch (PaginationParametersException $e) {
+            throw new UnprocessableEntityHttpException($e->getMessage(), $e);
+        }
+
+        $queryParameters = array_merge(
+            [
+                'pagination_type' => PaginationTypes::OFFSET,
+                'limit' => $this->apiConfiguration['pagination']['limit_by_default'],
+            ],
+            $request->query->all()
+        );
+
+        $paginatedProductModels = PaginationTypes::OFFSET === $queryParameters['pagination_type'] ?
+            $this->listOffset($queryParameters) :
+            $this->listSearchAfter($queryParameters);
+
+        return new JsonResponse($paginatedProductModels);
+    }
+
+    /**
+     * Get list of product models using 'offset' pagination mode.
+     *
+     * @param array $queryParameters
+     *
+     * @throws DocumentedHttpException
+     * @throws ServerErrorResponseException
+     *
+     * @return array
+     */
+    protected function listOffset(array $queryParameters)
+    {
+        $from = isset($queryParameters['page']) ? ($queryParameters['page'] - 1) * $queryParameters['limit'] : 0;
+
+        $pqb = $this->pqbFromSizeFactory->create(['limit' => (int) $queryParameters['limit'], 'from' => (int) $from]);
+        $queryParameters = array_merge(['page' => 1, 'with_count' => 'false'], $queryParameters);
+        $pqb->addSorter('id', Directions::ASCENDING);
+        $productModels = $pqb->execute();
+
+        $paginationParameters = [
+            'query_parameters'    => $queryParameters,
+            'list_route_name'     => 'pim_api_product_model_list',
+            'item_route_name'     => 'pim_api_product_model_get',
+            'item_identifier_key' => 'code',
+        ];
+
+        try {
+            $count = 'true' === $queryParameters['with_count'] ? $productModels->count() : null;
+            $paginatedProductModels = $this->offsetPaginator->paginate(
+                $this->normalizer->normalize($productModels, 'standard'),
+                $paginationParameters,
+                $count
+            );
+        } catch (ServerErrorResponseException $e) {
+            $message = json_decode($e->getMessage(), true);
+            if (null !== $message && isset($message['error']['root_cause'][0]['type'])
+                && 'query_phase_execution_exception' === $message['error']['root_cause'][0]['type']) {
+                throw new DocumentedHttpException(
+                    Documentation::URL_DOCUMENTATION . 'pagination.html#search-after-type',
+                    'You have reached the maximum number of pages you can retrieve with the "page" pagination type. Please use the search after pagination type instead',
+                    $e
+                );
+            }
+
+            throw new ServerErrorResponseException($e->getMessage(), $e->getCode(), $e);
+        }
+
+        return $paginatedProductModels;
+    }
+
+    /**
+     * Get list of product models using 'search after' pagination mode.
+     *
+     * @param array $queryParameters
+     *
+     * @return array
+     */
+    protected function listSearchAfter(array $queryParameters)
+    {
+        $pqbOptions = ['limit' => (int) $queryParameters['limit']];
+        $searchParameterCrypted = null;
+        if (isset($queryParameters['search_after'])) {
+            $searchParameterCrypted = $queryParameters['search_after'];
+            $searchParameterDecrypted = $this->primaryKeyEncrypter->decrypt($queryParameters['search_after']);
+            $pqbOptions['search_after_unique_key'] = $searchParameterDecrypted;
+            $pqbOptions['search_after'] = [$searchParameterDecrypted];
+        }
+        $pqb = $this->pqbSearchAfterFactory->create($pqbOptions);
+
+        $pqb->addSorter('id', Directions::ASCENDING);
+        $productModelCursor = $pqb->execute();
+
+        $productModels = [];
+        foreach ($productModelCursor as $productModel) {
+            $productModels[] = $productModel;
+        }
+
+        $lastProductModel = end($productModels);
+        reset($productModels);
+
+        $nextSearchAfter = false !== $lastProductModel ?
+            $this->primaryKeyEncrypter->encrypt($lastProductModel->getId()) :
+            null;
+
+        $parameters = [
+            'query_parameters'    => $queryParameters,
+            'search_after'        => [
+                'next' => $nextSearchAfter,
+                'self' => $searchParameterCrypted,
+            ],
+            'list_route_name'     => 'pim_api_product_model_list',
+            'item_route_name'     => 'pim_api_product_model_get',
+            'item_identifier_key' => 'code',
+        ];
+
+        $paginatedProductModels = $this->searchAfterPaginator->paginate(
+            $this->normalizer->normalize($productModels, 'standard'),
+            $parameters,
+            null
+        );
+
+        return $paginatedProductModels;
     }
 }

--- a/src/Pim/Bundle/ApiBundle/Resources/config/controllers.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/controllers.yml
@@ -163,7 +163,14 @@ services:
         class: '%pim_api.controller.product_model.class%'
         arguments:
             - '@pim_catalog.query.product_model_query_builder_factory'
+            - '@pim_catalog.query.product_model_query_builder_from_size_factory'
+            - '@pim_catalog.query.product_model_query_builder_search_after_size_factory'
             - '@pim_serializer'
+            - '@pim_api.pagination.parameter_validator'
+            - '@pim_api.pagination.offset_hal_paginator'
+            - '@pim_api.pagination.search_after_hal_paginator'
+            - '@pim_api.security.primary_key_encrypter'
+            - '%pim_api.configuration%'
 
     pim_api.controller.root_endpoint:
         class: '%pim_api.controller.root_endpoint.class%'

--- a/src/Pim/Bundle/ApiBundle/Resources/config/routing/product_model.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/routing/product_model.yml
@@ -1,3 +1,8 @@
+pim_api_product_model_list:
+    path: /product-models
+    defaults: { _controller: pim_api.controller.product_model:listAction, _format: json }
+    methods: [GET]
+
 pim_api_product_model_get:
     path: /product-models/{code}
     defaults: { _controller: pim_api.controller.product_model:getAction, _format: json }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/AbstractProductTestCase.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/AbstractProductTestCase.php
@@ -50,7 +50,7 @@ abstract class AbstractProductTestCase extends ApiTestCase
     }
 
     /**
-     * @param array  $data
+     * @param array $data
      *
      * @return ProductModelInterface
      */

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessLargeAndOrderedListProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessLargeAndOrderedListProductIntegration.php
@@ -4,7 +4,6 @@ namespace Pim\Bundle\ApiBundle\tests\integration\Controller\Product;
 
 use Akeneo\Test\Integration\Configuration;
 use Pim\Component\Catalog\Model\ProductInterface;
-use Symfony\Component\HttpFoundation\Response;
 
 /**
  * We want to test the API is capable of returning an ordered list of 100 items.

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/ProductModel/AbstractProductModelTestCase.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/ProductModel/AbstractProductModelTestCase.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Pim\Bundle\ApiBundle\tests\integration\Controller\ProductModel;
+
+use Akeneo\Test\Integration\Configuration;
+use Pim\Bundle\ApiBundle\tests\integration\Controller\Product\AbstractProductTestCase;
+
+class AbstractProductModelTestCase extends AbstractProductTestCase
+{
+    /** @var string[] */
+    protected $productModelCodes;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->productModelCodes = ['sweat', 'shoes', 'tshirt', 'trousers', 'hat', 'handbag'];
+
+        foreach ($this->productModelCodes as $item) {
+            $this->createProductModel(
+                [
+                    'code' => $item,
+                    'family_variant' => 'familyVariantA1',
+                    'values'  => [
+                        'a_price'  => [
+                            'data' => [
+                                'data' => [['amount' => '50', 'currency' => 'EUR']],
+                                'locale' => null,
+                                'scope' => null
+                            ],
+                        ],
+                        'a_number_float'  => [['data' => '12.5', 'locale' => null, 'scope' => null]],
+                        'a_localized_and_scopable_text_area'  => [
+                            ['data' => sprintf('I like %s!', $item), 'locale' => 'en_US', 'scope' => 'ecommerce']
+                        ],
+                    ]
+                ]
+            );
+        }
+    }
+
+    /**
+     * Return product models as JSON standard format
+     *
+     * @return array
+     */
+    protected function getStandardizedProductModels()
+    {
+        $standardizedProductModels = [];
+
+        foreach ($this->productModelCodes as $item) {
+            $standardizedProductModels[$item] = <<<JSON
+{
+    "_links":{
+        "self":{
+            "href":"http:\/\/localhost\/api\/rest\/v1\/product-models\/$item"
+        }
+    },
+    "code":"$item",
+    "family_variant":"familyVariantA1",
+    "parent":null,
+    "categories":[
+
+    ],
+    "values":{
+        "a_price":[
+            {
+                "locale":null,
+                "scope":null,
+                "data":[
+                    {
+                        "amount":"50.00",
+                        "currency":"EUR"
+                    }
+                ]
+            }
+        ],
+        "a_number_float":[
+            {
+                "locale":null,
+                "scope":null,
+                "data":"12.5000"
+            }
+        ],
+        "a_localized_and_scopable_text_area":[
+            {
+                "locale":"en_US",
+                "scope":"ecommerce",
+                "data":"I like $item!"
+            }
+        ]
+    },
+    "created":"2017-10-04T18:04:10+02:00",
+    "updated":"2017-10-04T18:04:10+02:00"
+}
+JSON;
+        }
+
+        return $standardizedProductModels;
+    }
+
+    /**
+     * @return Configuration
+     */
+    protected function getConfiguration()
+    {
+        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+    }
+}

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/ProductModel/LargeAndOrderedListProductModelIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/ProductModel/LargeAndOrderedListProductModelIntegration.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Pim\Bundle\ApiBundle\tests\integration\Controller\ProductModel;
+
+use Akeneo\Test\Integration\Configuration;
+use Pim\Bundle\ApiBundle\tests\integration\Controller\Product\AbstractProductTestCase;
+use Pim\Component\Catalog\Model\ProductModelInterface;
+
+class LargeAndOrderedListProductModelIntegration extends AbstractProductTestCase
+{
+    /** @var ProductModelInterface[] */
+    private $productModels;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->get('akeneo_elasticsearch.client.product_model')->resetIndex();
+
+        $data = [];
+        for ($i = 0; $i < $this->getListSize(); $i++) {
+            $data[] = [
+                'code' => 'model-' . str_pad($i, 4, '0', STR_PAD_LEFT),
+                'family_variant' => 'familyVariantA1'
+            ];
+        }
+
+        foreach ($data as $model) {
+            $productModel = $this->createProductModel($model);
+            $this->productModels[$productModel->getId()] = $productModel;
+        }
+
+        // the API will return products sorted alphabetical by MySQL ID, and that's what we expect
+        // for instance, if we have 100 products
+        // 1, 10, 100, 11, 12, 13, 14, 15, 16, 17, 18, 19, 2, 20, 21...
+        ksort($this->productModels, SORT_STRING);
+    }
+
+    public function testPaginationAllProductModels()
+    {
+        $standardizedProductModels = [];
+        foreach ($this->productModels as $productModel) {
+            $standardizedProductModels[] = $this->getStandardizedProductModel($productModel->getCode());
+        }
+        $standardizedProductModels = implode(',', $standardizedProductModels);
+        $lastEncryptedId = rawurlencode($this->getEncryptedId(end($this->productModels)));
+
+        $client = $this->createAuthenticatedClient();
+        $client->request('GET', 'api/rest/v1/product-models?limit=100&pagination_type=search_after');
+        $expected = <<<JSON
+{
+    "_links": {
+        "self"  : {"href": "http://localhost/api/rest/v1/product-models?pagination_type=search_after&limit=100"},
+        "first" : {"href": "http://localhost/api/rest/v1/product-models?pagination_type=search_after&limit=100"},
+        "next" : {"href": "http://localhost/api/rest/v1/product-models?pagination_type=search_after&limit=100&search_after={$lastEncryptedId}"}
+    },
+    "_embedded"    : {
+		"items": [
+            {$standardizedProductModels}
+		]
+    }
+}
+JSON;
+
+        $this->assertListResponse($client->getResponse(), $expected);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return new Configuration([Configuration::getTechnicalSqlCatalogPath()]);
+    }
+
+    /**
+     * @param string $code
+     *
+     * @return string
+     */
+    private function getStandardizedProductModel($code)
+    {
+        $standardized = <<<JSON
+{
+    "_links":{
+        "self":{
+            "href":"http:\/\/localhost\/api\/rest\/v1\/product-models\/$code"
+        }
+    },
+    "code":"$code",
+    "family_variant":"familyVariantA1",
+    "parent":null,
+    "categories":[],
+    "values":{},
+    "created":"2017-10-04T18:04:10+02:00",
+    "updated":"2017-10-04T18:04:10+02:00"
+}
+JSON;
+
+        return $standardized;
+    }
+
+    /**
+     * @param ProductModelInterface $productModel
+     *
+     * @return string
+     */
+    private function getEncryptedId(ProductModelInterface $productModel)
+    {
+        $encrypter = $this->get('pim_api.security.primary_key_encrypter');
+
+        return $encrypter->encrypt($productModel->getId());
+    }
+
+    /**
+     * We want to test the API is capable of returning a list of 100 items.
+     * (Twice the page of the cursor).
+     *
+     * @return int
+     */
+    private function getListSize()
+    {
+        $cursorPageSize = (int)$this->getParameter('pim_catalog.factory.product_cursor.page_size');
+
+        return $cursorPageSize * 2;
+    }
+}

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/ProductModel/ListOffsetProductModelIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/ProductModel/ListOffsetProductModelIntegration.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace Pim\Bundle\ApiBundle\tests\integration\Controller\ProductModel;
+
+use Symfony\Component\HttpFoundation\Response;
+
+class ListOffsetProductModelIntegration extends AbstractProductModelTestCase
+{
+    public function testSuccessfullyGetListOfProductModelWithoutParameter()
+    {
+        $client = $this->createAuthenticatedClient();
+        $client->request('GET', 'api/rest/v1/product-models');
+
+        $standardizedProducts = $this->getStandardizedProductModels();
+        $expected = <<<JSON
+{
+    "_links": {
+        "self"  : {"href": "http://localhost/api/rest/v1/product-models?page=1&with_count=false&pagination_type=page&limit=10"},
+        "first" : {"href": "http://localhost/api/rest/v1/product-models?page=1&with_count=false&pagination_type=page&limit=10"}
+    },
+    "current_page" : 1,
+    "_embedded"    : {
+		"items": [
+            {$standardizedProducts['sweat']},
+            {$standardizedProducts['shoes']},
+            {$standardizedProducts['tshirt']},
+            {$standardizedProducts['trousers']},
+            {$standardizedProducts['hat']},
+            {$standardizedProducts['handbag']}
+		]
+    }
+}
+JSON;
+
+        $this->assertListResponse($client->getResponse(), $expected);
+    }
+
+    public function testSuccessfullyGetListOfProductModelFirstPageWithCount()
+    {
+        $client = $this->createAuthenticatedClient();
+        $client->request('GET', 'api/rest/v1/product-models?with_count=true&limit=3');
+
+        $standardizedProducts = $this->getStandardizedProductModels();
+        $expected = <<<JSON
+{
+    "_links": {
+        "self"  : {"href": "http://localhost/api/rest/v1/product-models?page=1&with_count=true&pagination_type=page&limit=3"},
+        "first" : {"href": "http://localhost/api/rest/v1/product-models?page=1&with_count=true&pagination_type=page&limit=3"},
+        "next"  : {"href": "http://localhost/api/rest/v1/product-models?page=2&with_count=true&pagination_type=page&limit=3"}
+    },
+    "current_page" : 1,
+    "items_count"  : 6,
+    "_embedded"    : {
+		"items": [
+            {$standardizedProducts['sweat']},
+            {$standardizedProducts['shoes']},
+            {$standardizedProducts['tshirt']}
+		]
+    }
+}
+JSON;
+
+        $this->assertListResponse($client->getResponse(), $expected);
+    }
+
+    public function testSuccessfullyGetListOfProductModelFirstPageWithoutCount()
+    {
+        $client = $this->createAuthenticatedClient();
+        $client->request('GET', 'api/rest/v1/product-models?with_count=false&limit=3');
+
+        $standardizedProducts = $this->getStandardizedProductModels();
+        $expected = <<<JSON
+{
+    "_links": {
+        "self"  : {"href": "http://localhost/api/rest/v1/product-models?page=1&with_count=false&pagination_type=page&limit=3"},
+        "first" : {"href": "http://localhost/api/rest/v1/product-models?page=1&with_count=false&pagination_type=page&limit=3"},
+        "next"  : {"href": "http://localhost/api/rest/v1/product-models?page=2&with_count=false&pagination_type=page&limit=3"}
+    },
+    "current_page" : 1,
+    "_embedded"    : {
+		"items": [
+            {$standardizedProducts['sweat']},
+            {$standardizedProducts['shoes']},
+            {$standardizedProducts['tshirt']}
+		]
+    }
+}
+JSON;
+
+        $this->assertListResponse($client->getResponse(), $expected);
+    }
+
+    public function testSuccessfullyGetListOfProductModelLastPageWithCount()
+    {
+        $client = $this->createAuthenticatedClient();
+        $client->request('GET', 'api/rest/v1/product-models?with_count=true&limit=3&page=2');
+
+        $standardizedProducts = $this->getStandardizedProductModels();
+        $expected = <<<JSON
+{
+    "_links": {
+        "self"  : {"href": "http://localhost/api/rest/v1/product-models?page=2&with_count=true&pagination_type=page&limit=3"},
+        "first" : {"href": "http://localhost/api/rest/v1/product-models?page=1&with_count=true&pagination_type=page&limit=3"},
+        "previous" : {"href": "http://localhost/api/rest/v1/product-models?page=1&with_count=true&pagination_type=page&limit=3"},
+        "next"  : {"href": "http://localhost/api/rest/v1/product-models?page=3&with_count=true&pagination_type=page&limit=3"}
+    },
+    "current_page" : 2,
+    "items_count"  : 6,
+    "_embedded"    : {
+		"items": [
+            {$standardizedProducts['trousers']},
+            {$standardizedProducts['hat']},
+            {$standardizedProducts['handbag']}
+		]
+    }
+}
+JSON;
+
+        $this->assertListResponse($client->getResponse(), $expected);
+    }
+
+    public function testSuccessfullyGetListOfProductModelOutOfRange()
+    {
+        $client = $this->createAuthenticatedClient();
+        $client->request('GET', 'api/rest/v1/product-models?with_count=true&page=2');
+
+        $expected = <<<JSON
+{
+    "_links": {
+        "self" : {"href" : "http://localhost/api/rest/v1/product-models?page=2&with_count=true&pagination_type=page&limit=10"},
+        "first" : {"href" : "http://localhost/api/rest/v1/product-models?page=1&with_count=true&pagination_type=page&limit=10"},
+        "previous" : {"href" : "http://localhost/api/rest/v1/product-models?page=1&with_count=true&pagination_type=page&limit=10"}
+    },
+    "current_page" : 2,
+    "items_count"  : 6,
+    "_embedded"    : {
+		"items": []
+    }
+}
+JSON;
+
+        $this->assertListResponse($client->getResponse(), $expected);
+    }
+
+    public function testUnknownPaginationType()
+    {
+        $client = $this->createAuthenticatedClient();
+        $client->request('GET', 'api/rest/v1/product-models?pagination_type=unknown');
+        $response = $client->getResponse();
+
+        $expected = sprintf(
+            '{"code":%d,"message":"%s"}',
+            Response::HTTP_UNPROCESSABLE_ENTITY,
+            addslashes('Pagination type does not exist.')
+        );
+
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertSame($expected, $response->getContent());
+    }
+
+    public function testMaxPageWithOffsetPaginationType()
+    {
+        $client = $this->createAuthenticatedClient([], [], null, null, 'mary', 'mary');
+
+        $productModels = [];
+        for ($i = 0; $i <= 10001; $i++) {
+            $productModel = $this->get('pim_catalog.factory.product_model')->create();
+            $this->get('pim_catalog.updater.product_model')
+                ->update($productModel, [
+                    'code' => 'prod-model-' . $i,
+                    'family_variant' => 'familyVariantA1'
+                ]);
+            $productModels[] = $productModel;
+        }
+
+        $this->get('pim_catalog.saver.product_model')->saveAll($productModels);
+        $this->get('akeneo_elasticsearch.client.product_model')->refreshIndex();
+
+        $client->request('GET', 'api/rest/v1/product-models?page=101&limit=100');
+
+        $message = addslashes('You have reached the maximum number of pages you can retrieve with the "page" pagination type. Please use the search after pagination type instead');
+        $expected = <<<JSON
+{
+    "code":422,
+    "message":"${message}",
+    "_links":{
+        "documentation":{
+            "href": "http:\/\/api.akeneo.com\/documentation\/pagination.html#search-after-type"
+        }
+    }
+}
+JSON;
+
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $client->getResponse()->getStatusCode());
+        $this->assertJsonStringEqualsJsonString($expected, $client->getResponse()->getContent());
+    }
+}

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/ProductModel/ListSearchAfterProductModelIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/ProductModel/ListSearchAfterProductModelIntegration.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Pim\Bundle\ApiBundle\tests\integration\Controller\ProductModel;
+
+class ListSearchAfterProductModelIntegration extends AbstractProductModelTestCase
+{
+    public function testSearchAfterPaginationListProductModelsWithoutParameter()
+    {
+        $standardizedProducts = $this->getStandardizedProductModels();
+        $client = $this->createAuthenticatedClient();
+
+        $client->request('GET', 'api/rest/v1/product-models?pagination_type=search_after');
+        $expected = <<<JSON
+{
+    "_links": {
+        "self"  : {"href": "http://localhost/api/rest/v1/product-models?pagination_type=search_after&limit=10"},
+        "first" : {"href": "http://localhost/api/rest/v1/product-models?pagination_type=search_after&limit=10"}
+    },
+    "_embedded" : {
+        "items" : [
+            {$standardizedProducts['sweat']},
+            {$standardizedProducts['shoes']},
+            {$standardizedProducts['tshirt']},
+            {$standardizedProducts['trousers']},
+            {$standardizedProducts['hat']},
+            {$standardizedProducts['handbag']}
+        ]
+    }
+}
+JSON;
+
+        $this->assertListResponse($client->getResponse(), $expected);
+    }
+
+    public function testSearchAfterPaginationListProductModelsWithNextLink()
+    {
+        $standardizedProducts = $this->getStandardizedProductModels();
+        $client = $this->createAuthenticatedClient();
+
+        $id = [
+            'sweat'    => rawurlencode($this->getEncryptedId('sweat')),
+            'shoes'    => rawurlencode($this->getEncryptedId('shoes')),
+            'trousers' => rawurlencode($this->getEncryptedId('trousers'))
+        ];
+
+        $client->request('GET', sprintf('api/rest/v1/product-models?pagination_type=search_after&limit=3&search_after=%s', $id['sweat']));
+        $expected = <<<JSON
+{
+    "_links": {
+        "self"  : {"href": "http://localhost/api/rest/v1/product-models?pagination_type=search_after&limit=3&search_after={$id['sweat']}"},
+        "first" : {"href": "http://localhost/api/rest/v1/product-models?pagination_type=search_after&limit=3"},
+        "next"  : {"href": "http://localhost/api/rest/v1/product-models?pagination_type=search_after&limit=3&search_after={$id['trousers']}"}
+    },
+    "_embedded"    : {
+        "items" : [
+            {$standardizedProducts['shoes']},
+            {$standardizedProducts['tshirt']},
+            {$standardizedProducts['trousers']}
+        ]
+    }
+}
+JSON;
+
+        $this->assertListResponse($client->getResponse(), $expected);
+    }
+
+    public function testSearchAfterPaginationLastPageOfTheListOfProductModels()
+    {
+        $standardizedProducts = $this->getStandardizedProductModels();
+        $client = $this->createAuthenticatedClient();
+
+        $tshirtEncryptedId = rawurlencode($this->getEncryptedId('tshirt'));
+
+        $client->request('GET', sprintf('api/rest/v1/product-models?pagination_type=search_after&limit=4&search_after=%s' , $tshirtEncryptedId));
+        $expected = <<<JSON
+{
+    "_links": {
+        "self"  : {"href": "http://localhost/api/rest/v1/product-models?pagination_type=search_after&limit=4&search_after={$tshirtEncryptedId}"},
+        "first" : {"href": "http://localhost/api/rest/v1/product-models?pagination_type=search_after&limit=4"}
+    },
+    "_embedded"    : {
+        "items" : [
+            {$standardizedProducts['trousers']},
+            {$standardizedProducts['hat']},
+            {$standardizedProducts['handbag']}
+        ]
+    }
+}
+JSON;
+
+        $this->assertListResponse($client->getResponse(), $expected);
+    }
+
+    /**
+     * @param string $productModelIdentifier
+     */
+    private function getEncryptedId($productModelIdentifier)
+    {
+        $encrypter = $this->get('pim_api.security.primary_key_encrypter');
+        $repository = $this->get('pim_catalog.repository.product_model');
+
+        $productModel = $repository->findOneByIdentifier($productModelIdentifier);
+
+        return $encrypter->encrypt($productModel->getId());
+    }
+}

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/RootEndpointIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/RootEndpointIntegration.php
@@ -235,6 +235,10 @@ class RootEndpointIntegration extends ApiTestCase
             "pim_api_family_variant_list": {
                 "route": "/api/rest/v1/families/{familyCode}/variants",
                 "methods": ["GET"]
+            },
+            "pim_api_product_model_list": {
+                "route": "/api/rest/v1/product-models",
+                "methods": ["GET"]
             }
         }
     }

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/cursors.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/cursors.yml
@@ -47,3 +47,23 @@ services:
             - '%akeneo_elasticsearch.cursor.cursor.class%'
             - '%pim_catalog.factory.product_cursor.page_size%'
             - 'pim_catalog_product'
+
+    pim_catalog.factory.product_model_from_size_cursor:
+        class: '%akeneo_elasticsearch.cursor.from_size_cursor_factory.class%'
+        arguments:
+            - '@akeneo_elasticsearch.client.product_model'
+            - '@pim_catalog.object_manager.product'
+            - '%pim_catalog.entity.product_model.class%'
+            - '%akeneo_elasticsearch.cursor.from_size_cursor.class%'
+            - '%pim_catalog.factory.product_cursor.page_size%'
+            - 'pim_catalog_product'
+
+    pim_catalog.factory.product_model_search_after_size_cursor:
+        class: '%akeneo_elasticsearch.cursor.search_after_size_cursor_factory.class%'
+        arguments:
+            - '@akeneo_elasticsearch.client.product_model'
+            - '@pim_catalog.object_manager.product'
+            - '%pim_catalog.entity.product_model.class%'
+            - '%akeneo_elasticsearch.cursor.search_after_size_cursor.class%'
+            - '%pim_catalog.factory.product_cursor.page_size%'
+            - 'pim_catalog_product'

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
@@ -83,6 +83,26 @@ services:
             - '@pim_catalog.factory.product_model_cursor'
             - '@pim_catalog.query.product_query_builder_resolver'
 
+    pim_catalog.query.product_model_query_builder_from_size_factory:
+        class: '%pim_catalog.query.elasticsearch.product_query_builder_factory.class%'
+        arguments:
+            - '%pim_catalog.query.product_query_builder.class%'
+            - '@pim_catalog.repository.attribute'
+            - '@pim_catalog.query.filter.registry'
+            - '@pim_catalog.query.sorter.registry'
+            - '@pim_catalog.factory.product_model_from_size_cursor'
+            - '@pim_catalog.elasticsearch.product_query_builder_from_size_resolver'
+
+    pim_catalog.query.product_model_query_builder_search_after_size_factory:
+        class: '%pim_catalog.query.elasticsearch.product_query_builder_factory.class%'
+        arguments:
+            - '%pim_catalog.query.product_query_builder.class%'
+            - '@pim_catalog.repository.attribute'
+            - '@pim_catalog.query.filter.registry'
+            - '@pim_catalog.query.sorter.registry'
+            - '@pim_catalog.factory.product_model_search_after_size_cursor'
+            - '@pim_catalog.elasticsearch.product_query_builder_search_after_resolver'
+
     pim_catalog.query.product_query_builder_resolver:
         class: '%pim_catalog.query.product_query_builder_resolver.class%'
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Add in API a route to get list of product models using "offset" or "search after" pagination mode.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | OK
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
