### PR TITLE
PIM-6901: Fix ACL with a new role when we want to edit users

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -1,3 +1,9 @@
+# 1.7.x
+
+## Bug Fixes
+
+PIM-6901: Fix ACL with a new role when we want to edit users
+
 # 1.7.10 (2017-10-10)
 
 ## Bug Fixes

--- a/features/Context/Page/Role/Creation.php
+++ b/features/Context/Page/Role/Creation.php
@@ -15,4 +15,30 @@ class Creation extends Form
 {
     /** @var string */
     protected $path = '/user/role/create';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct($session, $pageFactory, $parameters = [])
+    {
+        parent::__construct($session, $pageFactory, $parameters);
+
+        $this->elements = array_merge(
+            [
+                'Permission' => [
+                    'css'        => '#rights-action',
+                    'decorators' => [
+                        'Pim\Behat\Decorator\Permission\PermissionDecorator'
+                    ]
+                ],
+                'API permission' => [
+                    'css'        => '#rights-api',
+                    'decorators' => [
+                        'Pim\Behat\Decorator\Permission\PermissionDecorator'
+                    ]
+                ],
+            ],
+            $this->elements
+        );
+    }
 }

--- a/features/user/edit_user.feature
+++ b/features/user/edit_user.feature
@@ -17,7 +17,6 @@ Feature: Edit a user
     Then I should see the flash message "User saved"
     And I should see the text "John Smith"
 
-  @javascript
   Scenario: Successfully edit and apply user preferences
     When I edit the "Peter" user
     And I visit the "Additional" tab
@@ -35,3 +34,21 @@ Feature: Edit a user
     And I should see the text "2015 Damenkollektion"
     And I should see the filters name, family and sku
     And I should not see the filter enabled
+
+  @jira https://akeneo.atlassian.net/browse/PIM-6901
+  Scenario: Successfully edit a user with a new role
+    Given I am on the role creation page
+    And I fill in the following information:
+      | Role (required) | Tata role |
+    And I visit the "Permissions" tab
+    And I grant rights to resource Edit users
+    Then I save the role
+    When I edit the "mary" user
+    And I visit the "Groups and Roles" tab
+    And I check "Tata role"
+    And I uncheck "User"
+    Then I save the user
+    And I logout
+    When I am logged in as "Mary"
+    And I edit the "admin" user
+    Then I should see the text "Edit user - John Doe"

--- a/src/Pim/Bundle/UserBundle/Resources/views/User/update.html.twig
+++ b/src/Pim/Bundle/UserBundle/Resources/views/User/update.html.twig
@@ -5,11 +5,6 @@
 {% set fullname = form.vars.value.fullName|default('N/A') %}
 {% oro_title_set({params : {"%username%": fullname }}) %}
 {% set title = form.vars.value.id ? 'Edit user'|trans ~ ' - ' ~ fullname : 'New user'|trans %}
-{% if editRoute %}
-    {% set formAction = path(editRoute) %}
-{% else %}
-    {% set formAction = form.vars.value.id ? path('oro_user_update', { id: form.vars.value.id}) : path('oro_user_create') %}
-{% endif %}
 
 {% block head_script %}
     <script type="text/javascript">
@@ -53,7 +48,7 @@
 {% block content %}
     {{ JSFV(form) }}
     {{ form_start(form, {
-        'action': formAction,
+        'action': editRoute,
         'attr': {
             'data-updated-title': 'confirmation.leave'|trans,
             'data-updated-message': 'confirmation.discard changes'|trans({ '%entity%': 'user.title'|trans })


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

on 1.7, when you : 
- create a new role
- allow to edit users with ACL
- try to edit a user

it does not work. And this, only for new role... Why? I really don't know :( Welcome to the hell of the ACL...

A [PR](https://github.com/akeneo/pim-community-dev/pull/5979) introduced this regression. 
We checked ACL on `updateAction` but it broke the scenario written above.
The fix is really simple, I revert code added by Oliver and removed the mish-mash of redirection route. 

Indeed, before when you wanted to update your account (`user/profile/edit` route), you were redirected to `/user/update/{your_id}`. Problem, on this route, if you have not the ACL `Edit users`, a 403 error was thrown.

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
