### PR TITLE
PIM-6872: fix exception when attribute sorted is not in mapping

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -10,6 +10,7 @@
 - PIM-6876: Escape u001f character to workaround a mysql bug
 - TIP-810: Add Symfony command to reset the ES indexes
 - TIP-809: Prevents ES from using the scoring system and bypass the max_clause_count limit.
+- PIM-6872: Fix PQB sorters with Elasticsearch
 
 ## Better UI\UX!
 

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Sorter/Attribute/AbstractAttributeSorter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Sorter/Attribute/AbstractAttributeSorter.php
@@ -42,6 +42,8 @@ abstract class AbstractAttributeSorter implements AttributeSorterInterface
 
     /**
      * {@inheritdoc}
+     *
+     * About "unmapped_type", see https://www.elastic.co/guide/en/elasticsearch/reference/5.x/search-request-sort.html#_ignoring_unmapped_fields
      */
     public function addAttributeSorter(AttributeInterface $attribute, $direction, $locale = null, $channel = null)
     {
@@ -64,6 +66,7 @@ abstract class AbstractAttributeSorter implements AttributeSorterInterface
                     $attributePath => [
                         'order'   => 'ASC',
                         'missing' => '_last',
+                        'unmapped_type' => 'long',
                     ],
                 ];
                 $this->searchQueryBuilder->addSort($sortClause);
@@ -74,6 +77,7 @@ abstract class AbstractAttributeSorter implements AttributeSorterInterface
                     $attributePath => [
                         'order'   => 'DESC',
                         'missing' => '_last',
+                        'unmapped_type' => 'long',
                     ],
                 ];
 

--- a/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Sorter/Attribute/BaseAttributeSorterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Sorter/Attribute/BaseAttributeSorterSpec.php
@@ -39,7 +39,8 @@ class BaseAttributeSorterSpec extends ObjectBehavior
         $sqb->addSort([
             'values.a_custom_attribute-backend_type.<all_channels>.<all_locales>' => [
                 'order' => 'ASC',
-                'missing' => '_last'
+                'missing' => '_last',
+                'unmapped_type' => 'long'
             ]
         ])->shouldBeCalled();
 
@@ -62,7 +63,8 @@ class BaseAttributeSorterSpec extends ObjectBehavior
         $sqb->addSort([
             'values.a_custom_attribute-backend_type.ecommerce.fr_FR' => [
                 'order' => 'ASC',
-                'missing' => '_last'
+                'missing' => '_last',
+                'unmapped_type' => 'long'
             ]
         ])->shouldBeCalled();
 
@@ -84,7 +86,8 @@ class BaseAttributeSorterSpec extends ObjectBehavior
         $sqb->addSort([
             'values.a_custom_attribute-backend_type.ecommerce.fr_FR' => [
                 'order' => 'DESC',
-                'missing' => '_last'
+                'missing' => '_last',
+                'unmapped_type' => 'long'
             ]
         ])->shouldBeCalled();
 

--- a/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Sorter/Attribute/MetricSorterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Sorter/Attribute/MetricSorterSpec.php
@@ -39,7 +39,8 @@ class MetricSorterSpec extends ObjectBehavior
         $sqb->addSort([
             'values.a_metric-metric.<all_channels>.<all_locales>.base_data' => [
                 'order' => 'ASC',
-                'missing' => '_last'
+                'missing' => '_last',
+                'unmapped_type' => 'long'
             ]
         ])->shouldBeCalled();
 
@@ -62,7 +63,8 @@ class MetricSorterSpec extends ObjectBehavior
         $sqb->addSort([
             'values.a_metric-metric.ecommerce.fr_FR.base_data' => [
                 'order' => 'ASC',
-                'missing' => '_last'
+                'missing' => '_last',
+                'unmapped_type' => 'long'
             ]
         ])->shouldBeCalled();
 
