### PR TITLE
Pim 6898 - Some data can break ES index and crashes new products indexing

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -15,6 +15,7 @@
 - PIM-6872: Fix PQB sorters with Elasticsearch
 - PIM-6859: Fix missing attribute values in PDF
 - PIM-6894: Allow any special characters in password field
+- PIM-6898: Fixes some data can break ES index and crashes new products indexing
 
 ## Better UI\UX!
 

--- a/src/Pim/Bundle/CatalogBundle/Resources/elasticsearch/index_configuration.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/elasticsearch/index_configuration.yml
@@ -30,14 +30,18 @@ mappings:
             -
                 family:
                     path_match: 'family.labels.*'
-                    match_mapping_type: 'string'
                     mapping:
                         type: 'keyword'
                         normalizer: 'family_normalizer'
             -
+                textarea_scopable_localizable_structure:
+                    path_match: 'values.*-textarea.*'
+                    match_mapping_type: 'object'
+                    mapping:
+                        type: 'object'
+            -
                 textarea:
                     path_match: 'values.*-textarea.*'
-                    match_mapping_type: 'string'
                     mapping:
                         fields:
                             preprocessed:
@@ -46,136 +50,180 @@ mappings:
                         type: 'text'
                         analyzer: 'textarea_analyzer'
             -
+                text_scopable_localizable_structure:
+                    path_match: 'values.*-text.*'
+                    match_mapping_type: 'object'
+                    mapping:
+                        type: 'object'
+            -
                 text:
                     path_match: 'values.*-text.*'
-                    match_mapping_type: 'string'
                     mapping:
                         type: 'keyword'
                         normalizer: 'text_normalizer'
             -
+                completeness_scopable_localizable_structure:
+                    path_match: 'completeness.*'
+                    match_mapping_type: 'object'
+                    mapping:
+                         type: 'object'
+            -
                 completeness:
-                     path_match: 'completeness.*'
-                     match_mapping_type: 'long'
-                     mapping:
+                    path_match: 'completeness.*'
+                    mapping:
                          type: 'integer'
+            -
+                decimal_scopable_localizable_structure:
+                    path_match: 'values.*-decimal.*'
+                    match_mapping_type: 'object'
+                    mapping:
+                        type: 'object'
             -
                 decimal:
                     path_match: 'values.*-decimal.*'
-                    match_mapping_type: 'string'
                     mapping:
                         type: 'double'
             -
+                boolean_scopable_localizable_structure:
+                    path_match: 'values.*-boolean.*'
+                    match_mapping_type: 'object'
+                    mapping:
+                        type: 'object'
+            -
+                boolean:
+                    path_match: 'values.*-boolean.*'
+                    mapping:
+                        type: 'boolean'
+            -
+                date_scopable_localizable_structure:
+                    path_match: 'values.*-date.*'
+                    match_mapping_type: 'object'
+                    mapping:
+                        type: 'object'
+            -
+                date:
+                    path_match: 'values.*-date.*'
+                    mapping:
+                        type: 'date'
+            -
+                option_scopable_localizable_structure:
+                    path_match: 'values.*-option.*'
+                    match_mapping_type: 'object'
+                    mapping:
+                        type: 'object'
+            -
                 option:
                     path_match: 'values.*-option.*'
-                    match_mapping_type: 'string'
                     mapping:
                         type: 'keyword'
+            -
+                options_scopable_localizable_structure:
+                    path_match: 'values.*-options.*'
+                    match_mapping_type: 'object'
+                    mapping:
+                        type: 'object'
             -
                 options:
                     path_match: 'values.*-options.*'
-                    match_mapping_type: 'string'
                     mapping:
                         type: 'keyword'
+            -
+                reference_data_option_scopable_localizable_structure:
+                    path_match: 'values.*-reference_data_option.*'
+                    match_mapping_type: 'object'
+                    mapping:
+                        type: 'object'
             -
                 reference_data_option:
                     path_match: 'values.*-reference_data_option.*'
