### PR TITLE
New continuous integration system (2.0)

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -1,0 +1,419 @@
+#!groovy
+
+import org.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateAction
+
+String[] editions = ["ce"]
+String[] features = ["features"]
+String launchUnitTests = "yes"
+String launchIntegrationTests = "yes"
+String launchBehatTests = "yes"
+
+stage("Build") {
+
+    milestone 1
+    if (env.BRANCH_NAME =~ /^PR-/) {
+        timeout(time:5, unit:'DAYS') {
+            userInput = input(message: 'Launch tests?', parameters: [
+                choice(choices: 'yes\nno', description: 'Run unit tests and code style checks', name: 'launchUnitTests'),
+                choice(choices: 'yes\nno', description: 'Run integration tests', name: 'launchIntegrationTests'),
+                choice(choices: 'yes\nno', description: 'Run behat tests', name: 'launchBehatTests'),
+                string(defaultValue: 'ee,ce', description: 'PIM edition the behat tests should run on (comma separated values)', name: 'editions'),
+                string(defaultValue: 'features,vendor/akeneo/pim-community-dev/features', description: 'Behat scenarios to build', name: 'features'),
+            ])
+
+            editions = userInput['editions'].tokenize(',')
+            features = userInput['features'].tokenize(',')
+            launchUnitTests = userInput['launchUnitTests']
+            launchIntegrationTests = userInput['launchIntegrationTests']
+            launchBehatTests = userInput['launchBehatTests']
+        }
+    }
+    milestone 2
+
+    parallel(
+        "pim-ce": {withBuildNode({
+            checkout scm
+            container("php") {
+                sh "composer update --ansi --optimize-autoloader --no-interaction --no-progress --prefer-dist --ignore-platform-reqs --no-suggest"
+                sh "bin/console --ansi assets:install"
+                sh "bin/console --ansi pim:installer:dump-require-paths"
+            }
+            container("node") {
+                sh "yarn config set cache-folder /shared/.yarn"
+                sh "yarn install --no-progress"
+                sh "yarn run webpack"
+            }
+            container("docker") {
+                sh "cp .ci/behat.community.yml behat.yml"
+                for (feature in features) {
+                    sh "sed -i \"/paths/a\\ \\ \\ \\ \\ \\ \\ \\ \\ \\ \\ \\ \\ \\ \\ \\ -\\ ${feature}\" behat.yml"
+                }
+
+                sh "cp app/config/parameters_test.yml.dist app/config/parameters_test.yml"
+                sh "sed -i \"s#database_host: .*#database_host: 127.0.0.1#g\" app/config/parameters_test.yml"
+                sh "sed -i \"s#index_hosts: .*#index_hosts: 'elastic:changeme@127.0.0.1:9200'#g\" app/config/parameters_test.yml"
+                sh "sed \"\$a    installer_data: 'PimInstallerBundle:minimal'\n\" app/config/parameters_test.yml"
+
+                sh "docker build -t eu.gcr.io/akeneo-ci/pim-community-dev:pull-request-${env.CHANGE_ID}-build-${env.BUILD_NUMBER}-ce ."
+                sh "gcloud docker -- push eu.gcr.io/akeneo-ci/pim-community-dev:pull-request-${env.CHANGE_ID}-build-${env.BUILD_NUMBER}-ce"
+            }
+        })},
+        "pim-ee": {
+            if (editions.contains("ee")) {
+                withBuildNode({
+                    checkout([$class: 'GitSCM',
+                      branches: [[name: '2.0']],
+                      userRemoteConfigs: [[credentialsId: 'github-credentials', url: 'https://github.com/akeneo/pim-enterprise-dev.git']]
+                    ])
+                    // Required to avoid permission error when "composer update"
+                    sh "mkdir -m 777 vendor"
+
+                    container("php") {
+                        sh "composer require --dev --no-update phpspec/phpspec:~3.4.2"
+                        sh "composer require --dev --no-update phpunit/phpunit:~5.7.22"
+                        sh "composer require --dev --no-update sebastian/exporter:~2.0.0"
+                        sh "composer require --dev --no-update liuggio/fastest:dev-master"
+                        sh "composer update --ansi --optimize-autoloader --no-interaction --no-progress --prefer-dist --no-scripts --ignore-platform-reqs --no-suggest"
+
+                        // Required to avoid permission error when "deleteDir()"
+                        sh "chmod 777 -R vendor/akeneo"
+
+                        dir('vendor/akeneo/pim-community-dev') {
+                            deleteDir()
+                            checkout scm
+                        }
+
+                        sh "php -d memory_limit=-1 /usr/bin/composer --ansi -n run-script post-update-cmd"
+                        sh "bin/console --ansi assets:install"
+                        sh "bin/console --ansi pim:installer:dump-require-paths"
+                    }
+                    container("node") {
+                        sh "yarn config set cache-folder /shared/.yarn"
+                        sh "yarn install --no-progress"
+                        sh "yarn run webpack"
+                    }
+                    container("docker") {
+                        sh "cp vendor/akeneo/pim-community-dev/.ci/behat.enterprise.yml behat.yml"
+                        sh "cp app/config/parameters_test.yml.dist app/config/parameters_test.yml"
+                        sh "sed -i \"s#database_host: .*#database_host: 127.0.0.1#g\" app/config/parameters_test.yml"
+                        sh "sed -i \"s#index_hosts: .*#index_hosts: 'elastic:changeme@127.0.0.1:9200'#g\" app/config/parameters_test.yml"
+                        sh "sed \"\$a    installer_data: 'PimEnterpriseInstallerBundle:minimal'\n\" app/config/parameters_test.yml"
+
+                        // Compatibility layer while the EE is not up to date with the new CI
+                        sh "cp vendor/akeneo/pim-community-dev/Dockerfile ."
+                        sh "cp -R vendor/akeneo/pim-community-dev/.ci ."
+                        for (feature in features) {
+                            sh "sed -i \"/paths/a\\ \\ \\ \\ \\ \\ \\ \\ \\ \\ \\ \\ \\ \\ \\ \\ -\\ ${feature}\" behat.yml"
+                        }
+
+                        sh "docker build -t eu.gcr.io/akeneo-ci/pim-community-dev:pull-request-${env.CHANGE_ID}-build-${env.BUILD_NUMBER}-ee ."
+                        sh "gcloud docker -- push eu.gcr.io/akeneo-ci/pim-community-dev:pull-request-${env.CHANGE_ID}-build-${env.BUILD_NUMBER}-ee"
+                    }
+                })
+            } else {
+                echo "Skipping Enterprise Edition matrix"
+            }
+        }
+    )
+}
+
+stage("Test") {
+    try {
+        parallel(
+            "phpunit": {
+                if (launchUnitTests.equals("yes")) {
+                    withPhp({
+                        try {
+                            sh "cd /home/jenkins/pim && vendor/bin/phpunit -c app/phpunit.xml.dist --testsuite PIM_Unit_Test --log-junit ${env.WORKSPACE}/junit_output.xml"
+                        } finally {
+                            junit "junit_output.xml"
+                        }
+                    })
+                } else {
+                    echo "Skipping unit test phpunit"
+                }
+            },
+            "phpspec": {
+                if (launchUnitTests.equals("yes")) {
+                    withPhp({
+                        sh "chown -R phpuser /home/jenkins/pim"
+                        try {
+                            sh "cd /home/jenkins/pim && su phpuser -c './vendor/bin/phpspec run --format=junit' > ${env.WORKSPACE}/junit_output.xml"
+                        } finally {
+                            junit "junit_output.xml"
+                        }
+                    })
+                } else {
+                    echo "Skipping unit test phpspec"
+                }
+            },
+            "php-cs-fixer": {
+                if (launchUnitTests.equals("yes")) {
+                    withPhp({
+                        try {
+                            sh "cd /home/jenkins/pim && vendor/bin/php-cs-fixer fix --diff --dry-run --config=.php_cs.php --format=junit > ${env.WORKSPACE}/junit_output.xml"
+                        } finally {
+                            junit "junit_output.xml"
+                        }
+                    })
+                } else {
+                    echo "Skipping unit test php-cs-fixer"
+                }
+            },
+            "grunt": {
+                if (launchUnitTests.equals("yes")) {
+                    withNode({
+                        sh "cd /home/jenkins/pim && yarn run lint"
+                    })
+                } else {
+                    echo "Skipping unit test grunt"
+                }
+            },
+            "php-coupling-detector": {
+                if (launchUnitTests.equals("yes")) {
+                    withPhp({
+                        sh "cd /home/jenkins/pim && vendor/bin/php-coupling-detector detect --config-file=.php_cd.php src"
+                    })
+                } else {
+                    echo "Skipping unit test php-coupling-detector"
+                }
+            },
+            "phpunit-integration-ce": {
+                if (launchIntegrationTests.equals("yes") && editions.contains("ce")) {
+                    queue({
+                        def files = sh (returnStdout: true, script: 'find /home/jenkins/pim/src /home/jenkins/pim/tests -name "*Integration.php" -exec sh -c "grep -Ho \'function test\' {} | uniq -c"  \\; | sed "s/:function test//"').tokenize('\n')
+                        def messages = new net.sf.json.JSONArray()
+
+                        for (file in files) {
+                            messages.add([
+                                [container: "php", script: "bin/console --env=test pim:install --force"],
+                                [container: "php", script: "chmod 777 -R var/cache var/logs app/archive /tmp/pim app/file_storage app/uploads"],
+                                [container: "php", script: "chmod 777 /tmp"],
+                                [container: "php", script: "mkdir -m 777 -p app/build/logs/behat web/media"],
+                                [
+                                    container: "php",
+                                    junit: [in: "/home/jenkins/pim/", name: "junit_output.xml"],
+                                    script: "php -d error_reporting='E_ALL' vendor/bin/phpunit -c app/phpunit.xml.dist " + file[1] + " --log-junit junit_output.xml"
+                                ]
+                            ])
+                        }
+
+                        return messages
+                    }, 30, "ce")
+                } else {
+                    echo "Skipping integration test"
+                }
+            },
+            "behat-ce": {
+                if (launchBehatTests.equals("yes") && editions.contains("ce")) {
+                    queue({
+                        def scenarios = sh (returnStdout: true, script: "cd /home/jenkins/pim && php vendor/bin/behat --list-scenarios").tokenize('\n')
+                        def messages = new net.sf.json.JSONArray()
+
+                        for (scenario in scenarios) {
+                            messages.add([
+                                [container: "php", script: "bin/console --env=behat --quiet pim:install --force"],
+                                [container: "php", script: "touch var/logs/behat.log"],
+                                [container: "php", script: "chmod 777 -R var/cache var/logs app/archive /tmp/pim app/file_storage app/uploads"],
+                                [container: "php", script: "mkdir -m 777 -p app/build/logs/behat web/media"],
+                                [container: "php", script: "sed -i '2 a umask(0000);' vendor/behat/behat/bin/behat"],
+                                [
+                                    container: "php",
+                                    junit: [in: "/home/jenkins/pim/app/build/logs/behat/", name: "*.xml"],
+                                    artifacts: [in: "/tmp/behat/screenshots", name: "*.png"],
+                                    script: "php vendor/bin/behat --strict -vv " + scenario
+                                ]
+                            ])
+                        }
+
+                        return messages
+                    }, 100, "ce")
+                } else {
+                    echo "Skipping behat test"
+                }
+            },
+            "phpunit-integration-ee": {
+                if (launchIntegrationTests.equals("yes") && editions.contains("ee")) {
+                    queue({
+                        def files = sh (returnStdout: true, script: 'find /home/jenkins/pim/src /home/jenkins/pim/tests -name "*Integration.php" -exec sh -c "grep -Ho \'function test\' {} | uniq -c"  \\; | sed "s/:function test//"').tokenize('\n')
+                        def messages = new net.sf.json.JSONArray()
+
+                        for (file in files) {
+                            messages.add([
+                                [container: "php", script: "bin/console --env=test pim:install --force"],
+                                [container: "php", script: "chmod 777 -R var/cache var/logs app/archive /tmp/pim app/file_storage app/uploads"],
+                                [container: "php", script: "mkdir -m 777 -p app/build/logs/behat web/media"],
+                                [
+                                    container: "php",
+                                    junit: [in: "/home/jenkins/pim/", name: "junit_output.xml"],
+                                    script: "php -d error_reporting='E_ALL' vendor/bin/phpunit -c app/phpunit.xml.dist " + file[1] + " --log-junit junit_output.xml"
+                                ]
+                            ])
+                        }
+
+                        return messages
+                    }, 10, "ee")
+                } else {
+                    echo "Skipping integration test"
+                }
+            },
+            "behat-ee": {
+                if (launchBehatTests.equals("yes") && editions.contains("ee")) {
+                    queue({
+                        def scenarios = sh (returnStdout: true, script: "cd /home/jenkins/pim && php vendor/bin/behat --list-scenarios").tokenize('\n')
+                        def messages = new net.sf.json.JSONArray()
+
+                        for (scenario in scenarios) {
+                            messages.add([
+                                [container: "php", script: "bin/console --env=behat --quiet pim:install --force"],
+                                [container: "php", script: "touch var/logs/behat.log"],
+                                [container: "php", script: "chmod 777 -R var/cache var/logs app/archive /tmp/pim app/file_storage app/uploads"],
+                                [container: "php", script: "mkdir -m 777 -p app/build/logs/behat web/media"],
+                                [container: "php", script: "sed -i '2 a umask(0000);' vendor/behat/behat/bin/behat"],
+                                [container: "php", script: "ln -s ../bin/console app/console"],
+                                [
+                                    container: "php",
+                                    junit: [in: "/home/jenkins/pim/app/build/logs/behat/", name: "*.xml"],
+                                    artifacts: [in: "/tmp/behat/screenshots", name: "*.png"],
+                                    script: "php vendor/bin/behat --strict -vv " + scenario
+                                ]
+                            ])
+                        }
+
+                        return messages
+                    }, 150, "ee")
+                } else {
+                    echo "Skipping behat test"
+                }
+            }
+        )
+    } finally {
+        clearTemplateNames()
+        podTemplate(label: "cleanup", containers: [
+            containerTemplate(name: "docker", image: "paulwoelfel/docker-gcloud", ttyEnabled: true, command: 'cat')
+        ]) {
+            node("cleanup") {
+                container("docker") {
+                    sh "gcloud -q container images delete eu.gcr.io/akeneo-ci/pim-community-dev:pull-request-${env.CHANGE_ID}-build-${env.BUILD_NUMBER}-ce"
+                    sh "gcloud -q container images delete eu.gcr.io/akeneo-ci/pim-community-dev:pull-request-${env.CHANGE_ID}-build-${env.BUILD_NUMBER}-ee"
+                }
+            }
+        }
+    }
+}
+
+def withBuildNode(body) {
+    clearTemplateNames()
+    def uuid = UUID.randomUUID().toString()
+
+    withCredentials([string(credentialsId: 'composer-token', variable: 'token')]) {
+        podTemplate(label: "build-" + uuid, containers: [
+            containerTemplate(name: "docker", image: "paulwoelfel/docker-gcloud", ttyEnabled: true, command: 'cat', envVars: [envVar(key: "DOCKER_API_VERSION", value: "1.23")], resourceRequestCpu: '100m', resourceRequestMemory: '200Mi'),
+            containerTemplate(name: "php", ttyEnabled: true, command: 'cat', image: "eu.gcr.io/akeneo-ci/php:7.1-fpm", envVars: [envVar(key: "COMPOSER_HOME", value: "/shared/.composer"), envVar(key: "COMPOSER_AUTH", value: "{\"github-oauth\":{\"github.com\": \"$token\"}}")], resourceRequestCpu: '750m', resourceRequestMemory: '2000Mi'),
+            containerTemplate(name: "node", ttyEnabled: true, command: 'cat', image: "node:8", resourceRequestCpu: '750m', resourceRequestMemory: '2000Mi')
+        ], volumes: [
+            nfsVolume(mountPath: '/shared', serverAddress: "${env.NFS_IP}", serverPath: '/exports', readOnly: false),
+            hostPathVolume(hostPath: "/var/run/docker.sock", mountPath: "/var/run/docker.sock")
+        ]) {
+            node("build-" + uuid) {
+                dir('/home/jenkins/pim') {
+                    body()
+                }
+            }
+        }
+    }
+}
+
+def withPhp(body) {
+    clearTemplateNames()
+    def uuid = UUID.randomUUID().toString()
+    podTemplate(label: "php-" + uuid, containers: [
+        containerTemplate(name: "php", ttyEnabled: true, command: 'cat', image: "eu.gcr.io/akeneo-ci/php:7.1-fpm", resourceRequestCpu: '500m', resourceRequestMemory: '1000Mi')
+    ], annotations: [
+        podAnnotation(key: "pod.beta.kubernetes.io/init-containers", value: "[{\"name\": \"pim\", \"imagePullPolicy\": \"Always\", \"image\": \"eu.gcr.io/akeneo-ci/pim-community-dev:pull-request-${env.CHANGE_ID}-build-${env.BUILD_NUMBER}-ce\", \"command\": [\"sh\", \"-c\", \"cp -Rp /pim /home/jenkins\"], \"volumeMounts\":[{\"name\":\"workspace-volume\",\"mountPath\":\"/home/jenkins\"}]}]")
+    ]) {
+        node("php-" + uuid) {
+            container("php") {
+                body()
+            }
+        }
+    }
+}
+
+def withNode(body) {
+    clearTemplateNames()
+    def uuid = UUID.randomUUID().toString()
+    podTemplate(label: "node-" + uuid, containers: [
+        containerTemplate(name: "node", ttyEnabled: true, alwaysPullImage: true, command: 'cat', image: "node:8", resourceRequestCpu: '500m', resourceRequestMemory: '1000Mi')
+    ], annotations: [
+        podAnnotation(key: "pod.beta.kubernetes.io/init-containers", value: "[{\"name\": \"pim\", \"imagePullPolicy\": \"Always\", \"image\": \"eu.gcr.io/akeneo-ci/pim-community-dev:pull-request-${env.CHANGE_ID}-build-${env.BUILD_NUMBER}-ce\", \"command\": [\"sh\", \"-c\", \"cp -Rp /pim /home/jenkins\"], \"volumeMounts\":[{\"name\":\"workspace-volume\",\"mountPath\":\"/home/jenkins\"}]}]")
+    ]) {
+        node("node-" + uuid) {
+            container("node") {
+                body()
+            }
+        }
+    }
+}
+
+def queue(body, scale, edition) {
+    clearTemplateNames()
+    def uuid = UUID.randomUUID().toString()
+    podTemplate(label: "pubsub-" + uuid, containers: [
+        containerTemplate(name: "php", ttyEnabled: true, command: 'cat', image: "eu.gcr.io/akeneo-ci/php:7.1-fpm", resourceRequestCpu: '100m', resourceRequestMemory: '200Mi'),
+        containerTemplate(name: "gcloud", ttyEnabled: true, command: 'cat', image: "eu.gcr.io/akeneo-ci/gcloud:1.0.17", resourceRequestCpu: '100m', resourceRequestMemory: '200Mi', envVars: [envVar(key: "PUBSUB_PROJECT_ID", value: "akeneo-ci")])
+    ], annotations: [
+        podAnnotation(key: "pod.beta.kubernetes.io/init-containers", value: "[{\"name\": \"pim\", \"imagePullPolicy\": \"Always\", \"image\": \"eu.gcr.io/akeneo-ci/pim-community-dev:pull-request-${env.CHANGE_ID}-build-${env.BUILD_NUMBER}-${edition}\", \"command\": [\"sh\", \"-c\", \"cp -Rp /pim /home/jenkins\"], \"volumeMounts\":[{\"name\":\"workspace-volume\",\"mountPath\":\"/home/jenkins\"}]}]")
+    ], volumes: [
+        hostPathVolume(hostPath: "/var/run/docker.sock", mountPath: "/var/run/docker.sock"),
+        hostPathVolume(hostPath: "/usr/bin/docker", mountPath: "/usr/bin/docker")
+    ]) {
+        node("pubsub-" + uuid) {
+            def messages = []
+
+            container("php") {
+                messages = body()
+            }
+
+            container("gcloud") {
+                sh "gcloud.phar pubsub:topic:create ${NODE_NAME}"
+                sh "gcloud.phar pubsub:topic:create ${NODE_NAME}-results"
+                sh "gcloud.phar pubsub:subscription:create ${NODE_NAME} ${NODE_NAME}-subscription"
+                sh "gcloud.phar pubsub:subscription:create ${NODE_NAME}-results ${NODE_NAME}-results-subscription"
+
+                def size = messages.size()
+
+                writeJSON file: 'output.json', json: messages
+                sh "gcloud.phar pubsub:message:publish ${NODE_NAME} output.json"
+
+                sh "sed -i 's#JOB_SCALE#${scale}#g' /home/jenkins/pim/.ci/k8s/pubsub_consumer_job.yaml"
+                sh "sed -i 's#JOB_NAME#${NODE_NAME}#g' /home/jenkins/pim/.ci/k8s/pubsub_consumer_job.yaml"
+                sh "sed -i 's#JOB_COMPLETIONS#${size}#g' /home/jenkins/pim/.ci/k8s/pubsub_consumer_job.yaml"
+                sh "sed -i 's#SUBSCRIPTION_NAME#${NODE_NAME}-subscription#g' /home/jenkins/pim/.ci/k8s/pubsub_consumer_job.yaml"
+                sh "sed -i 's#RESULT_TOPIC#${NODE_NAME}-results#g' /home/jenkins/pim/.ci/k8s/pubsub_consumer_job.yaml"
+                sh "sed -i 's#PIM_IMAGE#eu.gcr.io/akeneo-ci/pim-community-dev:pull-request-${env.CHANGE_ID}-build-${env.BUILD_NUMBER}-${edition}#g' /home/jenkins/pim/.ci/k8s/pubsub_consumer_job.yaml"
+
+                try {
+                    sh "kubectl apply -f /home/jenkins/pim/.ci/k8s/"
+                    sh "gcloud.phar job:wait ${NODE_NAME}-results-subscription ${size} ${env.WORKSPACE} --ansi"
+                } finally {
+                    sh "kubectl delete job ${NODE_NAME} --namespace=jenkins-prod"
+                    sh "gcloud.phar pubsub:topic:delete ${NODE_NAME}"
+                    sh "gcloud.phar pubsub:topic:delete ${NODE_NAME}-results"
+                    sh "gcloud.phar pubsub:subscription:delete ${NODE_NAME}-subscription"
+                    sh "gcloud.phar pubsub:subscription:delete ${NODE_NAME}-results-subscription"
+
+                    junit allowEmptyResults: true, testResults: 'junit/**/*.xml'
+                    archiveArtifacts allowEmptyArchive: true, artifacts: 'artifacts/**/*.png'
+                }
+            }
+        }
+    }
+}
+
+@NonCPS
+def clearTemplateNames() {
+    // see https://issues.jenkins-ci.org/browse/JENKINS-42184
+    def action = currentBuild.rawBuild.getAction(PodTemplateAction.class);
+    if(action) { action.names.clear() }
+}

