### PR TITLE
PIM-6346: Fix EntityWithFamilyVariant versioning

### DIFF
--- a/src/Pim/Bundle/VersioningBundle/Manager/VersionManager.php
+++ b/src/Pim/Bundle/VersioningBundle/Manager/VersionManager.php
@@ -2,7 +2,6 @@
 
 namespace Pim\Bundle\VersioningBundle\Manager;
 
-use Akeneo\Bundle\StorageUtilsBundle\Doctrine\SmartManagerRegistry;
 use Akeneo\Component\Versioning\Model\Version;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Persistence\ObjectManager;
@@ -50,6 +49,9 @@ class VersionManager
 
     /** @var VersionContext */
     protected $versionContext;
+
+    /** @var EventDispatcherInterface */
+    protected $eventDispatcher;
 
     /**
      * @param ObjectManager            $objectManager

--- a/src/Pim/Bundle/VersioningBundle/Normalizer/Flat/ProductModelNormalizer.php
+++ b/src/Pim/Bundle/VersioningBundle/Normalizer/Flat/ProductModelNormalizer.php
@@ -55,7 +55,7 @@ class ProductModelNormalizer extends SerializerAwareNormalizer implements Normal
      */
     private function normalizeValues(ProductModelInterface $productModel, $format = null, array $context = []): array
     {
-        $values = $productModel->getValues();
+        $values = $productModel->getValuesForVariation();
 
         $normalizedValues = [];
         foreach ($values as $value) {

--- a/src/Pim/Bundle/VersioningBundle/Normalizer/Flat/ProductNormalizer.php
+++ b/src/Pim/Bundle/VersioningBundle/Normalizer/Flat/ProductNormalizer.php
@@ -9,6 +9,7 @@ use Pim\Component\Catalog\Model\GroupInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Model\ValueCollectionInterface;
 use Pim\Component\Catalog\Model\ValueInterface;
+use Pim\Component\Catalog\Model\VariantProductInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\SerializerAwareInterface;
 use Symfony\Component\Serializer\SerializerAwareTrait;
@@ -116,11 +117,16 @@ class ProductNormalizer implements NormalizerInterface, SerializerAwareInterface
      */
     protected function getFilteredValues(ProductInterface $product, array $context = [])
     {
-        if (null === $this->filter) {
-            return $product->getValues();
+        if ($product instanceof VariantProductInterface) {
+            $values = $product->getValuesForVariation();
+        } else {
+            $values = $product->getValues();
         }
 
-        $values = $product->getValues();
+        if (null === $this->filter) {
+            return $values;
+        }
+
         foreach ($context['filter_types'] as $filterType) {
             $values = $this->filter->filterCollection(
                 $values,

--- a/src/Pim/Bundle/VersioningBundle/spec/Normalizer/Flat/ProductModelNormalizerSpec.php
+++ b/src/Pim/Bundle/VersioningBundle/spec/Normalizer/Flat/ProductModelNormalizerSpec.php
@@ -2,11 +2,11 @@
 
 namespace spec\Pim\Bundle\VersioningBundle\Normalizer\Flat;
 
-use Doctrine\Common\Collections\Collection;
 use Pim\Bundle\VersioningBundle\Normalizer\Flat\ProductModelNormalizer;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Model\ProductModelInterface;
+use Pim\Component\Catalog\Model\ValueCollectionInterface;
 use Pim\Component\Catalog\Model\ValueInterface;
 use Prophecy\Argument;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
@@ -43,14 +43,14 @@ class ProductModelNormalizerSpec extends ObjectBehavior
         Serializer $serializer,
         ProductModelInterface $productModel,
         ValueInterface $sku,
-        Collection $values,
+        ValueCollectionInterface $values,
         \Iterator $iterator
     ) {
         $this->setSerializer($serializer);
 
         $productModel->getCode()->willReturn($sku);
         $productModel->getCategoryCodes()->willReturn(['nice shoes', 'converse']);
-        $productModel->getValues()->willReturn($values);
+        $productModel->getValuesForVariation()->willReturn($values);
 
         $values->getIterator()->willReturn($iterator);
         $iterator->rewind()->shouldBeCalled();

--- a/src/Pim/Bundle/VersioningBundle/tests/integration/Manager/EntityWithVariantVersionIntegration.php
+++ b/src/Pim/Bundle/VersioningBundle/tests/integration/Manager/EntityWithVariantVersionIntegration.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\VersioningBundle\tests\integration\Manager;
+
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Doctrine\Common\Util\ClassUtils;
+use Pim\Component\Catalog\Model\EntityWithFamilyVariantInterface;
+use Pim\Component\Catalog\Model\ProductModelInterface;
+use Pim\Component\Catalog\Model\VariantProductInterface;
+
+/**
+ * @author    Damien Carcel <damien.carcel@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class EntityWithVariantVersionIntegration extends TestCase
+{
+    /**
+     * Ensure the different versions contains only the entity data and not the
+     * ones of its parent.
+     */
+    public function testProductModelAndVariantProductVersions(): void
+    {
+        $apollon = $this->get('pim_catalog.repository.product_model')->findOneByIdentifier('apollon');
+        $oldName = null === $apollon->getValue('name', 'en_US')
+            ? ''
+            : $apollon->getValue('name', 'en_US')->getData();
+
+        $this->updateProductModel($apollon, [
+            'values' => [
+                'name' => [
+                    [
+                        'locale' => 'en_US',
+                        'scope' => null,
+                        'data' => 'A new model name',
+                    ],
+                ],
+            ],
+        ]);
+
+        $apollonBlue = $this->get('pim_catalog.repository.product_model')->findOneByIdentifier('apollon_blue');
+        $oldComposition = null === $apollonBlue->getValue('composition')
+            ? ''
+            : $apollonBlue->getValue('composition')->getData();
+
+        $this->updateProductModel($apollonBlue, [
+            'values' => [
+                'composition' => [
+                    [
+                        'locale' => null,
+                        'scope' => null,
+                        'data' => 'A new composition',
+                    ],
+                ],
+            ],
+        ]);
+
+        $apollonBlueXXL = $this->get('pim_catalog.repository.variant_product')->findOneByIdentifier('1111111119');
+        $oldEAN = null === $apollonBlueXXL->getValue('ean')
+            ? ''
+            : $apollonBlueXXL->getValue('ean')->getData();
+
+        $this->updateVariantProduct($apollonBlueXXL, [
+            'values' => [
+                'ean' => [
+                    [
+                        'locale' => null,
+                        'scope' => null,
+                        'data' => '1234567890131666',
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertVersions($apollon, 'name-en_US', $oldName, 'A new model name');
+        $this->assertVersions($apollonBlue, 'composition', $oldComposition, 'A new composition');
+        $this->assertVersions($apollonBlueXXL, 'ean', $oldEAN, '1234567890131666');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration(): Configuration
+    {
+        return new Configuration([Configuration::getFunctionalCatalogPath('catalog_modeling')]);
+    }
+
+    /**
+     * @param EntityWithFamilyVariantInterface $entity
+     * @param string                           $field
+     * @param string                           $oldData
+     * @param string                           $newData
+     */
+    private function assertVersions(
+        EntityWithFamilyVariantInterface $entity,
+        string $field,
+        string $oldData,
+        string $newData
+    ): void {
+        $versions = $this->get('pim_versioning.repository.version')->getLogEntries(
+            ClassUtils::getClass($entity),
+            $entity->getId()
+        );
+        $this->assertSame(2, count($versions));
+
+        $lastVersion = $this->get('pim_versioning.repository.version')->getNewestLogEntry(
+            ClassUtils::getClass($entity),
+            $entity->getId()
+        );
+        $changeSet = $lastVersion->getChangeset();
+        $this->assertSame(1, count($changeSet));
+        $this->assertSame($changeSet[$field]['old'], $oldData);
+        $this->assertSame($changeSet[$field]['new'], $newData);
+    }
+
+    /**
+     * Each time we create a product model, a batch job is ran to calculate the
+     * completeness of its descendants.
+     *
+     * This is done by a batch job, and if several product models are created one
+     * after the other, we can end up with a MySQL error because several jobs run
+     * at the same time.
+     *
+     * Here, we use `akeneo_integration_tests.doctrine.job_execution` to be sure
+     * the batch jobs are done running before continuing the test.
+     *
+     * @param ProductModelInterface $productModel
+     * @param array                 $data
+     */
+    private function updateProductModel(ProductModelInterface $productModel, array $data): void
+    {
+        $this->get('pim_catalog.updater.product_model')->update($productModel, $data);
+
+        $errors = $this->get('pim_catalog.validator.product_model')->validate($productModel);
+        $this->assertEquals(0, $errors->count());
+
+        $this->get('pim_catalog.saver.product_model')->save($productModel);
+
+        if ($this->testKernel->getContainer()
+            ->get('akeneo_integration_tests.doctrine.job_execution')
+            ->isRunning('compute_product_models_descendants', 10)
+        ) {
+            throw new \RuntimeException('There are still "compute_product_models_descendants" jobs running.');
+        }
+    }
+
+    /**
+     * @param VariantProductInterface $variantProduct
+     * @param array                   $data
+     */
+    private function updateVariantProduct(VariantProductInterface $variantProduct, array $data): void
+    {
+        $this->get('pim_catalog.updater.product')->update($variantProduct, $data);
+
+        $errors = $this->get('pim_catalog.validator.product')->validate($variantProduct);
+        $this->assertEquals(0, $errors->count());
+
+        $this->get('pim_catalog.saver.product')->save($variantProduct);
+    }
+}

--- a/tests/IntegrationTestsBundle/Doctrine/JobExecution.php
+++ b/tests/IntegrationTestsBundle/Doctrine/JobExecution.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Test\IntegrationTestsBundle\Doctrine;
+
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * @author    Damien Carcel <damien.carcel@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class JobExecution
+{
+    /** @var EntityManagerInterface */
+    protected $entityManager;
+
+    /**
+     * @param EntityManagerInterface $entityManager
+     */
+    public function __construct(EntityManagerInterface $entityManager)
+    {
+        $this->entityManager = $entityManager;
+    }
+
+    /**
+     * Allows to know if a specific job instance still has running job
+     * executions after a certain time (in seconds). This check is performed
+     * every 200 milliseconds.
+     *
+     * @param string $jobInstanceCode
+     * @param int    $time
+     *
+     * @return bool
+     */
+    public function isRunning(string $jobInstanceCode, int $time): bool
+    {
+        $loop = 0;
+        $count = 0;
+        $maxLoopNumber = $time * 5;
+
+        while ($maxLoopNumber > $loop &&
+            0 !== $count = $this->countRunningJobs($jobInstanceCode)
+        ) {
+            usleep(200000);
+            $loop++;
+        }
+
+        if (0 !== $count) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Finds the number of current execution for an instance job.
+     *
+     * @param string $jobInstanceCode
+     *
+     * @return int
+     */
+    private function countRunningJobs(string $jobInstanceCode): int
+    {
+        $sql = <<<SQL
+SELECT count(`execution`.`id`)
+FROM `akeneo_batch_job_execution` AS `execution`
+LEFT JOIN `akeneo_batch_job_instance` AS `instance` ON `execution`.`job_instance_id` = `instance`.`id`
+WHERE `instance`.`code` = :job_instance_code
+AND `execution`.`exit_code` != 'COMPLETED'
+SQL;
+
+        return (int) $this->entityManager->getConnection()->fetchColumn($sql, [
+            'job_instance_code' => $jobInstanceCode,
+        ]);
+    }
+}

--- a/tests/IntegrationTestsBundle/Resources/config/services.yml
+++ b/tests/IntegrationTestsBundle/Resources/config/services.yml
@@ -3,6 +3,7 @@ parameters:
     akeneo_integration_tests.loader.fixtures_loader.class: Akeneo\Test\IntegrationTestsBundle\Loader\FixturesLoader
     akeneo_integration_tests.loader.database_schema_handler.class: Akeneo\Test\IntegrationTestsBundle\Loader\DatabaseSchemaHandler
     akeneo_integration_tests.doctrine.connection.connection_closer.class: Akeneo\Test\IntegrationTestsBundle\Doctrine\Connection\ConnectionCloser
+    akeneo_integration_tests.doctrine.job_execution.class: Akeneo\Test\IntegrationTestsBundle\Doctrine\JobExecution
     akeneo_integration_tests.security.system_user_authenticator.class: Akeneo\Test\IntegrationTestsBundle\Security\SystemUserAuthenticator
 
 services:
@@ -31,6 +32,11 @@ services:
         class: '%akeneo_integration_tests.doctrine.connection.connection_closer.class%'
         arguments:
             - '@doctrine'
+
+    akeneo_integration_tests.doctrine.job_execution:
+        class: '%akeneo_integration_tests.doctrine.job_execution.class%'
+        arguments:
+            - '@doctrine.orm.default_entity_manager'
 
     akeneo_integration_tests.security.system_user_authenticator:
         class: '%akeneo_integration_tests.security.system_user_authenticator.class%'


### PR DESCRIPTION
## Description

Versioning is broken on sub product models and variant products: the generated versions can contain the data of their parents, if they have been previously updated.

This PR ensure only the data from the saved entity are put in the version change set.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added Behats                      | -
| Added integration tests           | OK
| Changelog updated                 | -
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | OK
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