-                    match_mapping_type: 'string'
                     mapping:
                         type: 'keyword'
+            -
+                reference_data_options_scopable_localizable_structure:
+                    path_match: 'values.*-reference_data_options.*'
+                    match_mapping_type: 'object'
+                    mapping:
+                        type: 'object'
             -
                 reference_data_options:
                     path_match: 'values.*-reference_data_options.*'
-                    match_mapping_type: 'string'
                     mapping:
                         type: 'keyword'
             -
+                prices_data_options_scopable_localizable_structure:
+                    path_match: 'values.*-prices.*'
+                    match_mapping_type: 'object'
+                    mapping:
+                        type: 'object'
+            -
                 prices:
                     path_match: 'values.*-prices.*'
-                    match_mapping_type: 'string'
                     mapping:
                         type: 'double'
             -
                 metric_data:
-                    match_mapping_type: 'string'
+                    path_match: 'values.*-metric.*.data'
                     mapping:
                         index: 'no'
-                    path_match: 'values.*-metric.*.data'
             -
                 metric_base_data:
                     path_match: 'values.*-metric.*.base_data'
-                    match_mapping_type: 'string'
                     mapping:
                         type: 'double'
             -
                 metric_unit:
                     path_match: 'values.*-metric.*.unit'
-                    match_mapping_type: 'string'
                     mapping:
                         index: 'no'
             -
                 metric_base_unit:
                     path_match: 'values.*-metric.*.base_unit'
-                    match_mapping_type: 'string'
                     mapping:
                         index: 'no'
             -
                 media_extension:
                     path_match: 'values.*-media.*.extension'
-                    match_mapping_type: 'string'
                     mapping:
                         index: 'no'
             -
                 media_key:
                     path_match: 'values.*-media.*.key'
-                    match_mapping_type: 'string'
                     mapping:
                         index: 'no'
             -
                 media_hash:
                     path_match: 'values.*-media.*.hash'
-                    match_mapping_type: 'string'
                     mapping:
                         index: 'no'
             -
                 media_mime_type:
                     path_match: 'values.*-media.*.mime_type'
-                    match_mapping_type: 'string'
                     mapping:
                         index: 'no'
             -
                 media_original_filename:
                     path_match: 'values.*-media.*.original_filename'
-                    match_mapping_type: 'string'
                     mapping:
                         type: 'keyword'
             -
                 media_size:
                     path_match: 'values.*-media.*.size'
-                    match_mapping_type: 'string'
                     mapping:
                         index: 'no'
             -
                 media_storage:
                     path_match: 'values.*-media.*.storage'
-                    match_mapping_type: 'string'
                     mapping:
                         index: 'no'
             -
-                boolean:
-                    path_match: 'values.*-boolean.*'
-                    match_mapping_type: 'boolean'
+                in_group_structure:
+                    path_match: 'in_group.*'
+                    match_mapping_type: 'object'
                     mapping:
-                        type: 'boolean'
-            -
-                date:
-                    path_match: 'values.*-date.*'
-                    match_mapping_type: 'date'
-                    mapping:
-                        type: 'date'
+                        type: 'object'
             -
                 in_group:
                     path_match: 'in_group.*'
