### PR TITLE
[WIP] Thresholds example

### DIFF
--- a/app/config/pim_parameters.yml
+++ b/app/config/pim_parameters.yml
@@ -54,3 +54,8 @@ parameters:
     # Files used as configuration for the Elasticsearch index
     elasticsearch_index_configuration_files:
         - '%kernel.root_dir%/../src/Pim/Bundle/CatalogBundle/Resources/elasticsearch/index_configuration.yml'
+
+    scalability_thresholds_enabled: true
+    scalability_thresholds_catalog_product: 2000
+    scalability_thresholds_catalog_attribute: 100
+

--- a/src/Pim/Bundle/CatalogBundle/EventSubscriber/Scalability/AttributeCreationThresholdSubscriber.php
+++ b/src/Pim/Bundle/CatalogBundle/EventSubscriber/Scalability/AttributeCreationThresholdSubscriber.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\EventSubscriber\Scalability;
+
+use Akeneo\Component\StorageUtils\StorageEvents;
+use Pim\Bundle\CatalogBundle\Exception\TooManyEntitiesException;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+/**
+ * Thrown a TooManyEntitiesException when the user raised the attribute scalability threshold
+ * The thresholds are defined for each entity to guarantee an optimal use of Akeneo PIM on a standard infrastructure
+ * Each threshold can be increased depending on the project custom code, infrastructure and configuration
+ *
+ * @author    Nicolas Dupont <nicolas@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class AttributeCreationThresholdSubscriber implements EventSubscriberInterface
+{
+    /** @var AttributeRepositoryInterface */
+    private $repository;
+    /** @var int */
+    private $threshold;
+    /** @var bool */
+    private $enabled;
+
+    /**
+     * @param AttributeRepositoryInterface $repository
+     * @param int                          $threshold
+     * @param bool                         $enabled
+     */
+    public function __construct(AttributeRepositoryInterface $repository, int $threshold, bool $enabled)
+    {
+        $this->repository = $repository;
+        $this->threshold = $threshold;
+        $this->enabled = $enabled;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents() : array
+    {
+        return [
+            StorageEvents::PRE_SAVE => ['checkEntityMaximumThreshold'],
+        ];
+    }
+
+    /**
+     * Check if the threshold is reached
+     *
+     * @param GenericEvent $event
+     */
+    public function checkEntityMaximumThreshold(GenericEvent $event) : void
+    {
+        if (!$this->enabled) {
+            return;
+        }
+
+        $subject = $event->getSubject();
+        if ($subject instanceof AttributeInterface && null === $subject->getId()) {
+            $total = $this->repository->countAll();
+            if ($total >= $this->threshold) {
+                throw new TooManyEntitiesException(
+                    sprintf(
+                        '%d %s have already been created, to create more %s you have to increase the '.
+                        '"%s" parameter (current value %d)',
+                        $total,
+                        'attributes',
+                        'attributes',
+                        'scalability_thresholds_catalog_attribute',
+                        $this->threshold
+                    )
+                );
+            }
+        }
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/EventSubscriber/Scalability/ProductCreationThresholdSubscriber.php
+++ b/src/Pim/Bundle/CatalogBundle/EventSubscriber/Scalability/ProductCreationThresholdSubscriber.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\EventSubscriber\Scalability;
+
+use Akeneo\Component\StorageUtils\StorageEvents;
+use Pim\Bundle\CatalogBundle\Exception\TooManyEntitiesException;
+use Pim\Component\Catalog\Model\ProductInterface;
+use Pim\Component\Catalog\Repository\ProductRepositoryInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+/**
+ * Thrown a TooManyEntitiesException when the user raised the product scalability threshold
+ * The thresholds are defined for each entity to guarantee an optimal use of Akeneo PIM on a standard infrastructure
+ * Each threshold can be increased depending on the project custom code, infrastructure and configuration
+ *
+ * @author    Nicolas Dupont <nicolas@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ProductCreationThresholdSubscriber implements EventSubscriberInterface
+{
+    /** @var ProductRepositoryInterface */
+    private $repository;
+    /** @var int */
+    private $threshold;
+    /** @var bool */
+    private $enabled;
+
+    /**
+     * @param ProductRepositoryInterface $repository
+     * @param int                        $threshold
+     * @param bool                       $enabled
+     */
+    public function __construct(ProductRepositoryInterface $repository, int $threshold, bool $enabled)
+    {
+        $this->repository = $repository;
+        $this->threshold = $threshold;
+        $this->enabled = $enabled;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents() : array
+    {
+        return [
+            StorageEvents::PRE_SAVE => ['checkEntityMaximumThreshold'],
+        ];
+    }
+
+    /**
+     * Check if the threshold is reached
+     *
+     * @param GenericEvent $event
+     */
+    public function checkEntityMaximumThreshold(GenericEvent $event) : void
+    {
+        if (!$this->enabled) {
+            return;
+        }
+
+        $product = $event->getSubject();
+        if ($product instanceof ProductInterface && null === $product->getId()) {
+            $total = $this->repository->countAll();
+            if ($total >= $this->threshold) {
+                throw new TooManyEntitiesException(
+                    sprintf(
+                        '%d %s have already been created, to create more %s you have to increase the '.
+                        '"%s" parameter (current value %d)',
+                        $total,
+                        'products',
+                        'products',
+                        'scalability_thresholds_catalog_product',
+                        $this->threshold
+                    )
+                );
+            }
+        }
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Exception/TooManyEntitiesException.php
+++ b/src/Pim/Bundle/CatalogBundle/Exception/TooManyEntitiesException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\Exception;
+
+/**
+ * This exception should be thrown when the user raised a scalability threshold
+ * The thresholds are defined for each entity to guarantee an optimal use of Akeneo PIM on a standard infrastructure
+ * Each threshold can be increased depending on the project infrastructure configuration
+ *
+ * @author    Nicolas Dupont <nicolas@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class TooManyEntitiesException extends \RuntimeException
+{
+}

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/event_subscribers.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/event_subscribers.yml
@@ -13,6 +13,8 @@ parameters:
     pim_catalog.event_subscriber.index_product_models.class: Pim\Bundle\CatalogBundle\EventSubscriber\IndexProductModelsSubscriber
     pim_catalog.event_subscriber.compute_product_model_descendants.class: Pim\Bundle\CatalogBundle\EventSubscriber\ComputeProductModelDescendantsSubscriber
     pim_catalog.event_subscriber.add_unique_attributes_to_variant_product_attribute_set.class: Pim\Bundle\CatalogBundle\EventSubscriber\AddUniqueAttributesToVariantProductAttributeSetSubscriber
+    pim_catalog.event_subscriber.scalability.product_creation_threshold.class: Pim\Bundle\CatalogBundle\EventSubscriber\Scalability\ProductCreationThresholdSubscriber
+    pim_catalog.event_subscriber.scalability.attribute_creation_threshold.class: Pim\Bundle\CatalogBundle\EventSubscriber\Scalability\AttributeCreationThresholdSubscriber
 
 services:
     # Subscribers
@@ -111,5 +113,23 @@ services:
         class: '%pim_catalog.event_subscriber.add_unique_attributes_to_variant_product_attribute_set.class%'
         arguments:
             - '@pim_catalog.family_variant.add_unique_attributes'
+        tags:
+            - { name: kernel.event_subscriber }
+
+    pim_catalog.event_subscriber.scalability.product_creation_threshold.class:
+        class: '%pim_catalog.event_subscriber.scalability.product_creation_threshold.class%'
+        arguments:
+              - '@pim_catalog.repository.product'
+              - '%scalability_thresholds_catalog_product%'
+              - '%scalability_thresholds_enabled%'
+        tags:
+            - { name: kernel.event_subscriber }
+
+    pim_catalog.event_subscriber.scalability.attribute_creation_threshold.class:
+        class: '%pim_catalog.event_subscriber.scalability.attribute_creation_threshold.class%'
+        arguments:
+              - '@pim_catalog.repository.attribute'
+              - '%scalability_thresholds_catalog_attribute%'
+              - '%scalability_thresholds_enabled%'
         tags:
             - { name: kernel.event_subscriber }


### PR DESCRIPTION
Gives the possibility to define configured thresholds for entities creation, the idea is to enforce scalability recommendations by defining some explicit limits allowing to provide an optimal experience on a standard infrastructure.

Obviously these thresholds can be increased, for instance, on our cloud offer.

I also added a parameter to switch-off this check, it could allow us to provide this improvement in a patch without disturbing current users.

Behavior with this PR:
 - UI: needs to re-work validation error to display a clear message
 - API: Internal Server Error, could be catched / re-worked on create & upsert
 - Import: stops the process

![example](https://user-images.githubusercontent.com/2104359/31619839-f9073f8e-b295-11e7-9d06-3ee4777271d1.png)

![example-2](https://user-images.githubusercontent.com/2104359/31620574-e3f4be3a-b297-11e7-80fc-5adbf1e96536.png)

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
