### PR TITLE
Fix integration tests

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -22,7 +22,7 @@
 - API-397: As Mary, I want to only see my launched jobs in the dashboard
 - API-389: As Mary, I want to only see my launched jobs in the process tracker
 - PIM-6881: Fix common attributes design
-- PIM-6581: Fix completeness panel in case of a big number of channels
+- PIM-6851: Fix completeness panel in case of a big number of channels
 - PIM-6895: Improve performances on products datagrid
 
 ## Better manage products with variants!

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Attribute/ListAttributeIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Attribute/ListAttributeIntegration.php
@@ -261,7 +261,7 @@ JSON;
     "group"                  : "attributeGroupA",
     "unique"                 : false,
     "useable_as_grid_filter" : false,
-    "allowed_extensions"     : ["pdf", "doc", "docx"],
+    "allowed_extensions"     : ["pdf", "doc", "docx", "txt"],
     "metric_family"          : null,
     "default_metric_unit"    : null,
     "reference_data_name"    : null,

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/AbstractProductTestCase.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/AbstractProductTestCase.php
@@ -5,6 +5,7 @@ namespace Pim\Bundle\ApiBundle\tests\integration\Controller\Product;
 use Pim\Bundle\ApiBundle\tests\integration\ApiTestCase;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Model\ProductModelInterface;
+use Pim\Component\Catalog\Model\VariantProductInterface;
 use Pim\Component\Catalog\tests\integration\Normalizer\NormalizedProductCleaner;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -20,11 +21,22 @@ abstract class AbstractProductTestCase extends ApiTestCase
      * @param array  $data
      *
      * @return ProductInterface
