### PR TITLE
API-381: Create a family variant via API

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -10,6 +10,10 @@
 - PIM-6891: Keep the tab context between product and product model forms
 - PIM-6918: Fix error when deleteing boolean attribute linked to a published product
 
+## Better manage products with variants!
+
+- API-381: Create family variant via API.
+
 ## Better UI\UX!
 
 - PIM-6667: Update loading mask design

--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -1,9 +1,5 @@
 # 2.0.x
 
-## Better manage products with variants!
-
-- API-399: Create a product model
-
 ## Bug fixes
 
 - PIM-6898: Fixes some data can break ES index and crashes new products indexing
@@ -13,6 +9,8 @@
 ## Better manage products with variants!
 
 - API-381: Create family variant via API.
+- API-399: Create a product model
+- PIM-6903: Adds compare/translate functionality for product models
 
 ## Better UI\UX!
 
@@ -20,10 +18,6 @@
 - PIM-6504: Update action icons on datagrids
 - PIM-6848: Fix design on export builder fields
 - PIM-6868: CSS glitches compilation
-
-## Better manage products with variants!
-
-- PIM-6903: Adds compare/translate functionality for product models
 
 # 2.0.2 (2017-10-12)
 

--- a/src/Akeneo/Bundle/ElasticsearchBundle/tests/integration/ResetIndexesCommandIntegration.php
+++ b/src/Akeneo/Bundle/ElasticsearchBundle/tests/integration/ResetIndexesCommandIntegration.php
@@ -25,7 +25,7 @@ class ResetIndexesCommandIntegration extends TestCase
     }
 
     /**
-     * @return Configuration
+     * {@inheritdoc}
      */
     protected function getConfiguration(): Configuration
     {

--- a/src/Akeneo/Component/StorageUtils/Exception/InvalidPropertyTypeException.php
+++ b/src/Akeneo/Component/StorageUtils/Exception/InvalidPropertyTypeException.php
@@ -25,6 +25,7 @@ class InvalidPropertyTypeException extends PropertyException
     const VALID_ARRAY_STRUCTURE_EXPECTED_CODE = 201;
     const ARRAY_OF_ARRAYS_EXPECTED_CODE = 202;
     const ARRAY_KEY_EXPECTED_CODE = 203;
+    const ARRAY_OF_OBJECTS_EXPECTED_CODE = 204;
 
     /** @var mixed */
     protected $propertyValue;
@@ -251,6 +252,28 @@ class InvalidPropertyTypeException extends PropertyException
             $className,
             sprintf($message, $propertyName),
             self::ARRAY_OF_ARRAYS_EXPECTED_CODE
+        );
+    }
+
+    /**
+     * Build an exception when the data are not an array of objects.
+     *
+     * @param string $propertyName
+     * @param string $className
+     * @param mixed  $propertyValue a value that is not an array or does not contain object
+     *
+     * @return InvalidPropertyTypeException
+     */
+    public static function arrayOfObjectsExpected($propertyName, $className, $propertyValue)
+    {
+        $message = 'Property "%s" expects an array of objects as data.';
+
+        return new static(
+            $propertyName,
+            $propertyValue,
+            $className,
+            sprintf($message, $propertyName),
+            self::ARRAY_OF_OBJECTS_EXPECTED_CODE
         );
     }
 

--- a/src/Akeneo/Component/StorageUtils/spec/Exception/InvalidPropertyTypeExceptionSpec.php
+++ b/src/Akeneo/Component/StorageUtils/spec/Exception/InvalidPropertyTypeExceptionSpec.php
@@ -224,6 +224,30 @@ class InvalidPropertyTypeExceptionSpec extends ObjectBehavior
         $this->getCode()->shouldReturn($exception->getCode());
     }
 