@@ -84,7 +86,8 @@ class MetricSorterSpec extends ObjectBehavior
         $sqb->addSort([
             'values.a_metric-metric.ecommerce.fr_FR.base_data' => [
                 'order' => 'DESC',
-                'missing' => '_last'
+                'missing' => '_last',
+                'unmapped_type' => 'long'
             ]
         ])->shouldBeCalled();
 

--- a/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Sorter/Attribute/TextAreaSorterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Sorter/Attribute/TextAreaSorterSpec.php
@@ -38,7 +38,8 @@ class TextAreaSorterSpec extends ObjectBehavior
         $sqb->addSort([
             'values.a_text_area-textarea.<all_channels>.<all_locales>.preprocessed' => [
                 'order' => 'ASC',
-                'missing' => '_last'
+                'missing' => '_last',
+                'unmapped_type' => 'long'
             ]
         ])->shouldBeCalled();
 
@@ -56,7 +57,8 @@ class TextAreaSorterSpec extends ObjectBehavior
         $sqb->addSort([
             'values.a_text_area-textarea.ecommerce.fr_FR.preprocessed' => [
                 'order' => 'ASC',
-                'missing' => '_last'
+                'missing' => '_last',
+                'unmapped_type' => 'long'
             ]
         ])->shouldBeCalled();
 
@@ -74,7 +76,8 @@ class TextAreaSorterSpec extends ObjectBehavior
         $sqb->addSort([
             'values.a_text_area-textarea.ecommerce.fr_FR.preprocessed' => [
                 'order' => 'DESC',
-                'missing' => '_last'
+                'missing' => '_last',
+                'unmapped_type' => 'long'
             ]
         ])->shouldBeCalled();
 

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Boolean/LocalizableScopableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Boolean/LocalizableScopableSorterIntegration.php
@@ -80,4 +80,16 @@ class LocalizableScopableSorterIntegration extends AbstractProductQueryBuilderTe
     {
         $this->executeSorter([['a_localizable_scopable_yes_no', 'A_BAD_DIRECTION', ['locale' => 'fr_FR', 'scope' => 'tablet']]]);
     }
+
+    /**
+     * @jira https://akeneo.atlassian.net/browse/PIM-6872
+     */
+    public function testSorterWithNoDataOnSorterField()
+    {
+        $result = $this->executeSorter([['a_localizable_scopable_yes_no', Directions::DESCENDING, ['locale' => 'de_DE', 'scope' => 'ecommerce_china']]]);
+        $this->assertOrder($result, ['product_one', 'product_two', 'empty_product']);
+
+        $result = $this->executeSorter([['a_localizable_scopable_yes_no', Directions::ASCENDING, ['locale' => 'de_DE', 'scope' => 'ecommerce_china']]]);
+        $this->assertOrder($result, ['product_one', 'product_two', 'empty_product']);
+    }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Boolean/LocalizableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Boolean/LocalizableSorterIntegration.php
@@ -76,4 +76,16 @@ class LocalizableSorterIntegration extends AbstractProductQueryBuilderTestCase
     {
         $this->executeSorter([['a_localizable_yes_no', 'A_BAD_DIRECTION', ['locale' => 'fr_FR']]]);
     }
+
+    /**
+     * @jira https://akeneo.atlassian.net/browse/PIM-6872
+     */
+    public function testSorterWithNoDataOnSorterField()
+    {
+        $result = $this->executeSorter([['a_localizable_yes_no', Directions::DESCENDING, ['locale' => 'de_DE']]]);
+        $this->assertOrder($result, ['product_one', 'product_two', 'empty_product']);
+
+        $result = $this->executeSorter([['a_localizable_yes_no', Directions::ASCENDING, ['locale' => 'de_DE']]]);
+        $this->assertOrder($result, ['product_one', 'product_two', 'empty_product']);
+    }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Boolean/ScopableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Boolean/ScopableSorterIntegration.php
@@ -76,4 +76,16 @@ class ScopableSorterIntegration extends AbstractProductQueryBuilderTestCase
     {
         $this->executeSorter([['a_scopable_yes_no', 'A_BAD_DIRECTION', ['scope' => 'ecommerce']]]);
     }
