### PR TITLE
PIM-6895: Improve performances on products datagrid

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -22,6 +22,7 @@
 - API-397: As Mary, I want to only see my launched jobs in the dashboard
 - API-389: As Mary, I want to only see my launched jobs in the process tracker
 - PIM-6881: Fix common attributes design
+- PIM-6895: Improve performances on products datagrid
 
 ## Better manage products with variants!
 
@@ -43,6 +44,7 @@
 - Rename service `pim_catalog.validator.constraint.sibling_unique_variant_axes` into `pim_catalog.validator.constraint.unique_variant_axes`
 - Rename class parameter `pim_catalog.validator.constraint.sibling_unique_variant_axes.class` into `pim_catalog.validator.constraint.unique_variant_axes.class`
 - Replace the class parameter of the service `pim_catalog.repository.variant_product` with `pim_catalog.repository.variant_product.class`
+- Add method `getCodesIfExist` to `Akeneo\Component\Classification\Repository\CategoryRepositoryInterface`
 
 # 2.0.1 (2017-10-05)
 

--- a/src/Akeneo/Bundle/ClassificationBundle/Doctrine/ORM/Repository/CategoryRepository.php
+++ b/src/Akeneo/Bundle/ClassificationBundle/Doctrine/ORM/Repository/CategoryRepository.php
@@ -387,6 +387,26 @@ class CategoryRepository extends NestedTreeRepository implements
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function getCodesIfExist(array $codes = []): array
+    {
+        $categoryCodes = $this->createQueryBuilder('c')
+            ->select('c.code')
+            ->where('c.code IN (:codes)')
+            ->setParameter('codes', $codes)
+            ->getQuery()
+            ->getScalarResult();
+
+        $result = [];
+        foreach ($categoryCodes as $categoryCode) {
+            $result[] = $categoryCode['code'];
+        }
+
+        return $result;
+    }
+
+    /**
      * Shortcut to get all children query builder
      *
      * @param CategoryInterface $category    the requested node

--- a/src/Akeneo/Component/Classification/Repository/CategoryRepositoryInterface.php
+++ b/src/Akeneo/Component/Classification/Repository/CategoryRepositoryInterface.php
@@ -170,4 +170,13 @@ interface CategoryRepositoryInterface extends
      * @return array Multi-dimensional array representing the tree
      */
     public function getFilledTree(CategoryInterface $root, Collection $categories);
+
+    /**
+     * Return only codes which exist in database
+     *
+     * @param array $codes
+     *
+     * @return array
+     */
+    public function getCodesIfExist(array $codes = []): array;
 }

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/CategoryFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/CategoryFilter.php
@@ -143,11 +143,15 @@ class CategoryFilter extends AbstractFieldFilter implements FieldFilterInterface
 
         foreach ($values as $value) {
             FieldFilterHelper::checkIdentifier($field, $value, static::class);
-            if (null === $this->categoryRepository->findOneByIdentifier($value)) {
-                throw new ObjectNotFoundException(
-                    sprintf('Object "category" with code "%s" does not exist', $value)
-                );
-            }
+        }
+
+        $categoryCodes = $this->categoryRepository->getCodesIfExist($values);
+        if (count($categoryCodes) !== count($values)) {
+            $diff = array_diff($values, $categoryCodes);
+            $message = count($diff) > 1 ? 'Objects "category" with codes "%s" do not exist' : 'Object "category" with code "%s" does not exist';
+            throw new ObjectNotFoundException(
+                sprintf($message, implode(', ', $diff))
+            );
         }
     }
 