--- a/.ci/behat.community.yml
+++ b/.ci/behat.community.yml
@@ -1,0 +1,115 @@
+default:
+    suites:
+        all:
+            paths:
+            filters:
+                tags: "~skip&&~skip-pef&&~skip-nav&&~doc&&~unstable&&~unstable-app&&~deprecated&&~@unstable-app"
+            contexts:
+                - Behat\MinkExtension\Context\MinkContext
+                - Context\FeatureContext:
+                    - 'Context\FeatureContext'
+                    -
+                        base_url: 'http://127.0.0.1/'
+                        timeout: 50000
+                        window_width: 1280
+                        window_height: 1024
+                - Context\FixturesContext:
+                    - 'Context\FeatureContext'
+                - Context\CatalogConfigurationContext:
+                    - 'Context\FeatureContext'
+                - Context\WebUser:
+                    - 'Context\FeatureContext'
+                - Context\DataGridContext:
+                    - 'Context\FeatureContext'
+                - Context\CommandContext:
+                    - 'Context\FeatureContext'
+                - Context\NavigationContext:
+                    - 'Context\FeatureContext'
+                    - 'http://127.0.0.1/'
+                - Context\TransformationContext:
+                    - 'Context\FeatureContext'
+                - Context\AssertionContext:
+                    - 'Context\FeatureContext'
+                - Context\ViewSelectorContext:
+                    - 'Context\FeatureContext'
+                - Pim\Behat\Context\AttributeValidationContext:
+                    - 'Context\FeatureContext'
+                - Pim\Behat\Context\Domain\Collect\ImportProfilesContext:
+                    - 'Context\FeatureContext'
+                - Pim\Behat\Context\Domain\Enrich\AttributeTabContext:
+                    - 'Context\FeatureContext'
+                - Pim\Behat\Context\Domain\Enrich\CompletenessContext:
+                    - 'Context\FeatureContext'
+                - Pim\Behat\Context\Domain\Enrich\GridPaginationContext:
+                    - 'Context\FeatureContext'
+                - Pim\Behat\Context\Domain\Enrich\ProductGroupContext:
+                    - 'Context\FeatureContext'
+                - Pim\Behat\Context\Domain\Enrich\ProductModelContext:
+                    - 'Context\FeatureContext'
+                    - '@pim_catalog.repository.product_model'
+                    - '@doctrine.orm.entity_manager'
+                - Pim\Behat\Context\Domain\Enrich\VariantNavigationContext:
+                    - 'Context\FeatureContext'
+                - Pim\Behat\Context\Domain\Spread\ExportBuilderContext:
+                    - 'Context\FeatureContext'
+                - Pim\Behat\Context\Domain\Spread\ExportProfilesContext:
+                    - 'Context\FeatureContext'
+                - Pim\Behat\Context\Domain\Spread\XlsxFileContext:
+                    - 'Context\FeatureContext'
+                - Pim\Behat\Context\Domain\System\PermissionsContext:
+                    - 'Context\FeatureContext'
+                - Pim\Behat\Context\Domain\SecondaryActionsContext:
+                    - 'Context\FeatureContext'
+                - Pim\Behat\Context\Domain\TreeContext:
+                    - 'Context\FeatureContext'
+                - Pim\Behat\Context\HookContext:
+                    - 'Context\FeatureContext'
+                    - 1280
+                    - 1024
+                - Pim\Behat\Context\JobContext:
+                    - 'Context\FeatureContext'
+                - Pim\Behat\Context\Storage\FileInfoStorage:
+                    - 'Context\FeatureContext'
+                - Pim\Behat\Context\Storage\ProductStorage:
+                    - '@pim_connector.array_converter.flat_to_standard.product.attribute_column_info_extractor'
+                    - '@pim_catalog.repository.product'
+                    - '@doctrine.orm.default_entity_manager'
+                - Pim\Behat\Context\Storage\ProductModelStorage:
+                    - '@pim_connector.array_converter.flat_to_standard.product.attribute_column_info_extractor'
+                    - '@pim_catalog.repository.product_model'
+                    - '@pim_catalog.repository.family_variant'
+                    - '@pim_catalog.factory.product_model'
+                    - '@pim_catalog.updater.product_model'
+                    - '@pim_catalog.validator.product_model'
+                    - '@pim_catalog.saver.product_model'
+    extensions:
+        Behat\ChainedStepsExtension: ~
+        Behat\MinkExtension:
+            default_session: symfony2
+            javascript_session: selenium2
+            show_cmd: chromium-browser %s
+            sessions:
+                symfony2:
+                    symfony2: ~
+                selenium2:
+                    selenium2:
+                        wd_host: 'http://127.0.0.1:4444/wd/hub'
+            base_url: 'http://127.0.0.1/'
+            files_path: 'features/Context/fixtures/'
+        Behat\Symfony2Extension:
+            kernel:
+                env: behat
+                debug: false
+        SensioLabs\Behat\PageObjectExtension:
+            namespaces:
+                page: [Context\Page]
+            factory:
+                page_parameters:
+                    base_url: 'http://127.0.0.1/'
+        Pim\Behat\Extension\PimFormatter\PimFormatterExtension: ~
+        Liuggio\Fastest\Behat\ListFeaturesExtension\Extension: ~
+
+    formatters:
+        pretty: true
+        pim:
+            output_path: app/build/logs/behat/