+
+    /**
+     * @jira https://akeneo.atlassian.net/browse/PIM-6872
+     */
+    public function testSorterWithNoDataOnSorterField()
+    {
+        $result = $this->executeSorter([['a_scopable_yes_no', Directions::DESCENDING, ['scope' => 'ecommerce_china']]]);
+        $this->assertOrder($result, ['product_one', 'product_two', 'empty_product']);
+
+        $result = $this->executeSorter([['a_scopable_yes_no', Directions::ASCENDING, ['scope' => 'ecommerce_china']]]);
+        $this->assertOrder($result, ['product_one', 'product_two', 'empty_product']);
+    }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Date/LocalizableScopableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Date/LocalizableScopableSorterIntegration.php
@@ -49,6 +49,18 @@ class LocalizableScopableSorterIntegration extends AbstractProductQueryBuilderTe
     }
 
     /**
+     * @jira https://akeneo.atlassian.net/browse/PIM-6872
+     */
+    public function testSorterWithNoDataOnSorterField()
+    {
+        $result = $this->executeSorter([['a_localizable_scopable_date', Directions::DESCENDING, ['locale' => 'de_DE', 'scope' => 'ecommerce_china']]]);
+        $this->assertOrder($result, ['product_one', 'product_two', 'product_three', 'product_four', 'empty_product']);
+
+        $result = $this->executeSorter([['a_localizable_scopable_date', Directions::ASCENDING, ['locale' => 'de_DE', 'scope' => 'ecommerce_china']]]);
+        $this->assertOrder($result, ['product_one', 'product_two', 'product_three', 'product_four', 'empty_product']);
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function setUp()

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Date/LocalizableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Date/LocalizableSorterIntegration.php
@@ -37,6 +37,18 @@ class LocalizableSorterIntegration extends AbstractProductQueryBuilderTestCase
     }
 
     /**
+     * @jira https://akeneo.atlassian.net/browse/PIM-6872
+     */
+    public function testSorterWithNoDataOnSorterField()
+    {
+        $result = $this->executeSorter([['a_localizable_date', Directions::DESCENDING, ['locale' => 'de_DE']]]);
+        $this->assertOrder($result, ['product_one', 'product_two', 'product_three', 'empty_product']);
+
+        $result = $this->executeSorter([['a_localizable_date', Directions::ASCENDING, ['locale' => 'de_DE']]]);
+        $this->assertOrder($result, ['product_one', 'product_two', 'product_three', 'empty_product']);
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function setUp()

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Date/ScopableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Date/ScopableSorterIntegration.php
@@ -37,6 +37,18 @@ class ScopableSorterIntegration extends AbstractProductQueryBuilderTestCase
     }
 
     /**
+     * @jira https://akeneo.atlassian.net/browse/PIM-6872
+     */
+    public function testSorterWithNoDataOnSorterField()
+    {
+        $result = $this->executeSorter([['a_scopable_date', Directions::DESCENDING, ['scope' => 'ecommerce_china']]]);
+        $this->assertOrder($result, ['product_one', 'product_two', 'product_three', 'empty_product']);
+
+        $result = $this->executeSorter([['a_scopable_date', Directions::ASCENDING, ['scope' => 'ecommerce_china']]]);
+        $this->assertOrder($result, ['product_one', 'product_two', 'product_three', 'empty_product']);
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function setUp()

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Metric/LocalizableScopableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Metric/LocalizableScopableSorterIntegration.php
@@ -85,4 +85,16 @@ class LocalizableScopableSorterIntegration extends AbstractProductQueryBuilderTe
     {
         $this->executeSorter([['a_localizable_scopable_metric', 'A_BAD_DIRECTION', ['locale' => 'fr_FR', 'scope' => 'tablet']]]);
     }
+
+    /**
+     * @jira https://akeneo.atlassian.net/browse/PIM-6872
+     */
+    public function testSorterWithNoDataOnSorterField()
+    {
+        $result = $this->executeSorter([['a_localizable_scopable_metric', Directions::DESCENDING, ['locale' => 'de_DE', 'scope' => 'ecommerce_china']]]);
+        $this->assertOrder($result, ['product_one', 'product_two', 'product_three', 'product_four']);
+
+        $result = $this->executeSorter([['a_localizable_scopable_metric', Directions::ASCENDING, ['locale' => 'de_DE', 'scope' => 'ecommerce_china']]]);
+        $this->assertOrder($result, ['product_one', 'product_two', 'product_three', 'product_four']);
+    }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Metric/LocalizableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Metric/LocalizableSorterIntegration.php
@@ -79,4 +79,16 @@ class LocalizableSorterIntegration extends AbstractProductQueryBuilderTestCase
     {
         $this->executeSorter([['a_localizable_metric', 'A_BAD_DIRECTION', ['locale' => 'fr_FR']]]);
     }
+
+    /**
+     * @jira https://akeneo.atlassian.net/browse/PIM-6872
+     */
+    public function testSorterWithNoDataOnSorterField()
+    {
+        $result = $this->executeSorter([['a_localizable_metric', Directions::DESCENDING, ['locale' => 'de_DE']]]);
+        $this->assertOrder($result, ['product_one', 'product_two', 'product_three', 'empty_product']);
+
+        $result = $this->executeSorter([['a_localizable_metric', Directions::ASCENDING, ['locale' => 'de_DE']]]);
+        $this->assertOrder($result, ['product_one', 'product_two', 'product_three', 'empty_product']);
+    }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Metric/ScopableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Metric/ScopableSorterIntegration.php
@@ -79,4 +79,16 @@ class ScopableSorterIntegration extends AbstractProductQueryBuilderTestCase
     {
         $this->executeSorter([['a_scopable_metric', 'A_BAD_DIRECTION', ['scope' => 'ecommerce']]]);
     }
+
+    /**
+     * @jira https://akeneo.atlassian.net/browse/PIM-6872
+     */
+    public function testSorterWithNoDataOnSorterField()
+    {
+        $result = $this->executeSorter([['a_scopable_metric', Directions::DESCENDING, ['scope' => 'ecommerce_china']]]);
+        $this->assertOrder($result, ['product_one', 'product_two', 'product_three', 'empty_product']);
+
+        $result = $this->executeSorter([['a_scopable_metric', Directions::ASCENDING, ['scope' => 'ecommerce_china']]]);
+        $this->assertOrder($result, ['product_one', 'product_two', 'product_three', 'empty_product']);
+    }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Number/LocalizableScopableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Number/LocalizableScopableSorterIntegration.php
@@ -83,4 +83,16 @@ class LocalizableScopableSorterIntegration extends AbstractProductQueryBuilderTe
     {
         $this->executeSorter([['a_localizable_scopable_number', 'A_BAD_DIRECTION', ['locale' => 'en_US', 'scope' => 'ecommerce']]]);
     }
+
+    /**
+     * @jira https://akeneo.atlassian.net/browse/PIM-6872
+     */
+    public function testSorterWithNoDataOnSorterField()
+    {
+        $result = $this->executeSorter([['a_localizable_scopable_number', Directions::DESCENDING, ['locale' => 'de_DE', 'scope' => 'ecommerce_china']]]);
+        $this->assertOrder($result, ['product_one', 'product_two', 'product_three']);
+
+        $result = $this->executeSorter([['a_localizable_scopable_number', Directions::ASCENDING, ['locale' => 'de_DE', 'scope' => 'ecommerce_china']]]);
+        $this->assertOrder($result, ['product_one', 'product_two', 'product_three']);
+    }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Number/LocalizableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Number/LocalizableSorterIntegration.php
@@ -83,4 +83,16 @@ class LocalizableSorterIntegration extends AbstractProductQueryBuilderTestCase
     {
         $this->executeSorter([['a_localizable_number', 'A_BAD_DIRECTION', ['locale' => 'en_US']]]);
     }
+
+    /**
+     * @jira https://akeneo.atlassian.net/browse/PIM-6872
+     */
+    public function testSorterWithNoDataOnSorterField()
+    {
+        $result = $this->executeSorter([['a_localizable_number', Directions::DESCENDING, ['locale' => 'de_DE']]]);
+        $this->assertOrder($result, ['product_three', 'product_one', 'product_two']);
+
+        $result = $this->executeSorter([['a_localizable_number', Directions::ASCENDING, ['locale' => 'de_DE']]]);
+        $this->assertOrder($result, ['product_three', 'product_one', 'product_two']);
+    }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Number/ScopableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Number/ScopableSorterIntegration.php
@@ -77,4 +77,16 @@ class ScopableSorterIntegration extends AbstractProductQueryBuilderTestCase
     {
         $this->executeSorter([['a_scopable_number', 'A_BAD_DIRECTION', ['scope' => 'ecommerce']]]);
     }
+
+    /**
+     * @jira https://akeneo.atlassian.net/browse/PIM-6872
+     */
+    public function testSorterWithNoDataOnSorterField()
+    {
+        $result = $this->executeSorter([['a_scopable_number', Directions::DESCENDING, ['scope' => 'ecommerce_china']]]);
+        $this->assertOrder($result, ['product_one', 'product_two', 'empty_product']);
+
+        $result = $this->executeSorter([['a_scopable_number', Directions::ASCENDING, ['scope' => 'ecommerce_china']]]);
+        $this->assertOrder($result, ['product_one', 'product_two', 'empty_product']);
+    }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Option/LocalizableScopableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Option/LocalizableScopableSorterIntegration.php
@@ -116,4 +116,16 @@ class LocalizableScopableSorterIntegration extends AbstractProductQueryBuilderTe
             ],
         ]);
     }