-                    match_mapping_type: 'boolean'
                     mapping:
                         type: 'boolean'
 settings:

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/IndexProductsIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/IndexProductsIntegration.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\Elasticsearch\IndexConfiguration;
+
+use Akeneo\Bundle\ElasticsearchBundle\Client;
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+
+/**
+ * Integration tests on product mapping
+ *
+ * @author    Benoit Jacquemont <benoit.jacqumont@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class IndexProductsIntegration extends TestCase
+{
+    const DOCUMENT_TYPE = 'pim_catalog_product';
+
+    private const PAGE_SIZE = 100;
+
+    /** @var Client */
+    protected $esProductClient;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return new Configuration([Configuration::getMinimalCatalogPath()]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->esProductClient = $this->get('akeneo_elasticsearch.client.product');
+    }
+
+    public function testDateBeforeText()
+    {
+        $productWithDateInText = [
+            'identifier' => 'product_1',
+            'values'     => [
+                'name-text' => [
+                    '<all_channels>' => [
+                        '<all_locales>' => '2015/01/01',
+                    ],
+                ],
+            ]
+        ];
+
+        $this->esProductClient->index(self::DOCUMENT_TYPE, $productWithDateInText['identifier'], $productWithDateInText);
+
+
+        $productWithPureText = [
+            'identifier' => 'product_2',
+            'values'     => [
+                'name-text' => [
+                    '<all_channels>' => [
+                        '<all_locales>' => 'My nice product',
+                    ],
+                ],
+            ]
+        ];
+
+        $this->esProductClient->index(self::DOCUMENT_TYPE, $productWithPureText['identifier'], $productWithPureText);
+    }
+}


### PR DESCRIPTION
# A True Story of Type Mapping in Elasticsearch

## TL;DR
If the first value of text field looks like a date, ES will set the field type as date and reject all other values for this field that don't look like date. In this case, the index is broken and products with this field cannot be indexed anymore. Easy to reproduce with this product import file on an empty index: 
```
sku;name
sku-01;"2017-01-01"
sku-02;"My name"
```
*sku-02* will generate an exception.

## The Full Version
Once upon a time there was a search engine, called ES. As it was a nice search engine, properly indexing typed data.

But ES was talking in a non typed language called JSON.

One day, he received the following document:

`
{
    name : "My super document name"
}
`

After a quick look at the *name* field content, ES decided it was clearly a text data, and wrote on the wall that the *name* field was a `text` field. So the next time he got a *name* field in a document, he would knew right away that it was a `text` field.

But sometimes, the nice Devs needed to make sure that the data they send had the type they chose.

So ES asked a friend to help him. His name was _Mapping_.

Mapping had a nice job: he listened to the nice Devs and wrote on the wall the field names and their wanted types, even before any data with these fields have arrived.

But Devs can be oblivious: sometimes they sent fields they didn't even know could exist before. But still, they wanted to make sure that the fields had a type they chose themselves.

So Mapping asked his smarter little brother _Dynamic Mapping_ (a.k.a Dyn) to give him a hand.

You see, the nice thing with Dyn, is that he has some magical power: he doesn't need to know the name of a field to give it a type. He just need a set of conditions, for example a pattern that matches the name.

One day, a User asked Dyn if he could make sure that all field whose named ended with "-text" and guessed as `string` by ES would be treated as a `text`:
```yaml
text:
    path_match: 'values.*-text.*'
    match_mapping_type: 'string'
```

Some times latter, ES received this document:
`
{
    label-text: "This a nice label for my document"
}
`

ES guessed it was a string, and then Dyn hoped in, screaming all over the place: "It's a string, and the name finishes by text, so It's a text, IT'S A TEXT!". "So it shall be a text", said ES with a smile. And he wrote on the wall: "label-text is a text".

A quarter of second latter, ES received another document:
`
{
    manufacturer-text: "2013/01/17"
}
`

It was the first time ES met the *manufacturer-test* field, but it didn't take a long time for him to decide it clearly looked like a date, and marked the field as a `date` field.

When Dyn looked at the document, he wasn't interested. Only `string` mattered to him. So ES took the chalk stick and wrote himself on the wall: "manufacturer-text is a date field".

They didn't need to wait too long for the next document:
`
{
   manufacturer-text: "My nice manufacturer"
}
`

ES looked at the value field, then looked at the wall, where it was clearly written "manufacturer-text is a date field".

Then he looked backed again at the value of the field.