--- a/.ci/behat.enterprise.yml
+++ b/.ci/behat.enterprise.yml
@@ -1,0 +1,125 @@
+default:
+    suites:
+        all:
+            paths:
+            filters:
+                tags: "~skip&&~skip-pef&&~skip-nav&&~doc&&~unstable&&~unstable-app&&~deprecated&&~@unstable-app&&~ce"
+            contexts:
+                - Behat\MinkExtension\Context\MinkContext
+                - Context\EnterpriseFeatureContext:
+                    - 'Context\EnterpriseFeatureContext'
+                    -
+                        base_url: 'http://127.0.0.1/'
+                        timeout: 50000
+                        window_width: 1280
+                        window_height: 1024
+                - Context\EnterpriseFixturesContext:
+                    - 'Context\EnterpriseFeatureContext'
+                - Context\EnterpriseCatalogConfigurationContext:
+                    - 'Context\EnterpriseFeatureContext'
+                - Context\EnterpriseWebUser:
+                    - 'Context\EnterpriseFeatureContext'
+                - Context\EnterpriseDataGridContext:
+                    - 'Context\EnterpriseFeatureContext'
+                - Context\EnterpriseCommandContext:
+                    - 'Context\EnterpriseFeatureContext'
+                - Context\EnterpriseTransformationContext:
+                    - 'Context\EnterpriseFeatureContext'
+                - Context\EnterpriseAssertionContext:
+                    - 'Context\EnterpriseFeatureContext'
+                - Context\EnterpriseAssetContext:
+                    - 'Context\EnterpriseFeatureContext'
+                - Context\EnterpriseFileTransformerContext:
+                    - 'Context\EnterpriseFeatureContext'
+                - Pim\Behat\Context\AttributeValidationContext:
+                    - 'Context\EnterpriseFeatureContext'
+                - Pim\Behat\Context\Domain\Collect\ImportProfilesContext:
+                    - 'Context\EnterpriseFeatureContext'
+                - Pim\Behat\Context\Domain\Enrich\AttributeTabContext:
+                    - 'Context\EnterpriseFeatureContext'
+                - Pim\Behat\Context\Domain\Enrich\CompletenessContext:
+                    - 'Context\EnterpriseFeatureContext'
+                - Pim\Behat\Context\Domain\Enrich\GridPaginationContext:
+                    - 'Context\EnterpriseFeatureContext'
+                - Pim\Behat\Context\Domain\Enrich\ProductGroupContext:
+                    - 'Context\EnterpriseFeatureContext'
+                - Pim\Behat\Context\Domain\Enrich\ProductModelContext:
+                    - 'Context\EnterpriseFeatureContext'
+                    - '@pim_catalog.repository.product_model'
+                    - '@doctrine.orm.entity_manager'
+                - Pim\Behat\Context\Domain\Enrich\VariantNavigationContext:
+                    - 'Context\EnterpriseFeatureContext'
+                - Pim\Behat\Context\Domain\Spread\ExportBuilderContext:
+                    - 'Context\EnterpriseFeatureContext'
+                - Pim\Behat\Context\Domain\Spread\ExportProfilesContext:
+                    - 'Context\EnterpriseFeatureContext'
+                - Pim\Behat\Context\Domain\Spread\XlsxFileContext:
+                    - 'Context\EnterpriseFeatureContext'
+                - Pim\Behat\Context\Domain\System\PermissionsContext:
+                    - 'Context\EnterpriseFeatureContext'
+                - Pim\Behat\Context\Domain\SecondaryActionsContext:
+                    - 'Context\EnterpriseFeatureContext'
+                - Pim\Behat\Context\Domain\TreeContext:
+                    - 'Context\EnterpriseFeatureContext'
+                - Pim\Behat\Context\Storage\FileInfoStorage:
+                    - 'Context\EnterpriseFeatureContext'
+                - PimEnterprise\Behat\Context\ViewSelectorContext:
+                    - 'Context\EnterpriseFeatureContext'
+                - PimEnterprise\Behat\Context\DashboardContext:
+                    - 'Context\EnterpriseFeatureContext'
+                - PimEnterprise\Behat\Context\TeamworkAssistant\WidgetContext:
+                    - 'Context\EnterpriseFeatureContext'
+                - PimEnterprise\Behat\Context\TeamworkAssistant\ProjectContext:
+                    - 'Context\EnterpriseFeatureContext'
+                - PimEnterprise\Behat\Context\HookContext:
+                    - 'Context\EnterpriseFeatureContext'
+                    - 1280
+                    - 1024
+                - PimEnterprise\Behat\Context\JobContext:
+                    - 'Context\EnterpriseFeatureContext'
+                - PimEnterprise\Behat\Context\NavigationContext:
+                    - 'Context\EnterpriseFeatureContext'
+                    - 'http://127.0.0.1/'
+                - Pim\Behat\Context\Storage\ProductStorage:
+                    - '@pim_connector.array_converter.flat_to_standard.product.attribute_column_info_extractor'
+                    - '@pim_catalog.repository.product'
+                    - '@doctrine.orm.default_entity_manager'
+                - Pim\Behat\Context\Storage\ProductModelStorage:
+                    - '@pim_connector.array_converter.flat_to_standard.product.attribute_column_info_extractor'
+                    - '@pim_catalog.repository.product_model'
+                    - '@pim_catalog.repository.family_variant'
+                    - '@pim_catalog.factory.product_model'
+                    - '@pim_catalog.updater.product_model'
+                    - '@pim_catalog.validator.product_model'
+                    - '@pim_catalog.saver.product_model'
+    extensions:
+        Behat\ChainedStepsExtension: ~
+        Behat\MinkExtension:
+            default_session: symfony2
+            javascript_session: selenium2
+            show_cmd: chromium-browser %s
+            sessions:
+                symfony2:
+                    symfony2: ~
+                selenium2:
+                    selenium2:
+                        wd_host: 'http://127.0.0.1:4444/wd/hub'
+            base_url: 'http://127.0.0.1/'
+            files_path: 'features/Context/fixtures/'
+        Behat\Symfony2Extension:
+            kernel:
+                env: behat
+                debug: false
+        SensioLabs\Behat\PageObjectExtension:
+            namespaces:
+                page: [Context\Page]
+            factory:
+                page_parameters:
+                    base_url: 'http://127.0.0.1/'
+        Pim\Behat\Extension\PimFormatter\PimFormatterExtension: ~
+        Liuggio\Fastest\Behat\ListFeaturesExtension\Extension: ~
+
+    formatters:
+        pretty: true
+        pim:
+            output_path: app/build/logs/behat/