+
+    /**
+     * @jira https://akeneo.atlassian.net/browse/PIM-6872
+     */
+    public function testSorterWithNoDataOnSorterField()
+    {
+        $result = $this->executeSorter([['a_localizable_scopable_simple_select', Directions::DESCENDING, ['locale' => 'de_DE', 'scope' => 'ecommerce_china']]]);
+        $this->assertOrder($result, ['product_one', 'product_two', 'empty_product']);
+
+        $result = $this->executeSorter([['a_localizable_scopable_simple_select', Directions::ASCENDING, ['locale' => 'de_DE', 'scope' => 'ecommerce_china']]]);
+        $this->assertOrder($result, ['product_one', 'product_two', 'empty_product']);
+    }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Option/LocalizableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Option/LocalizableSorterIntegration.php
@@ -98,4 +98,16 @@ class LocalizableSorterIntegration extends AbstractProductQueryBuilderTestCase
     {
         $this->executeSorter([['a_localizable_simple_select', 'A_BAD_DIRECTION', ['locale' => 'en_US']]]);
     }
+
+    /**
+     * @jira https://akeneo.atlassian.net/browse/PIM-6872
+     */
+    public function testSorterWithNoDataOnSorterField()
+    {
+        $result = $this->executeSorter([['a_localizable_simple_select', Directions::DESCENDING, ['locale' => 'de_DE']]]);
+        $this->assertOrder($result, ['product_one', 'product_two', 'empty_product']);
+
+        $result = $this->executeSorter([['a_localizable_simple_select', Directions::ASCENDING, ['locale' => 'de_DE']]]);
+        $this->assertOrder($result, ['product_one', 'product_two', 'empty_product']);
+    }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Option/ScopableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Option/ScopableSorterIntegration.php
@@ -86,4 +86,16 @@ class ScopableSorterIntegration extends AbstractProductQueryBuilderTestCase
     {
         $this->executeSorter([['a_select_scopable_simple_select', 'A_BAD_DIRECTION', ['scope' => 'ecommerce']]]);
     }
