### PR TITLE
TIP-814 - Enabling X-Forwarded-* headers usage if TRUSTED_PROXY_IPS defined

### DIFF
--- a/web/app.php
+++ b/web/app.php
@@ -8,6 +8,25 @@ $kernel = new AppKernel('prod', false);
 // When using the HttpCache, you need to call the method in your front controller instead of relying on the configuration parameter
 //Request::enableHttpMethodParameterOverride();
 $request = Request::createFromGlobals();
+
+/* In case your app is running behind a reverse-proxy/load-balancer set an environment variable TRUSTED_PROXY_IPS
+   defining IPs or IP ranges as a comma list (example : TRUSTED_PROXY_IPS="10.0.0.0/8")
+   to allow usage of X-Forwarded-* headers */
+$loadBalancerTrustedIPs = getenv('TRUSTED_PROXY_IPS');
+if (!empty($loadBalancerTrustedIPs)) {
+    $ipsArray = explode(',', $loadBalancerTrustedIPs);
+    Request::setTrustedProxies(
+        // the IP address (or range) of your proxy
+        $ipsArray,
+        // trust *all* "X-Forwarded-*" headers
+        Request::HEADER_X_FORWARDED_ALL
+        // or, if your proxy instead uses the "Forwarded" header
+        // Request::HEADER_FORWARDED
+        // or, if you're using AWS ELB
+        // Request::HEADER_X_FORWARDED_AWS_ELB
+    );
+}
+
 $response = $kernel->handle($request);
 $response->send();
 $kernel->terminate($request, $response);


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

In case the PIM is running behind a Proxy (Reverse-Proxy or load-balancer), by default Symfony if not take in account X-Forwarded-* headers that allow to know to know the real request information (client IP, port, proto ...) :
http://symfony.com/doc/current/request/load_balancer_reverse_proxy.html#solution-settrustedproxies

For example if the proxy is taking charge of TLS/SSL and acces the PIM in HTTP, the application doesn't know that the client have accessed in HTTPS. So generated URL in responses will be with "http://".
This is true for example for links in the PIM API replies, but also some absolute links in PIM pages.
The Akeneo Serenity offer is using a reverse-proxy/load-balancer for scalability. The load-balancer is taking in charge TLS and redirect all HTTP accesses to HTTPS.

We are experimenting this problem on SaaS environments. Especially for API where API clients doesn't always accept redirections automatically.

The proposition is to allow to configure Symfony to take in account X-Forward-* headers when an environment variable name "TRUSTED_PROXIES_IPS" is defined (not empty).
This variable would contain IPs or IP ranges of trusted proxies as a comma list (example : TRUSTED_PROXIES_IPS="127.0.0.1,10.0.0.0/8").
The definition of this variable to something that is not null will allow usage of X-Forwarded-* headers.

Note: When using php-fpm, to access environment variables you'll need the fpm configuration parameter "clear_env" to "no".

TODO: document usage of this environment variable.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | Todo

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