--- a/.ci/k8s/pubsub_consumer_job.yaml
+++ b/.ci/k8s/pubsub_consumer_job.yaml
@@ -1,0 +1,135 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: JOB_NAME
+spec:
+  completions: JOB_COMPLETIONS
+  parallelism: JOB_SCALE
+  template:
+    spec:
+      initContainers:
+        - name: pim
+          image: PIM_IMAGE
+          command: ['sh', '-c', 'cp -Rp /pim /home/jenkins']
+          imagePullPolicy: Always
+          volumeMounts:
+            - { mountPath: /home/jenkins, name: pim }
+      containers:
+        - name: mysql
+          image: eu.gcr.io/akeneo-ci/mysql:5.7-5
+          volumeMounts:
+            - { name: tmp-pod, mountPath: /tmp/pod, readOnly: true }
+            - { name: mysql, mountPath: /var/lib/mysql }
+          env:
+            - { name: MYSQL_ROOT_PASSWORD, value: root }
+            - { name: MYSQL_USER, value: akeneo_pim }
+            - { name: MYSQL_PASSWORD, value: akeneo_pim }
+            - { name: MYSQL_DATABASE, value: akeneo_pim }
+          resources:
+            requests: {cpu: "100m", memory: "700Mi"}
+          readinessProbe:
+            timeoutSeconds: 5
+            initialDelaySeconds: 2
+            exec:
+              command: ["mysql", "-proot", "-h", "127.0.0.1", "-e", "SELECT 1"]
+        - name: elasticsearch
+          image: docker.elastic.co/elasticsearch/elasticsearch:5.5.2
+          command: ["/bin/bash", "-c"]
+          args:
+            - |
+              /usr/share/elasticsearch/bin/es-docker &
+              CHILD_PID=$!
+              (while true; do if [[ -f "/tmp/pod/main-terminated" ]]; then kill $CHILD_PID; fi; sleep 1; done) &
+              wait $CHILD_PID
+              if [[ -f "/tmp/pod/main-terminated" ]]; then exit 0; fi
+          env:
+            - { name: ES_JAVA_OPTS, value: "-Xms1g -Xmx1g" }
+          volumeMounts:
+            - { name: tmp-pod, mountPath: /tmp/pod, readOnly: true }
+          resources:
+            requests: {cpu: "100m", memory: "1500Mi"}
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 9200
+              httpHeaders:
+                - name: Authorization
+                  value: Basic ZWxhc3RpYzpjaGFuZ2VtZQ==
+            timeoutSeconds: 1
+            initialDelaySeconds: 5
+        - name: php
+          image: eu.gcr.io/akeneo-ci/php:7.1-fpm
+          imagePullPolicy: Always
+          command: ["/bin/bash", "-c"]
+          args:
+            - |
+              php-fpm &
+              CHILD_PID=$!
+              (while true; do if [[ -f "/tmp/pod/main-terminated" ]]; then kill $CHILD_PID; fi; sleep 1; done) &
+              wait $CHILD_PID
+              if [[ -f "/tmp/pod/main-terminated" ]]; then exit 0; fi
+          workingDir: /home/jenkins/pim
+          env:
+            - { name: BEHAT_TMPDIR, value: "/home/jenkins/pim/var/cache/tmp" }
+          volumeMounts:
+            - { name: pim, mountPath: /home/jenkins }
+            - { name: tmp-pod, mountPath: /tmp/pod, readOnly: true }
+            - { name: artifacts, mountPath: /tmp/behat/screenshots }
+          resources:
+            requests: {cpu: "300m", memory: "300Mi"}
+        - name: httpd
+          image: eu.gcr.io/akeneo-ci/httpd:2.4
+          command: ["/bin/bash", "-c"]
+          args:
+            - |
+              httpd-foreground &
+              CHILD_PID=$!
+              (while true; do if [[ -f "/tmp/pod/main-terminated" ]]; then kill $CHILD_PID; fi; sleep 1; done) &
+              wait $CHILD_PID
+              if [[ -f "/tmp/pod/main-terminated" ]]; then exit 0; fi
+          volumeMounts:
+            - { name: pim, mountPath: /home/jenkins }
+            - { name: tmp-pod, mountPath: /tmp/pod, readOnly: true }
+          resources:
+            requests: {cpu: "100m", memory: "200Mi"}
+        - name: selenium
+          image: selenium/standalone-firefox:2.53.1-beryllium
+          command: ["/bin/bash", "-c"]
+          args:
+            - |
+              /opt/bin/entry_point.sh &
+              CHILD_PID=$!
+              (while true; do if [[ -f "/tmp/pod/main-terminated" ]]; then kill $CHILD_PID; fi; sleep 1; done) &
+              wait $CHILD_PID
+              if [[ -f "/tmp/pod/main-terminated" ]]; then exit 0; fi
+          volumeMounts:
+            - { name: pim, mountPath: /home/jenkins }
+            - { name: artifacts, mountPath: /tmp/behat/screenshots }
+            - { name: tmp-pod, mountPath: /tmp/pod, readOnly: true }
+          env:
+            - { name: JAVA_OPTS, value: "-Xms1g -Xmx1g " }
+          resources:
+            requests: {cpu: "300m", memory: "1500Mi"}
+        - name: pubsub
+          image: eu.gcr.io/akeneo-ci/gcloud:1.0.17
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              trap "touch /tmp/pod/main-terminated" EXIT
+              gcloud.phar pubsub:message:consume SUBSCRIPTION_NAME RESULT_TOPIC
+          env:
+            - { name: REDIS_URI, value: "tcp://redis.jenkins-prod:6379" }
+            - { name: POD_NAME, valueFrom: { fieldRef: { fieldPath: metadata.name } } }
+            - { name: NAMESPACE, valueFrom: { fieldRef: { fieldPath: metadata.namespace } } }
+          volumeMounts:
+            - { name: pim, mountPath: /home/jenkins }
+            - { name: artifacts, mountPath: /tmp/behat/screenshots }
+            - { name: tmp-pod, mountPath: /tmp/pod }
+          resources:
+            requests: {cpu: "100m", memory: "100Mi"}
+      volumes:
+        - { name: pim, emptyDir: {medium: Memory}}
+        - { name: tmp-pod, emptyDir: {medium: Memory}}
+        - { name: artifacts, emptyDir: {medium: Memory}}
+        - { name: mysql, emptyDir: {medium: Memory}}
+      restartPolicy: Never

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM alpine:3.6
+
+ADD . /pim

