### PR TITLE
[PIM-6891] Keep the tab context between product and product model forms

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-6898: Fixes some data can break ES index and crashes new products indexing
+- PIM-6891: Keep the tab context between product and product model forms
 
 ## Better UI\UX!
 

--- a/features/product-model/ensure_tab_redirection.feature
+++ b/features/product-model/ensure_tab_redirection.feature
@@ -1,0 +1,21 @@
+@javascript
+Feature: Ensures the appropriate tab is displayed to the user
+  In order to ease the contributor's work
+  As a product manager
+  I should be redirected to my previous product edit form tab
+
+  Background:
+    Given a "catalog_modeling" catalog configuration
+    And I am logged in as "admin"
+
+  @jira https://akeneo.atlassian.net/browse/PIM-6449
+  Scenario: Successfully displays current tabs between product and product model edit forms
+    Given I am on the "model-tshirt-divided" product model page
+    And I visit the "History" column tab
+    When I am on the "model-tshirt-divided-navy-blue" product model page
+    Then I should be on the "History" column tab
+    When I am on the "tshirt-divided-navy-blue-xxs" product page
+    Then I should be on the "History" column tab
+    When I visit the "Categories" column tab
+    And I am on the "model-tshirt-divided-navy-blue" product model page
+    Then I should be on the "Categories" column tab

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_model/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_model/edit.yml
@@ -152,6 +152,7 @@ extensions:
         aclResourceId: pim_enrich_product_categories_view #TODO
         position: 100
         config:
+            tabCode: pim-product-edit-form-categories
             itemCategoryListRoute: pim_enrich_product_model_listcategories
             itemCategoryTreeRoute: pim_enrich_product_model_category_rest_list
 
@@ -227,6 +228,8 @@ extensions:
         targetZone: container
         aclResourceId: pim_enrich_product_model_history
         position: 140
+        config:
+            tabCode: pim-product-edit-form-history
 
     pim-product-model-edit-form-copy-scope-switcher:
         module: pim/product-edit-form/scope-switcher

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/categories.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/categories.js
@@ -75,7 +75,7 @@ define(
              */
             configure: function () {
                 this.trigger('tab:register', {
-                    code: this.code,
+                    code: (undefined === this.config.tabCode) ? this.code : this.config.tabCode,
                     isVisible: this.isVisible.bind(this),
                     label: __('pim_enrich.form.product.tab.categories.title')
                 });

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/history.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/history.js
@@ -48,8 +48,12 @@ define(
             /**
              * {@inheritdoc}
              */
-            initialize: function () {
+            initialize: function (config) {
                 this.actions = {};
+
+                if (undefined !== config) {
+                    this.config = config.config;
+                }
 
                 BaseForm.prototype.initialize.apply(this, arguments);
             },
@@ -59,7 +63,7 @@ define(
              */
             configure: function () {
                 this.trigger('tab:register', {
-                    code: this.code,
+                    code: (undefined === this.config.tabCode) ? this.code : this.config.tabCode,
                     label: __('pim_enrich.form.product.panel.history.title')
                 });
 
@@ -73,7 +77,12 @@ define(
              * {@inheritdoc}
              */
             render: function () {
-                if (!this.configured || this.code !== this.getParent().getCurrentTab()) {
+                if (!this.configured) {
+                    return this;
+                }
+
+                const tabCode = (undefined === this.config.tabCode) ? this.code : this.config.tabCode;
+                if (tabCode !== this.getParent().getCurrentTab()) {
                     return this;
                 }
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/form/column-tabs.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/form/column-tabs.html
@@ -1,2 +1,1 @@
 <div data-drop-zone="container" class="tab-container tab-content"></div>
-


### PR DESCRIPTION
When you switch from a "product edit form" and "product model edit form" page, the tab extensions does not have the same name.
I added a little trick to allow configuration of the tab code to register in user context to allow context save between these 2 forms.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | y
| Added integration tests           | -
| Changelog updated                 | y
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | y
| Migration script                  | -
| Tech Doc                          | -