### PR TITLE
 PIM-6346: Add history on product model edit page 

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -21,6 +21,7 @@
 
 ## Better manage products with variants!
 
+- PIM-6346: Add history on product model edit page
 - PIM-6863: Hide "Variant" meta in non variant products
 
 ## BC breaks

--- a/features/Context/Page/ProductModel/Edit.php
+++ b/features/Context/Page/ProductModel/Edit.php
@@ -14,6 +14,9 @@ use Pim\Behat\Decorator\ContextSwitcherDecorator;
  */
 class Edit extends ProductEditForm
 {
+    /** @var string */
+    protected $path = '#/enrich/product-model/{id}';
+
     /**
      * {@inheritdoc}
      */
@@ -34,6 +37,11 @@ class Edit extends ProductEditForm
         );
     }
 
-    /** @var string */
-    protected $path = '#/enrich/product-model/{id}';
+    /**
+     * {@inheritdoc}
+     */
+    public function getHistoryRows()
+    {
+        return $this->findAll('css', '.entity-version');
+    }
 }

--- a/features/product-model/display_product_model_history.feature
+++ b/features/product-model/display_product_model_history.feature
@@ -1,0 +1,23 @@
+@javascript
+Feature: Display the product model history
+  In order to know by who, when and what changes have been made to a product model
+  As a product manager
+  I need to have access to a product model history
+
+  Background:
+    Given a "catalog_modeling" catalog configuration
+    And I am logged in as "Julia"
+
+  Scenario: Display product model updates
+    Given I am on the "amor" product model page
+    When I visit the "History" column tab
+    Then there should be 1 update
+    When I visit the "Attributes" column tab
+    And I change the "Price" to "999 USD"
+    And I press the "Save" button
+    Then I should not see the text "There are unsaved changes."
+    When I visit the "History" column tab
+    Then there should be 2 update
+    And I should see history:
+      | version | property  | value   |
+      | 2       | Price USD | $999.00 |

--- a/features/product/history/display_variant_product_history.feature
+++ b/features/product/history/display_variant_product_history.feature
@@ -12,8 +12,7 @@ Feature: Display the variant product history
     And I change the "Weight" to "750 Gram"
     And I press the "Save" button
     Then I should not see the text "There are unsaved changes."
-    When the history of the product "tshirt-unique-color-kurt-l" has been built
-    And I visit the "History" column tab
+    When I visit the "History" column tab
     Then there should be 2 update
     And I should see history:
       | version | property | value |

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/acl.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/acl.yml
@@ -78,6 +78,10 @@ pim_enrich_product_model_categories_view:
     type: action
     label: pim_enrich.acl.product_model.categories_view
     group_name: pim_enrich.acl_group.product_model
+pim_enrich_product_model_history:
+    type: action
+    label: pim_enrich.acl.product_model.history
+    group_name: pim_enrich.acl_group.product_model
 
 # Mass edit action
 pim_enrich_mass_edit:

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_model/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_model/edit.yml
@@ -221,6 +221,13 @@ extensions:
         targetZone: self
         position: 90
 
+    pim-product-model-edit-form-history:
+        module: pim/product-model-edit-form/history
+        parent: pim-product-model-edit-form-column-tabs
+        targetZone: container
+        aclResourceId: pim_enrich_product_model_history
+        position: 140
+
     pim-product-model-edit-form-copy-scope-switcher:
         module: pim/product-edit-form/scope-switcher
         parent: pim-product-model-edit-form-copy

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
@@ -155,6 +155,11 @@ config:
                     options:
                         urls:
                             list: pim_enrich_mass_edit_action_sequential_edit_get
+                product-model-history:
+                    module: pim/base-fetcher
+                    options:
+                        urls:
+                            get: pim_enrich_product_model_history_rest_get
                 product-history:
                     module: pim/base-fetcher
                     options:
@@ -687,6 +692,7 @@ config:
         pim/product-model-edit-form/product-model-label: pimenrich/js/product-model/form/product-model-label
         pim/product-model-edit-form/save: pimenrich/js/product-model/form/save
         pim/product-model-edit-form/complete-variant-product: pimenrich/js/product-model/form/complete-variant-product
+        pim/product-model-edit-form/history: pimenrich/js/product/form/history
 
         # Attribute group
         pim/attribute-group-form/tab/attribute: pimenrich/js/attribute-group/form/tab/attribute
@@ -1125,6 +1131,7 @@ config:
 
         # Product model
         pim/template/product-model/complete-variant-product: pimenrich/templates/product_model/complete-variant-product.html
+        pim/template/product-model/history:                  pimenrich/templates/product/history.html
 
         # Order last
         pim/form: pimenrich/js/product/form

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/history.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/history.js
@@ -101,10 +101,10 @@ define(
              * Update the history by fetching it from the backend
              */
             update: function () {
-                const entityMeta = this.getFormData().meta;
+                const entity = this.getFormData();
 
-                if (entityMeta) {
-                    this.getHistoryFetcher(entityMeta).clear(entityMeta.id);
+                if (entity.meta) {
+                    this.getHistoryFetcher(entity).clear(entity.meta.id);
                 }
 
                 this.render();
@@ -116,21 +116,25 @@ define(
              * @return {Promise}
              */
             getVersions: function () {
-                const entityMeta = this.getFormData().meta;
+                const entity = this.getFormData();
 
-                return this.getHistoryFetcher(entityMeta).fetch(
-                    entityMeta.id,
-                    { entityId: entityMeta.id }
+                return this.getHistoryFetcher(entity).fetch(
+                    entity.meta.id,
+                    { entityId: entity.meta.id }
                 ).then(this.addAttributesLabelToVersions.bind(this));
             },
 
             /**
-             * @param {Object} entityMeta
+             * @param {Object} entity
              *
              * @returns Fetcher
              */
-            getHistoryFetcher: function (entityMeta) {
-                if (null !== entityMeta.family_variant) {
+            getHistoryFetcher: function (entity) {
+                if ('product_model' === entity.meta.model_type) {
+                    return FetcherRegistry.getFetcher('product-model-history');
+                }
+
+                if (null !== entity.meta.family_variant) {
                     return FetcherRegistry.getFetcher('variant-product-history');
                 }
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/messages.en.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/messages.en.yml
@@ -185,6 +185,7 @@ pim_enrich:
         product_model:
             edit_attributes: Edit attributes of a product model
             categories_view: Consult the categories of a product model
+            history: View product model history
         category:
             list: List categories
             create: Create a category


### PR DESCRIPTION
## Description

Add a history extension for product models.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | OK
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
