### PR TITLE
TIP-808: avoid BC break adding version strategy for js / css

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -2,7 +2,7 @@
 
 ## Tech improvements
 
-- TIP-808: Add version strategy for js and css assets
+- TIP-808: Add version strategy for js and css assets, no more need to ask final users to refresh their browser cache when applying a new patch!
 - PRE_SAVE and POST_SAVE events dispatched by instances of BaseSaver now include an "is_new" argument indicating if entities are being inserted or updated.
 - API-395: Get list of product models via API
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/bundles/twig.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/bundles/twig.yml
@@ -5,3 +5,11 @@ twig:
         ws:
             port:        '%websocket_port%'
             host:        '%websocket_host%'
+# Added in v2.0.2 to handle versioning strategy of assets (no need of refresh browser cache after a patch appliance)
+# It's defined in app/config/config.yml and also defined here to avoid breaking change for projects installed from standard distribs v2.0.0 or v2.0.1
+# TODO: To be droped in 2.1 when merging 2.0 branch into master branch
+framework:
+    assets:
+        packages:
+            frontend:
+                version_strategy: pim_enrich.version_strategy


### PR DESCRIPTION
When updating a standard edition installed with 2.0.0 or 2.0.1 to 2.0.x (upcoming 2.0.2), you need to add the missing configuration for asset versioning strategy in your project config.yml, if you don't, you'll have the following exception,

```
2017-10-10 11:49:46] request.CRITICAL: Uncaught PHP Exception Twig_Error_Runtime: "An exception has been thrown during the rendering of a template ("There is no "frontend" asset package.")." at /srv/pim/
vendor/akeneo/pim-community-dev/src/Oro/Bundle/AsseticBundle/Resources/views/Assets/oro_css.html.twig line 9 {"exception":"[object] (Twig_Error_Runtime(code: 0): An exception has been thrown during the re
ndering of a template (\"There is no \"frontend\" asset package.\"). at /srv/pim/vendor/akeneo/pim-community-dev/src/Oro/Bundle/AsseticBundle/Resources/views/Assets/oro_css.html.twig:9, Symfony\\Component
\\Asset\\Exception\\InvalidArgumentException(code: 0): There is no \"frontend\" asset package. at /srv/pim/vendor/symfony/symfony/src/Symfony/Component/Asset/Packages.php:83)"} []
```

Here is a hackish hack to put also this configuration in an existing "twig.yml" file loaded into config.yml in CE dev, EE dev, CE standard, EE standard. This way, if the configuration does not exists in you standard installation it will be defined through your vendor configuration.

This hack should be dropped when merging in 2.1 branch (as everybody will then have the relevant configuration in his config.yml project)

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