+     * @throws \Exception
      */
     protected function createProduct($identifier, array $data = [])
     {
         $product = $this->get('pim_catalog.builder.product')->createProduct($identifier);
         $this->get('pim_catalog.updater.product')->update($product, $data);
+
+        $errors = $this->get('pim_catalog.validator.product')->validate($product);
+        if (0 !== $errors->count()) {
+            throw new \Exception(sprintf(
+                'Impossible to setup test in %s: %s',
+                static::class,
+                $errors->get(0)->getMessage()
+            ));
+        }
+
         $this->get('pim_catalog.saver.product')->save($product);
 
         $this->get('akeneo_elasticsearch.client.product')->refreshIndex();
@@ -36,12 +48,23 @@ abstract class AbstractProductTestCase extends ApiTestCase
      * @param string $identifier
      * @param array  $data
      *
-     * @return ProductInterface
+     * @return VariantProductInterface
+     * @throws \Exception
      */
-    protected function createVariantProduct($identifier, array $data = []) : ProductInterface
+    protected function createVariantProduct($identifier, array $data = []) : VariantProductInterface
     {
         $product = $this->get('pim_catalog.builder.variant_product')->createProduct($identifier);
         $this->get('pim_catalog.updater.product')->update($product, $data);
+
+        $errors = $this->get('pim_catalog.validator.product')->validate($product);
+        if (0 !== $errors->count()) {
+            throw new \Exception(sprintf(
+                'Impossible to setup test in %s: %s',
+                static::class,
+                $errors->get(0)->getMessage()
+            ));
+        }
+
         $this->get('pim_catalog.saver.product')->save($product);
 
         $this->get('akeneo_elasticsearch.client.product')->refreshIndex();
@@ -53,13 +76,24 @@ abstract class AbstractProductTestCase extends ApiTestCase
      * @param array $data
      *
      * @return ProductModelInterface
+     * @throws \Exception
      */
     protected function createProductModel(array $data = []) : ProductModelInterface
     {
         $productModel = $this->get('pim_catalog.factory.product_model')->create();
         $this->get('pim_catalog.updater.product_model')->update($productModel, $data);
-        $this->get('pim_catalog.validator.product')->validate($productModel);
+
+        $errors = $this->get('pim_catalog.validator.product')->validate($productModel);
+        if (0 !== $errors->count()) {
+            throw new \Exception(sprintf(
+                'Impossible to setup test in %s: %s',
+                static::class,
+                $errors->get(0)->getMessage()
+            ));
+        }
         $this->get('pim_catalog.saver.product_model')->save($productModel);
+
+        $this->waitForProductModelsDescendantsJob();
 
         $this->get('akeneo_elasticsearch.client.product_model')->refreshIndex();
 
@@ -88,5 +122,50 @@ abstract class AbstractProductTestCase extends ApiTestCase
         }
 
         $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Each time we create a product model, a batch job is ran to calculate the
+     * completeness of its descendants.
+     *
+     * This is done by a batch job, and if several product models are created one
+     * after the other, we can end up with a MySQL error because several jobs run
+     * at the same time.
+     *
+     * So this method ensures the completeness is calculated, but will stop and
+     * throw an exception after 2 seconds max (we loops as we loop every 0.2
+     * seconds).
+     *
+     */
+    private function waitForProductModelsDescendantsJob()
+    {
+        $loop = 0;
+        $count = 0;
+        while (10 > $loop && 0 !== $count = $this->getComputeProductModelsDescendantsJobExecutionCount()) {
+            usleep(200000);
+            $loop++;
+        }
+
+        if (0 !== $count) {
+            throw new \PHPUnit_Framework_IncompleteTestError(sprintf('There is still running "" jobs: %d', $count));
+        }
+    }
+
+    /**
+     * Finds the number of execution for a project calculation job.
+     *
+     * @return int
+     */
+    private function getComputeProductModelsDescendantsJobExecutionCount()
+    {
+        $sql = <<<SQL
+SELECT count(`execution`.`id`)
+FROM `akeneo_batch_job_execution` AS `execution`
+LEFT JOIN `akeneo_batch_job_instance` AS `instance` ON `execution`.`job_instance_id` = `instance`.`id`
+WHERE `instance`.`code` = 'compute_product_models_descendants'
+AND `execution`.`exit_code` != 'COMPLETED'
+SQL;
+
+        return (int) $this->get('doctrine.orm.default_entity_manager')->getConnection()->fetchColumn($sql);
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateProductVariantIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateProductVariantIntegration.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Pim\Bundle\ApiBundle\tests\integration\Controller\Product;
 
 use Akeneo\Test\Integration\Configuration;
@@ -15,7 +17,7 @@ class PartialUpdateProductVariantIntegration extends AbstractProductTestCase
     /**
      * {@inheritdoc}
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -46,24 +48,9 @@ class PartialUpdateProductVariantIntegration extends AbstractProductTestCase
             ]
         );
 
-        // no locale, no scope, 1 category
-        $this->createVariantProduct('apollon_optionb_true', [
-            'categories' => ['master'],
-            'parent' => 'amor',
-            'values' => [
-                'a_yes_no' => [
-                    [
-                        'locale' => null,
-                        'scope' => null,
-                        'data' => true,
-                    ],
-                ],
-            ],
-        ]);
-
         // apollon_blue_m & apollon_blue_l, categorized in 2 trees (master and categoryA1)
         $this->createVariantProduct('apollon_optionb_false', [
-            'categories' => ['categoryA2', 'categoryA1'],
+            'categories' => ['master'],
             'parent' => 'amor',
             'values' => [
                 'a_yes_no' => [
@@ -79,7 +66,7 @@ class PartialUpdateProductVariantIntegration extends AbstractProductTestCase
         $this->products = $this->get('pim_catalog.repository.product')->findAll();
     }
 
-    public function testProductVariantCreationWithIdenticalIdentifiers()
+    public function testProductVariantCreationWithIdenticalIdentifiers(): void
     {
         $client = $this->createAuthenticatedClient();
 
@@ -94,7 +81,7 @@ class PartialUpdateProductVariantIntegration extends AbstractProductTestCase
             {
               "locale": null,
               "scope": null,
-              "data": true
+              "data": false
             }
           ]
         }
@@ -144,7 +131,7 @@ JSON;
                     [
                         "locale" => null,
                         "scope"  => null,
-                        "data"   => true,
+                        "data"   => false,
                     ],
                 ],
             ],
@@ -167,7 +154,7 @@ JSON;
         );
     }
 
-    public function testProductVariantCreationWithoutIdentifier()
+    public function testProductVariantCreationWithoutIdentifier(): void
     {
         $client = $this->createAuthenticatedClient();
 
@@ -204,7 +191,7 @@ JSON;
         );
     }
 
-    public function testProductVariantCreationWithDifferentIdentifiers()
+    public function testProductVariantCreationWithDifferentIdentifiers(): void
     {
         $client = $this->createAuthenticatedClient();
 
@@ -227,7 +214,7 @@ JSON;
         $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
     }
 
-    public function testProductVariantPartialUpdateWithTheIdentifierUpdatedWithNull()
+    public function testProductVariantPartialUpdateWithTheIdentifierUpdatedWithNull(): void
     {
         $client = $this->createAuthenticatedClient();
 
@@ -241,14 +228,14 @@ JSON;
             {
               "locale": null,
               "scope": null,
-              "data": true
+              "data": false
             }
           ]
         }
     }
 JSON;
 
-        $client->request('PATCH', 'api/rest/v1/products/apollon_optionb_true', [], [], [], $data);
+        $client->request('PATCH', 'api/rest/v1/products/apollon_optionb_false', [], [], [], $data);
 
         $expectedContent = [
             'code'    => 422,
@@ -267,14 +254,14 @@ JSON;
         $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
     }
 
-    public function testProductVariantPartialUpdateCannotUpdateFamily()
+    public function testProductVariantPartialUpdateCannotUpdateFamily(): void
     {
         $client = $this->createAuthenticatedClient();
 
         $data =
 <<<JSON
     {
-        "identifier": "apollon_optionb_true",
+        "identifier": "apollon_optionb_false",
         "family": "familyA2",
         "parent": "amor",
         "values": {
@@ -282,14 +269,14 @@ JSON;
             {
               "locale": null,
               "scope": null,
-              "data": true
+              "data": false
             }
           ]
         }
     }
 JSON;
 
-        $client->request('PATCH', 'api/rest/v1/products/apollon_optionb_true', [], [], [], $data);
+        $client->request('PATCH', 'api/rest/v1/products/apollon_optionb_false', [], [], [], $data);
 
         $expectedContent = [
             'code'    => 422,
@@ -308,14 +295,14 @@ JSON;
         $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
     }
 
-    public function testProductVariantPartialUpdateCannotSetFamilyToNull()
+    public function testProductVariantPartialUpdateCannotSetFamilyToNull(): void
     {
         $client = $this->createAuthenticatedClient();
 
         $data =
 <<<JSON
     {
-        "identifier": "apollon_optionb_true",
+        "identifier": "apollon_optionb_false",
         "parent": "amor",
         "family": null,
         "values": {
@@ -323,14 +310,14 @@ JSON;
             {
               "locale": null,
               "scope": null,
-              "data": true
+              "data": false
             }
           ]
         }
     }
 JSON;
 
-        $client->request('PATCH', 'api/rest/v1/products/apollon_optionb_true', [], [], [], $data);
+        $client->request('PATCH', 'api/rest/v1/products/apollon_optionb_false', [], [], [], $data);
 
         $expectedContent = [
             'code'    => 422,
@@ -338,7 +325,7 @@ JSON;
             'errors'  => [
                 [
                     'property' => 'family',
-                    'message'  => 'The family can\'t be "null" because your product with the identifier "apollon_optionb_true" is a variant product.',
+                    'message'  => 'The family can\'t be "null" because your product with the identifier "apollon_optionb_false" is a variant product.',
                 ],
             ],
         ];
@@ -349,14 +336,14 @@ JSON;
         $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
     }
 
-    public function testProductVariantPartialUpdateCannotSetFamilyToNullNoMatterTheOrder()
+    public function testProductVariantPartialUpdateCannotSetFamilyToNullNoMatterTheOrder(): void
     {
         $client = $this->createAuthenticatedClient();
 
         $data =
 <<<JSON
     {
-        "identifier": "apollon_optionb_true",
+        "identifier": "apollon_optionb_false",
         "family": null,
         "parent": "amor",
         "values": {
@@ -364,14 +351,14 @@ JSON;
             {
               "locale": null,
               "scope": null,
-              "data": true
+              "data": false
             }
           ]
         }
     }
 JSON;
 
-        $client->request('PATCH', 'api/rest/v1/products/apollon_optionb_true', [], [], [], $data);
+        $client->request('PATCH', 'api/rest/v1/products/apollon_optionb_false', [], [], [], $data);
 
         $expectedContent = [
             'code'    => 422,
@@ -379,7 +366,7 @@ JSON;
             'errors'  => [
                 [
                     'property' => 'family',
-                    'message'  => 'The family can\'t be "null" because your product with the identifier "apollon_optionb_true" is a variant product.',
+                    'message'  => 'The family can\'t be "null" because your product with the identifier "apollon_optionb_false" is a variant product.',
                 ],
             ],
         ];
@@ -390,14 +377,14 @@ JSON;
         $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
     }
 
-    public function testProductVariantPartialUpdateWithTheGroupsUpdated()
+    public function testProductVariantPartialUpdateWithTheGroupsUpdated(): void
     {
         $client = $this->createAuthenticatedClient();
 
         $data =
 <<<JSON
     {
-        "identifier": "apollon_optionb_true",
+        "identifier": "apollon_optionb_false",
         "groups": ["groupB", "groupA"],
         "parent": "amor",
         "values": {
@@ -405,17 +392,17 @@ JSON;
             {
               "locale": null,
               "scope": null,
-              "data": true
+              "data": false
             }
           ]
         }
     }
 JSON;
 
-        $client->request('PATCH', 'api/rest/v1/products/apollon_optionb_true', [], [], [], $data);
+        $client->request('PATCH', 'api/rest/v1/products/apollon_optionb_false', [], [], [], $data);
 
         $expectedProduct = [
-            'identifier'    => 'apollon_optionb_true',
+            'identifier'    => 'apollon_optionb_false',
             'family'        => "familyA",
             'parent'        => "amor",
             'groups'        => ['groupA', 'groupB'],
@@ -423,7 +410,7 @@ JSON;
             'enabled'       => true,
             'values'        => [
                 'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'apollon_optionb_true'],
+                    ['locale' => null, 'scope' => null, 'data' => 'apollon_optionb_false'],
                 ],
                 'a_simple_select' => [
                     ['locale' => null, 'scope' => null, 'data' => 'optionB'],
@@ -458,7 +445,7 @@ JSON;
                     [
                         "locale" => null,
                         "scope"  => null,
-                        "data"   => true,
+                        "data"   => false,
                     ],
                 ],
             ],
@@ -471,17 +458,17 @@ JSON;
 
         $this->assertSame('', $response->getContent());
         $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
-        $this->assertSameProducts($expectedProduct, 'apollon_optionb_true');
+        $this->assertSameProducts($expectedProduct, 'apollon_optionb_false');
     }
 
-    public function testProductVariantPartialUpdateWithTheGroupsDeleted()
+    public function testProductVariantPartialUpdateWithTheGroupsDeleted(): void
     {
         $client = $this->createAuthenticatedClient();
 
         $data =
 <<<JSON
     {
-        "identifier": "apollon_optionb_true",
+        "identifier": "apollon_optionb_false",
         "groups": [],
         "parent": "amor",
         "values": {
@@ -489,17 +476,17 @@ JSON;
             {
               "locale": null,
               "scope": null,
-              "data": true
+              "data": false
             }
           ]
         }
     }
 JSON;
 
-        $client->request('PATCH', 'api/rest/v1/products/apollon_optionb_true', [], [], [], $data);
+        $client->request('PATCH', 'api/rest/v1/products/apollon_optionb_false', [], [], [], $data);
 
         $expectedProduct = [
-            'identifier'    => 'apollon_optionb_true',
+            'identifier'    => 'apollon_optionb_false',
             'family'        => "familyA",
             'parent'        => "amor",
             'groups'        => [],
@@ -507,7 +494,7 @@ JSON;
             'enabled'       => true,
             'values'        => [
                 'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'apollon_optionb_true'],
+                    ['locale' => null, 'scope' => null, 'data' => 'apollon_optionb_false'],
                 ],
                 'a_simple_select' => [
                     ['locale' => null, 'scope' => null, 'data' => 'optionB'],
@@ -542,7 +529,7 @@ JSON;
                     [
                         "locale" => null,
                         "scope"  => null,
-                        "data"   => true,
+                        "data"   => false,
                     ],
                 ],
             ],
@@ -555,17 +542,17 @@ JSON;
 
         $this->assertSame('', $response->getContent());
         $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
-        $this->assertSameProducts($expectedProduct, 'apollon_optionb_true');
+        $this->assertSameProducts($expectedProduct, 'apollon_optionb_false');
     }
 
-    public function testProductVariantPartialUpdateWithTheCategoriesUpdated()
+    public function testProductVariantPartialUpdateWithTheCategoriesUpdated(): void
     {
         $client = $this->createAuthenticatedClient();
 
         $data =
             <<<JSON
     {
-        "identifier": "apollon_optionb_true",
+        "identifier": "apollon_optionb_false",
         "groups": [],
         "parent": "amor",
         "categories": ["categoryA"],
@@ -574,17 +561,17 @@ JSON;
             {
               "locale": null,
               "scope": null,
-              "data": true
+              "data": false
             }
           ]
         }
     }
 JSON;
 
-        $client->request('PATCH', 'api/rest/v1/products/apollon_optionb_true', [], [], [], $data);
+        $client->request('PATCH', 'api/rest/v1/products/apollon_optionb_false', [], [], [], $data);
 
         $expectedProduct = [
-            'identifier'    => 'apollon_optionb_true',
+            'identifier'    => 'apollon_optionb_false',
             'family'        => "familyA",
             'parent'        => "amor",
             'groups'        => [],
@@ -592,7 +579,7 @@ JSON;
             'enabled'       => true,
             'values'        => [
                 'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'apollon_optionb_true'],
+                    ['locale' => null, 'scope' => null, 'data' => 'apollon_optionb_false'],
                 ],
                 'a_simple_select' => [
                     ['locale' => null, 'scope' => null, 'data' => 'optionB'],
@@ -627,7 +614,7 @@ JSON;
                     [
                         "locale" => null,
                         "scope"  => null,
-                        "data"   => true,
+                        "data"   => false,
                     ],
                 ],
             ],
@@ -640,17 +627,17 @@ JSON;
 
         $this->assertSame('', $response->getContent());
         $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
-        $this->assertSameProducts($expectedProduct, 'apollon_optionb_true');
+        $this->assertSameProducts($expectedProduct, 'apollon_optionb_false');
     }
 
-    public function testProductVariantPartialUpdateWithTheCategoriesDeleted()
+    public function testProductVariantPartialUpdateWithTheCategoriesDeleted(): void
     {
         $client = $this->createAuthenticatedClient();
 
         $data =
             <<<JSON
     {
-        "identifier": "apollon_optionb_true",
+        "identifier": "apollon_optionb_false",
         "groups": [],
         "parent": "amor",
         "categories": [],
@@ -659,17 +646,17 @@ JSON;
             {
               "locale": null,
               "scope": null,
-              "data": true
+              "data": false
             }
           ]
         }
     }
 JSON;
 
-        $client->request('PATCH', 'api/rest/v1/products/apollon_optionb_true', [], [], [], $data);
+        $client->request('PATCH', 'api/rest/v1/products/apollon_optionb_false', [], [], [], $data);
 
         $expectedProduct = [
-            'identifier'    => 'apollon_optionb_true',
+            'identifier'    => 'apollon_optionb_false',
             'family'        => "familyA",
             'parent'        => "amor",
             'groups'        => [],
@@ -677,7 +664,7 @@ JSON;
             'enabled'       => true,
             'values'        => [
                 'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'apollon_optionb_true'],
+                    ['locale' => null, 'scope' => null, 'data' => 'apollon_optionb_false'],
                 ],
                 'a_simple_select' => [
                     ['locale' => null, 'scope' => null, 'data' => 'optionB'],
@@ -712,7 +699,7 @@ JSON;
                     [
                         "locale" => null,
                         "scope"  => null,
-                        "data"   => true,
+                        "data"   => false,
                     ],
                 ],
             ],
@@ -725,17 +712,17 @@ JSON;
 
         $this->assertSame('', $response->getContent());
         $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
-        $this->assertSameProducts($expectedProduct, 'apollon_optionb_true');
+        $this->assertSameProducts($expectedProduct, 'apollon_optionb_false');
     }
 
-    public function testProductVariantPartialUpdateWithTheAssociationsUpdated()
+    public function testProductVariantPartialUpdateWithTheAssociationsUpdated(): void
     {
         $client = $this->createAuthenticatedClient();
 
         $data =
 <<<JSON
     {
-        "identifier": "apollon_optionb_true",
+        "identifier": "apollon_optionb_false",
         "groups": [],
         "parent": "amor",
         "categories": [],
@@ -744,7 +731,7 @@ JSON;
             {
               "locale": null,
               "scope": null,
-              "data": true
+              "data": false
             }
           ]
         },
@@ -757,10 +744,10 @@ JSON;
     }
 JSON;
 
-        $client->request('PATCH', 'api/rest/v1/products/apollon_optionb_true', [], [], [], $data);
+        $client->request('PATCH', 'api/rest/v1/products/apollon_optionb_false', [], [], [], $data);
 
         $expectedProduct = [
-            'identifier'    => 'apollon_optionb_true',
+            'identifier'    => 'apollon_optionb_false',
             'family'        => "familyA",
             'parent'        => "amor",
             'groups'        => [],
@@ -768,7 +755,7 @@ JSON;
             'enabled'       => true,
             'values'        => [
                 'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'apollon_optionb_true'],
+                    ['locale' => null, 'scope' => null, 'data' => 'apollon_optionb_false'],
                 ],
                 'a_simple_select' => [
                     ['locale' => null, 'scope' => null, 'data' => 'optionB'],
@@ -803,7 +790,7 @@ JSON;
                     [
                         "locale" => null,
                         "scope"  => null,
-                        "data"   => true,
+                        "data"   => false,
                     ],
                 ],
             ],
@@ -821,10 +808,10 @@ JSON;
 
         $this->assertSame('', $response->getContent());
         $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
-        $this->assertSameProducts($expectedProduct, 'apollon_optionb_true');
+        $this->assertSameProducts($expectedProduct, 'apollon_optionb_false');
     }
 
-    public function testProductVariantPartialUpdateWithTheAssociationsDeletedOnGroups()
+    public function testProductVariantPartialUpdateWithTheAssociationsDeletedOnGroups(): void
     {
         $client = $this->createAuthenticatedClient();
 
@@ -919,7 +906,7 @@ JSON;
         $this->assertSameProducts($expectedProduct, 'apollon_optionb_false');
     }
 
-    public function testProductVariantPartialUpdateWithTheAssociationsDeleted()
+    public function testProductVariantPartialUpdateWithTheAssociationsDeleted(): void
     {
         $client = $this->createAuthenticatedClient();
 
@@ -1015,7 +1002,7 @@ JSON;
         $this->assertSameProducts($expectedProduct, 'apollon_optionb_false');
     }
 
-    public function testProductVariantPartialUpdateWithProductDisable()
+    public function testProductVariantPartialUpdateWithProductDisable(): void
     {
         $client = $this->createAuthenticatedClient();
 
@@ -1102,7 +1089,7 @@ JSON;
     }
 
 
-    public function testProductVariantPartialUpdateNewAxisValues()
+    public function testProductVariantPartialUpdateNewAxisValues(): void
     {
         $client = $this->createAuthenticatedClient();
 
@@ -1145,7 +1132,7 @@ JSON;
         $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
     }
 
-    public function testProductVariantPartialUpdateWhenProductValueAddedOnAttribute()
+    public function testProductVariantPartialUpdateWhenProductValueAddedOnAttribute(): void
     {
         $client = $this->createAuthenticatedClient();
 
@@ -1237,7 +1224,7 @@ JSON;
         $this->assertSameProducts($expectedProduct, 'apollon_optionb_false');
     }
 
-    public function testProductVariantPartialUpdateWhenProductValueDeletedOnAttribute()
+    public function testProductVariantPartialUpdateWhenProductValueDeletedOnAttribute(): void
     {
         $client = $this->createAuthenticatedClient();
 
@@ -1279,7 +1266,7 @@ JSON;
         $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
     }
 
-    public function testProductVariantPartialUpdateOnMultipleAttributes()
+    public function testProductVariantPartialUpdateOnMultipleAttributes(): void
     {
         $client = $this->createAuthenticatedClient();
 
@@ -1437,7 +1424,7 @@ JSON;
         $this->assertSameProducts($expectedProduct, 'apollon_optionb_false');
     }
 
-    public function testProductVariantPartialUpdateSetParentToNull()
+    public function testProductVariantPartialUpdateSetParentToNull(): void
     {
         $client = $this->createAuthenticatedClient();
 
@@ -1469,7 +1456,7 @@ JSON;
         $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
     }
 
-    public function testProductVariantCannotUpdateCommonAttribute()
+    public function testProductVariantCannotUpdateCommonAttribute(): void
     {
         $client = $this->createAuthenticatedClient();
 
@@ -1626,7 +1613,7 @@ JSON;
         $this->assertSameProducts($expectedProduct, 'apollon_optionb_false');
     }
 
-    public function testProductVariantPartialUpdateWithIgnoredProperties()
+    public function testProductVariantPartialUpdateWithIgnoredProperties(): void
     {
         $client = $this->createAuthenticatedClient();
 
@@ -1654,7 +1641,7 @@ JSON;
             'family'        => "familyA",
             'parent'        => "amor",
             'groups'        => [],
-            'categories'    => ['categoryA1', 'categoryA2'],
+            'categories'    => ['master'],
             'enabled'       => true,
             'values'        => [
                 'sku' => [
@@ -1718,7 +1705,7 @@ JSON;
         $this->assertNotSame('2014-06-14T13:12:50+02:00', $standardizedProduct['updated']);
     }
 
-    public function testPartialUpdateResponseWhenIdentifierPropertyNotEqualsToIdentifierInValues()
+    public function testPartialUpdateResponseWhenIdentifierPropertyNotEqualsToIdentifierInValues(): void
     {
         $client = $this->createAuthenticatedClient();
 
@@ -1757,7 +1744,7 @@ JSON;
         $this->assertSame('', $response->getContent());
     }
 
-    public function testPartialUpdateResponseWhenMissingIdentifierPropertyAndProvidedIdentifierInValues()
+    public function testPartialUpdateResponseWhenMissingIdentifierPropertyAndProvidedIdentifierInValues(): void
     {
         $client = $this->createAuthenticatedClient();
 
@@ -1798,7 +1785,7 @@ JSON;
      * @param array  $expectedProduct normalized data of the product that should be created
      * @param string $identifier identifier of the product that should be created
      */
-    protected function assertSameProducts(array $expectedProduct, $identifier)
+    protected function assertSameProducts(array $expectedProduct, string $identifier): void
     {
         $product = $this->get('pim_catalog.repository.product')->findOneByIdentifier($identifier);
         $standardizedProduct = $this->get('pim_serializer')->normalize($product, 'standard');
@@ -1812,7 +1799,7 @@ JSON;
     /**
      * {@inheritdoc}
      */
-    protected function getConfiguration()
+    protected function getConfiguration(): Configuration
     {
         return new Configuration([Configuration::getTechnicalCatalogPath()]);
     }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessListVariantProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessListVariantProductIntegration.php
@@ -20,7 +20,7 @@ class SuccessListVariantProductIntegration extends AbstractProductTestCase
         $this->createProductModel(
             [
                 'code' => 'amor',
-                'family_variant' => 'familyVariantA1',
+                'family_variant' => 'familyVariantA2',
                 'values'  => [
                     'a_price'  => [
                         'data' => ['data' => [['amount' => '50', 'currency' => 'EUR']], 'locale' => null, 'scope' => null],
@@ -32,87 +32,88 @@ class SuccessListVariantProductIntegration extends AbstractProductTestCase
         );
 
         // no locale, no scope, 1 category
-        $this->createVariantProduct('apollon_blue_s', [
+        $this->createVariantProduct('apollon_A_true', [
             'categories' => ['master'],
             'parent' => 'amor',
             'values' => [
-                'a_simple_select_size' => [
+                'a_simple_select' => [
                     [
                         'locale' => null,
                         'scope' => null,
-                        'data' => 's',
+                        'data' => 'optionA',
+                    ],
+                ],
+                'a_yes_no' => [
+                    [
+                        'locale' => null,
+                        'scope' => null,
+                        'data' => true,
                     ],
                 ],
             ],
         ]);
 
         // apollon_blue_m, categorized in 1 tree (master)
-        $this->createVariantProduct('apollon_blue_m', [
+        $this->createVariantProduct('apollon_B_true', [
             'categories' => ['categoryA'],
             'parent' => 'amor',
             'values' => [
-                'a_simple_select_color' => [
+                'a_simple_select' => [
                     [
                         'locale' => null,
                         'scope' => null,
-                        'data' => 'blue',
+                        'data' => 'optionB',
+                    ],
+                ],
+                'a_yes_no' => [
+                    [
+                        'locale' => null,
+                        'scope' => null,
+                        'data' => true,
                     ],
                 ],
             ],
         ]);
 
         // apollon_blue_l, categorized in 1 tree (master)
-        $this->createVariantProduct('apollon_blue_l', [
+        $this->createVariantProduct('apollon_A_false', [
             'categories' => ['categoryB', 'categoryC'],
             'parent' => 'amor',
             'values' => [
-                'a_simple_select_size' => [
+                'a_simple_select' => [
                     [
                         'locale' => null,
                         'scope' => null,
-                        'data' => 'l',
+                        'data' => 'optionA',
+                    ],
+                ],
+                'a_yes_no' => [
+                    [
+                        'locale' => null,
+                        'scope' => null,
+                        'data' => false,
                     ],
                 ],
             ],
         ]);
 
         // apollon_blue_m & apollon_blue_l, categorized in 2 trees (master and categoryA1)
-        $this->createVariantProduct('apollon_blue_xl', [
+        $this->createVariantProduct('apollon_B_false', [
             'categories' => ['categoryA2', 'categoryA1'],
             'parent' => 'amor',
             'values' => [
-                'a_simple_select_size' => [
+                'a_simple_select' => [
                     [
                         'locale' => null,
                         'scope' => null,
-                        'data' => 'xl',
+                        'data' => 'optionB',
                     ],
                 ],
-            ],
-        ]);
-
-        $this->createVariantProduct('apollon_blue_xxl', [
-            'categories' => ['categoryA1'],
-            'parent' => 'amor',
-            'values' => [
-                'a_simple_select_size' => [
+                'a_yes_no' => [
                     [
                         'locale' => null,
                         'scope' => null,
-                        'data' => 'xxl',
-                    ],
-                ],
-            ],
-        ]);
-
-        $this->createVariantProduct('apollon_blue_xs', [
-            'parent' => 'amor',
-            'values' => [
-                'a_simple_select_size' => [
-                    [
-                        'locale' => null,
-                        'scope' => null,
-                        'data' => 'xs',
+                        'data' => false,
                     ],
                 ],
             ],
@@ -139,12 +140,10 @@ class SuccessListVariantProductIntegration extends AbstractProductTestCase
     "current_page" : 1,
     "_embedded"    : {
 		"items": [
-            {$standardizedProducts['apollon_blue_s']},
-            {$standardizedProducts['apollon_blue_m']},
-            {$standardizedProducts['apollon_blue_l']},
-            {$standardizedProducts['apollon_blue_xl']},
-            {$standardizedProducts['apollon_blue_xxl']},
-            {$standardizedProducts['apollon_blue_xs']}
+            {$standardizedProducts['apollon_A_true']},
+            {$standardizedProducts['apollon_B_true']},
+            {$standardizedProducts['apollon_A_false']},
+            {$standardizedProducts['apollon_B_false']}
 		]
     }
 }
@@ -167,12 +166,12 @@ JSON;
         "next"  : {"href": "http://localhost/api/rest/v1/products?page=2&with_count=true&pagination_type=page&limit=3"}
     },
     "current_page" : 1,
-    "items_count"  : 6,
+    "items_count"  : 4,
     "_embedded"    : {
 		"items": [
-            {$standardizedProducts['apollon_blue_s']},
-            {$standardizedProducts['apollon_blue_m']},
-            {$standardizedProducts['apollon_blue_l']}
+            {$standardizedProducts['apollon_A_true']},
+            {$standardizedProducts['apollon_B_true']},
+            {$standardizedProducts['apollon_A_false']}
 		]
     }
 }
@@ -192,16 +191,13 @@ JSON;
     "_links": {
         "self"     : {"href": "http://localhost/api/rest/v1/products?page=2&with_count=true&pagination_type=page&limit=3"},
         "first"    : {"href": "http://localhost/api/rest/v1/products?page=1&with_count=true&pagination_type=page&limit=3"},
-        "previous" : {"href": "http://localhost/api/rest/v1/products?page=1&with_count=true&pagination_type=page&limit=3"},
-        "next"     : {"href": "http://localhost/api/rest/v1/products?page=3&with_count=true&pagination_type=page&limit=3"}
+        "previous" : {"href": "http://localhost/api/rest/v1/products?page=1&with_count=true&pagination_type=page&limit=3"}
     },
     "current_page" : 2,
-    "items_count"  : 6,
+    "items_count"  : 4,
     "_embedded"    : {
 		"items": [
-            {$standardizedProducts['apollon_blue_xl']},
-            {$standardizedProducts['apollon_blue_xxl']},
-            {$standardizedProducts['apollon_blue_xs']}
+            {$standardizedProducts['apollon_B_false']}
 		]
     }
 }
@@ -232,11 +228,10 @@ JSON;
     "current_page" : 1,
     "_embedded"    : {
         "items" : [
-            {$standardizedProducts['apollon_blue_s']},
-            {$standardizedProducts['apollon_blue_m']},
-            {$standardizedProducts['apollon_blue_l']},
-            {$standardizedProducts['apollon_blue_xl']},
-            {$standardizedProducts['apollon_blue_xxl']}
+            {$standardizedProducts['apollon_A_true']},
+            {$standardizedProducts['apollon_B_true']},
+            {$standardizedProducts['apollon_A_false']},
+            {$standardizedProducts['apollon_B_false']}
 		]
     }
 }
@@ -249,46 +244,31 @@ JSON;
     {
         $client = $this->createAuthenticatedClient();
 
-        $client->request('GET', 'api/rest/v1/products?attributes=a_simple_select_color&pagination_type=page');
+        $client->request('GET', 'api/rest/v1/products?attributes=a_simple_select&pagination_type=page');
         $expected = <<<JSON
 {
     "_links": {
-        "self"  : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&attributes=a_simple_select_color"},
-        "first" : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&attributes=a_simple_select_color"}
+        "self"  : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&attributes=a_simple_select"},
+        "first" : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&attributes=a_simple_select"}
     },
     "current_page" : 1,
     "_embedded"    : {
         "items" : [
             {
                 "_links" : {
-                    "self" : {"href" : "http://localhost/api/rest/v1/products/apollon_blue_s"}
+                    "self" : {"href" : "http://localhost/api/rest/v1/products/apollon_A_true"}
                 },
-                "identifier"    : "apollon_blue_s",
+                "identifier"    : "apollon_A_true",
                 "family"        : "familyA",
                 "parent"        : "amor",
                 "groups"        : [],
                 "categories"    : ["master"],
                 "enabled"       : true,
-                "values"        : {},
-                "created"       : "2017-01-23T11:44:25+01:00",
-                "updated"       : "2017-01-23T11:44:25+01:00",
-                "associations"  : {}
-            },
-            {
-                "_links" : {
-                    "self" : {"href" : "http://localhost/api/rest/v1/products/apollon_blue_m"}
-                },
-                "identifier"    : "apollon_blue_m",
-                "family"        : "familyA",
-                "parent"        : "amor",
-                "groups"        : [],
-                "categories"    : ["categoryA"],
-                "enabled"       : true,
                 "values": {
-                    "a_simple_select_color": [{
+                    "a_simple_select": [{
                         "locale": null,
                         "scope": null,
-                        "data": "blue"
+                        "data": "optionA"
                     }]
                 },
                 "created"       : "2017-01-23T11:44:25+01:00",
@@ -297,60 +277,63 @@ JSON;
             },
             {
                 "_links" : {
-                    "self" : {"href" : "http://localhost/api/rest/v1/products/apollon_blue_l"}
+                    "self" : {"href" : "http://localhost/api/rest/v1/products/apollon_B_true"}
                 },
-                "identifier"    : "apollon_blue_l",
+                "identifier"    : "apollon_B_true",
+                "family"        : "familyA",
+                "parent"        : "amor",
+                "groups"        : [],
+                "categories"    : ["categoryA"],
+                "enabled"       : true,
+                "values": {
+                    "a_simple_select": [{
+                        "locale": null,
+                        "scope": null,
+                        "data": "optionB"
+                    }]
+                },
+                "created"       : "2017-01-23T11:44:25+01:00",
+                "updated"       : "2017-01-23T11:44:25+01:00",
+                "associations"  : {}
+            },
+            {
+                "_links" : {
+                    "self" : {"href" : "http://localhost/api/rest/v1/products/apollon_A_false"}
+                },
+                "identifier"    : "apollon_A_false",
                 "family"        : "familyA",
                 "parent"        : "amor",
                 "groups"        : [],
                 "categories"    : ["categoryB", "categoryC"],
                 "enabled"       : true,
-                "values"        : {},
+                "values"        : {
+                    "a_simple_select": [{
+                        "locale": null,
+                        "scope": null,
+                        "data": "optionA"
+                    }]
+                },
                 "created"       : "2017-01-23T11:44:25+01:00",
                 "updated"       : "2017-01-23T11:44:25+01:00",
                 "associations"  : {}
             },
             {
                 "_links" : {
-                    "self" : {"href" : "http://localhost/api/rest/v1/products/apollon_blue_xl"}
+                    "self" : {"href" : "http://localhost/api/rest/v1/products/apollon_B_false"}
                 },
-                "identifier"    : "apollon_blue_xl",
+                "identifier"    : "apollon_B_false",
                 "family"        : "familyA",
                 "parent"        : "amor",
                 "groups"        : [],
                 "categories"    : ["categoryA1", "categoryA2"],
                 "enabled"       : true,
-                "values"        : {},
-                "created"       : "2017-01-23T11:44:25+01:00",
-                "updated"       : "2017-01-23T11:44:25+01:00",
-                "associations"  : {}
-            },
-            {
-                "_links" : {
-                    "self" : {"href" : "http://localhost/api/rest/v1/products/apollon_blue_xxl"}
+                "values"        : {
+                    "a_simple_select": [{
+                        "locale": null,
+                        "scope": null,
+                        "data": "optionB"
+                    }]
                 },
-                "identifier"    : "apollon_blue_xxl",
-                "family"        : "familyA",
-                "parent"        : "amor",
-                "groups"        : [],
-                "categories"    : ["categoryA1"],
-                "enabled"       : true,
-                "values"        : {},
-                "created"       : "2017-01-23T11:44:25+01:00",
-                "updated"       : "2017-01-23T11:44:25+01:00",
-                "associations"  : {}
-            },
-            {
-                "_links" : {
-                    "self" : {"href" : "http://localhost/api/rest/v1/products/apollon_blue_xs"}
-                },
-                "identifier"    : "apollon_blue_xs",
-                "family"        : "familyA",
-                "parent"        : "amor",
-                "groups"        : [],
-                "categories"    : [],
-                "enabled"       : true,
-                "values"        : [],
                 "created"       : "2017-01-23T11:44:25+01:00",
                 "updated"       : "2017-01-23T11:44:25+01:00",
                 "associations"  : {}
@@ -367,15 +350,15 @@ JSON;
     {
         $client = $this->createAuthenticatedClient();
 
-        $client->request('GET', 'api/rest/v1/products?scope=ecommerce&locales=en_US&attributes=a_simple_select_size,a_text_area,a_number_integer&pagination_type=page');
+        $client->request('GET', 'api/rest/v1/products?scope=ecommerce&locales=en_US&attributes=a_simple_select,a_text_area,a_number_integer&pagination_type=page');
         $expected = <<<JSON
 {
   "_links": {
     "self": {
-      "href": "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&scope=ecommerce&locales=en_US&attributes=a_simple_select_size%2Ca_text_area%2Ca_number_integer"
+      "href": "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&scope=ecommerce&locales=en_US&attributes=a_simple_select%2Ca_text_area%2Ca_number_integer"
     },
     "first": {
-      "href": "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&scope=ecommerce&locales=en_US&attributes=a_simple_select_size%2Ca_text_area%2Ca_number_integer"
+      "href": "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&scope=ecommerce&locales=en_US&attributes=a_simple_select%2Ca_text_area%2Ca_number_integer"
     }
   },
   "current_page": 1,
@@ -384,10 +367,10 @@ JSON;
       {
         "_links": {
           "self": {
-            "href": "http://localhost/api/rest/v1/products/apollon_blue_s"
+            "href": "http://localhost/api/rest/v1/products/apollon_A_true"
           }
         },
-        "identifier": "apollon_blue_s",
+        "identifier": "apollon_A_true",
         "family": "familyA",
         "parent": "amor",
         "groups": [
@@ -398,11 +381,11 @@ JSON;
         ],
         "enabled": true,
         "values": {
-          "a_simple_select_size": [
+          "a_simple_select": [
             {
               "locale": null,
               "scope": null,
-              "data": "s"
+              "data": "optionA"
             }
           ]
         },
@@ -415,10 +398,10 @@ JSON;
       {
         "_links": {
           "self": {
-            "href": "http://localhost/api/rest/v1/products/apollon_blue_m"
+            "href": "http://localhost/api/rest/v1/products/apollon_B_true"
           }
         },
-        "identifier": "apollon_blue_m",
+        "identifier": "apollon_B_true",
         "family": "familyA",
         "parent": "amor",
         "groups": [
@@ -429,7 +412,13 @@ JSON;
         ],
         "enabled": true,
         "values": {
-          
+          "a_simple_select": [
+            {
+              "locale": null,
+              "scope": null,
+              "data": "optionB"
+            }
+          ]
         },
         "created": "2017-09-25T14:02:11+02:00",
         "updated": "2017-09-25T14:02:11+02:00",
@@ -440,10 +429,10 @@ JSON;
       {
         "_links": {
           "self": {
-            "href": "http://localhost/api/rest/v1/products/apollon_blue_l"
+            "href": "http://localhost/api/rest/v1/products/apollon_A_false"
           }
         },
-        "identifier": "apollon_blue_l",
+        "identifier": "apollon_A_false",
         "family": "familyA",
         "parent": "amor",
         "groups": [
@@ -455,11 +444,11 @@ JSON;
         ],
         "enabled": true,
         "values": {
-          "a_simple_select_size": [
+          "a_simple_select": [
             {
               "locale": null,
               "scope": null,
-              "data": "l"
+              "data": "optionA"
             }
           ]
         },
@@ -472,10 +461,10 @@ JSON;
       {
         "_links": {
           "self": {
-            "href": "http://localhost/api/rest/v1/products/apollon_blue_xl"
+            "href": "http://localhost/api/rest/v1/products/apollon_B_false"
           }
         },
-        "identifier": "apollon_blue_xl",
+        "identifier": "apollon_B_false",
         "family": "familyA",
         "parent": "amor",
         "groups": [
@@ -487,143 +476,16 @@ JSON;
         ],
         "enabled": true,
         "values": {
-          "a_simple_select_size": [
+          "a_simple_select": [
             {
               "locale": null,
               "scope": null,
-              "data": "xl"
+              "data": "optionB"
             }
           ]
         },
         "created": "2017-09-25T14:02:11+02:00",
         "updated": "2017-09-25T14:02:11+02:00",
-        "associations": {
-          
-        }
-      },
-      {
-        "_links": {
-          "self": {
-            "href": "http://localhost/api/rest/v1/products/apollon_blue_xxl"
-          }
-        },
-        "identifier": "apollon_blue_xxl",
-        "family": "familyA",
-        "parent": "amor",
-        "groups": [
-          
-        ],
-        "categories": [
-          "categoryA1"
-        ],
-        "enabled": true,
-        "values": {
-          "a_simple_select_size": [
-            {
-              "locale": null,
-              "scope": null,
-              "data": "xxl"
-            }
-          ]
-        },
-        "created": "2017-09-25T14:02:11+02:00",
-        "updated": "2017-09-25T14:02:11+02:00",
-        "associations": {
-          
-        }
-      }
-    ]
-  }
-}
-JSON;
-
-        $this->assertListResponse($client->getResponse(), $expected);
-    }
-
-    public function testTheSecondPageOfTheListOfProductsWithOffsetPaginationWithoutCount()
-    {
-        $client = $this->createAuthenticatedClient();
-
-        $client->request('GET', 'api/rest/v1/products?attributes=a_simple_select_size&page=2&limit=2&pagination_type=page&with_count=false');
-        $expected = <<<JSON
-{
-  "_links": {
-    "self": {
-      "href": "http://localhost/api/rest/v1/products?page=2&with_count=false&pagination_type=page&limit=2&attributes=a_simple_select_size"
-    },
-    "first": {
-      "href": "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=2&attributes=a_simple_select_size"
-    },
-    "previous": {
-      "href": "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=2&attributes=a_simple_select_size"
-    },
-    "next": {
-      "href": "http://localhost/api/rest/v1/products?page=3&with_count=false&pagination_type=page&limit=2&attributes=a_simple_select_size"
-    }
-  },
-  "current_page": 2,
-  "_embedded": {
-    "items": [
-      {
-        "_links": {
-          "self": {
-            "href": "http://localhost/api/rest/v1/products/apollon_blue_l"
-          }
-        },
-        "identifier": "apollon_blue_l",
-        "family": "familyA",
-        "parent": "amor",
-        "groups": [
-          
-        ],
-        "categories": [
-          "categoryB",
-          "categoryC"
-        ],
-        "enabled": true,
-        "values": {
-          "a_simple_select_size": [
-            {
-              "locale": null,
-              "scope": null,
-              "data": "l"
-            }
-          ]
-        },
-        "created": "2017-09-20T17:50:44+02:00",
-        "updated": "2017-09-20T17:50:44+02:00",
-        "associations": {
-          
-        }
-      },
-      {
-        "_links": {
-          "self": {
-            "href": "http://localhost/api/rest/v1/products/apollon_blue_xl"
-          }
-        },
-        "identifier": "apollon_blue_xl",
-        "family": "familyA",
-        "parent": "amor",
-        "groups": [
-          
-        ],
-        "categories": [
-          "categoryA1",
-          "categoryA2"
-        ],
-        "enabled": true,
-        "values": {
-          "a_simple_select_size": [
-            {
-              "locale": null,
-              "scope": null,
-              "data": "xl"
-            }
-          ]
-        },
-        "created": "2017-09-20T17:50:44+02:00",
-        "updated": "2017-09-20T17:50:44+02:00",
         "associations": {
           
         }
@@ -649,7 +511,7 @@ JSON;
         "previous"    : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=true&pagination_type=page&limit=10"}
     },
     "current_page" : 2,
-    "items_count"  : 6,
+    "items_count"  : 4,
     "_embedded"    : {
         "items" : []
     }
@@ -663,7 +525,7 @@ JSON;
     {
         $client = $this->createAuthenticatedClient();
 
-        $search = '{"a_simple_select_size":[{"operator":"IN","value":["s"]}]}';
+        $search = '{"a_simple_select":[{"operator":"IN","value":["optionA"]}]}';
         $client->request('GET', 'api/rest/v1/products?pagination_type=page&search=' . $search);
         $searchEncoded = rawurlencode($search);
         $expected = <<<JSON
@@ -677,20 +539,83 @@ JSON;
         "items" : [
             {
                 "_links" : {
-                    "self" : {"href" : "http://localhost/api/rest/v1/products/apollon_blue_s"}
+                    "self" : {"href" : "http://localhost/api/rest/v1/products/apollon_A_true"}
                 },
-                "identifier"    : "apollon_blue_s",
+                "identifier"    : "apollon_A_true",
                 "family"        : "familyA",
                 "parent"        : "amor",
                 "groups"        : [],
                 "categories"    : ["master"],
                 "enabled"       : true,
                 "values": {
-                "a_simple_select_size": [
+                "a_simple_select": [
                   {
                     "locale": null,
                     "scope": null,
-                    "data": "s"
+                    "data": "optionA"
+                  }
+                ],
+                "a_yes_no": [
+                  {
+                    "locale": null,
+                    "scope": null,
+                    "data": true
+                  }
+                ],
+                "a_price": [
+                {
+                  "locale": null,
+                  "scope": null,
+                  "data": [
+                    {
+                      "amount": "50.00",
+                      "currency": "EUR"
+                    }
+                  ]
+                }
+                ],
+                "a_number_float": [
+                {
+                  "locale": null,
+                  "scope": null,
+                  "data": "12.5000"
+                }
+                ],
+                "a_localized_and_scopable_text_area": [
+                {
+                  "locale": "en_US",
+                  "scope": "ecommerce",
+                  "data": "my pink tshirt"
+                }
+                ]
+                },
+                "created"       : "2017-01-23T11:44:25+01:00",
+                "updated"       : "2017-01-23T11:44:25+01:00",
+                "associations"  : {}
+            },
+            {
+                "_links" : {
+                    "self" : {"href" : "http://localhost/api/rest/v1/products/apollon_A_false"}
+                },
+                "identifier"    : "apollon_A_false",
+                "family"        : "familyA",
+                "parent"        : "amor",
+                "groups"        : [],
+                "categories"    : ["categoryB", "categoryC"],
+                "enabled"       : true,
+                "values": {
+                "a_simple_select": [
+                  {
+                    "locale": null,
+                    "scope": null,
+                    "data": "optionA"
+                  }
+                ],
+                "a_yes_no": [
+                  {
+                    "locale": null,
+                    "scope": null,
+                    "data": false
                   }
                 ],
                 "a_price": [
@@ -736,7 +661,7 @@ JSON;
     {
         $client = $this->createAuthenticatedClient();
 
-        $search = '{"categories":[{"operator":"IN", "value":["categoryA"]}], "a_simple_select_color":[{"operator":"IN","value":["black"]}]}';
+        $search = '{"categories":[{"operator":"IN", "value":["categoryA"]}], "a_simple_select":[{"operator":"IN","value":["optionA"]}]}';
         $client->request('GET', 'api/rest/v1/products?pagination_type=page&search=' . $search);
         $searchEncoded = rawurlencode($search);
         $expected = <<<JSON
@@ -759,7 +684,7 @@ JSON;
     {
         $client = $this->createAuthenticatedClient();
 
-        $search = '{"completeness":[{"operator":"GREATER THAN ON ALL LOCALES","value":50,"locales":["en_US"],"scope":"ecommerce"}],"categories":[{"operator":"IN", "value":["categoryA"]}], "a_simple_select_size":[{"operator":"IN","value":["xl"]}]}';
+        $search = '{"completeness":[{"operator":"GREATER THAN ON ALL LOCALES","value":50,"locales":["en_US"],"scope":"ecommerce"}],"categories":[{"operator":"IN", "value":["categoryA"]}], "a_simple_select":[{"operator":"IN","value":["optionA"]}]}';
         $client->request('GET', 'api/rest/v1/products?search=' . $search);
         $searchEncoded = rawurlencode($search);
         $expected = <<<JSON
@@ -795,12 +720,10 @@ JSON;
     },
     "_embedded" : {
         "items" : [
-            {$standardizedProducts['apollon_blue_s']},
-            {$standardizedProducts['apollon_blue_m']},
-            {$standardizedProducts['apollon_blue_l']},
-            {$standardizedProducts['apollon_blue_xl']},
-            {$standardizedProducts['apollon_blue_xxl']},
-            {$standardizedProducts['apollon_blue_xs']}
+            {$standardizedProducts['apollon_A_true']},
+            {$standardizedProducts['apollon_B_true']},
+            {$standardizedProducts['apollon_A_false']},
+            {$standardizedProducts['apollon_B_false']}
         ]
     }
 }
@@ -815,24 +738,24 @@ JSON;
         $client = $this->createAuthenticatedClient();
 
         $id = [
-            'apollon_blue_s'  => rawurlencode($this->getEncryptedId('apollon_blue_s')),
-            'apollon_blue_m'  => rawurlencode($this->getEncryptedId('apollon_blue_m')),
-            'apollon_blue_xl' => rawurlencode($this->getEncryptedId('apollon_blue_xl')),
+            'apollon_A_true'  => rawurlencode($this->getEncryptedId('apollon_A_true')),
+            'apollon_A_false' => rawurlencode($this->getEncryptedId('apollon_A_false')),
+            'apollon_B_false' => rawurlencode($this->getEncryptedId('apollon_B_false')),
         ];
 
-        $client->request('GET', sprintf('api/rest/v1/products?pagination_type=search_after&limit=3&search_after=%s', $id['apollon_blue_s']));
+        $client->request('GET', sprintf('api/rest/v1/products?pagination_type=search_after&limit=3&search_after=%s', $id['apollon_A_true']));
         $expected = <<<JSON
 {
     "_links": {
-        "self"  : {"href": "http://localhost/api/rest/v1/products?pagination_type=search_after&limit=3&search_after={$id['apollon_blue_s']}"},
+        "self"  : {"href": "http://localhost/api/rest/v1/products?pagination_type=search_after&limit=3&search_after={$id['apollon_A_true']}"},
         "first" : {"href": "http://localhost/api/rest/v1/products?pagination_type=search_after&limit=3"},
-        "next"  : {"href": "http://localhost/api/rest/v1/products?pagination_type=search_after&limit=3&search_after={$id['apollon_blue_xl']}"}
+        "next"  : {"href": "http://localhost/api/rest/v1/products?pagination_type=search_after&limit=3&search_after={$id['apollon_B_false']}"}
     },
     "_embedded"    : {
         "items" : [
-            {$standardizedProducts['apollon_blue_m']},
-            {$standardizedProducts['apollon_blue_l']},
-            {$standardizedProducts['apollon_blue_xl']}
+            {$standardizedProducts['apollon_B_true']},
+            {$standardizedProducts['apollon_A_false']},
+            {$standardizedProducts['apollon_B_false']}
         ]
     }
 }
@@ -846,7 +769,7 @@ JSON;
         $standardizedProducts = $this->getStandardizedProducts();
         $client = $this->createAuthenticatedClient();
 
-        $encryptedId = rawurlencode($this->getEncryptedId('apollon_blue_l'));
+        $encryptedId = rawurlencode($this->getEncryptedId('apollon_B_true'));
 
         $client->request('GET', sprintf('api/rest/v1/products?pagination_type=search_after&limit=4&search_after=%s' , $encryptedId));
         $expected = <<<JSON
@@ -857,9 +780,8 @@ JSON;
     },
     "_embedded"    : {
         "items" : [
-            {$standardizedProducts['apollon_blue_xl']},
-            {$standardizedProducts['apollon_blue_xxl']},
-            {$standardizedProducts['apollon_blue_xs']}
+            {$standardizedProducts['apollon_A_false']},
+            {$standardizedProducts['apollon_B_false']}
         ]
     }
 }
@@ -885,14 +807,14 @@ JSON;
      * @return array
      */
     private function getStandardizedProducts() {
-        $standardizedProducts['apollon_blue_s'] = <<<JSON
+        $standardizedProducts['apollon_A_true'] = <<<JSON
 {
     "_links": {
         "self": {
-            "href": "http://localhost/api/rest/v1/products/apollon_blue_s"
+            "href": "http://localhost/api/rest/v1/products/apollon_A_true"
         }
     },
-  "identifier": "apollon_blue_s",
+  "identifier": "apollon_A_true",
   "family": "familyA",
   "parent": "amor",
   "groups": [],
@@ -901,11 +823,18 @@ JSON;
   ],
   "enabled": true,
   "values": {
-    "a_simple_select_size": [
+    "a_simple_select": [
       {
         "locale": null,
         "scope": null,
-        "data": "s"
+        "data": "optionA"
+      }
+    ],
+    "a_yes_no": [
+      {
+        "locale": null,
+        "scope": null,
+        "data": true
       }
     ],
     "a_price": [
@@ -941,14 +870,14 @@ JSON;
 }
 JSON;
 
-        $standardizedProducts['apollon_blue_m'] = <<<JSON
+        $standardizedProducts['apollon_B_true'] = <<<JSON
 {
     "_links": {
         "self": {
-            "href": "http://localhost/api/rest/v1/products/apollon_blue_m"
+            "href": "http://localhost/api/rest/v1/products/apollon_B_true"
         }
     },
-  "identifier": "apollon_blue_m",
+  "identifier": "apollon_B_true",
   "family": "familyA",
   "parent": "amor",
   "groups": [],
@@ -957,11 +886,18 @@ JSON;
   ],
   "enabled": true,
   "values": {
-    "a_simple_select_color": [
+    "a_simple_select": [
       {
         "locale": null,
         "scope": null,
-        "data": "blue"
+        "data": "optionB"
+      }
+    ],
+    "a_yes_no": [
+      {
+        "locale": null,
+        "scope": null,
+        "data": true
       }
     ],
     "a_price": [
@@ -997,14 +933,14 @@ JSON;
 }
 JSON;
 
-        $standardizedProducts['apollon_blue_l'] = <<<JSON
+        $standardizedProducts['apollon_A_false'] = <<<JSON
 {
     "_links": {
         "self": {
-            "href": "http://localhost/api/rest/v1/products/apollon_blue_l"
+            "href": "http://localhost/api/rest/v1/products/apollon_A_false"
         }
     },
-  "identifier": "apollon_blue_l",
+  "identifier": "apollon_A_false",
   "family": "familyA",
   "parent": "amor",
   "groups": [],
@@ -1014,11 +950,18 @@ JSON;
   ],
   "enabled": true,
   "values": {
-    "a_simple_select_size": [
+    "a_simple_select": [
       {
         "locale": null,
         "scope": null,
-        "data": "l"
+        "data": "optionA"
+      }
+    ],
+    "a_yes_no": [
+      {
+        "locale": null,
+        "scope": null,
+        "data": false
       }
     ],
     "a_price": [
@@ -1054,14 +997,14 @@ JSON;
 }
 JSON;
 
-        $standardizedProducts['apollon_blue_xl'] = <<<JSON
+        $standardizedProducts['apollon_B_false'] = <<<JSON
 {
     "_links": {
         "self": {
-            "href": "http://localhost/api/rest/v1/products/apollon_blue_xl"
+            "href": "http://localhost/api/rest/v1/products/apollon_B_false"
         }
     },
-  "identifier": "apollon_blue_xl",
+  "identifier": "apollon_B_false",
   "family": "familyA",
   "parent": "amor",
   "groups": [
@@ -1073,11 +1016,18 @@ JSON;
   ],
   "enabled": true,
   "values": {
-    "a_simple_select_size": [
+    "a_simple_select": [
       {
         "locale": null,
         "scope": null,
-        "data": "xl"
+        "data": "optionB"
+      }
+    ],
+    "a_yes_no": [
+      {
+        "locale": null,
+        "scope": null,
+        "data": false
       }
     ],
     "a_price": [
@@ -1113,126 +1063,6 @@ JSON;
     
   }
 }
-JSON;
-
-        $standardizedProducts['apollon_blue_xxl'] = <<<JSON
-{
-   "_links": {
-       "self": {
-           "href": "http://localhost/api/rest/v1/products/apollon_blue_xxl"
-       }
-   },
-  "identifier": "apollon_blue_xxl",
-  "family": "familyA",
-  "parent": "amor",
-  "groups": [
-    
-  ],
-  "categories": [
-    "categoryA1"
-  ],
-  "enabled": true,
-  "values": {
-    "a_simple_select_size": [
-      {
-        "locale": null,
-        "scope": null,
-        "data": "xxl"
-      }
-    ],
-    "a_price": [
-    {
-      "locale": null,
-      "scope": null,
-      "data": [
-        {
-          "amount": "50.00",
-          "currency": "EUR"
-        }
-      ]
-    }
-    ],
-          "a_number_float": [
-            {
-              "locale": null,
-              "scope": null,
-              "data": "12.5000"
-            }
-          ],
-          "a_localized_and_scopable_text_area": [
-            {
-              "locale": "en_US",
-              "scope": "ecommerce",
-              "data": "my pink tshirt"
-            }
-          ]
-        },
-  "created": "2017-09-20T15:37:40+02:00",
-  "updated": "2017-09-20T15:37:40+02:00",
-  "associations": {
-    
-  }
-}
-JSON;
-
-        $standardizedProducts['apollon_blue_xs'] = <<<JSON
-{
-    "_links": {
-        "self": {
-            "href": "http://localhost/api/rest/v1/products/apollon_blue_xs"
-        }
-    },
-    "identifier": "apollon_blue_xs",
-      "family": "familyA",
-      "parent": "amor",
-      "groups": [
-        
-      ],
-      "categories": [
-        
-      ],
-      "enabled": true,
-      "values": {
-        "a_simple_select_size": [
-          {
-            "locale": null,
-            "scope": null,
-            "data": "xs"
-          }
-        ],
-        "a_price": [
-        {
-          "locale": null,
-          "scope": null,
-          "data": [
-            {
-              "amount": "50.00",
-              "currency": "EUR"
-            }
-          ]
-        }
-        ],
-        "a_number_float": [
-        {
-          "locale": null,
-          "scope": null,
-          "data": "12.5000"
-        }
-        ],
-        "a_localized_and_scopable_text_area": [
-        {
-          "locale": "en_US",
-          "scope": "ecommerce",
-          "data": "my pink tshirt"
-        }
-        ]
-      },
-      "created": "2017-09-20T15:37:40+02:00",
-      "updated": "2017-09-20T15:37:40+02:00",
-      "associations": {
-        
-      }
-    }
 JSON;
 
         return $standardizedProducts;

--- a/src/Pim/Bundle/VersioningBundle/tests/integration/Normalizer/Flat/AttributeIntegration.php
+++ b/src/Pim/Bundle/VersioningBundle/tests/integration/Normalizer/Flat/AttributeIntegration.php
@@ -89,7 +89,7 @@ class AttributeIntegration extends AbstractFlatNormalizerTestCase
             'group'                  => 'attributeGroupA',
             'unique'                 => false,
             'useable_as_grid_filter' => false,
-            'allowed_extensions'     => 'pdf,doc,docx',
+            'allowed_extensions'     => 'pdf,doc,docx,txt',
             'metric_family'          => null,
             'default_metric_unit'    => null,
             'reference_data_name'    => null,

--- a/src/Pim/Component/Api/tests/integration/Normalizer/AttributeIntegration.php
+++ b/src/Pim/Component/Api/tests/integration/Normalizer/AttributeIntegration.php
@@ -89,7 +89,7 @@ class AttributeIntegration extends AbstractNormalizerTestCase
             'group'                  => 'attributeGroupA',
             'unique'                 => false,
             'useable_as_grid_filter' => false,
-            'allowed_extensions'     => ['pdf', 'doc', 'docx'],
+            'allowed_extensions'     => ['pdf', 'doc', 'docx', 'txt'],
             'metric_family'          => null,
             'default_metric_unit'    => null,
             'reference_data_name'    => null,

--- a/src/Pim/Component/Catalog/tests/integration/Normalizer/Standard/AttributeIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Normalizer/Standard/AttributeIntegration.php
@@ -89,7 +89,7 @@ class AttributeIntegration extends AbstractStandardNormalizerTestCase
             'group'                  => 'attributeGroupA',
             'unique'                 => false,
             'useable_as_grid_filter' => false,
-            'allowed_extensions'     => ['pdf', 'doc', 'docx'],
+            'allowed_extensions'     => ['pdf', 'doc', 'docx', 'txt'],
             'metric_family'          => null,
             'default_metric_unit'    => null,
             'reference_data_name'    => null,

--- a/tests/IntegrationTestsBundle/Loader/FixturesLoader.php
+++ b/tests/IntegrationTestsBundle/Loader/FixturesLoader.php
@@ -75,11 +75,12 @@ class FixturesLoader implements FixturesLoaderInterface
     public function load(Configuration $configuration): void
     {
         $this->systemUserAuthenticator->createSystemUser();
-        $this->container->get('akeneo_elasticsearch.client.product')->resetIndex();
         $this->container->get('akeneo_elasticsearch.client.product_model')->resetIndex();
 
         $files = $this->getFilesToLoad($configuration->getCatalogDirectories());
         $fixturesHash = $this->getHashForFiles($files);
+
+        $this->container->get('akeneo_elasticsearch.client.product')->resetIndex();
 
         $dumpFile = sys_get_temp_dir().self::CACHE_DIR.$fixturesHash.'.sql';
 

--- a/tests/catalog/technical/attributes.csv
+++ b/tests/catalog/technical/attributes.csv
@@ -1,7 +1,7 @@
 code;allowed_extensions;auto_option_sorting;available_locales;date_max;date_min;decimals_allowed;default_metric_unit;group;localizable;max_characters;max_file_size;metric_family;minimum_input_length;negative_allowed;number_max;number_min;reference_data_name;scopable;sort_order;type;unique;useable_as_grid_filter;validation_regexp;validation_rule;wysiwyg_enabled
 sku;;;;;;;;attributeGroupA;0;;;;;;;;;0;0;pim_catalog_identifier;1;1;;;
 a_date;;;;2050-12-31;2005-05-25;;;attributeGroupA;0;;;;;;;;;0;2;pim_catalog_date;0;0;;;
-a_file;pdf,doc,docx;;;;;;;attributeGroupA;0;;;;;;;;;0;1;pim_catalog_file;0;0;;;
+a_file;pdf,doc,docx,txt;;;;;;;attributeGroupA;0;;;;;;;;;0;1;pim_catalog_file;0;0;;;
 an_image;jpg,gif,png;;;;;;;attributeGroupA;0;;500;;;;;;;0;0;pim_catalog_image;0;0;;;
 a_metric;;;;;;1;KILOWATT;attributeGroupB;0;;;Power;;0;;;;0;0;pim_catalog_metric;0;0;;;
 a_metric_without_decimal;;;;;;0;METER;attributeGroupB;0;;;Length;;0;;;;0;0;pim_catalog_metric;0;0;;;


### PR DESCRIPTION
## Description

This PR fixes some broken integration tests.

There was 2 problems:
- Some tests were broken because of a fixed validation on variant axis values uniqueness,
- Other because of completeness with the following error in logs (random error, not the same tests were broken each run):
```
request.CRITICAL: Uncaught PHP Exception Doctrine\DBAL\Exception\UniqueConstraintViolationException: "An exception occurred while executing 'INSERT INTO pim_catalog_completeness (ratio, missing_count, required_count, locale_id, channel_id, product_id) VALUES (?, ?, ?, ?, ?, ?)' with params [26, 14, 19, 5, 1, 1]:  SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '1-5-1' for key 'searchunique_idx'" at /srv/pim/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php line 66 {"exception":"[object] (Doctrine\\DBAL\\Exception\\UniqueConstraintViolationException(code: 0): An exception occurred while executing 'INSERT INTO pim_catalog_completeness (ratio, missing_count, required_count, locale_id, channel_id, product_id) VALUES (?, ?, ?, ?, ?, ?)' with params [26, 14, 19, 5, 1, 1]:\n\nSQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '1-5-1' for key 'searchunique_idx' at /srv/pim/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php:66, Doctrine\\DBAL\\Driver\\PDOException(code: 23000): SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '1-5-1' for key 'searchunique_idx' at /srv/pim/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOStatement.php:107, PDOException(code: 23000): SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '1-5-1' for key 'searchunique_idx' at /srv/pim/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOStatement.php:105)"} []
```

This last error is caused by the product model completeness: when we save a product model, all its descendant (sub-product models, if any, and variant product) completenesses are recalculated with batch jobs. There can be several batch jobs running at the same time, which can lead to the error above.

I also moved the index reset done before loading the fixtures, so there is always some time between two reset, without adding a sleep that would make the tests slower. This will maybe reduce the occurence of "index already exists" (even make them disappear), until we find a real solution to make the reset work 100 % of the time...

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | OK
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