His face turned red. He reached into his left pocket, fetched out of it a big bold "Wrong type" exception and put it in the back of the messenger who brought the document. He then pushed him out of the door, screaming that the User must get his shit together and send proper data.

When the messenger returned to the User with the "Wrong type" exception hanging on his back, the User scratched his head, and after a moment, understood he didn't give Dyn the right information.

So he told Dyn that now every field ending with "-text" must be treated as `text`, regardless of their type:
```yaml
text:
    path_match: 'values.*-text.*'
```

Quite a long time latter, ES got this new document:
`
{
    material_text: "01-12-2012"
}
`
As before, ES recognized a `date`. But this time Dyn was interested, because he was interested in all "-text" fields, regardless of their guessed type. So Dyn wrote on the wall this beautiful truth: "material_text is a text".

And then things went perfectly well with the next document, and the one after, and so on. The Devs were happy, as ES, Dyn and Mapping.

But one day, another document arrived. It was different:
```
  {
    usage_text: {
        ecommerce: {
            en_US: "Mostly for the swimming pool"
        }
    }
  }
```

ES looked at the content of *usage_text*, and he saw an `object` in its full glory.

But Dyn didn't agree: it was called "-text", so it must be a text!

With his eyes watering, his breath short, ES put a hand on Dyn shoulder and explained to him that sometimes life is a bitch.

And then he proceed to kick the messenger ass out of the door again, the infamous "Wrong type" exception nailed on his back.

The Devs saw the messenger coming back from far away. They sat down, and started invoking the Ancient Gods of Dark Logic:

"Gods of Dark Logic, we call you!", prayed the Devs. "Our code is by our side, we seek a life of honor, free from all false architecture! Come, come, and compile!"

In the loudest of silence, the Gods of Dark Logic appeared, wrapped in their coat of Mathematical Pain, breathing fires from their bottomless mouths and sending lightning from their empty orbits.

At first, the Gods saw the dead messenger, laying on the floor, blood bubbling from below the "Wrong type" exception nailed on his back. And then, they looked inside Dyn soul.

"You fools!", the Gods shouted at the Devs, "Don't you know a single thing can be multiple?"

And then, they disappeared, their words still echoing in distance, leaving the Devs shivering.

The Devs spent a long time studying the riddle that was the Gods' gift.

And then they understood: this single riddle was multiple too. It was a meta-riddle!

Indeed, an object is a single thing that can contain multiple things, and at the same time, a single path mapping can be multiple too!

And they crafted a magical message they sent to Dyn:
```yaml
-
    text_scopable_localizable_structure:
        path_match: 'values.*-text.*'
        match_mapping_type: 'object'
-
    text:
        path_match: 'values.*-text.*'
```

In substance, it was saying to Dyn: "If you get a field with -text in its name and ES told you it's an `object`, it's cool, because it is indeed an `object`. And if you get any other type of field with -text in its name, then for sure it's a `text`".

Then another document arrived:
```
{
    packaging_text: {
        ecommerce: {
            en_US: "In small eco friendly package."
        }
    }
}
```
ES looked at the "packaging_text" field, saw a `object`. Dyn was very okay with that, he knew it could happen!

And then, magic did its magical stuff: the object got unwrap, unveiling two other fields: *packaging_text.ecommerce* and *packaging_text.ecommerce.en_US*. The first one was no story, as it was still an `object`. But the last one was not an `object`! So it was a `text`!

With confidence, Dyn proudly took his time to write on the wall: "packaging_text.ecommerce.en_US is a text", just below "packaging_text and packaging_text.ecommerce are objects."

And the indexing sailed smoothly on the Sea of No Error Anymore.

And ES, Mapping, Dyn and the Devs lived happily ever after...

... until their next adventure!

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | Yes
| Changelog updated                 | -
| Review and 2 GTM                  | WIP
| Micro Demo to the PO (Story only) | -
| Migration script                  | 
| Tech Doc                          | -