--- a/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Filter/Field/CategoryFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Filter/Field/CategoryFilterSpec.php
@@ -56,10 +56,9 @@ class CategoryFilterSpec extends ObjectBehavior
 
     function it_adds_a_filter_with_operator_IN_LIST(
         $categoryRepository,
-        CategoryInterface $category,
         SearchQueryBuilder $sqb
     ) {
-        $categoryRepository->findOneByIdentifier('t-shirt')->willReturn($category);
+        $categoryRepository->getCodesIfExist(['t-shirt'])->willReturn(['t-shirt']);
         $sqb->addFilter(
             [
                 'terms' => [
@@ -74,10 +73,9 @@ class CategoryFilterSpec extends ObjectBehavior
 
     function it_adds_a_filter_with_operator_NOT_IN_LIST(
         $categoryRepository,
-        CategoryInterface $category,
         SearchQueryBuilder $sqb
     ) {
-        $categoryRepository->findOneByIdentifier('t-shirt')->willReturn($category);
+        $categoryRepository->getCodesIfExist(['t-shirt'])->willReturn(['t-shirt']);
         $sqb->addMustNot(
             [
                 'terms' => [
@@ -95,7 +93,7 @@ class CategoryFilterSpec extends ObjectBehavior
         SearchQueryBuilder $sqb,
         CategoryInterface $tShirtCategory
     ) {
-        $categoryRepository->findOneByIdentifier('t-shirt')->willReturn($tShirtCategory);
+        $categoryRepository->getCodesIfExist(['t-shirt'])->willReturn(['t-shirt']);
 
         $tShirtCategory->getCode()->willReturn('t-shirt');
         $categoryRepository->getAllChildrenCodes($tShirtCategory)->willReturn(['alaiz-breizh', 'BZH']);
@@ -117,8 +115,7 @@ class CategoryFilterSpec extends ObjectBehavior
         SearchQueryBuilder $sqb,
         CategoryInterface $tShirtCategory
     ) {
-        $categoryRepository->findOneByIdentifier('t-shirt')->willReturn($tShirtCategory);
-
+        $categoryRepository->getCodesIfExist(['t-shirt'])->willReturn(['t-shirt']);
         $tShirtCategory->getCode()->willReturn('t-shirt');
         $categoryRepository->getAllChildrenCodes($tShirtCategory)->willReturn(['alaiz-breizh', 'BZH']);
         $categoryRepository->findOneBy(['code' => 't-shirt'])->willReturn($tShirtCategory);
@@ -136,10 +133,9 @@ class CategoryFilterSpec extends ObjectBehavior
 
     function it_adds_a_filter_with_operator_UNCLASSIFIED(
         $categoryRepository,
-        CategoryInterface $category,
         SearchQueryBuilder $sqb
     ) {
-        $categoryRepository->findOneByIdentifier('t-shirt')->willReturn($category);
+        $categoryRepository->getCodesIfExist(['t-shirt'])->willReturn(['t-shirt']);
 
         $sqb->addMustNot(
             [
@@ -153,10 +149,9 @@ class CategoryFilterSpec extends ObjectBehavior
 
     function it_adds_a_filter_with_operator_IN_LIST_OR_UNCLASSIFIED(
         $categoryRepository,
-        CategoryInterface $category,
         SearchQueryBuilder $sqb
     ) {
-        $categoryRepository->findOneByIdentifier('t-shirt')->willReturn($category);
+        $categoryRepository->getCodesIfExist(['t-shirt'])->willReturn(['t-shirt']);
 
         $sqb->addFilter([
             'bool' => [
@@ -289,7 +284,7 @@ class CategoryFilterSpec extends ObjectBehavior
         $categoryRepository,
         SearchQueryBuilder $sqb
     ) {
-        $categoryRepository->findOneByIdentifier('UNKNOWN_CATEGORY')->willReturn(null);
+        $categoryRepository->getCodesIfExist(['UNKNOWN_CATEGORY'])->willReturn([]);
 
         $this->setQueryBuilder($sqb);
 
@@ -298,12 +293,25 @@ class CategoryFilterSpec extends ObjectBehavior
         )->during('addFieldFilter', ['categories', Operators::IN_LIST, ['UNKNOWN_CATEGORY'], null, null, []]);
     }
 
+    function it_throws_an_exception_when_the_given_value_are_not_a_known_categories(
+        $categoryRepository,
+        SearchQueryBuilder $sqb
+    ) {
+        $categoryRepository->getCodesIfExist(['UNKNOWN_CATEGORY', 't-shirt', 'AN_OTHER_ERROR'])->willReturn(['t-shirt']);
+
+        $this->setQueryBuilder($sqb);
+
+        $this->shouldThrow(
+            new ObjectNotFoundException('Objects "category" with codes "UNKNOWN_CATEGORY, AN_OTHER_ERROR" do not exist')
+        )->during('addFieldFilter', ['categories', Operators::IN_LIST, ['UNKNOWN_CATEGORY', 't-shirt', 'AN_OTHER_ERROR'], null, null, []]);
+    }
+
     function it_throws_an_exception_when_it_filters_on_an_unsupported_operator(
         $categoryRepository,
         GroupInterface $group,
         SearchQueryBuilder $sqb
     ) {
-        $categoryRepository->findOneByIdentifier('t-shirt')->willReturn($group);
+        $categoryRepository->getCodesIfExist(['t-shirt'])->willReturn(['t-shirt']);
 
         $this->setQueryBuilder($sqb);
         $this->shouldThrow(

--- a/src/Pim/Bundle/DataGridBundle/Controller/Rest/DatagridViewController.php
+++ b/src/Pim/Bundle/DataGridBundle/Controller/Rest/DatagridViewController.php
@@ -246,7 +246,7 @@ class DatagridViewController
      */
     public function defaultViewColumnsAction($alias)
     {
-        $columns = array_keys($this->datagridViewManager->getColumnChoices($alias, true));
+        $columns = $this->datagridViewManager->getDefaultColumns($alias);
 
         return new JsonResponse($columns);
     }

--- a/src/Pim/Bundle/DataGridBundle/Manager/DatagridViewManager.php
+++ b/src/Pim/Bundle/DataGridBundle/Manager/DatagridViewManager.php
@@ -93,4 +93,23 @@ class DatagridViewManager
 
         return $choices;
     }
+
+    /**
+     * Get default datagrid columns for the provided datagrid alias
+     *
+     * @param string $alias
+     *
+     * @return array
+     */
+    public function getDefaultColumns(string $alias): array
+    {
+        $path = sprintf('[%s]', FormatterConfiguration::COLUMNS_KEY);
+
+        $columnsConfig = $this
+            ->datagridManager
+            ->getConfigurationForGrid($alias)
+            ->offsetGetByPath($path);
+
+        return is_array($columnsConfig) ? array_keys($columnsConfig) : [];
+    }
 }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

Improve performance of the PQB when we add categories in search. 
On CE, performance won't be improved, but on EE, as we inject all granted categories in PQB, performance are better. 
Problem comes from we hydrate categories, just to check if they exist.

On datagrid, with 10000 categories:
**Before**
![before](https://user-images.githubusercontent.com/1131230/31380289-38b314b2-adb1-11e7-975d-2363e2f3dbc0.png)

**After**
![after](https://user-images.githubusercontent.com/1131230/31380292-3aff9196-adb1-11e7-8773-2c8c733f412e.png)

It has an impact on the API too:
Before: GET http://enterprise-master.local/api/rest/v1/products => 5.9s
After: GET http://enterprise-master.local/api/rest/v1/products => 1.6s


About the change in `DatagridViewManager`, I was wondering why it took so much time to get default columns (which are defined in yml). In fact to get these columns, we called `$this->datagridManager->getDatagrid($alias)` which recreate a datagrid and call again the PQB. Now we call the configuration of the grid without load it.


<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
