### PR TITLE
PIM-6859: Fix missing attribute values in PDF

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -15,6 +15,7 @@
 - TIP-810: Add Symfony command to reset the ES indexes
 - TIP-809: Prevents ES from using the scoring system and bypass the max_clause_count limit.
 - PIM-6872: Fix PQB sorters with Elasticsearch
+- PIM-6859: Fix missing attribute values in PDF
 
 ## Better UI\UX!
 

--- a/src/Pim/Bundle/PdfGeneratorBundle/Resources/views/Product/renderPdf.html.twig
+++ b/src/Pim/Bundle/PdfGeneratorBundle/Resources/views/Product/renderPdf.html.twig
@@ -98,12 +98,14 @@
                         <h2>{{ group }}</h2>
                         {% for attribute in attributes %}
                             {% block attribute %}
+                                {% set locale_attribute = attribute.isLocalizable or attribute.isLocaleSpecific ? locale : null %}
+                                {% set channel_attribute = attribute.isScopable ? scope : null %}
+                                {% set content = product.getValue(attribute.code, locale_attribute, channel_attribute) %}
 
-                                {% if 'pim_catalog_image' == attribute.type and product.getValue(attribute.code, locale, scope).media is not null %}
-                                    {% set content = product.getValue(attribute.code, locale, scope).media.originalFilename %}
+                                {% if 'pim_catalog_image' == attribute.type and content.media is not null %}
+                                    {% set content = content.media.originalFilename %}
                                     {% set manualHeight = false %}
                                 {% else %}
-                                    {% set content = product.getValue(attribute.code, locale, scope) %}
                                     {% if content != null %}
                                         {% set manualHeight = attribute.label|length >(content.__toString()|length / 3) %}
                                     {% else %}


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

Fix product PDF. Only localizable & scopable were shown

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