+    function it_creates_a_not_array_of_objects_structure_exception()
+    {
+        $exception = InvalidPropertyTypeException::arrayOfObjectsExpected(
+            'attribute',
+            'Pim\Component\Catalog\Updater\Attribute',
+            ['string']
+        );
+
+        $this->beConstructedWith(
+            'attribute',
+            ['string'],
+            'Pim\Component\Catalog\Updater\Attribute',
+            'Property "attribute" expects an array of objects as data.',
+            InvalidPropertyTypeException::ARRAY_OF_OBJECTS_EXPECTED_CODE
+        );
+
+        $this->shouldBeAnInstanceOf(get_class($exception));
+        $this->getPropertyName()->shouldReturn($exception->getPropertyName());
+        $this->getPropertyValue()->shouldReturn($exception->getPropertyValue());
+        $this->getClassName()->shouldReturn($exception->getClassName());
+        $this->getMessage()->shouldReturn($exception->getMessage());
+        $this->getCode()->shouldReturn($exception->getCode());
+    }
+
     function it_creates_a_not_key_not_found_exception()
     {
         $exception = InvalidPropertyTypeException::arrayKeyExpected(

--- a/src/Pim/Bundle/ApiBundle/Controller/FamilyVariantController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/FamilyVariantController.php
@@ -4,16 +4,30 @@ declare(strict_types=1);
 
 namespace Pim\Bundle\ApiBundle\Controller;
 
+use Akeneo\Component\StorageUtils\Exception\PropertyException;
+use Akeneo\Component\StorageUtils\Exception\UnknownPropertyException;
+use Akeneo\Component\StorageUtils\Factory\SimpleFactoryInterface;
+use Akeneo\Component\StorageUtils\Saver\SaverInterface;
+use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Oro\Bundle\SecurityBundle\Annotation\AclAncestor;
+use Pim\Bundle\ApiBundle\Documentation;
+use Pim\Component\Api\Exception\DocumentedHttpException;
 use Pim\Component\Api\Exception\PaginationParametersException;
+use Pim\Component\Api\Exception\ViolationHttpException;
 use Pim\Component\Api\Pagination\PaginatorInterface;
 use Pim\Component\Api\Pagination\ParameterValidatorInterface;
 use Pim\Component\Api\Repository\ApiResourceRepositoryInterface;
+use Pim\Component\Catalog\Model\FamilyVariantInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+use Symfony\Component\Routing\Router;
+use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 /**
  * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
@@ -37,6 +51,21 @@ class FamilyVariantController
     /** @var ParameterValidatorInterface */
     protected $parameterValidator;
 
+    /** @var  ValidatorInterface */
+    protected $validator;
+
+    /** @var SimpleFactoryInterface */
+    protected $factory;
+
+    /** @var ObjectUpdaterInterface */
+    protected $updater;
+
+    /** @var SaverInterface */
+    protected $saver;
+
+    /** @var RouterInterface */
+    protected $router;
+
     /** @var array */
     protected $apiConfiguration;
 
@@ -46,6 +75,11 @@ class FamilyVariantController
      * @param NormalizerInterface            $normalizer
      * @param PaginatorInterface             $paginator
      * @param ParameterValidatorInterface    $parameterValidator
+     * @param ValidatorInterface             $validator
+     * @param SimpleFactoryInterface         $factory
+     * @param ObjectUpdaterInterface         $updater
+     * @param SaverInterface                 $saver
+     * @param RouterInterface                $router
      * @param array                          $apiConfiguration
      */
     public function __construct(
@@ -54,6 +88,11 @@ class FamilyVariantController
         NormalizerInterface $normalizer,
         PaginatorInterface $paginator,
         ParameterValidatorInterface $parameterValidator,
+        ValidatorInterface $validator,
+        SimpleFactoryInterface $factory,
+        ObjectUpdaterInterface $updater,
+        SaverInterface $saver,
+        RouterInterface $router,
         array $apiConfiguration
     ) {
         $this->familyRepository = $familyRepository;
@@ -61,6 +100,11 @@ class FamilyVariantController
         $this->normalizer = $normalizer;
         $this->paginator = $paginator;
         $this->parameterValidator = $parameterValidator;
+        $this->validator = $validator;
+        $this->factory = $factory;
+        $this->updater = $updater;
+        $this->saver = $saver;
+        $this->router = $router;
         $this->apiConfiguration = $apiConfiguration;
     }
 
@@ -75,7 +119,7 @@ class FamilyVariantController
      *
      * @AclAncestor("pim_api_family_variant_list")
      */
-    public function getAction(Request $request, string $familyCode, string $code)
+    public function getAction(Request $request, string $familyCode, string $code): JsonResponse
     {
         $family = $this->familyRepository->findOneByIdentifier($familyCode);
         if (null === $family) {
@@ -109,7 +153,7 @@ class FamilyVariantController
      *
      * @AclAncestor("pim_api_family_variant_list")
      */
-    public function listAction(Request $request, string $familyCode)
+    public function listAction(Request $request, string $familyCode): JsonResponse
     {
         $family = $this->familyRepository->findOneByIdentifier($familyCode);
         if (null === $family) {
@@ -150,5 +194,121 @@ class FamilyVariantController
         );
 
         return new JsonResponse($paginatedFamilies);
+    }
+
+    /**
+     * @param Request $request
+     * @param string  $familyCode
+     *
+     * @throws BadRequestHttpException
+     * @throws UnprocessableEntityHttpException
+     *
+     * @return Response
+     *
+     * @AclAncestor("pim_api_family_variant_edit")
+     */
+    public function createAction(Request $request, string $familyCode): Response
+    {
+        $data = $this->getDecodedContent($request->getContent());
+
+        if (isset($data['family'])) {
+            $exception = UnknownPropertyException::unknownProperty('family');
+            throw new DocumentedHttpException(
+                Documentation::URL . 'post_families_variant',
+                sprintf('%s Check the standard format documentation.', $exception->getMessage()),
+                $exception
+            );
+        }
+        $data['family'] = $familyCode;
+
+        $familyVariant = $this->factory->create();
+        $this->updateFamilyVariant($familyVariant, $data, 'post_families_variant');
+        $this->validateFamilyVariant($familyVariant);
+
+        $this->saver->save($familyVariant);
+
+        $response = $this->getResponse($familyVariant, Response::HTTP_CREATED);
+
+        return $response;
+    }
+
+    /**
+     * Get a response with a location header to the created or updated resource.
+     *
+     * @param FamilyVariantInterface $familyVariant
+     * @param string                 $status
+     *
+     * @return Response
+     */
+    protected function getResponse(FamilyVariantInterface $familyVariant, $status): Response
+    {
+        $response = new Response(null, $status);
+        $route = $this->router->generate(
+            'pim_api_family_variant_get',
+            ['familyCode' => $familyVariant->getFamily()->getCode(), 'code' => $familyVariant->getCode()],
+            Router::ABSOLUTE_URL
+        );
+        $response->headers->set('Location', $route);
+
+        return $response;
+    }
+
+    /**
+     * Update a family variant. It throws an error 422 if a problem occurred during the update.
+     *
+     * @param FamilyVariantInterface $familyVariant family variant to update
+     * @param array                  $data          data of the request already decoded, it should be the standard format
+     * @param string                 $anchor
+     *
+     * @throws DocumentedHttpException
+     */
+    protected function updateFamilyVariant(FamilyVariantInterface $familyVariant, array $data, $anchor): void
+    {
+        try {
+            $this->updater->update($familyVariant, $data);
+        } catch (PropertyException $exception) {
+            throw new DocumentedHttpException(
+                Documentation::URL . $anchor,
+                sprintf('%s Check the standard format documentation.', $exception->getMessage()),
+                $exception
+            );
+        }
+    }
+
+    /**
+     * Validate a family variant. It throws an error 422 with every violated constraints if
+     * the validation failed.
+     *
+     * @param FamilyVariantInterface $familyVariant
+     *
+     * @throws ViolationHttpException
+     */
+    protected function validateFamilyVariant(FamilyVariantInterface $familyVariant): void
+    {
+        $violations = $this->validator->validate($familyVariant);
+        if (0 !== $violations->count()) {
+            throw new ViolationHttpException($violations);
+        }
+    }
+
+
+    /**
+     * Get the JSON decoded content. If the content is not a valid JSON, it throws an error 400.
+     *
+     * @param string $content content of a request to decode
+     *
+     * @throws BadRequestHttpException
+     *
+     * @return array
+     */
+    protected function getDecodedContent($content): array
+    {
+        $decodedContent = json_decode($content, true);
+
+        if (null === $decodedContent) {
+            throw new BadRequestHttpException('Invalid json message received');
+        }
+
+        return $decodedContent;
     }
 }

--- a/src/Pim/Bundle/ApiBundle/Resources/config/acl.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/acl.yml
@@ -67,6 +67,10 @@ pim_api_family_variant_list:
     type: action
     label: pim_api.acl.family_variant.list
     group_name: pim_api.acl_group.family_variant
+pim_api_family_variant_edit:
+    type: action
+    label: pim_api.acl.family_variant.edit
+    group_name: pim_api.acl_group.family_variant
 
 pim_api_currency_list:
     type: action

--- a/src/Pim/Bundle/ApiBundle/Resources/config/acl_groups.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/acl_groups.yml
@@ -13,6 +13,9 @@ pim_api.acl_group.category:
 pim_api.acl_group.family:
     order: 20
     permission_group: api
+pim_api.acl_group.family_variant:
+    order: 20
+    permission_group: api
 pim_api.acl_group.channel:
     order: 20
     permission_group: api

--- a/src/Pim/Bundle/ApiBundle/Resources/config/controllers.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/controllers.yml
@@ -57,7 +57,7 @@ services:
             - '@pim_api.pagination.parameter_validator'
             - '@validator'
             - '@pim_catalog.factory.family_variant'
-            - '@pim_catalog.updater.family_variant'
+            - '@pim_api.updater.family_variant'
             - '@pim_catalog.saver.family_variant'
             - '@router'
             - '%pim_api.configuration%'

--- a/src/Pim/Bundle/ApiBundle/Resources/config/controllers.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/controllers.yml
@@ -55,6 +55,11 @@ services:
             - '@pim_serializer'
             - '@pim_api.pagination.offset_hal_paginator'
             - '@pim_api.pagination.parameter_validator'
+            - '@validator'
+            - '@pim_catalog.factory.family_variant'
+            - '@pim_catalog.updater.family_variant'
+            - '@pim_catalog.saver.family_variant'
+            - '@router'
             - '%pim_api.configuration%'
 
     pim_api.controller.attribute:

--- a/src/Pim/Bundle/ApiBundle/Resources/config/routing/family.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/routing/family.yml
@@ -32,3 +32,8 @@ pim_api_family_variant_get:
     path: /families/{familyCode}/variants/{code}
     defaults: { _controller: pim_api.controller.family_variant:getAction, _format: json }
     methods: [GET]
+
+pim_api_family_variant_create:
+    path: /families/{familyCode}/variants
+    defaults: { _controller: pim_api.controller.family_variant:createAction, _format: json }
+    methods: [POST]

--- a/src/Pim/Bundle/ApiBundle/Resources/config/updaters.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/updaters.yml
@@ -1,8 +1,13 @@
-
 parameters:
+    pim_api.updater.family_variant.class: Pim\Component\Api\Updater\FamilyVariantUpdater
     pim_api.updater.product_model.class: Pim\Component\Api\Updater\ProductModelUpdater
 
 services:
+    pim_api.updater.family_variant:
+        class: '%pim_api.updater.family_variant.class%'
+        arguments:
+            - '@pim_catalog.updater.family_variant'
+
     pim_api.updater.product_model:
         class: '%pim_api.updater.product_model.class%'
         arguments:

--- a/src/Pim/Bundle/ApiBundle/Resources/translations/messages.en.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/translations/messages.en.yml
@@ -16,6 +16,9 @@ pim_api:
         family:
             edit: Create and update families
             list: List families
+        family_variant:
+            edit: Create and update family variants
+            list: List family variants
         channel:
             edit: Create and update channels
             list: List channels
@@ -31,6 +34,7 @@ pim_api:
         attribute_group: Attribute groups
         category: Categories
         family: Families
+        family_variant: Family variants
         channel: Channels
         locale: Locales
         currency: Currencies

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/FamilyVariant/CreateFamilyVariantIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/FamilyVariant/CreateFamilyVariantIntegration.php
@@ -148,7 +148,7 @@ JSON;
         $expectedContent = <<<JSON
 {
 	"code": 422,
-	"message": "Property \"variant_attribute_sets\" expects an array as data, \"string\" given. Check the standard format documentation.",
+	"message": "Property \"variant_attribute_sets\" expects an array of objects as data. Check the standard format documentation.",
 	"_links": {
 		"documentation": {
 			"href": "http://api.akeneo.com/api-reference.html#post_families__family_code__variants"

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/FamilyVariant/CreateFamilyVariantIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/FamilyVariant/CreateFamilyVariantIntegration.php
@@ -209,6 +209,6 @@ JSON;
      */
     protected function getConfiguration()
     {
-        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/FamilyVariant/CreateFamilyVariantIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/FamilyVariant/CreateFamilyVariantIntegration.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace Pim\Bundle\ApiBundle\tests\integration\Controller\FamilyVariant;
+
+use Akeneo\Test\Integration\Configuration;
+use Pim\Bundle\ApiBundle\tests\integration\ApiTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+class CreateFamilyVariantIntegration extends ApiTestCase
+{
+    public function testFormatStandardWhenAFamilyVariantIsCreated()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data = <<<JSON
+{
+    "code": "new_family_variant",
+    "variant_attribute_sets": [
+        {
+            "level": 1,
+            "axes": ["a_ref_data_simple_select"],
+            "attributes": ["a_ref_data_simple_select"]
+        },
+        {
+            "level": 2,
+            "axes": ["a_yes_no"],
+            "attributes": ["a_yes_no"]
+        }
+    ],
+    "labels": {
+        "en_US": "English label"
+    }
+}
+JSON;
+
+        $client->request('POST', 'api/rest/v1/families/familyA/variants', [], [], [], $data);
+
+        $familyVariant = $this->get('pim_catalog.repository.family_variant')->findOneByIdentifier('new_family_variant');
+        $familyVariantStandard = [
+            'code'                   => 'new_family_variant',
+            'labels'                 => [
+                'en_US' => 'English label',
+            ],
+            'family'                 => 'familyA',
+            'variant_attribute_sets' => [
+                [
+                    'level'      => 1,
+                    'axes'       => ['a_ref_data_simple_select'],
+                    'attributes' => ['a_ref_data_simple_select'],
+                ],
+                [
+                    'level'      => 2,
+                    'axes'       => ['a_yes_no'],
+                    'attributes' => ['a_yes_no'],
+                ],
+            ],
+        ];
+        $normalizer = $this->get('pim_catalog.normalizer.standard.family_variant');
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+        $this->assertArrayHasKey('location', $response->headers->all());
+        $this->assertSame('http://localhost/api/rest/v1/families/familyA/variants/new_family_variant', $response->headers->get('location'));
+        $this->assertSame('', $response->getContent());
+        $this->assertSame($familyVariantStandard, $normalizer->normalize($familyVariant));
+    }
+
+    public function testResponseWhenContentIsEmpty()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data = '';
+
+        $expectedContent = [
+            'code'    => 400,
+            'message' => 'Invalid json message received',
+        ];
+
+        $client->request('POST', 'api/rest/v1/families/familyA/variants', [], [], [], $data);
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+        $this->assertSame($expectedContent, json_decode($response->getContent(), true));
+    }
+
+    public function testResponseWhenContentIsNotValid()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data = '{';
+
+        $expectedContent = [
+            'code'    => 400,
+            'message' => 'Invalid json message received',
+        ];
+
+        $client->request('POST', 'api/rest/v1/families/familyA/variants', [], [], [], $data);
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+        $this->assertSame($expectedContent, json_decode($response->getContent(), true));
+    }
+
+    public function testResponseWhenValidationFailed()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data = <<<JSON
+{
+    "code": "new_family_variant",
+    "variant_attribute_sets": [
+        {
+            "level": 2,
+            "axes": ["a_yes_no"],
+            "attributes": ["a_yes_no"]
+        }
+    ]
+}
+JSON;
+
+        $expectedContent = <<<JSON
+{
+    "code": 422,
+    "message": "Validation failed.",
+    "errors": [
+        {
+            "property":"variant_attribute_sets",
+            "message":"There is no variant attribute set for level \"1\""
+        }
+    ]
+}
+JSON;
+
+        $client->request('POST', 'api/rest/v1/families/familyA/variants', [], [], [], $data);
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertJsonStringEqualsJsonString($expectedContent, $response->getContent());
+    }
+
+    public function testResponseWhenFamilyIsProvided()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data = <<<JSON
+{
+    "code": "new_family_variant",
+    "family": "familyA",
+    "variant_attribute_sets": [
+        {
+            "level": 1,
+            "axes": ["a_ref_data_simple_select"],
+            "attributes": ["a_ref_data_simple_select"]
+        },
+        {
+            "level": 2,
+            "axes": ["a_yes_no"],
+            "attributes": ["a_yes_no"]
+        }
+    ]
+}
+JSON;
+
+        $expectedContent = <<<JSON
+{
+    "code": 422,
+    "message": "Property \"family\" does not exist. Check the standard format documentation.",
+    "_links": {
+        "documentation": {
+            "href": "http://api.akeneo.com/api-reference.html#post_families_variant"
+        }
+    }
+}
+JSON;
+
+        $client->request('POST', 'api/rest/v1/families/familyA/variants', [], [], [], $data);
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertJsonStringEqualsJsonString($expectedContent, $response->getContent());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return new Configuration([Configuration::getTechnicalCatalogPath()]);
+    }
+}

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/FamilyVariant/GetFamilyVariantIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/FamilyVariant/GetFamilyVariantIntegration.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Pim\Bundle\ApiBundle\tests\integration\Controller\Family;
+namespace Pim\Bundle\ApiBundle\tests\integration\Controller\FamilyVariant;
 
 use Akeneo\Test\Integration\Configuration;
 use Pim\Bundle\ApiBundle\tests\integration\ApiTestCase;

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/FamilyVariant/ListFamilyVariantIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/FamilyVariant/ListFamilyVariantIntegration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Pim\Bundle\ApiBundle\tests\integration\Controller\Family;
+namespace Pim\Bundle\ApiBundle\tests\integration\Controller\FamilyVariant;
 
 use Akeneo\Test\Integration\Configuration;
 use Pim\Bundle\ApiBundle\tests\integration\ApiTestCase;

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/RootEndpointIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/RootEndpointIntegration.php
@@ -246,6 +246,10 @@ class RootEndpointIntegration extends ApiTestCase
             "pim_api_product_model_create": {
                 "route": "/api/rest/v1/product-models",
                 "methods": ["POST"]
+            },
+            "pim_api_family_variant_create": {
+                "route": "/api/rest/v1/families/{familyCode}/variants",
+                "methods": ["POST"]
             }
         }
     }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Security/FamilyVariantAuthorizationIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Security/FamilyVariantAuthorizationIntegration.php
@@ -83,6 +83,45 @@ JSON;
         $this->assertJsonStringEqualsJsonString($expectedResponse, $response->getContent());
     }
 
