### PR TITLE
PIM-6894: Allow any special characters in password field

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -14,6 +14,7 @@
 - TIP-809: Prevents ES from using the scoring system and bypass the max_clause_count limit.
 - PIM-6872: Fix PQB sorters with Elasticsearch
 - PIM-6859: Fix missing attribute values in PDF
+- PIM-6894: Allow any special characters in password field
 
 ## Better UI\UX!
 

--- a/features/Pim/Behat/Context/NavigationContext.php
+++ b/features/Pim/Behat/Context/NavigationContext.php
@@ -95,11 +95,12 @@ class NavigationContext extends PimContext implements PageObjectAware
     }
 
     /**
-     * @param string $username
+     * @param string      $username
+     * @param string|null $password
      *
-     * @Given /^I am logged in as "([^"]*)"$/
+     * @Given /^I am logged in as "([^"]*)"( with password (?P<password>[^"]*))?$/
      */
-    public function iAmLoggedInAs($username)
+    public function iAmLoggedInAs($username, ?string $password = null)
     {
         $this->getMainContext()->getSubcontext('fixtures')->setUsername($username);
 
@@ -109,8 +110,9 @@ class NavigationContext extends PimContext implements PageObjectAware
             return $this->getSession()->getPage()->find('css', '.AknLogin-title');
         }, 'Cannot open the login page');
 
+        $password = null !== $password ? $password : $username;
         $this->getSession()->getPage()->fillField('_username', $username);
-        $this->getSession()->getPage()->fillField('_password', $username);
+        $this->getSession()->getPage()->fillField('_password', $password);
 
         $this->getSession()->getPage()->find('css', '.form-signin button')->press();
 

--- a/features/user/edit_my_account.feature
+++ b/features/user/edit_my_account.feature
@@ -25,3 +25,17 @@ Feature: Change my profile
     When I attach file "akeneo.jpg" to "Avatar"
     And I save the user
     Then I should see the flash message "User saved"
+
+  @jira https://akeneo.atlassian.net/browse/PIM-6894
+  Scenario: Successfully update my password with any characters
+    Given I edit the "Peter" user
+    When I visit the "Password" tab
+    And I fill in the following information:
+      | Current password      | Peter         |
+      | New password          | Peter{}()/\@: |
+      | New password (repeat) | Peter{}()/\@: |
+    And I save the user
+    Then I should not see the text "There are unsaved changes"
+    When I logout
+    And I am logged in as "Peter" with password Peter{}()/\@:
+    Then I am on the dashboard page

--- a/src/Oro/Bundle/UserBundle/Form/Type/ChangePasswordType.php
+++ b/src/Oro/Bundle/UserBundle/Form/Type/ChangePasswordType.php
@@ -60,7 +60,6 @@ class ChangePasswordType extends AbstractType
                 'first_options'      => ['label' => 'New password'],
                 'second_options'     => ['label' => 'Repeat new password'],
                 'mapped'             => false,
-                'constraints' => new Valid(),
             ]
         );
     }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

Remove constraints `Valid` on the `plainPassword` field. It's useless and cause a bug with special characters when the form is validated

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
