### PR TITLE
Fix category filter IN_LIST_OR_UNCLASSIFIED that does not support multiple usage of it

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/CategoryFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/CategoryFilter.php
@@ -100,21 +100,27 @@ class CategoryFilter extends AbstractFieldFilter implements FieldFilterInterface
                 break;
 
             case Operators::IN_LIST_OR_UNCLASSIFIED:
-                $shouldClauseInList = [
-                    'terms' => [
-                        'categories' => $value
-                    ],
-                ];
-                $shouldClauseUnclassified = [
+                $clause = [
                     'bool' => [
-                        'must_not' => [
-                            'exists' => ['field' => 'categories']
-                        ]
+                        'should' => [
+                            [
+                                'terms' => [
+                                    'categories' => $value
+                                ]
+                            ],
+                            [
+                                'bool' => [
+                                    'must_not' => [
+                                        'exists' => ['field' => 'categories']
+                                    ]
+                                ]
+                            ]
+                        ],
+                        'minimum_should_match' => 1,
                     ]
                 ];
 
-                $this->searchQueryBuilder->addShould($shouldClauseInList);
-                $this->searchQueryBuilder->addShould($shouldClauseUnclassified);
+                $this->searchQueryBuilder->addFilter($clause);
                 break;
             default:
                 throw InvalidOperatorException::notSupported($operator, static::class);

--- a/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Filter/Field/CategoryFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Filter/Field/CategoryFilterSpec.php
@@ -158,23 +158,25 @@ class CategoryFilterSpec extends ObjectBehavior
     ) {
         $categoryRepository->findOneByIdentifier('t-shirt')->willReturn($category);
 
-        $sqb->addShould(
-            [
-                'terms' => [
-                    'categories' => ['t-shirt'],
-                ],
-            ]
-        )->shouldBeCalled();
-
-        $sqb->addShould(
-            [
-                'bool' => [
-                    'must_not' => [
-                        'exists' => ['field' => 'categories'],
+        $sqb->addFilter([
+            'bool' => [
+                'should' => [
+                    [
+                        'terms' => [
+                            'categories' => ['t-shirt']
+                        ]
                     ],
+                    [
+                        'bool' => [
+                            'must_not' => [
+                                'exists' => ['field' => 'categories']
+                            ]
+                        ]
+                    ]
                 ],
+                'minimum_should_match' => 1,
             ]
-        )->shouldBeCalled();
+        ])->shouldBeCalled();
 
         $this->setQueryBuilder($sqb);
         $this->addFieldFilter('categories', Operators::IN_LIST_OR_UNCLASSIFIED, ['t-shirt'], 'en_US', 'ecommerce', []);

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/CategoryFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/CategoryFilterIntegration.php
@@ -57,6 +57,17 @@ class CategoryFilterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assert($result, ['bar', 'baz']);
     }
 
+    public function testOperatorInOrUnclassifiedInTwoDifferentFilters()
+    {
+        $this->createProduct('qux', ['categories' => ['categoryA1']]);
+
+        $result = $this->executeFilter([
+            ['categories', Operators::IN_LIST_OR_UNCLASSIFIED, ['categoryB']],
+            ['categories', Operators::IN_LIST_OR_UNCLASSIFIED, ['categoryA1']]
+        ]);
+        $this->assert($result, ['bar', 'baz', 'foo']);
+    }
+
     public function testOperatorInChildren()
     {
         $result = $this->executeFilter([['categories', Operators::IN_CHILDREN_LIST, ['master']]]);


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

The category filter IN_LIST_OR_UNCLASSIFIED does not work correctly when use multiple times this filter (and it's the case in EE for permission).

We did not discover this bug yet because in EE, the datagrid does not use the PQB filtered by permissions (on purpose?).
This bug is reproducible with the API in EE (every products are returned, even you use a filter IN_LIST_OR_UNCLASSIFIED).

For example, let's say you filter on `categoryA` and then on `categoryB` (in another service, in EE for permissions for example). It should only return product that are in `categoryA` AND in `categoryB` or not in category at all.

- Before this PR:

```
$pqb->addFilter('categories', Operators::IN_LIST_OR_UNCLASSIFIED, ['categoryA']);
$pqb->addFilter('categories', Operators::IN_LIST_OR_UNCLASSIFIED, ['categoryB']);
```
```
{
    "_source": ["identifier"],
	"query": {
		"constant_score": {
			"filter": {
				"bool": {
					"should": [{
						"terms": {
							"categories": ["categoryA"]
						}
					}, {
						"bool": {
							"must_not": {
								"exists": {
									"field": "categories"
								}
							}
						}
					}, {
						"terms": {
							"categories": ["categoryB"]
						}
					}, {
						"bool": {
							"must_not": {
								"exists": {
									"field": "categories"
								}
							}
						}
					}],
					"minimum_should_match": 1
				}
			}
		}
	}
}
```

<=>
`(category IN ('categoryA') or category is NULL or category IN 'categoryB' or category is null`

<=> 
Return products that are in `categoryA` OR in `categoryB`or not in category.

- After this PR:

```
$pqb->addFilter('categories', Operators::IN_LIST_OR_UNCLASSIFIED, ['categoryA']);
$pqb->addFilter('categories', Operators::IN_LIST_OR_UNCLASSIFIED, ['categoryB']);
```
```
{  
   "_source":[  
      "identifier"
   ],
   "query":{  
      "constant_score":{  
         "filter":{  
            "bool":{  
               "filter":[  
                  {  
                     "bool":{  
                        "should":[  
                           {  
                              "terms":{  
                                 "categories":[  
                                    "categoryA"
                                 ]
                              }
                           },
                           {  
                              "bool":{  
                                 "must_not":{  
                                    "exists":{  
                                       "field":"categories"
                                    }
                                 }
                              }
                           }
                        ],
                        "minimum_should_match":1
                     }
                  },
                  {  
                     "bool":{  
                        "should":[  
                           {  
                              "terms":{  
                                 "categories":[  
                                    "categoryB"
                                 ]
                              }
                           },
                           {  
                              "bool":{  
                                 "must_not":{  
                                    "exists":{  
                                       "field":"categories"
                                    }
                                 }
                              }
                           }
                        ],
                        "minimum_should_match":1
                     }
                  }
               ]
            }
         }
      }
   }
}
```

<=>
`(category IN ('categoryA') or category is NULL) AND (category IN 'categoryB' or category is null)`

<=> 
Return products that are in `categoryA` AND  in `categoryB`or not in category.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
