### PR TITLE
PIM-6847: Manage product and variant product history on frontend side

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -5,6 +5,10 @@
 - PIM-6865: Fix ACL on import profile page
 - PIM-6876: Escape u001f character to workaround a mysql bug
 
+## Better manage products with variants!
+
+- PIM-6863: Hide "Variant" meta in non variant products
+
 # 2.0.1 (2017-10-05)
 
 ## Bug Fixes

--- a/features/product/display_variant_product.feature
+++ b/features/product/display_variant_product.feature
@@ -1,0 +1,16 @@
+@javascript
+Feature: Display a variant product
+  In order to enrich the catalog
+  As a regular user
+  I need to be able display a variant product with their specific informations
+
+  Background:
+    Given a "catalog_modeling" catalog configuration
+    And I am logged in as "Mary"
+
+  Scenario: I can see the variant meta only in variant products
+    When I am on the "1111111111" product page
+    Then I should see the text "VARIANT"
+    And I should see the text "Clothing by color/size"
+    When I am on the "watch" product page
+    Then I should not see the text "VARIANT"

--- a/features/product/display_variant_product.feature
+++ b/features/product/display_variant_product.feature
@@ -2,7 +2,7 @@
 Feature: Display a variant product
   In order to enrich the catalog
   As a regular user
-  I need to be able display a variant product with their specific informations
+  I need to be able display a variant product with their specific information
 
   Background:
     Given a "catalog_modeling" catalog configuration

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
@@ -160,6 +160,11 @@ config:
                     options:
                         urls:
                             get: pim_enrich_product_history_rest_get
+                variant-product-history:
+                    module: pim/base-fetcher
+                    options:
+                        urls:
+                            get: pim_enrich_variant_product_history_rest_get
                 product:
                     module: pim/product-fetcher
                     options:

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/routing/product.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/routing/product.yml
@@ -55,8 +55,15 @@ pim_enrich_product_category_rest_list:
     methods: [GET]
 
 pim_enrich_product_history_rest_get:
-    path: /rest/{entityId}/history
+    path: /rest/product/{entityId}/history
     defaults: { _controller: pim_enrich.controller.rest.versioning:getAction, entityType: product }
+    requirements:
+        entityId: '[0-9a-f]+'
+    methods: [GET]
+
+pim_enrich_variant_product_history_rest_get:
+    path: /rest/variant-product/{entityId}/history
+    defaults: { _controller: pim_enrich.controller.rest.versioning:getAction, entityType: variant_product }
     requirements:
         entityId: '[0-9a-f]+'
     methods: [GET]

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/routing/product_model.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/routing/product_model.yml
@@ -29,8 +29,8 @@ pim_enrich_product_model_category_rest_list:
     methods: [GET]
 
 pim_enrich_product_model_history_rest_get:
-    path: /rest/{entityId}/history
-    defaults: { _controller: pim_enrich.controller.rest.versioning:getAction, entityType: product }
+    path: /rest/product-model/{entityId}/history
+    defaults: { _controller: pim_enrich.controller.rest.versioning:getAction, entityType: product_model }
     requirements:
         entityId: '[0-9a-f]+'
     methods: [GET]

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/history.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/history.js
@@ -101,8 +101,10 @@ define(
              * Update the history by fetching it from the backend
              */
             update: function () {
-                if (this.getFormData().meta) {
-                    FetcherRegistry.getFetcher('product-history').clear(this.getFormData().meta.id);
+                const entityMeta = this.getFormData().meta;
+
+                if (entityMeta) {
+                    this.getHistoryFetcher(entityMeta).clear(entityMeta.id);
                 }
 
                 this.render();
@@ -114,10 +116,25 @@ define(
              * @return {Promise}
              */
             getVersions: function () {
-                return FetcherRegistry.getFetcher('product-history').fetch(
-                    this.getFormData().meta.id,
-                    { entityId: this.getFormData().meta.id }
+                const entityMeta = this.getFormData().meta;
+
+                return this.getHistoryFetcher(entityMeta).fetch(
+                    entityMeta.id,
+                    { entityId: entityMeta.id }
                 ).then(this.addAttributesLabelToVersions.bind(this));
+            },
+
+            /**
+             * @param {Object} entityMeta
+             *
+             * @returns Fetcher
+             */
+            getHistoryFetcher: function (entityMeta) {
+                if (null !== entityMeta.family_variant) {
+                    return FetcherRegistry.getFetcher('variant-product-history');
+                }
+
+                return FetcherRegistry.getFetcher('product-history');
             },
 
             /**

--- a/src/Pim/Bundle/VersioningBundle/Builder/VersionBuilder.php
+++ b/src/Pim/Bundle/VersioningBundle/Builder/VersionBuilder.php
@@ -5,8 +5,6 @@ namespace Pim\Bundle\VersioningBundle\Builder;
 use Akeneo\Component\Versioning\Model\Version;
 use Doctrine\Common\Util\ClassUtils;
 use Pim\Bundle\VersioningBundle\Factory\VersionFactory;
-use Pim\Component\Catalog\Model\Product;
-use Pim\Component\Catalog\Model\ProductInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
@@ -35,10 +33,7 @@ class VersionBuilder
     }
 
     /**
-     * Builds a version for a versionable entity.
-     *
-     * Products and variant products will both have `Pim\Component\Catalog\Model\Product`
-     * as resource name.
+     * Build a version for a versionable entity
      *
      * @param object       $versionable
      * @param string       $author
@@ -49,8 +44,7 @@ class VersionBuilder
      */
     public function buildVersion($versionable, $author, Version $previousVersion = null, $context = null)
     {
-        $resourceName = $this->getResourceName($versionable);
-
+        $resourceName = ClassUtils::getClass($versionable);
         $resourceId = $versionable->getId();
 
         $versionNumber = $previousVersion ? $previousVersion->getVersion() + 1 : 1;
@@ -70,10 +64,7 @@ class VersionBuilder
     }
 
     /**
-     * Creates a pending version for a versionable entity.
-     *
-     * Products and variant products will both have `Pim\Component\Catalog\Model\Product`
-     * as resource name.
+     * Create a pending version for a versionable entity
      *
      * @param object      $versionable
      * @param string      $author
@@ -84,10 +75,8 @@ class VersionBuilder
      */
     public function createPendingVersion($versionable, $author, array $changeset, $context = null)
     {
-        $resourceName = $this->getResourceName($versionable);
-
         $version = $this->versionFactory->create(
-            $resourceName,
+            ClassUtils::getClass($versionable),
             $versionable->getId(),
             $author,
             $context
@@ -186,19 +175,5 @@ class VersionBuilder
                 return $item['old'] != $item['new'];
             }
         );
-    }
-
-    /**
-     * @param object $versionable
-     *
-     * @return string
-     */
-    protected function getResourceName($versionable)
-    {
-        if ($versionable instanceof ProductInterface) {
-            return Product::class;
-        }
-
-        return ClassUtils::getClass($versionable);
     }
 }

--- a/src/Pim/Bundle/VersioningBundle/EventSubscriber/AddRemoveVersionSubscriber.php
+++ b/src/Pim/Bundle/VersioningBundle/EventSubscriber/AddRemoveVersionSubscriber.php
@@ -9,8 +9,6 @@ use Akeneo\Component\Versioning\Model\VersionableInterface;
 use Doctrine\Common\Util\ClassUtils;
 use Pim\Bundle\VersioningBundle\Factory\VersionFactory;
 use Pim\Bundle\VersioningBundle\Repository\VersionRepositoryInterface;
-use Pim\Component\Catalog\Model\Product;
-use Pim\Component\Catalog\Model\ProductInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
@@ -89,12 +87,12 @@ class AddRemoveVersionSubscriber implements EventSubscriberInterface
         }
 
         $previousVersion = $this->versionRepository->getNewestLogEntry(
-            $this->getRessourceName($subject),
+            ClassUtils::getClass($subject),
             $event->getSubjectId()
         );
 
         $version = $this->versionFactory->create(
-            $this->getRessourceName($subject),
+            ClassUtils::getClass($subject),
             $event->getSubjectId(),
             $author,
             'Deleted'
@@ -106,19 +104,5 @@ class AddRemoveVersionSubscriber implements EventSubscriberInterface
 
         $options = $event->getArguments();
         $this->versionSaver->save($version, $options);
-    }
-
-    /**
-     * @param object $versionable
-     *
-     * @return string
-     */
-    private function getRessourceName($versionable)
-    {
-        if ($versionable instanceof ProductInterface) {
-            return Product::class;
-        }
-
-        return ClassUtils::getClass($versionable);
     }
 }


### PR DESCRIPTION
## Description

A first improvement was made in #6905 to allow variant product history to be displayed. This was done on the backend side, but was not an ideal solution (very dirty in fact).

This PR reverts the development previously made, and replaces it with a full frontend solution.

**Important** The first commit of this PR comes from my previous PR: #6929. I think I just forgot to push it... 😑 

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