+
+    /**
+     * @jira https://akeneo.atlassian.net/browse/PIM-6872
+     */
+    public function testSorterWithNoDataOnSorterField()
+    {
+        $result = $this->executeSorter([['a_select_scopable_simple_select', Directions::DESCENDING, ['scope' => 'ecommerce_china']]]);
+        $this->assertOrder($result, ['product_one', 'product_two', 'empty_product']);
+
+        $result = $this->executeSorter([['a_select_scopable_simple_select', Directions::ASCENDING, ['scope' => 'ecommerce_china']]]);
+        $this->assertOrder($result, ['product_one', 'product_two', 'empty_product']);
+    }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Text/LocalizableScopableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Text/LocalizableScopableSorterIntegration.php
@@ -106,4 +106,16 @@ class LocalizableScopableSorterIntegration extends AbstractProductQueryBuilderTe
             ],
         ]);
     }
+
+    /**
+     * @jira https://akeneo.atlassian.net/browse/PIM-6872
+     */
+    public function testSorterWithNoDataOnSorterField()
+    {
+        $result = $this->executeSorter([['a_localizable_scopable_text', Directions::DESCENDING, ['locale' => 'de_DE', 'scope' => 'ecommerce_china']]]);
+        $this->assertOrder($result, ['product_one', 'product_two', 'empty_product']);
+
+        $result = $this->executeSorter([['a_localizable_scopable_text', Directions::ASCENDING, ['locale' => 'de_DE', 'scope' => 'ecommerce_china']]]);
+        $this->assertOrder($result, ['product_one', 'product_two', 'empty_product']);
+    }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Text/LocalizableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Text/LocalizableSorterIntegration.php
@@ -88,4 +88,16 @@ class LocalizableSorterIntegration extends AbstractProductQueryBuilderTestCase
     {
         $this->executeSorter([['a_localizable_text', 'A_BAD_DIRECTION', ['locale' => 'en_US']]]);
     }