--- a/composer.json
+++ b/composer.json
@@ -86,10 +86,12 @@
         "kriswallsmith/buzz": "^0.15",
         "pdepend/pdepend": "2.1.*",
         "phpmd/phpmd": "1.*",
-        "phpspec/phpspec": "3.0.*",
-        "phpunit/phpunit": "5.4.*",
+        "phpspec/phpspec": "~3.4.2",
+        "phpunit/phpunit": "~5.7.22",
+        "sebastian/exporter": "~2.0.0",
         "sensiolabs/behat-page-object-extension": "2.1.0",
-        "squizlabs/php_codesniffer": "2.*"
+        "squizlabs/php_codesniffer": "2.*",
+        "liuggio/fastest": "1.4.4"
     },
     "suggest": {
         "akeneo/catalogs": "In order to install one of the Akeneo catalogs"

--- a/features/Context/AssertionContext.php
+++ b/features/Context/AssertionContext.php
@@ -348,12 +348,6 @@ class AssertionContext extends PimContext
                 return $block->find('css', sprintf('.entity-version[data-version="%d"]', $expectedVersion));
             }, sprintf('Cannot find the version "%s"', $expectedVersion));
 
-            if (!$row->hasClass('AknGrid-bodyRow--expanded')) {
-                $this->spin(function () use ($row) {
-                    return $row->find('css', '.version-expander');
-                }, sprintf('Can not find the expand button of version "%s"', json_encode($data)))->click();
-            }
-
             if (array_key_exists('author', $data)) {
                 $expectedAuthor = $data['author'];
                 $author = $row->find('css', '[data-column="author"]')->getText();
@@ -367,6 +361,12 @@ class AssertionContext extends PimContext
                         $author
                     )
                 );