+    public function testAccessDeniedForCreatingAFamilyVariant()
+    {
+        $data = <<<JSON
+{
+    "code": "new_family_variant",
+    "variant_attribute_sets": [
+        {
+            "level": 1,
+            "axes": ["a_ref_data_simple_select"],
+            "attributes": ["a_ref_data_simple_select"]
+        },
+        {
+            "level": 2,
+            "axes": ["a_yes_no"],
+            "attributes": ["a_yes_no"]
+        }
+    ],
+    "labels": {
+        "en_US": "English label"
+    }
+}
+JSON;
+
+        $client = $this->createAuthenticatedClient([], [], null, null, 'julia', 'julia');
+
+        $client->request('POST', 'api/rest/v1/families/familyA/variants', [], [], [], $data);
+
+        $expectedResponse = <<<JSON
+{
+    "code": 403,
+    "message": "Access forbidden. You are not allowed to create or update family variants."
+}
+JSON;
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
+        $this->assertJsonStringEqualsJsonString($expectedResponse, $response->getContent());
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/validation/familyvariant.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/validation/familyvariant.yml
@@ -15,8 +15,11 @@ Pim\Component\Catalog\Model\FamilyVariant:
                 message: Family variant code may contain only letters, numbers and underscores
             - Length:
                 max: 100
+        family:
+            - NotNull: ~
         translations:
             - Valid: ~
+
     getters:
         variantAttributeSets:
             - Symfony\Component\Validator\Constraints\Valid:

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/validators.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/validators.yml
@@ -72,8 +72,6 @@ services:
     # Validators
     pim_catalog.validator.constraint.family_variant_axes:
         class: '%pim_catalog.validator.constraint.family_variant_axes.class%'
-        arguments:
-            - '@translator'
         tags:
             - { name: validator.constraint_validator, alias: pim_family_variant }
 

--- a/src/Pim/Bundle/CatalogBundle/Resources/translations/messages.en.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/translations/messages.en.yml
@@ -1,39 +1,3 @@
 No products to remove: No products to remove
 "dot (.)":   dot (.)
 "comma (,)": comma (,)
-
-pim_catalog:
-    constraint:
-        family_variant_attributes_unique: Attributes must be unique, "%attributes%" are used several times in variant attributes sets
-        family_variant_axes_unique: Variant axes must be unique, "%attributes%" are used several times in variant attributes sets
-        family_variant_axes_attribute_type_unique: Variant axes "%axis%" cannot be unique or an identifier
-        family_variant_axes_attribute_type: Variant axes "%axis%" must be a boolean, a simple select, a simple reference data or a metric
-        family_variant_axes_wrong_type: Variant axes "%axis%" cannot be localizable, not scopable and not locale specific
-        family_variant_axes_number_of_axes: A variant attribute set cannot have more than 5 attributes
-        family_variant_no_axis: There should be at least one attribute defined as axis for the attribute set for level "%level%"
-        family_variant_axis_level: Attribute "%axis%" must be set as attribute in the same variant attribute set it was set as axis
-        family_variant_has_family_attribute: '"%attribute%" attribute cannot be added to "%family_variant%" family variant, as it is not an attribute of the "%family%" family'
-        family_variant_level_do_not_exist: There is no variant attribute set for level "%level%"
-        family_variant_no_level: There should be at least one level defined in the family variant
-        family_variant_maximum_number_of_level: Family variant cannot have more than "%level%" level
-        family_variant_unique_attributes_in_last_level: Unique attribute "%attribute%" must be set at the product level
-        product_identifier: These identifiers "%s" don't exist.
-        0: An unexpected error occurred.
-        100: Non-expected value
-        101: This field expects a boolean value.
-        102: This field expects a float value.
-        103: This field expects an integer value.
-        104: This field expects a numeric value.
-        105: This field expects a string value.
-        106: This field expects an array value.
-        107: This field expects an array of arrays as value.
-        200: An internal error occurred
-        201: An internal error occurred
-        202: This field expects a numeric value.
-        203: This field expects a string value.
-        204: This field expects a string value.
-        205: An internal error occurred
-        300: This field expects a valid entity code.
-        301: This field expects a valid scope and locale.
-        302: This field expects a valid scope.
-        303: This field expects a valid association format.

--- a/src/Pim/Bundle/CatalogBundle/Resources/translations/messages.en.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/translations/messages.en.yml
@@ -6,6 +6,7 @@ pim_catalog:
     constraint:
         family_variant_attributes_unique: Attributes must be unique, "%attributes%" are used several times in variant attributes sets
         family_variant_axes_unique: Variant axes must be unique, "%attributes%" are used several times in variant attributes sets
+        family_variant_axes_attribute_type_unique: Variant axes "%axis%" cannot be unique or an identifier
         family_variant_axes_attribute_type: Variant axes "%axis%" must be a boolean, a simple select, a simple reference data or a metric
         family_variant_axes_wrong_type: Variant axes "%axis%" cannot be localizable, not scopable and not locale specific
         family_variant_axes_number_of_axes: A variant attribute set cannot have more than 5 attributes
@@ -13,6 +14,8 @@ pim_catalog:
         family_variant_axis_level: Attribute "%axis%" must be set as attribute in the same variant attribute set it was set as axis
         family_variant_has_family_attribute: '"%attribute%" attribute cannot be added to "%family_variant%" family variant, as it is not an attribute of the "%family%" family'
         family_variant_level_do_not_exist: There is no variant attribute set for level "%level%"
+        family_variant_no_level: There should be at least one level defined in the family variant
+        family_variant_maximum_number_of_level: Family variant cannot have more than "%level%" level
         family_variant_unique_attributes_in_last_level: Unique attribute "%attribute%" must be set at the product level
         product_identifier: These identifiers "%s" don't exist.
         0: An unexpected error occurred.

--- a/src/Pim/Bundle/CatalogBundle/Resources/translations/validators.en.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/translations/validators.en.yml
@@ -44,3 +44,36 @@ pim_catalog:
         variant_product_has_parent: 'The variant product "%variant_product%" must have a parent'
         invalid_variant_product_parent: 'The variant product "%variant_product%" cannot have product model "%product_model%" as parent, (this product model can only have other product models as children)'
         modified_variant_axis_value: 'Variant axis "%variant_axis%" cannot be modified, "%provided_value%" given'
+        family_variant_attributes_unique: Attributes must be unique, "%attributes%" are used several times in variant attributes sets
+        family_variant_axes_unique: Variant axes must be unique, "%attributes%" are used several times in variant attributes sets
+        family_variant_axes_attribute_type_unique: Variant axes "%axis%" cannot be unique or an identifier
+        family_variant_axes_attribute_type: Variant axes "%axis%" must be a boolean, a simple select, a simple reference data or a metric
+        family_variant_axes_wrong_type: Variant axes "%axis%" cannot be localizable, not scopable and not locale specific
+        family_variant_axes_number_of_axes: 'A variant attribute set cannot have more than %max_axes_number% axes'
+        family_variant_no_axis: There should be at least one attribute defined as axis for the attribute set for level "%level%"
+        family_variant_axis_level: Attribute "%axis%" must be set as attribute in the same variant attribute set it was set as axis
+        family_variant_has_family_attribute: '"%attribute%" attribute cannot be added to "%family_variant%" family variant, as it is not an attribute of the "%family%" family'
+        family_variant_level_do_not_exist: There is no variant attribute set for level "%level%"
+        family_variant_no_level: There should be at least one level defined in the family variant
+        family_variant_maximum_number_of_level: Family variant cannot have more than "%level%" level
+        family_variant_unique_attributes_in_last_level: Unique attribute "%attribute%" must be set at the product level
+        product_identifier: These identifiers "%s" don't exist.
+        0: An unexpected error occurred.
+        100: Non-expected value
+        101: This field expects a boolean value.
+        102: This field expects a float value.
+        103: This field expects an integer value.
+        104: This field expects a numeric value.
+        105: This field expects a string value.
+        106: This field expects an array value.
+        107: This field expects an array of arrays as value.
+        200: An internal error occurred
+        201: An internal error occurred
+        202: This field expects a numeric value.
+        203: This field expects a string value.
+        204: This field expects a string value.
+        205: An internal error occurred
+        300: This field expects a valid entity code.
+        301: This field expects a valid scope and locale.
+        302: This field expects a valid scope.
+        303: This field expects a valid association format.

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Family/CreateFamilyVariantIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Family/CreateFamilyVariantIntegration.php
@@ -33,7 +33,7 @@ class CreateFamilyVariantIntegration extends TestCase
                 [
                     'axes' => ['size'],
                     'attributes' => ['sku', 'price'],
-                    'level'=> 2,
+                    'level'=> 1,
                 ]
             ],
         ]);