+
+    /**
+     * @jira https://akeneo.atlassian.net/browse/PIM-6872
+     */
+    public function testSorterWithNoDataOnSorterField()
+    {
+        $result = $this->executeSorter([['a_localizable_text', Directions::DESCENDING, ['locale' => 'de_DE']]]);
+        $this->assertOrder($result, ['product_one', 'product_two', 'empty_product']);
+
+        $result = $this->executeSorter([['a_localizable_text', Directions::ASCENDING, ['locale' => 'de_DE']]]);
+        $this->assertOrder($result, ['product_one', 'product_two', 'empty_product']);
+    }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Text/ScopableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/Text/ScopableSorterIntegration.php
@@ -76,4 +76,16 @@ class ScopableSorterIntegration extends AbstractProductQueryBuilderTestCase
     {
         $this->executeSorter([['a_scopable_text', 'A_BAD_DIRECTION', ['scope' => 'ecommerce']]]);
     }
+
+    /**
+     * @jira https://akeneo.atlassian.net/browse/PIM-6872
+     */
+    public function testSorterWithNoDataOnSorterField()
+    {
+        $result = $this->executeSorter([['a_scopable_text', Directions::DESCENDING, ['scope' => 'ecommerce_china']]]);
+        $this->assertOrder($result, ['product_one', 'product_two', 'empty_product']);
+
+        $result = $this->executeSorter([['a_scopable_text', Directions::ASCENDING, ['scope' => 'ecommerce_china']]]);
+        $this->assertOrder($result, ['product_one', 'product_two', 'empty_product']);
+    }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/TextArea/LocalizableScopableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/TextArea/LocalizableScopableSorterIntegration.php
@@ -84,6 +84,18 @@ class LocalizableScopableSorterIntegration extends AbstractProductQueryBuilderTe
     }
 
     /**
+     * @jira https://akeneo.atlassian.net/browse/PIM-6872
+     */
+    public function testSorterWithNoDataOnSorterField()
+    {
+        $result = $this->executeSorter([['a_localizable_scopable_text_area', Directions::DESCENDING, ['locale' => 'de_DE', 'scope' => 'ecommerce_china']]]);
+        $this->assertOrder($result, ['cat', 'cattle', 'dog', 'empty_product']);
+
+        $result = $this->executeSorter([['a_localizable_scopable_text_area', Directions::ASCENDING, ['locale' => 'de_DE', 'scope' => 'ecommerce_china']]]);
+        $this->assertOrder($result, ['cat', 'cattle', 'dog', 'empty_product']);
+    }
+
+    /**
      * @expectedException \Pim\Component\Catalog\Exception\InvalidDirectionException
      * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
      */

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/TextArea/LocalizableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/TextArea/LocalizableSorterIntegration.php
@@ -85,4 +85,16 @@ class LocalizableSorterIntegration extends AbstractProductQueryBuilderTestCase
     {
         $this->executeSorter([['a_localizable_text_area', 'A_BAD_DIRECTION', ['locale' => 'fr_FR']]]);
     }
