### PR TITLE
css should be included by the asset twig helper

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Resources/views/index.html.twig
+++ b/src/Pim/Bundle/EnrichBundle/Resources/views/index.html.twig
@@ -4,7 +4,7 @@
         <title>Loading...</title>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <link rel="shortcut icon" href="favicon.ico" />
-        <link rel="stylesheet" href="css/pim.css"/>
+        <link rel="stylesheet" href="{{ asset('css/pim.css') }}"/>
 
         <script type="text/javascript" src="{{asset('dist/manifest.min.js')}} "></script>
         <script type="text/javascript" src="{{asset('dist/lib.min.js')}} "></script>


### PR DESCRIPTION
The css file was in 404 when using the symfony dev environment.

using the asset helper fix that.

![capture d ecran 2017-10-12 a 11 51 16](https://user-images.githubusercontent.com/242870/31490569-af38543c-af44-11e7-88bd-e9ffb3fc475f.png)