@@ -452,11 +452,11 @@ class CreateFamilyVariantIntegration extends TestCase
                 'en_US' => 'My family variant'
             ],
             'variant_attribute_sets' => [
-                [
-                    'axes' => ['color'],
-                    'attributes' => ['weather_conditions', 'rating', 'side_view', 'top_view', 'lace_color'],
-                    'level'=> 1,
-                ],
+                //[
+                //    'axes' => ['color'],
+                //    'attributes' => ['weather_conditions', 'rating', 'side_view', 'top_view', 'lace_color', 'price'],
+                //    'level'=> 1,
+                //],
                 [
                     'axes' => ['size'],
                     'attributes' => ['sku', 'rating', 'price'],

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Family/CreateFamilyVariantIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Family/CreateFamilyVariantIntegration.php
@@ -398,6 +398,46 @@ class CreateFamilyVariantIntegration extends TestCase
     }
 
     /**
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException
+     * @expectedExceptionMessage Property "variant_attribute_sets" expects an array of objects as data.
+     */
+    public function testCreateFamilyVariantWithVariantAttributeSetAsString()
+    {
+        $familyVariant = $this->get('pim_catalog.factory.family_variant')->create();
+        $this->get('pim_catalog.updater.family_variant')->update(
+            $familyVariant,
+            [
+                'code'   => 'familyVariantCode',
+                'family' => 'boots',
+                'labels' => [
+                    'en_US' => 'My family variant'
+                ],
+                'variant_attribute_sets' => 'color',
+            ]
+        );
+    }
+
+    /**
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException
+     * @expectedExceptionMessage Property "variant_attribute_sets" expects an array of objects as data.
+     */
+    public function testCreateFamilyVariantWithVariantAttributeSetAsArrayOfString()
+    {
+        $familyVariant = $this->get('pim_catalog.factory.family_variant')->create();
+        $this->get('pim_catalog.updater.family_variant')->update(
+            $familyVariant,
+            [
+                'code'   => 'familyVariantCode',
+                'family' => 'boots',
+                'labels' => [
+                    'en_US' => 'My family variant'
+                ],
+                'variant_attribute_sets' => ['color'],
+            ]
+        );
+    }
+
+    /**
      * Validation: If level of attribute set is not specified it is not set, so validation must return an error.
      */
     public function testTheAttributeSetWithoutLevelSpecified()

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Family/CreateFamilyVariantIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Family/CreateFamilyVariantIntegration.php
@@ -21,7 +21,7 @@ class CreateFamilyVariantIntegration extends TestCase
         $this->get('pim_catalog.updater.family_variant')->update($familyVariant, [
             'code' => 'family_variant',
             'family' => 'boots',
-            'label' => [
+            'labels' => [
                 'en_US' => 'My family variant'
             ],
             'variant_attribute_sets' => [
@@ -101,7 +101,7 @@ class CreateFamilyVariantIntegration extends TestCase
         $this->get('pim_catalog.updater.family_variant')->update($familyVariant, [
             'code' => 'family_variant',
             'family' => 'boots',
-            'label' => [
+            'labels' => [
                 'en_US' => 'My family variant'
             ],
             'variant_attribute_sets' => [
@@ -165,6 +165,235 @@ class CreateFamilyVariantIntegration extends TestCase
         $errors = $this->get('validator')->validate($familyVariant);
         $this->assertEquals(1, $errors->count());
         $this->assertEquals('This value is already used.', $errors->get(0)->getMessage());
+        $this->assertSame('code', $errors->get(0)->getPropertyPath());
+    }
+
+    public function testFamilyVariantMissingCode()
+    {
+        $familyVariant = $this->get('pim_catalog.factory.family_variant')->create();
+        $this->get('pim_catalog.updater.family_variant')->update(
+            $familyVariant,
+            [
+                'family' => 'boots',
+                'labels' => [
+                    'en_US' => 'My family variant'
+                ],
+                'variant_attribute_sets' => [
+                    [
+                        'axes' => ['color'],
+                        'attributes' => ['weather_conditions', 'rating', 'side_view', 'top_view', 'lace_color'],
+                        'level'=> 1,
+                    ],
+                    [
+                        'axes' => ['size'],
+                        'attributes' => ['sku', 'price'],
+                        'level'=> 2,
+                    ]
+                ],
+            ]
+        );
+
+        $violations = $this->get('validator')->validate($familyVariant);
+
+        $this->assertCount(1, $violations);
+        $this->assertSame('This value should not be blank.', $violations->get(0)->getMessage());
+        $this->assertSame('code', $violations->get(0)->getPropertyPath());
+    }
+
+    public function testFamilyVariantBlankCode()
+    {
+        $familyVariant = $this->get('pim_catalog.factory.family_variant')->create();
+        $this->get('pim_catalog.updater.family_variant')->update(
+            $familyVariant,
+            [
+                'code'   => '',
+                'family' => 'boots',
+                'labels' => [
+                    'en_US' => 'My family variant'
+                ],
+                'variant_attribute_sets' => [
+                    [
+                        'axes' => ['color'],
+                        'attributes' => ['weather_conditions', 'rating', 'side_view', 'top_view', 'lace_color'],
+                        'level'=> 1,
+                    ],
+                    [
+                        'axes' => ['size'],
+                        'attributes' => ['sku', 'price'],
+                        'level'=> 2,
+                    ]
+                ],
+            ]
+        );
+
+        $violations = $this->get('validator')->validate($familyVariant);
+
+        $this->assertCount(1, $violations);
+        $this->assertSame('This value should not be blank.', $violations->get(0)->getMessage());
+        $this->assertSame('code', $violations->get(0)->getPropertyPath());
+    }
+
+    public function testFamilyVariantRegexCode()
+    {
+        $familyVariant = $this->get('pim_catalog.factory.family_variant')->create();
+        $this->get('pim_catalog.updater.family_variant')->update(
+            $familyVariant,
+            [
+                'code'   => '@code',
+                'family' => 'boots',
+                'labels' => [
+                    'en_US' => 'My family variant'
+                ],
+                'variant_attribute_sets' => [
+                    [
+                        'axes' => ['color'],
+                        'attributes' => ['weather_conditions', 'rating', 'side_view', 'top_view', 'lace_color'],
+                        'level'=> 1,
+                    ],
+                    [
+                        'axes' => ['size'],
+                        'attributes' => ['sku', 'price'],
+                        'level'=> 2,
+                    ]
+                ],
+            ]
+        );
+
+        $violations = $this->get('validator')->validate($familyVariant);
+
+        $this->assertCount(1, $violations);
+        $this->assertSame('Family variant code may contain only letters, numbers and underscores', $violations->get(0)->getMessage());
+        $this->assertSame('code', $violations->get(0)->getPropertyPath());
+    }
+
+    /**
+     * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyException
+     * @expectedExceptionMessage Property "family" expects a valid family code. The family does not exist, "unknown_family" given
+     */
+    public function testCreateFamilyVariantUnknownFamily()
+    {
+        $familyVariant = $this->get('pim_catalog.factory.family_variant')->create();
+        $this->get('pim_catalog.updater.family_variant')->update(
+            $familyVariant,
+            [
+                'code'   => 'familyVariantCode',
+                'family' => 'unknown_family',
+                'labels' => [
+                    'en_US' => 'My family variant'
+                ],
+                'variant_attribute_sets' => [
+                    [
+                        'axes' => ['color'],
+                        'attributes' => ['weather_conditions', 'rating', 'side_view', 'top_view', 'lace_color'],
+                        'level'=> 1,
+                    ],
+                    [
+                        'axes' => ['size'],
+                        'attributes' => ['sku', 'price'],
+                        'level'=> 2,
+                    ]
+                ],
+            ]
+        );
+    }
+
+    public function testCreateFamilyVariantMissingFamily()
+    {
+        $familyVariant = $this->get('pim_catalog.factory.family_variant')->create();
+        $this->get('pim_catalog.updater.family_variant')->update(
+            $familyVariant,
+            [
+                'code'   => 'familyVariantCode',
+                'labels' => [
+                    'en_US' => 'My family variant'
+                ],
+                'variant_attribute_sets' => [
+                    [
+                        'axes' => ['color'],
+                        'attributes' => ['weather_conditions', 'rating', 'side_view', 'top_view', 'lace_color'],
+                        'level'=> 1,
+                    ],
+                    [
+                        'axes' => ['size'],
+                        'attributes' => ['sku', 'price'],
+                        'level'=> 2,
+                    ]
+                ],
+            ]
+        );
+
+        $violations = $this->get('validator')->validate($familyVariant);
+
+        $this->assertCount(1, $violations);
+        $this->assertSame('This value should not be null.', $violations->get(0)->getMessage());
+        $this->assertSame('family', $violations->get(0)->getPropertyPath());
+    }
+
+    public function testFamilyVariantMissingAttributeSets()
+    {
+        $familyVariant = $this->get('pim_catalog.factory.family_variant')->create();
+        $this->get('pim_catalog.updater.family_variant')->update(
+            $familyVariant,
+            [
+                'code' => 'newFamilyVariantA1',
+                'family' => 'boots',
+            ]
+        );
+
+        $violations = $this->get('validator')->validate($familyVariant);
+
+        $this->assertCount(1, $violations);
+        $this->assertSame('There should be at least one level defined in the family variant', $violations->get(0)->getMessage());
+        $this->assertSame('variant_attribute_sets', $violations->get(0)->getPropertyPath());
+    }
+
+    public function testCreateFamilyVariantNoLevel()
+    {
+        $familyVariant = $this->get('pim_catalog.factory.family_variant')->create();
+        $this->get('pim_catalog.updater.family_variant')->update(
+            $familyVariant,
+            [
+                'code' => 'newFamilyVariantA1',
+                'family' => 'boots',
+                'variant_attribute_sets' => []
+            ]
+        );
+
+        $violations = $this->get('validator')->validate($familyVariant);
+
+        $this->assertCount(1, $violations);
+        $this->assertSame('There should be at least one level defined in the family variant', $violations->get(0)->getMessage());
+        $this->assertSame('variant_attribute_sets', $violations->get(0)->getPropertyPath());
+    }
+
+    /**
+     * TODO
+     */
+    public function testTheAttributeSetWithoutLevelSpecified()
+    {
+        $this->createDefaultFamilyVariant();
+
+        $familyVariant = $this->get('pim_catalog.factory.family_variant')->create();
+
+        $this->get('pim_catalog.updater.family_variant')->update($familyVariant, [
+            'code'                   => 'invalid_axis',
+            'family'                 => 'boots',
+            'labels'                 => [
+                'en_US' => 'My family variant'
+            ],
+            'variant_attribute_sets' => [
+                [
+                    'axes'       => ['color'],
+                    'attributes' => ['weather_conditions', 'rating', 'side_view', 'top_view', 'lace_color'],
+                    'level'      => 1,
+                ],
+                [
+                    'axes'       => ['size', 'color'],
+                    'attributes' => ['sku', 'price'],
+                    'level'      => 2,
+                ]
+            ],
+        ]);
     }
 
     /**
@@ -179,7 +408,7 @@ class CreateFamilyVariantIntegration extends TestCase
         $this->get('pim_catalog.updater.family_variant')->update($familyVariant, [
             'code' => 'invalid_axis',
             'family' => 'boots',
-            'label' => [
+            'labels' => [
                 'en_US' => 'My family variant'
             ],
             'variant_attribute_sets' => [
@@ -206,11 +435,10 @@ class CreateFamilyVariantIntegration extends TestCase
             'Attributes must be unique, "color" are used several times in variant attributes sets',
             $errors->get(1)->getMessage()
         );
+        $this->assertSame('variant_attribute_sets', $errors->get(0)->getPropertyPath());
+        $this->assertSame('variant_attribute_sets', $errors->get(1)->getPropertyPath());
     }
 
-    /**
-     * Validation: An attribute can only be used for one attribute set
-     */
     public function testTheAttributeSetAttributeUniqueness()
     {
         $this->createDefaultFamilyVariant();
@@ -220,7 +448,7 @@ class CreateFamilyVariantIntegration extends TestCase
         $this->get('pim_catalog.updater.family_variant')->update($familyVariant, [
             'code' => 'invalid_attribute',
             'family' => 'boots',
-            'label' => [
+            'labels' => [
                 'en_US' => 'My family variant'
             ],
             'variant_attribute_sets' => [
@@ -243,6 +471,7 @@ class CreateFamilyVariantIntegration extends TestCase
             'Attributes must be unique, "rating" are used several times in variant attributes sets',
             $errors->get(0)->getMessage()
         );
+        $this->assertSame('variant_attribute_sets', $errors->get(0)->getPropertyPath());
     }
 
     /**
@@ -258,7 +487,7 @@ class CreateFamilyVariantIntegration extends TestCase
         $this->get('pim_catalog.updater.family_variant')->update($familyVariant, [
             'code' => 'invalid_axis_type',
             'family' => 'boots',
-            'label' => [
+            'labels' => [
                 'en_US' => 'My family variant'
             ],
             'variant_attribute_sets' => [
@@ -286,6 +515,44 @@ class CreateFamilyVariantIntegration extends TestCase
             'Variant axes "name" cannot be localizable, not scopable and not locale specific',
             $errors->get(0)->getMessage()
         );
+
+        $this->assertSame('variant_attribute_sets', $errors->get(0)->getPropertyPath());
+        $this->assertSame('variant_attribute_sets', $errors->get(1)->getPropertyPath());
+    }
+
+    public function testCreateFamilyVariantWithIdentifierAsAxis()
+    {
+        $familyVariant = $this->get('pim_catalog.factory.family_variant')->create();
+        $this->get('pim_catalog.updater.family_variant')->update(
+            $familyVariant,
+            [
+                'code' => 'invalid_axis_type',
+                'family' => 'boots',
+                'labels' => [
+                    'en_US' => 'My family variant'
+                ],
+                'variant_attribute_sets' => [
+                    [
+                        'axes' => ['color'],
+                        'attributes' => ['side_view', 'rating', 'color', 'top_view', 'lace_color'],
+                        'level'=> 1,
+                    ],
+                    [
+                        'axes' => ['size', 'sku'],
+                        'attributes' => ['sku', 'weather_conditions'],
+                        'level'=> 2,
+                    ]
+                ]
+            ]
+        );
+
+        $violations = $this->get('validator')->validate($familyVariant);
+
+        $this->assertCount(2, $violations);
+        $this->assertSame('Variant axes "sku" cannot be unique or an identifier', $violations->get(0)->getMessage());
+        $this->assertSame('Variant axes "sku" must be a boolean, a simple select, a simple reference data or a metric', $violations->get(1)->getMessage());
+        $this->assertSame('variant_attribute_sets', $violations->get(0)->getPropertyPath());
+        $this->assertSame('variant_attribute_sets', $violations->get(1)->getPropertyPath());
     }
 
     /**
@@ -299,7 +566,7 @@ class CreateFamilyVariantIntegration extends TestCase
         $this->get('pim_catalog.updater.family_variant')->update($familyVariant, [
             'code' => 'family_variant',
             'family' => 'boots',
-            'label' => [
+            'labels' => [
                 'en_US' => 'My family variant'
             ],
             'variant_attribute_sets' => [
@@ -314,9 +581,36 @@ class CreateFamilyVariantIntegration extends TestCase
 
         $errors = $this->get('validator')->validate($familyVariant);
         $this->assertEquals(
-            'A variant attribute set cannot have more than 5 attributes',
+            'A variant attribute set cannot have more than 5 axes',
             $errors->get(2)->getMessage()
         );
+        $this->assertSame('variant_attribute_sets', $errors->get(2)->getPropertyPath());
+    }
+
+    public function testCreateFamilyVariantWithNoAttributeInAxes()
+    {
+        $familyVariant = $this->get('pim_catalog.factory.family_variant')->create();
+        $this->get('pim_catalog.updater.family_variant')->update($familyVariant, [
+            'code' => 'family_variant',
+            'family' => 'boots',
+            'labels' => [
+                'en_US' => 'My family variant'
+            ],
+            'variant_attribute_sets' => [
+                [
+                    'axes' => [],
+                    'attributes' => [],
+                    'level'=> 1,
+                ],
+
+            ],
+        ]);
+
+        $violations = $this->get('validator')->validate($familyVariant);
+
+        $this->assertCount(1, $violations);
+        $this->assertSame('A variant attribute set should have at least one axis', $violations->get(0)->getMessage());
+        $this->assertSame('variant_attribute_sets', $violations->get(0)->getPropertyPath());
     }
 
     /**
@@ -329,7 +623,7 @@ class CreateFamilyVariantIntegration extends TestCase
         $this->get('pim_catalog.updater.family_variant')->update($familyVariant, [
             'code' => 'family_variant',
             'family' => 'boots',
-            'label' => [
+            'labels' => [
                 'en_US' => 'My family variant'
             ],
             'variant_attribute_sets' => [
@@ -355,6 +649,43 @@ class CreateFamilyVariantIntegration extends TestCase
             'There is no variant attribute set for level "1"',
             $errors->get(0)->getMessage()
         );
+        $this->assertSame('variant_attribute_sets', $errors->get(0)->getPropertyPath());
+    }
+
+    public function testCreateFamilyVariantTooManyLevels()
+    {
+        $familyVariant = $this->get('pim_catalog.factory.family_variant')->create();
+
+        $this->get('pim_catalog.updater.family_variant')->update(
+            $familyVariant,
+            [
+                'code' => 'newFamilyVariantA1',
+                'family' => 'boots',
+                'variant_attribute_sets' => [
+                    [
+                        'axes' => ['color'],
+                        'attributes' => ['weather_conditions', 'rating', 'side_view', 'top_view'],
+                        'level'=> 1,
+                    ],
+                    [
+                        'axes' => ['lace_color'],
+                        'attributes' => ['price'],
+                        'level'=> 2,
+                    ],
+                    [
+                        'axes' => ['size'],
+                        'attributes' => ['sku'],
+                        'level'=> 3,
+                    ]
+                ]
+            ]
+        );
+
+        $violations = $this->get('validator')->validate($familyVariant);
+
+        $this->assertCount(1, $violations);
+        $this->assertSame('Family variant cannot have more than "2" level', $violations->get(0)->getMessage());
+        $this->assertSame('variant_attribute_sets', $violations->get(0)->getPropertyPath());
     }
 
     /**
@@ -367,7 +698,7 @@ class CreateFamilyVariantIntegration extends TestCase
         $this->get('pim_catalog.updater.family_variant')->update($familyVariant, [
             'code' => 'family_variant',
             'family' => 'boots',
-            'label' => [
+            'labels' => [
                 'en_US' => 'My family variant'
             ],
             'variant_attribute_sets' => [
@@ -394,6 +725,8 @@ class CreateFamilyVariantIntegration extends TestCase
             '"heel_color" attribute cannot be added to "family_variant" family variant, as it is not an attribute of the "boots" family',
             $errors->get(0)->getMessage()
         );
+
+        $this->assertSame('variant_attribute_sets', $errors->get(0)->getPropertyPath());
     }
 
     /**
@@ -407,7 +740,7 @@ class CreateFamilyVariantIntegration extends TestCase
         $this->get('pim_catalog.updater.family_variant')->update($familyVariant, [
             'code' => 'family_variant',
             'family' => 'boots',
-            'label' => [
+            'labels' => [
                 'en_US' => 'My family variant'
             ],
             'variant_attribute_sets' => [
@@ -437,6 +770,7 @@ class CreateFamilyVariantIntegration extends TestCase
             'Unique attribute "unique_attribute" must be set at the product level',
             $errors->get(0)->getMessage()
         );
+        $this->assertSame('variant_attribute_sets', $errors->get(0)->getPropertyPath());
     }
 
     /**
@@ -449,7 +783,7 @@ class CreateFamilyVariantIntegration extends TestCase
         $this->get('pim_catalog.updater.family_variant')->update($familyVariant, [
             'code' => 'family_variant',
             'family' => 'boots',
-            'label' => [
+            'labels' => [
                 'en_US' => 'My family variant'
             ],
             'variant_attribute_sets' => [
@@ -472,6 +806,7 @@ class CreateFamilyVariantIntegration extends TestCase
             'Unique attribute "sku" must be set at the product level',
             $errors->get(0)->getMessage()
         );
+        $this->assertSame('variant_attribute_sets', $errors->get(0)->getPropertyPath());
     }
 
     /**
@@ -485,7 +820,7 @@ class CreateFamilyVariantIntegration extends TestCase
         $this->get('pim_catalog.updater.family_variant')->update($familyVariant, [
             'code' => 'family_variant',
             'family' => 'boots',
-            'label' => [
+            'labels' => [
                 'en_US' => 'My family variant'
             ],
             'variant_attribute_sets' => [
@@ -516,7 +851,7 @@ class CreateFamilyVariantIntegration extends TestCase
         $this->get('pim_catalog.updater.family_variant')->update($familyVariant, [
             'code' => 'family_variant',
             'family' => 'boots',
-            'label' => [
+            'labels' => [
                 'en_US' => 'My family variant'
             ],
             'variant_attribute_sets' => [
@@ -543,6 +878,8 @@ class CreateFamilyVariantIntegration extends TestCase
             'Attributes must be unique, "size" are used several times in variant attributes sets',
             $errors->get(1)->getMessage()
         );
+        $this->assertSame('variant_attribute_sets', $errors->get(0)->getPropertyPath());
+        $this->assertSame('variant_attribute_sets', $errors->get(1)->getPropertyPath());
     }
 
     /**
@@ -558,7 +895,7 @@ class CreateFamilyVariantIntegration extends TestCase
         $this->get('pim_catalog.updater.family_variant')->update($familyVariant, [
             'code' => 'family_variant',
             'family' => 'boots',
-            'label' => [
+            'labels' => [
                 'en_US' => 'My family variant'
             ],
             'variant_attribute_sets' => [
@@ -596,7 +933,7 @@ class CreateFamilyVariantIntegration extends TestCase
         $this->get('pim_catalog.updater.family_variant')->update($familyVariant, [
             'code' => 'family_variant',
             'family' => 'boots',
-            'label' => [
+            'labels' => [
                 'en_US' => 'My family variant'
             ],
             'variant_attribute_sets' => [

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Family/UpdateFamilyVariantIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Family/UpdateFamilyVariantIntegration.php
@@ -44,7 +44,7 @@ class UpdateFamilyVariantIntegration extends TestCase
         $this->get('pim_catalog.updater.family_variant')->update(
             $familyVariant,
             [
-                'label' => [
+                'labels' => [
                     'en_US' => 'My family variant',
                 ],
                 'variant_attribute_sets' => [

--- a/src/Pim/Component/Api/Normalizer/FamilyVariantNormalizer.php
+++ b/src/Pim/Component/Api/Normalizer/FamilyVariantNormalizer.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Pim\Component\Api\Normalizer;
 
-use Pim\Component\Catalog\Model\FamilyInterface;
 use Pim\Component\Catalog\Model\FamilyVariantInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 

--- a/src/Pim/Component/Api/Updater/FamilyVariantUpdater.php
+++ b/src/Pim/Component/Api/Updater/FamilyVariantUpdater.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Component\Api\Updater;
+
+use Akeneo\Component\StorageUtils\Exception\UnknownPropertyException;
+use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
+use Pim\Bundle\ApiBundle\Documentation;
+use Pim\Component\Api\Exception\DocumentedHttpException;
+
+/**
+ * Update the family variant properties
+ *
+ * @author    Willy Mesnage <willy.mesnage@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class FamilyVariantUpdater implements ObjectUpdaterInterface
+{
+    /** @var ObjectUpdaterInterface */
+    private $familyUpdater;
+
+    /**
+     * @param ObjectUpdaterInterface $familyUpdater
+     */
+    public function __construct(ObjectUpdaterInterface $familyUpdater)
+    {
+        $this->familyUpdater = $familyUpdater;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws DocumentedHttpException
+     */
+    public function update($familyVariant, array $data, array $options = []): ObjectUpdaterInterface
+    {
+        if (isset($data['family'])) {
+            $exception = UnknownPropertyException::unknownProperty('family');
+            throw new DocumentedHttpException(
+                Documentation::URL . 'post_families__family_code__variants',
+                sprintf('%s Check the standard format documentation.', $exception->getMessage()),
+                $exception
+            );
+        }
+        $data['family'] = isset($options['familyCode']) ? $options['familyCode'] : null;
+
+        $this->familyUpdater->update($familyVariant, $data, $options);
+
+        return $this;
+    }
+}

--- a/src/Pim/Component/Api/spec/Normalizer/FamilyVariantNormalizerSpec.php
+++ b/src/Pim/Component/Api/spec/Normalizer/FamilyVariantNormalizerSpec.php
@@ -3,11 +3,8 @@
 namespace spec\Pim\Component\Api\Normalizer;
 
 use PhpSpec\ObjectBehavior;
-use Pim\Component\Api\Normalizer\FamilyNormalizer;
 use Pim\Component\Api\Normalizer\FamilyVariantNormalizer;
-use Pim\Component\Catalog\Model\FamilyInterface;
 use Pim\Component\Catalog\Model\FamilyVariantInterface;
-use Prophecy\Argument;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class FamilyVariantNormalizerSpec extends ObjectBehavior

--- a/src/Pim/Component/Api/spec/Pagination/ParameterValidatorSpec.php
+++ b/src/Pim/Component/Api/spec/Pagination/ParameterValidatorSpec.php
@@ -1,195 +1,197 @@
 <?php
 
-    namespace spec\Pim\Component\Api\Pagination;
+namespace spec\Pim\Component\Api\Pagination;
 
-    use PhpSpec\ObjectBehavior;
-    use Pim\Component\Api\Exception\PaginationParametersException;
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Api\Exception\PaginationParametersException;
+use Pim\Component\Api\Pagination\ParameterValidator;
+use Pim\Component\Api\Pagination\ParameterValidatorInterface;
 
-    class ParameterValidatorSpec extends ObjectBehavior
+class ParameterValidatorSpec extends ObjectBehavior
+{
+    function let()
     {
-        function let()
-        {
-            $this->beConstructedWith(['pagination' => ['limit_max' => 100]]);
-        }
-
-        function it_is_initializable()
-        {
-            $this->shouldHaveType('Pim\Component\Api\Pagination\ParameterValidator');
-        }
-
-        function it_is_a_parameter_validator()
-        {
-            $this->shouldImplement('Pim\Component\Api\Pagination\ParameterValidatorInterface');
-        }
-
-        function it_validates_offset_pagination_by_default()
-        {
-            $parameters = [
-                'page'  => '1.1',
-            ];
-
-            $this
-                ->shouldThrow(new PaginationParametersException('"1.1" is not a valid page number.'))
-                ->duringValidate($parameters);
-        }
-
-        function it_validates_limit_with_search_after_pagination()
-        {
-            $parameters = [
-                'limit'  => '1.1',
-            ];
-
-            $this
-                ->shouldThrow(new PaginationParametersException('"1.1" is not a valid limit number.'))
-                ->duringValidate($parameters);
-        }
-
-        function it_validates_with_count_with_boolean_string_values()
-        {
-            $this->validate(['with_count' => 'true']);
-            $this->validate(['with_count' => 'false']);
-        }
-
-        function it_ignores_with_count_with_search_after_pagination()
-        {
-            $this->validate(['with_count' => '1', 'pagination_type' => 'search_after'], ['support_search_after' => true]);
-            $this->validate(['with_count' => '0', 'pagination_type' => 'search_after'], ['support_search_after' => true]);
-        }
-
-        function it_validates_integer_values_with_offset_pagination()
-        {
-            $parameters = [
-                'page'            => 1,
-                'limit'           => 10,
-                'pagination_type' => 'page',
-            ];
-
-            $this->validate($parameters);
-        }
-
-        function it_validates_integer_as_string_values_with_offset_pagination()
-        {
-            $parameters = [
-                'page'            => '1',
-                'limit'           => '10',
-                'pagination_type' => 'page',
-            ];
-
-            $this->validate($parameters);
-        }
-
-        function it_does_not_validates_float_page_values_with_offset_pagination()
-        {
-            $parameters = [
-                'page'            => '1.1',
-                'pagination_type' => 'page',
-            ];
-
-            $this
-                ->shouldThrow(new PaginationParametersException('"1.1" is not a valid page number.'))
-                ->duringValidate($parameters);
-        }
-
-        function it_does_not_validate_string_page_value_with_offset_pagination()
-        {
-            $parameters = [
-                'page'            => 'string',
-                'pagination_type' => 'page',
-            ];
-
-            $this
-                ->shouldThrow(new PaginationParametersException('"string" is not a valid page number.'))
-                ->duringValidate($parameters);
-        }
-
-        function it_does_not_validate_negative_page_number_with_offset_pagination()
-        {
-            $parameters = [
-                'page'            => -5,
-                'pagination_type' => 'page',
-            ];
-
-            $this
-                ->shouldThrow(new PaginationParametersException('"-5" is not a valid page number.'))
-                ->duringValidate($parameters);
-        }
-
-        function it_does_not_validates_float_limit_values_with_offset_pagination()
-        {
-            $parameters = [
-                'limit'           => '1.1',
-                'pagination_type' => 'page',
-            ];
-
-            $this
-                ->shouldThrow(new PaginationParametersException('"1.1" is not a valid limit number.'))
-                ->duringValidate($parameters);
-        }
-
-        function it_does_not_validate_string_limit_value_with_offset_pagination()
-        {
-            $parameters = [
-                'limit'           => 'string',
-                'pagination_type' => 'page',
-            ];
-
-            $this
-                ->shouldThrow(new PaginationParametersException('"string" is not a valid limit number.'))
-                ->duringValidate($parameters);
-        }
-
-        function it_does_not_validate_negative_limit_number_with_offset_pagination()
-        {
-            $parameters = [
-                'limit'           => -5,
-                'pagination_type' => 'page',
-            ];
-
-            $this
-                ->shouldThrow(new PaginationParametersException('"-5" is not a valid limit number.'))
-                ->duringValidate($parameters);
-        }
-
-        function it_does_not_validate_limit_exceeding_maximum_limit_value_with_offset_pagination()
-        {
-            $parameters = [
-                'limit'           => 200,
-                'pagination_type' => 'page',
-            ];
-
-            $this
-                ->shouldThrow(new PaginationParametersException('You cannot request more than 100 items.'))
-                ->duringValidate($parameters);
-        }
-
-        function it_throws_an_exception_when_unknown_pagination_type()
-        {
-            $this
-                ->shouldThrow(new PaginationParametersException('Pagination type does not exist.'))
-                ->duringValidate(['pagination_type' => 'unknown']);
-        }
-
-        function it_throws_an_exception_when_search_after_pagination_not_supported()
-        {
-            $this ->shouldThrow(new PaginationParametersException('Pagination type does not exist.'))
-                ->duringValidate(['pagination_type' => 'unknown']);
-
-            $this ->shouldThrow(new PaginationParametersException('Pagination type does not exist.'))
-                ->duringValidate(['pagination_type' => 'unknown'], ['support_search_after' => false]);
-        }
-
-        function it_throws_an_exception_when_parameter_with_count_is_not_a_boolean()
-        {
-            $this ->shouldThrow(
-                new PaginationParametersException(
-                    'Parameter "with_count" has to be a boolean. Only "true" or "false" allowed, "1" given.'
-                ))
-                ->duringValidate(['with_count' => '1']);
-
-            $this ->shouldThrow(
-            new PaginationParametersException(
-                'Parameter "with_count" has to be a boolean. Only "true" or "false" allowed, "0" given.'
-            ))
-                ->duringValidate(['with_count' => '0']);
-        }
+        $this->beConstructedWith(['pagination' => ['limit_max' => 100]]);
     }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(ParameterValidator::class);
+    }
+
+    function it_is_a_parameter_validator()
+    {
+        $this->shouldImplement(ParameterValidatorInterface::class);
+    }
+
+    function it_validates_offset_pagination_by_default()
+    {
+        $parameters = [
+            'page'  => '1.1',
+        ];
+
+        $this
+            ->shouldThrow(new PaginationParametersException('"1.1" is not a valid page number.'))
+            ->duringValidate($parameters);
+    }
+
+    function it_validates_limit_with_search_after_pagination()
+    {
+        $parameters = [
+            'limit'  => '1.1',
+        ];
+
+        $this
+            ->shouldThrow(new PaginationParametersException('"1.1" is not a valid limit number.'))
+            ->duringValidate($parameters);
+    }
+
+    function it_validates_with_count_with_boolean_string_values()
+    {
+        $this->validate(['with_count' => 'true']);
+        $this->validate(['with_count' => 'false']);
+    }
+
+    function it_ignores_with_count_with_search_after_pagination()
+    {
+        $this->validate(['with_count' => '1', 'pagination_type' => 'search_after'], ['support_search_after' => true]);
+        $this->validate(['with_count' => '0', 'pagination_type' => 'search_after'], ['support_search_after' => true]);
+    }
+
+    function it_validates_integer_values_with_offset_pagination()
+    {
+        $parameters = [
+            'page'            => 1,
+            'limit'           => 10,
+            'pagination_type' => 'page',
+        ];
+
+        $this->validate($parameters);
+    }
+
+    function it_validates_integer_as_string_values_with_offset_pagination()
+    {
+        $parameters = [
+            'page'            => '1',
+            'limit'           => '10',
+            'pagination_type' => 'page',
+        ];
+
+        $this->validate($parameters);
+    }
+
+    function it_does_not_validates_float_page_values_with_offset_pagination()
+    {
+        $parameters = [
+            'page'            => '1.1',
+            'pagination_type' => 'page',
+        ];
+
+        $this
+            ->shouldThrow(new PaginationParametersException('"1.1" is not a valid page number.'))
+            ->duringValidate($parameters);
+    }
+
+    function it_does_not_validate_string_page_value_with_offset_pagination()
+    {
+        $parameters = [
+            'page'            => 'string',
+            'pagination_type' => 'page',
+        ];
+
+        $this
+            ->shouldThrow(new PaginationParametersException('"string" is not a valid page number.'))
+            ->duringValidate($parameters);
+    }
+
+    function it_does_not_validate_negative_page_number_with_offset_pagination()
+    {
+        $parameters = [
+            'page'            => -5,
+            'pagination_type' => 'page',
+        ];
+
+        $this
+            ->shouldThrow(new PaginationParametersException('"-5" is not a valid page number.'))
+            ->duringValidate($parameters);
+    }
+
+    function it_does_not_validates_float_limit_values_with_offset_pagination()
+    {
+        $parameters = [
+            'limit'           => '1.1',
+            'pagination_type' => 'page',
+        ];
+
+        $this
+            ->shouldThrow(new PaginationParametersException('"1.1" is not a valid limit number.'))
+            ->duringValidate($parameters);
+    }
+
+    function it_does_not_validate_string_limit_value_with_offset_pagination()
+    {
+        $parameters = [
+            'limit'           => 'string',
+            'pagination_type' => 'page',
+        ];
+
+        $this
+            ->shouldThrow(new PaginationParametersException('"string" is not a valid limit number.'))
+            ->duringValidate($parameters);
+    }
+
+    function it_does_not_validate_negative_limit_number_with_offset_pagination()
+    {
+        $parameters = [
+            'limit'           => -5,
+            'pagination_type' => 'page',
+        ];
+
+        $this
+            ->shouldThrow(new PaginationParametersException('"-5" is not a valid limit number.'))
+            ->duringValidate($parameters);
+    }
+
+    function it_does_not_validate_limit_exceeding_maximum_limit_value_with_offset_pagination()
+    {
+        $parameters = [
+            'limit'           => 200,
+            'pagination_type' => 'page',
+        ];
+
+        $this
+            ->shouldThrow(new PaginationParametersException('You cannot request more than 100 items.'))
+            ->duringValidate($parameters);
+    }
+
+    function it_throws_an_exception_when_unknown_pagination_type()
+    {
+        $this
+            ->shouldThrow(new PaginationParametersException('Pagination type does not exist.'))
+            ->duringValidate(['pagination_type' => 'unknown']);
+    }
+
+    function it_throws_an_exception_when_search_after_pagination_not_supported()
+    {
+        $this ->shouldThrow(new PaginationParametersException('Pagination type does not exist.'))
+            ->duringValidate(['pagination_type' => 'unknown']);
+
+        $this ->shouldThrow(new PaginationParametersException('Pagination type does not exist.'))
+            ->duringValidate(['pagination_type' => 'unknown'], ['support_search_after' => false]);
+    }
+
+    function it_throws_an_exception_when_parameter_with_count_is_not_a_boolean()
+    {
+        $this ->shouldThrow(
+            new PaginationParametersException(
+                'Parameter "with_count" has to be a boolean. Only "true" or "false" allowed, "1" given.'
+            ))
+            ->duringValidate(['with_count' => '1']);
+
+        $this ->shouldThrow(
+        new PaginationParametersException(
+            'Parameter "with_count" has to be a boolean. Only "true" or "false" allowed, "0" given.'
+        ))
+            ->duringValidate(['with_count' => '0']);
+    }
+}

--- a/src/Pim/Component/Api/spec/Updater/FamilyVariantUpdaterSpec.php
+++ b/src/Pim/Component/Api/spec/Updater/FamilyVariantUpdaterSpec.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace spec\Pim\Component\Api\Updater;
+
+use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Api\Exception\DocumentedHttpException;
+use Pim\Component\Api\Updater\FamilyVariantUpdater;
+use Pim\Component\Catalog\Model\FamilyVariantInterface;
+use Prophecy\Argument;
+
+class FamilyVariantUpdaterSpec extends ObjectBehavior
+{
+    function let(ObjectUpdaterInterface $familyUpdater)
+    {
+        $this->beConstructedWith($familyUpdater);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(FamilyVariantUpdater::class);
+    }
+
+    function it_is_an_updater()
+    {
+        $this->shouldImplement(ObjectUpdaterInterface::class);
+    }
+
+    function it_updates_a_family_variant($familyUpdater, FamilyVariantInterface $familyVariant)
+    {
+        $dataToUpdate = [
+            'code' => 'family_variant',
+            'labels' => [
+                'en_US' => 'My family variant'
+            ],
+            'variant_attribute_sets' => [
+                [
+                    'axes' => ['color'],
+                    'attributes' => ['description'],
+                    'level'=> 1,
+                ],
+
+            ],
+        ];
+        $data = [
+            'code' => 'family_variant',
+            'family' => 'boots',
+            'labels' => [
+                'en_US' => 'My family variant'
+            ],
+            'variant_attribute_sets' => [
+                [
+                    'axes' => ['color'],
+                    'attributes' => ['description'],
+                    'level'=> 1,
+                ],
+
+            ],
+        ];
+        $options = ['familyCode' => 'boots'];
+        $familyUpdater->update($familyVariant, $data, $options)->shouldBeCalled();
+
+        $this
+            ->shouldNotThrow(DocumentedHttpException::class)
+            ->during('update', [$familyVariant, $dataToUpdate, $options]);
+    }
+
+    function it_throws_a_documented_exception_if_family_field_is_filled(
+        $familyUpdater,
+        FamilyVariantInterface $familyVariant
+    ) {
+        $data = [
+            'code' => 'family_variant',
+            'family' => 'boot',
+            'labels' => [
+                'en_US' => 'My family variant'
+            ],
+            'variant_attribute_sets' => [
+                [
+                    'axes' => ['color'],
+                    'attributes' => ['description'],
+                    'level'=> 1,
+                ],
+
+            ],
+        ];
+        $options = ['familyCode' => 'boots'];
+        $familyUpdater->update(Argument::cetera())->shouldNotBeCalled();
+
+        $this
+            ->shouldThrow(DocumentedHttpException::class)
+            ->during('update', [$familyVariant, $data, $options]);
+    }
+}

--- a/src/Pim/Component/Catalog/Model/FamilyVariant.php
+++ b/src/Pim/Component/Catalog/Model/FamilyVariant.php
@@ -52,7 +52,7 @@ class FamilyVariant implements FamilyVariantInterface
     /**
      * {@inheritdoc}
      */
-    public function getCode(): string
+    public function getCode(): ?string
     {
         return $this->code;
     }
@@ -150,7 +150,7 @@ class FamilyVariant implements FamilyVariantInterface
     /**
      * {@inheritdoc}
      */
-    public function getFamily(): FamilyInterface
+    public function getFamily(): ?FamilyInterface
     {
         return $this->family;
     }

--- a/src/Pim/Component/Catalog/Model/FamilyVariantInterface.php
+++ b/src/Pim/Component/Catalog/Model/FamilyVariantInterface.php
@@ -13,12 +13,12 @@ use Doctrine\Common\Collections\Collection;
 interface FamilyVariantInterface extends TranslatableInterface
 {
     /**
-     * @return int
+     * @return null|int
      */
     public function getId(): ?int;
 
     /**
-     * @return string
+     * @return null|string
      */
     public function getCode(): ?string;
 
@@ -70,7 +70,7 @@ interface FamilyVariantInterface extends TranslatableInterface
     public function setFamily(FamilyInterface $family): void;
 
     /**
-     * @return FamilyInterface
+     * @return null|FamilyInterface
      */
     public function getFamily(): ?FamilyInterface;
 

--- a/src/Pim/Component/Catalog/Model/FamilyVariantInterface.php
+++ b/src/Pim/Component/Catalog/Model/FamilyVariantInterface.php
@@ -20,7 +20,7 @@ interface FamilyVariantInterface extends TranslatableInterface
     /**
      * @return string
      */
-    public function getCode(): string;
+    public function getCode(): ?string;
 
     /**
      * @param string $code
@@ -72,7 +72,7 @@ interface FamilyVariantInterface extends TranslatableInterface
     /**
      * @return FamilyInterface
      */
-    public function getFamily(): FamilyInterface;
+    public function getFamily(): ?FamilyInterface;
 
     /**
      * @return int

--- a/src/Pim/Component/Catalog/Updater/FamilyVariantUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/FamilyVariantUpdater.php
@@ -9,6 +9,7 @@ use Akeneo\Component\StorageUtils\Exception\ImmutablePropertyException;
 use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
+use Akeneo\Component\StorageUtils\Exception\UnknownPropertyException;
 use Akeneo\Component\StorageUtils\Factory\SimpleFactoryInterface;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
@@ -166,6 +167,8 @@ class FamilyVariantUpdater implements ObjectUpdaterInterface
                     }
                 }
                 break;
+            default:
+                throw UnknownPropertyException::unknownProperty($field);
         }
     }
 

--- a/src/Pim/Component/Catalog/Updater/FamilyVariantUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/FamilyVariantUpdater.php
@@ -128,7 +128,11 @@ class FamilyVariantUpdater implements ObjectUpdaterInterface
 
                 foreach ($value as $attributeSetData) {
                     if (!is_array($attributeSetData)) {
-                        throw InvalidPropertyTypeException::arrayExpected($field, static::class, $attributeSetData);
+                        throw InvalidPropertyTypeException::arrayOfObjectsExpected(
+                            $field,
+                            static::class,
+                            $attributeSetData
+                        );
                     }
                     if (!isset($attributeSetData['level'])) {
                         continue;

--- a/src/Pim/Component/Catalog/Updater/FamilyVariantUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/FamilyVariantUpdater.php
@@ -113,7 +113,7 @@ class FamilyVariantUpdater implements ObjectUpdaterInterface
                 break;
             case 'variant_attribute_sets':
                 if (!is_array($value)) {
-                    throw InvalidPropertyTypeException::arrayExpected($field, static::class, $value);
+                    throw InvalidPropertyTypeException::arrayOfObjectsExpected($field, static::class, $value);
                 }
 
                 if (null !== $familyVariant->getId() &&
@@ -127,20 +127,35 @@ class FamilyVariantUpdater implements ObjectUpdaterInterface
                 }
 
                 foreach ($value as $attributeSetData) {
+                    if (!is_array($attributeSetData)) {
+                        throw InvalidPropertyTypeException::arrayExpected($field, static::class, $attributeSetData);
+                    }
                     if (!isset($attributeSetData['level'])) {
                         continue;
                     }
 
                     if (isset($attributeSetData['axes']) && !is_array($attributeSetData['axes'])) {
-                        throw InvalidPropertyTypeException::arrayExpected($field, static::class, $value);
+                        throw InvalidPropertyTypeException::arrayExpected(
+                            sprintf('%s" in the property "%s', 'axes', $field),
+                            static::class,
+                            $attributeSetData['axes']
+                        );
                     }
 
                     if (isset($attributeSetData['attributes']) && !is_array($attributeSetData['attributes'])) {
-                        throw InvalidPropertyTypeException::arrayExpected($field, static::class, $value);
+                        throw InvalidPropertyTypeException::arrayExpected(
+                            sprintf('%s" in the property "%s', 'attributes', $field),
+                            static::class,
+                            $attributeSetData['attributes']
+                        );
                     }
 
-                    if (!is_numeric($attributeSetData['level'])) {
-                        throw InvalidPropertyTypeException::numericExpected($field, static::class, $value);
+                    if (!is_integer($attributeSetData['level'])) {
+                        throw InvalidPropertyTypeException::integerExpected(
+                            sprintf('%s" in the property "%s', 'level', $field),
+                            static::class,
+                            $attributeSetData['level']
+                        );
                     }
 
                     if (null === $attributeSet = $familyVariant->getVariantAttributeSet($attributeSetData['level'])) {

--- a/src/Pim/Component/Catalog/Validator/Constraints/FamilyVariant.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/FamilyVariant.php
@@ -11,6 +11,33 @@ use Symfony\Component\Validator\Constraint;
  */
 class FamilyVariant extends Constraint
 {
+    public const FAMILY_VARIANT_NO_LEVEL = 'pim_catalog.constraint.family_variant_no_level';
+
+    public const HAS_FAMILY_ATTRIBUTE = 'pim_catalog.constraint.family_variant_has_family_attribute';
+
+    public const UNIQUE_ATTRIBUTE_IN_LAST_LEVEL =
+        'pim_catalog.constraint.family_variant_unique_attributes_in_last_level';
+
+    public const ATTRIBUTES_UNIQUE = 'pim_catalog.constraint.family_variant_attributes_unique';
+
+    public const AXES_WRONG_TYPE = 'pim_catalog.constraint.family_variant_axes_wrong_type';
+
+    public const AXES_ATTRIBUTE_TYPE_UNIQUE = 'pim_catalog.constraint.family_variant_axes_attribute_type_unique';
+
+    public const AXES_ATTRIBUTE_TYPE = 'pim_catalog.constraint.family_variant_axes_attribute_type';
+
+    public const AXES_LEVEL = 'pim_catalog.constraint.family_variant_axis_level';
+
+    public const AXES_UNIQUE = 'pim_catalog.constraint.family_variant_axes_unique';
+
+    public const MAXIMUM_NUMBER_OF_LEVEL = 'pim_catalog.constraint.family_variant_maximum_number_of_level';
+
+    public const LEVEL_DO_NOT_EXIST = 'pim_catalog.constraint.family_variant_level_do_not_exist';
+
+    public const NUMBER_OF_AXES = 'pim_catalog.constraint.family_variant_axes_number_of_axes';
+
+    public const NO_AXIS = 'pim_catalog.constraint.family_variant_no_axis';
+
     /**
      * {@inheritdoc}
      */

--- a/src/Pim/Component/Catalog/Validator/Constraints/FamilyVariantValidator.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/FamilyVariantValidator.php
@@ -18,20 +18,9 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
  */
 class FamilyVariantValidator extends ConstraintValidator
 {
-    const MAXIMUM_LEVEL_NUMBER = 2;
+    private const MAXIMUM_LEVEL_NUMBER = 2;
 
-    const MAXIMUM_AXES_NUMBER = 5;
-
-    /** @var TranslatorInterface */
-    private $translator;
-
-    /**
-     * @param TranslatorInterface $translator
-     */
-    public function __construct(TranslatorInterface $translator)
-    {
-        $this->translator = $translator;
-    }
+    private const MAXIMUM_AXES_NUMBER = 5;
 
     /**
      * {@inheritdoc}
@@ -51,8 +40,9 @@ class FamilyVariantValidator extends ConstraintValidator
         $validateAttributesSets = true;
 
         if (0 === $familyVariant->getNumberOfLevel()) {
-            $message = $this->translator->trans('pim_catalog.constraint.family_variant_no_level');
-            $this->context->buildViolation($message)->atPath('variant_attribute_sets')->addViolation();
+            $this->context
+                ->buildViolation(FamilyVariant::FAMILY_VARIANT_NO_LEVEL)
+                ->addViolation();
             $validateAttributesSets = false;
         }
 
@@ -83,32 +73,27 @@ class FamilyVariantValidator extends ConstraintValidator
             $attributeCodes[] = $attribute->getCode();
 
             if (!$family->hasAttribute($attribute)) {
-                $message = $this->translator->trans('pim_catalog.constraint.family_variant_has_family_attribute');
-                $this->context->buildViolation($message, [
+                $this->context->buildViolation(FamilyVariant::HAS_FAMILY_ATTRIBUTE, [
                     '%attribute%' => $attribute->getCode(),
                     '%family%' => $family->getCode(),
                     '%family_variant%' => $familyVariant->getCode(),
-                ])->atPath('variant_attribute_sets')->addViolation();
+                ])->addViolation();
             }
 
             if ($attribute->isUnique() &&
                 null !== $lastLevelAttributeSet &&
                 !$lastLevelAttributeSet->hasAttribute($attribute)
             ) {
-                $message = $this->translator->trans(
-                    'pim_catalog.constraint.family_variant_unique_attributes_in_last_level'
-                );
-                $this->context->buildViolation($message, [
+                $this->context->buildViolation(FamilyVariant::UNIQUE_ATTRIBUTE_IN_LAST_LEVEL, [
                     '%attribute%' => $attribute->getCode(),
-                ])->atPath('variant_attribute_sets')->addViolation();
+                ])->addViolation();
             }
         }
 
         if (count($attributeCodes) !== count(array_unique($attributeCodes))) {
-            $message = $this->translator->trans('pim_catalog.constraint.family_variant_attributes_unique');
-            $this->context->buildViolation($message, [
+            $this->context->buildViolation(FamilyVariant::ATTRIBUTES_UNIQUE, [
                 '%attributes%' => implode(',', array_diff_assoc($attributeCodes, array_unique($attributeCodes)))
-            ])->atPath('variant_attribute_sets')->addViolation();
+            ])->addViolation();
         }
     }
 
@@ -125,25 +110,22 @@ class FamilyVariantValidator extends ConstraintValidator
         foreach ($axes as $axis) {
             $axisCodes[] = $axis->getCode();
             if ($axis->isLocalizable() || $axis->isScopable() || $axis->isLocaleSpecific()) {
-                $message = $this->translator->trans('pim_catalog.constraint.family_variant_axes_wrong_type');
-                $this->context->buildViolation($message, [
+                $this->context->buildViolation(FamilyVariant::AXES_WRONG_TYPE, [
                     '%axis%' => $axis->getCode(),
-                ])->atPath('variant_attribute_sets')->addViolation();
+                ])->addViolation();
             }
 
             if ($axis->isUnique()) {
-                $message = $this->translator->trans('pim_catalog.constraint.family_variant_axes_attribute_type_unique');
-                $this->context->buildViolation($message, [
+                $this->context->buildViolation(FamilyVariant::AXES_ATTRIBUTE_TYPE_UNIQUE, [
                     '%axis%' => $axis->getCode(),
-                ])->atPath('variant_attribute_sets')->addViolation();
+                ])->addViolation();
             }
 
             $availableTypes = FamilyVariantModel::getAvailableAxesAttributeTypes();
             if (!in_array($axis->getType(), $availableTypes)) {
-                $message = $this->translator->trans('pim_catalog.constraint.family_variant_axes_attribute_type');
-                $this->context->buildViolation($message, [
+                $this->context->buildViolation(FamilyVariant::AXES_ATTRIBUTE_TYPE, [
                     '%axis%' => $axis->getCode(),
-                ])->atPath('variant_attribute_sets')->addViolation();
+                ])->addViolation();
             }
 
             for ($level = 1; $level <= $familyVariant->getNumberOfLevel(); $level++) {
@@ -152,19 +134,17 @@ class FamilyVariantValidator extends ConstraintValidator
                     !$variantAttributeSet->getAxes()->contains($axis) &&
                     $variantAttributeSet->getAttributes()->contains($axis)
                 ) {
-                    $message = $this->translator->trans('pim_catalog.constraint.family_variant_axis_level');
-                    $this->context->buildViolation($message, [
+                    $this->context->buildViolation(FamilyVariant::AXES_LEVEL, [
                         '%axis%' => $axis->getCode(),
-                    ])->atPath('variant_attribute_sets')->addViolation();
+                    ])->addViolation();
                 }
             }
         }
 
         if (count($axisCodes) !== count(array_unique($axisCodes))) {
-            $message = $this->translator->trans('pim_catalog.constraint.family_variant_axes_unique');
-            $this->context->buildViolation($message, [
+            $this->context->buildViolation(FamilyVariant::AXES_UNIQUE, [
                 '%attributes%' => implode(array_diff_assoc($axisCodes, array_unique($axisCodes))),
-            ])->atPath('variant_attribute_sets')->addViolation();
+            ])->addViolation();
         }
     }
 
@@ -176,10 +156,11 @@ class FamilyVariantValidator extends ConstraintValidator
         $numberOfLevel = $familyVariant->getNumberOfLevel();
 
         if (self::MAXIMUM_LEVEL_NUMBER < $numberOfLevel) {
-            $message = $this->translator->trans('pim_catalog.constraint.family_variant_maximum_number_of_level');
             $this->context
-                ->buildViolation($message, ['%level%' => self::MAXIMUM_LEVEL_NUMBER,])
-                ->atPath('variant_attribute_sets')
+                ->buildViolation(
+                    FamilyVariant::MAXIMUM_NUMBER_OF_LEVEL,
+                    ['%level%' => self::MAXIMUM_LEVEL_NUMBER]
+                )
                 ->addViolation();
         }
 
@@ -188,18 +169,22 @@ class FamilyVariantValidator extends ConstraintValidator
             $attributeSet = $familyVariant->getVariantAttributeSet($i + 1);
 
             if (null === $attributeSet) {
-                $message = $this->translator->trans('pim_catalog.constraint.family_variant_level_do_not_exist');
-                $this->context->buildViolation($message, [
-                    '%level%' => $i + 1,
-                ])->atPath('variant_attribute_sets')->addViolation();
+                $this->context
+                    ->buildViolation(
+                        FamilyVariant::LEVEL_DO_NOT_EXIST,
+                        ['%level%' => $i + 1])
+                    ->addViolation();
             } elseif (static::MAXIMUM_AXES_NUMBER < $attributeSet->getAxes()->count()) {
-                $message = $this->translator->trans('pim_catalog.constraint.family_variant_axes_number_of_axes');
-                $this->context->buildViolation($message)->addViolation();
+                $this->context
+                    ->buildViolation(
+                        FamilyVariant::NUMBER_OF_AXES,
+                        ['%max_axes_number%' => static::MAXIMUM_AXES_NUMBER]
+                    )
+                    ->addViolation();
             } elseif (0 === $attributeSet->getAxes()->count()) {
-                $message = $this->translator->trans('pim_catalog.constraint.family_variant_no_axis');
-                $this->context->buildViolation($message, [
-                    '%level%' => $i + 1,
-                ])->addViolation();
+                $this->context
+                    ->buildViolation(FamilyVariant::NO_AXIS, ['%level%' => $i + 1])
+                    ->addViolation();
             }
 
             $i++;

--- a/src/Pim/Component/Catalog/Validator/Constraints/FamilyVariantValidator.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/FamilyVariantValidator.php
@@ -18,6 +18,8 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
  */
 class FamilyVariantValidator extends ConstraintValidator
 {
+    const MAXIMUM_LEVEL_NUMBER = 2;
+
     const MAXIMUM_AXES_NUMBER = 5;
 
     /** @var TranslatorInterface */
@@ -46,9 +48,24 @@ class FamilyVariantValidator extends ConstraintValidator
             throw new UnexpectedTypeException($constraint, FamilyVariant::class);
         }
 
-        $this->validateAxesAttributes($familyVariant);
-        $this->validateAttributes($familyVariant);
-        $this->validateNumberOfLevelAndAxis($familyVariant);
+        $validateAttributesSets = true;
+
+        if (0 === $familyVariant->getNumberOfLevel()) {
+            $message = $this->translator->trans('pim_catalog.constraint.family_variant_no_level');
+            $this->context->buildViolation($message)->atPath('variant_attribute_sets')->addViolation();
+            $validateAttributesSets = false;
+        }
+
+        // handled by another constraint
+        if (null === $familyVariant->getFamily()) {
+            $validateAttributesSets = false;
+        }
+
+        if (true === $validateAttributesSets) {
+            $this->validateAxesAttributes($familyVariant);
+            $this->validateAttributes($familyVariant);
+            $this->validateNumberOfLevelAndAxis($familyVariant);
+        }
     }
 
     /**
@@ -71,7 +88,7 @@ class FamilyVariantValidator extends ConstraintValidator
                     '%attribute%' => $attribute->getCode(),
                     '%family%' => $family->getCode(),
                     '%family_variant%' => $familyVariant->getCode(),
-                ])->addViolation();
+                ])->atPath('variant_attribute_sets')->addViolation();
             }
 
             if ($attribute->isUnique() &&
@@ -83,7 +100,7 @@ class FamilyVariantValidator extends ConstraintValidator
                 );
                 $this->context->buildViolation($message, [
                     '%attribute%' => $attribute->getCode(),
-                ])->addViolation();
+                ])->atPath('variant_attribute_sets')->addViolation();
             }
         }
 
@@ -91,7 +108,7 @@ class FamilyVariantValidator extends ConstraintValidator
             $message = $this->translator->trans('pim_catalog.constraint.family_variant_attributes_unique');
             $this->context->buildViolation($message, [
                 '%attributes%' => implode(',', array_diff_assoc($attributeCodes, array_unique($attributeCodes)))
-            ])->addViolation();
+            ])->atPath('variant_attribute_sets')->addViolation();
         }
     }
 
@@ -111,7 +128,14 @@ class FamilyVariantValidator extends ConstraintValidator
                 $message = $this->translator->trans('pim_catalog.constraint.family_variant_axes_wrong_type');
                 $this->context->buildViolation($message, [
                     '%axis%' => $axis->getCode(),
-                ])->addViolation();
+                ])->atPath('variant_attribute_sets')->addViolation();
+            }
+
+            if ($axis->isUnique()) {
+                $message = $this->translator->trans('pim_catalog.constraint.family_variant_axes_attribute_type_unique');
+                $this->context->buildViolation($message, [
+                    '%axis%' => $axis->getCode(),
+                ])->atPath('variant_attribute_sets')->addViolation();
             }
 
             $availableTypes = FamilyVariantModel::getAvailableAxesAttributeTypes();
@@ -119,7 +143,7 @@ class FamilyVariantValidator extends ConstraintValidator
                 $message = $this->translator->trans('pim_catalog.constraint.family_variant_axes_attribute_type');
                 $this->context->buildViolation($message, [
                     '%axis%' => $axis->getCode(),
-                ])->addViolation();
+                ])->atPath('variant_attribute_sets')->addViolation();
             }
 
             for ($level = 1; $level <= $familyVariant->getNumberOfLevel(); $level++) {
@@ -131,7 +155,7 @@ class FamilyVariantValidator extends ConstraintValidator
                     $message = $this->translator->trans('pim_catalog.constraint.family_variant_axis_level');
                     $this->context->buildViolation($message, [
                         '%axis%' => $axis->getCode(),
-                    ])->addViolation();
+                    ])->atPath('variant_attribute_sets')->addViolation();
                 }
             }
         }
@@ -140,7 +164,7 @@ class FamilyVariantValidator extends ConstraintValidator
             $message = $this->translator->trans('pim_catalog.constraint.family_variant_axes_unique');
             $this->context->buildViolation($message, [
                 '%attributes%' => implode(array_diff_assoc($axisCodes, array_unique($axisCodes))),
-            ])->addViolation();
+            ])->atPath('variant_attribute_sets')->addViolation();
         }
     }
 
@@ -150,6 +174,15 @@ class FamilyVariantValidator extends ConstraintValidator
     private function validateNumberOfLevelAndAxis(FamilyVariantInterface $familyVariant): void
     {
         $numberOfLevel = $familyVariant->getNumberOfLevel();
+
+        if (self::MAXIMUM_LEVEL_NUMBER < $numberOfLevel) {
+            $message = $this->translator->trans('pim_catalog.constraint.family_variant_maximum_number_of_level');
+            $this->context
+                ->buildViolation($message, ['%level%' => self::MAXIMUM_LEVEL_NUMBER,])
+                ->atPath('variant_attribute_sets')
+                ->addViolation();
+        }
+
         $i = 0;
         while ($i !== $numberOfLevel) {
             $attributeSet = $familyVariant->getVariantAttributeSet($i + 1);
@@ -158,7 +191,7 @@ class FamilyVariantValidator extends ConstraintValidator
                 $message = $this->translator->trans('pim_catalog.constraint.family_variant_level_do_not_exist');
                 $this->context->buildViolation($message, [
                     '%level%' => $i + 1,
-                ])->addViolation();
+                ])->atPath('variant_attribute_sets')->addViolation();
             } elseif (static::MAXIMUM_AXES_NUMBER < $attributeSet->getAxes()->count()) {
                 $message = $this->translator->trans('pim_catalog.constraint.family_variant_axes_number_of_axes');
                 $this->context->buildViolation($message)->addViolation();

--- a/tests/catalog/technical/acl.sql
+++ b/tests/catalog/technical/acl.sql
@@ -37,7 +37,8 @@ INSERT INTO `acl_classes` VALUES
     (15,'pim_api_currency_list'),
     (16,'pim_api_channel_edit'),
     (17,'pim_api_association_type_list'),
-    (18,'pim_api_association_type_edit')
+    (18,'pim_api_association_type_edit'),
+    (19,'pim_api_family_variant_edit')
 ;
 /*!40000 ALTER TABLE `acl_classes` ENABLE KEYS */;
 
@@ -65,7 +66,8 @@ INSERT INTO `acl_entries` VALUES
     (16,16,NULL,2,NULL,0,0,1,'all',0,0),
     (17,17,NULL,2,NULL,0,0,1,'all',0,0),
     (18,1,NULL,4,NULL,0,0,1,'all',0,0),
-    (19,18,NULL,2,NULL,0,0,1,'all',0,0)
+    (19,18,NULL,2,NULL,0,0,1,'all',0,0),
+    (20,19,NULL,2,NULL,0,0,1,'all',0,0)
 ;
 /*!40000 ALTER TABLE `acl_entries` ENABLE KEYS */;
 
@@ -92,7 +94,8 @@ INSERT INTO `acl_object_identities` VALUES
     (15,NULL,15,'action',1),
     (16,NULL,16,'action',1),
     (17,NULL,17,'action',1),
-    (18,NULL,18,'action',1)
+    (18,NULL,18,'action',1),
+    (19,NULL,19,'action',1)
 ;
 /*!40000 ALTER TABLE `acl_object_identities` ENABLE KEYS */;
 
@@ -119,7 +122,8 @@ INSERT INTO `acl_object_identity_ancestors` VALUES
     (15,15),
     (16,16),
     (17,17),
-    (18,18)
+    (18,18),
+    (19,19)
 ;
 /*!40000 ALTER TABLE `acl_object_identity_ancestors` ENABLE KEYS */;
 


### PR DESCRIPTION
It adds integration tests to check the family variant creation.
It adds a route to create a family variant via API and integration tests to check API.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | OK
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