+
+    /**
+     * @jira https://akeneo.atlassian.net/browse/PIM-6872
+     */
+    public function testSorterWithNoDataOnSorterField()
+    {
+        $result = $this->executeSorter([['a_localizable_text_area', Directions::DESCENDING, ['locale' => 'de_DE']]]);
+        $this->assertOrder($result, ['cat', 'cattle', 'dog', 'empty_product']);
+
+        $result = $this->executeSorter([['a_localizable_text_area', Directions::ASCENDING, ['locale' => 'de_DE']]]);
+        $this->assertOrder($result, ['cat', 'cattle', 'dog', 'empty_product']);
+    }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/TextArea/ScopableSorterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Sorter/TextArea/ScopableSorterIntegration.php
@@ -85,4 +85,16 @@ class ScopableSorterIntegration extends AbstractProductQueryBuilderTestCase
     {
         $this->executeSorter([['a_scopable_text_area', 'A_BAD_DIRECTION', ['scope' => 'ecommerce']]]);
     }
+
+    /**
+     * @jira https://akeneo.atlassian.net/browse/PIM-6872
+     */
+    public function testSorterWithNoDataOnSorterField()
+    {
+        $result = $this->executeSorter([['a_scopable_text_area', Directions::DESCENDING, ['scope' => 'ecommerce_china']]]);
+        $this->assertOrder($result, ['cat', 'cattle', 'dog', 'empty_product']);
+
+        $result = $this->executeSorter([['a_scopable_text_area', Directions::ASCENDING, ['scope' => 'ecommerce_china']]]);
+        $this->assertOrder($result, ['cat', 'cattle', 'dog', 'empty_product']);
+    }
 }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

In ES, the search request will fail if there is no mapping associated with a field

Example:
You want to sort on the attribute `description` with the channel `ecommerce`. 
If in all your data, you have no result for attribute `description` and the channel `ecommerce`, ES will throw:

`{"error":{"root_cause":[{"type":"query_shard_exception","reason":"No mapping found for [values.description-textarea.mobile.en_US.preprocessed] in order to sort on","index_uuid":"xt_aOy_hT5m2Y-rNHJkSUg","index":"akeneo_pim_product_and_product_model"}],"type":"search_phase_execution_exception","reason":"all shards failed","phase":"query","grouped":true,"failed_shards":[{"shard":0,"index":"akeneo_pim_product_and_product_model","node":"OQV8VTpeTHijWclZJW0RKA","reason":{"type":"query_shard_exception","reason":"No mapping found for [values.description-textarea.mobile.en_US.preprocessed] in order to sort on","index_uuid":"xt_aOy_hT5m2Y-rNHJkSUg","index":"akeneo_pim_product_and_product_model"}}]},"status":400}`

To prevent that, I added `unmapped_type` on sorter (see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-sort.html#_ignoring_unmapped_fields). 
I hardcoded with the value `string` but I don't know what I'm doing ^^
Initially, I tought we were obligate to put the same value defined in https://github.com/akeneo/pim-community-dev/blob/master/src/Pim/Bundle/CatalogBundle/Resources/elasticsearch/index_configuration.yml#L40, but it's not the case because integration tests are OK on boolean sorter, even with the `string` hardcoded.



<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