+            }
+
+            if (!$row->hasClass('AknGrid-bodyRow--expanded')) {
+                $this->spin(function () use ($row) {
+                    return $row->find('css', '.version-expander');
+                }, sprintf('Can not find the expand button of version "%s"', json_encode($data)))->click();
             }
 
             $changesetRow = $this->spin(function () use ($block, $expectedVersion) {

--- a/src/Akeneo/Bundle/ElasticsearchBundle/spec/Cursor/CursorSpec.php
+++ b/src/Akeneo/Bundle/ElasticsearchBundle/spec/Cursor/CursorSpec.php
@@ -57,7 +57,7 @@ class CursorSpec extends ObjectBehavior
     function it_is_countable()
     {
         $this->shouldImplement(\Countable::class);
-        $this->shouldHaveCount(4);
+        $this->count()->shouldReturn(4);
     }
 
     function it_is_iterable(

--- a/src/Akeneo/Bundle/ElasticsearchBundle/spec/Cursor/FromSizeCursorSpec.php
+++ b/src/Akeneo/Bundle/ElasticsearchBundle/spec/Cursor/FromSizeCursorSpec.php
@@ -63,7 +63,7 @@ class FromSizeCursorSpec extends ObjectBehavior
     function it_is_countable()
     {
         $this->shouldImplement(\Countable::class);
-        $this->shouldHaveCount(4);
+        $this->count()->shouldReturn(4);
     }
 
     function it_is_iterable(

--- a/src/Akeneo/Bundle/ElasticsearchBundle/spec/Cursor/SearchAfterSizeCursorSpec.php
+++ b/src/Akeneo/Bundle/ElasticsearchBundle/spec/Cursor/SearchAfterSizeCursorSpec.php
@@ -64,7 +64,7 @@ class SearchAfterSizeCursorSpec extends ObjectBehavior
     function it_is_countable()
     {
         $this->shouldImplement(\Countable::class);
-        $this->shouldHaveCount(4);
+        $this->count()->shouldReturn(4);
     }
 
     function it_is_iterable(

--- a/src/Akeneo/Component/StorageUtils/spec/Cursor/PaginatorSpec.php
+++ b/src/Akeneo/Component/StorageUtils/spec/Cursor/PaginatorSpec.php
@@ -89,7 +89,7 @@ class PaginatorSpec extends ObjectBehavior
         $cursor->count()->shouldBeCalled()->willReturn(13);
 
         // page size is 10 : so 1 page of 10 elements and a second of 3
-        $this->shouldHaveCount(2);
+        $this->count()->shouldReturn(2);
     }
 }
 

--- a/src/Pim/Bundle/EnrichBundle/spec/Elasticsearch/CursorSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Elasticsearch/CursorSpec.php
@@ -64,7 +64,7 @@ class CursorSpec extends ObjectBehavior
     function it_is_countable()
     {
         $this->shouldImplement(\Countable::class);
-        $this->shouldHaveCount(4);
+        $this->count()->shouldReturn(4);
     }
 
     function it_is_iterable(

--- a/src/Pim/Bundle/EnrichBundle/spec/Elasticsearch/FromSizeCursorSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Elasticsearch/FromSizeCursorSpec.php
@@ -67,7 +67,7 @@ class FromSizeCursorSpec extends ObjectBehavior
     function it_is_countable()
     {
         $this->shouldImplement(\Countable::class);
-        $this->shouldHaveCount(4);
+        $this->count()->shouldReturn(4);
     }
 
     function it_is_iterable(


### PR DESCRIPTION
In this pull request, in addition to the new Jenkinsfile and related files for the new continuous integration system to work, is 2 little notable changes:

### phpunit / phpspec upgrade
In order to list all the behat scenarios we decided to use a well maintained behat extension available for both behat2 and behat3 but this library required a newer version of phpunit and phpspec so we updated it. While doing so some tests failed so we had to rewrite them, basically shouldHaveCount changed its internal implementation and now calls more function on Iterable classes. we used `$this->count()->shouldReturn(xxx);` instead.

### Behat history instability fix
The step `I should see history` was poorly written and worked only with very slow firefox. It tried to look at a row that was just removed by the click on the "expand" button just before.

### Concerning the new files
Well it's a brand new Jenkinsfile, make sure to read it with caution. The Kubernetes job definition is also very important. The behat.*.yml are here to not have to do uggly "sed" in the Jenkinsfile. The enterprise one will be removed when the EE have been migrated on the new CI with the old behat.ci.yml at the root level as it will become useless. 