### PR TITLE
PIM-6858: add a default value for job type in job profile form

### DIFF
--- a/features/import/create_an_import.feature
+++ b/features/import/create_an_import.feature
@@ -27,5 +27,6 @@ Feature: Create an import
     When I fill in the following information:
       | Code  | PRODUCT_IMPORT  |
       | Label | Products import |
+    And the field Job should contain ""
     And I press the "Save" button
     Then I should see validation error "Failed to create an import with an unknown job definition"


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
