### PR TITLE
Fix #6983 wrong path when generating js routes

### DIFF
--- a/src/Pim/Bundle/InstallerBundle/Command/AssetsCommand.php
+++ b/src/Pim/Bundle/InstallerBundle/Command/AssetsCommand.php
@@ -55,10 +55,10 @@ class AssetsCommand extends ContainerAwareCommand
 
         $this->getEventDispatcher()->dispatch(InstallerEvents::PRE_ASSETS_DUMP);
 
+        $webDir = $this->getWebDir();
+
         if (true === $input->getOption('clean')) {
             try {
-                $webDir = $this->getWebDir();
-
                 $this->cleanDirectories([$webDir.'bundles', $webDir.'css', $webDir.'js']);
             } catch (\Exception $e) {
                 $output->writeln(sprintf('<error>Error during PIM installation. %s</error>', $e->getMessage()));
@@ -70,7 +70,7 @@ class AssetsCommand extends ContainerAwareCommand
 
         $this->commandExecutor
             ->runCommand('oro:navigation:init')
-            ->runCommand('fos:js-routing:dump', ['--target' => 'web/js/routes.js'])
+            ->runCommand('fos:js-routing:dump', ['--target' => $webDir.'js/routes.js'])
             ->runCommand('oro:requirejs:generate-config')
             ->runCommand('assets:install')
             ->runCommand('assetic:dump')


### PR DESCRIPTION
Fix the path where `js/routes.js`are being generated after executing `pim:installer:assets` as described in #6983.
 
| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | -
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -
